### PR TITLE
Scrape and process events for calendar

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -361,7 +361,7 @@ class ScriptableAdapter {
                             targetEvent.title = event.title;
                             targetEvent.startDate = event.startDate;
                             targetEvent.endDate = event.endDate;
-                            targetEvent.location = event.location;
+                            targetEvent.location = event.address || event.bar || '';
                             targetEvent.notes = event.notes;
                             targetEvent.url = event.url;
                             
@@ -383,9 +383,10 @@ class ScriptableAdapter {
                                 updateChanges.push('notes (replaced)');
                                 updateTarget.notes = event.notes;
                             }
-                            if (updateTarget.location !== event.location) {
+                            const newLocation = event.address || event.bar || '';
+                            if (updateTarget.location !== newLocation) {
                                 updateChanges.push('location (replaced)');
-                                updateTarget.location = event.location;
+                                updateTarget.location = newLocation;
                             }
                             if (updateTarget.url !== event.url && event.url) {
                                 updateChanges.push('url (replaced)');
@@ -408,7 +409,7 @@ class ScriptableAdapter {
                             calendarEvent.title = event.title;
                             calendarEvent.startDate = event.startDate;
                             calendarEvent.endDate = event.endDate;
-                            calendarEvent.location = event.location;
+                            calendarEvent.location = event.address || event.bar || '';
                             calendarEvent.notes = event.notes;
                             calendarEvent.calendar = calendar;
                             


### PR DESCRIPTION
Fix Scriptable calendar event saving by using string address for location instead of coordinate object.

The `CalendarEvent.location` property in Scriptable expects a string, but the event objects were providing a `location` object with `lat` and `lng` coordinates, leading to a "Expected value of type string but got value of type {string: number}" error. This PR updates the `scriptable-adapter.js` to correctly assign `event.address` (falling back to `event.bar`) to `calendarEvent.location` for new, merged, and updated events.

---
<a href="https://cursor.com/background-agent?bcId=bc-426f7ae3-1365-45a4-b441-93a5ef685ba3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-426f7ae3-1365-45a4-b441-93a5ef685ba3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

