### PR TITLE
Update project and read rules

### DIFF
--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Atlanta - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Atlanta - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Atlanta - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Atlanta - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Atlanta - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -207,8 +212,8 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Berlin - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Berlin - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Berlin - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Berlin - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Berlin - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -207,8 +212,8 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Chicago - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Chicago - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Chicago - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Chicago - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Chicago - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -107,7 +112,7 @@
   <meta property="og:title" content="Chicago - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Chicago - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/chicago/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=671933db">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=b97c3328">
 </head>
 <body>
     <header>
@@ -207,8 +212,8 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 

--- a/city.html
+++ b/city.html
@@ -8,41 +8,7 @@
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
     
-    <script>
-      (function() {
-        try {
-          var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
-            var url = new URL(window.location.href);
-            var params = url.searchParams;
-            var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
-            if (slug) {
-              slug = String(slug).trim().toLowerCase().replace(/\s+/g, '-');
-              var newUrl = '/' + slug + '/';
-              var preserved = [];
-              params.forEach(function(value, key) {
-                if (key !== 'city' && value != null && value !== '') {
-                  preserved.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
-                }
-              });
-              if (preserved.length > 0) {
-                newUrl += '?' + preserved.join('&');
-              }
-              if (url.hash && url.hash !== '#' + slug) {
-                newUrl += url.hash;
-              }
-              var currentFull = (window.location.pathname || '') + (window.location.search || '') + (window.location.hash || '');
-              if (newUrl !== currentFull) {
-                console.info('[CITY] Normalizing URL to canonical path:', newUrl);
-                window.location.replace(newUrl);
-              }
-            }
-          }
-        } catch (e) {
-          // Silently ignore normalization errors
-        }
-      })();
-    </script>
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking

--- a/denver/index.html
+++ b/denver/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Denver - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Denver - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Denver - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Denver - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Denver - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -107,7 +112,7 @@
   <meta property="og:title" content="Denver - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Denver - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/denver/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=312cb592">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=2ffb306a">
 </head>
 <body>
     <header>
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>

--- a/london/index.html
+++ b/london/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>London - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to London - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>London - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to London - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'London - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>

--- a/los-angeles/index.html
+++ b/los-angeles/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Los Angeles - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Los Angeles - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Los Angeles - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Los Angeles - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Los angeles - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>

--- a/new-orleans/index.html
+++ b/new-orleans/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>New Orleans - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to New Orleans - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>New Orleans - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to New Orleans - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'New orleans - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>

--- a/new-york/index.html
+++ b/new-york/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>New York - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to New York - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>New York - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to New York - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'New york - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -207,8 +212,8 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Palm Springs - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Palm Springs - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Palm Springs - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Palm Springs - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Palm springs - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>

--- a/portland/index.html
+++ b/portland/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Portland - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Portland - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Portland - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Portland - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Portland - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -107,7 +112,7 @@
   <meta property="og:title" content="Portland - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Portland - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/portland/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=0a429d18">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=00640b02">
 </head>
 <body>
     <header>
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Seattle - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Seattle - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Seattle - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Seattle - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Seattle - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -107,7 +112,7 @@
   <meta property="og:title" content="Seattle - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Seattle - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/seattle/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=8a9da074">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=dc02c73a">
 </head>
 <body>
     <header>
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>

--- a/sf/index.html
+++ b/sf/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>San Francisco - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to San Francisco - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>San Francisco - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to San Francisco - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Sf - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -107,7 +112,7 @@
   <meta property="og:title" content="San Francisco - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to San Francisco - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/sf/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=9e3022a6">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=52729587">
 </head>
 <body>
     <header>
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sitges - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Sitges - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Sitges - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Sitges - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Sitges - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Toronto - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Toronto - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Toronto - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Toronto - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Toronto - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -4,16 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Las Vegas - chunky.dad Bear Guide</title>
-    <meta name="description" content="Complete gay bear guide to Las Vegas - events, bars, and the hottest bear scene">
-    <link rel="icon" type="image/png" href="../Rising_Star_Ryan_Head_Compressed.png">
-    <link rel="apple-touch-icon" href="../Rising_Star_Ryan_Head_Compressed.png">
     
     <script>
       (function() {
         try {
+          // Only run normalization if we're on a city page
           var path = window.location.pathname || '';
-          if (path.indexOf('city.html') !== -1) {
+          if (path.indexOf('city.html') !== -1 || path.split('/').filter(Boolean).length > 0) {
             var url = new URL(window.location.href);
             var params = url.searchParams;
             var slug = params.get('city') || (window.location.hash ? window.location.hash.replace('#', '') : '');
@@ -44,6 +41,12 @@
         }
       })();
     </script>
+    <title>Las Vegas - chunky.dad Bear Guide</title>
+    <meta name="description" content="Complete gay bear guide to Las Vegas - events, bars, and the hottest bear scene">
+    <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    
+    <!-- URL normalization moved to GitHub Actions build process -->
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>
       // Initialize Google Analytics 4 with Image-based tracking
@@ -58,7 +61,7 @@
           
           // Send page view
           const pageUrl = window.location.href;
-          const pageTitle = document.title || 'Vegas - chunky.dad Bear Guide';
+          const pageTitle = document.title || 'City Guide - chunky.dad Bear Guide';
           const referrer = document.referrer || '';
           
           // Build analytics URL
@@ -98,6 +101,8 @@
     
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <!-- Bootstrap Icons (for recognizable iconography) -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" crossorigin="anonymous">
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" 
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" 
@@ -107,7 +112,7 @@
   <meta property="og:title" content="Las Vegas - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Las Vegas - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/vegas/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=0b7a9bd8">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=f54d9d56">
 </head>
 <body>
     <header>
@@ -207,14 +212,14 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
-    <script src="../js/components.js"></script>
     <script src="../js/header-manager.js"></script>
+    <script src="../js/components.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 
             integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" 
             crossorigin="anonymous"
-            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity})"></script>
+            onerror="if(window.logger){logger.error('SYSTEM', 'Failed to load Leaflet.js', {url: this.src, integrity: this.integrity});}else{console.error('Failed to load Leaflet.js from', this.src);}"></script>
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>


### PR DESCRIPTION
Simplify `city.html` header by moving URL normalization to the GitHub Actions build process.

This change cleans up the static `city.html` template, improves maintainability by centralizing the URL normalization logic in the build script, and ensures city-specific content is present in the initial HTML for better SEO, all while preserving the city selector dropdown functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d4ead7a-d15f-4fdd-aab5-59c0b96c2573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d4ead7a-d15f-4fdd-aab5-59c0b96c2573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

