### PR TITLE
Update event with main and cursorrules

### DIFF
--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -18,10 +18,6 @@
         "include": ["eventbrite\\.com\\/e\\/"]
       },
       "metadata": {
-        "title": {
-          "value": "MEGAWOOF",
-          "merge": "clobber"
-        },
         "shortTitle": {
           "value": "MEGA-WOOF",
           "merge": "upsert"


### PR DESCRIPTION
Remove hardcoded title override for Megawoof events to enable proper merging with existing calendar entries.

The scraper configuration was forcing all events from the "Megawoof America" parser to have the title "MEGAWOOF". This prevented the system's merge logic from correctly identifying and merging new events (like "D>U>R>O! SUMMER — NIGHT FOAM EDITION") with existing, related calendar entries (like "Megawoof: DURO"), leading to duplicate or conflicting events instead of updates. Removing this override allows the original event titles to be used, enabling correct merge behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf725236-e665-4d37-bc4d-494736549e03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf725236-e665-4d37-bc4d-494736549e03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

