### PR TITLE
Changes from background agent bc-7ae9ff6b-00c5-4e66-8477-adf765959eef

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2206,7 +2206,11 @@ class ScriptableAdapter {
             ${event._original && event._action !== 'new' ? (() => {
                 const hasDifferences = this.hasEventDifferences(event);
                 const eventId = event.key || Math.random();
-                const isExpanded = false; // Start collapsed; expand on click
+                
+                // Only show comparison section if there are actual differences
+                if (!hasDifferences) return '';
+                
+                const isExpanded = hasDifferences; // Auto-expand if there are differences
                 
                 return `
                 <div style="margin-top: 15px; border-top: 1px solid #e0e0e0; padding-top: 15px;">


### PR DESCRIPTION
Fixes event scraper diff display to only show comparison sections when differences exist and auto-expand them.

The previous behavior caused comparison sections to render and be collapsed by default even for events without actual changes, leading to a confusing UI. This PR ensures diff sections only appear when relevant and are expanded for immediate visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ae9ff6b-00c5-4e66-8477-adf765959eef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ae9ff6b-00c5-4e66-8477-adf765959eef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

