### PR TITLE
Changes from background agent bc-a607b086-97e0-4f56-b272-1cea9fb65467

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -708,7 +708,7 @@ class SharedCore {
         };
         
         // Parse the final notes to get all the merged fields for display
-        const finalFields = this.parseNotesIntoFields(finalEvent.notes);
+        const finalFields = this.parseNotesIntoFields(finalEvent.notes || '');
         
         // Prepare priority config and existing fields for comparison blocks below
         const fieldPrioritiesForCompare = newEvent._fieldPriorities || {};
@@ -824,6 +824,12 @@ class SharedCore {
     // Parse notes back into field/value pairs
     parseNotesIntoFields(notes) {
         const fields = {};
+        
+        // Handle undefined or null notes
+        if (!notes) {
+            return fields;
+        }
+        
         const lines = notes.split('\n');
         
         // Map of normalized aliases (lowercased, spaces removed) to canonical field names
@@ -1536,7 +1542,7 @@ class SharedCore {
                 
                 // Calculate merge diff for display purposes
                 const originalFields = this.parseNotesIntoFields(analysis.existingEvent.notes || '');
-                const mergedFields = this.parseNotesIntoFields(analyzedEvent.notes);
+                const mergedFields = this.parseNotesIntoFields(analyzedEvent.notes || '');
                 
                 console.log(`📊 SharedCore: Comparing fields for merge diff - Original: ${Object.keys(originalFields).length} fields, Merged: ${Object.keys(mergedFields).length} fields`);
                 


### PR DESCRIPTION
Fix `TypeError` in `parseNotesIntoFields` by adding null checks for the `notes` parameter to prevent crashes.

The `parseNotesIntoFields` function was attempting to call `.split()` on its `notes` parameter, which could be `undefined` in certain scenarios, leading to a `TypeError` and script failure. This change defensively handles `undefined` or `null` `notes` values and ensures all call sites pass a default empty string for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-a607b086-97e0-4f56-b272-1cea9fb65467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a607b086-97e0-4f56-b272-1cea9fb65467">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

