### PR TITLE
Fix calendar item selection bug

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -581,6 +581,14 @@ class DynamicCalendarLoader extends CalendarCore {
             
             // Reset all markers to normal appearance
             this.resetAllMapMarkers();
+            
+            // Explicitly ensure all calendar event items are unselected
+            // This is important to handle cases where the calendar is re-rendered
+            document.querySelectorAll('.event-item').forEach(item => {
+                item.classList.remove('selected');
+            });
+            
+            logger.debug('EVENT', 'Cleared all selections and ensured calendar events are unselected');
         }
     }
 


### PR DESCRIPTION
Explicitly remove the 'selected' class from calendar event items to fix a visual deselection bug.

The `updateSelectionVisualState` method was not consistently clearing the visual 'selected' state for calendar events when an event was deselected. This led to a discrepancy where the event was deselected in the data, URL, and other views, but the calendar event still appeared visually selected due to CSS. Adding an explicit loop to remove the 'selected' class from all `.event-item` elements ensures the visual state is always synchronized when no event is selected.

---
<a href="https://cursor.com/background-agent?bcId=bc-516ae98c-b12b-442b-91da-613d13798f5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-516ae98c-b12b-442b-91da-613d13798f5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

