### PR TITLE
Update calendar hyphenation and shortName logic

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1946,9 +1946,9 @@ body.index-page main {
 .event-name {
     font-weight: 600;
     margin-bottom: 0.2rem;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    hyphens: auto;
+    word-wrap: normal;
+    overflow-wrap: normal;
+    hyphens: none;
     display: -webkit-box;
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
@@ -4385,10 +4385,11 @@ footer {
   line-height: var(--event-name-line-height);
   margin-bottom: 0.1rem;
   
-  /* Let JavaScript handle the line building, CSS provides final overflow protection */
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-  hyphens: auto;
+  /* Let JavaScript handle the line building completely */
+  word-wrap: normal;
+  overflow-wrap: normal;
+  hyphens: none;
+  word-break: normal;
   
   /* Provide 3-line clamp as final safety net */
   display: -webkit-box;

--- a/testing/manifest.json
+++ b/testing/manifest.json
@@ -1,70 +1,75 @@
 {
-  "generated": "2025-08-10T00:32:18.570Z",
+  "generated": "2025-08-13T03:48:55.216Z",
   "files": [
     {
       "name": "breakpoint-test.html",
-      "size": 34162,
-      "modified": "2025-08-07T18:06:54.852Z"
+      "size": 34161,
+      "modified": "2025-08-06T04:31:52.616Z"
     },
     {
       "name": "hero-variations-tester.html",
       "size": 26248,
-      "modified": "2025-08-07T18:06:54.852Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     },
     {
       "name": "iframe-fix-test.html",
       "size": 9922,
-      "modified": "2025-08-07T18:06:54.852Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     },
     {
       "name": "index.html",
       "size": 18216,
-      "modified": "2025-08-07T18:06:54.852Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     },
     {
       "name": "style-test.html",
       "size": 26360,
-      "modified": "2025-08-07T18:06:54.856Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     },
     {
       "name": "test-calendar-logging.html",
       "size": 68099,
-      "modified": "2025-08-07T18:06:54.856Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     },
     {
       "name": "test-display-modes.html",
       "size": 10729,
-      "modified": "2025-08-07T18:06:54.856Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     },
     {
       "name": "test-error-logging-fix.html",
       "size": 6806,
-      "modified": "2025-08-07T18:06:54.856Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     },
     {
       "name": "test-eventbrite-address-fix.html",
       "size": 7179,
-      "modified": "2025-08-07T18:06:54.856Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     },
     {
       "name": "test-google-sheets-loader.html",
       "size": 40540,
-      "modified": "2025-08-07T18:06:54.856Z"
+      "modified": "2025-08-06T04:31:52.620Z"
+    },
+    {
+      "name": "test-hyphenation-fix.html",
+      "size": 6108,
+      "modified": "2025-08-13T03:48:49.586Z"
     },
     {
       "name": "test-map-icons.html",
       "size": 61258,
-      "modified": "2025-08-07T18:06:54.856Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     },
     {
       "name": "test-unified-scraper.html",
       "size": 32064,
-      "modified": "2025-08-07T18:06:54.856Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     },
     {
       "name": "ultimate-style-tester.html",
       "size": 116287,
-      "modified": "2025-08-07T18:06:54.856Z"
+      "modified": "2025-08-06T04:31:52.620Z"
     }
   ]
 }

--- a/testing/test-hyphenation-fix.html
+++ b/testing/test-hyphenation-fix.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Hyphenation Fix</title>
+    <link rel="stylesheet" href="../styles.css">
+    <style>
+        body {
+            padding: 20px;
+            font-family: 'Poppins', sans-serif;
+        }
+        .test-container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+        .test-section {
+            margin-bottom: 40px;
+            padding: 20px;
+            background: #f5f5f5;
+            border-radius: 8px;
+        }
+        .test-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .test-event {
+            background: white;
+            padding: 15px;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .event-name {
+            background: #ffe4e4;
+            padding: 5px;
+            border: 1px solid #ffcccc;
+            margin-bottom: 10px;
+        }
+        .test-info {
+            font-size: 0.8rem;
+            color: #666;
+            margin-top: 10px;
+        }
+        h2 {
+            color: #333;
+            margin-bottom: 10px;
+        }
+        .description {
+            color: #666;
+            margin-bottom: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="test-container">
+        <h1>Hyphenation Fix Test</h1>
+        <p>Testing the new hyphenation logic for event names with shortName support</p>
+
+        <div class="test-section">
+            <h2>Test 1: ShortName with Optional Hyphens</h2>
+            <p class="description">
+                These events have shortNames with "-" as optional hyphenation points.
+                If the text fits, hyphens should be removed. Otherwise, they're used as breakpoints.
+            </p>
+            <div class="test-grid" id="test1-grid"></div>
+        </div>
+
+        <div class="test-section">
+            <h2>Test 2: ShortName with Escaped Hyphens</h2>
+            <p class="description">
+                These events have shortNames with "\-" which are literal hyphens that must always be kept.
+            </p>
+            <div class="test-grid" id="test2-grid"></div>
+        </div>
+
+        <div class="test-section">
+            <h2>Test 3: Regular Names (No ShortName)</h2>
+            <p class="description">
+                These events only have regular names. Hyphens in regular names should always be kept literally.
+            </p>
+            <div class="test-grid" id="test3-grid"></div>
+        </div>
+
+        <div class="test-section">
+            <h2>Test 4: Mixed Cases</h2>
+            <p class="description">
+                Testing various edge cases and combinations.
+            </p>
+            <div class="test-grid" id="test4-grid"></div>
+        </div>
+    </div>
+
+    <script src="../js/logger.js"></script>
+    <script src="../js/calendar-core.js"></script>
+    <script src="../js/dynamic-calendar-loader.js"></script>
+    <script>
+        // Initialize the calendar loader
+        const loader = new DynamicCalendarLoader();
+        loader.currentCity = 'test';
+        
+        // Test data
+        const test1Events = [
+            { name: 'Bear Night at Eagle', shortName: 'Bear-Night' },
+            { name: 'Happy Hour Special Event', shortName: 'Happy-Hour' },
+            { name: 'Weekend Dance Party Extravaganza', shortName: 'Weekend-Dance-Party' },
+            { name: 'MEGA WOOF Party', shortName: 'MEGA-WOOF' }
+        ];
+
+        const test2Events = [
+            { name: 'Co-Ed Night', shortName: 'Co\\-Ed Night' },
+            { name: 'Ex-Military Meetup', shortName: 'Ex\\-Military' },
+            { name: 'Non-Stop Dancing', shortName: 'Non\\-Stop Dance' },
+            { name: 'Mid-Week Special', shortName: 'Mid\\-Week' }
+        ];
+
+        const test3Events = [
+            { name: 'Bear-Night at Eagle' },
+            { name: 'Happy-Hour Special' },
+            { name: 'Co-Ed Dance Party' },
+            { name: 'Non-Stop Weekend Fun' }
+        ];
+
+        const test4Events = [
+            { name: 'Super Long Event Name That Should Wrap Naturally Without Breaking Words Unnecessarily', shortName: 'Super-Long-Event' },
+            { name: 'Short', shortName: 'S' },
+            { name: 'ABC DEF GHI JKL MNO PQR STU VWX YZ', shortName: 'ABC-DEF-GHI' },
+            { name: 'Mix\\-ed Hyphen-ation Test', shortName: 'Mix\\-ed-Test' }
+        ];
+
+        // Function to render test events
+        function renderTestEvents(events, containerId) {
+            const container = document.getElementById(containerId);
+            
+            events.forEach(event => {
+                const eventDiv = document.createElement('div');
+                eventDiv.className = 'test-event';
+                
+                // Process the event name using the calendar loader's logic
+                const processedName = loader.getSmartEventNameForBreakpoint(event, 'mobile');
+                
+                eventDiv.innerHTML = `
+                    <div class="event-name">${processedName}</div>
+                    <div class="test-info">
+                        <strong>Original:</strong> ${event.name}<br>
+                        ${event.shortName ? `<strong>ShortName:</strong> ${event.shortName}<br>` : ''}
+                        <strong>Processed:</strong> ${processedName}
+                    </div>
+                `;
+                
+                container.appendChild(eventDiv);
+            });
+        }
+
+        // Render all test cases
+        renderTestEvents(test1Events, 'test1-grid');
+        renderTestEvents(test2Events, 'test2-grid');
+        renderTestEvents(test3Events, 'test3-grid');
+        renderTestEvents(test4Events, 'test4-grid');
+
+        // Log test completion
+        logger.componentLoad('TEST', 'Hyphenation test page loaded', {
+            totalTests: test1Events.length + test2Events.length + test3Events.length + test4Events.length
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Refactor event name hyphenation and line-breaking to correctly handle `shortName` rules and prevent artificial word breaks.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd6ab5f5-1f50-471b-8169-fa18619e772d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd6ab5f5-1f50-471b-8169-fa18619e772d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

