### PR TITLE
Fix event slug logic and order list

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -360,7 +360,7 @@ class CalendarCore {
                 };
             }
 
-            eventData.slug = this.generateSlug(eventData.name);
+            eventData.slug = this.generateSlug(eventData.name, calendarEvent.start);
 
             // Log timezone usage for debugging
             if (eventData.startTimezone || eventData.calendarTimezone) {
@@ -498,12 +498,20 @@ class CalendarCore {
     }
 
     // Generate URL slug from event name
-    generateSlug(name) {
-        return name.toLowerCase()
+    generateSlug(name, startDate = null) {
+        const baseSlug = name.toLowerCase()
             .replace(/[^a-z0-9\s-]/g, '')
             .replace(/\s+/g, '-')
             .replace(/-+/g, '-')
             .trim();
+        
+        // Add date/time suffix to ensure uniqueness for events with same name
+        if (startDate) {
+            const timestamp = startDate.getTime();
+            return `${baseSlug}-${timestamp}`;
+        }
+        
+        return baseSlug;
     }
 
     // Date and time utility methods

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1310,6 +1310,20 @@ class DynamicCalendarLoader extends CalendarCore {
             return this.isEventInPeriod(event.startDate, start, end);
         });
         
+        // Sort events by upcoming time (earliest first)
+        filtered.sort((a, b) => {
+            const dateA = new Date(a.startDate);
+            const dateB = new Date(b.startDate);
+            
+            // If dates are the same, sort by start time
+            if (dateA.toDateString() === dateB.toDateString()) {
+                return dateA.getTime() - dateB.getTime();
+            }
+            
+            // Otherwise sort by date
+            return dateA.getTime() - dateB.getTime();
+        });
+        
         return filtered;
     }
 
@@ -1870,6 +1884,7 @@ class DynamicCalendarLoader extends CalendarCore {
                     eventsList.innerHTML = '<div class="loading-message">📅 Getting events...</div>';
                 }
             } else if (filteredEvents?.length > 0) {
+                // Events are already sorted by upcoming time in getFilteredEvents()
                 eventsList.innerHTML = filteredEvents.map(event => this.generateEventCard(event)).join('');
             } else {
                 eventsList.innerHTML = '';


### PR DESCRIPTION
Fixes slug collisions for events with identical names and orders event lists by upcoming time.

---
<a href="https://cursor.com/background-agent?bcId=bc-631611ff-3fab-4513-a252-d9c9f3c25d90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-631611ff-3fab-4513-a252-d9c9f3c25d90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

