### PR TITLE
Normalize parser result shape

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -158,6 +158,21 @@ class SharedCore {
         return normalized.length > 0 ? normalized : null;
     }
 
+    normalizeParseResult(parseResult, defaults = {}) {
+        const result = parseResult && typeof parseResult === 'object' && !Array.isArray(parseResult)
+            ? parseResult
+            : {};
+        const fallbackEvents = Array.isArray(parseResult) ? parseResult : [];
+
+        return {
+            ...result,
+            events: Array.isArray(result.events) ? result.events : fallbackEvents,
+            additionalLinks: Array.isArray(result.additionalLinks) ? result.additionalLinks : [],
+            source: result.source || defaults.source || '',
+            url: result.url || defaults.url || ''
+        };
+    }
+
     resolveAutomationContext(config) {
         const runtime = config && typeof config === 'object'
             ? (config.runtime || config.runContext || {})
@@ -376,15 +391,19 @@ class SharedCore {
                 }
                 
                 // Parse events (consolidated logging)
-                let parseResult = await Promise.resolve(
+                const rawParseResult = await Promise.resolve(
                     urlParser.parseEvents(htmlData, effectiveParserConfig, mainConfig?.cities || null)
                 );
+                const parseResult = this.normalizeParseResult(rawParseResult, {
+                    source: urlParserName,
+                    url: htmlData && htmlData.url ? htmlData.url : url
+                });
                 const eventCount = parseResult?.events?.length || 0;
                 const linkCount = parseResult?.additionalLinks?.length || 0;
                 const linkSuffix = linkCount > 0 ? `, ${linkCount} link${linkCount === 1 ? '' : 's'}` : '';
                 await displayAdapter.logInfo(`SYSTEM: Parsed ${url} → ${eventCount} event${eventCount === 1 ? '' : 's'}${linkSuffix}`);
                 
-                if (parseResult.events) {
+                if (parseResult.events.length > 0) {
                     // Apply field priorities to determine which parser data to trust
                     const filteredEvents = parseResult.events.map(event => 
                         this.applyFieldPriorities(event, effectiveParserConfig, mainConfig)
@@ -399,7 +418,7 @@ class SharedCore {
                 }
 
                 // Process additional URLs if we have them (for enriching existing events, not creating new ones)
-                if (parseResult.additionalLinks && parseResult.additionalLinks.length > 0) {
+                if (parseResult.additionalLinks.length > 0) {
                     // Deduplicate additional URLs before processing
                     const deduplicatedUrls = this.deduplicateUrls(parseResult.additionalLinks, globalProcessedUrls);
                     await displayAdapter.logInfo(`SYSTEM: Processing ${parseResult.additionalLinks.length} additional URLs → ${deduplicatedUrls.length} unique for detail pages`);
@@ -558,13 +577,16 @@ class SharedCore {
                     ...parserConfig,
                     urlDiscoveryDepth: Math.max(0, maxDepth - currentDepth)
                 };
-                const parseResult = await Promise.resolve(
+                const rawParseResult = await Promise.resolve(
                     urlParser.parseEvents(htmlData, detailParserConfig, mainConfig?.cities || null)
                 );
+                const parseResult = this.normalizeParseResult(rawParseResult, {
+                    source: urlParserName,
+                    url: htmlData && htmlData.url ? htmlData.url : url
+                });
                 
                 // Handle additional URLs if depth allows and parser wants URL discovery
-                const shouldProcessUrls = parseResult.additionalLinks && 
-                                        parseResult.additionalLinks.length > 0 &&
+                const shouldProcessUrls = parseResult.additionalLinks.length > 0 &&
                                         currentDepth < maxDepth &&
                                         parserConfig.urlDiscoveryDepth > 0;
                 
@@ -589,12 +611,12 @@ class SharedCore {
                                 allowParserAutoSwitch
                             );
                         }
-                } else if (parseResult.additionalLinks && parseResult.additionalLinks.length > 0) {
+                } else if (parseResult.additionalLinks.length > 0) {
                     await displayAdapter.logInfo(`SYSTEM: Detail page ${url} found ${parseResult.additionalLinks.length} additional URLs, but depth limit (${maxDepth}) reached or URL discovery disabled - ignoring`);
                 }
                 
                 // Process detail page events - either enrich existing or add new events
-                if (parseResult.events && parseResult.events.length > 0) {
+                if (parseResult.events.length > 0) {
                     // Apply field priorities to detail page events (same as main page events)
                     // CRITICAL FIX: Detail page events need the same enrichment as main page events
                     const enrichedDetailEvents = parseResult.events.map(event => 
@@ -654,9 +676,13 @@ class SharedCore {
 
                 // Request link discovery but skip deep recursion — we manage depth ourselves
                 const discoveryConfig = { ...parserConfig, urlDiscoveryDepth: 1 };
-                const parseResult = await Promise.resolve(urlParser.parseEvents(htmlData, discoveryConfig, null));
+                const rawParseResult = await Promise.resolve(urlParser.parseEvents(htmlData, discoveryConfig, null));
+                const parseResult = this.normalizeParseResult(rawParseResult, {
+                    source: detectedParser,
+                    url: htmlData && htmlData.url ? htmlData.url : url
+                });
 
-                const childLinks = parseResult.additionalLinks || [];
+                const childLinks = parseResult.additionalLinks;
                 const deduped = this.deduplicateUrls(childLinks, processedUrls);
                 for (const childUrl of deduped) {
                     allNodes.add(childUrl);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add `SharedCore.normalizeParseResult()` to enforce parser outputs with `events` and `additionalLinks` arrays plus default `source` and `url`.
- Route main parsing, detail-page parsing, and discovery-only parsing through the normalized result shape.
- Keep existing `additionalLinks` naming, parser behavior, discovery depth behavior, and classification behavior unchanged.

### Testing
- `node --check scripts/shared-core.js`
- Focused Node smoke test for direct normalization and mocked parser flow.
- `git diff --check`
- `node --check scripts/bear-event-scraper-unified.js && node --check scripts/adapters/scriptable-adapter.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b92fdf97-22fa-4213-a2d2-d530527a3b52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b92fdf97-22fa-4213-a2d2-d530527a3b52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

