### PR TITLE
Fix city.html load failed error

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -207,6 +207,8 @@ class ChunkyDadApp {
                 // Don't await city page modules to prevent hanging
                 this.initializeCityPageModules().catch(error => {
                     logger.componentError('SYSTEM', 'City page module initialization failed', error);
+                    // Show user-friendly error message
+                    this.showCalendarError();
                 });
             }
             
@@ -409,6 +411,30 @@ class ChunkyDadApp {
 
     getPathUtils() {
         return this.pathUtils;
+    }
+
+    // Show calendar error message when initialization fails
+    showCalendarError() {
+        const eventsList = document.querySelector('.events-list');
+        if (eventsList) {
+            eventsList.innerHTML = `
+                <div class="error-message">
+                    <h3>📅 Calendar Temporarily Unavailable</h3>
+                    <p>We're having trouble loading the calendar data. This usually resolves itself within a few minutes.</p>
+                    <p>Please try refreshing the page, or check back later.</p>
+                    <button onclick="window.location.reload()" class="cta-button">🔄 Refresh Page</button>
+                </div>
+            `;
+        }
+        
+        const calendarGrid = document.querySelector('.calendar-grid');
+        if (calendarGrid) {
+            calendarGrid.innerHTML = `
+                <div class="calendar-error">
+                    <p>Calendar data is temporarily unavailable. Please try refreshing the page.</p>
+                </div>
+            `;
+        }
     }
 
     // Global function for scrolling (backward compatibility)

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -385,15 +385,27 @@ class DynamicCalendarLoader extends CalendarCore {
         try {
             const urlParams = new URLSearchParams(window.location.search);
             const cityParam = urlParams.get('city');
-            if (cityParam) return cityParam;
+            if (cityParam) {
+                logger.debug('CITY', 'City detected from URL parameter', { city: cityParam });
+                return cityParam;
+            }
 
             // Fallback: detect from first path segment (supports aliases)
             const slug = this.getCitySlugFromPath();
-            if (slug) return slug;
+            if (slug) {
+                logger.debug('CITY', 'City detected from path segment', { city: slug });
+                return slug;
+            }
 
             // Legacy: hash or default
             const hash = window.location.hash.replace('#', '');
-            return hash || 'new-york';
+            const defaultCity = hash || 'new-york';
+            logger.debug('CITY', 'Using default city (no URL params or path detected)', { 
+                city: defaultCity, 
+                hash: window.location.hash,
+                pathname: window.location.pathname 
+            });
+            return defaultCity;
         } catch (e) {
             logger.warn('CITY', 'Failed to resolve city from URL, defaulting to new-york', { error: e?.message });
             return 'new-york';
@@ -1316,7 +1328,10 @@ class DynamicCalendarLoader extends CalendarCore {
                 window.CITY_CONFIG && 
                 window.CITY_CONFIG[pathSegments[0].toLowerCase()];
             
-            const needsParentPath = isTesting || isInCitySubdirectory;
+            // city.html pages are served from root, so no prefix needed
+            const isCityHtmlPage = pathname.includes('city.html');
+            
+            const needsParentPath = (isTesting || isInCitySubdirectory) && !isCityHtmlPage;
             const prefix = needsParentPath ? '../' : '';
             
             return `${prefix}data/calendars/${cityKey}.ics`;
@@ -2765,6 +2780,7 @@ class DynamicCalendarLoader extends CalendarCore {
             this.allEvents = [];
             // Show error message instead of empty calendar
             this.showCalendarError();
+            // Don't re-throw the error to prevent unhandled promise rejection
             return;
         }
         
@@ -2979,7 +2995,9 @@ calculatedData: {
             logger.componentLoad('CALENDAR', 'Dynamic CalendarLoader initialization completed successfully');
         } catch (error) {
             logger.componentError('CALENDAR', 'Calendar initialization failed', error);
-            throw error;
+            // Show user-friendly error message instead of throwing
+            this.showCalendarError();
+            // Don't re-throw to prevent unhandled promise rejection
         } finally {
             this.isInitializing = false;
         }

--- a/styles.css
+++ b/styles.css
@@ -5759,3 +5759,19 @@ footer {
     box-shadow: 0 4px 12px rgba(0,0,0,0.2);
 }
 
+/* Calendar Error Styles */
+.calendar-error {
+    text-align: center;
+    padding: 20px;
+    background: var(--background-lighter);
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    margin: 20px 0;
+    color: var(--text-secondary);
+}
+
+.calendar-error p {
+    margin: 0;
+    font-size: 0.9rem;
+}
+


### PR DESCRIPTION
Fix calendar data loading and unhandled promise rejections on `city.html` by correcting path resolution and enhancing error handling.

When `city.html` was accessed directly (e.g., `example.com/city.html`), the `buildLocalCalendarUrl` method incorrectly assumed a subdirectory structure, leading to "Load failed" TypeErrors. This PR adjusts the path logic for `city.html` and introduces user-friendly error messages and robust promise rejection handling to prevent a broken user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-eff6c687-7f7b-413a-aa27-92ecd2ef6a4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eff6c687-7f7b-413a-aa27-92ecd2ef6a4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

