### PR TITLE
Changes from background agent bc-5b6e41cf-12a0-422e-8dbf-ac74de277bac

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1074,6 +1074,9 @@ class ScriptableAdapter {
                             identifier: c.identifier
                         }));
                     }
+                    if (key === 'placeId') {
+                        return undefined; // Hide placeId from debug display
+                    }
                     if (typeof value === 'function') {
                         return '[Function]';
                     }
@@ -2445,6 +2448,9 @@ class ScriptableAdapter {
                                                 identifier: c.identifier
                                             }));
                                         }
+                                        if (key === 'placeId') {
+                                            return undefined; // Hide placeId from debug display
+                                        }
                                         if (typeof value === 'function') {
                                             return '[Function]';
                                         }
@@ -2536,6 +2542,9 @@ class ScriptableAdapter {
                             identifier: c.identifier
                         }));
                     }
+                    if (key === 'placeId') {
+                        return undefined; // Hide placeId from debug display
+                    }
                     if (typeof value === 'function') {
                         return '[Function]'; // Show functions exist but don't break JSON
                     }
@@ -2557,6 +2566,9 @@ class ScriptableAdapter {
                                         startDate: c.startDate,
                                         identifier: c.identifier
                                     }));
+                                }
+                                if (key === 'placeId') {
+                                    return undefined; // Hide placeId from debug display
                                 }
                                 if (typeof value === 'function') {
                                     return '[Function]';


### PR DESCRIPTION
Hide `placeId` from Scriptable rich display and console debug output.

The `placeId` field was being included in `JSON.stringify` calls for display purposes because it wasn't explicitly filtered out. This PR adds the necessary filtering to prevent its display in the rich HTML UI and console logs, while preserving its internal use for Google Maps URL generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b6e41cf-12a0-422e-8dbf-ac74de277bac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b6e41cf-12a0-422e-8dbf-ac74de277bac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

