### PR TITLE
Check hero background color consistency

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -943,13 +943,7 @@ body.index-page main {
     transition: 0.3s;
 }
 
-/* Hero Section */
-.hero {
-    background: var(--solid-primary);
-    color: var(--text-inverse);
-    display: flex;
-    align-items: center;
-}
+/* Hero Section - Removed duplicate rule that was overriding gradient background */
 
 
 

--- a/styles.css
+++ b/styles.css
@@ -943,16 +943,6 @@ body.index-page main {
     transition: 0.3s;
 }
 
-/* Hero Section - Additional properties for alignment and display */
-.hero {
-    color: var(--text-inverse);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 100vh;
-    text-align: center;
-    position: relative;
-}
 
 
 

--- a/styles.css
+++ b/styles.css
@@ -943,7 +943,16 @@ body.index-page main {
     transition: 0.3s;
 }
 
-/* Hero Section - Removed duplicate rule that was overriding gradient background */
+/* Hero Section - Additional properties for alignment and display */
+.hero {
+    color: var(--text-inverse);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    text-align: center;
+    position: relative;
+}
 
 
 


### PR DESCRIPTION
Remove duplicate `.hero` CSS rule to restore the intended gradient background for the hero section.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e71bd2b-22b2-4a55-a0c8-1a6050053daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3e71bd2b-22b2-4a55-a0c8-1a6050053daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

