### PR TITLE
Fix city.html load failed error

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -6,6 +6,11 @@ class CalendarCore {
         this.locationCache = new Map();
         this.calendarTimezone = null; // Store calendar's default timezone
         this.timezoneData = null; // Store detailed timezone information
+        
+        // Day name arrays for consistent formatting
+        this.dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+        this.dayAbbrevs = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        
         logger.componentInit('CALENDAR', 'Calendar core initialized');
     }
 
@@ -693,16 +698,13 @@ class CalendarCore {
         const pattern = this.parseRecurrencePattern(recurrence);
         if (!pattern) return null;
         
-        const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-        const dayAbbrevs = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-        
         // Handle weekly events
         if (pattern.frequency === 'WEEKLY') {
             if (pattern.byDay && pattern.byDay.length === 1) {
                 const dayCode = pattern.byDay[0];
                 const dayIndex = this.getDayIndexFromCode(dayCode);
                 if (dayIndex !== -1) {
-                    return `Every ${dayAbbrevs[dayIndex]}`;
+                    return `Every ${this.dayAbbrevs[dayIndex]}`;
                 }
             }
             return pattern.interval === 1 ? 'Weekly' : `Every ${pattern.interval} weeks`;
@@ -717,9 +719,9 @@ class CalendarCore {
                     const occurrence = this.getOccurrenceFromDayCode(dayCode);
                     if (occurrence > 0) {
                         const ordinal = this.getOrdinal(occurrence);
-                        return `${ordinal} ${dayAbbrevs[dayIndex]} of month`;
+                        return `${ordinal} ${this.dayAbbrevs[dayIndex]} of month`;
                     } else if (occurrence < 0) {
-                        return `Last ${dayAbbrevs[dayIndex]} of month`;
+                        return `Last ${this.dayAbbrevs[dayIndex]} of month`;
                     }
                 }
             }


### PR DESCRIPTION
Move `dayNames` and `dayAbbrevs` arrays to class properties to resolve `TypeError` caused by local scope.

Commit `ecd34d9e8a6687e39535f825ba0ac6dbe64daaee` introduced a `TypeError` where `dayAbbrevs` was referenced in `getRecurrenceDescription` but was only defined as a local variable within that method, leading to an "Unhandled promise rejection" when accessed. This change makes `dayNames` and `dayAbbrevs` accessible as class properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-854f77bb-2892-4517-9566-ab44f7c25259">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-854f77bb-2892-4517-9566-ab44f7c25259">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

