### PR TITLE
Fix calendar event deselect visual bug

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -485,10 +485,11 @@ class DynamicCalendarLoader extends CalendarCore {
     // Clear current event selection
     clearEventSelection() {
         const hadSelection = !!this.selectedEventSlug;
+        const previousSlug = this.selectedEventSlug;
         this.selectedEventSlug = null;
         this.selectedEventDateISO = null;
         if (hadSelection) {
-            logger.userInteraction('EVENT', 'Event selection cleared');
+            logger.userInteraction('EVENT', 'Event selection cleared', { previousSlug });
             // Update visual selection state across all views
             this.updateSelectionVisualState();
         }
@@ -502,6 +503,7 @@ class DynamicCalendarLoader extends CalendarCore {
         if (this.selectedEventSlug === eventSlug && this.selectedEventDateISO === normalizedDateISO) {
             logger.userInteraction('EVENT', 'Deselecting event (same slug and date)', { eventSlug, date: normalizedDateISO });
             this.clearEventSelection();
+            // clearEventSelection() already calls updateSelectionVisualState(), so we don't need to call it again
         } else {
             this.selectedEventSlug = eventSlug;
             this.selectedEventDateISO = normalizedDateISO;
@@ -512,10 +514,10 @@ class DynamicCalendarLoader extends CalendarCore {
                 this.currentDate = parsed;
             }
             logger.userInteraction('EVENT', 'Event selected', { eventSlug, date: normalizedDateISO });
+            
+            // Update visual selection state across all views
+            this.updateSelectionVisualState();
         }
-        
-        // Update visual selection state across all views
-        this.updateSelectionVisualState();
         
         // Reflect selection in URL
         this.syncUrl(true);
@@ -530,7 +532,9 @@ class DynamicCalendarLoader extends CalendarCore {
         });
         
         // Clear all previous selections
-        document.querySelectorAll('.event-card.selected, .event-item.selected').forEach(el => {
+        const selectedElements = document.querySelectorAll('.event-card.selected, .event-item.selected');
+        logger.debug('EVENT', 'Clearing previous selections', { count: selectedElements.length });
+        selectedElements.forEach(el => {
             el.classList.remove('selected');
         });
         


### PR DESCRIPTION
Fixes calendar event deselection visual bug.

The `toggleEventSelection` method was calling `updateSelectionVisualState()` twice when an already-selected event was clicked: once directly, and once indirectly via `clearEventSelection()`. This double invocation created a race condition or interference, preventing the `selected` CSS class from being reliably removed from the event element, leading to the visual bug. The fix ensures `updateSelectionVisualState()` is only called once per selection/deselection cycle.

---
<a href="https://cursor.com/background-agent?bcId=bc-608d2e59-4f90-437a-b180-e23d18806a4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-608d2e59-4f90-437a-b180-e23d18806a4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

