### PR TITLE
Update card images and remove event image url

### DIFF
--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -117,17 +117,11 @@
     .layout-minimal .description { font-size: 16px; color: #888; line-height: 1.6; }
     .layout-minimal .brand { position: absolute; bottom: 30px; left: 60px; font-size: 14px; font-weight: 700; color: #aaa; text-transform: uppercase; letter-spacing: 2px; }
 
-    /* NEW LAYOUT: Color Blocks (bold editorial) */
-    .layout-blocks { position: relative; background: #000; }
-    .layout-blocks .block-a { position: absolute; inset: 0 60% 0 0; background: var(--og-bg-1); }
-    .layout-blocks .block-b { position: absolute; inset: 0 0 0 60%; background: var(--og-bg-3); filter: brightness(0.7); }
-    .layout-blocks .event-title { position: absolute; left: 60px; top: 60px; right: 50%; color: #fff; font-size: 86px; font-weight: 900; line-height: 0.95; text-transform: uppercase; letter-spacing: -1px; }
-    .layout-blocks .meta { position: absolute; left: 60px; bottom: 60px; color: #fff; font-size: 20px; opacity: 0.9; }
-    .layout-blocks .poster { position: absolute; right: 80px; top: 80px; width: 420px; height: 470px; background-size: cover; background-position: center; box-shadow: 0 30px 80px rgba(0,0,0,0.5); border: 10px solid #111; }
 
     /* NEW LAYOUT: Glass Card */
     .layout-glass { position: relative; backdrop-filter: blur(0px); }
     .layout-glass .cover { filter: brightness(0.6); }
+    .layout-glass .event-image { position: absolute; right: 80px; top: 80px; width: 200px; height: 200px; object-fit: contain; z-index: 2; }
     .layout-glass .glass { position: absolute; inset: 80px; background: rgba(255,255,255,0.12); border: 1px solid rgba(255,255,255,0.25); border-radius: 24px; backdrop-filter: blur(12px); box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
     .layout-glass .glass .inner { position: absolute; inset: 0; padding: 40px; color: #fff; }
     .layout-glass .event-title { font-size: 72px; font-weight: 900; line-height: 0.95; text-shadow: 0 6px 30px rgba(0,0,0,0.6); }
@@ -325,10 +319,6 @@
           <label for="coverInput">Background/Cover Image URL</label>
           <input id="coverInput" type="url" placeholder="https://example.com/cover.jpg">
         </div>
-        <div class="field-4">
-          <label for="imageInput">Event Image URL</label>
-          <input id="imageInput" type="url" placeholder="https://example.com/event-image.jpg">
-        </div>
       </section>
 
       <section class="variants-grid" id="variantsGrid"></section>
@@ -353,7 +343,6 @@
       const customA = document.getElementById('customA');
       const customB = document.getElementById('customB');
       const coverInput = document.getElementById('coverInput');
-      const imageInput = document.getElementById('imageInput');
       const grid = document.getElementById('variantsGrid');
 
       class CreativeCalendarPreview extends DynamicCalendarLoader {
@@ -439,7 +428,7 @@
             time: ev.time || 'Time TBA',
             city: getCityConfig(this.currentCity)?.name || 'City',
             description: ev.tea || 'Join us for an amazing bear community event!',
-            image: (imageInput.value || '').trim() || (ev.image || '').trim(),
+            image: (coverInput.value || '').trim() || (ev.image || '').trim(),
             cover: (coverInput.value || '').trim(),
             theme: themeSelect.value
           };
@@ -474,7 +463,7 @@
             this.render();
           });
 
-          [themeSelect, coverInput, imageInput].forEach(el => {
+          [themeSelect, coverInput].forEach(el => {
             el.addEventListener('input', () => this.render());
             el.addEventListener('change', () => this.render());
           });
@@ -520,7 +509,7 @@
               if (d) d.textContent = `${data.date} · ${data.time}`;
               if (v) v.textContent = `@ ${data.venue}`;
               if (desc) desc.textContent = data.description;
-              if (img) { if (data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
+              if (img) { if (data.cover) { img.style.backgroundImage = `url('${data.cover}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
               if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
@@ -535,17 +524,8 @@
               if (v) v.textContent = `@ ${data.venue} · ${data.time}`;
               if (desc) desc.textContent = data.description;
               if (dateBadge) dateBadge.textContent = data.date;
-              if (img) { if (data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
+              // Image is now always the chunky.dad icon, no need to set background-image
               if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
-              break;
-            }
-            case 'blocks': {
-              const t = artboard.querySelector('.event-title');
-              const meta = artboard.querySelector('.meta');
-              const poster = artboard.querySelector('.poster');
-              if (t) t.textContent = data.event;
-              if (meta) meta.textContent = `${data.date} · ${data.time} · @ ${data.venue}`;
-              if (poster) { if (data.image) { poster.style.backgroundImage = `url('${data.image}')`; poster.style.display = 'block'; } else { poster.style.display = 'none'; } }
               break;
             }
             case 'glass': {
@@ -559,6 +539,7 @@
               if (v) v.textContent = `@ ${data.venue}`;
               if (desc) desc.textContent = data.description;
               if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
+              // Image is now always the chunky.dad icon, no need to set background-image
               break;
             }
             case 'circle': {
@@ -571,17 +552,16 @@
               if (d) d.textContent = `${data.date} · ${data.time}`;
               if (v) v.textContent = `@ ${data.venue}`;
               if (desc) desc.textContent = data.description;
-              if (img) { if (data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
+              if (img) { if (data.cover) { img.style.backgroundImage = `url('${data.cover}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
               break;
             }
             case 'speech': {
               const head = artboard.querySelector('.headline');
               const bubble = artboard.querySelector('.speech-bubble');
-              const img = artboard.querySelector('.event-image');
               const cov = artboard.querySelector('.cover');
               if (head) head.textContent = data.event;
               if (bubble) bubble.textContent = `${data.date} · ${data.time} @ ${data.venue}. ${data.description}`;
-              if (img) { if (data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
+              // Image is now always the chunky.dad icon, no need to set background-image
               if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
@@ -591,7 +571,7 @@
               const avatar = artboard.querySelector('.event-avatar');
               if (title) title.textContent = data.event;
               if (bubble) bubble.textContent = `Join us ${data.date} at ${data.time}! We're hosting an amazing event at ${data.venue}. ${data.description}`;
-              if (avatar && data.image) avatar.style.backgroundImage = `url('${data.image}')`;
+              if (avatar && data.cover) avatar.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'speech-dual': {
@@ -600,7 +580,7 @@
               const avatar = artboard.querySelector('.event-avatar');
               if (bubble1) bubble1.textContent = `Hey! Have you heard about ${data.event}?`;
               if (bubble2) bubble2.textContent = `Yes! It's ${data.date} at ${data.time} @ ${data.venue}. ${data.description}`;
-              if (avatar && data.image) avatar.style.backgroundImage = `url('${data.image}')`;
+              if (avatar && data.cover) avatar.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'speech-terminal': {
@@ -616,7 +596,7 @@ INFO: ${data.description}<br/>
 $ ./join_event.sh<br/>
 Loading... <span class="cursor">█</span>`;
               }
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img && data.cover) img.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'speech-story': {
@@ -627,7 +607,7 @@ Loading... <span class="cursor">█</span>`;
               const time = artboard.querySelector('.profile-time');
               if (title) title.textContent = data.event;
               if (bubble) bubble.textContent = `Can't wait for this! ${data.date} at ${data.time} 🎉`;
-              if (bg && (data.image || data.cover)) bg.style.backgroundImage = `url('${data.image || data.cover}')`;
+              if (bg && data.cover) bg.style.backgroundImage = `url('${data.cover}')`;
               if (name) name.textContent = 'chunky.dad';
               if (time) time.textContent = '2h ago';
               break;
@@ -638,7 +618,7 @@ Loading... <span class="cursor">█</span>`;
               const img = artboard.querySelector('.event-image');
               if (title) title.textContent = data.event;
               if (cloud) cloud.textContent = `I'm dreaming about ${data.event}... ${data.date} at ${data.venue} will be perfect! ${data.description}`;
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img && data.cover) img.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'speech-messenger': {
@@ -647,7 +627,7 @@ Loading... <span class="cursor">█</span>`;
               const img = artboard.querySelector('.message-image');
               if (title) title.textContent = data.event;
               if (bubble) bubble.textContent = `Hey! ${data.event} is happening ${data.date} at ${data.time} @ ${data.venue}. You coming?`;
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img && data.cover) img.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'speech-discord': {
@@ -660,7 +640,7 @@ Loading... <span class="cursor">█</span>`;
               if (author) author.textContent = 'chunky.dad';
               if (time) time.textContent = 'Today at 12:34 PM';
               if (text) text.textContent = `@everyone ${data.event} is happening ${data.date} at ${data.venue}!`;
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img && data.cover) img.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
 
@@ -719,7 +699,7 @@ Loading... <span class="cursor">█</span>`;
                   <div class="overlay"></div>
                   <div class="date-badge"></div>
                 </div>
-                <div class="event-image"></div>
+                <img class="event-image" src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" />
                 <div class="card-body">
                   <div class="event-title"></div>
                   <div class="venue"></div>
@@ -728,15 +708,9 @@ Loading... <span class="cursor">█</span>`;
                 <div class="brand">chunky.dad</div>
               </div>
             `,
-            'blocks': `
-              <div class="block-a"></div>
-              <div class="block-b"></div>
-              <div class="event-title"></div>
-              <div class="meta"></div>
-              <div class="poster"></div>
-            `,
             'glass': `
               <div class="cover"></div>
+              <img class="event-image" src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" />
               <div class="glass">
                 <div class="inner">
                   <div class="event-title"></div>
@@ -761,7 +735,7 @@ Loading... <span class="cursor">█</span>`;
               <div class="headline"></div>
               <img class="logo-avatar" src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" />
               <div class="speech-bubble"></div>
-              <div class="event-image"></div>
+              <img class="event-image" src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" />
               <div class="brand">chunky.dad</div>
             `,
             'speech-event': `
@@ -870,7 +844,6 @@ Loading... <span class="cursor">█</span>`;
           const VARIANTS = [
             { key: 'split', name: 'Split Screen', class: 'layout-split-screen', description: 'Dynamic diagonal composition with image focus' },
             { key: 'minimal', name: 'Minimalist Card', class: 'layout-minimal', description: 'Clean modern design with subtle shadows' },
-            { key: 'blocks', name: 'Color Blocks', class: 'layout-blocks', description: 'Bold two-column color composition' },
             { key: 'glass', name: 'Glass Card', class: 'layout-glass', description: 'Frosted glass over photo backdrop' },
             { key: 'circle', name: 'Circle Focus', class: 'layout-circle', description: 'Circular image focus with side text' },
             { key: 'speech', name: 'Speech Bubble', class: 'layout-speech', description: 'Logo speaks about the event' },


### PR DESCRIPTION
Remove the 'color blocks' layout, update minimalist, glass, and speech bubble cards to use a static chunky.dad icon, and consolidate event image inputs to use the cover image URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-50a75971-2fc5-4545-b5da-64d81b9d251f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-50a75971-2fc5-4545-b5da-64d81b9d251f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

