### PR TITLE
Fix weekly recurring event error

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -935,7 +935,8 @@ class CalendarCore {
                         const daysToAdd = daysUntilTarget === 0 ? (7 * pattern.interval) : daysUntilTarget;
                         current.setDate(current.getDate() + daysToAdd);
                     } else {
-                        throw new Error('Weekly recurrence without BYDAY is not supported');
+                        // Weekly event without BYDAY - default to same day of week as original event
+                        current.setDate(current.getDate() + (7 * pattern.interval));
                     }
                     break;
                 case 'MONTHLY':


### PR DESCRIPTION
Fix weekly recurrence handling to default to the same day of the week when `BYDAY` is not specified.

Previously, weekly recurrence patterns without a `BYDAY` parameter would throw an error, preventing events from displaying. This change ensures such events are handled gracefully by repeating on the same day of the week, resolving the "Weekly recurrence without BYDAY is not supported" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7f2e125-6127-41e0-b132-d0dafba0d0a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7f2e125-6127-41e0-b132-d0dafba0d0a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

