### PR TITLE
Fix map icon selection whitespace

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1215,8 +1215,8 @@ class DynamicCalendarLoader extends CalendarCore {
                                  onerror="this.parentElement.innerHTML='<span class=\\'marker-text\\'>${textFallback}</span>'; this.parentElement.classList.add('text-marker');">
                         </div>
                     `,
-                    iconSize: [40, 40],
-                    iconAnchor: [20, 20],
+                    iconSize: [42, 42],
+                    iconAnchor: [21, 21],
                     popupAnchor: [0, -16]
                 });
             } catch (error) {
@@ -1233,8 +1233,8 @@ class DynamicCalendarLoader extends CalendarCore {
                     <span class="marker-text">${markerText}</span>
                 </div>
             `,
-            iconSize: [40, 40],
-            iconAnchor: [20, 20],
+            iconSize: [42, 42],
+            iconAnchor: [21, 21],
             popupAnchor: [0, -16]
         });
     }

--- a/styles.css
+++ b/styles.css
@@ -2718,8 +2718,8 @@ body.index-page main {
 
 .favicon-marker-container {
     position: relative;
-    width: 40px;
-    height: 40px;
+    width: 38px;
+    height: 38px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -2742,8 +2742,8 @@ body.index-page main {
 }
 
 .favicon-marker-icon {
-    width: 38px;
-    height: 38px;
+    width: 36px;
+    height: 36px;
     object-fit: cover;
     object-position: center;
     border-radius: 4px;
@@ -3666,13 +3666,13 @@ footer {
     }
 
     .favicon-marker-container {
-        width: 36px;
-        height: 36px;
+        width: 34px;
+        height: 34px;
     }
 
     .favicon-marker-icon {
-        width: 34px;
-        height: 34px;
+        width: 32px;
+        height: 32px;
         object-fit: cover;
         object-position: center;
         flex-shrink: 0;


### PR DESCRIPTION
Adjust map icon sizing to remove whitespace when selected.

Previously, a mismatch between Leaflet's `iconSize` (40x40px) and the CSS `transform: scale(1.05)` on selected markers (resulting in 42x42px visual size) caused a 2px overflow appearing as whitespace. This PR updates the Leaflet `iconSize` to 42x42px and proportionally reduces the base CSS dimensions of the marker container and icon to correctly fit the scaled visual within the allocated space.

---
<a href="https://cursor.com/background-agent?bcId=bc-fa3a4f70-b38b-4cdf-b9d2-d653586ca280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fa3a4f70-b38b-4cdf-b9d2-d653586ca280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

