### PR TITLE
Remove city page calendar failure message and css

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -129,19 +129,6 @@ class ChunkyDadApp {
                 // Don't await city page modules to prevent hanging
                 this.initializeCityPageModules().catch(error => {
                     logger.componentError('SYSTEM', 'City page module initialization failed', error);
-                    
-                    // Show user-friendly error if calendar fails to load
-                    const eventsContainer = document.querySelector('.events-list');
-                    if (eventsContainer && eventsContainer.innerHTML.includes('Getting events...')) {
-                        eventsContainer.innerHTML = `
-                            <div class="error-message">
-                                <h3>📅 Events Temporarily Unavailable</h3>
-                                <p>We're having trouble loading events right now.</p>
-                                <p><strong>Try:</strong> Refreshing the page or check back in a few minutes.</p>
-                                <button onclick="location.reload()" class="retry-btn">🔄 Refresh Page</button>
-                            </div>
-                        `;
-                    }
                 });
             }
             

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2390,22 +2390,7 @@ calculatedData: {
             logger.componentLoad('CALENDAR', 'Dynamic CalendarLoader initialization completed successfully');
         } catch (error) {
             logger.componentError('CALENDAR', 'Calendar initialization failed', error);
-            
-            // Show error message in events container if initialization fails
-            const eventsContainer = document.querySelector('.events-list');
-            if (eventsContainer) {
-                eventsContainer.innerHTML = `
-                    <div class="error-message">
-                        <h3>📅 Calendar Loading Failed</h3>
-                        <p>We're having trouble loading events for this city.</p>
-                        <p><strong>Try:</strong> Refreshing the page or check back later.</p>
-                        <button onclick="location.reload()" class="retry-btn">🔄 Retry</button>
-                    </div>
-                `;
-            }
-            
-            // Don't throw error to prevent app from crashing
-            logger.warn('CALENDAR', 'Calendar initialization failed, but continuing app startup');
+            throw error;
         } finally {
             this.isInitializing = false;
         }

--- a/styles.css
+++ b/styles.css
@@ -3769,46 +3769,7 @@ footer {
     z-index: 10;
 }
 
-/* Error Message Styles */
-.error-message {
-    text-align: center;
-    padding: 40px 20px;
-    background: var(--background-lighter);
-    border-radius: 8px;
-    border-left: 4px solid #f44336;
-    margin: 20px 0;
-}
 
-.error-message h3 {
-    color: #f44336;
-    margin: 0 0 15px 0;
-    font-size: 1.2rem;
-}
-
-.error-message p {
-    color: var(--text-secondary);
-    margin: 10px 0;
-    line-height: 1.5;
-}
-
-.retry-btn {
-    background: var(--primary-color);
-    color: white;
-    border: none;
-    padding: 12px 24px;
-    border-radius: 25px;
-    font-size: 16px;
-    font-weight: 600;
-    cursor: pointer;
-    margin-top: 15px;
-    transition: all 0.3s ease;
-}
-
-.retry-btn:hover {
-    background: var(--primary-hover);
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
-}
 
 .no-events-message {
     text-align: center;


### PR DESCRIPTION
Remove error message displays and their associated CSS that were overriding city page events.

The code, originally added in commit `346fa10` for "improved error handling," was causing "Calendar Loading Failed" and "Events Temporarily Unavailable" messages to appear unexpectedly and override legitimate content on city pages, which was not the desired behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-41f6ab6d-8914-4bed-9d36-08c38d202d86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41f6ab6d-8914-4bed-9d36-08c38d202d86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

