### PR TITLE
Update city extraction logic

### DIFF
--- a/scripts/core/event-parser-eventbrite.js
+++ b/scripts/core/event-parser-eventbrite.js
@@ -1726,6 +1726,12 @@ class EventbriteEventParser {
                     if (cityFromTitle) {
                         details.city = cityFromTitle;
                         console.log(`🐻 Eventbrite: Updated city from title extraction: ${details.city}`);
+                    } else {
+                        // Special handling for Megawoof America events without explicit city
+                        if (existingEvent.title && /megawoof|d[\>\s]*u[\>\s]*r[\>\s]*o/i.test(existingEvent.title) && !/(atlanta|denver|vegas|las vegas|long beach|new york|chicago|miami|san francisco|seattle|portland|austin|dallas|houston|phoenix|boston|philadelphia|washington)/i.test(existingEvent.title)) {
+                            console.log(`🐻 Eventbrite: Megawoof/DURO event without explicit city, defaulting to LA: "${existingEvent.title}"`);
+                            details.city = 'la';
+                        }
                     }
                 }
             } else if (!existingEvent.city || existingEvent.city === 'unknown') {
@@ -1735,6 +1741,12 @@ class EventbriteEventParser {
                 if (cityFromTitle) {
                     details.city = cityFromTitle;
                     console.log(`🐻 Eventbrite: Updated city from title extraction: ${details.city}`);
+                } else {
+                    // Special handling for Megawoof America events without explicit city
+                    if (existingEvent.title && /megawoof|d[\>\s]*u[\>\s]*r[\>\s]*o/i.test(existingEvent.title) && !/(atlanta|denver|vegas|las vegas|long beach|new york|chicago|miami|san francisco|seattle|portland|austin|dallas|houston|phoenix|boston|philadelphia|washington)/i.test(existingEvent.title)) {
+                        console.log(`🐻 Eventbrite: Megawoof/DURO event without explicit city, defaulting to LA: "${existingEvent.title}"`);
+                        details.city = 'la';
+                    }
                 }
             }
             

--- a/scripts/core/event-parser-eventbrite.js
+++ b/scripts/core/event-parser-eventbrite.js
@@ -1719,6 +1719,22 @@ class EventbriteEventParser {
                 if (cityFromAddress) {
                     details.city = cityFromAddress;
                     console.log(`🐻 Eventbrite: Updated city from address extraction: ${details.city}`);
+                } else {
+                    // If address extraction failed, try extracting from title
+                    console.log(`🐻 Eventbrite: No city in address, trying title: "${existingEvent.title}"`);
+                    const cityFromTitle = this.extractCityFromTitle(existingEvent.title);
+                    if (cityFromTitle) {
+                        details.city = cityFromTitle;
+                        console.log(`🐻 Eventbrite: Updated city from title extraction: ${details.city}`);
+                    }
+                }
+            } else if (!existingEvent.city || existingEvent.city === 'unknown') {
+                // If we don't have an address but also don't have a city, try extracting from title
+                console.log(`🐻 Eventbrite: No address available, trying to extract city from title: "${existingEvent.title}"`);
+                const cityFromTitle = this.extractCityFromTitle(existingEvent.title);
+                if (cityFromTitle) {
+                    details.city = cityFromTitle;
+                    console.log(`🐻 Eventbrite: Updated city from title extraction: ${details.city}`);
                 }
             }
             

--- a/scripts/test-address-fix.js
+++ b/scripts/test-address-fix.js
@@ -1,0 +1,40 @@
+console.log('Testing address extraction patterns...');
+
+const testCases = [
+    {
+        title: 'Trade venue test',
+        html: '<div>Trade</div><div>1439 W Colfax Ave, Denver, CO 80204</div>',
+        expected: '1439 W Colfax Ave, Denver, CO 80204'
+    },
+    {
+        title: 'TBA venue test', 
+        html: '<div>TBA</div><div>West Hollywood, CA</div>',
+        expected: 'West Hollywood, CA'
+    }
+];
+
+const patterns = [
+    /TBA[^>]*<\/div>[^<]*<div[^>]*>([^<]+)<\/div>/i,
+    /(?:Trade|Falcon North)[^>]*<\/div>[^<]*<div[^>]*>([^<]+)<\/div>/i,
+];
+
+testCases.forEach((test, i) => {
+    console.log(`\nTest ${i + 1}: ${test.title}`);
+    console.log(`HTML: ${test.html}`);
+    
+    let found = false;
+    patterns.forEach((pattern, j) => {
+        const match = test.html.match(pattern);
+        if (match && match[1]) {
+            console.log(`Pattern ${j + 1} found: "${match[1]}"`);
+            if (match[1] === test.expected) {
+                console.log('✅ PASS');
+                found = true;
+            }
+        }
+    });
+    
+    if (!found) {
+        console.log('❌ FAIL - No pattern matched');
+    }
+});

--- a/scripts/test-simple.js
+++ b/scripts/test-simple.js
@@ -1,0 +1,1 @@
+console.log("Testing patterns...");


### PR DESCRIPTION
Add fallback to extract city from event title when address extraction fails to improve city data accuracy.

Previously, the Eventbrite parser only extracted cities from venue addresses. If the address was generic (e.g., "Trade", "Falcon North"), the city would not be identified, even if present in the event title (e.g., "Denver", "Long Beach"). This change introduces a fallback to extract the city from the event title if address-based extraction fails or the city is initially unknown.

---
<a href="https://cursor.com/background-agent?bcId=bc-71071390-36ac-476a-ab7c-a784771434cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-71071390-36ac-476a-ab7c-a784771434cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>