### PR TITLE
Fix city selector display issue

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -59,7 +59,7 @@ header {
     right: 0;
     z-index: 9998;
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-    overflow: hidden;
+    overflow: visible;
 }
 
 /* City Switcher */
@@ -68,6 +68,8 @@ header {
     margin-left: auto;
     margin-right: 1rem;
     z-index: 10001;
+    /* Ensure dropdown is not clipped */
+    overflow: visible;
 }
 
 .city-switcher-btn {
@@ -129,13 +131,20 @@ header {
     border: 1px solid rgba(255, 255, 255, 0.2);
     pointer-events: none;
     visibility: hidden;
+    /* Ensure dropdown is always above other elements */
+    position: absolute !important;
+    z-index: 10002 !important;
+    /* Ensure dropdown is not clipped by any parent */
+    max-height: 80vh;
+    overflow-y: auto;
 }
 
 .city-dropdown.open {
-    opacity: 1;
-    transform: translateY(0);
-    pointer-events: auto;
-    visibility: visible;
+    opacity: 1 !important;
+    transform: translateY(0) !important;
+    pointer-events: auto !important;
+    visibility: visible !important;
+    display: block !important;
 }
 
 .city-option {
@@ -202,6 +211,8 @@ header {
     position: relative;
     width: 100%;
     box-sizing: border-box;
+    /* Ensure dropdowns are not clipped */
+    overflow: visible;
 }
 
 .logo h1 {


### PR DESCRIPTION
Fix city selector dropdown not appearing by resolving header overflow and enhancing its visibility logic.

The primary issue was that the `header` element had `overflow: hidden`, which clipped the dynamically rendered city dropdown. This PR changes `header`'s `overflow` to `visible` and adds robust CSS (`!important` rules, `max-height`, `overflow-y`) and JavaScript (inline style forcing, positioning checks, touch support) to ensure the dropdown is always visible, clickable, and correctly positioned.