### PR TITLE
Fix bear directory loading error

### DIFF
--- a/js/bear-directory.js
+++ b/js/bear-directory.js
@@ -35,6 +35,9 @@ class BearDirectory {
     init() {
         logger.componentInit('DIRECTORY', 'Initializing BearDirectory');
         
+        // Initialize DOM elements first
+        this.initializeElements();
+        
         // Load data
         this.loadGoogleSheetsData();
         
@@ -46,6 +49,18 @@ class BearDirectory {
         
         // Load Instagram embed script
         this.loadInstagramEmbed();
+    }
+    
+    initializeElements() {
+        // Get DOM element references
+        this.elements.grid = document.getElementById('directoryGrid');
+        this.elements.searchInput = document.getElementById('searchInput');
+        this.elements.sortSelect = document.getElementById('sortSelect');
+        this.elements.filterButtons = document.querySelectorAll('.filter-btn');
+        this.elements.loadingIndicator = document.getElementById('loadingIndicator');
+        this.elements.errorMessage = document.getElementById('errorMessage');
+        
+        logger.componentInit('DIRECTORY', 'DOM elements initialized');
     }
     
     initMap() {
@@ -91,7 +106,9 @@ class BearDirectory {
             });
             
             // Hide loading indicator and display data
-            this.elements.loadingIndicator.style.display = 'none';
+            if (this.elements.loadingIndicator) {
+                this.elements.loadingIndicator.style.display = 'none';
+            }
             this.displayDirectory();
             this.updateMap();
             
@@ -339,25 +356,31 @@ class BearDirectory {
     
     setupEventListeners() {
         // Search functionality
-        this.elements.searchInput.addEventListener('input', (e) => {
-            this.handleSearch(e.target.value);
-        });
+        if (this.elements.searchInput) {
+            this.elements.searchInput.addEventListener('input', (e) => {
+                this.handleSearch(e.target.value);
+            });
+        }
         
         // Sort functionality
-        this.elements.sortSelect.addEventListener('change', (e) => {
-            this.handleSort(e.target.value);
-        });
+        if (this.elements.sortSelect) {
+            this.elements.sortSelect.addEventListener('change', (e) => {
+                this.handleSort(e.target.value);
+            });
+        }
         
         // Filter buttons
-        this.elements.filterButtons.forEach(button => {
-            button.addEventListener('click', (e) => {
-                this.handleFilter(e.target.dataset.filter);
-                
-                // Update active state
-                this.elements.filterButtons.forEach(btn => btn.classList.remove('active'));
-                e.target.classList.add('active');
+        if (this.elements.filterButtons && this.elements.filterButtons.length > 0) {
+            this.elements.filterButtons.forEach(button => {
+                button.addEventListener('click', (e) => {
+                    this.handleFilter(e.target.dataset.filter);
+                    
+                    // Update active state
+                    this.elements.filterButtons.forEach(btn => btn.classList.remove('active'));
+                    e.target.classList.add('active');
+                });
             });
-        });
+        }
         
         // Display mode buttons
         const displayModeButtons = document.querySelectorAll('.display-mode-btn');
@@ -577,8 +600,12 @@ class BearDirectory {
     }
     
     showError() {
-        this.elements.loadingIndicator.style.display = 'none';
-        this.elements.errorMessage.style.display = 'block';
+        if (this.elements.loadingIndicator) {
+            this.elements.loadingIndicator.style.display = 'none';
+        }
+        if (this.elements.errorMessage) {
+            this.elements.errorMessage.style.display = 'block';
+        }
         
         logger.componentError('DIRECTORY', 'Error state displayed');
     }


### PR DESCRIPTION
Initialize DOM elements and add null checks in `BearDirectory` to fix "null is not an object" errors.

The `BearDirectory` class was attempting to access DOM elements (like `this.elements.loadingIndicator`) before they were properly assigned references from the DOM. This PR introduces an `initializeElements()` method to explicitly get these references at the start of the `init()` process and adds null checks where these elements are used to prevent future errors if an element is missing.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-f64acb51-9996-4cc6-80b5-79072dfe4094) · [Cursor](https://cursor.com/background-agent?bcId=bc-f64acb51-9996-4cc6-80b5-79072dfe4094)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)