### PR TITLE
Update map icon css boundaries

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2680,6 +2680,7 @@ body.index-page main {
     border-radius: 6px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.2);
     transition: all 0.2s ease;
+    overflow: hidden;
 }
 
 .favicon-marker-container:hover {


### PR DESCRIPTION
Add `overflow: hidden` to `.favicon-marker-container` to prevent map icons from overflowing their bounding box on hover.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9b36a4e-1e7a-47a6-a2e6-0dfe1e196e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f9b36a4e-1e7a-47a6-a2e6-0dfe1e196e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

