### PR TITLE
Update share icon and center icons

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1617,7 +1617,7 @@ class DynamicCalendarLoader extends CalendarCore {
                     <div class="event-links">
                         ${linksHtml}
                         <button class="share-event-btn icon-only" data-event-slug="${event.slug}" data-event-name="${event.name}" data-event-venue="${event.bar || ''}" data-event-time="${event.day} ${event.time}" title="Share this event" aria-label="Share this event">
-                            <span class="share-icon" aria-hidden="true"><i class="bi bi-share"></i></span>
+                            <span class="share-icon" aria-hidden="true"><i class="bi bi-box-arrow-up"></i></span>
                         </button>
                     </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -2243,11 +2243,15 @@ body.index-page main {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    position: relative;
 }
 
 .icon-only i {
     font-size: 1rem;
     line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .event-links a {
@@ -2297,7 +2301,7 @@ body.index-page main {
 }
 
 .share-event-btn .share-icon {
-    font-size: 1rem;
+    display: contents; /* Makes the span wrapper transparent to layout */
 }
 
 /* Enhanced event link styling */
@@ -3403,7 +3407,7 @@ footer {
     }
     
     .share-event-btn .share-icon {
-        font-size: 0.9rem;
+        display: contents; /* Makes the span wrapper transparent to layout */
     }
 
     .event-day {


### PR DESCRIPTION
Replace the share icon with `bi-box-arrow-up` and improve the centering of icons within their circular containers.

The previous share icon was `bi-share`, and the icons in circles were visually off-center. This PR updates the icon and adjusts CSS (`.icon-only`, `.share-event-btn .share-icon`) to use flexbox and `display: contents` for precise centering.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4147941-448e-4065-ace9-14aaeb99fa4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b4147941-448e-4065-ace9-14aaeb99fa4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

