### PR TITLE
Fix boton city name in event processing

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1645,15 +1645,9 @@ class SharedCore {
         for (const [patterns, city] of Object.entries(this.cityMappings)) {
             const patternList = patterns.split('|');
             for (const pattern of patternList) {
-                // First try exact match for single words
-                if (lowerAddress === pattern) {
-                    console.log(`🗺️ SharedCore: Found exact address match "${pattern}", returning: "${city}"`);
-                    return city;
-                }
-                // Then use word boundaries to avoid substring matches (e.g., "la" in "Atlanta")
+                // Use word boundaries to avoid substring matches (e.g., "la" in "Atlanta")
                 const regex = new RegExp(`\\b${pattern.replace(/\s+/g, '\\s+')}\\b`, 'i');
                 if (regex.test(lowerAddress)) {
-                    console.log(`🗺️ SharedCore: Found address pattern "${pattern}", returning: "${city}"`);
                     return city;
                 }
             }
@@ -1672,12 +1666,12 @@ class SharedCore {
             for (const [patterns, city] of Object.entries(this.cityMappings)) {
                 const patternList = patterns.split('|');
                 for (const pattern of patternList) {
-                    // First try exact match (most reliable for single words)
+                    // Try exact match first (simpler and more reliable)
                     if (cityName === pattern) {
                         console.log(`🗺️ SharedCore: Found exact city pattern match "${pattern}" in address part "${cityName}", returning: "${city}"`);
                         return city;
                     }
-                    // Then try word boundaries for multi-word patterns
+                    // Then use word boundaries to avoid substring matches
                     const regex = new RegExp(`\\b${pattern.replace(/\s+/g, '\\s+')}\\b`, 'i');
                     if (regex.test(cityName)) {
                         console.log(`🗺️ SharedCore: Found city pattern "${pattern}" in address part "${cityName}", returning: "${city}"`);

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1645,9 +1645,15 @@ class SharedCore {
         for (const [patterns, city] of Object.entries(this.cityMappings)) {
             const patternList = patterns.split('|');
             for (const pattern of patternList) {
-                // Use word boundaries to avoid substring matches (e.g., "la" in "Atlanta")
+                // First try exact match for single words
+                if (lowerAddress === pattern) {
+                    console.log(`🗺️ SharedCore: Found exact address match "${pattern}", returning: "${city}"`);
+                    return city;
+                }
+                // Then use word boundaries to avoid substring matches (e.g., "la" in "Atlanta")
                 const regex = new RegExp(`\\b${pattern.replace(/\s+/g, '\\s+')}\\b`, 'i');
                 if (regex.test(lowerAddress)) {
+                    console.log(`🗺️ SharedCore: Found address pattern "${pattern}", returning: "${city}"`);
                     return city;
                 }
             }
@@ -1666,7 +1672,12 @@ class SharedCore {
             for (const [patterns, city] of Object.entries(this.cityMappings)) {
                 const patternList = patterns.split('|');
                 for (const pattern of patternList) {
-                    // Use word boundaries to avoid substring matches
+                    // First try exact match (most reliable for single words)
+                    if (cityName === pattern) {
+                        console.log(`🗺️ SharedCore: Found exact city pattern match "${pattern}" in address part "${cityName}", returning: "${city}"`);
+                        return city;
+                    }
+                    // Then try word boundaries for multi-word patterns
                     const regex = new RegExp(`\\b${pattern.replace(/\s+/g, '\\s+')}\\b`, 'i');
                     if (regex.test(cityName)) {
                         console.log(`🗺️ SharedCore: Found city pattern "${pattern}" in address part "${cityName}", returning: "${city}"`);


### PR DESCRIPTION
Add exact string matching to city extraction logic to correctly identify city names from addresses.

The previous regex-only approach in `extractCityFromAddress` failed to correctly map single-word misspellings (e.g., "Boton" to "Boston") even when they were present in the city mappings. This led to "No timezone configuration found" errors and incorrect calendar creation. Adding an exact string match before the regex ensures these cases are handled properly.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e3ff842-909e-4283-8ae6-83f90b2ecf88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e3ff842-909e-4283-8ae6-83f90b2ecf88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

