### PR TITLE
Update from main and process cursor rules

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2711,6 +2711,10 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
                 // Replaced with new value
                 flowIcon = '→';
                 resultText = '<span style="color: #ff9500;">NEW</span>';
+            } else if (finalValue === existingValue && existingValue !== newValue) {
+                // Preserved existing value when values differ
+                flowIcon = '←';
+                resultText = '<span style="color: #007aff;">EXISTING</span>';
             } else if (finalValue && finalValue !== existingValue && finalValue !== newValue) {
                 // Merged/combined value
                 flowIcon = '↔';


### PR DESCRIPTION
Fixes incorrect 'NO CHANGE' display when existing value is preserved over a different new value.

The previous logic in `scriptable-adapter.js` would incorrectly display "NO CHANGE" when the merge strategy was "preserve" and the existing value was kept, even if the existing and new values were actually different. This was due to the comparison falling through to a default 'else' case. This PR adds a specific condition to correctly show 'EXISTING' with a left arrow in such scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4742c2b-c113-4125-b1ec-fc0380f504fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4742c2b-c113-4125-b1ec-fc0380f504fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

