### PR TITLE
Update from main and process cursorrules

### DIFF
--- a/js/debug-overlay.js
+++ b/js/debug-overlay.js
@@ -135,7 +135,10 @@ class DebugOverlay {
     drag(e) {
         if (!this.isDragging) return;
         
-        e.preventDefault();
+        // Only call preventDefault if it's available (Event object, not Touch object)
+        if (e.preventDefault && typeof e.preventDefault === 'function') {
+            e.preventDefault();
+        }
         
         let newX = e.clientX - this.dragOffset.x;
         let newY = e.clientY - this.dragOffset.y;


### PR DESCRIPTION
Safely call `preventDefault()` in `DebugOverlay.drag` to fix mobile dragging.

On mobile, `e.touches[0]` (a Touch object) was passed to the `drag` method, which then attempted to call `preventDefault()` on it. However, `preventDefault()` is a method of the Event object, not the Touch object, leading to a `TypeError`. This PR adds a check to ensure `preventDefault()` is only called if it exists on the event object.

---

[Open in Web](https://www.cursor.com/agents?id=bc-fd79ba09-8502-4886-913d-3e831d458af5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-fd79ba09-8502-4886-913d-3e831d458af5)