### PR TITLE
Revert ineffective ios26 fixes and merge

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -96,8 +96,6 @@ class NavigationManager {
 
         logger.componentInit('NAV', 'Setting up dynamic header for index page');
         
-        // iOS 26 specific: Ensure header is immediately visible to prevent loading delay
-        this.ensureIOS26HeaderVisibility();
         
         let lastScrollY = window.scrollY;
         let ticking = false;
@@ -141,34 +139,6 @@ class NavigationManager {
         logger.componentLoad('NAV', 'Dynamic header scroll listener attached');
     }
 
-    // iOS 26 specific: Ensure header is immediately visible to prevent loading delay
-    ensureIOS26HeaderVisibility() {
-        const ua = navigator.userAgent || navigator.vendor || window.opera || '';
-        const isIOS = /iP(hone|od|ad)/.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
-        const isSafari = /^((?!chrome|android).)*safari/i.test(ua);
-        const iosVersion = this.getIOSVersion(ua);
-        const isIOS26 = iosVersion >= 18;
-
-        if (!isIOS || !isSafari || !isIOS26) return;
-
-        logger.info('NAV', 'iOS 26 detected - ensuring immediate header visibility', {
-            iosVersion,
-            isIOS26
-        });
-
-        // Simple fix: just make header visible immediately on iOS 26
-        if (this.header) {
-            this.header.style.opacity = '1';
-            this.header.style.transform = 'translateY(0)';
-            this.header.classList.add('visible');
-        }
-    }
-
-    // Helper method to extract iOS version from user agent
-    getIOSVersion(userAgent) {
-        const match = userAgent.match(/OS (\d+)_/);
-        return match ? parseInt(match[1], 10) : 0;
-    }
 }
 
 // Export for use in other modules

--- a/styles.css
+++ b/styles.css
@@ -158,43 +158,6 @@ header {
     overflow: visible;
 }
 
-/* iOS 26 Safari specific fixes for header positioning */
-@supports (-webkit-touch-callout: none) {
-    /* iOS Safari detection */
-    header {
-        /* Ensure header stays visible on iOS 26 */
-        position: fixed !important;
-        top: 0 !important;
-        left: 0 !important;
-        right: 0 !important;
-        z-index: 9998 !important;
-        /* Prevent header from being pushed off-screen */
-        transform: translateZ(0);
-        -webkit-transform: translateZ(0);
-        /* Force hardware acceleration */
-        will-change: transform;
-    }
-    
-    /* Additional iOS 26 viewport fixes */
-    @media screen and (max-width: 1024px) {
-        header {
-            /* Ensure header is always visible on mobile iOS */
-            position: fixed !important;
-            top: 0 !important;
-            /* Prevent iOS Safari from hiding header during scroll */
-            -webkit-overflow-scrolling: touch;
-            /* iOS 26 specific: Override the hidden state to prevent loading delay */
-            opacity: 1 !important;
-            transform: translateY(0) !important;
-        }
-        
-        /* Override the index page hidden header state on iOS 26 */
-        body.index-page header {
-            opacity: 1 !important;
-            transform: translateY(0) !important;
-        }
-    }
-}
 
 /* Dynamic header behavior for index page */
 body.index-page header {

--- a/styles.css
+++ b/styles.css
@@ -5631,7 +5631,7 @@ footer {
     .bear-intel-form input,
     .bear-intel-form textarea,
     .bear-intel-form select {
-        font-size: 16px; /* Prevents zoom on iOS */
+        font-size: 16px;
     }
 }
 


### PR DESCRIPTION
Remove all iOS-specific workarounds from header management and related styles to simplify the codebase.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c352d3d-ca03-43d0-971c-6051432b2547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c352d3d-ca03-43d0-971c-6051432b2547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

