### PR TITLE
Update code and apply cursor rule

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -292,7 +292,7 @@ header {
     position: relative;
     width: 100%;
     box-sizing: border-box;
-    height: 80px;
+    height: 100%;
     /* Ensure dropdowns are not clipped */
     overflow: visible;
 }


### PR DESCRIPTION
Adjust header height to 100% to resolve inconsistent title spacing.

The previous fixed height of 80px on the `header` element, combined with other internal elements also having fixed heights, caused redundant height constraints and inconsistent spacing under the title.