### PR TITLE
Fix calendar item selection bug

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -491,6 +491,11 @@ class DynamicCalendarLoader extends CalendarCore {
             logger.userInteraction('EVENT', 'Event selection cleared');
             // Update visual selection state across all views
             this.updateSelectionVisualState();
+            
+            // Also ensure selection is cleared after a small delay to handle any DOM updates
+            setTimeout(() => {
+                this.updateSelectionVisualState();
+            }, 10);
         }
     }
     
@@ -529,7 +534,7 @@ class DynamicCalendarLoader extends CalendarCore {
             markersBySlugExists: !!window.eventsMapMarkersBySlug
         });
         
-        // Clear all previous selections
+        // Always clear all previous selections first - this is critical for deselection
         document.querySelectorAll('.event-card.selected, .event-item.selected').forEach(el => {
             el.classList.remove('selected');
         });
@@ -584,11 +589,20 @@ class DynamicCalendarLoader extends CalendarCore {
             
             // Explicitly ensure all calendar event items are unselected
             // This is important to handle cases where the calendar is re-rendered
+            // Use a more aggressive approach to ensure all selections are cleared
             document.querySelectorAll('.event-item').forEach(item => {
                 item.classList.remove('selected');
             });
             
-            logger.debug('EVENT', 'Cleared all selections and ensured calendar events are unselected');
+            // Also clear any event cards that might still be selected
+            document.querySelectorAll('.event-card').forEach(card => {
+                card.classList.remove('selected');
+            });
+            
+            logger.debug('EVENT', 'Cleared all selections and ensured calendar events are unselected', {
+                eventItemsCleared: document.querySelectorAll('.event-item').length,
+                eventCardsCleared: document.querySelectorAll('.event-card').length
+            });
         }
     }
 


### PR DESCRIPTION
Fixes week/month calendar event CSS selection state not clearing when deselected.

When an event was deselected by clicking it again, the `selected` CSS class sometimes persisted. This was caused by a race condition where `updateSelectionVisualState()` was called to clear the selection, but then the calendar re-rendered and called `updateSelectionVisualState()` again, potentially overriding the deselection before the DOM fully updated. The fix makes the clearing more robust and adds a delayed re-check to ensure the visual state is correctly updated.

---
<a href="https://cursor.com/background-agent?bcId=bc-33d36140-2b97-42ee-a118-505332746cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33d36140-2b97-42ee-a118-505332746cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

