### PR TITLE
Update code and disable sitges parser

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -163,7 +163,7 @@ const scraperConfig = {
     },
     {
       name: "Bears Sitges Week",
-      enabled: true,
+      enabled: false,
       urls: ["https://bearssitges.org/bears-sitges-week/"],
       alwaysBear: true,
       urlDiscoveryDepth: 0,


### PR DESCRIPTION
Disable the Bears Sitges Week parser as the event is over for the year and no further progress was made.

---
<a href="https://cursor.com/background-agent?bcId=bc-3be16b21-f51e-4254-95e7-2fb2551911ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3be16b21-f51e-4254-95e7-2fb2551911ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

