### PR TITLE
Fix recurring override detection for Scriptable matches

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1725,7 +1725,7 @@ class SharedCore {
         };
     }
 
-    shouldCreateOverrideFromRecurringMatch(existingEvent) {
+    shouldCreateOverrideFromRecurringMatch(existingEvent, existingEventsData = null) {
         if (!existingEvent || typeof existingEvent !== 'object') {
             return false;
         }
@@ -1753,11 +1753,55 @@ class SharedCore {
             return true;
         }
         const recurrenceRule = fields.recurrence || existingEvent.recurrence;
-        return Boolean(recurrenceRule);
+        if (recurrenceRule) {
+            return true;
+        }
+
+        // Scriptable can return recurring instances without explicit recurrence fields.
+        // If multiple events in the current candidate set share a UID on different dates,
+        // treat this as recurring so edits create overrides instead of mutating originals.
+        const sourceUid = eventIdentifierInfo.uid || notesIdentifierInfo.uid || notesIdentifierRaw || null;
+        const normalizedSourceUid = this.normalizeOverrideUid(sourceUid);
+        if (!normalizedSourceUid || !Array.isArray(existingEventsData) || existingEventsData.length === 0) {
+            return false;
+        }
+
+        const sourceStartDate = existingEvent.startDate instanceof Date
+            ? existingEvent.startDate
+            : this.parseDate(existingEvent.startDate);
+        const sourceDateKey = sourceStartDate ? this.normalizeEventDate(sourceStartDate) : '';
+        for (const candidateEvent of existingEventsData) {
+            if (!candidateEvent || candidateEvent === existingEvent) {
+                continue;
+            }
+            const candidateFields = this.parseNotesIntoFields(candidateEvent.notes || '');
+            const candidateIdentifierRaw = normalizeIdentifier(candidateEvent.identifier || '');
+            const candidateIdentifierInfo = this.parseScriptableIdentifier(candidateIdentifierRaw);
+            const candidateNotesIdentifierRaw = normalizeIdentifier(
+                candidateFields.uid || candidateFields.identifier || candidateFields.id || ''
+            );
+            const candidateNotesIdentifierInfo = this.parseScriptableIdentifier(candidateNotesIdentifierRaw);
+            const candidateUid = this.normalizeOverrideUid(
+                candidateIdentifierInfo.uid || candidateNotesIdentifierInfo.uid || candidateNotesIdentifierRaw || ''
+            );
+            if (!candidateUid || candidateUid !== normalizedSourceUid) {
+                continue;
+            }
+
+            const candidateStartDate = candidateEvent.startDate instanceof Date
+                ? candidateEvent.startDate
+                : this.parseDate(candidateEvent.startDate);
+            const candidateDateKey = candidateStartDate ? this.normalizeEventDate(candidateStartDate) : '';
+            if (!sourceDateKey || !candidateDateKey || candidateDateKey !== sourceDateKey) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     resolveRecurringMergeCandidate(existingEventsData, existingEvent) {
-        if (!this.shouldCreateOverrideFromRecurringMatch(existingEvent)) {
+        if (!this.shouldCreateOverrideFromRecurringMatch(existingEvent, existingEventsData)) {
             return null;
         }
 
@@ -2712,6 +2756,10 @@ class SharedCore {
             if (keyMatch && keyMatch.matchType === 'identifier') {
                 const existingEvent = keyMatch.event;
                 const matchedKey = keyMatch.matchedKey || null;
+                const recurringMergeDecision = this.resolveRecurringMergeCandidate(existingEventsData, existingEvent);
+                if (recurringMergeDecision) {
+                    return recurringMergeDecision;
+                }
                 return {
                     action: 'merge',
                     reason: 'Identifier match found',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- detect recurring source events when Scriptable returns multiple same-UID instances without explicit recurrence metadata
- run recurring override resolution for identifier matches so recurring instance edits create overrides instead of mutating source events
- keep existing override-key matching behavior unchanged

## Testing
- `node -e "const { SharedCore } = require('./scripts/shared-core.js'); const core = new SharedCore({ test:{patterns:['test']} }); const existingEvent = { title:'Bear Night', startDate:new Date('2026-04-05T20:00:00Z'), endDate:new Date('2026-04-06T01:00:00Z'), identifier:'UID123', notes:'uid: UID123\nkey: bear-night|2026-04-05|club|test\nrecurrence: FREQ=WEEKLY', location:'Club', url:'' }; const existingEvents=[existingEvent]; const recurringWithIdentifier = { title:'Bear Night', startDate:new Date('2026-04-12T20:00:00Z'), endDate:new Date('2026-04-13T01:00:00Z'), key:'bear-night|2026-04-05|club|test', source:'test', identifier:'UID123', searchStartDate:new Date('2026-04-05T20:00:00Z') }; console.log(JSON.stringify(core.analyzeEventAction(recurringWithIdentifier, existingEvents), null, 2));"`
- `node -e "const { SharedCore } = require('./scripts/shared-core.js'); const core = new SharedCore({ nyc:{patterns:['new york']} }); const mk=(d)=>({ title:'GOLDILOXX', startDate:new Date(d), endDate:new Date(new Date(d).getTime()+3600000), identifier:'2DDB:88ctfpug1icbk4iofj0kgj4u78@google.com', notes:'matchKey: goldiloxx*|2026-04-*|*\nshortName: GOLDI-LOXX\nuid: 88ctfpug1icbk4iofj0kgj4u78@google.com' }); const existing=[mk('2026-03-29T01:00:00Z'), mk('2026-04-26T01:00:00Z'), mk('2026-05-31T01:00:00Z')]; const incoming={ title:'GOLDILOXX', startDate:new Date('2026-04-19T01:00:00Z'), endDate:new Date('2026-04-19T08:00:00Z'), city:'nyc', source:'redeyetickets', matchKey:'goldiloxx*|2026-04-*|*' }; const analysis=core.analyzeEventAction(incoming, existing); console.log(JSON.stringify({action:analysis.action, reason:analysis.reason, hasSourceEvent:Boolean(analysis.sourceEvent), hasExistingEvent:Boolean(analysis.existingEvent), existingKey:analysis.existingKey, overrideIdentity:analysis.overrideIdentity||null}, null, 2));"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf82dd87-e8af-4636-932a-a8bbeb26947b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf82dd87-e8af-4636-932a-a8bbeb26947b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

