### PR TITLE
Update code and read cursorrules

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -205,21 +205,18 @@ body.index-page header.visible {
     background-position: right 0.5rem center;
     background-size: 0.8rem;
     padding-right: 1.8rem;
-    /* Hide text content, show only emoji by pushing text out of view */
-    text-indent: -9999px;
-    overflow: hidden;
+    /* Show emoji and text properly */
+    text-align: center;
+    font-size: 1.2rem;
+    line-height: 1;
 }
 
-.city-switcher-select::before {
-    content: attr(data-emoji);
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    text-indent: 0;
-    font-size: 1.8rem;
-    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.2));
-    transition: transform 0.3s ease;
+/* Style the selected option text to show emoji prominently */
+.city-switcher-select option {
+    background: var(--dropdown-bg);
+    color: var(--text-primary);
+    padding: 0.5rem;
+    font-size: 1rem;
 }
 
 .city-switcher-select:hover {
@@ -227,10 +224,6 @@ body.index-page header.visible {
     border-color: rgba(255, 255, 255, 0.6);
     transform: translateY(-2px);
     box-shadow: 0 8px 30px var(--shadow-heavy);
-}
-
-.city-switcher-select:hover::before {
-    transform: translate(-50%, -50%) scale(1.1);
 }
 
 .city-switcher-select:active {


### PR DESCRIPTION
Fix city switcher emoji and carrot display by updating CSS to correctly render content in the native select element.

The previous CSS attempted to use `::before` pseudo-elements and `text-indent: -9999px` to display emojis on a native `<select>` element, which is not supported and resulted in hidden content. This PR removes the unsupported styling and applies direct text styling to ensure both emoji and city names are visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a9c7fe6-97c6-44f2-8f2e-da2499fe2430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a9c7fe6-97c6-44f2-8f2e-da2499fe2430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

