### PR TITLE
Update city switcher display and behavior

### DIFF
--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Atlanta - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/atlanta/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=397ff69b">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🍑">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🍑">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Berlin - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/berlin/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=097049b2">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🇩🇪">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🇩🇪">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Chicago - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/chicago/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=b97c3328">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🏙️">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🏙️">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/city.html
+++ b/city.html
@@ -144,6 +144,13 @@
                 <div class="logo">
                     <h1><a href="index.html"><img src="Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad logo" class="logo-img"> chunky.dad</a></h1>
                 </div>
+                
+                <!-- Native Select City Switcher with emoji-only display -->
+                <div class="city-switcher-native">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🏙️">
+                        <!-- Options will be populated by JavaScript -->
+                    </select>
+                </div>
             </div>
         </nav>
     </header>

--- a/denver/index.html
+++ b/denver/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Denver - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/denver/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=2ffb306a">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🏔️">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🏔️">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -683,8 +683,7 @@ class DynamicCalendarLoader extends CalendarCore {
     // Set up city selector and populate with available cities
     setupCitySelector() {
         const availableCitiesList = document.getElementById('available-cities-list');
-        
-
+        const citySwitcherSelect = document.getElementById('city-switcher-select');
 
         // Populate available cities list for error page
         if (availableCitiesList) {
@@ -695,6 +694,21 @@ class DynamicCalendarLoader extends CalendarCore {
                         ${city.emoji} ${city.name}
                     </a>
                 `).join('');
+        }
+
+        // Populate city switcher dropdown
+        if (citySwitcherSelect) {
+            const availableCities = getAvailableCities().filter(city => hasCityCalendar(city.key));
+            
+            citySwitcherSelect.innerHTML = availableCities.map(city => {
+                const isSelected = city.key === this.currentCity ? 'selected' : '';
+                return `<option value="${city.key}/" ${isSelected}>${city.emoji} ${city.name}</option>`;
+            }).join('');
+
+            // Set the data-emoji attribute to the current city's emoji
+            if (this.currentCityConfig) {
+                citySwitcherSelect.setAttribute('data-emoji', this.currentCityConfig.emoji);
+            }
         }
     }
 

--- a/london/index.html
+++ b/london/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to London - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/london/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=4a8fa3d2">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🇬🇧">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🇬🇧">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/los-angeles/index.html
+++ b/los-angeles/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Los Angeles - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/los-angeles/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=bddc5ad6">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🌴">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🌴">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/new-orleans/index.html
+++ b/new-orleans/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to New Orleans - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/new-orleans/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=4abb3a96">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🎷">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🎷">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/new-york/index.html
+++ b/new-york/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to New York - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/new-york/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=b5833a5b">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🗽">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🗽">
                         
                             <option value="../new-york/" selected>🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Palm Springs - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/palm-springs/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=174b56cf">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🌴">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🌴">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/portland/index.html
+++ b/portland/index.html
@@ -144,13 +144,6 @@
   <meta property="og:url" content="https://chunky.dad/portland/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=d6313c56">
   
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +155,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🌲">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🌲">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/portland/index.html
+++ b/portland/index.html
@@ -143,7 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Portland - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/portland/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=d6313c56">
-  
 </head>
 <body>
         <header>

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Seattle - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/seattle/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=0849a85b">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🌲">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🌲">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" selected>🌲 Seattle</option>

--- a/sf/index.html
+++ b/sf/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to San Francisco - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/sf/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=f22af676">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🌉">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🌉">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Sitges - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/sitges/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=640b21d7">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🏖️">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🏖️">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/tools/generate-city-pages.js
+++ b/tools/generate-city-pages.js
@@ -58,7 +58,7 @@ function generateCityHeader(html, cityKey, cityConfig) {
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="${cityConfig.emoji}">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="${cityConfig.emoji}">
                         ${nativeSelectOptions}
                     </select>
                 </div>
@@ -157,18 +157,7 @@ function buildCityHtml(baseHtml, cityKey, cityConfig) {
     }
   }
 
-  // Add JavaScript for emoji updating
-  const emojiUpdateScript = `
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>`;
-
-  // Inject the script before the closing head tag
-  html = html.replace('</head>', `  ${emojiUpdateScript}\n</head>`);
+  // No longer need emoji update script - emoji is set by data-emoji attribute
 
   // Rewrite asset and link paths for subdirectory depth
   html = html.replace(/href="(styles\.css)"/g, 'href="../$1"');

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Toronto - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/toronto/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=842100d3">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🍁">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🍁">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -143,14 +143,6 @@
   <meta property="og:description" content="Complete gay bear guide to Las Vegas - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/vegas/">
   <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=fe21e21a">
-  
-    <script>
-      function updateCityEmoji(select) {
-        const selectedOption = select.options[select.selectedIndex];
-        const emoji = selectedOption.textContent.split(' ')[0]; // Get emoji part
-        select.setAttribute('data-emoji', emoji);
-      }
-    </script>
 </head>
 <body>
         <header>
@@ -162,7 +154,7 @@
                 
                 <!-- Native Select City Switcher with emoji-only display -->
                 <div class="city-switcher-native">
-                    <select id="city-switcher-select" class="city-switcher-select" onchange="updateCityEmoji(this); window.location.href=this.value" data-emoji="🎰">
+                    <select id="city-switcher-select" class="city-switcher-select" onchange="window.location.href=this.value" data-emoji="🎰">
                         
                             <option value="../new-york/" >🗽 New York</option>
                             <option value="../seattle/" >🌲 Seattle</option>


### PR DESCRIPTION
Add native city switcher to `city.html` and simplify city selection logic to display only emojis and load the next page.

The existing CSS already supported emoji-only display, so the changes focused on integrating the native `<select>` element into the main `city.html` template and streamlining the `onchange` behavior across all city pages to simply navigate to the selected city's page, removing the need for dynamic emoji updates on selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f8b718f-6529-427e-ba40-6e609256cd98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f8b718f-6529-427e-ba40-6e609256cd98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

