### PR TITLE
Changes from background agent bc-8d0a0c7b-1325-414b-831c-822a65a1f96a

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -763,16 +763,15 @@ class SharedCore {
                 const priorityConfig = fieldPrioritiesForCompare[fieldName];
                 const mergeStrategy = priorityConfig?.merge || 'preserve';
                 
-                // For preserve strategy, only add if the field existed in the original event
+                // For preserve strategy, don't add fields that don't exist in calendar (preserve undefined)
                 if (mergeStrategy === 'preserve') {
-                    // Check if field existed in original event (either as direct field or in notes)
-                    const existedInOriginal = existingEvent[fieldName] !== undefined || existingFields[fieldName] !== undefined;
-                    if (existedInOriginal) {
-                        finalEvent[fieldName] = finalFields[fieldName];
-                    }
-                    // If it didn't exist in original, don't add it (preserve undefined)
-                } else {
-                    // For upsert and clobber strategies, add the field
+                    // Don't add - preserve the undefined calendar value
+                    return;
+                } else if (mergeStrategy === 'upsert') {
+                    // Only add if calendar doesn't have the field (which we already checked with !finalEvent[fieldName])
+                    finalEvent[fieldName] = finalFields[fieldName];
+                } else if (mergeStrategy === 'clobber') {
+                    // Always add the scraped value (this should have been handled by merge logic above, but ensure it's here)
                     finalEvent[fieldName] = finalFields[fieldName];
                 }
             }
@@ -883,10 +882,16 @@ class SharedCore {
         if (finalEvent._mergeInfo?.extractedFields && finalEvent._fieldPriorities) {
             Object.entries(finalEvent._mergeInfo.extractedFields).forEach(([fieldName, fieldInfo]) => {
                 const priorityConfig = finalEvent._fieldPriorities[fieldName];
-                // Only add fields that have non-preserve merge strategy or have upsert and field is missing
-                if (priorityConfig && priorityConfig.merge === 'upsert' && !finalEvent[fieldName]) {
+                const mergeStrategy = priorityConfig?.merge || 'preserve';
+                
+                if (mergeStrategy === 'preserve') {
+                    // For preserve: don't add fields - use calendar value (even if undefined)
+                    // Do nothing - preserve strategy should have been handled by main merge logic
+                } else if (mergeStrategy === 'upsert' && !finalEvent[fieldName]) {
+                    // For upsert: only add if field is missing from calendar
                     finalEvent[fieldName] = fieldInfo.value;
-                } else if (priorityConfig && priorityConfig.merge === 'clobber') {
+                } else if (mergeStrategy === 'clobber') {
+                    // For clobber: always use scraped value (should already be set by main merge logic)
                     finalEvent[fieldName] = fieldInfo.value;
                 }
                 // For preserve strategy: do nothing - keep existing value or undefined
@@ -1855,40 +1860,35 @@ class SharedCore {
             
             switch (strategy) {
                 case 'preserve':
-                    // Always use existing value if it exists
-                    if (existingValue !== undefined && existingValue !== null && existingValue !== '') {
-                        event[fieldName] = existingValue;
-                        event._mergeInfo.mergedFields[fieldName] = 'existing';
-                        return true;
-                    }
-                    break;
+                    // Always use calendar value, even if undefined
+                    event[fieldName] = existingValue;
+                    event._mergeInfo.mergedFields[fieldName] = 'existing';
+                    return true;
                     
                 case 'upsert':
-                    // Only add new value if existing doesn't have it
-                    if (!existingValue && newValue) {
-                        // Keep new value (do nothing as it's already in event)
+                    // Prefer calendar if exists, otherwise add scraped
+                    if (existingValue !== undefined && existingValue !== null && existingValue !== '') {
+                        // Calendar has value, use it
+                        event[fieldName] = existingValue;
+                        event._mergeInfo.mergedFields[fieldName] = 'existing';
+                        return true;
+                    } else if (newValue !== undefined && newValue !== null && newValue !== '') {
+                        // Calendar doesn't have value, use scraped
+                        event[fieldName] = newValue;
                         event._mergeInfo.mergedFields[fieldName] = 'new';
                         return true;
-                    } else if (existingValue) {
-                        // Existing has value, keep it
+                    } else {
+                        // Neither has value, use calendar (undefined)
                         event[fieldName] = existingValue;
                         event._mergeInfo.mergedFields[fieldName] = 'existing';
                         return true;
                     }
-                    break;
                     
                 case 'clobber':
-                    // Use new value if it exists, otherwise keep existing
-                    if (newValue !== undefined && newValue !== null && newValue !== '') {
-                        // Keep new value (do nothing as it's already in event)
-                        event._mergeInfo.mergedFields[fieldName] = 'new';
-                        return true;
-                    } else if (existingValue) {
-                        event[fieldName] = existingValue;
-                        event._mergeInfo.mergedFields[fieldName] = 'existing';
-                        return true;
-                    }
-                    break;
+                    // Always use scraped value
+                    event[fieldName] = newValue;
+                    event._mergeInfo.mergedFields[fieldName] = 'new';
+                    return true;
             }
             
             return false;


### PR DESCRIPTION
Fix merge strategy application for 'preserve' and 'clobber' on event fields to ensure correct data handling during enrichment.

The `preserve` strategy for the `bar` field was not respected, leading to new values being added even when the existing event had no value. The `clobber` strategy for the `gmaps` field was being overridden by the `enrichEventLocation` function, which regenerated the URL after the merge. This PR ensures these merge strategies are correctly applied throughout the event processing pipeline.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d0a0c7b-1325-414b-831c-822a65a1f96a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d0a0c7b-1325-414b-831c-822a65a1f96a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

