### PR TITLE
Add CSS Pattern backgrounds to OpenGraph tester

### DIFF
--- a/data/css-patterns.json
+++ b/data/css-patterns.json
@@ -1,0 +1,1783 @@
+{
+  "source": "https://css-pattern.com/",
+  "downloadedAt": "2026-05-12T17:33:31.786Z",
+  "count": 157,
+  "patterns": [
+    {
+      "id": "3d-diamond",
+      "name": "Diamond pattern with 3D effect",
+      "source": "https://css-pattern.com/3d-diamond/",
+      "size": 65,
+      "colors": {
+        "c1": "#dadee1",
+        "c2": "#4a99b4",
+        "c3": "#9cceb5"
+      },
+      "declarations": "--s: var(--css-pattern-size, 65px);\n  --c1: var(--css-pattern-color-1, #dadee1);\n  --c2: var(--css-pattern-color-2, #4a99b4);\n  --c3: var(--css-pattern-color-3, #9cceb5);\n  --_c: 75%,var(--c3) 52.72deg,#0000 0;\n  --_g1: conic-gradient(from -116.36deg at 25% var(--_c));\n  --_g2: conic-gradient(from   63.43deg at 75% var(--_c));\n  background:\n    var(--_g1), var(--_g1) calc(3*var(--s)) calc(var(--s)/2),\n    var(--_g2), var(--_g2) calc(3*var(--s)) calc(var(--s)/2),\n    conic-gradient(\n      var(--c2)   63.43deg ,var(--c1) 0 116.36deg,\n      var(--c2) 0 180deg   ,var(--c1) 0 243.43deg,\n      var(--c2) 0 296.15deg,var(--c1) 0);\n  background-size: calc(2*var(--s)) var(--s);"
+    },
+    {
+      "id": "3d-nested-triangles",
+      "name": "Nested triangles pattern with 3D effect",
+      "source": "https://css-pattern.com/3d-nested-triangles/",
+      "size": 162,
+      "colors": {
+        "c1": "#cd2942",
+        "c2": "#62928c",
+        "c3": "#e8cba9",
+        "c4": "#33152e",
+        "c5": "#414352"
+      },
+      "declarations": "--s: var(--css-pattern-size, 162px);\n  --c1: var(--css-pattern-color-1, #cd2942);\n  --c2: var(--css-pattern-color-2, #62928c);\n  --c3: var(--css-pattern-color-3, #e8cba9);\n  --c4: var(--css-pattern-color-4, #33152e);\n  --c5: var(--css-pattern-color-5, #414352);\n  --_g: conic-gradient(from 30deg at 50% 25%,#0000 300deg,var(--c1) 0);\n  background:\n    var(--_g) calc(0.2885*var(--s)) calc(7*var(--s)/12),\n    var(--_g) 0 calc(var(--s)/12),\n    conic-gradient(from 120deg at 50% calc(250%/3),var(--c2) 120deg,#0000 0),\n    repeating-conic-gradient(from 30deg,#0000 0 60deg,var(--c3) 0 120deg),\n    repeating-conic-gradient(var(--c4) 0 60deg,var(--c2) 0 120deg,var(--c5) 0 180deg);\n  background-size: calc(0.577*var(--s)) var(--s);"
+    },
+    {
+      "id": "3d-rectangles",
+      "name": "Rectangles pattern with 3D effect",
+      "source": "https://css-pattern.com/3d-rectangles/",
+      "size": 194,
+      "colors": {
+        "c1": "#f6edb3",
+        "c2": "#acc4a3",
+        "c3": "#55897c"
+      },
+      "declarations": "--s: var(--css-pattern-size, 194px);\n  --c1: var(--css-pattern-color-1, #f6edb3);\n  --c2: var(--css-pattern-color-2, #acc4a3);\n  --c3: var(--css-pattern-color-3, #55897c);\n  --_l:#0000 calc(25%/3),var(--c1) 0 25%,#0000 0;\n  --_g:conic-gradient(from 120deg at 50% 87.5%,var(--c1) 120deg,#0000 0);\n  background:\n    var(--_g),var(--_g) 0 calc(var(--s)/2),\n    conic-gradient(from 180deg at 75%,var(--c2) 60deg,#0000 0),\n    conic-gradient(from 60deg at 75% 75%,var(--c1) 0 60deg,#0000 0),\n    linear-gradient(150deg,var(--_l)) 0 calc(var(--s)/2),\n    conic-gradient(at 25% 25%,#0000 50%,var(--c2) 0 240deg,var(--c1) 0 300deg,var(--c2) 0),\n    linear-gradient(-150deg,var(--_l)) var(--c3);\n  background-size: calc(0.866*var(--s)) var(--s);"
+    },
+    {
+      "id": "3d-squares",
+      "name": "Squares pattern with 3D effect",
+      "source": "https://css-pattern.com/3d-squares/",
+      "size": 222,
+      "colors": {
+        "c1": "#7f727b",
+        "c2": "#d6b4c2",
+        "c3": "#baa0ab"
+      },
+      "declarations": "--s: var(--css-pattern-size, 222px);\n  --c1: var(--css-pattern-color-1, #7f727b);\n  --c2: var(--css-pattern-color-2, #d6b4c2);\n  --c3: var(--css-pattern-color-3, #baa0ab);\n  --_g: var(--c1) 10%,var(--c2) 10.5% 19%,#0000 19.5% 80.5%,var(--c2) 81% 89.5%,var(--c3) 90%;\n  --_c: from -90deg at 37.5% 50%,#0000 75%;\n  --_l1: linear-gradient(145deg,var(--_g));\n  --_l2: linear-gradient( 35deg,var(--_g));\n  background: \n    var(--_l1), var(--_l1) calc(var(--s)/2) var(--s),\n    var(--_l2), var(--_l2) calc(var(--s)/2) var(--s),\n    conic-gradient(var(--_c),var(--c1) 0) calc(var(--s)/8) 0,\n    conic-gradient(var(--_c),var(--c3) 0) calc(var(--s)/2) 0,\n    linear-gradient(90deg,var(--c3) 38%,var(--c1) 0 50%,var(--c3) 0 62%,var(--c1) 0);\n  background-size: var(--s) calc(2*var(--s)/3);"
+    },
+    {
+      "id": "3d-triangles",
+      "name": "Triangles pattern with 3D effect",
+      "source": "https://css-pattern.com/3d-triangles/",
+      "size": 105,
+      "colors": {
+        "c1": "#b9b9b9",
+        "c2": "#dcdcdc",
+        "c3": "#fafafa"
+      },
+      "declarations": "--s: var(--css-pattern-size, 105px);\n  --c1: var(--css-pattern-color-1, #b9b9b9);\n  --c2: var(--css-pattern-color-2, #dcdcdc);\n  --c3: var(--css-pattern-color-3, #fafafa);\n  background:\n    conic-gradient(from 75deg,var(--c1)   15deg ,var(--c2) 0 30deg ,#0000 0 180deg,\n                              var(--c2) 0 195deg,var(--c1) 0 210deg,#0000 0) \n       calc(var(--s)/2) calc(.5*var(--s)/tan(30deg)),\n    conic-gradient(var(--c1)   30deg ,var(--c3) 0 75deg ,var(--c1) 0 90deg, var(--c2) 0 105deg,\n                   var(--c3) 0 150deg,var(--c2) 0 180deg,var(--c3) 0 210deg,var(--c1) 0 256deg,\n                   var(--c2) 0 270deg,var(--c1) 0 286deg,var(--c2) 0 331deg,var(--c3) 0);\n  background-size: var(--s) calc(var(--s)/tan(30deg));"
+    },
+    {
+      "id": "3d-wavy",
+      "name": "Wavy pattern with 3D effect",
+      "source": "https://css-pattern.com/3d-wavy/",
+      "size": 100,
+      "colors": {
+        "c1": "#F8B195",
+        "c2": "#355C7D"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #F8B195);\n  --c2: var(--css-pattern-color-2, #355C7D);\n  --_g: \n     var(--c2) 6%  14%,var(--c1) 16% 24%,var(--c2) 26% 34%,var(--c1) 36% 44%,\n     var(--c2) 46% 54%,var(--c1) 56% 64%,var(--c2) 66% 74%,var(--c1) 76% 84%,var(--c2) 86% 94%;\n  background:\n    radial-gradient(100% 100% at 100% 0,var(--c1) 4%,var(--_g),#0008 96%,#0000),\n    radial-gradient(100% 100% at 0 100%,#0000, #0008 4%,var(--_g),var(--c1) 96%)\n    var(--c1);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "3d-zig-zag",
+      "name": "Zig-Zag pattern with 3D effect",
+      "source": "https://css-pattern.com/3d-zig-zag/",
+      "size": 36,
+      "colors": {
+        "c1": "#000000",
+        "c2": "#d2d3d5",
+        "c3": "#727c7e"
+      },
+      "declarations": "--s: var(--css-pattern-size, 36px);\n  --c1: var(--css-pattern-color-1, #000000);\n  --c2: var(--css-pattern-color-2, #d2d3d5);\n  --c3: var(--css-pattern-color-3, #727c7e);\n  --g1: conic-gradient(at calc(250%/3) calc(50%/3),var(--c2) 60deg,#0000 0 300deg,var(--c1) 0);\n  --g2: conic-gradient(at calc(50%/3) 50%,#0000 75%,var(--c1) 0);\n  --g3: conic-gradient(at calc(100%/3) 50%,#0000 75%,var(--c2) 0);\n  --g4: conic-gradient(from 59deg at calc(200%/3) calc(249%/9),var(--c3) 61deg,#0000 62deg);\n  --g5: conic-gradient(from 60deg at 50% calc(250%/3),#f1f1f1  60deg,var(--c1) 0 120deg,#0000 0);\n  --_p: calc(9*tan(30deg)*var(--s));\n  background:\n    var(--g1) calc(-1*var(--s)) 0,var(--g1) calc(2*var(--s)) var(--_p),\n    var(--g2),var(--g2) calc(3*var(--s)) var(--_p),\n    var(--g3),var(--g3) calc(3*var(--s)) var(--_p),\n    var(--g4),var(--g4) calc(3*var(--s)) var(--_p),\n    var(--g5) calc(3*var(--s)) 0,var(--g5) 0 var(--_p) var(--c3);\n  background-size: calc(6*var(--s)) calc(2*var(--_p));"
+    },
+    {
+      "id": "abstract",
+      "name": "Abstract",
+      "source": "https://css-pattern.com/abstract/",
+      "size": 50,
+      "colors": {
+        "c1": "#5E412F",
+        "c2": "#CCC68D"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #5E412F);\n  --c2: var(--css-pattern-color-2, #CCC68D);\n  --c:calc(50%/3),#0000 75%,var(--c1) 0;\n  --g:conic-gradient(at 50% var(--c));\n  --l:conic-gradient(at var(--c));\n  background:\n    var(--g),\n    var(--g) calc(var(--s)/2) var(--s),\n    var(--g) var(--s) calc(2*var(--s)),\n    var(--l) calc(2*var(--s)) 0,\n    var(--l) 0 var(--s) var(--c2);\n  background-size: calc(3*var(--s)) calc(3*var(--s));"
+    },
+    {
+      "id": "alternating-arc",
+      "name": "Alternating arc",
+      "source": "https://css-pattern.com/alternating-arc/",
+      "size": 16,
+      "colors": {
+        "c1": "#D88A8A",
+        "c2": "#474843"
+      },
+      "declarations": "--s: var(--css-pattern-size, 16px);\n  --c1: var(--css-pattern-color-1, #D88A8A);\n  --c2: var(--css-pattern-color-2, #474843);\n  --g:#0000 66%,var(--c1) 67% 98%,#0000;\n  background:\n    radial-gradient(30% 50% at 30% 100%,var(--g)),\n    radial-gradient(30% 50% at 70%   0%,var(--g)) var(--s) 0,\n    repeating-linear-gradient(90deg,var(--c1) 0 10%,var(--c2) 0 50%);\n  background-size: calc(10*var(--s)) calc(6*var(--s));"
+    },
+    {
+      "id": "arabesque-style",
+      "name": "Arabesque style",
+      "source": "https://css-pattern.com/arabesque-style/",
+      "size": 50,
+      "colors": {
+        "c1": "#084c7f",
+        "c2": "#fef5e9"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #084c7f);\n  --c2: var(--css-pattern-color-2, #fef5e9);\n  --t: calc(var(--s)/10);\n  --_c: #0000 calc(98% - var(--t)),var(--c1) calc(100% - var(--t)) 98%,#0000;\n  --_s: calc(2*var(--s)) calc(5*var(--s)/2);\n  --_r0: /var(--_s) radial-gradient(calc(var(--s)/2) at 0    20%,var(--_c));\n  --_r1: /var(--_s) radial-gradient(calc(var(--s)/2) at 100% 20%,var(--_c));\n  background:\n    0 0 var(--_r0),calc(-1*var(--s)) calc(5*var(--s)/4) var(--_r0),\n    var(--s) 0 var(--_r1),0 calc(5*var(--s)/4) var(--_r1),\n    conic-gradient(at var(--t) calc(20% + 2*var(--t)),#0000 75%,var(--c1) 0)\n    calc(var(--t)/-2) calc(var(--s) - var(--t))/var(--s) calc(5*var(--s)/4),\n    repeating-conic-gradient(var(--c2) 0 25%,#0000 0 50%)\n    var(--s) calc(var(--s)/-8)/var(--_s),\n    conic-gradient(from 90deg at var(--t) var(--t),var(--c2) 25%,var(--c1) 0) \n    calc((var(--s) - var(--t))/2) calc((var(--s) - var(--t))/2)/var(--s) calc(5*var(--s)/4);"
+    },
+    {
+      "id": "arc",
+      "name": "Arc",
+      "source": "https://css-pattern.com/arc/",
+      "size": 16,
+      "colors": {
+        "c1": "#E4844A",
+        "c2": "#0D6759"
+      },
+      "declarations": "--s: var(--css-pattern-size, 16px);\n  --c1: var(--css-pattern-color-1, #E4844A);\n  --c2: var(--css-pattern-color-2, #0D6759);\n  --g:radial-gradient(30% 50% at 30% 100%,#0000 66%,var(--c1) 67% 98%,#0000);\n  background:\n    var(--g),var(--g) calc(5*var(--s)) calc(3*var(--s)),\n    repeating-linear-gradient(90deg,var(--c1) 0 10%,var(--c2) 0 50%);\n  background-size: calc(10*var(--s)) calc(6*var(--s));"
+    },
+    {
+      "id": "arrows",
+      "name": "Arrows",
+      "source": "https://css-pattern.com/arrows/",
+      "size": 100,
+      "colors": {
+        "c1": "#CFF09E",
+        "c2": "#3B8686"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #CFF09E);\n  --c2: var(--css-pattern-color-2, #3B8686);\n  background:\n    conic-gradient(#0000 75%,var(--c1) 0) 0 calc(var(--s)/4),\n    conic-gradient(from 45deg,var(--c1) 25%,var(--c2) 0);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "brick",
+      "name": "Brick",
+      "source": "https://css-pattern.com/brick/",
+      "size": 50,
+      "colors": {
+        "c1": "#774F38",
+        "c2": "#F1D4AF"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #774F38);\n  --c2: var(--css-pattern-color-2, #F1D4AF);\n  --g:conic-gradient(at 90% 40%,#0000 75%,var(--c1) 0);\n  background: var(--g),var(--g) var(--s) var(--s) var(--c2);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "butterflies",
+      "name": "Butterflies",
+      "source": "https://css-pattern.com/butterflies/",
+      "size": 90,
+      "colors": {
+        "c1": "#ECF081",
+        "c2": "#AB3E5B"
+      },
+      "declarations": "--s: var(--css-pattern-size, 90px);\n  --c1: var(--css-pattern-color-1, #ECF081);\n  --c2: var(--css-pattern-color-2, #AB3E5B);\n  background:\n    conic-gradient(at 25% 75%,#0000 25%,var(--c1) 0)\n     calc(var(--s)/-8) calc(var(--s)/8)/var(--s) var(--s),\n    radial-gradient(50% 50%,var(--c1) 24%,var(--c2) 26% 74%,#0000 76%) \n     0 0/var(--s) var(--s),\n    conic-gradient(var(--c1) 75%,var(--c2) 0) \n     calc(var(--s)/2) calc(var(--s)/2)/\n     calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "checkerboard-optical-illusion",
+      "name": "Checkerboard optical illusion",
+      "source": "https://css-pattern.com/checkerboard-optical-illusion/",
+      "size": 80,
+      "colors": {
+        "c1": "#6B5344",
+        "c2": "#F8ECC9"
+      },
+      "declarations": "--s: var(--css-pattern-size, 80px);\n  --c1: var(--css-pattern-color-1, #6B5344);\n  --c2: var(--css-pattern-color-2, #F8ECC9);\n  --c:var(--c1) 0;\n  --g:conic-gradient(at 50% 25%,#0000 75%,var(--c));\n  background:\n    repeating-linear-gradient(#0000 0 48%,var(--c) 50%),var(--g),\n    conic-gradient(#0000 75%,var(--c)) calc(var(--s)/4) calc(var(--s)/2),\n    var(--g) calc(var(--s)/2) var(--s) var(--c2);\n  background-size: var(--s) var(--s),var(--s) calc(2*var(--s));"
+    },
+    {
+      "id": "chevron-stripes",
+      "name": "Chevron stripes",
+      "source": "https://css-pattern.com/chevron-stripes/",
+      "size": 65,
+      "colors": {
+        "c1": "#ECD078",
+        "c2": "#0B486B"
+      },
+      "declarations": "--s: var(--css-pattern-size, 65px);\n  --c1: var(--css-pattern-color-1, #ECD078);\n  --c2: var(--css-pattern-color-2, #0B486B);\n  --g: calc(var(--s)/5);\n  --_l: #0000 calc(33% - .866*var(--g)),var(--c1) calc(33.2% - .866*var(--g)) 33%,#0000 34%;\n  background:\n    repeating-linear-gradient(var(--c1) 0 var(--g), #0000 0 50%)\n     0 calc(.866*var(--s) - var(--g)/2),\n    conic-gradient(from -150deg at var(--g) 50%,var(--c1) 120deg,#0000 0),\n    linear-gradient(-120deg,var(--_l)),linear-gradient( -60deg,var(--_l))\n    var(--c2);\n  background-size: var(--s) calc(3.466*var(--s));"
+    },
+    {
+      "id": "chevrons",
+      "name": "Chevrons",
+      "source": "https://css-pattern.com/chevrons/",
+      "size": 150,
+      "colors": {
+        "c1": "#633D2E",
+        "c2": "#F7AF63"
+      },
+      "declarations": "--s: var(--css-pattern-size, 150px);\n  --c1: var(--css-pattern-color-1, #633D2E);\n  --c2: var(--css-pattern-color-2, #F7AF63);\n  --l:var(--c1) 20%,#0000 0;\n  --g:35%,var(--c2) 0 45%,var(--c1) 0;\n  background:\n    linear-gradient(45deg,var(--l) 45%,var(--c1) 0 70%,#0000 0),\n    linear-gradient(-45deg,var(--l) var(--g) 70%,#0000 0),\n    linear-gradient(45deg,var(--c1) var(--g));\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "christmas-tree",
+      "name": "Christmas tree",
+      "source": "https://css-pattern.com/christmas-tree/",
+      "size": 75,
+      "colors": {
+        "c1": "#ffffff",
+        "c2": "#a31e39",
+        "c3": "#31570e"
+      },
+      "declarations": "--s: var(--css-pattern-size, 75px);\n  --c1: var(--css-pattern-color-1, #ffffff);\n  --c2: var(--css-pattern-color-2, #a31e39);\n  --c3: var(--css-pattern-color-3, #31570e);\n  --_c:#0000,var(--c1) 1deg 79deg,#0000 81deg;\n  --g0:conic-gradient(from 140deg at 50% 87.5% ,var(--_c));\n  --g1:conic-gradient(from 140deg at 50% 81.25%,var(--_c));\n  --g2:conic-gradient(from 140deg at 50% 75%   ,var(--_c));\n  --g3:conic-gradient(at 10% 20%,#0000 75%,var(--c1) 0);\n  background:\n    var(--g0) 0 calc(var(--s)/-4),var(--g0) var(--s) calc(3*var(--s)/4),\n    var(--g1) ,var(--g1) var(--s) var(--s),\n    var(--g2) 0 calc(var(--s)/ 4),var(--g2) var(--s) calc(5*var(--s)/4),\n    var(--g3) calc( var(--s)/-10) var(--s),\n    var(--g3) calc(9*var(--s)/10) calc(2*var(--s)),\n    repeating-conic-gradient(from 45deg,var(--c2) 0 25%,var(--c3) 0 50%);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "christmas",
+      "name": "Christmas style",
+      "source": "https://css-pattern.com/christmas/",
+      "size": 48,
+      "colors": {
+        "c1": "#d8d8d8",
+        "c2": "#bb2528",
+        "c3": "#146b3a"
+      },
+      "declarations": "--s: var(--css-pattern-size, 48px);\n  --c1: var(--css-pattern-color-1, #d8d8d8);\n  --c2: var(--css-pattern-color-2, #bb2528);\n  --c3: var(--css-pattern-color-3, #146b3a);\n  --b: calc(var(--s)/2.67);\n  --_r: calc(1.28*var(--s) + var(--b)/2) at left 50%;\n  --_f: calc(100% - var(--b)),var(--c1) calc(101% - var(--b)) 100%,#0000 101%;\n  --g0: calc(-.8*var(--s)),var(--c2) var(--_f);\n  --g1: calc(-.8*var(--s)),var(--c3) var(--_f);\n  --_s: calc(1.5*var(--s) + var(--b));\n  background: \n    radial-gradient(var(--_r) bottom var(--g0)) calc(2*var(--s)) calc(-1*var(--_s)),\n    radial-gradient(var(--_r) bottom var(--g1)) calc(-1*var(--s)) calc(var(--_s)/-2),\n    radial-gradient(var(--_r) top    var(--g1)) 0 var(--_s),\n    radial-gradient(var(--_r) top    var(--g0)) var(--s) calc(var(--_s)/ 2),\n    linear-gradient(var(--c2) 50%,var(--c3) 0);\n  background-size: calc(4*var(--s)) var(--_s);"
+    },
+    {
+      "id": "circles-curved-lines",
+      "name": "circles & curved lines",
+      "source": "https://css-pattern.com/circles-curved-lines/",
+      "size": 70,
+      "colors": {
+        "c1": "#6B5344",
+        "c2": "#F8ECC9"
+      },
+      "declarations": "--s: var(--css-pattern-size, 70px);\n  --c1: var(--css-pattern-color-1, #6B5344);\n  --c2: var(--css-pattern-color-2, #F8ECC9);\n  --_l: #0000 46%,var(--c1) 47% 53%,#0000 54%;\n  background:\n    radial-gradient(100% 100% at 100% 100%,var(--_l)) var(--s) var(--s),\n    radial-gradient(100% 100% at 0    0   ,var(--_l)) var(--s) var(--s),\n    radial-gradient(100% 100%,#0000 22%,var(--c1) 23% 29%, #0000 30% 34%,var(--c1) 35% 41%,#0000 42%),\n    var(--c2);\n  background-size: calc(var(--s)*2) calc(var(--s)*2);"
+    },
+    {
+      "id": "circles-diagonals",
+      "name": "Circles & Diagonals",
+      "source": "https://css-pattern.com/circles-diagonals/",
+      "size": 120,
+      "colors": {
+        "c1": "#53777A",
+        "c2": "#FC9D9A"
+      },
+      "declarations": "--s: var(--css-pattern-size, 120px);\n  --c1: var(--css-pattern-color-1, #53777A);\n  --c2: var(--css-pattern-color-2, #FC9D9A);\n  background:\n    radial-gradient(var(--c1) 14%,var(--c2) 15% 30%,var(--c1) 31% 44%,var(--c2) 45% 60%,#0000 61%),\n    linear-gradient( 45deg,#0000 46%,var(--c2) 0 54%,#0000 0),\n    linear-gradient(-45deg,#0000 46%,var(--c2) 0 54%,#0000 0) var(--c1);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "circles-pills",
+      "name": "Circles & Pills",
+      "source": "https://css-pattern.com/circles-pills/",
+      "size": 80,
+      "colors": {
+        "c1": "#a2d2ff",
+        "c2": "#9a031e"
+      },
+      "declarations": "--s: var(--css-pattern-size, 80px);\n  --c1: var(--css-pattern-color-1, #a2d2ff);\n  --c2: var(--css-pattern-color-2, #9a031e);\n  --_g:/calc(3*var(--s)) calc(2*var(--s)) \n    conic-gradient(at 33% 25%,#0000 75%,var(--c1) 0);\n  background:\n     calc(var(--s)/-2) calc(var(--s)/4) var(--_g),\n     calc(var(--s)/2) calc(5*var(--s)/4) var(--_g),\n    radial-gradient(var(--c1) 34%,var(--c2) 36%) 0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "circles-squares",
+      "name": "Circles & squares",
+      "source": "https://css-pattern.com/circles-squares/",
+      "size": 100,
+      "colors": {
+        "c1": "#FCD036",
+        "c2": "#987F69"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #FCD036);\n  --c2: var(--css-pattern-color-2, #987F69);\n  --_g: var(--c1) 0 100%,#0000 102%;\n  background:\n    conic-gradient(#0000 75%,var(--_g)) calc(var(--s)/4) calc(var(--s)/4),\n    radial-gradient(65% 65% at 50% -50%,var(--_g)),\n    radial-gradient(65% 65% at -50% 50%,var(--_g)),\n    radial-gradient(65% 65% at 50% 150%,var(--_g)),\n    radial-gradient(65% 65% at 150% 50%,var(--_g))\n    var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "citrus-shapes",
+      "name": "Citrus shapes",
+      "source": "https://css-pattern.com/citrus-shapes/",
+      "size": 55,
+      "colors": {
+        "c1": "#F9F2E7",
+        "c2": "#88A65E",
+        "c3": "#BFB35A"
+      },
+      "declarations": "--s: var(--css-pattern-size, 55px);\n  --c1: var(--css-pattern-color-1, #F9F2E7);\n  --c2: var(--css-pattern-color-2, #88A65E);\n  --c3: var(--css-pattern-color-3, #BFB35A);\n  --b: calc(var(--s)/3.67);\n  --_r: calc(1.28*var(--s) + var(--b)/2) at top 50%;\n  --_f: calc(99.5% - var(--b)),var(--c1) calc(101% - var(--b)) 99.5%,#0000 101%;\n  --_g0: calc(-.8*var(--s)), var(--c2) var(--_f);\n  --_g1: calc(-.8*var(--s)), var(--c3) var(--_f);\n  --_s: calc(1.8*var(--s) + var(--b));\n  background: \n    radial-gradient(var(--_r) right var(--_g0)) calc(-1*var(--_s)) var(--s),\n    radial-gradient(var(--_r) left  var(--_g1))         var(--_s)  calc(-1*var(--s)),\n    radial-gradient(var(--_r) right var(--_g1)) calc(var(--_s)/-2) calc(-1*var(--s)),\n    radial-gradient(var(--_r) left  var(--_g0)) calc(var(--_s)/ 2) var(--s),\n    linear-gradient(90deg,var(--c2) 50%,var(--c3) 0);\n  background-size: var(--_s) calc(4*var(--s));"
+    },
+    {
+      "id": "colorful-circles",
+      "name": "Colorful overlapping circles",
+      "source": "https://css-pattern.com/colorful-circles/",
+      "size": 120,
+      "colors": {
+        "c1": "#1a2030",
+        "c2": "#0f9177",
+        "c3": "#fdebad",
+        "c4": "#d34434",
+        "c5": "#b5d999"
+      },
+      "declarations": "--s: var(--css-pattern-size, 120px);\n  --c1: var(--css-pattern-color-1, #1a2030);\n  --c2: var(--css-pattern-color-2, #0f9177);\n  --c3: var(--css-pattern-color-3, #fdebad);\n  --c4: var(--css-pattern-color-4, #d34434);\n  --c5: var(--css-pattern-color-5, #b5d999);\n  --_g: radial-gradient(#0000 70%,var(--c1) 71%);\n  background:\n    var(--_g),var(--_g) calc(var(--s)/2) calc(var(--s)/2),\n    conic-gradient(var(--c2) 25%,var(--c3) 0 50%,var(--c4) 0 75%,var(--c5) 0);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "concentric-arrows",
+      "name": "Concentric arrows",
+      "source": "https://css-pattern.com/concentric-arrows/",
+      "size": 124,
+      "colors": {
+        "c1": "#90c0b2",
+        "c2": "#f9fbef"
+      },
+      "declarations": "--s: var(--css-pattern-size, 124px);\n  --c1: var(--css-pattern-color-1, #90c0b2);\n  --c2: var(--css-pattern-color-2, #f9fbef);\n  --g:var(--c1) 0 25%,var(--c2) 0 50%,#0000 0;\n  background: \n    conic-gradient(from 135deg at 25% 75%, var(--g)) \n     calc(var(--s)/4) calc(var(--s)/-4), \n    conic-gradient(from -45deg at 75% 25%, var(--g))\n     calc(var(--s)/-4) calc(var(--s)/4), \n    repeating-conic-gradient(var(--g));\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "connected-squares",
+      "name": "Connected squares",
+      "source": "https://css-pattern.com/connected-squares/",
+      "size": 160,
+      "colors": {
+        "c1": "#D3E2B6",
+        "c2": "#AACCB1"
+      },
+      "declarations": "--s: var(--css-pattern-size, 160px);\n  --c1: var(--css-pattern-color-1, #D3E2B6);\n  --c2: var(--css-pattern-color-2, #AACCB1);\n  background:\n    conic-gradient(at 25% 25%,#0000 75%,var(--c1) 0)\n     0 calc(3*var(--s)/4),\n    conic-gradient(#0000 75%,var(--c2) 0) \n     calc(var(--s)/-8) calc(5*var(--s)/8),\n    conic-gradient(at 25% 75%,var(--c1) 25%,var(--c2) 0);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "cube-columns",
+      "name": "Cube columns",
+      "source": "https://css-pattern.com/cube-columns/",
+      "size": 82,
+      "colors": {
+        "c1": "#b2b2b2",
+        "c2": "#ffffff",
+        "c3": "#d9d9d9"
+      },
+      "declarations": "--s: var(--css-pattern-size, 82px);\n  --c1: var(--css-pattern-color-1, #b2b2b2);\n  --c2: var(--css-pattern-color-2, #ffffff);\n  --c3: var(--css-pattern-color-3, #d9d9d9);\n  --_g: var(--c3) 0 120deg,#0000 0;\n  background:\n    conic-gradient(from -60deg at 50% calc(100%/3),var(--_g)),\n    conic-gradient(from 120deg at 50% calc(200%/3),var(--_g)),\n    conic-gradient(from  60deg at calc(200%/3),var(--c3) 60deg,var(--c2) 0 120deg,#0000 0),\n    conic-gradient(from 180deg at calc(100%/3),var(--c1) 60deg,var(--_g)),\n    linear-gradient(90deg,var(--c1)   calc(100%/6),var(--c2) 0 50%,\n                          var(--c1) 0 calc(500%/6),var(--c2) 0);\n  background-size: calc(1.732*var(--s)) var(--s);"
+    },
+    {
+      "id": "cubes-illusion",
+      "name": "Cubes illusion",
+      "source": "https://css-pattern.com/cubes-illusion/",
+      "size": 200,
+      "colors": {
+        "c1": "#1d1d1d",
+        "c2": "#4e4f51",
+        "c3": "#3c3c3c"
+      },
+      "declarations": "--s: var(--css-pattern-size, 200px);\n  --c1: var(--css-pattern-color-1, #1d1d1d);\n  --c2: var(--css-pattern-color-2, #4e4f51);\n  --c3: var(--css-pattern-color-3, #3c3c3c);\n  background:\n    repeating-conic-gradient(from 30deg,#0000 0 120deg,var(--c3) 0 50%) \n     calc(var(--s)/2) calc(var(--s)*tan(30deg)/2),\n    repeating-conic-gradient(from 30deg,var(--c1) 0 60deg,var(--c2) 0 120deg,var(--c3) 0 50%);\n  background-size: var(--s) calc(var(--s)*tan(30deg));"
+    },
+    {
+      "id": "cubes",
+      "name": "Cubes",
+      "source": "https://css-pattern.com/cubes/",
+      "size": 100,
+      "colors": {
+        "c1": "#99B2B7",
+        "c2": "#EDC951"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #99B2B7);\n  --c2: var(--css-pattern-color-2, #EDC951);\n  background:\n    conic-gradient(at 80% 80%,var(--c1) 75%,#0000 0),\n    linear-gradient(135deg,var(--c1) calc(40%/3),\n      #0000 0 calc(200%/3),var(--c1) 0),\n    conic-gradient(from 45deg at calc(160%/3) calc(80%/3),\n      #0008 135deg,#0000 0 225deg,#0004 0)\n    var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "curved-lines",
+      "name": "Curved lines",
+      "source": "https://css-pattern.com/curved-lines/",
+      "size": 100,
+      "colors": {
+        "c1": "#fff0e5",
+        "c2": "#025d8c",
+        "c3": "#e1642a"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #fff0e5);\n  --c2: var(--css-pattern-color-2, #025d8c);\n  --c3: var(--css-pattern-color-3, #e1642a);\n  --_g: 50%,#0000 37%,var(--c1) 39% 70%,#0000 72%;\n  --_t: 50%,var(--c2) 40deg,var(--c3) 0 140deg,var(--c2) 0 180deg,#0000 0;\n  --_s: 47% 50% at;\n  background: \n    radial-gradient(var(--_s) -10% var(--_g)) 0 calc(var(--s)/2),\n    radial-gradient(var(--_s) -10% var(--_g)) calc(var(--s)/2) 0,\n    radial-gradient(var(--_s) 110% var(--_g)),\n    radial-gradient(var(--_s) 110% var(--_g)) calc(var(--s)/2) calc(var(--s)/2),\n    conic-gradient(from   0deg at 55% var(--_t)) calc(var(--s)/4) 0,\n    conic-gradient(from 180deg at 45% var(--_t)) calc(var(--s)/4) 0,\n    var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "curved-segments",
+      "name": "Curved segments",
+      "source": "https://css-pattern.com/curved-segments/",
+      "size": 60,
+      "colors": {
+        "c1": "#7BB0A8",
+        "c2": "#A7DBAB"
+      },
+      "declarations": "--s: var(--css-pattern-size, 60px);\n  --c1: var(--css-pattern-color-1, #7BB0A8);\n  --c2: var(--css-pattern-color-2, #A7DBAB);\n  --_c: var(--c1) calc(100% - var(--s)/2) 99%,#0000;\n  --_g: var(--s),#0000 calc(99% - var(--s)/2),var(--_c);\n  background:\n    radial-gradient(var(--s) at 100% var(--_g)),\n    radial-gradient(calc(var(--s)/4) at 50% calc(100%/3),var(--_c)) var(--s) 0,\n    radial-gradient(var(--s) at   0% var(--_g)) 0 calc(3*var(--s))\n    var(--c2);\n  background-size: \n    calc(2*var(--s)) calc(9*var(--s)/4),\n    calc(2*var(--s)) calc(3*var(--s)/4);"
+    },
+    {
+      "id": "curvy",
+      "name": "curvy",
+      "source": "https://css-pattern.com/curvy/",
+      "size": 80,
+      "colors": {
+        "c1": "#5E8C6A",
+        "c2": "#bfb35a"
+      },
+      "declarations": "--s: var(--css-pattern-size, 80px);\n  --c1: var(--css-pattern-color-1, #5E8C6A);\n  --c2: var(--css-pattern-color-2, #bfb35a);\n  --_s: calc(2*var(--s)) calc(2*var(--s));\n  --_g: 35.36% 35.36% at;\n  --_c: #0000 66%,var(--c2) 68% 70%,#0000 72%;\n  background:\n    radial-gradient(var(--_g) 100% 25%,var(--_c)) var(--s) var(--s)/var(--_s),\n    radial-gradient(var(--_g) 0    75%,var(--_c)) var(--s) var(--s)/var(--_s),\n    radial-gradient(var(--_g) 100% 25%,var(--_c)) 0 0/var(--_s),\n    radial-gradient(var(--_g) 0    75%,var(--_c)) 0 0/var(--_s),\n    repeating-conic-gradient(var(--c1) 0 25%,#0000 0 50%) 0 0/var(--_s),\n    radial-gradient(var(--_c)) 0 calc(var(--s)/2)/var(--s) var(--s)\n    var(--c1);"
+    },
+    {
+      "id": "diagonal-arc",
+      "name": "Diagonal arc",
+      "source": "https://css-pattern.com/diagonal-arc/",
+      "size": 52,
+      "colors": {
+        "c1": "#DFBA69",
+        "c2": "#5A2E2E"
+      },
+      "declarations": "--s: var(--css-pattern-size, 52px);\n  --c1: var(--css-pattern-color-1, #DFBA69);\n  --c2: var(--css-pattern-color-2, #5A2E2E);\n  --p:35%,#0000 calc(35% + 1px);\n  background:\n    radial-gradient(at 0 100%,var(--c1) var(--p)) var(--s) 0,\n    radial-gradient(at 0 100%,var(--c2) var(--p)) 0 var(--s),\n    repeating-conic-gradient(from 45deg,var(--c2) 0 25%,var(--c1) 0 50%);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "diagonal-arrows",
+      "name": "Diagonal arrows",
+      "source": "https://css-pattern.com/diagonal-arrows/",
+      "size": 62,
+      "colors": {
+        "c1": "#CF4647",
+        "c2": "#524656"
+      },
+      "declarations": "--s: var(--css-pattern-size, 62px);\n  --c1: var(--css-pattern-color-1, #CF4647);\n  --c2: var(--css-pattern-color-2, #524656);\n  background:\n    conic-gradient(from  45deg at 75% 75%,var(--c1) 25%,var(--c2) 0 50%,#0000 0)\n     0 0/var(--s) var(--s),\n    conic-gradient(from 225deg at 25% 25%,var(--c2) 25%,var(--c1) 0 50%,#0000 0)\n     0 0/var(--s) var(--s),\n    repeating-conic-gradient(var(--c2) 0 25%,var(--c1) 0 50%)\n     0 0/calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "diagonal-brick",
+      "name": "Diagonal brick",
+      "source": "https://css-pattern.com/diagonal-brick/",
+      "size": 100,
+      "colors": {
+        "c1": "#D3643B",
+        "c2": "#333333"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #D3643B);\n  --c2: var(--css-pattern-color-2, #333333);\n  --c:var(--c2) 20% 30%;\n  background:\n    linear-gradient(135deg,#0000 20%,var(--c),#0000 0),\n    repeating-linear-gradient(45deg,var(--c),var(--c1) 0 70%);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "diagonal-chevrons",
+      "name": "Diagonal chevrons",
+      "source": "https://css-pattern.com/diagonal-chevrons/",
+      "size": 100,
+      "colors": {
+        "c1": "#7A6A53",
+        "c2": "#D9CEB2"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #7A6A53);\n  --c2: var(--css-pattern-color-2, #D9CEB2);\n  background:\n    conic-gradient(var(--c1)   135deg,var(--c2) 0 270deg,\n                   var(--c1) 0 315deg,var(--c2) 0)\n    0/var(--s) var(--s);"
+    },
+    {
+      "id": "diagonal-herringbone",
+      "name": "Diagonal herringbone",
+      "source": "https://css-pattern.com/diagonal-herringbone/",
+      "size": 65,
+      "colors": {
+        "c1": "#ECD078",
+        "c2": "#542437"
+      },
+      "declarations": "--s: var(--css-pattern-size, 65px);\n  --c1: var(--css-pattern-color-1, #ECD078);\n  --c2: var(--css-pattern-color-2, #542437);\n  --l1:#0000  48%,var(--c1) 0 52%,#0000 0;\n  --l2:#0000 1.3%,var(--c2) 0 32%,#0000 0;\n  background:\n    linear-gradient(-45deg,var(--l2)),\n    linear-gradient( 45deg,var(--l1)),\n    linear-gradient( 45deg,var(--l2)) calc(var(--s)/2) calc(var(--s)/2),\n    linear-gradient(-45deg,var(--l1)) var(--c2);\n  background-size: calc(2*var(--s)) var(--s),var(--s) var(--s);"
+    },
+    {
+      "id": "diagonal-lines",
+      "name": "Diagonal lines",
+      "source": "https://css-pattern.com/diagonal-lines/",
+      "size": 86,
+      "colors": {
+        "c1": "#88ABC2",
+        "c2": "#FAD3B2"
+      },
+      "declarations": "--s: var(--css-pattern-size, 86px);\n  --c1: var(--css-pattern-color-1, #88ABC2);\n  --c2: var(--css-pattern-color-2, #FAD3B2);\n  --g:#0000 45%,var(--c1) 46% 54%,#0000 55%;\n  background:\n    linear-gradient( 60deg,var(--g)),\n    linear-gradient(-60deg,var(--g)) var(--c2);\n  background-size: var(--s) calc(tan(60deg)*var(--s));"
+    },
+    {
+      "id": "diagonal-rectangles",
+      "name": "Diagonal rectangles",
+      "source": "https://css-pattern.com/diagonal-rectangles/",
+      "size": 150,
+      "colors": {
+        "c1": "#5E412F",
+        "c2": "#FCEBB6"
+      },
+      "declarations": "--s: var(--css-pattern-size, 150px);\n  --c1: var(--css-pattern-color-1, #5E412F);\n  --c2: var(--css-pattern-color-2, #FCEBB6);\n  background:\n    linear-gradient(135deg,#0000 18.75%,var(--c1) 0 31.25%,#0000 0),\n    repeating-linear-gradient(45deg,var(--c1) -6.25% 6.25%,var(--c2) 0 18.75%);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "diagonal-squares",
+      "name": "Diagonal squares",
+      "source": "https://css-pattern.com/diagonal-squares/",
+      "size": 100,
+      "colors": {
+        "c1": "#00A0B0",
+        "c2": "#EB6841"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #00A0B0);\n  --c2: var(--css-pattern-color-2, #EB6841);\n  --_g: var(--c1) 0 25%,#0000 0 50%;\n  background:\n   repeating-conic-gradient(at 33% 33%,var(--_g)),\n   repeating-conic-gradient(at 66% 66%,var(--_g)),\n   var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "diagonal-wavy-squares",
+      "name": "Diagonal wavy lines & squares",
+      "source": "https://css-pattern.com/diagonal-wavy-squares/",
+      "size": 40,
+      "colors": {
+        "c1": "#AB3E5B",
+        "c2": "#F9F2E7"
+      },
+      "declarations": "--s: var(--css-pattern-size, 40px);\n  --c1: var(--css-pattern-color-1, #AB3E5B);\n  --c2: var(--css-pattern-color-2, #F9F2E7);\n  --_g:#0000 17.5%,var(--c1) 18% 35%,var(--c2) 35.5% 39%,#0000 40%;\n  background:\n    radial-gradient(at 100% 0,var(--_g))\n     0       calc(var(--s)/-2)/calc(2*var(--s)) calc(2*var(--s)),\n    radial-gradient(at 0 100%,var(--_g))\n     calc(var(--s)/2) var(--s)/calc(2*var(--s)) calc(2*var(--s)),\n    conic-gradient(#0000 75%,var(--c1) 0) 0 0/var(--s) var(--s) \n     var(--c2);"
+    },
+    {
+      "id": "diagonal-wavy",
+      "name": "Diagonal wavy lines",
+      "source": "https://css-pattern.com/diagonal-wavy/",
+      "size": 100,
+      "colors": {
+        "c1": "#CC2A41",
+        "c2": "#351330"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #CC2A41);\n  --c2: var(--css-pattern-color-2, #351330);\n  --_g: #0000 24%,\n    var(--c2) 26% 34%,var(--c1) 36% 44%,\n    var(--c2) 46% 54%,var(--c1) 56% 64%,\n    var(--c2) 66% 74%,#0000 76%;\n  background:\n    radial-gradient(100% 100% at 100% 0,var(--_g)),\n    radial-gradient(100% 100% at 0 100%,var(--_g)),\n    radial-gradient(var(--c2) 14%,var(--c1) 16%) \n     calc(var(--s)/2) calc(var(--s)/2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "diagonal-zig-zag",
+      "name": "Diagonal Zig-Zag",
+      "source": "https://css-pattern.com/diagonal-zig-zag/",
+      "size": 60,
+      "colors": {
+        "c1": "#ffdc56",
+        "c2": "#fe6601",
+        "c3": "#803201"
+      },
+      "declarations": "--s: var(--css-pattern-size, 60px);\n  --c1: var(--css-pattern-color-1, #ffdc56);\n  --c2: var(--css-pattern-color-2, #fe6601);\n  --c3: var(--css-pattern-color-3, #803201);\n  --_s: calc(2*var(--s)) calc(2*var(--s));\n  --_g1: var(--_s) conic-gradient(at calc(500%/6) 50%,var(--c3) 25%,#0000 0);\n  --_g2: var(--_s) conic-gradient(at calc(200%/3) 50%,var(--c2) 25%,#0000 0);\n  background:\n    var(--s) var(--s)/var(--_g1),0 0/var(--_g1),\n    var(--s) var(--s)/var(--_g2),0 0/var(--_g2),\n    repeating-conic-gradient(var(--c1) 0 25%,#0000 0 50%) 0 0/var(--_s),\n    linear-gradient(var(--c1) calc(100%/3),var(--c2) 0 calc(200%/3),var(--c3) 0)\n     0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "distorted-mesh",
+      "name": "Distorted mesh",
+      "source": "https://css-pattern.com/distorted-mesh/",
+      "size": 140,
+      "colors": {
+        "c1": "#170409",
+        "c2": "#67917A"
+      },
+      "declarations": "--s: var(--css-pattern-size, 140px);\n  --c1: var(--css-pattern-color-1, #170409);\n  --c2: var(--css-pattern-color-2, #67917A);\n  --_g: #0000 52%,var(--c1) 54% 57%,#0000 59%;\n  background: \n   radial-gradient(farthest-side at -33.33% 50%,var(--_g)) 0 calc(var(--s)/2),\n   radial-gradient(farthest-side at 50% 133.33%,var(--_g)) calc(var(--s)/2) 0,\n   radial-gradient(farthest-side at 133.33% 50%,var(--_g)),\n   radial-gradient(farthest-side at 50% -33.33%,var(--_g)),\n   var(--c2);\n  background-size: calc(var(--s)/4.667) var(--s),var(--s) calc(var(--s)/4.667);"
+    },
+    {
+      "id": "double-arrows",
+      "name": "Double arrows",
+      "source": "https://css-pattern.com/double-arrows/",
+      "size": 100,
+      "colors": {
+        "c1": "#E8BF56",
+        "c2": "#91204D"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #E8BF56);\n  --c2: var(--css-pattern-color-2, #91204D);\n  --_l:#0000 43.75%,var(--c1) 0 56.25%,#0000 0;\n  --_s:calc(var(--s)/4) calc(var(--s)/-4)/\n       calc(var(--s)*2) calc(var(--s)*2);\n  background:\n    linear-gradient(-45deg,var(--_l)) var(--_s),\n    linear-gradient( 45deg,var(--_l)) var(--_s),\n    conic-gradient(var(--c2) 75%,var(--c1) 0) 0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "elongated-hexagons",
+      "name": "Elongated hexagons",
+      "source": "https://css-pattern.com/elongated-hexagons/",
+      "size": 100,
+      "colors": {
+        "c1": "#EEDD99",
+        "c2": "#BBBB88"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #EEDD99);\n  --c2: var(--css-pattern-color-2, #BBBB88);\n  --c:#0000 0 25%,var(--c1) 0 50%;\n  background:\n    repeating-conic-gradient(from -45deg at 75% 37.5%,var(--c)),\n    conic-gradient(var(--c2) 50%,#0000 0),\n    repeating-conic-gradient(from  45deg at 25% 87.5%,var(--c))\n    var(--c2);\n  background-size: var(--s) calc(2*var(--s));"
+    },
+    {
+      "id": "equal-sign",
+      "name": "Equal sign (rotated rectangles)",
+      "source": "https://css-pattern.com/equal-sign/",
+      "size": 200,
+      "colors": {
+        "c1": "#ffffff",
+        "c2": "#1095c1"
+      },
+      "declarations": "--s: var(--css-pattern-size, 200px);\n  --c1: var(--css-pattern-color-1, #ffffff);\n  --c2: var(--css-pattern-color-2, #1095c1);\n  --_g: #0000 8%,var(--c1) 0 17%,#0000 0 58%;\n  background: \n    linear-gradient(135deg,#0000 20.5%,var(--c1) 0 29.5%,#0000 0) 0 calc(var(--s)/4),\n    linear-gradient( 45deg,var(--_g)) calc(var(--s)/2) 0,\n    linear-gradient(135deg,var(--_g),var(--c1) 0 67%,#0000 0),        \n    linear-gradient( 45deg,var(--_g),var(--c1) 0 67%,#0000 0 83%,var(--c1) 0 92%,#0000 0),\n    var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "equilateral-triangles",
+      "name": "Equilateral triangles",
+      "source": "https://css-pattern.com/equilateral-triangles/",
+      "size": 120,
+      "colors": {
+        "c1": "#FA6900",
+        "c2": "#D95B43",
+        "c3": "#ECD078"
+      },
+      "declarations": "--s: var(--css-pattern-size, 120px);\n  --c1: var(--css-pattern-color-1, #FA6900);\n  --c2: var(--css-pattern-color-2, #D95B43);\n  --c3: var(--css-pattern-color-3, #ECD078);\n  background:\n    conic-gradient(from 150deg at 50% 33%,#0000,var(--c1) .5deg 60deg,#0000 60.5deg) \n      calc(var(--s)/2) calc(var(--s)/sqrt(2)),\n    conic-gradient(from -30deg at 50% 66%,#0000,var(--c2) .5deg 60deg,var(--c3) 60.5deg);\n  background-size: var(--s) calc(.5*var(--s)/tan(30deg));"
+    },
+    {
+      "id": "fence",
+      "name": "Fence",
+      "source": "https://css-pattern.com/fence/",
+      "size": 100,
+      "colors": {
+        "c1": "#88C425",
+        "c2": "#1B676B"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #88C425);\n  --c2: var(--css-pattern-color-2, #1B676B);\n  --g:var(--c2) -5% 5%,#0000 0 45%;\n  background:\n    linear-gradient(45deg,#0000 10%,var(--c1) 0 40%,#0000 0),\n    repeating-linear-gradient( 45deg,var(--g)),\n    repeating-linear-gradient(-45deg,var(--g)) var(--c1);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "flower-petals",
+      "name": "Flower petals",
+      "source": "https://css-pattern.com/flower-petals/",
+      "size": 60,
+      "colors": {
+        "c1": "#F2B4A8",
+        "c2": "#91204D"
+      },
+      "declarations": "--s: var(--css-pattern-size, 60px);\n  --c1: var(--css-pattern-color-1, #F2B4A8);\n  --c2: var(--css-pattern-color-2, #91204D);\n  --_g: radial-gradient(25% 25% at 25% 25%,var(--c1) 99%,#0000 101%);\n  background:\n   var(--_g) var(--s) var(--s)/calc(2*var(--s)) calc(2*var(--s)),\n   var(--_g) 0 0/calc(2*var(--s)) calc(2*var(--s)),\n   radial-gradient(50% 50%,var(--c2) 98%,#0000) 0 0/var(--s) var(--s),\n   repeating-conic-gradient(var(--c2) 0 25%,var(--c1) 0 50%) \n     calc(.5*var(--s)) 0/calc(2*var(--s)) var(--s);"
+    },
+    {
+      "id": "folded-zig-zag",
+      "name": "Folded Zig-Zag",
+      "source": "https://css-pattern.com/folded-zig-zag/",
+      "size": 84,
+      "colors": {
+        "c1": "#ffffff",
+        "c2": "#71e9a0",
+        "c3": "#2a6a9b"
+      },
+      "declarations": "--s: var(--css-pattern-size, 84px);\n  --c1: var(--css-pattern-color-1, #ffffff);\n  --c2: var(--css-pattern-color-2, #71e9a0);\n  --c3: var(--css-pattern-color-3, #2a6a9b);\n  --a:from -30deg at;\n  background:\n    linear-gradient(#0000 50%,#0004 0),\n    conic-gradient(var(--a) 90%,var(--c1) 240deg,#0000     0),\n    conic-gradient(var(--a) 75%,var(--c2) 240deg,#0000     0),\n    conic-gradient(var(--a) 25%,#0000     240deg,var(--c1) 0),\n    conic-gradient(var(--a) 40%,var(--c1) 240deg,var(--c3) 0);\n  background-size: calc(1.5*var(--s)) var(--s);"
+    },
+    {
+      "id": "geometric-flowers",
+      "name": "Geometric flowers",
+      "source": "https://css-pattern.com/geometric-flowers/",
+      "size": 64,
+      "colors": {
+        "c1": "#C02942",
+        "c2": "#53777A",
+        "c3": "#ECD078",
+        "c4": "#D95B43"
+      },
+      "declarations": "--s: var(--css-pattern-size, 64px);\n  --c1: var(--css-pattern-color-1, #C02942);\n  --c2: var(--css-pattern-color-2, #53777A);\n  --c3: var(--css-pattern-color-3, #ECD078);\n  --c4: var(--css-pattern-color-4, #D95B43);\n  background:\n    radial-gradient(var(--c1) 24%,#0000 25%),\n    radial-gradient(var(--c2) 30%,#0000 32%) calc(var(--s)/2) calc(var(--s)/2),\n    repeating-conic-gradient(from 30deg,var(--c3) 0 30deg,var(--c4) 0 25%);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "graph-paper",
+      "name": "Graph paper",
+      "source": "https://css-pattern.com/graph-paper/",
+      "size": 100,
+      "colors": {
+        "c1": "#336666",
+        "c2": "#ffffff"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #336666);\n  --c2: var(--css-pattern-color-2, #ffffff);\n  --_g: #0000 90deg,var(--c1) 0;\n  background: \n    conic-gradient(from 90deg at 2px 2px,var(--_g)),\n    conic-gradient(from 90deg at 1px 1px,var(--_g)),\n    var(--c2);\n  background-size: var(--s) var(--s), calc(var(--s)/5) calc(var(--s)/5);"
+    },
+    {
+      "id": "half-circles",
+      "name": "Half circles",
+      "source": "https://css-pattern.com/half-circles/",
+      "size": 71,
+      "colors": {
+        "c1": "#78C0A8",
+        "c2": "#FCEBB6"
+      },
+      "declarations": "--s: var(--css-pattern-size, 71px);\n  --c1: var(--css-pattern-color-1, #78C0A8);\n  --c2: var(--css-pattern-color-2, #FCEBB6);\n  background:\n    radial-gradient(36% 72% at 25% -50%,var(--c2) 98%,#0000)\n     0 0/calc(2*var(--s)) var(--s),\n    radial-gradient(36% 72% at 75% 150%,var(--c2) 98%,#0000)\n     0 0/calc(2*var(--s)) var(--s),\n    radial-gradient(72% 36% at 150% 25%,var(--c2) 98%,#0000)\n     0 0/var(--s) calc(2*var(--s)),\n    radial-gradient(72% 36% at -50% 75%,var(--c2) 98%,#0000)\n     0 0/var(--s) calc(2*var(--s)),\n    repeating-conic-gradient(var(--c2) 0 45deg,var(--c1) 0 25%)\n     0 0/calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "hearts",
+      "name": "Hearts",
+      "source": "https://css-pattern.com/hearts/",
+      "size": 120,
+      "colors": {
+        "c1": "#e7525b",
+        "c2": "#78dbf0"
+      },
+      "declarations": "--s: var(--css-pattern-size, 120px);\n  --c1: var(--css-pattern-color-1, #e7525b);\n  --c2: var(--css-pattern-color-2, #78dbf0);\n  --_g: 80%,var(--c1) 25.4%,#0000 26%;\n  background:\n   radial-gradient(at 80% var(--_g)),\n   radial-gradient(at 20% var(--_g)),\n   conic-gradient(from -45deg at 50% 41%,var(--c1) 90deg,var(--c2) 0) \n      calc(var(--s)/2) 0;\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "herringbone",
+      "name": "Herringbone",
+      "source": "https://css-pattern.com/herringbone/",
+      "size": 50,
+      "colors": {
+        "c1": "#F8E4C1",
+        "c2": "#2B4E72"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #F8E4C1);\n  --c2: var(--css-pattern-color-2, #2B4E72);\n  --c:#0000 75%,var(--c1) 0;\n  --g1:conic-gradient(at 78% 3%,var(--c));\n  --g2:conic-gradient(at 3% 78%,var(--c));\n  background:\n    var(--g1),\n    var(--g1) var(--s) var(--s),\n    var(--g1) calc(2*var(--s)) calc(2*var(--s)),\n    var(--g1) calc(3*var(--s)) calc(3*var(--s)),\n    var(--g2) 0 calc(3*var(--s)),\n    var(--g2) var(--s) 0,\n    var(--g2) calc(2*var(--s)) var(--s),\n    var(--g2) calc(3*var(--s)) calc(2*var(--s))\n    var(--c2);\n  background-size: calc(4*var(--s)) calc(4*var(--s));"
+    },
+    {
+      "id": "hexagons-squares-triangles",
+      "name": "Hexagons, squares & triangles",
+      "source": "https://css-pattern.com/hexagons-squares-triangles/",
+      "size": 41,
+      "colors": {
+        "c1": "#F2C45A",
+        "c2": "#5E8C6A",
+        "c3": "#88A65E"
+      },
+      "declarations": "--s: var(--css-pattern-size, 41px);\n  --c1: var(--css-pattern-color-1, #F2C45A);\n  --c2: var(--css-pattern-color-2, #5E8C6A);\n  --c3: var(--css-pattern-color-3, #88A65E);\n  --_g:,var(--c1) 25%,var(--c2) 0 150deg,var(--c1) 0 240deg,#0000 0;\n  background:\n    conic-gradient(from  60deg at calc(3.866*var(--s)),var(--c2) 60deg,#0000 0)\n     calc(1.366*var(--s)) calc(1.366*var(--s)),\n    conic-gradient(from 240deg at calc( .866*var(--s)),var(--c2) 60deg,#0000 0)\n     calc(2.366*var(--s)) calc(1.366*var(--s)),\n    conic-gradient(at var(--s) var(--s),#0000 75%,var(--c1) 0)\n     calc(1.366*var(--s)) calc(var(--s)/-2),\n    conic-gradient(from 30deg at calc(-.288*var(--s)) 50%, #0000 120deg,var(--c3) 0),\n    conic-gradient(from 90deg at calc(3.732*var(--s)) calc(1.866*var(--s)),\n     var(--c3) 120deg,#0000 0),\n    conic-gradient(from -30deg at calc(3.732*var(--s)) calc(.866*var(--s)),\n     var(--c3) 120deg,var(--c1) 0 210deg,#0000 0),\n    conic-gradient(from 150deg at calc( .866*var(--s))var(--_g)),\n    conic-gradient(from -30deg at calc(2.866*var(--s))var(--_g)) var(--c3);\n  background-size: calc(4.732*var(--s)) calc(2.732*var(--s));"
+    },
+    {
+      "id": "honeycomb",
+      "name": "Honeycomb",
+      "source": "https://css-pattern.com/honeycomb/",
+      "size": 37,
+      "colors": {
+        "c1": "#2FB8AC",
+        "c2": "#ECBE13"
+      },
+      "declarations": "--s: var(--css-pattern-size, 37px);\n  --c1: var(--css-pattern-color-1, #2FB8AC);\n  --c2: var(--css-pattern-color-2, #ECBE13);\n  --c:#0000,var(--c1) .5deg 119.5deg,#0000 120deg;\n  --g1:conic-gradient(from  60deg at 56.25% calc(425%/6),var(--c));\n  --g2:conic-gradient(from 180deg at 43.75% calc(425%/6),var(--c));\n  --g3:conic-gradient(from -60deg at 50%   calc(175%/12),var(--c));\n  background:\n    var(--g1),var(--g1) var(--s) calc(1.73*var(--s)),\n    var(--g2),var(--g2) var(--s) calc(1.73*var(--s)),\n    var(--g3) var(--s) 0,var(--g3) 0 calc(1.73*var(--s)) \n    var(--c2);\n  background-size: calc(2*var(--s)) calc(3.46*var(--s));"
+    },
+    {
+      "id": "houndstooth",
+      "name": "Houndstooth",
+      "source": "https://css-pattern.com/houndstooth/",
+      "size": 100,
+      "colors": {
+        "c1": "#5B7C8D",
+        "c2": "#EDF6EE"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #5B7C8D);\n  --c2: var(--css-pattern-color-2, #EDF6EE);\n  background:\n    conic-gradient(var(--c1) 25%,#0000 0 50%,var(--c2) 0 75%,#0000 0),\n    linear-gradient(135deg,\n      var(--c1) 0 12.5%,var(--c2) 0 25%,\n      var(--c1) 0 37.5%,var(--c2) 0 62.5%,\n      var(--c1) 0 75%  ,var(--c2) 0 87.5%,\n      var(--c1) 0);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "intersecting-diagonals",
+      "name": "Intersecting diagonals",
+      "source": "https://css-pattern.com/intersecting-diagonals/",
+      "size": 150,
+      "colors": {
+        "c1": "#0D6759",
+        "c2": "#E5EDB8"
+      },
+      "declarations": "--s: var(--css-pattern-size, 150px);\n  --c1: var(--css-pattern-color-1, #0D6759);\n  --c2: var(--css-pattern-color-2, #E5EDB8);\n  background:\n    linear-gradient(45deg,var(--c1) 12.5%,var(--c2) 0 25%,#0000 0 75%,var(--c2) 0 87.5%,var(--c1) 0)\n     calc(var(--s)/2) calc(var(--s)/2),\n    linear-gradient(45deg,var(--c2) 12.5%,var(--c1) 0 25%,#0000 0 75%,var(--c1) 0 87.5%,var(--c2) 0),\n    repeating-linear-gradient(-45deg,var(--c1) 0 12.5%,var(--c2) 0 25%,var(--c1) 0 37.5%,var(--c2) 0 62.5%);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "intersecting-rhombus",
+      "name": "Intersecting Rhombus",
+      "source": "https://css-pattern.com/intersecting-rhombus/",
+      "size": 100,
+      "colors": {
+        "c1": "#1BB0CE",
+        "c2": "#DAD6CA"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #1BB0CE);\n  --c2: var(--css-pattern-color-2, #DAD6CA);\n  --_l:#0000 34%,var(--c1) 0 41%,#0000 0 59%,var(--c1) 0 66%,#0000 0;\n  background:\n    linear-gradient(-45deg,var(--_l)),\n    linear-gradient( 45deg,var(--_l)) var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "intersecting-wavy-lines",
+      "name": "Intersecting wavy lines",
+      "source": "https://css-pattern.com/intersecting-wavy-lines/",
+      "size": 6,
+      "colors": {
+        "c1": "#3B2D38",
+        "c2": "#F02475"
+      },
+      "declarations": "--s: var(--css-pattern-size, 6px);\n  --c1: var(--css-pattern-color-1, #3B2D38);\n  --c2: var(--css-pattern-color-2, #F02475);\n  --g:#0000 66%,var(--c1) 68% 98%,#0000;\n  background:\n    radial-gradient(30% 30% at 0%   30%,var(--g))\n     var(--s) calc(9*var(--s)),\n    radial-gradient(30% 30% at 100% 30%,var(--g))\n     var(--s) calc(-1*var(--s)),\n    radial-gradient(30% 30% at 30% 100%,var(--g))\n     calc(10*var(--s)) 0,\n    radial-gradient(30% 30% at 30% 0%  ,var(--g))\n     var(--c2);\n  background-size: calc(20*var(--s)) calc(20*var(--s));"
+    },
+    {
+      "id": "irregular-hexagons",
+      "name": "Irregular hexagons",
+      "source": "https://css-pattern.com/irregular-hexagons/",
+      "size": 65,
+      "colors": {
+        "c1": "#ECD078",
+        "c2": "#542437"
+      },
+      "declarations": "--s: var(--css-pattern-size, 65px);\n  --c1: var(--css-pattern-color-1, #ECD078);\n  --c2: var(--css-pattern-color-2, #542437);\n  background:\n    repeating-conic-gradient(var(--c1) 0 25%,#0000 0 50%)\n     calc(var(--s)/-2) 0/calc(4*var(--s)) calc(2*var(--s)),\n    conic-gradient(#0000 50%,var(--c2) 0)\n     0 0/calc(2*var(--s)) 1%,\n    repeating-conic-gradient(from 45deg,var(--c2) 0 25%,var(--c1) 0 50%)\n     0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "irregular-zig-zag",
+      "name": "Irregular Zig-Zag",
+      "source": "https://css-pattern.com/irregular-zig-zag/",
+      "size": 66,
+      "colors": {
+        "c1": "#B38184",
+        "c2": "#413E4A"
+      },
+      "declarations": "--s: var(--css-pattern-size, 66px);\n  --c1: var(--css-pattern-color-1, #B38184);\n  --c2: var(--css-pattern-color-2, #413E4A);\n  --c: var(--c1) 25%;\n  background: \n    conic-gradient(from -45deg at 75% 12.5%,var(--c),#0000 0),\n    conic-gradient(from 135deg at 25% 87.5%,var(--c),#0000 0) \n     0 calc(var(--s)/2),\n    conic-gradient(from 180deg at 50% 75%,#0000 62.5%,var(--c)),\n    conic-gradient(            at 50% 25%,#0000 62.5%,var(--c)) \n     0 calc(var(--s)/2) var(--c2);\n  background-size: var(--s) calc(2*var(--s));"
+    },
+    {
+      "id": "l-shape",
+      "name": "L shape",
+      "source": "https://css-pattern.com/l-shape/",
+      "size": 90,
+      "colors": {
+        "c1": "#696758",
+        "c2": "#EEE6AB"
+      },
+      "declarations": "--s: var(--css-pattern-size, 90px);\n  --c1: var(--css-pattern-color-1, #696758);\n  --c2: var(--css-pattern-color-2, #EEE6AB);\n  --g:at calc(100%/3) 25%,#0000 75%,;\n  background:\n    conic-gradient(var(--g)var(--c1) 0),\n    conic-gradient(var(--g)var(--c2) 0) 0 var(--s),\n    repeating-conic-gradient(at calc(200%/3),\n      var(--c1) 0 25%,var(--c2) 0 50%);\n  background-size: var(--s) calc(4*var(--s)/3);"
+    },
+    {
+      "id": "leafs",
+      "name": "Leafs",
+      "source": "https://css-pattern.com/leafs/",
+      "size": 50,
+      "colors": {
+        "c1": "#9D2053",
+        "c2": "#B5D8EB"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #9D2053);\n  --c2: var(--css-pattern-color-2, #B5D8EB);\n  --c:var(--c1) 99%,#0000 101%;\n  background:\n    radial-gradient(var(--s) at 100% 100%,var(--c)),\n    radial-gradient(var(--s) at 100% 0   ,var(--c)) calc(3*var(--s)/2) 0,\n    radial-gradient(var(--s) at 0    100%,var(--c)) calc(  var(--s)/2) 0,\n    radial-gradient(var(--s) at 0    0   ,var(--c)) calc(2*var(--s)) 0\n    var(--c2);\n  background-size: calc(3*var(--s)) calc(5*var(--s)/2);"
+    },
+    {
+      "id": "lines-dots",
+      "name": "Lines & dots",
+      "source": "https://css-pattern.com/lines-dots/",
+      "size": 60,
+      "colors": {
+        "c1": "#DEE8BE",
+        "c2": "#CD8C52"
+      },
+      "declarations": "--s: var(--css-pattern-size, 60px);\n  --c1: var(--css-pattern-color-1, #DEE8BE);\n  --c2: var(--css-pattern-color-2, #CD8C52);\n  --c:#0000 71%,var(--c1) 0 79%,#0000 0;\n  --_s:calc(var(--s)/2)/calc(2*var(--s)) calc(2*var(--s));\n  background:\n    linear-gradient(45deg,var(--c))\n     calc(var(--s)/-2) var(--_s),\n    linear-gradient(135deg,var(--c))\n     calc(var(--s)/2) var(--_s),\n    radial-gradient(var(--c1) 35%,var(--c2) 37%)\n     0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "linked-squares",
+      "name": "Linked squares",
+      "source": "https://css-pattern.com/linked-squares/",
+      "size": 100,
+      "colors": {
+        "c1": "#C3CCAF",
+        "c2": "#67434F"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #C3CCAF);\n  --c2: var(--css-pattern-color-2, #67434F);\n  --_s: calc(2*var(--s)) calc(2*var(--s));\n  --_g: var(--_s) conic-gradient(at 40% 40%,#0000 75%,var(--c1) 0);\n  --_p: var(--_s) conic-gradient(at 20% 20%,#0000 75%,var(--c2) 0);\n  background:\n    calc( .9*var(--s)) calc( .9*var(--s))/var(--_p),\n    calc(-.1*var(--s)) calc(-.1*var(--s))/var(--_p),\n    calc( .7*var(--s)) calc( .7*var(--s))/var(--_g),\n    calc(-.3*var(--s)) calc(-.3*var(--s))/var(--_g),\n    conic-gradient(from 90deg at 20% 20%,var(--c2) 25%,var(--c1) 0) \n     0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "lollipop",
+      "name": "Lollipop",
+      "source": "https://css-pattern.com/lollipop/",
+      "size": 56,
+      "colors": {
+        "c1": "#3FB8AF",
+        "c2": "#FF9E9D"
+      },
+      "declarations": "--s: var(--css-pattern-size, 56px);\n  --c1: var(--css-pattern-color-1, #3FB8AF);\n  --c2: var(--css-pattern-color-2, #FF9E9D);\n  --_c1: var(--c1) 99%,#0000 101%;\n  --_c2: var(--c2) 99%,#0000 101%;\n  --r:calc(var(--s)*.866);\n  --g0:radial-gradient(var(--s),var(--_c1));\n  --g1:radial-gradient(var(--s),var(--_c2));\n  --f:radial-gradient(var(--s) at calc(100% + var(--r)) 50%,var(--_c1));\n  --p:radial-gradient(var(--s) at 100% 50%,var(--_c2));\n  background:\n    var(--f) 0 calc(-5*var(--s)/2),\n    var(--f) calc(-2*var(--r)) calc(var(--s)/2),\n    var(--p) 0 calc(-2*var(--s)),\n    var(--g0) var(--r) calc(-5*var(--s)/2),\n    var(--g1) var(--r) calc( 5*var(--s)/2),\n    radial-gradient(var(--s) at 100% 100%,var(--_c1)) 0 calc(-1*var(--s)),   \n    radial-gradient(var(--s) at 0%   50% ,var(--_c1)) 0 calc(-4*var(--s)),\n    var(--g1) calc(-1*var(--r)) calc(-7*var(--s)/2),\n    var(--g0) calc(-1*var(--r)) calc(-5*var(--s)/2),\n    var(--p) calc(-2*var(--r)) var(--s),\n    var(--g0) calc(-1*var(--r)) calc(var(--s)/ 2),\n    var(--g1) calc(-1*var(--r)) calc(var(--s)/-2),\n    var(--g0) 0 calc(-1*var(--s)),\n    var(--g1) var(--r) calc(var(--s)/-2),\n    var(--g0) var(--r) calc(var(--s)/ 2) \n    var(--c2);\n  background-size: calc(4*var(--r)) calc(6*var(--s));"
+    },
+    {
+      "id": "loop-circles",
+      "name": "Loop circles",
+      "source": "https://css-pattern.com/loop-circles/",
+      "size": 150,
+      "colors": {
+        "c1": "#CCBF82",
+        "c2": "#604848"
+      },
+      "declarations": "--s: var(--css-pattern-size, 150px);\n  --c1: var(--css-pattern-color-1, #CCBF82);\n  --c2: var(--css-pattern-color-2, #604848);\n  --_g: var(--c1)        6.1%,var(--c2)  6.4% 18.6%,var(--c1) 18.9% 31.1%,\n        var(--c2) 31.4% 43.6%,var(--c1) 43.9% 56.1%,var(--c2) 56.4% 68.6%,#0000 68.9%;\n  background:\n    radial-gradient(var(--s) at 100% 0   ,var(--_g)),\n    radial-gradient(var(--s) at 0    0   ,var(--_g)),\n    radial-gradient(var(--s) at 0    100%,var(--_g)),\n    radial-gradient(var(--s) at 100% 100%,var(--_g)) var(--c1);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "maze",
+      "name": "Maze style",
+      "source": "https://css-pattern.com/maze/",
+      "size": 80,
+      "colors": {
+        "c1": "#E9E0D1",
+        "c2": "#59A80F"
+      },
+      "declarations": "--s: var(--css-pattern-size, 80px);\n  --c1: var(--css-pattern-color-1, #E9E0D1);\n  --c2: var(--css-pattern-color-2, #59A80F);\n  --c:#0000 75%,var(--c1) 0;\n  --g:/calc(2*var(--s)) var(--s) \n    conic-gradient(at 62.5% 25%,var(--c));\n  background:\n    calc(  var(--s)/4) calc(var(--s)/ 4) var(--g),\n    calc(5*var(--s)/4) calc(var(--s)/-4) var(--g),\n    linear-gradient(90deg,var(--c)) 0/var(--s) var(--s)\n    var(--c2);"
+    },
+    {
+      "id": "meander",
+      "name": "Meander",
+      "source": "https://css-pattern.com/meander/",
+      "size": 120,
+      "colors": {
+        "c1": "#72e21f",
+        "c2": "#044012"
+      },
+      "declarations": "--s: var(--css-pattern-size, 120px);\n  --c1: var(--css-pattern-color-1, #72e21f);\n  --c2: var(--css-pattern-color-2, #044012);\n  --_c: var(--c1) 25%,#0000 0;\n  --_g1: conic-gradient(at 62.5% 12.5%,var(--_c));\n  --_g2: conic-gradient(at 87.5% 62.5%,var(--_c));\n  --_g3: conic-gradient(at 25%   12.5%,var(--_c));\n  background:\n    var(--_g1) calc( var(--s)/-8) calc(var(--s)/2),var(--_g1) calc(-3*var(--s)/8) calc(var(--s)/4),\n    var(--_g2) calc(3*var(--s)/8) calc(var(--s)/4),var(--_g2) calc(  var(--s)/-8) 0,\n    var(--_g3) 0 calc(var(--s)/-4),var(--_g3) calc(var(--s)/-4) 0,\n    conic-gradient(at 87.5% 87.5%,var(--_c)) calc(var(--s)/8) 0\n    var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "mosaic-parallelograms",
+      "name": "Mosaic parallelograms & squares",
+      "source": "https://css-pattern.com/mosaic-parallelograms/",
+      "size": 125,
+      "colors": {
+        "c1": "#F8CA00",
+        "c2": "#BD1550"
+      },
+      "declarations": "--s: var(--css-pattern-size, 125px);\n  --c1: var(--css-pattern-color-1, #F8CA00);\n  --c2: var(--css-pattern-color-2, #BD1550);\n  --_g: var(--c1) 90deg,var(--c2) 0 135deg,#0000 0;\n  background:\n    conic-gradient(from  -45deg at calc(100%/3)   calc(100%/3)  ,var(--c1) 90deg,#0000 0 ),\n    conic-gradient(from -135deg at calc(100%/3)   calc(2*100%/3),var(--_g)),\n    conic-gradient(from  135deg at calc(2*100%/3) calc(2*100%/3),var(--_g)),\n    conic-gradient(from   45deg at calc(2*100%/3) calc(100%/3)  ,var(--_g),var(--c1) 0 225deg,var(--c2) 0);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "mosaic-triangles",
+      "name": "Mosaic triangles",
+      "source": "https://css-pattern.com/mosaic-triangles/",
+      "size": 36,
+      "colors": {
+        "c1": "#b62f31",
+        "c2": "#ecdacb",
+        "c3": "#8e1f08"
+      },
+      "declarations": "--s: var(--css-pattern-size, 36px);\n  --c1: var(--css-pattern-color-1, #b62f31);\n  --c2: var(--css-pattern-color-2, #ecdacb);\n  --c3: var(--css-pattern-color-3, #8e1f08);\n  --_g: calc(2*var(--s)*1.732) calc(2*var(--s)) \n    conic-gradient(from 60deg at 62.5% 50%,var(--c3) 60deg,#0000 0);\n  background:\n       calc( 2.598*var(--s)/2) calc(var(--s)/ 2)/var(--_g),\n       calc(-0.866*var(--s)/2) calc(var(--s)/-2)/var(--_g),\n    repeating-conic-gradient(var(--c2) 0 90deg,#0000 0 180deg) \n       0 0/calc(2*var(--s)*1.732) calc(2*var(--s)),\n    repeating-conic-gradient(from 60deg,var(--c1) 0 60deg,var(--c2) 0 180deg) \n       0 0/calc(var(--s)*1.732) var(--s);"
+    },
+    {
+      "id": "multicolor-circles",
+      "name": "Multicolor circles",
+      "source": "https://css-pattern.com/multicolor-circles/",
+      "size": 80,
+      "colors": {
+        "c1": "#F8CA00",
+        "c2": "#8A9B0F",
+        "c3": "#C02942",
+        "c4": "#53777A",
+        "c5": "#C5BC8E"
+      },
+      "declarations": "--s: var(--css-pattern-size, 80px);\n  --c1: var(--css-pattern-color-1, #F8CA00);\n  --c2: var(--css-pattern-color-2, #8A9B0F);\n  --c3: var(--css-pattern-color-3, #C02942);\n  --c4: var(--css-pattern-color-4, #53777A);\n  --c5: var(--css-pattern-color-5, #C5BC8E);\n  --_g:conic-gradient(at 25%,#0000 75%,var(--c1) 0);\n  --_s:/calc(2*var(--s)) calc(2*var(--s));\n  background:\n    radial-gradient(#0000 64%,var(--c5) 65%) \n     0 0/var(--s) var(--s),\n    var(--_g) 0 0 var(--_s),\n    var(--_g) var(--s) var(--s) var(--_s),\n    repeating-conic-gradient(#0000 0 25%,var(--c2) 0 50%)\n     0 0 var(--_s),\n    linear-gradient(var(--c3) 50%,var(--c4) 0) \n     0 0/1% var(--s);"
+    },
+    {
+      "id": "nested-diamond",
+      "name": "Nested diamond",
+      "source": "https://css-pattern.com/nested-diamond/",
+      "size": 100,
+      "colors": {
+        "c1": "#668284",
+        "c2": "#B6D8C0",
+        "c3": "#B9D7D9"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #668284);\n  --c2: var(--css-pattern-color-2, #B6D8C0);\n  --c3: var(--css-pattern-color-3, #B9D7D9);\n  --_g: #0000, var(--c1) 1deg 30deg,var(--c2) 31deg 89deg,var(--c1) 90deg 119deg,#0000 120deg;\n  background:\n    conic-gradient(from -60deg at 50% 28.86%,var(--_g)),\n    conic-gradient(from  30deg at 71.14% 50%,var(--_g)),\n    conic-gradient(from 120deg at 50% 71.14%,var(--_g)),\n    conic-gradient(from 210deg at 28.86% 50%,var(--_g))\n    var(--c3);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "nested-rhombus",
+      "name": "Nested rhombus",
+      "source": "https://css-pattern.com/nested-rhombus/",
+      "size": 100,
+      "colors": {
+        "c1": "#1BB0CE",
+        "c2": "#DAD6CA"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #1BB0CE);\n  --c2: var(--css-pattern-color-2, #DAD6CA);\n  --_g1: \n    var(--c1)   calc(25%/3) ,#0000 0 calc(50%/3),\n    var(--c1) 0 25%         ,#0000 0 75%,\n    var(--c1) 0 calc(250%/3),#0000 0 calc(275%/3),\n    var(--c1) 0;\n  --_g2: \n    #0000   calc(25%/3) ,var(--c1) 0 calc(50%/3),\n    #0000 0 calc(250%/3),var(--c1) 0 calc(275%/3),\n    #0000 0;\n  background:\n    linear-gradient( 45deg,var(--_g2)),linear-gradient( 45deg,var(--_g1)),\n    linear-gradient(-45deg,var(--_g2)),linear-gradient(-45deg,var(--_g1))\n    var(--c2);\n  background-position: 0 0,var(--s) var(--s);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "nested-squares",
+      "name": "Nested squares",
+      "source": "https://css-pattern.com/nested-squares/",
+      "size": 120,
+      "colors": {
+        "c1": "#FF6B6B",
+        "c2": "#556270"
+      },
+      "declarations": "--s: var(--css-pattern-size, 120px);\n  --c1: var(--css-pattern-color-1, #FF6B6B);\n  --c2: var(--css-pattern-color-2, #556270);\n  background:\n    conic-gradient(at calc(50%/3) calc(50%/3),#0000 75%,var(--c2) 0)\n     calc(var(--s)/3) calc(var(--s)/3),\n    conic-gradient(#0000 75%,var(--c1) 0) \n     calc(var(--s)/6) calc(var(--s)/6),\n    conic-gradient(at calc(250%/3) calc(250%/3),var(--c1) 75%,var(--c2) 0);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "nested-triangles",
+      "name": "Nested triangles",
+      "source": "https://css-pattern.com/nested-triangles/",
+      "size": 80,
+      "colors": {
+        "c1": "#D95B43",
+        "c2": "#A7DBD8"
+      },
+      "declarations": "--s: var(--css-pattern-size, 80px);\n  --c1: var(--css-pattern-color-1, #D95B43);\n  --c2: var(--css-pattern-color-2, #A7DBD8);\n  background:\n    conic-gradient(from -30deg at 50% calc(100% - var(--s)/2),var(--c1) 60deg,#0000 0)\n     calc(var(--s)/2) calc(var(--s)/6),\n    conic-gradient(from 150deg at 50% calc(var(--s)/2)       ,var(--c2) 60deg,#0000 0)\n     0 calc(var(--s)/-6),\n    conic-gradient(from 150deg at 50% 0,var(--c1) 60deg,var(--c2) 0);\n  background-size: var(--s) calc(var(--s)*cos(30deg));"
+    },
+    {
+      "id": "octagons-squares",
+      "name": "Octagons & squares",
+      "source": "https://css-pattern.com/octagons-squares/",
+      "size": 20,
+      "colors": {
+        "c1": "#C7956D",
+        "c2": "#5E4352"
+      },
+      "declarations": "--s: var(--css-pattern-size, 20px);\n  --c1: var(--css-pattern-color-1, #C7956D);\n  --c2: var(--css-pattern-color-2, #5E4352);\n  --c:#0000 46.46%,var(--c1) 0 53.53%,#0000 0;\n  --d:calc(10*var(--s)) calc(10*var(--s));\n  --g:/var(--d) conic-gradient(at 40% 40%,#0000 75%,var(--c1) 0);\n  background:\n    conic-gradient(at 40% 40%,#0000 75%,var(--c2) 0) \n     calc(9*var(--s)) calc(9*var(--s))/\n     calc(5*var(--s)) calc(5*var(--s)),\n    calc(8*var(--s)) calc(8*var(--s)) var(--g),\n    calc(3*var(--s)) calc(3*var(--s)) var(--g),\n    linear-gradient( 45deg,var(--c)) 0 0/var(--d),\n    linear-gradient(-45deg,var(--c)) 0 0/var(--d) var(--c2);"
+    },
+    {
+      "id": "octagons",
+      "name": "Octagons",
+      "source": "https://css-pattern.com/octagons/",
+      "size": 150,
+      "colors": {
+        "c1": "#5E9FA3",
+        "c2": "#DCD1B4"
+      },
+      "declarations": "--s: var(--css-pattern-size, 150px);\n  --c1: var(--css-pattern-color-1, #5E9FA3);\n  --c2: var(--css-pattern-color-2, #DCD1B4);\n  --c:#0000,var(--c1) 2deg 133deg,#0000 135deg;\n  --g1:conic-gradient(from -112.5deg at 25% 25%,var(--c));\n  --g2:conic-gradient(from -22.5deg  at 75% 25%,var(--c));\n  --g3:conic-gradient(from  67.5deg  at 75% 75%,var(--c));\n  --g4:conic-gradient(from 157.5deg  at 25% 75%,var(--c));\n  background: \n    var(--g1),var(--g1),var(--g2),var(--g2),\n    var(--g3),var(--g3),var(--g4),var(--g4) var(--c2);\n  background-position: 0 0,calc(var(--s)/2) calc(var(--s)/2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "octagram",
+      "name": "Octagram",
+      "source": "https://css-pattern.com/octagram/",
+      "size": 150,
+      "colors": {
+        "c1": "#D5DED9",
+        "c2": "#7A6A53"
+      },
+      "declarations": "--s: var(--css-pattern-size, 150px);\n  --c1: var(--css-pattern-color-1, #D5DED9);\n  --c2: var(--css-pattern-color-2, #7A6A53);\n  --_l:#0000 43.75%,var(--c1) 0 56.25%,#0000 0;\n  background:\n    conic-gradient(#0000 75%,var(--c1) 0) \n     calc(var(--s)/-8) calc(var(--s)/-8)/calc(var(--s)/2) calc(var(--s)/2),\n    repeating-conic-gradient(var(--c2) 0 25%,#0000 0 50%) \n     calc(var(--s)/-4) calc(var(--s)/-4)/var(--s) var(--s),\n    linear-gradient(-45deg,var(--_l))0 0/var(--s) var(--s),\n    linear-gradient( 45deg,var(--_l))0 0/var(--s) var(--s) var(--c2);"
+    },
+    {
+      "id": "optical-illusion",
+      "name": "Optical illusion",
+      "source": "https://css-pattern.com/optical-illusion/",
+      "size": 50,
+      "colors": {
+        "c1": "#5E412F",
+        "c2": "#FCEBB6"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #5E412F);\n  --c2: var(--css-pattern-color-2, #FCEBB6);\n  background:\n    radial-gradient(25% 50%,var(--c1) 98%,#0000)\n     var(--s) 0/calc(2*var(--s)) var(--s),\n    radial-gradient(25% 50%,var(--c2) 98%,#0000)\n     0 0/calc(2*var(--s)) var(--s),\n    repeating-conic-gradient(var(--c1) 0 25%,var(--c2) 0 50%) \n     0 0/calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "outline-circles",
+      "name": "Outline circles",
+      "source": "https://css-pattern.com/outline-circles/",
+      "size": 220,
+      "colors": {
+        "c1": "#774F38",
+        "c2": "#F1D4AF"
+      },
+      "declarations": "--s: var(--css-pattern-size, 220px);\n  --c1: var(--css-pattern-color-1, #774F38);\n  --c2: var(--css-pattern-color-2, #F1D4AF);\n  --_g:radial-gradient(#0000 60%,var(--c1) 61% 63%,#0000 64% 77%,var(--c1) 78% 80%,#0000 81%);\n  --_c:,#0000 75%,var(--c2) 0;\n  background:\n    conic-gradient(at 12% 20% var(--_c)) calc(var(--s)* .44) calc(.9*var(--s)),\n    conic-gradient(at 12% 20% var(--_c)) calc(var(--s)*-.06) calc(.4*var(--s)),\n    conic-gradient(at 20% 12% var(--_c)) calc(.9*var(--s)) calc(var(--s)* .44),\n    conic-gradient(at 20% 12% var(--_c)) calc(.4*var(--s)) calc(var(--s)*-.06),\n    var(--_g),var(--_g) calc(var(--s)/2) calc(var(--s)/2) var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "outline-leafs",
+      "name": "Outline leafs",
+      "source": "https://css-pattern.com/outline-leafs/",
+      "size": 50,
+      "colors": {
+        "c1": "#F2F26F",
+        "c2": "#A0C55F"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #F2F26F);\n  --c2: var(--css-pattern-color-2, #A0C55F);\n  --c:#0000 79%,var(--c1) 81% 99%,var(--c2) 101% 150%,#0000 0;\n  background:\n    radial-gradient(var(--s) at 100% 100%,var(--c)),\n    radial-gradient(var(--s) at 100% 0   ,var(--c)) calc(3*var(--s)/2) 0,\n    radial-gradient(var(--s) at 0    100%,var(--c)) calc(  var(--s)/2) 0,\n    radial-gradient(var(--s) at 0    0   ,var(--c)) calc(2*var(--s)) 0,\n    repeating-linear-gradient(90deg,\n      var(--c1) 0 calc(20%/3),#0000 0 calc(70%/3),\n      var(--c1) 0 30%,#0000 0 50%) calc(var(--s)/-5) 0 var(--c2);\n  background-size: calc(3*var(--s)) calc(5*var(--s)/2);"
+    },
+    {
+      "id": "outline-ovals",
+      "name": "Outline ovals",
+      "source": "https://css-pattern.com/outline-ovals/",
+      "size": 29,
+      "colors": {
+        "c1": "#615375",
+        "c2": "#8EB2C5"
+      },
+      "declarations": "--s: var(--css-pattern-size, 29px);\n  --c1: var(--css-pattern-color-1, #615375);\n  --c2: var(--css-pattern-color-2, #8EB2C5);\n  --g:#0000 calc(100% - var(--s)/3 - 1px),var(--c1) \n      calc(100% - var(--s)/3) calc(100% - 1px),#0000;\n  --r:calc(2.414*var(--s));\n  --p:calc(1.414*var(--s));\n  background:\n    radial-gradient(var(--r) at 0    0   ,var(--g)) var(--r) var(--r),\n    radial-gradient(var(--s) at 0    0   ,var(--g)) var(--p) var(--p),\n    radial-gradient(var(--r) at 0    100%,var(--g)) 0 var(--p),\n    radial-gradient(var(--s) at 0    100%,var(--g)) calc(-1*var(--s)) var(--r),\n    radial-gradient(var(--r) at 100% 0   ,var(--g)) var(--p) 0,\n    radial-gradient(var(--s) at 100% 0   ,var(--g)) var(--r) calc(-1*var(--s)),\n    radial-gradient(var(--r) at 100% 100%,var(--g)) calc(-1*var(--s)) calc(-1*var(--s)),\n    radial-gradient(var(--s) at 100% 100%,var(--g)) var(--c2);\n  background-size: calc(2*var(--r)) calc(2*var(--r));"
+    },
+    {
+      "id": "outline-rectangles",
+      "name": "Outline rectangles",
+      "source": "https://css-pattern.com/outline-rectangles/",
+      "size": 60,
+      "colors": {
+        "c1": "#53777A",
+        "c2": "#CFF09E"
+      },
+      "declarations": "--s: var(--css-pattern-size, 60px);\n  --c1: var(--css-pattern-color-1, #53777A);\n  --c2: var(--css-pattern-color-2, #CFF09E);\n  --g1:conic-gradient(at 37.5% 87.5%,#0000 75%,var(--c1) 0);\n  --g2:conic-gradient(at 12.5% 62.5%,#0000 75%,var(--c2) 0);\n  background:\n    var(--g2) calc(  var(--s)/4) calc(  var(--s)/4),\n    var(--g2) calc(5*var(--s)/4) calc(5*var(--s)/4),\n    var(--g1),var(--g1) var(--s) var(--s) var(--c2);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "outline-triangles",
+      "name": "Outline triangles",
+      "source": "https://css-pattern.com/outline-triangles/",
+      "size": 112,
+      "colors": {
+        "c1": "#490A3D",
+        "c2": "#F56991"
+      },
+      "declarations": "--s: var(--css-pattern-size, 112px);\n  --c1: var(--css-pattern-color-1, #490A3D);\n  --c2: var(--css-pattern-color-2, #F56991);\n  --g1:conic-gradient(from -45deg at 60%,#0000 75%,var(--c1) 0);\n  --g2:conic-gradient(from -45deg at 30%,#0000 75%,var(--c2) 0);\n  background: \n    var(--g2) calc(var(--s)/8) 0,var(--g2) calc(5*var(--s)/8) var(--s),\n    var(--g1),var(--g1) calc(var(--s)/2) var(--s) var(--c2);\n  background-size: var(--s) calc(2*var(--s));"
+    },
+    {
+      "id": "ovals",
+      "name": "Ovals",
+      "source": "https://css-pattern.com/ovals/",
+      "size": 29,
+      "colors": {
+        "c1": "#FFE545",
+        "c2": "#C2A34F"
+      },
+      "declarations": "--s: var(--css-pattern-size, 29px);\n  --c1: var(--css-pattern-color-1, #FFE545);\n  --c2: var(--css-pattern-color-2, #C2A34F);\n  --c:var(--c1) calc(100% - 2px),#0000;\n  --r:calc(2.414*var(--s));\n  --p:calc(1.414*var(--s));\n  --g:radial-gradient(var(--s),var(--c));\n  background:\n    radial-gradient(var(--r) at 0    0   ,var(--c)),\n    radial-gradient(var(--r) at 0    100%,var(--c)),\n    radial-gradient(var(--r) at 100% 0   ,var(--c)),\n    radial-gradient(var(--r) at 100% 100%,var(--c)),\n    var(--g),var(--g),var(--g),var(--g) var(--c2);\n  background-position: \n    var(--r) var(--r),0 var(--p),var(--p) 0,\n    calc(-1*var(--s)) calc(-1*var(--s));\n  background-size: calc(2*var(--r)) calc(2*var(--r));"
+    },
+    {
+      "id": "overlapping-circles",
+      "name": "Overlapping circles",
+      "source": "https://css-pattern.com/overlapping-circles/",
+      "size": 150,
+      "colors": {
+        "c1": "#f7d2a1",
+        "c2": "#05057e"
+      },
+      "declarations": "--s: var(--css-pattern-size, 150px);\n  --c1: var(--css-pattern-color-1, #f7d2a1);\n  --c2: var(--css-pattern-color-2, #05057e);\n  --_g: \n     var(--c1) 0%  5% ,var(--c2) 6%  15%,var(--c1) 16% 25%,var(--c2) 26% 35%,var(--c1) 36% 45%,\n     var(--c2) 46% 55%,var(--c1) 56% 65%,var(--c2) 66% 75%,var(--c1) 76% 85%,var(--c2) 86% 95%,\n     #0000 96%;\n  background:\n    radial-gradient(50% 50% at 100% 0,var(--_g)),\n    radial-gradient(50% 50% at 0 100%,var(--_g)),\n    radial-gradient(50% 50%,var(--_g)),\n    radial-gradient(50% 50%,var(--_g)) calc(var(--s)/2) calc(var(--s)/2)\n    var(--c1);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "overlapping-cubes",
+      "name": "Overlapping cubes",
+      "source": "https://css-pattern.com/overlapping-cubes/",
+      "size": 84,
+      "colors": {
+        "c1": "#f2f2f2",
+        "c2": "#cdcbcc",
+        "c3": "#999999"
+      },
+      "declarations": "--s: var(--css-pattern-size, 84px);\n  --c1: var(--css-pattern-color-1, #f2f2f2);\n  --c2: var(--css-pattern-color-2, #cdcbcc);\n  --c3: var(--css-pattern-color-3, #999999);\n  --_g: 0 120deg,#0000 0;\n  background:\n    conic-gradient(             at calc(250%/3) calc(100%/3),var(--c3) var(--_g)),\n    conic-gradient(from -120deg at calc( 50%/3) calc(100%/3),var(--c2) var(--_g)),\n    conic-gradient(from  120deg at calc(100%/3) calc(250%/3),var(--c1) var(--_g)),\n    conic-gradient(from  120deg at calc(200%/3) calc(250%/3),var(--c1) var(--_g)),\n    conic-gradient(from -180deg at calc(100%/3) 50%,var(--c2)  60deg,var(--c1) var(--_g)),\n    conic-gradient(from   60deg at calc(200%/3) 50%,var(--c1)  60deg,var(--c3) var(--_g)),\n    conic-gradient(from  -60deg at 50% calc(100%/3),var(--c1) 120deg,var(--c2) 0 240deg,var(--c3) 0);\n  background-size: calc(var(--s)*sqrt(3)) var(--s);"
+    },
+    {
+      "id": "overlapping-squares",
+      "name": "Overlapping squares",
+      "source": "https://css-pattern.com/overlapping-squares/",
+      "size": 50,
+      "colors": {
+        "c1": "#87BDB1",
+        "c2": "#D3E2B6"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #87BDB1);\n  --c2: var(--css-pattern-color-2, #D3E2B6);\n  --c:#0000 75%,var(--c1) 0;\n  --g1:conic-gradient(at calc(200%/3) 10%,var(--c));\n  --g2:conic-gradient(at 10% calc(200%/3),var(--c));\n  background:\n    var(--g1), var(--g2),\n    var(--g1) var(--s) var(--s),\n    var(--g2) var(--s) var(--s),\n    var(--g1) calc(2*var(--s)) calc(2*var(--s)),\n    var(--g2) calc(2*var(--s)) calc(2*var(--s)) var(--c2);\n  background-size: calc(3*var(--s)) calc(3*var(--s));"
+    },
+    {
+      "id": "parallelograms",
+      "name": "Parallelograms",
+      "source": "https://css-pattern.com/parallelograms/",
+      "size": 100,
+      "colors": {
+        "c1": "#4ECDC4",
+        "c2": "#556270"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #4ECDC4);\n  --c2: var(--css-pattern-color-2, #556270);\n  background: \n    linear-gradient(atan(-.5),var(--c1) 33%,var(--c2) 33.5% 66.5%,var(--c1) 67%) \n    0/var(--s) var(--s);"
+    },
+    {
+      "id": "pill-shapes",
+      "name": "Pill shapes",
+      "source": "https://css-pattern.com/pill-shapes/",
+      "size": 34,
+      "colors": {
+        "c1": "#ECBE13",
+        "c2": "#309292"
+      },
+      "declarations": "--s: var(--css-pattern-size, 34px);\n  --c1: var(--css-pattern-color-1, #ECBE13);\n  --c2: var(--css-pattern-color-2, #309292);\n  --_g: radial-gradient(calc(var(--s)/2),var(--c1) 97%,#0000);\n  background:\n    var(--_g),var(--_g) calc(2*var(--s)) calc(2*var(--s)),\n    repeating-conic-gradient(from 45deg,#0000 0 25%,var(--c2) 0 50%) calc(-.707*var(--s)) calc(-.707*var(--s)),\n    repeating-linear-gradient(135deg,var(--c1) calc(var(--s)/-2) calc(var(--s)/2),var(--c2) 0 calc(2.328*var(--s)));\n  background-size: calc(4*var(--s)) calc(4*var(--s));"
+    },
+    {
+      "id": "pills",
+      "name": "Pills",
+      "source": "https://css-pattern.com/pills/",
+      "size": 60,
+      "colors": {
+        "c1": "#DCD1B4",
+        "c2": "#5E9FA3"
+      },
+      "declarations": "--s: var(--css-pattern-size, 60px);\n  --c1: var(--css-pattern-color-1, #DCD1B4);\n  --c2: var(--css-pattern-color-2, #5E9FA3);\n  background:\n    repeating-conic-gradient(var(--c1) 0 25%,#0000 0 50%)\n     0 0/calc(4*var(--s)) calc(2*var(--s)),\n    conic-gradient(#0000 50%,var(--c2) 0)\n     calc(var(--s)/2) 0/calc(2*var(--s)) 1%,\n    radial-gradient(var(--c2) 70%,var(--c1) 72%)\n     0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "pixel",
+      "name": "Pixel style",
+      "source": "https://css-pattern.com/pixel/",
+      "size": 50,
+      "colors": {
+        "c1": "#E08E79",
+        "c2": "#774F38"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #E08E79);\n  --c2: var(--css-pattern-color-2, #774F38);\n  --c: var(--c1) 0 25%,var(--c2) 0 50%,#0000 0;\n  background:\n    conic-gradient(from 180deg,var(--c)) \n    0/var(--s) var(--s),\n    repeating-conic-gradient(from 90deg,var(--c))\n    0/calc(3*var(--s)) calc(3*var(--s));"
+    },
+    {
+      "id": "plus-sign",
+      "name": "Plus sign",
+      "source": "https://css-pattern.com/plus-sign/",
+      "size": 40,
+      "colors": {
+        "c1": "#C0D860",
+        "c2": "#604848"
+      },
+      "declarations": "--s: var(--css-pattern-size, 40px);\n  --c1: var(--css-pattern-color-1, #C0D860);\n  --c2: var(--css-pattern-color-2, #604848);\n  --_c: #0000 75%,var(--c1) 0;\n  --_g1: conic-gradient(at 10% 50%,var(--_c));\n  --_g2: conic-gradient(at 50% 10%,var(--_c));\n  background:\n    var(--_g1),\n    var(--_g1) calc(1*var(--s)) calc(3*var(--s)),\n    var(--_g1) calc(2*var(--s)) calc(1*var(--s)),\n    var(--_g1) calc(3*var(--s)) calc(4*var(--s)),\n    var(--_g1) calc(4*var(--s)) calc(2*var(--s)),\n    var(--_g2) 0                calc(4*var(--s)),\n    var(--_g2) calc(1*var(--s)) calc(2*var(--s)),\n    var(--_g2) calc(2*var(--s)) 0,\n    var(--_g2) calc(3*var(--s)) calc(3*var(--s)),\n    var(--_g2) calc(4*var(--s)) calc(1*var(--s)),\n    var(--c2);\n  background-size: calc(5*var(--s)) calc(5*var(--s));"
+    },
+    {
+      "id": "pointy-cross",
+      "name": "Pointy cross",
+      "source": "https://css-pattern.com/pointy-cross/",
+      "size": 100,
+      "colors": {
+        "c1": "#E5FCC2",
+        "c2": "#45ADA8"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #E5FCC2);\n  --c2: var(--css-pattern-color-2, #45ADA8);\n  --_l:#0000 43.75%,var(--c1) 0 56.25%,#0000 0;\n  --_s:calc(var(--s)/-4) calc(var(--s)/-4)/\n       calc(var(--s)*2)  calc(var(--s)*2);\n  background:\n    linear-gradient(-45deg,var(--_l)) var(--_s),\n    linear-gradient( 45deg,var(--_l)) var(--_s),\n    conic-gradient(var(--c2) 75%,var(--c1) 0) 0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "pointy-shapes",
+      "name": "Pointy shapes",
+      "source": "https://css-pattern.com/pointy-shapes/",
+      "size": 60,
+      "colors": {
+        "c1": "#542437",
+        "c2": "#CFBE27"
+      },
+      "declarations": "--s: var(--css-pattern-size, 60px);\n  --c1: var(--css-pattern-color-1, #542437);\n  --c2: var(--css-pattern-color-2, #CFBE27);\n  --p: calc(var(--s)/2)/calc(2*var(--s)) var(--s);\n  background:\n    radial-gradient(var(--s),var(--c1) 49%,#0000 50%) var(--s) var(--p),\n    radial-gradient(var(--s),var(--c2) 49%,#0000 50%) 0        var(--p),\n    linear-gradient(var(--c1) 50%,var(--c2) 0) 0 0/1% calc(2*var(--s));"
+    },
+    {
+      "id": "quarter-circles",
+      "name": "Quarter circles",
+      "source": "https://css-pattern.com/quarter-circles/",
+      "size": 64,
+      "colors": {
+        "c1": "#036564",
+        "c2": "#E8DDCB"
+      },
+      "declarations": "--s: var(--css-pattern-size, 64px);\n  --c1: var(--css-pattern-color-1, #036564);\n  --c2: var(--css-pattern-color-2, #E8DDCB);\n  --_g: var(--c1) 35%, #0000 36%;\n  background: \n    radial-gradient(at 100% 100%, var(--_g)),\n    radial-gradient(at 0    0   , var(--_g))\n    var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "quatrefoils",
+      "name": "Quatrefoils",
+      "source": "https://css-pattern.com/quatrefoils/",
+      "size": 60,
+      "colors": {
+        "c1": "#b09f79",
+        "c2": "#476074"
+      },
+      "declarations": "--s: var(--css-pattern-size, 60px);\n  --c1: var(--css-pattern-color-1, #b09f79);\n  --c2: var(--css-pattern-color-2, #476074);\n  --_g: #0000 83%,var(--c1) 85% 99%,#0000 101%;\n  background:\n    radial-gradient(27% 29% at right ,var(--_g)) calc(var(--s)/ 2) var(--s),\n    radial-gradient(27% 29% at left  ,var(--_g)) calc(var(--s)/-2) var(--s),\n    radial-gradient(29% 27% at top   ,var(--_g)) 0 calc(var(--s)/ 2),\n    radial-gradient(29% 27% at bottom,var(--_g)) 0 calc(var(--s)/-2)\n    var(--c2);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "rectangles-3d",
+      "name": "Rectangles pattern with 3D effect",
+      "source": "https://css-pattern.com/rectangles-3d/",
+      "size": 100,
+      "colors": {
+        "c1": "#f6edb3",
+        "c2": "#acc4a3",
+        "c3": "#55897c"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #f6edb3);\n  --c2: var(--css-pattern-color-2, #acc4a3);\n  --c3: var(--css-pattern-color-3, #55897c);\n  background: \n    repeating-conic-gradient(#0000 0 25%,var(--c1) 0 50%)\n    0 0/calc(2*var(--s)) var(--s),\n    linear-gradient(-45deg,var(--c2) 33.3%,var(--c3) 0)\n    0 0/var(--s) calc(var(--s)/2);"
+    },
+    {
+      "id": "rectangles-lines",
+      "name": "Rectangles & Lines",
+      "source": "https://css-pattern.com/rectangles-lines/",
+      "size": 160,
+      "colors": {
+        "c1": "#1C2130",
+        "c2": "#B3E099"
+      },
+      "declarations": "--s: var(--css-pattern-size, 160px);\n  --c1: var(--css-pattern-color-1, #1C2130);\n  --c2: var(--css-pattern-color-2, #B3E099);\n  --_c:5%,#0000 75%,var(--c1) 0;\n  --_g:/var(--s) var(--s) conic-gradient(at var(--_c));\n  --_l:/var(--s) var(--s) conic-gradient(at 50% var(--_c));\n  background:\n    0 calc(7*var(--s)/10) var(--_l),\n    calc(var(--s)/2) calc(var(--s)/5) var(--_l),\n    calc(var(--s)/5) 0 var(--_g),\n    calc(7*var(--s)/10) calc(var(--s)/2) var(--_g),\n    conic-gradient(at 90% 90%,var(--c1) 75%,var(--c2) 0)\n    0 0/calc(var(--s)/2) calc(var(--s)/2);"
+    },
+    {
+      "id": "rectangles-parallelograms",
+      "name": "Rectangles & parallelograms",
+      "source": "https://css-pattern.com/rectangles-parallelograms/",
+      "size": 150,
+      "colors": {
+        "c1": "#FF847C",
+        "c2": "#E84A5F",
+        "c3": "#FECEA8",
+        "c4": "#99B898"
+      },
+      "declarations": "--s: var(--css-pattern-size, 150px);\n  --c1: var(--css-pattern-color-1, #FF847C);\n  --c2: var(--css-pattern-color-2, #E84A5F);\n  --c3: var(--css-pattern-color-3, #FECEA8);\n  --c4: var(--css-pattern-color-4, #99B898);\n  background:\n    conic-gradient(from  45deg at 75% 75%, var(--c3) 90deg,var(--c1) 0 180deg,#0000 0),\n    conic-gradient(from -45deg at 25% 25%, var(--c3) 90deg,#0000 0),\n    conic-gradient(from -45deg at 50% 100%,#0000 180deg,var(--c3) 0),\n    conic-gradient(from -45deg,var(--c1) 90deg, var(--c2) 0 225deg,var(--c4) 0);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "retro-circles",
+      "name": "Retro style circles",
+      "source": "https://css-pattern.com/retro-circles/",
+      "size": 100,
+      "colors": {
+        "c1": "#80BCA3",
+        "c2": "#655643"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #80BCA3);\n  --c2: var(--css-pattern-color-2, #655643);\n  background:\n    radial-gradient(var(--c2) 15%,\n      #0000 17% 20%,var(--c2) 22% 25%,\n      #0000 27% 30%,var(--c2) 32% 35%,\n      #0000 37% 40%,var(--c2) 42% 45%,\n      #0000 47% 50%,var(--c2) 52% 55%, var(--c1) 57%)\n     calc(var(--s)/2) 0/var(--s) var(--s),\n    repeating-conic-gradient(var(--c2) 0 25%,var(--c1) 0 50%)\n     0 0/calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "rhombus-circles",
+      "name": "Rhombus & circles",
+      "source": "https://css-pattern.com/rhombus-circles/",
+      "size": 90,
+      "colors": {
+        "c1": "#DDD9AB",
+        "c2": "#E5625C"
+      },
+      "declarations": "--s: var(--css-pattern-size, 90px);\n  --c1: var(--css-pattern-color-1, #DDD9AB);\n  --c2: var(--css-pattern-color-2, #E5625C);\n  --g:#0000 calc(125%/3),var(--c1) 0 calc(175%/3),#0000 0;\n  --p:calc(var(--s)/2) calc(var(--s)/2)/calc(2*var(--s)) calc(2*var(--s));\n  background:\n    radial-gradient(var(--c1) 34%,#0000 36%) 0 0/var(--s) var(--s),\n    linear-gradient( 45deg,var(--g)) var(--p),\n    linear-gradient(-45deg,var(--g)) var(--p) var(--c2);"
+    },
+    {
+      "id": "rhombus-nested",
+      "name": "Nested rhombus",
+      "source": "https://css-pattern.com/rhombus-nested/",
+      "size": 80,
+      "colors": {
+        "c1": "#542437",
+        "c2": "#C02942"
+      },
+      "declarations": "--s: var(--css-pattern-size, 80px);\n  --c1: var(--css-pattern-color-1, #542437);\n  --c2: var(--css-pattern-color-2, #C02942);\n  --_g: \n    #0000 calc(-650%/13) calc(50%/13),var(--c1) 0 calc(100%/13),\n    #0000 0 calc(150%/13),var(--c1) 0 calc(200%/13),\n    #0000 0 calc(250%/13),var(--c1) 0 calc(300%/13);\n  --_g0: repeating-linear-gradient( 45deg,var(--_g));\n  --_g1: repeating-linear-gradient(-45deg,var(--_g));\n  background:\n    var(--_g0),var(--_g0) var(--s) var(--s),\n    var(--_g1),var(--_g1) var(--s) var(--s) var(--c2);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "rhombus-octagons",
+      "name": "Rhombus & Octagons",
+      "source": "https://css-pattern.com/rhombus-octagons/",
+      "size": 120,
+      "colors": {
+        "c1": "#4E395D",
+        "c2": "#8EBE94"
+      },
+      "declarations": "--s: var(--css-pattern-size, 120px);\n  --c1: var(--css-pattern-color-1, #4E395D);\n  --c2: var(--css-pattern-color-2, #8EBE94);\n  --_g:var(--c1) 15%,var(--c2) 0 28%,#0000 0 72%,var(--c2) 0 85%,var(--c1) 0;\n  background:\n    conic-gradient(from 90deg at 2px 2px,#0000 25%,var(--c1) 0) -1px -1px,\n    linear-gradient(-45deg,var(--_g)),linear-gradient(45deg,var(--_g)),\n    conic-gradient(from 90deg at 40% 40%,var(--c1) 25%,var(--c2) 0) \n     calc(var(--s)/-5) calc(var(--s)/-5);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "rhombus-rectangles",
+      "name": "Rhombus & rectangles",
+      "source": "https://css-pattern.com/rhombus-rectangles/",
+      "size": 170,
+      "colors": {
+        "c1": "#3B8686",
+        "c2": "#CFF09E"
+      },
+      "declarations": "--s: var(--css-pattern-size, 170px);\n  --c1: var(--css-pattern-color-1, #3B8686);\n  --c2: var(--css-pattern-color-2, #CFF09E);\n  --_c: #0000 75%,var(--c1) 0;\n  --_g1: conic-gradient(at 20.71% 50%,var(--_c));\n  --_g2: conic-gradient(at 50% 20.71%,var(--_c));\n  background:\n    var(--_g1) calc(var(--s)/ 6.828) calc(var(--s)/2),var(--_g1) calc(var(--s)/-2.828) 0,\n    conic-gradient(from   45deg at 29.29% 29.29%,var(--_c)) calc(var(--s)/-6.828) 0,\n    var(--_g2) calc(var(--s)/2) calc(var(--s)/-2.828),var(--_g2) 0 calc(var(--s)/ 6.828),\n    conic-gradient(from -135deg at 29.29% 70.71%,var(--_c)) calc(var(--s)/-6.828) 0,\n    var(--c2);\n  background-size: var(--s) var(--s), var(--s) var(--s), calc(var(--s)/2) calc(var(--s)/2);"
+    },
+    {
+      "id": "rhombus-squares",
+      "name": "Rhombus & squares",
+      "source": "https://css-pattern.com/rhombus-squares/",
+      "size": 90,
+      "colors": {
+        "c1": "#C2CBCE",
+        "c2": "#CE1836"
+      },
+      "declarations": "--s: var(--css-pattern-size, 90px);\n  --c1: var(--css-pattern-color-1, #C2CBCE);\n  --c2: var(--css-pattern-color-2, #CE1836);\n  --g:#0000 calc(125%/3),var(--c1) 0 calc(175%/3),#0000 0;\n  --p:0 0/calc(2*var(--s)) calc(2*var(--s));\n  background:\n    conic-gradient(#0000 75%,var(--c1) 0) \n     calc(3*var(--s)/4) calc(3*var(--s)/4)/var(--s) var(--s),\n    linear-gradient( 45deg,var(--g)) var(--p),\n    linear-gradient(-45deg,var(--g)) var(--p) var(--c2);"
+    },
+    {
+      "id": "rhombus-stripes",
+      "name": "Rhombus & stripes",
+      "source": "https://css-pattern.com/rhombus-stripes/",
+      "size": 64,
+      "colors": {
+        "c1": "#EB6841",
+        "c2": "#EDC951"
+      },
+      "declarations": "--s: var(--css-pattern-size, 64px);\n  --c1: var(--css-pattern-color-1, #EB6841);\n  --c2: var(--css-pattern-color-2, #EDC951);\n  background:\n    conic-gradient(from -45deg,var(--c1) 90deg,#0000 0 180deg,var(--c2) 0 270deg,#0000 0)   \n      0 calc(var(--s)/2)/var(--s) var(--s),    \n    conic-gradient(from 135deg at 50% 0,var(--c1) 90deg,var(--c2) 0)  \n      0 0/calc(2*var(--s)) var(--s);"
+    },
+    {
+      "id": "rhombus",
+      "name": "Rhombus",
+      "source": "https://css-pattern.com/rhombus/",
+      "size": 100,
+      "colors": {
+        "c1": "#F8EDD1",
+        "c2": "#D88A8A",
+        "c3": "#9D9D93"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #F8EDD1);\n  --c2: var(--css-pattern-color-2, #D88A8A);\n  --c3: var(--css-pattern-color-3, #9D9D93);\n  --c:#0000 48%,var(--c1) 0 52%,#0000 0;\n  background:\n    linear-gradient(-45deg,var(--c)),linear-gradient( 45deg,var(--c)),\n    repeating-conic-gradient(from 45deg,var(--c2) 0 25%,var(--c3) 0 50%);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "right-triangles",
+      "name": "Right triangles",
+      "source": "https://css-pattern.com/right-triangles/",
+      "size": 70,
+      "colors": {
+        "c1": "#F67280",
+        "c2": "#355C7D"
+      },
+      "declarations": "--s: var(--css-pattern-size, 70px);\n  --c1: var(--css-pattern-color-1, #F67280);\n  --c2: var(--css-pattern-color-2, #355C7D);\n  --_g:,#0000 75%,var(--c1) 0;\n  background:\n    linear-gradient(-45deg var(--_g)),\n    linear-gradient( 45deg var(--_g)) \n     0 calc(var(--s)/2) var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "rotated-squares",
+      "name": "Rotated squares",
+      "source": "https://css-pattern.com/rotated-squares/",
+      "size": 150,
+      "colors": {
+        "c1": "#046D8B",
+        "c2": "#2FB8AC"
+      },
+      "declarations": "--s: var(--css-pattern-size, 150px);\n  --c1: var(--css-pattern-color-1, #046D8B);\n  --c2: var(--css-pattern-color-2, #2FB8AC);\n  --_g: #0000 90deg,var(--c1) 0;\n  background:\n    conic-gradient(from 116.56deg at calc(100%/3) 0   ,var(--_g)),\n    conic-gradient(from -63.44deg at calc(200%/3) 100%,var(--_g))\n    var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "semi-circles",
+      "name": "Semi circles & full circles",
+      "source": "https://css-pattern.com/semi-circles/",
+      "size": 50,
+      "colors": {
+        "c1": "#CFF09E",
+        "c2": "#0B486B"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #CFF09E);\n  --c2: var(--css-pattern-color-2, #0B486B);\n  --_g: radial-gradient(var(--c2) 49%,#0000 50%);\n  background:\n   var(--_g) calc(var(--s)/-2) calc(var(--s)/2),\n   repeating-conic-gradient(from 45deg,var(--c1) 0 25%,#0000 0 50%)\n     calc(var(--s)/2) calc(var(--s)/2),\n   var(--_g),var(--_g) var(--s) var(--s) var(--c1);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "shuriken",
+      "name": "Shuriken",
+      "source": "https://css-pattern.com/shuriken/",
+      "size": 30,
+      "colors": {
+        "c1": "#88C425",
+        "c2": "#1B676B"
+      },
+      "declarations": "--s: var(--css-pattern-size, 30px);\n  --c1: var(--css-pattern-color-1, #88C425);\n  --c2: var(--css-pattern-color-2, #1B676B);\n  --c: var(--c1) 25%,#0000 0;\n  --_s:/calc(6*var(--s)) calc(6*var(--s));\n  --g1:var(--_s) conic-gradient(from  45deg at     calc(250%/3),var(--c));\n  --g2:var(--_s) conic-gradient(from 135deg at 50% calc(250%/3),var(--c));\n  --g3:var(--_s) conic-gradient(from 225deg at     calc(50%/3) ,var(--c));\n  --g4:var(--_s) conic-gradient(from -45deg at 50% calc(50%/3) ,var(--c));\n  background:\n    calc(2*var(--s)) calc(5*var(--s)) var(--g4),\n    calc(5*var(--s)) calc(2*var(--s)) var(--g4),\n    0                calc(4*var(--s)) var(--g3),\n    calc(3*var(--s)) var(--s)         var(--g3),\n    calc(2*var(--s)) calc(3*var(--s)) var(--g2),\n    calc(5*var(--s)) 0                var(--g2),\n    var(--s)         var(--s)         var(--g1),\n    calc(4*var(--s)) calc(4*var(--s)) var(--g1),\n    conic-gradient(at calc(100%/3) calc(200%/3),var(--c))\n     0 0/calc(3*var(--s)) calc(3*var(--s)) var(--c2);"
+    },
+    {
+      "id": "spheres",
+      "name": "Two color Spheres",
+      "source": "https://css-pattern.com/spheres/",
+      "size": 90,
+      "colors": {
+        "c1": "#DAD8A7",
+        "c2": "#FF3D7F",
+        "c3": "#34DFD2"
+      },
+      "declarations": "--s: var(--css-pattern-size, 90px);\n  --c1: var(--css-pattern-color-1, #DAD8A7);\n  --c2: var(--css-pattern-color-2, #FF3D7F);\n  --c3: var(--css-pattern-color-3, #34DFD2);\n  --_s:0 0/var(--s) var(--s);\n  background:\n    radial-gradient(#0000 50%,#0002 54%,var(--c1) 57%) var(--_s),\n    radial-gradient(circle at 40% 30%,#0000 4%,#000 90%) var(--_s),\n    repeating-conic-gradient(var(--c2) 0 25%,var(--c3) 0 50%)\n     0 0/calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "squares-2",
+      "name": "Squares",
+      "source": "https://css-pattern.com/squares-2/",
+      "size": 100,
+      "colors": {
+        "c1": "#955e3e",
+        "c2": "#f1d4af"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #955e3e);\n  --c2: var(--css-pattern-color-2, #f1d4af);\n  --_g:var(--c1) 17.67%,#0000 0 82.33%,var(--c1) 0;\n  background:\n    linear-gradient( 45deg,var(--_g)),\n    linear-gradient(-45deg,var(--_g)),\n    conic-gradient(var(--c2) 75%,var(--c1) 0) \n     calc(var(--s)/4) calc(var(--s)/4);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "squares-rhombus",
+      "name": "Squares & Rhombus",
+      "source": "https://css-pattern.com/squares-rhombus/",
+      "size": 104,
+      "colors": {
+        "c1": "#73626E",
+        "c2": "#add8e6"
+      },
+      "declarations": "--s: var(--css-pattern-size, 104px);\n  --c1: var(--css-pattern-color-1, #73626E);\n  --c2: var(--css-pattern-color-2, #add8e6);\n  background:\n    conic-gradient(var(--c2) 25%,#0000 0 50%,var(--c1) 0 75%,#0000 0)\n    calc(var(--s)/4) calc(var(--s)/4),\n    repeating-conic-gradient(from 45deg,var(--c1) 0 25%,var(--c2) 0 50%);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "squares",
+      "name": "Squares",
+      "source": "https://css-pattern.com/squares/",
+      "size": 50,
+      "colors": {
+        "c1": "#0B2E59",
+        "c2": "#0D6759"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #0B2E59);\n  --c2: var(--css-pattern-color-2, #0D6759);\n  background:\n    conic-gradient(at 25% 25%,#0000 75%,var(--c1) 0) var(--s) var(--s),\n    repeating-conic-gradient(at 25% 25%,var(--c1) 0 25%,var(--c2) 0 50%);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "stairs",
+      "name": "Stairs pattern with 3D effect",
+      "source": "https://css-pattern.com/stairs/",
+      "size": 50,
+      "colors": {
+        "c1": "#f86466",
+        "c2": "#000000",
+        "c3": "#ffffff"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #f86466);\n  --c2: var(--css-pattern-color-2, #000000);\n  --c3: var(--css-pattern-color-3, #ffffff);\n  --_g: conic-gradient(at 50% 25%,#0000 75%,var(--c1) 0);\n  background:\n    var(--_g),var(--_g) var(--s) var(--s),\n    var(--_g) calc(2*var(--s)) calc(2*var(--s)),\n    var(--_g) calc(3*var(--s)) calc(3*var(--s)),\n    repeating-linear-gradient(135deg,var(--c2) 0 12.5%,var(--c3) 0 25%);\n  background-size: calc(4*var(--s)) calc(4*var(--s));"
+    },
+    {
+      "id": "stars",
+      "name": "Stars",
+      "source": "https://css-pattern.com/stars/",
+      "size": 90,
+      "colors": {
+        "c1": "#fff220",
+        "c2": "#e181c2"
+      },
+      "declarations": "--s: var(--css-pattern-size, 90px);\n  --c1: var(--css-pattern-color-1, #fff220);\n  --c2: var(--css-pattern-color-2, #e181c2);\n  --d: calc(var(--s)/10);\n  --_g: var(--c1) 36deg, #0000 0;\n  background:\n    conic-gradient(from 162deg at calc(var(--s) * .5)  calc(var(--s) * .68), var(--_g)),\n    conic-gradient(from 18deg  at calc(var(--s) * .19) calc(var(--s) * .59), var(--_g)),\n    conic-gradient(from 306deg at calc(var(--s) * .81) calc(var(--s) * .59), var(--_g)),\n    var(--c2);\n  background-position: 0 calc(var(--s) * 0.35);\n  background-size: calc(var(--s) + var(--d)) calc(var(--s) + var(--d));"
+    },
+    {
+      "id": "striped-circles",
+      "name": "Striped circles",
+      "source": "https://css-pattern.com/striped-circles/",
+      "size": 76,
+      "colors": {
+        "c1": "#1a144a",
+        "c2": "#2eb044"
+      },
+      "declarations": "--s: var(--css-pattern-size, 76px);\n  --c1: var(--css-pattern-color-1, #1a144a);\n  --c2: var(--css-pattern-color-2, #2eb044);\n  --_g: conic-gradient(var(--c1) 25%,#0000 0) 0 0;\n  background:\n    var(--_g)/calc(2*var(--s)) calc(var(--s)/9.5),\n    var(--_g)/calc(var(--s)/9.5) calc(2*var(--s)),\n    repeating-conic-gradient(#0000 0 25%,var(--c1) 0 50%) \n     var(--s) 0 /calc(2*var(--s)) calc(2*var(--s)),\n    radial-gradient(50% 50%,var(--c2) 98%,var(--c1)) \n     0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "tetris",
+      "name": "Tetris style",
+      "source": "https://css-pattern.com/tetris/",
+      "size": 100,
+      "colors": {
+        "c1": "#ffd500",
+        "c2": "#0341ae"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #ffd500);\n  --c2: var(--css-pattern-color-2, #0341ae);\n  background:\n    conic-gradient(at 50% 25%,var(--c2) 25%,#0000 0)\n     calc(var(--s)/-4) calc(var(--s)/-2),\n    conic-gradient(at 25% 25%,var(--c1) 25%,#0000 0 75%,var(--c2) 0)\n     calc(var(--s)/4) calc(var(--s)/-4),\n    conic-gradient(from -90deg at 75% 25%,var(--c2) 75%,var(--c1) 0);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "thick-wavy",
+      "name": "Thick wavy lines",
+      "source": "https://css-pattern.com/thick-wavy/",
+      "size": 50,
+      "colors": {
+        "c1": "#D9CEB2",
+        "c2": "#948C75"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #D9CEB2);\n  --c2: var(--css-pattern-color-2, #948C75);\n  --_g: calc(2*var(--s)) calc(2*var(--s)) \n    radial-gradient(25% 25%,var(--c1) 99%,#0000 101%);\n  background:\n    0 var(--s)/var(--_g),var(--s) 0/var(--_g),\n    radial-gradient(50% 50%,var(--c2) 97%,#0000)\n     calc(var(--s)/2) calc(var(--s)/2)/var(--s) var(--s),\n    linear-gradient(90deg,var(--c1) 50%,var(--c2) 0) \n     0 0/calc(2*var(--s));"
+    },
+    {
+      "id": "three-braided-lines",
+      "name": "Three Braided lines",
+      "source": "https://css-pattern.com/three-braided-lines/",
+      "size": 30,
+      "colors": {
+        "c1": "#5E9FA3",
+        "c2": "#B05574",
+        "c3": "#B39C82",
+        "c4": "#DCD1B4"
+      },
+      "declarations": "--s: var(--css-pattern-size, 30px);\n  --c1: var(--css-pattern-color-1, #5E9FA3);\n  --c2: var(--css-pattern-color-2, #B05574);\n  --c3: var(--css-pattern-color-3, #B39C82);\n  --c4: var(--css-pattern-color-4, #DCD1B4);\n  background:\n    conic-gradient(at 50% calc(100%/6),var(--c1) 60deg,#0000 0),\n    conic-gradient(at calc(100%/6) 50%,#0000 240deg,var(--c1) 0),\n    conic-gradient(from 180deg at calc(100%/6) calc(500%/6),var(--c1) 60deg,#0000 0),\n    conic-gradient(from 180deg at calc(500%/6),#0000 240deg,var(--c1) 0) calc(4*.866*var(--s)) 0,\n    repeating-linear-gradient(-150deg,var(--c2) 0 calc(100%/6),#0000   0 50%),\n    repeating-linear-gradient(-30deg, var(--c3) 0 calc(100%/6),var(--c4) 0 50%);\n  background-size: calc(6*.866*var(--s)) calc(3*var(--s));"
+    },
+    {
+      "id": "tiny-squares",
+      "name": "Tiny squares",
+      "source": "https://css-pattern.com/tiny-squares/",
+      "size": 30,
+      "colors": {
+        "c1": "#8C2318",
+        "c2": "#F2C45A"
+      },
+      "declarations": "--s: var(--css-pattern-size, 30px);\n  --c1: var(--css-pattern-color-1, #8C2318);\n  --c2: var(--css-pattern-color-2, #F2C45A);\n  background:\n    conic-gradient(at 60% 60%,var(--c1) 75%,#0000 0)\n     0 0/calc(5*var(--s)/2) calc(5*var(--s)/2),\n    repeating-conic-gradient(var(--c1) 0 25%,#0000 0 50%)\n     0 0/calc(5*var(--s)) calc(5*var(--s)),\n    repeating-conic-gradient(var(--c2) 0 25%,var(--c1) 0 50%)\n     0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "trapezoids",
+      "name": "Trapezoids",
+      "source": "https://css-pattern.com/trapezoids/",
+      "size": 133,
+      "colors": {
+        "c1": "#67917A",
+        "c2": "#B8AF03"
+      },
+      "declarations": "--s: var(--css-pattern-size, 133px);\n  --c1: var(--css-pattern-color-1, #67917A);\n  --c2: var(--css-pattern-color-2, #B8AF03);\n  --c:var(--c1) 0 60deg,#0000 0 50%;\n  background:\n    repeating-conic-gradient(from -15deg,var(--c))\n     calc(var(--s)/2) calc(var(--s)/2),\n    repeating-conic-gradient(from  15deg,var(--c))\n    var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "triangle-tiles",
+      "name": "Triangle tiles",
+      "source": "https://css-pattern.com/triangle-tiles/",
+      "size": 100,
+      "colors": {
+        "c1": "#F2E9E1",
+        "c2": "#99B2B7"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #F2E9E1);\n  --c2: var(--css-pattern-color-2, #99B2B7);\n  background:\n    repeating-conic-gradient(var(--c1) 0 45deg,var(--c2) 0 90deg)\n    0/var(--s) var(--s);"
+    },
+    {
+      "id": "triangles-chevrons",
+      "name": "Triangles & Chevrons",
+      "source": "https://css-pattern.com/triangles-chevrons/",
+      "size": 64,
+      "colors": {
+        "c1": "#E0E4CC",
+        "c2": "#69D2E7"
+      },
+      "declarations": "--s: var(--css-pattern-size, 64px);\n  --c1: var(--css-pattern-color-1, #E0E4CC);\n  --c2: var(--css-pattern-color-2, #69D2E7);\n  --_g: 90deg,#0000 0;\n  background:\n    conic-gradient(from 135deg,var(--c1) var(--_g)) var(--s) calc(var(--s)/2),\n    conic-gradient(from 135deg,var(--c2) var(--_g)),\n    conic-gradient(from 135deg at 50% 0,var(--c1) var(--_g)) var(--c2);\n  background-size: calc(2*var(--s)) var(--s);"
+    },
+    {
+      "id": "triangles-grid",
+      "name": "Triangles grid",
+      "source": "https://css-pattern.com/triangles-grid/",
+      "size": 200,
+      "colors": {
+        "c1": "#dc9d37",
+        "c2": "#fed450",
+        "c3": "#125c65",
+        "c4": "#bc4a33",
+        "c5": "#ffffff"
+      },
+      "declarations": "--s: var(--css-pattern-size, 200px);\n  --c1: var(--css-pattern-color-1, #dc9d37);\n  --c2: var(--css-pattern-color-2, #fed450);\n  --c3: var(--css-pattern-color-3, #125c65);\n  --c4: var(--css-pattern-color-4, #bc4a33);\n  --c5: var(--css-pattern-color-5, #ffffff);\n  --_g: var(--c1) 25%,var(--c2) 0 50%,#0000 0;\n  --_l1: var(--c5) 0 1px,#0000 0 calc(25% - 1px),var(--c5) 0 25%;\n  --_l2: var(--c5) 0 1px,#0000 0 calc(50% - 1px),var(--c5) 0 50%;\n  background:\n    repeating-linear-gradient( 45deg,var(--_l1)),\n    repeating-linear-gradient(-45deg,var(--_l1)),\n    repeating-linear-gradient(  0deg,var(--_l2)),\n    repeating-linear-gradient( 90deg,var(--_l2)),\n    conic-gradient(from 135deg at 25% 75%,var(--_g)),\n    conic-gradient(from 225deg at 25% 25%,var(--_g)),\n    conic-gradient(from  45deg at 75% 75%,var(--_g)),\n    conic-gradient(from -45deg at 75% 25%,var(--_g)),\n    repeating-conic-gradient(var(--c3) 0 45deg,var(--c4) 0 90deg);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "triangles-mosaic",
+      "name": "Mosaic triangles",
+      "source": "https://css-pattern.com/triangles-mosaic/",
+      "size": 70,
+      "colors": {
+        "c1": "#655643",
+        "c2": "#80BCA3"
+      },
+      "declarations": "--s: var(--css-pattern-size, 70px);\n  --c1: var(--css-pattern-color-1, #655643);\n  --c2: var(--css-pattern-color-2, #80BCA3);\n  --g:,var(--c1) 25%,var(--c2) 0 50%,#0000 0;\n  background:\n    repeating-conic-gradient(var(--c1) 0 30deg,#0000 0 150deg,var(--c2) 0 50%)\n     calc(1.5*var(--s)) calc(.865*var(--s)),\n    conic-gradient(from  30deg at 75% 75%var(--g)),\n    conic-gradient(from -30deg at 75% 25%var(--g)),\n    conic-gradient(from 150deg at 25% 75%var(--g)),\n    conic-gradient(from 210deg at 25% 25%var(--g)),\n    repeating-conic-gradient(var(--c1) 0 30deg,var(--c2) 0 60deg);\n  background-size: calc(3*var(--s)) calc(1.73*var(--s));"
+    },
+    {
+      "id": "triangles-outline",
+      "name": "Outline triangles",
+      "source": "https://css-pattern.com/triangles-outline/",
+      "size": 112,
+      "colors": {
+        "c1": "#C7F464",
+        "c2": "#8A9B0F"
+      },
+      "declarations": "--s: var(--css-pattern-size, 112px);\n  --c1: var(--css-pattern-color-1, #C7F464);\n  --c2: var(--css-pattern-color-2, #8A9B0F);\n  background: \n    conic-gradient(from  45deg at 70%,var(--c2) 25%,#0000 0) calc(5*var(--s)/8) var(--s),\n    conic-gradient(from  45deg at 40%,var(--c1) 25%,#0000 0) calc(3*var(--s)/4) var(--s),\n    conic-gradient(from -45deg at 30%,#0000 75%,var(--c2) 0) calc(var(--s)/8) 0,\n    conic-gradient(from -45deg at 60%,var(--c2) 75%,var(--c1) 0);\n  background-size: var(--s) calc(2*var(--s));"
+    },
+    {
+      "id": "triangles-squares",
+      "name": "Triangles & squares",
+      "source": "https://css-pattern.com/triangles-squares/",
+      "size": 160,
+      "colors": {
+        "c1": "#E08E79",
+        "c2": "#F1D4AF",
+        "c3": "#955E3E"
+      },
+      "declarations": "--s: var(--css-pattern-size, 160px);\n  --c1: var(--css-pattern-color-1, #E08E79);\n  --c2: var(--css-pattern-color-2, #F1D4AF);\n  --c3: var(--css-pattern-color-3, #955E3E);\n  background:\n    conic-gradient(from  15deg at 86.6%,\n      var(--c3) 25%,var(--c2) 0 150deg,#0000 0),\n    conic-gradient(from -75deg at 50% 13.39%,\n      var(--c1) 60deg,var(--c3) 0 150deg,\n      var(--c2) 0 210deg,#0000 0),\n    conic-gradient(from 15deg at 36.6% 63.4%,\n     var(--c1) 60deg,var(--c3) 0 150deg,\n     var(--c1) 0 210deg,var(--c2) 0 75%,var(--c3) 0);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "triangles-trapezoids",
+      "name": "Triangles & trapezoids",
+      "source": "https://css-pattern.com/triangles-trapezoids/",
+      "size": 76,
+      "colors": {
+        "c1": "#F77825",
+        "c2": "#60B99A",
+        "c3": "#F1EFA5",
+        "c4": "#554236"
+      },
+      "declarations": "--s: var(--css-pattern-size, 76px);\n  --c1: var(--css-pattern-color-1, #F77825);\n  --c2: var(--css-pattern-color-2, #60B99A);\n  --c3: var(--css-pattern-color-3, #F1EFA5);\n  --c4: var(--css-pattern-color-4, #554236);\n  background:\n    conic-gradient(from 150deg,var(--c1)    60deg,#0000 0 180deg,\n                               var(--c2) 0 240deg,#0000 0) var(--s) 0,\n    conic-gradient(from -30deg,var(--c1)    60deg,var(--c3) 0 120deg,var(--c4) 0 180deg,\n                               var(--c2) 0 240deg,var(--c3) 0 300deg,var(--c4) 0);\n  background-size: calc(2*var(--s)) var(--s);"
+    },
+    {
+      "id": "triangles",
+      "name": "Triangles",
+      "source": "https://css-pattern.com/triangles/",
+      "size": 76,
+      "colors": {
+        "c1": "#F6D86B",
+        "c2": "#F10C49"
+      },
+      "declarations": "--s: var(--css-pattern-size, 76px);\n  --c1: var(--css-pattern-color-1, #F6D86B);\n  --c2: var(--css-pattern-color-2, #F10C49);\n  background:\n    conic-gradient(\n      var(--c2) atan(2), var(--c1) 0 calc(180deg - atan(2)),\n      var(--c2) 0 180deg,var(--c1) 0 calc(180deg + atan(2)),\n      var(--c2) 0 calc(360deg - atan(2)),var(--c1) 0);\n  background-size: calc(2*var(--s)) var(--s);"
+    },
+    {
+      "id": "two-braided-lines",
+      "name": "Two Braided lines",
+      "source": "https://css-pattern.com/two-braided-lines/",
+      "size": 20,
+      "colors": {
+        "c1": "#C02942",
+        "c2": "#53777A",
+        "c3": "#ECD078"
+      },
+      "declarations": "--s: var(--css-pattern-size, 20px);\n  --c1: var(--css-pattern-color-1, #C02942);\n  --c2: var(--css-pattern-color-2, #53777A);\n  --c3: var(--css-pattern-color-3, #ECD078);\n  --g: var(--s);\n  background:\n     conic-gradient(at var(--s) calc(100% - var(--s)),#0000 270deg,var(--c1) 0) calc(var(--s) + var(--g)) 0,\n     linear-gradient(var(--c2) var(--s),#0000 0) 0 var(--g),\n     conic-gradient(at var(--s) calc(100% - var(--s)),#0000 90deg,var(--c2) 0 180deg, var(--c1) 0),\n     var(--c3);\n  background-size: calc(2*(var(--s) + var(--g))) calc(2*(var(--s) + var(--g)));"
+    },
+    {
+      "id": "two-color-brick",
+      "name": "Two color brick",
+      "source": "https://css-pattern.com/two-color-brick/",
+      "size": 50,
+      "colors": {
+        "c1": "#c0b299",
+        "c2": "#a4a9aa",
+        "c3": "#2c2e2a"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #c0b299);\n  --c2: var(--css-pattern-color-2, #a4a9aa);\n  --c3: var(--css-pattern-color-3, #2c2e2a);\n  --p:at 45% 40%,#0000 75%,;\n  --g1:conic-gradient(var(--p) var(--c1) 0);\n  --g2:conic-gradient(var(--p) var(--c2) 0);\n  background:\n    var(--g1),var(--g2) calc(2*var(--s)) 0,\n    var(--g2) calc(3*var(--s)) var(--s),\n    var(--g1) var(--s) var(--s) var(--c3);\n  background-size: calc(4*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "two-color-circles",
+      "name": "Two color circles",
+      "source": "https://css-pattern.com/two-color-circles/",
+      "size": 100,
+      "colors": {
+        "c1": "#5A3D31",
+        "c2": "#E5EDB8"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #5A3D31);\n  --c2: var(--css-pattern-color-2, #E5EDB8);\n  background:\n    radial-gradient(#0000 50%,var(--c1) 52% 55%,var(--c2) 57%)\n    0 0/var(--s) var(--s),\n    repeating-linear-gradient(45deg,var(--c1) 0 25%,var(--c2) 0 50%)\n    0 0/calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "two-color-diagonal-arrows",
+      "name": "Two color diagonal arrows",
+      "source": "https://css-pattern.com/two-color-diagonal-arrows/",
+      "size": 85,
+      "colors": {
+        "c1": "#339194",
+        "c2": "#F6D86B"
+      },
+      "declarations": "--s: var(--css-pattern-size, 85px);\n  --c1: var(--css-pattern-color-1, #339194);\n  --c2: var(--css-pattern-color-2, #F6D86B);\n  --g1:conic-gradient(from  45deg at 62.5% 12.5%,#0000 75%,var(--c1) 0);\n  --g2:conic-gradient(from -45deg at 12.5% 12.5%,#0000 75%,var(--c1) 0);\n  --g3:conic-gradient(from 225deg at 87.5% 87.5%,#0000 75%,var(--c2) 0);\n  --g4:conic-gradient(from 135deg at 87.5% 37.5%,#0000 75%,var(--c2) 0);\n  background:\n    var(--g4),var(--g4) var(--s) var(--s),\n    var(--g3),var(--g3) var(--s) var(--s),\n    var(--g2),var(--g2) var(--s) var(--s),\n    var(--g1),var(--g1) var(--s) var(--s),\n    repeating-linear-gradient(135deg,var(--c2) 0 12.5%,var(--c1) 0 25%);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "two-color-hexagons",
+      "name": "Two color hexagons",
+      "source": "https://css-pattern.com/two-color-hexagons/",
+      "size": 76,
+      "colors": {
+        "c1": "#ff9f6a",
+        "c2": "#1f5e79"
+      },
+      "declarations": "--s: var(--css-pattern-size, 76px);\n  --c1: var(--css-pattern-color-1, #ff9f6a);\n  --c2: var(--css-pattern-color-2, #1f5e79);\n  background:\n    conic-gradient(from 30deg at 80%,\n       var(--c1) 60deg,var(--c2) 0 120deg,#0000 0),\n    conic-gradient(from -30deg,\n      var(--c2)   120deg,var(--c1) 0 240deg,\n      var(--c2) 0 300deg,var(--c1) 0);\n  background-size: calc(3*var(--s)/2) var(--s);"
+    },
+    {
+      "id": "two-color-nested-squares",
+      "name": "Two color nested squares",
+      "source": "https://css-pattern.com/two-color-nested-squares/",
+      "size": 121,
+      "colors": {
+        "c1": "#DFBA69",
+        "c2": "#5A2E2E"
+      },
+      "declarations": "--s: var(--css-pattern-size, 121px);\n  --c1: var(--css-pattern-color-1, #DFBA69);\n  --c2: var(--css-pattern-color-2, #5A2E2E);\n  --c: var(--c1) 12.5%,var(--c2) 0 25%,#0000 0;\n  background:\n    conic-gradient(at 80% 20%,var(--c))\n     calc(2*var(--s)/-5) calc(2*var(--s)/5),\n    conic-gradient(from 180deg at 60% 40%,var(--c))\n     calc(var(--s)/5) calc(var(--s)/-5),\n    conic-gradient(at 0% 100%,var(--c));\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "two-color-wavy",
+      "name": "Two color wavy",
+      "source": "https://css-pattern.com/two-color-wavy/",
+      "size": 150,
+      "colors": {
+        "c1": "#EAFF87",
+        "c2": "#FF714B"
+      },
+      "declarations": "--s: var(--css-pattern-size, 150px);\n  --c1: var(--css-pattern-color-1, #EAFF87);\n  --c2: var(--css-pattern-color-2, #FF714B);\n  --l:var(--c1) 99%,#0000 101%;\n  --p:var(--c2) 99%,#0000 101%;\n  --r:closest-corner at;\n  background:\n    radial-gradient(var(--r)-25% 25%,var(--p)),\n    radial-gradient(var(--r)25% -25%,var(--p)),\n    radial-gradient(var(--r)125% 75%,var(--p)),\n    radial-gradient(var(--r)75% 125%,var(--p)),\n    radial-gradient(var(--r)75% 75%,var(--l)),\n    radial-gradient(var(--r)25% 25%,var(--l)) var(--c2);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "wave-circles",
+      "name": "Wave & circles",
+      "source": "https://css-pattern.com/wave-circles/",
+      "size": 160,
+      "colors": {
+        "c1": "#A14016",
+        "c2": "#CFC89A"
+      },
+      "declarations": "--s: var(--css-pattern-size, 160px);\n  --c1: var(--css-pattern-color-1, #A14016);\n  --c2: var(--css-pattern-color-2, #CFC89A);\n  --_g: var(--s) var(--s) \n    radial-gradient(var(--c1) 17%,var(--c2) 18% 35%,#0000 36.5%);\n  background: \n    calc(var(--s)/-4) calc(var(--s)/-4)/var(--_g),\n    calc(var(--s)/ 4) calc(var(--s)/ 4)/var(--_g),\n    radial-gradient(var(--c2) 34%,var(--c1) 36% 68%,#0000 70%) \n     0 0/calc(var(--s)/2) calc(var(--s)/2),\n    repeating-linear-gradient(45deg,var(--c1) -12.5% 12.5%,var(--c2) 0 37.5%)\n     0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "waves",
+      "name": "Waves",
+      "source": "https://css-pattern.com/waves/",
+      "size": 30,
+      "colors": {
+        "c1": "#E5FCC2",
+        "c2": "#45ADA8"
+      },
+      "declarations": "--s: var(--css-pattern-size, 30px);\n  --c1: var(--css-pattern-color-1, #E5FCC2);\n  --c2: var(--css-pattern-color-2, #45ADA8);\n  --_s:37.5% 12.5% at 62.5%;\n  --_g:34% 99%,#0000 101%;\n  --g1:radial-gradient(var(--_s) 100%,#0000 32%,var(--c1) var(--_g));\n  --g2:radial-gradient(var(--_s) 0   ,#0000 32%,var(--c1) var(--_g));\n  --g3:radial-gradient(var(--_s) 100%,#0000 32%,var(--c2) var(--_g));\n  --g4:radial-gradient(var(--_s) 0   ,#0000 32%,var(--c2) var(--_g));\n  background:\n    var(--g1),\n    var(--g2) 0                calc(3*var(--s)),\n    var(--g3) var(--s)         calc(3*var(--s)),\n    var(--g4) var(--s)         calc(6*var(--s)),\n    var(--g1) calc(2*var(--s)) calc(6*var(--s)),\n    var(--g2) calc(2*var(--s)) calc(9*var(--s)),\n    var(--g3) calc(3*var(--s)) calc(9*var(--s)),\n    var(--g4) calc(3*var(--s)) 0,\n    repeating-linear-gradient(var(--c1) 0 25%,var(--c2) 0 50%);\n  background-size: calc(4*var(--s)) calc(12*var(--s));"
+    },
+    {
+      "id": "wavy-3d",
+      "name": "Wavy pattern with 3D effect",
+      "source": "https://css-pattern.com/wavy-3d/",
+      "size": 100,
+      "colors": {
+        "c1": "#E1F5C4",
+        "c2": "#3B8183"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #E1F5C4);\n  --c2: var(--css-pattern-color-2, #3B8183);\n  --_g:#0000, #0004 5%,\n     var(--c2) 6%  14%,var(--c1) 16% 24%,var(--c2) 26% 34%,var(--c1) 36% 44%,\n     var(--c2) 46% 54%,var(--c1) 56% 64%,var(--c2) 66% 74%,var(--c1) 76% 84%,\n     var(--c2) 86% 94%,#0004 95%,#0000;\n  background:\n    radial-gradient(100% 50% at 100% 0   ,var(--_g)),\n    radial-gradient(100% 50% at 0    50% ,var(--_g)),\n    radial-gradient(100% 50% at 100% 100%,var(--_g));\n  background-size: var(--s) calc(2*var(--s));"
+    },
+    {
+      "id": "wavy-checkerboard",
+      "name": "Wavy checkerboard",
+      "source": "https://css-pattern.com/wavy-checkerboard/",
+      "size": 104,
+      "colors": {
+        "c1": "#403B33",
+        "c2": "#94C7B6"
+      },
+      "declarations": "--s: var(--css-pattern-size, 104px);\n  --c1: var(--css-pattern-color-1, #403B33);\n  --c2: var(--css-pattern-color-2, #94C7B6);\n  --g1:/calc(2*var(--s)) calc(2*var(--s)) \n       radial-gradient(at 100% 0,var(--c2) 17.5%,#0000 18%);\n  --g2:/calc(2*var(--s)) calc(2*var(--s)) \n       radial-gradient(at 0 100%,var(--c2) 17.5%,#0000 18%);\n  --_s:0 calc(var(--s)/2)/var(--s) var(--s);\n  background:\n    calc(var(--s)/ 2) var(--s) var(--g1),\n    calc(var(--s)/-2) 0        var(--g1),\n    calc(var(--s)/-2) var(--s) var(--g2),\n    calc(var(--s)/ 2) 0        var(--g2),\n    radial-gradient(at 100% 0,var(--c1) 35%,#0000 35.5%) var(--_s),\n    radial-gradient(at 0 100%,var(--c1) 35%,#0000 35.5%) var(--_s),\n    repeating-conic-gradient(from 45deg,var(--c1) 0 25%,var(--c2) 0 50%)\n     0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "wavy-lines-circles",
+      "name": "Wavy lines & circles",
+      "source": "https://css-pattern.com/wavy-lines-circles/",
+      "size": 40,
+      "colors": {
+        "c1": "#73C8A9",
+        "c2": "#DEE1B6",
+        "c3": "#BD5532",
+        "c4": "#373B44"
+      },
+      "declarations": "--s: var(--css-pattern-size, 40px);\n  --c1: var(--css-pattern-color-1, #73C8A9);\n  --c2: var(--css-pattern-color-2, #DEE1B6);\n  --c3: var(--css-pattern-color-3, #BD5532);\n  --c4: var(--css-pattern-color-4, #373B44);\n  --c:,#0000 39%,var(--c1) 40% 93%,#0000 94%;\n  --_s:calc(1.5*var(--s))/calc(4*var(--s)) calc(3*var(--s));\n  background:\n    radial-gradient(calc(1.5*var(--s)) at 37.5%   0%var(--c))\n     calc(-.5*var(--s)) var(--_s),\n    radial-gradient(calc(1.5*var(--s)) at 37.5% 100%var(--c))\n     calc(1.5*var(--s)) var(--_s),\n    radial-gradient(25% calc(50%/3),#0000 96%,var(--c2))\n     0 0/calc(2*var(--s)) calc(3*var(--s)),\n    repeating-conic-gradient(var(--c3) 0 25%,var(--c4) 0 50%)\n     0 0/calc(4*var(--s)) calc(6*var(--s));"
+    },
+    {
+      "id": "wavy-lines",
+      "name": "Multicolor wavy lines",
+      "source": "https://css-pattern.com/wavy-lines/",
+      "size": 140,
+      "colors": {
+        "c1": "#AB3E5B",
+        "c2": "#FFBE40",
+        "c3": "#ACCEC0",
+        "c4": "#61A6AB"
+      },
+      "declarations": "--s: var(--css-pattern-size, 140px);\n  --c1: var(--css-pattern-color-1, #AB3E5B);\n  --c2: var(--css-pattern-color-2, #FFBE40);\n  --c3: var(--css-pattern-color-3, #ACCEC0);\n  --c4: var(--css-pattern-color-4, #61A6AB);\n  --_g: \n    #0000 25%,#0008 47%,var(--c1)  53% 147%,var(--c2) 153% 247%,\n    var(--c1) 253% 347%,var(--c2) 353% 447%,var(--c1) 453% 547%,#0008 553%,#0000 575%;\n  --_s: calc(25%/3) calc(25%/4) at 50%;\n  background:\n    radial-gradient(var(--_s) 100%,var(--_g)),\n    radial-gradient(var(--_s) 100%,var(--_g)) calc(var(--s)/2) calc(3*var(--s)/4),\n    radial-gradient(var(--_s) 0   ,var(--_g)) calc(var(--s)/2) 0,\n    radial-gradient(var(--_s) 0   ,var(--_g)) 0                calc(3*var(--s)/4),\n    repeating-linear-gradient(90deg,var(--c3) calc(25%/-6) calc(25%/6),var(--c4) 0 calc(25%/2));\n  background-size: var(--s) calc(3*var(--s)/2);"
+    },
+    {
+      "id": "z-shape",
+      "name": "Z shape",
+      "source": "https://css-pattern.com/z-shape/",
+      "size": 106,
+      "colors": {
+        "c1": "#EAFDE6",
+        "c2": "#519548"
+      },
+      "declarations": "--s: var(--css-pattern-size, 106px);\n  --c1: var(--css-pattern-color-1, #EAFDE6);\n  --c2: var(--css-pattern-color-2, #519548);\n  background:\n    conic-gradient(from  30deg at 87.5% 75%,var(--c1)  60deg,var(--c2) 0 120deg,#0000 0) 0 calc(.2165*var(--s)),\n    conic-gradient(from -90deg at 50%   25%,var(--c2)  60deg,var(--c1) 0 180deg,#0000 0),\n    conic-gradient(from  90deg at 50%   75%,var(--c2) 120deg,var(--c1) 0 180deg,#0000 0),\n    conic-gradient(from -30deg at 87.5% 50%,var(--c2) 120deg,var(--c1) 0 240deg,#0000 0),\n    conic-gradient(from  90deg at 37.5% 50%,var(--c2) 120deg,var(--c1) 0 180deg,var(--c2) 0 240deg,var(--c1) 0);\n  background-size: var(--s) calc(.866*var(--s));"
+    },
+    {
+      "id": "zig-zag-3d",
+      "name": "Zig-Zag pattern with 3D effect",
+      "source": "https://css-pattern.com/zig-zag-3d/",
+      "size": 90,
+      "colors": {
+        "c1": "#78C0A8",
+        "c2": "#ADD8E6"
+      },
+      "declarations": "--s: var(--css-pattern-size, 90px);\n  --c1: var(--css-pattern-color-1, #78C0A8);\n  --c2: var(--css-pattern-color-2, #ADD8E6);\n  --g:from 45deg at 50% 35%,#0000 75%,;\n  --_s:var(--s) calc(2*var(--s));\n  background:\n    conic-gradient(var(--g)var(--c2) 0) \n     calc(var(--s)/2) var(--s)/var(--_s),\n    conic-gradient(var(--g)var(--c1) 0) \n     calc(var(--s)/2)        0/var(--_s),\n    conic-gradient(#0004 135deg,#0000 0 225deg,#0009 0)\n     0 0/var(--s) var(--s),\n    linear-gradient(var(--c1) 50%,var(--c2) 0) \n     0 var(--s)/var(--_s);"
+    },
+    {
+      "id": "zig-zag-diagonal",
+      "name": "Diagonal Zig-Zag",
+      "source": "https://css-pattern.com/zig-zag-diagonal/",
+      "size": 50,
+      "colors": {
+        "c1": "#292522",
+        "c2": "#EFD9B4"
+      },
+      "declarations": "--s: var(--css-pattern-size, 50px);\n  --c1: var(--css-pattern-color-1, #292522);\n  --c2: var(--css-pattern-color-2, #EFD9B4);\n  --c: #0000 75%,var(--c1) 0;\n  --g1: conic-gradient(at 75% 25%,var(--c));\n  --g2: conic-gradient(at 25% 75%,var(--c));\n  background: \n    var(--g1),var(--g1) var(--s) var(--s),\n    var(--g2),var(--g2) var(--s) var(--s) var(--c2);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "zig-zag-pixel",
+      "name": "Pixelated Zig-Zag",
+      "source": "https://css-pattern.com/zig-zag-pixel/",
+      "size": 60,
+      "colors": {
+        "c1": "#1C2130",
+        "c2": "#D14334"
+      },
+      "declarations": "--s: var(--css-pattern-size, 60px);\n  --c1: var(--css-pattern-color-1, #1C2130);\n  --c2: var(--css-pattern-color-2, #D14334);\n  background:  \n    repeating-conic-gradient(var(--c1) 0 25%,#0000 0 50%)\n    0 0/calc(3*var(--s)) calc(2*var(--s)),\n    repeating-conic-gradient(var(--c2) 0 25%,var(--c1) 0 50%)\n    0 0/var(--s) var(--s);"
+    },
+    {
+      "id": "zig-zag-rectangles",
+      "name": "Zig-Zag & rectangles",
+      "source": "https://css-pattern.com/zig-zag-rectangles/",
+      "size": 100,
+      "colors": {
+        "c1": "#FDF1CC",
+        "c2": "#987F69"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #FDF1CC);\n  --c2: var(--css-pattern-color-2, #987F69);\n  --g: var(--c1)    3.125%,var(--c2) 0 9.375%,\n       var(--c1) 0 15.625%,var(--c2) 0 21.875%,\n       var(--c1) 0 28.125%,#0000 0;\n  background: \n    linear-gradient(225deg,#0000    3.125%,var(--c2) 0 9.375%,\n                           #0000 0 78.125%,var(--c2) 0 84.375%,#0000 0) \n     0 calc(var(--s)/2),\n    linear-gradient( 45deg,var(--g)) 0 var(--s),\n    linear-gradient( 45deg,var(--g)) calc(var(--s)/-2) calc(var(--s)/-2),\n    linear-gradient(225deg,var(--g)) var(--s) 0,\n    linear-gradient(225deg,var(--g)) calc(var(--s)/2) var(--s),\n    repeating-linear-gradient(-45deg,var(--c1) -3.125% 3.125%,var(--c2) 0 9.375%);\n  background-size: calc(2*var(--s)) calc(2*var(--s));"
+    },
+    {
+      "id": "zig-zag-stripes",
+      "name": "Zig-Zag stripes",
+      "source": "https://css-pattern.com/zig-zag-stripes/",
+      "size": 120,
+      "colors": {
+        "c1": "#403B33",
+        "c2": "#E3AD40"
+      },
+      "declarations": "--s: var(--css-pattern-size, 120px);\n  --c1: var(--css-pattern-color-1, #403B33);\n  --c2: var(--css-pattern-color-2, #E3AD40);\n  --g:,var(--c1) 25%,#0000 0;\n  background:\n    conic-gradient(from  45deg at 75% 75%var(--g)),\n    conic-gradient(from 135deg at 25% 75%var(--g)),\n    conic-gradient(from -45deg at 75% 25%var(--g)),\n    conic-gradient(from 225deg at 25% 25%var(--g)),\n    repeating-conic-gradient(from -45deg,var(--c1) 0 45deg,var(--c2) 0 50%);\n  background-size: var(--s) var(--s);"
+    },
+    {
+      "id": "zig-zag",
+      "name": "Zig-Zag",
+      "source": "https://css-pattern.com/zig-zag/",
+      "size": 100,
+      "colors": {
+        "c1": "#ECEDDC",
+        "c2": "#29AB87"
+      },
+      "declarations": "--s: var(--css-pattern-size, 100px);\n  --c1: var(--css-pattern-color-1, #ECEDDC);\n  --c2: var(--css-pattern-color-2, #29AB87);\n  --_g: var(--c1) 90deg,#0000 90.5deg;\n  background:\n   conic-gradient(from -45deg,var(--_g)),\n   conic-gradient(from 135deg,var(--_g)) calc(var(--s)/2) 0,\n   var(--c2);\n  background-size: var(--s) var(--s);"
+    }
+  ]
+}

--- a/testing/manifest.json
+++ b/testing/manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "test-og-event-layouts-calendar.html",
-      "size": 77359,
+      "size": 84802,
       "icon": "📅",
       "description": "Old School Blueprint - Classic event layouts, tried and true"
     },

--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -275,11 +275,21 @@
     .layout-banner .event-cta { background: #fff; color: #111; padding: 16px 40px; border-radius: 50px; font-size: 24px; font-weight: 700; margin-top: 20px; box-shadow: 0 8px 24px rgba(0,0,0,0.3); }
 
     /* === Pattern Layouts with Rim Effect === */
+    .artboard.layout-css-pattern,
     .artboard.layout-pattern-dots,
     .artboard.layout-pattern-stripes,
     .artboard.layout-pattern-grid,
     .artboard.layout-pattern-zigzag { background: #000; position: relative; overflow: hidden; }
 
+    .layout-css-pattern .css-pattern-bg {
+      position: absolute; inset: 0; z-index: 0;
+      background-color: #06060a;
+    }
+    .layout-css-pattern .pattern-vignette {
+      position: absolute; inset: 0; z-index: 1;
+      background: radial-gradient(circle at 50% 45%, rgba(0,0,0,0) 0 45%, rgba(0,0,0,0.35) 100%);
+      pointer-events: none;
+    }
     .layout-pattern-dots .pattern-bg {
       position: absolute; inset: 0; z-index: 0;
       background-color: #06060a;
@@ -303,6 +313,7 @@
       background-image: linear-gradient(135deg, var(--pattern-color, rgba(255,255,255,0.18)) 25%, transparent 25%) -10px 0, linear-gradient(225deg, var(--pattern-color, rgba(255,255,255,0.18)) 25%, transparent 25%) -10px 0, linear-gradient(315deg, var(--pattern-color, rgba(255,255,255,0.18)) 25%, transparent 25%), linear-gradient(45deg, var(--pattern-color, rgba(255,255,255,0.18)) 25%, transparent 25%);
       background-size: 20px 20px;
     }
+    .layout-css-pattern .content-box,
     .layout-pattern-dots .content-box,
     .layout-pattern-stripes .content-box,
     .layout-pattern-grid .content-box,
@@ -316,6 +327,8 @@
       padding: 60px 72px;
       color: #fff;
     }
+    .layout-css-pattern .content-box { z-index: 2; }
+    .layout-css-pattern .brand,
     .layout-pattern-dots .brand,
     .layout-pattern-stripes .brand,
     .layout-pattern-grid .brand,
@@ -323,14 +336,17 @@
       font-size: 15px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase;
       color: var(--rim-color, #667eea); margin-bottom: 18px;
     }
+    .layout-css-pattern .event-title,
     .layout-pattern-dots .event-title,
     .layout-pattern-stripes .event-title,
     .layout-pattern-grid .event-title,
     .layout-pattern-zigzag .event-title { font-size: 66px; line-height: 0.95; font-weight: 900; margin-bottom: 20px; }
+    .layout-css-pattern .event-date,
     .layout-pattern-dots .event-date,
     .layout-pattern-stripes .event-date,
     .layout-pattern-grid .event-date,
     .layout-pattern-zigzag .event-date { font-size: 26px; opacity: 0.9; margin-bottom: 8px; }
+    .layout-css-pattern .event-venue,
     .layout-pattern-dots .event-venue,
     .layout-pattern-stripes .event-venue,
     .layout-pattern-grid .event-venue,
@@ -340,6 +356,7 @@
     .favicon-colors-info { display: flex; align-items: center; gap: 10px; margin-top: 14px; padding: 10px 14px; background: var(--background-light); border-radius: 10px; font-size: 13px; color: var(--text-secondary); }
     .favicon-color-swatch { width: 28px; height: 28px; border-radius: 6px; border: 2px solid var(--border-lighter); flex-shrink: 0; }
     .favicon-colors-info .no-colors { opacity: 0.65; }
+    .pattern-source-note { margin-top: 10px; color: var(--text-secondary); font-size: 13px; line-height: 1.4; }
 
     @media (max-width: 768px) {
       .controls-grid { grid-template-columns: 1fr; }
@@ -364,7 +381,7 @@
       <div class="page-title">
         <div>
           <h2>🎨 OpenGraph Image Studio</h2>
-          <div class="subtitle">Create stunning social media preview images for your events • 17 beautiful layouts including 5 simple designs</div>
+          <div class="subtitle">Create stunning social media preview images for your events • downloaded CSS Pattern backgrounds included</div>
         </div>
       </div>
 
@@ -480,6 +497,23 @@
         </div>
 
         <div class="controls-section">
+          <h3>🧩 CSS Pattern Background</h3>
+          <div class="controls-grid">
+            <div class="control-field" style="grid-column: span 2;">
+              <label for="cssPatternSelect">Downloaded pattern</label>
+              <select id="cssPatternSelect">
+                <option>Loading CSS patterns...</option>
+              </select>
+            </div>
+            <div class="control-field">
+              <label for="cssPatternSize">Pattern size</label>
+              <input id="cssPatternSize" type="range" min="20" max="260" value="90">
+            </div>
+          </div>
+          <div class="pattern-source-note" id="cssPatternMeta">Patterns load from the local downloaded CSS Pattern data file.</div>
+        </div>
+
+        <div class="controls-section">
           <h3>🖼️ Cover Image</h3>
           <div class="control-field full">
             <label for="coverInput">Image URL (optional - uses event image if available)</label>
@@ -510,6 +544,9 @@
       const randomBtn = document.getElementById('randomBtn');
       const customA = document.getElementById('customA');
       const customB = document.getElementById('customB');
+      const cssPatternSelect = document.getElementById('cssPatternSelect');
+      const cssPatternSize = document.getElementById('cssPatternSize');
+      const cssPatternMeta = document.getElementById('cssPatternMeta');
       const coverInput = document.getElementById('coverInput');
       const grid = document.getElementById('variantsGrid');
       const themeOptions = document.querySelectorAll('.theme-option');
@@ -524,6 +561,8 @@
           this.selectedEvent = null;
           this.eventColorsMap = new Map();
           this.barColorsMap = new Map();
+          this.cssPatterns = [];
+          this.currentCssPattern = null;
         }
 
         getInitialCityFromUrl() {
@@ -538,6 +577,7 @@
 
         async init() {
           this.populateCities();
+          await this.loadCssPatterns();
           await this.loadCity(this.currentCity);
           this.attachHandlers();
           this.updateThemeVars();
@@ -549,6 +589,52 @@
           const cities = getAvailableCities();
           citySelect.innerHTML = cities.map(c => `<option value="${c.key}">${c.emoji} ${c.name}</option>`).join('');
           citySelect.value = this.currentCity;
+        }
+
+        async loadCssPatterns() {
+          try {
+            const response = await fetch('../data/css-patterns.json');
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+            const data = await response.json();
+            this.cssPatterns = Array.isArray(data.patterns)
+              ? data.patterns.filter(pattern => this.isSafeCssPattern(pattern))
+              : [];
+            this.currentCssPattern = this.cssPatterns[0] || null;
+            this.populateCssPatternSelect();
+            logger.componentLoad(COMPONENT, 'Loaded CSS Pattern backgrounds', { count: this.cssPatterns.length });
+          } catch (e) {
+            this.cssPatterns = [];
+            this.currentCssPattern = null;
+            cssPatternSelect.innerHTML = '<option>No CSS patterns loaded</option>';
+            cssPatternSelect.disabled = true;
+            cssPatternMeta.textContent = 'Could not load downloaded CSS Pattern data.';
+            logger.componentError(COMPONENT, 'Failed to load CSS Pattern backgrounds', e);
+          }
+        }
+
+        populateCssPatternSelect() {
+          if (!this.cssPatterns.length) {
+            cssPatternSelect.innerHTML = '<option>No CSS patterns loaded</option>';
+            cssPatternSelect.disabled = true;
+            return;
+          }
+
+          cssPatternSelect.disabled = false;
+          cssPatternSelect.innerHTML = this.cssPatterns
+            .map(pattern => `<option value="${pattern.id}">${pattern.name}</option>`)
+            .join('');
+          cssPatternSelect.value = this.currentCssPattern.id;
+          this.syncCssPatternControls();
+        }
+
+        syncCssPatternControls() {
+          if (!this.currentCssPattern) return;
+
+          if (this.currentCssPattern.size) {
+            cssPatternSize.value = Math.max(20, Math.min(260, this.currentCssPattern.size));
+          }
+          cssPatternMeta.textContent = `${this.cssPatterns.length} downloaded patterns available. Current source: ${this.currentCssPattern.source}`;
         }
 
         async loadCity(cityKey) {
@@ -675,6 +761,64 @@
           return THEME_COLORS[currentTheme] || '#667eea';
         }
 
+        isSafeCssPattern(pattern) {
+          return pattern
+            && typeof pattern.id === 'string'
+            && typeof pattern.name === 'string'
+            && typeof pattern.declarations === 'string'
+            && !/url\s*\(|@|<|>|expression\s*\(|javascript\s*:/i.test(pattern.declarations)
+            && this.parseCssDeclarations(pattern.declarations).length > 0;
+        }
+
+        parseCssDeclarations(declarations) {
+          return declarations
+            .split(';')
+            .map(part => part.trim())
+            .filter(Boolean)
+            .map(part => {
+              const separator = part.indexOf(':');
+              if (separator === -1) return null;
+              return {
+                property: part.slice(0, separator).trim(),
+                value: part.slice(separator + 1).trim()
+              };
+            })
+            .filter(item => item && (
+              item.property === 'background'
+              || item.property === 'background-color'
+              || item.property === 'background-image'
+              || item.property === 'background-position'
+              || item.property === 'background-size'
+              || item.property === 'background-repeat'
+              || /^--[a-zA-Z0-9_-]+$/.test(item.property)
+            ));
+        }
+
+        getCssPatternPalette(pattern) {
+          const fc = this.getFaviconColors();
+          const defaults = Object.values(pattern?.colors || {}).filter(color => /^#[0-9a-fA-F]{6}$/.test(color));
+          const themed = currentTheme === 'favicon' && fc
+            ? [fc.bg, fc.fg || '#ffffff', '#06060a']
+            : [this.getRimColorForTheme(), customB.value || '#06060a', '#06060a', '#f8f8ff'];
+          return [...themed, ...defaults];
+        }
+
+        applyCssPattern(element) {
+          if (!element || !this.currentCssPattern) return;
+
+          element.removeAttribute('style');
+          this.parseCssDeclarations(this.currentCssPattern.declarations).forEach(({ property, value }) => {
+            element.style.setProperty(property, value);
+          });
+
+          const palette = this.getCssPatternPalette(this.currentCssPattern);
+          Object.keys(this.currentCssPattern.colors || {}).forEach((key, index) => {
+            const color = palette[index] || this.currentCssPattern.colors[key];
+            element.style.setProperty(`--css-pattern-color-${index + 1}`, color);
+          });
+          element.style.setProperty('--css-pattern-size', `${cssPatternSize.value}px`);
+        }
+
         attachHandlers() {
           citySelect.addEventListener('change', async () => {
             const cityKey = citySelect.value;
@@ -705,6 +849,12 @@
           });
 
           coverInput.addEventListener('input', () => this.render());
+          cssPatternSelect.addEventListener('change', () => {
+            this.currentCssPattern = this.cssPatterns.find(pattern => pattern.id === cssPatternSelect.value) || this.cssPatterns[0] || null;
+            this.syncCssPatternControls();
+            this.render();
+          });
+          cssPatternSize.addEventListener('input', () => this.render());
 
           // Theme selection
           themeOptions.forEach(option => {
@@ -932,6 +1082,7 @@ Loading... <span class="cursor">█</span>`;
               if (bg && data.cover) bg.style.backgroundImage = `url('${data.cover}')`;
               break;
             }
+            case 'css-pattern':
             case 'pattern-dots':
             case 'pattern-stripes':
             case 'pattern-grid':
@@ -939,9 +1090,11 @@ Loading... <span class="cursor">█</span>`;
               const t = artboard.querySelector('.event-title');
               const d = artboard.querySelector('.event-date');
               const v = artboard.querySelector('.event-venue');
+              const cssBg = artboard.querySelector('.css-pattern-bg');
               if (t) t.textContent = data.event;
               if (d) d.textContent = `${data.date} · ${data.time}`;
               if (v) v.textContent = `@ ${data.venue}`;
+              if (cssBg) this.applyCssPattern(cssBg);
               break;
             }
           }
@@ -1158,6 +1311,16 @@ Loading... <span class="cursor">█</span>`;
                 <div class="event-cta">Get Tickets</div>
               </div>
             `,
+            'css-pattern': `
+              <div class="css-pattern-bg"></div>
+              <div class="pattern-vignette"></div>
+              <div class="content-box">
+                <div class="brand">chunky.dad</div>
+                <div class="event-title"></div>
+                <div class="event-date"></div>
+                <div class="event-venue"></div>
+              </div>
+            `,
             'pattern-dots': `
               <div class="pattern-bg"></div>
               <div class="content-box">
@@ -1239,6 +1402,7 @@ Loading... <span class="cursor">█</span>`;
             { key: 'speech-discord', name: 'Discord', class: 'layout-speech-discord', description: 'Gaming chat style' },
 
             // Pattern Layouts with Colored Rim
+            { key: 'css-pattern', name: '🧩 CSS Pattern.com', class: 'layout-css-pattern', description: 'Downloaded gradient pattern background' },
             { key: 'pattern-dots', name: '🔵 Pattern: Dots', class: 'layout-pattern-dots', description: 'Polka dot background with colored rim' },
             { key: 'pattern-stripes', name: '🔷 Pattern: Stripes', class: 'layout-pattern-stripes', description: 'Diagonal stripe background with colored rim' },
             { key: 'pattern-grid', name: '⬜ Pattern: Grid', class: 'layout-pattern-grid', description: 'Blueprint grid background with colored rim' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a downloaded `data/css-patterns.json` dataset with 157 sanitized CSS Pattern backgrounds.
- Add a CSS Pattern selector and size control to the OpenGraph tester.
- Add a new OpenGraph layout that renders the selected downloaded gradient pattern with theme colors.
- Refresh the testing manifest metadata for the updated tester file size.

### Testing
- Static check compared the downloaded sources against the live `https://css-pattern.com/` index: 157 upstream pattern pages matched 157 downloaded records.
- Static check validated unique IDs, safe CSS declarations, background CSS presence, and OpenGraph tester wiring.
- Static check parsed the tester inline scripts without syntax errors.
- Browser/manual testing intentionally skipped because the latest request asked to double-check without running the website.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4fbabc1-f551-4c80-8831-11f94b463ac3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4fbabc1-f551-4c80-8831-11f94b463ac3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

