### PR TITLE
Fix bear event scraper not found error

### DIFF
--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -431,18 +431,22 @@ if (typeof importModule !== 'undefined') {
     // Scriptable environment
     main().catch(console.error);
 } else if (typeof window !== 'undefined' && window.document) {
-    // Web environment - expose functions globally
-    window.BearEventScraper = BearEventScraper;
-    window.runBearEventScraper = main;
-    
-    // Auto-run if page is loaded
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', () => {
+    // Web environment - load modules and expose functions globally
+    loadModules().then(() => {
+        window.BearEventScraper = BearEventScraper;
+        window.runBearEventScraper = main;
+        
+        // Auto-run if page is loaded
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => {
+                console.log('Bear Event Scraper loaded. Call runBearEventScraper() to start.');
+            });
+        } else {
             console.log('Bear Event Scraper loaded. Call runBearEventScraper() to start.');
-        });
-    } else {
-        console.log('Bear Event Scraper loaded. Call runBearEventScraper() to start.');
-    }
+        }
+    }).catch(error => {
+        console.error('Failed to load Bear Event Scraper modules:', error);
+    });
 }
 
 // Export for module systems


### PR DESCRIPTION
Ensure `BearEventScraper` modules are loaded before exposing the class in the web environment.

The `loadModules()` function was not being called in browser environments, leading to the `BearEventScraper` class being exposed to `window` before its internal dependencies were available, causing "Can't find variable" errors. This change ensures modules are loaded asynchronously before the class is made accessible.

---

[Open in Web](https://cursor.com/agents?id=bc-412471d2-fb1e-406b-9375-e96dd266d1b3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-412471d2-fb1e-406b-9375-e96dd266d1b3) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)