### PR TITLE
Changes from background agent bc-75c46a4b-2f48-4ac0-8acb-5dbd76be2092

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -519,6 +519,7 @@ class SharedCore {
         
         // Handle normalized title (with the original title normalization logic)
         let normalizedTitle = String(event.originalTitle || event.title || '').toLowerCase().trim();
+        const originalTitle = normalizedTitle; // Store original value before normalization
         
         // Apply the original title normalization for ${normalizedTitle}
         if (format.includes('${normalizedTitle}')) {
@@ -534,9 +535,12 @@ class SharedCore {
                 .replace(/^-+|-+$/g, '');
             
             if (normalizedTitle !== originalTitle) {
-
+                // Title was normalized for deduplication
             }
         }
+        
+        // Initialize key from format template
+        let key = format;
         
         // Replace template variables
         key = key.replace(/\$\{title\}/g, String(event.title || '').toLowerCase().trim());


### PR DESCRIPTION
Fixes `Can't find variable` errors in event key generation by declaring `originalTitle` and initializing `key`.

The `generateKeyFromFormat` function was failing due to two undeclared variables:
1. `originalTitle`: Referenced on line 536, but not declared. This is now fixed by assigning the initial `normalizedTitle` to `originalTitle`.
2. `key`: Used for template replacement, but not initialized. This is now fixed by initializing `key` with the `format` parameter.
These changes ensure the event key generation process is robust and prevents runtime errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-75c46a4b-2f48-4ac0-8acb-5dbd76be2092">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75c46a4b-2f48-4ac0-8acb-5dbd76be2092">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

