### PR TITLE
Fix city page analytics collection call

### DIFF
--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Atlanta - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Berlin - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Chicago - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/city.html
+++ b/city.html
@@ -43,14 +43,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/denver/index.html
+++ b/denver/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Denver - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/index.html
+++ b/index.html
@@ -17,14 +17,56 @@
     <meta name="twitter:description" content="The ultimate travel guide for gay bears - city guides, events, and bear-owned businesses worldwide">
     <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
     
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'chunky.dad - Gay Bear Travel Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="styles.css">

--- a/london/index.html
+++ b/london/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'London - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/los-angeles/index.html
+++ b/los-angeles/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Los angeles - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/new-orleans/index.html
+++ b/new-orleans/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'New orleans - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/new-york/index.html
+++ b/new-york/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'New york - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Palm springs - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/portland/index.html
+++ b/portland/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Portland - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Seattle - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/sf/index.html
+++ b/sf/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Sf - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Sitges - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Toronto - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -44,14 +44,56 @@
         }
       })();
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-YKQBFFQR5E"></script>
+    <!-- Google Analytics 4 - Image-based tracking -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-YKQBFFQR5E');
+      // Initialize Google Analytics 4 with Image-based tracking
+      (function() {
+        try {
+          // Create a unique client ID if not exists
+          let clientId = localStorage.getItem('ga_client_id');
+          if (!clientId) {
+            clientId = 'GA1.2.' + Math.random().toString(36).substr(2, 9) + '.' + Math.floor(Date.now() / 1000);
+            localStorage.setItem('ga_client_id', clientId);
+          }
+          
+          // Send page view
+          const pageUrl = window.location.href;
+          const pageTitle = document.title || 'Vegas - chunky.dad Bear Guide';
+          const referrer = document.referrer || '';
+          
+          // Build analytics URL
+          const analyticsUrl = 'https://www.google-analytics.com/g/collect?' + 
+            'v=2&' +
+            'tid=G-YKQBFFQR5E&' +
+            'cid=' + encodeURIComponent(clientId) + '&' +
+            't=pageview&' +
+            'dl=' + encodeURIComponent(pageUrl) + '&' +
+            'dt=' + encodeURIComponent(pageTitle) + '&' +
+            'dr=' + encodeURIComponent(referrer) + '&' +
+            'ul=en-us&' +
+            'de=UTF-8&' +
+            'sd=24-bit&' +
+            'sr=1920x1080&' +
+            'vp=1920x1080&' +
+            'je=0&' +
+            'uip=' + encodeURIComponent(window.location.hostname) + '&' +
+            'uua=' + encodeURIComponent(navigator.userAgent) + '&' +
+            'z=' + Math.floor(Math.random() * 2147483647);
+          
+          // Send via Image request
+          new Image().src = analyticsUrl;
+          
+          // Log success for debugging
+          if (window.logger) {
+            logger.debug('SYSTEM', 'Analytics pageview sent', { url: analyticsUrl });
+          }
+        } catch (error) {
+          // Log error but don't break the page
+          if (window.logger) {
+            logger.error('SYSTEM', 'Analytics tracking failed', error);
+          }
+        }
+      })();
     </script>
     
     <link rel="stylesheet" href="../styles.css">


### PR DESCRIPTION
Replaced gtag.js with image-based Google Analytics 4 tracking to resolve failing analytics collect calls across the site.

---
<a href="https://cursor.com/background-agent?bcId=bc-9292045b-4272-4295-84bc-606fc56b9ebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9292045b-4272-4295-84bc-606fc56b9ebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

