### PR TITLE
Fix ios google maps url construction

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -345,9 +345,14 @@ class EventbriteParser {
             
             // Generate Google Maps URL (SharedCore will filter out TBA venues)
             let gmapsUrl = '';
-            if (eventData.venue?.google_place_id) {
+            if (eventData.venue?.google_place_id && coordinates) {
+                // Use iOS-compatible format with both coordinates and place_id
+                gmapsUrl = `https://www.google.com/maps/search/?api=1&query=${coordinates.lat}%2C${coordinates.lng}&query_place_id=${eventData.venue.google_place_id}`;
+                console.log(`🎫 Eventbrite: Generated iOS-compatible Google Maps URL from Place ID and coordinates for "${title}": ${gmapsUrl}`);
+            } else if (eventData.venue?.google_place_id) {
+                // Fallback to place_id only if no coordinates available
                 gmapsUrl = `https://maps.google.com/?q=place_id:${eventData.venue.google_place_id}`;
-                console.log(`🎫 Eventbrite: Generated Google Maps URL from Place ID for "${title}": ${gmapsUrl}`);
+                console.log(`🎫 Eventbrite: Generated Google Maps URL from Place ID only (no coordinates) for "${title}": ${gmapsUrl}`);
             } else if (coordinates) {
                 gmapsUrl = `https://maps.google.com/?q=${coordinates.lat},${coordinates.lng}`;
                 console.log(`🎫 Eventbrite: Generated Google Maps URL from coordinates for "${title}": ${gmapsUrl}`);


### PR DESCRIPTION
Update Google Maps URL format in Eventbrite parser to ensure compatibility with iOS Google Maps app.

Previously, URLs constructed with only `place_id` (e.g., `?q=place_id:`) did not correctly open the Google Maps application on iOS devices. This PR introduces a new URL format (`/maps/search/?api=1&query=lat,lng&query_place_id=`) that includes both coordinates and the place ID, ensuring the link works reliably across web browsers and mobile Google Maps applications (iOS and Android).

---
<a href="https://cursor.com/background-agent?bcId=bc-5cfa37ed-0f31-4c29-8c7f-e6ee949064ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5cfa37ed-0f31-4c29-8c7f-e6ee949064ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

