### PR TITLE
Scrape and process events from multiple sources

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -239,7 +239,8 @@ class SharedCore {
                         displayAdapter,
                         processedUrls,
                         undefined,
-                        mainConfig
+                        mainConfig,
+                        parserName
                     );
                     await displayAdapter.logSuccess(`SYSTEM: Enriched ${allEvents.length} events with detail page information`);
                 }
@@ -274,7 +275,7 @@ class SharedCore {
         };
     }
 
-    async enrichEventsWithDetailPages(existingEvents, additionalLinks, parsers, parserConfig, httpAdapter, displayAdapter, processedUrls, currentDepth = 1, mainConfig = null) {
+    async enrichEventsWithDetailPages(existingEvents, additionalLinks, parsers, parserConfig, httpAdapter, displayAdapter, processedUrls, currentDepth = 1, mainConfig = null, parserName = null) {
         const maxUrls = parserConfig.maxAdditionalUrls || 12;
         const urlsToProcess = additionalLinks.slice(0, maxUrls);
         const maxDepth = parserConfig.urlDiscoveryDepth || 1;
@@ -292,7 +293,7 @@ class SharedCore {
                 const htmlData = await httpAdapter.fetchData(url);
                 
                 // Detect parser for this specific URL (allows mid-run switching)
-                const urlParserName = this.detectParserFromUrl(url) || parserName;
+                const urlParserName = this.detectParserFromUrl(url) || parserName || 'generic';
                 const urlParser = parsers[urlParserName];
                 
                 // CRITICAL FIX: Look up the correct parser configuration for the detected parser type
@@ -339,7 +340,8 @@ class SharedCore {
                                 displayAdapter,
                                 processedUrls,
                                 currentDepth + 1,
-                                mainConfig
+                                mainConfig,
+                                urlParserName
                             );
                         }
                 } else if (parseResult.additionalLinks && parseResult.additionalLinks.length > 0) {


### PR DESCRIPTION
Fix "Can't find variable: parserName" error by passing parserName to detail page enrichment.

The `enrichEventsWithDetailPages` function was not receiving the `parserName` parameter, causing a runtime error when attempting to use the variable for logging and parser detection during detail page processing. This PR updates the function signature and all call sites to correctly pass the `parserName` (or `urlParserName` for recursive calls), ensuring the correct parser context is always available. A fallback to 'generic' was also added for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-92f7a8e7-dc9b-41b0-bff7-b70fc4a996c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92f7a8e7-dc9b-41b0-bff7-b70fc4a996c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

