### PR TITLE
Update code and read rules

### DIFF
--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Atlanta</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Berlin</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Chicago</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/denver/index.html
+++ b/denver/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Denver</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/london/index.html
+++ b/london/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">London</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/los-angeles/index.html
+++ b/los-angeles/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Los Angeles</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/new-orleans/index.html
+++ b/new-orleans/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">New Orleans</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/new-york/index.html
+++ b/new-york/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">New York</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Palm Springs</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/portland/index.html
+++ b/portland/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Portland</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Seattle</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/sf/index.html
+++ b/sf/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">San Francisco</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Sitges</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/tools/generate-city-pages.js
+++ b/tools/generate-city-pages.js
@@ -60,7 +60,7 @@ function generateCityHeader(html, cityKey, cityConfig) {
                         <span class="city-name">${cityConfig.name}</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">${cityOptions}
+                    <div class="city-dropdown">${cityOptions}
                     </div>
                 </div>
                 

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Toronto</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -160,7 +160,7 @@
                         <span class="city-name">Las Vegas</span>
                         <span class="city-carrot">▼</span>
                     </label>
-                    <div class="city-dropdown" style="opacity: 0; visibility: hidden;">
+                    <div class="city-dropdown">
                             <a href="../new-york/" class="city-option">
                                 <span class="city-option-emoji">🗽</span>
                                 <span class="city-option-name">New York</span>


### PR DESCRIPTION
Remove inline `opacity: 0; visibility: hidden;` from city switcher dropdowns to fix popup visibility.

The inline styles had higher specificity than the CSS rules designed to show/hide the dropdown, causing the popup to remain hidden even when toggled. Removing these inline styles allows the existing CSS to correctly manage the dropdown's visibility and animation. The generator script was also updated to prevent this issue in future city pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7bcb61e-5826-4158-8c12-3c50cc6011e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7bcb61e-5826-4158-8c12-3c50cc6011e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

