### PR TITLE
Merge main and fix city page

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -3321,11 +3321,11 @@ class DynamicCalendarLoader extends CalendarCore {
         this.allEvents = [fakeEvent];
         
         // Debug: Check what the period bounds are and if fake event will be included
-        const fakeEventDate = new Date(fakeEvent.startDate);
-        const isInPeriod = fakeEventDate >= start && fakeEventDate <= end;
+        const fakeEventDateForCheck = new Date(fakeEvent.startDate);
+        const isInPeriod = fakeEventDateForCheck >= start && fakeEventDateForCheck <= end;
         
         logger.info('CALENDAR', '🔍 DEBUG: Fake event filtering check', {
-            fakeEventDate: fakeEventDate.toISOString(),
+            fakeEventDate: fakeEventDateForCheck.toISOString(),
             periodStart: start.toISOString(),
             periodEnd: end.toISOString(),
             isInPeriod,


### PR DESCRIPTION
Rename duplicate `fakeEventDate` variable to fix city page JavaScript error.

A recent merge (commit `7b46f03e9dc0678f2b8ba4f9e4d26471718a35ca`) introduced a duplicate `const fakeEventDate` declaration in `js/dynamic-calendar-loader.js`, leading to a JavaScript syntax error that prevented the city page from loading.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7eec59f-7ec6-423c-a066-b578cebe5b19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7eec59f-7ec6-423c-a066-b578cebe5b19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

