### PR TITLE
Revert map image size changes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2730,9 +2730,9 @@ body.index-page main {
 }
 
 .favicon-marker-icon {
-    width: 40px;
-    height: 40px;
-    object-fit: cover;
+    width: 24px;
+    height: 24px;
+    object-fit: contain;
     border-radius: 2px;
 }
 
@@ -3643,8 +3643,8 @@ footer {
     }
 
     .favicon-marker-icon {
-        width: 36px;
-        height: 36px;
+        width: 22px;
+        height: 22px;
     }
 
     .marker-text {


### PR DESCRIPTION
Revert map image size adjustments to restore original favicon marker icon dimensions and object-fit behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed0e401f-906e-497d-84b3-c02c683abea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed0e401f-906e-497d-84b3-c02c683abea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

