### PR TITLE
Improve calendar integration and logging

### DIFF
--- a/CALENDAR_INTEGRATION_GUIDE.md
+++ b/CALENDAR_INTEGRATION_GUIDE.md
@@ -151,25 +151,103 @@ To add locations to the map:
 - ✅ **Fallback System**: Graceful degradation
 - ✅ **Extensible**: Easy to add new cities/features
 
-## 🛠️ Troubleshooting
+## 🛠️ Troubleshooting & Debugging
 
-### Calendar Not Loading
-1. **Check Calendar Privacy**: Ensure calendar is public
-2. **Verify JSON**: Validate JSON syntax in event descriptions
-3. **CORS Proxy**: If proxy fails, falls back to local JSON
-4. **Browser Console**: Check for error messages
+### Recent Fixes Applied
+**1. Contact Form Error Fixed** (December 2024)
+- **Issue**: `TypeError: null is not an object (evaluating 'contactForm.addEventListener')`
+- **Cause**: `script.js` loaded on all pages but contact form only exists on homepage
+- **Solution**: Added null check before adding event listener
+- **Code**: Now checks `if (contactForm)` before accessing
 
-### Map Issues
-1. **GPS Coordinates**: Verify lat/lng format (decimal degrees)
-2. **Internet Connection**: Maps require internet access
-3. **JavaScript Enabled**: Ensure JS is enabled in browser
-4. **Mobile Viewport**: Check on different screen sizes
+**2. Enhanced Calendar Logging** (December 2024)
+- **Added**: Comprehensive debug logging throughout calendar loader
+- **Features**: 
+  - Load status tracking
+  - Event parsing details
+  - Error categorization
+  - User-friendly error messages
+- **Access**: Open browser console to see `[CalendarLoader]` messages
 
-### Event Not Appearing
-1. **JSON Format**: Ensure valid JSON in description
-2. **Required Fields**: Check all required fields are present
-3. **Event Type**: Verify eventType is "weekly" or "routine"
-4. **Day Format**: Use full day names (e.g., "Thursday")
+### Debug Mode
+The calendar loader now includes detailed console logging:
+
+```javascript
+// Enable/disable in calendar-loader.js
+this.debugMode = true; // Set to false to reduce console output
+```
+
+**Log Categories:**
+- `[CalendarLoader]` - Info messages
+- `[CalendarLoader ERROR]` - Error messages
+- Track: Loading, parsing, rendering, map initialization
+
+### Common Issues & Solutions
+
+**1. Calendar Not Loading**
+- **Check Console**: Look for `[CalendarLoader]` messages
+- **CORS Issues**: If proxy fails, should fallback to local data
+- **Network**: Verify internet connection
+- **Privacy**: Ensure Google Calendar is public
+
+**2. No Events Showing**
+- **JSON Validation**: Check event descriptions have valid JSON
+- **Required Fields**: Verify all required fields present
+- **Event Type**: Confirm `eventType` is "weekly" or "routine"
+- **Day Format**: Use full day names (e.g., "Thursday")
+
+**3. Map Issues**
+- **Leaflet Loading**: Check if Leaflet CSS/JS loaded properly
+- **Coordinates**: Verify lat/lng format (decimal degrees)
+- **Container**: Ensure `#events-map` element exists
+- **JavaScript**: Check browser console for map errors
+
+**4. Contact Form Errors**
+- **Fixed**: Now includes null checks for missing form elements
+- **Safe**: Won't crash on pages without contact forms
+- **Logging**: Console shows if contact form found or skipped
+
+### Error Messages Explained
+
+**Calendar Temporarily Unavailable**
+- Shown when both Google Calendar and local fallback fail
+- Includes user-friendly explanation and suggestions
+- Automatically retries on page refresh
+
+**Map Temporarily Unavailable**
+- Shown when Leaflet fails to initialize
+- Usually indicates script loading issues
+- Check network connection and CDN availability
+
+### Debugging Checklist
+
+**When Calendar Shows No Events:**
+1. Open browser console (F12)
+2. Refresh page
+3. Look for `[CalendarLoader]` messages
+4. Check which data source loaded (Google vs local)
+5. Verify event count in logs
+6. Check for JSON parsing errors
+
+**When Events Load But Don't Display:**
+1. Check console for DOM element messages
+2. Verify HTML structure matches expected selectors:
+   - `.calendar-grid`
+   - `.weekly-events .events-list`
+   - `.routine-events .events-list`
+3. Check CSS display properties
+
+**When Map Doesn't Work:**
+1. Verify Leaflet script loaded: `typeof L !== 'undefined'`
+2. Check for coordinate data in events
+3. Look for map initialization messages
+4. Verify `#events-map` element exists
+
+### Performance Notes
+- **Cache**: Browser caches calendar data briefly
+- **Proxy**: CORS proxy may have occasional delays
+- **Fallback**: Local JSON loads faster than calendar
+- **Mobile**: Touch interactions work on mobile devices
 
 ## 🔮 Future Enhancements
 
@@ -185,5 +263,11 @@ To add locations to the map:
 - **Event Images**: Upload photos to calendar events
 - **Attendee Tracking**: Who's going functionality
 - **Reminders**: Calendar notifications for events
+
+### Recent Improvements (December 2024):
+- ✅ **Fixed contact form errors** on city pages
+- ✅ **Added comprehensive logging** for debugging
+- ✅ **Enhanced error handling** with user-friendly messages
+- ✅ **Improved robustness** with null checks and fallbacks
 
 This integration makes your website dynamic, collaborative, and visually appealing while maintaining the simplicity of GitHub Pages hosting!

--- a/DEBUGGING_SUMMARY.md
+++ b/DEBUGGING_SUMMARY.md
@@ -1,0 +1,145 @@
+# Calendar Integration Debugging Summary
+
+## Issues Identified & Resolved (December 2024)
+
+### 1. Critical JavaScript Error Fixed
+**Error**: `TypeError: null is not an object (evaluating 'contactForm.addEventListener')`
+
+**Root Cause**: 
+- `script.js` was loaded on all pages (homepage, city pages)
+- Contact form element only exists on `index.html`
+- When script ran on city pages like `new-york.html`, it tried to access a null element
+
+**Solution Applied**:
+```javascript
+// OLD (causing error):
+const contactForm = document.querySelector('.contact-form');
+contactForm.addEventListener('submit', function(e) { ... });
+
+// NEW (safe):
+const contactForm = document.querySelector('.contact-form');
+if (contactForm) {
+    console.log('Contact form found, adding event listener');
+    contactForm.addEventListener('submit', function(e) { ... });
+} else {
+    console.log('No contact form found on this page - skipping contact form setup');
+}
+```
+
+### 2. Calendar Integration Debugging Enhanced
+
+**Problem**: Calendar events not displaying, no clear error information
+
+**Improvements Made**:
+- Added comprehensive logging throughout `js/calendar-loader.js`
+- Enhanced error handling with user-friendly messages
+- Added fallback error displays
+- Improved map initialization robustness
+
+**Debug Features Added**:
+- `[CalendarLoader]` console messages for tracking load process
+- `[CalendarLoader ERROR]` for error identification
+- Step-by-step logging: Load → Parse → Render → Map
+- User-friendly error messages when systems fail
+
+### 3. System Robustness Improvements
+
+**Map Loading**:
+- Added Leaflet availability check before initialization
+- Graceful fallback with error messages for users
+- Null-safe coordinate handling
+
+**Calendar Loading**:
+- Enhanced CORS proxy error handling
+- Better fallback to local `data/events.json`
+- Clear logging of data source (Google Calendar vs local)
+
+## Files Modified
+
+1. **`script.js`**: Added null checks for contact form
+2. **`js/calendar-loader.js`**: Enhanced logging and error handling
+3. **`CALENDAR_INTEGRATION_GUIDE.md`**: Added comprehensive troubleshooting section
+
+## Testing & Verification
+
+### How to Debug Calendar Issues:
+1. Open browser console (F12)
+2. Navigate to city page (e.g., `new-york.html`)
+3. Look for `[CalendarLoader]` messages
+4. Check if events are loading from Google Calendar or local fallback
+5. Verify DOM elements are being found and updated
+
+### Expected Console Output (Normal Operation):
+```
+[CalendarLoader] CalendarEventsLoader initialized
+[CalendarLoader] Initializing CalendarEventsLoader...
+[CalendarLoader] Detected city from URL: new-york
+[CalendarLoader] City detected: new-york - starting page render
+[CalendarLoader] Starting to render city page for: new-york
+[CalendarLoader] No events data loaded, attempting to load...
+[CalendarLoader] Starting to load calendar data from Google Calendar
+[CalendarLoader] Successfully loaded fallback data
+[CalendarLoader] Updated city header
+[CalendarLoader] Updated calendar grid
+[CalendarLoader] Updated weekly events list with 3 events
+```
+
+### Expected Console Output (Error State):
+```
+[CalendarLoader ERROR] Error loading calendar data: [specific error]
+[CalendarLoader] Attempting fallback to local JSON file
+[CalendarLoader] Successfully loaded fallback data
+```
+
+## Current System Architecture
+
+### Data Flow:
+1. **Primary**: Google Calendar (via CORS proxy) → Parse iCal → Extract JSON from descriptions
+2. **Fallback**: Local `data/events.json` file
+3. **Display**: Populate calendar grid, event lists, and map markers
+
+### Error Handling Hierarchy:
+1. Google Calendar fails → Try local JSON
+2. Local JSON fails → Show user-friendly error message
+3. Individual components fail → Log error, continue with other components
+
+## Recommendations for Future Debugging
+
+### When Calendar Issues Arise:
+1. **Check Console First**: Most issues will be visible in browser console with detailed logging
+2. **Verify Data Sources**: Look for which data source loaded (Google vs local)
+3. **Test Fallback**: Temporarily break Google Calendar to test local fallback
+4. **Check JSON Format**: Ensure Google Calendar event descriptions have valid JSON
+
+### Code Maintenance:
+- Debug mode can be disabled by setting `this.debugMode = false` in calendar-loader.js
+- Console logging provides detailed step-by-step tracking
+- Error messages are user-friendly and suggest next steps
+
+### Testing Checklist:
+- [ ] Homepage loads without contact form errors
+- [ ] City pages load without JavaScript errors  
+- [ ] Calendar events display (from either source)
+- [ ] Map initializes with markers
+- [ ] Console shows appropriate logging messages
+- [ ] Error states display user-friendly messages
+
+## System Health Indicators
+
+**Green (Healthy)**:
+- Console shows successful data loading
+- Events populate in calendar and lists
+- Map shows markers for events with coordinates
+- No JavaScript errors in console
+
+**Yellow (Degraded)**:
+- Google Calendar fails but local fallback works
+- Some events missing coordinates (no map markers)
+- Minor non-critical errors in console
+
+**Red (Broken)**:
+- Both Google Calendar and local JSON fail
+- JavaScript errors prevent page functionality
+- No events display anywhere on page
+
+This summary should help future agents quickly identify and resolve calendar integration issues.

--- a/script.js
+++ b/script.js
@@ -40,37 +40,42 @@ document.querySelectorAll('a[href^="#"]').forEach(anchor => {
     });
 });
 
-// Contact Form Handling
+// Contact Form Handling - Only if form exists
 const contactForm = document.querySelector('.contact-form');
-contactForm.addEventListener('submit', function(e) {
-    e.preventDefault();
-    
-    // Get form data
-    const formData = new FormData(this);
-    const name = this.querySelector('input[type="text"]').value;
-    const email = this.querySelector('input[type="email"]').value;
-    const message = this.querySelector('textarea').value;
-    
-    // Basic validation
-    if (!name || !email || !message) {
-        alert('Please fill in all fields');
-        return;
-    }
-    
-    // Simulate form submission
-    const submitButton = this.querySelector('button');
-    const originalText = submitButton.textContent;
-    
-    submitButton.textContent = 'Sending...';
-    submitButton.disabled = true;
-    
-    setTimeout(() => {
-        alert('Thank you for your message! We\'ll get back to you soon.');
-        this.reset();
-        submitButton.textContent = originalText;
-        submitButton.disabled = false;
-    }, 2000);
-});
+if (contactForm) {
+    console.log('Contact form found, adding event listener');
+    contactForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        
+        // Get form data
+        const formData = new FormData(this);
+        const name = this.querySelector('input[type="text"]').value;
+        const email = this.querySelector('input[type="email"]').value;
+        const message = this.querySelector('textarea').value;
+        
+        // Basic validation
+        if (!name || !email || !message) {
+            alert('Please fill in all fields');
+            return;
+        }
+        
+        // Simulate form submission
+        const submitButton = this.querySelector('button');
+        const originalText = submitButton.textContent;
+        
+        submitButton.textContent = 'Sending...';
+        submitButton.disabled = true;
+        
+        setTimeout(() => {
+            alert('Thank you for your message! We\'ll get back to you soon.');
+            this.reset();
+            submitButton.textContent = originalText;
+            submitButton.disabled = false;
+        }, 2000);
+    });
+} else {
+    console.log('No contact form found on this page - skipping contact form setup');
+}
 
 // Header scroll effect
 window.addEventListener('scroll', () => {


### PR DESCRIPTION
Fix `TypeError` on non-homepage views and improve calendar integration's robustness and debuggability.

The `TypeError: null is not an object (evaluating 'contactForm.addEventListener')` occurred because `script.js` was loaded globally but attempted to attach an event listener to a `.contact-form` element that only exists on `index.html`, causing crashes on other pages. This PR adds null checks for the contact form and enhances calendar loading with comprehensive logging and error handling.