### PR TITLE
Update event url parsing logic

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -745,7 +745,7 @@ class EventbriteParser {
                 address: finalAddress,
                 city: city,
                 timezone: eventTimezone,
-                url: url, // Use consistent 'url' field name across all parsers
+                url: null, // Don't put Eventbrite URL in url field - only use ticketUrl
                 ticketUrl: url, // For Eventbrite events, the event URL IS the ticket URL
                 cover: price, // Use 'cover' field name that calendar-core.js expects
                 ...(image && { image: image }), // Only include image if we found one

--- a/scripts/parsers/linktree-parser.js
+++ b/scripts/parsers/linktree-parser.js
@@ -169,8 +169,8 @@ class LinktreeParser {
                 address: null, // Will be filled by other parsers
                 city: null, // Will be filled by other parsers
                 timezone: null, // Will be filled by other parsers
-                url: url, // The ticket/event URL
-                ticketUrl: url, // Same as URL for most cases
+                url: sourceUrl, // The linktree URL goes in url field
+                ticketUrl: url, // The ticket/event URL goes in ticketUrl field
                 cover: '', // Will be filled by other parsers
                 image: '', // Will be filled by other parsers
                 source: this.config.source,

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -207,7 +207,7 @@ const scraperConfig = {
         address: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         startDate: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         endDate: { priority: ["eventbrite", "linktree"], merge: "clobber" },
-        url: { priority: ["eventbrite", "linktree"], merge: "clobber" },
+        url: { priority: ["linktree", "eventbrite"], merge: "clobber" }, // Prefer linktree URL over eventbrite
         gmaps: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         image: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         cover: { priority: ["eventbrite", "linktree"], merge: "clobber" },


### PR DESCRIPTION
Update Eventbrite and Linktree parsers and Cubhouse configuration to control which URLs populate the `url` and `ticketUrl` fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ebd56e9-e147-4a9a-92a7-150d6341efa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2ebd56e9-e147-4a9a-92a7-150d6341efa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

