### PR TITLE
Update code and remove status colors

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -28,12 +28,6 @@
     --black: #000000;
     --transparent: transparent;
     
-    /* Status Colors */
-    --success-color: #4ecdc4;
-    --warning-color: #ffd700;
-    --error-color: #dc2626;
-    --color-online: #10b981;
-    --color-offline: #6b7280;
     
     /* Joke Bubble Colors */
     --joke-bubble-background: var(--white);
@@ -61,10 +55,8 @@
     /* Solid Color Alternatives */
     --solid-primary: var(--primary-color);
     --solid-secondary: var(--secondary-color);
-    --solid-success: var(--success-color);
     --solid-warning: var(--background-light);
     --solid-light: var(--background-light);
-    --solid-error: var(--error-color);
     
 }
 
@@ -354,7 +346,7 @@ body.index-page header.visible {
 }
 
 .debug-label {
-    color: var(--warning-color);
+    color: var(--text-secondary);
     font-weight: bold;
     margin-right: 0.5rem;
 }
@@ -2793,16 +2785,16 @@ body.index-page main {
 }
 
 #location-btn.location-success {
-    color: var(--success-color);
+    color: var(--primary-color);
     background: var(--background-primary);
-    border-color: var(--success-color);
+    border-color: var(--primary-color);
     backdrop-filter: blur(10px);
 }
 
 #location-btn.location-error {
-    color: var(--error-color);
+    color: var(--secondary-color);
     background: var(--background-primary);
-    border-color: var(--error-color);
+    border-color: var(--secondary-color);
     backdrop-filter: blur(10px);
 }
 
@@ -2827,7 +2819,7 @@ body.index-page main {
 
 .error-message {
     background: var(--solid-error);
-    border: 2px solid var(--color-error);
+    border: 2px solid var(--secondary-color);
     border-radius: 15px;
     padding: 2rem;
     margin: 2rem 0;
@@ -2835,19 +2827,19 @@ body.index-page main {
 }
 
 .error-message h3 {
-    color: var(--color-error);
+    color: var(--secondary-color);
     margin-bottom: 1rem;
     font-size: 1.3rem;
 }
 
 .error-message p {
-    color: var(--error-color);
+    color: var(--secondary-color);
     margin-bottom: 1rem;
     line-height: 1.6;
 }
 
 .error-message ul {
-    color: var(--error-color);
+    color: var(--secondary-color);
     text-align: left;
     margin: 1rem 0;
     padding-left: 1.5rem;
@@ -2858,7 +2850,7 @@ body.index-page main {
 }
 
 .error-message a {
-    color: var(--error-color);
+    color: var(--secondary-color);
     font-weight: 600;
     text-decoration: none;
 }
@@ -4087,12 +4079,12 @@ footer {
 }
 
 .calendar-day.calendar-overview.has-events {
-    border-color: var(--color-online);
+    border-color: var(--primary-color);
             background: var(--background-light);
 }
 
 .calendar-day.calendar-overview.has-events:hover {
-    border-color: var(--success-color);
+    border-color: var(--accent-color);
             background: var(--background-light);
 }
 
@@ -4113,7 +4105,7 @@ footer {
 .event-dot {
     width: 6px;
     height: 6px;
-    background: var(--color-online);
+    background: var(--primary-color);
     border-radius: 50%;
 }
 
@@ -4260,20 +4252,20 @@ footer {
 }
 
 .modal-event-item .event-venue {
-    color: var(--color-offline);
+    color: var(--text-muted);
     font-weight: 500;
     font-size: 0.9rem;
 }
 
 .modal-event-item .event-cover {
-    color: var(--success-color);
+    color: var(--primary-color);
     font-weight: 500;
     font-size: 0.9rem;
 }
 
 .no-modal-events {
     text-align: center;
-    color: var(--color-offline);
+    color: var(--text-muted);
     font-style: italic;
     margin: 2rem 0;
 }
@@ -4847,7 +4839,7 @@ footer {
 .error-message {
     text-align: center;
     padding: 4rem 0;
-    color: var(--error-color);
+    color: var(--secondary-color);
 }
 
 /* Directory Grid */
@@ -4938,7 +4930,7 @@ footer {
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    color: var(--error-color);
+    color: var(--secondary-color);
     font-size: 0.9rem;
 }
 

--- a/testing/ultimate-style-tester.html
+++ b/testing/ultimate-style-tester.html
@@ -615,52 +615,6 @@
                 </div>
             </div>
 
-            <!-- Status Colors Section -->
-            <div class="control-section">
-                <h3 onclick="toggleSection(this.parentElement)">
-                    🚦 Status Colors
-                    <span class="toggle-icon">▼</span>
-                </h3>
-                <div class="section-content">
-                    <div class="color-grid">
-                        <div class="color-control">
-                            <label>Success</label>
-                            <div class="color-input-group">
-                                <input type="color" id="success-color" class="color-picker" value="#4ecdc4">
-                                <input type="text" id="success-color-text" class="color-input" value="#4ecdc4">
-                            </div>
-                        </div>
-                        <div class="color-control">
-                            <label>Warning</label>
-                            <div class="color-input-group">
-                                <input type="color" id="warning-color" class="color-picker" value="#ffd700">
-                                <input type="text" id="warning-color-text" class="color-input" value="#ffd700">
-                            </div>
-                        </div>
-                        <div class="color-control">
-                            <label>Error</label>
-                            <div class="color-input-group">
-                                <input type="color" id="error-color" class="color-picker" value="#dc2626">
-                                <input type="text" id="error-color-text" class="color-input" value="#dc2626">
-                            </div>
-                        </div>
-                        <div class="color-control">
-                            <label>Online</label>
-                            <div class="color-input-group">
-                                <input type="color" id="color-online" class="color-picker" value="#10b981">
-                                <input type="text" id="color-online-text" class="color-input" value="#10b981">
-                            </div>
-                        </div>
-                        <div class="color-control">
-                            <label>Offline</label>
-                            <div class="color-input-group">
-                                <input type="color" id="color-offline" class="color-picker" value="#6b7280">
-                                <input type="text" id="color-offline-text" class="color-input" value="#6b7280">
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
 
             <!-- Basic Colors Section -->
             <div class="control-section">
@@ -785,20 +739,6 @@
                             </div>
                         </div>
                         <div class="color-control">
-                            <label>Success Start</label>
-                            <div class="color-input-group">
-                                <input type="color" id="gradient-success-start" class="color-picker" value="#4ecdc4">
-                                <input type="text" id="gradient-success-start-text" class="color-input" value="#4ecdc4">
-                            </div>
-                        </div>
-                        <div class="color-control">
-                            <label>Success End</label>
-                            <div class="color-input-group">
-                                <input type="color" id="gradient-success-end" class="color-picker" value="#667eea">
-                                <input type="text" id="gradient-success-end-text" class="color-input" value="#667eea">
-                            </div>
-                        </div>
-                        <div class="color-control">
                             <label>Light Start</label>
                             <div class="color-input-group">
                                 <input type="color" id="gradient-light-start" class="color-picker" value="#ffffff">
@@ -905,19 +845,12 @@
                         'border-light': '#e8f2ff',
                         'border-lighter': '#d0e1ff',
                         'border-dark': '#333333',
-                        'success-color': '#4ecdc4',
-                        'warning-color': '#ffd700',
-                        'error-color': '#dc2626',
-                        'color-online': '#10b981',
-                        'color-offline': '#6b7280',
                         'white': '#ffffff',
                         'black': '#000000',
                         'gradient-primary-start': '#667eea',
                         'gradient-primary-end': '#764ba2',
                         'gradient-secondary-start': '#ff6b6b',
                         'gradient-secondary-end': '#ee5a24',
-                        'gradient-success-start': '#4ecdc4',
-                        'gradient-success-end': '#667eea',
                         'gradient-light-start': '#ffffff',
                         'gradient-light-end': '#f8f9ff'
                     },
@@ -938,14 +871,7 @@
                         'border-light': '#2a2d2a',
                         'border-lighter': '#1a1a2e',
                         'border-dark': '#ffffff',
-                        'success-color': '#4ecdc4',
-                        'warning-color': '#ffd700',
-                        'error-color': '#ff6b6b',
                         'info-color': '#45b7d1',
-                        'color-online': '#4ecdc4',
-                        'color-offline': '#666666',
-                        'color-busy': '#ffd700',
-                        'color-away': '#ff6b6b',
                         'color-danger': '#ff6b6b',
                         'color-danger-dark': '#ee5a24',
                         'white': '#ffffff',
@@ -954,8 +880,6 @@
                         'gradient-primary-end': '#45b7d1',
                         'gradient-secondary-start': '#ff6b6b',
                         'gradient-secondary-end': '#ee5a24',
-                        'gradient-success-start': '#4ecdc4',
-                        'gradient-success-end': '#45b7d1',
                         'gradient-light-start': '#1a1a2e',
                         'gradient-light-end': '#16213e'
                     },
@@ -976,14 +900,7 @@
                         'border-light': '#333333',
                         'border-lighter': '#444444',
                         'border-dark': '#ffffff',
-                        'success-color': '#4ecdc4',
-                        'warning-color': '#FFD700',
-                        'error-color': '#ff6b6b',
                         'info-color': '#45b7d1',
-                        'color-online': '#4ecdc4',
-                        'color-offline': '#666666',
-                        'color-busy': '#FFD700',
-                        'color-away': '#ff6b6b',
                         'color-danger': '#ff6b6b',
                         'color-danger-dark': '#ee5a24',
                         'white': '#ffffff',
@@ -992,8 +909,6 @@
                         'gradient-primary-end': '#8B4513',
                         'gradient-secondary-start': '#8B4513',
                         'gradient-secondary-end': '#FFD700',
-                        'gradient-success-start': '#4ecdc4',
-                        'gradient-success-end': '#45b7d1',
                         'gradient-light-start': '#000000',
                         'gradient-light-end': '#111111'
                     },
@@ -1014,14 +929,7 @@
                         'border-light': '#333333',
                         'border-lighter': '#444444',
                         'border-dark': '#ffffff',
-                        'success-color': '#00ffff',
-                        'warning-color': '#ffff00',
-                        'error-color': '#ff00ff',
                         'info-color': '#00ffff',
-                        'color-online': '#00ffff',
-                        'color-offline': '#666666',
-                        'color-busy': '#ffff00',
-                        'color-away': '#ff00ff',
                         'color-danger': '#ff00ff',
                         'color-danger-dark': '#cc00cc',
                         'white': '#ffffff',
@@ -1030,8 +938,6 @@
                         'gradient-primary-end': '#ffff00',
                         'gradient-secondary-start': '#00ffff',
                         'gradient-secondary-end': '#ffff00',
-                        'gradient-success-start': '#00ffff',
-                        'gradient-success-end': '#ffff00',
                         'gradient-light-start': '#000000',
                         'gradient-light-end': '#111111'
                     },
@@ -1052,14 +958,7 @@
                         'border-light': '#5c4830',
                         'border-lighter': '#6c5840',
                         'border-dark': '#ffffff',
-                        'success-color': '#ffd23f',
-                        'warning-color': '#f7931e',
-                        'error-color': '#ff6b35',
                         'info-color': '#f7931e',
-                        'color-online': '#ffd23f',
-                        'color-offline': '#cccccc',
-                        'color-busy': '#f7931e',
-                        'color-away': '#ff6b35',
                         'color-danger': '#ff6b35',
                         'color-danger-dark': '#cc5528',
                         'white': '#ffffff',
@@ -1068,8 +967,6 @@
                         'gradient-primary-end': '#ffd23f',
                         'gradient-secondary-start': '#f7931e',
                         'gradient-secondary-end': '#ffd23f',
-                        'gradient-success-start': '#ffd23f',
-                        'gradient-success-end': '#f7931e',
                         'gradient-light-start': '#2c1810',
                         'gradient-light-end': '#3c2820'
                     },
@@ -1090,14 +987,7 @@
                         'border-light': '#004d6d',
                         'border-lighter': '#005d7d',
                         'border-dark': '#ffffff',
-                        'success-color': '#90e0ef',
-                        'warning-color': '#00b4d8',
-                        'error-color': '#006994',
                         'info-color': '#00b4d8',
-                        'color-online': '#90e0ef',
-                        'color-offline': '#cccccc',
-                        'color-busy': '#00b4d8',
-                        'color-away': '#006994',
                         'color-danger': '#006994',
                         'color-danger-dark': '#004d6d',
                         'white': '#ffffff',
@@ -1106,8 +996,6 @@
                         'gradient-primary-end': '#90e0ef',
                         'gradient-secondary-start': '#00b4d8',
                         'gradient-secondary-end': '#90e0ef',
-                        'gradient-success-start': '#90e0ef',
-                        'gradient-success-end': '#00b4d8',
                         'gradient-light-start': '#001d3d',
                         'gradient-light-end': '#002d4d'
                     },
@@ -1128,14 +1016,7 @@
                         'border-light': '#C5C0A0',
                         'border-lighter': '#D2CDAB',
                         'border-dark': '#685159',
-                        'success-color': '#BCBBA3',
-                        'warning-color': '#E14F38',
-                        'error-color': '#E14F38',
                         'info-color': '#978B7D',
-                        'color-online': '#BCBBA3',
-                        'color-offline': '#999999',
-                        'color-busy': '#E14F38',
-                        'color-away': '#978B7D',
                         'color-danger': '#E14F38',
                         'color-danger-dark': '#B83D2A',
                         'white': '#ffffff',
@@ -1144,8 +1025,6 @@
                         'gradient-primary-end': '#E14F38',
                         'gradient-secondary-start': '#978B7D',
                         'gradient-secondary-end': '#E14F38',
-                        'gradient-success-start': '#BCBBA3',
-                        'gradient-success-end': '#978B7D',
                         'gradient-light-start': '#FEF3CE',
                         'gradient-light-end': '#D2CDAB'
                     },
@@ -1166,14 +1045,7 @@
                         'border-light': '#C5C0A0',
                         'border-lighter': '#D2CDAB',
                         'border-dark': '#51443E',
-                        'success-color': '#51443E',
-                        'warning-color': '#E14F38',
-                        'error-color': '#E14F38',
                         'info-color': '#2A2D2A',
-                        'color-online': '#51443E',
-                        'color-offline': '#999999',
-                        'color-busy': '#E14F38',
-                        'color-away': '#2A2D2A',
                         'color-danger': '#E14F38',
                         'color-danger-dark': '#B83D2A',
                         'white': '#ffffff',
@@ -1182,8 +1054,6 @@
                         'gradient-primary-end': '#E14F38',
                         'gradient-secondary-start': '#2A2D2A',
                         'gradient-secondary-end': '#E14F38',
-                        'gradient-success-start': '#51443E',
-                        'gradient-success-end': '#2A2D2A',
                         'gradient-light-start': '#FEF3CE',
                         'gradient-light-end': '#D2CDAB'
                     },
@@ -1204,14 +1074,7 @@
                         'border-light': '#4A4D4A',
                         'border-lighter': '#5A5D5A',
                         'border-dark': '#000000',
-                        'success-color': '#FD9433',
-                        'warning-color': '#E14F38',
-                        'error-color': '#E14F38',
                         'info-color': '#7094A0',
-                        'color-online': '#FD9433',
-                        'color-offline': '#999999',
-                        'color-busy': '#E14F38',
-                        'color-away': '#7094A0',
                         'color-danger': '#E14F38',
                         'color-danger-dark': '#B83D2A',
                         'white': '#ffffff',
@@ -1220,8 +1083,6 @@
                         'gradient-primary-end': '#7094A0',
                         'gradient-secondary-start': '#E14F38',
                         'gradient-secondary-end': '#7094A0',
-                        'gradient-success-start': '#FD9433',
-                        'gradient-success-end': '#E14F38',
                         'gradient-light-start': '#51443E',
                         'gradient-light-end': '#2A2D2A'
                     },
@@ -1242,14 +1103,7 @@
                         'border-light': '#e8e2d8',
                         'border-lighter': '#f8f5f0',
                         'border-dark': '#2e2e2e',
-                        'success-color': '#ffcc00',
-                        'warning-color': '#d94f57',
-                        'error-color': '#d94f57',
                         'info-color': '#533d8b',
-                        'color-online': '#ffcc00',
-                        'color-offline': '#999999',
-                        'color-busy': '#d94f57',
-                        'color-away': '#533d8b',
                         'color-danger': '#d94f57',
                         'color-danger-dark': '#B83D2A',
                         'white': '#ffffff',
@@ -1258,8 +1112,6 @@
                         'gradient-primary-end': '#533d8b',
                         'gradient-secondary-start': '#d94f57',
                         'gradient-secondary-end': '#533d8b',
-                        'gradient-success-start': '#ffcc00',
-                        'gradient-success-end': '#d94f57',
                         'gradient-light-start': '#f2ede5',
                         'gradient-light-end': '#f2ede5'
                     },
@@ -1280,14 +1132,7 @@
                         'border-light': '#e5e5e5',
                         'border-lighter': '#f0f0f0',
                         'border-dark': '#14213d',
-                        'success-color': '#fca311',
-                        'warning-color': '#ffd700',
-                        'error-color': '#dc2626',
                         'info-color': '#14213d',
-                        'color-online': '#fca311',
-                        'color-offline': '#6b7280',
-                        'color-busy': '#ffd700',
-                        'color-away': '#fca311',
                         'color-danger': '#dc2626',
                         'color-danger-dark': '#b91c1c',
                         'white': '#ffffff',
@@ -1296,8 +1141,6 @@
                         'gradient-primary-end': '#fca311',
                         'gradient-secondary-start': '#fca311',
                         'gradient-secondary-end': '#e5e5e5',
-                        'gradient-success-start': '#fca311',
-                        'gradient-success-end': '#14213d',
                         'gradient-light-start': '#ffffff',
                         'gradient-light-end': '#f8f9ff'
                     },
@@ -1318,14 +1161,7 @@
                         'border-light': '#003554',
                         'border-lighter': '#004564',
                         'border-dark': '#ffecd1',
-                        'success-color': '#ff7d00',
-                        'warning-color': '#ffd700',
-                        'error-color': '#ff7d00',
                         'info-color': '#15616d',
-                        'color-online': '#ff7d00',
-                        'color-offline': '#666666',
-                        'color-busy': '#ffd700',
-                        'color-away': '#ff7d00',
                         'color-danger': '#ff7d00',
                         'color-danger-dark': '#cc6400',
                         'white': '#ffffff',
@@ -1334,8 +1170,6 @@
                         'gradient-primary-end': '#ff7d00',
                         'gradient-secondary-start': '#ff7d00',
                         'gradient-secondary-end': '#ffecd1',
-                        'gradient-success-start': '#ff7d00',
-                        'gradient-success-end': '#15616d',
                         'gradient-light-start': '#001524',
                         'gradient-light-end': '#002034'
                     }
@@ -1514,11 +1348,6 @@
                         --border-light: ${document.getElementById('border-light').value};
                         --border-lighter: ${document.getElementById('border-lighter').value};
                         --border-dark: ${document.getElementById('border-dark').value};
-                        --success-color: ${document.getElementById('success-color').value};
-                        --warning-color: ${document.getElementById('warning-color').value};
-                        --error-color: ${document.getElementById('error-color').value};
-                        --color-online: ${document.getElementById('color-online').value};
-                        --color-offline: ${document.getElementById('color-offline').value};
                         --white: ${document.getElementById('white').value};
                         --black: ${document.getElementById('black').value};
                         
@@ -1538,7 +1367,6 @@
                         /* Gradients */
                         --gradient-primary: linear-gradient(135deg, ${document.getElementById('gradient-primary-start').value} 0%, ${document.getElementById('gradient-primary-end').value} 100%);
                         --gradient-secondary: linear-gradient(45deg, ${document.getElementById('gradient-secondary-start').value}, ${document.getElementById('gradient-secondary-end').value});
-                        --gradient-success: linear-gradient(45deg, ${document.getElementById('gradient-success-start').value}, ${document.getElementById('gradient-success-end').value} 100%);
                         --gradient-warning: linear-gradient(135deg, ${document.getElementById('background-primary').value} 0%, ${document.getElementById('background-light').value} 100%);
                         --gradient-light: linear-gradient(135deg, ${document.getElementById('gradient-light-start').value} 0%, ${document.getElementById('gradient-light-end').value} 100%);
                         --gradient-error: linear-gradient(135deg, ${document.getElementById('background-light').value} 0%, ${document.getElementById('background-light').value} 100%);
@@ -1676,7 +1504,7 @@
                         'color-online', 'color-offline', 'color-busy', 'color-away',
                         'white', 'black',
                         'gradient-primary-start', 'gradient-primary-end', 'gradient-secondary-start', 'gradient-secondary-end',
-                        'gradient-success-start', 'gradient-success-end', 'gradient-light-start', 'gradient-light-end'
+                        'gradient-light-start', 'gradient-light-end'
                     ];
                     colorKeys.forEach((key, index) => {
                         const color = shuffledColors[index % shuffledColors.length];
@@ -1739,19 +1567,12 @@
                     'border-light': backgrounds[6] || shuffledColors[13],
                     'border-lighter': backgrounds[7] || shuffledColors[14],
                     'border-dark': darks[3] || shuffledColors[15],
-                    'success-color': accents[2] || shuffledColors[16],
-                    'warning-color': accents[3] || shuffledColors[17],
-                    'error-color': accents[4] || shuffledColors[18],
-                    'color-online': accents[6] || shuffledColors[20],
-                    'color-offline': accents[7] || shuffledColors[21],
                     'white': shuffledColors[28],
                     'black': shuffledColors[29],
                     'gradient-primary-start': accents[17] || shuffledColors[36],
                     'gradient-primary-end': accents[18] || shuffledColors[37],
                     'gradient-secondary-start': accents[19] || shuffledColors[38],
                     'gradient-secondary-end': accents[20] || shuffledColors[39],
-                    'gradient-success-start': accents[21] || shuffledColors[40],
-                    'gradient-success-end': accents[22] || shuffledColors[41],
                     'gradient-light-start': backgrounds[8] || shuffledColors[42],
                     'gradient-light-end': backgrounds[9] || shuffledColors[43]
                 };
@@ -1951,7 +1772,7 @@
                         'color-online', 'color-offline', 'color-busy', 'color-away',
                         'white', 'black',
                         'gradient-primary-start', 'gradient-primary-end', 'gradient-secondary-start', 'gradient-secondary-end',
-                        'gradient-success-start', 'gradient-success-end', 'gradient-light-start', 'gradient-light-end'
+                        'gradient-light-start', 'gradient-light-end'
                     ];
                     let hasCustomColors = false;
                     
@@ -2033,19 +1854,12 @@
                     'border-light': document.getElementById('border-light').value,
                     'border-lighter': document.getElementById('border-lighter').value,
                     'border-dark': document.getElementById('border-dark').value,
-                    'success-color': document.getElementById('success-color').value,
-                    'warning-color': document.getElementById('warning-color').value,
-                    'error-color': document.getElementById('error-color').value,
-                    'color-online': document.getElementById('color-online').value,
-                    'color-offline': document.getElementById('color-offline').value,
                     'white': document.getElementById('white').value,
                     'black': document.getElementById('black').value,
                     'gradient-primary-start': document.getElementById('gradient-primary-start').value,
                     'gradient-primary-end': document.getElementById('gradient-primary-end').value,
                     'gradient-secondary-start': document.getElementById('gradient-secondary-start').value,
                     'gradient-secondary-end': document.getElementById('gradient-secondary-end').value,
-                    'gradient-success-start': document.getElementById('gradient-success-start').value,
-                    'gradient-success-end': document.getElementById('gradient-success-end').value,
                     'gradient-light-start': document.getElementById('gradient-light-start').value,
                     'gradient-light-end': document.getElementById('gradient-light-end').value
                 };


### PR DESCRIPTION
Remove status colors from CSS and the ultimate style tester to simplify the color system.

This PR removes specific status color variables (e.g., success, warning, error, online, offline) and their usages from `styles.css`, replacing them with existing, more general color variables. It also cleans up the `ultimate-style-tester.html` by removing the corresponding UI controls and JavaScript references, streamlining the color management.

---
<a href="https://cursor.com/background-agent?bcId=bc-1311378e-16ca-4621-b628-5f4b6e8718d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1311378e-16ca-4621-b628-5f4b6e8718d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

