### PR TITLE
Merge calendar events for date overrides

### DIFF
--- a/data/calendars/philadelphia.ics
+++ b/data/calendars/philadelphia.ics
@@ -8,14 +8,14 @@ X-WR-TIMEZONE:America/New_York
 BEGIN:VEVENT
 DTSTART:20251101T010000Z
 DTEND:20251101T060000Z
-DTSTAMP:20251010T210327Z
+DTSTAMP:20251011T220844Z
 UID:3D97C917-CD83-44B2-A03C-0F6095F987D2
 CREATED:20250930T142205Z
 DESCRIPTION:description: CUBHOUSE returns on October 31st for a HALLOWEEN D
  ANCE PART!\nbar: 254\naddress: 254 South 12th Street\, Philadelphia\, PA 19
  107\ntimezone: America/New_York\nticketUrl: https://www.eventbrite.com/e/cu
  bhouse-philly-halloween-dance-party-tickets-1633106779339\ncover: $18.09 - 
- $29.14 (as of 10/10)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.
+ $29.14 (as of 10/11)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.
  com%2Fimages%2F1107233553%2F2544065821071%2F1%2Foriginal.20250828-015122?cr
  op=focalpoint&fit=crop&w=600&auto=format%2Ccompress&q=75&sharp=10&fp-x=4.75
  680933852e-05&fp-y=8.98832684825e-05&s=af53a251c09f02c722723a1a4c940b29\nsh
@@ -23,7 +23,7 @@ DESCRIPTION:description: CUBHOUSE returns on October 31st for a HALLOWEEN D
  rl: https://linktr.ee/cubhouse\ngmaps: https://www.google.com/maps/search/?
  api=1&query=39.9470542%2C-75.161054&query_place_id=101718083\nkey: cubhouse
  -philly-halloween-dance-party|2025-11-01|254|eventbrite
-LAST-MODIFIED:20251010T210249Z
+LAST-MODIFIED:20251011T213435Z
 LOCATION:39.9470542\, -75.161054
 SEQUENCE:0
 STATUS:CONFIRMED

--- a/data/calendars/update-summary.json
+++ b/data/calendars/update-summary.json
@@ -1,145 +1,145 @@
 {
-  "lastUpdated": "2025-10-10T21:03:27.283Z",
+  "lastUpdated": "2025-10-11T22:08:44.411Z",
   "cities": {
     "new-york": {
       "name": "New York",
       "status": "success",
       "dataLength": 6429,
       "eventCount": 8,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "seattle": {
       "name": "Seattle",
       "status": "success",
       "dataLength": 6772,
       "eventCount": 7,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "los-angeles": {
       "name": "Los Angeles",
       "status": "success",
       "dataLength": 5788,
       "eventCount": 5,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "toronto": {
       "name": "Toronto",
       "status": "success",
       "dataLength": 197,
       "eventCount": 0,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "london": {
       "name": "London",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "chicago": {
       "name": "Chicago",
       "status": "success",
       "dataLength": 8560,
       "eventCount": 8,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "berlin": {
       "name": "Berlin",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "palm-springs": {
       "name": "Palm Springs",
       "status": "success",
       "dataLength": 205,
       "eventCount": 0,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "denver": {
       "name": "Denver",
       "status": "success",
       "dataLength": 3435,
       "eventCount": 3,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "vegas": {
       "name": "Las Vegas",
       "status": "success",
       "dataLength": 3894,
       "eventCount": 3,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "atlanta": {
       "name": "Atlanta",
       "status": "success",
       "dataLength": 2532,
       "eventCount": 2,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "new-orleans": {
       "name": "New Orleans",
       "status": "success",
       "dataLength": 1324,
       "eventCount": 1,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "sf": {
       "name": "San Francisco",
       "status": "success",
       "dataLength": 4970,
       "eventCount": 4,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "portland": {
       "name": "Portland",
       "status": "success",
       "dataLength": 6391,
       "eventCount": 5,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "sitges": {
       "name": "Sitges",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "boston": {
       "name": "Boston",
       "status": "success",
       "dataLength": 196,
       "eventCount": 0,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "phoenix": {
       "name": "Phoenix",
       "status": "success",
       "dataLength": 1479,
       "eventCount": 1,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "provincetown": {
       "name": "Provincetown",
       "status": "success",
       "dataLength": 202,
       "eventCount": 0,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "san-diego": {
       "name": "San Diego",
       "status": "success",
       "dataLength": 1533,
       "eventCount": 1,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     },
     "philadelphia": {
       "name": "Philadelphia",
       "status": "success",
       "dataLength": 1535,
       "eventCount": 1,
-      "lastUpdated": "2025-10-10T21:03:27.283Z"
+      "lastUpdated": "2025-10-11T22:08:44.411Z"
     }
   }
 }

--- a/new-york/goldiloxx-6c462174/index.html
+++ b/new-york/goldiloxx-6c462174/index.html
@@ -5,27 +5,27 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>GOLDILOXX – New York – chunky.dad</title>
-  <meta name="description" content="Saturday · 9PM-4AM · @ Red Eye NY &amp; The Cockpit">
+  <meta name="description" content="Saturday · 9PM-6AM · @ Red Eye NY &amp; The Cockpit">
   <link rel="canonical" href="/new-york/">
   <meta property="og:type" content="article">
   <meta property="og:title" content="GOLDILOXX – New York – chunky.dad">
-  <meta property="og:description" content="Saturday · 9PM-4AM · @ Red Eye NY &amp; The Cockpit">
+  <meta property="og:description" content="Saturday · 9PM-6AM · @ Red Eye NY &amp; The Cockpit">
   <meta property="og:url" content="https://chunky.dad/new-york/goldiloxx-6c462174/">
-  <meta property="og:image" content="https://chunky.dad/img/og/new-york/goldiloxx-6c462174.png?v=fc13a574">
+  <meta property="og:image" content="https://chunky.dad/img/og/new-york/goldiloxx-6c462174.png?v=67f5a437">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="GOLDILOXX – New York – chunky.dad">
-  <meta name="twitter:description" content="Saturday · 9PM-4AM · @ Red Eye NY &amp; The Cockpit">
-  <meta name="twitter:image" content="https://chunky.dad/img/og/new-york/goldiloxx-6c462174.png?v=fc13a574">
-  <meta http-equiv="refresh" content="0; url=../?event=goldiloxx-6c462174&date=2025-07-26&view=week">
+  <meta name="twitter:description" content="Saturday · 9PM-6AM · @ Red Eye NY &amp; The Cockpit">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/new-york/goldiloxx-6c462174.png?v=67f5a437">
+  <meta http-equiv="refresh" content="0; url=../?event=goldiloxx-6c462174&date=2025-10-25&view=week">
 </head>
 <body>
-  <noscript><meta http-equiv="refresh" content="0; url=../?event=goldiloxx-6c462174&date=2025-07-26&view=week"></noscript>
+  <noscript><meta http-equiv="refresh" content="0; url=../?event=goldiloxx-6c462174&date=2025-10-25&view=week"></noscript>
   <script>
     (function(){
       try {
         var hash = window.location.hash || '';
         // Prefer incoming params (date/view) when provided; always enforce event param
-        var target = new URL("../?event=goldiloxx-6c462174&date=2025-07-26&view=week", window.location.href);
+        var target = new URL("../?event=goldiloxx-6c462174&date=2025-10-25&view=week", window.location.href);
         var incoming = new URL(window.location.href);
         // Copy ALL incoming params over target (override)
         incoming.searchParams.forEach(function(v, k){
@@ -36,7 +36,7 @@
         var finalUrl = target.pathname + '?' + target.searchParams.toString() + hash;
         location.replace(finalUrl);
       } catch (e) {
-        location.replace("../?event=goldiloxx-6c462174&date=2025-07-26&view=week");
+        location.replace("../?event=goldiloxx-6c462174&date=2025-10-25&view=week");
       }
     })();
   </script>

--- a/philadelphia/cubhouse-philly-halloween-dance-party-7f59fc8c/index.html
+++ b/philadelphia/cubhouse-philly-halloween-dance-party-7f59fc8c/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="CUBHOUSE PHILLY HALLOWEEN DANCE PARTY – Philadelphia – chunky.dad">
   <meta property="og:description" content="Friday · 9PM-2AM · @ 254">
   <meta property="og:url" content="https://chunky.dad/philadelphia/cubhouse-philly-halloween-dance-party-7f59fc8c/">
-  <meta property="og:image" content="https://chunky.dad/img/og/philadelphia/cubhouse-philly-halloween-dance-party-7f59fc8c.png?v=9d18f366">
+  <meta property="og:image" content="https://chunky.dad/img/og/philadelphia/cubhouse-philly-halloween-dance-party-7f59fc8c.png?v=f2fba1b7">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="CUBHOUSE PHILLY HALLOWEEN DANCE PARTY – Philadelphia – chunky.dad">
   <meta name="twitter:description" content="Friday · 9PM-2AM · @ 254">
-  <meta name="twitter:image" content="https://chunky.dad/img/og/philadelphia/cubhouse-philly-halloween-dance-party-7f59fc8c.png?v=9d18f366">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/philadelphia/cubhouse-philly-halloween-dance-party-7f59fc8c.png?v=f2fba1b7">
   <meta http-equiv="refresh" content="0; url=../?event=cubhouse-philly-halloween-dance-party-7f59fc8c&date=2025-10-31&view=week">
 </head>
 <body>


### PR DESCRIPTION
Implement iCal event merging to display recurring event overrides correctly, showing only the specific overridden event while preserving its recurrence data.

Previously, iCal data containing recurring events with specific date overrides (identified by `RECURRENCE-ID`) would display both the generic recurring event and the specific override as separate entries. This led to duplicate or incorrect event listings for dates with overrides, such as the Goldiloxx event on October 25th, 2025. This change ensures that for such dates, only the merged, overridden event is displayed, combining the specific details of the override with the recurrence information of the base event.

---
<a href="https://cursor.com/background-agent?bcId=bc-492f30ca-156e-4940-bcc2-4d1deae8250b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-492f30ca-156e-4940-bcc2-4d1deae8250b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

