### PR TITLE
Remove top bar and simplify views

### DIFF
--- a/city.html
+++ b/city.html
@@ -20,9 +20,6 @@
                     <h1><a href="index.html">🐻 Chunky Dad</a></h1>
                 </div>
                 
-                <!-- Scrolling city title that appears in header on scroll -->
-                <div class="header-city-title" id="header-city-title"></div>
-                
                 <ul class="nav-menu">
                     <li><a href="index.html">Home</a></li>
                     <li><a href="index.html#cities">Cities</a></li>
@@ -34,13 +31,6 @@
                     <span></span>
                     <span></span>
                     <span></span>
-                </div>
-            </div>
-            
-            <!-- Header city selector that appears on scroll -->
-            <div class="header-city-selector" id="header-city-selector">
-                <div class="header-city-buttons" id="header-city-buttons">
-                    <!-- Will be populated by JavaScript -->
                 </div>
             </div>
         </nav>

--- a/styles.css
+++ b/styles.css
@@ -1401,35 +1401,36 @@ footer {
     }
 
     .calendar-day.month-day {
-        min-height: 100px;
+        min-height: 80px;
     }
 
     .calendar-day.month-day .day-header {
-        padding: 0;
+        padding: 6px 8px;
     }
 
     .calendar-day.month-day .day-number {
-        font-size: 1rem;
+        font-size: 0.9rem;
     }
 
     .calendar-day.month-day .day-events {
-        padding: 0;
-        gap: 0;
+        padding: 4px 6px;
+        gap: 2px;
     }
 
     .event-item.month-event {
-        padding: 0;
-        border-radius: 0;
+        padding: 3px 5px;
+        border-radius: 4px;
+        font-size: 0.7rem;
     }
 
     .event-item.month-event .event-name {
-        font-size: 0.8rem;
-        line-height: 1.2;
+        font-size: 0.7rem;
+        line-height: 1.1;
     }
 
     .more-events {
-        font-size: 0.7rem;
-        padding: 4px;
+        font-size: 0.6rem;
+        padding: 2px 4px;
     }
 
     .calendar-header {
@@ -1657,45 +1658,46 @@ footer {
 
     /* Month View for very small screens */
     .calendar-grid.month-view-grid {
-        gap: 0;
+        gap: 1px;
     }
 
     .calendar-day.month-day {
-        min-height: 85px;
+        min-height: 70px;
     }
 
     .calendar-day.month-day .day-header {
-        padding: 0;
+        padding: 4px 6px;
     }
 
     .calendar-day.month-day .day-number {
-        font-size: 0.9rem;
+        font-size: 0.8rem;
     }
 
     .calendar-day.month-day .day-indicator {
-        font-size: 0.65rem;
-        padding: 2px 5px;
+        font-size: 0.6rem;
+        padding: 1px 3px;
     }
 
     .calendar-day.month-day .day-events {
-        padding: 0;
-        gap: 0;
+        padding: 2px 4px;
+        gap: 1px;
     }
 
     .event-item.month-event {
-        padding: 0;
-        border-radius: 0;
+        padding: 2px 4px;
+        border-radius: 3px;
+        font-size: 0.6rem;
     }
 
     .event-item.month-event .event-name {
-        font-size: 0.75rem;
-        line-height: 1.1;
+        font-size: 0.6rem;
+        line-height: 1.0;
     }
 
     .more-events {
-        font-size: 0.65rem;
-        padding: 3px;
-        border-radius: 4px;
+        font-size: 0.55rem;
+        padding: 2px 3px;
+        border-radius: 3px;
     }
 
     .calendar-header h2 {
@@ -2193,16 +2195,16 @@ footer {
 .event-item.enhanced {
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(248, 249, 255, 0.95) 100%);
     color: #333;
-    padding: 1rem;
-    border-radius: 16px;
-    font-size: 0.9rem;
+    padding: 0.7rem;
+    border-radius: 12px;
+    font-size: 0.85rem;
     cursor: pointer;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     border-left: 4px solid #667eea;
     position: relative;
     overflow: hidden;
     box-shadow: 0 4px 15px rgba(0,0,0,0.08);
-    margin-bottom: 0.8rem;
+    margin-bottom: 0.6rem;
 }
 
 .event-item.enhanced:last-child {
@@ -2211,30 +2213,24 @@ footer {
 
 .event-item.enhanced .event-name {
     font-weight: 700;
-    margin-bottom: 0.6rem;
-    font-size: 1.1rem;
-    line-height: 1.4;
+    margin-bottom: 0.4rem;
+    font-size: 1rem;
+    line-height: 1.3;
     color: #333;
 }
 
 .event-item.enhanced .event-time {
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     color: #667eea;
     font-weight: 600;
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.3rem;
 }
 
 .event-item.enhanced .event-venue {
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     color: #6b7280;
     font-weight: 500;
-    margin-bottom: 0.4rem;
-}
-
-.event-item.enhanced .event-cover {
-    font-size: 0.85rem;
-    color: #059669;
-    font-weight: 500;
+    margin-bottom: 0.3rem;
 }
 
 /* Calendar Overview Styles */
@@ -2562,7 +2558,7 @@ footer {
     padding: 0;
     overflow: hidden;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    min-height: 140px;
+    min-height: 100px;
     display: flex;
     flex-direction: column;
 }
@@ -2592,7 +2588,7 @@ footer {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 10px 14px;
+    padding: 6px 10px;
     background: #f8f9ff;
     border-bottom: 1px solid #e8f2ff;
     flex-shrink: 0;
@@ -2629,18 +2625,18 @@ footer {
 
 .calendar-day.month-day .day-events {
     flex: 1;
-    padding: 10px;
+    padding: 6px 8px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 3px;
     overflow: hidden;
 }
 
 .event-item.month-event {
     background: linear-gradient(135deg, #e8f2ff 0%, #f0f4ff 100%);
     border: 1px solid #d0e1ff;
-    border-radius: 8px;
-    padding: 8px 10px;
+    border-radius: 6px;
+    padding: 4px 6px;
     margin: 0;
     transition: all 0.2s ease;
     cursor: pointer;
@@ -2655,10 +2651,10 @@ footer {
 }
 
 .event-item.month-event .event-name {
-    font-size: 0.85rem;
+    font-size: 0.75rem;
     font-weight: 600;
     margin: 0;
-    line-height: 1.3;
+    line-height: 1.2;
     word-wrap: break-word;
     overflow-wrap: break-word;
 }
@@ -2791,174 +2787,7 @@ footer {
     }
 }
 
-/* Creative title bar interactions */
-.header-expanded {
-    height: auto;
-    padding-bottom: 1rem;
-}
 
-/* Scrolling city title in header */
-.header-city-title {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    opacity: 0;
-    font-size: 1.2rem;
-    font-weight: 600;
-    color: white;
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-    pointer-events: none;
-    z-index: 15;
-    white-space: nowrap;
-}
-
-.header-city-title.visible {
-    opacity: 1;
-    transform: translate(-50%, -50%) scale(1);
-}
-
-.header-city-title.hidden {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0.9);
-}
-
-/* Hide logo when city title is visible */
-.nav-container {
-    position: relative;
-}
-
-.scrolled-header .logo h1 {
-    opacity: 0;
-    transition: opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-/* Ensure proper layering */
-.logo {
-    position: relative;
-    z-index: 5;
-}
-
-/* Scrollable city selector in header */
-.header-city-selector {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(10px);
-    padding: 1rem 2rem;
-    transform: translateY(-100%);
-    opacity: 0;
-    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-}
-
-.header-city-selector.visible {
-    transform: translateY(0);
-    opacity: 1;
-}
-
-.header-city-buttons {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-    max-width: 800px;
-    margin: 0 auto;
-}
-
-.header-city-button {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
-    border: 1px solid rgba(102, 126, 234, 0.3);
-    border-radius: 20px;
-    color: #333;
-    text-decoration: none;
-    font-size: 0.9rem;
-    font-weight: 500;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    white-space: nowrap;
-}
-
-.header-city-button:hover {
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.2) 0%, rgba(118, 75, 162, 0.2) 100%);
-    border-color: rgba(102, 126, 234, 0.5);
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.2);
-}
-
-.header-city-button.active {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    border-color: #667eea;
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
-}
-
-.header-city-button.coming-soon {
-    opacity: 0.6;
-    cursor: not-allowed;
-}
-
-.header-city-button.coming-soon:hover {
-    transform: none;
-    box-shadow: none;
-}
-
-.header-city-emoji {
-    font-size: 1rem;
-}
-
-.header-city-name {
-    font-size: 0.85rem;
-}
-
-/* Enhanced scroll effects */
-.scrolled-header {
-    background: rgba(102, 126, 234, 0.95);
-    backdrop-filter: blur(15px);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-}
-
-/* Mobile responsive adjustments for header interactions */
-@media (max-width: 768px) {
-    .nav-container {
-        padding: 1rem;
-    }
-    
-    .header-city-title {
-        font-size: 1rem;
-    }
-    
-    .header-city-selector {
-        padding: 0.8rem 1rem;
-    }
-    
-    .header-city-buttons {
-        gap: 0.3rem;
-        max-width: none;
-    }
-    
-    .header-city-button {
-        padding: 0.4rem 0.8rem;
-        font-size: 0.8rem;
-    }
-    
-    .header-city-emoji {
-        font-size: 0.9rem;
-    }
-    
-    .header-city-name {
-        font-size: 0.75rem;
-    }
-}
 
 /* Enhanced Today Highlighting for Week View */
 .calendar-day.week-view.current {


### PR DESCRIPTION
Remove scroll-triggered header elements and simplify calendar views to improve mobile display and prevent UI overlap.

The original scrolling header elements (`header-city-title`, `header-city-selector`) were causing an overlap with the existing navigation bar, hindering functionality. Additionally, the week and month calendar views displayed excessive data, leading to a cluttered experience on smaller screen sizes. This PR addresses these issues by removing the problematic header components and optimizing calendar content and styling for better readability and space utilization on mobile devices.