### PR TITLE
Fix calendar loading bug after merge

### DIFF
--- a/js/compact-card-renderer.js
+++ b/js/compact-card-renderer.js
@@ -57,7 +57,7 @@ class CompactCardRenderer {
 
     getItems() {
         if (this.type === 'city') {
-            return window.getAvailableCities ? getAvailableCities() : null;
+            return (typeof getAvailableCities === 'function') ? getAvailableCities() : null;
         } else if (this.type === 'event') {
             return window.getAvailableBearEvents ? getAvailableBearEvents() : null;
         }

--- a/js/today-events.js
+++ b/js/today-events.js
@@ -16,7 +16,13 @@ class TodayEventsAggregator extends DynamicCalendarLoader {
         return;
       }
 
-      const cities = (window.getAvailableCities ? getAvailableCities() : []).filter(c => hasCityCalendar(c.key));
+      // Check if city-config functions are available
+      if (typeof getAvailableCities !== 'function' || typeof hasCityCalendar !== 'function') {
+        logger.warn('CALENDAR', 'City config functions not available for today events aggregation');
+        return;
+      }
+      
+      const cities = getAvailableCities().filter(c => hasCityCalendar(c.key));
       const selectedCities = cities.slice(0, this.maxCities);
 
       logger.info('CALENDAR', 'Loading cached ICS for today aggregation', { 
@@ -249,7 +255,7 @@ class TodayEventsAggregator extends DynamicCalendarLoader {
     cityValue.className = 'value';
     
     // Get city emoji from config
-    const cityConfig = getCityConfig(ev.cityKey);
+    const cityConfig = (typeof getCityConfig === 'function') ? getCityConfig(ev.cityKey) : null;
     const cityEmoji = cityConfig ? cityConfig.emoji : '';
     const cityDisplayText = cityEmoji ? `${cityEmoji} ${ev.cityName || ''}` : (ev.cityName || '');
     cityValue.textContent = cityDisplayText;


### PR DESCRIPTION
Add robust dependency checks and waiting logic for city-config functions to fix calendar initialization ReferenceError on city.html.

The calendar was failing to initialize with a `ReferenceError` because `DynamicCalendarLoader` was attempting to use functions from `city-config.js` before they were fully loaded and available in the global scope, creating a race condition. This PR introduces checks and waiting mechanisms to ensure these dependencies are ready before use.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c027054-7da7-4433-bdea-088383250cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c027054-7da7-4433-bdea-088383250cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

