### PR TITLE
Update gradients and fix mobile event time

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -39,11 +39,11 @@
     
     /* Gradients */
     --gradient-primary: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
-    --gradient-secondary: linear-gradient(45deg, var(--secondary-color), var(--accent-color) 100%);
+    --gradient-secondary: linear-gradient(45deg, rgb(255, 107, 107), rgb(238, 90, 36));
     --gradient-success: linear-gradient(45deg, var(--success-color), var(--primary-color) 100%);
     --gradient-warning: linear-gradient(135deg, var(--background-primary) 0%, var(--background-light) 100%);
     --gradient-light: linear-gradient(135deg, var(--background-primary) 0%, var(--background-light) 100%);
-    --gradient-success-alt: linear-gradient(45deg, var(--success-color), var(--primary-color) 100%);
+    --gradient-success-alt: linear-gradient(45deg, rgb(16, 185, 129), rgb(5, 150, 105));
     --gradient-error: linear-gradient(135deg, var(--background-light) 0%, var(--background-light) 100%);
     
     /* Shadows */
@@ -2070,6 +2070,8 @@ footer {
         text-align: left;
         gap: 0.5rem;
         padding-right: 100px; /* Add space for floating event-meta */
+        overflow: visible;
+        position: relative;
     }
 
     .event-meta {
@@ -2080,6 +2082,8 @@ footer {
         gap: 0.5rem;
         flex-shrink: 0;
         z-index: 10;
+        max-width: 90px; /* Ensure it doesn't overflow */
+        overflow: visible;
     }
 
     .event-day {
@@ -2459,6 +2463,9 @@ footer {
     .event-day {
         font-size: 0.8rem;
         padding: 0.25rem 0.6rem;
+        white-space: nowrap;
+        overflow: visible;
+        text-overflow: clip;
     }
 
     .recurring-badge {


### PR DESCRIPTION
Update specific CSS gradient variables and fix mobile display of event short day text.

The mobile event short day text (e.g., 'thu') was not visible due to `event-meta` being absolutely positioned and causing clipping/overflow issues within the `event-header` on mobile. Adjustments to `max-width`, `overflow`, `white-space`, and `position` ensure proper display.