### PR TITLE
Update styles and sync with main

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2041,7 +2041,7 @@ footer {
 
     .calendar-controls {
         flex-direction: row;
-        gap: 0.3rem;
+        gap: 0.25rem;
         flex-wrap: wrap;
         justify-content: center;
         align-items: center;
@@ -2054,18 +2054,29 @@ footer {
         max-width: none;
         width: auto;
         flex-shrink: 0;
+        padding: 0.25rem;
+        gap: 0.5rem;
     }
     
     .view-toggle {
         order: 2;
+        flex-direction: row;
+        gap: 2px;
+        padding: 2px;
+        flex-shrink: 0;
     }
     
     .today-btn {
         order: 3;
+        padding: 0.4rem 0.6rem;
+        font-size: 0.7rem;
+        flex-shrink: 0;
     }
 
     .date-range {
-        font-size: 1rem;
+        font-size: 0.7rem;
+        min-width: 80px;
+        padding: 0;
     }
 
     .calendar-day {
@@ -2088,7 +2099,7 @@ footer {
     }
 
     .event-item {
-        padding: 0.6rem 0;
+        padding: 0;
         margin-bottom: 0;
         border-radius: 6px;
     }
@@ -2437,26 +2448,27 @@ footer {
     }
 
     .view-btn {
-        padding: 0.5rem 0.8rem;
-        font-size: 0.8rem;
+        padding: 0.4rem 0.6rem;
+        font-size: 0.7rem;
+        min-width: auto;
     }
 
     .nav-btn {
-        padding: 0.5rem;
-        font-size: 1rem;
-        width: 36px;
-        height: 36px;
+        padding: 0.4rem;
+        font-size: 0.9rem;
+        width: 30px;
+        height: 30px;
     }
 
     .date-range {
-        font-size: 0.8rem;
-        padding: 0.5rem 0.8rem;
-        min-width: 100px;
+        font-size: 0.7rem;
+        padding: 0.4rem 0.6rem;
+        min-width: 80px;
     }
 
     .today-btn {
-        padding: 0.5rem 0.8rem;
-        font-size: 0.8rem;
+        padding: 0.4rem 0.6rem;
+        font-size: 0.7rem;
     }
 
     .calendar-day {
@@ -2469,7 +2481,7 @@ footer {
     }
 
     .event-item {
-        padding: 0.5rem 0;
+        padding: 0;
         margin-bottom: 0;
         border-radius: 4px;
     }


### PR DESCRIPTION
Removed `.event-item` padding and compacted `.calendar-controls` at 768px+ to improve layout consistency.

The `.calendar-controls` at 768px and above were too large compared to their more compact and visually appealing 480px version. This PR applies similar compact styling to the larger breakpoints. Unwanted padding on `.event-item` at 768px+ was also removed.