### PR TITLE
Update linktree event url and merge

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -214,7 +214,7 @@ const scraperConfig = {
         address: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         startDate: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         endDate: { priority: ["eventbrite", "linktree"], merge: "clobber" },
-        url: { priority: ["linktree", "eventbrite"], merge: "clobber" }, // Prefer linktree URL over eventbrite
+        url: { priority: ["static"], merge: "clobber" }, // Always use static Linktree URL
         location: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         gmaps: { priority: ["eventbrite", "linktree"], merge: "clobber" },
         image: { priority: ["eventbrite", "linktree"], merge: "clobber" },
@@ -225,7 +225,8 @@ const scraperConfig = {
       // Static metadata to add to all Cubhouse events
       metadata: {
         shortName: { value: "CUB-HOUSE" },
-        instagram: { value: "https://www.instagram.com/cubhouse.philly" }
+        instagram: { value: "https://www.instagram.com/cubhouse.philly" },
+        url: { value: "https://linktr.ee/cubhouse" }
       }
     }
   ],


### PR DESCRIPTION
Statically set the URL for Cubhouse events to resolve merging conflicts with Linktree events that lack event objects.

Linktree events for Cubhouse do not provide a standard event object, making it impossible to merge their URLs with Eventbrite events. By setting a static URL in the configuration, all Cubhouse events will consistently use the Linktree URL, bypassing the merging issue and ensuring data consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-9abe0799-aae7-4729-bb0e-6041157163fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9abe0799-aae7-4729-bb0e-6041157163fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

