### PR TITLE
Update index page event links

### DIFF
--- a/js/today-events.js
+++ b/js/today-events.js
@@ -260,9 +260,18 @@ class TodayEventsAggregator extends DynamicCalendarLoader {
 
     card.appendChild(details);
 
-    // Add link functionality
+    // Add link functionality - link directly to the specific event
     card.addEventListener('click', () => {
-      window.location.href = `${ev.cityKey}/`;
+      const eventSlug = ev.slug || ev.name?.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+      const eventDate = ev.startDate ? new Date(ev.startDate).toISOString().split('T')[0] : '';
+      const eventUrl = eventSlug ? `${ev.cityKey}/?event=${encodeURIComponent(eventSlug)}${eventDate ? `&date=${eventDate}` : ''}` : `${ev.cityKey}/`;
+      logger.userInteraction('EVENT', 'Today event clicked', { 
+        eventSlug, 
+        cityKey: ev.cityKey, 
+        eventUrl,
+        eventName: ev.name 
+      });
+      window.location.href = eventUrl;
     });
     card.style.cursor = 'pointer';
 


### PR DESCRIPTION
Link 'today' section events directly to their specific event page to improve user navigation.

Previously, clicking an event in the 'Upcoming Parties' section only navigated to the city's main page. This change updates the click handler to construct a URL with `event` and `date` parameters, allowing the city page to automatically highlight and scroll to the selected event.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5d3bea7-4697-4835-a758-9fdb92722fc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5d3bea7-4697-4835-a758-9fdb92722fc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

