### PR TITLE
Update code and fix timezone error

### DIFF
--- a/scripts/display-saved-run.js
+++ b/scripts/display-saved-run.js
@@ -296,8 +296,10 @@ class SavedRunDisplay {
             };
 
             // Initialize adapter and display results
+            // Load configuration to get cities data for timezone lookup
+            const scraperConfig = importModule('scraper-input');
             const { ScriptableAdapter } = importModule('adapters/scriptable-adapter');
-            this.adapter = new ScriptableAdapter();
+            this.adapter = new ScriptableAdapter(scraperConfig);
             await this.adapter.displayResults(resultsLike);
         } catch (e) {
             console.log(`📱 Display: Failed to display saved run: ${e.message}`);


### PR DESCRIPTION
Fix "Display previous runs" by passing `scraperConfig` to `ScriptableAdapter`.

The `ScriptableAdapter` was initialized without the necessary cities configuration, leading to a "No timezone configuration found for city" error when attempting to display saved runs. This change ensures the adapter has the required configuration to resolve timezones.

---
<a href="https://cursor.com/background-agent?bcId=bc-91da12d5-a70e-47d1-a088-37b588a2054b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-91da12d5-a70e-47d1-a088-37b588a2054b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

