### PR TITLE
Sync and style calendars for consistency

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -518,11 +518,16 @@ class DynamicCalendarLoader extends CalendarCore {
 
             const eventsHtml = dayEvents.length > 0 
                 ? dayEvents.map(event => {
+                    // Mobile-friendly shortened versions
+                    const shortVenue = event.bar.split(' ')[0] || event.bar;
+                    const shortName = event.name.length > 20 ? event.name.substring(0, 17) + '...' : event.name;
                     return `
                         <div class="event-item" data-event-slug="${event.slug}" title="${event.name} at ${event.bar} - ${event.time}">
                             <div class="event-name">${event.name}</div>
+                            <div class="event-name-mobile">${shortName}</div>
                             <div class="event-time">${event.time}</div>
                             <div class="event-venue">${event.bar}</div>
+                            <div class="event-venue-mobile">${shortVenue}</div>
                         </div>
                     `;
                 }).join('')
@@ -607,10 +612,15 @@ class DynamicCalendarLoader extends CalendarCore {
             
             const eventsHtml = eventsToShow.length > 0 
                 ? eventsToShow.map(event => {
+                    const shortVenue = event.bar.split(' ')[0] || event.bar;
+                    const shortName = event.name.length > 20 ? event.name.substring(0, 17) + '...' : event.name;
                     return `
                         <div class="event-item" data-event-slug="${event.slug}" title="${event.name} at ${event.bar} - ${event.time}">
                             <div class="event-name">${event.name}</div>
+                            <div class="event-name-mobile">${shortName}</div>
                             <div class="event-time">${event.time}</div>
+                            <div class="event-venue">${event.bar}</div>
+                            <div class="event-venue-mobile">${shortVenue}</div>
                         </div>
                     `;
                 }).join('') + (additionalEventsCount > 0 ? `<div class="more-events">+${additionalEventsCount}</div>` : '')

--- a/styles.css
+++ b/styles.css
@@ -3281,6 +3281,36 @@ footer {
     }
 }
 
+/* Mobile-specific event name/venue for both week and month views */
+.event-name-mobile,
+.event-venue-mobile {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .event-name {
+    display: none;
+  }
+  .event-venue {
+    display: none;
+  }
+  .event-name-mobile {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    margin-bottom: 0.1rem;
+    word-break: break-word;
+  }
+  .event-venue-mobile {
+    display: block;
+    font-size: 0.7rem;
+    color: #667eea;
+    font-weight: 500;
+    margin-bottom: 0.1rem;
+    word-break: break-word;
+  }
+}
+
 
 
 


### PR DESCRIPTION
Unify calendar styling and markup for week and month views to ensure consistency and improve mobile experience.

The week calendar previously displayed too much information on small screens, leading to a cluttered layout compared to the month view. This PR refactors the CSS and JavaScript to use a single, consistent styling approach for both calendar types, including responsive adjustments to show truncated event names and venues on mobile for both views.