### PR TITLE
Fix calendar initialization error

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -3334,7 +3334,7 @@ class DynamicCalendarLoader extends CalendarCore {
         });
         
         logger.componentLoad('CITY', `City page rendered successfully for ${this.currentCity}`, {
-            eventCount: data.events.length,
+            eventCount: this.allEvents ? this.allEvents.length : 0,
             measurementWidth: measurementWidth
         });
     }


### PR DESCRIPTION
Fixes `ReferenceError: Can't find variable: data` by replacing an out-of-scope variable reference in error logging.

The `data` variable was declared within a `try` block, but a logging statement outside this block attempted to access `data.events.length`. When the `try` block failed, `data` was undefined in the outer scope, leading to the `ReferenceError`. The fix uses `this.allEvents`, which is always available, to provide the event count for logging.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb65898f-63f6-4260-9492-32bab4f88235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb65898f-63f6-4260-9492-32bab4f88235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

