### PR TITLE
Simplify applyMetadataOverrides script

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -198,12 +198,8 @@ class SharedCore {
 
         await displayAdapter.logInfo(`SYSTEM: Total events collected: ${allEvents.length}`);
 
-        // Apply metadata overrides if configured
-        if (parserConfig.metadata && parserConfig.metadata.overrideTitle) {
-            await displayAdapter.logInfo('SYSTEM: Applying metadata overrides...');
-            this.applyMetadataOverrides(allEvents, parserConfig.metadata);
-            await displayAdapter.logInfo(`SYSTEM: Applied metadata overrides to ${allEvents.length} events`);
-        }
+        // Note: Metadata is now applied dynamically by parsers using the {value, merge} format
+        // The applyMetadataOverrides method is deprecated but kept for backward compatibility
 
         // Filter and process events
         await displayAdapter.logInfo('SYSTEM: Filtering future events...');
@@ -281,35 +277,19 @@ class SharedCore {
         }
     }
 
-    // Apply metadata overrides to events (for hardcoded titles, etc.)
+    // DEPRECATED: This method uses the old hardcoded approach for metadata overrides
+    // Modern parsers now handle metadata dynamically using the {value, merge} format
+    // Kept for backward compatibility only - consider removing in future versions
     applyMetadataOverrides(events, metadata) {
-        if (!metadata || !events) return;
-        
-        events.forEach(event => {
-            // Store original title for debugging if we're overriding
-            if (metadata.overrideTitle && metadata.title && event.title !== metadata.title) {
-                event.originalTitle = event.title;
-                event.title = metadata.title;
-                console.log(`🔄 SharedCore: Override title applied - Original: "${event.originalTitle}" → New: "${event.title}"`);
-            }
-            
-            // Apply short title if provided
-            if (metadata.shortTitle) {
-                event.shortTitle = metadata.shortTitle;
-            }
-            
-            // Apply other metadata properties
-            if (metadata.instagram) {
-                event.instagram = metadata.instagram;
-            }
-            
-            // Add any other metadata properties that might be useful
-            Object.keys(metadata).forEach(key => {
-                if (!['overrideTitle', 'title', 'shortTitle'].includes(key)) {
-                    event[key] = metadata[key];
-                }
-            });
-        });
+        // This method is deprecated. Metadata is now applied by parsers using the dynamic approach.
+        // The new format in scraper-input.json is:
+        // "metadata": {
+        //   "fieldName": {
+        //     "value": "field value",
+        //     "merge": "clobber|upsert|preserve"
+        //   }
+        // }
+        console.log('⚠️ SharedCore: applyMetadataOverrides is deprecated. Metadata should be applied by parsers.');
     }
 
     // Pure utility functions


### PR DESCRIPTION
Deprecate and simplify `applyMetadataOverrides` as metadata is now handled dynamically by parsers.

The `applyMetadataOverrides` method previously applied hardcoded metadata fields (e.g., `title`, `shortTitle`). This functionality is now redundant because parsers (e.g., `eventbrite-parser.js`) dynamically apply metadata using a `{value, merge}` format, making the old method unnecessary. The method is kept for backward compatibility with a deprecation warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f18a90b-a436-4c22-8bc2-3a22c085bc56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f18a90b-a436-4c22-8bc2-3a22c085bc56">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>