### PR TITLE
Remove cursor index and read directory

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -3290,8 +3290,6 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
         }
     }
 
-    // Index functionality removed - using directory reading instead
-
     listSavedRuns() {
         // Read directory contents directly - no index needed
         try {
@@ -3397,8 +3395,6 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
             await afterCleanup();
         }
     }
-
-    // Index functionality removed - using directory reading instead
 
     // Log helpers (prefer user's file logger)
     getLogFilePath() {

--- a/scripts/display-saved-run.js
+++ b/scripts/display-saved-run.js
@@ -40,24 +40,20 @@ class SavedRunDisplay {
     }
 
     listSavedRuns() {
-        const indexRelPath = `chunky-dad-scraper/runs/index.json`;
-        try {
-            const index = jsonFileManager.read(indexRelPath) || [];
-            return Array.isArray(index) ? index.filter(item => item && item.runId).sort((a, b) => (b.runId || '').localeCompare(a.runId || '')) : [];
-        } catch (e) {
-            console.log(`📱 Display: Failed to read run index: ${e.message}`);
-        }
-        // Fallback: read directory contents
+        // Read directory contents directly - no index needed
         try {
             const fm = FileManager.iCloud();
             const base = jsonFileManager.getCurrentDir();
             const runsDir = `${base}chunky-dad-scraper/runs`;
             if (!fm.fileExists(runsDir)) return [];
             return fm.listContents(runsDir)
-                .filter(name => name.endsWith('.json') && name !== 'index.json')
+                .filter(name => name.endsWith('.json'))
                 .map(name => ({ runId: name.replace('.json',''), timestamp: null }))
                 .sort((a, b) => (b.runId || '').localeCompare(a.runId || ''));
-        } catch (_) { return []; }
+        } catch (e) {
+            console.log(`📱 Display: Failed to read runs directory: ${e.message}`);
+            return [];
+        }
     }
 
     loadSavedRun(runId) {


### PR DESCRIPTION
Remove index-based run management and switch to direct directory reading to fix "Failed to read run index" errors.

The previous index-based approach was prone to corruption and caused display failures. This change simplifies the architecture and improves reliability by directly listing and reading run files from the directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-707d650a-a20c-40af-a101-a239481c1294">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-707d650a-a20c-40af-a101-a239481c1294">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

