### PR TITLE
Merge main, read rules, fix calendar render error

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2732,8 +2732,14 @@ class DynamicCalendarLoader extends CalendarCore {
         try {
             const data = await this.loadCalendarData(this.currentCity);
             
-            if (!data) {
-                logger.error('CALENDAR', '🔍 RENDER: Failed to load calendar data - showing error message');
+            if (!data || !data.events || !data.cityConfig) {
+                logger.error('CALENDAR', '🔍 RENDER: Failed to load calendar data - showing error message', {
+                    dataIsNull: data === null,
+                    dataIsUndefined: data === undefined,
+                    hasEvents: data && !!data.events,
+                    hasCityConfig: data && !!data.cityConfig,
+                    dataType: typeof data
+                });
                 // Clear fake event from allEvents to prevent it from showing
                 this.allEvents = [];
                 // Show error message instead of empty calendar


### PR DESCRIPTION
Add null/undefined checks for calendar data to prevent `TypeError` when loading city pages.

The `loadCalendarData` method can return `null` or an incomplete object, which previously caused a `TypeError` in `renderCityPage` when attempting to access `data.events` or `data.cityConfig`. This fix ensures graceful error handling and displays a user-friendly message instead of crashing.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e762dd3-2737-4f91-ba04-f7261d7b7fa0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e762dd3-2737-4f91-ba04-f7261d7b7fa0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

