### PR TITLE
Extend image downloader for bar downloads

### DIFF
--- a/.github/workflows/bars-sync.yml
+++ b/.github/workflows/bars-sync.yml
@@ -27,6 +27,18 @@ jobs:
     - name: Sync bars data
       run: node tools/sync-bars.js
       
+    - name: Download bar images and favicons
+      run: |
+        node tools/download-images.js
+        git add -A img/bars/ img/favicons/ 2>/dev/null || true
+        if git diff --staged --quiet; then
+          echo "No bar image changes to commit"
+        else
+          git commit -m "🖼️ Download/update bar images and favicons"
+          git push
+          echo "✓ Bar images and favicons updated and committed"
+        fi
+      
     - name: Commit updated bars data
       run: |
         git config --local user.email "action@github.com"

--- a/tools/sync-bars.js
+++ b/tools/sync-bars.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Import the extended image downloader
-const { downloadBarImage, generateBarFilename } = require('./download-images.js');
+const { downloadImageWithInfo } = require('./download-images.js');
 
 // Simplified bars sync script using public Google Sheets (like bear artists)
 async function syncBars() {
@@ -697,12 +697,12 @@ async function downloadBarImages(bars) {
     for (const bar of bars) {
         if (bar.image) {
             try {
-                const result = await downloadBarImage(bar.image, {
+                const result = await downloadImageWithInfo(bar.image, {
                     name: bar.name,
                     city: bar.city,
                     wikipedia: bar.wikipedia,
                     website: bar.website
-                });
+                }, 'bar');
                 
                 if (result.success) {
                     if (result.skipped) {

--- a/tools/sync-bars.js
+++ b/tools/sync-bars.js
@@ -3,6 +3,9 @@
 const fs = require('fs');
 const path = require('path');
 
+// Import the extended image downloader
+const { downloadBarImage, generateBarFilename } = require('./download-images.js');
+
 // Simplified bars sync script using public Google Sheets (like bear artists)
 async function syncBars() {
     console.log('🔄 Starting simplified bars sync...');
@@ -35,6 +38,10 @@ async function syncBars() {
         // 5. Save merged data locally
         console.log('💾 Saving merged data locally...');
         await saveBarsLocally(enrichedBars);
+        
+        // 6. Download bar images using the extended image downloader
+        console.log('🖼️  Downloading bar images...');
+        await downloadBarImages(enrichedBars);
         
         console.log('✅ Simplified sync completed successfully!');
         
@@ -679,6 +686,44 @@ function convertDMSToDecimal(dms) {
     const lonDecimal = lonDir === 'W' ? -lon : lon;
     
     return `${latDecimal}, ${lonDecimal}`;
+}
+
+// Download bar images using the extended image downloader
+async function downloadBarImages(bars) {
+    let totalDownloaded = 0;
+    let totalSkipped = 0;
+    let totalFailed = 0;
+    
+    for (const bar of bars) {
+        if (bar.image) {
+            try {
+                const result = await downloadBarImage(bar.image, {
+                    name: bar.name,
+                    city: bar.city,
+                    wikipedia: bar.wikipedia,
+                    website: bar.website
+                });
+                
+                if (result.success) {
+                    if (result.skipped) {
+                        totalSkipped++;
+                    } else {
+                        totalDownloaded++;
+                    }
+                } else {
+                    totalFailed++;
+                }
+            } catch (error) {
+                console.error(`❌ Failed to download image for ${bar.name}:`, error.message);
+                totalFailed++;
+            }
+        }
+    }
+    
+    console.log(`📊 Bar image download summary:`);
+    console.log(`✅ Downloaded: ${totalDownloaded}`);
+    console.log(`⏭️  Skipped: ${totalSkipped}`);
+    console.log(`❌ Failed: ${totalFailed}`);
 }
 
 // Run the sync

--- a/tools/sync-bars.js
+++ b/tools/sync-bars.js
@@ -702,7 +702,7 @@ async function downloadBarImages(bars) {
                     city: bar.city,
                     wikipedia: bar.wikipedia,
                     website: bar.website
-                }, 'bar');
+                });
                 
                 if (result.success) {
                     if (result.skipped) {


### PR DESCRIPTION
Extend the image downloader to support bars and migrate Wikipedia icon scraping to centralize image downloading logic.

The existing event image downloader had special logic for Linktree. This PR generalizes that logic to also handle bar images, including Wikipedia-hosted icons and favicons, ensuring consistent image handling and filename generation (using Wikipedia URL as key) across both events and bars. This avoids duplicating image download code in the bar sync script.

---
<a href="https://cursor.com/background-agent?bcId=bc-23a74410-7d63-4efd-af37-c2d10a4e6a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23a74410-7d63-4efd-af37-c2d10a4e6a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

