### PR TITLE
Temporarily stop favicon fetching

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1052,34 +1052,35 @@ class DynamicCalendarLoader extends CalendarCore {
 
     // Create marker icon with favicon or three letters
     createMarkerIcon(event) {
-        if (event.website) {
-            try {
-                // Ensure URL has protocol
-                let url = event.website;
-                if (!url.startsWith('http://') && !url.startsWith('https://')) {
-                    url = 'https://' + url;
-                }
-                
-                const hostname = new URL(url).hostname;
-                const faviconUrl = `https://www.google.com/s2/favicons?domain=${hostname}&sz=32`;
-                const textFallback = this.getMarkerText(event);
-                
-                return L.divIcon({
-                    className: 'favicon-marker',
-                    html: `
-                        <div class="favicon-marker-container">
-                            <img src="${faviconUrl}" alt="venue" class="favicon-marker-icon"
-                                 onerror="this.parentElement.innerHTML='<span class=\\'marker-text\\'>${textFallback}</span>'; this.parentElement.classList.add('text-marker');">
-                        </div>
-                    `,
-                    iconSize: [32, 32],
-                    iconAnchor: [16, 16],
-                    popupAnchor: [0, -16]
-                });
-            } catch (error) {
-                logger.warn('MAP', 'Failed to create favicon marker', { website: event.website, error: error.message });
-            }
-        }
+        // TEMPORARILY DISABLED: Skip favicon fetching for testing
+        // if (event.website) {
+        //     try {
+        //         // Ensure URL has protocol
+        //         let url = event.website;
+        //         if (!url.startsWith('http://') && !url.startsWith('https://')) {
+        //             url = 'https://' + url;
+        //         }
+        //         
+        //         const hostname = new URL(url).hostname;
+        //         const faviconUrl = `https://www.google.com/s2/favicons?domain=${hostname}&sz=32`;
+        //         const textFallback = this.getMarkerText(event);
+        //         
+        //         return L.divIcon({
+        //             className: 'favicon-marker',
+        //             html: `
+        //                 <div class="favicon-marker-container">
+        //                     <img src="${faviconUrl}" alt="venue" class="favicon-marker-icon"
+        //                          onerror="this.parentElement.innerHTML='<span class=\\'marker-text\\'>${textFallback}</span>'; this.parentElement.classList.add('text-marker');">
+        //                 </div>
+        //             `,
+        //             iconSize: [32, 32],
+        //             iconAnchor: [16, 16],
+        //             popupAnchor: [0, -16]
+        //         });
+        //     } catch (error) {
+        //         logger.warn('MAP', 'Failed to create favicon marker', { website: event.website, error: error.message });
+        //     }
+        // }
         
         // Use text from shorter field or shortName or name
         const markerText = this.getMarkerText(event);


### PR DESCRIPTION
Temporarily disable favicon fetching in `dynamic-calendar-loader.js` to facilitate debugging an unrelated issue.

This change was requested to allow the user to isolate a bug they are investigating. Favicon fetching will be re-enabled after their tests are complete.

---
<a href="https://cursor.com/background-agent?bcId=bc-6978d422-b308-49cf-9554-6a65c43bba80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6978d422-b308-49cf-9554-6a65c43bba80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

