### PR TITLE
Optimize calendar event name rendering

### DIFF
--- a/testing/hyphenation-test.html
+++ b/testing/hyphenation-test.html
@@ -188,60 +188,40 @@ Website: https://example.com</code></pre>
 
         // Smart nickname hyphenation logic (matches the main system)
         function getSmartEventName(event, maxWidthPx = null) {
-            // (A) Start with nickname if available, else event name, else bar
             let base = event.shortName || event.name || event.bar || '';
             if (!base) return '';
-            // Always convert '\-' to '-' (escaped hyphens)
             base = base.replace(/\\-/g, '-');
-            // (B) If a word will fit horizontally, remove any '-' and show it all
-            // (C) If a word won't fit, keep the '-' if they were added in
-            // Try to show three lines max, splitting on spaces and hyphens
-            // We'll simulate width by character count if maxWidthPx is not provided
-            // (real width calc would require DOM, so we use heuristics)
             const maxCharsPerLine = maxWidthPx ? Math.floor(maxWidthPx / 10) : (window.innerWidth <= 400 ? 8 : 14);
-            // Split on spaces and hyphens
-            let parts = base.split(/[-\s]+/);
-            // Remove empty
-            parts = parts.filter(Boolean);
-            // Try to fit as many as possible in three lines
+            // Try unhyphenated version first (remove all hyphens)
+            let unhyphenated = base.replace(/-/g, '');
+            if (unhyphenated.length <= maxCharsPerLine * 3) {
+                let lines = [];
+                for (let i = 0; i < unhyphenated.length; i += maxCharsPerLine) {
+                    lines.push(unhyphenated.slice(i, i + maxCharsPerLine));
+                    if (lines.length === 3) break;
+                }
+                if (unhyphenated.length > maxCharsPerLine * 3) {
+                    lines[2] = lines[2].replace(/\s+$/, '') + '...';
+                }
+                return lines.join('\n');
+            }
+            // If it doesn't fit, use hyphenated version and split for lines
+            let hyphenParts = base.split('-');
             let lines = [];
             let currentLine = '';
-            for (let i = 0; i < parts.length; i++) {
-                let part = parts[i];
-                // If adding this part would overflow the line, start a new line
-                if ((currentLine + (currentLine ? ' ' : '') + part).length > maxCharsPerLine) {
+            for (let i = 0; i < hyphenParts.length; i++) {
+                let part = hyphenParts[i].trim();
+                if ((currentLine + (currentLine ? '-' : '') + part).length > maxCharsPerLine) {
                     if (currentLine) lines.push(currentLine);
                     currentLine = part;
                     if (lines.length === 3) break;
                 } else {
-                    currentLine += (currentLine ? ' ' : '') + part;
+                    currentLine += (currentLine ? '-' : '') + part;
                 }
             }
             if (currentLine && lines.length < 3) lines.push(currentLine);
-            // If we couldn't fit all, add ellipsis
-            if (lines.length === 3 && parts.length > 3) {
+            if (lines.length === 3 && hyphenParts.length > 3) {
                 lines[2] = lines[2].replace(/\s+$/, '') + '...';
-            }
-            // If the original had hyphens and we had to break, keep hyphens in the output
-            if (base.includes('-') && lines.length > 1) {
-                // Re-split with hyphens for more faithful output
-                let hyphenParts = base.split('-');
-                lines = [];
-                currentLine = '';
-                for (let i = 0; i < hyphenParts.length; i++) {
-                    let part = hyphenParts[i].trim();
-                    if ((currentLine + (currentLine ? '-' : '') + part).length > maxCharsPerLine) {
-                        if (currentLine) lines.push(currentLine);
-                        currentLine = part;
-                        if (lines.length === 3) break;
-                    } else {
-                        currentLine += (currentLine ? '-' : '') + part;
-                    }
-                }
-                if (currentLine && lines.length < 3) lines.push(currentLine);
-                if (lines.length === 3 && hyphenParts.length > 3) {
-                    lines[2] = lines[2].replace(/\s+$/, '') + '...';
-                }
             }
             return lines.join('\n');
         }


### PR DESCRIPTION
Refactor event name display logic to prioritize unhyphenated versions when fitting, and update the testing playground.

The logic now first attempts to display the unhyphenated version of the event name/nickname. If it fits within the available space (simulated by character count), that version is used. Otherwise, it falls back to the hyphenated version, preserving hyphens for readability and line breaks. Escaped hyphens (`\-`) are always converted to normal hyphens. The `testing/hyphenation-test.html` file has been updated to reflect this new logic and includes an interactive playground for testing various scenarios.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-085bd4ff-7a37-414c-87fe-3fbdcfcbc5ce) · [Cursor](https://cursor.com/background-agent?bcId=bc-085bd4ff-7a37-414c-87fe-3fbdcfcbc5ce)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)