### PR TITLE
Update code and read rules

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -624,13 +624,13 @@ class DynamicCalendarLoader extends CalendarCore {
                 if (marker._icon) {
                     if (slug === eventSlug) {
                         // Highlight the selected marker
-                        marker._icon.style.transform = 'translate(-20px, -20px) scale(1.4)';
+                        marker._icon.style.transform = 'scale(1.4)';
                         marker._icon.style.zIndex = '1010';
                         marker._icon.style.filter = 'drop-shadow(0 6px 12px rgba(255, 165, 0, 0.8)) brightness(1.2)';
                         marker._icon.style.opacity = '1';
                     } else {
                         // Dim unselected markers
-                        marker._icon.style.transform = 'translate(-20px, -20px)';
+                        marker._icon.style.transform = 'scale(1)';
                         marker._icon.style.zIndex = '1000';
                         marker._icon.style.filter = 'brightness(0.7)';
                         marker._icon.style.opacity = '0.8';
@@ -650,7 +650,7 @@ class DynamicCalendarLoader extends CalendarCore {
         if (window.eventsMapMarkersBySlug) {
             Object.values(window.eventsMapMarkersBySlug).forEach(marker => {
                 if (marker._icon) {
-                    marker._icon.style.transform = 'translate(-20px, -20px)';
+                    marker._icon.style.transform = 'scale(1)';
                     marker._icon.style.zIndex = '1000';
                     marker._icon.style.filter = 'none';
                     marker._icon.style.opacity = '1';


### PR DESCRIPTION
Remove redundant `translate` transform from map markers to fix incorrect positioning when selected.

The `translate(-20px, -20px)` transform was conflicting with the `iconAnchor: [20, 20]` property, which already correctly centers the 40x40 map icons. Removing the redundant `translate` ensures markers remain in their intended geographic positions while still allowing for scaling effects.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5422522-6c92-4575-b533-2ffaf4ef315e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5422522-6c92-4575-b533-2ffaf4ef315e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

