### PR TITLE
Improve ai-web-parser multi-event image pairing

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -675,8 +675,12 @@ class AiWebParser {
         const source = String(html || '');
         const sourceSegments = Array.isArray(segments) ? segments : [];
         if (!source || sourceSegments.length < 2) return sourceSegments;
-        const orderedPageImages = this.extractOrderedImageUrlsFromHtml(source, sourceUrl, sourceSegments.length + 2);
-        if (orderedPageImages.length < 2) return sourceSegments;
+        const pageImageRecords = this.extractOrderedImageRecordsFromHtml(
+            source,
+            sourceUrl,
+            Math.max(sourceSegments.length * 4, sourceSegments.length + 6)
+        );
+        if (pageImageRecords.length < 2) return sourceSegments;
 
         const primarySegmentImages = sourceSegments.map(segment => {
             const images = this.extractOrderedImageUrlsFromHtml(
@@ -693,8 +697,18 @@ class AiWebParser {
             return sourceSegments;
         }
 
+        const pageTextRecords = this.extractBodyPartRecords(source);
+        const segmentBounds = sourceSegments.map(segment => this.findMultiEventSegmentTextBounds(
+            source,
+            segment && Array.isArray(segment.lines) ? segment.lines : [],
+            pageTextRecords
+        ));
+        const matchedImageUrls = this.matchOrderedImagesToSegments(segmentBounds, pageImageRecords);
+        const orderedPageImages = pageImageRecords.map(record => record.url);
+        const fallbackSequentialImageUrls = orderedPageImages.slice(0, sourceSegments.length);
+
         return sourceSegments.map((segment, index) => {
-            const orderedImage = orderedPageImages[index];
+            const orderedImage = matchedImageUrls[index] || fallbackSequentialImageUrls[index];
             if (!orderedImage || !segment || typeof segment !== 'object') return segment;
             const existingImages = this.extractOrderedImageUrlsFromHtml(
                 segment && typeof segment.html === 'string' ? segment.html : '',
@@ -709,7 +723,111 @@ class AiWebParser {
         });
     }
 
-    extractOrderedImageUrlsFromHtml(html, sourceUrl = '', maxUrls = Infinity) {
+    matchOrderedImagesToSegments(segmentBounds, imageRecords) {
+        const boundsList = Array.isArray(segmentBounds) ? segmentBounds : [];
+        const records = Array.isArray(imageRecords) ? imageRecords : [];
+        if (boundsList.length === 0 || records.length === 0) return [];
+        if (!boundsList.some(bounds => bounds && Number.isFinite(bounds.rawStart) && Number.isFinite(bounds.rawEnd))) {
+            return [];
+        }
+
+        const betterState = (current, candidate) => {
+            if (!candidate) return current;
+            if (!current) return candidate;
+            if (candidate.matches !== current.matches) {
+                return candidate.matches > current.matches ? candidate : current;
+            }
+            if (candidate.cost !== current.cost) {
+                return candidate.cost < current.cost ? candidate : current;
+            }
+            return candidate.steps < current.steps ? candidate : current;
+        };
+
+        const dp = Array.from({ length: boundsList.length + 1 }, () => Array(records.length + 1).fill(null));
+        dp[0][0] = { matches: 0, cost: 0, steps: 0, prev: null, action: '' };
+
+        for (let segmentIndex = 0; segmentIndex <= boundsList.length; segmentIndex++) {
+            for (let imageIndex = 0; imageIndex <= records.length; imageIndex++) {
+                const state = dp[segmentIndex][imageIndex];
+                if (!state) continue;
+
+                if (segmentIndex < boundsList.length) {
+                    dp[segmentIndex + 1][imageIndex] = betterState(dp[segmentIndex + 1][imageIndex], {
+                        matches: state.matches,
+                        cost: state.cost,
+                        steps: state.steps + 1,
+                        prev: [segmentIndex, imageIndex],
+                        action: 'skip-segment'
+                    });
+                }
+
+                if (imageIndex < records.length) {
+                    dp[segmentIndex][imageIndex + 1] = betterState(dp[segmentIndex][imageIndex + 1], {
+                        matches: state.matches,
+                        cost: state.cost,
+                        steps: state.steps + 1,
+                        prev: [segmentIndex, imageIndex],
+                        action: 'skip-image'
+                    });
+                }
+
+                if (segmentIndex < boundsList.length && imageIndex < records.length) {
+                    const pairingCost = this.getSegmentImagePairingCost(boundsList[segmentIndex], records[imageIndex]);
+                    if (Number.isFinite(pairingCost)) {
+                        dp[segmentIndex + 1][imageIndex + 1] = betterState(dp[segmentIndex + 1][imageIndex + 1], {
+                            matches: state.matches + 1,
+                            cost: state.cost + pairingCost,
+                            steps: state.steps + 1,
+                            prev: [segmentIndex, imageIndex],
+                            action: 'match'
+                        });
+                    }
+                }
+            }
+        }
+
+        const matchedUrls = [];
+        let segmentIndex = boundsList.length;
+        let imageIndex = records.length;
+        let state = dp[segmentIndex][imageIndex];
+        while (state && state.prev) {
+            if (state.action === 'match') {
+                matchedUrls[segmentIndex - 1] = records[imageIndex - 1].url;
+            }
+            const [prevSegmentIndex, prevImageIndex] = state.prev;
+            segmentIndex = prevSegmentIndex;
+            imageIndex = prevImageIndex;
+            state = dp[segmentIndex][imageIndex];
+        }
+        return matchedUrls;
+    }
+
+    getSegmentImagePairingCost(segmentBounds, imageRecord) {
+        if (!segmentBounds || !imageRecord) return Infinity;
+        const segmentStart = Number(segmentBounds.rawStart);
+        const segmentEnd = Number(segmentBounds.rawEnd);
+        const imageStart = Number(imageRecord.start);
+        const rawImageEnd = Number(imageRecord.end);
+        const imageEnd = Number.isFinite(rawImageEnd) && rawImageEnd >= imageStart ? rawImageEnd : imageStart;
+        if (!Number.isFinite(segmentStart) || !Number.isFinite(segmentEnd) || !Number.isFinite(imageStart)) {
+            return Infinity;
+        }
+
+        if (imageStart <= segmentEnd && imageEnd >= segmentStart) {
+            return 0;
+        }
+        if (imageEnd <= segmentStart) {
+            const gap = segmentStart - imageEnd;
+            return gap <= 12000 ? gap : Infinity;
+        }
+        if (imageStart >= segmentEnd) {
+            const gap = imageStart - segmentEnd;
+            return gap <= 5000 ? gap + 2000 : Infinity;
+        }
+        return Infinity;
+    }
+
+    extractOrderedImageRecordsFromHtml(html, sourceUrl = '', maxUrls = Infinity) {
         const source = String(html || '');
         if (!source) return [];
         const limit = Number.isFinite(Number(maxUrls)) ? Math.max(0, Math.floor(Number(maxUrls))) : Infinity;
@@ -717,7 +835,7 @@ class AiWebParser {
 
         const results = [];
         const seen = new Set();
-        const addImageUrl = rawUrl => {
+        const addImageRecord = (rawUrl, start, end) => {
             const normalized = this.normalizeUrl(String(rawUrl || '').trim(), sourceUrl);
             if (!normalized) return;
             const unwrapped = this.unwrapImageProxyUrl(normalized);
@@ -725,7 +843,11 @@ class AiWebParser {
             if (!finalUrl || seen.has(finalUrl)) return;
             if (!this.hasSupportedImageFilenameAtEnd(finalUrl) && !this.hasLikelyImageUrl(finalUrl)) return;
             seen.add(finalUrl);
-            results.push(finalUrl);
+            results.push({
+                url: finalUrl,
+                start: Number.isFinite(Number(start)) ? Number(start) : -1,
+                end: Number.isFinite(Number(end)) ? Number(end) : (Number.isFinite(Number(start)) ? Number(start) : -1)
+            });
         };
 
         const attrPatterns = [
@@ -741,10 +863,10 @@ class AiWebParser {
                 if (pattern.source.includes('srcset')) {
                     attributeValue.split(',').forEach(part => {
                         const candidate = String(part || '').trim().split(/\s+/)[0];
-                        if (candidate) addImageUrl(candidate);
+                        if (candidate) addImageRecord(candidate, match.index, pattern.lastIndex);
                     });
                 } else {
-                    addImageUrl(attributeValue);
+                    addImageRecord(attributeValue, match.index, pattern.lastIndex);
                 }
                 if (results.length >= limit) return results.slice(0, limit);
             }
@@ -752,10 +874,17 @@ class AiWebParser {
 
         const rawCandidates = this.extractUrlCandidatesFromRawHtml(source);
         for (const candidate of rawCandidates) {
-            addImageUrl(candidate);
+            const rawUrl = candidate && typeof candidate === 'object' ? candidate.url : candidate;
+            addImageRecord(rawUrl, -1, -1);
             if (results.length >= limit) break;
         }
         return results.slice(0, limit);
+    }
+
+    extractOrderedImageUrlsFromHtml(html, sourceUrl = '', maxUrls = Infinity) {
+        return this.extractOrderedImageRecordsFromHtml(html, sourceUrl, maxUrls)
+            .map(record => record.url)
+            .filter(Boolean);
     }
     trimLeadingMultiEventNoise(lines) {
         const normalizedLines = (Array.isArray(lines) ? lines : [])
@@ -840,16 +969,13 @@ class AiWebParser {
             .filter(Boolean);
         if (!source || segmentLines.length === 0) return '';
 
-        const records = this.extractBodyPartRecords(source);
-        const matchedRecords = this.findBodyPartRecordsForLines(records, segmentLines);
-        if (matchedRecords.length === 0) return segmentLines.join('\n');
-
-        const firstStart = Math.min(...matchedRecords.map(record => record.rawStart).filter(value => Number.isFinite(value)));
-        const lastEnd = Math.max(...matchedRecords.map(record => record.rawEnd).filter(value => Number.isFinite(value)));
-        if (!Number.isFinite(firstStart) || !Number.isFinite(lastEnd) || lastEnd <= firstStart) {
+        const textBounds = this.findMultiEventSegmentTextBounds(source, segmentLines);
+        if (!textBounds) {
             return segmentLines.join('\n');
         }
 
+        const firstStart = textBounds.rawStart;
+        const lastEnd = textBounds.rawEnd;
         const rawStart = this.findMultiEventSegmentResourceStart(source, firstStart);
         // If we already captured an image block before the segment text, stop at the
         // text boundary so we do not accidentally absorb the next segment's image.
@@ -857,6 +983,30 @@ class AiWebParser {
             ? lastEnd
             : this.findMultiEventSegmentResourceEnd(source, lastEnd);
         return source.slice(rawStart, rawEnd);
+    }
+
+    findMultiEventSegmentTextBounds(html, lines, records = null) {
+        const source = String(html || '');
+        const segmentLines = (Array.isArray(lines) ? lines : [])
+            .map(line => this.normalizeWhitespace(line))
+            .filter(Boolean);
+        if (!source || segmentLines.length === 0) return null;
+
+        const bodyPartRecords = Array.isArray(records) ? records : this.extractBodyPartRecords(source);
+        const matchedRecords = this.findBodyPartRecordsForLines(bodyPartRecords, segmentLines);
+        if (matchedRecords.length === 0) return null;
+
+        const firstStart = Math.min(...matchedRecords.map(record => record.rawStart).filter(value => Number.isFinite(value)));
+        const lastEnd = Math.max(...matchedRecords.map(record => record.rawEnd).filter(value => Number.isFinite(value)));
+        if (!Number.isFinite(firstStart) || !Number.isFinite(lastEnd) || lastEnd <= firstStart) {
+            return null;
+        }
+
+        return {
+            rawStart: firstStart,
+            rawEnd: lastEnd,
+            matchedRecords
+        };
     }
 
     findBodyPartRecordsForLines(records, lines) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -4,8 +4,11 @@ const assert = require('node:assert/strict');
 const { AiWebParser } = require('./ai-web-parser');
 
 function normalizeUrl(url, baseUrl = 'https://furball.example/events') {
+  const value = String(url || '').trim();
+  if (!value) return '';
+  if (/^https?:\/\//i.test(value)) return value;
   try {
-    return new URL(String(url || '').trim(), baseUrl).toString();
+    return new URL(value, baseUrl || 'https://furball.example/events').toString();
   } catch (_) {
     return '';
   }
@@ -30,18 +33,16 @@ test('pairs nearby row-split event images to the matching multi-event segments',
           <div class="event-card-image"><img src="/images/event-2.jpg" alt="Furball Pool Party flyer" /></div>
         </section>
 
-        <section class="events-grid">
-          <article class="event-card-copy">
-            <p>July 10, 2026</p>
-            <h3>FURBALL BLACKOUT</h3>
-            <p>3 Dollar Bill</p>
-          </article>
-          <article class="event-card-copy">
-            <p>July 24, 2026</p>
-            <h3>FURBALL POOL PARTY</h3>
-            <p>Elsewhere Rooftop</p>
-          </article>
-        </section>
+        <article class="event-card-copy">
+          <p>July 10, 2026</p>
+          <h3>FURBALL BLACKOUT</h3>
+          <p>3 Dollar Bill</p>
+        </article>
+        <article class="event-card-copy">
+          <p>July 24, 2026</p>
+          <h3>FURBALL POOL PARTY</h3>
+          <p>Elsewhere Rooftop</p>
+        </article>
 
         <article class="event-card">
           <div class="event-card-image"><img src="/images/event-3.jpg" alt="Furball Summer Bash flyer" /></div>

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1,0 +1,87 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { AiWebParser } = require('./ai-web-parser');
+
+function normalizeUrl(url, baseUrl = 'https://furball.example/events') {
+  try {
+    return new URL(String(url || '').trim(), baseUrl).toString();
+  } catch (_) {
+    return '';
+  }
+}
+
+function createParser() {
+  return new AiWebParser({ normalizeUrl });
+}
+
+test('pairs nearby row-split event images to the matching multi-event segments', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://furball.example/events';
+  const html = `
+    <html>
+      <body>
+        <section class="page-hero">
+          <img src="/images/hero-banner.jpg" alt="Hero banner" />
+        </section>
+
+        <section class="events-grid">
+          <div class="event-card-image"><img src="/images/event-1.jpg" alt="Furball Blackout flyer" /></div>
+          <div class="event-card-image"><img src="/images/event-2.jpg" alt="Furball Pool Party flyer" /></div>
+        </section>
+
+        <section class="events-grid">
+          <article class="event-card-copy">
+            <p>July 10, 2026</p>
+            <h3>FURBALL BLACKOUT</h3>
+            <p>3 Dollar Bill</p>
+          </article>
+          <article class="event-card-copy">
+            <p>July 24, 2026</p>
+            <h3>FURBALL POOL PARTY</h3>
+            <p>Elsewhere Rooftop</p>
+          </article>
+        </section>
+
+        <article class="event-card">
+          <div class="event-card-image"><img src="/images/event-3.jpg" alt="Furball Summer Bash flyer" /></div>
+          <div class="event-card-copy">
+            <p>August 14, 2026</p>
+            <h3>FURBALL SUMMER BASH</h3>
+            <p>Knockdown Center</p>
+          </div>
+        </article>
+
+        <article class="event-card">
+          <div class="event-card-image"><img src="/images/event-4.jpg" alt="Furball Labor Day flyer" /></div>
+          <div class="event-card-copy">
+            <p>September 4, 2026</p>
+            <h3>FURBALL LABOR DAY</h3>
+            <p>House of Yes</p>
+          </div>
+        </article>
+      </body>
+    </html>
+  `;
+
+  const segments = parser.buildMultiEventSegments(html, sourceUrl);
+  assert.equal(segments.length, 4);
+
+  const pairedImages = segments.map(segment => {
+    const diagnostics = parser.describeMultiEventSegment(segment, sourceUrl);
+    return diagnostics.imageUrls[0] || '';
+  });
+
+  assert.deepEqual(pairedImages, [
+    'https://furball.example/images/event-1.jpg',
+    'https://furball.example/images/event-2.jpg',
+    'https://furball.example/images/event-3.jpg',
+    'https://furball.example/images/event-4.jpg'
+  ]);
+  assert.ok(!pairedImages.includes('https://furball.example/images/hero-banner.jpg'));
+  assert.deepEqual(segments.slice(0, 2).map(segment => segment.imageHintUrls), [
+    ['https://furball.example/images/event-1.jpg'],
+    ['https://furball.example/images/event-2.jpg']
+  ]);
+  assert.deepEqual(segments.slice(2).map(segment => segment.imageHintUrls || null), [null, null]);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the brittle sequential multi-event image hint fallback with position-aware ordered matching
- reuse extracted text bounds so row-split layouts pair event fliers to the closest matching segment instead of whatever page image appears at the same index
- add a focused parser regression test covering a Furball-style image-row/text-row layout without making the parser site-specific

## Testing
- `node --test scripts/parsers/ai-web-parser.test.js`
- `node --check scripts/parsers/ai-web-parser.js`
- `node --check scripts/parsers/ai-web-parser.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99011098-6b28-4935-9948-c44b47fbfb6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99011098-6b28-4935-9948-c44b47fbfb6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

