### PR TITLE
Update hero section with viewport height feature

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -906,7 +906,6 @@ body.index-page main {
     color: var(--text-inverse);
     display: flex;
     align-items: center;
-    min-height: 100vh;
 }
 
 


### PR DESCRIPTION
Remove redundant `min-height: 100vh` from `.hero` class to align with `full-viewport-height` dynamic sizing.

The `full-viewport-height` class already provides `height: 100vh` with a `@supports` fallback to `height: 100dvh`, which is the desired behavior for the hero section to account for mobile browser UI changes. The `min-height: 100vh` was a conflicting and unnecessary declaration.

---

[Open in Web](https://cursor.com/agents?id=bc-b048b03a-94e4-4ebb-9ab0-b391a9fee275) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b048b03a-94e4-4ebb-9ab0-b391a9fee275) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)