### PR TITLE
Adjust hero section layout for desktop

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -447,20 +447,22 @@ body.index-page header.visible {
     position: relative;
     z-index: 1;
     height: 85vh;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
     align-items: center;
 }
 
 .hero-content {
-    text-align: center;
+    text-align: left;
     color: var(--text-inverse);
     position: relative;
+    order: 2;
     padding: 2rem 0;
 }
 
 .hero-logo {
+    order: 1;
     margin-bottom: 0;
     display: flex;
     justify-content: center;
@@ -572,7 +574,8 @@ body.index-page header.visible {
     }
     
     .hero-container {
-        grid-template-columns: 1fr;
+        display: flex;
+        flex-direction: column;
         gap: 1rem;
         padding: 0 2rem;
         text-align: center;


### PR DESCRIPTION
Adjust hero section layout to display title under the image and add vertical spacing.

---

[Open in Web](https://cursor.com/agents?id=bc-b5596dc0-bb5b-471e-815c-faba91cd275a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b5596dc0-bb5b-471e-815c-faba91cd275a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)