### PR TITLE
Changes from background agent bc-1f776cdf-e02a-45d0-9136-27d66883078f

### DIFF
--- a/scripts/parsers/bearracuda-parser.js
+++ b/scripts/parsers/bearracuda-parser.js
@@ -259,7 +259,7 @@ class BearraccudaParser {
                 bar: venueInfo.name, // Use 'bar' field name that calendar-core.js expects
                 location: null, // No coordinates available in HTML parsing
                 address: address,
-                city: city,
+                city: city || 'unknown',
                 website: sourceUrl, // Always use the bearracuda.com detail page URL
                 cover: '', // No cover charge info found in the sample
                 image: this.extractImage(html),
@@ -304,8 +304,9 @@ class BearraccudaParser {
                 return null;
             }
             if (!city) {
-                console.warn(`🐻 Bearracuda: No city information found - cannot create event`);
-                return null;
+                console.warn(`🐻 Bearracuda: No city information found - will use 'unknown' as fallback`);
+                // Don't return null - we can still create the event with unknown city
+                // The calendar system will route it to the default calendar
             }
             
             console.log(`🐻 Bearracuda: Created event "${title}" for ${city} on ${startDate || dateInfo}`);

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -162,7 +162,7 @@ class SharedCore {
                 
                 await displayAdapter.logInfo(`SYSTEM: Parsing events with ${parserName} parser...`);
                 // Pass parser config and city config separately
-                const parseResult = parser.parseEvents(htmlData, parserConfig, mainConfig.cities);
+                const parseResult = parser.parseEvents(htmlData, parserConfig, mainConfig?.cities || null);
                 
                 await displayAdapter.logInfo(`SYSTEM: Parse result: ${parseResult?.events?.length || 0} events found`);
                 if (parseResult?.additionalLinks) {
@@ -197,7 +197,9 @@ class SharedCore {
                         parserConfig, 
                         httpAdapter, 
                         displayAdapter,
-                        processedUrls
+                        processedUrls,
+                        1,
+                        mainConfig
                     );
                     await displayAdapter.logSuccess(`SYSTEM: Enriched ${allEvents.length} events with detail page information`);
                 }
@@ -238,7 +240,7 @@ class SharedCore {
         };
     }
 
-    async enrichEventsWithDetailPages(existingEvents, additionalLinks, parser, parserConfig, httpAdapter, displayAdapter, processedUrls, currentDepth = 1) {
+    async enrichEventsWithDetailPages(existingEvents, additionalLinks, parser, parserConfig, httpAdapter, displayAdapter, processedUrls, currentDepth = 1, mainConfig = null) {
         const maxUrls = parserConfig.maxAdditionalUrls || 12;
         const urlsToProcess = additionalLinks.slice(0, maxUrls);
         const maxDepth = parserConfig.urlDiscoveryDepth || 1;
@@ -265,7 +267,7 @@ class SharedCore {
                 };
                 
                 // Pass detail page config and city config separately
-                const parseResult = parser.parseEvents(htmlData, detailPageConfig, mainConfig.cities);
+                const parseResult = parser.parseEvents(htmlData, detailPageConfig, mainConfig?.cities || null);
                 
                 // Handle additional URLs if depth allows
                 if (parseResult.additionalLinks && parseResult.additionalLinks.length > 0) {
@@ -286,7 +288,8 @@ class SharedCore {
                                 httpAdapter,
                                 displayAdapter,
                                 processedUrls,
-                                currentDepth + 1
+                                currentDepth + 1,
+                                mainConfig
                             );
                         }
                     } else {
@@ -335,6 +338,10 @@ class SharedCore {
                 }
             } catch (error) {
                 await displayAdapter.logWarn(`SYSTEM: Failed to process detail page URL: ${url}`);
+                await displayAdapter.logError(`SYSTEM: Detail page error: ${error.message || error}`);
+                if (error.stack) {
+                    await displayAdapter.logError(`SYSTEM: Detail page stack trace: ${error.stack}`);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes detail page processing and enhances error logging for the event scraper.

The scraper was failing to process event detail pages due to `mainConfig` not being passed to `enrichEventsWithDetailPages`, causing `mainConfig.cities` to be undefined. Additionally, errors were being swallowed with generic messages, and the bearracuda parser's city validation was overly strict, preventing events from being created even when other data was present.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f776cdf-e02a-45d0-9136-27d66883078f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f776cdf-e02a-45d0-9136-27d66883078f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

