### PR TITLE
Update code and read rules

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -624,12 +624,14 @@ class DynamicCalendarLoader extends CalendarCore {
                 if (marker._icon) {
                     if (slug === eventSlug) {
                         // Highlight the selected marker
+                        marker._icon.style.transformOrigin = 'center center';
                         marker._icon.style.transform = 'scale(1.4)';
                         marker._icon.style.zIndex = '1010';
                         marker._icon.style.filter = 'drop-shadow(0 6px 12px rgba(255, 165, 0, 0.8)) brightness(1.2)';
                         marker._icon.style.opacity = '1';
                     } else {
                         // Dim unselected markers
+                        marker._icon.style.transformOrigin = 'center center';
                         marker._icon.style.transform = 'scale(1)';
                         marker._icon.style.zIndex = '1000';
                         marker._icon.style.filter = 'brightness(0.7)';
@@ -650,6 +652,7 @@ class DynamicCalendarLoader extends CalendarCore {
         if (window.eventsMapMarkersBySlug) {
             Object.values(window.eventsMapMarkersBySlug).forEach(marker => {
                 if (marker._icon) {
+                    marker._icon.style.transformOrigin = 'center center';
                     marker._icon.style.transform = 'scale(1)';
                     marker._icon.style.zIndex = '1000';
                     marker._icon.style.filter = 'none';

--- a/styles.css
+++ b/styles.css
@@ -2706,6 +2706,7 @@ body.index-page main {
 .favicon-marker {
     background: none;
     border: none;
+    transform-origin: center center;
 }
 
 .favicon-marker-container {


### PR DESCRIPTION
Add `transform-origin: center center` to map marker styling to prevent icons from jumping to the top-left when scaled.

---
<a href="https://cursor.com/background-agent?bcId=bc-5aabebf5-0d5b-4512-a7e9-e3287bdd5160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5aabebf5-0d5b-4512-a7e9-e3287bdd5160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

