### PR TITLE
Fix links in event-test-index.html

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,16 @@
+/* CSS Custom Properties */
+:root {
+    --primary-color: #667eea;
+    --secondary-color: #ff6b6b;
+    --accent-color: #764ba2;
+    --success-color: #4ecdc4;
+    --warning-color: #ffd700;
+    --text-primary: #333;
+    --text-secondary: #666;
+    --background-light: #f8f9ff;
+    --border-light: #e8f2ff;
+}
+
 /* Reset and Base Styles */
 * {
     margin: 0;


### PR DESCRIPTION
Add missing CSS custom properties to `styles.css` to enable correct styling for test pages.

Test pages linked from `event-test-index.html` were attempting to use CSS variables (e.g., `--primary-color`) that were undefined, leading to broken layouts and functionality.