### PR TITLE
Adjust city-picker z-index in header

### DIFF
--- a/js/header-manager.js
+++ b/js/header-manager.js
@@ -141,7 +141,7 @@ class HeaderManager {
         citySelector.appendChild(dropdown);
         navContainer.appendChild(citySelector);
 
-        this.logger.componentLoad('HEADER', 'City selector added to header');
+        this.logger.componentLoad('HEADER', 'City selector added to header with z-index: 10000');
     }
 
     toggleDropdown(dropdown) {

--- a/styles.css
+++ b/styles.css
@@ -119,7 +119,7 @@ header {
     padding: 0.5rem;
     margin-top: 0.5rem;
     min-width: 200px;
-    z-index: 1001;
+    z-index: 10000;
     opacity: 0;
     transform: translateY(-10px);
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
Increase city-picker dropdown z-index to ensure it appears above the city hero section.

The original z-index of `1001` for the `.city-dropdown-menu` was insufficient, causing it to render beneath the `city-hero` section on `city.html` pages. By increasing the `z-index` to `10000`, the dropdown now correctly overlays all other page elements, including the hero section and modals.