### PR TITLE
Update main page event title styling

### DIFF
--- a/js/compact-card-renderer.js
+++ b/js/compact-card-renderer.js
@@ -95,7 +95,9 @@ class CompactCardRenderer {
             content.className = 'event-content';
 
             const name = document.createElement('span');
-            name.className = 'event-name';
+            // Use different class for main page vs city page events
+            const isMainPage = document.body.classList.contains('index-page');
+            name.className = isMainPage ? 'main-event-title' : 'event-name';
             name.textContent = item.name;
 
             const dates = document.createElement('span');
@@ -146,7 +148,9 @@ class CompactCardRenderer {
             content.className = 'event-content';
 
             const name = document.createElement('span');
-            name.className = 'event-name';
+            // Use different class for main page vs city page events
+            const isMainPage = document.body.classList.contains('index-page');
+            name.className = isMainPage ? 'main-event-title' : 'event-name';
             name.textContent = 'More Events';
 
             const subtitle = document.createElement('span');

--- a/styles.css
+++ b/styles.css
@@ -1214,6 +1214,17 @@ body.index-page main {
     text-align: center;
 }
 
+/* Main page event titles with inverse text color */
+.event-compact-card .event-title-main {
+    font-size: 0.95rem;
+    font-weight: 600;
+    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.3);
+    letter-spacing: 0.3px;
+    line-height: 1.2;
+    text-align: center;
+    color: var(--primary-color);
+}
+
 .event-compact-card .event-dates {
     font-size: 0.8rem;
     font-weight: 500;

--- a/styles.css
+++ b/styles.css
@@ -1214,15 +1214,15 @@ body.index-page main {
     text-align: center;
 }
 
-/* Main page event titles with inverse text color */
-.event-compact-card .event-title-main {
+/* Main page event title with inverse text color */
+.event-compact-card .main-event-title {
     font-size: 0.95rem;
     font-weight: 600;
-    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.3);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
     letter-spacing: 0.3px;
     line-height: 1.2;
     text-align: center;
-    color: var(--primary-color);
+    color: rgba(255, 255, 255, 0.9);
 }
 
 .event-compact-card .event-dates {


### PR DESCRIPTION
Resolve main page event title styling conflict by introducing `main-event-title` with inverse text color.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5fc771f-31bb-4284-a99b-67059fcac89c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c5fc771f-31bb-4284-a99b-67059fcac89c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

