### PR TITLE
Fix favicon padding on map

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2730,9 +2730,9 @@ body.index-page main {
 }
 
 .favicon-marker-icon {
-    width: 24px;
-    height: 24px;
-    object-fit: contain;
+    width: 40px;
+    height: 40px;
+    object-fit: cover;
     border-radius: 2px;
 }
 
@@ -3643,8 +3643,8 @@ footer {
     }
 
     .favicon-marker-icon {
-        width: 22px;
-        height: 22px;
+        width: 36px;
+        height: 36px;
     }
 
     .marker-text {


### PR DESCRIPTION
Expand favicon images on the map to fill their containers and remove white padding.

The favicons were 24x24px within 40x40px containers, using `object-fit: contain`, which created unwanted white space. This PR adjusts the icon size to match the container and sets `object-fit: cover` to ensure the image fills the space completely.

---
<a href="https://cursor.com/background-agent?bcId=bc-23101075-8f2b-4ad4-ad73-21c3089e21af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23101075-8f2b-4ad4-ad73-21c3089e21af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

