### PR TITLE
Fix calendar loading error in city.html

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -818,7 +818,9 @@ class CalendarCore {
         
         if (!recurring) {
             // One-off event - show the date (same as calendar)
-            const parts = startDate.split('-');
+            const startDateStr = startDate instanceof Date ? 
+                startDate.toISOString().split('T')[0] : startDate;
+            const parts = startDateStr.split('-');
             const month = parseInt(parts[1]);
             const date = parseInt(parts[2]);
             return `${month}/${date}`;
@@ -854,7 +856,9 @@ class CalendarCore {
         }
         
         // For monthly events without calendar context, show next occurrence
-        const parts = startDate.split('-');
+        const startDateStr = startDate instanceof Date ? 
+            startDate.toISOString().split('T')[0] : startDate;
+        const parts = startDateStr.split('-');
         const month = parseInt(parts[1]);
         const date = parseInt(parts[2]);
         return `${month}/${date}`;
@@ -866,7 +870,9 @@ class CalendarCore {
         
         if (!event.recurring || !event.recurrence) {
             // One-off event - check if it falls within the period
-            const parts = event.startDate.split('-');
+            const startDateStr = event.startDate instanceof Date ? 
+                event.startDate.toISOString().split('T')[0] : event.startDate;
+            const parts = startDateStr.split('-');
             const eventDate = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]));
             if (eventDate >= periodStart && eventDate <= periodEnd) {
                 dates.push(eventDate);
@@ -878,7 +884,9 @@ class CalendarCore {
         const pattern = this.parseRecurrencePattern(event.recurrence);
         if (!pattern) return dates;
         
-        const parts = event.startDate.split('-');
+        const startDateStr = event.startDate instanceof Date ? 
+            event.startDate.toISOString().split('T')[0] : event.startDate;
+        const parts = startDateStr.split('-');
         const eventStartDate = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]));
         if (eventStartDate > periodEnd) return dates;
         


### PR DESCRIPTION
Fix calendar loading TypeError by ensuring `startDate` is a string before calling `.split('-')`.

Commit `ecd34d9e8a6687e39535f825ba0ac6dbe64daaee` introduced code expecting `startDate` to be a string for splitting. However, `startDate` is a Date object (from `parseICalDate` in `parseEventData`), leading to a TypeError. This PR converts the Date object to an ISO string before splitting, resolving the error.

---
<a href="https://cursor.com/background-agent?bcId=bc-aea324b0-a89b-43db-a4bd-ac392296f975">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aea324b0-a89b-43db-a4bd-ac392296f975">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

