### PR TITLE
Changes from background agent bc-374c8f3a-5a93-4bc0-8f80-7b4391bd6520

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1108,6 +1108,7 @@ class ScriptableAdapter {
                 const globalDryRun = results.config?.config?.dryRun;
                 const hasActiveEvents = eventsFromActiveParsers.length > 0;
                 
+                console.log(`📱 Scriptable: - DEBUG config object: ${JSON.stringify(results.config?.config, null, 2)}`);
                 console.log(`📱 Scriptable: - globalDryRun: ${globalDryRun}`);
                 console.log(`📱 Scriptable: - eventsFromActiveParsers: ${eventsFromActiveParsers.length}`);
                 console.log(`📱 Scriptable: - hasActiveEvents: ${hasActiveEvents}`);

--- a/scripts/scraper-input.json
+++ b/scripts/scraper-input.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "dryRun": true,
+    "dryRun": false,
     "daysToLookAhead": null
   },
   "parsers": [
@@ -13,7 +13,7 @@
       "requireDetailPages": true,
       "maxAdditionalUrls": 20,
       "urlDiscoveryDepth": 1,
-      "dryRun": true,
+      "dryRun": false,
       "daysToLookAhead": null,
       "mergeMode": "upsert",
       "urlFilters": {
@@ -70,7 +70,7 @@
       "requireDetailPages": true,
       "maxAdditionalUrls": 20,
       "urlDiscoveryDepth": 1,
-      "dryRun": true,
+      "dryRun": false,
       "daysToLookAhead": null,
       "mergeMode": "upsert",
       "urlFilters": {
@@ -128,7 +128,7 @@
       "requireDetailPages": true,
       "maxAdditionalUrls": 20,
       "urlDiscoveryDepth": 1,
-      "dryRun": true,
+      "dryRun": false,
       "daysToLookAhead": null,
       "mergeMode": "upsert",
       "urlFilters": {
@@ -184,7 +184,7 @@
       "requireDetailPages": true,
       "maxAdditionalUrls": 20,
       "urlDiscoveryDepth": 1,
-      "dryRun": true,
+      "dryRun": false,
       "daysToLookAhead": null,
       "mergeMode": "upsert",
       "urlFilters": {


### PR DESCRIPTION
Disable dry run mode by setting all `dryRun` flags to `false` in the configuration file.

The script was not writing to the calendar because it checks both a global `dryRun` setting and individual `dryRun` settings for each parser. If any of these were `true`, the script would remain in dry run mode. This PR ensures all instances are `false` to allow calendar writes.

---
<a href="https://cursor.com/background-agent?bcId=bc-374c8f3a-5a93-4bc0-8f80-7b4391bd6520">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-374c8f3a-5a93-4bc0-8f80-7b4391bd6520">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

