### PR TITLE
Update code and fix map icon square

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2829,8 +2829,12 @@ body.index-page main {
 
 
 /* Map Marker Selection States */
-.leaflet-marker-icon.marker-selected {
+.leaflet-marker-icon.marker-selected .favicon-marker-container {
     border: 2px solid var(--primary-color) !important;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3) !important;
+}
+
+.leaflet-marker-icon.marker-selected {
     z-index: 1010 !important;
 }
 


### PR DESCRIPTION
Fixes an unwanted square border around selected map icons by targeting the correct CSS element and adds a subtle box-shadow.

Previously, the `.leaflet-marker-icon.marker-selected` rule applied a border to the parent Leaflet marker element, causing an additional square outline around the already-styled `.favicon-marker-container`. This change moves the border to the `.favicon-marker-container` itself, ensuring the border is applied only to the intended icon area.

---
<a href="https://cursor.com/background-agent?bcId=bc-08d7059c-962f-41a7-b744-7b70f702b01f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-08d7059c-962f-41a7-b744-7b70f702b01f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

