### PR TITLE
Update code and apply cursor rules

### DIFF
--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -151,7 +151,7 @@
     /* Original Speech Bubble (logo talks) */
     .layout-speech { background: var(--og-bg-4); position: relative; }
     .layout-speech .cover { position: absolute; inset: 0; background-size: cover; background-position: center; opacity: 0.2; }
-    .layout-speech .logo-avatar { position: absolute; left: 80px; bottom: 80px; width: 160px; height: 160px; box-shadow: 0 10px 40px rgba(0,0,0,0.4); object-fit: cover; }
+    .layout-speech .logo-avatar { position: absolute; left: 80px; bottom: 80px; width: 160px; height: 160px; box-shadow: 0 10px 40px rgba(0,0,0,0.4); object-fit: contain; }
     .layout-speech .speech-bubble { position: absolute; left: 270px; bottom: 160px; max-width: 760px; background: #fff; color: #111; border-radius: 22px; padding: 22px 26px; box-shadow: 0 20px 60px rgba(0,0,0,0.35); font-size: 26px; line-height: 1.25; }
     .layout-speech .speech-bubble:after { content: ""; position: absolute; left: -28px; bottom: 22px; width: 0; height: 0; border-top: 20px solid transparent; border-bottom: 20px solid transparent; border-right: 28px solid #fff; filter: drop-shadow(0 6px 6px rgba(0,0,0,0.2)); }
     .layout-speech .headline { position: absolute; left: 80px; top: 70px; right: 60px; color: #fff; font-size: 64px; line-height: 0.95; font-weight: 900; text-shadow: 0 6px 30px rgba(0,0,0,0.6); }
@@ -169,7 +169,7 @@
 
     /* Speech Bubble 3: Dual Conversation */
     .layout-speech-dual { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); position: relative; }
-    .layout-speech-dual .logo-avatar { position: absolute; left: 60px; top: 120px; width: 120px; height: 120px; object-fit: cover; }
+    .layout-speech-dual .logo-avatar { position: absolute; left: 60px; top: 120px; width: 120px; height: 120px; object-fit: contain; }
     .layout-speech-dual .event-avatar { position: absolute; right: 60px; bottom: 120px; width: 140px; height: 140px; border-radius: 50%; box-shadow: 0 12px 35px rgba(0,0,0,0.4); border: 5px solid rgba(255,255,255,0.9); background-size: cover; background-position: center; }
     .layout-speech-dual .speech-bubble-1 { position: absolute; left: 200px; top: 80px; max-width: 450px; background: #fff; color: #111; border-radius: 18px; padding: 18px 22px; box-shadow: 0 15px 40px rgba(0,0,0,0.3); font-size: 20px; line-height: 1.3; }
     .layout-speech-dual .speech-bubble-1:after { content: ""; position: absolute; left: -18px; top: 20px; width: 0; height: 0; border-top: 15px solid transparent; border-bottom: 15px solid transparent; border-right: 18px solid #fff; filter: drop-shadow(0 4px 4px rgba(0,0,0,0.15)); }
@@ -197,7 +197,7 @@
     .layout-speech-story .story-bg { position: absolute; inset: 0; background-size: cover; background-position: center; filter: brightness(0.7); }
     .layout-speech-story .story-overlay { position: absolute; inset: 0; background: linear-gradient(180deg, rgba(0,0,0,0.3) 0%, rgba(0,0,0,0.1) 50%, rgba(0,0,0,0.6) 100%); }
     .layout-speech-story .profile-section { position: absolute; top: 30px; left: 30px; right: 30px; display: flex; align-items: center; gap: 15px; }
-    .layout-speech-story .profile-avatar { width: 60px; height: 60px; border: 3px solid #fff; background: #fff; object-fit: cover; }
+    .layout-speech-story .profile-avatar { width: 60px; height: 60px; border: 3px solid #fff; background: #fff; object-fit: contain; }
     .layout-speech-story .profile-info { color: #fff; }
     .layout-speech-story .profile-name { font-size: 16px; font-weight: 700; margin-bottom: 2px; }
     .layout-speech-story .profile-time { font-size: 12px; opacity: 0.8; }
@@ -206,7 +206,7 @@
 
     /* Speech Bubble 9: Thought Cloud */
     .layout-speech-thought { background: var(--og-bg-2); position: relative; }
-    .layout-speech-thought .dreamer { position: absolute; left: 80px; bottom: 80px; width: 180px; height: 180px; object-fit: cover; }
+    .layout-speech-thought .dreamer { position: absolute; left: 80px; bottom: 80px; width: 180px; height: 180px; object-fit: contain; }
     .layout-speech-thought .thought-cloud { position: absolute; left: 320px; bottom: 200px; max-width: 700px; background: #fff; color: #333; border-radius: 50px; padding: 32px 40px; box-shadow: 0 25px 60px rgba(0,0,0,0.3); font-size: 24px; line-height: 1.4; position: relative; }
     .layout-speech-thought .thought-bubble-1 { position: absolute; left: -40px; bottom: 30px; width: 30px; height: 30px; background: #fff; border-radius: 50%; box-shadow: 0 5px 15px rgba(0,0,0,0.2); }
     .layout-speech-thought .thought-bubble-2 { position: absolute; left: -20px; bottom: 10px; width: 20px; height: 20px; background: #fff; border-radius: 50%; box-shadow: 0 5px 15px rgba(0,0,0,0.2); }
@@ -219,7 +219,7 @@
     .layout-speech-messenger { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); position: relative; }
     .layout-speech-messenger .chat-container { position: absolute; inset: 60px; background: #fff; border-radius: 20px; overflow: hidden; box-shadow: 0 20px 50px rgba(0,0,0,0.2); }
     .layout-speech-messenger .chat-header { position: absolute; top: 0; left: 0; right: 0; height: 80px; background: #4267B2; display: flex; align-items: center; padding: 0 20px; gap: 15px; }
-    .layout-speech-messenger .chat-avatar { width: 50px; height: 50px; object-fit: cover; }
+    .layout-speech-messenger .chat-avatar { width: 50px; height: 50px; object-fit: contain; }
     .layout-speech-messenger .chat-title { color: #fff; font-size: 20px; font-weight: 700; }
     .layout-speech-messenger .chat-body { position: absolute; top: 80px; left: 0; right: 0; bottom: 0; padding: 30px; background: #f0f2f5; }
     .layout-speech-messenger .message-bubble { background: #4267B2; color: #fff; border-radius: 20px; padding: 16px 20px; font-size: 18px; line-height: 1.4; max-width: 400px; margin-left: auto; margin-bottom: 15px; }
@@ -240,7 +240,7 @@
     .layout-speech-discord .channel-name { color: #fff; font-size: 18px; font-weight: 600; }
     .layout-speech-discord .discord-messages { position: absolute; top: 60px; left: 0; right: 0; bottom: 0; padding: 20px; }
     .layout-speech-discord .message { display: flex; gap: 15px; margin-bottom: 20px; }
-    .layout-speech-discord .message-avatar { width: 40px; height: 40px; object-fit: cover; flex-shrink: 0; }
+    .layout-speech-discord .message-avatar { width: 40px; height: 40px; object-fit: contain; flex-shrink: 0; }
     .layout-speech-discord .message-content { flex: 1; }
     .layout-speech-discord .message-header { display: flex; align-items: baseline; gap: 10px; margin-bottom: 5px; }
     .layout-speech-discord .message-author { color: #fff; font-size: 16px; font-weight: 600; }


### PR DESCRIPTION
Change `object-fit` from `cover` to `contain` for logo avatars in OG tester layouts to prevent image cropping.

---
<a href="https://cursor.com/background-agent?bcId=bc-b636ebe9-761c-404c-949d-de5e6a376210">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b636ebe9-761c-404c-949d-de5e6a376210">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

