### PR TITLE
Fix deselect button positioning

### DIFF
--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/city.html
+++ b/city.html
@@ -189,10 +189,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/denver/index.html
+++ b/denver/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/london/index.html
+++ b/london/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/los-angeles/index.html
+++ b/los-angeles/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/new-orleans/index.html
+++ b/new-orleans/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/new-york/index.html
+++ b/new-york/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/portland/index.html
+++ b/portland/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/sf/index.html
+++ b/sf/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -274,10 +274,11 @@
                 </div>
                 <div class="calendar-grid">
                 </div>
-                <!-- Floating clear selection button -->
-                <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
             </div>
         </section>
+        
+        <!-- Floating clear selection button - moved outside of weekly-calendar to prevent positioning issues -->
+        <button class="floating-clear-btn" id="clear-selection-btn" style="display: none;" title="Clear Selection">×</button>
 
         <section class="events">
             <div class="container">


### PR DESCRIPTION
Move the deselect button out of the transformed weekly calendar section to fix its fixed positioning.

Elements with CSS transforms (even `translateY(0)`) create a new containing block for `position: fixed` children. This caused the deselect button to be positioned relative to the `.weekly-calendar` section instead of the viewport, making it appear in the middle and scroll with the page. Moving the button outside this transformed parent ensures it correctly adheres to `position: fixed` relative to the viewport.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9af526b-2898-44f2-9daf-1773ca9e06cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9af526b-2898-44f2-9daf-1773ca9e06cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

