### PR TITLE
Update code and check map icon state

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -618,13 +618,19 @@ class DynamicCalendarLoader extends CalendarCore {
 
     // Helper method to highlight a specific map marker
     highlightMapMarker(eventSlug) {
-        if (!window.eventsMap || !window.eventsMapMarkersBySlug || !window.eventsMapMarkersBySlug[eventSlug]) {
+        if (!window.eventsMap || !window.eventsMapMarkersBySlug) {
             logger.debug('MAP', 'Cannot highlight map marker - map or markers not ready', {
                 eventSlug,
                 mapExists: !!window.eventsMap,
-                markersBySlugExists: !!window.eventsMapMarkersBySlug,
-                markerExists: !!(window.eventsMapMarkersBySlug && window.eventsMapMarkersBySlug[eventSlug])
+                markersBySlugExists: !!window.eventsMapMarkersBySlug
             });
+            return;
+        }
+        
+        // If the selected event doesn't have a map marker, reset all markers to normal
+        if (!window.eventsMapMarkersBySlug[eventSlug]) {
+            logger.debug('MAP', 'Selected event has no map marker, resetting all markers to normal', { eventSlug });
+            this.resetAllMapMarkers();
             return;
         }
         
@@ -653,13 +659,15 @@ class DynamicCalendarLoader extends CalendarCore {
     // Helper method to reset all map markers to normal appearance
     resetAllMapMarkers() {
         if (window.eventsMapMarkersBySlug) {
+            const markerCount = Object.keys(window.eventsMapMarkersBySlug).length;
             Object.values(window.eventsMapMarkersBySlug).forEach(marker => {
                 if (marker._icon) {
                     // Remove all marker state classes
                     marker._icon.classList.remove('marker-selected', 'marker-dimmed');
                 }
             });
-            logger.debug('MAP', 'All markers reset to normal appearance');
+            logger.debug('MAP', 'All markers reset to normal appearance', { markerCount });
+            logger.userInteraction('MAP', 'All map markers reset to normal appearance', { markerCount });
         }
     }
 


### PR DESCRIPTION
Reset map markers when a non-map event is selected to ensure map icons always appear unselected.

Previously, the `highlightMapMarker` method would return early if the selected event did not have a corresponding map marker. This meant that if a user selected an event not on the map, any previously highlighted or dimmed map markers would remain in that state, incorrectly suggesting a map item was still selected. This change ensures `resetAllMapMarkers()` is called in such cases, clearing the visual state.

---
<a href="https://cursor.com/background-agent?bcId=bc-d749737d-1e79-4898-9b0a-fe7cf58b9e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d749737d-1e79-4898-9b0a-fe7cf58b9e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

