### PR TITLE
Update eventbrite address parsing logic

### DIFF
--- a/scripts/core/event-parser-eventbrite.js
+++ b/scripts/core/event-parser-eventbrite.js
@@ -493,6 +493,12 @@ class EventbriteEventParser {
         const descElement = element.querySelector('.event-description, .summary, p:not([class*="Typography"])');
         event.description = descElement ? descElement.textContent.trim() : '';
 
+        // Transfer _potentialAddress to main address field if we have one
+        if (event._potentialAddress && !event.address) {
+            event.address = event._potentialAddress;
+            console.log(`🐻 Eventbrite: Transferred potential address to main address field: "${event.address}"`);
+        }
+
         // Apply source-specific metadata if configured
         if (this.config.metadata) {
             this.applyMetadata(event, this.config.metadata);

--- a/testing/test-eventbrite-address-fix.html
+++ b/testing/test-eventbrite-address-fix.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>🐻 Test Eventbrite Address Parsing Fix</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        
+        .header {
+            background: #333;
+            color: white;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+        
+        .test-section {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        
+        .result {
+            background: #f8f9fa;
+            border: 1px solid #dee2e6;
+            padding: 15px;
+            border-radius: 4px;
+            margin-top: 10px;
+            white-space: pre-wrap;
+            font-family: monospace;
+        }
+        
+        .success {
+            border-color: #28a745;
+            background: #d4edda;
+        }
+        
+        .error {
+            border-color: #dc3545;
+            background: #f8d7da;
+        }
+        
+        button {
+            background: #007cba;
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin: 10px 0;
+        }
+        
+        button:hover {
+            background: #0056b3;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>🐻 Test Eventbrite Address Parsing Fix</h1>
+        <p>This page tests the fix for properly separating venue names from addresses in Eventbrite events.</p>
+    </div>
+
+    <div class="test-section">
+        <h2>Test Case: TBA + DTLA Los Angeles Address</h2>
+        <p>Testing the scenario described in the issue where venue and address are on separate lines:</p>
+        <ul>
+            <li><strong>Line 1:</strong> TBA (venue name)</li>
+            <li><strong>Line 2:</strong> DTLA Los Angeles, CA 90013 (address)</li>
+        </ul>
+        
+        <button onclick="runAddressParsingTest()">Run Address Parsing Test</button>
+        <div id="test-result" class="result"></div>
+    </div>
+
+    <div class="test-section">
+        <h2>Test Megawoof Event URL</h2>
+        <p>Test the actual Megawoof event mentioned in the issue:</p>
+        <p><strong>URL:</strong> <a href="https://www.eventbrite.com/e/megawoof-america-denver-massive-2-parties-1-ticket-tickets-1381219547849" target="_blank">Megawoof America Denver Event</a></p>
+        
+        <button onclick="testMegawoofEvent()">Test Megawoof Event Parsing</button>
+        <div id="megawoof-result" class="result"></div>
+    </div>
+
+    <script src="../scripts/core/event-parser-eventbrite.js"></script>
+    <script>
+        // Mock DOM element for testing
+        function createMockElement(venueText) {
+            return {
+                querySelectorAll: (selector) => {
+                    if (selector === '.Typography_body-md__487rx') {
+                        return [
+                            { textContent: 'Event Title' },
+                            { textContent: venueText }
+                        ];
+                    }
+                    return [];
+                },
+                querySelector: () => null,
+                textContent: 'Mock Event',
+                getAttribute: () => null
+            };
+        }
+
+        function runAddressParsingTest() {
+            const resultDiv = document.getElementById('test-result');
+            resultDiv.textContent = 'Running test...';
+            
+            try {
+                // Create parser instance
+                const parser = new EventbriteEventParser();
+                
+                // Create mock element with TBA + address on separate lines
+                const mockElement = createMockElement('TBA\nDTLA Los Angeles, CA 90013');
+                
+                // Parse the event
+                const event = parser.parseEventElement(mockElement, 'https://test.com');
+                
+                // Check results
+                const results = {
+                    venue: event.venue,
+                    potentialAddress: event._potentialAddress,
+                    address: event.address,
+                    city: event.city,
+                    location: event.location
+                };
+                
+                let success = true;
+                let issues = [];
+                
+                // Validate results
+                if (event.venue !== 'TBA') {
+                    success = false;
+                    issues.push(`Expected venue 'TBA', got '${event.venue}'`);
+                }
+                
+                if (event._potentialAddress !== 'DTLA Los Angeles, CA 90013') {
+                    success = false;
+                    issues.push(`Expected _potentialAddress 'DTLA Los Angeles, CA 90013', got '${event._potentialAddress}'`);
+                }
+                
+                if (event.address !== 'DTLA Los Angeles, CA 90013') {
+                    success = false;
+                    issues.push(`Expected address 'DTLA Los Angeles, CA 90013', got '${event.address}'`);
+                }
+                
+                if (event.city !== 'la' && event.city !== 'denver') {
+                    success = false;
+                    issues.push(`Expected city 'la' or 'denver', got '${event.city}'`);
+                }
+                
+                // Display results
+                let output = 'TEST RESULTS:\n\n';
+                output += JSON.stringify(results, null, 2);
+                
+                if (success) {
+                    output += '\n\n✅ TEST PASSED: Address parsing is working correctly!';
+                    resultDiv.className = 'result success';
+                } else {
+                    output += '\n\n❌ TEST FAILED:\n' + issues.join('\n');
+                    resultDiv.className = 'result error';
+                }
+                
+                resultDiv.textContent = output;
+                
+            } catch (error) {
+                resultDiv.className = 'result error';
+                resultDiv.textContent = `❌ TEST ERROR: ${error.message}\n\nStack trace:\n${error.stack}`;
+            }
+        }
+
+        function testMegawoofEvent() {
+            const resultDiv = document.getElementById('megawoof-result');
+            resultDiv.textContent = 'This test requires fetching the actual Eventbrite page, which cannot be done from this static test page due to CORS restrictions.\n\nTo test the Megawoof event:\n1. Use the unified scraper test page\n2. Or run the scraper script directly\n3. Check the console logs for address parsing messages';
+            resultDiv.className = 'result';
+        }
+
+        // Auto-run the test when page loads
+        window.addEventListener('load', () => {
+            console.log('🐻 Test page loaded. Click "Run Address Parsing Test" to test the fix.');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Transfer `_potentialAddress` to `event.address` in Eventbrite parser to fix city extraction.

The Eventbrite scraper correctly identified venue and address when separated by newlines (e.g., "TBA" and "DTLA Los Angeles, CA 90013"). However, the extracted address was stored in `_potentialAddress` but not propagated to `event.address`, leading to "No city found" errors because the city extraction logic relied on `event.address`. This PR ensures the address is correctly assigned.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c491cf9-ccfa-42c6-9dee-b3afef470d79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c491cf9-ccfa-42c6-9dee-b3afef470d79">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>