### PR TITLE
Update code and read debug rules

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5254,6 +5254,23 @@ footer {
     width: auto;
 }
 
+/* Ensure header and controls are always visible in minimized state */
+.debug-overlay.debug-minimized .debug-header {
+    display: flex !important;
+}
+
+.debug-overlay.debug-minimized .debug-header-controls {
+    display: flex !important;
+}
+
+.debug-overlay.debug-minimized .debug-close,
+.debug-overlay.debug-minimized .debug-toggle,
+.debug-overlay.debug-minimized .debug-minimize {
+    display: flex !important;
+    pointer-events: auto !important;
+    cursor: pointer !important;
+}
+
 .debug-overlay.debug-full .debug-essential {
     display: none;
 }


### PR DESCRIPTION
Fixes debug overlay stuck in minimized mode by ensuring controls are always visible and adding recovery mechanisms.

The debug overlay would save its 'minimized' state in localStorage, and the CSS would then hide all content, including the buttons, making it impossible to interact with or expand. This PR ensures buttons are always visible and adds double-click to expand, plus console commands for recovery.

---
<a href="https://cursor.com/background-agent?bcId=bc-05d12d76-a7bb-44a7-a1ac-4d717324ac2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-05d12d76-a7bb-44a7-a1ac-4d717324ac2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

