### PR TITLE
Update city page layout for desktop/tablet

### DIFF
--- a/city.html
+++ b/city.html
@@ -215,6 +215,8 @@
 
         <section class="events-map-section">
             <div class="container">
+                <h2>📍 Event Locations</h2>
+                <p>Click on events in the calendar to see their locations on the map</p>
                 <div class="map-container">
                     <div id="events-map"></div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -1688,7 +1688,128 @@ body.index-page main {
     background: var(--solid-light);
 }
 
+/* Desktop/Tablet Layout - Map on right, content on left */
+@media (min-width: 768px) {
+    .city-page {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-areas: 
+            "calendar map"
+            "events map";
+        gap: 2rem;
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 2rem;
+        min-height: 100vh;
+    }
+    
+    .weekly-calendar {
+        grid-area: calendar;
+        padding: 0;
+    }
+    
+    .events {
+        grid-area: events;
+        padding: 0;
+    }
+    
+    .events-map-section {
+        grid-area: map;
+        padding: 0;
+        position: sticky;
+        top: 2rem;
+        height: fit-content;
+        max-height: calc(100vh - 4rem);
+        overflow: hidden;
+        background: transparent;
+    }
+    
+    .events-map-section::before {
+        display: none;
+    }
+    
+    .events-map-section .container {
+        padding: 0;
+        height: 100%;
+    }
+    
+    .map-container {
+        height: 100%;
+        min-height: 500px;
+    }
+    
+    #events-map {
+        height: 100%;
+        min-height: 500px;
+    }
+    
+    /* Ensure proper spacing for left column content */
+    .weekly-calendar .container {
+        padding: 0;
+    }
+    
+    .events .container {
+        padding: 0;
+    }
+    
+    /* Adjust calendar header for desktop layout */
+    .calendar-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+    }
+    
+    .calendar-controls {
+        width: 100%;
+        justify-content: space-between;
+    }
+    
+    /* Ensure events list has proper spacing */
+    .events-list {
+        margin-top: 1rem;
+    }
+    
+    /* Style the map section for desktop layout */
+    .events-map-section h2 {
+        text-align: left;
+        margin-bottom: 1rem;
+        font-size: 1.8rem;
+        color: var(--text-primary);
+    }
+    
+    .events-map-section p {
+        text-align: left;
+        margin-bottom: 1.5rem;
+        font-size: 1rem;
+        max-width: none;
+        margin-left: 0;
+        margin-right: 0;
+        padding: 0;
+    }
+}
 
+/* Large desktop screens - optimize layout further */
+@media (min-width: 1200px) {
+    .city-page {
+        grid-template-columns: 1.2fr 0.8fr;
+        gap: 3rem;
+        padding: 3rem;
+    }
+    
+    .events-map-section {
+        top: 3rem;
+        max-height: calc(100vh - 6rem);
+    }
+    
+    .map-container {
+        min-height: 600px;
+    }
+    
+    #events-map {
+        min-height: 600px;
+    }
+}
 
 /* Smooth content reveal for sections */
 .content-hidden {


### PR DESCRIPTION
Implement responsive layout for city pages, moving the map to the right and content to the left on desktop/tablet.

---
<a href="https://cursor.com/background-agent?bcId=bc-f68e7d43-3a2c-40d3-8ac4-0806149d1794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f68e7d43-3a2c-40d3-8ac4-0806149d1794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

