### PR TITLE
Investigate icon width centering issue

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2755,6 +2755,7 @@ body.index-page main {
     box-shadow: 0 2px 8px rgba(0,0,0,0.2);
     transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
     overflow: hidden;
+    box-sizing: border-box;
 }
 
 .favicon-marker-container:hover {
@@ -2763,12 +2764,13 @@ body.index-page main {
 }
 
 .favicon-marker-icon {
-    width: 100%;
-    height: 100%;
+    width: 32px;
+    height: 32px;
     object-fit: cover;
     object-position: center;
     border-radius: 4px;
     transition: all 0.2s ease;
+    flex-shrink: 0;
 }
 
 /* Text marker styling */
@@ -3683,10 +3685,11 @@ footer {
     }
 
     .favicon-marker-icon {
-        width: 100%;
-        height: 100%;
+        width: 28px;
+        height: 28px;
         object-fit: cover;
         object-position: center;
+        flex-shrink: 0;
     }
 
     .marker-text {


### PR DESCRIPTION
Explicitly set map icon dimensions to 32px (28px on mobile) to fix incorrect width calculation and centering issues.

The `.favicon-marker-container` had `width: 40px` and a `2px` border with `box-sizing: border-box`, making the content area 36px. The `.favicon-marker-icon` was `width: 100%`, which should have been 36px, but was rendering as 31.671875px due to CSS calculation precision. This PR directly sets the icon's width and height to the desired 32px (accounting for the 2px border on each side of the 36px content area) and 28px for mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-c657b9d9-b179-4088-9c73-f6cd15e179ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c657b9d9-b179-4088-9c73-f6cd15e179ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

