### PR TITLE
Update hero styling and merge main

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -142,7 +142,7 @@ html {
 
 /* Header and Navigation */
 header {
-    background: var(--gradient-primary);
+    background: var(--solid-primary);
     box-shadow: 0 2px 10px var(--shadow-light);
     position: fixed;
     top: 0;
@@ -323,7 +323,7 @@ body.index-page header.visible {
     left: 0;
     right: 0;
     bottom: 0;
-    background: var(--gradient-primary);
+    background: var(--solid-primary);
     opacity: 0;
     transition: opacity 0.3s ease;
     pointer-events: none;
@@ -442,7 +442,7 @@ body.index-page header.visible {
 
 /* Hero Section */
 .hero {
-    background: var(--gradient-primary);
+    background: var(--solid-primary);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -451,17 +451,6 @@ body.index-page header.visible {
     padding-bottom: 4rem;
 }
 
-.hero::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: radial-gradient(circle at 30% 70%, rgba(255, 255, 255, 0.1) 0%, transparent 50%),
-                radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.05) 0%, transparent 50%);
-    pointer-events: none;
-}
 
 .hero-container {
     max-width: 1200px;


### PR DESCRIPTION
Remove gradient effects from the hero section and header, and update related backgrounds and hover effects to use a solid primary color.

The user explicitly requested to eliminate gradients from the header and hero section, making them a solid primary color. This PR removes the `::before` pseudo-element that was creating the gradient overlay in the hero section and updates the background properties for the header, hero section, and a city option hover effect to use a solid primary color.

---
<a href="https://cursor.com/background-agent?bcId=bc-b288e6e8-39bb-43a4-bb86-c8f781d492ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b288e6e8-39bb-43a4-bb86-c8f781d492ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

