### PR TITLE
Update furball parser and merge

### DIFF
--- a/scripts/parsers/furball-parser.js
+++ b/scripts/parsers/furball-parser.js
@@ -128,14 +128,26 @@ class FurballParser {
             let bar = '';
             let address = '';
             if (venueLine) {
-                const parts = venueLine.split(/\s-\s/);
-                bar = (parts[0] || '').trim();
-                address = (parts[1] || '').trim();
+                // Extract venue name and address from the venue line
+                // The venue line contains the full event description, we need to extract the last "Venue - City" part
+                const venueMatch = venueLine.match(/(\w+)\s*-\s*([^&]+?)(?:\s*&nbsp;)?\s*$/);
+                if (venueMatch) {
+                    bar = venueMatch[1].trim();
+                    address = venueMatch[2].trim()
+                        .replace(/&nbsp;/g, '')
+                        .replace(/\s+/g, ' ')
+                        .trim();
+                }
             }
 
             // Build title by taking non-date, non-venue lines
             const titleParts = lines.filter(l => l !== dateMatch[0] && l !== venueLine);
             let title = titleParts.join(' — ').trim();
+            
+            // If no title found, use default
+            if (!title) {
+                title = 'FURBALL';
+            }
 
             // Ticket URL: pick anchor hrefs by label/text only
             const ticketUrls = this.extractNearbyTicketLinks(block);

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -156,6 +156,7 @@ const scraperConfig = {
         cover: { priority: ["furball"], merge: "clobber" }
       },
       metadata: {
+        title: { value: "FURBALL", merge: "clobber" },
         shortName: { value: "FUR-BALL" },
         instagram: { value: "https://instagram.com/furballnyc/" }
       }


### PR DESCRIPTION
Refactor Furball parser to accurately extract event names, venues, and addresses.

The previous parser incorrectly extracted venue names (bar field) by including dates and descriptions, left event titles undefined, and included HTML entities (`&nbsp;`) in addresses. This PR updates the parsing logic to extract only the venue name, cleans up address strings, and sets "FURBALL" as the default event title.

---
<a href="https://cursor.com/background-agent?bcId=bc-773fc09b-4125-46a8-8c45-f2561ea95feb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-773fc09b-4125-46a8-8c45-f2561ea95feb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

