### PR TITLE
Update bear parser and fix data fetching

### DIFF
--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -128,10 +128,19 @@ class BearEventScraper {
             console.log(`Processing: ${source.name}`);
             
             try {
+                // Handle multiple URLs per source (use first URL or single URL)
+                const urls = Array.isArray(source.urls) ? source.urls : [source.url || source.urls];
+                const primaryUrl = urls[0];
+                
+                if (!primaryUrl) {
+                    console.error(`  ✗ Error: No URL found for ${source.name}`);
+                    continue;
+                }
+                
                 // 1. Input - Fetch data using the actual InputAdapter
-                console.log(`  → Fetching data from ${source.url}`);
+                console.log(`  → Fetching data from ${primaryUrl}`);
                 const rawData = await this.inputAdapter.fetchData({
-                    url: source.url,
+                    url: primaryUrl,
                     parser: source.parser,
                     timeout: 10000 // 10 second timeout
                 });


### PR DESCRIPTION
Update scraper to correctly read URLs from `urls` array in configuration, fixing "undefined" URL errors.

The scraper was failing because it expected a singular `source.url` property, but the `scraper-input.json` configuration defines URLs as an array `source.urls`. This caused the scraper to attempt fetching data from an `undefined` URL, leading to "Expected value of type string but got value of type undefined" errors. This change ensures the scraper uses the first URL from the `urls` array, while maintaining backward compatibility for a singular `url` property.

---

[Open in Web](https://cursor.com/agents?id=bc-f7cfa44f-d088-4bf6-aa43-41f85e068c33) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f7cfa44f-d088-4bf6-aa43-41f85e068c33) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)