### PR TITLE
Changes from background agent bc-af8a0537-a079-421c-9510-41129df7a6cd

### DIFF
--- a/scripts/parsers/bearracuda-parser.js
+++ b/scripts/parsers/bearracuda-parser.js
@@ -743,11 +743,13 @@ class BearraccudaParser {
             if (descriptionMatch) {
                 sections.description = descriptionMatch[1]
                     .replace(/<br[^>]*>/gi, '\n')
+                    .replace(/<[^>]*>/g, '') // Strip all HTML tags
                     .replace(/&nbsp;/g, ' ')
                     .replace(/&amp;/g, '&')
                     .replace(/&lt;/g, '<')
                     .replace(/&gt;/g, '>')
                     .replace(/&quot;/g, '"')
+                    .replace(/\s+/g, ' ') // Normalize whitespace
                     .trim();
             }
 


### PR DESCRIPTION
Improve HTML stripping in Bearracuda parser to prevent raw HTML from appearing in event descriptions.

The `extractStructuredDescription` method in the Bearracuda parser was not fully stripping HTML tags from event descriptions, particularly for events like "Treasure Trail Portland". This resulted in raw `<div>` tags and other HTML content being included in the final description, making it unreadable. The fix adds a comprehensive HTML tag stripping and whitespace normalization step to ensure only clean text is extracted.

---
<a href="https://cursor.com/background-agent?bcId=bc-af8a0537-a079-421c-9510-41129df7a6cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af8a0537-a079-421c-9510-41129df7a6cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

