### PR TITLE
Update calendar cover display logic

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -185,7 +185,6 @@ class CalendarCore {
                 name: calendarEvent.title,
                 day: this.getDayFromDate(calendarEvent.start),
                 time: this.getTimeRange(calendarEvent.start, calendarEvent.end),
-                cover: 'Check event details',
                 eventType: this.getEventType(calendarEvent.recurrence),
                 recurring: !!calendarEvent.recurrence,
                 recurrence: calendarEvent.recurrence,
@@ -205,7 +204,9 @@ class CalendarCore {
                 const additionalData = this.parseKeyValueDescription(calendarEvent.description);
                 if (additionalData) {
                     eventData.bar = additionalData.bar;
-                    eventData.cover = additionalData.cover || eventData.cover;
+                    if (additionalData.cover) {
+                        eventData.cover = additionalData.cover;
+                    }
                     eventData.tea = additionalData.tea || additionalData.description;
                     eventData.website = additionalData.website;
                     eventData.instagram = additionalData.instagram;

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -160,7 +160,7 @@ class DynamicCalendarLoader extends CalendarCore {
                                 <div class="event-details">
                                     <span class="event-time">${event.time}</span>
                                     <span class="event-venue">${event.bar}</span>
-                                    <span class="event-cover">${event.cover}</span>
+                                    ${event.cover && event.cover.trim() && event.cover.toLowerCase() !== 'free' && event.cover.toLowerCase() !== 'no cover' ? `<span class="event-cover">${event.cover}</span>` : ''}
                                 </div>
                             </div>
                         `).join('')

--- a/testing/cover-field-test.html
+++ b/testing/cover-field-test.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cover Field Test - chunky.dad</title>
+    <link rel="stylesheet" href="../styles.css">
+    <style>
+        .test-container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            font-family: 'Poppins', sans-serif;
+        }
+        .test-event {
+            background: #f5f5f5;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 10px 0;
+        }
+        .test-event h3 {
+            color: #333;
+            margin: 0 0 10px 0;
+        }
+        .test-event .cover-info {
+            background: #e8f4fd;
+            padding: 10px;
+            border-radius: 4px;
+            margin: 10px 0;
+        }
+        .test-event .cover-info.has-cover {
+            background: #d4edda;
+        }
+        .test-event .cover-info.no-cover {
+            background: #f8d7da;
+        }
+        .test-result {
+            font-weight: bold;
+            margin-top: 10px;
+        }
+        .test-result.pass {
+            color: #28a745;
+        }
+        .test-result.fail {
+            color: #dc3545;
+        }
+    </style>
+</head>
+<body>
+    <div class="test-container">
+        <h1>Cover Field Test</h1>
+        <p>Testing that cover field is only displayed when it has meaningful content.</p>
+        
+        <div id="test-results"></div>
+    </div>
+
+    <script src="../js/logger.js"></script>
+    <script src="../js/calendar-core.js"></script>
+    <script src="../js/dynamic-calendar-loader.js"></script>
+    <script>
+        // Test data with different cover scenarios
+        const testEvents = [
+            {
+                title: 'Event with Cover',
+                description: 'Cover: $10\nBar: Test Bar\nTea: Great event!',
+                start: new Date('2024-01-15T19:00:00'),
+                end: new Date('2024-01-15T23:00:00'),
+                location: '40.7128,-74.0060'
+            },
+            {
+                title: 'Event without Cover',
+                description: 'Bar: Another Bar\nTea: No cover mentioned',
+                start: new Date('2024-01-16T20:00:00'),
+                end: new Date('2024-01-16T02:00:00'),
+                location: '40.7589,-73.9851'
+            },
+            {
+                title: 'Event with Free Cover',
+                description: 'Cover: Free\nBar: Free Bar\nTea: No cost!',
+                start: new Date('2024-01-17T18:00:00'),
+                end: new Date('2024-01-17T22:00:00'),
+                location: '40.7505,-73.9934'
+            },
+            {
+                title: 'Event with No Cover',
+                description: 'Cover: No cover\nBar: No Cover Bar\nTea: No cover event',
+                start: new Date('2024-01-18T21:00:00'),
+                end: new Date('2024-01-18T01:00:00'),
+                location: '40.7614,-73.9776'
+            }
+        ];
+
+        function runCoverFieldTest() {
+            const calendarCore = new CalendarCore();
+            const resultsContainer = document.getElementById('test-results');
+            let testResults = '';
+
+            testEvents.forEach((testEvent, index) => {
+                // Parse the event using our calendar core
+                const parsedEvent = calendarCore.parseEventData(testEvent);
+                
+                // Check if cover field is properly handled
+                const hasCover = parsedEvent.cover && 
+                                parsedEvent.cover.trim() && 
+                                parsedEvent.cover.toLowerCase() !== 'free' && 
+                                parsedEvent.cover.toLowerCase() !== 'no cover';
+                
+                const expectedResult = index === 0; // Only first event should have cover
+                const testPassed = hasCover === expectedResult;
+                
+                testResults += `
+                    <div class="test-event">
+                        <h3>${parsedEvent.name}</h3>
+                        <div class="cover-info ${hasCover ? 'has-cover' : 'no-cover'}">
+                            <strong>Cover Field:</strong> ${parsedEvent.cover || 'undefined'}
+                            <br><strong>Has Meaningful Cover:</strong> ${hasCover ? 'Yes' : 'No'}
+                        </div>
+                        <div class="test-result ${testPassed ? 'pass' : 'fail'}">
+                            ${testPassed ? '✅ PASS' : '❌ FAIL'} - Expected: ${expectedResult ? 'Has cover' : 'No cover'}
+                        </div>
+                    </div>
+                `;
+            });
+
+            resultsContainer.innerHTML = testResults;
+        }
+
+        // Run the test when page loads
+        window.addEventListener('load', runCoverFieldTest);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Remove default 'cover' value and refine display logic to only show meaningful event cover information.