### PR TITLE
Merge main and fix tester icon bugs

### DIFF
--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -169,7 +169,7 @@
 
     /* Speech Bubble 3: Dual Conversation */
     .layout-speech-dual { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); position: relative; }
-    .layout-speech-dual .logo-avatar { position: absolute; left: 60px; top: 120px; width: 120px; height: 120px; box-shadow: 0 10px 30px rgba(0,0,0,0.3); object-fit: cover; }
+    .layout-speech-dual .logo-avatar { position: absolute; left: 60px; top: 120px; width: 120px; height: 120px; object-fit: cover; }
     .layout-speech-dual .event-avatar { position: absolute; right: 60px; bottom: 120px; width: 140px; height: 140px; border-radius: 50%; box-shadow: 0 12px 35px rgba(0,0,0,0.4); border: 5px solid rgba(255,255,255,0.9); background-size: cover; background-position: center; }
     .layout-speech-dual .speech-bubble-1 { position: absolute; left: 200px; top: 80px; max-width: 450px; background: #fff; color: #111; border-radius: 18px; padding: 18px 22px; box-shadow: 0 15px 40px rgba(0,0,0,0.3); font-size: 20px; line-height: 1.3; }
     .layout-speech-dual .speech-bubble-1:after { content: ""; position: absolute; left: -18px; top: 20px; width: 0; height: 0; border-top: 15px solid transparent; border-bottom: 15px solid transparent; border-right: 18px solid #fff; filter: drop-shadow(0 4px 4px rgba(0,0,0,0.15)); }
@@ -206,7 +206,7 @@
 
     /* Speech Bubble 9: Thought Cloud */
     .layout-speech-thought { background: var(--og-bg-2); position: relative; }
-    .layout-speech-thought .dreamer { position: absolute; left: 80px; bottom: 80px; width: 180px; height: 180px; box-shadow: 0 15px 40px rgba(0,0,0,0.3); object-fit: cover; }
+    .layout-speech-thought .dreamer { position: absolute; left: 80px; bottom: 80px; width: 180px; height: 180px; object-fit: cover; }
     .layout-speech-thought .thought-cloud { position: absolute; left: 320px; bottom: 200px; max-width: 700px; background: #fff; color: #333; border-radius: 50px; padding: 32px 40px; box-shadow: 0 25px 60px rgba(0,0,0,0.3); font-size: 24px; line-height: 1.4; position: relative; }
     .layout-speech-thought .thought-bubble-1 { position: absolute; left: -40px; bottom: 30px; width: 30px; height: 30px; background: #fff; border-radius: 50%; box-shadow: 0 5px 15px rgba(0,0,0,0.2); }
     .layout-speech-thought .thought-bubble-2 { position: absolute; left: -20px; bottom: 10px; width: 20px; height: 20px; background: #fff; border-radius: 50%; box-shadow: 0 5px 15px rgba(0,0,0,0.2); }


### PR DESCRIPTION
Remove box shadows from chunky-dad icons in Dual Conversation and Thought Cloud layouts to fix visual artifacts.

---
<a href="https://cursor.com/background-agent?bcId=bc-de947138-e6ce-4cf7-ae77-19ba0ae87d11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de947138-e6ce-4cf7-ae77-19ba0ae87d11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

