### PR TITLE
Normalize city URLs and update analytics

### DIFF
--- a/city.html
+++ b/city.html
@@ -8,6 +8,41 @@
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>


### PR DESCRIPTION
Add early URL normalization script to `city.html` to redirect `city.html?city=...` to canonical `/{slug}/` paths, ensuring consistent user experience and accurate Google Analytics tracking.

---
<a href="https://cursor.com/background-agent?bcId=bc-6aa7bd1f-01b5-46b7-9163-01f5ef870ffc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6aa7bd1f-01b5-46b7-9163-01f5ef870ffc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

