### PR TITLE
Changes from background agent bc-13922924-6278-4256-967a-fbf05e7c4cba

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -613,6 +613,7 @@ class EventbriteParser {
                 city: city,
                 timezone: this.getTimezoneForCity(city, cityConfig),
                 url: url, // Use consistent 'url' field name across all parsers
+                ticketUrl: url, // For Eventbrite events, the event URL IS the ticket URL
                 cover: price, // Use 'cover' field name that calendar-core.js expects
                 ...(finalImage && { image: finalImage }), // Only include image if we found one
                 // Don't include gmaps here - let SharedCore generate it from placeId


### PR DESCRIPTION
Add `ticketUrl` to the Eventbrite parser to correctly capture ticket URLs and prevent their removal during merges.

The Eventbrite parser was previously only setting the `url` field, but not `ticketUrl`. During event merging, the field priority system would remove `ticketUrl` from existing calendar events because the incoming Eventbrite data lacked it. Since the event URL for Eventbrite pages is inherently the ticket URL, this change populates both fields with the same value, resolving the data loss during merges.

---
<a href="https://cursor.com/background-agent?bcId=bc-13922924-6278-4256-967a-fbf05e7c4cba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13922924-6278-4256-967a-fbf05e7c4cba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

