### PR TITLE
Adjust test-map-icons header css

### DIFF
--- a/testing/test-map-icons.html
+++ b/testing/test-map-icons.html
@@ -561,7 +561,7 @@
 </head>
 <body>
     <div class="container">
-        <header class="header">
+        <div class="header">
             <h1 class="title">🗺️ Map Icon Laboratory</h1>
             <p class="subtitle">Advanced icon testing & customization for chunky.dad maps</p>
             
@@ -585,7 +585,7 @@
                     <strong>🌐 Favicon Support:</strong> Automatic website favicon detection and fallbacks
                 </div>
             </div>
-        </header>
+        </div>
 
         <div class="controls-section">
             <div class="control-panel">


### PR DESCRIPTION
Change `<header>` to `<div>` in `test-map-icons.html` to prevent the header from being fixed.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fe8d429-bada-4f92-bd14-1d8bf946af1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6fe8d429-bada-4f92-bd14-1d8bf946af1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

