### PR TITLE
Fix calendar navigation bug

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1020,7 +1020,16 @@ class DynamicCalendarLoader extends CalendarCore {
         if (this.currentView === 'week') {
             this.currentDate.setDate(this.currentDate.getDate() + (delta * 7));
         } else {
+            // Prevent month skip when current day exceeds next month's length (e.g., Jan 31 -> Mar 3)
+            const previousDay = this.currentDate.getDate();
+            this.currentDate.setDate(1);
             this.currentDate.setMonth(this.currentDate.getMonth() + delta);
+            const lastDayOfTargetMonth = new Date(
+                this.currentDate.getFullYear(),
+                this.currentDate.getMonth() + 1,
+                0
+            ).getDate();
+            this.currentDate.setDate(Math.min(previousDay, lastDayOfTargetMonth));
         }
         
         // Only update display immediately if not part of a swipe animation


### PR DESCRIPTION
Fix calendar month navigation to prevent skipping a month when swiping from a day that exceeds the next month's length.

---
<a href="https://cursor.com/background-agent?bcId=bc-2abb47b7-7bef-4215-8eaa-ebc8305ccf4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2abb47b7-7bef-4215-8eaa-ebc8305ccf4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

