### PR TITLE
Fix map icon rendering bug after branch merge

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -627,8 +627,7 @@ class DynamicCalendarLoader extends CalendarCore {
                         marker._icon.style.zIndex = '1010';
                         marker._icon.style.filter = 'none'; // Remove problematic filters
                         marker._icon.style.opacity = '1';
-                        // CRITICAL FIX: Don't override transform - let Leaflet manage positioning
-                        marker._icon.style.removeProperty('transform');
+                        // NEVER remove transform - Leaflet needs it for positioning
                         // Add border highlight instead of filter effects to avoid positioning issues
                         marker._icon.style.border = '3px solid #FFA500';
                         marker._icon.style.borderRadius = '50%';
@@ -638,8 +637,7 @@ class DynamicCalendarLoader extends CalendarCore {
                         marker._icon.style.zIndex = '1000';
                         marker._icon.style.filter = 'none'; // Remove problematic filters
                         marker._icon.style.opacity = '0.6'; // Use opacity instead of brightness filter
-                        // CRITICAL FIX: Don't override transform - let Leaflet manage positioning
-                        marker._icon.style.removeProperty('transform');
+                        // NEVER remove transform - Leaflet needs it for positioning
                         // Remove any highlight styling
                         marker._icon.style.border = 'none';
                         marker._icon.style.boxShadow = 'none';
@@ -662,8 +660,7 @@ class DynamicCalendarLoader extends CalendarCore {
                     marker._icon.style.zIndex = '1000';
                     marker._icon.style.filter = 'none';
                     marker._icon.style.opacity = '1';
-                    // CRITICAL FIX: Don't override transform - let Leaflet manage positioning
-                    marker._icon.style.removeProperty('transform');
+                    // NEVER remove transform - Leaflet needs it for positioning
                     // Reset highlight styling
                     marker._icon.style.border = 'none';
                     marker._icon.style.boxShadow = 'none';


### PR DESCRIPTION
Prevent map markers from losing position by no longer removing Leaflet's critical `transform` CSS property.

The previous "fix" incorrectly removed the `transform` property, which Leaflet uses for marker positioning. This caused markers to break when selected/deselecting. Zooming to user location temporarily fixed it by forcing Leaflet to reapply transforms. This PR ensures Leaflet's positioning is never overridden.

---
<a href="https://cursor.com/background-agent?bcId=bc-e565bb3f-f8e3-4474-93b3-ce25ffeb059b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e565bb3f-f8e3-4474-93b3-ce25ffeb059b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

