### PR TITLE
Changes from background agent bc-439c52ba-65f6-4e46-8f15-8e65f6513460

### DIFF
--- a/scripts/parsers/chunk-parser.js
+++ b/scripts/parsers/chunk-parser.js
@@ -170,57 +170,35 @@ class ChunkParser {
             }
             
             // CHUNK provides dates with timezone offsets in their JSON-LD
-            // PROBLEM: They use "local time as if it was in PST" but the timezone offset may be wrong
-            // SOLUTION: Parse the date/time as local, then let SharedCore apply the correct city timezone
+            // SOLUTION: Parse the ISO string directly - JavaScript Date handles timezone conversion correctly
             let startDate = null;
             let endDate = null;
             
             if (jsonData.startDate) {
                 console.log(`🎉 Chunk: Parsing start date from JSON-LD: ${jsonData.startDate}`);
                 
-                // Step 1: Extract date/time components directly from the string
-                // This ignores the timezone offset and treats the time as local
-                const match = jsonData.startDate.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
-                if (match) {
-                    const [, year, month, day, hours, minutes, seconds] = match;
-                    
-                    // Step 2: Create a new local Date object with the extracted components
-                    // Month is 0-based in Date constructor, so subtract 1
-                    startDate = new Date(
-                        parseInt(year), 
-                        parseInt(month) - 1, 
-                        parseInt(day), 
-                        parseInt(hours), 
-                        parseInt(minutes), 
-                        parseInt(seconds)
-                    );
-                    
-                    console.log(`🎉 Chunk: Extracted local components: ${year}-${month}-${day} ${hours}:${minutes}:${seconds}`);
-                    console.log(`🎉 Chunk: Created local date object: ${startDate.toISOString()}`);
-                } else {
+                // Parse the ISO string directly - JavaScript Date handles timezone conversion correctly
+                startDate = new Date(jsonData.startDate);
+                
+                if (isNaN(startDate.getTime())) {
                     console.warn(`🎉 Chunk: Could not parse date format: ${jsonData.startDate}`);
                     startDate = null;
+                } else {
+                    console.log(`🎉 Chunk: Created date from ISO string: ${startDate.toISOString()}`);
                 }
             }
             
             if (jsonData.endDate) {
-                const match = jsonData.endDate.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
-                if (match) {
-                    const [, year, month, day, hours, minutes, seconds] = match;
-                    
-                    endDate = new Date(
-                        parseInt(year), 
-                        parseInt(month) - 1, 
-                        parseInt(day), 
-                        parseInt(hours), 
-                        parseInt(minutes), 
-                        parseInt(seconds)
-                    );
-                    
-                    console.log(`🎉 Chunk: Created local end date object: ${endDate.toISOString()}`);
-                } else {
+                console.log(`🎉 Chunk: Parsing end date from JSON-LD: ${jsonData.endDate}`);
+                
+                // Parse the ISO string directly - JavaScript Date handles timezone conversion correctly
+                endDate = new Date(jsonData.endDate);
+                
+                if (isNaN(endDate.getTime())) {
                     console.warn(`🎉 Chunk: Could not parse end date format: ${jsonData.endDate}`);
                     endDate = null;
+                } else {
+                    console.log(`🎉 Chunk: Created end date from ISO string: ${endDate.toISOString()}`);
                 }
             }
             


### PR DESCRIPTION
Simplify date parsing in `chunk-parser.js` to correctly handle timezones from JSON-LD.

The previous implementation manually extracted date components and constructed `Date` objects in the user's local timezone, leading to incorrect time shifts (e.g., SF 10 PM appearing as 7 PM in NYC). By directly parsing the ISO 8601 strings from JSON-LD, JavaScript's `Date` constructor correctly interprets the embedded timezone offsets, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-439c52ba-65f6-4e46-8f15-8e65f6513460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-439c52ba-65f6-4e46-8f15-8e65f6513460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

