### PR TITLE
Update code and process website names

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -735,24 +735,8 @@ class EventbriteParser {
                 console.log(`🎫 Eventbrite: No timezone found for "${title}"`);
             }
             
-            // Extract shortName from title - remove common prefixes and suffixes
-            let shortName = title;
-            if (title) {
-                // Remove common event prefixes
-                shortName = title.replace(/^(Bear Happy Hour|Coach After Dark|Megawoof|Bearracuda|Furball|Chunk|Furball)\s*[-:]\s*/i, '');
-                // Remove common suffixes
-                shortName = shortName.replace(/\s*[-:]\s*(NYC|LA|SF|Chicago|Miami|Denver|Vegas|Atlanta|Boston|Philadelphia|Austin|Dallas|Houston|Phoenix|Seattle|Portland|Orlando|Tampa|DC|Washington|New Orleans|Toronto|London|Berlin|Sitges|Palm Springs|Sacramento|San Diego|Long Beach|Santa Monica|West Hollywood|WeHo|DTLA|Downtown Los Angeles|Hollywood|Castro|San Jose|Oakland|Key West|Fort Lauderdale|Miami Beach|South Beach|Bostom|Bostun|Bostan|Boton|Philly|Chi|ATL|SF|NYC|LA|DC|MIA|DEN|VEG|CHI|BOS|PHL|AUS|DAL|HOU|PHX|SEA|PDX|ORL|TPA|NOLA|TOR|LON|BER|SIT|PS|SAC|SD|LB|SM|WH|DTLA|DTLA|HOLLY|CASTRO|SJ|OAK|KW|FTL|MB|SB|BOS|PHL|CHI|ATL|SF|NYC|LA|DC|MIA|DEN|VEG|CHI|BOS|PHL|AUS|DAL|HOU|PHX|SEA|PDX|ORL|TPA|NOLA|TOR|LON|BER|SIT|PS|SAC|SD|LB|SM|WH|DTLA|DTLA|HOLLY|CASTRO|SJ|OAK|KW|FTL|MB|SB)$/i, '');
-                // Clean up extra spaces
-                shortName = shortName.trim();
-                // If nothing left, use original title
-                if (!shortName) {
-                    shortName = title;
-                }
-            }
-
             const event = {
                 title: title,
-                shortName: shortName,
                 description: description,
                 startDate: startDate ? new Date(startDate) : null,
                 endDate: endDate ? new Date(endDate) : null,

--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -735,8 +735,24 @@ class EventbriteParser {
                 console.log(`🎫 Eventbrite: No timezone found for "${title}"`);
             }
             
+            // Extract shortName from title - remove common prefixes and suffixes
+            let shortName = title;
+            if (title) {
+                // Remove common event prefixes
+                shortName = title.replace(/^(Bear Happy Hour|Coach After Dark|Megawoof|Bearracuda|Furball|Chunk|Furball)\s*[-:]\s*/i, '');
+                // Remove common suffixes
+                shortName = shortName.replace(/\s*[-:]\s*(NYC|LA|SF|Chicago|Miami|Denver|Vegas|Atlanta|Boston|Philadelphia|Austin|Dallas|Houston|Phoenix|Seattle|Portland|Orlando|Tampa|DC|Washington|New Orleans|Toronto|London|Berlin|Sitges|Palm Springs|Sacramento|San Diego|Long Beach|Santa Monica|West Hollywood|WeHo|DTLA|Downtown Los Angeles|Hollywood|Castro|San Jose|Oakland|Key West|Fort Lauderdale|Miami Beach|South Beach|Bostom|Bostun|Bostan|Boton|Philly|Chi|ATL|SF|NYC|LA|DC|MIA|DEN|VEG|CHI|BOS|PHL|AUS|DAL|HOU|PHX|SEA|PDX|ORL|TPA|NOLA|TOR|LON|BER|SIT|PS|SAC|SD|LB|SM|WH|DTLA|DTLA|HOLLY|CASTRO|SJ|OAK|KW|FTL|MB|SB|BOS|PHL|CHI|ATL|SF|NYC|LA|DC|MIA|DEN|VEG|CHI|BOS|PHL|AUS|DAL|HOU|PHX|SEA|PDX|ORL|TPA|NOLA|TOR|LON|BER|SIT|PS|SAC|SD|LB|SM|WH|DTLA|DTLA|HOLLY|CASTRO|SJ|OAK|KW|FTL|MB|SB)$/i, '');
+                // Clean up extra spaces
+                shortName = shortName.trim();
+                // If nothing left, use original title
+                if (!shortName) {
+                    shortName = title;
+                }
+            }
+
             const event = {
                 title: title,
+                shortName: shortName,
                 description: description,
                 startDate: startDate ? new Date(startDate) : null,
                 endDate: endDate ? new Date(endDate) : null,

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -50,7 +50,7 @@ const scraperConfig = {
       dryRun: false,
       fieldPriorities: {
         title: { priority: ["eventbrite"], merge: "clobber" },
-        shortName: { priority: ["eventbrite"], merge: "upsert" },
+        shortName: { priority: ["static"], merge: "upsert" },
         instagram: { priority: ["static"], merge: "clobber" },
         description: { priority: ["eventbrite"], merge: "clobber" },
         bar: { priority: ["eventbrite"], merge: "clobber" },

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -50,7 +50,7 @@ const scraperConfig = {
       dryRun: false,
       fieldPriorities: {
         title: { priority: ["eventbrite"], merge: "clobber" },
-        shortName: { priority: ["static"], merge: "upsert" },
+        shortName: { priority: ["eventbrite"], merge: "upsert" },
         instagram: { priority: ["static"], merge: "clobber" },
         description: { priority: ["eventbrite"], merge: "clobber" },
         bar: { priority: ["eventbrite"], merge: "clobber" },
@@ -63,7 +63,6 @@ const scraperConfig = {
         cover: { priority: ["eventbrite"], merge: "clobber" }
       },
       metadata: {
-        shortName: { value: "Coach After Dark" },
         instagram: { value: "https://www.instagram.com/coachafterdark" }
       }
     },


### PR DESCRIPTION
Remove hardcoded "Coach After Dark" fallback and add intelligent `shortName` extraction from Eventbrite titles to prevent incorrect defaults.

The previous setup hardcoded "Coach After Dark" as a `shortName` fallback for a specific parser, leading to incorrect event names when parsing failed or a short name was needed. This PR updates the parsing logic to dynamically extract and clean event titles from Eventbrite, ensuring accurate `shortName` values.

---
<a href="https://cursor.com/background-agent?bcId=bc-9171af03-095f-4c15-bcc0-7c7a51886e04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9171af03-095f-4c15-bcc0-7c7a51886e04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

