### PR TITLE
Remove spacing in calendar layout

### DIFF
--- a/calendar-spacing-removal-summary.md
+++ b/calendar-spacing-removal-summary.md
@@ -1,0 +1,71 @@
+# Calendar Spacing Removal Summary
+
+## Overview
+Removed all spacing and padding from calendar components to create a tight, edge-to-edge layout without gaps between calendar items, events, or borders.
+
+## Main Changes Made
+
+### 1. Calendar Grid Spacing
+- **Desktop**: Removed `gap: 1rem` from `.calendar-grid`, set to `gap: 0`
+- **Week View**: Removed `gap: 0.8rem` from `.calendar-grid.week-view-grid`, set to `gap: 0`
+
+### 2. Calendar Day Containers
+- **Desktop**: Removed `padding: 1.2rem` from `.calendar-day`, set to `padding: 0`
+- **Desktop**: Removed `border-radius: 15px` from `.calendar-day`, set to `border-radius: 0`
+
+### 3. Day Headers
+- **Desktop**: Removed `margin-bottom: 1rem` and `padding-bottom: 0.5rem` from `.day-header`, set both to `0`
+
+### 4. Event Containers
+- **Desktop**: Removed `gap: 0.5rem` from `.events`, set to `gap: 0`
+
+### 5. Individual Event Items
+- **Desktop**: Removed `padding: 1rem` from `.event-item`, set to `padding: 0`
+- **Desktop**: Removed `border-radius: 12px` from `.event-item`, set to `border-radius: 0`
+
+### 6. Event Content Spacing
+- **Desktop**: Removed `margin-bottom: 0.3rem` from `.event-name`, set to `margin-bottom: 0`
+- **Desktop**: Removed `margin-bottom: 0.2rem` from `.event-time`, set to `margin-bottom: 0`
+
+### 7. No Events Message
+- **Desktop**: Removed `padding: 1rem` from `.no-events`, set to `padding: 0`
+
+## Mobile Responsive Changes
+
+### Mobile (max-width: 768px)
+- **Week View Grid**: `gap: 0.8rem` → `gap: 0`
+- **Week View Days**: `padding: 1.2rem` → `padding: 0`
+- **Week View Headers**: `margin-bottom: 1rem` and `padding-bottom: 0.8rem` → both `0`
+- **Enhanced Events**: `padding: 1.2rem` and `margin-bottom: 1rem` → both `0`
+- **Overview Grid**: `gap: 0.3rem` → `gap: 0`
+- **Overview Days**: `padding: 0.6rem` → `padding: 0`
+- **Month Grid**: `gap: 2px` → `gap: 0`
+- **Month Headers**: `padding: 6px 8px` → `padding: 0`
+- **Month Events Container**: `padding: 6px` and `gap: 4px` → both `0`
+- **Month Event Items**: `padding: 6px 8px` and `border-radius: 6px` → `padding: 0` and `border-radius: 0`
+
+### Small Mobile (max-width: 480px)
+- **Week View Grid**: `gap: 0.6rem` → `gap: 0`
+- **Week View Days**: `padding: 1rem` and `border-radius: 15px` → `padding: 0` and `border-radius: 0`
+- **Enhanced Events**: `padding: 1rem`, `border-radius: 12px`, `margin-bottom: 0.8rem` → all set to `0`
+- **Overview Grid**: `gap: 0.2rem` → `gap: 0`
+- **Overview Days**: `padding: 0.4rem` → `padding: 0`
+- **Month Grid**: `gap: 1px` → `gap: 0`
+- **Month Headers**: `padding: 4px 6px` → `padding: 0`
+- **Month Events Container**: `padding: 4px` and `gap: 3px` → both `0`
+- **Month Event Items**: `padding: 4px 6px` and `border-radius: 5px` → `padding: 0` and `border-radius: 0`
+
+### Additional Mobile Breakpoints
+- **General Calendar Days**: All `padding` values set to `0`, all `border-radius` values set to `0`
+- **Day Headers**: All `margin-bottom` and `padding-bottom` values set to `0`
+- **Event Items**: All `padding` and `margin-bottom` values set to `0`
+
+## Result
+The calendar now displays with:
+- No gaps between calendar day boxes
+- No internal padding within day containers
+- No spacing between events within each day
+- No margins between event content elements
+- Complete edge-to-edge layout without any visual separation
+
+This creates a more compact, space-efficient calendar view where all content is tightly packed without visual breathing room.

--- a/styles.css
+++ b/styles.css
@@ -593,7 +593,7 @@ header {
 .calendar-grid {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
-    gap: 1rem;
+    gap: 0;
     margin-bottom: 1rem;
     position: relative;
     z-index: 2;
@@ -601,7 +601,7 @@ header {
 
 /* Tighter spacing for week view */
 .calendar-grid.week-view-grid {
-    gap: 0.8rem;
+    gap: 0;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
@@ -622,8 +622,8 @@ header {
 
 .calendar-day {
     background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-    border-radius: 15px;
-    padding: 1.2rem;
+    border-radius: 0;
+    padding: 0;
     text-align: left;
     min-height: 160px;
     box-shadow: 0 6px 20px rgba(0,0,0,0.08);
@@ -672,8 +672,8 @@ header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1rem;
-    padding-bottom: 0.5rem;
+    margin-bottom: 0;
+    padding-bottom: 0;
     border-bottom: 1px solid rgba(0,0,0,0.1);
 }
 
@@ -721,14 +721,14 @@ header {
 .events {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0;
 }
 
 .event-item {
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(248, 249, 255, 0.95) 100%);
     color: #333;
-    padding: 1rem;
-    border-radius: 12px;
+    padding: 0;
+    border-radius: 0;
     font-size: 0.85rem;
     cursor: pointer;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -772,7 +772,7 @@ header {
 
 .event-name {
     font-weight: 700;
-    margin-bottom: 0.3rem;
+    margin-bottom: 0;
     font-size: 0.9rem;
     line-height: 1.3;
 }
@@ -780,7 +780,7 @@ header {
 .event-time {
     font-size: 0.8rem;
     opacity: 0.9;
-    margin-bottom: 0.2rem;
+    margin-bottom: 0;
     font-weight: 500;
     color: #667eea;
 }
@@ -797,7 +797,7 @@ header {
     color: #999;
     font-style: italic;
     text-align: center;
-    padding: 1rem;
+    padding: 0;
     font-size: 0.9rem;
 }
 
@@ -1345,17 +1345,17 @@ footer {
     /* Enhanced Week View Mobile */
     .calendar-grid.week-view-grid {
         grid-template-columns: 1fr;
-        gap: 0.8rem;
+        gap: 0;
     }
 
     .calendar-day.week-view {
         min-height: 180px;
-        padding: 1.2rem;
+        padding: 0;
     }
 
     .calendar-day.week-view .day-header {
-        margin-bottom: 1rem;
-        padding-bottom: 0.8rem;
+        margin-bottom: 0;
+        padding-bottom: 0;
     }
 
     .calendar-day.week-view .day-meta {
@@ -1363,8 +1363,8 @@ footer {
     }
 
     .event-item.enhanced {
-        padding: 1.2rem;
-        margin-bottom: 1rem;
+        padding: 0;
+        margin-bottom: 0;
     }
 
     .event-item.enhanced .event-name {
@@ -1373,12 +1373,12 @@ footer {
 
     /* Calendar Overview Mobile */
     .calendar-overview-grid {
-        gap: 0.3rem;
+        gap: 0;
     }
 
     .calendar-day.calendar-overview {
         min-height: 60px;
-        padding: 0.6rem;
+        padding: 0;
     }
 
     .day-number {
@@ -1397,7 +1397,7 @@ footer {
 
     /* Month View Mobile Improvements */
     .calendar-grid.month-view-grid {
-        gap: 2px;
+        gap: 0;
     }
 
     .calendar-day.month-day {
@@ -1405,7 +1405,7 @@ footer {
     }
 
     .calendar-day.month-day .day-header {
-        padding: 6px 8px;
+        padding: 0;
     }
 
     .calendar-day.month-day .day-number {
@@ -1413,13 +1413,13 @@ footer {
     }
 
     .calendar-day.month-day .day-events {
-        padding: 6px;
-        gap: 4px;
+        padding: 0;
+        gap: 0;
     }
 
     .event-item.month-event {
-        padding: 6px 8px;
-        border-radius: 6px;
+        padding: 0;
+        border-radius: 0;
     }
 
     .event-item.month-event .event-name {
@@ -1457,13 +1457,13 @@ footer {
     }
 
     .calendar-day {
-        padding: 1rem;
-        border-radius: 12px;
+        padding: 0;
+        border-radius: 0;
     }
 
     .day-header {
-        margin-bottom: 0.8rem;
-        padding-bottom: 0.5rem;
+        margin-bottom: 0;
+        padding-bottom: 0;
     }
 
     .day-indicator {
@@ -1476,8 +1476,8 @@ footer {
     }
 
     .event-item {
-        padding: 0.8rem;
-        margin-bottom: 0.5rem;
+        padding: 0;
+        margin-bottom: 0;
     }
 
     .city-header h1 {
@@ -1602,19 +1602,19 @@ footer {
 
     /* Enhanced Week View for very small screens */
     .calendar-grid.week-view-grid {
-        gap: 0.6rem;
+        gap: 0;
     }
 
     .calendar-day.week-view {
         min-height: 140px;
-        padding: 1rem;
-        border-radius: 15px;
+        padding: 0;
+        border-radius: 0;
     }
 
     .event-item.enhanced {
-        padding: 1rem;
-        border-radius: 12px;
-        margin-bottom: 0.8rem;
+        padding: 0;
+        border-radius: 0;
+        margin-bottom: 0;
     }
 
     .event-item.enhanced .event-name {
@@ -1629,12 +1629,12 @@ footer {
 
     /* Calendar Overview for very small screens */
     .calendar-overview-grid {
-        gap: 0.2rem;
+        gap: 0;
     }
 
     .calendar-day.calendar-overview {
         min-height: 50px;
-        padding: 0.4rem;
+        padding: 0;
     }
 
     .day-number {
@@ -1657,7 +1657,7 @@ footer {
 
     /* Month View for very small screens */
     .calendar-grid.month-view-grid {
-        gap: 1px;
+        gap: 0;
     }
 
     .calendar-day.month-day {
@@ -1665,7 +1665,7 @@ footer {
     }
 
     .calendar-day.month-day .day-header {
-        padding: 4px 6px;
+        padding: 0;
     }
 
     .calendar-day.month-day .day-number {
@@ -1678,13 +1678,13 @@ footer {
     }
 
     .calendar-day.month-day .day-events {
-        padding: 4px;
-        gap: 3px;
+        padding: 0;
+        gap: 0;
     }
 
     .event-item.month-event {
-        padding: 4px 6px;
-        border-radius: 5px;
+        padding: 0;
+        border-radius: 0;
     }
 
     .event-item.month-event .event-name {
@@ -1725,8 +1725,8 @@ footer {
     }
 
     .calendar-day {
-        padding: 0.8rem;
-        border-radius: 10px;
+        padding: 0;
+        border-radius: 0;
     }
 
     .calendar-day h3 {
@@ -1734,8 +1734,8 @@ footer {
     }
 
     .event-item {
-        padding: 0.6rem;
-        margin-bottom: 0.4rem;
+        padding: 0;
+        margin-bottom: 0;
     }
 
     .event-name {


### PR DESCRIPTION
Remove all spacing, padding, and border-radius from calendar components to create a compact, edge-to-edge layout.