### PR TITLE
Fix map icon image sizing

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1226,9 +1226,9 @@ class DynamicCalendarLoader extends CalendarCore {
                                  onerror="this.parentElement.innerHTML='<span class=\\'marker-text\\'>${textFallback}</span>'; this.parentElement.classList.add('text-marker');">
                         </div>
                     `,
-                    iconSize: [48, 48],
-                    iconAnchor: [24, 24],
-                    popupAnchor: [0, -20]
+                    iconSize: [40, 40],
+                    iconAnchor: [20, 20],
+                    popupAnchor: [0, -16]
                 });
             } catch (error) {
                 logger.warn('MAP', 'Failed to create favicon marker', { website: event.website, error: error.message });
@@ -1244,9 +1244,9 @@ class DynamicCalendarLoader extends CalendarCore {
                     <span class="marker-text">${markerText}</span>
                 </div>
             `,
-            iconSize: [48, 48],
-            iconAnchor: [24, 24],
-            popupAnchor: [0, -20]
+            iconSize: [40, 40],
+            iconAnchor: [20, 20],
+            popupAnchor: [0, -16]
         });
     }
 

--- a/styles.css
+++ b/styles.css
@@ -2744,8 +2744,8 @@ body.index-page main {
 
 .favicon-marker-container {
     position: relative;
-    width: 48px;
-    height: 48px;
+    width: 40px;
+    height: 40px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -2763,8 +2763,8 @@ body.index-page main {
 }
 
 .favicon-marker-icon {
-    width: 32px;
-    height: 32px;
+    width: 36px;
+    height: 36px;
     object-fit: cover;
     border-radius: 2px;
 }
@@ -3671,13 +3671,13 @@ footer {
     }
 
     .favicon-marker-container {
-        width: 44px;
-        height: 44px;
+        width: 36px;
+        height: 36px;
     }
 
     .favicon-marker-icon {
-        width: 28px;
-        height: 28px;
+        width: 32px;
+        height: 32px;
         object-fit: cover;
     }
 


### PR DESCRIPTION
Revert map marker container sizes and increase internal icon sizes to make images bigger within smaller squares.

The previous commit made the map marker squares themselves bigger (48px containers with 32px icons) instead of making the images inside the squares bigger. This PR fixes the issue by reverting the container sizes to their original smaller dimensions while increasing the size of the icons within them, ensuring better visual balance and prominence for the favicon images.

---
<a href="https://cursor.com/background-agent?bcId=bc-699b143f-5268-4a41-9b06-fc256d0d0491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-699b143f-5268-4a41-9b06-fc256d0d0491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

