### PR TITLE
Fix calendar load errors when FilenameUtils is missing

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -45,6 +45,7 @@ class DynamicCalendarLoader extends CalendarCore {
         // Location features
         this.userLocation = null;
         this.locationFeaturesEnabled = false;
+        this.hasWarnedMissingFilenameUtils = false;
         
         // Set up window resize listener to clear measurement cache
         this.setupResizeListener();
@@ -1494,17 +1495,34 @@ class DynamicCalendarLoader extends CalendarCore {
     
     // Convert external image URL to local path for cached data
     convertImageUrlToLocal(imageUrl, eventData) {
+        const filenameUtils = window.FilenameUtils;
+        if (!filenameUtils || typeof filenameUtils.convertImageUrlToLocalPath !== 'function') {
+            if (!this.hasWarnedMissingFilenameUtils) {
+                this.hasWarnedMissingFilenameUtils = true;
+                logger.warn('CALENDAR', 'FilenameUtils unavailable; using image URL as-is', {
+                    city: this.currentCity,
+                    dataSource: this.dataSource
+                });
+            }
+            return imageUrl;
+        }
+
         const eventInfo = {
             name: eventData.name,
             startDate: eventData.startDate,
             recurring: eventData.recurring
         };
-        
-        return window.FilenameUtils.convertImageUrlToLocalPath(
-            imageUrl,
-            eventInfo,
-            'img/events'
-        );
+
+        try {
+            return filenameUtils.convertImageUrlToLocalPath(
+                imageUrl,
+                eventInfo,
+                'img/events'
+            );
+        } catch (error) {
+            logger.componentError('CALENDAR', 'Failed converting cached image URL; using original URL', error);
+            return imageUrl;
+        }
     }
 
 

--- a/test-calendar-init.html
+++ b/test-calendar-init.html
@@ -19,6 +19,7 @@
     <script src="js/city-config.js"></script>
     <script src="js/event-schema.js"></script>
     <script src="js/calendar-core.js"></script>
+    <script src="js/filename-utils.js"></script>
     <script src="js/dynamic-calendar-loader.js"></script>
 
     <script>

--- a/testing/manifest.json
+++ b/testing/manifest.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "test-calendar-logging.html",
-      "size": 68665,
+      "size": 68767,
       "icon": "🔍",
       "description": "Debug Scope - Look deep inside calendar processing (magnify those logs)"
     },
@@ -26,7 +26,7 @@
     },
     {
       "name": "test-og-event-layouts-calendar.html",
-      "size": 65521,
+      "size": 65619,
       "icon": "📅",
       "description": "Old School Blueprint - Classic event layouts, tried and true"
     },

--- a/testing/test-calendar-logging.html
+++ b/testing/test-calendar-logging.html
@@ -744,6 +744,7 @@
     <script src="../js/navigation.js"></script>
     <script src="../js/page-effects.js"></script>
     <script src="../js/forms.js"></script>
+    <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     
     <!-- Debugging-specific script -->

--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -420,6 +420,7 @@
   <script src="../js/city-config.js"></script>
   <script src="../js/event-schema.js"></script>
   <script src="../js/calendar-core.js"></script>
+  <script src="../js/filename-utils.js"></script>
   <script src="../js/dynamic-calendar-loader.js"></script>
   <script>
     (function(){


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Added a defensive guard in `js/dynamic-calendar-loader.js` so cached event image URL conversion no longer throws when `window.FilenameUtils` is unavailable.
- Added `filename-utils.js` script includes to calendar test pages that use `dynamic-calendar-loader.js`:
  - `testing/test-calendar-logging.html`
  - `testing/test-og-event-layouts-calendar.html`
  - `test-calendar-init.html`
- This keeps normal city pages and testing tools consistent and avoids false fallback/error paths caused by missing utility initialization.

## Why
A calendar load warning/error was being triggered with:

`undefined is not an object (evaluating 'window.FilenameUtils.convertImageUrlToLocalPath')`

This occurred in test/debug pages that loaded `dynamic-calendar-loader.js` without loading `filename-utils.js` first.

## Validation
- ✅ Automated browser verification using Puppeteer against both:
  - `http://127.0.0.1:8000/testing/test-calendar-logging.html?city=nyc`
  - `http://127.0.0.1:8000/nyc/`
  Confirmed no `FilenameUtils` TypeError/warnings and events render on both pages.
- ✅ Manual walkthrough artifacts:
  - [calendar-filenameutils-fix-demo.mp4](https://cursor.com/agents/bc-3986f5f4-7f5d-4aa4-a1bb-7a8532a085e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar-filenameutils-fix-demo.mp4)
  - [NYC calendar loaded](https://cursor.com/agents/bc-3986f5f4-7f5d-4aa4-a1bb-7a8532a085e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnyc-calendar-loaded.png)

## Notes
- `testing/manifest.json` was auto-updated by the repository commit hook when test HTML files changed.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3986f5f4-7f5d-4aa4-a1bb-7a8532a085e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3986f5f4-7f5d-4aa4-a1bb-7a8532a085e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

