### PR TITLE
Changes from background agent bc-ec52b163-ec89-4ce4-969e-80ebd2ac258a

### DIFF
--- a/scripts/parsers/chunk-parser.js
+++ b/scripts/parsers/chunk-parser.js
@@ -353,17 +353,6 @@ class ChunkParser {
         // Return all found URLs (no limit if maxAdditionalUrls is null)
         return Array.from(urls);
     }
-
-    // Get timezone identifier for a city using centralized configuration
-    getTimezoneForCity(city, cityConfig = null) {
-        // City config must be provided - no fallbacks
-        if (!cityConfig || !cityConfig[city]) {
-            console.log(`🎉 Chunk: No timezone configuration found for city: ${city}`);
-            return null;
-        }
-        
-        return cityConfig[city].timezone;
-    }
 }
 
 // Export for both environments

--- a/scripts/parsers/chunk-parser.js
+++ b/scripts/parsers/chunk-parser.js
@@ -170,17 +170,57 @@ class ChunkParser {
             }
             
             // CHUNK provides dates with timezone offsets in their JSON-LD
-            // IMPORTANT: They often use the WRONG timezone (e.g., Pacific time for Chicago events)
-            // So we must use the date AS PROVIDED and let JavaScript handle the conversion
-            // Do NOT try to re-interpret the time in a different timezone
-            let startDate = jsonData.startDate ? new Date(jsonData.startDate) : null;
-            let endDate = jsonData.endDate ? new Date(jsonData.endDate) : null;
+            // PROBLEM: They use "local time as if it was in PST" but the timezone offset may be wrong
+            // SOLUTION: Parse the date/time as local, then let SharedCore apply the correct city timezone
+            let startDate = null;
+            let endDate = null;
             
-            // Log what we're parsing for debugging
             if (jsonData.startDate) {
-                console.log(`🎉 Chunk: Parsing start date directly from JSON-LD: ${jsonData.startDate}`);
-                if (startDate) {
-                    console.log(`🎉 Chunk: Converted to UTC: ${startDate.toISOString()}`);
+                console.log(`🎉 Chunk: Parsing start date from JSON-LD: ${jsonData.startDate}`);
+                
+                // Step 1: Extract date/time components directly from the string
+                // This ignores the timezone offset and treats the time as local
+                const match = jsonData.startDate.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
+                if (match) {
+                    const [, year, month, day, hours, minutes, seconds] = match;
+                    
+                    // Step 2: Create a new local Date object with the extracted components
+                    // Month is 0-based in Date constructor, so subtract 1
+                    startDate = new Date(
+                        parseInt(year), 
+                        parseInt(month) - 1, 
+                        parseInt(day), 
+                        parseInt(hours), 
+                        parseInt(minutes), 
+                        parseInt(seconds)
+                    );
+                    
+                    console.log(`🎉 Chunk: Extracted local components: ${year}-${month}-${day} ${hours}:${minutes}:${seconds}`);
+                    console.log(`🎉 Chunk: Created local date object: ${startDate.toISOString()}`);
+                } else {
+                    console.warn(`🎉 Chunk: Could not parse date format: ${jsonData.startDate}`);
+                    startDate = null;
+                }
+            }
+            
+            if (jsonData.endDate) {
+                const match = jsonData.endDate.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
+                if (match) {
+                    const [, year, month, day, hours, minutes, seconds] = match;
+                    
+                    endDate = new Date(
+                        parseInt(year), 
+                        parseInt(month) - 1, 
+                        parseInt(day), 
+                        parseInt(hours), 
+                        parseInt(minutes), 
+                        parseInt(seconds)
+                    );
+                    
+                    console.log(`🎉 Chunk: Created local end date object: ${endDate.toISOString()}`);
+                } else {
+                    console.warn(`🎉 Chunk: Could not parse end date format: ${jsonData.endDate}`);
+                    endDate = null;
                 }
             }
             
@@ -247,7 +287,7 @@ class ChunkParser {
                 location: location, // Coordinates as "lat, lng" string (same format as eventbrite parser)
                 address: address,
                 city: null, // Let SharedCore detect city from address/venue
-                timezone: null, // Let SharedCore assign timezone based on detected city
+                timezone: null, // Will be set by SharedCore after city detection
                 url: url,
                 ticketUrl: ticketUrl,
                 cover: price,
@@ -314,9 +354,16 @@ class ChunkParser {
         return Array.from(urls);
     }
 
-
-
-
+    // Get timezone identifier for a city using centralized configuration
+    getTimezoneForCity(city, cityConfig = null) {
+        // City config must be provided - no fallbacks
+        if (!cityConfig || !cityConfig[city]) {
+            console.log(`🎉 Chunk: No timezone configuration found for city: ${city}`);
+            return null;
+        }
+        
+        return cityConfig[city].timezone;
+    }
 }
 
 // Export for both environments

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -32,6 +32,9 @@ class SharedCore {
             'leather bears', 'bear night', 'bear party', 'polar bear', 'grizzly'
         ];
         
+        // Store cities config for timezone assignment
+        this.cities = cities;
+        
         // Initialize city mappings from centralized cities config
         this.cityMappings = this.convertCitiesConfigToCityMappings(cities);
         
@@ -1400,6 +1403,13 @@ class SharedCore {
         // Extract city if not already present (parser may have set it for venue-specific logic)
         if (!event.city) {
             event.city = this.extractCityFromEvent(event);
+        }
+        
+        // Apply timezone from city configuration if not already set
+        // This is needed for parsers like chunk that pass timezone: null
+        if (!event.timezone && event.city && this.cities[event.city]) {
+            event.timezone = this.cities[event.city].timezone;
+            console.log(`🗺️ SharedCore: Applied timezone ${event.timezone} for city ${event.city}`);
         }
         
         // Check if venue name indicates TBA/placeholder (these often have fake addresses/coordinates)


### PR DESCRIPTION
Update Chunk parser date handling to preserve local times and enable SharedCore to apply the correct city timezone, fixing incorrect date shifts.

The Chunk website's JSON-LD provided dates with timezone offsets that were often incorrect (e.g., PST offset for Chicago events). The previous parsing method (`new Date(dateString)`) interpreted these offsets, leading to shifted dates and times. This PR modifies the Chunk parser to extract date/time components as local values, ignoring the provided offset. SharedCore then assigns the correct timezone based on the event's city configuration, ensuring accurate event times.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec52b163-ec89-4ce4-969e-80ebd2ac258a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec52b163-ec89-4ce4-969e-80ebd2ac258a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

