### PR TITLE
Update code and check url rules

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -466,7 +466,7 @@ class CalendarCore {
             'bar': 'bar', 'location': 'bar', 'host': 'bar',
             'cover': 'cover', 'cost': 'cover', 'price': 'cover',
             'tea': 'tea', 'info': 'tea', 'description': 'tea',
-            'website': 'website', 'instagram': 'instagram', 'facebook': 'facebook',
+            'website': 'website', 'url': 'website', 'instagram': 'instagram', 'facebook': 'facebook',
             'ticketurl': 'ticketUrl', 'ticket url': 'ticketUrl', 'tickets': 'ticketUrl', 'ticket': 'ticketUrl',
             'type': 'type', 'eventtype': 'type', 'recurring': 'recurring',
             'gmaps': 'gmaps', 'google maps': 'gmaps',


### PR DESCRIPTION
Add 'url' to the `keyMap` in `calendar-core.js` to correctly parse URLs from event descriptions.

Previously, only 'website' was mapped to the `website` field, causing URLs specified with 'url:' to be ignored during event parsing. This change ensures both 'url:' and 'website:' are recognized.

---
<a href="https://cursor.com/background-agent?bcId=bc-41d43402-6c23-4879-935d-2f664a9ed245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41d43402-6c23-4879-935d-2f664a9ed245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

