### PR TITLE
Add open graph image support and plan

### DIFF
--- a/.github/workflows/update-calendar-data.yml
+++ b/.github/workflows/update-calendar-data.yml
@@ -225,6 +225,21 @@ jobs:
             echo "CALENDAR_CHANGED=true" >> $GITHUB_ENV
           fi
       
+      - name: Generate event pages when calendar changed
+        if: env.CALENDAR_CHANGED == 'true'
+        run: |
+          node tools/generate-event-pages.js
+          # Stage only generated event pages under city directories
+          git add */*/index.html 2>/dev/null || true
+          if git diff --staged --quiet; then
+            echo "No event page changes to commit"
+            echo "EVENT_PAGES_CHANGED=false" >> $GITHUB_ENV
+          else
+            git commit -m "🧩 Regenerate event pages from calendars"
+            git push
+            echo "EVENT_PAGES_CHANGED=true" >> $GITHUB_ENV
+          fi
+      
       - name: Update test manifest only if calendar data changed
         run: |
           if [ "$CALENDAR_CHANGED" = "true" ] && [ -f "testing/generate-manifest.js" ]; then

--- a/.github/workflows/update-calendar-data.yml
+++ b/.github/workflows/update-calendar-data.yml
@@ -239,6 +239,23 @@ jobs:
             git push
             echo "EVENT_PAGES_CHANGED=true" >> $GITHUB_ENV
           fi
+
+      - name: Install Puppeteer when event pages changed
+        if: env.EVENT_PAGES_CHANGED == 'true'
+        run: |
+          npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Generate OG images for events
+        if: env.EVENT_PAGES_CHANGED == 'true'
+        run: |
+          node tools/generate-og-images.js
+          git add img/og/ 2>/dev/null || true
+          if git diff --staged --quiet; then
+            echo "No OG image changes to commit"
+          else
+            git commit -m "🖼️ Generate/update OG images for events"
+            git push
+          fi
       
       - name: Update test manifest only if calendar data changed
         run: |

--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Atlanta - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Atlanta - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/atlanta/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Berlin - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Berlin - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/berlin/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/chicago/belly-up-1757192400000/index.html
+++ b/chicago/belly-up-1757192400000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="Belly Up – Chicago – chunky.dad">
   <meta property="og:description" content="Saturday · 9PM-5AM · @ Jackhammer">
   <meta property="og:url" content="https://chunky.dad/chicago/belly-up-1757192400000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/chicago/belly-up-1757192400000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Belly Up – Chicago – chunky.dad">
   <meta name="twitter:description" content="Saturday · 9PM-5AM · @ Jackhammer">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/chicago/belly-up-1757192400000.png">
   <meta http-equiv="refresh" content="0; url=../?event=belly-up-1757192400000">
 </head>
 <body>

--- a/chicago/belly-up-1757192400000/index.html
+++ b/chicago/belly-up-1757192400000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Belly Up – Chicago – chunky.dad</title>
+  <meta name="description" content="Saturday · 9PM-5AM · @ Jackhammer">
+  <link rel="canonical" href="/chicago/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Belly Up – Chicago – chunky.dad">
+  <meta property="og:description" content="Saturday · 9PM-5AM · @ Jackhammer">
+  <meta property="og:url" content="https://chunky.dad/chicago/belly-up-1757192400000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Belly Up – Chicago – chunky.dad">
+  <meta name="twitter:description" content="Saturday · 9PM-5AM · @ Jackhammer">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=belly-up-1757192400000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=belly-up-1757192400000"></noscript>
+  <script>location.replace("../?event=belly-up-1757192400000");</script>
+</body>
+</html>

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Chicago - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Chicago - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/chicago/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/denver/denver-1757214000000/index.html
+++ b/denver/denver-1757214000000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="DENVER – Denver – chunky.dad">
   <meta property="og:description" content="Sunday · 3AM-8AM · @ Summit">
   <meta property="og:url" content="https://chunky.dad/denver/denver-1757214000000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/denver/denver-1757214000000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="DENVER – Denver – chunky.dad">
   <meta name="twitter:description" content="Sunday · 3AM-8AM · @ Summit">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/denver/denver-1757214000000.png">
   <meta http-equiv="refresh" content="0; url=../?event=denver-1757214000000">
 </head>
 <body>

--- a/denver/denver-1757214000000/index.html
+++ b/denver/denver-1757214000000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DENVER – Denver – chunky.dad</title>
+  <meta name="description" content="Sunday · 3AM-8AM · @ Summit">
+  <link rel="canonical" href="/denver/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="DENVER – Denver – chunky.dad">
+  <meta property="og:description" content="Sunday · 3AM-8AM · @ Summit">
+  <meta property="og:url" content="https://chunky.dad/denver/denver-1757214000000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="DENVER – Denver – chunky.dad">
+  <meta name="twitter:description" content="Sunday · 3AM-8AM · @ Summit">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=denver-1757214000000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=denver-1757214000000"></noscript>
+  <script>location.replace("../?event=denver-1757214000000");</script>
+</body>
+</html>

--- a/denver/index.html
+++ b/denver/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Denver - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Denver - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/denver/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,15 @@
     <meta name="description" content="The ultimate travel guide for gay bears - city guides, events, and bear-owned businesses worldwide">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="chunky.dad - Your Gay Bear Travel Guide">
+    <meta property="og:description" content="The ultimate travel guide for gay bears - city guides, events, and bear-owned businesses worldwide">
+    <meta property="og:url" content="https://chunky.dad/">
+    <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="chunky.dad - Your Gay Bear Travel Guide">
+    <meta name="twitter:description" content="The ultimate travel guide for gay bears - city guides, events, and bear-owned businesses worldwide">
+    <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
     
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>

--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -487,12 +487,17 @@ class CalendarCore {
             }
             
             // Convert HTML breaks to newlines
-            textBlock = textBlock.replace(/<br\s?\/?>/gi, "\n");
+            textBlock = textBlock.replace(/<br\s?\/?>(?=\s*\n?)/gi, "\n");
             
-            // Remove any remaining HTML tags
-            const tempDiv = document.createElement('div');
-            tempDiv.innerHTML = textBlock;
-            textBlock = tempDiv.textContent || tempDiv.innerText || '';
+            // Remove any remaining HTML tags - use DOM when available, else regex fallback
+            if (typeof document !== 'undefined' && document.createElement) {
+                const tempDiv = document.createElement('div');
+                tempDiv.innerHTML = textBlock;
+                textBlock = tempDiv.textContent || tempDiv.innerText || '';
+            } else {
+                // Basic fallback: strip tags
+                textBlock = textBlock.replace(/<[^>]+>/g, '');
+            }
         }
         
         // Replace escaped newlines with actual newlines

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2109,6 +2109,24 @@ class DynamicCalendarLoader extends CalendarCore {
             } else if (filteredEvents?.length > 0) {
                 // Events are already sorted by upcoming time in getFilteredEvents()
                 eventsList.innerHTML = filteredEvents.map(event => this.generateEventCard(event)).join('');
+
+                // Deep-link: highlight event from ?event=<slug> or #<slug>
+                try {
+                    const url = new URL(window.location.href);
+                    const eventParam = url.searchParams.get('event') || (window.location.hash ? window.location.hash.replace('#','') : '');
+                    if (eventParam) {
+                        const selector = `.event-card[data-event-slug="${CSS && CSS.escape ? CSS.escape(eventParam) : eventParam}"]`;
+                        const target = document.querySelector(selector);
+                        if (target) {
+                            target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                            target.classList.add('highlight');
+                            setTimeout(() => target.classList.remove('highlight'), 2000);
+                            logger.debug('EVENT', `Deep-linked event highlighted: ${eventParam}`);
+                        } else {
+                            logger.debug('EVENT', `Deep-linked event not found in current render: ${eventParam}`);
+                        }
+                    }
+                } catch (_) {}
             } else {
                 eventsList.innerHTML = '<div class="loading-message">No events found for this period. Try switching Week/Month or check back soon.</div>';
                 logger.info('CALENDAR', 'No events to display for current period', {

--- a/london/index.html
+++ b/london/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="London - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to London - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/london/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/los-angeles/index.html
+++ b/los-angeles/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Los Angeles - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Los Angeles - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/los-angeles/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/los-angeles/megawoof-1756587600000/index.html
+++ b/los-angeles/megawoof-1756587600000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="MEGAWOOF – Los Angeles – chunky.dad">
   <meta property="og:description" content="Saturday · 9PM-2AM · @ Falcon North">
   <meta property="og:url" content="https://chunky.dad/los-angeles/megawoof-1756587600000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/los-angeles/megawoof-1756587600000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="MEGAWOOF – Los Angeles – chunky.dad">
   <meta name="twitter:description" content="Saturday · 9PM-2AM · @ Falcon North">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/los-angeles/megawoof-1756587600000.png">
   <meta http-equiv="refresh" content="0; url=../?event=megawoof-1756587600000">
 </head>
 <body>

--- a/los-angeles/megawoof-1756587600000/index.html
+++ b/los-angeles/megawoof-1756587600000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MEGAWOOF – Los Angeles – chunky.dad</title>
+  <meta name="description" content="Saturday · 9PM-2AM · @ Falcon North">
+  <link rel="canonical" href="/los-angeles/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="MEGAWOOF – Los Angeles – chunky.dad">
+  <meta property="og:description" content="Saturday · 9PM-2AM · @ Falcon North">
+  <meta property="og:url" content="https://chunky.dad/los-angeles/megawoof-1756587600000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="MEGAWOOF – Los Angeles – chunky.dad">
+  <meta name="twitter:description" content="Saturday · 9PM-2AM · @ Falcon North">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=megawoof-1756587600000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=megawoof-1756587600000"></noscript>
+  <script>location.replace("../?event=megawoof-1756587600000");</script>
+</body>
+</html>

--- a/new-orleans/index.html
+++ b/new-orleans/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="New Orleans - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to New Orleans - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/new-orleans/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/new-york/index.html
+++ b/new-york/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="New York - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to New York - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/new-york/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/package.json
+++ b/package.json
@@ -23,5 +23,7 @@
   "author": "Your Name",
   "license": "MIT",
   "devDependencies": {},
-  "dependencies": {}
+  "dependencies": {
+    "puppeteer": "22.15.0"
+  }
 }

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Palm Springs - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Palm Springs - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/palm-springs/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/portland/bearracuda-portland-16-year-anniversary-1757822400000/index.html
+++ b/portland/bearracuda-portland-16-year-anniversary-1757822400000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="Bearracuda Portland 16 YEAR Anniversary – Portland – chunky.dad">
   <meta property="og:description" content="Sunday · 4AM-9AM · @ Bossanova Ballroom">
   <meta property="og:url" content="https://chunky.dad/portland/bearracuda-portland-16-year-anniversary-1757822400000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/portland/bearracuda-portland-16-year-anniversary-1757822400000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Bearracuda Portland 16 YEAR Anniversary – Portland – chunky.dad">
   <meta name="twitter:description" content="Sunday · 4AM-9AM · @ Bossanova Ballroom">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/portland/bearracuda-portland-16-year-anniversary-1757822400000.png">
   <meta http-equiv="refresh" content="0; url=../?event=bearracuda-portland-16-year-anniversary-1757822400000">
 </head>
 <body>

--- a/portland/bearracuda-portland-16-year-anniversary-1757822400000/index.html
+++ b/portland/bearracuda-portland-16-year-anniversary-1757822400000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bearracuda Portland 16 YEAR Anniversary – Portland – chunky.dad</title>
+  <meta name="description" content="Sunday · 4AM-9AM · @ Bossanova Ballroom">
+  <link rel="canonical" href="/portland/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Bearracuda Portland 16 YEAR Anniversary – Portland – chunky.dad">
+  <meta property="og:description" content="Sunday · 4AM-9AM · @ Bossanova Ballroom">
+  <meta property="og:url" content="https://chunky.dad/portland/bearracuda-portland-16-year-anniversary-1757822400000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Bearracuda Portland 16 YEAR Anniversary – Portland – chunky.dad">
+  <meta name="twitter:description" content="Sunday · 4AM-9AM · @ Bossanova Ballroom">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=bearracuda-portland-16-year-anniversary-1757822400000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=bearracuda-portland-16-year-anniversary-1757822400000"></noscript>
+  <script>location.replace("../?event=bearracuda-portland-16-year-anniversary-1757822400000");</script>
+</body>
+</html>

--- a/portland/bearracuda-portland-saturday-november-15th-1763269200000/index.html
+++ b/portland/bearracuda-portland-saturday-november-15th-1763269200000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="Bearracuda Portland - Saturday, November 15th – Portland – chunky.dad">
   <meta property="og:description" content="Sunday · 5AM-10AM · @ Bossanova Ballroom">
   <meta property="og:url" content="https://chunky.dad/portland/bearracuda-portland-saturday-november-15th-1763269200000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/portland/bearracuda-portland-saturday-november-15th-1763269200000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Bearracuda Portland - Saturday, November 15th – Portland – chunky.dad">
   <meta name="twitter:description" content="Sunday · 5AM-10AM · @ Bossanova Ballroom">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/portland/bearracuda-portland-saturday-november-15th-1763269200000.png">
   <meta http-equiv="refresh" content="0; url=../?event=bearracuda-portland-saturday-november-15th-1763269200000">
 </head>
 <body>

--- a/portland/bearracuda-portland-saturday-november-15th-1763269200000/index.html
+++ b/portland/bearracuda-portland-saturday-november-15th-1763269200000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bearracuda Portland - Saturday, November 15th – Portland – chunky.dad</title>
+  <meta name="description" content="Sunday · 5AM-10AM · @ Bossanova Ballroom">
+  <link rel="canonical" href="/portland/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Bearracuda Portland - Saturday, November 15th – Portland – chunky.dad">
+  <meta property="og:description" content="Sunday · 5AM-10AM · @ Bossanova Ballroom">
+  <meta property="og:url" content="https://chunky.dad/portland/bearracuda-portland-saturday-november-15th-1763269200000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Bearracuda Portland - Saturday, November 15th – Portland – chunky.dad">
+  <meta name="twitter:description" content="Sunday · 5AM-10AM · @ Bossanova Ballroom">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=bearracuda-portland-saturday-november-15th-1763269200000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=bearracuda-portland-saturday-november-15th-1763269200000"></noscript>
+  <script>location.replace("../?event=bearracuda-portland-saturday-november-15th-1763269200000");</script>
+</body>
+</html>

--- a/portland/index.html
+++ b/portland/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Portland - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Portland - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/portland/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/portland/treasure-trail-portland-1761516000000/index.html
+++ b/portland/treasure-trail-portland-1761516000000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="TREASURE TRAIL: Portland – Portland – chunky.dad">
   <meta property="og:description" content="Sunday · 10PM-3AM · @ Sanctuary Club">
   <meta property="og:url" content="https://chunky.dad/portland/treasure-trail-portland-1761516000000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/portland/treasure-trail-portland-1761516000000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="TREASURE TRAIL: Portland – Portland – chunky.dad">
   <meta name="twitter:description" content="Sunday · 10PM-3AM · @ Sanctuary Club">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/portland/treasure-trail-portland-1761516000000.png">
   <meta http-equiv="refresh" content="0; url=../?event=treasure-trail-portland-1761516000000">
 </head>
 <body>

--- a/portland/treasure-trail-portland-1761516000000/index.html
+++ b/portland/treasure-trail-portland-1761516000000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TREASURE TRAIL: Portland – Portland – chunky.dad</title>
+  <meta name="description" content="Sunday · 10PM-3AM · @ Sanctuary Club">
+  <link rel="canonical" href="/portland/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="TREASURE TRAIL: Portland – Portland – chunky.dad">
+  <meta property="og:description" content="Sunday · 10PM-3AM · @ Sanctuary Club">
+  <meta property="og:url" content="https://chunky.dad/portland/treasure-trail-portland-1761516000000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="TREASURE TRAIL: Portland – Portland – chunky.dad">
+  <meta name="twitter:description" content="Sunday · 10PM-3AM · @ Sanctuary Club">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=treasure-trail-portland-1761516000000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=treasure-trail-portland-1761516000000"></noscript>
+  <script>location.replace("../?event=treasure-trail-portland-1761516000000");</script>
+</body>
+</html>

--- a/seattle/bearracuda-seattle-serious-wood-1760130000000/index.html
+++ b/seattle/bearracuda-seattle-serious-wood-1760130000000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="Bearracuda Seattle: SERIOUS WOOD – Seattle – chunky.dad">
   <meta property="og:description" content="Friday · 9PM-3AM · @ MASSIVE">
   <meta property="og:url" content="https://chunky.dad/seattle/bearracuda-seattle-serious-wood-1760130000000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/seattle/bearracuda-seattle-serious-wood-1760130000000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Bearracuda Seattle: SERIOUS WOOD – Seattle – chunky.dad">
   <meta name="twitter:description" content="Friday · 9PM-3AM · @ MASSIVE">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/seattle/bearracuda-seattle-serious-wood-1760130000000.png">
   <meta http-equiv="refresh" content="0; url=../?event=bearracuda-seattle-serious-wood-1760130000000">
 </head>
 <body>

--- a/seattle/bearracuda-seattle-serious-wood-1760130000000/index.html
+++ b/seattle/bearracuda-seattle-serious-wood-1760130000000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bearracuda Seattle: SERIOUS WOOD – Seattle – chunky.dad</title>
+  <meta name="description" content="Friday · 9PM-3AM · @ MASSIVE">
+  <link rel="canonical" href="/seattle/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Bearracuda Seattle: SERIOUS WOOD – Seattle – chunky.dad">
+  <meta property="og:description" content="Friday · 9PM-3AM · @ MASSIVE">
+  <meta property="og:url" content="https://chunky.dad/seattle/bearracuda-seattle-serious-wood-1760130000000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Bearracuda Seattle: SERIOUS WOOD – Seattle – chunky.dad">
+  <meta name="twitter:description" content="Friday · 9PM-3AM · @ MASSIVE">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=bearracuda-seattle-serious-wood-1760130000000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=bearracuda-seattle-serious-wood-1760130000000"></noscript>
+  <script>location.replace("../?event=bearracuda-seattle-serious-wood-1760130000000");</script>
+</body>
+</html>

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Seattle - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Seattle - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/seattle/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/seattle/treasure-trail-seattle-1758920400000/index.html
+++ b/seattle/treasure-trail-seattle-1758920400000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Treasure Trail: SEATTLE – Seattle – chunky.dad</title>
+  <meta name="description" content="Friday · 9PM-3AM · @ MASSIVE">
+  <link rel="canonical" href="/seattle/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Treasure Trail: SEATTLE – Seattle – chunky.dad">
+  <meta property="og:description" content="Friday · 9PM-3AM · @ MASSIVE">
+  <meta property="og:url" content="https://chunky.dad/seattle/treasure-trail-seattle-1758920400000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Treasure Trail: SEATTLE – Seattle – chunky.dad">
+  <meta name="twitter:description" content="Friday · 9PM-3AM · @ MASSIVE">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=treasure-trail-seattle-1758920400000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=treasure-trail-seattle-1758920400000"></noscript>
+  <script>location.replace("../?event=treasure-trail-seattle-1758920400000");</script>
+</body>
+</html>

--- a/seattle/treasure-trail-seattle-1758920400000/index.html
+++ b/seattle/treasure-trail-seattle-1758920400000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="Treasure Trail: SEATTLE – Seattle – chunky.dad">
   <meta property="og:description" content="Friday · 9PM-3AM · @ MASSIVE">
   <meta property="og:url" content="https://chunky.dad/seattle/treasure-trail-seattle-1758920400000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/seattle/treasure-trail-seattle-1758920400000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Treasure Trail: SEATTLE – Seattle – chunky.dad">
   <meta name="twitter:description" content="Friday · 9PM-3AM · @ MASSIVE">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/seattle/treasure-trail-seattle-1758920400000.png">
   <meta http-equiv="refresh" content="0; url=../?event=treasure-trail-seattle-1758920400000">
 </head>
 <body>

--- a/sf/bearracuda-sf-presents-horse-meat-disco-1758945600000/index.html
+++ b/sf/bearracuda-sf-presents-horse-meat-disco-1758945600000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="Bearracuda SF presents: HORSE MEAT DISCO – San Francisco – chunky.dad">
   <meta property="og:description" content="Saturday · 4AM-10AM · @ The Public Works SF">
   <meta property="og:url" content="https://chunky.dad/sf/bearracuda-sf-presents-horse-meat-disco-1758945600000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/sf/bearracuda-sf-presents-horse-meat-disco-1758945600000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Bearracuda SF presents: HORSE MEAT DISCO – San Francisco – chunky.dad">
   <meta name="twitter:description" content="Saturday · 4AM-10AM · @ The Public Works SF">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/sf/bearracuda-sf-presents-horse-meat-disco-1758945600000.png">
   <meta http-equiv="refresh" content="0; url=../?event=bearracuda-sf-presents-horse-meat-disco-1758945600000">
 </head>
 <body>

--- a/sf/bearracuda-sf-presents-horse-meat-disco-1758945600000/index.html
+++ b/sf/bearracuda-sf-presents-horse-meat-disco-1758945600000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bearracuda SF presents: HORSE MEAT DISCO – San Francisco – chunky.dad</title>
+  <meta name="description" content="Saturday · 4AM-10AM · @ The Public Works SF">
+  <link rel="canonical" href="/sf/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Bearracuda SF presents: HORSE MEAT DISCO – San Francisco – chunky.dad">
+  <meta property="og:description" content="Saturday · 4AM-10AM · @ The Public Works SF">
+  <meta property="og:url" content="https://chunky.dad/sf/bearracuda-sf-presents-horse-meat-disco-1758945600000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Bearracuda SF presents: HORSE MEAT DISCO – San Francisco – chunky.dad">
+  <meta name="twitter:description" content="Saturday · 4AM-10AM · @ The Public Works SF">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=bearracuda-sf-presents-horse-meat-disco-1758945600000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=bearracuda-sf-presents-horse-meat-disco-1758945600000"></noscript>
+  <script>location.replace("../?event=bearracuda-sf-presents-horse-meat-disco-1758945600000");</script>
+</body>
+</html>

--- a/sf/index.html
+++ b/sf/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="San Francisco - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to San Francisco - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/sf/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,103 +2,103 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://chunky.dad/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://chunky.dad/atlanta/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/berlin/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/chicago/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/denver/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/london/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/los-angeles/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/new-orleans/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/new-york/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/palm-springs/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/portland/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/seattle/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/sf/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/sitges/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/toronto/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/vegas/</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://chunky.dad/bear-directory.html</loc>
-    <lastmod>2025-08-31</lastmod>
+    <lastmod>2025-09-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Sitges - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Sitges - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/sitges/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/tools/generate-city-pages.js
+++ b/tools/generate-city-pages.js
@@ -60,11 +60,13 @@ function buildCityHtml(baseHtml, cityKey, cityConfig) {
   }
 
   // Basic OpenGraph tags (optional but included by default)
+  const ogImageUrl = `https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png`;
   const ogTags = [
     `<meta property="og:type" content="website">`,
     `<meta property="og:title" content="${cityTitle}">`,
     `<meta property="og:description" content="${cityDesc}">`,
-    `<meta property="og:url" content="https://chunky.dad${canonicalHref}">`
+    `<meta property="og:url" content="https://chunky.dad${canonicalHref}">`,
+    `<meta property="og:image" content="${ogImageUrl}">`
   ].join('\n  ');
 
   if (!html.includes('property="og:title"')) {
@@ -73,6 +75,11 @@ function buildCityHtml(baseHtml, cityKey, cityConfig) {
     html = html.replace(/<meta property="og:title"[^>]*>/, `<meta property="og:title" content="${cityTitle}">`)
                .replace(/<meta property="og:description"[^>]*>/, `<meta property="og:description" content="${cityDesc}">`)
                .replace(/<meta property="og:url"[^>]*>/, `<meta property="og:url" content="https:\/\/chunky.dad${canonicalHref}">`);
+    if (html.includes('property="og:image"')) {
+      html = html.replace(/<meta property="og:image"[^>]*>/, `<meta property="og:image" content="${ogImageUrl}">`);
+    } else {
+      html = html.replace('</head>', `  <meta property="og:image" content="${ogImageUrl}">\n</head>`);
+    }
   }
 
   // Rewrite asset and link paths for subdirectory depth

--- a/tools/generate-event-pages.js
+++ b/tools/generate-event-pages.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// Resolve project root
+const ROOT = path.resolve(__dirname, '..');
+
+// Load CITY_CONFIG from js/city-config.js (Node-compatible export exists)
+let CITY_CONFIG;
+try {
+  const cityModule = require(path.join(ROOT, 'js', 'city-config.js'));
+  CITY_CONFIG = cityModule.CITY_CONFIG || {};
+} catch (e) {
+  console.error('Failed to load CITY_CONFIG from js/city-config.js:', e.message);
+  process.exit(1);
+}
+
+// Load CalendarCore for ICS parsing (Node-compatible after DOM guard)
+let CalendarCore;
+try {
+  CalendarCore = require(path.join(ROOT, 'js', 'calendar-core.js'));
+} catch (e) {
+  console.error('Failed to load CalendarCore:', e.message);
+  process.exit(1);
+}
+
+// Simple logger shim for Node environment to satisfy references
+global.logger = {
+  debug() {}, info() {}, warn() {}, error() {}, componentInit() {}, componentLoad() {}, componentError() {}, time() {}, timeEnd() {}, apiCall() {}, performance() {}
+};
+
+// Config
+const OUTPUT_DAYS_WINDOW = parseInt(process.env.EVENT_STUB_DAYS || '180', 10); // Upcoming days to generate
+const MARKER = '<!-- generated: chunky.dad event page -->';
+const SITE_BASE = 'https://chunky.dad';
+const FALLBACK_IMAGE = `${SITE_BASE}/Rising_Star_Ryan_Head_Compressed.png`;
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeIfChanged(filePath, content) {
+  if (fs.existsSync(filePath)) {
+    const existing = fs.readFileSync(filePath, 'utf8');
+    if (existing === content) return false;
+  }
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, content);
+  return true;
+}
+
+function sanitize(text) {
+  return String(text || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function getIcsPath(cityKey) {
+  return path.join(ROOT, 'data', 'calendars', `${cityKey}.ics`);
+}
+
+function withinWindow(date, now, days) {
+  if (!date) return false;
+  const diffMs = date.getTime() - now.getTime();
+  const diffDays = diffMs / (1000 * 60 * 60 * 24);
+  return diffDays >= -2 && diffDays <= days; // small negative tolerance for late events
+}
+
+function buildEventHtml(cityKey, cityName, event) {
+  const title = `${sanitize(event.name)} – ${cityName} – chunky.dad`;
+  const descriptionParts = [];
+  if (event.day) descriptionParts.push(event.day);
+  if (event.time) descriptionParts.push(event.time);
+  if (event.bar) descriptionParts.push(`@ ${event.bar}`);
+  const description = sanitize(descriptionParts.join(' · ')) || `${cityName} bear event`;
+  const url = `${SITE_BASE}/${cityKey}/${encodeURIComponent(event.slug)}/`;
+  const ogImage = event.image || FALLBACK_IMAGE;
+
+  const canonical = `/${cityKey}/`;
+  const redirectTarget = `../?event=${encodeURIComponent(event.slug)}`;
+
+  return `<!DOCTYPE html>
+${MARKER}
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title}</title>
+  <meta name="description" content="${description}">
+  <link rel="canonical" href="${canonical}">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="${title}">
+  <meta property="og:description" content="${description}">
+  <meta property="og:url" content="${url}">
+  <meta property="og:image" content="${ogImage}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${title}">
+  <meta name="twitter:description" content="${description}">
+  <meta name="twitter:image" content="${ogImage}">
+  <meta http-equiv="refresh" content="0; url=${redirectTarget}">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=${redirectTarget}"></noscript>
+  <script>location.replace(${JSON.stringify(redirectTarget)});</script>
+</body>
+</html>`;
+}
+
+function pruneOldEventDirs(cityKey, validSlugs) {
+  const cityDir = path.join(ROOT, cityKey);
+  if (!fs.existsSync(cityDir)) return 0;
+  let removed = 0;
+  const entries = fs.readdirSync(cityDir, { withFileTypes: true });
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    const slugDir = path.join(cityDir, ent.name);
+    const indexFile = path.join(slugDir, 'index.html');
+    if (fs.existsSync(indexFile)) {
+      const html = fs.readFileSync(indexFile, 'utf8');
+      if (html.includes('generated: chunky.dad event page') && !validSlugs.has(ent.name)) {
+        fs.rmSync(slugDir, { recursive: true, force: true });
+        removed++;
+      }
+    }
+  }
+  return removed;
+}
+
+async function main() {
+  let totalChanges = 0;
+  const now = new Date();
+  const calendar = new CalendarCore();
+
+  const visibleCities = Object.entries(CITY_CONFIG).filter(([, cfg]) => cfg && cfg.visible !== false);
+  for (const [cityKey, cfg] of visibleCities) {
+    const icsPath = getIcsPath(cityKey);
+    if (!fs.existsSync(icsPath)) {
+      console.log(`⏭️  No ICS for ${cityKey}, skipping event pages`);
+      continue;
+    }
+
+    const icalText = fs.readFileSync(icsPath, 'utf8');
+    const events = calendar.parseICalData(icalText) || [];
+    const upcoming = events.filter(ev => withinWindow(ev.startDate, now, OUTPUT_DAYS_WINDOW));
+
+    // Map by slug to guarantee unique stubs
+    const uniqueBySlug = new Map();
+    for (const ev of upcoming) {
+      if (!ev.slug) continue;
+      if (!uniqueBySlug.has(ev.slug)) uniqueBySlug.set(ev.slug, ev);
+    }
+
+    const validSlugs = new Set(uniqueBySlug.keys());
+    let cityChanges = 0;
+
+    // Write stubs
+    for (const [slug, ev] of uniqueBySlug.entries()) {
+      const outFile = path.join(ROOT, cityKey, slug, 'index.html');
+      const html = buildEventHtml(cityKey, cfg.name || cityKey, ev);
+      if (writeIfChanged(outFile, html)) {
+        cityChanges++;
+        console.log(`✓ Wrote ${path.relative(ROOT, outFile)}`);
+      } else {
+        console.log(`⏭️  No change for ${path.relative(ROOT, outFile)}`);
+      }
+    }
+
+    // Prune removed events for this city (only our generated ones)
+    const removed = pruneOldEventDirs(cityKey, validSlugs);
+    if (removed > 0) cityChanges += removed;
+
+    if (cityChanges > 0) totalChanges += cityChanges;
+  }
+
+  if (totalChanges === 0) {
+    console.log('No event pages changed.');
+  } else {
+    console.log(`Event page generation complete. ${totalChanges} change(s).`);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error generating event pages:', err);
+  process.exit(1);
+});
+

--- a/tools/generate-event-pages.js
+++ b/tools/generate-event-pages.js
@@ -73,7 +73,9 @@ function buildEventHtml(cityKey, cityName, event) {
   if (event.bar) descriptionParts.push(`@ ${event.bar}`);
   const description = sanitize(descriptionParts.join(' · ')) || `${cityName} bear event`;
   const url = `${SITE_BASE}/${cityKey}/${encodeURIComponent(event.slug)}/`;
-  const ogImage = event.image || FALLBACK_IMAGE;
+  // Prefer generated per-event OG image if present
+  const generatedPng = `/img/og/${cityKey}/${encodeURIComponent(event.slug)}.png`;
+  const ogImage = event.image || `${SITE_BASE}${generatedPng}` || FALLBACK_IMAGE;
 
   const canonical = `/${cityKey}/`;
   const redirectTarget = `../?event=${encodeURIComponent(event.slug)}`;

--- a/tools/generate-og-images.js
+++ b/tools/generate-og-images.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// Resolve project root
+const ROOT = path.resolve(__dirname, '..');
+const SITE_BASE = 'https://chunky.dad';
+const OUTPUT_DIR = path.join(ROOT, 'img', 'og');
+
+// Lazy-load puppeteer only when invoked in CI to keep local fast
+async function getPuppeteer() {
+  try {
+    return await import('puppeteer');
+  } catch (e) {
+    console.error('Puppeteer is required to generate images. Ensure it is installed.');
+    throw e;
+  }
+}
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+function writeIfChanged(filePath, buffer) {
+  if (fs.existsSync(filePath)) {
+    const existing = fs.readFileSync(filePath);
+    if (Buffer.compare(existing, buffer) === 0) return false;
+  }
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, buffer);
+  return true;
+}
+
+function sanitize(text) {
+  return String(text || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// Build a minimal HTML snippet (no external CSS/fonts) for deterministic render
+function buildTemplate({ cityName, eventName, day, time, bar }) {
+  const title = sanitize(eventName);
+  const subtitle = [sanitize(cityName), sanitize(day), sanitize(time)].filter(Boolean).join(' • ');
+  const venue = bar ? `@ ${sanitize(bar)}` : '';
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    html, body { margin: 0; padding: 0; width: 1200px; height: 630px; }
+    body {
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      display: flex; flex-direction: column; justify-content: center; align-items: center;
+      background: linear-gradient(135deg, #10151a 0%, #1c2833 100%);
+      color: #fff;
+    }
+    .card { width: 1080px; height: 510px; border-radius: 24px; padding: 48px; background: rgba(255,255,255,0.06); box-shadow: 0 20px 60px rgba(0,0,0,0.4); display: flex; flex-direction: column; justify-content: center; }
+    .brand { font-weight: 700; letter-spacing: 0.6px; color: #f8f9fa; opacity: 0.9; margin-bottom: 18px; }
+    .title { font-size: 64px; line-height: 1.05; font-weight: 800; margin: 0 0 18px; }
+    .subtitle { font-size: 28px; color: #d0d7de; margin: 0 0 8px; }
+    .venue { font-size: 28px; color: #e6edf3; margin: 0; }
+  </style>
+  <title>${title}</title>
+  </head>
+  <body>
+    <div class="card">
+      <div class="brand">chunky.dad</div>
+      <div class="title">${title}</div>
+      <div class="subtitle">${subtitle}</div>
+      ${venue ? `<div class="venue">${venue}</div>` : ''}
+    </div>
+  </body>
+</html>`;
+}
+
+async function main() {
+  // Load config and events by reading generated event stub pages
+  // Source of truth for which events need images: directories under each city with index.html
+  const cityDirs = fs.readdirSync(ROOT, { withFileTypes: true }).filter(d => d.isDirectory());
+  const targets = [];
+
+  for (const dir of cityDirs) {
+    const cityKey = dir.name;
+    // Skip non-city directories
+    const indexHtml = path.join(ROOT, cityKey, 'index.html');
+    if (!fs.existsSync(indexHtml)) continue;
+
+    const eventDirs = fs.readdirSync(path.join(ROOT, cityKey), { withFileTypes: true }).filter(d => d.isDirectory());
+    for (const evDir of eventDirs) {
+      const evIndex = path.join(ROOT, cityKey, evDir.name, 'index.html');
+      if (!fs.existsSync(evIndex)) continue;
+      const html = fs.readFileSync(evIndex, 'utf8');
+      // Only generate when og:image is not already a per-event PNG under /img/og/
+      const hasGenerated = html.includes(`/img/og/${cityKey}/${evDir.name}.png`);
+      if (hasGenerated) continue;
+
+      // Extract minimal data from title/description for rendering
+      const titleMatch = html.match(/<meta property="og:title" content="([^"]+)"/);
+      const descMatch = html.match(/<meta property="og:description" content="([^"]+)"/);
+      const cityFromCanonical = (html.match(/<link rel="canonical" href="\/([^/]+)\//) || [])[1] || cityKey;
+      const title = titleMatch ? titleMatch[1] : `${cityKey} event`;
+      const desc = descMatch ? descMatch[1] : '';
+      let day = '', time = '', bar = '';
+      if (desc) {
+        // Attempt to split: City • Day • Time · @ Venue
+        const parts = desc.split(' · ');
+        const primary = parts[0] || '';
+        const pbits = primary.split(' • ');
+        // title format used earlier: <Event> – <City> – chunky.dad
+        // desc format: Day · Time · @ Bar (if present)
+        if (pbits.length >= 2) {
+          // Might be City • Day • Time or Day • Time; prefer last two as day/time
+          day = pbits[pbits.length - 2] || '';
+          time = pbits[pbits.length - 1] || '';
+        }
+        const venuePart = parts.find(p => p.startsWith('@ '));
+        if (venuePart) bar = venuePart.replace(/^@\s*/, '');
+      }
+      targets.push({ cityKey: cityFromCanonical, slug: evDir.name, title, day, time, bar });
+    }
+  }
+
+  if (targets.length === 0) {
+    console.log('No OG images to generate.');
+    return;
+  }
+
+  const { default: puppeteer } = await getPuppeteer();
+  const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-setuid-sandbox'] });
+  let changes = 0;
+  try {
+    for (const t of targets) {
+      const page = await browser.newPage();
+      await page.setViewport({ width: 1200, height: 630, deviceScaleFactor: 1 });
+      const html = buildTemplate({ cityName: t.cityKey, eventName: t.title, day: t.day, time: t.time, bar: t.bar });
+      await page.setContent(html, { waitUntil: 'networkidle0' });
+      const buffer = await page.screenshot({ type: 'png' });
+      const outPath = path.join(OUTPUT_DIR, t.cityKey, `${t.slug}.png`);
+      if (writeIfChanged(outPath, buffer)) {
+        changes++;
+        console.log(`✓ Generated ${path.relative(ROOT, outPath)}`);
+      } else {
+        console.log(`⏭️  No change for ${path.relative(ROOT, outPath)}`);
+      }
+      await page.close();
+    }
+  } finally {
+    await browser.close();
+  }
+
+  if (changes === 0) {
+    console.log('No OG image changes.');
+  } else {
+    console.log(`OG image generation complete. ${changes} change(s).`);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error generating OG images:', err);
+  process.exit(1);
+});
+

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Toronto - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Toronto - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/toronto/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -9,6 +9,41 @@
     <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
+    <script>
+      (function() {
+        try {
+          var path = window.location.pathname || '';
+          if (path.indexOf('city.html') !== -1) {
+            var url = new URL(window.location.href);
+            var params = url.searchParams;
+            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
+            if (slug) {
+              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
+              var newUrl = '/' + slug + '/';
+              var preserved = [];
+              params.forEach(function(value, key) {
+                if (key !== 'city' && value != null && value !== '') {
+                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+                }
+              });
+              if (preserved.length > 0) {
+                newUrl += '?' + preserved.join('&');
+              }
+              if (url.hash && url.hash !== '#' + slug) {
+                newUrl += url.hash;
+              }
+              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
+              if (newUrl !== currentFull) {
+                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
+                window.location.replace(newUrl);
+              }
+            }
+          }
+        } catch (e) {
+          // Silently ignore normalization errors
+        }
+      })();
+    </script>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
     <script>
@@ -30,6 +65,7 @@
   <meta property="og:title" content="Las Vegas - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Las Vegas - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/vegas/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
 </head>
 <body>
     <header>

--- a/vegas/megawoof-1756612800000/index.html
+++ b/vegas/megawoof-1756612800000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MEGAWOOF – Las Vegas – chunky.dad</title>
+  <meta name="description" content="Sunday · 4AM-9AM · @ Dust Las Vegas">
+  <link rel="canonical" href="/vegas/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="MEGAWOOF – Las Vegas – chunky.dad">
+  <meta property="og:description" content="Sunday · 4AM-9AM · @ Dust Las Vegas">
+  <meta property="og:url" content="https://chunky.dad/vegas/megawoof-1756612800000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="MEGAWOOF – Las Vegas – chunky.dad">
+  <meta name="twitter:description" content="Sunday · 4AM-9AM · @ Dust Las Vegas">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=megawoof-1756612800000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=megawoof-1756612800000"></noscript>
+  <script>location.replace("../?event=megawoof-1756612800000");</script>
+</body>
+</html>

--- a/vegas/megawoof-1756612800000/index.html
+++ b/vegas/megawoof-1756612800000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="MEGAWOOF – Las Vegas – chunky.dad">
   <meta property="og:description" content="Sunday · 4AM-9AM · @ Dust Las Vegas">
   <meta property="og:url" content="https://chunky.dad/vegas/megawoof-1756612800000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/vegas/megawoof-1756612800000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="MEGAWOOF – Las Vegas – chunky.dad">
   <meta name="twitter:description" content="Sunday · 4AM-9AM · @ Dust Las Vegas">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/vegas/megawoof-1756612800000.png">
   <meta http-equiv="refresh" content="0; url=../?event=megawoof-1756612800000">
 </head>
 <body>

--- a/vegas/megawoof-1762056000000/index.html
+++ b/vegas/megawoof-1762056000000/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!-- generated: chunky.dad event page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MEGAWOOF – Las Vegas – chunky.dad</title>
+  <meta name="description" content="Sunday · 4AM-11AM · @ Dust Las Vegas">
+  <link rel="canonical" href="/vegas/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="MEGAWOOF – Las Vegas – chunky.dad">
+  <meta property="og:description" content="Sunday · 4AM-11AM · @ Dust Las Vegas">
+  <meta property="og:url" content="https://chunky.dad/vegas/megawoof-1762056000000/">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="MEGAWOOF – Las Vegas – chunky.dad">
+  <meta name="twitter:description" content="Sunday · 4AM-11AM · @ Dust Las Vegas">
+  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta http-equiv="refresh" content="0; url=../?event=megawoof-1762056000000">
+</head>
+<body>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=megawoof-1762056000000"></noscript>
+  <script>location.replace("../?event=megawoof-1762056000000");</script>
+</body>
+</html>

--- a/vegas/megawoof-1762056000000/index.html
+++ b/vegas/megawoof-1762056000000/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="MEGAWOOF – Las Vegas – chunky.dad">
   <meta property="og:description" content="Sunday · 4AM-11AM · @ Dust Las Vegas">
   <meta property="og:url" content="https://chunky.dad/vegas/megawoof-1762056000000/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta property="og:image" content="https://chunky.dad/img/og/vegas/megawoof-1762056000000.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="MEGAWOOF – Las Vegas – chunky.dad">
   <meta name="twitter:description" content="Sunday · 4AM-11AM · @ Dust Las Vegas">
-  <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/vegas/megawoof-1762056000000.png">
   <meta http-equiv="refresh" content="0; url=../?event=megawoof-1762056000000">
 </head>
 <body>


### PR DESCRIPTION
Add Open Graph (OG) tag support for the main page, city pages, and individual event pages to improve social sharing and SEO.

Event-specific pages are generated as static HTML stubs (`/<city>/<event-slug>/index.html`) containing only OG metadata and a JavaScript redirect to the main city page with a deep-link query parameter (`/<city>/?event=<slug>`). This allows social media bots to correctly unfurl event details while maintaining a single-page application experience for users.

---
<a href="https://cursor.com/background-agent?bcId=bc-1938fe9a-f884-4959-9d6b-5fb3384ac13f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1938fe9a-f884-4959-9d6b-5fb3384ac13f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

