### PR TITLE
Remove left from dad joke bubble

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -573,7 +573,6 @@ body.index-page header.visible {
 .dad-joke-bubble {
     position: fixed;
     bottom: 15rem;
-    left: 5%;
     max-width: 320px;
     min-width: 280px;
     background: rgba(255, 255, 255, 0.95);
@@ -615,7 +614,6 @@ body.index-page header.visible {
 @media (max-height: 700px) and (min-width: 769px) {
     .dad-joke-bubble {
         bottom: 8rem;
-        left: 2%;
         max-width: 280px;
         min-width: 240px;
     }
@@ -624,7 +622,6 @@ body.index-page header.visible {
 @media (max-height: 600px) and (min-width: 769px) {
     .dad-joke-bubble {
         bottom: 5rem;
-        left: 2%;
         max-width: 250px;
         min-width: 200px;
         font-size: 0.8rem;
@@ -763,7 +760,6 @@ body.index-page header.visible {
         position: relative;
         top: auto;
         bottom: auto;
-        left: auto;
         right: auto;
         margin: 2rem auto;
         max-width: 90%;

--- a/testing/hero-variations-tester.html
+++ b/testing/hero-variations-tester.html
@@ -259,7 +259,6 @@
         .dad-joke-bubble {
             position: absolute;
             top: 20%;
-            left: 10%;
             max-width: 300px;
             background: rgba(255, 255, 255, 0.95);
             color: #333;
@@ -494,7 +493,6 @@
             .dad-joke-bubble {
                 position: relative;
                 top: auto;
-                left: auto;
                 margin: 2rem auto;
                 max-width: 90%;
             }


### PR DESCRIPTION
Remove `left` property from `.dad-joke-bubble` class definitions.

This change was requested to modify the horizontal positioning of the dad joke bubble, allowing other CSS properties to control its placement.

---

[Open in Web](https://cursor.com/agents?id=bc-fe09381e-bd22-4cb9-a434-9e0c6d4b89d3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-fe09381e-bd22-4cb9-a434-9e0c6d4b89d3) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)