### PR TITLE
Update calendar and map display

### DIFF
--- a/city.html
+++ b/city.html
@@ -61,7 +61,7 @@
 
         <section class="weekly-calendar">
             <div class="container">
-                <h2 style="text-align: center; margin-bottom: 2rem; color: #333; font-size: 2rem;">What's the vibe?</h2>
+                <h2 class="whats-the-vibe-header">What's the vibe?</h2>
                 <div class="calendar-header">
                     <h2 id="calendar-title">This Week's Schedule</h2>
                     <div class="calendar-controls">

--- a/styles.css
+++ b/styles.css
@@ -40,7 +40,6 @@ html {
     }
     
     * {
-        max-width: 100%;
         box-sizing: border-box;
     }
     
@@ -690,7 +689,28 @@ header {
     position: relative;
     z-index: 2;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: 0;
+}
+
+.whats-the-vibe-header {
+    text-align: center;
+    margin-bottom: 2rem;
+    color: #333;
+    font-size: 2rem;
+}
+
+/* Desktop layout - header to the left of buttons */
+@media (min-width: 769px) {
+    .calendar-header {
+        align-items: flex-start;
+    }
+    
+    .whats-the-vibe-header {
+        text-align: left;
+        margin-bottom: 0;
+        margin-right: 2rem;
+        flex-shrink: 0;
+    }
 }
 
 .calendar-header h2 {
@@ -1208,10 +1228,6 @@ header {
     margin-bottom: 0.5rem;
 }
 
-.detail-row.tea {
-    margin-top: 0.5rem;
-}
-
 .label {
     font-weight: 600;
     color: #333;
@@ -1473,7 +1489,6 @@ header {
     border: 4px solid white;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     padding: 4px;
-    max-width: 100%;
     box-sizing: border-box;
 }
 
@@ -1931,8 +1946,13 @@ footer {
 
     .calendar-header {
         flex-direction: column;
-        gap: 1rem;
+        gap: 0;
         padding: 0.5rem;
+    }
+
+    .whats-the-vibe-header {
+        margin-bottom: 0;
+        margin-top: 1rem;
     }
 
     .calendar-header h2 {


### PR DESCRIPTION
Refine UI for city pages by fixing map icon alignment, calendar header layout, and detail row spacing.

The `max-width: 100%` in global and map styles caused map icons to misalign, particularly at higher zoom levels. The calendar header and "What's the vibe" section required specific responsive adjustments for spacing and button alignment. Additionally, the `.detail-row.tea` rule was removed to ensure consistent spacing across all detail rows.