### PR TITLE
Fix icon location button circle bug

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -3680,8 +3680,14 @@ async function showMyLocation() {
                 fillColor: '#4285f4',
                 fillOpacity: 0.2,
                 radius: 500,
-                weight: 3
+                weight: 3,
+                pane: 'overlayPane'
             }).addTo(window.eventsMap).bindPopup(popupText);
+            
+            // Ensure location circle stays below selected markers
+            if (window.myLocationCircle._path) {
+                window.myLocationCircle._path.style.zIndex = '1000';
+            }
             
             // Calculate bounds that include both user location and all event markers
             const bounds = L.latLngBounds([[location.lat, location.lng]]);

--- a/styles.css
+++ b/styles.css
@@ -2835,6 +2835,12 @@ body.index-page main {
     z-index: 1010 !important;
 }
 
+/* Ensure location button doesn't get marker-selected styling */
+#location-btn.marker-selected,
+.map-control-btn.marker-selected {
+    border-radius: 8px !important;
+}
+
 .leaflet-marker-icon.marker-dimmed {
     opacity: 0.6 !important;
     z-index: 1000 !important;

--- a/styles.css
+++ b/styles.css
@@ -2894,6 +2894,9 @@ body.index-page main {
 }
 
 /* My Location Circle */
+.leaflet-interactive[stroke="#4285f4"] {
+    z-index: 1000 !important;
+}
 
 
 


### PR DESCRIPTION
Prevent the location button from displaying a circular background when a map icon is selected.

The existing CSS rule `.leaflet-marker-icon.marker-selected` applied a `border-radius: 50% !important;` to selected markers. This rule was inadvertently affecting the location button, causing it to display a circle behind it. The new rule specifically targets `#location-btn` and `.map-control-btn` with `border-radius: 8px !important;` to ensure they retain their intended rectangular shape.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bcc4135-d779-408f-bf00-7875a88d1def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0bcc4135-d779-408f-bf00-7875a88d1def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

