### PR TITLE
Update city switcher dropdown and test native menu

### DIFF
--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/atlanta</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" selected>🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Atlanta">
@@ -160,7 +183,7 @@
                         <span class="city-name">Atlanta</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/berlin</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" selected>🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Berlin">
@@ -160,7 +183,7 @@
                         <span class="city-name">Berlin</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/chicago</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" selected>🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Chicago">
@@ -160,7 +183,7 @@
                         <span class="city-name">Chicago</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/denver/index.html
+++ b/denver/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/denver</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" selected>🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Denver">
@@ -160,7 +183,7 @@
                         <span class="city-name">Denver</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/london/index.html
+++ b/london/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/london</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" selected>🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently London">
@@ -160,7 +183,7 @@
                         <span class="city-name">London</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/los-angeles/index.html
+++ b/los-angeles/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/los-angeles</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" selected>🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Los Angeles">
@@ -160,7 +183,7 @@
                         <span class="city-name">Los Angeles</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/new-orleans/index.html
+++ b/new-orleans/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/new-orleans</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" selected>🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently New Orleans">
@@ -160,7 +183,7 @@
                         <span class="city-name">New Orleans</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/new-york/index.html
+++ b/new-york/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/new-york</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" selected>🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently New York">
@@ -160,7 +183,7 @@
                         <span class="city-name">New York</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/palm-springs</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" selected>🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Palm Springs">
@@ -160,7 +183,7 @@
                         <span class="city-name">Palm Springs</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/portland/index.html
+++ b/portland/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/portland</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" selected>🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Portland">
@@ -160,7 +183,7 @@
                         <span class="city-name">Portland</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/seattle</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" selected>🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Seattle">
@@ -160,7 +183,7 @@
                         <span class="city-name">Seattle</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/sf/index.html
+++ b/sf/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/sf</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" selected>🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently San Francisco">
@@ -160,7 +183,7 @@
                         <span class="city-name">San Francisco</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/sitges</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" selected>🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Sitges">
@@ -160,7 +183,7 @@
                         <span class="city-name">Sitges</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/styles.css
+++ b/styles.css
@@ -171,7 +171,56 @@ body.index-page header.visible {
     opacity: 1;
 }
 
-/* City Switcher */
+/* City Switcher - Native Select (EXPERIMENTAL) */
+.city-switcher-native {
+    position: relative;
+    margin-left: auto;
+    margin-right: 1rem;
+    z-index: 10001;
+}
+
+.city-switcher-select {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0.25) 100%);
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 12px;
+    padding: 0.5rem 1rem;
+    color: var(--text-inverse);
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    backdrop-filter: blur(15px);
+    box-shadow: 0 4px 20px var(--shadow-medium);
+    min-width: 200px;
+    appearance: none;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 0.7rem center;
+    background-size: 1rem;
+    padding-right: 2.5rem;
+}
+
+.city-switcher-select:hover {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.25) 0%, rgba(255, 255, 255, 0.35) 100%);
+    border-color: rgba(255, 255, 255, 0.6);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 30px var(--shadow-heavy);
+}
+
+.city-switcher-select:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.8);
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.2);
+}
+
+.city-switcher-select option {
+    background: var(--dropdown-bg);
+    color: var(--text-primary);
+    padding: 0.5rem;
+}
+
+/* City Switcher - Custom (COMMENTED OUT FOR TESTING) */
 .city-switcher {
     position: relative;
     margin-left: auto;
@@ -3248,6 +3297,20 @@ footer {
     }
 
     /* Mobile header adjustments */
+    .city-switcher-native {
+        margin-right: 0.5rem;
+    }
+
+    .city-switcher-select {
+        min-width: 140px;
+        font-size: 0.8rem;
+        padding: 0.3rem 0.6rem;
+        padding-right: 1.8rem;
+        min-height: 36px;
+        height: 36px;
+        border-radius: 8px;
+    }
+
     .city-switcher {
         margin-right: 0.5rem;
     }
@@ -3318,6 +3381,16 @@ footer {
 
     .logo h1 {
         font-size: 1.2rem;
+    }
+    
+    .city-switcher-select {
+        min-width: 120px;
+        font-size: 0.75rem;
+        padding: 0.2rem 0.5rem;
+        padding-right: 1.5rem;
+        min-height: 32px;
+        height: 32px;
+        border-radius: 6px;
     }
     
     .city-switcher-btn {

--- a/tools/generate-city-pages.js
+++ b/tools/generate-city-pages.js
@@ -37,12 +37,16 @@ function generateCityHeader(html, cityKey, cityConfig) {
     .filter(([, cfg]) => cfg && cfg.visible !== false)
     .map(([key, cfg]) => ({ key, ...cfg }));
 
-  // Build city dropdown options HTML with direct links
+  // Build city dropdown options HTML with direct links (for custom dropdown)
   const cityOptions = availableCities.map(city => `
                             <a href="../${city.key}/" class="city-option">
                                 <span class="city-option-emoji">${city.emoji}</span>
                                 <span class="city-option-name">${city.name}</span>
                             </a>`).join('');
+
+  // Build native select options HTML
+  const nativeSelectOptions = availableCities.map(city => `
+                            <option value="../${city.key}/" ${city.key === cityKey ? 'selected' : ''}>${city.emoji} ${city.name}</option>`).join('');
 
   // Create complete header HTML with pre-populated city selector
   const headerHtml = `    <header>
@@ -52,7 +56,15 @@ function generateCityHeader(html, cityKey, cityConfig) {
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/${cityKey}</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        ${nativeSelectOptions}
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently ${cityConfig.name}">
@@ -60,9 +72,10 @@ function generateCityHeader(html, cityKey, cityConfig) {
                         <span class="city-name">${cityConfig.name}</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">${cityOptions}
+                    <div class="city-dropdown">${cityOptions}
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/toronto</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" selected>🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" >🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Toronto">
@@ -160,7 +183,7 @@
                         <span class="city-name">Toronto</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -152,7 +152,30 @@
                     <h1><a href="../index.html"><img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad/vegas</a></h1>
                 </div>
                 
-                <!-- Pure HTML/CSS city selector -->
+                <!-- Native Select City Switcher (EXPERIMENTAL) -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value">
+                        
+                            <option value="../new-york/" >🗽 New York</option>
+                            <option value="../seattle/" >🌲 Seattle</option>
+                            <option value="../los-angeles/" >🌴 Los Angeles</option>
+                            <option value="../toronto/" >🍁 Toronto</option>
+                            <option value="../london/" >🇬🇧 London</option>
+                            <option value="../chicago/" >🏙️ Chicago</option>
+                            <option value="../berlin/" >🇩🇪 Berlin</option>
+                            <option value="../palm-springs/" >🌴 Palm Springs</option>
+                            <option value="../denver/" >🏔️ Denver</option>
+                            <option value="../vegas/" selected>🎰 Las Vegas</option>
+                            <option value="../atlanta/" >🍑 Atlanta</option>
+                            <option value="../new-orleans/" >🎷 New Orleans</option>
+                            <option value="../sf/" >🌉 San Francisco</option>
+                            <option value="../portland/" >🌲 Portland</option>
+                            <option value="../sitges/" >🏖️ Sitges</option>
+                    </select>
+                </div>
+                
+                <!-- Custom HTML/CSS city selector (COMMENTED OUT FOR TESTING) -->
+                <!--
                 <div class="city-switcher">
                     <input type="checkbox" id="city-switcher-toggle" class="city-switcher-toggle">
                     <label for="city-switcher-toggle" class="city-switcher-btn" aria-label="Switch city - currently Las Vegas">
@@ -160,7 +183,7 @@
                         <span class="city-name">Las Vegas</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>
@@ -223,6 +246,7 @@
                             </a>
                     </div>
                 </div>
+                -->
                 
                 <div class="hamburger">
                     <span></span>


### PR DESCRIPTION
Fix invisible city switcher and implement an experimental native select dropdown.

The custom city switcher dropdown was rendered permanently invisible due to hardcoded inline styles `opacity: 0; visibility: hidden;` in the generator script. This PR removes those inline styles and introduces an experimental native `<select>` element for the city switcher, commenting out the custom HTML/CSS version. The native select aims to improve accessibility and reliability while maintaining the site's visual design.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac2b7d72-bb55-4a7b-b21a-1194807777f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac2b7d72-bb55-4a7b-b21a-1194807777f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

