### PR TITLE
Update event scraper for naming and city parsing

### DIFF
--- a/scripts/core/event-parser-eventbrite.js
+++ b/scripts/core/event-parser-eventbrite.js
@@ -536,6 +536,23 @@ class EventbriteEventParser {
         if (metadata.overrideTitle && metadata.title) {
             console.log(`🐻 Eventbrite: Overriding title "${event.title}" with "${metadata.title}"`);
             event.originalTitle = event.title; // Preserve original title
+            
+            // Extract city from original title for calendar association
+            const cityMatch = event.title.match(/(?:MEGAWOOF\s+AMERICA\s*-?\s*)?([A-Z\s]+?)(?:\s*[-:]|$)/i);
+            if (cityMatch) {
+                const extractedCity = cityMatch[1].trim().replace(/\s+/g, ' ');
+                // Clean up common patterns
+                const cleanCity = extractedCity
+                    .replace(/^(MEGAWOOF\s+AMERICA\s*-?\s*)/i, '')
+                    .replace(/\s*(MASSIVE|LABOR\s+DAY|BEAR\s+WATCHERS).*$/i, '')
+                    .trim();
+                
+                if (cleanCity && cleanCity.length > 0 && cleanCity !== 'AMERICA') {
+                    event.city = cleanCity;
+                    console.log(`🐻 Eventbrite: Extracted city "${cleanCity}" from title`);
+                }
+            }
+            
             event.title = metadata.title;
         }
         
@@ -1053,7 +1070,7 @@ class EventbriteEventParser {
                                 address: address,
                                 coordinates: coordinates,
                                 googleMapsLink: googleMapsLink,
-                                description: eventData.summary || '',
+                                // description removed to avoid mapping to real event description
                                 source: this.config.source,
                                 timestamp: new Date().toISOString(),
                                 isPlaceholder: false,
@@ -1103,7 +1120,7 @@ class EventbriteEventParser {
                                         url: item.url,
                                         date: item.startDate,
                                         location: item.location ? item.location.name : null,
-                                        description: item.description || '',
+                                        // description removed to avoid mapping to real event description
                                         source: this.config.source,
                                         timestamp: new Date().toISOString(),
                                         isPlaceholder: false,
@@ -1122,7 +1139,7 @@ class EventbriteEventParser {
                                 url: jsonData.url,
                                 date: jsonData.startDate,
                                 location: jsonData.location ? jsonData.location.name : null,
-                                description: jsonData.description || '',
+                                // description removed to avoid mapping to real event description
                                 source: this.config.source,
                                 timestamp: new Date().toISOString(),
                                 isPlaceholder: false,
@@ -1142,7 +1159,7 @@ class EventbriteEventParser {
                                         url: item.url,
                                         date: item.startDate,
                                         location: item.location ? item.location.name : null,
-                                        description: item.description || '',
+                                        // description removed to avoid mapping to real event description
                                         source: this.config.source,
                                         timestamp: new Date().toISOString(),
                                         isPlaceholder: false,

--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -15,7 +15,7 @@
         "include": ["eventbrite\\.com\\/e\\/"]
       },
       "metadata": {
-        "title": "MEGAWOOF",
+        "title": "Megawoof",
         "shortTitle": "MEGA-WOOF",
         "instagram": "https://www.instagram.com/megawoof_america",
         "overrideTitle": true


### PR DESCRIPTION
Override Eventbrite event titles to 'Megawoof', remove descriptions, and extract cities from original titles.

---
<a href="https://cursor.com/background-agent?bcId=bc-86a1a063-5a44-4db3-a64c-7e22a8a2f1d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86a1a063-5a44-4db3-a64c-7e22a8a2f1d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>