### PR TITLE
Clarify merge intent vs calendar write actions in Scriptable and metrics views

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1545,32 +1545,26 @@ class ScriptableAdapter {
             // Show event actions summary if available
             const allEvents = this.getAllEventsFromResults(results);
             if (allEvents && allEvents.length > 0) {
-                const actionsCount = {
-                    new: 0, add: 0, merge: 0, conflict: 0, enriched: 0
-                };
-                
-                let hasActions = false;
-                allEvents.forEach(event => {
-                    if (event._action) {
-                        hasActions = true;
-                        const action = event._action.toLowerCase();
-                        if (actionsCount.hasOwnProperty(action)) {
-                            actionsCount[action]++;
-                        }
-                    }
-                });
-                
-                if (hasActions) {
-                    console.log('\n🎯 Event Actions:');
-                    Object.entries(actionsCount).forEach(([action, count]) => {
-                        if (count > 0) {
-                            const actionIcon = {
-                                'new': '➕', 'add': '➕', 'merge': '🔄',
-                                'conflict': '⚠️', 'enriched': '✨'
-                            }[action] || '❓';
-                            console.log(`   ${actionIcon} ${action.toUpperCase()}: ${count}`);
-                        }
-                    });
+                const intentCounts = this.countMetricsActions(allEvents);
+                const writeCounts = this.countMetricsCalendarActions(allEvents);
+                const hasIntentCounts = Object.values(intentCounts).some(count => count > 0);
+                const hasWriteCounts = Object.values(writeCounts).some(count => count > 0);
+
+                if (hasIntentCounts) {
+                    console.log('\n🎯 Intent Actions:');
+                    if (intentCounts.new > 0) console.log(`   ➕ NEW: ${intentCounts.new}`);
+                    if (intentCounts.merge > 0) console.log(`   🔄 MERGE: ${intentCounts.merge}`);
+                    if (intentCounts.conflict > 0) console.log(`   ⚠️ CONFLICT: ${intentCounts.conflict}`);
+                    if (intentCounts.missing_calendar > 0) console.log(`   ❌ MISSING_CALENDAR: ${intentCounts.missing_calendar}`);
+                    if (intentCounts.other > 0) console.log(`   ❓ OTHER: ${intentCounts.other}`);
+                }
+
+                if (hasWriteCounts) {
+                    console.log('\n📝 Calendar Write Plan:');
+                    if (writeCounts.create > 0) console.log(`   ➕ CREATE: ${writeCounts.create}`);
+                    if (writeCounts.update > 0) console.log(`   🔄 UPDATE: ${writeCounts.update}`);
+                    if (writeCounts.skip > 0) console.log(`   ⏭️ SKIP: ${writeCounts.skip}`);
+                    if (writeCounts.other > 0) console.log(`   ❓ OTHER: ${writeCounts.other}`);
                 }
             }
             
@@ -1904,16 +1898,17 @@ class ScriptableAdapter {
             return;
         }
         
-        // Group events by action type
+        // Group events by intent action type (display intent can differ from write action)
         const eventsByAction = {
             new: [],
             merge: [],
             conflict: [],
+            missing_calendar: [],
             other: []
         };
         
         allEvents.forEach(event => {
-            const action = event._action || 'other';
+            const action = this.normalizeIntentAction(event) || 'other';
             if (eventsByAction[action]) {
                 eventsByAction[action].push(event);
             } else {
@@ -1926,6 +1921,7 @@ class ScriptableAdapter {
         console.log(`   ➕ New: ${eventsByAction.new.length} events`);
         console.log(`   🔀 Merge: ${eventsByAction.merge.length} events`);
         console.log(`   ⚠️  Conflict: ${eventsByAction.conflict.length} events`);
+        console.log(`   ❌ Missing Calendar: ${eventsByAction.missing_calendar.length} events`);
         if (eventsByAction.other.length > 0) {
             console.log(`   ❓ Other: ${eventsByAction.other.length} events`);
         }
@@ -1946,6 +1942,7 @@ class ScriptableAdapter {
             const event = events[0];
             console.log(`• ${event.title || event.name}`);
             console.log(`  📍 ${event.venue || event.bar || 'TBD'} | 📱 ${this.getCalendarNameForDisplay(event)}`);
+            console.log(`  🎯 Intent: ${this.formatIntentActionLabel(this.normalizeIntentAction(event))} | 📝 Write: ${this.formatWriteActionLabel(this.getWriteActionFromEvent(event))}`);
             const eventDateForDisplay = new Date(event.startDate);
             // Get timezone from city configuration instead of expecting it on the event
             const timezone = this.getTimezoneForCity(event.city);
@@ -2008,23 +2005,21 @@ class ScriptableAdapter {
         // Show action breakdown if events have been analyzed
         const actionsCount = {
             new: 0,
-            add: 0,
             merge: 0,
             conflict: 0,
-            enriched: 0,
-            unknown: 0
+            missing_calendar: 0,
+            other: 0
         };
         
         let hasActions = false;
         allEvents.forEach(event => {
-            if (event._action) {
-                hasActions = true;
-                const action = event._action.toLowerCase();
-                if (actionsCount.hasOwnProperty(action)) {
-                    actionsCount[action]++;
-                } else {
-                    actionsCount.unknown++;
-                }
+            const action = this.normalizeIntentAction(event);
+            if (!action) return;
+            hasActions = true;
+            if (actionsCount.hasOwnProperty(action)) {
+                actionsCount[action]++;
+            } else {
+                actionsCount.other++;
             }
         });
         
@@ -2034,11 +2029,10 @@ class ScriptableAdapter {
                 if (count > 0) {
                     const actionIcon = {
                         'new': '➕',
-                        'add': '➕',
                         'merge': '🔄',
                         'conflict': '⚠️',
-                        'enriched': '✨',
-                        'unknown': '❓'
+                        'missing_calendar': '❌',
+                        'other': '❓'
                     }[action] || '❓';
                     
                     console.log(`   ${actionIcon} ${action.toUpperCase()}: ${count} events`);
@@ -2206,14 +2200,13 @@ class ScriptableAdapter {
         const headerLogoData = await this.loadHeaderLogoData();
         const headerLogoSrc = headerLogoData || HEADER_LOGO_URL;
         
-        // Group events by their pre-analyzed actions (set by shared-core)
+        // Group events by intent actions (intent can differ from write action for overrides)
         const newEvents = [];
         const mergeEvents = [];
         const conflictEvents = [];
         
         for (const event of allEvents) {
-            // Events should already have _action set by shared-core
-            switch (event._action) {
+            switch (this.normalizeIntentAction(event)) {
                 case 'new':
                     newEvents.push(event);
                     break;
@@ -2221,8 +2214,6 @@ class ScriptableAdapter {
                     mergeEvents.push(event);
                     break;
                 case 'conflict':
-                case 'key_conflict':
-                case 'time_conflict':
                 case 'missing_calendar':
                     conflictEvents.push(event);
                     break;
@@ -2639,6 +2630,12 @@ class ScriptableAdapter {
         
         .badge-error::before {
             content: "❌ ";
+        }
+
+        .write-action-note {
+            margin: -4px 0 10px;
+            font-size: 12px;
+            color: var(--text-secondary);
         }
         
         .conflict-info {
@@ -3782,12 +3779,15 @@ class ScriptableAdapter {
     
     // Generate HTML for individual event card
     generateEventCard(event) {
+        const intentAction = this.normalizeIntentAction(event) || 'other';
+        const writeAction = this.getWriteActionFromEvent(event);
         const actionBadge = {
             'new': '<span class="action-badge badge-new">NEW</span>',
             'merge': '<span class="action-badge badge-merge">MERGE</span>',
             'conflict': '<span class="action-badge badge-warning">CONFLICT</span>',
             'missing_calendar': '<span class="action-badge badge-error">MISSING CALENDAR</span>'
-        }[event._action] || '';
+        }[intentAction] || '<span class="action-badge badge-warning">OTHER</span>';
+        const actionNote = `<div class="write-action-note">Intent: ${this.formatIntentActionLabel(intentAction)} • Write: ${this.formatWriteActionLabel(writeAction)}</div>`;
         
         const eventDate = new Date(event.startDate);
         const endDate = event.endDate ? new Date(event.endDate) : null;
@@ -3833,6 +3833,7 @@ class ScriptableAdapter {
         let html = `
         <div class="event-card">
             ${actionBadge}
+            ${actionNote}
             <div class="event-title">${this.escapeHtml(event.title || event.name)}</div>
             
             <!-- Main Event Info -->
@@ -3967,7 +3968,7 @@ class ScriptableAdapter {
             </div>
             
             <!-- Show comparison for all non-new events with original data -->
-            ${event._original && event._action !== 'new' ? (() => {
+            ${event._original && this.normalizeIntentAction(event) !== 'new' ? (() => {
                 const hasDifferences = this.hasEventDifferences(event);
                 const eventId = event.key || `event-${Math.random().toString(36).substr(2, 9)}`;
                 // Decode HTML entities before creating safe ID
@@ -5024,18 +5025,19 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
         const alert = new Alert();
         alert.title = "Execute Calendar Actions?";
         
-        // Count actions by type
-        const actionCounts = {};
-        analyzedEvents.forEach(event => {
-            const action = event._action || 'unknown';
-            actionCounts[action] = (actionCounts[action] || 0) + 1;
-        });
+        // Count actions by type (intent and write)
+        const intentCounts = this.countMetricsActions(analyzedEvents);
+        const writeCounts = this.countMetricsCalendarActions(analyzedEvents);
         
         let message = "Ready to execute the following calendar actions:\n\n";
-        if (actionCounts.new) message += `➕ Create ${actionCounts.new} new events\n`;
-        if (actionCounts.merge) message += `🔄 Merge ${actionCounts.merge} events\n`;
-        if (actionCounts.conflict) message += `⚠️ Skip ${actionCounts.conflict} conflicted events\n`;
-        if (actionCounts.missing_calendar) message += `❌ Skip ${actionCounts.missing_calendar} events (missing calendars)\n`;
+        if (intentCounts.new) message += `🎯 Intent NEW: ${intentCounts.new} events\n`;
+        if (intentCounts.merge) message += `🎯 Intent MERGE: ${intentCounts.merge} events\n`;
+        if (intentCounts.conflict) message += `🎯 Intent CONFLICT: ${intentCounts.conflict} events\n`;
+        if (intentCounts.new || intentCounts.merge || intentCounts.conflict) message += `\n`;
+        if (writeCounts.create) message += `➕ Create ${writeCounts.create} events\n`;
+        if (writeCounts.update) message += `🔄 Update ${writeCounts.update} events\n`;
+        if (writeCounts.skip) message += `⚠️ Skip ${writeCounts.skip} events\n`;
+        if (writeCounts.other) message += `❓ Other write actions: ${writeCounts.other}\n`;
         
         alert.message = message;
         alert.addAction("Execute");
@@ -5374,8 +5376,41 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
         };
     }
 
-    normalizeMetricsIntentAction(event) {
+    normalizeWriteAction(event) {
         const action = String(event?._action || '').toLowerCase();
+        if (!action) return null;
+        if (action === 'key_conflict' || action === 'time_conflict') return 'conflict';
+        return action;
+    }
+
+    getWriteActionFromEvent(event) {
+        const action = this.normalizeWriteAction(event);
+        if (!action) return null;
+        if (action === 'new') return 'create';
+        if (action === 'merge') return 'update';
+        if (action === 'conflict' || action === 'missing_calendar') return 'skip';
+        return 'other';
+    }
+
+    formatIntentActionLabel(action) {
+        const normalized = String(action || '').toLowerCase();
+        if (normalized === 'merge') return 'MERGE';
+        if (normalized === 'new') return 'NEW';
+        if (normalized === 'conflict') return 'CONFLICT';
+        if (normalized === 'missing_calendar') return 'MISSING_CALENDAR';
+        return 'OTHER';
+    }
+
+    formatWriteActionLabel(action) {
+        const normalized = String(action || '').toLowerCase();
+        if (normalized === 'create') return 'CREATE';
+        if (normalized === 'update') return 'UPDATE';
+        if (normalized === 'skip') return 'SKIP';
+        return 'OTHER';
+    }
+
+    normalizeIntentAction(event) {
+        const action = this.normalizeWriteAction(event);
         if (!action) return null;
         if (action !== 'new') return action;
 
@@ -5391,6 +5426,10 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
             return 'merge';
         }
         return 'new';
+    }
+
+    normalizeMetricsIntentAction(event) {
+        return this.normalizeIntentAction(event);
     }
 
     countMetricsActions(events) {
@@ -5432,7 +5471,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
         const counts = this.createMetricsCalendarActionCounts();
         if (!Array.isArray(events)) return counts;
         events.forEach(event => {
-            const action = String(event?._action || '').toLowerCase();
+            const action = this.normalizeWriteAction(event);
             if (!action) return;
             if (action === 'new') {
                 counts.create += 1;
@@ -5457,7 +5496,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
                 countsByParser[parserName] = this.createMetricsCalendarActionCounts();
             }
             const counts = countsByParser[parserName];
-            const action = String(event?._action || '').toLowerCase();
+            const action = this.normalizeWriteAction(event);
             if (!action) return;
             if (action === 'new') {
                 counts.create += 1;

--- a/scripts/display-run-metrics.js
+++ b/scripts/display-run-metrics.js
@@ -509,6 +509,16 @@ class MetricsDisplay {
     };
   }
 
+  createCalendarActionCounts() {
+    return {
+      create: 0,
+      update: 0,
+      skip: 0,
+      failed: 0,
+      other: 0
+    };
+  }
+
   createParserTotals() {
     return {
       total_events: 0,
@@ -559,7 +569,25 @@ class MetricsDisplay {
     const errorsCount = Number.isFinite(record.errors_count) ? record.errors_count : 0;
     const warningsCount = this.getRunWarningCount(record);
     const status = this.getRunStatusFromCounts(errorsCount, warningsCount, record.status);
-    return { ...record, warnings_count: warningsCount, status };
+    const calendarActions = {
+      ...this.createCalendarActionCounts(),
+      ...(record?.calendar_actions || {})
+    };
+    const parsers = Array.isArray(record?.parsers)
+      ? record.parsers.map(parser => ({
+          ...parser,
+          actions: { ...this.createActionCounts(), ...(parser?.actions || {}) },
+          calendar_actions: { ...this.createCalendarActionCounts(), ...(parser?.calendar_actions || {}) }
+        }))
+      : [];
+    return {
+      ...record,
+      warnings_count: warningsCount,
+      status,
+      actions: { ...this.createActionCounts(), ...(record?.actions || {}) },
+      calendar_actions: calendarActions,
+      parsers
+    };
   }
 
   sumActions(actions) {
@@ -602,6 +630,7 @@ class MetricsDisplay {
             runs: 0,
             totals: this.createParserTotals(),
             actions: this.createActionCounts(),
+            calendarActions: this.createCalendarActionCounts(),
             durationMsTotal: 0,
             statusCounts: this.createStatusCounts()
           };
@@ -616,6 +645,10 @@ class MetricsDisplay {
         const actions = parserRecord?.actions || {};
         Object.keys(bucket.actions).forEach(key => {
           bucket.actions[key] += actions[key] || 0;
+        });
+        const calendarActions = parserRecord?.calendar_actions || {};
+        Object.keys(bucket.calendarActions).forEach(key => {
+          bucket.calendarActions[key] += calendarActions[key] || 0;
         });
         const statusKey = this.getRunStatusBucketKey(record?.status);
         if (statusKey && bucket.statusCounts) {
@@ -670,14 +703,17 @@ class MetricsDisplay {
       const lastRun = lastRuns[name] || null;
       const record = lastRun?.parser || null;
       const actions = record?.actions ? record.actions : this.createActionCounts();
+      const calendarActions = record?.calendar_actions ? record.calendar_actions : this.createCalendarActionCounts();
       const totalEvents = record?.total_events || 0;
       const summaryTotals = summaryParsers?.[name]?.totals || null;
       const allTimeRuns = summaryTotals?.runs || 0;
       const allTimeTotals = summaryTotals?.totals || this.createParserTotals();
       const allTimeActions = summaryTotals?.actions || this.createActionCounts();
+      const allTimeCalendarActions = summaryTotals?.calendar_actions || this.createCalendarActionCounts();
       const allTimeDurationMs = summaryTotals?.duration_ms_total || 0;
       const historyTotals = historyByParser?.[name]?.totals || this.createParserTotals();
       const historyActions = historyByParser?.[name]?.actions || this.createActionCounts();
+      const historyCalendarActions = historyByParser?.[name]?.calendarActions || this.createCalendarActionCounts();
       const historyRuns = historyByParser?.[name]?.runs || 0;
       const historyDurationMs = historyByParser?.[name]?.durationMsTotal || 0;
       const ran = !!record || allTimeRuns > 0 || historyRuns > 0;
@@ -694,6 +730,7 @@ class MetricsDisplay {
         finalBearEvents: record?.final_bear_events || 0,
         durationMs: record?.duration_ms || null,
         actions,
+        calendarActions,
         warningCount,
         lastRunAt: lastRun?.record?.finished_at || null,
         lastRunId: lastRun?.record?.run_id || null,
@@ -701,10 +738,12 @@ class MetricsDisplay {
         allTimeRuns,
         allTimeTotals,
         allTimeActions,
+        allTimeCalendarActions,
         allTimeDurationMs,
         historyRuns,
         historyTotals,
         historyActions,
+        historyCalendarActions,
         historyDurationMs
       };
     });
@@ -728,6 +767,7 @@ class MetricsDisplay {
       const summaryTotals = summaryParsers?.[name]?.totals || null;
       const historyTotals = historyByParser?.[name] || null;
       const actions = summaryTotals?.actions || historyTotals?.actions || this.createActionCounts();
+      const calendarActions = summaryTotals?.calendar_actions || historyTotals?.calendarActions || this.createCalendarActionCounts();
       const runs = Number.isFinite(summaryTotals?.runs) ? summaryTotals.runs : (historyTotals?.runs || 0);
       const statusCounts = this.normalizeStatusCounts(
         summaryTotals?.statuses || historyTotals?.statusCounts || this.createStatusCounts()
@@ -735,6 +775,7 @@ class MetricsDisplay {
       return {
         name,
         actions,
+        calendarActions,
         runs,
         statusCounts
       };
@@ -783,6 +824,16 @@ class MetricsDisplay {
     if (actions.new) parts.push(`adds ${actions.new}`);
     if (actions.merge) parts.push(`merges ${actions.merge}`);
     if (actions.conflict) parts.push(`conflicts ${actions.conflict}`);
+    if (parts.length === 0) return 'none';
+    return parts.join(', ');
+  }
+
+  formatCalendarActions(actions) {
+    if (!actions) return 'n/a';
+    const parts = [];
+    if (actions.create) parts.push(`create ${actions.create}`);
+    if (actions.update) parts.push(`update ${actions.update}`);
+    if (actions.skip) parts.push(`skip ${actions.skip}`);
     if (parts.length === 0) return 'none';
     return parts.join(', ');
   }
@@ -880,6 +931,7 @@ class MetricsDisplay {
         errorsCount: record?.errors_count || 0,
         warningsCount,
         actions: record?.actions ? record.actions : this.createActionCounts(),
+        calendarActions: record?.calendar_actions ? record.calendar_actions : this.createCalendarActionCounts(),
         totals: record?.totals || {},
         finalEvents: record?.totals?.final_bear_events || 0,
         totalEvents: record?.totals?.total_events || 0,
@@ -888,6 +940,12 @@ class MetricsDisplay {
         parserNames
       };
     });
+  }
+
+  getRunActionSources(run) {
+    const intentActions = run?.actions || this.createActionCounts();
+    const writeActions = run?.calendarActions || this.createCalendarActionCounts();
+    return { intentActions, writeActions };
   }
 
   normalizeRunStatusFilter(value) {
@@ -2230,9 +2288,15 @@ class MetricsDisplay {
       const actionSource = hasLastRun
         ? record.actions
         : (hasAllTime ? record.allTimeActions : record.historyActions);
-      const actions = widget.addText(`Actions: ${this.formatActions(actionSource)}`);
+      const calendarActionSource = hasLastRun
+        ? record.calendarActions
+        : (hasAllTime ? record.allTimeCalendarActions : record.historyCalendarActions);
+      const actions = widget.addText(`Intent: ${this.formatActions(actionSource)}`);
       actions.font = Font.systemFont(FONT_SIZES.widget.small);
       actions.textColor = new Color(BRAND.textMuted);
+      const writeActions = widget.addText(`Writes: ${this.formatCalendarActions(calendarActionSource)}`);
+      writeActions.font = Font.systemFont(FONT_SIZES.widget.small);
+      writeActions.textColor = new Color(BRAND.textMuted);
     }
   }
 
@@ -2365,6 +2429,7 @@ class MetricsDisplay {
     const totals = summary.totals;
     const statusCounts = this.normalizeStatusCounts(totals.statuses);
     const actions = totals.actions || this.createActionCounts();
+    const calendarActions = totals.calendar_actions || this.createCalendarActionCounts();
     const runs = totals.runs || 0;
     const parserCount = Array.isArray(context?.parserHealth?.items) ? context.parserHealth.items.length : 0;
     const successPercent = this.formatPercent(statusCounts.success || 0, runs);
@@ -2388,6 +2453,10 @@ class MetricsDisplay {
     const actionsText = widget.addText(actionsLine);
     actionsText.font = Font.systemFont(FONT_SIZES.widget.small);
     actionsText.textColor = new Color(BRAND.textMuted);
+    const writesLine = `Writes Create ${this.formatNumber(calendarActions.create || 0)} • Update ${this.formatNumber(calendarActions.update || 0)} • Skip ${this.formatNumber(calendarActions.skip || 0)}`;
+    const writesText = widget.addText(writesLine);
+    writesText.font = Font.systemFont(FONT_SIZES.widget.small);
+    writesText.textColor = new Color(BRAND.textMuted);
   }
 
   async renderWidget(data, view) {
@@ -3117,6 +3186,7 @@ class MetricsDisplay {
           const totals = summary.totals;
           const statusCounts = this.normalizeStatusCounts(totals.statuses);
           const actions = totals.actions || this.createActionCounts();
+          const calendarActions = totals.calendar_actions || this.createCalendarActionCounts();
           const runs = totals.runs || 0;
           const actionTotal = this.sumDisplayActions(actions);
           const parserCount = allTimeParserRows.length || parserItems.length;
@@ -3134,6 +3204,11 @@ class MetricsDisplay {
               ${buildMetric('Adds', this.formatNumber(actions.new || 0), this.formatPercent(actions.new || 0, actionTotal))}
               ${buildMetric('Merges', this.formatNumber(actions.merge || 0), this.formatPercent(actions.merge || 0, actionTotal))}
               ${buildMetric('Conflicts', this.formatNumber(actions.conflict || 0), this.formatPercent(actions.conflict || 0, actionTotal))}
+            </div>
+            <div class="metrics-grid">
+              ${buildMetric('Create writes', this.formatNumber(calendarActions.create || 0))}
+              ${buildMetric('Update writes', this.formatNumber(calendarActions.update || 0))}
+              ${buildMetric('Skip writes', this.formatNumber(calendarActions.skip || 0))}
             </div>`;
           cards.push(buildSection('All Time Totals', totalsGrid));
           const parserTotals = allTimeParserRows;
@@ -3187,7 +3262,13 @@ class MetricsDisplay {
               <div class="metrics-grid">
                 ${buildMetric('Final events', this.formatNumber(record.finalBearEvents || 0))}
                 ${buildMetric('Duration', this.formatDuration(record.durationMs))}
-                ${buildMetric('Actions', this.formatActions(record.actions))}
+                ${buildMetric('Intent actions', this.formatActions(record.actions))}
+              </div>
+              <div class="meta-row">
+                <div class="meta-item">
+                  <span class="meta-label">Calendar writes</span>
+                  <span class="meta-value">${escapeHtml(this.formatCalendarActions(record.calendarActions))}</span>
+                </div>
               </div>
               ${lastRunAction}`;
             const lastRunSubtitle = `Last run ${this.formatRelativeTime(record.lastRunAt)}`;
@@ -3200,6 +3281,7 @@ class MetricsDisplay {
             const totals = hasAllTime ? (record.allTimeTotals || {}) : (record.historyTotals || {});
             const runsCount = hasAllTime ? record.allTimeRuns : record.historyRuns;
             const actions = hasAllTime ? record.allTimeActions : record.historyActions;
+            const calendarActions = hasAllTime ? record.allTimeCalendarActions : record.historyCalendarActions;
             const avgDurationMs = runsCount > 0
               ? Math.round((hasAllTime ? record.allTimeDurationMs : record.historyDurationMs) / runsCount)
               : null;
@@ -3212,8 +3294,12 @@ class MetricsDisplay {
               </div>
               <div class="meta-row">
                 <div class="meta-item">
-                  <span class="meta-label">Actions</span>
+                  <span class="meta-label">Intent actions</span>
                   <span class="meta-value">${escapeHtml(this.formatActions(actions))}</span>
+                </div>
+                <div class="meta-item">
+                  <span class="meta-label">Calendar writes</span>
+                  <span class="meta-value">${escapeHtml(this.formatCalendarActions(calendarActions))}</span>
                 </div>
               </div>`;
             cards.push(buildSection(hasAllTime ? 'All Time Totals' : 'Recent Totals', metricsGrid));
@@ -4509,6 +4595,7 @@ class MetricsDisplay {
         const totals = summary.totals;
         const statusCounts = this.normalizeStatusCounts(totals.statuses);
         const actions = totals.actions || this.createActionCounts();
+        const calendarActions = totals.calendar_actions || this.createCalendarActionCounts();
         const runs = totals.runs || 0;
         const parserCount = allTimeParserRows.length || (parserHealth?.items?.length || 0);
         const actionTotal = this.sumDisplayActions(actions);
@@ -4533,6 +4620,11 @@ class MetricsDisplay {
           `Adds: ${this.formatNumber(actions.new || 0)} (${addPercent}) • Merges: ${this.formatNumber(actions.merge || 0)} (${mergePercent})`,
           `Conflicts: ${this.formatNumber(actions.conflict || 0)} (${conflictPercent})`
         );
+        this.addInfoRow(
+          table,
+          `Calendar writes: ${this.formatCalendarActions(calendarActions)}`,
+          `Create ${this.formatNumber(calendarActions.create || 0)} • Update ${this.formatNumber(calendarActions.update || 0)} • Skip ${this.formatNumber(calendarActions.skip || 0)}`
+        );
 
         const parserRows = allTimeParserRows;
         if (parserRows.length > 0) {
@@ -4545,10 +4637,10 @@ class MetricsDisplay {
             const rowSuccessPercent = this.formatPercent(rowStatuses.success || 0, rowRuns);
             const rowWarningPercent = this.formatPercent(rowStatuses.warning || 0, rowRuns);
             const rowFailedPercent = this.formatPercent(rowStatuses.failed || 0, rowRuns);
+            const rowCalendarActions = row.calendarActions || this.createCalendarActionCounts();
             const summaryLine = [
-              `Adds ${this.formatNumber(rowActions.new || 0)}`,
-              `Merges ${this.formatNumber(rowActions.merge || 0)}`,
-              `Conflicts ${this.formatNumber(rowActions.conflict || 0)}`,
+              `Intent ${this.formatActions(rowActions)}`,
+              `Writes ${this.formatCalendarActions(rowCalendarActions)}`,
               `Success ${this.formatNumber(rowStatuses.success || 0)} (${rowSuccessPercent})`,
               `Warnings ${this.formatNumber(rowStatuses.warning || 0)} (${rowWarningPercent})`,
               `Failed ${this.formatNumber(rowStatuses.failed || 0)} (${rowFailedPercent})`
@@ -4588,7 +4680,8 @@ class MetricsDisplay {
             `Last run: ${this.formatRelativeTime(record.lastRunAt)}`,
             `Final events: ${this.formatNumber(record.finalBearEvents)}`
           );
-          this.addInfoRow(table, `Duration: ${this.formatDuration(record.durationMs)}`, `Actions: ${this.formatActions(record.actions)}`);
+          this.addInfoRow(table, `Duration: ${this.formatDuration(record.durationMs)}`, `Intent actions: ${this.formatActions(record.actions)}`);
+          this.addInfoRow(table, 'Calendar writes', this.formatCalendarActions(record.calendarActions));
           if (record?.lastRunId) {
             const linkRow = new UITableRow();
             linkRow.backgroundColor = new Color(BRAND.secondary);
@@ -4618,7 +4711,8 @@ class MetricsDisplay {
             `Runs: ${this.formatNumber(record.allTimeRuns || 0)}`,
             `Total events: ${this.formatNumber(totals.total_events || 0)}`
           );
-          this.addInfoRow(table, 'All Time Actions', this.formatActions(record.allTimeActions));
+          this.addInfoRow(table, 'All Time Intent Actions', this.formatActions(record.allTimeActions));
+          this.addInfoRow(table, 'All Time Calendar Writes', this.formatCalendarActions(record.allTimeCalendarActions));
           const avgDurationMs = record.allTimeRuns > 0
             ? Math.round(record.allTimeDurationMs / record.allTimeRuns)
             : null;
@@ -4633,7 +4727,8 @@ class MetricsDisplay {
             `Runs: ${this.formatNumber(record.historyRuns || 0)}`,
             `Total events: ${this.formatNumber(totals.total_events || 0)}`
           );
-          this.addInfoRow(table, 'Recent Actions', this.formatActions(record.historyActions));
+          this.addInfoRow(table, 'Recent Intent Actions', this.formatActions(record.historyActions));
+          this.addInfoRow(table, 'Recent Calendar Writes', this.formatCalendarActions(record.historyCalendarActions));
           const avgDurationMs = record.historyRuns > 0
             ? Math.round(record.historyDurationMs / record.historyRuns)
             : null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- classify events using **intent action** for display (`new`/`merge`/`conflict`) while keeping `_action` as the **calendar write action source**
- add explicit intent/write labeling in Scriptable console summaries, enriched event preview rows, rich event cards, and execute prompt copy
- extend `display-run-metrics` to ingest and surface `calendar_actions` alongside intent actions across widget, app tables, run cards, parser detail, and aggregate summaries

## Details
### Scriptable UI behavior
- override-create events are now displayed as merge intent when override identity/source-reason indicates an override workflow
- UI now shows both dimensions together (for example: `Intent: MERGE • Write: CREATE`) so users can see logical merge semantics and actual save operation at the same time
- merge comparison sections now use intent classification so override-create events still show merge comparison context

### Metrics behavior
- metrics records and parser records are normalized to always include `calendar_actions`
- run and parser health models now carry both:
  - `actions` (intent)
  - `calendarActions` (write operations)
- aggregate and parser detail surfaces now show intent totals and write totals side-by-side

## Validation
- `node --check scripts/adapters/scriptable-adapter.js`
- `node --check scripts/display-run-metrics.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fe31f50-9fba-4182-8a4a-6d6102c3754e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fe31f50-9fba-4182-8a4a-6d6102c3754e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

