### PR TITLE
Tighten AI web OCR defaults

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -111,7 +111,16 @@ class AiWebParser {
         this.likelyImageQueryRegex = /(?:^|[?&])(w|h|q|fit|crop|auto|fm|format|s)=/;
         this.inlineUrlPattern = /(?:https?:\/\/|\/)[^\s"'<>]+/gi;
         this.aiPromptHistory = [];
+        this.defaultOcrModel = 'qwen2.5vl:3b';
         this.defaultOcrPrompt = "Please extract all text from this image exactly as it appears. Return a JSON object with a single key 'text' containing the full extracted text, preserving line breaks as \\n. Do not add commentary.";
+        this.defaultOcrRequestConfig = {
+            timeoutSeconds: 300,
+            keepAlive: '5m',
+            numCtx: 8192,
+            numPredict: 2000,
+            temperature: 0,
+            think: false
+        };
         this.urlParsePattern = /^(https?:)\/\/([^\/?#]+)([^?#]*)?(\?[^#]*)?(#.*)?$/i;
         // NOTE/TODO: If we need to support additional structured payload URL fields,
         // add alias keys here and mirror them in collectEventUrlsFromDataObject().
@@ -1513,6 +1522,7 @@ class AiWebParser {
         }
 
         const base64Image = await this.loadImageAsBase64(imageUrl, ocrConfig.timeoutSeconds);
+        console.log(`🤖 AI Web: OCR image attached via base64 payload (${base64Image.length} chars)`);
         const payload = {
             model: ocrConfig.model,
             prompt: ocrConfig.prompt,
@@ -1527,8 +1537,7 @@ class AiWebParser {
                 temperature: ocrConfig.temperature
             }
         };
-        const historyPrompt = `${ocrConfig.prompt}\nOCR_IMAGE_URL: ${imageUrl}`;
-        const rawResponse = await this.sendAiRequest(ocrConfig, payload, passLabel, historyPrompt);
+        const rawResponse = await this.sendAiRequest(ocrConfig, payload, passLabel, ocrConfig.prompt);
         if (!rawResponse) return null;
         const text = this.parseOcrResponse(rawResponse);
         if (!text) {
@@ -2373,26 +2382,26 @@ class AiWebParser {
         return {
             enabled: rawOcr.enabled !== false,
             endpoint: String(rawOcr.endpoint || baseAiConfig.endpoint || ''),
-            model: String(rawOcr.model || 'qwen2.5vl:3b'),
+            model: String(rawOcr.model || this.defaultOcrModel),
             prompt: String(rawOcr.prompt || this.defaultOcrPrompt),
             timeoutSeconds: Number.isFinite(Number(rawOcr.timeoutSeconds))
                 ? Number(rawOcr.timeoutSeconds)
-                : baseAiConfig.timeoutSeconds,
+                : this.defaultOcrRequestConfig.timeoutSeconds,
             keepAlive: Object.prototype.hasOwnProperty.call(rawOcr, 'keepAlive')
                 ? String(rawOcr.keepAlive)
-                : baseAiConfig.keepAlive,
+                : this.defaultOcrRequestConfig.keepAlive,
             numCtx: Number.isFinite(Number(rawOcr.numCtx))
                 ? Number(rawOcr.numCtx)
-                : baseAiConfig.numCtx,
+                : this.defaultOcrRequestConfig.numCtx,
             numPredict: Number.isFinite(Number(rawOcr.numPredict))
                 ? Number(rawOcr.numPredict)
-                : baseAiConfig.numPredict,
+                : this.defaultOcrRequestConfig.numPredict,
             temperature: Number.isFinite(Number(rawOcr.temperature))
                 ? Number(rawOcr.temperature)
-                : baseAiConfig.temperature,
+                : this.defaultOcrRequestConfig.temperature,
             think: Object.prototype.hasOwnProperty.call(rawOcr, 'think')
                 ? Boolean(rawOcr.think)
-                : baseAiConfig.think,
+                : this.defaultOcrRequestConfig.think,
             maxImages,
             maxTextChars,
             cacheEnabled: rawOcr.cache !== false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- give AI Web OCR its own default request settings tuned for vision OCR
- stop logging/recording OCR prompts with `OCR_IMAGE_URL`
- keep OCR image delivery on the existing base64 `images` payload path

## Testing
- local Node validation of `getOcrConfig()` defaults and OCR request payload behavior
- no live Ollama requests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9feae45f-5357-449c-90a8-23c57316e9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9feae45f-5357-449c-90a8-23c57316e9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

