### PR TITLE
Update hero padding and dad joke bubble styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -456,12 +456,10 @@ body.index-page header.visible {
     color: var(--text-inverse);
     position: relative;
     order: 1;
-    padding: 0 2rem 3rem 2rem;
 }
 
 @media (min-width: 769px) {
     .hero-content {
-        padding: 0 2rem 3rem 0;
     }
 }
 
@@ -595,13 +593,7 @@ body.index-page header.visible {
     order: 2;
 }
 
-.dad-joke-bubble::before {
-    content: '🐻';
-    position: absolute;
-    top: -15px;
-    left: 25px;
-    font-size: 1.5rem;
-}
+
 
 .dad-joke-bubble::after {
     content: '';
@@ -762,10 +754,6 @@ body.index-page header.visible {
     }
     
     .dad-joke-bubble::before {
-        display: none;
-    }
-    
-    .dad-joke-bubble::after {
         display: none;
     }
     


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor CSS to remove padding from `.hero-content`, delete the `dad-joke-bubble::before` element, and ensure the `dad-joke-bubble::after` element is always visible.

---

[Open in Web](https://cursor.com/agents?id=bc-d6b39a17-266c-4ac1-aac9-6d9447100a7f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d6b39a17-266c-4ac1-aac9-6d9447100a7f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)