### PR TITLE
Fix calendar event selection logic

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -503,6 +503,13 @@ class DynamicCalendarLoader extends CalendarCore {
         // Check if this event is already selected
         const wasAlreadySelected = this.selectedEventSlug === eventSlug && this.selectedEventDateISO === normalizedDateISO;
         
+        logger.debug('EVENT', 'Toggle event selection', {
+            eventSlug,
+            date: normalizedDateISO,
+            wasAlreadySelected,
+            currentSelection: this.selectedEventSlug
+        });
+        
         // Always clear current selection first (but don't call updateSelectionVisualState yet)
         const hadSelection = !!this.selectedEventSlug;
         const previousSlug = this.selectedEventSlug;
@@ -539,11 +546,27 @@ class DynamicCalendarLoader extends CalendarCore {
             markersBySlugExists: !!window.eventsMapMarkersBySlug
         });
         
-        // Clear all previous selections
+        // Clear all previous selections - be more aggressive about clearing
         const selectedElements = document.querySelectorAll('.event-card.selected, .event-item.selected');
         logger.debug('EVENT', 'Clearing previous selections', { count: selectedElements.length });
         selectedElements.forEach(el => {
             el.classList.remove('selected');
+        });
+        
+        // Also clear all event cards and items regardless of current state
+        // This ensures we catch any elements that might have been missed
+        const allCards = document.querySelectorAll('.event-card');
+        const allItems = document.querySelectorAll('.event-item');
+        logger.debug('EVENT', 'Clearing all event elements', { 
+            cardsCount: allCards.length, 
+            itemsCount: allItems.length 
+        });
+        
+        allCards.forEach(card => {
+            card.classList.remove('selected');
+        });
+        allItems.forEach(item => {
+            item.classList.remove('selected');
         });
         
         // Get events list
@@ -582,12 +605,6 @@ class DynamicCalendarLoader extends CalendarCore {
             
             // Reset all markers to normal appearance
             this.resetAllMapMarkers();
-            
-            // Explicitly ensure all calendar event items are unselected
-            // This is important to handle cases where the calendar is re-rendered
-            document.querySelectorAll('.event-item').forEach(item => {
-                item.classList.remove('selected');
-            });
             
             logger.debug('EVENT', 'Cleared all selections and ensured calendar events are unselected');
         }


### PR DESCRIPTION
Improve calendar event deselection visual state by making CSS class removal more robust.

The existing `updateSelectionVisualState` method sometimes failed to remove the `selected` CSS class from calendar events when an already-selected event was clicked. This was due to the clearing logic only targeting elements *already* having the `selected` class, which could miss elements in certain timing scenarios. The fix ensures all event cards and items are explicitly deselected to guarantee visual consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-a115a6a6-d9ba-4256-bb46-f72e05ab1d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a115a6a6-d9ba-4256-bb46-f72e05ab1d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

