### PR TITLE
Changes from background agent bc-6f8a63bd-789b-4469-9148-fc8f1eb2dab7

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2958,7 +2958,9 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
             'originalTitle', 'name', // These are usually duplicates of title
             // Scriptable-specific properties that shouldn't be in notes
             'identifier', 'availability', 'timeZone', 'calendar', 'addRecurrenceRule',
-            'removeAllRecurrenceRules', 'save', 'remove', 'presentEdit', '_staticFields'
+            'removeAllRecurrenceRules', 'save', 'remove', 'presentEdit', '_staticFields',
+            // Location-specific fields that shouldn't be in notes (used internally)
+            'placeId'
         ]);
         
         // Helper function to check if a field should be included


### PR DESCRIPTION
Fix inconsistent multi-line descriptions in calendar notes and hide `placeId` from Scriptable display.

The description field would subtly change due to inconsistent whitespace handling when parsing multi-line values from calendar notes. A new `normalizeMultilineText` function is now applied consistently when reading from and writing to calendar notes. Additionally, the `placeId` field, an internal identifier for Google Maps, is now explicitly excluded from calendar notes and comparison displays.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f8a63bd-789b-4469-9148-fc8f1eb2dab7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f8a63bd-789b-4469-9148-fc8f1eb2dab7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

