### PR TITLE
Investigate and update analyzeEventActions fields

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1129,6 +1129,11 @@ class SharedCore {
             };
             analyzedEvent._action = analysis.action;
             
+            // If action is conflict and we have a specific conflict type, use that as the action
+            if (analysis.action === 'conflict' && analysis.conflictType) {
+                analyzedEvent._action = analysis.conflictType;
+            }
+            
             // Handle merge action by performing the merge here
             if (analysis.action === 'merge' && analysis.existingEvent) {
                 // Perform the merge and store the result
@@ -1203,7 +1208,12 @@ class SharedCore {
         for (const event of newEvents) {
             const analysis = this.analyzeEventAction(event, existingEventsData);
             
-            switch (analysis.action) {
+            // Use the specific conflict type as the action if available
+            const actionType = (analysis.action === 'conflict' && analysis.conflictType) 
+                ? analysis.conflictType 
+                : analysis.action;
+            
+            switch (actionType) {
                 case 'new':
                     actions.newEvents.push({ event, analysis });
                     break;
@@ -1214,6 +1224,8 @@ class SharedCore {
                     actions.mergeEvents.push({ event, analysis });
                     break;
                 case 'conflict':
+                case 'key_conflict':
+                case 'time_conflict':
                     actions.conflictEvents.push({ event, analysis });
                     break;
             }


### PR DESCRIPTION
Update event action handling to correctly display specific conflict types.

Previously, `key_conflict` and `time_conflict` were stored as `conflictType` but the UI expected them as `_action`, leading to incorrect display. This change ensures the UI displays the correct badge for these specific conflict types.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5f48d16-3fa3-4663-8879-1323c4569ce2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5f48d16-3fa3-4663-8879-1323c4569ce2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

