### PR TITLE
Changes from background agent bc-75e8dff5-de4e-478f-9e3f-b8d78370408b

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -592,31 +592,39 @@ class EventbriteParser {
                 }
             }
             
-            const event = {
+            // Create event object with safer property assignment
+            const event = {};
+            
+            // Assign properties one by one to avoid readonly issues
+            event.title = title;
+            event.description = description;
+            event.startDate = startDate ? new Date(startDate) : null;
+            event.endDate = endDate ? new Date(endDate) : null;
+            event.bar = finalVenue; // Use 'bar' field name that calendar-core.js expects
+            event.location = finalCoordinates ? `${finalCoordinates.lat}, ${finalCoordinates.lng}` : null; // Store coordinates as "lat,lng" string in location field
+            event.address = finalAddress;
+            event.city = city;
+            event.timezone = this.getTimezoneForCity(city, cityConfig);
+            event.url = url; // Use consistent 'url' field name across all parsers
+            event.ticketUrl = url; // For Eventbrite events, the event URL IS the ticket URL
+            event.cover = price; // Use 'cover' field name that calendar-core.js expects
+            
+            // Add image if we found one
+            if (image) {
+                event.image = image;
+            }
+            
+            // Don't include gmaps here - let SharedCore generate it from placeId
+            event.placeId = finalPlaceId || null; // Pass place_id to SharedCore for iOS-compatible URL generation
+            event.source = this.config.source;
+            
+            // Properly handle bear event detection based on configuration
+            event.isBearEvent = this.config.alwaysBear || this.isBearEvent({
                 title: title,
-                description: description,
-                startDate: startDate ? new Date(startDate) : null,
-                endDate: endDate ? new Date(endDate) : null,
-                bar: finalVenue, // Use 'bar' field name that calendar-core.js expects
-                location: finalCoordinates ? `${finalCoordinates.lat}, ${finalCoordinates.lng}` : null, // Store coordinates as "lat,lng" string in location field
-                address: finalAddress,
-                city: city,
-                timezone: this.getTimezoneForCity(city, cityConfig),
-                url: url, // Use consistent 'url' field name across all parsers
-                ticketUrl: url, // For Eventbrite events, the event URL IS the ticket URL
-                cover: price, // Use 'cover' field name that calendar-core.js expects
-                ...(image && { image: image }), // Only include image if we found one
-                // Don't include gmaps here - let SharedCore generate it from placeId
-                placeId: finalPlaceId || null, // Pass place_id to SharedCore for iOS-compatible URL generation
-                source: this.config.source,
-                // Properly handle bear event detection based on configuration
-                isBearEvent: this.config.alwaysBear || this.isBearEvent({
-                    title: title,
-                    description: '',
-                    venue: finalVenue,
-                    url: url
-                })
-            };
+                description: '',
+                venue: finalVenue,
+                url: url
+            });
             
             // Apply source-specific metadata values from config
             if (parserConfig.metadata) {
@@ -625,7 +633,11 @@ class EventbriteParser {
                     
                     // Apply value if it exists (source-specific overrides)
                     if (typeof metaValue === 'object' && metaValue !== null && 'value' in metaValue) {
-                        event[key] = metaValue.value;
+                        try {
+                            event[key] = metaValue.value;
+                        } catch (assignError) {
+                            console.warn(`🎫 Eventbrite: Could not assign metadata ${key}: ${assignError.message}`);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Refactor Eventbrite parser's event object creation to fix "readonly property" errors during JSON parsing.

The Eventbrite parser was encountering `TypeError: Attempted to assign to readonly property` when processing JSON event data from detail pages. This was due to an object literal spread syntax combined with subsequent property assignments, which can cause issues in strict mode environments like Scriptable where certain properties might become implicitly read-only. The fix reconstructs the event object by assigning properties individually and adds a `try-catch` block for metadata assignment to prevent future failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-75e8dff5-de4e-478f-9e3f-b8d78370408b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75e8dff5-de4e-478f-9e3f-b8d78370408b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

