### PR TITLE
Scrape and process bear events

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -76,7 +76,7 @@ class SharedCore {
             }
         }
         
-        console.log(`🗺️ SharedCore: Created city mappings:`, cityMappings);
+        console.log(`🗺️ SharedCore: Created city mappings: ${JSON.stringify(cityMappings)}`);
         return cityMappings;
     }
 
@@ -1412,9 +1412,10 @@ class SharedCore {
         const hadUrlBefore = 'url' in event;
         const urlValueBefore = event.url;
         
-        // Extract city if not already present (parser may have set it for venue-specific logic)
-        if (!event.city) {
-            event.city = this.extractCityFromEvent(event);
+        // Extract and normalize city (parser may have set it for venue-specific logic, but we need to normalize it)
+        const extractedCity = this.extractCityFromEvent(event);
+        if (extractedCity) {
+            event.city = extractedCity;
         }
         
         // Apply timezone from city configuration if not already set
@@ -1431,7 +1432,7 @@ class SharedCore {
             console.log(`   URL: "${event.url}"`);
             console.log(`   Source: "${event.source}"`);
             console.log(`   City extracted from: ${event.city ? 'event.city field' : 'address parsing'}`);
-            console.log(`🚨 Available cities:`, Object.keys(this.cities || {}));
+            console.log(`🚨 Available cities: ${JSON.stringify(Object.keys(this.cities || {}))}`);
             console.log(`🚨 This error is coming from SharedCore`);
         }
         
@@ -1654,7 +1655,7 @@ class SharedCore {
         
         // Try to extract city name from address components
         const addressParts = address.split(',').map(part => part.trim());
-        console.log(`🗺️ SharedCore: Address parts for "${address}":`, addressParts);
+        console.log(`🗺️ SharedCore: Address parts for "${address}": ${JSON.stringify(addressParts)}`);
         
         // Check each address part for city matches
         for (const part of addressParts) {


### PR DESCRIPTION
Ensure event cities are always normalized, fixing timezone lookup errors for cities pre-set by parsers with unnormalized names.

The `enrichEventLocation` function previously skipped city normalization if `event.city` was already set by a parser (e.g., "boton"). This led to subsequent errors when trying to find timezone configurations for the unnormalized city. The fix modifies `enrichEventLocation` to always call `extractCityFromEvent` to ensure `event.city` is normalized to its canonical form (e.g., "boston"), resolving these lookup issues. Additionally, several `console.log` statements were updated for Scriptable compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe48c9e4-f5c3-49f4-9b69-d2043114c85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe48c9e4-f5c3-49f4-9b69-d2043114c85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

