### PR TITLE
Simplify calendar grid css for smaller screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4249,9 +4249,7 @@ footer {
 
 /* For larger tablets, show both but make buttons smaller */
 @media (min-width: 769px) and (max-width: 1024px) {
-    .calendar-grid.week-view-grid {
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    }
+    /* Removed calendar-grid.week-view-grid styling to keep single-column layout */
 
     .calendar-day.week-view {
         min-height: 180px;


### PR DESCRIPTION
Remove `grid-template-columns` styling for `.calendar-grid` at larger screen sizes to maintain a single-column layout.

The previous styling for screens 769px and above caused the calendar grid to display in an "ugly" multi-column format, so it was removed to ensure the cleaner single-column layout (used for 768px and below) is applied universally.

---
<a href="https://cursor.com/background-agent?bcId=bc-aae4f0b9-ad14-4973-97bf-d4cdb0dda47e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aae4f0b9-ad14-4973-97bf-d4cdb0dda47e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

