### PR TITLE
Migrate city settings to input file

### DIFF
--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -174,20 +174,20 @@ class BearEventScraperOrchestrator {
 
             console.log('🐻 Orchestrator: Starting event scraping process...');
 
-            // Create shared core instance first
-            console.log('🐻 Orchestrator: Creating shared core instance...');
-            const sharedCore = new this.modules.SharedCore();
-            console.log('🐻 Orchestrator: ✓ Shared core instance created');
-
-            // Create adapter instance
+            // Create adapter instance first
             console.log('🐻 Orchestrator: Creating adapter instance...');
             const adapter = new this.modules.adapter();
             console.log('🐻 Orchestrator: ✓ Adapter instance created');
             
-            // Load configuration
+            // Load configuration early so we can pass cities config to SharedCore
             console.log('🐻 Orchestrator: Loading configuration...');
             const config = await adapter.loadConfiguration();
             console.log(`🐻 Orchestrator: ✓ Configuration loaded with ${config.parsers?.length || 0} parsers`);
+            
+            // Create shared core instance with cities configuration
+            console.log('🐻 Orchestrator: Creating shared core instance...');
+            const sharedCore = new this.modules.SharedCore(config.cities);
+            console.log('🐻 Orchestrator: ✓ Shared core instance created');
             
             // Create adapter with calendar mappings if available
             let finalAdapter = adapter;

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -22,7 +22,7 @@
 
 
 class SharedCore {
-    constructor() {
+    constructor(cities = null) {
         this.visitedUrls = new Set();
         this.bearKeywords = [
             'bear', 'bears', 'woof', 'grr', 'furry', 'hairy', 'daddy', 'cub', 
@@ -30,38 +30,8 @@ class SharedCore {
             'leather bears', 'bear night', 'bear party', 'polar bear', 'grizzly'
         ];
         
-        // City mapping for consistent location detection across all parsers
-        this.cityMappings = {
-            'new york|nyc|manhattan|brooklyn|queens|bronx': 'nyc',
-            'los angeles|hollywood|west hollywood|weho|dtla|downtown los angeles': 'la',
-            'san francisco|sf|castro': 'sf',
-            'chicago|chi': 'chicago',
-            'atlanta|atl': 'atlanta',
-            'miami|south beach|miami beach': 'miami',
-            'seattle': 'seattle',
-            'portland': 'portland',
-            'denver': 'denver',
-            'las vegas|vegas': 'vegas',
-            'boston': 'boston',
-            'philadelphia|philly': 'philadelphia',
-            'austin': 'austin',
-            'dallas': 'dallas',
-            'houston': 'houston',
-            'phoenix': 'phoenix',
-            'long beach': 'la',  // Long Beach is part of LA metro area
-            'santa monica': 'la',
-            'palm springs': 'palm-springs',  // Palm Springs gets its own area
-            'sitges': 'sitges',  // Sitges gets its own area
-            'san diego': 'san diego',
-            'sacramento': 'sacramento',
-            'san jose': 'sf',  // Bay Area
-            'oakland': 'sf',   // Bay Area
-            'fort lauderdale': 'miami',
-            'key west': 'miami',
-            'toronto': 'toronto',
-            'london': 'london',
-            'berlin': 'berlin'
-        };
+        // Initialize city mappings - use provided cities config or fallback to hardcoded
+        this.cityMappings = this.initializeCityMappings(cities);
         
         // URL-to-parser mapping for automatic parser detection
         this.urlParserMappings = [
@@ -75,6 +45,64 @@ class SharedCore {
             }
             // Generic parser will be used as fallback if no pattern matches
         ];
+    }
+
+    // Initialize city mappings from cities config or use hardcoded fallback
+    initializeCityMappings(cities) {
+        if (cities && typeof cities === 'object') {
+            console.log('🌍 SharedCore: Using centralized cities configuration from input file');
+            return this.convertCitiesConfigToCityMappings(cities);
+        } else {
+            console.log('🌍 SharedCore: Using hardcoded cityMappings (fallback mode)');
+            // Hardcoded fallback city mapping for consistent location detection across all parsers
+            return {
+                'new york|nyc|manhattan|brooklyn|queens|bronx': 'nyc',
+                'los angeles|hollywood|west hollywood|weho|dtla|downtown los angeles': 'la',
+                'san francisco|sf|castro': 'sf',
+                'chicago|chi': 'chicago',
+                'atlanta|atl': 'atlanta',
+                'miami|south beach|miami beach': 'miami',
+                'seattle': 'seattle',
+                'portland': 'portland',
+                'denver': 'denver',
+                'las vegas|vegas': 'vegas',
+                'boston': 'boston',
+                'philadelphia|philly': 'philadelphia',
+                'austin': 'austin',
+                'dallas': 'dallas',
+                'houston': 'houston',
+                'phoenix': 'phoenix',
+                'long beach': 'la',  // Long Beach is part of LA metro area
+                'santa monica': 'la',
+                'palm springs': 'palm-springs',  // Palm Springs gets its own area
+                'sitges': 'sitges',  // Sitges gets its own area
+                'san diego': 'san diego',
+                'sacramento': 'sacramento',
+                'san jose': 'sf',  // Bay Area
+                'oakland': 'sf',   // Bay Area
+                'fort lauderdale': 'miami',
+                'key west': 'miami',
+                'toronto': 'toronto',
+                'london': 'london',
+                'berlin': 'berlin'
+            };
+        }
+    }
+
+    // Convert cities config format to internal cityMappings format
+    convertCitiesConfigToCityMappings(cities) {
+        const cityMappings = {};
+        
+        for (const [cityKey, cityConfig] of Object.entries(cities)) {
+            if (cityConfig.patterns && Array.isArray(cityConfig.patterns)) {
+                // Convert array of patterns to pipe-separated string format
+                const pipePatterns = cityConfig.patterns.join('|');
+                cityMappings[pipePatterns] = cityKey;
+            }
+        }
+        
+        console.log(`🌍 SharedCore: Converted ${Object.keys(cities).length} cities from config to ${Object.keys(cityMappings).length} mapping patterns`);
+        return cityMappings;
     }
 
     // Detect parser type from URL - allows automatic parser selection based on URL patterns


### PR DESCRIPTION
Centralize city configuration in `shared-core.js` by accepting an input `cities` parameter, moving away from hardcoded definitions to improve maintainability and data consistency.

This PR implements Phase 1 of a larger migration plan to establish `scraper-input.js` as the single source of truth for city configurations. It introduces a fallback to the existing hardcoded city mappings, ensuring no functionality is broken while enabling the use of more comprehensive city data (including timezones and calendar mappings) from the input file.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6f2dba7-4208-4811-a15b-3ba7d1a6194e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6f2dba7-4208-4811-a15b-3ba7d1a6194e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

