### PR TITLE
Update code and fix clobber bug

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -647,9 +647,18 @@ class SharedCore {
         });
         
         // Add any existing fields that weren't in scraped data
+        // BUT respect merge strategies - don't override clobber results
         Object.keys(existingFields).forEach(fieldName => {
             if (!mergedEvent[fieldName] && existingFields[fieldName]) {
-                mergedEvent[fieldName] = existingFields[fieldName];
+                // Check if this field has a merge strategy that should be respected
+                const priorityConfig = fieldPriorities[fieldName];
+                const mergeStrategy = priorityConfig?.merge || 'preserve';
+                
+                // Only add existing fields if NOT clobber strategy
+                // Clobber should be allowed to clear fields (set to undefined)
+                if (mergeStrategy !== 'clobber') {
+                    mergedEvent[fieldName] = existingFields[fieldName];
+                }
             }
         });
         


### PR DESCRIPTION
Fix clobber merge strategy to always replace the existing value, even if the new value is empty.

The previous implementation in `scripts/shared-core.js` incorrectly checked if `newValue` was not empty (`newValue !== ''`). This caused the clobber strategy to fall back to preserving the `existingValue` when `newValue` was empty, null, or undefined, which is not the expected "always replace" behavior for clobber.

---
<a href="https://cursor.com/background-agent?bcId=bc-0206cb1e-7630-4856-b64f-725ded214f38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0206cb1e-7630-4856-b64f-725ded214f38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

