### PR TITLE
Fix event title and timing display

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2077,9 +2077,8 @@ body.index-page main {
 .event-time {
     font-size: 0.75rem;
     color: var(--primary-color);
-    font-weight: 600;
+    font-weight: 500;
     margin-bottom: 0.1rem;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 .event-venue {
@@ -4116,8 +4115,7 @@ footer {
 .event-item.selected .event-name,
 .event-item.selected .event-time,
 .event-item.selected .event-venue {
-    color: white !important;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    color: var(--text-inverse) !important;
 }
 
 

--- a/styles.css
+++ b/styles.css
@@ -2071,13 +2071,16 @@ body.index-page main {
     -webkit-box-orient: vertical;
     overflow: hidden;
     max-height: calc(var(--event-name-line-height) * 3em);
+    color: #222;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
 .event-time {
     font-size: 0.75rem;
     color: var(--primary-color);
-    font-weight: 500;
+    font-weight: 600;
     margin-bottom: 0.1rem;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 .event-venue {
@@ -4108,6 +4111,14 @@ footer {
     color: white !important;
     font-weight: bold;
     border-radius: 4px;
+}
+
+/* Ensure all text in selected event items is white */
+.event-item.selected .event-name,
+.event-item.selected .event-time,
+.event-item.selected .event-venue {
+    color: white !important;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
 

--- a/styles.css
+++ b/styles.css
@@ -2071,8 +2071,7 @@ body.index-page main {
     -webkit-box-orient: vertical;
     overflow: hidden;
     max-height: calc(var(--event-name-line-height) * 3em);
-    color: #222;
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    color: var(--text-primary);
 }
 
 .event-time {


### PR DESCRIPTION
Improve readability of event titles and timing information in the city page week/month section.

Unselected event titles had low contrast, and selected event timing text was not displaying as white due to CSS specificity issues. This PR adjusts colors, font weights, and adds text shadows to enhance visibility for both selected and unselected states.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fda7a69-2345-4198-aceb-12c702fa6109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1fda7a69-2345-4198-aceb-12c702fa6109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

