### PR TITLE
Changes from background agent bc-a5fbcd50-e1b1-4745-92c9-7b395ff11d8a

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -33,7 +33,8 @@ const scraperConfig = {
         url: { priority: ["eventbrite"], merge: "clobber" },
         gmaps: { priority: ["eventbrite"], merge: "clobber" },
         image: { priority: ["eventbrite"], merge: "clobber" },
-        cover: { priority: ["eventbrite"], merge: "clobber" }
+        cover: { priority: ["eventbrite"], merge: "clobber" },
+        timezone: { priority: ["eventbrite"], merge: "clobber" }
       },
       metadata: {
         title: { value: "MEGAWOOF" },
@@ -60,7 +61,8 @@ const scraperConfig = {
         url: { priority: ["eventbrite"], merge: "clobber" },
         gmaps: { priority: ["eventbrite"], merge: "clobber" },
         image: { priority: ["eventbrite"], merge: "clobber" },
-        cover: { priority: ["eventbrite"], merge: "clobber" }
+        cover: { priority: ["eventbrite"], merge: "clobber" },
+        timezone: { priority: ["eventbrite"], merge: "clobber" }
       },
       metadata: {
         shortName: { value: "Coach After Dark" },
@@ -93,7 +95,8 @@ const scraperConfig = {
         cover: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         facebook: { priority: ["bearracuda", "eventbrite"], merge: "clobber" },
         ticketUrl: { priority: ["bearracuda", "eventbrite"], merge: "clobber" },
-        key: { priority: ["bearracuda", "eventbrite"], merge: "clobber" }
+        key: { priority: ["bearracuda", "eventbrite"], merge: "clobber" },
+        timezone: { priority: ["bearracuda", "eventbrite"], merge: "clobber" }
       },
       metadata: {
         shortName: { value: "Bear-rac-uda" },


### PR DESCRIPTION
Add `timezone` to `fieldPriorities` in scraper configurations.

The `timezone` field was being lost during event merging due to its absence in `fieldPriorities`, leading to "Sample event missing timezone" errors in the scraper output. This change ensures timezone data is properly preserved.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5fbcd50-e1b1-4745-92c9-7b395ff11d8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5fbcd50-e1b1-4745-92c9-7b395ff11d8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

