### PR TITLE
Changes from background agent bc-bf04bc48-55c7-4d4b-b6fa-19b62c7a50ed

### DIFF
--- a/scripts/parsers/eventbrite-parser.js
+++ b/scripts/parsers/eventbrite-parser.js
@@ -751,7 +751,8 @@ class EventbriteParser {
                 address: finalAddress,
                 city: city,
                 timezone: eventTimezone,
-                url: null, // Don't put Eventbrite URL in url field - only use ticketUrl
+                // Don't set url field to null - let other parsers (like linktree) provide the URL
+                // Only set url if we have a meaningful value, otherwise omit the field entirely
                 ticketUrl: url, // For Eventbrite events, the event URL IS the ticket URL
                 cover: price, // Use 'cover' field name that calendar-core.js expects
                 ...(image && { image: image }), // Only include image if we found one


### PR DESCRIPTION
Modify Eventbrite parser to omit the `url` field when no meaningful value is present, preventing it from overwriting valid URLs from other sources.

The Eventbrite parser was explicitly setting `url: null`, which, due to the "clobber" merge strategy, was replacing valid URLs provided by higher-priority parsers (e.g., Linktree). This change ensures that if Eventbrite doesn't have a primary event URL, it doesn't nullify one provided by another source.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf04bc48-55c7-4d4b-b6fa-19b62c7a50ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf04bc48-55c7-4d4b-b6fa-19b62c7a50ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

