### PR TITLE
Changes from background agent bc-67dc411e-73dd-41ac-ab8a-d954e4b32987

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -342,6 +342,7 @@ class ScriptableAdapter {
             console.log(`📱 Scriptable: Executing actions for ${analyzedEvents.length} events`);
             const failedEvents = [];
             const actionCounts = { merge: [], update: [], skip: [], create: [] };
+            let processedCount = 0;
             
             for (const event of analyzedEvents) {
                 try {
@@ -434,7 +435,7 @@ class ScriptableAdapter {
                 if (actionCounts.update.length > 0) actionSummary.push(`${actionCounts.update.length} updated`);
                 if (actionCounts.skip.length > 0) actionSummary.push(`${actionCounts.skip.length} skipped`);
                 
-                console.log(`📱 Scriptable: ✓ Processed ${totalActions} events: ${actionSummary.join(', ')}`);
+                console.log(`📱 Scriptable: ✓ Processed ${processedCount} events: ${actionSummary.join(', ')}`);
             }
             
             if (failedEvents.length > 0) {


### PR DESCRIPTION
Initialize `processedCount` to fix a runtime error and correctly report processed event counts.

The `processedCount` variable was used in the `executeCalendarActions` function's success log without prior declaration, causing a "Can't find variable" error and a misleading "Failed to process X events" message. This change initializes the variable and updates the log to correctly reflect the number of events processed.

---
<a href="https://cursor.com/background-agent?bcId=bc-67dc411e-73dd-41ac-ab8a-d954e4b32987">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67dc411e-73dd-41ac-ab8a-d954e4b32987">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

