### PR TITLE
Debug sitges parser memory issue

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -168,6 +168,7 @@ const scraperConfig = {
       alwaysBear: true,
       urlDiscoveryDepth: 0,
       dryRun: false,
+      maxDays: 1,  // TEMPORARY: Limit to 1 day to prevent memory issues
       fieldPriorities: {
         title: { priority: ["bears-sitges"], merge: "clobber" },
         instagram: { priority: ["static"], merge: "clobber" },


### PR DESCRIPTION
Add a `maxDays` configuration to the Bears Sitges parser to temporarily limit data processing and prevent out-of-memory errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc10e5e3-44c2-40da-970d-0654e7beb180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc10e5e3-44c2-40da-970d-0654e7beb180">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

