### PR TITLE
Changes from background agent bc-c368219f-4ef1-4eec-aa20-e0fb450e947b

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -221,7 +221,7 @@ class EventbriteParser {
                             if (eventData.url && eventData.name && (eventData.name.text || typeof eventData.name === 'string')) {
                                 // Double-check that it's actually a future event
                                 if (this.isFutureEvent(eventData)) {
-                                    const event = this.parseJsonEvent(eventData, null, parserConfig, serverData);
+                                    const event = this.parseJsonEvent(eventData, null, parserConfig, serverData, cityConfig);
                                     if (event) {
                                         events.push(event);
                                         console.log(`🎫 Eventbrite: Parsed future event: ${event.title} (${event.startDate || event.date})`);
@@ -265,7 +265,7 @@ class EventbriteParser {
                         console.log(`🎫 Eventbrite: Detail page validation - hasFields: ${hasRequiredFields}, isFuture: ${isFuture}, name: "${adaptedEventData.name}"`);
                         
                         if (hasRequiredFields && isFuture) {
-                            const event = this.parseJsonEvent(adaptedEventData, null, parserConfig, serverData);
+                            const event = this.parseJsonEvent(adaptedEventData, null, parserConfig, serverData, cityConfig);
                             if (event) {
                                 events.push(event);
                                 console.log(`🎫 Eventbrite: Parsed individual event: ${event.title} (${event.startDate || event.date})`);
@@ -360,7 +360,7 @@ class EventbriteParser {
     }
 
     // Parse a JSON event object into our standard format
-    parseJsonEvent(eventData, htmlContext = null, parserConfig = {}, serverData = null) {
+    parseJsonEvent(eventData, htmlContext = null, parserConfig = {}, serverData = null, cityConfig = null) {
         try {
             // Handle both organizer page format (name.text) and detail page format (name as string)
             const title = eventData.name?.text || eventData.name || eventData.title || '';


### PR DESCRIPTION
Pass `cityConfig` to `parseJsonEvent` in Eventbrite parser to resolve `cityConfig is not defined` errors and ensure proper timezone assignment.

The `parseJsonEvent` method in `eventbrite-parser.js` was attempting to use `cityConfig` (specifically for timezone determination) without it being passed as a parameter. This resulted in `ReferenceError: Can't find variable: cityConfig` during Eventbrite parsing and subsequently led to "Sample event missing timezone" errors in the Scriptable environment. This change ensures `cityConfig` is correctly propagated to the method.

---
<a href="https://cursor.com/background-agent?bcId=bc-c368219f-4ef1-4eec-aa20-e0fb450e947b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c368219f-4ef1-4eec-aa20-e0fb450e947b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

