### PR TITLE
Fix calendar link icon alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2253,7 +2253,7 @@ body.index-page main {
     align-items: center;
     justify-content: center;
     position: relative;
-    top: -1px; /* Adjust icon positioning to center better in circle */
+    top: 0px; /* Center icon properly in circle */
 }
 
 .event-links a {


### PR DESCRIPTION
Adjust icon positioning in `.icon-only i` to correctly center link icons on the dynamic calendar.

The `top: -1px` rule was causing link icons (e.g., Facebook, Instagram) to appear 1 pixel too high within their circular containers on the city.html dynamic calendar. Removing this offset allows the existing `display: flex`, `align-items: center`, and `justify-content: center` rules to properly center the icons vertically.

---
<a href="https://cursor.com/background-agent?bcId=bc-af6adee8-bbff-433d-b84f-ea3d24204523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af6adee8-bbff-433d-b84f-ea3d24204523">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

