### PR TITLE
Clean up and condense events list

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -557,56 +557,63 @@ class DynamicCalendarLoader {
         });
     }
 
-    // Generate event card (same as original)
+    // Generate event card (cleaned up and condensed)
     generateEventCard(event) {
         const linksHtml = event.links ? event.links.map(link => 
-            `<a href="${link.url}" target="_blank" rel="noopener">${link.label}</a>`
+            `<a href="${link.url}" target="_blank" rel="noopener" class="event-link">${link.label}</a>`
         ).join('') : '';
 
+        // Only show cover if it exists and isn't a placeholder
+        const shouldShowCover = event.cover && 
+            event.cover !== 'Check event details' && 
+            event.cover !== 'TBD' && 
+            event.cover !== 'N/A' && 
+            event.cover.trim() !== '';
+
+        const coverHtml = shouldShowCover ? `
+            <div class="event-info-item">
+                <span class="info-icon">💰</span>
+                <span class="info-text">${event.cover}</span>
+            </div>
+        ` : '';
+
         const teaHtml = event.tea ? `
-            <div class="detail-row tea">
-                <span class="label">Tea:</span>
-                <span class="value">${event.tea}</span>
+            <div class="event-info-item">
+                <span class="info-icon">🍵</span>
+                <span class="info-text">${event.tea}</span>
             </div>
         ` : '';
 
         const locationHtml = event.coordinates && event.coordinates.lat && event.coordinates.lng ? 
-            `<div class="detail-row">
-                <span class="label">Location:</span>
-                <span class="value">
-                    <a href="#" onclick="showOnMap(${event.coordinates.lat}, ${event.coordinates.lng}, '${event.name}', '${event.bar}')" class="map-link">
-                        📍 ${event.bar}
-                    </a>
-                </span>
+            `<div class="event-info-item">
+                <span class="info-icon">📍</span>
+                <a href="#" onclick="showOnMap(${event.coordinates.lat}, ${event.coordinates.lng}, '${event.name}', '${event.bar}')" class="map-link">
+                    ${event.bar}
+                </a>
             </div>` :
-            `<div class="detail-row">
-                <span class="label">Bar:</span>
-                <span class="value">${event.bar}</span>
+            `<div class="event-info-item">
+                <span class="info-icon">📍</span>
+                <span class="info-text">${event.bar}</span>
             </div>`;
 
         const recurringBadge = event.recurring ? 
-            `<span class="recurring-badge">🔄 ${event.eventType}</span>` : '';
+            `<span class="recurring-badge-compact">🔄</span>` : '';
 
         return `
-            <div class="event-card detailed" data-event-slug="${event.slug}" data-lat="${event.coordinates?.lat || ''}" data-lng="${event.coordinates?.lng || ''}">
-                <div class="event-header">
-                    <h3>${event.name}</h3>
-                    <div class="event-meta">
-                        <div class="event-day">${event.day} ${event.time}</div>
+            <div class="event-card compact" data-event-slug="${event.slug}" data-lat="${event.coordinates?.lat || ''}" data-lng="${event.coordinates?.lng || ''}">
+                <div class="event-header-compact">
+                    <h3 class="event-title">${event.name}</h3>
+                    <div class="event-timing">
+                        <span class="event-day-time">${event.day} ${event.time}</span>
                         ${recurringBadge}
                     </div>
                 </div>
-                <div class="event-details">
+                <div class="event-info">
                     ${locationHtml}
-                    <div class="detail-row">
-                        <span class="label">Cover:</span>
-                        <span class="value">${event.cover}</span>
-                    </div>
+                    ${coverHtml}
                     ${teaHtml}
-                    <div class="event-links">
-                        ${linksHtml}
-                    </div>
                 </div>
+                ${linksHtml ? `<div class="event-links-compact">${linksHtml}</div>` : ''}
             </div>
         `;
     }

--- a/script.js
+++ b/script.js
@@ -289,14 +289,14 @@ style.textContent = `
     }
     
     /* Smooth event card interactions */
-    .event-card.detailed {
+    .event-card.compact {
         transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
         will-change: transform;
     }
     
-    .event-card.detailed:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 15px 40px rgba(0,0,0,0.15);
+    .event-card.compact:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 8px 25px rgba(0,0,0,0.12);
     }
 `;
 document.head.appendChild(style);

--- a/styles.css
+++ b/styles.css
@@ -835,116 +835,123 @@ header {
 .events-list {
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 1.5rem;
 }
 
-.event-card.detailed {
+/* Compact Event Card Styling */
+.event-card.compact {
     background: white;
-    border-radius: 15px;
-    padding: 2rem;
-    box-shadow: 0 5px 20px rgba(0,0,0,0.1);
+    border-radius: 12px;
+    padding: 1.25rem;
+    box-shadow: 0 3px 15px rgba(0,0,0,0.08);
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     position: relative;
-    will-change: transform;
+    border: 1px solid #f0f0f0;
 }
 
-.event-card.detailed:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+.event-card.compact:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 25px rgba(0,0,0,0.12);
+    border-color: #e0e0e0;
 }
 
-.event-card.detailed.highlight {
+.event-card.compact.highlight {
     background: linear-gradient(135deg, #fff7ed 0%, #fed7aa 100%);
     border: 2px solid #f97316;
-    transform: scale(1.02);
+    transform: scale(1.01);
 }
 
-.event-card.detailed .event-header {
+.event-header-compact {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    margin-bottom: 1.5rem;
-    border-bottom: 2px solid #f0f0f0;
-    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+    gap: 1rem;
 }
 
-.event-card.detailed h3 {
-    font-size: 1.5rem;
+.event-title {
+    font-size: 1.3rem;
     color: #333;
     margin: 0;
     flex: 1;
+    font-weight: 600;
+    line-height: 1.3;
 }
 
-.event-meta {
+.event-timing {
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
+    align-items: center;
     gap: 0.5rem;
+    flex-shrink: 0;
 }
 
-.event-day {
-    background: linear-gradient(45deg, #ff6b6b, #ee5a24);
+.event-day-time {
+    background: linear-gradient(45deg, #667eea, #764ba2);
     color: white;
-    padding: 0.5rem 1rem;
-    border-radius: 20px;
-    font-size: 0.9rem;
+    padding: 0.4rem 0.8rem;
+    border-radius: 15px;
+    font-size: 0.85rem;
     font-weight: 600;
     white-space: nowrap;
 }
 
-.recurring-badge {
+.recurring-badge-compact {
     background: linear-gradient(45deg, #10b981, #059669);
     color: white;
-    padding: 0.3rem 0.8rem;
-    border-radius: 15px;
-    font-size: 0.8rem;
+    padding: 0.3rem 0.5rem;
+    border-radius: 12px;
+    font-size: 0.75rem;
     font-weight: 500;
     display: inline-block;
+    line-height: 1;
 }
 
-.detail-row {
+.event-info {
     display: flex;
-    margin-bottom: 0.5rem;
+    flex-direction: column;
+    gap: 0.6rem;
 }
 
-.detail-row.tea {
-    margin-top: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid #e0e0e0;
+.event-info-item {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.95rem;
 }
 
-.label {
-    font-weight: 600;
-    color: #333;
-    min-width: 60px;
-    margin-right: 1rem;
+.info-icon {
+    font-size: 1.1rem;
+    width: 24px;
+    flex-shrink: 0;
+    text-align: center;
 }
 
-.value {
-    color: #666;
-    flex: 1;
+.info-text {
+    color: #555;
+    font-weight: 500;
 }
 
-.event-links {
+.event-links-compact {
     margin-top: 1rem;
     display: flex;
-    gap: 1rem;
+    gap: 0.75rem;
     flex-wrap: wrap;
 }
 
-.event-links a {
+.event-link {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
     text-decoration: none;
-    padding: 0.5rem 1rem;
-    border-radius: 20px;
-    font-size: 0.9rem;
+    padding: 0.4rem 0.8rem;
+    border-radius: 15px;
+    font-size: 0.85rem;
     font-weight: 500;
-    transition: transform 0.3s ease;
+    transition: all 0.3s ease;
 }
 
-.event-links a:hover {
-    transform: translateY(-2px);
+.event-link:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
 }
 
 /* City CTA Section */
@@ -1518,7 +1525,7 @@ footer {
         font-size: 2.5rem;
     }
 
-    .event-card.detailed .event-header {
+    .event-header-compact {
         flex-direction: column;
         text-align: center;
         gap: 0.5rem;
@@ -1804,22 +1811,41 @@ footer {
         font-size: 0.7rem;
     }
 
-    .event-card.detailed {
+    .event-card.compact {
         padding: 1rem;
     }
 
-    .event-card.detailed h3 {
+    .event-title {
         font-size: 1.1rem;
     }
 
-    .event-day {
+    .event-header-compact {
+        flex-direction: column;
+        gap: 0.75rem;
+        align-items: flex-start;
+    }
+
+    .event-timing {
+        align-self: flex-start;
+    }
+
+    .event-day-time {
         font-size: 0.8rem;
         padding: 0.25rem 0.6rem;
     }
 
-    .recurring-badge {
+    .recurring-badge-compact {
         font-size: 0.65rem;
         padding: 0.15rem 0.4rem;
+    }
+
+    .event-info-item {
+        font-size: 0.9rem;
+    }
+
+    .info-icon {
+        font-size: 1rem;
+        width: 20px;
     }
 
     #events-map {


### PR DESCRIPTION
Redesign event cards to be more compact and visually appealing, fixing display issues with cover, spacing, and date/time.

This PR addresses user feedback to clean up and condense the event list by:
1.  Conditionally rendering the cover field only when valid data exists.
2.  Removing unnecessary spacing between event details like cover and tea.
3.  Integrating date/time and recurrence into a more compact header.
The changes also aim to make the overall event list smaller and prettier, as requested.