### PR TITLE
Changes from background agent bc-acd70118-60a2-44e6-a48d-2ad9f30da61f

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -35,7 +35,7 @@ Static website for gay bear travel guide with city guides, events, and bear-owne
 ├── scripts/            # Scriptable automation scripts
 │   ├── README.md       # Scripts documentation
 │   ├── scriptable-complete-api.md # Complete Scriptable API reference (54 classes)
-│   ├── bear-event-scraper-v*.js   # Bear event scraping scripts
+│   ├── bear-event-scraper-unified.js # Unified bear event scraper
 │   └── scraper-config.json        # Scraper configuration
 ├── testing/            # Test files and utilities
 │   ├── index.html      # Dynamic test file browser
@@ -188,7 +188,7 @@ logger.error('COMPONENT', 'error message', optionalData);
 - **Debugging issues**: Check console logs, filter by component, review error messages
 - **Performance optimization**: Use logger.time/timeEnd for timing analysis
 - **Scriptable development**: Reference `scripts/scriptable-complete-api.md` for API usage
-- **Event scraper updates**: Modify bear-event-scraper-v*.js files in scripts/ folder
+- **Event scraper updates**: Modify bear-event-scraper-unified.js and related modules in scripts/ folder
 
 ## IMPORTANT RESTRICTIONS
 - **NEVER create new *.md files** - no documentation, summaries, or guides

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -937,18 +937,27 @@ class SharedCore {
         // === PARSED PROPERTIES (used by calendar-core.js) ===
         
         // Add bar/venue name first if available
-        if ((event.venue || event.bar) && shouldIncludeField('venue') && shouldIncludeField('bar')) {
-            notes.push(`Bar: ${event.venue || event.bar}`);
+        if (event.venue || event.bar) {
+            // Include if either venue OR bar is not preserved
+            if ((event.venue && shouldIncludeField('venue')) || (event.bar && shouldIncludeField('bar'))) {
+                notes.push(`Bar: ${event.venue || event.bar}`);
+            }
         }
         
         // Add description/tea in key-value format
-        if (shouldIncludeField('description') && ((event.description && event.description.trim()) || (event.tea && event.tea.trim()))) {
-            notes.push(`Description: ${event.description || event.tea}`);
+        if ((event.description && event.description.trim()) || (event.tea && event.tea.trim())) {
+            // Include if either description OR tea is not preserved
+            if ((event.description && shouldIncludeField('description')) || (event.tea && shouldIncludeField('tea'))) {
+                notes.push(`Description: ${event.description || event.tea}`);
+            }
         }
         
         // Add price/cover
-        if ((event.price || event.cover) && shouldIncludeField('price') && shouldIncludeField('cover')) {
-            notes.push(`Price: ${event.price || event.cover}`);
+        if (event.price || event.cover) {
+            // Include if either price OR cover is not preserved
+            if ((event.price && shouldIncludeField('price')) || (event.cover && shouldIncludeField('cover'))) {
+                notes.push(`Price: ${event.price || event.cover}`);
+            }
         }
         
         // Add event type
@@ -985,13 +994,19 @@ class SharedCore {
         }
         
         // Add website URL - prefer event.website, fallback to event.url
-        if ((event.website || event.url) && shouldIncludeField('website') && shouldIncludeField('url')) {
-            notes.push(`Website: ${event.website || event.url}`);
+        if (event.website || event.url) {
+            // Include if either website OR url is not preserved
+            if ((event.website && shouldIncludeField('website')) || (event.url && shouldIncludeField('url'))) {
+                notes.push(`Website: ${event.website || event.url}`);
+            }
         }
         
         // Handle both gmaps and googleMapsLink fields
-        if ((event.gmaps || event.googleMapsLink) && shouldIncludeField('gmaps') && shouldIncludeField('googleMapsLink')) {
-            notes.push(`Gmaps: ${event.gmaps || event.googleMapsLink}`);
+        if (event.gmaps || event.googleMapsLink) {
+            // Include if either gmaps OR googleMapsLink is not preserved
+            if ((event.gmaps && shouldIncludeField('gmaps')) || (event.googleMapsLink && shouldIncludeField('googleMapsLink'))) {
+                notes.push(`Gmaps: ${event.gmaps || event.googleMapsLink}`);
+            }
         }
         
         // === DEBUG PROPERTIES (not parsed by calendar-core.js) ===


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Improve event merge logic and description preservation, and update `.cursorrules` to reflect current scraper architecture.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, events that should have been merged (e.g., MEGAWOOF/DURO conflicts) were incorrectly flagged as `CONFLICT` due to incomplete merge detection in `analyzeEventForCalendar`. Additionally, the `formatEventNotes` function was not respecting the `"merge": "preserve"` strategy for event descriptions, leading to unwanted overwrites or redundant additions in the notes field.

---
<a href="https://cursor.com/background-agent?bcId=bc-acd70118-60a2-44e6-a48d-2ad9f30da61f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-acd70118-60a2-44e6-a48d-2ad9f30da61f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>