### PR TITLE
Update calendar core with image url support

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -336,6 +336,9 @@ class CalendarCore {
                     if (additionalData.cover) {
                         eventData.cover = additionalData.cover;
                     }
+                    if (additionalData.image) {
+                        eventData.image = additionalData.image;
+                    }
                     eventData.tea = additionalData.tea || additionalData.description;
                     eventData.website = additionalData.website;
                     eventData.instagram = additionalData.instagram;
@@ -458,7 +461,8 @@ class CalendarCore {
             'type': 'type', 'eventtype': 'type', 'recurring': 'recurring',
             'gmaps': 'gmaps', 'google maps': 'gmaps',
             'shortname': 'shortName', 'short name': 'shortName', 'short': 'shortName', 'nickname': 'shortName', 'nick name': 'shortName', 'nick': 'shortName',
-            'shortername': 'shorterName', 'shorter name': 'shorterName', 'shorter': 'shorterName'
+            'shortername': 'shorterName', 'shorter name': 'shorterName', 'shorter': 'shorterName',
+            'image': 'image'
         };
 
         // Clean up any remaining carriage returns that might interfere with parsing
@@ -535,7 +539,7 @@ class CalendarCore {
                     const mappedKey = keyMap[key] || key;
                     
                     // Additional validation for URLs
-                    if (['website', 'instagram', 'facebook', 'gmaps'].includes(mappedKey)) {
+                    if (['website', 'instagram', 'facebook', 'gmaps', 'image'].includes(mappedKey)) {
                         // Ensure we have a valid URL
                         if (value.startsWith('http://') || value.startsWith('https://')) {
                             data[mappedKey] = value;

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2930,6 +2930,7 @@ calculatedData: {
             coordinates: null,
             cover: 'Test Event',
             tea: 'This is a test event for character limit testing',
+            image: testEventData.image || null,
             links: []
         };
         


### PR DESCRIPTION
Add `image` URL field support to calendar event objects and the calendar loader tester.

---
<a href="https://cursor.com/background-agent?bcId=bc-02e14069-f0f1-42f0-a425-861d21e2a083">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02e14069-f0f1-42f0-a425-861d21e2a083">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

