### PR TITLE
Fix bears-sitges parser initialization bug

### DIFF
--- a/scripts/parsers/bears-sitges-parser.js
+++ b/scripts/parsers/bears-sitges-parser.js
@@ -49,6 +49,42 @@ class BearsSitgesParser {
   }
 
   /**
+   * Main parsing method - receives HTML data and returns events + additional links
+   * @param {Object} htmlData - Object containing html and url properties
+   * @param {Object} parserConfig - Parser configuration
+   * @param {Object} cityConfig - City configuration
+   * @returns {Object} Object with events, additionalLinks, source, and url
+   */
+  parseEvents(htmlData, parserConfig = {}, cityConfig = null) {
+    try {
+      const events = [];
+      const html = htmlData.html;
+      
+      if (!html) {
+        console.warn('🐻 Bears Sitges: No HTML content to parse');
+        return { events: [], additionalLinks: [], source: this.name, url: htmlData.url };
+      }
+      
+      // Parse events using the existing parse method
+      const parsedEvents = this.parse(html, htmlData.url);
+      events.push(...parsedEvents);
+      
+      // Bears Sitges doesn't have additional links to discover
+      const additionalLinks = [];
+      
+      return { 
+        events, 
+        additionalLinks, 
+        source: this.name, 
+        url: htmlData.url 
+      };
+    } catch (error) {
+      console.log(`BearsSitgesParser parseEvents error: ${error.message}`);
+      return { events: [], additionalLinks: [], source: this.name, url: htmlData.url };
+    }
+  }
+
+  /**
    * Extract event dates from the Bears Sitges Week page
    * @param {string} html - Raw HTML content
    * @returns {Object} Object mapping day names to Date objects
@@ -412,10 +448,10 @@ class BearsSitgesParser {
 
 // Export for different environments
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = BearsSitgesParser;
+  module.exports = { BearsSitgesParser };
 } else if (typeof window !== 'undefined') {
   window.BearsSitgesParser = BearsSitgesParser;
 } else {
   // Scriptable environment
-  BearsSitgesParser;
+  this.BearsSitgesParser = BearsSitgesParser;
 }


### PR DESCRIPTION
Fix `bears-sitges` parser to correctly load and parse events by correcting export formats and adding the `parseEvents` method.

The `bears-sitges` parser failed to load due to incorrect module exports for both Node.js and Scriptable environments, causing "undefined is not a constructor" and "ParserClass is not a constructor" errors. It also lacked the `parseEvents` method expected by the orchestrator, leading to "urlParser.parseEvents is not a function" errors. These changes align the parser with the standard interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-44360469-8446-4b4b-bc37-591e9ae5df01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44360469-8446-4b4b-bc37-591e9ae5df01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

