### PR TITLE
Changes from background agent bc-659e2271-8e32-4823-bc7e-2ce0a22805b2

### DIFF
--- a/scripts/parsers/bearracuda-parser.js
+++ b/scripts/parsers/bearracuda-parser.js
@@ -640,7 +640,7 @@ class BearraccudaParser {
             'la': /losangeles|la/i,
             'nyc': /newyork|nyc/i,
             'seattle': /treasureseattle|seattle/i,
-            'portland': /treasureportland|portland/i
+            'portland': /treasureportland|portland|pdx/i
         };
         
         for (const [city, pattern] of Object.entries(urlPatterns)) {
@@ -1001,7 +1001,7 @@ class BearraccudaParser {
             'atlanta': /(atlanta|atl)/i,
             'denver': /(denver)/i,
             'vegas': /(vegas|las vegas)/i,
-            'la': /(los angeles|la|long beach)/i,
+            'la': /(los angeles|\bla\b|long beach)/i,
             'nyc': /(new york|nyc|manhattan)/i,
             'chicago': /(chicago)/i,
             'miami': /(miami)/i,

--- a/testing/manifest.json
+++ b/testing/manifest.json
@@ -1,95 +1,100 @@
 {
-  "generated": "2025-08-17T00:02:35.697Z",
+  "generated": "2025-08-17T00:04:07.611Z",
   "files": [
     {
       "name": "breakpoint-test.html",
       "size": 34161,
-      "modified": "2025-08-17T00:02:32.126Z"
+      "modified": "2025-08-16T14:57:02.954Z"
     },
     {
       "name": "calendar-timeout-test.html",
       "size": 9897,
-      "modified": "2025-08-17T00:02:32.126Z"
+      "modified": "2025-08-16T14:57:02.954Z"
     },
     {
       "name": "debug-calendar-loading.html",
       "size": 4061,
-      "modified": "2025-08-17T00:02:32.126Z"
+      "modified": "2025-08-16T14:57:02.954Z"
     },
     {
       "name": "hero-variations-tester.html",
       "size": 26248,
-      "modified": "2025-08-17T00:02:32.126Z"
+      "modified": "2025-08-16T14:57:02.954Z"
     },
     {
       "name": "iframe-fix-test.html",
       "size": 9922,
-      "modified": "2025-08-17T00:02:32.126Z"
+      "modified": "2025-08-16T14:57:02.954Z"
     },
     {
       "name": "index.html",
       "size": 18216,
-      "modified": "2025-08-17T00:02:32.126Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "simple-calendar-test.html",
       "size": 1795,
-      "modified": "2025-08-17T00:02:32.126Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "style-test.html",
       "size": 26360,
-      "modified": "2025-08-17T00:02:32.126Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "test-calendar-logging.html",
       "size": 68099,
-      "modified": "2025-08-17T00:02:32.127Z"
+      "modified": "2025-08-16T14:57:02.958Z"
+    },
+    {
+      "name": "test-city-extraction.html",
+      "size": 3926,
+      "modified": "2025-08-17T00:04:04.013Z"
     },
     {
       "name": "test-direct-google-calendar.html",
       "size": 8920,
-      "modified": "2025-08-17T00:02:32.127Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "test-display-modes.html",
       "size": 10729,
-      "modified": "2025-08-17T00:02:32.127Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "test-error-logging-fix.html",
       "size": 6806,
-      "modified": "2025-08-17T00:02:32.127Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "test-eventbrite-address-fix.html",
       "size": 7179,
-      "modified": "2025-08-17T00:02:32.127Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "test-google-sheets-loader.html",
       "size": 40540,
-      "modified": "2025-08-17T00:02:32.127Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "test-hyphenation-fix.html",
       "size": 6108,
-      "modified": "2025-08-17T00:02:32.127Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "test-map-icons.html",
       "size": 61258,
-      "modified": "2025-08-17T00:02:32.127Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "test-unified-scraper.html",
       "size": 32064,
-      "modified": "2025-08-17T00:02:32.127Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     },
     {
       "name": "ultimate-style-tester.html",
       "size": 116287,
-      "modified": "2025-08-17T00:02:32.128Z"
+      "modified": "2025-08-16T14:57:02.958Z"
     }
   ]
 }

--- a/testing/test-city-extraction.html
+++ b/testing/test-city-extraction.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>City Extraction Test</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .test-case { margin: 10px 0; padding: 10px; border: 1px solid #ccc; }
+        .pass { background-color: #d4edda; }
+        .fail { background-color: #f8d7da; }
+    </style>
+</head>
+<body>
+    <h1>Bearracuda Parser City Extraction Test</h1>
+    <div id="results"></div>
+
+    <script src="../scripts/parsers/bearracuda-parser.js"></script>
+    <script>
+        // Test cases for city extraction
+        const testCases = [
+            // URL extraction tests
+            { type: 'URL', input: 'https://bearracuda.com/events/pdx16/', expected: 'portland', description: 'Portland PDX URL' },
+            { type: 'URL', input: 'https://bearracuda.com/events/atlantabearpride/', expected: 'atlanta', description: 'Atlanta URL' },
+            { type: 'URL', input: 'https://bearracuda.com/events/chicagoaug/', expected: 'chicago', description: 'Chicago URL' },
+            { type: 'URL', input: 'https://bearracuda.com/events/treasureseattle/', expected: 'seattle', description: 'Seattle URL' },
+            
+            // Text extraction tests
+            { type: 'TEXT', input: 'Portland 16th Anniversary', expected: 'portland', description: 'Portland in title' },
+            { type: 'TEXT', input: 'Los Angeles Bear Party', expected: 'la', description: 'Los Angeles in title' },
+            { type: 'TEXT', input: 'LA Bear Night', expected: 'la', description: 'LA abbreviation' },
+            { type: 'TEXT', input: 'Atlanta Bear Pride', expected: 'atlanta', description: 'Atlanta in title' },
+            { type: 'TEXT', input: 'Chicago Summer Event', expected: 'chicago', description: 'Chicago in title' },
+            { type: 'TEXT', input: 'Seattle Treasure Trail', expected: 'seattle', description: 'Seattle in title' }
+        ];
+
+        function runTests() {
+            const parser = new BearraccudaParser();
+            const results = document.getElementById('results');
+            let passCount = 0;
+            let totalCount = testCases.length;
+
+            testCases.forEach((testCase, index) => {
+                const testDiv = document.createElement('div');
+                testDiv.className = 'test-case';
+                
+                let actual;
+                if (testCase.type === 'URL') {
+                    actual = parser.extractCityFromUrl(testCase.input);
+                } else {
+                    actual = parser.extractCityFromText(testCase.input);
+                }
+                
+                const passed = actual === testCase.expected;
+                if (passed) passCount++;
+                
+                testDiv.classList.add(passed ? 'pass' : 'fail');
+                testDiv.innerHTML = `
+                    <strong>Test ${index + 1}: ${testCase.description}</strong><br>
+                    Type: ${testCase.type}<br>
+                    Input: "${testCase.input}"<br>
+                    Expected: "${testCase.expected}"<br>
+                    Actual: "${actual}"<br>
+                    Result: ${passed ? 'PASS' : 'FAIL'}
+                `;
+                
+                results.appendChild(testDiv);
+            });
+
+            // Summary
+            const summaryDiv = document.createElement('div');
+            summaryDiv.style.marginTop = '20px';
+            summaryDiv.style.fontWeight = 'bold';
+            summaryDiv.innerHTML = `
+                <h2>Summary: ${passCount}/${totalCount} tests passed</h2>
+                ${passCount === totalCount ? '✅ All tests passed!' : '❌ Some tests failed'}
+            `;
+            results.appendChild(summaryDiv);
+        }
+
+        // Run tests when page loads
+        window.addEventListener('load', runTests);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Fixes incorrect city categorization for Portland events by refining URL and text extraction patterns in the Bearracuda parser.

The previous implementation failed to recognize "pdx" in Portland URLs and incorrectly matched "la" as a substring within "Portland" in event titles. This PR adds "pdx" to the Portland URL pattern and introduces word boundaries to the "la" text pattern to ensure accurate city assignment.

---
<a href="https://cursor.com/background-agent?bcId=bc-659e2271-8e32-4823-bc7e-2ce0a22805b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-659e2271-8e32-4823-bc7e-2ce0a22805b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

