### PR TITLE
Fix event display and merge issues

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1669,9 +1669,9 @@ class ScriptableAdapter {
                         <table style="width: 100%; font-size: 12px; border-collapse: collapse; table-layout: fixed;">
                             <tr>
                                 <th style="text-align: left; padding: 5px; border-bottom: 1px solid #ddd; width: 20%;">Field</th>
-                                <th style="text-align: left; padding: 5px; border-bottom: 1px solid #ddd; width: 30%;">New Event</th>
-                                <th style="text-align: center; padding: 5px; border-bottom: 1px solid #ddd; width: 10%;">→</th>
                                 <th style="text-align: left; padding: 5px; border-bottom: 1px solid #ddd; width: 30%;">Existing Event</th>
+                                <th style="text-align: center; padding: 5px; border-bottom: 1px solid #ddd; width: 10%;">Flow</th>
+                                <th style="text-align: left; padding: 5px; border-bottom: 1px solid #ddd; width: 30%;">New Event</th>
                                 <th style="text-align: left; padding: 5px; border-bottom: 1px solid #ddd; width: 10%;">Result</th>
                             </tr>
                             ${this.generateComparisonRows(event)}
@@ -2189,13 +2189,18 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
         const rows = [];
         
         fieldsToCompare.forEach(field => {
-            const newValue = event._original.new[field] || '';
-            const existingValue = event._original.existing?.[field] || '';
+            let newValue = event._original.new[field] || '';
+            let existingValue = event._original.existing?.[field] || '';
             const finalValue = event[field] || '';
             const strategy = event._fieldMergeStrategies?.[field] || 'preserve';
             const wasUsed = event._mergeInfo?.mergedFields?.[field];
             
-            // Skip if both are empty
+            // Check if this field was extracted from existing event's notes
+            if (!existingValue && event._mergeInfo?.extractedFields?.[field]) {
+                existingValue = event._mergeInfo.extractedFields[field].value;
+            }
+            
+            // Skip if both are empty and no final value
             if (!newValue && !existingValue && !finalValue) return;
             
             // Format values for display
@@ -2248,13 +2253,13 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
                         <br><small style="color: #666;">${strategy}</small>
                     </td>
                     <td style="padding: 5px; border-bottom: 1px solid #eee; word-break: break-word; max-width: 150px;">
-                        ${formatValue(newValue)}
+                        ${formatValue(existingValue)}
                     </td>
                     <td style="padding: 5px; border-bottom: 1px solid #eee; text-align: center; font-size: 16px; color: #007aff;">
                         ${flowIcon}
                     </td>
                     <td style="padding: 5px; border-bottom: 1px solid #eee; word-break: break-word; max-width: 150px;">
-                        ${formatValue(existingValue)}
+                        ${formatValue(newValue)}
                     </td>
                     <td style="padding: 5px; border-bottom: 1px solid #eee; text-align: center;">
                         ${resultText}
@@ -2274,12 +2279,17 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
         let html = '<div style="font-family: monospace; font-size: 12px; background: #f8f8f8; padding: 10px; border-radius: 5px;">';
         
         fieldsToCompare.forEach(field => {
-            const newValue = event._original.new[field] || '';
-            const existingValue = event._original.existing?.[field] || '';
+            let newValue = event._original.new[field] || '';
+            let existingValue = event._original.existing?.[field] || '';
             const finalValue = event[field] || '';
             const strategy = event._fieldMergeStrategies?.[field] || 'preserve';
             
-            // Skip if both are empty
+            // Check if this field was extracted from existing event's notes
+            if (!existingValue && event._mergeInfo?.extractedFields?.[field]) {
+                existingValue = event._mergeInfo.extractedFields[field].value;
+            }
+            
+            // Skip if both are empty and no final value
             if (!newValue && !existingValue && !finalValue) return;
             
             // Format dates

--- a/testing/manifest.json
+++ b/testing/manifest.json
@@ -1,70 +1,70 @@
 {
-  "generated": "2025-08-03T15:42:34.196Z",
+  "generated": "2025-08-04T03:26:33.886Z",
   "files": [
     {
       "name": "breakpoint-test.html",
       "size": 34162,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.297Z"
     },
     {
       "name": "hero-variations-tester.html",
       "size": 26248,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.297Z"
     },
     {
       "name": "iframe-fix-test.html",
       "size": 9922,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.297Z"
     },
     {
       "name": "index.html",
       "size": 18216,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.301Z"
     },
     {
       "name": "style-test.html",
       "size": 26360,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.301Z"
     },
     {
       "name": "test-calendar-logging.html",
       "size": 68099,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.301Z"
     },
     {
       "name": "test-display-modes.html",
       "size": 10729,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.301Z"
     },
     {
       "name": "test-error-logging-fix.html",
       "size": 6806,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.301Z"
     },
     {
       "name": "test-eventbrite-address-fix.html",
       "size": 7179,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.301Z"
     },
     {
       "name": "test-google-sheets-loader.html",
       "size": 40540,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.301Z"
     },
     {
       "name": "test-map-icons.html",
       "size": 61258,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.301Z"
     },
     {
       "name": "test-unified-scraper.html",
       "size": 32064,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.301Z"
     },
     {
       "name": "ultimate-style-tester.html",
       "size": 116287,
-      "modified": "2025-08-03T14:28:47.919Z"
+      "modified": "2025-08-04T03:23:24.301Z"
     }
   ]
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Corrects the merge display table by fixing arrow direction and showing extracted fields like 'tea' and 'instagram'.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The merge display table's column headers and data flow were misaligned, showing "New Event → Existing Event" when the logical flow was the reverse. Additionally, fields extracted from the existing event's notes (e.g., `tea`, `instagram`) were not displayed in the comparison table or line diff because the rendering logic did not account for values stored in `_mergeInfo.extractedFields`. This update ensures accurate visual representation of merge conflicts and extracted data.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d3ea07a-795c-4c74-bafa-2de24827fa95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d3ea07a-795c-4c74-bafa-2de24827fa95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>