### PR TITLE
Update favicon url and merge main

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1162,7 +1162,7 @@ class DynamicCalendarLoader extends CalendarCore {
                 // Convert to local favicon URL if using cached data
                 if (this.dataSource === 'cached') {
                     const originalFaviconUrl = faviconUrl;
-                    faviconUrl = window.FilenameUtils.convertFaviconUrlToLocalPath(faviconUrl, 'img/favicons');
+                    faviconUrl = window.FilenameUtils.convertFaviconUrlToLocalPath(faviconUrl, '/img/favicons');
                     
                     logger.debug('MAP', 'Using local favicon for cached data', {
                         hostname,


### PR DESCRIPTION
Fix favicon URL resolution by making the path absolute in `dynamic-calendar-loader.js`.

Previously, the favicon path was constructed as a relative path (`img/favicons`). On city-specific pages (e.g., `/new-york/`), this would incorrectly resolve to `https://chunky.dad/new-york/img/favicons/...`. Changing it to an absolute path (`/img/favicons`) ensures it always resolves correctly from the root, like `https://chunky.dad/img/favicons/...`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0c5b23b-dd16-49d3-9546-5bf61b0625d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0c5b23b-dd16-49d3-9546-5bf61b0625d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

