### PR TITLE
Update mega wood parser website link

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -30,7 +30,7 @@ const scraperConfig = {
         address: { priority: ["eventbrite"], merge: "clobber" },
         startDate: { priority: ["eventbrite"], merge: "clobber" },
         endDate: { priority: ["eventbrite"], merge: "clobber" },
-        url: { priority: ["eventbrite"], merge: "clobber" },
+        url: { priority: ["static"], merge: "clobber" },
         gmaps: { priority: ["eventbrite"], merge: "clobber" },
         image: { priority: ["eventbrite"], merge: "clobber" },
         cover: { priority: ["eventbrite"], merge: "clobber" }

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -38,7 +38,8 @@ const scraperConfig = {
       metadata: {
         title: { value: "MEGAWOOF" },
         shortName: { value: "MEGA-WOOF" },
-        instagram: { value: "https://www.instagram.com/megawoof_america" }
+        instagram: { value: "https://www.instagram.com/megawoof_america" },
+        url: { value: "https://linktr.ee/megawoof_america" }
       }
     },
     {


### PR DESCRIPTION
Add Linktree URL to Megawoof America parser metadata to use it as the default website for all events.

---
<a href="https://cursor.com/background-agent?bcId=bc-12a137bb-1f97-46b8-9ec8-0d894b38bf27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12a137bb-1f97-46b8-9ec8-0d894b38bf27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

