### PR TITLE
Fix scriptable module loading error

### DIFF
--- a/scripts/parsers/generic-parser.js
+++ b/scripts/parsers/generic-parser.js
@@ -247,7 +247,6 @@ class GenericParser {
                 image: '',
                 source: this.config.source,
                 isBearEvent: false // Will be filtered later based on keywords
-                cover: price || '', // Use 'cover' field name that calendar-core.js expects
             };
             
             // Apply all metadata fields from config


### PR DESCRIPTION
Remove duplicate `cover` property assignment in `generic-parser.js` to fix a syntax error preventing module import.

A duplicate line `cover: price || '',` at line 250 in `scripts/parsers/generic-parser.js` caused a JavaScript syntax error. This error prevented the `importModule` function from loading the `generic-parser` module, leading to the `TypeError: undefined is not an object` error and the scriptable code failing to execute.

---
<a href="https://cursor.com/background-agent?bcId=bc-f6bc09cd-6d7c-4059-9365-aedc6953e878">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f6bc09cd-6d7c-4059-9365-aedc6953e878">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

