### PR TITLE
Update main and enforce header padding

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -104,7 +104,7 @@ body {
     scroll-behavior: smooth;
     margin: 0;
     padding: 0;
-    padding-top: 80px; /* Account for fixed header */
+    padding-top: 60px; /* Account for fixed header */
     overflow-x: hidden; /* Prevent horizontal scroll */
 }
 
@@ -3321,10 +3321,6 @@ footer {
 }
 
 @media (max-width: 480px) {
-    body {
-        padding-top: 50px; /* Even smaller header height */
-    }
-    
     header {
         height: 50px;
     }

--- a/styles.css
+++ b/styles.css
@@ -3321,6 +3321,10 @@ footer {
 }
 
 @media (max-width: 480px) {
+    body {
+        padding-top: 50px; /* Even smaller header height */
+    }
+    
     header {
         height: 50px;
     }


### PR DESCRIPTION
Update header padding to a default of 60px and remove larger or conflicting smaller settings.

The previous default `body padding-top` of `80px` was reduced to `60px`. Additionally, a `50px` padding for mobile breakpoints was removed to ensure the `60px` default is consistently applied, as per the task requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-02746d06-043a-4462-b9c7-1174b90f1e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02746d06-043a-4462-b9c7-1174b90f1e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

