### PR TITLE
Update code and read rules

### DIFF
--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -185,14 +185,11 @@ class BearEventScraperOrchestrator {
             // Create shared core instance with cities configuration
             const sharedCore = new this.modules.SharedCore(config.cities);
             
-            // Create adapter with cities configuration
-            let finalAdapter = adapter;
-            if (config.cities) {
-                finalAdapter = new this.modules.adapter({
-                    cities: config.cities,
-                    ...this.config
-                });
-            }
+            // Create adapter with cities configuration - always create new instance with cities
+            const finalAdapter = new this.modules.adapter({
+                cities: config.cities,
+                ...this.config
+            });
 
             // Create parser instances
             const parsers = {};
@@ -288,7 +285,8 @@ class BearEventScraperOrchestrator {
             // Try to show user-friendly error
             if (this.modules?.adapter) {
                 try {
-                    const adapter = new this.modules.adapter();
+                    // Create adapter with minimal config for error display
+                    const adapter = new this.modules.adapter({ cities: {} });
                     const errorName = error.name || 'Unknown Error';
                     const errorMessage = error.message || 'An unexpected error occurred';
                     await adapter.showError('Bear Event Scraper Error', `${errorName}: ${errorMessage}\n\nCheck console for full details.`);


### PR DESCRIPTION
Ensure `ScriptableAdapter` is always initialized with city configurations to prevent timezone lookup errors.

Previously, the `ScriptableAdapter` was instantiated twice in `bear-event-scraper-unified.js`. The first instance, used for initial configuration loading, lacked city data, leading to 'No timezone configuration found' errors when attempting timezone lookups. This PR ensures all adapter instances, including those in error handling, receive the `cities` configuration, resolving the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-34e095c9-3add-4a8a-8d50-32cb9686759f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34e095c9-3add-4a8a-8d50-32cb9686759f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

