### PR TITLE
Merge megawoof event data

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1137,6 +1137,12 @@ class SharedCore {
                 analyzedEvent._mergedUrl = mergedData.url;
                 analyzedEvent._existingEvent = analysis.existingEvent;
                 
+                // Store original data for comparison display
+                analyzedEvent._original = {
+                    new: { ...event },
+                    existing: analysis.existingEvent
+                };
+                
                 // Calculate merge diff for display purposes
                 const originalFields = this.parseNotesIntoFields(analysis.existingEvent.notes || '');
                 const mergedFields = this.parseNotesIntoFields(mergedData.notes);


### PR DESCRIPTION
Restore merge diff table display by setting `_original` property for merge events.

The merge diff table in the scriptable output relies on the `_original` property, which was not being set for events categorized as 'merge'. This fix ensures that property is present, allowing the comparison table to render correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a8bb645-d7c4-45f7-a425-9e395edfe0ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a8bb645-d7c4-45f7-a425-9e395edfe0ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

