### PR TITLE
Fix cache cleanup UI and display segment images

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -4559,11 +4559,20 @@ class ScriptableAdapter {
 
         const totalSegments = segmentUrlEntries.reduce((sum, [, segs]) => sum + segs.length, 0);
         const urlBlocks = segmentUrlEntries.map(([url, segs]) => {
-            const segmentItems = segs.map(seg =>
-                `<div style="padding:4px 8px; background:var(--background-light); border-left:3px solid var(--border-color); margin-bottom:4px; font-size:11px; font-family:monospace;"><span style="opacity:0.6;">Segment ${seg.index} (${seg.lineCount} lines):</span> ${this.escapeHtml(seg.preview)}</div>`
-            ).join('');
-            return `<div style="margin-bottom:10px;">
-                <div style="font-size:11px; font-family:monospace; opacity:0.7; margin-bottom:4px;">${this.escapeHtml(url)} — ${segs.length} segment(s)</div>
+            const segmentItems = segs.map(seg => {
+                const imageHtml = (Array.isArray(seg.imageUrls) && seg.imageUrls.length > 0)
+                    ? `<div style="margin-top:8px; display:flex; gap:8px; overflow-x:auto; padding-bottom:4px;">
+                        ${seg.imageUrls.map(img => `<img src="${this.escapeHtml(img)}" style="height:80px; width:auto; border-radius:6px; border:1px solid var(--border-color); background:var(--background-primary); object-fit:cover;" onerror="this.style.display='none'">`).join('')}
+                       </div>`
+                    : '';
+                return `<div style="padding:8px; background:var(--background-light); border-left:3px solid var(--border-color); margin-bottom:6px; font-size:11px; font-family:monospace; border-radius:0 6px 6px 0;">
+                    <div style="margin-bottom:4px;"><span style="opacity:0.6; font-weight:bold;">Segment ${seg.index} (${seg.lineCount} lines):</span></div>
+                    <div style="line-height:1.4; color:var(--text-primary);">${this.escapeHtml(seg.preview)}</div>
+                    ${imageHtml}
+                </div>`;
+            }).join('');
+            return `<div style="margin-bottom:12px;">
+                <div style="font-size:11px; font-family:monospace; opacity:0.7; margin-bottom:6px; word-break:break-all; border-bottom:1px solid var(--border-color); padding-bottom:2px;">${this.escapeHtml(url)} — ${segs.length} segment(s)</div>
                 ${segmentItems}
             </div>`;
         }).join('');

--- a/scripts/page-cache-maintenance.js
+++ b/scripts/page-cache-maintenance.js
@@ -168,8 +168,11 @@ class PageCacheMaintenance {
     try {
       this.ensureCacheDir();
       const request = new Request(LOGO_URL);
+      request.timeoutInterval = 15;
       const image = await request.loadImage();
-      this.fm.writeImage(cachePath, image);
+      if (image) {
+        this.fm.writeImage(cachePath, image);
+      }
       return image;
     } catch (error) {
       console.log(`PageCacheMaintenance: Logo download failed: ${error.message}`);
@@ -242,11 +245,11 @@ class PageCacheMaintenance {
     return this.buildScriptableUrl(this.getSelfScriptName(), params);
   }
 
-  listDirectoryEntries(path) {
+  async listDirectoryEntries(path) {
     if (!this.fm.fileExists(path)) return [];
     try {
       try {
-        this.fm.downloadFileFromiCloud(path);
+        await this.fm.downloadFileFromiCloud(path);
       } catch (_) {}
       return this.fm.listContents(path) || [];
     } catch (error) {
@@ -255,15 +258,15 @@ class PageCacheMaintenance {
     }
   }
 
-  analyzeHostDirectory(hostName, hostPath, thresholdMs, nowMs, scope = null) {
-    const entryNames = this.listDirectoryEntries(hostPath);
+  async analyzeHostDirectory(hostName, hostPath, thresholdMs, nowMs, scope = null) {
+    const entryNames = await this.listDirectoryEntries(hostPath);
     const files = [];
     let oldFileCount = 0;
     let recentFileCount = 0;
     let oldestDate = null;
     let newestDate = null;
 
-    entryNames.forEach(entryName => {
+    for (const entryName of entryNames) {
       const entryPath = this.fm.joinPath(hostPath, entryName);
       let isDirectory = false;
       try {
@@ -271,7 +274,7 @@ class PageCacheMaintenance {
       } catch (_) {
         isDirectory = false;
       }
-      if (isDirectory || !String(entryName).toLowerCase().endsWith('.json')) return;
+      if (isDirectory || !String(entryName).toLowerCase().endsWith('.json')) continue;
 
       let modifiedAt = null;
       try {
@@ -304,7 +307,7 @@ class PageCacheMaintenance {
         ageDays,
         isOld
       });
-    });
+    }
 
     files.sort((left, right) => {
       const leftAge = Number.isFinite(left.ageDays) ? left.ageDays : -1;
@@ -328,13 +331,12 @@ class PageCacheMaintenance {
     };
   }
 
-  analyzeCacheScope(scope, days) {
+  async analyzeCacheScope(scope, days) {
     const nowMs = Date.now();
     const thresholdMs = days * 24 * 60 * 60 * 1000;
-    const hosts = [];
-    const rootEntries = this.listDirectoryEntries(scope.dir);
+    const rootEntries = await this.listDirectoryEntries(scope.dir);
 
-    rootEntries.forEach(entryName => {
+    const hostPromises = rootEntries.map(async entryName => {
       const entryPath = this.fm.joinPath(scope.dir, entryName);
       let isDirectory = false;
       try {
@@ -342,9 +344,11 @@ class PageCacheMaintenance {
       } catch (_) {
         isDirectory = false;
       }
-      if (!isDirectory) return;
-      hosts.push(this.analyzeHostDirectory(entryName, entryPath, thresholdMs, nowMs, scope));
+      if (!isDirectory) return null;
+      return this.analyzeHostDirectory(entryName, entryPath, thresholdMs, nowMs, scope);
     });
+
+    const hosts = (await Promise.all(hostPromises)).filter(Boolean);
 
     hosts.sort((left, right) => {
       if (right.oldFileCount !== left.oldFileCount) return right.oldFileCount - left.oldFileCount;
@@ -366,8 +370,9 @@ class PageCacheMaintenance {
     };
   }
 
-  analyzePageCache(days) {
-    const scopes = this.cacheScopes.map(scope => this.analyzeCacheScope(scope, days));
+  async analyzePageCache(days) {
+    const scopePromises = this.cacheScopes.map(scope => this.analyzeCacheScope(scope, days));
+    const scopes = await Promise.all(scopePromises);
     const hosts = scopes.reduce((allHosts, scope) => allHosts.concat(scope.hosts), []);
     hosts.sort((left, right) => {
       if (right.oldFileCount !== left.oldFileCount) return right.oldFileCount - left.oldFileCount;
@@ -457,7 +462,7 @@ class PageCacheMaintenance {
     const deleteHosts = this.parseBoolean(
       this.runtime.queryParameters?.deleteHosts || this.runtime.queryParameters?.pruneHosts
     );
-    const analysis = this.analyzePageCache(days);
+    const analysis = await this.analyzePageCache(days);
     if (analysis.oldFileCount === 0 && (!deleteHosts || analysis.removableHostCount === 0)) {
       return {
         days,
@@ -834,7 +839,8 @@ class PageCacheMaintenance {
     await WebView.loadHTML(html, null, null, true);
   }
 
-  async renderWidget(analysis) {
+  async renderWidget(days) {
+    const analysis = await this.analyzePageCache(days);
     const widget = new ListWidget();
     widget.backgroundColor = new Color(BRAND.primary);
     widget.setPadding(12, 12, 12, 12);
@@ -879,12 +885,12 @@ class PageCacheMaintenance {
     const maintenance = new PageCacheMaintenance();
     const days = maintenance.getSelectedDays();
     const actionResult = maintenance.runtime.runsInWidget ? null : await maintenance.maybeRunAction(days);
-    const analysis = maintenance.analyzePageCache(days);
 
     if (maintenance.runtime.runsInWidget) {
-      const widget = await maintenance.renderWidget(analysis);
+      const widget = await maintenance.renderWidget(days);
       Script.setWidget(widget);
     } else {
+      const analysis = await maintenance.analyzePageCache(days);
       await maintenance.renderApp(analysis, actionResult);
     }
   } catch (error) {


### PR DESCRIPTION
This PR improves the scripts folder by:
1.  **Displaying images in segments during discovery-only passes**: I've updated the `ScriptableAdapter` to render image galleries for discovered segments, helping with segmentation debugging.
2.  **Fixing the cache cleanup script UI**: The UI was hanging due to heavy synchronous file I/O during cache analysis (especially after adding OCR caching). I've refactored the analysis logic to be asynchronous and improved iCloud file handling to ensure the UI remains responsive. I also added a timeout to the logo image request to prevent network-related hangs.

---
*PR created automatically by Jules for task [17242815531551520804](https://jules.google.com/task/17242815531551520804) started by @stanleyrya*