### PR TITLE
Fix footer to always be at bottom

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -106,9 +106,9 @@ body {
     padding: 0;
     padding-top: 80px; /* Account for fixed header */
     overflow-x: hidden; /* Prevent horizontal scroll */
-    display: grid;
-    grid-template-rows: auto 1fr auto;
     min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
 
 /* Index page specific styles - no top padding for hero */
@@ -2909,6 +2909,11 @@ body.index-page main {
 
 .error-message a:hover {
     text-decoration: underline;
+}
+
+/* Main content takes remaining space */
+main {
+    flex: 1;
 }
 
 /* Footer */

--- a/styles.css
+++ b/styles.css
@@ -106,6 +106,9 @@ body {
     padding: 0;
     padding-top: 80px; /* Account for fixed header */
     overflow-x: hidden; /* Prevent horizontal scroll */
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    min-height: 100vh;
 }
 
 /* Index page specific styles - no top padding for hero */
@@ -115,6 +118,7 @@ body.index-page {
 
 html {
     overflow-x: hidden; /* Prevent horizontal scroll */
+    height: 100%;
 }
 
 /* Prevent all elements from overflowing on small screens */


### PR DESCRIPTION
Implement a flexbox layout for the page body to ensure the footer is at the bottom of the content and the page has a minimum height.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cb035ff-79d4-4c85-9b3d-2f8dd5bb346b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2cb035ff-79d4-4c85-9b3d-2f8dd5bb346b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

