### PR TITLE
Update code and fix script errors

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -48,7 +48,7 @@ class EventbriteParser {
             }
             
             // Extract events from embedded JSON data (modern Eventbrite approach - JSON only)
-            const jsonEvents = this.extractEventsFromJson(html, parserConfig, htmlData);
+            const jsonEvents = this.extractEventsFromJson(html, parserConfig, htmlData, cityConfig);
             if (jsonEvents.length > 0) {
                 console.log(`🎫 Eventbrite: Found ${jsonEvents.length} events in embedded JSON data`);
                 events.push(...jsonEvents);
@@ -194,7 +194,7 @@ class EventbriteParser {
     }
 
     // Extract events from embedded JSON data (modern Eventbrite)
-    extractEventsFromJson(html, parserConfig = {}, htmlData = null) {
+    extractEventsFromJson(html, parserConfig = {}, htmlData = null, cityConfig = null) {
         const events = [];
         
         try {


### PR DESCRIPTION
Pass `cityConfig` to `extractEventsFromJson` in Eventbrite parser to resolve "Can't find variable" error.

The `extractEventsFromJson` method was attempting to access `cityConfig` directly, but it was not included in its parameters, causing a runtime error when parsing Eventbrite pages. This change ensures `cityConfig` is correctly passed and available.

---
<a href="https://cursor.com/background-agent?bcId=bc-79fa3aa2-efdf-4e8e-9aff-8dc4d999c781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79fa3aa2-efdf-4e8e-9aff-8dc4d999c781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

