### PR TITLE
Investigate icon placement bug and sync

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -623,19 +623,24 @@ class DynamicCalendarLoader extends CalendarCore {
             Object.entries(window.eventsMapMarkersBySlug).forEach(([slug, marker]) => {
                 if (marker._icon) {
                     if (slug === eventSlug) {
-                        // Highlight the selected marker - bring to front without scaling
+                        // Highlight the selected marker - use border and box-shadow instead of filters
                         marker._icon.style.zIndex = '1010';
-                        marker._icon.style.filter = 'drop-shadow(0 6px 12px rgba(255, 165, 0, 0.8)) brightness(1.2)';
+                        marker._icon.style.filter = 'none'; // Remove problematic filters
                         marker._icon.style.opacity = '1';
-                        // Remove any transform to prevent positioning issues
                         marker._icon.style.transform = 'none';
+                        // Add border highlight instead of filter effects to avoid positioning issues
+                        marker._icon.style.border = '3px solid #FFA500';
+                        marker._icon.style.borderRadius = '50%';
+                        marker._icon.style.boxShadow = '0 0 15px rgba(255, 165, 0, 0.8)';
                     } else {
                         // Dim unselected markers
                         marker._icon.style.zIndex = '1000';
-                        marker._icon.style.filter = 'brightness(0.7)';
-                        marker._icon.style.opacity = '0.8';
-                        // Remove any transform to prevent positioning issues
+                        marker._icon.style.filter = 'none'; // Remove problematic filters
+                        marker._icon.style.opacity = '0.6'; // Use opacity instead of brightness filter
                         marker._icon.style.transform = 'none';
+                        // Remove any highlight styling
+                        marker._icon.style.border = 'none';
+                        marker._icon.style.boxShadow = 'none';
                     }
                 }
             });
@@ -655,8 +660,10 @@ class DynamicCalendarLoader extends CalendarCore {
                     marker._icon.style.zIndex = '1000';
                     marker._icon.style.filter = 'none';
                     marker._icon.style.opacity = '1';
-                    // Remove any transform to prevent positioning issues
                     marker._icon.style.transform = 'none';
+                    // Reset highlight styling
+                    marker._icon.style.border = 'none';
+                    marker._icon.style.boxShadow = 'none';
                 }
             });
             logger.debug('MAP', 'All markers reset to normal appearance');


### PR DESCRIPTION
Replace CSS filters with border/box-shadow for map marker highlighting to fix icon positioning issues during selection.

The previous implementation used CSS filters (`drop-shadow`, `brightness`) for highlighting selected map markers. These filters interfered with Leaflet's absolute positioning, causing markers to incorrectly jump to the top-left corner (0,0) when applied. This change uses standard CSS properties (`border`, `box-shadow`, `opacity`) which are compatible with Leaflet's rendering and resolve the positioning bug.

---
<a href="https://cursor.com/background-agent?bcId=bc-53fdf077-e0b5-4370-b37e-ac4ccea67261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53fdf077-e0b5-4370-b37e-ac4ccea67261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

