### PR TITLE
Fix map event selection and deselection

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -624,6 +624,9 @@ class DynamicCalendarLoader extends CalendarCore {
                 mapExists: !!window.eventsMap,
                 markersBySlugExists: !!window.eventsMapMarkersBySlug
             });
+            // Even if map isn't ready, reset any existing markers to ensure clean state
+            logger.debug('MAP', 'Map not ready, resetting any existing markers to ensure clean state', { eventSlug });
+            this.resetAllMapMarkers();
             return;
         }
         

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -630,10 +630,10 @@ class DynamicCalendarLoader extends CalendarCore {
             return;
         }
         
-        // If the selected event doesn't have a map marker, reset all markers to normal
+        // If the selected event doesn't have a map marker, dim all markers (selection is still active)
         if (!window.eventsMapMarkersBySlug[eventSlug]) {
-            logger.debug('MAP', 'Selected event has no map marker, resetting all markers to normal', { eventSlug });
-            this.resetAllMapMarkers();
+            logger.debug('MAP', 'Selected event has no map marker, dimming all markers', { eventSlug });
+            this.dimAllMapMarkers();
             return;
         }
         
@@ -671,6 +671,22 @@ class DynamicCalendarLoader extends CalendarCore {
             });
             logger.debug('MAP', 'All markers reset to normal appearance', { markerCount });
             logger.userInteraction('MAP', 'All map markers reset to normal appearance', { markerCount });
+        }
+    }
+
+    // Helper method to dim all map markers (when selection exists but no marker is selected)
+    dimAllMapMarkers() {
+        if (window.eventsMapMarkersBySlug) {
+            const markerCount = Object.keys(window.eventsMapMarkersBySlug).length;
+            Object.values(window.eventsMapMarkersBySlug).forEach(marker => {
+                if (marker._icon) {
+                    // Remove selection classes and add dimmed class
+                    marker._icon.classList.remove('marker-selected');
+                    marker._icon.classList.add('marker-dimmed');
+                }
+            });
+            logger.debug('MAP', 'All markers dimmed (selection active but no marker selected)', { markerCount });
+            logger.userInteraction('MAP', 'All map markers dimmed (selection active but no marker selected)', { markerCount });
         }
     }
 

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -624,9 +624,6 @@ class DynamicCalendarLoader extends CalendarCore {
                 mapExists: !!window.eventsMap,
                 markersBySlugExists: !!window.eventsMapMarkersBySlug
             });
-            // Even if map isn't ready, reset any existing markers to ensure clean state
-            logger.debug('MAP', 'Map not ready, resetting any existing markers to ensure clean state', { eventSlug });
-            this.resetAllMapMarkers();
             return;
         }
         

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -633,7 +633,14 @@ class DynamicCalendarLoader extends CalendarCore {
         // If the selected event doesn't have a map marker, dim all markers (selection is still active)
         if (!window.eventsMapMarkersBySlug[eventSlug]) {
             logger.debug('MAP', 'Selected event has no map marker, dimming all markers', { eventSlug });
-            this.dimAllMapMarkers();
+            // Dim all markers since selection is active but no marker is selected
+            Object.values(window.eventsMapMarkersBySlug).forEach(marker => {
+                if (marker._icon) {
+                    marker._icon.classList.remove('marker-selected');
+                    marker._icon.classList.add('marker-dimmed');
+                }
+            });
+            logger.userInteraction('MAP', 'All markers dimmed (selection active but no marker selected)', { eventSlug });
             return;
         }
         
@@ -674,21 +681,6 @@ class DynamicCalendarLoader extends CalendarCore {
         }
     }
 
-    // Helper method to dim all map markers (when selection exists but no marker is selected)
-    dimAllMapMarkers() {
-        if (window.eventsMapMarkersBySlug) {
-            const markerCount = Object.keys(window.eventsMapMarkersBySlug).length;
-            Object.values(window.eventsMapMarkersBySlug).forEach(marker => {
-                if (marker._icon) {
-                    // Remove selection classes and add dimmed class
-                    marker._icon.classList.remove('marker-selected');
-                    marker._icon.classList.add('marker-dimmed');
-                }
-            });
-            logger.debug('MAP', 'All markers dimmed (selection active but no marker selected)', { markerCount });
-            logger.userInteraction('MAP', 'All map markers dimmed (selection active but no marker selected)', { markerCount });
-        }
-    }
 
     // Helper: detect slug from first path segment, similar to app-level logic
     getCitySlugFromPath() {

--- a/styles.css
+++ b/styles.css
@@ -2843,6 +2843,12 @@ body.index-page main {
     z-index: 1000 !important;
 }
 
+.leaflet-marker-icon.marker-deselected .favicon-marker-container {
+    border: 2px solid #ccc !important;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15) !important;
+    opacity: 0.8 !important;
+}
+
 
 #location-btn.location-loading {
     animation: pulse 1.5s ease-in-out infinite;

--- a/styles.css
+++ b/styles.css
@@ -2843,12 +2843,6 @@ body.index-page main {
     z-index: 1000 !important;
 }
 
-.leaflet-marker-icon.marker-deselected .favicon-marker-container {
-    border: 2px solid #ccc !important;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.15) !important;
-    opacity: 0.8 !important;
-}
-
 
 #location-btn.location-loading {
     animation: pulse 1.5s ease-in-out infinite;


### PR DESCRIPTION
Dim all map markers when a selected event has no corresponding map marker.

Previously, if an event was selected but did not exist on the map, markers would revert to their normal state. This change ensures that all markers appear dimmed in this scenario, correctly indicating that a selection is still active.

---
<a href="https://cursor.com/background-agent?bcId=bc-70cb762d-08b9-454d-982f-eca47f101e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-70cb762d-08b9-454d-982f-eca47f101e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

