### PR TITLE
Adjust map icon styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2846,14 +2846,12 @@ body.index-page main {
 /* Map Marker Selection States */
 .leaflet-marker-icon.marker-selected .favicon-marker-container {
     border-color: var(--primary-color) !important;
-    border-width: 3px !important;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.3) !important;
+    border-width: 2px !important;
     position: relative !important;
     overflow: hidden !important;
 }
 
 .leaflet-marker-icon.marker-selected .favicon-marker-container:hover {
-    box-shadow: 0 6px 16px rgba(0,0,0,0.4) !important;
 }
 
 .leaflet-marker-icon.marker-selected .favicon-marker-icon {


### PR DESCRIPTION
Shrink map icon container border to 2px and remove box-shadow effects to refine the selected and hover states.

The user explicitly requested these aesthetic adjustments to achieve a cleaner and more subtle visual presentation for map icons.

---
<a href="https://cursor.com/background-agent?bcId=bc-a97032dc-f8b0-479b-9cd2-ae1ee23bfeb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a97032dc-f8b0-479b-9cd2-ae1ee23bfeb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

