### PR TITLE
Adjust header height for better spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -69,6 +69,8 @@ header {
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     overflow: visible;
     height: 80px;
+    display: flex;
+    align-items: center;
 }
 
 /* City Switcher */
@@ -292,7 +294,6 @@ header {
     position: relative;
     width: 100%;
     box-sizing: border-box;
-    height: 80px;
     /* Ensure dropdowns are not clipped */
     overflow: visible;
 }


### PR DESCRIPTION
Vertically center header content to reduce perceived excessive space under title and button.

The header had a fixed height, but its content was not vertically aligned, causing an appearance of excessive space below the title and button. Adding `display: flex` and `align-items: center` ensures the content is vertically centered within the fixed header height, balancing the spacing and addressing the 'too tall' issue.