### PR TITLE
Update map icon z-index and opacity

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -623,19 +623,19 @@ class DynamicCalendarLoader extends CalendarCore {
             Object.entries(window.eventsMapMarkersBySlug).forEach(([slug, marker]) => {
                 if (marker._icon) {
                     if (slug === eventSlug) {
-                        // Highlight the selected marker
-                        marker._icon.style.transformOrigin = 'center center';
-                        marker._icon.style.transform = 'scale(1.4)';
+                        // Highlight the selected marker - bring to front without scaling
                         marker._icon.style.zIndex = '1010';
                         marker._icon.style.filter = 'drop-shadow(0 6px 12px rgba(255, 165, 0, 0.8)) brightness(1.2)';
                         marker._icon.style.opacity = '1';
+                        // Remove any transform to prevent positioning issues
+                        marker._icon.style.transform = 'none';
                     } else {
                         // Dim unselected markers
-                        marker._icon.style.transformOrigin = 'center center';
-                        marker._icon.style.transform = 'scale(1)';
                         marker._icon.style.zIndex = '1000';
                         marker._icon.style.filter = 'brightness(0.7)';
                         marker._icon.style.opacity = '0.8';
+                        // Remove any transform to prevent positioning issues
+                        marker._icon.style.transform = 'none';
                     }
                 }
             });
@@ -652,11 +652,11 @@ class DynamicCalendarLoader extends CalendarCore {
         if (window.eventsMapMarkersBySlug) {
             Object.values(window.eventsMapMarkersBySlug).forEach(marker => {
                 if (marker._icon) {
-                    marker._icon.style.transformOrigin = 'center center';
-                    marker._icon.style.transform = 'scale(1)';
                     marker._icon.style.zIndex = '1000';
                     marker._icon.style.filter = 'none';
                     marker._icon.style.opacity = '1';
+                    // Remove any transform to prevent positioning issues
+                    marker._icon.style.transform = 'none';
                 }
             });
             logger.debug('MAP', 'All markers reset to normal appearance');


### PR DESCRIPTION
Remove `transform: scale` from map markers and add `transform: none` to prevent icons from moving from their original map location when selected.

The previous `transform: scale` was causing map icons to shift position when highlighted. This change ensures icons remain static on the map while still allowing z-index and opacity adjustments for visual feedback, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b031500-f33c-4a0a-b074-fb96c1089336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b031500-f33c-4a0a-b074-fb96c1089336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

