### PR TITLE
Update event styling and layout

### DIFF
--- a/city.html
+++ b/city.html
@@ -61,6 +61,7 @@
 
         <section class="weekly-calendar">
             <div class="container">
+                <h2 style="text-align: center; margin-bottom: 2rem; color: #333; font-size: 2rem;">What's the vibe?</h2>
                 <div class="calendar-header">
                     <h2 id="calendar-title">This Week's Schedule</h2>
                     <div class="calendar-controls">
@@ -84,7 +85,6 @@
 
         <section class="events">
             <div class="container">
-                <h2 style="text-align: center; margin-bottom: 1rem; color: #333; font-size: 2rem;">What's the vibe?</h2>
                 <div class="events-list">
                     <div class="loading-message">🎉 Getting events...</div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -510,7 +510,6 @@ header {
 /* Events Section */
 .events {
     padding: 0;
-    background: linear-gradient(135deg, #ffffff 0%, #f8f9ff 100%);
 }
 
 .events h2 {
@@ -571,7 +570,6 @@ header {
 .event-details {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
     margin-top: 1rem;
 }
 
@@ -644,6 +642,7 @@ header {
 /* City Page Styles */
 .city-page {
     padding-top: 0px;
+    background: linear-gradient(135deg, #ffffff 0%, #f8f9ff 100%);
 }
 
 
@@ -669,7 +668,6 @@ header {
 /* Weekly Calendar */
 .weekly-calendar {
     padding: 0;
-    background: linear-gradient(135deg, #ffffff 0%, #f8f9ff 100%);
     position: relative;
 }
 
@@ -1163,9 +1161,6 @@ header {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    margin-bottom: 1.5rem;
-    border-bottom: 2px solid #f0f0f0;
-    padding-bottom: 1rem;
     padding-right: 100px; /* Add space for floating event-meta */
 }
 
@@ -1178,8 +1173,8 @@ header {
 
 .event-meta {
     position: absolute;
-    top: 1rem;
-    right: 1rem;
+    top: 0;
+    right: 0;
     display: flex;
     flex-direction: column;
     align-items: flex-end;
@@ -1292,7 +1287,6 @@ header {
 .event-card.detailed .event-links {
     margin-top: 12px;
     text-align: left;
-    padding-top: 8px;
 }
 
 .event-card.detailed .event-links .event-link {
@@ -1424,7 +1418,6 @@ header {
 /* Enhanced Map Section */
 .events-map-section {
     padding: 2rem 0;
-    background: linear-gradient(135deg, #ffffff 0%, #f8f9ff 100%);
     position: relative;
     overflow: hidden;
 }
@@ -2012,8 +2005,8 @@ footer {
 
     .event-meta {
         position: absolute;
-        top: 0.5rem;
-        right: 0.5rem;
+        top: 0;
+        right: 0;
         flex-direction: column;
         gap: 0.5rem;
         flex-shrink: 0;


### PR DESCRIPTION
Clean up event styling, reposition "What's the vibe?" header, and fix the continuous background gradient on the city page.

The linear gradient background was restarting in each section (`.weekly-calendar`, `.events`, `.events-map-section`), causing visual breaks. This PR unifies it by applying a single gradient to the `.city-page` wrapper for a seamless flow. Event card styling was adjusted for a tighter, more organized appearance, and the header was moved for better visual hierarchy.