### PR TITLE
Fix event name pixel math

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -676,6 +676,12 @@ class DynamicCalendarLoader extends CalendarCore {
             // The previous logic was double-correcting for zoom, causing exponential scaling
             // Now charsPerPixel represents the true character density at current zoom
             
+            // COMMENTED OUT - Keep for safety in case we made a mistake:
+            // When zoomed IN (visualZoom > 1), text appears larger, so FEWER characters fit
+            // When zoomed OUT (visualZoom < 1), text appears smaller, so MORE characters fit
+            // Therefore, we DIVIDE by zoom level, not multiply
+            // charsPerPixel = charsPerPixel / visualZoom;
+            
             document.body.removeChild(testElement);
             
             logger.info('CALENDAR', `🔍 CALCULATION: Calculated chars per pixel: ${charsPerPixel.toFixed(4)} (${pixelsPerChar.toFixed(2)}px per char, zoom: ${visualZoom.toFixed(2)})`, {

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -669,15 +669,12 @@ class DynamicCalendarLoader extends CalendarCore {
             const actualFontWeight = computedStyles.fontWeight;
             const actualFontFamily = computedStyles.fontFamily;
             
-            // Simple zoom adjustment: use visual viewport scale for zoom detection
+            // Get visual zoom for logging purposes only - don't adjust calculation
             const visualZoom = (window.visualViewport && window.visualViewport.scale) || 1;
             
-            // When zoomed IN (visualZoom > 1), text appears larger, so FEWER characters fit
-            // When zoomed OUT (visualZoom < 1), text appears smaller, so MORE characters fit
-            // Therefore, we DIVIDE by zoom level, not multiply
-            charsPerPixel = charsPerPixel / visualZoom;
-            
-
+            // REMOVED ZOOM ADJUSTMENT: getEventTextWidth() already measures at current zoom level
+            // The previous logic was double-correcting for zoom, causing exponential scaling
+            // Now charsPerPixel represents the true character density at current zoom
             
             document.body.removeChild(testElement);
             
@@ -691,7 +688,8 @@ class DynamicCalendarLoader extends CalendarCore {
                 actualFontSize,
                 actualFontWeight,
                 actualFontFamily,
-                screenWidth: window.innerWidth
+                screenWidth: window.innerWidth,
+                note: 'Zoom adjustment removed - getEventTextWidth() already accounts for zoom'
             });
             
             // Cache the result


### PR DESCRIPTION
Remove redundant zoom adjustment in `calculateCharsPerPixel` to fix inaccurate character fitting.

The `getEventTextWidth()` method already measures the available width at the current zoom level. The previous `charsPerPixel = charsPerPixel / visualZoom` line was a double-correction, causing the calculation to overestimate the number of characters that could fit, particularly at different zoom levels. This fix ensures the character limit is accurately calculated based on the actual pixel width.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed542c1e-3fbe-46e0-97f0-f347986edabd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ed542c1e-3fbe-46e0-97f0-f347986edabd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

