### PR TITLE
Fix recurring event links on main page

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -893,6 +893,14 @@ class CalendarCore {
         const pattern = this.parseRecurrencePattern(event.recurrence);
         if (!pattern) return dates;
         
+        logger.debug('CALENDAR', 'Generating visible event dates for recurring event', {
+            eventName: event.name,
+            recurrence: event.recurrence,
+            pattern: pattern,
+            periodStart: periodStart.toISOString().split('T')[0],
+            periodEnd: periodEnd.toISOString().split('T')[0]
+        });
+        
         const startDateStr = event.startDate instanceof Date ? 
             event.startDate.toISOString().split('T')[0] : event.startDate;
         const parts = startDateStr.split('-');
@@ -915,7 +923,39 @@ class CalendarCore {
                     current.setDate(current.getDate() + pattern.interval);
                     break;
                 case 'WEEKLY':
-                    current.setDate(current.getDate() + (7 * pattern.interval));
+                    if (pattern.byDay && pattern.byDay.length > 0) {
+                        // Weekly event with specific days - find next occurrence of the specified day
+                        const targetDayIndex = this.getDayIndexFromCode(pattern.byDay[0]);
+                        logger.debug('CALENDAR', 'Processing weekly event with specific day', {
+                            eventName: event.name,
+                            byDay: pattern.byDay[0],
+                            targetDayIndex: targetDayIndex,
+                            currentDay: current.getDay(),
+                            currentDate: current.toISOString().split('T')[0]
+                        });
+                        
+                        if (targetDayIndex !== -1) {
+                            // Find the next occurrence of the target day
+                            const daysUntilTarget = (targetDayIndex - current.getDay() + 7) % 7;
+                            const daysToAdd = daysUntilTarget === 0 ? (7 * pattern.interval) : daysUntilTarget;
+                            logger.debug('CALENDAR', 'Calculating next occurrence', {
+                                daysUntilTarget: daysUntilTarget,
+                                daysToAdd: daysToAdd,
+                                interval: pattern.interval
+                            });
+                            current.setDate(current.getDate() + daysToAdd);
+                        } else {
+                            // Fallback to simple weekly increment
+                            logger.warn('CALENDAR', 'Invalid day code, using fallback', {
+                                byDay: pattern.byDay[0]
+                            });
+                            current.setDate(current.getDate() + (7 * pattern.interval));
+                        }
+                    } else {
+                        // No specific day specified - use simple weekly increment
+                        logger.debug('CALENDAR', 'Weekly event without specific day, using simple increment');
+                        current.setDate(current.getDate() + (7 * pattern.interval));
+                    }
                     break;
                 case 'MONTHLY':
                     current.setMonth(current.getMonth() + pattern.interval);

--- a/js/today-events.js
+++ b/js/today-events.js
@@ -284,12 +284,28 @@ class TodayEventsAggregator extends DynamicCalendarLoader {
           endOfToday.setHours(23, 59, 59, 999);
           
           const visibleDates = this.getVisibleEventDates(ev, startOfToday, endOfToday);
+          logger.debug('CALENDAR', 'Calculating event date for recurring event', {
+            eventName: ev.name,
+            originalStartDate: ev.startDate,
+            recurrence: ev.recurrence,
+            visibleDates: visibleDates.map(d => d.toISOString().split('T')[0]),
+            today: today.toISOString().split('T')[0]
+          });
+          
           if (visibleDates.length > 0) {
             // Use the first occurrence found for today
             eventDate = visibleDates[0].toISOString().split('T')[0];
+            logger.debug('CALENDAR', 'Using calculated occurrence date', {
+              eventName: ev.name,
+              calculatedDate: eventDate
+            });
           } else {
             // Fallback to original date if no occurrence found for today
             eventDate = new Date(ev.startDate).toISOString().split('T')[0];
+            logger.warn('CALENDAR', 'No occurrence found for today, using original date', {
+              eventName: ev.name,
+              originalDate: eventDate
+            });
           }
         } else {
           // For one-time events, use the original date


### PR DESCRIPTION
Enhance `getVisibleEventDates` to correctly calculate occurrence dates for weekly recurring events with specific days, fixing "Today Events" links.

Previously, weekly recurring events with a `BYDAY` rule were incorrectly calculating occurrences by simply adding 7 days, which could lead to links navigating to the wrong day if the original event's start day didn't match the `BYDAY` rule. This change ensures the link points to the actual occurrence date.

---
<a href="https://cursor.com/background-agent?bcId=bc-69f19c2f-0d19-4a1c-a450-298abab10585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69f19c2f-0d19-4a1c-a450-298abab10585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

