### PR TITLE
Changes from background agent bc-2411fd60-d5eb-43d0-8c63-a5ce169d411b

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -87,7 +87,7 @@ const scraperConfig = {
         address: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         startDate: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         endDate: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
-        url: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
+        url: { priority: ["bearracuda", "eventbrite"], merge: "clobber" },
         gmaps: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         image: { priority: ["bearracuda", "eventbrite"], merge: "clobber" },
         cover: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -606,8 +606,8 @@ class SharedCore {
                         chosenValue = existingValue;
                         reason = `${existingSource} has higher priority (index ${existingIndex} vs ${newIndex})`;
                     }
-                } else {
-                    // New source has higher priority (or same priority)
+                } else if (newIndex < existingIndex) {
+                    // New source has higher priority
                     // But if new value is empty and existing value is not empty, use existing value
                     if (isEmpty(newValue) && !isEmpty(existingValue)) {
                         chosenValue = existingValue;
@@ -616,6 +616,10 @@ class SharedCore {
                         chosenValue = newValue;
                         reason = `${newSource} has higher priority (index ${newIndex} vs ${existingIndex})`;
                     }
+                } else {
+                    // Same priority - preserve existing value to avoid overriding previous merges
+                    chosenValue = existingValue;
+                    reason = `same priority (index ${existingIndex} vs ${newIndex}) - preserving existing`;
                 }
             } else if (existingIndex !== -1) {
                 // Only existing source is in priority list


### PR DESCRIPTION
Prioritize Bearracuda URLs and prevent image/URL overrides during same-source merges to ensure correct event data.

The scraper was incorrectly using Eventbrite URLs over Bearracuda URLs due to misconfigured priority. Additionally, a bug in the merge logic caused higher-priority Bearracuda image and URL data to be overwritten when two events from the same source (e.g., two Eventbrite entries for the same event) were merged, as the logic defaulted to the "new" event's values instead of preserving existing, potentially enriched, data.

---
<a href="https://cursor.com/background-agent?bcId=bc-2411fd60-d5eb-43d0-8c63-a5ce169d411b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2411fd60-d5eb-43d0-8c63-a5ce169d411b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

