### PR TITLE
Investigate map icon circle css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2831,7 +2831,6 @@ body.index-page main {
 /* Map Marker Selection States */
 .leaflet-marker-icon.marker-selected {
     border: 2px solid var(--primary-color) !important;
-    border-radius: 50% !important;
     z-index: 1010 !important;
 }
 


### PR DESCRIPTION
Remove unwanted circular border from selected map icons.

The `border-radius: 50%` was causing a circular border around selected map markers, which was not the intended design and looked bad. This change removes the circular border while preserving other selection styling like the colored border and higher z-index.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6ea657b-51e3-4ff8-b7f9-ad0af3491fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6ea657b-51e3-4ff8-b7f9-ad0af3491fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

