### PR TITLE
Changes from background agent bc-0908383c-1395-4545-bd93-9fe077245d0b

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -578,8 +578,15 @@ class SharedCore {
         
         return {
             title: mergedEvent.title,
+            startDate: mergedEvent.startDate,
+            endDate: mergedEvent.endDate,
+            location: mergedEvent.location,
             notes: notes,
-            url: mergedEvent.website
+            url: mergedEvent.website,
+            city: mergedEvent.city || newEvent.city || existingEvent.city, // Preserve city field
+            key: mergedEvent.key || newEvent.key,
+            _parserConfig: mergedEvent._parserConfig || newEvent._parserConfig,
+            _fieldMergeStrategies: mergedEvent._fieldMergeStrategies
         };
     }
 


### PR DESCRIPTION
Preserve essential event fields during cross-parser deduplication to fix "Calendar not found" errors.

The `mergeEventData` function was previously dropping critical fields like `city`, `startDate`, and `location` when merging duplicate events from different parsers. This caused events to be incorrectly assigned to a non-existent "default" calendar, leading to script failures. This PR ensures all necessary event data is retained during merging.

---
<a href="https://cursor.com/background-agent?bcId=bc-0908383c-1395-4545-bd93-9fe077245d0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0908383c-1395-4545-bd93-9fe077245d0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

