### PR TITLE
Update parser for D>U>R>O event mapping

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -548,6 +548,13 @@ class EventbriteParser {
                 else if (/(orlando)/i.test(title)) city = 'orlando';
                 else if (/(tampa)/i.test(title)) city = 'tampa';
                 
+                // Fallback: Check for "D>U>R>O" pattern and map to LA if no other city found
+                // This handles megawoof events that use this pattern but may expand to other cities later
+                if (!city && /d>u>r>o/i.test(title)) {
+                    city = 'la';
+                    console.log(`🎫 Eventbrite: Found D>U>R>O pattern in title, mapping to LA as fallback: "${title}"`);
+                }
+                
                 if (city) {
                     console.log(`🎫 Eventbrite: Extracted city "${city}" from title: "${title}"`);
                 }

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1682,6 +1682,13 @@ class SharedCore {
             }
         }
         
+        // Fallback: Check for "D>U>R>O" pattern and map to LA if no other city found
+        // This handles megawoof events that use this pattern but may expand to other cities later
+        if (lowerText.includes('d>u>r>o')) {
+            console.log('🏙️ SharedCore: Found D>U>R>O pattern, mapping to LA as fallback');
+            return 'la';
+        }
+        
         return null;
     }
     

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1682,13 +1682,6 @@ class SharedCore {
             }
         }
         
-        // Fallback: Check for "D>U>R>O" pattern and map to LA if no other city found
-        // This handles megawoof events that use this pattern but may expand to other cities later
-        if (lowerText.includes('d>u>r>o')) {
-            console.log('🏙️ SharedCore: Found D>U>R>O pattern, mapping to LA as fallback');
-            return 'la';
-        }
-        
         return null;
     }
     


### PR DESCRIPTION
Add a fallback to map 'D>U>R>O' events to LA in `extractCityFromText` only if no other city is found, resolving a megawoof parser issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-765fd2ca-08d1-473c-99fa-c5b6747ded3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-765fd2ca-08d1-473c-99fa-c5b6747ded3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

