### PR TITLE
Update code and fix style tester error

### DIFF
--- a/testing/manifest.json
+++ b/testing/manifest.json
@@ -1,55 +1,55 @@
 {
-  "generated": "2025-07-26T03:05:17.948Z",
+  "generated": "2025-07-26T03:33:35.773Z",
   "files": [
     {
       "name": "breakpoint-test.html",
       "size": 34162,
-      "modified": "2025-07-26T02:59:37.573Z"
+      "modified": "2025-07-26T03:30:58.906Z"
     },
     {
       "name": "hero-variations-tester.html",
       "size": 26243,
-      "modified": "2025-07-26T03:05:09.421Z"
+      "modified": "2025-07-26T03:30:58.906Z"
     },
     {
       "name": "iframe-fix-test.html",
       "size": 9922,
-      "modified": "2025-07-26T02:59:37.573Z"
+      "modified": "2025-07-26T03:30:58.906Z"
     },
     {
       "name": "index.html",
       "size": 18216,
-      "modified": "2025-07-26T02:59:37.573Z"
+      "modified": "2025-07-26T03:30:58.906Z"
     },
     {
       "name": "style-test.html",
       "size": 26360,
-      "modified": "2025-07-26T02:59:37.573Z"
+      "modified": "2025-07-26T03:30:58.906Z"
     },
     {
       "name": "test-calendar-logging.html",
       "size": 68099,
-      "modified": "2025-07-26T02:59:37.573Z"
+      "modified": "2025-07-26T03:30:58.906Z"
     },
     {
       "name": "test-display-modes.html",
       "size": 10729,
-      "modified": "2025-07-26T02:59:37.573Z"
+      "modified": "2025-07-26T03:30:58.906Z"
     },
     {
       "name": "test-google-sheets-loader.html",
       "size": 40540,
-      "modified": "2025-07-26T02:59:37.573Z"
+      "modified": "2025-07-26T03:30:58.906Z"
     },
     {
       "name": "test-map-icons.html",
-      "size": 39531,
-      "modified": "2025-07-26T02:59:37.573Z"
+      "size": 50002,
+      "modified": "2025-07-26T03:30:58.906Z"
     },
     {
       "name": "ultimate-style-tester.html",
-      "size": 110803,
-      "modified": "2025-07-26T02:59:37.573Z"
+      "size": 112330,
+      "modified": "2025-07-26T03:32:59.274Z"
     }
   ]
 }

--- a/testing/ultimate-style-tester.html
+++ b/testing/ultimate-style-tester.html
@@ -941,11 +941,19 @@
 
         class StyleTester {
             constructor() {
+                console.log('StyleTester: Initializing...');
                 this.currentTheme = 'default';
                 this.currentView = 'desktop';
                 this.iframe = document.getElementById('website-iframe');
                 this.iframeLoaded = false;
                 this.pendingStyles = [];
+                
+                // Add error handling for iframe
+                if (!this.iframe) {
+                    console.warn('StyleTester: website-iframe element not found');
+                }
+                
+                console.log('StyleTester: Initialization complete');
                 
                 this.themes = {
                     default: {
@@ -1622,7 +1630,12 @@
             }
 
             applyTheme(themeName) {
-                if (!this.themes[themeName]) return;
+                console.log(`StyleTester: Applying theme "${themeName}"`);
+                
+                if (!this.themes[themeName]) {
+                    console.error(`StyleTester: Theme "${themeName}" not found`);
+                    return;
+                }
                 
                 this.currentTheme = themeName;
                 const theme = this.themes[themeName];
@@ -2289,8 +2302,29 @@
             }
         }
 
-        // Initialize the style tester when the page loads
-        let styleTester;
+        // Initialize the style tester immediately and make it globally available
+        let styleTester = null;
+        
+        // Create a proxy object that safely handles method calls
+        window.styleTester = new Proxy({}, {
+            get(target, prop) {
+                if (styleTester && typeof styleTester[prop] === 'function') {
+                    return (...args) => styleTester[prop](...args);
+                } else if (styleTester && styleTester[prop] !== undefined) {
+                    return styleTester[prop];
+                } else {
+                    return (...args) => {
+                        console.warn(`StyleTester not ready or method ${prop} not found. Retrying in 100ms...`);
+                        setTimeout(() => {
+                            if (styleTester && typeof styleTester[prop] === 'function') {
+                                styleTester[prop](...args);
+                            }
+                        }, 100);
+                    };
+                }
+            }
+        });
+        
         document.addEventListener('DOMContentLoaded', () => {
             styleTester = new StyleTester();
         });


### PR DESCRIPTION
Fixes `TypeError: undefined is not an object` in Ultimate Style Tester by ensuring `styleTester` is globally available on page load.

The `styleTester` object was initialized only after `DOMContentLoaded`, but HTML button `onclick` handlers attempted to call its methods immediately upon page load. This created a race condition where the object was not yet defined when accessed, leading to the `TypeError`. The fix uses a Proxy to make `window.styleTester` immediately available, gracefully handling calls before the full object is ready.

---

[Open in Web](https://cursor.com/agents?id=bc-ab5bcc88-ab4e-48ea-96ba-0f84a9203bc7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ab5bcc88-ab4e-48ea-96ba-0f84a9203bc7) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)