### PR TITLE
Update test files and swap card images

### DIFF
--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -117,13 +117,6 @@
     .layout-minimal .description { font-size: 16px; color: #888; line-height: 1.6; }
     .layout-minimal .brand { position: absolute; bottom: 30px; left: 60px; font-size: 14px; font-weight: 700; color: #aaa; text-transform: uppercase; letter-spacing: 2px; }
 
-    /* NEW LAYOUT: Color Blocks (bold editorial) */
-    .layout-blocks { position: relative; background: #000; }
-    .layout-blocks .block-a { position: absolute; inset: 0 60% 0 0; background: var(--og-bg-1); }
-    .layout-blocks .block-b { position: absolute; inset: 0 0 0 60%; background: var(--og-bg-3); filter: brightness(0.7); }
-    .layout-blocks .event-title { position: absolute; left: 60px; top: 60px; right: 50%; color: #fff; font-size: 86px; font-weight: 900; line-height: 0.95; text-transform: uppercase; letter-spacing: -1px; }
-    .layout-blocks .meta { position: absolute; left: 60px; bottom: 60px; color: #fff; font-size: 20px; opacity: 0.9; }
-    .layout-blocks .poster { position: absolute; right: 80px; top: 80px; width: 420px; height: 470px; background-size: cover; background-position: center; box-shadow: 0 30px 80px rgba(0,0,0,0.5); border: 10px solid #111; }
 
     /* NEW LAYOUT: Glass Card */
     .layout-glass { position: relative; backdrop-filter: blur(0px); }
@@ -520,7 +513,7 @@
               if (d) d.textContent = `${data.date} · ${data.time}`;
               if (v) v.textContent = `@ ${data.venue}`;
               if (desc) desc.textContent = data.description;
-              if (img) { if (data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
+              if (img) { img.style.backgroundImage = `url('../Rising_Star_Ryan_Head_Compressed.png')`; img.style.display = 'block'; }
               if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
@@ -535,17 +528,8 @@
               if (v) v.textContent = `@ ${data.venue} · ${data.time}`;
               if (desc) desc.textContent = data.description;
               if (dateBadge) dateBadge.textContent = data.date;
-              if (img) { if (data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
-              if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
-              break;
-            }
-            case 'blocks': {
-              const t = artboard.querySelector('.event-title');
-              const meta = artboard.querySelector('.meta');
-              const poster = artboard.querySelector('.poster');
-              if (t) t.textContent = data.event;
-              if (meta) meta.textContent = `${data.date} · ${data.time} · @ ${data.venue}`;
-              if (poster) { if (data.image) { poster.style.backgroundImage = `url('${data.image}')`; poster.style.display = 'block'; } else { poster.style.display = 'none'; } }
+              if (img) { if (data.cover) { img.style.backgroundImage = `url('${data.cover}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
+              if (cov && data.image) cov.style.backgroundImage = `url('${data.image}')`;
               break;
             }
             case 'glass': {
@@ -558,7 +542,7 @@
               if (d) d.textContent = `${data.date} · ${data.time}`;
               if (v) v.textContent = `@ ${data.venue}`;
               if (desc) desc.textContent = data.description;
-              if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
+              if (cov && data.image) cov.style.backgroundImage = `url('${data.image}')`;
               break;
             }
             case 'circle': {
@@ -571,7 +555,7 @@
               if (d) d.textContent = `${data.date} · ${data.time}`;
               if (v) v.textContent = `@ ${data.venue}`;
               if (desc) desc.textContent = data.description;
-              if (img) { if (data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
+              if (img) { img.style.backgroundImage = `url('../Rising_Star_Ryan_Head_Compressed.png')`; img.style.display = 'block'; }
               break;
             }
             case 'speech': {
@@ -581,8 +565,8 @@
               const cov = artboard.querySelector('.cover');
               if (head) head.textContent = data.event;
               if (bubble) bubble.textContent = `${data.date} · ${data.time} @ ${data.venue}. ${data.description}`;
-              if (img) { if (data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
-              if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
+              if (img) { if (data.cover) { img.style.backgroundImage = `url('${data.cover}')`; img.style.display = 'block'; } else { img.style.display = 'none'; } }
+              if (cov && data.image) cov.style.backgroundImage = `url('${data.image}')`;
               break;
             }
             case 'speech-event': {
@@ -591,7 +575,7 @@
               const avatar = artboard.querySelector('.event-avatar');
               if (title) title.textContent = data.event;
               if (bubble) bubble.textContent = `Join us ${data.date} at ${data.time}! We're hosting an amazing event at ${data.venue}. ${data.description}`;
-              if (avatar && data.image) avatar.style.backgroundImage = `url('${data.image}')`;
+              if (avatar) avatar.style.backgroundImage = `url('../Rising_Star_Ryan_Head_Compressed.png')`;
               break;
             }
             case 'speech-dual': {
@@ -600,7 +584,7 @@
               const avatar = artboard.querySelector('.event-avatar');
               if (bubble1) bubble1.textContent = `Hey! Have you heard about ${data.event}?`;
               if (bubble2) bubble2.textContent = `Yes! It's ${data.date} at ${data.time} @ ${data.venue}. ${data.description}`;
-              if (avatar && data.image) avatar.style.backgroundImage = `url('${data.image}')`;
+              if (avatar) avatar.style.backgroundImage = `url('../Rising_Star_Ryan_Head_Compressed.png')`;
               break;
             }
             case 'speech-terminal': {
@@ -616,7 +600,7 @@ INFO: ${data.description}<br/>
 $ ./join_event.sh<br/>
 Loading... <span class="cursor">█</span>`;
               }
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img) img.style.backgroundImage = `url('../Rising_Star_Ryan_Head_Compressed.png')`;
               break;
             }
             case 'speech-story': {
@@ -627,7 +611,7 @@ Loading... <span class="cursor">█</span>`;
               const time = artboard.querySelector('.profile-time');
               if (title) title.textContent = data.event;
               if (bubble) bubble.textContent = `Can't wait for this! ${data.date} at ${data.time} 🎉`;
-              if (bg && (data.image || data.cover)) bg.style.backgroundImage = `url('${data.image || data.cover}')`;
+              if (bg && data.cover) bg.style.backgroundImage = `url('${data.cover}')`;
               if (name) name.textContent = 'chunky.dad';
               if (time) time.textContent = '2h ago';
               break;
@@ -638,7 +622,7 @@ Loading... <span class="cursor">█</span>`;
               const img = artboard.querySelector('.event-image');
               if (title) title.textContent = data.event;
               if (cloud) cloud.textContent = `I'm dreaming about ${data.event}... ${data.date} at ${data.venue} will be perfect! ${data.description}`;
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img) img.style.backgroundImage = `url('../Rising_Star_Ryan_Head_Compressed.png')`;
               break;
             }
             case 'speech-messenger': {
@@ -647,7 +631,7 @@ Loading... <span class="cursor">█</span>`;
               const img = artboard.querySelector('.message-image');
               if (title) title.textContent = data.event;
               if (bubble) bubble.textContent = `Hey! ${data.event} is happening ${data.date} at ${data.time} @ ${data.venue}. You coming?`;
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img) img.style.backgroundImage = `url('../Rising_Star_Ryan_Head_Compressed.png')`;
               break;
             }
             case 'speech-discord': {
@@ -660,7 +644,7 @@ Loading... <span class="cursor">█</span>`;
               if (author) author.textContent = 'chunky.dad';
               if (time) time.textContent = 'Today at 12:34 PM';
               if (text) text.textContent = `@everyone ${data.event} is happening ${data.date} at ${data.venue}!`;
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img) img.style.backgroundImage = `url('../Rising_Star_Ryan_Head_Compressed.png')`;
               break;
             }
 
@@ -727,13 +711,6 @@ Loading... <span class="cursor">█</span>`;
                 </div>
                 <div class="brand">chunky.dad</div>
               </div>
-            `,
-            'blocks': `
-              <div class="block-a"></div>
-              <div class="block-b"></div>
-              <div class="event-title"></div>
-              <div class="meta"></div>
-              <div class="poster"></div>
             `,
             'glass': `
               <div class="cover"></div>
@@ -870,7 +847,6 @@ Loading... <span class="cursor">█</span>`;
           const VARIANTS = [
             { key: 'split', name: 'Split Screen', class: 'layout-split-screen', description: 'Dynamic diagonal composition with image focus' },
             { key: 'minimal', name: 'Minimalist Card', class: 'layout-minimal', description: 'Clean modern design with subtle shadows' },
-            { key: 'blocks', name: 'Color Blocks', class: 'layout-blocks', description: 'Bold two-column color composition' },
             { key: 'glass', name: 'Glass Card', class: 'layout-glass', description: 'Frosted glass over photo backdrop' },
             { key: 'circle', name: 'Circle Focus', class: 'layout-circle', description: 'Circular image focus with side text' },
             { key: 'speech', name: 'Speech Bubble', class: 'layout-speech', description: 'Logo speaks about the event' },


### PR DESCRIPTION
Remove 'Color Blocks' layout, swap images in 'Minimalist', 'Glass Card', and 'Speech Bubble' layouts, and standardize event image usage with a default image for most other layouts.

---
<a href="https://cursor.com/background-agent?bcId=bc-11323d88-49fb-4d1a-a314-edff81382953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11323d88-49fb-4d1a-a314-edff81382953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

