### PR TITLE
Fix calendar deselection bug in week/month view

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -498,7 +498,9 @@ class DynamicCalendarLoader extends CalendarCore {
     toggleEventSelection(eventSlug, eventDateISO) {
         if (!eventSlug) return;
         const normalizedDateISO = eventDateISO && /^\d{4}-\d{2}-\d{2}$/.test(eventDateISO) ? eventDateISO : this.formatDateToISO(this.currentDate);
+        
         if (this.selectedEventSlug === eventSlug && this.selectedEventDateISO === normalizedDateISO) {
+            logger.userInteraction('EVENT', 'Deselecting event (same slug and date)', { eventSlug, date: normalizedDateISO });
             this.clearEventSelection();
         } else {
             this.selectedEventSlug = eventSlug;
@@ -3044,9 +3046,14 @@ class DynamicCalendarLoader extends CalendarCore {
                             const eventSlug = item.dataset.eventSlug;
                             // Determine the date for this event from the closest day element
                             const dayEl = item.closest('[data-date]');
-                            const dayISO = dayEl ? dayEl.getAttribute('data-date') : this.formatDateToISO(this.currentDate);
+                            const dayFromElement = dayEl ? dayEl.getAttribute('data-date') : this.formatDateToISO(this.currentDate);
+                            // Prefer the date from selectedEventDateISO if it matches slug, else use date from day element
+                            const dayISO = this.selectedEventSlug === eventSlug && this.selectedEventDateISO ? this.selectedEventDateISO : dayFromElement;
                             logger.userInteraction('EVENT', `Calendar event clicked: ${eventSlug}`, {
                                 eventSlug,
+                                dayFromElement,
+                                dayISO,
+                                selectedEventDateISO: this.selectedEventDateISO,
                                 city: this.currentCity
                             });
                             


### PR DESCRIPTION
Fix deselection bug in week/month calendar view by ensuring consistent date comparison across event click handlers.

Previously, the date used for deselection in the week/month view was always derived from the clicked element, which could differ from the `selectedEventDateISO` stored when the event was initially selected (e.g., from a list view). This mismatch prevented `toggleEventSelection` from correctly identifying the event for deselection.

---
<a href="https://cursor.com/background-agent?bcId=bc-04c91c9c-265e-4cac-be4e-6cfc3cf1da7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04c91c9c-265e-4cac-be4e-6cfc3cf1da7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

