### PR TITLE
Fix monthly occurrence rule bug

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -741,12 +741,15 @@ class CalendarCore {
         return 'Recurring';
     }
 
-    // Helper method to get day index from day code (e.g., "MO" -> 1)
+    // Helper method to get day index from day code (e.g., "MO" -> 1, "-1SA" -> 6)
     getDayIndexFromCode(dayCode) {
         const dayMap = {
             'SU': 0, 'MO': 1, 'TU': 2, 'WE': 3, 'TH': 4, 'FR': 5, 'SA': 6
         };
-        return dayMap[dayCode] || -1;
+        
+        // Extract just the day part if the dayCode includes occurrence (e.g., "-1SA" -> "SA")
+        const dayPart = dayCode.replace(/^-?\d+/, '');
+        return dayMap[dayPart] || -1;
     }
 
     // Helper method to get occurrence number from day code (e.g., "2TU" -> 2)


### PR DESCRIPTION
Fix `getDayIndexFromCode` to correctly parse day codes with occurrences, resolving incorrect display of monthly recurring events like "last Saturday of month".

---
<a href="https://cursor.com/background-agent?bcId=bc-8485b8ee-5e1a-486b-98a9-d1f65ee05267">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8485b8ee-5e1a-486b-98a9-d1f65ee05267">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

