### PR TITLE
Remove event item padding on small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2083,11 +2083,7 @@ footer {
         font-size: 1.8rem;
     }
 
-    .event-item {
-        padding: 0.6rem 0;
-        margin-bottom: 0;
-        border-radius: 6px;
-    }
+
 
 
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `padding: 0;` to `.event-item` within the `max-width: 768px` media query to remove inherited padding.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, `.event-item` within the `@media (max-width: 768px)` rule inherited `padding: 0.2rem` from the `@media (max-width: 1024px)` rule. This change explicitly sets padding to zero for screens up to 768px, ensuring no padding is applied on smaller devices.