### PR TITLE
Update event badge styling and colors

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -816,6 +816,11 @@ class CalendarCore {
     getDateBadgeContent(event, calendarPeriod = null) {
         const { recurring, startDate } = event;
         
+        // For weekly events, never show date badge (too many events to be useful)
+        if (event.eventType === 'weekly') {
+            return null;
+        }
+        
         if (!recurring) {
             // One-off event - show the date (same as calendar)
             const startDateStr = startDate instanceof Date ? 
@@ -848,11 +853,6 @@ class CalendarCore {
                 const remaining = visibleDates.length - 1;
                 return `${first.getMonth() + 1}/${first.getDate()} +${remaining} more`;
             }
-        }
-        
-        // For weekly events without calendar context, don't show dates
-        if (event.eventType === 'weekly') {
-            return null;
         }
         
         // For monthly events without calendar context, show next occurrence

--- a/styles.css
+++ b/styles.css
@@ -1414,7 +1414,7 @@ body.index-page main {
 }
 
 .today-event-card .event-day {
-    background: var(--solid-secondary);
+    background: var(--accent-color);
     color: var(--white);
     padding: 0.4rem 0.8rem;
     border-radius: 15px;
@@ -1424,7 +1424,7 @@ body.index-page main {
 }
 
 .today-event-card .recurring-badge {
-    background: var(--solid-secondary);
+    background: var(--accent-color);
     color: var(--white);
     padding: 0.3rem 0.6rem;
     border-radius: 12px;
@@ -1433,7 +1433,7 @@ body.index-page main {
 }
 
 .today-event-card .date-badge {
-    background: var(--solid-secondary);
+    background: var(--accent-color);
     color: var(--white);
     padding: 0.3rem 0.6rem;
     border-radius: 12px;
@@ -2279,7 +2279,7 @@ body.index-page main {
 }
 
 .event-day {
-    background: var(--solid-secondary);
+    background: var(--accent-color);
     color: var(--white);
     padding: 0.5rem 1rem;
     border-radius: 20px;
@@ -2305,7 +2305,7 @@ body.index-page main {
 }
 
 .recurring-badge {
-    background: var(--solid-secondary);
+    background: var(--accent-color);
     color: var(--white);
     padding: 0.3rem 0.8rem;
     border-radius: 15px;
@@ -2315,7 +2315,7 @@ body.index-page main {
 }
 
 .date-badge {
-    background: var(--solid-secondary);
+    background: var(--accent-color);
     color: var(--white);
     padding: 0.3rem 0.8rem;
     border-radius: 15px;


### PR DESCRIPTION
Remove date badges for weekly events and unify all event badge colors to purple.

Previously, date badges for weekly events could still appear when a calendar context was present, leading to visual clutter. This change ensures date badges are never shown for weekly events, regardless of context.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ec1d972-c4d5-46fd-81b7-af5ff74ab5d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ec1d972-c4d5-46fd-81b7-af5ff74ab5d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

