### PR TITLE
Changes from background agent bc-d22b78eb-00b7-49f0-a3d2-9adb711f46d8

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1445,7 +1445,7 @@ class SharedCore {
         const fieldsToExclude = new Set(['isBearEvent', 'source']); // city is kept for calendar mapping
         Object.keys(event).forEach(key => {
             if (!key.startsWith('_') && !(key in calendarEvent) && !fieldsToExclude.has(key)) {
-                if (strategies[key] === 'preserve') return;
+                if (priorities[key]?.merge === 'preserve') return;
                 // Only copy fields that have values and should be included
                 if (event[key] !== undefined && event[key] !== null && event[key] !== '') {
                     calendarEvent[key] = event[key];


### PR DESCRIPTION
Fix `ReferenceError: Can't find variable: strategies` by using the correct `priorities` variable for merge strategy.

The `formatEventForCalendar` function in `scripts/shared-core.js` was attempting to access `strategies[key]` to determine if a field should be preserved, but `strategies` was an undefined variable. This led to a `ReferenceError` during event processing. The fix replaces the incorrect `strategies[key]` reference with `priorities[key]?.merge`, which correctly accesses the defined field priorities for merge behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-d22b78eb-00b7-49f0-a3d2-9adb711f46d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d22b78eb-00b7-49f0-a3d2-9adb711f46d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

