### PR TITLE
Fix detail-row spacing and overlap issue

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1288,6 +1288,13 @@ header {
     align-items: flex-start;
 }
 
+.detail-row::before {
+    content: '';
+    width: 80px;
+    flex-shrink: 0;
+    order: -1;
+}
+
 .label {
     font-weight: 600;
     color: var(--text-primary);


### PR DESCRIPTION
Add `::before` pseudo-element to `.detail-row` to create spacing and prevent `.value` overlap.