### PR TITLE
Update event processing and handle duplicates

### DIFF
--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -17,7 +17,7 @@
         "include": ["eventbrite\\.com\\/e\\/"]
       },
       "metadata": {
-        "title": "Megawoof",
+        "title": "MEGAWOOF",
         "shortTitle": "MEGA-WOOF",
         "instagram": "https://www.instagram.com/megawoof_america",
         "overrideTitle": true


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Apply metadata overrides and improve duplicate detection for Megawoof events.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, hardcoded titles from `scraper-input.json` were not applied, and variations of "Megawoof" and "DURO" events were not recognized as duplicates. This PR ensures consistent branding and accurate deduplication by applying overrides early in the processing pipeline and normalizing event titles for key generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c95dd1d-b5c7-4a11-86eb-dbf58ac9073b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c95dd1d-b5c7-4a11-86eb-dbf58ac9073b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>