### PR TITLE
Adjust index html color gradients

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -53,9 +53,9 @@
     
     /* Section Background Gradients - Progressive Transitions */
     --gradient-hero: var(--primary-color);
-    --gradient-cities: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 75%);
+    --gradient-cities: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 25%);
     --gradient-events: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 50%);
-    --gradient-today-events: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 25%);
+    --gradient-today-events: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 15%);
     --gradient-directory: var(--secondary-color);
     
     /* Alias for backward compatibility */

--- a/styles.css
+++ b/styles.css
@@ -53,9 +53,9 @@
     
     /* Section Background Gradients - Hard Stop Transitions */
     --gradient-hero: var(--primary-color);
-    --gradient-cities: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color) 75%, var(--secondary-color) 75%, var(--secondary-color) 100%);
-    --gradient-events: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color) 60%, var(--secondary-color) 60%, var(--secondary-color) 100%);
-    --gradient-today-events: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color) 80%, var(--secondary-color) 80%, var(--secondary-color) 100%);
+    --gradient-cities: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color) 85%, var(--secondary-color) 85%, var(--secondary-color) 100%);
+    --gradient-events: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color) 50%, var(--secondary-color) 50%, var(--secondary-color) 100%);
+    --gradient-today-events: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color) 15%, var(--secondary-color) 15%, var(--secondary-color) 100%);
     --gradient-directory: var(--secondary-color);
     
     /* Alias for backward compatibility */

--- a/styles.css
+++ b/styles.css
@@ -51,11 +51,11 @@
     --event-name-font-weight: 600;
     --event-name-line-height: 1.2;
     
-    /* Section Background Gradients - Progressive Transitions */
+    /* Section Background Gradients - Hard Stop Transitions */
     --gradient-hero: var(--primary-color);
-    --gradient-cities: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 25%);
-    --gradient-events: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 50%);
-    --gradient-today-events: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 15%);
+    --gradient-cities: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color) 75%, var(--secondary-color) 75%, var(--secondary-color) 100%);
+    --gradient-events: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color) 60%, var(--secondary-color) 60%, var(--secondary-color) 100%);
+    --gradient-today-events: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-color) 80%, var(--secondary-color) 80%, var(--secondary-color) 100%);
     --gradient-directory: var(--secondary-color);
     
     /* Alias for backward compatibility */


### PR DESCRIPTION
Adjusted gradient color stops in `styles.css` to reduce the prominence of the secondary color, making them more subtle as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-65cf9964-0313-4222-ba7c-ede91ea10642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-65cf9964-0313-4222-ba7c-ede91ea10642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

