### PR TITLE
Fix city page file references

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,3 +1,57 @@
+// Path utility for resolving asset paths based on current page location
+class PathUtils {
+    constructor() {
+        this.isSubdirectory = this.detectSubdirectory();
+        this.pathPrefix = this.isSubdirectory ? '../' : '';
+    }
+    
+    // Detect if we're in a city subdirectory
+    detectSubdirectory() {
+        const pathname = window.location.pathname;
+        // Check if we're in a city directory (not root, not testing, not tools)
+        const pathSegments = pathname.split('/').filter(Boolean);
+        
+        // If we have path segments and the first one isn't a known root file
+        if (pathSegments.length > 0) {
+            const firstSegment = pathSegments[0].toLowerCase();
+            // Skip known root files and testing directories
+            const rootFiles = ['index.html', 'city.html', 'bear-directory.html', 'test', 'testing', 'tools', 'scripts'];
+            const isRootFile = rootFiles.some(file => firstSegment.includes(file));
+            
+            // If not a root file and we have segments, we're likely in a subdirectory
+            if (!isRootFile && pathSegments.length >= 1) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+    
+    // Resolve asset path based on current location
+    resolvePath(assetPath) {
+        // Don't modify absolute URLs or data URLs
+        if (assetPath.startsWith('http') || assetPath.startsWith('//') || assetPath.startsWith('data:')) {
+            return assetPath;
+        }
+        
+        // Don't modify paths that already have ../ prefix
+        if (assetPath.startsWith('../')) {
+            return assetPath;
+        }
+        
+        return this.pathPrefix + assetPath;
+    }
+    
+    // Convenience method for the common logo image
+    getLogoPath() {
+        return this.resolvePath('Rising_Star_Ryan_Head_Compressed.png');
+    }
+}
+
+// Initialize PathUtils early so it's available to all modules
+const pathUtils = new PathUtils();
+window.pathUtils = pathUtils;
+
 // Global error handlers
 window.addEventListener('unhandledrejection', function(event) {
     // Enhanced logging for promise rejections with better context
@@ -77,6 +131,9 @@ class ChunkyDadApp {
         this.isCityPage = this.checkIfCityPage();
         this.isTestPage = this.checkIfTestPage();
         this.isDirectoryPage = this.checkIfDirectoryPage();
+        
+        // Initialize path utilities
+        this.pathUtils = window.pathUtils;
         
         // Initialize modules
         this.componentsManager = null;
@@ -367,6 +424,10 @@ class ChunkyDadApp {
 
     getTodayEventsAggregator() {
         return this.todayEventsAggregator;
+    }
+
+    getPathUtils() {
+        return this.pathUtils;
     }
 
     // Global function for scrolling (backward compatibility)

--- a/js/bear-directory.js
+++ b/js/bear-directory.js
@@ -246,9 +246,10 @@ class BearDirectory {
             displayContent = this.createInstagramContent(item);
         } else {
             // No specific display content - show placeholder
+            const logoPath = window.pathUtils ? window.pathUtils.getLogoPath() : 'Rising_Star_Ryan_Head_Compressed.png';
             displayContent = `
                 <div class="tile-placeholder">
-                    <div class="bear-icon"><img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" class="bear-directory-icon"></div>
+                    <div class="bear-icon"><img src="${logoPath}" alt="chunky.dad" class="bear-directory-icon"></div>
                 </div>`;
         }
         
@@ -293,7 +294,7 @@ class BearDirectory {
                 </blockquote>
             </div>` :
             `<div class="tile-placeholder">
-                <div class="bear-icon"><img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" class="bear-directory-icon"></div>
+                <div class="bear-icon"><img src="${window.pathUtils ? window.pathUtils.getLogoPath() : 'Rising_Star_Ryan_Head_Compressed.png'}" alt="chunky.dad" class="bear-directory-icon"></div>
             </div>`;
             
         return instagramContent;
@@ -308,7 +309,8 @@ class BearDirectory {
             'shop': '🛍️',
             'service': '💼'
         };
-        return icons[type.toLowerCase()] || '<img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" class="bear-directory-icon">';
+        const logoPath = window.pathUtils ? window.pathUtils.getLogoPath() : 'Rising_Star_Ryan_Head_Compressed.png';
+        return icons[type.toLowerCase()] || `<img src="${logoPath}" alt="chunky.dad" class="bear-directory-icon">`;
     }
     
     updateMap() {

--- a/js/components.js
+++ b/js/components.js
@@ -45,11 +45,12 @@ class ComponentsManager {
             return;
         }
 
+        const logoPath = window.pathUtils ? window.pathUtils.getLogoPath() : 'Rising_Star_Ryan_Head_Compressed.png';
         const modalHTML = `
             <div id="bear-intel-modal" class="bear-intel-modal" style="display: none;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h3><img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" class="modal-icon"> Share Bear Intel</h3>
+                        <h3><img src="${logoPath}" alt="chunky.dad" class="modal-icon"> Share Bear Intel</h3>
                         <button class="modal-close" id="modal-close-btn">&times;</button>
                     </div>
                     <div class="modal-body">
@@ -65,7 +66,7 @@ class ComponentsManager {
                                 <option value="other">Other Bear Intel</option>
                             </select>
                             <textarea placeholder="Tell us about it! Include city, address, and any special details..." rows="4" required></textarea>
-                            <button type="submit">Send Bear Intel <img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" class="button-icon"></button>
+                            <button type="submit">Send Bear Intel <img src="${logoPath}" alt="chunky.dad" class="button-icon"></button>
                         </form>
                     </div>
                 </div>
@@ -79,11 +80,12 @@ class ComponentsManager {
 
     // Method to get the modal HTML for pages that need it before JS loads
     static getModalHTML() {
+        const logoPath = window.pathUtils ? window.pathUtils.getLogoPath() : 'Rising_Star_Ryan_Head_Compressed.png';
         return `
             <div id="bear-intel-modal" class="bear-intel-modal" style="display: none;">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h3><img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" class="modal-icon"> Share Bear Intel</h3>
+                        <h3><img src="${logoPath}" alt="chunky.dad" class="modal-icon"> Share Bear Intel</h3>
                         <button class="modal-close" id="modal-close-btn">&times;</button>
                     </div>
                     <div class="modal-body">
@@ -99,7 +101,7 @@ class ComponentsManager {
                                 <option value="other">Other Bear Intel</option>
                             </select>
                             <textarea placeholder="Tell us about it! Include city, address, and any special details..." rows="4" required></textarea>
-                            <button type="submit">Send Bear Intel <img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" class="button-icon"></button>
+                            <button type="submit">Send Bear Intel <img src="${logoPath}" alt="chunky.dad" class="button-icon"></button>
                         </form>
                     </div>
                 </div>

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1932,11 +1932,12 @@ class DynamicCalendarLoader extends CalendarCore {
             const markers = []; // Store markers for fit all function
             
             // Create custom marker icon
+            const logoPath = window.pathUtils ? window.pathUtils.getLogoPath() : 'Rising_Star_Ryan_Head_Compressed.png';
             const customIcon = L.divIcon({
                 className: 'custom-marker',
                 html: `
                     <div class="marker-pin">
-                        <div class="marker-icon"><img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" class="map-marker-icon"></div>
+                        <div class="marker-icon"><img src="${logoPath}" alt="chunky.dad" class="map-marker-icon"></div>
                     </div>
                 `,
                 iconSize: [44, 56],

--- a/js/header-manager.js
+++ b/js/header-manager.js
@@ -41,17 +41,18 @@ class HeaderManager {
             return;
         }
 
-        let title = '<img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad';
+        const logoPath = window.pathUtils ? window.pathUtils.getLogoPath() : 'Rising_Star_Ryan_Head_Compressed.png';
+        let title = `<img src="${logoPath}" alt="chunky.dad logo" class="logo-img"> chunky.dad`;
         
         if (this.isCityPage()) {
             const cityKey = this.getCityFromURL();
             const cityConfig = getCityConfig(cityKey);
             if (cityConfig) {
-                title = `<img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/${cityKey}`;
+                title = `<img src="${logoPath}" alt="chunky.dad logo" class="logo-img"> chunky.dad/${cityKey}`;
                 this.currentCity = cityConfig;
             }
         } else if (this.isTestPage) {
-            title = '<img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad [DEBUG]';
+            title = `<img src="${logoPath}" alt="chunky.dad logo" class="logo-img"> chunky.dad [DEBUG]`;
         }
 
         // Update the title

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,56 +1,6 @@
 // Centralized Logging System for chunky.dad
 // Provides consistent, useful debugging information for users and developers
 
-// Path utility for resolving asset paths based on current page location
-class PathUtils {
-    constructor() {
-        this.isSubdirectory = this.detectSubdirectory();
-        this.pathPrefix = this.isSubdirectory ? '../' : '';
-    }
-    
-    // Detect if we're in a city subdirectory
-    detectSubdirectory() {
-        const pathname = window.location.pathname;
-        // Check if we're in a city directory (not root, not testing, not tools)
-        const pathSegments = pathname.split('/').filter(Boolean);
-        
-        // If we have path segments and the first one isn't a known root file
-        if (pathSegments.length > 0) {
-            const firstSegment = pathSegments[0].toLowerCase();
-            // Skip known root files and testing directories
-            const rootFiles = ['index.html', 'city.html', 'bear-directory.html', 'test', 'testing', 'tools', 'scripts'];
-            const isRootFile = rootFiles.some(file => firstSegment.includes(file));
-            
-            // If not a root file and we have segments, we're likely in a subdirectory
-            if (!isRootFile && pathSegments.length >= 1) {
-                return true;
-            }
-        }
-        
-        return false;
-    }
-    
-    // Resolve asset path based on current location
-    resolvePath(assetPath) {
-        // Don't modify absolute URLs or data URLs
-        if (assetPath.startsWith('http') || assetPath.startsWith('//') || assetPath.startsWith('data:')) {
-            return assetPath;
-        }
-        
-        // Don't modify paths that already have ../ prefix
-        if (assetPath.startsWith('../')) {
-            return assetPath;
-        }
-        
-        return this.pathPrefix + assetPath;
-    }
-    
-    // Convenience method for the common logo image
-    getLogoPath() {
-        return this.resolvePath('Rising_Star_Ryan_Head_Compressed.png');
-    }
-}
-
 class ChunkyLogger {
     constructor() {
         this.debugMode = true; // Set to false in production
@@ -97,9 +47,6 @@ class ChunkyLogger {
                 readyState: document.readyState
             });
         });
-        
-        // Add path resolution utility
-        this.pathUtils = new PathUtils();
         
         // Monitor DOM ready
         if (document.readyState === 'loading') {
@@ -268,12 +215,10 @@ class ChunkyLogger {
 
 // Create global logger instance
 const logger = new ChunkyLogger();
-const pathUtils = new PathUtils();
 
 // Export for use in other modules
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { logger, pathUtils };
+    module.exports = logger;
 } else {
     window.logger = logger;
-    window.pathUtils = pathUtils;
 }

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,6 +1,56 @@
 // Centralized Logging System for chunky.dad
 // Provides consistent, useful debugging information for users and developers
 
+// Path utility for resolving asset paths based on current page location
+class PathUtils {
+    constructor() {
+        this.isSubdirectory = this.detectSubdirectory();
+        this.pathPrefix = this.isSubdirectory ? '../' : '';
+    }
+    
+    // Detect if we're in a city subdirectory
+    detectSubdirectory() {
+        const pathname = window.location.pathname;
+        // Check if we're in a city directory (not root, not testing, not tools)
+        const pathSegments = pathname.split('/').filter(Boolean);
+        
+        // If we have path segments and the first one isn't a known root file
+        if (pathSegments.length > 0) {
+            const firstSegment = pathSegments[0].toLowerCase();
+            // Skip known root files and testing directories
+            const rootFiles = ['index.html', 'city.html', 'bear-directory.html', 'test', 'testing', 'tools', 'scripts'];
+            const isRootFile = rootFiles.some(file => firstSegment.includes(file));
+            
+            // If not a root file and we have segments, we're likely in a subdirectory
+            if (!isRootFile && pathSegments.length >= 1) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+    
+    // Resolve asset path based on current location
+    resolvePath(assetPath) {
+        // Don't modify absolute URLs or data URLs
+        if (assetPath.startsWith('http') || assetPath.startsWith('//') || assetPath.startsWith('data:')) {
+            return assetPath;
+        }
+        
+        // Don't modify paths that already have ../ prefix
+        if (assetPath.startsWith('../')) {
+            return assetPath;
+        }
+        
+        return this.pathPrefix + assetPath;
+    }
+    
+    // Convenience method for the common logo image
+    getLogoPath() {
+        return this.resolvePath('Rising_Star_Ryan_Head_Compressed.png');
+    }
+}
+
 class ChunkyLogger {
     constructor() {
         this.debugMode = true; // Set to false in production
@@ -47,6 +97,9 @@ class ChunkyLogger {
                 readyState: document.readyState
             });
         });
+        
+        // Add path resolution utility
+        this.pathUtils = new PathUtils();
         
         // Monitor DOM ready
         if (document.readyState === 'loading') {
@@ -215,10 +268,12 @@ class ChunkyLogger {
 
 // Create global logger instance
 const logger = new ChunkyLogger();
+const pathUtils = new PathUtils();
 
 // Export for use in other modules
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = logger;
+    module.exports = { logger, pathUtils };
 } else {
     window.logger = logger;
+    window.pathUtils = pathUtils;
 }


### PR DESCRIPTION
Introduce `PathUtils` to dynamically resolve asset paths in JavaScript files, fixing broken image and component loading on city pages.

The new city page generation system created files in subdirectories (e.g., `/seattle/index.html`). While the HTML references were correctly prefixed with `../` by the generation script, several JavaScript files (e.g., `components.js`, `header-manager.js`, `dynamic-calendar-loader.js`, `bear-directory.js`) contained hardcoded image paths (e.g., `Rising_Star_Ryan_Head_Compressed.png`) that did not account for the subdirectory structure. This PR resolves this by adding a `PathUtils` class to detect subdirectory locations and dynamically prepend `../` to asset paths, ensuring all resources load correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-11e0b3bd-d9e6-4d6d-a895-1921bc59f20c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11e0b3bd-d9e6-4d6d-a895-1921bc59f20c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

