### PR TITLE
Scrape event data with fetch errors

### DIFF
--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -139,7 +139,12 @@ class BearEventScraper {
                 
                 // Create input adapter and fetch data
                 const inputAdapter = InputAdapters.createInputAdapter();
-                const rawData = await inputAdapter.fetchData(source);
+                // Extract first URL from urls array for compatibility
+                const sourceWithUrl = {
+                    ...source,
+                    url: source.urls && source.urls.length > 0 ? source.urls[0] : source.url
+                };
+                const rawData = await inputAdapter.fetchData(sourceWithUrl);
                 
                 // Create event processor and process events
                 const processor = new EventProcessor(this.config);
@@ -151,7 +156,7 @@ class BearEventScraper {
                 // Store source-specific statistics
                 sourceStatistics.push({
                     source: source.name,
-                    url: source.url,
+                    url: sourceWithUrl.url,
                     ...statistics
                 });
                 
@@ -159,7 +164,7 @@ class BearEventScraper {
                     success: true,
                     events: events,
                     source: source.name,
-                    url: source.url,
+                    url: sourceWithUrl.url,
                     statistics: statistics,
                     timestamp: new Date().toISOString()
                 };
@@ -173,11 +178,13 @@ class BearEventScraper {
                 
             } catch (error) {
                 console.error(`❌ ${source.name}: ${error.message}`);
+                // Extract URL for error reporting
+                const errorUrl = source.urls && source.urls.length > 0 ? source.urls[0] : source.url;
                 results.push({
                     success: false,
                     error: error.message,
                     source: source.name,
-                    url: source.url,
+                    url: errorUrl,
                     timestamp: new Date().toISOString()
                 });
             }


### PR DESCRIPTION
Fix scraper to correctly process `urls` arrays from configuration, resolving 'undefined' URL errors.

The `scraper-input.json` defines source URLs as `urls` (an array), but the scraper code expected a singular `source.url`. This led to "Expected value of type string but got value of type undefined" errors during data fetching. This PR extracts the first URL from the `urls` array to ensure compatibility with the `fetchData` method and consistent logging.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecf96996-86ea-4b9a-ab4d-e7e5e7cf2932">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecf96996-86ea-4b9a-ab4d-e7e5e7cf2932">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>