### PR TITLE
Clean up css colors for dynamic calendar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,7 @@
 body {
     font-family: 'Poppins', sans-serif;
     line-height: 1.6;
-    color: #333;
+    color: var(--text-primary);
     scroll-behavior: smooth;
     margin: 0;
     padding: 0;
@@ -58,7 +58,7 @@ html {
 
 /* Header and Navigation */
 header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
     box-shadow: 0 2px 10px rgba(0,0,0,0.1);
     position: fixed;
     top: 0;

--- a/testing/ultimate-style-tester.html
+++ b/testing/ultimate-style-tester.html
@@ -702,174 +702,91 @@
                 </div>
             </div>
 
+            <!-- Primary Colors -->
             <div class="control-section">
                 <h3>🎨 Primary Colors</h3>
-                <div class="color-section">
-                    <div class="color-control">
-                        <label>Primary Color</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="primary-color" value="#667eea">
-                            <input type="text" class="color-input" id="primary-color-text" value="#667eea">
-                        </div>
+                <div class="color-control">
+                    <label for="primary-color">Primary Color (--primary-color)</label>
+                    <div class="color-input-group">
+                        <input type="color" class="color-picker" id="primary-color" value="#667eea">
+                        <input type="text" class="color-input" id="primary-color-text" value="#667eea">
                     </div>
-                    <div class="color-control">
-                        <label>Secondary Color</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="secondary-color" value="#ff6b6b">
-                            <input type="text" class="color-input" id="secondary-color-text" value="#ff6b6b">
-                        </div>
+                </div>
+                
+                <div class="color-control">
+                    <label for="secondary-color">Secondary Color (--secondary-color)</label>
+                    <div class="color-input-group">
+                        <input type="color" class="color-picker" id="secondary-color" value="#ff6b6b">
+                        <input type="text" class="color-input" id="secondary-color-text" value="#ff6b6b">
                     </div>
-                    <div class="color-control">
-                        <label>Accent Color</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="accent-color" value="#764ba2">
-                            <input type="text" class="color-input" id="accent-color-text" value="#764ba2">
-                        </div>
+                </div>
+                
+                <div class="color-control">
+                    <label for="accent-color">Accent Color (--accent-color)</label>
+                    <div class="color-input-group">
+                        <input type="color" class="color-picker" id="accent-color" value="#764ba2">
+                        <input type="text" class="color-input" id="accent-color-text" value="#764ba2">
+                    </div>
+                </div>
+                
+                <div class="color-control">
+                    <label for="success-color">Success Color (--success-color)</label>
+                    <div class="color-input-group">
+                        <input type="color" class="color-picker" id="success-color" value="#4ecdc4">
+                        <input type="text" class="color-input" id="success-color-text" value="#4ecdc4">
+                    </div>
+                </div>
+
+                <div class="color-control">
+                    <label for="warning-color">Warning Color (--warning-color)</label>
+                    <div class="color-input-group">
+                        <input type="color" class="color-picker" id="warning-color" value="#ffd700">
+                        <input type="text" class="color-input" id="warning-color-text" value="#ffd700">
                     </div>
                 </div>
             </div>
 
+            <!-- Text Colors -->
             <div class="control-section">
                 <h3>📝 Text Colors</h3>
-                <div class="color-section">
-                    <div class="color-control">
-                        <label>Primary Text</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="text-primary-color" value="#333333">
-                            <input type="text" class="color-input" id="text-primary-color-text" value="#333333">
-                        </div>
+                <div class="color-control">
+                    <label for="text-primary-color">Primary Text (--text-primary)</label>
+                    <div class="color-input-group">
+                        <input type="color" class="color-picker" id="text-primary-color" value="#333333">
+                        <input type="text" class="color-input" id="text-primary-color-text" value="#333333">
                     </div>
-                    <div class="color-control">
-                        <label>Secondary Text</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="text-secondary-color" value="#666666">
-                            <input type="text" class="color-input" id="text-secondary-color-text" value="#666666">
-                        </div>
-                    </div>
-                    <div class="color-control">
-                        <label>Muted Text</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="muted-text-color" value="#999999">
-                            <input type="text" class="color-input" id="muted-text-color-text" value="#999999">
-                        </div>
+                </div>
+                
+                <div class="color-control">
+                    <label for="text-secondary-color">Secondary Text (--text-secondary)</label>
+                    <div class="color-input-group">
+                        <input type="color" class="color-picker" id="text-secondary-color" value="#666666">
+                        <input type="text" class="color-input" id="text-secondary-color-text" value="#666666">
                     </div>
                 </div>
             </div>
 
+            <!-- Background and Border Colors -->
             <div class="control-section">
-                <h3>🎭 Background Colors</h3>
-                <div class="color-section">
-                    <div class="color-control">
-                        <label>Light Background</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="background-light-color" value="#f8f9ff">
-                            <input type="text" class="color-input" id="background-light-color-text" value="#f8f9ff">
-                        </div>
+                <h3>🎭 Background & Border Colors</h3>
+                <div class="color-control">
+                    <label for="background-light-color">Light Background (--background-light)</label>
+                    <div class="color-input-group">
+                        <input type="color" class="color-picker" id="background-light-color" value="#f8f9ff">
+                        <input type="text" class="color-input" id="background-light-color-text" value="#f8f9ff">
                     </div>
-                    <div class="color-control">
-                        <label>Dark Background</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="background-dark-color" value="#1a1a2e">
-                            <input type="text" class="color-input" id="background-dark-color-text" value="#1a1a2e">
-                        </div>
-                    </div>
-                    <div class="color-control">
-                        <label>Card Background</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="card-background-color" value="#ffffff">
-                            <input type="text" class="color-input" id="card-background-color-text" value="#ffffff">
-                        </div>
+                </div>
+                
+                <div class="color-control">
+                    <label for="border-light-color">Light Border (--border-light)</label>
+                    <div class="color-input-group">
+                        <input type="color" class="color-picker" id="border-light-color" value="#e8f2ff">
+                        <input type="text" class="color-input" id="border-light-color-text" value="#e8f2ff">
                     </div>
                 </div>
             </div>
 
-            <div class="control-section">
-                <h3>🔗 Border Colors</h3>
-                <div class="color-section">
-                    <div class="color-control">
-                        <label>Light Border</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="border-light-color" value="#e8f2ff">
-                            <input type="text" class="color-input" id="border-light-color-text" value="#e8f2ff">
-                        </div>
-                    </div>
-                    <div class="color-control">
-                        <label>Medium Border</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="border-medium-color" value="#e0e0e0">
-                            <input type="text" class="color-input" id="border-medium-color-text" value="#e0e0e0">
-                        </div>
-                    </div>
-                </div>
-            </div>
 
-            <div class="control-section">
-                <h3>🎯 Status Colors</h3>
-                <div class="color-section">
-                    <div class="color-control">
-                        <label>Success Color</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="success-color" value="#4ecdc4">
-                            <input type="text" class="color-input" id="success-color-text" value="#4ecdc4">
-                        </div>
-                    </div>
-                    <div class="color-control">
-                        <label>Success Light</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="success-light-color" value="#10b981">
-                            <input type="text" class="color-input" id="success-light-color-text" value="#10b981">
-                        </div>
-                    </div>
-                    <div class="color-control">
-                        <label>Warning Color</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="warning-color" value="#ffd700">
-                            <input type="text" class="color-input" id="warning-color-text" value="#ffd700">
-                        </div>
-                    </div>
-                    <div class="color-control">
-                        <label>Error Color</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="error-color" value="#dc2626">
-                            <input type="text" class="color-input" id="error-color-text" value="#dc2626">
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="control-section">
-                <h3>🌈 Extended Colors</h3>
-                <div class="color-section">
-                    <div class="color-control">
-                        <label>Blue Accent</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="blue-accent-color" value="#45b7d1">
-                            <input type="text" class="color-input" id="blue-accent-color-text" value="#45b7d1">
-                        </div>
-                    </div>
-                    <div class="color-control">
-                        <label>Purple Blue</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="purple-blue-color" value="#5a67d8">
-                            <input type="text" class="color-input" id="purple-blue-color-text" value="#5a67d8">
-                        </div>
-                    </div>
-                    <div class="color-control">
-                        <label>Teal</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="teal-color" value="#44a08d">
-                            <input type="text" class="color-input" id="teal-color-text" value="#44a08d">
-                        </div>
-                    </div>
-                    <div class="color-control">
-                        <label>Orange</label>
-                        <div class="color-input-group">
-                            <input type="color" class="color-picker" id="orange-color" value="#ee5a24">
-                            <input type="text" class="color-input" id="orange-color-text" value="#ee5a24">
-                        </div>
-                    </div>
-                </div>
-            </div>
 
             <div class="control-section">
                 <h3>⚙️ Advanced Controls</h3>
@@ -1023,20 +940,10 @@
                         accent: '#764ba2',
                         'text-primary': '#333333',
                         'text-secondary': '#666666',
-                        'muted-text': '#999999',
                         'background-light': '#f8f9ff',
-                        'background-dark': '#1a1a2e',
-                        'card-background': '#ffffff',
                         'border-light': '#e8f2ff',
-                        'border-medium': '#e0e0e0',
                         success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#ffd700',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
+                        warning: '#ffd700'
                     },
                     'bear-flag': {
                         primary: '#000000',
@@ -1044,20 +951,10 @@
                         accent: '#FFD700',
                         'text-primary': '#FFFFFF',
                         'text-secondary': '#CCCCCC',
-                        'muted-text': '#999999',
                         'background-light': '#000000',
-                        'background-dark': '#0f0f0f',
-                        'card-background': '#1a1a1a',
                         'border-light': '#333333',
-                        'border-medium': '#555555',
                         success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#FFD700',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
+                        warning: '#FFD700'
                     },
                     'dark-mode': {
                         primary: '#4ecdc4',
@@ -1065,20 +962,10 @@
                         accent: '#45b7d1',
                         'text-primary': '#ffffff',
                         'text-secondary': '#cccccc',
-                        'muted-text': '#999999',
                         'background-light': '#1a1a2e',
-                        'background-dark': '#0f0f23',
-                        'card-background': '#2a2a3e',
                         'border-light': '#333344',
-                        'border-medium': '#444455',
                         success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#ffd700',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
+                        warning: '#ffd700'
                     },
                     neon: {
                         primary: '#ff00ff',
@@ -1086,20 +973,10 @@
                         accent: '#ffff00',
                         'text-primary': '#ffffff',
                         'text-secondary': '#cccccc',
-                        'muted-text': '#999999',
                         'background-light': '#000000',
-                        'background-dark': '#0f0f0f',
-                        'card-background': '#1a1a1a',
                         'border-light': '#333333',
-                        'border-medium': '#555555',
                         success: '#00ff00',
-                        'success-light': '#00cc00',
-                        warning: '#ffff00',
-                        error: '#ff0000',
-                        'blue-accent': '#00ffff',
-                        'purple-blue': '#ff00ff',
-                        teal: '#00ff80',
-                        orange: '#ff8000'
+                        warning: '#ffff00'
                     },
                     sunset: {
                         primary: '#ff6b35',
@@ -1107,20 +984,10 @@
                         accent: '#ffd23f',
                         'text-primary': '#ffffff',
                         'text-secondary': '#eeeeee',
-                        'muted-text': '#cccccc',
                         'background-light': '#2c1810',
-                        'background-dark': '#1a0e08',
-                        'card-background': '#3c2820',
                         'border-light': '#5c3830',
-                        'border-medium': '#7c4840',
                         success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#ffd23f',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
+                        warning: '#ffd23f'
                     },
                     ocean: {
                         primary: '#006994',
@@ -1128,62 +995,10 @@
                         accent: '#90e0ef',
                         'text-primary': '#ffffff',
                         'text-secondary': '#e0e0e0',
-                        'muted-text': '#b0b0b0',
                         'background-light': '#001d3d',
-                        'background-dark': '#001122',
-                        'card-background': '#002d4d',
                         'border-light': '#003d5d',
-                        'border-medium': '#004d6d',
                         success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#ffd700',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
-                    },
-                    forest: {
-                        primary: '#2d5016',
-                        secondary: '#4a7c59',
-                        accent: '#7fb069',
-                        'text-primary': '#ffffff',
-                        'text-secondary': '#e0e0e0',
-                        'muted-text': '#b0b0b0',
-                        'background-light': '#1a2f1a',
-                        'background-dark': '#0f1f0f',
-                        'card-background': '#2a3f2a',
-                        'border-light': '#3a4f3a',
-                        'border-medium': '#4a5f4a',
-                        success: '#7fb069',
-                        'success-light': '#10b981',
-                        warning: '#ffd700',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
-                    },
-                    rainbow: {
-                        primary: '#ff0000',
-                        secondary: '#00ff00',
-                        accent: '#0000ff',
-                        'text-primary': '#ffffff',
-                        'text-secondary': '#eeeeee',
-                        'muted-text': '#cccccc',
-                        'background-light': '#000000',
-                        'background-dark': '#0f0f0f',
-                        'card-background': '#1a1a1a',
-                        'border-light': '#333333',
-                        'border-medium': '#555555',
-                        success: '#00ff00',
-                        'success-light': '#00cc00',
-                        warning: '#ffff00',
-                        error: '#ff0000',
-                        'blue-accent': '#0080ff',
-                        'purple-blue': '#8000ff',
-                        teal: '#00ff80',
-                        orange: '#ff8000'
+                        warning: '#ffd700'
                     },
                     pride: {
                         primary: '#ff0018',
@@ -1191,83 +1006,10 @@
                         accent: '#ffff41',
                         'text-primary': '#ffffff',
                         'text-secondary': '#eeeeee',
-                        'muted-text': '#cccccc',
                         'background-light': '#000000',
-                        'background-dark': '#0f0f0f',
-                        'card-background': '#1a1a1a',
                         'border-light': '#333333',
-                        'border-medium': '#555555',
                         success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#ffff41',
-                        error: '#dc2626',
-                        'blue-accent': '#0080ff',
-                        'purple-blue': '#8000ff',
-                        teal: '#00ff80',
-                        orange: '#ff8000'
-                    },
-                    retro: {
-                        primary: '#ff6b9d',
-                        secondary: '#c44569',
-                        accent: '#f9ca24',
-                        'text-primary': '#ffffff',
-                        'text-secondary': '#eeeeee',
-                        'muted-text': '#cccccc',
-                        'background-light': '#2d3436',
-                        'background-dark': '#1d2426',
-                        'card-background': '#3d4446',
-                        'border-light': '#4d5456',
-                        'border-medium': '#5d6466',
-                        success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#f9ca24',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
-                    },
-                    cyberpunk: {
-                        primary: '#ff00ff',
-                        secondary: '#00ffff',
-                        accent: '#ffff00',
-                        'text-primary': '#ffffff',
-                        'text-secondary': '#cccccc',
-                        'muted-text': '#999999',
-                        'background-light': '#000000',
-                        'background-dark': '#0f0f0f',
-                        'card-background': '#1a1a1a',
-                        'border-light': '#333333',
-                        'border-medium': '#555555',
-                        success: '#00ff00',
-                        'success-light': '#00cc00',
-                        warning: '#ffff00',
-                        error: '#ff0000',
-                        'blue-accent': '#00ffff',
-                        'purple-blue': '#ff00ff',
-                        teal: '#00ff80',
-                        orange: '#ff8000'
-                    },
-                    vintage: {
-                        primary: '#8b4513',
-                        secondary: '#daa520',
-                        accent: '#cd853f',
-                        'text-primary': '#2f1b14',
-                        'text-secondary': '#4f3b34',
-                        'muted-text': '#6f5b54',
-                        'background-light': '#f5f5dc',
-                        'background-dark': '#e5e5cc',
-                        'card-background': '#ffffff',
-                        'border-light': '#d5d5bc',
-                        'border-medium': '#c5c5ac',
-                        success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#daa520',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
+                        warning: '#ffff41'
                     },
                     minimal: {
                         primary: '#333333',
@@ -1275,62 +1017,10 @@
                         accent: '#999999',
                         'text-primary': '#000000',
                         'text-secondary': '#333333',
-                        'muted-text': '#666666',
                         'background-light': '#ffffff',
-                        'background-dark': '#f0f0f0',
-                        'card-background': '#ffffff',
                         'border-light': '#e0e0e0',
-                        'border-medium': '#cccccc',
                         success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#ffd700',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
-                    },
-                    gradient: {
-                        primary: '#667eea',
-                        secondary: '#764ba2',
-                        accent: '#f093fb',
-                        'text-primary': '#ffffff',
-                        'text-secondary': '#eeeeee',
-                        'muted-text': '#cccccc',
-                        'background-light': '#667eea',
-                        'background-dark': '#564ba2',
-                        'card-background': '#7788ee',
-                        'border-light': '#8899ff',
-                        'border-medium': '#99aaff',
-                        success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#ffd700',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
-                    },
-                    monochrome: {
-                        primary: '#000000',
-                        secondary: '#333333',
-                        accent: '#666666',
-                        'text-primary': '#ffffff',
-                        'text-secondary': '#cccccc',
-                        'muted-text': '#999999',
-                        'background-light': '#000000',
-                        'background-dark': '#0f0f0f',
-                        'card-background': '#1a1a1a',
-                        'border-light': '#333333',
-                        'border-medium': '#555555',
-                        success: '#4ecdc4',
-                        'success-light': '#10b981',
-                        warning: '#ffd700',
-                        error: '#dc2626',
-                        'blue-accent': '#45b7d1',
-                        'purple-blue': '#5a67d8',
-                        teal: '#44a08d',
-                        orange: '#ee5a24'
+                        warning: '#ffd700'
                     }
                 };
                 
@@ -1463,20 +1153,10 @@
                     accent: document.getElementById('accent-color-text').value,
                     'text-primary': document.getElementById('text-primary-color-text').value,
                     'text-secondary': document.getElementById('text-secondary-color-text').value,
-                    'muted-text': document.getElementById('muted-text-color-text').value,
                     'background-light': document.getElementById('background-light-color-text').value,
-                    'background-dark': document.getElementById('background-dark-color-text').value,
-                    'card-background': document.getElementById('card-background-color-text').value,
                     'border-light': document.getElementById('border-light-color-text').value,
-                    'border-medium': document.getElementById('border-medium-color-text').value,
                     success: document.getElementById('success-color-text').value,
-                    'success-light': document.getElementById('success-light-color-text').value,
-                    warning: document.getElementById('warning-color-text').value,
-                    error: document.getElementById('error-color-text').value,
-                    'blue-accent': document.getElementById('blue-accent-color-text').value,
-                    'purple-blue': document.getElementById('purple-blue-color-text').value,
-                    teal: document.getElementById('teal-color-text').value,
-                    orange: document.getElementById('orange-color-text').value
+                    warning: document.getElementById('warning-color-text').value
                 };
 
                 const css = `
@@ -1502,7 +1182,7 @@
                     }
                     
                     .city-card, .event-card, .category-card {
-                        background-color: ${colors['card-background']} !important;
+                        background-color: ${colors['background-light']} !important;
                         color: ${colors['text-primary']} !important;
                         border: 1px solid ${colors['border-light']} !important;
                     }
@@ -1518,7 +1198,7 @@
                     }
                     
                     .cta-button.secondary {
-                        background: linear-gradient(45deg, ${colors.secondary}, ${colors.orange}) !important;
+                        background: linear-gradient(45deg, ${colors.secondary}, ${colors.warning}) !important;
                         color: ${colors['background-light']} !important;
                     }
                     
@@ -1533,7 +1213,7 @@
                     }
                     
                     .city-dropdown {
-                        background: ${colors['card-background']} !important;
+                        background: ${colors['background-light']} !important;
                         border: 1px solid ${colors['border-light']} !important;
                     }
                     
@@ -1547,7 +1227,7 @@
                     }
                     
                     .calendar-day {
-                        background: ${colors['card-background']} !important;
+                        background: ${colors['background-light']} !important;
                         border: 1px solid ${colors['border-light']} !important;
                         color: ${colors['text-primary']} !important;
                     }
@@ -1575,7 +1255,7 @@
                     }
                     
                     .event-time {
-                        color: ${colors['blue-accent']} !important;
+                        color: ${colors.primary} !important;
                     }
                     
                     .event-venue {
@@ -1598,12 +1278,12 @@
                     }
                     
                     .event-day {
-                        background: linear-gradient(45deg, ${colors.secondary}, ${colors.orange}) !important;
+                        background: linear-gradient(45deg, ${colors.secondary}, ${colors.warning}) !important;
                         color: ${colors['background-light']} !important;
                     }
                     
                     .recurring-badge {
-                        background: linear-gradient(45deg, ${colors['success-light']}, ${colors.success}) !important;
+                        background: linear-gradient(45deg, ${colors.success}, ${colors.success}) !important;
                         color: ${colors['background-light']} !important;
                     }
                     
@@ -1613,7 +1293,7 @@
                     }
                     
                     .event-link:hover {
-                        background: linear-gradient(135deg, ${colors['purple-blue']} 0%, ${colors.accent} 100%) !important;
+                        background: linear-gradient(135deg, ${colors.accent} 0%, ${colors.primary} 100%) !important;
                         color: ${colors['background-light']} !important;
                     }
                     
@@ -1628,7 +1308,7 @@
                     }
                     
                     .today-btn {
-                        background: linear-gradient(135deg, ${colors.secondary} 0%, ${colors.orange} 100%) !important;
+                        background: linear-gradient(135deg, ${colors.secondary} 0%, ${colors.warning} 100%) !important;
                         color: ${colors['background-light']} !important;
                     }
                     
@@ -1638,7 +1318,7 @@
                     }
                     
                     .no-events {
-                        color: ${colors['muted-text']} !important;
+                        color: ${colors['text-secondary']} !important;
                     }
                     
                     .calendar-day.current .no-events {
@@ -1646,9 +1326,9 @@
                     }
                     
                     .error-message {
-                        background: ${colors.error}20 !important;
-                        border: 2px solid ${colors.error} !important;
-                        color: ${colors.error} !important;
+                        background: ${colors.secondary}20 !important;
+                        border: 2px solid ${colors.secondary} !important;
+                        color: ${colors.secondary} !important;
                     }
                     
                     .contact-form input:focus,
@@ -1658,7 +1338,7 @@
                     }
                     
                     .contact-form button {
-                        background: linear-gradient(45deg, ${colors.secondary}, ${colors.orange}) !important;
+                        background: linear-gradient(45deg, ${colors.secondary}, ${colors.warning}) !important;
                         color: ${colors['background-light']} !important;
                     }
                     
@@ -1954,10 +1634,8 @@
 
             updateShareURL() {
                 const colorKeys = [
-                    'primary', 'secondary', 'accent', 'text-primary', 'text-secondary', 
-                    'muted-text', 'background-light', 'background-dark', 'card-background',
-                    'border-light', 'border-medium', 'success', 'success-light', 'warning',
-                    'error', 'blue-accent', 'purple-blue', 'teal', 'orange'
+                    'primary', 'secondary', 'accent', 'text-primary', 'text-secondary',
+                    'background-light', 'border-light', 'success', 'warning'
                 ];
 
                 const colors = {};
@@ -1994,10 +1672,8 @@
 
                 // Load custom colors from URL
                 const colorKeys = [
-                    'primary', 'secondary', 'accent', 'text-primary', 'text-secondary', 
-                    'muted-text', 'background-light', 'background-dark', 'card-background',
-                    'border-light', 'border-medium', 'success', 'success-light', 'warning',
-                    'error', 'blue-accent', 'purple-blue', 'teal', 'orange'
+                    'primary', 'secondary', 'accent', 'text-primary', 'text-secondary',
+                    'background-light', 'border-light', 'success', 'warning'
                 ];
                 
                 colorKeys.forEach(key => {


### PR DESCRIPTION
Clean up CSS color definitions and fix the ultimate style tester.

The `ultimate-style-tester.html` was non-functional due to attempting to control many color variables that did not exist in `styles.css`. This PR removes the non-existent color controls and theme definitions from `testing/ultimate-style-tester.html`, ensuring it only manipulates the 9 actual CSS variables. It also begins converting hardcoded colors in `styles.css` to use these variables for consistency.