### PR TITLE
Fix city page x button positioning

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1832,7 +1832,7 @@ body.index-page main {
 }
 
 .floating-clear-btn {
-    position: sticky;
+    position: fixed;
     bottom: 20px;
     left: 20px;
     background: var(--color-away);
@@ -1850,9 +1850,7 @@ body.index-page main {
     align-items: center;
     justify-content: center;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-    z-index: 10;
-    float: left;
-    margin-top: auto;
+    z-index: 1000;
 }
 
 .floating-clear-btn:hover {


### PR DESCRIPTION
Fix the positioning of the X button on the city page to be fixed in the bottom-left and appear above other content.

The previous `position: sticky` combined with `float: left` was causing conflicting behavior, preventing the button from staying consistently in the desired bottom-left corner and above other elements. Changing to `position: fixed` and increasing `z-index` resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-f969f369-fd7f-4e88-ae00-f1efa02f2a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f969f369-fd7f-4e88-ae00-f1efa02f2a85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

