### PR TITLE
Update code and fix metadata parsing

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -444,7 +444,7 @@ class CalendarCore {
             .replace(/\\\\/g, '\\');   // Unescape backslashes (\\ -> \)
     }
     
-    // Check if a key is valid for metadata (single word, reasonable length)
+    // Check if a key is valid for metadata (words with spaces allowed, reasonable length)
     isValidMetadataKey(key) {
         if (!key || typeof key !== 'string') {
             return false;
@@ -452,10 +452,10 @@ class CalendarCore {
         
         const trimmedKey = key.trim();
         
-        // Must be a single word (no spaces) and reasonable length
-        return /^[a-zA-Z][a-zA-Z0-9]*$/.test(trimmedKey) && 
+        // Must be words (spaces allowed between words) and reasonable length
+        return /^[a-zA-Z][a-zA-Z0-9\s]*[a-zA-Z0-9]$/.test(trimmedKey) && 
                trimmedKey.length >= 2 && 
-               trimmedKey.length <= 20;
+               trimmedKey.length <= 30;
     }
 
     // Parse description for key-value pairs

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1020,7 +1020,7 @@ class SharedCore {
             .replace(/:/g, '\\:');     // Escape colons (: -> \:)
     }
     
-    // Check if a key is valid for metadata (single word, reasonable length)
+    // Check if a key is valid for metadata (words with spaces allowed, reasonable length)
     isValidMetadataKey(key) {
         if (!key || typeof key !== 'string') {
             return false;
@@ -1028,10 +1028,10 @@ class SharedCore {
         
         const trimmedKey = key.trim();
         
-        // Must be a single word (no spaces) and reasonable length
-        return /^[a-zA-Z][a-zA-Z0-9]*$/.test(trimmedKey) && 
+        // Must be words (spaces allowed between words) and reasonable length
+        return /^[a-zA-Z][a-zA-Z0-9\s]*[a-zA-Z0-9]$/.test(trimmedKey) && 
                trimmedKey.length >= 2 && 
-               trimmedKey.length <= 20;
+               trimmedKey.length <= 30;
     }
     
     // Parse notes back into field/value pairs


### PR DESCRIPTION
Allow multi-word metadata keys by updating the validation regex and length limit.

The previous regex `^[a-zA-Z][a-zA-Z0-9]*$` only permitted single-word keys, causing keys like "Google Maps" to be incorrectly flagged as invalid and ignored, even if a mapping existed. This PR updates the regex to allow spaces and increases the maximum key length to support these multi-word keys.

---
<a href="https://cursor.com/background-agent?bcId=bc-a2d0e255-462a-4b52-8764-9ee1f39dfa81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a2d0e255-462a-4b52-8764-9ee1f39dfa81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

