### PR TITLE
Update from main and fix map item fit

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2754,7 +2754,7 @@ body.index-page main {
     border-radius: 6px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.2);
     transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-    overflow: hidden;
+    overflow: visible;
     box-sizing: border-box;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -2754,13 +2754,17 @@ body.index-page main {
     border-radius: 6px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.2);
     transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-    overflow: visible;
+    overflow: hidden;
     box-sizing: border-box;
 }
 
 .favicon-marker-container:hover {
     transform: scale(1.05);
     box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+}
+
+.favicon-marker-container:hover .favicon-marker-icon {
+    transform: scale(1.05);
 }
 
 .favicon-marker-icon {
@@ -2873,6 +2877,10 @@ body.index-page main {
 }
 
 .leaflet-marker-icon.marker-selected .favicon-marker-container:hover {
+    transform: scale(1.05) !important;
+}
+
+.leaflet-marker-icon.marker-selected .favicon-marker-icon {
     transform: scale(1.05) !important;
 }
 


### PR DESCRIPTION
Change `.favicon-marker-container` overflow to visible to prevent clipping of scaled map marker images.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d6a12c6-61e7-4cf1-b2e7-12dd30fb6926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d6a12c6-61e7-4cf1-b2e7-12dd30fb6926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

