### PR TITLE
Changes from background agent bc-33e49948-f111-4791-ab55-dfe58617b6c5

### DIFF
--- a/scripts/parsers/bearracuda-parser.js
+++ b/scripts/parsers/bearracuda-parser.js
@@ -61,10 +61,10 @@ class BearraccudaParser {
                     console.log(`🐻 Bearracuda: Successfully parsed event: ${event.title}`);
                     events.push(event);
                     
-                    // If eventbrite URL is found, add it as an additional link for depth=2 processing
-                    if (event.eventbriteUrl && parserConfig.requireDetailPages) {
-                        additionalLinks.push(event.eventbriteUrl);
-                        console.log(`🐻 Bearracuda: Added eventbrite URL as additional link: ${event.eventbriteUrl}`);
+                    // If ticket URL is found and it's an eventbrite URL, add it as an additional link for depth=2 processing
+                    if (event.ticketUrl && event.ticketUrl.includes('eventbrite') && parserConfig.requireDetailPages) {
+                        additionalLinks.push(event.ticketUrl);
+                        console.log(`🐻 Bearracuda: Added eventbrite ticket URL as additional link: ${event.ticketUrl}`);
                     }
                 } else {
                     console.log('🐻 Bearracuda: Failed to parse event from detail page - parseEventDetailPage returned null');
@@ -314,9 +314,8 @@ class BearraccudaParser {
                 // Don't include gmaps here - let SharedCore generate it from address/placeId
                 source: this.config.source,
                 // Additional bearracuda-specific fields
-                facebookEvent: links.facebook,
-                ticketUrl: links.tickets || links.eventbrite, // Prefer general tickets over eventbrite-specific
-                eventbriteUrl: links.eventbrite, // Store eventbrite URL separately
+                facebook: links.facebook,
+                ticketUrl: links.tickets || links.eventbrite, // Use ticketUrl as the primary ticket field
                 placeId: structuredSections.location.placeId || null, // Pass place ID to shared-core for gmaps generation
                 isBearEvent: true // Bearracuda events are always bear events
             };

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -870,7 +870,13 @@ class SharedCore {
             'googleMapsLink': 'gmaps',
             'googlemaps': 'gmaps',
             'googlemapslink': 'gmaps',
-            'google maps': 'gmaps'
+            'google maps': 'gmaps',
+            
+            // Ticket/purchase aliases
+            'ticketurl': 'ticketUrl',
+            'ticket url': 'ticketUrl',
+            'tickets': 'ticketUrl',
+            'ticket': 'ticketUrl'
         };
         
         const normalize = (str) => (str || '').toLowerCase().replace(/\s+/g, '');


### PR DESCRIPTION
Standardize Facebook event field to `facebook` and consolidate ticket URLs to `ticketUrl` for consistent data storage and retrieval.

The `facebookEvent` field was not being recognized during canonicalization due to a naming mismatch (`facebookEvent` vs `facebook`). Additionally, `ticketUrl` was not being consistently saved, and `eventbriteUrl` was redundant, leading to incomplete event data. This PR addresses these by standardizing field names and consolidating ticket URLs as requested by the user, without adding fallbacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-33e49948-f111-4791-ab55-dfe58617b6c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33e49948-f111-4791-ab55-dfe58617b6c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

