### PR TITLE
Update logos and event styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ MIT License - feel free to use this as a template for community travel guides!
 
 ---
 
-Made with ![chunky.dad logo](chunky-dad-emoji.png) for the bear community. Travel safe, have fun, and support bear businesses!
+Made with ![chunky.dad logo](Rising_Star_Ryan_Head_Full.png) for the bear community. Travel safe, have fun, and support bear businesses!

--- a/bear-directory.html
+++ b/bear-directory.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bear Directory - Artists & Businesses | chunky.dad</title>
     <meta name="description" content="Discover bear-owned businesses and artists from around the world">
-    <link rel="icon" type="image/png" href="chunky-dad-emoji.png">
-    <link rel="apple-touch-icon" href="chunky-dad-emoji.png">
+    <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Full.png">
+    <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Full.png">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Leaflet CSS for map -->
@@ -19,7 +19,7 @@
         <nav>
             <div class="nav-container">
                 <div class="logo">
-                    <h1><a href="index.html"><img src="chunky-dad-emoji.png" alt="chunky.dad logo" class="logo-img"> chunky.dad</a></h1>
+                    <h1><a href="index.html"><img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad logo" class="logo-img"> chunky.dad</a></h1>
                 </div>
                 <ul class="nav-menu">
                     <li><a href="index.html">Home</a></li>

--- a/city.html
+++ b/city.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>City Guide - chunky.dad Bear Guide</title>
     <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="chunky-dad-emoji.png">
-    <link rel="apple-touch-icon" href="chunky-dad-emoji.png">
+    <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Full.png">
+    <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Full.png">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Leaflet CSS -->
@@ -19,7 +19,7 @@
         <nav>
             <div class="nav-container">
                 <div class="logo">
-                    <h1><a href="index.html"><img src="chunky-dad-emoji.png" alt="chunky.dad logo" class="logo-img"> chunky.dad</a></h1>
+                    <h1><a href="index.html"><img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad logo" class="logo-img"> chunky.dad</a></h1>
                 </div>
                 
                 <!-- Navigation menu hidden on city pages - only show on index.html -->

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>chunky.dad - Your Gay Bear Travel Guide</title>
     <meta name="description" content="The ultimate travel guide for gay bears - city guides, events, and bear-owned businesses worldwide">
-    <link rel="icon" type="image/png" href="chunky-dad-emoji.png">
-    <link rel="apple-touch-icon" href="chunky-dad-emoji.png">
+    <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Full.png">
+    <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Full.png">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
@@ -15,7 +15,7 @@
         <nav>
             <div class="nav-container">
                 <div class="logo">
-                    <h1><a href="index.html"><img src="chunky-dad-emoji.png" alt="chunky.dad logo" class="logo-img"> chunky.dad</a></h1>
+                    <h1><a href="index.html"><img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad logo" class="logo-img"> chunky.dad</a></h1>
                 </div>
                 <ul class="nav-menu">
                 </ul>
@@ -56,7 +56,7 @@
         <section id="bear-art" class="bear-art-section">
             <div class="container">
                 <div class="bear-art-content">
-                    <h2><img src="chunky-dad-emoji.png" alt="chunky.dad" class="section-icon"> Bear Businesses</h2>
+                    <h2><img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="section-icon"> Bear Businesses</h2>
                     <a href="bear-directory.html" class="bear-art-button">
                         Browse Bear Directory →
                     </a>

--- a/js/bear-directory.js
+++ b/js/bear-directory.js
@@ -248,7 +248,7 @@ class BearDirectory {
             // No specific display content - show placeholder
             displayContent = `
                 <div class="tile-placeholder">
-                    <div class="bear-icon"><img src="chunky-dad-emoji.png" alt="chunky.dad" class="bear-directory-icon"></div>
+                    <div class="bear-icon"><img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="bear-directory-icon"></div>
                 </div>`;
         }
         
@@ -293,7 +293,7 @@ class BearDirectory {
                 </blockquote>
             </div>` :
             `<div class="tile-placeholder">
-                <div class="bear-icon"><img src="chunky-dad-emoji.png" alt="chunky.dad" class="bear-directory-icon"></div>
+                <div class="bear-icon"><img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="bear-directory-icon"></div>
             </div>`;
             
         return instagramContent;
@@ -308,7 +308,7 @@ class BearDirectory {
             'shop': '🛍️',
             'service': '💼'
         };
-        return icons[type.toLowerCase()] || '<img src="chunky-dad-emoji.png" alt="chunky.dad" class="bear-directory-icon">';
+        return icons[type.toLowerCase()] || '<img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="bear-directory-icon">';
     }
     
     updateMap() {

--- a/js/components.js
+++ b/js/components.js
@@ -49,7 +49,7 @@ class ComponentsManager {
             <div id="bear-intel-modal" class="bear-intel-modal" style="display: none;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h3><img src="chunky-dad-emoji.png" alt="chunky.dad" class="modal-icon"> Share Bear Intel</h3>
+                        <h3><img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="modal-icon"> Share Bear Intel</h3>
                         <button class="modal-close" id="modal-close-btn">&times;</button>
                     </div>
                     <div class="modal-body">
@@ -65,7 +65,7 @@ class ComponentsManager {
                                 <option value="other">Other Bear Intel</option>
                             </select>
                             <textarea placeholder="Tell us about it! Include city, address, and any special details..." rows="4" required></textarea>
-                            <button type="submit">Send Bear Intel <img src="chunky-dad-emoji.png" alt="chunky.dad" class="button-icon"></button>
+                            <button type="submit">Send Bear Intel <img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="button-icon"></button>
                         </form>
                     </div>
                 </div>
@@ -83,7 +83,7 @@ class ComponentsManager {
             <div id="bear-intel-modal" class="bear-intel-modal" style="display: none;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h3><img src="chunky-dad-emoji.png" alt="chunky.dad" class="modal-icon"> Share Bear Intel</h3>
+                        <h3><img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="modal-icon"> Share Bear Intel</h3>
                         <button class="modal-close" id="modal-close-btn">&times;</button>
                     </div>
                     <div class="modal-body">
@@ -99,7 +99,7 @@ class ComponentsManager {
                                 <option value="other">Other Bear Intel</option>
                             </select>
                             <textarea placeholder="Tell us about it! Include city, address, and any special details..." rows="4" required></textarea>
-                            <button type="submit">Send Bear Intel <img src="chunky-dad-emoji.png" alt="chunky.dad" class="button-icon"></button>
+                            <button type="submit">Send Bear Intel <img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="button-icon"></button>
                         </form>
                     </div>
                 </div>

--- a/js/debug-overlay.js
+++ b/js/debug-overlay.js
@@ -54,7 +54,7 @@ class DebugOverlay {
         
         this.overlay.innerHTML = `
             <div class="debug-header">
-                <span class="debug-title"><img src="chunky-dad-emoji.png" alt="chunky.dad" class="debug-icon"> DEBUG</span>
+                <span class="debug-title"><img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="debug-icon"> DEBUG</span>
                 <div class="debug-header-controls">
                     <button class="debug-toggle" aria-label="Toggle debug view" title="Toggle view">⌃</button>
                     <button class="debug-minimize" aria-label="Minimize debug overlay" title="Minimize">-</button>

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1525,7 +1525,7 @@ class DynamicCalendarLoader extends CalendarCore {
                 className: 'custom-marker',
                 html: `
                     <div class="marker-pin">
-                        <div class="marker-icon"><img src="chunky-dad-emoji.png" alt="chunky.dad" class="map-marker-icon"></div>
+                        <div class="marker-icon"><img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="map-marker-icon"></div>
                     </div>
                 `,
                 iconSize: [44, 56],

--- a/js/event-config.js
+++ b/js/event-config.js
@@ -153,14 +153,11 @@ function formatEventDates(event) {
     const startFormatted = start.toLocaleDateString('en-US', options);
     const endFormatted = end.toLocaleDateString('en-US', options);
     
-    // If same year, show it once at the end
-    const year = start.getFullYear();
-    
     if (start.getTime() === end.getTime()) {
-        return `${startFormatted}, ${year}`;
+        return startFormatted;
     }
     
-    return `${startFormatted} - ${endFormatted}, ${year}`;
+    return `${startFormatted} - ${endFormatted}`;
 }
 
 // Make functions globally available for browser use

--- a/js/header-manager.js
+++ b/js/header-manager.js
@@ -41,17 +41,17 @@ class HeaderManager {
             return;
         }
 
-        let title = '<img src="chunky-dad-emoji.png" alt="chunky.dad logo" class="logo-img"> chunky.dad';
+        let title = '<img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad logo" class="logo-img"> chunky.dad';
         
         if (this.isCityPage()) {
             const cityKey = this.getCityFromURL();
             const cityConfig = getCityConfig(cityKey);
             if (cityConfig) {
-                title = `<img src="chunky-dad-emoji.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/${cityKey}`;
+                title = `<img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/${cityKey}`;
                 this.currentCity = cityConfig;
             }
         } else if (this.isTestPage) {
-            title = '<img src="chunky-dad-emoji.png" alt="chunky.dad logo" class="logo-img"> chunky.dad [DEBUG]';
+            title = '<img src="Rising_Star_Ryan_Head_Full.png" alt="chunky.dad logo" class="logo-img"> chunky.dad [DEBUG]';
         }
 
         // Update the title

--- a/styles.css
+++ b/styles.css
@@ -673,21 +673,9 @@ header {
 
 .event-compact-grid {
     gap: 1rem;
-    justify-content: center;
-    max-width: calc(100vw - 2rem);
-    margin: 0 auto;
 }
 
-/* When events can fit in viewport, center them */
-@media (min-width: 1400px) {
-    .event-compact-grid {
-        padding: 0.5rem 2rem;
-        transform: none;
-        justify-content: center;
-        width: 100%;
-        max-width: 1200px;
-    }
-}
+
 
 /* Shared Compact Card Base Styles */
 .city-compact-card,
@@ -707,9 +695,8 @@ header {
 }
 
 .event-compact-card {
-    gap: 1rem;
-    min-width: 200px;
-    max-width: 200px;
+    gap: 0.5rem;
+    min-width: 100px;
 }
 
 /* Shared Emoji Box Styles */
@@ -1055,8 +1042,7 @@ header {
     }
     
     .event-compact-card {
-        min-width: 160px;
-        max-width: 160px;
+        min-width: 85px;
     }
     
     .city-compact-card .city-emoji-box,
@@ -1107,18 +1093,9 @@ header {
     
     .event-compact-grid {
         gap: 1rem;
-        justify-content: flex-start;
     }
     
-    /* Better mobile centering for smaller screens */
-    @media (max-width: 768px) {
-        .event-compact-grid {
-            padding: 0.5rem 1rem;
-            transform: none;
-            justify-content: flex-start;
-            overflow-x: auto;
-        }
-    }
+
     
     .city-grid {
         grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));

--- a/testing/style-test.html
+++ b/testing/style-test.html
@@ -567,11 +567,11 @@
                     <h4>6. News Ticker</h4>
                     <div class="ticker-container">
                         <div class="ticker-content">
-                            <span class="ticker-item"><img src="../chunky-dad-emoji.png" alt="chunky.dad" class="button-icon"> Bear Happy Hour Tonight</span>
+                            <span class="ticker-item"><img src="../Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="button-icon"> Bear Happy Hour Tonight</span>
                             <span class="ticker-item">🎉 Weekend Pool Party</span>
                             <span class="ticker-item">🍺 New Bear Bar Opening</span>
                             <span class="ticker-item">🏳️‍🌈 Pride Events This Month</span>
-                            <span class="ticker-item"><img src="../chunky-dad-emoji.png" alt="chunky.dad" class="button-icon"> Bear Happy Hour Tonight</span>
+                            <span class="ticker-item"><img src="../Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="button-icon"> Bear Happy Hour Tonight</span>
                             <span class="ticker-item">🎉 Weekend Pool Party</span>
                         </div>
                     </div>

--- a/testing/test-calendar-logging.html
+++ b/testing/test-calendar-logging.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Calendar Debugging Tool - chunky.dad</title>
     <meta name="description" content="Advanced debugging tool for calendar event processing">
-    <link rel="icon" type="image/png" href="../chunky-dad-emoji.png">
-    <link rel="apple-touch-icon" href="../chunky-dad-emoji.png">
+    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Full.png">
+    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Full.png">
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Leaflet CSS -->
@@ -511,7 +511,7 @@
         <nav>
             <div class="nav-container">
                 <div class="logo">
-                    <h1><a href="index.html"><img src="../chunky-dad-emoji.png" alt="chunky.dad logo" class="logo-img"> chunky.dad - Calendar Debugger</a></h1>
+                    <h1><a href="index.html"><img src="../Rising_Star_Ryan_Head_Full.png" alt="chunky.dad logo" class="logo-img"> chunky.dad - Calendar Debugger</a></h1>
                 </div>
                 
                 <ul class="nav-menu">
@@ -716,7 +716,7 @@
 
     <footer>
         <div class="container">
-            <p>&copy; 2025 chunky.dad Calendar Debugger. Made with <img src="../chunky-dad-emoji.png" alt="chunky.dad" class="button-icon"> for debugging.</p>
+            <p>&copy; 2025 chunky.dad Calendar Debugger. Made with <img src="../Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="button-icon"> for debugging.</p>
         </div>
     </footer>
 

--- a/testing/test-google-sheets-loader.html
+++ b/testing/test-google-sheets-loader.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Google Sheets Loader Testing Tool - chunky.dad</title>
     <meta name="description" content="Advanced testing and debugging tool for Google Sheets data loading">
-    <link rel="icon" type="image/png" href="../chunky-dad-emoji.png">
-    <link rel="apple-touch-icon" href="../chunky-dad-emoji.png">
+    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Full.png">
+    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Full.png">
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Leaflet CSS -->
@@ -332,7 +332,7 @@
         <nav>
             <div class="nav-container">
                 <div class="logo">
-                    <h1><a href="../index.html"><img src="../chunky-dad-emoji.png" alt="chunky.dad logo" class="logo-img"> chunky.dad</a></h1>
+                    <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Full.png" alt="chunky.dad logo" class="logo-img"> chunky.dad</a></h1>
                 </div>
                 <ul class="nav-menu">
                     <li><a href="../index.html">Home</a></li>
@@ -351,7 +351,7 @@
     <main>
         <div class="container">
             <h2 style="color: #FFA500; text-align: center; margin: 2rem 0;">
-                <img src="../chunky-dad-emoji.png" alt="chunky.dad" class="section-icon"> Google Sheets Loader Testing Tool
+                <img src="../Rising_Star_Ryan_Head_Full.png" alt="chunky.dad" class="section-icon"> Google Sheets Loader Testing Tool
             </h2>
             
             <!-- Configuration Panel -->


### PR DESCRIPTION
Replace old logo with "Rising Star Ryan", unify bear event card styling, and shorten event dates.

The previous "Genmoji" logo has been replaced with the new "Rising Star Ryan" logo across all HTML, JavaScript, and markdown files, including favicons. Additionally, the CSS for bear event cards has been adjusted to match the width and centering of city event cards for a consistent look, and event dates now display without the year for a cleaner appearance.

---

[Open in Web](https://cursor.com/agents?id=bc-0cc8eed2-fbab-458d-816c-baea82f54235) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0cc8eed2-fbab-458d-816c-baea82f54235) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)