### PR TITLE
Fix calendar event repetition logic

### DIFF
--- a/calendar-bug-fix-summary.md
+++ b/calendar-bug-fix-summary.md
@@ -1,0 +1,107 @@
+# Calendar Recurring Event Bug Fix
+
+## Issue Description
+
+The calendar parsing logic was incorrectly handling recurring events. Monthly events (like those with `RRULE:FREQ=MONTHLY;BYMONTHDAY=26`) were being displayed every week instead of monthly.
+
+## Root Cause
+
+The bug was in three locations where recurring events were being filtered:
+
+1. **`isRecurringEventInPeriod` function** (lines 614-631)
+2. **Week view generation** (lines 657-659) 
+3. **Month view generation** (lines 737-739)
+
+All three locations were using the same flawed logic:
+```javascript
+event.startDate.getDay() === day.getDay()
+```
+
+This logic only checked if the day of the week matched, completely ignoring the actual recurrence pattern specified in the RRULE.
+
+### Example of the Problem
+- Event: "Goldiloxx" with `RRULE:FREQ=MONTHLY;BYMONTHDAY=26`
+- Should appear: Only on the 26th of each month
+- Actually appeared: Every Saturday (if the 26th was a Saturday in the original event)
+
+## Solution
+
+### 1. Created a new helper function `isEventOccurringOnDate`
+
+This function properly parses the RRULE and determines if an event should occur on a specific date:
+
+```javascript
+isEventOccurringOnDate(event, date) {
+    if (!event.recurring || !event.startDate) return false;
+    
+    const eventDate = new Date(event.startDate);
+    const checkDate = new Date(date);
+    
+    // Make sure we're not checking before the event started
+    if (checkDate < eventDate) return false;
+    
+    // Parse the recurrence rule to determine the pattern
+    const recurrence = event.recurrence || '';
+    
+    if (recurrence.includes('FREQ=WEEKLY')) {
+        // Weekly events: occur on the same day of the week
+        return eventDate.getDay() === checkDate.getDay();
+    } else if (recurrence.includes('FREQ=MONTHLY')) {
+        // Monthly events: check for BYMONTHDAY pattern
+        if (recurrence.includes('BYMONTHDAY=')) {
+            const dayMatch = recurrence.match(/BYMONTHDAY=(\d+)/);
+            if (dayMatch) {
+                const targetDay = parseInt(dayMatch[1]);
+                return checkDate.getDate() === targetDay;
+            }
+        }
+        // Fallback: same day of month as original event
+        return eventDate.getDate() === checkDate.getDate();
+    } else if (recurrence.includes('FREQ=DAILY')) {
+        // Daily events: occur every day
+        return true;
+    } else if (recurrence.includes('FREQ=YEARLY')) {
+        // Yearly events: same month and day
+        return eventDate.getMonth() === checkDate.getMonth() && 
+               eventDate.getDate() === checkDate.getDate();
+    }
+    
+    // Default fallback for other recurring patterns - use day of week
+    return eventDate.getDay() === checkDate.getDay();
+}
+```
+
+### 2. Updated all three locations to use the new function
+
+- **`isRecurringEventInPeriod`**: Now calls `this.isEventOccurringOnDate(event, current)`
+- **Week view generation**: Now calls `this.isEventOccurringOnDate(event, day)`  
+- **Month view generation**: Now calls `this.isEventOccurringOnDate(event, day)`
+
+### 3. Ensured recurrence data is properly stored
+
+Added `recurrence: calendarEvent.recurrence` to the event data object to ensure the RRULE string is available for parsing.
+
+## Supported Recurrence Patterns
+
+The fix now properly handles:
+
+- **`FREQ=WEEKLY`**: Events repeat on the same day of the week
+- **`FREQ=MONTHLY`**: Events repeat monthly, with support for `BYMONTHDAY=N` pattern
+- **`FREQ=DAILY`**: Events repeat every day
+- **`FREQ=YEARLY`**: Events repeat on the same month and day each year
+
+## Impact
+
+- ✅ Monthly events like "Goldiloxx" now appear only on the specified day of the month
+- ✅ Weekly events continue to work correctly  
+- ✅ Daily and yearly events are now supported
+- ✅ The calendar accurately reflects the intended recurrence patterns from Google Calendar
+
+## Testing
+
+To test the fix:
+1. Look for events with `RRULE:FREQ=MONTHLY;BYMONTHDAY=26` in the calendar data
+2. Navigate through different months in the calendar view
+3. Verify the event only appears on the 26th of each month, not every week
+
+The "Goldiloxx" event should now correctly appear monthly on the 26th instead of weekly on Saturdays.


### PR DESCRIPTION
Fix calendar recurring event display to correctly interpret RRULE, preventing monthly events from appearing weekly.

The previous logic for recurring events only checked if the day of the week matched (`event.startDate.getDay() === day.getDay()`), ignoring the actual `RRULE` frequency. This led to monthly events (e.g., `FREQ=MONTHLY;BYMONTHDAY=26`) being displayed every week if the original event's start day of the week matched the current day.