### PR TITLE
Update card images and consolidate urls

### DIFF
--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -315,12 +315,8 @@
           <input id="customB" type="color" value="#4a00e0" title="Custom color B">
         </div>
         <div class="field-4">
-          <label for="coverInput">Background/Cover Image URL</label>
-          <input id="coverInput" type="url" placeholder="https://example.com/cover.jpg">
-        </div>
-        <div class="field-4">
-          <label for="imageInput">Event Image URL</label>
-          <input id="imageInput" type="url" placeholder="https://example.com/event-image.jpg">
+          <label for="coverInput">Image URL</label>
+          <input id="coverInput" type="url" placeholder="https://example.com/image.jpg">
         </div>
       </section>
 
@@ -346,7 +342,6 @@
       const customA = document.getElementById('customA');
       const customB = document.getElementById('customB');
       const coverInput = document.getElementById('coverInput');
-      const imageInput = document.getElementById('imageInput');
       const grid = document.getElementById('variantsGrid');
 
       class CreativeCalendarPreview extends DynamicCalendarLoader {
@@ -432,8 +427,7 @@
             time: ev.time || 'Time TBA',
             city: getCityConfig(this.currentCity)?.name || 'City',
             description: ev.tea || 'Join us for an amazing bear community event!',
-            image: (imageInput.value || '').trim() || (ev.image || '').trim(),
-            cover: (coverInput.value || '').trim(),
+            cover: (coverInput.value || '').trim() || (ev.image || '').trim(),
             theme: themeSelect.value
           };
         }
@@ -467,7 +461,7 @@
             this.render();
           });
 
-          [themeSelect, coverInput, imageInput].forEach(el => {
+          [themeSelect, coverInput].forEach(el => {
             el.addEventListener('input', () => this.render());
             el.addEventListener('change', () => this.render());
           });
@@ -513,7 +507,7 @@
               if (d) d.textContent = `${data.date} · ${data.time}`;
               if (v) v.textContent = `@ ${data.venue}`;
               if (desc) desc.textContent = data.description;
-              if (img && data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; }
+              if (img && data.cover) { img.style.backgroundImage = `url('${data.cover}')`; img.style.display = 'block'; }
               if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
@@ -528,8 +522,8 @@
               if (v) v.textContent = `@ ${data.venue} · ${data.time}`;
               if (desc) desc.textContent = data.description;
               if (dateBadge) dateBadge.textContent = data.date;
-              if (img) { img.style.backgroundImage = `url('../Rising_Star_Ryan_Head_Compressed.png')`; img.style.display = 'block'; }
-              if (cov && data.image) cov.style.backgroundImage = `url('${data.image}')`;
+              if (img && data.cover) { img.style.backgroundImage = `url('${data.cover}')`; img.style.display = 'block'; }
+              if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'glass': {
@@ -555,7 +549,7 @@
               if (d) d.textContent = `${data.date} · ${data.time}`;
               if (v) v.textContent = `@ ${data.venue}`;
               if (desc) desc.textContent = data.description;
-              if (img && data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; }
+              if (img && data.cover) { img.style.backgroundImage = `url('${data.cover}')`; img.style.display = 'block'; }
               break;
             }
             case 'speech': {
@@ -565,7 +559,7 @@
               const cov = artboard.querySelector('.cover');
               if (head) head.textContent = data.event;
               if (bubble) bubble.textContent = `${data.date} · ${data.time} @ ${data.venue}. ${data.description}`;
-              if (img && data.image) { img.style.backgroundImage = `url('${data.image}')`; img.style.display = 'block'; }
+              if (img && data.cover) { img.style.backgroundImage = `url('${data.cover}')`; img.style.display = 'block'; }
               if (cov && data.cover) cov.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
@@ -575,7 +569,7 @@
               const avatar = artboard.querySelector('.event-avatar');
               if (title) title.textContent = data.event;
               if (bubble) bubble.textContent = `Join us ${data.date} at ${data.time}! We're hosting an amazing event at ${data.venue}. ${data.description}`;
-              if (avatar && data.image) avatar.style.backgroundImage = `url('${data.image}')`;
+              if (avatar && data.cover) avatar.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'speech-dual': {
@@ -584,7 +578,7 @@
               const avatar = artboard.querySelector('.event-avatar');
               if (bubble1) bubble1.textContent = `Hey! Have you heard about ${data.event}?`;
               if (bubble2) bubble2.textContent = `Yes! It's ${data.date} at ${data.time} @ ${data.venue}. ${data.description}`;
-              if (avatar && data.image) avatar.style.backgroundImage = `url('${data.image}')`;
+              if (avatar && data.cover) avatar.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'speech-terminal': {
@@ -600,7 +594,7 @@ INFO: ${data.description}<br/>
 $ ./join_event.sh<br/>
 Loading... <span class="cursor">█</span>`;
               }
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img && data.cover) img.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'speech-story': {
@@ -611,7 +605,7 @@ Loading... <span class="cursor">█</span>`;
               const time = artboard.querySelector('.profile-time');
               if (title) title.textContent = data.event;
               if (bubble) bubble.textContent = `Can't wait for this! ${data.date} at ${data.time} 🎉`;
-              if (bg && data.image) bg.style.backgroundImage = `url('${data.image}')`;
+              if (bg && data.cover) bg.style.backgroundImage = `url('${data.cover}')`;
               if (name) name.textContent = 'chunky.dad';
               if (time) time.textContent = '2h ago';
               break;
@@ -622,7 +616,7 @@ Loading... <span class="cursor">█</span>`;
               const img = artboard.querySelector('.event-image');
               if (title) title.textContent = data.event;
               if (cloud) cloud.textContent = `I'm dreaming about ${data.event}... ${data.date} at ${data.venue} will be perfect! ${data.description}`;
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img && data.cover) img.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'speech-messenger': {
@@ -631,7 +625,7 @@ Loading... <span class="cursor">█</span>`;
               const img = artboard.querySelector('.message-image');
               if (title) title.textContent = data.event;
               if (bubble) bubble.textContent = `Hey! ${data.event} is happening ${data.date} at ${data.time} @ ${data.venue}. You coming?`;
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img && data.cover) img.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
             case 'speech-discord': {
@@ -644,7 +638,7 @@ Loading... <span class="cursor">█</span>`;
               if (author) author.textContent = 'chunky.dad';
               if (time) time.textContent = 'Today at 12:34 PM';
               if (text) text.textContent = `@everyone ${data.event} is happening ${data.date} at ${data.venue}!`;
-              if (img && data.image) img.style.backgroundImage = `url('${data.image}')`;
+              if (img && data.cover) img.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
 


### PR DESCRIPTION
Refactor image handling in `test-og-event-layouts-calendar.html` to use a single image URL input.

This change simplifies image management by consolidating "event image URL" and "cover image URL" into one field, making the test file easier to use and maintain. All card layouts now utilize this single image source.

---
<a href="https://cursor.com/background-agent?bcId=bc-ffa9e1f9-1136-464f-aa6a-ccbc414162ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ffa9e1f9-1136-464f-aa6a-ccbc414162ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

