### PR TITLE
Debug map marker behavior on city pages

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -627,7 +627,8 @@ class DynamicCalendarLoader extends CalendarCore {
                         marker._icon.style.zIndex = '1010';
                         marker._icon.style.filter = 'none'; // Remove problematic filters
                         marker._icon.style.opacity = '1';
-                        marker._icon.style.transform = 'none';
+                        // CRITICAL FIX: Don't override transform - let Leaflet manage positioning
+                        marker._icon.style.removeProperty('transform');
                         // Add border highlight instead of filter effects to avoid positioning issues
                         marker._icon.style.border = '3px solid #FFA500';
                         marker._icon.style.borderRadius = '50%';
@@ -637,7 +638,8 @@ class DynamicCalendarLoader extends CalendarCore {
                         marker._icon.style.zIndex = '1000';
                         marker._icon.style.filter = 'none'; // Remove problematic filters
                         marker._icon.style.opacity = '0.6'; // Use opacity instead of brightness filter
-                        marker._icon.style.transform = 'none';
+                        // CRITICAL FIX: Don't override transform - let Leaflet manage positioning
+                        marker._icon.style.removeProperty('transform');
                         // Remove any highlight styling
                         marker._icon.style.border = 'none';
                         marker._icon.style.boxShadow = 'none';
@@ -660,7 +662,8 @@ class DynamicCalendarLoader extends CalendarCore {
                     marker._icon.style.zIndex = '1000';
                     marker._icon.style.filter = 'none';
                     marker._icon.style.opacity = '1';
-                    marker._icon.style.transform = 'none';
+                    // CRITICAL FIX: Don't override transform - let Leaflet manage positioning
+                    marker._icon.style.removeProperty('transform');
                     // Reset highlight styling
                     marker._icon.style.border = 'none';
                     marker._icon.style.boxShadow = 'none';


### PR DESCRIPTION
Fix map markers snapping to top-left by removing `transform: none` override.

Leaflet uses CSS `transform` for marker positioning. Setting `marker._icon.style.transform = 'none'` was overriding Leaflet's positioning, causing markers to incorrectly snap to the (0,0) coordinate. Removing this explicit `transform` style allows Leaflet to correctly manage marker positions.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6322762-a83a-4bdf-896c-8b51dd705fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6322762-a83a-4bdf-896c-8b51dd705fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

