### PR TITLE
Update today events display and data

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
 
         <section id="today-events" class="bear-events-compact">
             <div class="container">
-                <h2>🗓️ Today’s Events</h2>
+                <h2>🎉 Bear Events</h2>
                 <div class="event-scroll-container">
                     <div class="event-compact-grid" id="today-event-grid">
                         <!-- Today events will be dynamically rendered by TodayEventsAggregator -->


### PR DESCRIPTION
Refactor today events display to use the correct title, show relevant events for today/tomorrow, and improve time/location formatting.

The previous filtering logic for "today's events" was incorrectly including past events that merely overlapped with the current day. This has been updated to only show events that *start* today or tomorrow, addressing the "yesterday's data" issue. Additionally, the event title, time display (now using "today" or "tomorrow"), and location layout (bar first, then city on a new line) have been adjusted to meet the specified requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f383958-6c10-4a17-a285-5a0783498c54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f383958-6c10-4a17-a285-5a0783498c54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

