### PR TITLE
Changes from background agent bc-15455d8e-09ab-4735-af87-5fc3bf4d7dd2

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -31,6 +31,7 @@ const scraperConfig = {
         startDate: { priority: ["eventbrite"], merge: "clobber" },
         endDate: { priority: ["eventbrite"], merge: "clobber" },
         url: { priority: ["static"], merge: "clobber" },
+        location: { priority: ["eventbrite"], merge: "clobber" },
         gmaps: { priority: ["eventbrite"], merge: "clobber" },
         image: { priority: ["eventbrite"], merge: "clobber" },
         cover: { priority: ["eventbrite"], merge: "clobber" }
@@ -59,6 +60,7 @@ const scraperConfig = {
         startDate: { priority: ["eventbrite"], merge: "clobber" },
         endDate: { priority: ["eventbrite"], merge: "clobber" },
         url: { priority: ["eventbrite"], merge: "clobber" },
+        location: { priority: ["eventbrite"], merge: "clobber" },
         gmaps: { priority: ["eventbrite"], merge: "clobber" },
         image: { priority: ["eventbrite"], merge: "clobber" },
         cover: { priority: ["eventbrite"], merge: "clobber" }
@@ -121,6 +123,7 @@ const scraperConfig = {
         startDate: { priority: ["chunk"], merge: "clobber" },
         endDate: { priority: ["chunk"], merge: "clobber" },
         url: { priority: ["chunk"], merge: "clobber" },
+        location: { priority: ["chunk"], merge: "clobber" },
         gmaps: { priority: ["chunk"], merge: "clobber" },
         image: { priority: ["chunk"], merge: "clobber" },
         cover: { priority: ["chunk"], merge: "clobber" },
@@ -151,6 +154,7 @@ const scraperConfig = {
         startDate: { priority: ["furball"], merge: "clobber" },
         endDate: { priority: ["furball"], merge: "clobber" },
         url: { priority: ["furball"], merge: "clobber" },
+        location: { priority: ["furball"], merge: "clobber" },
         ticketUrl: { priority: ["furball"], merge: "clobber" },
         gmaps: { priority: ["furball"], merge: "clobber" },
         image: { priority: ["furball"], merge: "clobber" },
@@ -180,6 +184,7 @@ const scraperConfig = {
         startDate: { priority: ["bears-sitges"], merge: "clobber" },
         endDate: { priority: ["bears-sitges"], merge: "clobber" },
         url: { priority: ["bears-sitges"], merge: "clobber" },
+        location: { priority: ["bears-sitges"], merge: "clobber" },
         gmaps: { priority: ["bears-sitges"], merge: "clobber" },
         image: { priority: ["bears-sitges"], merge: "clobber" },
         cover: { priority: ["bears-sitges"], merge: "clobber" }
@@ -210,6 +215,7 @@ const scraperConfig = {
         startDate: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         endDate: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         url: { priority: ["linktree", "eventbrite"], merge: "clobber" }, // Prefer linktree URL over eventbrite
+        location: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         gmaps: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         image: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         cover: { priority: ["eventbrite", "linktree"], merge: "clobber" },

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -88,6 +88,7 @@ const scraperConfig = {
         startDate: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         endDate: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         url: { priority: ["bearracuda", "eventbrite"], merge: "clobber" },
+        location: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         gmaps: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },
         image: { priority: ["bearracuda", "eventbrite"], merge: "clobber" },
         cover: { priority: ["eventbrite", "bearracuda"], merge: "clobber" },


### PR DESCRIPTION
Add `location` field priority to Bearracuda parser config to preserve Eventbrite-sourced coordinates during event merging.

Previously, the absence of a `location` field priority meant that `location: null` from the Bearracuda parser could override valid coordinates extracted by the Eventbrite parser during the merge process. This change ensures Eventbrite coordinates are prioritized.

---
<a href="https://cursor.com/background-agent?bcId=bc-15455d8e-09ab-4735-af87-5fc3bf4d7dd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15455d8e-09ab-4735-af87-5fc3bf4d7dd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

