### PR TITLE
Update calendar day padding for smaller screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2106,7 +2106,7 @@ footer {
     }
 
     .calendar-day.month-day .day-events {
-        padding: 1.2rem 0.2rem 0.2rem 0.2rem;
+        padding: 1.2rem 0 0 0;
         gap: 0.5px;
         height: 100%;
     }


### PR DESCRIPTION
Set padding to 0 on left, right, and bottom for `.calendar-day.month-day .day-events` at max-width 768px to improve responsiveness.

---

[Open in Web](https://www.cursor.com/agents?id=bc-fb1be85e-d5f9-4c9c-af93-2724d74b4eaf) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-fb1be85e-d5f9-4c9c-af93-2724d74b4eaf)