### PR TITLE
Changes from background agent bc-4889d7f3-9662-48f6-aabf-014b5d424425

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -3071,8 +3071,6 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
                 html += `<span style=\"color: #28a745;\">+</span> ${this.escapeHtml(formatValue(finalValue))} <em style=\"color: #666;\">(merged result)</em>`;
                 html += `</div>`;
             }
-            
-            html += `</div>`;
         });
         
         html += '</div>';


### PR DESCRIPTION
Remove extraneous `</div>` tag to fix malformed HTML in merge comparison display.

---
<a href="https://cursor.com/background-agent?bcId=bc-4889d7f3-9662-48f6-aabf-014b5d424425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4889d7f3-9662-48f6-aabf-014b5d424425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

