### PR TITLE
Changes from background agent bc-02a2ad4e-7f94-4886-89fd-3da01b03a210

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -182,6 +182,9 @@ const scraperConfig = {
         },
         cover: {
           merge: "clobber"
+        },
+        key: {
+          merge: "clobber"
         }
       }
     },
@@ -238,6 +241,9 @@ const scraperConfig = {
           merge: "clobber"
         },
         cover: {
+          merge: "clobber"
+        },
+        key: {
           merge: "clobber"
         }
       }


### PR DESCRIPTION
Update Bearracuda parser configurations to clobber old event keys and ensure correct title display.

The previous merge strategy for the `key` field defaulted to "upsert", causing old keys from existing calendar events to be preserved in notes and leading to "undefined" titles in the output. Changing the strategy to "clobber" ensures the new, correctly formatted key is always applied.

---
<a href="https://cursor.com/background-agent?bcId=bc-02a2ad4e-7f94-4886-89fd-3da01b03a210">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02a2ad4e-7f94-4886-89fd-3da01b03a210">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

