### PR TITLE
Update code and check shared core

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -669,7 +669,7 @@ class SharedCore {
             endDate: resolvedEndDate,
             location: resolvedLocation,
             notes: mergedData.notes,
-            url: mergedData.url
+            url: mergedData.url,
             
             // Preserve existing event reference for saving
             _existingEvent: existingEvent,


### PR DESCRIPTION
Add missing comma in `shared-core.js` to fix a `TypeError` preventing module import and scraper initialization.

The `TypeError: undefined is not an object (evaluating 'importModule('shared-core')')` was caused by a missing comma in an object literal on line 672 of `scripts/shared-core.js`. This syntax error prevented the `shared-core` module from being correctly loaded in the Scriptable environment, thus failing the initialization of the Bear Event Scraper. Adding the comma resolves the parsing issue and allows the scraper to function.

---
<a href="https://cursor.com/background-agent?bcId=bc-db643c64-c757-4d59-acef-804c922a4021">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db643c64-c757-4d59-acef-804c922a4021">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

