### PR TITLE
Conditionally use proxy for calendar data

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1026,14 +1026,15 @@ class DynamicCalendarLoader extends CalendarCore {
             return null;
         }
         
-        // Check for forceProxy URL parameter (default: true)
+        // Check for proxy URL parameter - only use proxy when explicitly requested
         const urlParams = new URLSearchParams(window.location.search);
-        const forceProxy = urlParams.get('forceProxy') !== 'false';
+        const useProxy = urlParams.has('proxy');
         
         logger.time('CALENDAR', `Loading ${cityConfig.name} calendar data`);
         
-        // If forceProxy is true, skip cached data and go directly to proxy
-        if (forceProxy) {
+        // If proxy parameter is set, skip cached data and go directly to proxy
+        if (useProxy) {
+            logger.info('CALENDAR', 'Proxy parameter detected - using proxy for calendar data');
             const proxyResult = await this.loadCalendarDataViaProxy(cityKey, cityConfig);
             if (proxyResult) return proxyResult;
             return this.loadCalendarDataFallback(cityKey, cityConfig);


### PR DESCRIPTION
Change calendar data loading to only use proxy when the `proxy` URL parameter is present, fixing the incorrect default behavior of always using the proxy.

---
<a href="https://cursor.com/background-agent?bcId=bc-b22f0167-150c-49d8-9ece-c78f778fe562">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b22f0167-150c-49d8-9ece-c78f778fe562">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

