### PR TITLE
Add bear happy hour eventbrite parser

### DIFF
--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -33,7 +33,10 @@
         "description": {
           "merge": "upsert"
         },
-        "venue": {
+        "bar": {
+          "merge": "clobber"
+        },
+        "address": {
           "merge": "clobber"
         },
         "startDate": {
@@ -43,10 +46,13 @@
           "merge": "clobber"
         },
         "website": {
-          "merge": "upsert"
+          "merge": "clobber"
         },
         "gmaps": {
-          "merge": "upsert"
+          "merge": "clobber"
+        },
+        "image": {
+          "merge": "clobber"
         },
         "cover": {
           "merge": "clobber"
@@ -81,8 +87,11 @@
         "description": {
           "merge": "upsert"
         },
-        "venue": {
-          "merge": "upsert"
+        "bar": {
+          "merge": "clobber"
+        },
+        "address": {
+          "merge": "clobber"
         },
         "startDate": {
           "merge": "clobber"
@@ -91,10 +100,13 @@
           "merge": "clobber"
         },
         "website": {
-          "merge": "upsert"
+          "merge": "clobber"
         },
         "gmaps": {
-          "merge": "upsert"
+          "merge": "clobber"
+        },
+        "image": {
+          "merge": "clobber"
         },
         "cover": {
           "merge": "clobber"

--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -49,6 +49,52 @@
           "merge": "upsert"
         }
       }
+    },
+    {
+      "name": "Bear Happy Hour",
+      "parser": "eventbrite",
+      "urls": ["https://www.eventbrite.com/o/bear-happy-hour-87043830313"],
+      "alwaysBear": true,
+      "requireDetailPages": true,
+      "maxAdditionalUrls": 20,
+      "dryRun": true,
+      "daysToLookAhead": null,
+      "mergeMode": "upsert",
+      "urlFilters": {
+        "include": ["eventbrite\\.com\\/e\\/"]
+      },
+      "metadata": {
+        "title": {
+          "value": "Coach After Dark",
+          "merge": "upsert"
+        },
+        "shortName": {
+          "value": "Coach After Dark",
+          "merge": "upsert"
+        },
+        "instagram": {
+          "value": "https://www.instagram.com/coachafterdark",
+          "merge": "upsert"
+        },
+        "description": {
+          "merge": "preserve"
+        },
+        "venue": {
+          "merge": "upsert"
+        },
+        "startDate": {
+          "merge": "clobber"
+        },
+        "endDate": {
+          "merge": "clobber"
+        },
+        "website": {
+          "merge": "upsert"
+        },
+        "gmaps": {
+          "merge": "upsert"
+        }
+      }
     }
   ],
   "calendarMappings": {

--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -47,6 +47,9 @@
         },
         "gmaps": {
           "merge": "upsert"
+        },
+        "cover": {
+          "merge": "upsert"
         }
       }
     },
@@ -64,10 +67,6 @@
         "include": ["eventbrite\\.com\\/e\\/"]
       },
       "metadata": {
-        "title": {
-          "value": "Coach After Dark",
-          "merge": "upsert"
-        },
         "shortName": {
           "value": "Coach After Dark",
           "merge": "upsert"
@@ -92,6 +91,9 @@
           "merge": "upsert"
         },
         "gmaps": {
+          "merge": "upsert"
+        },
+        "cover": {
           "merge": "upsert"
         }
       }

--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -31,7 +31,7 @@
           "merge": "clobber"
         },
         "description": {
-          "merge": "preserve"
+          "merge": "upsert"
         },
         "venue": {
           "merge": "clobber"
@@ -67,6 +67,9 @@
         "include": ["eventbrite\\.com\\/e\\/"]
       },
       "metadata": {
+        "title": {
+          "merge": "upsert"
+        },
         "shortName": {
           "value": "Coach After Dark",
           "merge": "upsert"
@@ -76,7 +79,7 @@
           "merge": "upsert"
         },
         "description": {
-          "merge": "preserve"
+          "merge": "upsert"
         },
         "venue": {
           "merge": "upsert"

--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -49,7 +49,7 @@
           "merge": "upsert"
         },
         "cover": {
-          "merge": "upsert"
+          "merge": "clobber"
         }
       }
     },
@@ -97,7 +97,7 @@
           "merge": "upsert"
         },
         "cover": {
-          "merge": "upsert"
+          "merge": "clobber"
         }
       }
     }


### PR DESCRIPTION
Adds a new Eventbrite parser configuration for the Bear Happy Hour organizer page to enable scraping events from this source.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a3213bb-b7aa-4e27-8992-e1a5ac601564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a3213bb-b7aa-4e27-8992-e1a5ac601564">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

