### PR TITLE
Update image downloader for Wikipedia support

### DIFF
--- a/tools/download-images.js
+++ b/tools/download-images.js
@@ -1240,9 +1240,9 @@ async function main() {
   }
   
   // Process Wikipedia images with multiple sizes
-  if (imageUrls.wikipediaUrls && imageUrls.wikipediaUrls.size > 0) {
+  if (allImageUrls.wikipediaUrls && allImageUrls.wikipediaUrls.size > 0) {
     console.log('\\n📚 Processing Wikipedia images with multiple sizes...');
-    for (const wikipediaUrl of imageUrls.wikipediaUrls) {
+    for (const wikipediaUrl of allImageUrls.wikipediaUrls) {
       try {
         // Extract image URL from Wikipedia page
         const imageUrl = await extractWikipediaImage(wikipediaUrl);

--- a/tools/download-images.js
+++ b/tools/download-images.js
@@ -1165,6 +1165,23 @@ async function main() {
     }
   }
   
+  // Download bar images with bar information
+  console.log('\\n🍺 Downloading bar images...');
+  for (const barWithImage of allImageUrls.barsWithInfo) {
+    const result = await downloadBarImage(barWithImage.imageUrl, {
+      name: barWithImage.name,
+      city: barWithImage.city
+    });
+    if (result.success) {
+      if (result.skipped) {
+        totalSkipped++;
+      } else {
+        totalDownloaded++;
+      }
+    } else {
+      totalFailed++;
+    }
+  }
   
   // Download high-quality favicons (64px for map markers)
   console.log('\n🗺️  Downloading high-quality favicons (64px)...');
@@ -1305,4 +1322,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { downloadImage, downloadImageWithSize, downloadEventImage, extractImageUrls, extractLinktreeProfilePicture, isLinktreeUrl, extractWikipediaImage, isWikipediaUrl, fetchPageContent, generateLinktreeFaviconFilename, generateWikipediaFaviconFilename, downloadImageWithCustomFilename, shouldDownloadImage };
+module.exports = { downloadImage, downloadImageWithSize, downloadEventImage, downloadBarImage, extractImageUrls, extractBarsImageUrls, extractLinktreeProfilePicture, isLinktreeUrl, extractWikipediaImage, isWikipediaUrl, fetchPageContent, generateLinktreeFaviconFilename, generateWikipediaFaviconFilename, generateBarFilename, downloadImageWithCustomFilename, shouldDownloadImage };


### PR DESCRIPTION
Add Wikipedia URL support and extend the image downloader to process bar data, generalizing its functionality beyond event-specific logic.

The image downloader was previously only processing event data. This PR modifies it to also extract and download images from bar data, ensuring that Wikipedia URLs found in bar entries are also processed, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b14e250-c2e7-4728-93ee-3696ca6dfff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b14e250-c2e7-4728-93ee-3696ca6dfff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

