### PR TITLE
Update enrichEventLocation to prefer address

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -703,15 +703,13 @@ class SharedCore {
             event.city = this.extractCityFromEvent(event);
         }
         
-        // Add Google Maps link only for full addresses
+        // Add Google Maps link - prefer address over coordinates
         if (event.address && this.isFullAddress(event.address)) {
-            if (event.coordinates && event.coordinates.lat && event.coordinates.lng) {
-                // Use coordinates if available
-                event.googleMapsLink = `https://maps.google.com/?q=${event.coordinates.lat},${event.coordinates.lng}`;
-            } else {
-                // Use address
-                event.googleMapsLink = `https://maps.google.com/?q=${encodeURIComponent(event.address)}`;
-            }
+            // Use address when available and it's a full address
+            event.googleMapsLink = `https://maps.google.com/?q=${encodeURIComponent(event.address)}`;
+        } else if (event.coordinates && event.coordinates.lat && event.coordinates.lng) {
+            // Fall back to coordinates if no full address
+            event.googleMapsLink = `https://maps.google.com/?q=${event.coordinates.lat},${event.coordinates.lng}`;
         }
         
         return event;


### PR DESCRIPTION
Prioritize address for event location links and display venue names as clickable links in the calendar UI.

This change ensures that Google Maps links for events use a full address when available for better accuracy, falling back to coordinates otherwise. Additionally, venue names are now prominently displayed and clickable in both the main calendar view and the day events modal, providing direct access to Google Maps for the location.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae8e8262-4070-4545-af49-560b99672b0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae8e8262-4070-4545-af49-560b99672b0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

