### PR TITLE
Add OCR cache-backed recovery to AI web parser

### DIFF
--- a/scripts/page-cache-maintenance.js
+++ b/scripts/page-cache-maintenance.js
@@ -40,6 +40,23 @@ class PageCacheMaintenance {
     this.baseDir = this.fm.joinPath(documentsDir, 'chunky-dad-scraper');
     this.storageDir = this.fm.joinPath(this.baseDir, 'storage');
     this.pageStorageDir = this.fm.joinPath(this.storageDir, 'pages');
+    this.ocrStorageDir = this.fm.joinPath(this.storageDir, 'ocr');
+    this.cacheScopes = [
+      {
+        key: 'pages',
+        label: 'Page cache',
+        dir: this.pageStorageDir,
+        emptyLabel: 'downloaded website files',
+        footerLabel: 'storage/pages'
+      },
+      {
+        key: 'ocr',
+        label: 'OCR cache',
+        dir: this.ocrStorageDir,
+        emptyLabel: 'saved OCR responses',
+        footerLabel: 'storage/ocr'
+      }
+    ];
     this.cacheDir = this.fm.joinPath(this.baseDir, 'cache');
     this.runtime = this.getRuntimeContext();
   }
@@ -232,7 +249,7 @@ class PageCacheMaintenance {
     }
   }
 
-  analyzeHostDirectory(hostName, hostPath, thresholdMs, nowMs) {
+  analyzeHostDirectory(hostName, hostPath, thresholdMs, nowMs, scope = null) {
     const entryNames = this.listDirectoryEntries(hostPath);
     const files = [];
     let oldFileCount = 0;
@@ -291,6 +308,8 @@ class PageCacheMaintenance {
     });
 
     return {
+      scopeKey: scope && scope.key ? scope.key : 'pages',
+      scopeLabel: scope && scope.label ? scope.label : 'Page cache',
       hostName,
       hostPath,
       totalFileCount: files.length,
@@ -303,14 +322,14 @@ class PageCacheMaintenance {
     };
   }
 
-  analyzePageCache(days) {
+  analyzeCacheScope(scope, days) {
     const nowMs = Date.now();
     const thresholdMs = days * 24 * 60 * 60 * 1000;
     const hosts = [];
-    const rootEntries = this.listDirectoryEntries(this.pageStorageDir);
+    const rootEntries = this.listDirectoryEntries(scope.dir);
 
     rootEntries.forEach(entryName => {
-      const entryPath = this.fm.joinPath(this.pageStorageDir, entryName);
+      const entryPath = this.fm.joinPath(scope.dir, entryName);
       let isDirectory = false;
       try {
         isDirectory = this.fm.isDirectory(entryPath);
@@ -318,7 +337,7 @@ class PageCacheMaintenance {
         isDirectory = false;
       }
       if (!isDirectory) return;
-      hosts.push(this.analyzeHostDirectory(entryName, entryPath, thresholdMs, nowMs));
+      hosts.push(this.analyzeHostDirectory(entryName, entryPath, thresholdMs, nowMs, scope));
     });
 
     hosts.sort((left, right) => {
@@ -328,10 +347,38 @@ class PageCacheMaintenance {
     });
 
     return {
+      key: scope.key,
+      label: scope.label,
+      dir: scope.dir,
+      exists: this.fm.fileExists(scope.dir),
+      hostCount: hosts.length,
+      totalFileCount: hosts.reduce((sum, host) => sum + host.totalFileCount, 0),
+      oldFileCount: hosts.reduce((sum, host) => sum + host.oldFileCount, 0),
+      recentFileCount: hosts.reduce((sum, host) => sum + host.recentFileCount, 0),
+      removableHostCount: hosts.filter(host => host.removableAfterPrune).length,
+      hosts
+    };
+  }
+
+  analyzePageCache(days) {
+    const scopes = this.cacheScopes.map(scope => this.analyzeCacheScope(scope, days));
+    const hosts = scopes.reduce((allHosts, scope) => allHosts.concat(scope.hosts), []);
+    hosts.sort((left, right) => {
+      if (right.oldFileCount !== left.oldFileCount) return right.oldFileCount - left.oldFileCount;
+      if (right.totalFileCount !== left.totalFileCount) return right.totalFileCount - left.totalFileCount;
+      if (String(left.scopeLabel) !== String(right.scopeLabel)) {
+        return String(left.scopeLabel).localeCompare(String(right.scopeLabel));
+      }
+      return String(left.hostName).localeCompare(String(right.hostName));
+    });
+
+    return {
       generatedAt: new Date(),
       days,
-      exists: this.fm.fileExists(this.pageStorageDir),
+      exists: scopes.some(scope => scope.exists),
       pageStorageDir: this.pageStorageDir,
+      ocrStorageDir: this.ocrStorageDir,
+      cacheScopes: scopes,
       hostCount: hosts.length,
       totalFileCount: hosts.reduce((sum, host) => sum + host.totalFileCount, 0),
       oldFileCount: hosts.reduce((sum, host) => sum + host.oldFileCount, 0),
@@ -351,7 +398,7 @@ class PageCacheMaintenance {
       messageLines.push(`${analysis.removableHostCount} host folder(s) can be removed if empty after pruning.`);
     }
     messageLines.push('');
-    messageLines.push('This only touches downloaded website cache files under storage/pages.');
+    messageLines.push('This only touches cache files under storage/pages and storage/ocr.');
     alert.message = messageLines.join('\n');
     alert.addAction(deleteHosts ? 'Delete files + hosts' : 'Delete files');
     alert.addCancelAction('Cancel');
@@ -474,6 +521,7 @@ class PageCacheMaintenance {
           ? `${this.formatNumber(host.oldFileCount)} old • ${this.formatNumber(host.recentFileCount)} recent`
           : `${this.formatNumber(host.recentFileCount)} recent`;
         const hostMeta = [
+          this.escapeHtml(host.scopeLabel),
           `Total ${this.formatNumber(host.totalFileCount)}`,
           `Oldest ${this.escapeHtml(this.formatFileDate(host.oldestDate))}`,
           `Newest ${this.escapeHtml(this.formatFileDate(host.newestDate))}`,
@@ -481,7 +529,7 @@ class PageCacheMaintenance {
         ].join(' • ');
         return `
           <tr>
-            <td>${this.escapeHtml(host.hostName)}</td>
+            <td>${this.escapeHtml(host.hostName)}<br><span style="color: var(--muted); font-size: 12px;">${this.escapeHtml(host.scopeLabel)}</span></td>
             <td><span class="badge ${host.oldFileCount > 0 ? 'danger' : 'success'}">${this.escapeHtml(hostStatus)}</span></td>
             <td>${hostMeta}</td>
           </tr>
@@ -489,9 +537,9 @@ class PageCacheMaintenance {
       }).join('');
 
     const emptyState = !analysis.exists
-      ? `<div class="empty-card">No page cache directory exists yet.<br><span>${this.escapeHtml(analysis.pageStorageDir)}</span></div>`
+      ? `<div class="empty-card">No cache directories exist yet.<br><span>${this.escapeHtml(`${analysis.pageStorageDir}\n${analysis.ocrStorageDir}`)}</span></div>`
       : (analysis.totalFileCount === 0
-        ? `<div class="empty-card">No downloaded website files found.<br><span>${this.escapeHtml(analysis.pageStorageDir)}</span></div>`
+        ? `<div class="empty-card">No cached page or OCR files found.<br><span>${this.escapeHtml(`${analysis.pageStorageDir}\n${analysis.ocrStorageDir}`)}</span></div>`
         : '');
 
     return `<!doctype html>
@@ -499,7 +547,7 @@ class PageCacheMaintenance {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Page Cache Maintenance</title>
+  <title>Cache Maintenance</title>
   <style>
     :root {
       color-scheme: dark;
@@ -704,8 +752,8 @@ class PageCacheMaintenance {
       <div class="hero-main">
         ${logoDataUri ? `<img class="logo" src="${logoDataUri}" alt="Chunky Dad">` : ''}
         <div>
-          <h1>Page Cache Maintenance</h1>
-          <div class="subtitle">Review and prune downloaded website files in storage/pages.</div>
+          <h1>Cache Maintenance</h1>
+          <div class="subtitle">Review and prune cached website files in storage/pages and OCR results in storage/ocr.</div>
         </div>
       </div>
       <div class="meta">
@@ -771,7 +819,7 @@ class PageCacheMaintenance {
       </div>
     `}
 
-    <div class="footer">${this.escapeHtml(analysis.pageStorageDir)}</div>
+    <div class="footer">${this.escapeHtml(`${analysis.pageStorageDir} • ${analysis.ocrStorageDir}`)}</div>
   </div>
 </body>
 </html>`;
@@ -788,7 +836,7 @@ class PageCacheMaintenance {
     widget.setPadding(12, 12, 12, 12);
     widget.url = this.buildSelfUrl({ days: analysis.days });
 
-    const title = widget.addText('Page Cache');
+    const title = widget.addText('Cache');
     title.font = Font.boldSystemFont(FONT_SIZES.widget.label);
     title.textColor = new Color(BRAND.text);
 
@@ -820,6 +868,9 @@ class PageCacheMaintenance {
 }
 
 (async () => {
+  if (typeof module !== 'undefined' && module.exports) {
+    return;
+  }
   try {
     const maintenance = new PageCacheMaintenance();
     const days = maintenance.getSelectedDays();
@@ -838,7 +889,7 @@ class PageCacheMaintenance {
       const widget = new ListWidget();
       widget.backgroundColor = new Color(BRAND.primary);
       widget.setPadding(12, 12, 12, 12);
-      const title = widget.addText('Page Cache');
+      const title = widget.addText('Cache');
       title.font = Font.boldSystemFont(FONT_SIZES.widget.label);
       title.textColor = new Color(BRAND.text);
       widget.addSpacer(4);
@@ -859,3 +910,7 @@ class PageCacheMaintenance {
     }
   }
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { PageCacheMaintenance };
+}

--- a/scripts/page-cache-maintenance.js
+++ b/scripts/page-cache-maintenance.js
@@ -46,19 +46,25 @@ class PageCacheMaintenance {
         key: 'pages',
         label: 'Page cache',
         dir: this.pageStorageDir,
-        emptyLabel: 'downloaded website files',
         footerLabel: 'storage/pages'
       },
       {
         key: 'ocr',
         label: 'OCR cache',
         dir: this.ocrStorageDir,
-        emptyLabel: 'saved OCR responses',
         footerLabel: 'storage/ocr'
       }
     ];
     this.cacheDir = this.fm.joinPath(this.baseDir, 'cache');
     this.runtime = this.getRuntimeContext();
+  }
+
+  getCacheScopeFooterSummary(separator = ' and ') {
+    return this.cacheScopes.map(scope => scope.footerLabel).join(separator);
+  }
+
+  getCacheScopeDirectorySummary(separator = '\n') {
+    return this.cacheScopes.map(scope => scope.dir).join(separator);
   }
 
   getRuntimeContext() {
@@ -376,8 +382,6 @@ class PageCacheMaintenance {
       generatedAt: new Date(),
       days,
       exists: scopes.some(scope => scope.exists),
-      pageStorageDir: this.pageStorageDir,
-      ocrStorageDir: this.ocrStorageDir,
       cacheScopes: scopes,
       hostCount: hosts.length,
       totalFileCount: hosts.reduce((sum, host) => sum + host.totalFileCount, 0),
@@ -398,7 +402,7 @@ class PageCacheMaintenance {
       messageLines.push(`${analysis.removableHostCount} host folder(s) can be removed if empty after pruning.`);
     }
     messageLines.push('');
-    messageLines.push('This only touches cache files under storage/pages and storage/ocr.');
+    messageLines.push(`This only touches cache files under ${this.getCacheScopeFooterSummary()}.`);
     alert.message = messageLines.join('\n');
     alert.addAction(deleteHosts ? 'Delete files + hosts' : 'Delete files');
     alert.addCancelAction('Cancel');
@@ -537,9 +541,9 @@ class PageCacheMaintenance {
       }).join('');
 
     const emptyState = !analysis.exists
-      ? `<div class="empty-card">No cache directories exist yet.<br><span>${this.escapeHtml(`${analysis.pageStorageDir}\n${analysis.ocrStorageDir}`)}</span></div>`
+      ? `<div class="empty-card">No cache directories exist yet.<br><span>${this.escapeHtml(this.getCacheScopeDirectorySummary())}</span></div>`
       : (analysis.totalFileCount === 0
-        ? `<div class="empty-card">No cached page or OCR files found.<br><span>${this.escapeHtml(`${analysis.pageStorageDir}\n${analysis.ocrStorageDir}`)}</span></div>`
+        ? `<div class="empty-card">No cached files found.<br><span>${this.escapeHtml(this.getCacheScopeDirectorySummary())}</span></div>`
         : '');
 
     return `<!doctype html>
@@ -753,7 +757,7 @@ class PageCacheMaintenance {
         ${logoDataUri ? `<img class="logo" src="${logoDataUri}" alt="Chunky Dad">` : ''}
         <div>
           <h1>Cache Maintenance</h1>
-          <div class="subtitle">Review and prune cached website files in storage/pages and OCR results in storage/ocr.</div>
+          <div class="subtitle">Review and prune cached files in ${this.escapeHtml(this.getCacheScopeFooterSummary())}.</div>
         </div>
       </div>
       <div class="meta">
@@ -819,7 +823,7 @@ class PageCacheMaintenance {
       </div>
     `}
 
-    <div class="footer">${this.escapeHtml(`${analysis.pageStorageDir} • ${analysis.ocrStorageDir}`)}</div>
+    <div class="footer">${this.escapeHtml(this.getCacheScopeDirectorySummary(' • '))}</div>
   </div>
 </body>
 </html>`;

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -111,7 +111,6 @@ class AiWebParser {
         this.likelyImageQueryRegex = /(?:^|[?&])(w|h|q|fit|crop|auto|fm|format|s)=/;
         this.inlineUrlPattern = /(?:https?:\/\/|\/)[^\s"'<>]+/gi;
         this.aiPromptHistory = [];
-        this.defaultOcrTargetFields = ['startDate', 'endDate', 'title', 'description', 'bar', 'address', 'location'];
         this.defaultOcrPrompt = "Please extract all text from this image exactly as it appears. Return a JSON object with a single key 'text' containing the full extracted text, preserving line breaks as \\n. Do not add commentary.";
         this.urlParsePattern = /^(https?:)\/\/([^\/?#]+)([^?#]*)?(\?[^#]*)?(#.*)?$/i;
         // NOTE/TODO: If we need to support additional structured payload URL fields,
@@ -1477,13 +1476,6 @@ class AiWebParser {
             .trim();
     }
 
-    getMissingOcrFields(promptFields, mergedEvent, ocrConfig = {}) {
-        const configuredFields = new Set(Array.isArray(ocrConfig.targetFields) ? ocrConfig.targetFields : []);
-        return this.getRemainingPromptFields(promptFields, mergedEvent)
-            .map(field => this.normalizePromptFieldName(field))
-            .filter(field => field && configuredFields.has(field));
-    }
-
     collectOcrCandidateImageUrls(htmlData, ocrConfig = {}) {
         const sourceUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
         const candidates = [];
@@ -1578,7 +1570,13 @@ class AiWebParser {
             diagnostics.skippedReason = 'missing-endpoint-or-model';
             return { merged: mergedEvent, diagnostics };
         }
-        const missingTargetFields = this.getMissingOcrFields(promptFields, mergedEvent, ocrConfig);
+        let missingTargetFields = this.getRemainingPromptFields(promptFields, mergedEvent)
+            .map(field => this.normalizePromptFieldName(field))
+            .filter(Boolean);
+        if (Array.isArray(ocrConfig.targetFields) && ocrConfig.targetFields.length > 0) {
+            const configuredFields = new Set(ocrConfig.targetFields);
+            missingTargetFields = missingTargetFields.filter(field => configuredFields.has(field));
+        }
         diagnostics.attemptedFields = [...missingTargetFields];
         if (ocrConfig.requireMissingFields && missingTargetFields.length === 0) {
             diagnostics.skippedReason = 'no-target-fields-missing';
@@ -2359,14 +2357,13 @@ class AiWebParser {
         const rawOcr = parserAiConfig.ocr && typeof parserAiConfig.ocr === 'object'
             ? parserAiConfig.ocr
             : {};
-        const configuredTargetFields = Array.isArray(rawOcr.targetFields) && rawOcr.targetFields.length > 0
-            ? rawOcr.targetFields
-            : this.defaultOcrTargetFields;
-        const targetFields = Array.from(new Set(
-            configuredTargetFields
-                .map(field => this.normalizePromptFieldName(field))
-                .filter(Boolean)
-        ));
+        const targetFields = Array.isArray(rawOcr.targetFields) && rawOcr.targetFields.length > 0
+            ? Array.from(new Set(
+                rawOcr.targetFields
+                    .map(field => this.normalizePromptFieldName(field))
+                    .filter(Boolean)
+            ))
+            : null;
         const maxImages = Number.isFinite(Number(rawOcr.maxImages))
             ? Math.max(1, Math.min(4, Math.floor(Number(rawOcr.maxImages))))
             : 2;

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -111,6 +111,8 @@ class AiWebParser {
         this.likelyImageQueryRegex = /(?:^|[?&])(w|h|q|fit|crop|auto|fm|format|s)=/;
         this.inlineUrlPattern = /(?:https?:\/\/|\/)[^\s"'<>]+/gi;
         this.aiPromptHistory = [];
+        this.defaultOcrTargetFields = ['startDate', 'endDate', 'title', 'description', 'bar', 'address', 'location'];
+        this.defaultOcrPrompt = "Please extract all text from this image exactly as it appears. Return a JSON object with a single key 'text' containing the full extracted text, preserving line breaks as \\n. Do not add commentary.";
         this.urlParsePattern = /^(https?:)\/\/([^\/?#]+)([^?#]*)?(\?[^#]*)?(#.*)?$/i;
         // NOTE/TODO: If we need to support additional structured payload URL fields,
         // add alias keys here and mirror them in collectEventUrlsFromDataObject().
@@ -1218,6 +1220,427 @@ class AiWebParser {
         };
     }
 
+    sanitizeCacheSegment(segment) {
+        return String(segment || 'index')
+            .toLowerCase()
+            .replace(/[^a-z0-9._-]+/g, '-')
+            .replace(/^-+|-+$/g, '') || 'index';
+    }
+
+    hashCacheValue(value) {
+        let hash = 2166136261;
+        const input = String(value || '');
+        for (let i = 0; i < input.length; i++) {
+            hash ^= input.charCodeAt(i);
+            hash = Math.imul(hash, 16777619);
+        }
+        return (hash >>> 0).toString(36);
+    }
+
+    getOcrCacheRuntime() {
+        if (typeof FileManager !== 'undefined') {
+            try {
+                const fm = FileManager.iCloud();
+                const documentsDir = fm.documentsDirectory();
+                const baseDir = this.config.ocrCacheDir
+                    ? String(this.config.ocrCacheDir)
+                    : fm.joinPath(fm.joinPath(fm.joinPath(documentsDir, 'chunky-dad-scraper'), 'storage'), 'ocr');
+                return {
+                    type: 'scriptable',
+                    fm,
+                    baseDir
+                };
+            } catch (error) {
+                console.log(`🤖 AI Web: OCR cache setup unavailable in Scriptable: ${error.message}`);
+                return null;
+            }
+        }
+        if (typeof require === 'function') {
+            try {
+                const fs = require('fs');
+                const path = require('path');
+                const os = require('os');
+                const baseDir = this.config.ocrCacheDir
+                    ? String(this.config.ocrCacheDir)
+                    : path.join(os.homedir(), '.chunky-dad-scraper', 'storage', 'ocr');
+                return {
+                    type: 'node',
+                    fs,
+                    path,
+                    baseDir
+                };
+            } catch (error) {
+                console.log(`🤖 AI Web: OCR cache setup unavailable in Node: ${error.message}`);
+                return null;
+            }
+        }
+        return null;
+    }
+
+    getOcrCachePathParts(imageUrl, ocrConfig = {}) {
+        const rawUrl = String(imageUrl || '').trim();
+        const normalizedSource = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(rawUrl) || rawUrl);
+        const normalizedUrl = normalizedSource || rawUrl;
+        const parsed = this.parseUrlComponents(normalizedUrl);
+        const requestSignature = JSON.stringify({
+            model: String(ocrConfig.model || ''),
+            prompt: String(ocrConfig.prompt || ''),
+            options: {
+                numCtx: Number.isFinite(Number(ocrConfig.numCtx)) ? Number(ocrConfig.numCtx) : null,
+                numPredict: Number.isFinite(Number(ocrConfig.numPredict)) ? Number(ocrConfig.numPredict) : null,
+                temperature: Number.isFinite(Number(ocrConfig.temperature)) ? Number(ocrConfig.temperature) : null,
+                think: Boolean(ocrConfig.think),
+                keepAlive: String(ocrConfig.keepAlive || '')
+            }
+        });
+        const signatureHash = this.hashCacheValue(requestSignature);
+
+        if (parsed) {
+            const hostDir = this.sanitizeCacheSegment(parsed.hostname || 'unknown-host');
+            const pathSegments = String(parsed.pathname || '/')
+                .split('/')
+                .filter(Boolean)
+                .map(segment => this.sanitizeCacheSegment(segment))
+                .filter(Boolean);
+            let fileBase = pathSegments.length > 0 ? pathSegments.join('__') : 'index';
+            if (parsed.search) {
+                fileBase += `--q-${this.hashCacheValue(parsed.search)}`;
+            }
+            fileBase += `--ocr-${signatureHash}`;
+            if (fileBase.length > 140) {
+                fileBase = `${fileBase.slice(0, 96)}--${this.hashCacheValue(fileBase)}`;
+            }
+            return {
+                normalizedUrl,
+                hostDir,
+                fileName: `${fileBase}.json`,
+                signatureHash
+            };
+        }
+
+        return {
+            normalizedUrl,
+            hostDir: 'unknown-host',
+            fileName: `${this.hashCacheValue(`${normalizedUrl}|${signatureHash}`)}.json`,
+            signatureHash
+        };
+    }
+
+    async readCachedOcrResult(imageUrl, ocrConfig = {}) {
+        if (!ocrConfig.cacheEnabled) return null;
+        const runtime = this.getOcrCacheRuntime();
+        if (!runtime) return null;
+        const { normalizedUrl, hostDir, fileName } = this.getOcrCachePathParts(imageUrl, ocrConfig);
+
+        try {
+            let cachePath;
+            let rawPayload = null;
+            if (runtime.type === 'scriptable') {
+                const hostDirPath = runtime.fm.joinPath(runtime.baseDir, hostDir);
+                cachePath = runtime.fm.joinPath(hostDirPath, fileName);
+                if (!runtime.fm.fileExists(cachePath)) return null;
+                try {
+                    await runtime.fm.downloadFileFromiCloud(cachePath);
+                } catch (_) {}
+                rawPayload = runtime.fm.readString(cachePath);
+            } else {
+                cachePath = runtime.path.join(runtime.baseDir, hostDir, fileName);
+                rawPayload = await runtime.fs.promises.readFile(cachePath, 'utf8');
+            }
+            const cached = JSON.parse(rawPayload);
+            const responseText = cached && cached.response && typeof cached.response.text === 'string'
+                ? cached.response.text
+                : (typeof cached.text === 'string' ? cached.text : '');
+            if (!responseText) return null;
+            return {
+                imageUrl: cached.url || normalizedUrl,
+                text: responseText,
+                cachePath,
+                cached: true
+            };
+        } catch (error) {
+            const missingFile = error && (error.code === 'ENOENT' || /does not exist/i.test(String(error.message || '')));
+            if (!missingFile) {
+                console.log(`🤖 AI Web: OCR cache read failed for ${imageUrl}: ${error.message}`);
+            }
+            return null;
+        }
+    }
+
+    async writeCachedOcrResult(imageUrl, ocrConfig = {}, text = '') {
+        if (!ocrConfig.cacheEnabled) return null;
+        const resultText = String(text || '').trim();
+        if (!resultText) return null;
+        const runtime = this.getOcrCacheRuntime();
+        if (!runtime) return null;
+        const { normalizedUrl, hostDir, fileName, signatureHash } = this.getOcrCachePathParts(imageUrl, ocrConfig);
+        const payload = {
+            url: normalizedUrl,
+            cachedAt: new Date().toISOString(),
+            cacheKeyVersion: 1,
+            request: {
+                endpoint: String(ocrConfig.endpoint || ''),
+                model: String(ocrConfig.model || ''),
+                prompt: String(ocrConfig.prompt || ''),
+                signatureHash,
+                options: {
+                    numCtx: Number.isFinite(Number(ocrConfig.numCtx)) ? Number(ocrConfig.numCtx) : null,
+                    numPredict: Number.isFinite(Number(ocrConfig.numPredict)) ? Number(ocrConfig.numPredict) : null,
+                    temperature: Number.isFinite(Number(ocrConfig.temperature)) ? Number(ocrConfig.temperature) : null,
+                    think: Boolean(ocrConfig.think),
+                    keepAlive: String(ocrConfig.keepAlive || '')
+                }
+            },
+            response: {
+                text: resultText
+            }
+        };
+
+        try {
+            let cachePath;
+            if (runtime.type === 'scriptable') {
+                const hostDirPath = runtime.fm.joinPath(runtime.baseDir, hostDir);
+                if (!runtime.fm.fileExists(runtime.baseDir)) runtime.fm.createDirectory(runtime.baseDir, true);
+                if (!runtime.fm.fileExists(hostDirPath)) runtime.fm.createDirectory(hostDirPath, true);
+                cachePath = runtime.fm.joinPath(hostDirPath, fileName);
+                runtime.fm.writeString(cachePath, JSON.stringify(payload, null, 2));
+            } else {
+                const hostDirPath = runtime.path.join(runtime.baseDir, hostDir);
+                await runtime.fs.promises.mkdir(hostDirPath, { recursive: true });
+                cachePath = runtime.path.join(hostDirPath, fileName);
+                await runtime.fs.promises.writeFile(cachePath, JSON.stringify(payload, null, 2), 'utf8');
+            }
+            return cachePath;
+        } catch (error) {
+            console.log(`🤖 AI Web: OCR cache write failed for ${imageUrl}: ${error.message}`);
+            return null;
+        }
+    }
+
+    async loadImageAsBase64(imageUrl, timeoutSeconds) {
+        const rawUrl = String(imageUrl || '').trim();
+        const normalizedUrl = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(rawUrl) || rawUrl);
+        if (!normalizedUrl) {
+            throw new Error('Missing image URL');
+        }
+        if (typeof Request !== 'undefined') {
+            const request = new Request(normalizedUrl);
+            request.timeoutInterval = timeoutSeconds;
+            const image = await request.loadImage();
+            const jpegData = Data.fromJPEG(image);
+            return jpegData.toBase64String();
+        }
+        if (typeof fetch === 'function') {
+            const response = await fetch(normalizedUrl, {
+                signal: AbortSignal.timeout(timeoutSeconds * 1000)
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status} while downloading OCR image`);
+            }
+            const buffer = await response.arrayBuffer();
+            if (typeof Buffer !== 'undefined') {
+                return Buffer.from(buffer).toString('base64');
+            }
+            if (typeof btoa === 'function') {
+                let binary = '';
+                const bytes = new Uint8Array(buffer);
+                for (let i = 0; i < bytes.length; i++) {
+                    binary += String.fromCharCode(bytes[i]);
+                }
+                return btoa(binary);
+            }
+        }
+        throw new Error('No image HTTP client available');
+    }
+
+    parseOcrResponse(rawText) {
+        const parsed = this.parseAiEventResponse(rawText);
+        const text = parsed && typeof parsed.text === 'string' ? parsed.text : '';
+        return text
+            .replace(/\r\n?/g, '\n')
+            .trim();
+    }
+
+    getMissingOcrFields(promptFields, mergedEvent, ocrConfig = {}) {
+        const configuredFields = new Set(Array.isArray(ocrConfig.targetFields) ? ocrConfig.targetFields : []);
+        return this.getRemainingPromptFields(promptFields, mergedEvent)
+            .map(field => this.normalizePromptFieldName(field))
+            .filter(field => field && configuredFields.has(field));
+    }
+
+    collectOcrCandidateImageUrls(htmlData, ocrConfig = {}) {
+        const sourceUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
+        const candidates = [];
+        const seen = new Set();
+        const addImageUrl = rawUrl => {
+            const normalized = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(String(rawUrl || '').trim()) || String(rawUrl || '').trim());
+            if (!normalized) return;
+            if (!this.hasSupportedImageFilenameAtEnd(normalized) && !this.hasLikelyImageUrl(normalized)) return;
+            if (seen.has(normalized)) return;
+            seen.add(normalized);
+            candidates.push(normalized);
+        };
+        const preferred = this.buildImageEvidenceContextFromText(
+            htmlData && typeof htmlData.html === 'string' ? htmlData.html : '',
+            sourceUrl
+        );
+        preferred.forEach(addImageUrl);
+        this.buildImageEvidenceContext(htmlData).forEach(addImageUrl);
+        return candidates.slice(0, Math.max(1, Number(ocrConfig.maxImages) || 1));
+    }
+
+    buildOcrSnippet(imageUrl, text) {
+        return [
+            `OCR_IMAGE_URL: ${String(imageUrl || '').trim()}`,
+            'OCR_IMAGE_TEXT',
+            String(text || '').trim()
+        ].filter(Boolean).join('\n');
+    }
+
+    async getOcrTextForImage(imageUrl, ocrConfig = {}, passLabel = 'ocr') {
+        const cached = await this.readCachedOcrResult(imageUrl, ocrConfig);
+        if (cached && cached.text) {
+            console.log(`🤖 AI Web: OCR cache hit for ${cached.imageUrl || imageUrl}`);
+            return cached;
+        }
+
+        const base64Image = await this.loadImageAsBase64(imageUrl, ocrConfig.timeoutSeconds);
+        const payload = {
+            model: ocrConfig.model,
+            prompt: ocrConfig.prompt,
+            images: [base64Image],
+            format: 'json',
+            stream: false,
+            think: ocrConfig.think,
+            keep_alive: ocrConfig.keepAlive,
+            options: {
+                num_ctx: ocrConfig.numCtx,
+                num_predict: ocrConfig.numPredict,
+                temperature: ocrConfig.temperature
+            }
+        };
+        const historyPrompt = `${ocrConfig.prompt}\nOCR_IMAGE_URL: ${imageUrl}`;
+        const rawResponse = await this.sendAiRequest(ocrConfig, payload, passLabel, historyPrompt);
+        if (!rawResponse) return null;
+        const text = this.parseOcrResponse(rawResponse);
+        if (!text) {
+            console.warn(`🤖 AI Web: OCR response for ${imageUrl} did not include text`);
+            return null;
+        }
+        const cachePath = await this.writeCachedOcrResult(imageUrl, ocrConfig, text);
+        return {
+            imageUrl,
+            text,
+            cachePath,
+            cached: false
+        };
+    }
+
+    async recoverMissingFieldsFromImages(htmlData, aiConfig, cityConfig, parserConfig, promptFields, mergedEvent, validationState, extractionTrace) {
+        const ocrConfig = this.getOcrConfig(parserConfig, aiConfig);
+        const missingBefore = this.getRemainingPromptFields(promptFields, mergedEvent)
+            .map(field => this.normalizePromptFieldName(field))
+            .filter(Boolean);
+        const diagnostics = {
+            enabled: ocrConfig.enabled,
+            model: String(ocrConfig.model || ''),
+            missingBefore,
+            missingAfter: [...missingBefore],
+            attemptedFields: [],
+            recoveredFields: [],
+            attemptedImageCount: 0,
+            processedImageCount: 0,
+            cacheHits: 0,
+            images: [],
+            skippedReason: null
+        };
+        if (!ocrConfig.enabled) {
+            diagnostics.skippedReason = 'disabled';
+            return { merged: mergedEvent, diagnostics };
+        }
+        if (!ocrConfig.endpoint || !ocrConfig.model) {
+            diagnostics.skippedReason = 'missing-endpoint-or-model';
+            return { merged: mergedEvent, diagnostics };
+        }
+        const missingTargetFields = this.getMissingOcrFields(promptFields, mergedEvent, ocrConfig);
+        diagnostics.attemptedFields = [...missingTargetFields];
+        if (ocrConfig.requireMissingFields && missingTargetFields.length === 0) {
+            diagnostics.skippedReason = 'no-target-fields-missing';
+            return { merged: mergedEvent, diagnostics };
+        }
+        const imageUrls = this.collectOcrCandidateImageUrls(htmlData, ocrConfig);
+        diagnostics.attemptedImageCount = imageUrls.length;
+        if (imageUrls.length === 0) {
+            diagnostics.skippedReason = 'no-image-candidates';
+            return { merged: mergedEvent, diagnostics };
+        }
+
+        const snippets = [];
+        for (let index = 0; index < imageUrls.length; index++) {
+            const imageUrl = imageUrls[index];
+            try {
+                const ocrResult = await this.getOcrTextForImage(imageUrl, ocrConfig, `ocr ${index + 1}/${imageUrls.length}`);
+                if (!ocrResult || !ocrResult.text) {
+                    diagnostics.images.push({
+                        url: imageUrl,
+                        textChars: 0,
+                        cached: false,
+                        status: 'empty'
+                    });
+                    continue;
+                }
+                const trimmedText = ocrResult.text.length > ocrConfig.maxTextChars
+                    ? `${ocrResult.text.slice(0, ocrConfig.maxTextChars)}…`
+                    : ocrResult.text;
+                snippets.push(this.buildOcrSnippet(imageUrl, trimmedText));
+                diagnostics.processedImageCount += 1;
+                if (ocrResult.cached) diagnostics.cacheHits += 1;
+                diagnostics.images.push({
+                    url: imageUrl,
+                    textChars: trimmedText.length,
+                    cached: Boolean(ocrResult.cached),
+                    status: 'ok'
+                });
+            } catch (error) {
+                diagnostics.images.push({
+                    url: imageUrl,
+                    textChars: 0,
+                    cached: false,
+                    status: 'error',
+                    error: error && error.message ? error.message : String(error || '')
+                });
+                console.warn(`🤖 AI Web: OCR failed for ${imageUrl}: ${error.message}`);
+            }
+        }
+
+        if (snippets.length === 0) {
+            diagnostics.skippedReason = 'no-ocr-text';
+            return { merged: mergedEvent, diagnostics };
+        }
+
+        const partial = await this.extractFieldsAcrossSnippets(
+            htmlData,
+            aiConfig,
+            cityConfig,
+            parserConfig,
+            missingTargetFields,
+            snippets,
+            'ocr',
+            validationState,
+            {
+                partitionLabel: 'content',
+                extractionTrace,
+                promptVariant: 'alternate'
+            }
+        );
+        const merged = this.mergeAiEventFields(mergedEvent, partial);
+        diagnostics.missingAfter = this.getRemainingPromptFields(promptFields, merged)
+            .map(field => this.normalizePromptFieldName(field))
+            .filter(Boolean);
+        diagnostics.recoveredFields = missingBefore.filter(field => !diagnostics.missingAfter.includes(field));
+        return { merged, diagnostics };
+    }
+
     scoreAdditionalUrl(url, sourceUrl, context = '') {
         let score = 0;
         const parsedUrl = this.parseUrlComponents(url);
@@ -1909,6 +2332,59 @@ class AiWebParser {
             think: Object.prototype.hasOwnProperty.call(aiConfig, 'think') ? Boolean(aiConfig.think) : false,
             timeoutSeconds: Number.isFinite(Number(aiConfig.timeoutSeconds)) ? Number(aiConfig.timeoutSeconds) : 120,
             keepAlive: Object.prototype.hasOwnProperty.call(aiConfig, 'keepAlive') ? String(aiConfig.keepAlive) : '5m'
+        };
+    }
+
+    getOcrConfig(parserConfig = {}, aiConfig = null) {
+        const baseAiConfig = aiConfig && typeof aiConfig === 'object' ? aiConfig : this.getAiConfig(parserConfig);
+        const parserAiConfig = parserConfig && parserConfig.ai && typeof parserConfig.ai === 'object'
+            ? parserConfig.ai
+            : {};
+        const rawOcr = parserAiConfig.ocr && typeof parserAiConfig.ocr === 'object'
+            ? parserAiConfig.ocr
+            : {};
+        const configuredTargetFields = Array.isArray(rawOcr.targetFields) && rawOcr.targetFields.length > 0
+            ? rawOcr.targetFields
+            : this.defaultOcrTargetFields;
+        const targetFields = Array.from(new Set(
+            configuredTargetFields
+                .map(field => this.normalizePromptFieldName(field))
+                .filter(Boolean)
+        ));
+        const maxImages = Number.isFinite(Number(rawOcr.maxImages))
+            ? Math.max(1, Math.min(4, Math.floor(Number(rawOcr.maxImages))))
+            : 2;
+        const maxTextChars = Number.isFinite(Number(rawOcr.maxTextChars))
+            ? Math.max(250, Math.floor(Number(rawOcr.maxTextChars)))
+            : 4000;
+        return {
+            enabled: rawOcr.enabled !== false,
+            endpoint: String(rawOcr.endpoint || baseAiConfig.endpoint || ''),
+            model: String(rawOcr.model || 'qwen2.5vl:3b'),
+            prompt: String(rawOcr.prompt || this.defaultOcrPrompt),
+            timeoutSeconds: Number.isFinite(Number(rawOcr.timeoutSeconds))
+                ? Number(rawOcr.timeoutSeconds)
+                : baseAiConfig.timeoutSeconds,
+            keepAlive: Object.prototype.hasOwnProperty.call(rawOcr, 'keepAlive')
+                ? String(rawOcr.keepAlive)
+                : baseAiConfig.keepAlive,
+            numCtx: Number.isFinite(Number(rawOcr.numCtx))
+                ? Number(rawOcr.numCtx)
+                : baseAiConfig.numCtx,
+            numPredict: Number.isFinite(Number(rawOcr.numPredict))
+                ? Number(rawOcr.numPredict)
+                : baseAiConfig.numPredict,
+            temperature: Number.isFinite(Number(rawOcr.temperature))
+                ? Number(rawOcr.temperature)
+                : baseAiConfig.temperature,
+            think: Object.prototype.hasOwnProperty.call(rawOcr, 'think')
+                ? Boolean(rawOcr.think)
+                : baseAiConfig.think,
+            maxImages,
+            maxTextChars,
+            cacheEnabled: rawOcr.cache !== false,
+            requireMissingFields: rawOcr.requireMissingFields !== false,
+            targetFields
         };
     }
 
@@ -2705,6 +3181,23 @@ class AiWebParser {
             if (retryPasses >= confidenceRuntime.maxRetryPasses) break;
         }
 
+        const ocrRecovery = await this.recoverMissingFieldsFromImages(
+            htmlData,
+            aiConfig,
+            cityConfig,
+            parserConfig,
+            promptFields,
+            merged,
+            validationState,
+            extractionTrace
+        );
+        merged = ocrRecovery && ocrRecovery.merged && typeof ocrRecovery.merged === 'object'
+            ? ocrRecovery.merged
+            : merged;
+        const ocrDiagnostics = ocrRecovery && ocrRecovery.diagnostics && typeof ocrRecovery.diagnostics === 'object'
+            ? ocrRecovery.diagnostics
+            : null;
+
         const confidenceDiagnostics = this.buildConfidenceDiagnostics(
             sectionBundle,
             promptFields,
@@ -2728,6 +3221,7 @@ class AiWebParser {
                 maxRetryPasses: confidenceRuntime.maxRetryPasses
             }
         };
+        confidenceDiagnostics.ocr = ocrDiagnostics;
 
         if (merged && typeof merged === 'object' && validationState.validatedFields.size > 0) {
             merged.__preValidatedFields = Array.from(validationState.validatedFields);
@@ -3065,26 +3559,17 @@ ${String(rawResponse || '')}`;
         return null;
     }
 
-    async callAiGenerate(aiConfig, prompt, passLabel) {
-        if (!prompt) return null;
+    async sendAiRequest(aiConfig, payload, passLabel, promptForHistory = '') {
         const label = passLabel ? ` (${passLabel} pass)` : '';
+        const prompt = String(promptForHistory || (payload && typeof payload.prompt === 'string' ? payload.prompt : ''));
         const promptChars = prompt.length;
-        this.recordAiPrompt(prompt, passLabel, aiConfig);
-        const payload = {
-            model: aiConfig.model,
-            prompt,
-            format: 'json',
-            stream: false,
-            think: aiConfig.think,
-            keep_alive: aiConfig.keepAlive,
-            options: {
-                num_ctx: aiConfig.numCtx,
-                num_predict: aiConfig.numPredict,
-                temperature: aiConfig.temperature
-            }
-        };
+        if (prompt) {
+            this.recordAiPrompt(prompt, passLabel, aiConfig);
+        }
         console.log(`🤖 AI Web: Sending AI request${label} to ${aiConfig.endpoint} — model: ${aiConfig.model}, stream: ${payload.stream}, prompt: ${promptChars} chars`);
-        console.log(`🤖 AI Web: Full prompt${label} (${promptChars} chars)\n${prompt}`);
+        if (prompt) {
+            console.log(`🤖 AI Web: Full prompt${label} (${promptChars} chars)\n${prompt}`);
+        }
         const startTime = Date.now();
         try {
             let responseText = null;
@@ -3139,6 +3624,24 @@ ${String(rawResponse || '')}`;
             console.warn(`🤖 AI Web: AI request${label} to ${aiConfig.endpoint} with model ${aiConfig.model} failed after ${elapsed}ms (${errorType}): ${error.message}`);
             return null;
         }
+    }
+
+    async callAiGenerate(aiConfig, prompt, passLabel) {
+        if (!prompt) return null;
+        const payload = {
+            model: aiConfig.model,
+            prompt,
+            format: 'json',
+            stream: false,
+            think: aiConfig.think,
+            keep_alive: aiConfig.keepAlive,
+            options: {
+                num_ctx: aiConfig.numCtx,
+                num_predict: aiConfig.numPredict,
+                temperature: aiConfig.temperature
+            }
+        };
+        return this.sendAiRequest(aiConfig, payload, passLabel, prompt);
     }
 
     extractFirstJsonObject(text) {

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1280,7 +1280,23 @@ class AiWebParser {
     getOcrCachePathParts(imageUrl, ocrConfig = {}) {
         const rawUrl = String(imageUrl || '').trim();
         const normalizedSource = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(rawUrl) || rawUrl);
-        const normalizedUrl = normalizedSource || rawUrl;
+        let normalizedUrl = normalizedSource || rawUrl;
+        try {
+            if (typeof URL === 'function' && normalizedUrl) {
+                const parsed = new URL(normalizedUrl);
+                parsed.hash = '';
+                parsed.protocol = String(parsed.protocol || '').toLowerCase();
+                parsed.hostname = String(parsed.hostname || '').toLowerCase();
+                const searchEntries = Array.from(parsed.searchParams.entries())
+                    .sort(([leftKey, leftValue], [rightKey, rightValue]) => {
+                        if (leftKey === rightKey) return leftValue.localeCompare(rightValue);
+                        return leftKey.localeCompare(rightKey);
+                    });
+                parsed.search = '';
+                searchEntries.forEach(([key, value]) => parsed.searchParams.append(key, value));
+                normalizedUrl = parsed.toString();
+            }
+        } catch (_) {}
         const parsed = this.parseUrlComponents(normalizedUrl);
         const requestSignature = JSON.stringify({
             model: String(ocrConfig.model || ''),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep OCR recovery minimal by reusing the parser’s existing requested/missing prompt fields instead of maintaining a second hardcoded field list
- keep OCR cache results in `storage/ocr`, keyed by normalized image URL plus the OCR model/request parameters
- simplify `scripts/page-cache-maintenance.js` so page/OCR scope strings are derived from shared scope metadata instead of repeated literals

## Testing
- `node --check scripts/parsers/ai-web-parser.js`
- `node --check scripts/page-cache-maintenance.js`
- focused local verification of OCR cache round-trip/keying, OCR recovery reusing current missing prompt fields, and maintenance analysis/prune across both `storage/pages` and `storage/ocr`
- no live AI endpoint calls were made during testing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-467f9b8b-64e3-460c-ad1f-c98a76de0ce3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-467f9b8b-64e3-460c-ad1f-c98a76de0ce3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

