### PR TITLE
Simplify dynamic calendar short name hyphenation

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -523,9 +523,9 @@ class DynamicCalendarLoader extends CalendarCore {
             return fullName;
         }
         
-        // 2. Use shorter name if we have one (it's only 3 chars, always fits)
-        if (shorterName) {
-            logger.info('CALENDAR', `🔍 SMART_NAME: Full title too long, using shorter name: "${shorterName}"`);
+        // 2. Use shorter name if we only have space for that
+        if (shorterName && shorterName.length <= totalCharsAvailable) {
+            logger.info('CALENDAR', `🔍 SMART_NAME: Only space for shorter name, using: "${shorterName}"`);
             return shorterName;
         }
         


### PR DESCRIPTION
Simplify event name selection logic to fix incorrect short name hyphenation.

The previous `getSmartEventNameForBreakpoint` method had complex logic, including an "effective length" calculation that removed hyphens for measurement, but then displayed them with soft hyphens. This mismatch caused `shortName` values like "MEGA-WOOF" to split incorrectly. The updated logic now prioritizes `fullName`, then `shorterName`, and finally `shortName` (with correct soft hyphen application) based on available space, ensuring consistent measurement and display.

---
<a href="https://cursor.com/background-agent?bcId=bc-d278bca2-fd53-41e3-bc94-c97fb48b4cf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d278bca2-fd53-41e3-bc94-c97fb48b4cf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

