### PR TITLE
Create friendly urls for city pages

### DIFF
--- a/atlanta.html
+++ b/atlanta.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Atlanta - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Atlanta - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Atlanta - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'atlanta',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/berlin.html
+++ b/berlin.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Berlin - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Berlin - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Berlin - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'berlin',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/chicago.html
+++ b/chicago.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Chicago - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Chicago - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Chicago - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'chicago',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/denver.html
+++ b/denver.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Denver - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Denver - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Denver - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'denver',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/index.html
+++ b/index.html
@@ -125,6 +125,7 @@
     <script src="js/dad-jokes.js"></script>
     <script src="js/debug-overlay.js"></script>
     <script src="js/city-config.js"></script>
+    <script src="js/url-router.js"></script>
     <script src="js/event-config.js"></script>
     <script src="js/compact-card-renderer.js"></script>
     <script src="js/components.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -90,6 +90,7 @@ class ChunkyDadApp {
         this.bearEventRenderer = null;
         this.dadJokesManager = null;
         this.todayEventsAggregator = null;
+        this.urlRouter = null;
         
         logger.componentInit('SYSTEM', 'chunky.dad App initializing', {
             isMainPage: this.isMainPage,
@@ -109,7 +110,14 @@ class ChunkyDadApp {
     }
 
     checkIfCityPage() {
-        return window.location.pathname.includes('city.html');
+        // Check for traditional city.html OR friendly city URLs
+        if (window.location.pathname.includes('city.html')) {
+            return true;
+        }
+        
+        // Check if this is a friendly city URL
+        const path = window.location.pathname.replace(/^\/+|\/+$/g, '');
+        return path && window.CITY_CONFIG && window.CITY_CONFIG[path];
     }
 
     checkIfTestPage() {
@@ -148,6 +156,12 @@ class ChunkyDadApp {
 
     initializeCoreModules() {
         logger.info('SYSTEM', 'Initializing core modules');
+        
+        // Initialize URL router first (handles friendly URLs)
+        if (window.URLRouter) {
+            this.urlRouter = new URLRouter();
+            window.urlRouter = this.urlRouter;
+        }
         
         // Components manager injects common UI elements
         this.componentsManager = new ComponentsManager();

--- a/js/compact-card-renderer.js
+++ b/js/compact-card-renderer.js
@@ -66,7 +66,14 @@ class CompactCardRenderer {
 
     createCard(item) {
         const link = document.createElement('a');
-        link.href = `${this.type}.html?${this.type}=${item.key}`;
+        
+        // Use friendly URLs for cities, traditional URLs for events
+        if (this.type === 'city') {
+            link.href = `/${item.key}`;
+        } else {
+            link.href = `${this.type}.html?${this.type}=${item.key}`;
+        }
+        
         link.className = `${this.type}-compact-card`;
 
         // Create emoji box

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -376,8 +376,22 @@ class DynamicCalendarLoader extends CalendarCore {
         });
     }
 
-    // Get city from URL parameters
+    // Get city from URL parameters or friendly URL path
     getCityFromURL() {
+        // First check if this is a dedicated city page with configuration
+        if (window.CITY_PAGE_CONFIG && window.CITY_PAGE_CONFIG.cityKey) {
+            return window.CITY_PAGE_CONFIG.cityKey;
+        }
+        
+        // Check if URL router is available and has a current city
+        if (window.urlRouter && window.urlRouter.getCurrentCity) {
+            const routerCity = window.urlRouter.getCurrentCity();
+            if (routerCity) {
+                return routerCity;
+            }
+        }
+        
+        // Fallback to traditional URL parameters
         const urlParams = new URLSearchParams(window.location.search);
         const cityParam = urlParams.get('city');
         
@@ -401,7 +415,7 @@ class DynamicCalendarLoader extends CalendarCore {
             availableCitiesList.innerHTML = getAvailableCities()
                 .filter(city => hasCityCalendar(city.key))
                 .map(city => `
-                    <a href="city.html?city=${city.key}" class="city-link">
+                    <a href="/${city.key}" class="city-link">
                         ${city.emoji} ${city.name}
                     </a>
                 `).join('');

--- a/js/header-manager.js
+++ b/js/header-manager.js
@@ -239,7 +239,14 @@ class HeaderManager {
 
     switchCity(cityKey) {
         this.logger.userInteraction('HEADER', `Switching to city: ${cityKey}`);
-        window.location.href = `city.html?city=${cityKey}`;
+        
+        // Use URL router for friendly URLs if available
+        if (window.urlRouter) {
+            window.urlRouter.navigateToCity(cityKey);
+        } else {
+            // Fallback to traditional URL
+            window.location.href = `city.html?city=${cityKey}`;
+        }
     }
 
     setupDebugOptions() {

--- a/js/today-events.js
+++ b/js/today-events.js
@@ -166,7 +166,7 @@ class TodayEventsAggregator {
 
   createEventCard(ev) {
     const link = document.createElement('a');
-    link.href = `city.html?city=${ev.cityKey}`;
+    link.href = `/${ev.cityKey}`;
     link.className = 'event-compact-card';
 
     const emojiBox = document.createElement('div');

--- a/js/url-router.js
+++ b/js/url-router.js
@@ -1,0 +1,318 @@
+// URL Router Module - Handles friendly city URLs and client-side routing
+class URLRouter {
+    constructor() {
+        this.cityConfig = window.CITY_CONFIG || {};
+        this.logger = window.logger;
+        this.init();
+    }
+
+    init() {
+        this.logger.componentInit('SYSTEM', 'URL Router initializing');
+        
+        // Handle routing on page load
+        this.handleInitialRoute();
+        
+        // Listen for browser back/forward navigation
+        window.addEventListener('popstate', (event) => {
+            this.logger.userInteraction('SYSTEM', 'Browser navigation detected', {
+                pathname: window.location.pathname,
+                state: event.state
+            });
+            this.handleRoute();
+        });
+        
+        this.logger.componentLoad('SYSTEM', 'URL Router initialized');
+    }
+
+    handleInitialRoute() {
+        const path = window.location.pathname;
+        const cityKey = this.extractCityFromPath(path);
+        
+        this.logger.info('SYSTEM', 'Processing initial route', {
+            originalPath: path,
+            extractedCity: cityKey,
+            isCityRoute: !!cityKey
+        });
+
+        if (cityKey) {
+            this.handleCityRoute(cityKey);
+        }
+    }
+
+    handleRoute() {
+        const path = window.location.pathname;
+        const cityKey = this.extractCityFromPath(path);
+        
+        if (cityKey) {
+            this.handleCityRoute(cityKey);
+        }
+    }
+
+    extractCityFromPath(path) {
+        // Remove leading/trailing slashes and get the first segment
+        const segments = path.replace(/^\/+|\/+$/g, '').split('/');
+        const potentialCity = segments[0];
+        
+        // Check if this matches a known city key
+        if (potentialCity && this.cityConfig[potentialCity]) {
+            return potentialCity;
+        }
+        
+        return null;
+    }
+
+    handleCityRoute(cityKey) {
+        const cityConfig = this.cityConfig[cityKey];
+        
+        if (!cityConfig) {
+            this.logger.error('SYSTEM', 'City not found in configuration', { cityKey });
+            this.handleCityNotFound(cityKey);
+            return;
+        }
+
+        this.logger.info('SYSTEM', 'Handling city route', {
+            cityKey,
+            cityName: cityConfig.name,
+            currentPath: window.location.pathname
+        });
+
+        // Check if we're already on the city page
+        if (window.location.pathname.includes('city.html')) {
+            // Already on city page, just update the city parameter
+            this.updateCityOnCurrentPage(cityKey);
+        } else {
+            // Need to navigate to city page
+            this.navigateToCityPage(cityKey);
+        }
+    }
+
+    updateCityOnCurrentPage(cityKey) {
+        this.logger.info('SYSTEM', 'Updating city on current page', { cityKey });
+        
+        // Update URL without page reload to show friendly URL
+        const friendlyUrl = `/${cityKey}`;
+        window.history.replaceState({ cityKey }, '', friendlyUrl);
+        
+        // Update Google Analytics page view
+        this.trackPageView(friendlyUrl, `${this.cityConfig[cityKey].name} - chunky.dad`);
+        
+        // Trigger city update if calendar loader is available
+        if (window.calendarLoader && window.calendarLoader.loadCityCalendar) {
+            window.calendarLoader.loadCityCalendar(cityKey);
+        }
+        
+        // Update header for city
+        if (window.chunkyApp && window.chunkyApp.updateHeaderForCity) {
+            window.chunkyApp.updateHeaderForCity(cityKey);
+        }
+    }
+
+    navigateToCityPage(cityKey) {
+        this.logger.info('SYSTEM', 'Navigating to city page', { cityKey });
+        
+        // Use pushState to navigate without page reload
+        const friendlyUrl = `/${cityKey}`;
+        window.history.pushState({ cityKey }, '', friendlyUrl);
+        
+        // Load city.html content dynamically
+        this.loadCityPageContent(cityKey);
+    }
+
+    async loadCityPageContent(cityKey) {
+        try {
+            this.logger.time('SYSTEM', 'Loading city page content');
+            
+            // Fetch city.html content
+            const response = await fetch('/city.html');
+            if (!response.ok) {
+                throw new Error(`Failed to load city page: ${response.status}`);
+            }
+            
+            const html = await response.text();
+            
+            // Create a temporary container to parse the HTML
+            const tempDiv = document.createElement('div');
+            tempDiv.innerHTML = html;
+            
+            // Extract the main content (everything inside body except scripts)
+            const bodyContent = tempDiv.querySelector('body');
+            const scripts = bodyContent.querySelectorAll('script');
+            
+            // Remove scripts from the content (we'll handle them separately)
+            scripts.forEach(script => script.remove());
+            
+            // Replace current page content
+            document.body.innerHTML = bodyContent.innerHTML;
+            
+            // Update page title and meta
+            const cityConfig = this.cityConfig[cityKey];
+            document.title = `${cityConfig.name} - chunky.dad Bear Guide`;
+            
+            // Update meta description
+            const metaDesc = document.querySelector('meta[name="description"]');
+            if (metaDesc) {
+                metaDesc.content = `Gay bear guide to ${cityConfig.name} - events, bars, and the hottest bear scene`;
+            }
+            
+            // Track page view with friendly URL
+            this.trackPageView(`/${cityKey}`, `${cityConfig.name} - chunky.dad`);
+            
+            // Reinitialize the app for the new content
+            await this.reinitializeApp(cityKey);
+            
+            this.logger.timeEnd('SYSTEM', 'Loading city page content');
+            this.logger.componentLoad('SYSTEM', 'City page content loaded successfully', { cityKey });
+            
+        } catch (error) {
+            this.logger.componentError('SYSTEM', 'Failed to load city page content', error);
+            this.handleRouteError(cityKey, error);
+        }
+    }
+
+    async reinitializeApp(cityKey) {
+        try {
+            // Reinitialize the chunky dad app with the new content
+            if (window.ChunkyDadApp) {
+                // Create new app instance
+                window.chunkyApp = new window.ChunkyDadApp();
+                
+                // Set the city parameter for the calendar loader
+                if (window.calendarLoader) {
+                    // Override the getCityFromURL method to return our city
+                    window.calendarLoader.getCityFromURL = () => cityKey;
+                }
+            }
+        } catch (error) {
+            this.logger.componentError('SYSTEM', 'Failed to reinitialize app', error);
+        }
+    }
+
+    handleCityNotFound(cityKey) {
+        this.logger.warn('SYSTEM', 'City not found, showing error page', { cityKey });
+        
+        // Show city not found section
+        const notFoundSection = document.querySelector('.city-not-found');
+        const cityPageSection = document.querySelector('.city-page');
+        
+        if (notFoundSection) {
+            notFoundSection.style.display = 'block';
+        }
+        if (cityPageSection) {
+            cityPageSection.style.display = 'none';
+        }
+        
+        // Populate available cities list
+        this.populateAvailableCities();
+        
+        // Update page title
+        document.title = 'City Not Found - chunky.dad';
+        
+        // Track 404 page view
+        this.trackPageView(`/${cityKey}`, 'City Not Found - chunky.dad');
+    }
+
+    populateAvailableCities() {
+        const container = document.getElementById('available-cities-list');
+        if (!container) return;
+        
+        const cities = Object.keys(this.cityConfig)
+            .filter(key => this.cityConfig[key].visible !== false)
+            .map(key => {
+                const config = this.cityConfig[key];
+                return `<a href="/${key}" class="city-link">${config.emoji} ${config.name}</a>`;
+            })
+            .join('');
+        
+        container.innerHTML = cities;
+        
+        // Add click handlers for the new links
+        container.querySelectorAll('.city-link').forEach(link => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const href = link.getAttribute('href');
+                const cityKey = href.replace('/', '');
+                this.navigateToCity(cityKey);
+            });
+        });
+    }
+
+    handleRouteError(cityKey, error) {
+        this.logger.componentError('SYSTEM', 'Route handling failed', { cityKey, error });
+        
+        // Fallback to traditional URL
+        const fallbackUrl = `/city.html?city=${cityKey}`;
+        this.logger.info('SYSTEM', 'Falling back to traditional URL', { fallbackUrl });
+        window.location.href = fallbackUrl;
+    }
+
+    // Public method to navigate to a city with friendly URL
+    navigateToCity(cityKey) {
+        if (!this.cityConfig[cityKey]) {
+            this.logger.error('SYSTEM', 'Cannot navigate to unknown city', { cityKey });
+            return;
+        }
+        
+        this.logger.userInteraction('SYSTEM', 'Navigating to city via router', { cityKey });
+        
+        const friendlyUrl = `/${cityKey}`;
+        window.history.pushState({ cityKey }, '', friendlyUrl);
+        this.handleCityRoute(cityKey);
+    }
+
+    // Enhanced analytics tracking for friendly URLs
+    // This ensures consistent analytics tracking regardless of how the page was accessed:
+    // - Direct access to /seattle tracks as "/seattle" 
+    // - Navigation from index tracks as "/seattle"
+    // - Traditional city.html?city=seattle would track as "/seattle" if routed through this system
+    trackPageView(path, title) {
+        if (typeof gtag !== 'undefined') {
+            // Track the friendly URL path, not the underlying city.html
+            // This provides consistent analytics regardless of access method
+            gtag('config', 'G-YKQBFFQR5E', {
+                page_title: title,
+                page_location: window.location.origin + path
+            });
+            
+            // Send page view event with the canonical friendly URL
+            gtag('event', 'page_view', {
+                page_title: title,
+                page_location: window.location.origin + path,
+                custom_parameters: {
+                    access_method: window.CITY_PAGE_CONFIG?.friendlyUrl ? 'friendly_url' : 'traditional_url'
+                }
+            });
+            
+            this.logger.info('SYSTEM', 'Analytics page view tracked', {
+                path,
+                title,
+                fullUrl: window.location.origin + path,
+                accessMethod: window.CITY_PAGE_CONFIG?.friendlyUrl ? 'friendly_url' : 'traditional_url'
+            });
+        } else {
+            this.logger.warn('SYSTEM', 'Google Analytics not available for tracking');
+        }
+    }
+
+    // Helper method to get current city from URL
+    getCurrentCity() {
+        return this.extractCityFromPath(window.location.pathname);
+    }
+
+    // Helper method to generate friendly URL for a city
+    getFriendlyUrl(cityKey) {
+        return `/${cityKey}`;
+    }
+
+    // Helper method to check if current URL is a friendly city URL
+    isFriendlyUrl() {
+        return !!this.extractCityFromPath(window.location.pathname);
+    }
+}
+
+// Make URLRouter globally available
+window.URLRouter = URLRouter;
+
+// Export for use in other modules
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = URLRouter;
+}

--- a/london.html
+++ b/london.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>London - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to London - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'London - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'london',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/los-angeles.html
+++ b/los-angeles.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Los Angeles - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Los Angeles - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Los Angeles - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'los-angeles',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/new-orleans.html
+++ b/new-orleans.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>New Orleans - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to New Orleans - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'New Orleans - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'new-orleans',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/new-york.html
+++ b/new-york.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>New York - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to New York - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'New York - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'new-york',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "python3 -m http.server 8000",
     "update-test-index": "cd testing && node generate-file-list.js",
     "update-test-manifest": "cd testing && node generate-manifest.js",
+    "generate-city-pages": "node scripts/generate-city-pages.js",
     "setup-hooks": "bash .github/hooks/setup-hooks.sh",
     "postinstall": "npm run setup-hooks"
   },

--- a/palm-springs.html
+++ b/palm-springs.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Palm Springs - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Palm Springs - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Palm Springs - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'palm-springs',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/portland.html
+++ b/portland.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Portland - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Portland - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Portland - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'portland',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/scripts/generate-city-pages.js
+++ b/scripts/generate-city-pages.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+// Script to generate individual HTML files for each city
+// This enables friendly URLs like /seattle instead of /city.html?city=seattle
+
+const fs = require('fs');
+const path = require('path');
+
+// Import city configuration
+const cityConfigPath = path.join(__dirname, '../js/city-config.js');
+const cityConfigContent = fs.readFileSync(cityConfigPath, 'utf8');
+
+// Extract CITY_CONFIG object from the file
+const configMatch = cityConfigContent.match(/const CITY_CONFIG = ({[\s\S]*?});/);
+if (!configMatch) {
+    console.error('❌ Could not extract CITY_CONFIG from city-config.js');
+    process.exit(1);
+}
+
+// Parse the configuration
+const CITY_CONFIG = eval(`(${configMatch[1]})`);
+
+// Read the base city.html template
+const templatePath = path.join(__dirname, '../city.html');
+const template = fs.readFileSync(templatePath, 'utf8');
+
+// Generate HTML for each city
+Object.keys(CITY_CONFIG).forEach(cityKey => {
+    const cityConfig = CITY_CONFIG[cityKey];
+    
+    if (cityConfig.visible === false) {
+        console.log(`⏭️  Skipping ${cityKey} (not visible)`);
+        return;
+    }
+    
+    console.log(`🏙️  Generating ${cityKey}.html for ${cityConfig.name}`);
+    
+    // Create city-specific HTML
+    let cityHtml = template;
+    
+    // Update title and meta description
+    cityHtml = cityHtml.replace(
+        '<title>City Guide - chunky.dad Bear Guide</title>',
+        `<title>${cityConfig.name} - chunky.dad Bear Guide</title>`
+    );
+    
+    cityHtml = cityHtml.replace(
+        '<meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">',
+        `<meta name="description" content="Gay bear guide to ${cityConfig.name} - events, bars, and the hottest bear scene">`
+    );
+    
+    // Add city-specific configuration script
+    const configScript = `    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: '${cityKey}',
+            friendlyUrl: true
+        };
+    </script>`;
+    
+    // Insert the config script after the Google Analytics script
+    cityHtml = cityHtml.replace(
+        '</script>\n    \n    <link rel="stylesheet"',
+        `</script>\n    \n${configScript}\n    \n    <link rel="stylesheet"`
+    );
+    
+    // Update Google Analytics configuration for this specific page
+    cityHtml = cityHtml.replace(
+        "gtag('config', 'G-YKQBFFQR5E');",
+        `gtag('config', 'G-YKQBFFQR5E', {
+        page_title: '${cityConfig.name} - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });`
+    );
+    
+    // Write the city-specific HTML file
+    const outputPath = path.join(__dirname, `../${cityKey}.html`);
+    fs.writeFileSync(outputPath, cityHtml);
+    
+    console.log(`✅ Created ${cityKey}.html`);
+});
+
+console.log(`\n🎉 Generated ${Object.keys(CITY_CONFIG).filter(k => CITY_CONFIG[k].visible !== false).length} city pages`);
+console.log('\n📝 Next steps:');
+console.log('1. Test the pages locally: npm run dev');
+console.log('2. Visit http://localhost:8000/seattle to test');
+console.log('3. Commit and push to deploy to GitHub Pages');

--- a/seattle.html
+++ b/seattle.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Seattle - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Seattle - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Seattle - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'seattle',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/sf.html
+++ b/sf.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>San Francisco - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to San Francisco - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'San Francisco - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'sf',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/sitges.html
+++ b/sitges.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Sitges - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Sitges - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Sitges - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'sitges',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/testing/manifest.json
+++ b/testing/manifest.json
@@ -53,6 +53,10 @@
       "size": 7179
     },
     {
+      "name": "test-friendly-urls.html",
+      "size": 6093
+    },
+    {
       "name": "test-google-sheets-loader.html",
       "size": 40540
     },

--- a/testing/test-friendly-urls.html
+++ b/testing/test-friendly-urls.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Friendly URLs Test - chunky.dad</title>
+    <link rel="stylesheet" href="../styles.css">
+    <style>
+        .test-container {
+            max-width: 800px;
+            margin: 2rem auto;
+            padding: 2rem;
+            background: var(--card-bg);
+            border-radius: 12px;
+            box-shadow: var(--shadow);
+        }
+        .test-section {
+            margin: 2rem 0;
+            padding: 1rem;
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+        }
+        .test-links {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1rem;
+            margin: 1rem 0;
+        }
+        .test-link {
+            display: block;
+            padding: 1rem;
+            background: var(--primary-color);
+            color: white;
+            text-decoration: none;
+            border-radius: 8px;
+            text-align: center;
+            transition: background-color 0.3s ease;
+        }
+        .test-link:hover {
+            background: var(--primary-dark);
+        }
+        .result {
+            margin: 1rem 0;
+            padding: 1rem;
+            background: #f0f0f0;
+            border-radius: 4px;
+            font-family: monospace;
+        }
+    </style>
+</head>
+<body>
+    <div class="test-container">
+        <h1>🧪 Friendly URLs Test</h1>
+        <p>Testing the new friendly URL system for city pages.</p>
+        
+        <div class="test-section">
+            <h2>📍 Friendly City URLs</h2>
+            <p>Click these links to test the new friendly URL format:</p>
+            <div class="test-links" id="friendly-links">
+                <!-- Will be populated by JavaScript -->
+            </div>
+        </div>
+        
+        <div class="test-section">
+            <h2>🔗 Traditional URLs (for comparison)</h2>
+            <p>These use the old URL parameter format:</p>
+            <div class="test-links" id="traditional-links">
+                <!-- Will be populated by JavaScript -->
+            </div>
+        </div>
+        
+        <div class="test-section">
+            <h2>📊 Current Page Info</h2>
+            <div class="result" id="page-info">
+                <!-- Will be populated by JavaScript -->
+            </div>
+        </div>
+        
+        <div class="test-section">
+            <h2>🧭 Router Status</h2>
+            <div class="result" id="router-status">
+                <!-- Will be populated by JavaScript -->
+            </div>
+        </div>
+    </div>
+
+    <!-- Load necessary scripts -->
+    <script src="../js/logger.js"></script>
+    <script src="../js/city-config.js"></script>
+    <script src="../js/url-router.js"></script>
+    
+    <script>
+        // Test script
+        document.addEventListener('DOMContentLoaded', () => {
+            logger.componentInit('TEST', 'Friendly URLs test page initializing');
+            
+            // Populate friendly links
+            const friendlyContainer = document.getElementById('friendly-links');
+            const traditionalContainer = document.getElementById('traditional-links');
+            const pageInfoContainer = document.getElementById('page-info');
+            const routerStatusContainer = document.getElementById('router-status');
+            
+            if (window.CITY_CONFIG) {
+                const cities = Object.keys(window.CITY_CONFIG)
+                    .filter(key => window.CITY_CONFIG[key].visible !== false)
+                    .slice(0, 6); // Show first 6 cities for testing
+                
+                // Friendly URLs
+                friendlyContainer.innerHTML = cities.map(cityKey => {
+                    const config = window.CITY_CONFIG[cityKey];
+                    return `<a href="../${cityKey}.html" class="test-link" target="_blank">
+                        ${config.emoji} ${config.name}<br>
+                        <small>/${cityKey}</small>
+                    </a>`;
+                }).join('');
+                
+                // Traditional URLs
+                traditionalContainer.innerHTML = cities.map(cityKey => {
+                    const config = window.CITY_CONFIG[cityKey];
+                    return `<a href="../city.html?city=${cityKey}" class="test-link" target="_blank">
+                        ${config.emoji} ${config.name}<br>
+                        <small>/city.html?city=${cityKey}</small>
+                    </a>`;
+                }).join('');
+            }
+            
+            // Page info
+            pageInfoContainer.innerHTML = `
+                <strong>Current URL:</strong> ${window.location.href}<br>
+                <strong>Pathname:</strong> ${window.location.pathname}<br>
+                <strong>Search:</strong> ${window.location.search}<br>
+                <strong>Hash:</strong> ${window.location.hash}<br>
+                <strong>User Agent:</strong> ${navigator.userAgent.substring(0, 80)}...
+            `;
+            
+            // Router status
+            if (window.URLRouter) {
+                const router = new URLRouter();
+                const currentCity = router.getCurrentCity();
+                
+                routerStatusContainer.innerHTML = `
+                    <strong>Router Available:</strong> ✅ Yes<br>
+                    <strong>Current City:</strong> ${currentCity || 'None detected'}<br>
+                    <strong>Is Friendly URL:</strong> ${router.isFriendlyUrl() ? '✅ Yes' : '❌ No'}<br>
+                    <strong>Available Cities:</strong> ${Object.keys(window.CITY_CONFIG).length}
+                `;
+            } else {
+                routerStatusContainer.innerHTML = `
+                    <strong>Router Available:</strong> ❌ No<br>
+                    <strong>Status:</strong> URLRouter class not loaded
+                `;
+            }
+            
+            logger.componentLoad('TEST', 'Friendly URLs test page loaded');
+        });
+    </script>
+</body>
+</html>

--- a/toronto.html
+++ b/toronto.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Toronto - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Toronto - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Toronto - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'toronto',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/vegas.html
+++ b/vegas.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>City Guide - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
+    <title>Las Vegas - chunky.dad Bear Guide</title>
+    <meta name="description" content="Gay bear guide to Las Vegas - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
@@ -15,7 +15,19 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-YKQBFFQR5E');
+      gtag('config', 'G-YKQBFFQR5E', {
+        page_title: 'Las Vegas - chunky.dad Bear Guide',
+        page_location: window.location.href
+      });
+    </script>
+    
+    <!-- City-specific configuration -->
+    <script>
+        // Set the city for this page
+        window.CITY_PAGE_CONFIG = {
+            cityKey: 'vegas',
+            friendlyUrl: true
+        };
     </script>
     
     <link rel="stylesheet" href="styles.css">


### PR DESCRIPTION
Adds friendly URLs for city pages (e.g., `/seattle`) to enhance shareability, SEO, and analytics consistency.

This implementation generates static HTML files for each city from a template, managed by a new `generate-city-pages.js` script. A client-side `url-router.js` handles navigation and ensures Google Analytics tracks canonical friendly URLs, while maintaining backward compatibility with traditional `city.html?city=key` links. This approach is scalable and compatible with GitHub Pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1df9375-c33a-4e3d-b932-a9beeadafdcf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d1df9375-c33a-4e3d-b932-a9beeadafdcf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

