### PR TITLE
Adjust city page layout for larger screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1688,53 +1688,6 @@ body.index-page main {
     background: var(--solid-light);
 }
 
-/* Tablet/Desktop Layout - Map to the right */
-@media (min-width: 1024px) {
-    .city-page {
-        display: grid;
-        grid-template-columns: 1fr 500px;
-        grid-template-rows: auto auto auto;
-        gap: 0 2rem;
-        max-width: 1600px;
-        margin: 0 auto;
-        padding: 0 2rem;
-    }
-    
-    /* Calendar takes top-left */
-    .city-page .weekly-calendar {
-        grid-column: 1;
-        grid-row: 1;
-    }
-    
-    /* Events take bottom-left */
-    .city-page .events {
-        grid-column: 1;
-        grid-row: 2;
-    }
-    
-    /* Map takes full right column with sticky positioning */
-    .city-page .events-map-section {
-        grid-column: 2;
-        grid-row: 1 / 3;
-        position: sticky;
-        top: 1rem;
-        height: fit-content;
-        max-height: calc(100vh - 2rem);
-        padding: 0;
-    }
-    
-    .city-page .events-map-section .container {
-        padding: 0;
-    }
-    
-    /* Make map taller on desktop */
-    .city-page #events-map {
-        height: 70vh;
-        min-height: 600px;
-        max-height: 800px;
-    }
-}
-
 
 
 /* Smooth content reveal for sections */
@@ -4764,6 +4717,47 @@ footer {
     /* Hide spacer cards on desktop since we don't need them */
     .spacer-card {
         display: none;
+    }
+    
+    /* City page grid layout - map to the right */
+    .city-page {
+        display: grid;
+        grid-template-columns: 1fr 500px;
+        grid-template-rows: auto auto;
+        gap: 0 2rem;
+        max-width: 1600px;
+        margin: 0 auto;
+        padding: 0 2rem;
+    }
+    
+    .city-page .weekly-calendar {
+        grid-column: 1;
+        grid-row: 1;
+    }
+    
+    .city-page .events {
+        grid-column: 1;
+        grid-row: 2;
+    }
+    
+    .city-page .events-map-section {
+        grid-column: 2;
+        grid-row: 1 / 3;
+        position: sticky;
+        top: 1rem;
+        height: fit-content;
+        max-height: calc(100vh - 2rem);
+        padding: 0;
+    }
+    
+    .city-page .events-map-section .container {
+        padding: 0;
+    }
+    
+    .city-page #events-map {
+        height: 70vh;
+        min-height: 600px;
+        max-height: 800px;
     }
 }
 


### PR DESCRIPTION
Adjust city page layout for tablet/desktop screens to display more data by moving the map to the right, while preserving mobile styling.

The existing layout on `city.html` caused less data to be visible on larger screens as elements scaled up. This change introduces a two-column grid for screens 1024px and wider, allowing the calendar and events to remain on the left while the map takes a sticky position on the right, optimizing space utilization without affecting mobile views.

---
<a href="https://cursor.com/background-agent?bcId=bc-3173338a-4381-4f8e-97f1-4cec01cc4e4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3173338a-4381-4f8e-97f1-4cec01cc4e4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

