### PR TITLE
Update parsers and check field consistency

### DIFF
--- a/scripts/parsers/bearracuda-parser.js
+++ b/scripts/parsers/bearracuda-parser.js
@@ -260,7 +260,7 @@ class BearraccudaParser {
                 location: null, // No coordinates available in HTML parsing
                 address: address,
                 city: city,
-                website: sourceUrl, // Always use the bearracuda.com detail page URL
+                url: sourceUrl, // Use consistent 'url' field name across all parsers
                 cover: '', // No cover charge info found in the sample
                 image: this.extractImage(html),
                 gmaps: this.generateGoogleMapsUrl(address),
@@ -269,7 +269,6 @@ class BearraccudaParser {
                 facebookEvent: links.facebook,
                 ticketUrl: links.eventbrite,
                 eventbriteUrl: links.eventbrite, // Store eventbrite URL separately
-                detailPageUrl: sourceUrl, // Store the bearracuda detail page URL
                 isBearEvent: true // Bearracuda events are always bear events
             };
             

--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -382,7 +382,7 @@ class EventbriteParser {
                 location: coordinates ? `${coordinates.lat}, ${coordinates.lng}` : null, // Store coordinates as "lat,lng" string in location field
                 address: address,
                 city: city,
-                website: url, // Use 'website' field name that calendar-core.js expects
+                url: url, // Use consistent 'url' field name across all parsers
                 cover: price, // Use 'cover' field name that calendar-core.js expects
                 image: image,
                 gmaps: gmapsUrl, // Google Maps URL for enhanced location access

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -309,8 +309,8 @@ class SharedCore {
                     
                     // Find the matching existing event by URL
                     const matchingEvent = existingEvents.find(event => 
-                        event.website === detailEvent.website ||
-                        event.website === url ||
+                        event.url === detailEvent.url ||
+                        event.url === url ||
                         (event.title && detailEvent.title && event.title.trim() === detailEvent.title.trim())
                     );
                     
@@ -592,7 +592,7 @@ class SharedCore {
             endDate: mergedEvent.endDate,
             location: mergedEvent.location,
             notes: notes,
-            url: mergedEvent.website,
+            url: mergedEvent.url, // Now consistent across all parsers
             city: mergedEvent.city || newEvent.city || existingEvent.city, // Preserve city field
             key: mergedEvent.key || newEvent.key,
             _parserConfig: mergedEvent._parserConfig || newEvent._parserConfig,


### PR DESCRIPTION
Standardizes URL field to `url` across all parsers and adds address extraction to `generic-parser.js` for improved consistency and maintainability.

Previously, parsers used `website` while `shared-core.js` expected `url` and performed a mapping. This PR eliminates that inconsistency by making all parsers use `url` directly. Additionally, the `generic-parser.js` was updated to extract address information, aligning it with other parsers. Redundant fields like `detailPageUrl` were also removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d20a681-9be7-41a6-85c2-d29abc20bfe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d20a681-9be7-41a6-85c2-d29abc20bfe3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

