### PR TITLE
Update map link generation for incomplete addresses

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -731,6 +731,23 @@ class SharedCore {
         const cleanAddress = address.trim();
         if (cleanAddress.length < 10) return false; // Too short to be a full address
         
+        // Check for TBA or similar placeholder values
+        if (/^(TBA|TBD|To Be Announced|To Be Determined)$/i.test(cleanAddress)) {
+            return false;
+        }
+        
+        // Check for partial addresses that are just area/neighborhood + city + zip
+        // Examples: "DTLA Los Angeles, CA 90013", "Downtown Denver, CO 80202"
+        const partialAddressPatterns = [
+            /^(DTLA|Downtown|Midtown|Uptown|North|South|East|West|Central)\s+[A-Za-z\s]+,\s*[A-Z]{2}\s*\d{5}$/i,
+            /^[A-Za-z\s]+\s+(District|Area|Zone|Neighborhood)\s*,?\s*[A-Za-z\s]+,\s*[A-Z]{2}\s*\d{5}$/i
+        ];
+        
+        // If it matches a partial address pattern, it's not a full address
+        if (partialAddressPatterns.some(pattern => pattern.test(cleanAddress))) {
+            return false;
+        }
+        
         // Check for common full address patterns
         const fullAddressPatterns = [
             /\d+\s+\w+.*street|st|avenue|ave|road|rd|drive|dr|boulevard|blvd|lane|ln|way|place|pl|court|ct/i,


### PR DESCRIPTION
Update `isFullAddress` to prevent Google Maps links for 'TBA' and partial addresses.

This change ensures that Google Maps links are not generated for events with placeholder addresses (e.g., "TBA") or incomplete addresses that only specify an area/neighborhood (e.g., "DTLA Los Angeles, CA 90013") without a specific street number and name.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7f164fe-8481-43a2-8571-05f3a31e9ec5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7f164fe-8481-43a2-8571-05f3a31e9ec5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

