### PR TITLE
Update eventbrite scraper for megawoof

### DIFF
--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -5,9 +5,9 @@
 console.log('bear-event-scraper-unified.js is loading...');
 
 // Import core modules (environment-specific loading)
-let ScriptableInputHandler, WebInputHandler;
-let MegawoofEventParser, BearraccudaEventParser, GenericEventParser;
-let ScriptableDisplayHandler, WebDisplayHandler;
+let ScriptableInputHandler, WebInputHandlerModule;
+let EventbriteEventParser, BearraccudaEventParser, GenericEventParser;
+let ScriptableDisplayHandler, WebDisplayHandlerModule;
 
 async function loadModules() {
     const isScriptable = typeof importModule !== 'undefined';
@@ -22,13 +22,13 @@ async function loadModules() {
             const displayModule = importModule('core/display-handler-scriptable');
             
             // Import event parsers
-            const megawoofModule = importModule('core/event-parser-megawoof');
+            const eventbriteModule = importModule('core/event-parser-eventbrite');
             const bearraccudaModule = importModule('core/event-parser-bearraccuda');
             const genericModule = importModule('core/event-parser-generic');
             
             ScriptableInputHandler = inputModule.ScriptableInputHandler;
             ScriptableDisplayHandler = displayModule.ScriptableDisplayHandler;
-            MegawoofEventParser = megawoofModule.MegawoofEventParser;
+            EventbriteEventParser = eventbriteModule.EventbriteEventParser;
             BearraccudaEventParser = bearraccudaModule.BearraccudaEventParser;
             GenericEventParser = genericModule.GenericEventParser;
             
@@ -42,19 +42,19 @@ async function loadModules() {
         if (typeof window !== 'undefined') {
             console.log('Loading core modules for web environment...');
             
-            WebInputHandler = window.WebInputHandler;
-            WebDisplayHandler = window.WebDisplayHandler;
-            MegawoofEventParser = window.MegawoofEventParser;
+            WebInputHandlerModule = window.WebInputHandler;
+            WebDisplayHandlerModule = window.WebDisplayHandler;
+            EventbriteEventParser = window.EventbriteEventParser;
             BearraccudaEventParser = window.BearraccudaEventParser;
             GenericEventParser = window.GenericEventParser;
             
-            if (WebInputHandler && WebDisplayHandler && MegawoofEventParser && BearraccudaEventParser && GenericEventParser) {
+            if (WebInputHandlerModule && WebDisplayHandlerModule && EventbriteEventParser && BearraccudaEventParser && GenericEventParser) {
                 console.log('✓ Successfully loaded core modules for web');
             } else {
                 const missing = [];
-                if (!WebInputHandler) missing.push('WebInputHandler');
-                if (!WebDisplayHandler) missing.push('WebDisplayHandler');
-                if (!MegawoofEventParser) missing.push('MegawoofEventParser');
+                if (!WebInputHandlerModule) missing.push('WebInputHandler');
+                if (!WebDisplayHandlerModule) missing.push('WebDisplayHandler');
+                if (!EventbriteEventParser) missing.push('EventbriteEventParser');
                 if (!BearraccudaEventParser) missing.push('BearraccudaEventParser');
                 if (!GenericEventParser) missing.push('GenericEventParser');
                 throw new Error(`Core modules not found: ${missing.join(', ')}. Ensure all handler and parser files are loaded via script tags.`);
@@ -108,13 +108,13 @@ class BearEventScraper {
                 this.inputHandler = new ScriptableInputHandler(this.config);
                 this.displayHandler = new ScriptableDisplayHandler(this.config);
             } else {
-                this.inputHandler = new WebInputHandler(this.config);
-                this.displayHandler = new WebDisplayHandler(this.config);
+                this.inputHandler = new WebInputHandlerModule(this.config);
+                this.displayHandler = new WebDisplayHandlerModule(this.config);
             }
             
             // Initialize event parsers
             this.eventParsers = {
-                'megawoof': new MegawoofEventParser(),
+                'eventbrite': new EventbriteEventParser(),
                 'bearraccuda': new BearraccudaEventParser(),
                 'generic': new GenericEventParser()
             };
@@ -649,9 +649,9 @@ if (typeof importModule !== 'undefined') {
     console.log('🌐 Bear Event Scraper loaded for web environment');
     console.log('Available classes:', {
         BearEventScraper: typeof BearEventScraper !== 'undefined',
-        WebInputHandler: typeof WebInputHandler !== 'undefined',
-        WebDisplayHandler: typeof WebDisplayHandler !== 'undefined',
-        MegawoofEventParser: typeof MegawoofEventParser !== 'undefined',
+        WebInputHandler: typeof window.WebInputHandler !== 'undefined',
+        WebDisplayHandler: typeof window.WebDisplayHandler !== 'undefined',
+        EventbriteEventParser: typeof EventbriteEventParser !== 'undefined',
         BearraccudaEventParser: typeof BearraccudaEventParser !== 'undefined',
         GenericEventParser: typeof GenericEventParser !== 'undefined'
     });

--- a/scripts/core/event-parser-eventbrite.js
+++ b/scripts/core/event-parser-eventbrite.js
@@ -1,0 +1,268 @@
+// Event Parser - Eventbrite
+// Specialized parser for Eventbrite event website structure
+// Works with all Eventbrite events, not just Megawoof
+
+class EventbriteEventParser {
+    constructor(config = {}) {
+        this.config = {
+            source: 'Eventbrite',
+            baseUrl: 'https://www.eventbrite.com',
+            ...config
+        };
+        
+        this.bearKeywords = [
+            'megawoof', 'bear', 'bears', 'woof', 'grr', 'furry', 'hairy',
+            'daddy', 'cub', 'otter', 'leather', 'muscle bear', 'bearracuda',
+            'furball', 'leather bears', 'bear night', 'bear party'
+        ];
+    }
+
+    // Parse HTML content from Eventbrite
+    parseEvents(htmlData) {
+        try {
+            console.log(`🐻 Eventbrite: Parsing events from ${htmlData.url}`);
+            
+            const events = [];
+            const html = htmlData.html;
+            
+            if (!html) {
+                console.warn('🐻 Eventbrite: No HTML content to parse');
+                return { events: [], additionalLinks: [], source: this.config.source, url: htmlData.url };
+            }
+            
+            // Create a temporary DOM element to parse HTML
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, 'text/html');
+            
+            // Eventbrite-specific selectors - updated for the provided HTML structure
+            const eventElements = doc.querySelectorAll('.event-card, .Container_root__4i85v, [data-testid="event-card-tracking-layer"], .event-card-link, [class*="event"]');
+            
+            console.log(`🐻 Eventbrite: Found ${eventElements.length} potential event elements`);
+            
+            eventElements.forEach((element, index) => {
+                try {
+                    const event = this.parseEventElement(element, htmlData.url);
+                    if (event && event.title && event.title !== 'Untitled Event') {
+                        // For eventbrite, we consider all events as potentially bear events
+                        // but still run the bear check for proper classification
+                        event.isBearEvent = this.isBearEvent(event);
+                        events.push(event);
+                    }
+                } catch (error) {
+                    console.warn(`🐻 Eventbrite: Failed to parse event ${index}:`, error);
+                }
+            });
+            
+            // Also look for additional event links
+            const additionalLinks = this.extractAdditionalLinks(doc, htmlData.url);
+            
+            console.log(`🐻 Eventbrite: Found ${events.length} events, ${additionalLinks.length} additional links`);
+            
+            return {
+                events,
+                additionalLinks,
+                source: this.config.source,
+                url: htmlData.url
+            };
+            
+        } catch (error) {
+            console.error('🐻 Eventbrite: Error parsing events:', error);
+            return { events: [], additionalLinks: [], source: this.config.source, url: htmlData.url };
+        }
+    }
+
+    parseEventElement(element, sourceUrl) {
+        const event = {
+            source: this.config.source,
+            url: sourceUrl,
+            timestamp: new Date().toISOString()
+        };
+
+        // Extract title - Eventbrite specific selectors
+        const titleElement = element.querySelector('h3, .Typography_body-lg__487rx, .event-card__clamp-line--two, [aria-label*="View"], [class*="title"]');
+        if (titleElement) {
+            event.title = titleElement.textContent.trim();
+        } else {
+            // Try to get title from aria-label if available
+            const linkElement = element.querySelector('a[aria-label]');
+            if (linkElement) {
+                const ariaLabel = linkElement.getAttribute('aria-label');
+                if (ariaLabel && ariaLabel.startsWith('View ')) {
+                    event.title = ariaLabel.replace('View ', '').trim();
+                }
+            }
+        }
+
+        // Extract date/time - Eventbrite specific
+        const dateElement = element.querySelector('.Typography_body-md__487rx, [class*="date"], time, p');
+        if (dateElement) {
+            const dateText = dateElement.textContent.trim();
+            // Look for date patterns like "Sat, Aug 23 • 9:00 PM"
+            if (dateText.match(/\w+,\s+\w+\s+\d+|\d{1,2}\/\d{1,2}\/\d{4}|\d{4}-\d{2}-\d{2}/)) {
+                event.dateString = dateText;
+                event.date = this.parseDate(dateText);
+            }
+        }
+
+        // Extract venue/location - Eventbrite specific
+        const venueElements = element.querySelectorAll('.Typography_body-md__487rx');
+        if (venueElements.length > 1) {
+            // Usually the second Typography_body-md element is the venue
+            event.venue = venueElements[1].textContent.trim();
+        }
+
+        // Extract price
+        const priceElement = element.querySelector('.Typography_body-md-bold__487rx, [class*="price"]');
+        if (priceElement) {
+            event.price = priceElement.textContent.trim();
+        }
+
+        // Extract event URL - This is crucial for Eventbrite
+        const linkElement = element.querySelector('a[href*="eventbrite.com/e/"]') || 
+                          element.querySelector('a[data-event-id]') ||
+                          element.closest('a[href*="eventbrite.com/e/"]');
+        
+        if (linkElement) {
+            let href = linkElement.getAttribute('href');
+            if (href) {
+                // Clean up the URL - remove query parameters that aren't needed
+                if (href.includes('?')) {
+                    href = href.split('?')[0];
+                }
+                
+                if (href.startsWith('http')) {
+                    event.eventUrl = href;
+                } else if (href.startsWith('/')) {
+                    event.eventUrl = `https://www.eventbrite.com${href}`;
+                } else {
+                    event.eventUrl = `https://www.eventbrite.com/${href}`;
+                }
+            }
+        }
+
+        // Extract city from venue, URL, or other indicators
+        event.city = this.extractCity(event.venue + ' ' + (event.description || '') + ' ' + sourceUrl);
+
+        // Extract description from various possible elements
+        const descElement = element.querySelector('.event-description, .summary, p:not([class*="Typography"])');
+        event.description = descElement ? descElement.textContent.trim() : '';
+
+        return event;
+    }
+
+    parseDate(dateString) {
+        if (!dateString) return null;
+        
+        try {
+            // Clean up the date string
+            let cleanDateString = dateString.replace(/[^\w\s:,-]/g, ' ').trim();
+            
+            // Handle Eventbrite date formats like "Sat, Aug 23 • 9:00 PM"
+            if (cleanDateString.includes('•')) {
+                cleanDateString = cleanDateString.replace('•', '').trim();
+            }
+            
+            // Try to parse various date formats
+            const patterns = [
+                /(\w{3}),?\s+(\w{3})\s+(\d{1,2})\s+(\d{1,2}:\d{2}\s*(AM|PM)?)/i, // "Sat, Aug 23 9:00 PM"
+                /(\w+)\s+(\d{1,2}),?\s+(\d{4})/i, // "January 15, 2024"
+                /(\d{1,2})\/(\d{1,2})\/(\d{4})/,   // "01/15/2024"
+                /(\d{4})-(\d{1,2})-(\d{1,2})/,    // "2024-01-15"
+            ];
+            
+            // For Eventbrite dates without year, assume current or next year
+            if (cleanDateString.match(/\w{3},?\s+\w{3}\s+\d{1,2}/i) && !cleanDateString.match(/\d{4}/)) {
+                const currentYear = new Date().getFullYear();
+                cleanDateString += ` ${currentYear}`;
+            }
+            
+            const parsed = new Date(cleanDateString);
+            if (!isNaN(parsed.getTime())) {
+                return parsed.toISOString();
+            }
+            
+            // If that fails, try with a more aggressive cleanup
+            const fallbackString = dateString.replace(/[^\w\s:]/g, ' ').replace(/\s+/g, ' ').trim();
+            const fallbackParsed = new Date(fallbackString);
+            return !isNaN(fallbackParsed.getTime()) ? fallbackParsed.toISOString() : null;
+            
+        } catch (error) {
+            console.warn(`🐻 Eventbrite: Failed to parse date "${dateString}":`, error);
+            return null;
+        }
+    }
+
+    extractCity(text) {
+        const cityPatterns = {
+            'nyc': /new york|nyc|manhattan|brooklyn|queens|bronx/i,
+            'sf': /san francisco|sf|bay area/i,
+            'la': /los angeles|la|hollywood|west hollywood/i,
+            'chicago': /chicago/i,
+            'seattle': /seattle/i,
+            'dc': /washington|dc|district of columbia/i,
+            'boston': /boston/i,
+            'atlanta': /atlanta/i,
+            'miami': /miami|south beach/i,
+            'dallas': /dallas/i,
+            'denver': /denver/i,
+            'portland': /portland/i,
+            'philadelphia': /philadelphia|philly/i,
+            'phoenix': /phoenix/i,
+            'austin': /austin/i,
+            'vegas': /las vegas|vegas/i
+        };
+
+        for (const [city, pattern] of Object.entries(cityPatterns)) {
+            if (pattern.test(text)) {
+                return city;
+            }
+        }
+        
+        return 'unknown';
+    }
+
+    isBearEvent(event) {
+        const searchText = `${event.title} ${event.description || ''} ${event.venue || ''}`.toLowerCase();
+        return this.bearKeywords.some(keyword => searchText.includes(keyword.toLowerCase()));
+    }
+
+    extractAdditionalLinks(doc, baseUrl) {
+        const links = [];
+        
+        // Look for eventbrite event links specifically
+        const linkElements = doc.querySelectorAll('a[href*="eventbrite.com/e/"]');
+        
+        linkElements.forEach(link => {
+            const href = link.getAttribute('href');
+            if (href) {
+                try {
+                    let fullUrl = href.startsWith('http') ? href : new URL(href, baseUrl).href;
+                    
+                    // Clean up URL - remove query parameters except event ID
+                    if (fullUrl.includes('?')) {
+                        const [baseEventUrl] = fullUrl.split('?');
+                        fullUrl = baseEventUrl;
+                    }
+                    
+                    if (!links.includes(fullUrl)) {
+                        links.push(fullUrl);
+                    }
+                } catch (error) {
+                    console.warn(`🐻 Eventbrite: Invalid link found: ${href}`);
+                }
+            }
+        });
+        
+        return links.slice(0, 20); // Limit to 20 additional links per page
+    }
+}
+
+// Export for both environments
+if (typeof window !== 'undefined') {
+    window.EventbriteEventParser = EventbriteEventParser;
+} else if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { EventbriteEventParser };
+} else {
+    // Scriptable environment
+    this.EventbriteEventParser = EventbriteEventParser;
+}

--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -6,44 +6,8 @@
   },
   "parsers": [
     {
-      "name": "Furball NYC",
-      "parser": "furball",
-      "urls": [
-        "https://www.furball.nyc",
-        "https://www.furball.nyc/ticket-information",
-        "https://www.furball.nyc/upcoming-schedule"
-      ],
-      "city": "nyc",
-      "alwaysBear": true,
-      "description": "Joe Fiore's infamous furry dance parties across multiple cities"
-    },
-    {
-      "name": "Rockbar NYC",
-      "parser": "rockbar",
-      "urls": ["https://www.rockbarnyc.com/calendar"],
-      "city": "nyc",
-      "requireDetailPages": true,
-      "maxAdditionalUrls": 8,
-      "allowlist": ["rockstrap", "underbear", "bears night out", "leather night", "bear happy hour", "woof"],
-      "requireKeywords": true,
-      "description": "NYC leather/bear bar with regular themed nights",
-      "urlFilters": {
-        "exclude": ["\\?", "#", "facebook\\.com", "instagram\\.com"]
-      }
-    },
-    {
-      "name": "Bearracuda",
-      "parser": "bearracuda",
-      "urls": ["https://bearracuda.com/#events"],
-      "city": "multi",
-      "alwaysBear": true,
-      "requireDetailPages": true,
-      "urlExtractionMethod": "parser-specific",
-      "description": "Multi-city bear dance parties and events"
-    },
-    {
       "name": "Megawoof America",
-      "parser": "megawoof",
+      "parser": "eventbrite",
       "urls": ["https://www.eventbrite.com/o/megawoof-america-18118978189"],
       "city": "multi",
       "alwaysBear": true,
@@ -53,39 +17,6 @@
       "urlFilters": {
         "include": ["eventbrite\\.com\\/e\\/"]
       }
-    },
-    {
-      "name": "SF Eagle",
-      "parser": "sf-eagle",
-      "urls": ["https://sf-eagle.com/events/"],
-      "city": "sf",
-      "requireDetailPages": true,
-      "maxAdditionalUrls": 12,
-      "allowlist": ["bear", "cub", "otter", "leather bears"],
-      "requireKeywords": true,
-      "description": "San Francisco's legendary leather/bear bar"
-    },
-    {
-      "name": "Eagle NY",
-      "parser": "eagle-ny",
-      "urls": ["https://www.eagle-ny.com/events/"],
-      "city": "nyc",
-      "requireDetailPages": true,
-      "maxAdditionalUrls": 10,
-      "allowlist": ["bear", "cub", "otter", "woof", "furball"],
-      "requireKeywords": true,
-      "description": "New York's Eagle Bar events and parties"
-    },
-    {
-      "name": "Precinct DTLA",
-      "parser": "precinct",
-      "urls": ["https://www.precinctdtla.com/events/"],
-      "city": "la",
-      "requireDetailPages": true,
-      "maxAdditionalUrls": 8,
-      "allowlist": ["bear", "cub", "bearracuda", "woof"],
-      "requireKeywords": true,
-      "description": "Los Angeles downtown leather/bear venue"
     }
   ],
   "calendarMappings": {

--- a/testing/test-eventbrite-parser.html
+++ b/testing/test-eventbrite-parser.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Eventbrite Parser Test</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        
+        .header {
+            background: #333;
+            color: white;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+        
+        .test-section {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        
+        .sample-html {
+            background: #f8f8f8;
+            border: 1px solid #ddd;
+            padding: 15px;
+            border-radius: 4px;
+            font-family: monospace;
+            font-size: 12px;
+            max-height: 300px;
+            overflow-y: auto;
+            margin-bottom: 20px;
+        }
+        
+        .results {
+            background: #e8f5e8;
+            border: 1px solid #4caf50;
+            padding: 15px;
+            border-radius: 4px;
+            margin-top: 20px;
+        }
+        
+        .error {
+            background: #ffebee;
+            border: 1px solid #f44336;
+            color: #c62828;
+        }
+        
+        button {
+            background: #007cba;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 16px;
+            margin: 10px 10px 10px 0;
+        }
+        
+        button:hover {
+            background: #005a87;
+        }
+        
+        .event-details {
+            background: #f0f0f0;
+            padding: 10px;
+            margin: 10px 0;
+            border-radius: 4px;
+        }
+        
+        .event-link {
+            color: #007cba;
+            text-decoration: none;
+            font-weight: bold;
+        }
+        
+        .event-link:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>🎫 Eventbrite Parser Test</h1>
+        <p>Test the new EventbriteEventParser with the provided HTML sample</p>
+    </div>
+    
+    <div class="test-section">
+        <h3>Sample HTML (Megawoof Event from Eventbrite)</h3>
+        <div class="sample-html" id="sampleHtml">
+            <!-- The sample HTML will be inserted here -->
+        </div>
+        
+        <button onclick="testParser()">Test Eventbrite Parser</button>
+        <button onclick="clearResults()">Clear Results</button>
+        
+        <div id="results"></div>
+    </div>
+    
+    <!-- Load the eventbrite parser -->
+    <script src="../scripts/core/event-parser-eventbrite.js"></script>
+    
+    <script>
+        // The provided HTML sample
+        const sampleHtml = `<div class="Container_root__4i85v NestedActionContainer_root__1jtfr event-card event-card__vertical" style="--ContainerBgColor: #fff; --ContainerBorderRadius: 16px; --ContainerElevationFocusWithin: 0px 2px 8px rgba(30, 10, 60, 0.06), 0px 4px 12px rgba(30, 10, 60, 0.08); --ContainerElevationHover: 0px 2px 8px rgba(30, 10, 60, 0.06), 0px 4px 12px rgba(30, 10, 60, 0.08);"><div data-testid="event-card-tracking-layer" style="position: absolute; top: 0px; left: 0px; height: 100%; pointer-events: none; width: 100%;"></div><a href="https://www.eventbrite.com/e/megawoof-america-denver-massive-2-parties-1-ticket-tickets-1381219547849?aff=ebdsoporgprofile" rel="noopener" target="_blank" class="event-card-link " aria-label="View MEGAWOOF AMERICA DENVER  : MASSIVE 2 Parties 1 Ticket" data-event-id="1381219547849" data-event-paid-status="paid" data-event-location="Denver, CO" data-event-category="community"><div class="event-card-image__aspect-container" data-testid="event-card-image-container" style="--image-aspect-ratio: 2; --image-aspect-ratio-mobile: 2; --image-width: 100%; --image-width-mobile: 100%; --image-background-color: #231d1b;"><img height="256" width="512" class="event-card-image" src="https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1042921273%2F185013722403%2F1%2Foriginal.20250531-143913?crop=focalpoint&amp;fit=crop&amp;auto=format%2Ccompress&amp;q=75&amp;sharp=10&amp;fp-x=0.005&amp;fp-y=0.005&amp;s=b37e8fdbdbd0f2e9cf130e8f23f20acf" loading="eager" alt="MEGAWOOF AMERICA DENVER  : MASSIVE 2 Parties 1 Ticket primary image" fetchpriority="high"></div></a><section class="event-card-details" style="--EventCardDetailsPadding: 16px 8px 12px 12px; --EventCardDetailsFlexGrow: 2; --EventCardDetailsPosition: relative;"><div class="Stack_root__1ksk7" style="--Space: 4px;"><h3 class="Typography_root__487rx #3a3247 Typography_body-lg__487rx event-card__clamp-line--two Typography_align-match-parent__487rx" style="--TypographyColor: #3a3247;">MEGAWOOF AMERICA DENVER  : MASSIVE 2 Parties 1 Ticket</h3><p class="Typography_root__487rx #585163 Typography_body-md__487rx event-card__clamp-line--one Typography_align-match-parent__487rx" style="--TypographyColor: #585163;">Sat, Aug 23 •  9:00 PM </p><p class="Typography_root__487rx #585163 Typography_body-md__487rx event-card__clamp-line--one Typography_align-match-parent__487rx" style="--TypographyColor: #585163;">Trade</p><p class="Typography_root__487rx #3a3247 Typography_body-md-bold__487rx Typography_align-match-parent__487rx" style="--TypographyColor: #3a3247;">From $16.84</p><section class="event-card-actions" data-event-id="1381219547849" data-event-paid-status="paid" style="--EventCardActionsPosition: absolute; --EventCardActionsTop: -22px; --EventCardActionsRight: 8px; --EventCardActionsGap: 8px;" data-event-location="Denver, CO" data-event-category="community"><span class="eds-icon-button eds-icon-button--outline" data-spec="icon-button"><button data-event-id="1381219547849" class="eds-btn--button eds-btn--none eds-btn--icon-only" type="button" aria-pressed="false"><i class="eds-vector-image eds-icon--small eds-vector-image--grey-700 eds-vector-image--block" title="" data-spec="icon" data-testid="icon"><svg id="heart-chunky_svg__eds-icon--user-chunky_svg" x="0" y="0" viewBox="0 0 24 24" xml:space="preserve"><path id="heart-chunky_svg__eds-icon--heart-chunky_base" fill-rule="evenodd" clip-rule="evenodd" d="M18.8 6.2C18.1 5.4 17 5 16 5c-1 0-2 .4-2.8 1.2L12 7.4l-1.2-1.2C10 5.4 9 5 8 5c-1 0-2 .4-2.8 1.2-1.5 1.6-1.5 4.2 0 5.8l6.8 7 6.8-7c1.6-1.6 1.6-4.2 0-5.8zm-1.4 4.4L12 16.1l-5.4-5.5c-.8-.8-.8-2.2 0-3C7 7.2 7.5 7 8 7c.5 0 1 .2 1.4.6l2.6 2.7 2.7-2.7c.3-.4.8-.6 1.3-.6s1 .2 1.4.6c.8.8.8 2.2 0 3z"></path></svg><span class="eds-is-hidden-accessible">Save this event: MEGAWOOF AMERICA DENVER  : MASSIVE 2 Parties 1 Ticket</span></i></button></span><span class="eds-icon-button eds-icon-button--outline" data-spec="icon-button"><button class="eds-btn--button eds-btn--none eds-btn--icon-only" type="button"><i class="eds-vector-image eds-icon--small eds-vector-image--block" title="" data-spec="icon" data-testid="icon"><svg id="share-ios-chunky_svg__eds-icon--share-ios-chunky_svg" x="0" y="0" viewBox="0 0 24 24" xml:space="preserve"><path id="share-ios-chunky_svg__eds-icon--share-ios-chunky_base" fill-rule="evenodd" clip-rule="evenodd" d="M18 16v2H6v-2H4v4h16v-4z"></path><path id="share-ios-chunky_svg__eds-icon--share-ios-chunky_arrow" fill-rule="evenodd" clip-rule="evenodd" d="M12 4L7 9l1.4 1.4L11 7.8V16h2V7.8l2.6 2.6L17 9l-5-5z"></path></svg><span class="eds-is-hidden-accessible">Share this event: MEGAWOOF AMERICA DENVER  : MASSIVE 2 Parties 1 Ticket</span></i></button></span></section></div></section></div>`;
+        
+        // Display the sample HTML
+        document.getElementById('sampleHtml').textContent = sampleHtml;
+        
+        function testParser() {
+            const resultsDiv = document.getElementById('results');
+            resultsDiv.innerHTML = '<p>Testing parser...</p>';
+            
+            try {
+                // Check if EventbriteEventParser is loaded
+                if (typeof EventbriteEventParser === 'undefined') {
+                    throw new Error('EventbriteEventParser is not loaded');
+                }
+                
+                // Create parser instance
+                const parser = new EventbriteEventParser();
+                
+                // Create mock HTML data
+                const htmlData = {
+                    html: sampleHtml,
+                    url: 'https://www.eventbrite.com/o/megawoof-america-18118978189'
+                };
+                
+                // Parse the events
+                const result = parser.parseEvents(htmlData);
+                
+                // Display results
+                let resultHtml = '<div class="results"><h4>✅ Parser Test Results</h4>';
+                
+                if (result.events && result.events.length > 0) {
+                    const event = result.events[0];
+                    resultHtml += `
+                        <div class="event-details">
+                            <h5>📅 Parsed Event:</h5>
+                            <p><strong>Title:</strong> ${event.title || 'N/A'}</p>
+                            <p><strong>Date:</strong> ${event.dateString || 'N/A'}</p>
+                            <p><strong>Venue:</strong> ${event.venue || 'N/A'}</p>
+                            <p><strong>City:</strong> ${event.city || 'N/A'}</p>
+                            <p><strong>Price:</strong> ${event.price || 'N/A'}</p>
+                            <p><strong>Is Bear Event:</strong> ${event.isBearEvent ? '🐻 Yes' : '❌ No'}</p>
+                            <p><strong>Event URL:</strong> ${event.eventUrl ? `<a href="${event.eventUrl}" target="_blank" class="event-link">${event.eventUrl}</a>` : 'N/A'}</p>
+                        </div>
+                    `;
+                    
+                    // Check if the expected URL is extracted
+                    const expectedUrl = 'https://www.eventbrite.com/e/megawoof-america-denver-massive-2-parties-1-ticket-tickets-1381219547849';
+                    if (event.eventUrl && event.eventUrl.includes('1381219547849')) {
+                        resultHtml += '<p style="color: green; font-weight: bold;">✅ SUCCESS: Correct event URL extracted!</p>';
+                    } else {
+                        resultHtml += '<p style="color: red; font-weight: bold;">❌ ISSUE: Expected URL not found or incorrect</p>';
+                        resultHtml += `<p>Expected URL pattern: ${expectedUrl}</p>`;
+                    }
+                } else {
+                    resultHtml += '<p style="color: red;">❌ No events parsed from the HTML sample</p>';
+                }
+                
+                resultHtml += `
+                    <p><strong>Additional Links Found:</strong> ${result.additionalLinks ? result.additionalLinks.length : 0}</p>
+                    <p><strong>Source:</strong> ${result.source}</p>
+                </div>`;
+                
+                resultsDiv.innerHTML = resultHtml;
+                
+            } catch (error) {
+                resultsDiv.innerHTML = `<div class="results error">
+                    <h4>❌ Parser Test Failed</h4>
+                    <p><strong>Error:</strong> ${error.message}</p>
+                    <p><strong>Stack:</strong> ${error.stack}</p>
+                </div>`;
+            }
+        }
+        
+        function clearResults() {
+            document.getElementById('results').innerHTML = '';
+        }
+        
+        // Auto-run test when page loads
+        document.addEventListener('DOMContentLoaded', function() {
+            console.log('Eventbrite Parser Test Ready');
+            testParser(); // Auto-run the test
+        });
+    </script>
+</body>
+</html>

--- a/testing/test-unified-scraper.html
+++ b/testing/test-unified-scraper.html
@@ -186,13 +186,7 @@
             Source:
             <select id="sourceSelect">
                 <option value="all">All Sources</option>
-                <option value="furball">Furball NYC</option>
-                <option value="rockbar">Rockbar NYC</option>
-                <option value="bearracuda">Bearracuda</option>
-                <option value="megawoof">Megawoof America</option>
-                <option value="sf-eagle">SF Eagle</option>
-                <option value="eagle-ny">Eagle NY</option>
-                <option value="precinct">Precinct DTLA</option>
+                <option value="eventbrite">Eventbrite (Megawoof America)</option>
             </select>
         </label>
         
@@ -231,7 +225,7 @@
     <!-- New modular architecture -->
     <script src="../scripts/core/input-handler-web.js" onerror="console.error('Failed to load input-handler-web.js')"></script>
     <script src="../scripts/core/display-handler-web.js" onerror="console.error('Failed to load display-handler-web.js')"></script>
-    <script src="../scripts/core/event-parser-megawoof.js" onerror="console.error('Failed to load event-parser-megawoof.js')"></script>
+    <script src="../scripts/core/event-parser-eventbrite.js" onerror="console.error('Failed to load event-parser-eventbrite.js')"></script>
     <script src="../scripts/core/event-parser-bearraccuda.js" onerror="console.error('Failed to load event-parser-bearraccuda.js')"></script>
     <script src="../scripts/core/event-parser-generic.js" onerror="console.error('Failed to load event-parser-generic.js')"></script>
     <script src="../scripts/bear-event-scraper-unified.js" onerror="console.error('Failed to load bear-event-scraper-unified.js')"></script>
@@ -466,7 +460,7 @@
             const moduleStatus = {
                 WebInputHandler: typeof WebInputHandler !== 'undefined',
                 WebDisplayHandler: typeof WebDisplayHandler !== 'undefined',
-                MegawoofEventParser: typeof MegawoofEventParser !== 'undefined',
+                EventbriteEventParser: typeof EventbriteEventParser !== 'undefined',
                 BearraccudaEventParser: typeof BearraccudaEventParser !== 'undefined',
                 GenericEventParser: typeof GenericEventParser !== 'undefined',
                 BearEventScraper: typeof BearEventScraper !== 'undefined'


### PR DESCRIPTION
Refactor event scraper to fix module declaration errors and generalize the Megawoof parser to handle all Eventbrite events.

The `Uncaught SyntaxError: Identifier 'WebInputHandler' has already been declared` error was due to a naming conflict between a `let` declaration in `bear-event-scraper-unified.js` and a global `window.WebInputHandler` property. This PR renames the internal module references to avoid this conflict. Additionally, the Megawoof parser has been refactored into a more generic `EventbriteEventParser` to support all Eventbrite events, as requested, and the scraper input configuration has been updated to focus solely on Eventbrite.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc05d6de-3fc4-4481-b9dc-1837eff539ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc05d6de-3fc4-4481-b9dc-1837eff539ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>