### PR TITLE
Scrape bear events and handle errors

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -129,7 +129,7 @@ class EventbriteParser {
                 endIndex++;
             }
             
-            let jsonString = html.substring(start, i);
+            let jsonString = html.substring(startIndex, i);
             
             // Clean up control characters that can break JSON parsing
             // Properly escape control characters that need to be escaped in JSON strings
@@ -605,7 +605,7 @@ class EventbriteParser {
                 url: url, // Use consistent 'url' field name across all parsers
                 ticketUrl: url, // For Eventbrite events, the event URL IS the ticket URL
                 cover: price, // Use 'cover' field name that calendar-core.js expects
-                ...(finalImage && { image: finalImage }), // Only include image if we found one
+                ...(image && { image: image }), // Only include image if we found one
                 // Don't include gmaps here - let SharedCore generate it from placeId
                 placeId: finalPlaceId || null, // Pass place_id to SharedCore for iOS-compatible URL generation
                 source: this.config.source,

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -234,7 +234,7 @@ class SharedCore {
                 // Process additional URLs if we have them (for enriching existing events, not creating new ones)
                 if (parseResult.additionalLinks && parseResult.additionalLinks.length > 0) {
                     // Deduplicate additional URLs before processing
-                    const deduplicatedUrls = this.deduplicateUrls(parseResult.additionalLinks, processedUrls);
+                    const deduplicatedUrls = this.deduplicateUrls(parseResult.additionalLinks, globalProcessedUrls);
                     await displayAdapter.logInfo(`SYSTEM: Processing ${parseResult.additionalLinks.length} additional URLs → ${deduplicatedUrls.length} unique for detail pages`);
                     
                     await this.enrichEventsWithDetailPages(
@@ -244,7 +244,7 @@ class SharedCore {
                         parserConfig, 
                         httpAdapter, 
                         displayAdapter,
-                        processedUrls,
+                        globalProcessedUrls,
                         undefined,
                         mainConfig,
                         parserName


### PR DESCRIPTION
Fixes `ReferenceError` issues in Eventbrite and SharedCore parsers to enable proper event scraping.

The `start` variable in `eventbrite-parser.js` was incorrectly referenced instead of `startIndex`. The `processedUrls` variable in `shared-core.js` was using an incorrect scope, leading to a `ReferenceError`. Additionally, `finalImage` was referenced instead of `image` in `eventbrite-parser.js`. These fixes resolve critical variable scoping and naming errors that prevented the event scraper from functioning.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa01ae4c-3671-4bc4-995f-92165ea26dbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa01ae4c-3671-4bc4-995f-92165ea26dbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

