### PR TITLE
Fix recurring override reruns by flattening existing matches

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1584,17 +1584,9 @@ class ScriptableAdapter {
                             const overrideRecurrenceId = typeof event.overrideRecurrenceId === 'string' ? event.overrideRecurrenceId.trim() : '';
                             const hasOverrideUid = overrideUid.length > 0;
                             const hasOverrideRecurrenceId = overrideRecurrenceId.length > 0;
-                            const writeAction = String(event._writeAction || '').toLowerCase() || 'update';
 
                             if (hasOverrideUid !== hasOverrideRecurrenceId) {
                                 throw new Error('Override identity requires both overrideUid and overrideRecurrenceId');
-                            }
-
-                            if (writeAction === 'create') {
-                                actionCounts.create.push(event.title);
-                                await this.createCalendarEvent(event, calendar);
-                                processedCount++;
-                                break;
                             }
 
                             if (hasOverrideUid && hasOverrideRecurrenceId) {
@@ -5613,10 +5605,6 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
     }
 
     normalizeWriteAction(event) {
-        const explicitWriteAction = String(event?._writeAction || '').toLowerCase().trim();
-        if (explicitWriteAction === 'update') return 'merge';
-        if (explicitWriteAction === 'create') return 'new';
-        if (explicitWriteAction === 'skip') return 'conflict';
         const action = String(event?._action || '').toLowerCase();
         if (!action) return null;
         if (action === 'key_conflict' || action === 'time_conflict') return 'conflict';

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1242,6 +1242,65 @@ class ScriptableAdapter {
                 return { start, end };
             };
 
+            const dedupeEventsByIdentifier = (events) => {
+                const list = Array.isArray(events) ? events : [];
+                if (list.length === 0) return [];
+                const seen = new Set();
+                const deduped = [];
+                list.forEach(existingEvent => {
+                    if (!existingEvent) return;
+                    const identifier = this.getEventIdentifier(existingEvent);
+                    if (identifier && seen.has(identifier)) {
+                        return;
+                    }
+                    if (identifier) {
+                        seen.add(identifier);
+                    }
+                    deduped.push(existingEvent);
+                });
+                return deduped;
+            };
+
+            const classifyEventsForMatching = (events) => {
+                const list = Array.isArray(events) ? events : [];
+                const eventMetadata = list.map(existingEvent => {
+                    if (!existingEvent) return null;
+                    const identity = this.getEventOverrideIdentity(existingEvent);
+                    const sourceUid = this.normalizeOverrideUid(identity.sourceUid || this.getEventUid(existingEvent));
+                    const startDate = existingEvent.startDate instanceof Date
+                        ? existingEvent.startDate
+                        : new Date(existingEvent.startDate || 0);
+                    const eventDateKey = this.normalizeEventDate(startDate);
+                    const overrideDateKey = identity.recurrenceDateKey || eventDateKey;
+                    return {
+                        event: existingEvent,
+                        sourceUid,
+                        eventDateKey,
+                        isOverride: Boolean(identity.overrideKey),
+                        overrideDateKey
+                    };
+                }).filter(Boolean);
+
+                const overridesByUidDate = new Set();
+                eventMetadata.forEach(item => {
+                    if (!item.isOverride || !item.sourceUid || !item.overrideDateKey) {
+                        return;
+                    }
+                    overridesByUidDate.add(`${item.sourceUid.toLowerCase()}::${item.overrideDateKey}`);
+                });
+
+                // Flatten by shadowing source events when an override exists for same uid+date.
+                // Keep all unrelated occurrences so recurring series can still match non-overridden dates.
+                const flattened = eventMetadata.filter(item => {
+                    if (item.isOverride) return true;
+                    if (!item.sourceUid || !item.eventDateKey) return true;
+                    const shadowKey = `${item.sourceUid.toLowerCase()}::${item.eventDateKey}`;
+                    return !overridesByUidDate.has(shadowKey);
+                }).map(item => item.event);
+
+                return dedupeEventsByIdentifier(flattened);
+            };
+
             // Keep the tighter, multi-window logic scoped to identifier-based edits only.
             // For normal scraper runs, use the original single-window approach.
             if (!hasIdentifier) {
@@ -1270,7 +1329,9 @@ class ScriptableAdapter {
                         console.log(`📱 Scriptable: Related[${index + 1}] "${existing.title || '(no title)'}" @ ${startIso}`);
                     });
                 }
-                return existingEvents;
+                const flattenedEvents = classifyEventsForMatching(existingEvents);
+                console.log(`📱 Scriptable: Existing events flattened=${flattenedEvents.length} (raw=${existingEvents.length})`);
+                return flattenedEvents;
             }
 
             // Identifier edit: only use the old visible date (pre-edit).
@@ -1308,12 +1369,185 @@ class ScriptableAdapter {
                     console.log(`📱 Scriptable: Related[${index + 1}] "${existing.title || '(no title)'}" @ ${startIso}`);
                 });
             }
-            return allEvents;
+            const flattenedEvents = classifyEventsForMatching(allEvents);
+            console.log(`📱 Scriptable: Existing events flattened=${flattenedEvents.length} (raw=${allEvents.length})`);
+            return flattenedEvents;
             
         } catch (error) {
             console.log(`📱 Scriptable: ✗ Failed to get existing events: ${error.message}`);
             return [];
         }
+    }
+
+    isEventRecurring(event) {
+        if (!event || typeof event !== 'object') return false;
+        if (typeof event.isRecurring === 'boolean') {
+            return event.isRecurring;
+        }
+        if (typeof event.recurrenceRule === 'string' && event.recurrenceRule.trim().length > 0) {
+            return true;
+        }
+        if (Array.isArray(event.recurrenceRules) && event.recurrenceRules.length > 0) {
+            return true;
+        }
+        const notes = String(event.notes || '').toLowerCase();
+        if (notes.includes('recurrence:') || notes.includes('rrule')) {
+            return true;
+        }
+        return false;
+    }
+
+    getEventIdentifier(event) {
+        if (!event || typeof event !== 'object') return '';
+        const uid = this.getEventUid(event);
+        const startDate = event.startDate instanceof Date
+            ? event.startDate
+            : new Date(event.startDate || 0);
+        const startIso = startDate instanceof Date && !isNaN(startDate.getTime())
+            ? startDate.toISOString()
+            : '';
+        const title = String(event.title || '').trim().toLowerCase();
+        return [uid, startIso, title].join('|');
+    }
+
+    normalizeOverrideUid(value) {
+        if (value === null || value === undefined) return '';
+        return String(value).trim();
+    }
+
+    normalizeOverrideRecurrenceId(value) {
+        if (value === null || value === undefined) return '';
+        const trimmed = String(value).trim();
+        if (!trimmed) return '';
+        const withTimezoneMatch = trimmed.match(/^TZID=([^:]+):(\d{8}(?:T\d{4,6}Z?)?)$/i);
+        if (withTimezoneMatch) {
+            const timezone = withTimezoneMatch[1].trim();
+            const recurrenceValue = withTimezoneMatch[2].toUpperCase();
+            if (!timezone) return '';
+            return `TZID=${timezone}:${recurrenceValue}`;
+        }
+        const withoutTimezoneMatch = trimmed.match(/^(\d{8}(?:T\d{4,6}Z?)?)$/i);
+        if (withoutTimezoneMatch) {
+            return withoutTimezoneMatch[1].toUpperCase();
+        }
+        return '';
+    }
+
+    normalizeEventDate(dateInput) {
+        if (!dateInput) return '';
+        const date = dateInput instanceof Date ? dateInput : new Date(dateInput);
+        if (!(date instanceof Date) || isNaN(date.getTime())) return '';
+        const year = date.getUTCFullYear();
+        const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+        const day = String(date.getUTCDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+    }
+
+    buildOverrideKey(overrideUid, overrideRecurrenceId) {
+        const uid = this.normalizeOverrideUid(overrideUid);
+        const recurrenceId = this.normalizeOverrideRecurrenceId(overrideRecurrenceId);
+        if (!uid || !recurrenceId) return '';
+        return `${uid.toLowerCase()}::${recurrenceId}`;
+    }
+
+    parseScriptableIdentifier(value) {
+        if (!value) return { uid: null, recurrenceDate: null };
+        const raw = String(value).trim();
+        if (!raw) return { uid: null, recurrenceDate: null };
+        const colonIndex = raw.indexOf(':');
+        const afterColon = colonIndex >= 0 ? raw.slice(colonIndex + 1) : raw;
+        const ridMatch = afterColon.match(/\/RID=(\d+)/i);
+        const uid = ridMatch ? afterColon.slice(0, ridMatch.index) : afterColon;
+        return {
+            uid: uid && uid.length > 0 ? uid : null,
+            recurrenceDate: null
+        };
+    }
+
+    parseNotesIntoFields(notes) {
+        const fields = {};
+        if (!notes || typeof notes !== 'string') return fields;
+        const lines = notes.split('\n');
+        const aliasToCanonical = {
+            'overrideuid': 'overrideUid',
+            'overriderecurrenceid': 'overrideRecurrenceId',
+            'uid': 'uid',
+            'identifier': 'identifier',
+            'id': 'id',
+            'recurrence': 'recurrence'
+        };
+        const normalize = (str) => (str || '').toLowerCase().replace(/\s+/g, '');
+        let currentKey = null;
+        let currentValue = '';
+        lines.forEach((line, index) => {
+            const colonIndex = line.indexOf(':');
+            if (colonIndex > 0) {
+                if (currentKey && currentValue) {
+                    const normalizedKey = normalize(currentKey);
+                    const canonicalKey = aliasToCanonical.hasOwnProperty(normalizedKey)
+                        ? aliasToCanonical[normalizedKey]
+                        : currentKey;
+                    fields[canonicalKey] = currentValue;
+                }
+                const rawKey = line.substring(0, colonIndex).trim();
+                const rawValue = line.substring(colonIndex + 1).trim();
+                if (rawKey) {
+                    currentKey = rawKey;
+                    currentValue = rawValue;
+                }
+            } else if (currentKey && line.trim()) {
+                currentValue += `\n${line.trim()}`;
+            }
+            if (index === lines.length - 1 && currentKey && currentValue) {
+                const normalizedKey = normalize(currentKey);
+                const canonicalKey = aliasToCanonical.hasOwnProperty(normalizedKey)
+                    ? aliasToCanonical[normalizedKey]
+                    : currentKey;
+                fields[canonicalKey] = currentValue;
+            }
+        });
+        return fields;
+    }
+
+    getEventUid(event) {
+        if (!event || typeof event !== 'object') return '';
+        const fields = this.parseNotesIntoFields(event.notes || '');
+        const identifierInfo = this.parseScriptableIdentifier(event.identifier || '');
+        const uid = identifierInfo.uid ||
+            this.normalizeOverrideUid(fields.uid || fields.identifier || fields.id || '');
+        return uid || '';
+    }
+
+    getEventOverrideIdentity(event) {
+        if (!event || typeof event !== 'object') {
+            return { overrideUid: '', overrideRecurrenceId: '', overrideKey: '', sourceUid: '', recurrenceDateKey: '' };
+        }
+        const fields = this.parseNotesIntoFields(event.notes || '');
+        const parsedIdentifier = this.parseScriptableIdentifier(event.identifier || '');
+        const sourceUid = this.normalizeOverrideUid(
+            fields.uid ||
+            fields.identifier ||
+            fields.id ||
+            parsedIdentifier.uid ||
+            ''
+        );
+        const overrideUid = this.normalizeOverrideUid(fields.overrideUid || event.overrideUid || '');
+        const overrideRecurrenceId = this.normalizeOverrideRecurrenceId(
+            fields.overrideRecurrenceId || event.overrideRecurrenceId || ''
+        );
+        const recurrenceDate = event.startDate instanceof Date
+            ? event.startDate
+            : new Date(event.startDate || 0);
+        const recurrenceDateKey = recurrenceDate instanceof Date && !isNaN(recurrenceDate.getTime())
+            ? this.normalizeEventDate(recurrenceDate)
+            : '';
+        return {
+            overrideUid,
+            overrideRecurrenceId,
+            overrideKey: this.buildOverrideKey(overrideUid, overrideRecurrenceId),
+            sourceUid,
+            recurrenceDateKey
+        };
     }
     
     // Execute calendar actions determined by shared-core
@@ -1350,22 +1584,24 @@ class ScriptableAdapter {
                             const overrideRecurrenceId = typeof event.overrideRecurrenceId === 'string' ? event.overrideRecurrenceId.trim() : '';
                             const hasOverrideUid = overrideUid.length > 0;
                             const hasOverrideRecurrenceId = overrideRecurrenceId.length > 0;
+                            const writeAction = String(event._writeAction || '').toLowerCase() || 'update';
 
                             if (hasOverrideUid !== hasOverrideRecurrenceId) {
                                 throw new Error('Override identity requires both overrideUid and overrideRecurrenceId');
                             }
 
+                            if (writeAction === 'create') {
+                                actionCounts.create.push(event.title);
+                                await this.createCalendarEvent(event, calendar);
+                                processedCount++;
+                                break;
+                            }
+
                             if (hasOverrideUid && hasOverrideRecurrenceId) {
-                                const targetOverrideKey = `${overrideUid.toLowerCase()}::${overrideRecurrenceId}`;
-                                const existingKey = typeof event._existingKey === 'string' ? event._existingKey : '';
-                                const overrideMergeAllowed = existingKey === targetOverrideKey;
-                                if (!overrideMergeAllowed) {
-                                    const keyLabel = existingKey || 'none';
-                                    console.log(`📱 Scriptable: Prevented override merge "${event.title}" (existingKey=${keyLabel}) - creating new override`);
-                                    actionCounts.create.push(event.title);
-                                    await this.createCalendarEvent(event, calendar);
-                                    processedCount++;
-                                    break;
+                                const targetOverrideKey = this.buildOverrideKey(overrideUid, overrideRecurrenceId);
+                                const existingKey = this.normalizeOverrideUid(event._existingKey || '');
+                                if (existingKey && existingKey !== targetOverrideKey) {
+                                    console.log(`📱 Scriptable: Override key mismatch "${event.title}" existing=${existingKey} target=${targetOverrideKey}`);
                                 }
                             }
 
@@ -5377,6 +5613,10 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : '✅ No e
     }
 
     normalizeWriteAction(event) {
+        const explicitWriteAction = String(event?._writeAction || '').toLowerCase().trim();
+        if (explicitWriteAction === 'update') return 'merge';
+        if (explicitWriteAction === 'create') return 'new';
+        if (explicitWriteAction === 'skip') return 'conflict';
         const action = String(event?._action || '').toLowerCase();
         if (!action) return null;
         if (action === 'key_conflict' || action === 'time_conflict') return 'conflict';

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1722,15 +1722,6 @@ class SharedCore {
         };
     }
 
-    determineWriteActionForAnalysis(analysis) {
-        const action = String(analysis && analysis.action ? analysis.action : '').toLowerCase();
-        if (!action) return null;
-        if (action === 'merge') return 'update';
-        if (action === 'new') return 'create';
-        if (action === 'conflict') return 'skip';
-        return 'other';
-    }
-
     finalizeAnalysisResult(event, analysis) {
         const result = analysis && typeof analysis === 'object'
             ? { ...analysis }
@@ -1749,7 +1740,6 @@ class SharedCore {
             }
         }
 
-        result.writeAction = this.determineWriteActionForAnalysis(result);
         return result;
     }
 
@@ -2542,7 +2532,7 @@ class SharedCore {
         const excludeFields = new Set([
             'title', 'startDate', 'endDate', 'location', 'coordinates', 'notes',
             'isBearEvent', 'source', 'city', 'setDescription', '_analysis', '_action', 
-            '_existingEvent', '_existingKey', '_writeAction', '_conflicts', '_parserConfig', '_fieldPriorities',
+            '_existingEvent', '_existingKey', '_conflicts', '_parserConfig', '_fieldPriorities',
             '_original', '_mergeInfo', '_changes', '_mergeDiff',
             'originalTitle', 'name', // These are usually duplicates of title
             // Scriptable-specific properties that shouldn't be in notes
@@ -2641,11 +2631,9 @@ class SharedCore {
                 action: analysis.action,
                 reason: analysis.reason,
                 sourceEvent: Boolean(analysis.sourceEvent),
-                hasOverrideIdentity: Boolean(analysis.overrideIdentity),
-                writeAction: analysis.writeAction || this.determineWriteActionForAnalysis(analysis)
+                hasOverrideIdentity: Boolean(analysis.overrideIdentity)
             };
             analyzedEvent._action = analysis.action;
-            analyzedEvent._writeAction = analysis.writeAction || this.determineWriteActionForAnalysis(analysis);
             
             // Handle merge action by creating complete final event object
             if (analysis.action === 'merge' && analysis.existingEvent) {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1692,6 +1692,67 @@ class SharedCore {
         return null;
     }
 
+    buildOverrideKey(overrideUid, overrideRecurrenceId) {
+        const normalizedUid = this.normalizeOverrideUid(overrideUid);
+        const normalizedRecurrenceId = this.normalizeOverrideRecurrenceId(overrideRecurrenceId);
+        if (!normalizedUid || !normalizedRecurrenceId) {
+            return '';
+        }
+        return `${normalizedUid.toLowerCase()}::${normalizedRecurrenceId}`;
+    }
+
+    getOverrideIdentityFromEvent(existingEvent) {
+        if (!existingEvent || typeof existingEvent !== 'object') {
+            return null;
+        }
+        const fields = this.parseNotesIntoFields(existingEvent.notes || '');
+        const overrideUid = this.normalizeOverrideUid(
+            fields.overrideUid || existingEvent.overrideUid || ''
+        );
+        const overrideRecurrenceId = this.normalizeOverrideRecurrenceId(
+            fields.overrideRecurrenceId || existingEvent.overrideRecurrenceId || ''
+        );
+        if (!overrideUid || !overrideRecurrenceId) {
+            return null;
+        }
+        return {
+            overrideUid,
+            overrideRecurrenceId,
+            overrideKey: this.buildOverrideKey(overrideUid, overrideRecurrenceId)
+        };
+    }
+
+    determineWriteActionForAnalysis(analysis) {
+        const action = String(analysis && analysis.action ? analysis.action : '').toLowerCase();
+        if (!action) return null;
+        if (action === 'merge') return 'update';
+        if (action === 'new') return 'create';
+        if (action === 'conflict') return 'skip';
+        return 'other';
+    }
+
+    finalizeAnalysisResult(event, analysis) {
+        const result = analysis && typeof analysis === 'object'
+            ? { ...analysis }
+            : { action: 'conflict', reason: 'Invalid analysis result' };
+
+        const existingOverrideIdentity = this.getOverrideIdentityFromEvent(result.existingEvent);
+
+        if (existingOverrideIdentity && existingOverrideIdentity.overrideKey) {
+            result.existingKey = existingOverrideIdentity.overrideKey;
+        } else if (typeof result.existingKey === 'string' && result.existingKey.includes('::')) {
+            const [rawUid, ...rawRecurrenceParts] = result.existingKey.split('::');
+            const rawRecurrenceId = rawRecurrenceParts.join('::');
+            const normalizedExistingOverrideKey = this.buildOverrideKey(rawUid, rawRecurrenceId);
+            if (normalizedExistingOverrideKey) {
+                result.existingKey = normalizedExistingOverrideKey;
+            }
+        }
+
+        result.writeAction = this.determineWriteActionForAnalysis(result);
+        return result;
+    }
+
     deriveOverrideIdentityFromSourceEvent(existingEvent) {
         if (!existingEvent || typeof existingEvent !== 'object') {
             return null;
@@ -2481,7 +2542,7 @@ class SharedCore {
         const excludeFields = new Set([
             'title', 'startDate', 'endDate', 'location', 'coordinates', 'notes',
             'isBearEvent', 'source', 'city', 'setDescription', '_analysis', '_action', 
-            '_existingEvent', '_existingKey', '_conflicts', '_parserConfig', '_fieldPriorities',
+            '_existingEvent', '_existingKey', '_writeAction', '_conflicts', '_parserConfig', '_fieldPriorities',
             '_original', '_mergeInfo', '_changes', '_mergeDiff',
             'originalTitle', 'name', // These are usually duplicates of title
             // Scriptable-specific properties that shouldn't be in notes
@@ -2580,9 +2641,11 @@ class SharedCore {
                 action: analysis.action,
                 reason: analysis.reason,
                 sourceEvent: Boolean(analysis.sourceEvent),
-                hasOverrideIdentity: Boolean(analysis.overrideIdentity)
+                hasOverrideIdentity: Boolean(analysis.overrideIdentity),
+                writeAction: analysis.writeAction || this.determineWriteActionForAnalysis(analysis)
             };
             analyzedEvent._action = analysis.action;
+            analyzedEvent._writeAction = analysis.writeAction || this.determineWriteActionForAnalysis(analysis);
             
             // Handle merge action by creating complete final event object
             if (analysis.action === 'merge' && analysis.existingEvent) {
@@ -2707,6 +2770,7 @@ class SharedCore {
     
     // Analyze a single event against existing events
     analyzeEventAction(event, existingEventsData, mergeMode = 'upsert') {
+        const finalize = (result) => this.finalizeAnalysisResult(event, result);
         const hasIdentifier = Boolean(event && (event.identifier || event.id));
         const incomingOverrideUid = this.normalizeOverrideUid(event && event.overrideUid);
         const incomingOverrideRecurrenceId = this.normalizeOverrideRecurrenceId(event && event.overrideRecurrenceId);
@@ -2717,7 +2781,7 @@ class SharedCore {
             }
 
             if (!existingEventsData || existingEventsData.length === 0) {
-                return { action: 'new', reason: 'Override match not found' };
+                return finalize({ action: 'new', reason: 'Override match not found' });
             }
 
             const existingOverrideMatch = this.findEventByOverrideKey(
@@ -2726,12 +2790,12 @@ class SharedCore {
                 incomingOverrideRecurrenceId
             );
             if (existingOverrideMatch) {
-                return {
+                return finalize({
                     action: 'merge',
                     reason: 'Override match found',
                     existingEvent: existingOverrideMatch.event,
                     existingKey: existingOverrideMatch.existingKey
-                };
+                });
             }
 
             const sourceEvent = this.findOverrideSourceEvent(
@@ -2741,20 +2805,20 @@ class SharedCore {
             );
             const targetOverrideKey = `${incomingOverrideUid.toLowerCase()}::${incomingOverrideRecurrenceId}`;
             if (sourceEvent) {
-                return {
+                return finalize({
                     action: 'new',
                     reason: 'Override source match found',
                     sourceEvent,
                     existingKey: targetOverrideKey
-                };
+                });
             }
 
-            return { action: 'new', reason: 'Override match not found', existingKey: targetOverrideKey };
+            return finalize({ action: 'new', reason: 'Override match not found', existingKey: targetOverrideKey });
         }
 
         if (hasIdentifier) {
             if (!existingEventsData || existingEventsData.length === 0) {
-                return { action: 'conflict', reason: 'Identifier match not found' };
+                return finalize({ action: 'conflict', reason: 'Identifier match not found' });
             }
             const keyMatch = this.findEventByKey(existingEventsData, event);
             if (keyMatch && keyMatch.matchType === 'identifier') {
@@ -2762,20 +2826,20 @@ class SharedCore {
                 const matchedKey = keyMatch.matchedKey || null;
                 const recurringMergeDecision = this.resolveRecurringMergeCandidate(existingEventsData, existingEvent);
                 if (recurringMergeDecision) {
-                    return recurringMergeDecision;
+                    return finalize(recurringMergeDecision);
                 }
-                return {
+                return finalize({
                     action: 'merge',
                     reason: 'Identifier match found',
                     existingEvent: existingEvent,
                     existingKey: matchedKey
-                };
+                });
             }
-            return { action: 'conflict', reason: 'Identifier match not found' };
+            return finalize({ action: 'conflict', reason: 'Identifier match not found' });
         }
         
         if (!existingEventsData || existingEventsData.length === 0) {
-            return { action: 'new', reason: 'No existing events found' };
+            return finalize({ action: 'new', reason: 'No existing events found' });
         }
         
         // Check for key-based merging first (exact or wildcard)
@@ -2786,25 +2850,25 @@ class SharedCore {
             const matchedKey = keyMatch.matchedKey || null;
             const recurringMergeDecision = this.resolveRecurringMergeCandidate(existingEventsData, existingEvent);
             if (recurringMergeDecision) {
-                return recurringMergeDecision;
+                return finalize(recurringMergeDecision);
             }
             
             if (keyMatch.matchType === 'exact') {
-                return {
+                return finalize({
                     action: 'merge',
                     reason: 'Key match found',
                     existingEvent: existingEvent,
                     existingKey: matchedKey
-                };
+                });
             }
             
             if (keyMatch.matchType === 'wildcard') {
-                return {
+                return finalize({
                     action: 'merge',
                     reason: 'Wildcard key match found',
                     existingEvent: existingEvent,
                     existingKey: matchedKey
-                };
+                });
             }
         }
         
@@ -2817,13 +2881,13 @@ class SharedCore {
         if (exactMatch) {
             const recurringMergeDecision = this.resolveRecurringMergeCandidate(existingEventsData, exactMatch);
             if (recurringMergeDecision) {
-                return recurringMergeDecision;
+                return finalize(recurringMergeDecision);
             }
-            return {
+            return finalize({
                 action: 'merge',
                 reason: 'Similar event found',
                 existingEvent: exactMatch
-            };
+            });
         }
         
         // Check for overlapping events - only merge when time and title/venue are similar
@@ -2854,22 +2918,22 @@ class SharedCore {
             if (mergeableConflict) {
                 const recurringMergeDecision = this.resolveRecurringMergeCandidate(existingEventsData, mergeableConflict);
                 if (recurringMergeDecision) {
-                    return recurringMergeDecision;
+                    return finalize(recurringMergeDecision);
                 }
-                return {
+                return finalize({
                     action: 'merge',
                     reason: 'Mergeable overlap detected',
                     existingEvent: mergeableConflict
-                };
+                });
             }
             
-            return {
+            return finalize({
                 action: 'new',
                 reason: 'Overlapping event with different title/venue'
-            };
+            });
         }
         
-        return { action: 'new', reason: 'No conflicts found' };
+        return finalize({ action: 'new', reason: 'No conflicts found' });
     }
     
     // Check if a key matches a pattern with simple wildcards (pure logic)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- flatten Scriptable existing-event candidates so override occurrences shadow base recurring occurrences for the same `sourceUid + date`, then continue through normal merge/new analysis.
- keep canonical override-key normalization in `SharedCore` analysis so override matches are stable across reruns.
- remove the extra execution-time write-intent branch (`_writeAction`) and rely on normal analyzed actions only (`new` => create, `merge` => update).

## Testing
- `node --check scripts/shared-core.js`
- `node --check scripts/adapters/scriptable-adapter.js`
- `node -e '...shared-core wildcard merge repro...'` (verifies canonical override key output for merge path)
- `node -e '...adapter flattening simulation...'` (verifies overridden base occurrence is removed from candidate set while other recurrence dates remain)

## Notes
- no UI changes; scraper/runtime behavior only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86ffd163-fa42-4839-8c13-9f58d9b978aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86ffd163-fa42-4839-8c13-9f58d9b978aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

