### PR TITLE
Update theme color from main variable

### DIFF
--- a/bear-directory.html
+++ b/bear-directory.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Discover bear-owned businesses and artists from around the world">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
+    <meta name="theme-color" content="#ffffff">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Leaflet CSS for map -->

--- a/city.html
+++ b/city.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
+    <meta name="theme-color" content="#ffffff">
     
     <script>
       (function() {

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <meta name="twitter:title" content="chunky.dad - Your Gay Bear Travel Guide">
     <meta name="twitter:description" content="The ultimate travel guide for gay bears - city guides, events, and bear-owned businesses worldwide">
     <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
+    <meta name="theme-color" content="#ffffff">
     
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>


### PR DESCRIPTION
Add `theme-color` meta tag to main HTML pages to match the site's primary background color.

The user requested this to ensure the browser's UI matches the site's main background. The direct hex value `#ffffff` was used as meta tags do not support CSS variables. This change applies to `index.html`, `city.html`, and `bear-directory.html`, ensuring consistency across key pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6dda297-90e9-47d0-ad0b-900319c23bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6dda297-90e9-47d0-ad0b-900319c23bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

