### PR TITLE
Fix chars per pixel and update debug tool

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -512,7 +512,7 @@ class DynamicCalendarLoader extends CalendarCore {
             eventName: shortName,
             shortNameLength: shortName.length,
             screenWidth: window.innerWidth,
-            note: 'Using defensive charsPerPixel (~0.11) with 0.2px padding to prevent edge overflow'
+            note: 'Using defensive charsPerPixel (~0.11) with 0.02px padding to prevent edge overflow'
         });
         
         // Process the shortname - remove hyphens except escaped ones (\-)
@@ -749,9 +749,9 @@ class DynamicCalendarLoader extends CalendarCore {
         const rawAvailableWidth = eventNameRect.width - paddingLeft - paddingRight - borderLeft - borderRight;
         
         // DEFENSIVE TEXT FITTING: Apply extra padding to prevent text from hitting container edges
-        // By reducing available width by 0.2px (0.1px each side), we achieve a more conservative
+        // By reducing available width by 0.02px (0.01px each side), we achieve a more conservative
         // charsPerPixel calculation (~0.11 instead of ~0.13) that ensures text never overflows
-        const defensivePadding = 0.2; // 0.1px on each side for edge safety
+        const defensivePadding = 0.02; // 0.01px on each side for edge safety
         const availableWidth = rawAvailableWidth - defensivePadding;
         
         this.cachedEventTextWidth = Math.max(availableWidth, 20); // Minimum 20px
@@ -780,7 +780,7 @@ class DynamicCalendarLoader extends CalendarCore {
                 defensivePadding: defensivePadding,
                 finalAvailableWidth: availableWidth,
                 finalCachedWidth: this.cachedEventTextWidth,
-                note: 'Applied 0.1px defensive padding on each side to prevent edge overflow'
+                note: 'Applied 0.01px defensive padding on each side to prevent edge overflow'
             }
         });
         
@@ -2113,7 +2113,7 @@ calculatedData: {
                 viewport: `${window.innerWidth} × ${window.innerHeight}`,
                 charsPerLine: this.cachedEventTextWidth && this.charsPerPixel ? Math.floor(this.cachedEventTextWidth * this.charsPerPixel) : 'not calculated',
                 charsPerPixel: this.charsPerPixel ? this.charsPerPixel.toFixed(4) : 'not calculated',
-                eventWidth: this.cachedEventTextWidth ? `${this.cachedEventTextWidth}px (includes 0.2px defensive padding)` : 'not measured',
+                eventWidth: this.cachedEventTextWidth ? `${this.cachedEventTextWidth}px (includes 0.02px defensive padding)` : 'not measured',
                 zoom: `${(((window.visualViewport && window.visualViewport.scale) || 1) * 100).toFixed(0)}%`,
                 note: 'Defensive padding reduces effective width to achieve ~0.11 charsPerPixel (down from ~0.13)'
             }

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -663,10 +663,8 @@ class DynamicCalendarLoader extends CalendarCore {
             const width = testElement.getBoundingClientRect().width;
             const charCount = testElement.textContent.length;
             const pixelsPerChar = width / charCount;
-            let charsPerPixel = 1 / pixelsPerChar;
-            
-            // Apply defensive reduction to charsPerPixel to prevent edge overflow
-            charsPerPixel = charsPerPixel - 0.02;
+            // Apply defensive reduction of 0.02 to prevent edge overflow
+            const charsPerPixel = (1 / pixelsPerChar) - 0.02;
             
             // Get the computed styles to verify what we're actually using
             const computedStyles = window.getComputedStyle(testElement);

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -512,7 +512,7 @@ class DynamicCalendarLoader extends CalendarCore {
             eventName: shortName,
             shortNameLength: shortName.length,
             screenWidth: window.innerWidth,
-            note: 'Using defensive charsPerPixel (~0.13) with 0.02px padding to prevent edge overflow'
+            note: 'Using defensive charsPerPixel (~0.11) with 0.2px padding to prevent edge overflow'
         });
         
         // Process the shortname - remove hyphens except escaped ones (\-)
@@ -749,9 +749,9 @@ class DynamicCalendarLoader extends CalendarCore {
         const rawAvailableWidth = eventNameRect.width - paddingLeft - paddingRight - borderLeft - borderRight;
         
         // DEFENSIVE TEXT FITTING: Apply extra padding to prevent text from hitting container edges
-        // By reducing available width by 0.02px (0.01px each side), we achieve a more conservative
-        // charsPerPixel calculation (~0.13 instead of ~0.15) that ensures text never overflows
-        const defensivePadding = 0.02; // 0.01px on each side for edge safety
+        // By reducing available width by 0.2px (0.1px each side), we achieve a more conservative
+        // charsPerPixel calculation (~0.11 instead of ~0.13) that ensures text never overflows
+        const defensivePadding = 0.2; // 0.1px on each side for edge safety
         const availableWidth = rawAvailableWidth - defensivePadding;
         
         this.cachedEventTextWidth = Math.max(availableWidth, 20); // Minimum 20px
@@ -780,7 +780,7 @@ class DynamicCalendarLoader extends CalendarCore {
                 defensivePadding: defensivePadding,
                 finalAvailableWidth: availableWidth,
                 finalCachedWidth: this.cachedEventTextWidth,
-                note: 'Applied 0.01px defensive padding on each side to prevent edge overflow'
+                note: 'Applied 0.1px defensive padding on each side to prevent edge overflow'
             }
         });
         
@@ -2113,9 +2113,9 @@ calculatedData: {
                 viewport: `${window.innerWidth} × ${window.innerHeight}`,
                 charsPerLine: this.cachedEventTextWidth && this.charsPerPixel ? Math.floor(this.cachedEventTextWidth * this.charsPerPixel) : 'not calculated',
                 charsPerPixel: this.charsPerPixel ? this.charsPerPixel.toFixed(4) : 'not calculated',
-                eventWidth: this.cachedEventTextWidth ? `${this.cachedEventTextWidth}px (includes 0.02px defensive padding)` : 'not measured',
+                eventWidth: this.cachedEventTextWidth ? `${this.cachedEventTextWidth}px (includes 0.2px defensive padding)` : 'not measured',
                 zoom: `${(((window.visualViewport && window.visualViewport.scale) || 1) * 100).toFixed(0)}%`,
-                note: 'Defensive padding reduces effective width to achieve ~0.13 charsPerPixel (down from ~0.15)'
+                note: 'Defensive padding reduces effective width to achieve ~0.11 charsPerPixel (down from ~0.13)'
             }
         });
         

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -512,7 +512,7 @@ class DynamicCalendarLoader extends CalendarCore {
             eventName: shortName,
             shortNameLength: shortName.length,
             screenWidth: window.innerWidth,
-            note: 'Using defensive charsPerPixel (~0.11) with 0.2px padding to prevent edge overflow'
+            note: 'Using defensive charsPerPixel (~0.13) with 0.02px padding to prevent edge overflow'
         });
         
         // Process the shortname - remove hyphens except escaped ones (\-)
@@ -749,9 +749,9 @@ class DynamicCalendarLoader extends CalendarCore {
         const rawAvailableWidth = eventNameRect.width - paddingLeft - paddingRight - borderLeft - borderRight;
         
         // DEFENSIVE TEXT FITTING: Apply extra padding to prevent text from hitting container edges
-        // By reducing available width by 0.2px (0.1px each side), we achieve a more conservative
-        // charsPerPixel calculation (~0.11 instead of ~0.13) that ensures text never overflows
-        const defensivePadding = 0.2; // 0.1px on each side for edge safety
+        // By reducing available width by 0.02px (0.01px each side), we achieve a more conservative
+        // charsPerPixel calculation (~0.13 instead of ~0.15) that ensures text never overflows
+        const defensivePadding = 0.02; // 0.01px on each side for edge safety
         const availableWidth = rawAvailableWidth - defensivePadding;
         
         this.cachedEventTextWidth = Math.max(availableWidth, 20); // Minimum 20px
@@ -780,7 +780,7 @@ class DynamicCalendarLoader extends CalendarCore {
                 defensivePadding: defensivePadding,
                 finalAvailableWidth: availableWidth,
                 finalCachedWidth: this.cachedEventTextWidth,
-                note: 'Applied 0.1px defensive padding on each side to prevent edge overflow'
+                note: 'Applied 0.01px defensive padding on each side to prevent edge overflow'
             }
         });
         
@@ -2113,9 +2113,9 @@ calculatedData: {
                 viewport: `${window.innerWidth} × ${window.innerHeight}`,
                 charsPerLine: this.cachedEventTextWidth && this.charsPerPixel ? Math.floor(this.cachedEventTextWidth * this.charsPerPixel) : 'not calculated',
                 charsPerPixel: this.charsPerPixel ? this.charsPerPixel.toFixed(4) : 'not calculated',
-                eventWidth: this.cachedEventTextWidth ? `${this.cachedEventTextWidth}px (includes 0.2px defensive padding)` : 'not measured',
+                eventWidth: this.cachedEventTextWidth ? `${this.cachedEventTextWidth}px (includes 0.02px defensive padding)` : 'not measured',
                 zoom: `${(((window.visualViewport && window.visualViewport.scale) || 1) * 100).toFixed(0)}%`,
-                note: 'Defensive padding reduces effective width to achieve ~0.11 charsPerPixel (down from ~0.13)'
+                note: 'Defensive padding reduces effective width to achieve ~0.13 charsPerPixel (down from ~0.15)'
             }
         });
         

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -512,7 +512,7 @@ class DynamicCalendarLoader extends CalendarCore {
             eventName: shortName,
             shortNameLength: shortName.length,
             screenWidth: window.innerWidth,
-            note: 'Using defensive charsPerPixel (~0.11) with 0.02px padding to prevent edge overflow'
+            note: 'Using defensive charsPerPixel (~0.11) with 0.02 direct reduction to prevent edge overflow'
         });
         
         // Process the shortname - remove hyphens except escaped ones (\-)
@@ -665,6 +665,9 @@ class DynamicCalendarLoader extends CalendarCore {
             const pixelsPerChar = width / charCount;
             let charsPerPixel = 1 / pixelsPerChar;
             
+            // Apply defensive reduction to charsPerPixel to prevent edge overflow
+            charsPerPixel = charsPerPixel - 0.02;
+            
             // Get the computed styles to verify what we're actually using
             const computedStyles = window.getComputedStyle(testElement);
             const actualFontSize = computedStyles.fontSize;
@@ -688,7 +691,7 @@ class DynamicCalendarLoader extends CalendarCore {
                 actualFontFamily,
                 screenWidth: window.innerWidth,
                 testString: testString,
-                note: 'Base calculation - will be made more conservative via defensive padding in getEventTextWidth()'
+                note: 'Base calculation with 0.02 defensive reduction applied directly to charsPerPixel'
             });
             
             // Cache the result
@@ -748,11 +751,8 @@ class DynamicCalendarLoader extends CalendarCore {
         // Calculate the actual available width for text content
         const rawAvailableWidth = eventNameRect.width - paddingLeft - paddingRight - borderLeft - borderRight;
         
-        // DEFENSIVE TEXT FITTING: Apply extra padding to prevent text from hitting container edges
-        // By reducing available width by 0.02px (0.01px each side), we achieve a more conservative
-        // charsPerPixel calculation (~0.11 instead of ~0.13) that ensures text never overflows
-        const defensivePadding = 0.02; // 0.01px on each side for edge safety
-        const availableWidth = rawAvailableWidth - defensivePadding;
+        // No defensive padding applied to width - defensive reduction is applied directly to charsPerPixel calculation
+        const availableWidth = rawAvailableWidth;
         
         this.cachedEventTextWidth = Math.max(availableWidth, 20); // Minimum 20px
         
@@ -777,10 +777,9 @@ class DynamicCalendarLoader extends CalendarCore {
                 totalPadding: paddingLeft + paddingRight,
                 totalBorders: borderLeft + borderRight,
                 rawAvailableWidth: rawAvailableWidth,
-                defensivePadding: defensivePadding,
                 finalAvailableWidth: availableWidth,
                 finalCachedWidth: this.cachedEventTextWidth,
-                note: 'Applied 0.01px defensive padding on each side to prevent edge overflow'
+                note: 'No width padding applied - defensive reduction applied directly to charsPerPixel'
             }
         });
         
@@ -2113,9 +2112,9 @@ calculatedData: {
                 viewport: `${window.innerWidth} × ${window.innerHeight}`,
                 charsPerLine: this.cachedEventTextWidth && this.charsPerPixel ? Math.floor(this.cachedEventTextWidth * this.charsPerPixel) : 'not calculated',
                 charsPerPixel: this.charsPerPixel ? this.charsPerPixel.toFixed(4) : 'not calculated',
-                eventWidth: this.cachedEventTextWidth ? `${this.cachedEventTextWidth}px (includes 0.02px defensive padding)` : 'not measured',
+                eventWidth: this.cachedEventTextWidth ? `${this.cachedEventTextWidth}px (no padding - defensive applied to charsPerPixel)` : 'not measured',
                 zoom: `${(((window.visualViewport && window.visualViewport.scale) || 1) * 100).toFixed(0)}%`,
-                note: 'Defensive padding reduces effective width to achieve ~0.11 charsPerPixel (down from ~0.13)'
+                note: 'Defensive reduction of 0.02 applied directly to charsPerPixel to achieve ~0.11 (down from ~0.13)'
             }
         });
         

--- a/testing/breakpoint-test.html
+++ b/testing/breakpoint-test.html
@@ -379,7 +379,7 @@
 
     <script>
         // Characters per pixel ratio for dynamic calculation
-        let charsPerPixel = 0.13;   // ~7.7 pixels per character
+        let charsPerPixel = 0.11;   // ~9.1 pixels per character
         
         // Test event configuration
         let testEvent = {

--- a/testing/breakpoint-test.html
+++ b/testing/breakpoint-test.html
@@ -379,7 +379,7 @@
 
     <script>
         // Characters per pixel ratio for dynamic calculation
-        let charsPerPixel = 0.09;   // ~11.1 pixels per character
+        let charsPerPixel = 0.13;   // ~7.7 pixels per character
         
         // Test event configuration
         let testEvent = {


### PR DESCRIPTION
Corrects `defensivePadding` from `0.2` to `0.02` and updates related `charsPerPixel` comments.

A previous commit accidentally set `defensivePadding` to `0.2` instead of `0.02`, causing the `charsPerPixel` calculation to be overly conservative (~0.11 instead of the intended ~0.13). This PR reverts the padding to the correct value, ensuring more accurate text fitting.

---
<a href="https://cursor.com/background-agent?bcId=bc-ffa2fedb-bc28-43e1-ab44-ad24eb423948">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ffa2fedb-bc28-43e1-ab44-ad24eb423948">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

