### PR TITLE
Update code and remove legacy merge

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -342,7 +342,7 @@ class SharedCore {
             } else {
                 // Merge with existing event if needed
                 const existing = seen.get(key);
-                const merged = this.mergeEvents(existing, event);
+                const merged = this.mergeEventData(existing, event);
                 merged.key = key; // Ensure merged event has the key
                 seen.set(key, merged);
                 
@@ -582,12 +582,6 @@ class SharedCore {
         }
         
         return lines.join('\n');
-    }
-
-    // Merge events using field-level merge strategies
-    mergeEvents(existing, newEvent) {
-        // Always use the comprehensive merge with field strategies
-        return this.mergeEventData(existing, newEvent);
     }
 
     // Helper method to normalize event dates for consistent comparison across timezones

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -584,22 +584,10 @@ class SharedCore {
         return lines.join('\n');
     }
 
-    // Simple merge for backward compatibility
+    // Merge events using field-level merge strategies
     mergeEvents(existing, newEvent) {
-        // Use the new comprehensive merge if we have merge strategies
-        if (newEvent._fieldMergeStrategies) {
-            return this.mergeEventData(existing, newEvent);
-        }
-        
-        // Otherwise fall back to simple merge
-        return {
-            ...existing,
-            description: existing.description || newEvent.description,
-            url: existing.url || newEvent.url,
-            image: existing.image || newEvent.image,
-            price: existing.price || newEvent.price,
-            // Keep the most complete event data
-        };
+        // Always use the comprehensive merge with field strategies
+        return this.mergeEventData(existing, newEvent);
     }
 
     // Helper method to normalize event dates for consistent comparison across timezones


### PR DESCRIPTION
Remove unused legacy merge logic from `mergeEvents` to simplify the codebase.

The `mergeEvents` method previously contained a fallback "legacy merge" path. However, all event parsers now consistently set `_fieldMergeStrategies`, ensuring that the more comprehensive `mergeEventData` method is always used. This change removes the dead code, making the method cleaner and more maintainable without affecting functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d52277a-4afa-40a6-bee9-493e0766d6a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d52277a-4afa-40a6-bee9-493e0766d6a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

