### PR TITLE
Update from main and process cursorrules

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -82,7 +82,7 @@ const scraperConfig = {
         title: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         shortName: { priority: ["static"], merge: "upsert" },
         instagram: { priority: ["static"], merge: "clobber" },
-        description: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
+        description: { priority: ["bearracuda", "eventbrite"], merge: "clobber" },
         bar: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         address: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         startDate: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1712,6 +1712,11 @@ class SharedCore {
             };
             analyzedEvent._action = analysis.action;
             
+            // Generate notes for new events so they show preview
+            if (analysis.action === 'new') {
+                analyzedEvent.notes = this.formatEventNotes(analyzedEvent);
+            }
+            
             // Handle merge action by creating complete final event object
             if (analysis.action === 'merge' && analysis.existingEvent) {
                 // Create final merged event that represents exactly what will be saved


### PR DESCRIPTION
Update event description priority and fix note field preview for new events.

The `description` field priority was updated to prefer "bearracuda" over "eventbrite" as per user preference. Additionally, new events now correctly generate their `notes` field, resolving an issue where the "Calendar Notes Preview" was not visible for newly created events.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa77a4c5-b454-4980-bc79-97ae08d75355">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fa77a4c5-b454-4980-bc79-97ae08d75355">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

