### PR TITLE
Update event data and fix json copy buttons

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1051,23 +1051,8 @@ class SharedCore {
     // Format event notes with all metadata in key-value format
     formatEventNotes(event) {
         const notes = [];
-        const fieldStrategies = event._fieldMergeStrategies || {};
         
-        // Helper function to check if a field should be included
-        const shouldIncludeField = (fieldName) => {
-            // For new events, include all fields
-            if (event._action === 'new') {
-                return true;
-            }
-            
-            // For merged events, include all fields that have values
-            // The merge logic has already applied the strategies to determine 
-            // which values to use (existing vs new), so we just need to include
-            // any field that has a value in the merged event
-            return true;
-        };
-        
-        // Fields to exclude from notes
+        // Fields to exclude from notes (core calendar fields and internal metadata)
         const excludeFields = new Set([
             'title', 'startDate', 'endDate', 'location', 'address', 'coordinates',
             'isBearEvent', 'source', 'city', 'setDescription', '_analysis', '_action', 
@@ -1076,15 +1061,13 @@ class SharedCore {
             'originalTitle', 'name' // These are usually duplicates of title
         ]);
         
-        // Add all fields that have values
+        // Add all fields that have values (merge logic has already determined correct values)
         Object.keys(event).forEach(fieldName => {
             if (!excludeFields.has(fieldName) && 
                 event[fieldName] !== undefined && 
                 event[fieldName] !== null && 
                 event[fieldName] !== '') {
-                if (shouldIncludeField(fieldName)) {
-                    notes.push(`${fieldName}: ${event[fieldName]}`);
-                }
+                notes.push(`${fieldName}: ${event[fieldName]}`);
             }
         });
         

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1055,9 +1055,16 @@ class SharedCore {
         
         // Helper function to check if a field should be included
         const shouldIncludeField = (fieldName) => {
-            const strategy = fieldStrategies[fieldName];
-            // Only include if not "preserve" or if it's a new event
-            return strategy !== 'preserve' || event._action === 'new';
+            // For new events, include all fields
+            if (event._action === 'new') {
+                return true;
+            }
+            
+            // For merged events, include all fields that have values
+            // The merge logic has already applied the strategies to determine 
+            // which values to use (existing vs new), so we just need to include
+            // any field that has a value in the merged event
+            return true;
         };
         
         // Fields to exclude from notes


### PR DESCRIPTION
Enhances event notes merging to include all relevant fields and adds robust clipboard functionality for JSON copy buttons.

Previously, the event merging logic only considered fields parsed from existing notes for updates, leading to new event object properties (e.g., `googleMapsLink`, `shortTitle`) not being correctly incorporated into the final `notes` string, despite defined merge strategies. This PR ensures these fields are now properly merged. Additionally, the JSON copy buttons were unreliable due to `navigator.clipboard` limitations in some environments; a fallback mechanism has been added for improved compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-e50cb348-9f7e-4f1f-bc95-8b05b2e41d43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e50cb348-9f7e-4f1f-bc95-8b05b2e41d43">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

