### PR TITLE
Sync and display merged calendar events

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2071,10 +2071,10 @@ class ScriptableAdapter {
                         <span><a href="${this.escapeHtml(event.url)}" target="_blank" rel="noopener" style="color: #007aff;">Event Link</a></span>
                     </div>
                 ` : ''}
-                ${event.gmaps || event.googleMapsLink ? `
+                ${event.googleMapsLink ? `
                     <div class="event-detail">
                         <span>🗺️</span>
-                        <span><a href="${this.escapeHtml(event.gmaps || event.googleMapsLink)}" target="_blank" rel="noopener" style="color: #007aff;">Google Maps</a></span>
+                        <span><a href="${this.escapeHtml(event.googleMapsLink)}" target="_blank" rel="noopener" style="color: #007aff;">Google Maps</a></span>
                     </div>
                 ` : ''}
                 ${event.price ? `
@@ -2706,25 +2706,6 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
                 allFields.add(field);
             }
         });
-        
-        // Deduplicate synonyms in favor of canonical keys
-        const has = (key) => allFields.has(key);
-        const remove = (keys) => keys.forEach(k => allFields.delete(k));
-        
-        // Description
-        if (has('description')) remove(['tea', 'info']);
-        
-        // Venue/location
-        if (has('venue')) remove(['location', 'bar', 'host']);
-        
-        // Price
-        if (has('price')) remove(['cover', 'cost']);
-        
-        // Short title/name variants
-        if (has('shortTitle')) remove(['shorttitle', 'shortname', 'shortername', 'short title', 'short name', 'shorter name']);
-        
-        // Google Maps link variants
-        if (has('googleMapsLink')) remove(['gmaps', 'googlemaps', 'googlemapslink', 'google maps']);
         
         // Convert to array and sort with logical grouping
         const fieldArray = Array.from(allFields);

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2093,14 +2093,11 @@ class ScriptableAdapter {
                                 // Parse and format notes for better readability
                                 const lines = notes.split('\n');
                                 let formattedHtml = '';
-                                let seenBlank = false;
                                 
                                 lines.forEach(line => {
                                     const trimmed = line.trim();
                                     if (trimmed === '') {
-                                        // Treat first blank line as a simple separator
                                         formattedHtml += '<br>';
-                                        seenBlank = true;
                                         return;
                                     }
                                     

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2214,15 +2214,6 @@ class ScriptableAdapter {
             })() : ''}
             
             <!-- Simplified metadata -->
-            ${event.key || event.source ? `
-                <div class="event-metadata" style="margin-top: 10px; font-size: 11px; color: #666;">
-                    ${event.source ? `<span>Source: ${event.source}</span>` : ''}
-                    ${event.key ? `<span style="margin-left: 10px;">Key: ${this.escapeHtml(event.key)}</span>` : ''}
-                </div>
-            ` : ''}
-            
-
-            
             ${event._action === 'conflict' && event._conflicts ? `
                 <div class="conflict-info">
                     <strong>⚠️ Overlapping Events:</strong> ${event._conflicts.length} event(s) at same time

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -481,7 +481,7 @@ class SharedCore {
         const applyStrategy = (fieldName, existingValue, newValue) => {
             // Allow mapping of strategy keys (location uses 'venue' in strategies)
             const strategyKey = (fieldName === 'location' && !fieldStrategies[fieldName]) ? 'venue' : fieldName;
-            const strategy = fieldStrategies[strategyKey] || 'preserve';
+            const strategy = (fieldStrategies[strategyKey] !== undefined) ? fieldStrategies[strategyKey] : 'upsert';
             switch (strategy) {
                 case 'clobber':
                     return (newValue !== undefined && newValue !== null && newValue !== '') ? newValue : existingValue;
@@ -498,7 +498,7 @@ class SharedCore {
         // Resolve calendar core fields using strategies
         const resolvedStartDate = applyStrategy('startDate', existingEvent.startDate, newEvent.startDate);
         const resolvedEndDate = applyStrategy('endDate', existingEvent.endDate, newEvent.endDate || newEvent.startDate);
-        const resolvedLocation = applyStrategy('location', existingEvent.location, newEvent.venue || newEvent.location);
+        const resolvedLocation = applyStrategy('location', existingEvent.location, newEvent.location);
         
         // Create the final event object that represents exactly what will be saved
         const finalEvent = {
@@ -584,7 +584,7 @@ class SharedCore {
         // Track which fields were merged and how
         ['title', 'startDate', 'endDate', 'location', 'url', 'notes'].forEach(field => {
             const existingValue = existingEvent[field];
-            const newValue = newEvent[field] || (field === 'location' ? (newEvent.venue || newEvent.location) : undefined);
+            const newValue = newEvent[field];
             const finalValue = finalEvent[field];
             
             if (finalValue === existingValue && existingValue !== newValue) {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -423,13 +423,7 @@ class SharedCore {
             if (key.startsWith('_')) return;
             
             // Get strategy for this field, with field name variations support
-            let strategy = (
-                fieldStrategies[key] !== undefined ? fieldStrategies[key] :
-                fieldStrategies[key.toLowerCase()] !== undefined ? fieldStrategies[key.toLowerCase()] :
-                (key === 'googleMapsLink' && fieldStrategies['gmaps'] !== undefined) ? fieldStrategies['gmaps'] :
-                (key === 'gmaps' && fieldStrategies['googleMapsLink'] !== undefined) ? fieldStrategies['googleMapsLink'] :
-                'upsert'
-            );
+            let strategy = (fieldStrategies[key] !== undefined) ? fieldStrategies[key] : 'upsert';
             
             const existingValue = existingEvent[key] || existingFields[key];
             const newValue = newEvent[key];
@@ -479,9 +473,7 @@ class SharedCore {
         // Helper to apply merge strategy for core calendar fields
         const fieldStrategies = newEvent._fieldMergeStrategies || {};
         const applyStrategy = (fieldName, existingValue, newValue) => {
-            // Allow mapping of strategy keys (location uses 'venue' in strategies)
-            const strategyKey = (fieldName === 'location' && !fieldStrategies[fieldName]) ? 'venue' : fieldName;
-            const strategy = (fieldStrategies[strategyKey] !== undefined) ? fieldStrategies[strategyKey] : 'upsert';
+            const strategy = (fieldStrategies[fieldName] !== undefined) ? fieldStrategies[fieldName] : 'upsert';
             switch (strategy) {
                 case 'clobber':
                     return (newValue !== undefined && newValue !== null && newValue !== '') ? newValue : existingValue;

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -423,16 +423,13 @@ class SharedCore {
             if (key.startsWith('_')) return;
             
             // Get strategy for this field, with field name variations support
-            let strategy = fieldStrategies[key] || fieldStrategies[key.toLowerCase()] || 'preserve';
-            
-            // Handle common field name variations
-            if (strategy === 'preserve') {
-                if (key === 'googleMapsLink' && fieldStrategies['gmaps']) {
-                    strategy = fieldStrategies['gmaps'];
-                } else if (key === 'gmaps' && fieldStrategies['googleMapsLink']) {
-                    strategy = fieldStrategies['googleMapsLink'];
-                }
-            }
+            let strategy = (
+                fieldStrategies[key] !== undefined ? fieldStrategies[key] :
+                fieldStrategies[key.toLowerCase()] !== undefined ? fieldStrategies[key.toLowerCase()] :
+                (key === 'googleMapsLink' && fieldStrategies['gmaps'] !== undefined) ? fieldStrategies['gmaps'] :
+                (key === 'gmaps' && fieldStrategies['googleMapsLink'] !== undefined) ? fieldStrategies['googleMapsLink'] :
+                'upsert'
+            );
             
             const existingValue = existingEvent[key] || existingFields[key];
             const newValue = newEvent[key];
@@ -461,11 +458,6 @@ class SharedCore {
                     break;
             }
         });
-        
-        // Ensure important metadata fields are present for notes
-        if (!mergedEvent.key && newEvent.key) {
-            mergedEvent.key = newEvent.key;
-        }
         
         // Use the existing formatEventNotes function to generate notes
         const notes = this.formatEventNotes(mergedEvent);

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -612,7 +612,7 @@ class SharedCore {
         // This ensures the object structure matches what gets saved and makes debugging easier
         if (finalEvent._mergeInfo?.extractedFields && finalEvent._fieldMergeStrategies) {
             Object.entries(finalEvent._mergeInfo.extractedFields).forEach(([fieldName, fieldInfo]) => {
-                const strategy = finalEvent._fieldMergeStrategies[fieldName] || (fieldName === 'location' ? finalEvent._fieldMergeStrategies['venue'] : undefined);
+                const strategy = finalEvent._fieldMergeStrategies[fieldName];
                 // Only add fields that were preserved (not overridden by new values)
                 if (strategy === 'preserve' && !finalEvent[fieldName]) {
                     finalEvent[fieldName] = fieldInfo.value;


### PR DESCRIPTION
Enhances merged event display by ensuring notes show all details, merge strategies are applied to core fields, and comparison tables deduplicate aliases.

This PR resolves several inconsistencies in how merged events are displayed. Specifically, it ensures that the "Calendar notes preview" correctly shows all key-value pairs like description and key, that `clobber` strategies for `startDate`, `endDate`, and `location` are honored, and that the comparison table only displays canonical field names (e.g., `googleMapsLink` instead of `googlemapslink` and `gmaps`, `shortTitle` instead of `shottitle`).

---
<a href="https://cursor.com/background-agent?bcId=bc-c0f09c72-1564-432e-b318-5a934ae4b5a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0f09c72-1564-432e-b318-5a934ae4b5a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

