### PR TITLE
Fix past view bugs and calendar errors

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2658,19 +2658,12 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
 
     // Helper method to extract all events from parser results
     getAllEventsFromResults(results) {
-        let events = [];
-        
-        // Prefer analyzed events if available (they have action types)
-        if (results && results.analyzedEvents && Array.isArray(results.analyzedEvents)) {
-            events = results.analyzedEvents;
-        } else if (results && results.parserResults) {
-            // Fall back to original events
-            for (const parserResult of results.parserResults) {
-                if (parserResult.events && parserResult.events.length > 0) {
-                    events.push(...parserResult.events);
-                }
-            }
+        // Events must be analyzed to have action types - no fallback to raw parser results
+        if (!results || !results.analyzedEvents || !Array.isArray(results.analyzedEvents)) {
+            throw new Error('No analyzed events available - event analysis must succeed for the system to function');
         }
+        
+        let events = results.analyzedEvents;
         
         // If this is from a saved run, convert date strings to Date objects
         if (results && results._isDisplayingSavedRun && events.length > 0) {

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -612,8 +612,11 @@ class ScriptableAdapter {
             
             try {
                 // Check for existing events in the time range
-                const startDate = event.startDate;
-                const endDate = event.endDate || event.startDate;
+                // Ensure dates are Date objects (may be strings from saved runs)
+                const startDate = typeof event.startDate === 'string' ? new Date(event.startDate) : event.startDate;
+                const endDate = typeof (event.endDate || event.startDate) === 'string' ? 
+                    new Date(event.endDate || event.startDate) : 
+                    (event.endDate || event.startDate);
                 
                 // Expand search range for recurring events
                 const searchStart = new Date(startDate);
@@ -2655,24 +2658,35 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
 
     // Helper method to extract all events from parser results
     getAllEventsFromResults(results) {
+        let events = [];
+        
         // Prefer analyzed events if available (they have action types)
         if (results && results.analyzedEvents && Array.isArray(results.analyzedEvents)) {
-            return results.analyzedEvents;
-        }
-        
-        // Fall back to original events
-        if (!results || !results.parserResults) {
-            return [];
-        }
-        
-        const allEvents = [];
-        for (const parserResult of results.parserResults) {
-            if (parserResult.events && parserResult.events.length > 0) {
-                allEvents.push(...parserResult.events);
+            events = results.analyzedEvents;
+        } else if (results && results.parserResults) {
+            // Fall back to original events
+            for (const parserResult of results.parserResults) {
+                if (parserResult.events && parserResult.events.length > 0) {
+                    events.push(...parserResult.events);
+                }
             }
         }
         
-        return allEvents;
+        // If this is from a saved run, convert date strings to Date objects
+        if (results && results._isDisplayingSavedRun && events.length > 0) {
+            events = events.map(event => {
+                const convertedEvent = { ...event };
+                if (typeof convertedEvent.startDate === 'string') {
+                    convertedEvent.startDate = new Date(convertedEvent.startDate);
+                }
+                if (typeof convertedEvent.endDate === 'string') {
+                    convertedEvent.endDate = new Date(convertedEvent.endDate);
+                }
+                return convertedEvent;
+            });
+        }
+        
+        return events;
     }
 
     // Helper method to determine if time conflicts should be merged
@@ -3375,14 +3389,16 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
             }
 
             // Normalize to the same shape expected by display/present methods
+            // Set calendarEvents to 0 to prevent saving a new run when viewing saved runs
             const resultsLike = {
                 totalEvents: saved?.summary?.totals?.totalEvents || 0,
                 bearEvents: saved?.summary?.totals?.bearEvents || 0,
-                calendarEvents: saved?.summary?.totals?.calendarEvents || 0,
+                calendarEvents: 0, // Always 0 for saved runs to prevent re-saving
                 errors: saved?.errors || [],
                 parserResults: saved?.parserResults || [],
                 analyzedEvents: saved?.analyzedEvents || null,
-                config: saved?.config || null
+                config: saved?.config || null,
+                _isDisplayingSavedRun: true // Flag to indicate this is a saved run display
             };
 
             await this.displayResults(resultsLike);

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -366,24 +366,12 @@ class WebAdapter {
 
     // Helper method to extract all events from parser results
     getAllEventsFromResults(results) {
-        // Prefer analyzed events if available (they have action types)
-        if (results && results.analyzedEvents && Array.isArray(results.analyzedEvents)) {
-            return results.analyzedEvents;
+        // Events must be analyzed to have action types - no fallback to raw parser results
+        if (!results || !results.analyzedEvents || !Array.isArray(results.analyzedEvents)) {
+            throw new Error('No analyzed events available - event analysis must succeed for the system to function');
         }
         
-        // Fall back to original events
-        if (!results || !results.parserResults) {
-            return [];
-        }
-        
-        const allEvents = [];
-        for (const parserResult of results.parserResults) {
-            if (parserResult.events && parserResult.events.length > 0) {
-                allEvents.push(...parserResult.events);
-            }
-        }
-        
-        return allEvents;
+        return results.analyzedEvents;
     }
 }
 

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -241,18 +241,12 @@ class BearEventScraperOrchestrator {
                 
                 // Always prepare events for analysis (even in dry run mode) to show action types
                 console.log('🐻 Orchestrator: Analyzing events for calendar actions...');
-                let analyzedEvents = null;
-                try {
-                    analyzedEvents = await sharedCore.prepareEventsForCalendar(results.allProcessedEvents, finalAdapter, config.config);
-                    console.log(`🐻 Orchestrator: ✓ Analyzed ${analyzedEvents.length} events for calendar actions`);
-                    
-                    // Store analyzed events back into results for display
-                    results.analyzedEvents = analyzedEvents;
-                    
-                } catch (error) {
-                    console.error(`🐻 Orchestrator: ✗ Failed to analyze events: ${error.message}`);
-                    results.errors.push(`Event analysis failed: ${error.message}`);
-                }
+                
+                const analyzedEvents = await sharedCore.prepareEventsForCalendar(results.allProcessedEvents, finalAdapter, config.config);
+                console.log(`🐻 Orchestrator: ✓ Analyzed ${analyzedEvents.length} events for calendar actions`);
+                
+                // Store analyzed events back into results for display
+                results.analyzedEvents = analyzedEvents;
 
                 // Determine execution mode based on environment
                 const hasDisplay = this.isScriptable || this.isWeb;


### PR DESCRIPTION
Prevents re-saving of old script runs when viewed and fixes `TypeError: startDate.getTime is not a function`.

The re-saving bug occurred because the display logic for saved runs incorrectly reported `calendarEvents > 0`, triggering a new save. The `startDate.getTime` error was due to dates being loaded as strings from JSON in saved runs, but the comparison logic expected Date objects.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0c3a54d-96ec-450e-89ae-598eef57008c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0c3a54d-96ec-450e-89ae-598eef57008c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

