### PR TITLE
Changes from background agent bc-062b7442-99cb-4028-9216-0bbe59ec7c7c

### DIFF
--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -1,19 +1,19 @@
 {
   "config": {
-    "dryRun": true,
+    "dryRun": false,
     "daysToLookAhead": null
   },
   "parsers": [
     {
       "name": "Megawoof America",
       "parser": "eventbrite",
-      "enabled": false,
+      "enabled": true,
       "urls": ["https://www.eventbrite.com/o/megawoof-america-18118978189"],
       "alwaysBear": true,
       "requireDetailPages": true,
       "maxAdditionalUrls": 20,
       "urlDiscoveryDepth": 1,
-      "dryRun": true,
+      "dryRun": false,
       "daysToLookAhead": null,
       "mergeMode": "upsert",
       "urlFilters": {
@@ -64,13 +64,13 @@
     {
       "name": "Bear Happy Hour",
       "parser": "eventbrite",
-      "enabled": false,
+      "enabled": true,
       "urls": ["https://www.eventbrite.com/o/bear-happy-hour-87043830313"],
       "alwaysBear": true,
       "requireDetailPages": true,
       "maxAdditionalUrls": 20,
       "urlDiscoveryDepth": 1,
-      "dryRun": true,
+      "dryRun": false,
       "daysToLookAhead": null,
       "mergeMode": "upsert",
       "urlFilters": {
@@ -128,7 +128,7 @@
       "requireDetailPages": true,
       "maxAdditionalUrls": 20,
       "urlDiscoveryDepth": 1,
-      "dryRun": true,
+      "dryRun": false,
       "daysToLookAhead": null,
       "mergeMode": "upsert",
       "urlFilters": {
@@ -178,13 +178,13 @@
     {
       "name": "Bearracuda Eventbrite",
       "parser": "eventbrite",
-      "enabled": false,
+      "enabled": true,
       "urls": ["https://www.eventbrite.com/o/bearracuda-21867032189"],
       "alwaysBear": true,
       "requireDetailPages": true,
       "maxAdditionalUrls": 20,
       "urlDiscoveryDepth": 1,
-      "dryRun": true,
+      "dryRun": false,
       "daysToLookAhead": null,
       "mergeMode": "upsert",
       "urlFilters": {


### PR DESCRIPTION
Enable event saving and all parsers by disabling dry run mode and activating disabled parsers in `scraper-input.json`.

The previous configuration had `dryRun` set to `true` globally and for individual parsers, preventing any events from being saved to the calendar. Additionally, most parsers were disabled. This PR corrects these settings to allow events to be scraped and saved as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-062b7442-99cb-4028-9216-0bbe59ec7c7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-062b7442-99cb-4028-9216-0bbe59ec7c7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

