### PR TITLE
Update code and fix eventbrite parser

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -611,14 +611,26 @@ class EventbriteParser {
                 }
             }
             
-            // Determine timezone: prefer original Eventbrite timezone, fallback to city-based timezone
-            let eventTimezone = originalTimezone;
-            if (!eventTimezone && city) {
+            // Determine timezone: prefer city-based timezone when available, fallback to original Eventbrite timezone
+            // This fixes cases where Eventbrite has incorrect timezone but parser correctly detects city
+            let eventTimezone = null;
+            if (city) {
                 eventTimezone = this.getTimezoneForCity(city, cityConfig);
-                console.log(`🎫 Eventbrite: Using city-based timezone for "${title}": ${eventTimezone}`);
-            } else if (eventTimezone) {
+                if (eventTimezone) {
+                    console.log(`🎫 Eventbrite: Using city-based timezone for "${title}": ${eventTimezone}`);
+                    if (originalTimezone && originalTimezone !== eventTimezone) {
+                        console.log(`🎫 Eventbrite: Overriding Eventbrite timezone "${originalTimezone}" with city-based timezone "${eventTimezone}" for "${title}"`);
+                    }
+                }
+            }
+            
+            // Fallback to original Eventbrite timezone if no city-based timezone found
+            if (!eventTimezone && originalTimezone) {
+                eventTimezone = originalTimezone;
                 console.log(`🎫 Eventbrite: Using original Eventbrite timezone for "${title}": ${eventTimezone}`);
-            } else {
+            }
+            
+            if (!eventTimezone) {
                 console.log(`🎫 Eventbrite: No timezone found for "${title}"`);
             }
             


### PR DESCRIPTION
Prioritize city-based timezone over Eventbrite's original timezone in the Eventbrite parser to fix incorrect timezone assignments.

The previous logic would always use the `originalTimezone` provided by Eventbrite if present, even when the parser's city detection (e.g., from event title patterns) indicated a different, more accurate timezone. This led to events like "DURO" being incorrectly assigned a "Europe/Rome" timezone instead of "America/Los_Angeles" despite being detected as an LA event. This change ensures that if the parser can confidently determine a city-based timezone, it will be used, overriding potentially incorrect Eventbrite data.

---
<a href="https://cursor.com/background-agent?bcId=bc-f749b3af-d122-4132-8fc2-be8bcbfc61b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f749b3af-d122-4132-8fc2-be8bcbfc61b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

