### PR TITLE
Update calendar controls breakpoint

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3687,7 +3687,7 @@ footer {
     }
 }
 
-/* Calendar controls for medium-small screens */
+/* Calendar controls for medium screens */
 @media (max-width: 768px) {
     .calendar-controls {
         flex-direction: row;
@@ -3696,7 +3696,10 @@ footer {
         flex-wrap: wrap;
         justify-content: center;
     }
-    
+}
+
+/* Calendar controls for medium-small screens */
+@media (max-width: 550px) {
     .view-toggle {
         flex-direction: row;
         gap: 2px;

--- a/styles.css
+++ b/styles.css
@@ -3688,7 +3688,7 @@ footer {
 }
 
 /* Calendar controls for medium-small screens */
-@media (max-width: 550px) {
+@media (max-width: 768px) {
     .calendar-controls {
         flex-direction: row;
         gap: 0.25rem;


### PR DESCRIPTION
Update `.calendar-controls` media query breakpoint from 550px to 768px to extend its responsive range.

---
<a href="https://cursor.com/background-agent?bcId=bc-45873b2c-40a0-41da-a954-b70e0b840ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45873b2c-40a0-41da-a954-b70e0b840ea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

