### PR TITLE
Update header meta color to main purple

### DIFF
--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Atlanta - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/bear-directory.html
+++ b/bear-directory.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Discover bear-owned businesses and artists from around the world">
     <link rel="icon" type="image/png" href="Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Leaflet CSS for map -->

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Berlin - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Chicago - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/city.html
+++ b/city.html
@@ -7,7 +7,7 @@
     <meta name="description" content="Complete gay bear guide to your city - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/denver/index.html
+++ b/denver/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Denver - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta name="twitter:title" content="chunky.dad - Your Gay Bear Travel Guide">
     <meta name="twitter:description" content="The ultimate travel guide for gay bears - city guides, events, and bear-owned businesses worldwide">
     <meta name="twitter:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <!-- Google Analytics 4 - Image-based tracking -->
     <script>

--- a/london/index.html
+++ b/london/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to London - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/los-angeles/index.html
+++ b/los-angeles/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Los Angeles - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/new-orleans/index.html
+++ b/new-orleans/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to New Orleans - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/new-york/index.html
+++ b/new-york/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to New York - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Palm Springs - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/portland/index.html
+++ b/portland/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Portland - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Seattle - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/sf/index.html
+++ b/sf/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to San Francisco - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Sitges - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Toronto - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Complete gay bear guide to Las Vegas - events, bars, and the hottest bear scene">
     <link rel="icon" type="image/png" href="/Rising_Star_Ryan_Head_Compressed.png">
     <link rel="apple-touch-icon" href="/Rising_Star_Ryan_Head_Compressed.png">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#667eea">
     
     <script>
       (function() {


### PR DESCRIPTION
Update `theme-color` meta tags to use the primary purple brand color (`#667eea`) for consistent browser UI theming.

---
<a href="https://cursor.com/background-agent?bcId=bc-e38dedb1-af61-40d1-82da-ac528721f6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e38dedb1-af61-40d1-82da-ac528721f6bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

