### PR TITLE
Fix hyphenation tester TypeError

### DIFF
--- a/testing/hyphenation-test.html
+++ b/testing/hyphenation-test.html
@@ -278,5 +278,10 @@ Website: https://example.com</code></pre>
             <pre id="playground-output" style="background:#f8f8f8; border:1px solid #ccc; padding:1em; min-height:2em; font-size:1.1em;"></pre>
         </div>
     </div>
+    
+    <!-- Load required JavaScript files -->
+    <script src="../js/logger.js"></script>
+    <script src="../js/calendar-core.js"></script>
+    <script src="../js/dynamic-calendar-loader.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Add missing script imports to `hyphenation-test.html` to fix `TypeError`.

The hyphenation tester was failing with `TypeError: undefined is not an object (evaluating 'window.DynamicCalendarLoader.formatEventNickname')` because the necessary JavaScript files (`logger.js`, `calendar-core.js`, and `dynamic-calendar-loader.js`) were not being loaded. This PR adds these scripts to resolve the error.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-cdfc5045-146a-4bee-b196-9d67814be35a) · [Cursor](https://cursor.com/background-agent?bcId=bc-cdfc5045-146a-4bee-b196-9d67814be35a)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)