### PR TITLE
Improve CSS tester and URL handling

### DIFF
--- a/testing/ultimate-style-tester.html
+++ b/testing/ultimate-style-tester.html
@@ -785,43 +785,43 @@
                         <div class="color-control">
                             <label>Light</label>
                             <div class="color-input-group">
-                                <input type="color" id="shadow-light" class="color-picker" value="#000000">
-                                <input type="text" id="shadow-light-text" class="color-input" value="rgba(0, 0, 0, 0.1)">
+                                                <input type="color" id="shadow-light" class="color-picker" value="#000000">
+                <input type="text" id="shadow-light-text" class="color-input" value="transparent">
                             </div>
                         </div>
                         <div class="color-control">
                             <label>Medium</label>
                             <div class="color-input-group">
-                                <input type="color" id="shadow-medium" class="color-picker" value="#000000">
-                                <input type="text" id="shadow-medium-text" class="color-input" value="rgba(0, 0, 0, 0.15)">
+                                                <input type="color" id="shadow-medium" class="color-picker" value="#000000">
+                <input type="text" id="shadow-medium-text" class="color-input" value="transparent">
                             </div>
                         </div>
                         <div class="color-control">
                             <label>Heavy</label>
                             <div class="color-input-group">
-                                <input type="color" id="shadow-heavy" class="color-picker" value="#000000">
-                                <input type="text" id="shadow-heavy-text" class="color-input" value="rgba(0, 0, 0, 0.25)">
+                                                <input type="color" id="shadow-heavy" class="color-picker" value="#000000">
+                <input type="text" id="shadow-heavy-text" class="color-input" value="transparent">
                             </div>
                         </div>
                         <div class="color-control">
                             <label>Primary</label>
                             <div class="color-input-group">
-                                <input type="color" id="shadow-primary" class="color-picker" value="#667eea">
-                                <input type="text" id="shadow-primary-text" class="color-input" value="rgba(102, 126, 234, 0.3)">
+                                                <input type="color" id="shadow-primary" class="color-picker" value="#667eea">
+                <input type="text" id="shadow-primary-text" class="color-input" value="transparent">
                             </div>
                         </div>
                         <div class="color-control">
                             <label>Success</label>
                             <div class="color-input-group">
-                                <input type="color" id="shadow-success" class="color-picker" value="#4ecdc4">
-                                <input type="text" id="shadow-success-text" class="color-input" value="rgba(78, 205, 196, 0.3)">
+                                                <input type="color" id="shadow-success" class="color-picker" value="#4ecdc4">
+                <input type="text" id="shadow-success-text" class="color-input" value="transparent">
                             </div>
                         </div>
                         <div class="color-control">
                             <label>Error</label>
                             <div class="color-input-group">
-                                <input type="color" id="shadow-error" class="color-picker" value="#dc2626">
-                                <input type="text" id="shadow-error-text" class="color-input" value="rgba(220, 38, 38, 0.3)">
+                                                <input type="color" id="shadow-error" class="color-picker" value="#dc2626">
+                <input type="text" id="shadow-error-text" class="color-input" value="transparent">
                             </div>
                         </div>
                     </div>
@@ -979,12 +979,12 @@
                         'color-success-dark': '#059669',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(0, 0, 0, 0.1)',
-                        'shadow-medium': 'rgba(0, 0, 0, 0.15)',
-                        'shadow-heavy': 'rgba(0, 0, 0, 0.25)',
-                        'shadow-primary': 'rgba(102, 126, 234, 0.3)',
-                        'shadow-success': 'rgba(78, 205, 196, 0.3)',
-                        'shadow-error': 'rgba(220, 38, 38, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#667eea',
                         'gradient-primary-end': '#764ba2',
                         'gradient-secondary-start': '#ff6b6b',
@@ -1025,12 +1025,12 @@
                         'color-success-dark': '#45b7d1',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(0, 0, 0, 0.3)',
-                        'shadow-medium': 'rgba(0, 0, 0, 0.4)',
-                        'shadow-heavy': 'rgba(0, 0, 0, 0.6)',
-                        'shadow-primary': 'rgba(78, 205, 196, 0.3)',
-                        'shadow-success': 'rgba(78, 205, 196, 0.3)',
-                        'shadow-error': 'rgba(255, 107, 107, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#4ecdc4',
                         'gradient-primary-end': '#45b7d1',
                         'gradient-secondary-start': '#ff6b6b',
@@ -1071,12 +1071,12 @@
                         'color-success-dark': '#45b7d1',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(0, 0, 0, 0.3)',
-                        'shadow-medium': 'rgba(0, 0, 0, 0.4)',
-                        'shadow-heavy': 'rgba(0, 0, 0, 0.6)',
-                        'shadow-primary': 'rgba(0, 0, 0, 0.3)',
-                        'shadow-success': 'rgba(78, 205, 196, 0.3)',
-                        'shadow-error': 'rgba(255, 107, 107, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#000000',
                         'gradient-primary-end': '#8B4513',
                         'gradient-secondary-start': '#8B4513',
@@ -1117,12 +1117,12 @@
                         'color-success-dark': '#00cccc',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(255, 0, 255, 0.3)',
-                        'shadow-medium': 'rgba(0, 255, 255, 0.3)',
-                        'shadow-heavy': 'rgba(255, 255, 0, 0.3)',
-                        'shadow-primary': 'rgba(255, 0, 255, 0.3)',
-                        'shadow-success': 'rgba(0, 255, 255, 0.3)',
-                        'shadow-error': 'rgba(255, 0, 255, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#ff00ff',
                         'gradient-primary-end': '#ffff00',
                         'gradient-secondary-start': '#00ffff',
@@ -1163,12 +1163,12 @@
                         'color-success-dark': '#f7931e',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(255, 107, 53, 0.3)',
-                        'shadow-medium': 'rgba(247, 147, 30, 0.3)',
-                        'shadow-heavy': 'rgba(255, 210, 63, 0.3)',
-                        'shadow-primary': 'rgba(255, 107, 53, 0.3)',
-                        'shadow-success': 'rgba(255, 210, 63, 0.3)',
-                        'shadow-error': 'rgba(255, 107, 53, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#ff6b35',
                         'gradient-primary-end': '#ffd23f',
                         'gradient-secondary-start': '#f7931e',
@@ -1209,12 +1209,12 @@
                         'color-success-dark': '#00b4d8',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(0, 105, 148, 0.3)',
-                        'shadow-medium': 'rgba(0, 180, 216, 0.3)',
-                        'shadow-heavy': 'rgba(144, 224, 239, 0.3)',
-                        'shadow-primary': 'rgba(0, 105, 148, 0.3)',
-                        'shadow-success': 'rgba(144, 224, 239, 0.3)',
-                        'shadow-error': 'rgba(0, 105, 148, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#006994',
                         'gradient-primary-end': '#90e0ef',
                         'gradient-secondary-start': '#00b4d8',
@@ -1255,12 +1255,12 @@
                         'color-success-dark': '#978B7D',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(188, 187, 163, 0.3)',
-                        'shadow-medium': 'rgba(151, 139, 125, 0.3)',
-                        'shadow-heavy': 'rgba(225, 79, 56, 0.3)',
-                        'shadow-primary': 'rgba(188, 187, 163, 0.3)',
-                        'shadow-success': 'rgba(188, 187, 163, 0.3)',
-                        'shadow-error': 'rgba(225, 79, 56, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#BCBBA3',
                         'gradient-primary-end': '#E14F38',
                         'gradient-secondary-start': '#978B7D',
@@ -1301,12 +1301,12 @@
                         'color-success-dark': '#2A2D2A',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(81, 68, 62, 0.3)',
-                        'shadow-medium': 'rgba(42, 45, 42, 0.3)',
-                        'shadow-heavy': 'rgba(225, 79, 56, 0.3)',
-                        'shadow-primary': 'rgba(81, 68, 62, 0.3)',
-                        'shadow-success': 'rgba(81, 68, 62, 0.3)',
-                        'shadow-error': 'rgba(225, 79, 56, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#51443E',
                         'gradient-primary-end': '#E14F38',
                         'gradient-secondary-start': '#2A2D2A',
@@ -1347,12 +1347,12 @@
                         'color-success-dark': '#E14F38',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(253, 148, 51, 0.3)',
-                        'shadow-medium': 'rgba(225, 79, 56, 0.3)',
-                        'shadow-heavy': 'rgba(112, 148, 160, 0.3)',
-                        'shadow-primary': 'rgba(253, 148, 51, 0.3)',
-                        'shadow-success': 'rgba(253, 148, 51, 0.3)',
-                        'shadow-error': 'rgba(225, 79, 56, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#FD9433',
                         'gradient-primary-end': '#7094A0',
                         'gradient-secondary-start': '#E14F38',
@@ -1393,12 +1393,12 @@
                         'color-success-dark': '#d94f57',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(255, 204, 0, 0.3)',
-                        'shadow-medium': 'rgba(217, 79, 87, 0.3)',
-                        'shadow-heavy': 'rgba(83, 61, 139, 0.3)',
-                        'shadow-primary': 'rgba(255, 204, 0, 0.3)',
-                        'shadow-success': 'rgba(255, 204, 0, 0.3)',
-                        'shadow-error': 'rgba(217, 79, 87, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#ffcc00',
                         'gradient-primary-end': '#533d8b',
                         'gradient-secondary-start': '#d94f57',
@@ -1439,12 +1439,12 @@
                         'color-success-dark': '#e0940f',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(20, 33, 61, 0.1)',
-                        'shadow-medium': 'rgba(20, 33, 61, 0.15)',
-                        'shadow-heavy': 'rgba(20, 33, 61, 0.25)',
-                        'shadow-primary': 'rgba(20, 33, 61, 0.3)',
-                        'shadow-success': 'rgba(252, 163, 17, 0.3)',
-                        'shadow-error': 'rgba(220, 38, 38, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#14213d',
                         'gradient-primary-end': '#fca311',
                         'gradient-secondary-start': '#fca311',
@@ -1485,12 +1485,12 @@
                         'color-success-dark': '#cc6400',
                         'white': '#ffffff',
                         'black': '#000000',
-                        'shadow-light': 'rgba(21, 97, 109, 0.3)',
-                        'shadow-medium': 'rgba(255, 125, 0, 0.3)',
-                        'shadow-heavy': 'rgba(255, 236, 209, 0.3)',
-                        'shadow-primary': 'rgba(21, 97, 109, 0.3)',
-                        'shadow-success': 'rgba(255, 125, 0, 0.3)',
-                        'shadow-error': 'rgba(255, 125, 0, 0.3)',
+                        'shadow-light': 'transparent',
+                        'shadow-medium': 'transparent',
+                        'shadow-heavy': 'transparent',
+                        'shadow-primary': 'transparent',
+                        'shadow-success': 'transparent',
+                        'shadow-error': 'transparent',
                         'gradient-primary-start': '#15616d',
                         'gradient-primary-end': '#ff7d00',
                         'gradient-secondary-start': '#ff7d00',
@@ -1532,13 +1532,13 @@
                     });
                 });
 
-                // Auto-apply changes after a delay
+                // Auto-apply changes and update URL after a delay
                 let applyTimeout;
                 colorInputs.forEach(input => {
                     input.addEventListener('input', () => {
                         clearTimeout(applyTimeout);
                         applyTimeout = setTimeout(() => {
-                            this.applyCustomColors();
+                            this.applyCustomColors(); // This also calls updateURL()
                         }, 500);
                     });
                 });
@@ -1647,6 +1647,7 @@
 
                 this.applyCustomColors();
                 this.updateStatusBar();
+                this.updateURL();
                 this.showNotification(`Applied ${themeName} theme!`);
             }
 
@@ -1715,6 +1716,9 @@
                 this.currentTheme = 'custom';
                 this.updateStatusBar();
                 
+                // Auto-update URL to reflect current state
+                this.updateURL();
+                
                 this.showNotification('Colors applied!');
             }
 
@@ -1780,6 +1784,7 @@
                 event.target.classList.add('active');
                 
                 this.updateStatusBar();
+                this.updateURL();
                 this.showNotification(`${view} view activated!`);
             }
 
@@ -2246,6 +2251,12 @@
                 params.set('view', this.currentView);
                 
                 return `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+            }
+
+            updateURL() {
+                const newUrl = this.generateShareURL();
+                // Update the URL without reloading the page
+                window.history.replaceState({}, '', newUrl);
             }
 
             updateStatusBar() {


### PR DESCRIPTION
Disable default shadows and enable automatic URL updates in `ultimate-style-tester.html`.

This fixes an issue where shared URLs would load the correct state but then prevent further edits from being reflected in the URL, making it impossible to re-share updated designs. It also ensures shadows are transparent by default across all themes and input fields.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f5e125c2-a6b8-4f62-9189-fa761b32b7ba) · [Cursor](https://cursor.com/background-agent?bcId=bc-f5e125c2-a6b8-4f62-9189-fa761b32b7ba)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)