### PR TITLE
Investigate map icon spacing bug

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2871,9 +2871,11 @@ body.index-page main {
 
 /* Map Marker Selection States */
 .leaflet-marker-icon.marker-selected .favicon-marker-container {
-    border: 2px solid var(--primary-color) !important;
+    border-color: var(--accent-color) !important;
     box-shadow: 0 4px 12px rgba(0,0,0,0.3) !important;
     transform: scale(1.05) !important;
+    position: relative !important;
+    overflow: hidden !important;
 }
 
 .leaflet-marker-icon.marker-selected .favicon-marker-container:hover {
@@ -2882,10 +2884,12 @@ body.index-page main {
 
 .leaflet-marker-icon.marker-selected .favicon-marker-icon {
     transform: none !important;
+    position: relative !important;
 }
 
 .leaflet-marker-icon.marker-selected {
     z-index: 1010 !important;
+    position: relative !important;
 }
 
 .leaflet-marker-icon.marker-dimmed {


### PR DESCRIPTION
Fixes map icon spacing issue by resolving double border and improving positioning for selected markers.

The previous CSS applied a border twice when an icon was selected, causing a visual white space. This PR changes the selected border to only modify the color and adds positioning/overflow properties to ensure smooth rendering and prevent artifacts during scaling.

---
<a href="https://cursor.com/background-agent?bcId=bc-a84d3c16-6e60-4a71-b81d-664f98c507d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a84d3c16-6e60-4a71-b81d-664f98c507d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

