### PR TITLE
Fix calendar event sizing and unify view styles

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -687,11 +687,42 @@ class DynamicCalendarLoader extends CalendarCore {
             return null;
         }
         
-        // Measure the actual rendered event name width
-        const eventNameRect = eventName.getBoundingClientRect();
-        this.cachedEventTextWidth = eventNameRect.width;
+        // Get the parent event item container to measure the actual available space
+        const eventItem = eventName.closest('.event-item');
+        if (!eventItem) {
+            logger.debug('CALENDAR', 'Event item container not found for measurement');
+            return null;
+        }
         
-        logger.info('CALENDAR', `Measured actual event text width from fake event: ${this.cachedEventTextWidth}px`);
+        // Measure the event item's inner width (excluding padding and borders)
+        const eventItemStyle = window.getComputedStyle(eventItem);
+        const eventItemRect = eventItem.getBoundingClientRect();
+        const paddingLeft = parseFloat(eventItemStyle.paddingLeft) || 0;
+        const paddingRight = parseFloat(eventItemStyle.paddingRight) || 0;
+        const borderLeft = parseFloat(eventItemStyle.borderLeftWidth) || 0;
+        const borderRight = parseFloat(eventItemStyle.borderRightWidth) || 0;
+        
+        // Calculate the actual available width for text content
+        const availableWidth = eventItemRect.width - paddingLeft - paddingRight - borderLeft - borderRight;
+        
+        // Also check if there are any sibling elements that might take up space
+        const eventTime = eventItem.querySelector('.event-time');
+        const eventVenue = eventItem.querySelector('.event-venue');
+        
+        // For vertical layouts, we don't need to subtract sibling widths
+        // For horizontal layouts, we would need to subtract them
+        // Since our events are typically vertical, we use the full width
+        
+        this.cachedEventTextWidth = Math.max(availableWidth, 20); // Minimum 20px
+        
+        logger.info('CALENDAR', `Measured actual event text width from container: ${this.cachedEventTextWidth}px`, {
+            eventItemWidth: eventItemRect.width,
+            paddingLeft,
+            paddingRight,
+            borderLeft,
+            borderRight,
+            calculatedWidth: availableWidth
+        });
         
         return this.cachedEventTextWidth;
     }

--- a/styles.css
+++ b/styles.css
@@ -1788,7 +1788,7 @@ body.index-page main {
     background: var(--background-primary);
     border: 1px solid var(--border-light);
     border-radius: 8px;
-    padding: 0.75rem;
+    padding: 0.5rem;
     min-height: 120px;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     display: flex;
@@ -1888,16 +1888,17 @@ body.index-page main {
     gap: 0;
 }
 
-/* Daily events container spacing fix for week view */
+/* Daily events container - unified spacing for both week and month views */
 .daily-events {
-    padding: 0.5rem;
+    padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.3rem;
+    gap: 0.2rem;
 }
 
-/* Remove padding from daily events in week view for tight fit */
-.calendar-day.week-view .daily-events {
+/* Keep the same tight spacing for both views */
+.calendar-day.week-view .daily-events,
+.calendar-day.month-day .daily-events {
     padding: 0;
     gap: 0.2rem;
 }
@@ -1981,7 +1982,7 @@ body.index-page main {
 
 @media (max-width: 768px) {
     .calendar-day {
-        padding: 0.5rem;
+        padding: 0.4rem;
         min-height: 100px;
     }
     
@@ -2021,7 +2022,7 @@ body.index-page main {
 @media (max-width: 480px) {
     
     .calendar-day {
-        padding: 0.4rem;
+        padding: 0.3rem;
         min-height: 80px;
     }
     
@@ -2875,8 +2876,8 @@ footer {
     }
 
     .calendar-day.month-day .day-events {
-        padding: 1.2rem 0 0 0;
-        gap: 0.5px;
+        padding: 1rem 0 0 0;
+        gap: 0.2rem;
         height: 100%;
     }
 
@@ -3252,8 +3253,8 @@ footer {
     }
 
     .calendar-day.month-day .day-events {
-        padding: 1rem 0.15rem 0.15rem 0.15rem;
-        gap: 1px;
+        padding: 1rem 0.1rem 0.1rem 0.1rem;
+        gap: 0.2rem;
     }
 
     /* Hide today indicator in month view on small screens */
@@ -3641,8 +3642,8 @@ footer {
     }
 
     .calendar-day.month-day .day-events {
-        padding: 0.9rem 0.1rem 0.1rem 0.1rem;
-        gap: 0;
+        padding: 0.8rem 0.1rem 0.1rem 0.1rem;
+        gap: 0.1rem;
     }
 
 


### PR DESCRIPTION
Refactor calendar event text sizing to measure container width and unify month/week view spacing for consistent layout.

The `getEventTextWidth()` function previously measured the rendered text itself, leading to inaccurate calculations for how many characters could fit. It now correctly measures the available space within the event item container. Additionally, the month view had excessive padding compared to the week view; this PR consolidates CSS to apply a tighter, more consistent spacing across both views, improving visual consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-d918103f-5f36-4472-abc1-0836561a5226">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d918103f-5f36-4472-abc1-0836561a5226">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

