### PR TITLE
Fix detail-row ::before and remove label min-width

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1290,7 +1290,7 @@ header {
 /* Add spacer for first detail-row to protect against recurring-badge overlap */
 .detail-row:first-child::before {
     content: '';
-    position: absolute;
+    position: relative;
     top: 0;
     right: 0;
     width: 90px; /* Match the width of recurring-badge + some buffer */


### PR DESCRIPTION
Apply `position: relative` and `order: 3` to `.detail-row:first-child::before` to enable its spacer functionality and remove `min-width` from `.label`.