### PR TITLE
Update code and fix map icon bug

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2510,6 +2510,14 @@ class DynamicCalendarLoader extends CalendarCore {
                         // Create custom marker icon with favicon or fallback
                         const markerIcon = this.createMarkerIcon(event);
                         
+                        logger.debug('MAP', 'Creating marker', {
+                            eventName: event.name,
+                            coordinates: event.coordinates,
+                            iconSize: markerIcon.options.iconSize,
+                            iconAnchor: markerIcon.options.iconAnchor,
+                            popupAnchor: markerIcon.options.popupAnchor
+                        });
+                        
                         const marker = L.marker([event.coordinates.lat, event.coordinates.lng], {
                             icon: markerIcon,
                             eventSlug: event.slug

--- a/styles.css
+++ b/styles.css
@@ -2706,6 +2706,34 @@ body.index-page main {
 .favicon-marker {
     background: none;
     border: none;
+    position: relative;
+}
+
+/* Ensure Leaflet divIcon positioning works correctly */
+.leaflet-div-icon {
+    background: none !important;
+    border: none !important;
+    position: absolute !important;
+    /* Ensure proper positioning */
+    margin: 0 !important;
+    padding: 0 !important;
+    /* Reset any potential CSS interference */
+    top: auto !important;
+    left: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+}
+
+.leaflet-marker-icon {
+    position: absolute !important;
+    /* Ensure proper positioning */
+    margin: 0 !important;
+    padding: 0 !important;
+    /* Reset any potential CSS interference */
+    top: auto !important;
+    left: auto !important;
+    right: auto !important;
+    bottom: auto !important;
 }
 
 .favicon-marker-container {
@@ -2721,6 +2749,14 @@ body.index-page main {
     box-shadow: 0 2px 8px rgba(0,0,0,0.2);
     transition: all 0.2s ease;
     overflow: hidden;
+    /* Ensure proper positioning within Leaflet */
+    margin: 0;
+    padding: 0;
+    /* Prevent positioning conflicts with Leaflet */
+    top: auto !important;
+    left: auto !important;
+    right: auto !important;
+    bottom: auto !important;
 }
 
 .favicon-marker-container:hover {


### PR DESCRIPTION
Fix map icon positioning by resolving CSS conflicts with Leaflet's marker system.

The map icons were incorrectly moving to the top-left corner when selected because custom CSS rules were interfering with Leaflet's expected absolute positioning for markers. The changes explicitly reset conflicting positioning properties on `.favicon-marker`, `.leaflet-div-icon`, `.leaflet-marker-icon`, and `.favicon-marker-container` to allow Leaflet to manage marker placement correctly. Debug logs were also added to aid future troubleshooting.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c279353-44fa-4c34-97cd-21525e2cdbd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7c279353-44fa-4c34-97cd-21525e2cdbd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

