### PR TITLE
Adjust map icon sizing for mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3698,6 +3698,14 @@ footer {
         padding: 2px;
     }
 
+    /* Mobile: Make map icons fill the container box */
+    @media (max-width: 768px) {
+        .favicon-marker-icon {
+            width: 100%;
+            height: 100%;
+        }
+    }
+
 
 
     .events-map-section h2 {

--- a/styles.css
+++ b/styles.css
@@ -3685,8 +3685,8 @@ footer {
     }
 
     .favicon-marker-icon {
-        width: 28px;
-        height: 28px;
+        width: 100%;
+        height: 100%;
         object-fit: cover;
         object-position: center;
         flex-shrink: 0;
@@ -3696,14 +3696,6 @@ footer {
         font-size: 9px;
         letter-spacing: -0.1px;
         padding: 2px;
-    }
-
-    /* Mobile: Make map icons fill the container box */
-    @media (max-width: 768px) {
-        .favicon-marker-icon {
-            width: 100%;
-            height: 100%;
-        }
     }
 
 

--- a/styles.css
+++ b/styles.css
@@ -3685,8 +3685,8 @@ footer {
     }
 
     .favicon-marker-icon {
-        width: 100%;
-        height: 100%;
+        width: 34px;
+        height: 34px;
         object-fit: cover;
         object-position: center;
         flex-shrink: 0;

--- a/styles.css
+++ b/styles.css
@@ -2764,8 +2764,8 @@ body.index-page main {
 }
 
 .favicon-marker-icon {
-    width: 32px;
-    height: 32px;
+    width: 38px;
+    height: 38px;
     object-fit: cover;
     object-position: center;
     border-radius: 4px;


### PR DESCRIPTION
Update mobile map icon sizing to fill the container box.

Previously, map icons on mobile were fixed at 28px x 28px within a 36px x 36px container, leaving empty space. This change makes them fill the container completely for a better mobile experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab6dce03-7900-46a0-9c19-d84c29bcf612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab6dce03-7900-46a0-9c19-d84c29bcf612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

