### PR TITLE
Remove city emoji width CSS

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -562,9 +562,8 @@ header {
     transform: translateX(5px);
 }
 
-.compact-city-card .city-emoji {
+.city-emoji {
     font-size: 2rem;
-    width: 50px;
     text-align: center;
 }
 


### PR DESCRIPTION
Remove `width: 50px` from `.city-emoji` as it is not needed and should not have a special width on any screen size.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-d3d5e414-f512-4f5c-b1dc-175dc72bed2b) · [Cursor](https://cursor.com/background-agent?bcId=bc-d3d5e414-f512-4f5c-b1dc-175dc72bed2b)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)