### PR TITLE
Fix missing EventSchema script on calendar test pages

### DIFF
--- a/test-calendar-init.html
+++ b/test-calendar-init.html
@@ -17,6 +17,7 @@
     <!-- Load all required scripts in the same order as city.html -->
     <script src="js/logger.js"></script>
     <script src="js/city-config.js"></script>
+    <script src="js/event-schema.js"></script>
     <script src="js/calendar-core.js"></script>
     <script src="js/dynamic-calendar-loader.js"></script>
 
@@ -28,7 +29,6 @@
             div.className = `log ${type}`;
             div.innerHTML = `<pre>${message}</pre>`;
             logs.appendChild(div);
-            console.log(message);
         }
 
         async function testCalendarInit() {

--- a/test-calendar-loading.html
+++ b/test-calendar-loading.html
@@ -25,6 +25,7 @@
 
     <script src="js/logger.js"></script>
     <script src="js/city-config.js"></script>
+    <script src="js/event-schema.js"></script>
     <script src="js/calendar-core.js"></script>
 
     <script>

--- a/testing/test-calendar-logging.html
+++ b/testing/test-calendar-logging.html
@@ -735,6 +735,7 @@
     <script src="../js/logger.js"></script>
 <script src="../js/debug-overlay.js"></script>
 <script src="../js/city-config.js"></script>
+    <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" 

--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -418,6 +418,7 @@
 
   <script src="../js/logger.js"></script>
   <script src="../js/city-config.js"></script>
+  <script src="../js/event-schema.js"></script>
   <script src="../js/calendar-core.js"></script>
   <script src="../js/dynamic-calendar-loader.js"></script>
   <script>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add the missing `event-schema.js` script include before `calendar-core.js` on calendar test/tool pages that parse events.
- Update the affected pages so they match the dependency order used by working city/main pages.
- Remove recursive console logging in `test-calendar-init.html`'s `addLog()` helper to avoid stack overflow during test execution.
- Audit HTML pages that load calendar scripts and verify no page now loads `calendar-core.js`/`dynamic-calendar-loader.js` without `event-schema.js`.

## Testing
- Verified in browser that `testing/test-calendar-logging.html?city=nyc` loads events and displays non-zero stats.
- Verified in browser that `test-calendar-loading.html` reaches successful parse output.
- Verified in browser that `testing/test-og-event-layouts-calendar.html?city=nyc` loads without EventSchema initialization errors.
- Ran a repo-wide audit command to ensure zero HTML pages remain with missing `event-schema.js` dependency.

## Walkthrough Artifacts
[calendar_debugger_eventschema_fix_demo.mp4](https://cursor.com/agents/bc-8232147a-f6dd-4497-b022-1cc9582f290e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_debugger_eventschema_fix_demo.mp4)
[Calendar logging page after fix](https://cursor.com/agents/bc-8232147a-f6dd-4497-b022-1cc9582f290e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_calendar_logging_after_fix.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8232147a-f6dd-4497-b022-1cc9582f290e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8232147a-f6dd-4497-b022-1cc9582f290e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

