### PR TITLE
Refactor OCR download artifacts and parser usage

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1208,6 +1208,62 @@ class ScriptableAdapter {
         }
     }
 
+    getOcrSummaryPath(url) {
+        const { hostDir, fileName } = this.getPageCachePathParts(url);
+        const summaryDir = this.fm.joinPath(this.ocrStorageDir, hostDir);
+        const summaryFileName = fileName.replace(/\.json$/i, '--summary.json');
+        return {
+            summaryDir,
+            summaryPath: this.fm.joinPath(summaryDir, summaryFileName)
+        };
+    }
+
+    async writeOcrSummary(url, results) {
+        const summaryInfo = this.getOcrSummaryPath(url);
+        if (!summaryInfo || !results) return null;
+        this.ensureDirectoryExists(summaryInfo.summaryDir);
+        const payload = {
+            url,
+            createdAt: new Date().toISOString(),
+            model: this.config.ocrModel || 'qwen2.5vl:3b',
+            summary: results.summary || null,
+            images: Array.isArray(results.images)
+                ? results.images.map((image, index) => ({
+                    index: index + 1,
+                    imageUrl: image.imageUrl,
+                    sourceType: image.sourceType || 'unknown',
+                    width: Number.isFinite(Number(image.width)) ? Number(image.width) : null,
+                    height: Number.isFinite(Number(image.height)) ? Number(image.height) : null,
+                    area: Number.isFinite(Number(image.area)) ? Number(image.area) : null,
+                    baseImageUrl: image.baseImageUrl || null,
+                    ocrChars: Number.isFinite(Number(image.ocrChars))
+                        ? Number(image.ocrChars)
+                        : (typeof image.ocrText === 'string' ? image.ocrText.length : 0),
+                    textPreview: typeof image.ocrText === 'string'
+                        ? (image.ocrText.length > 240 ? `${image.ocrText.slice(0, 240)}…` : image.ocrText)
+                        : '',
+                    classification: image.classification || null,
+                    cached: Boolean(image.cached),
+                    ocrCached: Boolean(image.ocrCached),
+                    classificationCached: Boolean(image.classificationCached)
+                }))
+                : []
+        };
+        this.fm.writeString(summaryInfo.summaryPath, JSON.stringify(payload, null, 2));
+        return summaryInfo.summaryPath;
+    }
+
+    async persistOcrResults(url, results) {
+        const summaryPath = await this.writeOcrSummary(url, results);
+        if (summaryPath) {
+            results.summaryPath = summaryPath;
+            if (results.summary && typeof results.summary === 'object') {
+                results.summary.summaryPath = summaryPath;
+            }
+        }
+        return results;
+    }
+
     async readCachedOcrResult(imageUrl, ocrConfig, type = 'ocr') {
         if (ocrConfig.cacheEnabled === false) return null;
 

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1208,62 +1208,6 @@ class ScriptableAdapter {
         }
     }
 
-    getOcrSummaryPath(url) {
-        const { hostDir, fileName } = this.getPageCachePathParts(url);
-        const summaryDir = this.fm.joinPath(this.ocrStorageDir, hostDir);
-        const summaryFileName = fileName.replace(/\.json$/i, '--summary.json');
-        return {
-            summaryDir,
-            summaryPath: this.fm.joinPath(summaryDir, summaryFileName)
-        };
-    }
-
-    async writeOcrSummary(url, results) {
-        const summaryInfo = this.getOcrSummaryPath(url);
-        if (!summaryInfo || !results) return null;
-        this.ensureDirectoryExists(summaryInfo.summaryDir);
-        const payload = {
-            url,
-            createdAt: new Date().toISOString(),
-            model: this.config.ocrModel || 'qwen2.5vl:3b',
-            summary: results.summary || null,
-            images: Array.isArray(results.images)
-                ? results.images.map((image, index) => ({
-                    index: index + 1,
-                    imageUrl: image.imageUrl,
-                    sourceType: image.sourceType || 'unknown',
-                    width: Number.isFinite(Number(image.width)) ? Number(image.width) : null,
-                    height: Number.isFinite(Number(image.height)) ? Number(image.height) : null,
-                    area: Number.isFinite(Number(image.area)) ? Number(image.area) : null,
-                    baseImageUrl: image.baseImageUrl || null,
-                    ocrChars: Number.isFinite(Number(image.ocrChars))
-                        ? Number(image.ocrChars)
-                        : (typeof image.ocrText === 'string' ? image.ocrText.length : 0),
-                    textPreview: typeof image.ocrText === 'string'
-                        ? (image.ocrText.length > 240 ? `${image.ocrText.slice(0, 240)}…` : image.ocrText)
-                        : '',
-                    classification: image.classification || null,
-                    cached: Boolean(image.cached),
-                    ocrCached: Boolean(image.ocrCached),
-                    classificationCached: Boolean(image.classificationCached)
-                }))
-                : []
-        };
-        this.fm.writeString(summaryInfo.summaryPath, JSON.stringify(payload, null, 2));
-        return summaryInfo.summaryPath;
-    }
-
-    async persistOcrResults(url, results) {
-        const summaryPath = await this.writeOcrSummary(url, results);
-        if (summaryPath) {
-            results.summaryPath = summaryPath;
-            if (results.summary && typeof results.summary === 'object') {
-                results.summary.summaryPath = summaryPath;
-            }
-        }
-        return results;
-    }
-
     async readCachedOcrResult(imageUrl, ocrConfig, type = 'ocr') {
         if (ocrConfig.cacheEnabled === false) return null;
 
@@ -1314,6 +1258,49 @@ class ScriptableAdapter {
         } catch (error) {
             console.log(`📱 Scriptable: OCR cache write failed: ${error.message}`);
         }
+    }
+
+    async persistOcrResults(url, results) {
+        if (!results) {
+            return results;
+        }
+        const { hostDir, fileName } = this.getPageCachePathParts(url);
+        const summaryDir = this.fm.joinPath(this.ocrStorageDir, hostDir);
+        this.ensureDirectoryExists(summaryDir);
+        const summaryPath = this.fm.joinPath(summaryDir, fileName.replace(/\.json$/i, '--summary.json'));
+        const payload = {
+            url,
+            createdAt: new Date().toISOString(),
+            model: this.config.ocrModel || 'qwen2.5vl:3b',
+            summary: results.summary || null,
+            images: Array.isArray(results.images)
+                ? results.images.map((image, index) => ({
+                    index: index + 1,
+                    imageUrl: image.imageUrl,
+                    sourceType: image.sourceType || 'unknown',
+                    width: Number.isFinite(Number(image.width)) ? Number(image.width) : null,
+                    height: Number.isFinite(Number(image.height)) ? Number(image.height) : null,
+                    area: Number.isFinite(Number(image.area)) ? Number(image.area) : null,
+                    baseImageUrl: image.baseImageUrl || null,
+                    ocrChars: Number.isFinite(Number(image.ocrChars))
+                        ? Number(image.ocrChars)
+                        : (typeof image.ocrText === 'string' ? image.ocrText.length : 0),
+                    textPreview: typeof image.ocrText === 'string'
+                        ? (image.ocrText.length > 240 ? `${image.ocrText.slice(0, 240)}…` : image.ocrText)
+                        : '',
+                    classification: image.classification || null,
+                    cached: Boolean(image.cached),
+                    ocrCached: Boolean(image.ocrCached),
+                    classificationCached: Boolean(image.classificationCached)
+                }))
+                : []
+        };
+        this.fm.writeString(summaryPath, JSON.stringify(payload, null, 2));
+        results.summaryPath = summaryPath;
+        if (results.summary && typeof results.summary === 'object') {
+            results.summary.summaryPath = summaryPath;
+        }
+        return results;
     }
 
         hasNonEmptyValue(value) {

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -1046,6 +1046,63 @@ class WebAdapter {
         }
     }
 
+    getOcrSummaryPath(url) {
+        if (!this.isNode || !this.fs || !this.path || !this.pageStorageDir) return null;
+        const { hostDir, fileName } = this.getPageCachePathParts(url);
+        const summaryDir = this.path.join(this.path.dirname(this.pageStorageDir), 'ocr', hostDir);
+        const summaryFileName = fileName.replace(/\.json$/i, '--summary.json');
+        return {
+            summaryDir,
+            summaryPath: this.path.join(summaryDir, summaryFileName)
+        };
+    }
+
+    async writeOcrSummary(url, results) {
+        const summaryInfo = this.getOcrSummaryPath(url);
+        if (!summaryInfo || !results) return null;
+        const payload = {
+            url,
+            createdAt: new Date().toISOString(),
+            model: this.config.ocrModel || 'qwen2.5vl:3b',
+            summary: results.summary || null,
+            images: Array.isArray(results.images)
+                ? results.images.map((image, index) => ({
+                    index: index + 1,
+                    imageUrl: image.imageUrl,
+                    sourceType: image.sourceType || 'unknown',
+                    width: Number.isFinite(Number(image.width)) ? Number(image.width) : null,
+                    height: Number.isFinite(Number(image.height)) ? Number(image.height) : null,
+                    area: Number.isFinite(Number(image.area)) ? Number(image.area) : null,
+                    baseImageUrl: image.baseImageUrl || null,
+                    ocrChars: Number.isFinite(Number(image.ocrChars))
+                        ? Number(image.ocrChars)
+                        : (typeof image.ocrText === 'string' ? image.ocrText.length : 0),
+                    textPreview: typeof image.ocrText === 'string'
+                        ? (image.ocrText.length > 240 ? `${image.ocrText.slice(0, 240)}…` : image.ocrText)
+                        : '',
+                    classification: image.classification || null,
+                    cached: Boolean(image.cached),
+                    ocrCached: Boolean(image.ocrCached),
+                    classificationCached: Boolean(image.classificationCached)
+                }))
+                : []
+        };
+        await this.fs.promises.mkdir(summaryInfo.summaryDir, { recursive: true });
+        await this.fs.promises.writeFile(summaryInfo.summaryPath, JSON.stringify(payload, null, 2), 'utf8');
+        return summaryInfo.summaryPath;
+    }
+
+    async persistOcrResults(url, results) {
+        const summaryPath = await this.writeOcrSummary(url, results);
+        if (summaryPath) {
+            results.summaryPath = summaryPath;
+            if (results.summary && typeof results.summary === 'object') {
+                results.summary.summaryPath = summaryPath;
+            }
+        }
+        return results;
+    }
+
     async readCachedOcrResult(imageUrl, ocrConfig, type = 'ocr') {
         if (!this.isNode || !this.fs || !this.path || !this.pageStorageDir) return null;
         if (ocrConfig.cacheEnabled === false) return null;

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -1046,63 +1046,6 @@ class WebAdapter {
         }
     }
 
-    getOcrSummaryPath(url) {
-        if (!this.isNode || !this.fs || !this.path || !this.pageStorageDir) return null;
-        const { hostDir, fileName } = this.getPageCachePathParts(url);
-        const summaryDir = this.path.join(this.path.dirname(this.pageStorageDir), 'ocr', hostDir);
-        const summaryFileName = fileName.replace(/\.json$/i, '--summary.json');
-        return {
-            summaryDir,
-            summaryPath: this.path.join(summaryDir, summaryFileName)
-        };
-    }
-
-    async writeOcrSummary(url, results) {
-        const summaryInfo = this.getOcrSummaryPath(url);
-        if (!summaryInfo || !results) return null;
-        const payload = {
-            url,
-            createdAt: new Date().toISOString(),
-            model: this.config.ocrModel || 'qwen2.5vl:3b',
-            summary: results.summary || null,
-            images: Array.isArray(results.images)
-                ? results.images.map((image, index) => ({
-                    index: index + 1,
-                    imageUrl: image.imageUrl,
-                    sourceType: image.sourceType || 'unknown',
-                    width: Number.isFinite(Number(image.width)) ? Number(image.width) : null,
-                    height: Number.isFinite(Number(image.height)) ? Number(image.height) : null,
-                    area: Number.isFinite(Number(image.area)) ? Number(image.area) : null,
-                    baseImageUrl: image.baseImageUrl || null,
-                    ocrChars: Number.isFinite(Number(image.ocrChars))
-                        ? Number(image.ocrChars)
-                        : (typeof image.ocrText === 'string' ? image.ocrText.length : 0),
-                    textPreview: typeof image.ocrText === 'string'
-                        ? (image.ocrText.length > 240 ? `${image.ocrText.slice(0, 240)}…` : image.ocrText)
-                        : '',
-                    classification: image.classification || null,
-                    cached: Boolean(image.cached),
-                    ocrCached: Boolean(image.ocrCached),
-                    classificationCached: Boolean(image.classificationCached)
-                }))
-                : []
-        };
-        await this.fs.promises.mkdir(summaryInfo.summaryDir, { recursive: true });
-        await this.fs.promises.writeFile(summaryInfo.summaryPath, JSON.stringify(payload, null, 2), 'utf8');
-        return summaryInfo.summaryPath;
-    }
-
-    async persistOcrResults(url, results) {
-        const summaryPath = await this.writeOcrSummary(url, results);
-        if (summaryPath) {
-            results.summaryPath = summaryPath;
-            if (results.summary && typeof results.summary === 'object') {
-                results.summary.summaryPath = summaryPath;
-            }
-        }
-        return results;
-    }
-
     async readCachedOcrResult(imageUrl, ocrConfig, type = 'ocr') {
         if (!this.isNode || !this.fs || !this.path || !this.pageStorageDir) return null;
         if (ocrConfig.cacheEnabled === false) return null;
@@ -1146,6 +1089,49 @@ class WebAdapter {
         } catch (error) {
             console.log(`🟢 Node.js: OCR cache write failed: ${error.message}`);
         }
+    }
+
+    async persistOcrResults(url, results) {
+        if (!this.isNode || !this.fs || !this.path || !this.pageStorageDir || !results) {
+            return results;
+        }
+        const { hostDir, fileName } = this.getPageCachePathParts(url);
+        const summaryDir = this.path.join(this.path.dirname(this.pageStorageDir), 'ocr', hostDir);
+        const summaryPath = this.path.join(summaryDir, fileName.replace(/\.json$/i, '--summary.json'));
+        const payload = {
+            url,
+            createdAt: new Date().toISOString(),
+            model: this.config.ocrModel || 'qwen2.5vl:3b',
+            summary: results.summary || null,
+            images: Array.isArray(results.images)
+                ? results.images.map((image, index) => ({
+                    index: index + 1,
+                    imageUrl: image.imageUrl,
+                    sourceType: image.sourceType || 'unknown',
+                    width: Number.isFinite(Number(image.width)) ? Number(image.width) : null,
+                    height: Number.isFinite(Number(image.height)) ? Number(image.height) : null,
+                    area: Number.isFinite(Number(image.area)) ? Number(image.area) : null,
+                    baseImageUrl: image.baseImageUrl || null,
+                    ocrChars: Number.isFinite(Number(image.ocrChars))
+                        ? Number(image.ocrChars)
+                        : (typeof image.ocrText === 'string' ? image.ocrText.length : 0),
+                    textPreview: typeof image.ocrText === 'string'
+                        ? (image.ocrText.length > 240 ? `${image.ocrText.slice(0, 240)}…` : image.ocrText)
+                        : '',
+                    classification: image.classification || null,
+                    cached: Boolean(image.cached),
+                    ocrCached: Boolean(image.ocrCached),
+                    classificationCached: Boolean(image.classificationCached)
+                }))
+                : []
+        };
+        await this.fs.promises.mkdir(summaryDir, { recursive: true });
+        await this.fs.promises.writeFile(summaryPath, JSON.stringify(payload, null, 2), 'utf8');
+        results.summaryPath = summaryPath;
+        if (results.summary && typeof results.summary === 'object') {
+            results.summary.summaryPath = summaryPath;
+        }
+        return results;
     }
 
     // Helper method to extract all events from parser results

--- a/scripts/ocr-processor.js
+++ b/scripts/ocr-processor.js
@@ -106,7 +106,8 @@ Image context: ${imageContext || 'Unknown context'}`;
                 images.push({
                     url,
                     width: widthMatch ? parseInt(widthMatch[1], 10) : null,
-                    height: heightMatch ? parseInt(heightMatch[1], 10) : null
+                    height: heightMatch ? parseInt(heightMatch[1], 10) : null,
+                    sourceType: 'img'
                 });
             }
         }
@@ -117,7 +118,12 @@ Image context: ${imageContext || 'Unknown context'}`;
             const url = this.normalizeImageUrl(match[1], baseUrl);
             if (url && !seen.has(url)) {
                 seen.add(url);
-                images.push({ url, width: null, height: null });
+                images.push({
+                    url,
+                    width: null,
+                    height: null,
+                    sourceType: 'background'
+                });
             }
         }
 
@@ -127,11 +133,43 @@ Image context: ${imageContext || 'Unknown context'}`;
             const url = this.normalizeImageUrl(match[1], baseUrl);
             if (url && !seen.has(url)) {
                 seen.add(url);
-                images.push({ url, width: null, height: null });
+                images.push({
+                    url,
+                    width: null,
+                    height: null,
+                    sourceType: 'picture'
+                });
             }
         }
 
         return images;
+    }
+
+    normalizeImageCandidate(image) {
+        if (!image) return null;
+        if (typeof image === 'string') {
+            return {
+                url: image,
+                width: null,
+                height: null,
+                sourceType: 'unknown'
+            };
+        }
+        return {
+            url: image.url,
+            width: Number.isFinite(Number(image.width)) ? Number(image.width) : null,
+            height: Number.isFinite(Number(image.height)) ? Number(image.height) : null,
+            sourceType: typeof image.sourceType === 'string' && image.sourceType.trim()
+                ? image.sourceType.trim().toLowerCase()
+                : 'unknown'
+        };
+    }
+
+    getImageArea(image) {
+        if (!image || !Number.isFinite(Number(image.width)) || !Number.isFinite(Number(image.height))) {
+            return null;
+        }
+        return Number(image.width) * Number(image.height);
     }
 
     /**
@@ -388,8 +426,19 @@ Image context: ${imageContext || 'Unknown context'}`;
     /**
      * Classify an image based on OCR text
      */
-    classifyImage(imageUrl, ocrText) {
+    classifyImage(imageInput, ocrText) {
+        const image = this.normalizeImageCandidate(imageInput);
+        const imageUrl = image && image.url ? image.url : String(imageInput || '');
+        const sourceType = image && image.sourceType ? image.sourceType : 'unknown';
+
         if (!ocrText) {
+            if (sourceType === 'background') {
+                return {
+                    type: this.imageClassificationTypes.BACKGROUND,
+                    confidence: 0.65,
+                    details: 'Background-image source with no extracted text'
+                };
+            }
             return {
                 type: this.imageClassificationTypes.UNKNOWN,
                 confidence: 0.0,
@@ -487,6 +536,14 @@ Image context: ${imageContext || 'Unknown context'}`;
                     details: `Found ${matchCount} keyword matches`
                 };
             }
+        }
+
+        if (bestClassification.type === this.imageClassificationTypes.UNKNOWN && sourceType === 'background') {
+            return {
+                type: this.imageClassificationTypes.BACKGROUND,
+                confidence: 0.6,
+                details: 'Background-image source with low OCR signal'
+            };
         }
 
         return bestClassification;
@@ -652,7 +709,13 @@ Image context: ${imageContext || 'Unknown context'}`;
     /**
      * Process a single image with OCR and classification
      */
-    async processSingleImage(imageUrl) {
+    async processSingleImage(imageInput) {
+        const image = this.normalizeImageCandidate(imageInput);
+        if (!image || !image.url) {
+            return null;
+        }
+        const imageUrl = image.url;
+
         // Check if we've reached max images
         if (this.seenUrls.size >= this.config.maxImages) {
             return null;
@@ -674,9 +737,18 @@ Image context: ${imageContext || 'Unknown context'}`;
         if (!ocrResult) {
             return {
                 imageUrl,
+                sourceType: image.sourceType,
+                width: image.width,
+                height: image.height,
+                area: this.getImageArea(image),
+                baseImageUrl: this.getBaseImageUrl(imageUrl),
                 ocrText: null,
                 classification: null,
-                cached: false
+                cached: false,
+                ocrCached: false,
+                classificationCached: false,
+                ocrResponse: null,
+                classificationResponse: null
             };
         }
 
@@ -701,19 +773,31 @@ Image context: ${imageContext || 'Unknown context'}`;
         }
 
         // If classification failed, use heuristic classification
-        if (!classification && ocrText) {
-            classification = this.classifyImage(imageUrl, ocrText);
+        if (!classification) {
+            classification = this.classifyImage(image, ocrText);
         }
 
         return {
             imageUrl,
+            sourceType: image.sourceType,
+            width: image.width,
+            height: image.height,
+            area: this.getImageArea(image),
+            baseImageUrl: this.getBaseImageUrl(imageUrl),
             ocrText: ocrText || '',
+            ocrChars: ocrText ? ocrText.length : 0,
             classification: classification || {
                 type: this.imageClassificationTypes.UNKNOWN,
                 confidence: 0.0,
                 details: 'Classification unavailable'
             },
-            cached: ocrResult.cached || false
+            cached: Boolean(ocrResult.cached || (classificationResult && classificationResult.cached)),
+            ocrCached: Boolean(ocrResult.cached),
+            classificationCached: Boolean(classificationResult && classificationResult.cached),
+            ocrResponse: ocrResult.response || ocrResult.text || null,
+            classificationResponse: classificationResult
+                ? (classificationResult.response || classificationResult.text || null)
+                : null
         };
     }
 
@@ -730,6 +814,7 @@ Image context: ${imageContext || 'Unknown context'}`;
         // Select best resolutions for grouped images
         const bestGroupedUrls = this.selectBestResolutions(resolutionGroups);
         const bestGroupedSet = new Set(bestGroupedUrls);
+        const imageByUrl = new Map(images.map(image => [image.url, image]));
 
         // Find URLs that were in a group but NOT the best
         const rejectedUrls = new Set();
@@ -766,7 +851,7 @@ Image context: ${imageContext || 'Unknown context'}`;
         const results = [];
         
         for (const imageUrl of urlsToProcess) {
-            const result = await this.processSingleImage(imageUrl);
+            const result = await this.processSingleImage(imageByUrl.get(imageUrl) || imageUrl);
             
             if (result) {
                 results.push(result);
@@ -801,8 +886,12 @@ Image context: ${imageContext || 'Unknown context'}`;
             imagesWithText: 0,
             totalTextChars: 0,
             classifications: {},
-            typesFound: []
+            typesFound: [],
+            usefulImages: 0,
+            averageClassificationConfidence: 0
         };
+        let totalConfidence = 0;
+        let classifiedImages = 0;
 
         for (const result of results) {
             if (result.ocrText && result.ocrText.length > 0) {
@@ -813,12 +902,23 @@ Image context: ${imageContext || 'Unknown context'}`;
             if (result.classification) {
                 const type = result.classification.type;
                 summary.classifications[type] = (summary.classifications[type] || 0) + 1;
+                if (type && type !== this.imageClassificationTypes.UNKNOWN && type !== this.imageClassificationTypes.BACKGROUND) {
+                    summary.usefulImages++;
+                }
+                if (Number.isFinite(Number(result.classification.confidence))) {
+                    totalConfidence += Number(result.classification.confidence);
+                    classifiedImages++;
+                }
                 
                 if (!summary.typesFound.includes(type)) {
                     summary.typesFound.push(type);
                 }
             }
         }
+
+        summary.averageClassificationConfidence = classifiedImages > 0
+            ? Number((totalConfidence / classifiedImages).toFixed(3))
+            : 0;
 
         return summary;
     }

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1852,6 +1852,9 @@ class AiWebParser {
             return { merged: mergedEvent, diagnostics: { skippedReason: 'missing-endpoint-or-model' } };
         }
 
+        const ocrResults = htmlData.ocrResults;
+        const ocrImages = Array.isArray(ocrResults.images) ? ocrResults.images.filter(Boolean) : [];
+
         const diagnostics = {
             enabled: ocrConfig.enabled,
             model: String(ocrConfig.model || ''),
@@ -1861,9 +1864,7 @@ class AiWebParser {
             cached: 0
         };
 
-        // Get OCR results from htmlData
-        const ocrResults = htmlData.ocrResults;
-        diagnostics.totalImages = ocrResults.images.length;
+        diagnostics.totalImages = ocrImages.length;
         
         // Process each OCR result
         for (const imageResult of ocrResults.images) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep OCR/image classification in the page-download phase
- keep per-image OCR/classification cache files under `storage/ocr`
- add a per-page OCR summary artifact alongside those cached OCR files
- enrich OCR processor metadata and summary output for larger/useful images
- keep `ai-web-parser` consuming downloaded OCR results in its active path

## Testing
- syntax-check the modified scripts with `node --check`
- run a mocked `ocr-processor` exercise with no network calls

## Notes
- OCR/page cache behavior changed; deleting existing `storage/pages` and `storage/ocr` caches is the cleanest way to refresh old data if needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19048724-cd73-4ef3-808a-c5e8002d4526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19048724-cd73-4ef3-808a-c5e8002d4526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

