### PR TITLE
Update main and fix scriptable module loading

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1656,5 +1656,12 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
     }
 }
 
-// Export for Scriptable environment
-module.exports = { ScriptableAdapter };
+// Export for both environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { ScriptableAdapter };
+} else if (typeof window !== 'undefined') {
+    window.ScriptableAdapter = ScriptableAdapter;
+} else {
+    // Scriptable environment
+    this.ScriptableAdapter = ScriptableAdapter;
+}


### PR DESCRIPTION
Update `scriptable-adapter.js` export pattern to fix module loading errors in Scriptable.

The `TypeError: undefined is not an object (evaluating 'importModule('adapters/scriptable-adapter')')` occurred because `scriptable-adapter.js` was only exporting its class using `module.exports`, which is a Node.js pattern. Scriptable environments require a different export mechanism (`this.ScriptableAdapter = ScriptableAdapter;`). The change ensures the `ScriptableAdapter` class is properly exposed for `importModule` calls in Scriptable.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9a16297-fda9-4b0d-8105-11bd706312e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9a16297-fda9-4b0d-8105-11bd706312e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>