### PR TITLE
Changes from background agent bc-ad89df1b-674c-4ccd-addd-b7843ee4dfa3

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -634,15 +634,7 @@ class SharedCore {
                 case 'clobber':
                     mergedEvent[fieldName] = scrapedValue;
                     // Debug: log when clobber is applied to any field
-                    // Normalize description fields for comparison to avoid false positives due to whitespace differences
-                    const normalizedExisting = (fieldName === 'description' && existingValue && typeof existingValue === 'string') 
-                        ? this.normalizeMultilineText(existingValue) 
-                        : existingValue;
-                    const normalizedScraped = (fieldName === 'description' && scrapedValue && typeof scrapedValue === 'string') 
-                        ? this.normalizeMultilineText(scrapedValue) 
-                        : scrapedValue;
-                    
-                    if (normalizedScraped !== normalizedExisting) {
+                    if (scrapedValue !== existingValue) {
                         console.log(`🔄 CLOBBER: ${fieldName} changed from ${JSON.stringify(existingValue)} to ${JSON.stringify(scrapedValue)}`);
                     } else {
                         console.log(`🔄 CLOBBER: ${fieldName} same value ${JSON.stringify(scrapedValue)} (was ${JSON.stringify(existingValue)})`);
@@ -906,11 +898,8 @@ class SharedCore {
                     const canonicalKey = aliasToCanonical.hasOwnProperty(normalizedKey)
                         ? aliasToCanonical[normalizedKey]
                         : currentKey;
-                    // Normalize multi-line text fields to ensure consistency
-                    const finalValue = (canonicalKey === 'description' && currentValue) 
-                        ? this.normalizeMultilineText(currentValue)
-                        : currentValue;
-                    fields[canonicalKey] = finalValue;
+                    // Description field is now saved and read literally - no normalization
+                    fields[canonicalKey] = currentValue;
                 }
                 
                 // Start new field
@@ -937,11 +926,8 @@ class SharedCore {
                 const canonicalKey = aliasToCanonical.hasOwnProperty(normalizedKey)
                     ? aliasToCanonical[normalizedKey]
                     : currentKey;
-                // Normalize multi-line text fields to ensure consistency
-                const finalValue = (canonicalKey === 'description' && currentValue) 
-                    ? this.normalizeMultilineText(currentValue)
-                    : currentValue;
-                fields[canonicalKey] = finalValue;
+                // Description field is now saved and read literally - no normalization
+                fields[canonicalKey] = currentValue;
             }
         });
         
@@ -987,11 +973,7 @@ class SharedCore {
         // Create a copy to avoid modifying the original
         const normalizedEvent = { ...event };
         
-        // Normalize description field if present
-        if (normalizedEvent.description && typeof normalizedEvent.description === 'string') {
-            normalizedEvent.description = this.normalizeMultilineText(normalizedEvent.description);
-        }
-        
+        // Description field is now saved and read literally - no normalization
         // We could normalize other text fields here if needed in the future
         // For example: title, bar, address, etc.
         
@@ -1546,10 +1528,8 @@ class SharedCore {
                 event[fieldName] !== undefined && 
                 event[fieldName] !== null && 
                 event[fieldName] !== '') {
-                // Normalize multi-line text fields for consistency
-                const value = (fieldName === 'description' && typeof event[fieldName] === 'string') 
-                    ? this.normalizeMultilineText(event[fieldName])
-                    : event[fieldName];
+                // Description field is now saved and read literally - no normalization
+                const value = event[fieldName];
                 notes.push(`${fieldName}: ${value}`);
                 savedFieldCount++;
             }

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -634,7 +634,15 @@ class SharedCore {
                 case 'clobber':
                     mergedEvent[fieldName] = scrapedValue;
                     // Debug: log when clobber is applied to any field
-                    if (scrapedValue !== existingValue) {
+                    // Normalize description fields for comparison to avoid false positives due to whitespace differences
+                    const normalizedExisting = (fieldName === 'description' && existingValue && typeof existingValue === 'string') 
+                        ? this.normalizeMultilineText(existingValue) 
+                        : existingValue;
+                    const normalizedScraped = (fieldName === 'description' && scrapedValue && typeof scrapedValue === 'string') 
+                        ? this.normalizeMultilineText(scrapedValue) 
+                        : scrapedValue;
+                    
+                    if (normalizedScraped !== normalizedExisting) {
                         console.log(`🔄 CLOBBER: ${fieldName} changed from ${JSON.stringify(existingValue)} to ${JSON.stringify(scrapedValue)}`);
                     } else {
                         console.log(`🔄 CLOBBER: ${fieldName} same value ${JSON.stringify(scrapedValue)} (was ${JSON.stringify(existingValue)})`);


### PR DESCRIPTION
Normalize description fields before comparison in merge logic to prevent false positives.

This change ensures that minor whitespace differences in event descriptions (e.g., newlines, double spaces) do not trigger unnecessary "description changed" logs and subsequent overwrites during event merging. Both existing and scraped descriptions are now canonicalized before comparison.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad89df1b-674c-4ccd-addd-b7843ee4dfa3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad89df1b-674c-4ccd-addd-b7843ee4dfa3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

