### PR TITLE
Improve OCR with image classification and fix cache shadowing bug

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2103,7 +2103,7 @@ class ScriptableAdapter {
         const payload = {
             url: normalizedUrl,
             cachedAt: new Date().toISOString(),
-            cacheKeyVersion: 1,
+            cacheKeyVersion: 2,
             request: {
                 endpoint: String(ocrConfig.endpoint || ''),
                 model: String(ocrConfig.model || ''),

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2057,21 +2057,42 @@ class ScriptableAdapter {
                 ? cached.response.text
                 : (typeof cached.text === 'string' ? cached.text : '');
             if (!responseText) return null;
-            return {
+
+            const result = {
                 imageUrl: cached.url || normalizedUrl,
                 text: responseText,
                 cachePath,
                 cached: true
             };
+
+            if (cached && cached.response) {
+                if (cached.response.classification) result.classification = cached.response.classification;
+                if (typeof cached.response.confidence === 'number') result.confidence = cached.response.confidence;
+            }
+
+            return result;
         } catch (error) {
             return null;
         }
     }
 
-    async writeCachedOcrResult(imageUrl, ocrConfig, text, cacheHelpers) {
+    async writeCachedOcrResult(imageUrl, ocrConfig, responseData, cacheHelpers) {
         if (!ocrConfig.cacheEnabled) return null;
-        const resultText = String(text || '').trim();
+
+        let resultText = '';
+        let classification = null;
+        let confidence = null;
+
+        if (typeof responseData === 'object' && responseData !== null) {
+            resultText = String(responseData.text || '').trim();
+            classification = responseData.classification || null;
+            confidence = responseData.confidence || null;
+        } else {
+            resultText = String(responseData || '').trim();
+        }
+
         if (!resultText) return null;
+
         const fm = FileManager.iCloud();
         const documentsDir = fm.documentsDirectory();
         const baseDir = fm.joinPath(fm.joinPath(fm.joinPath(documentsDir, 'chunky-dad-scraper'), 'storage'), 'ocr');
@@ -2097,7 +2118,9 @@ class ScriptableAdapter {
                 }
             },
             response: {
-                text: resultText
+                text: resultText,
+                classification,
+                confidence
             }
         };
 

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -643,23 +643,44 @@ class WebAdapter {
                 ? cached.response.text
                 : (typeof cached.text === 'string' ? cached.text : '');
             if (!responseText) return null;
-            return {
+
+            const result = {
                 imageUrl: cached.url || normalizedUrl,
                 text: responseText,
                 cachePath,
                 cached: true
             };
+
+            if (cached && cached.response) {
+                if (cached.response.classification) result.classification = cached.response.classification;
+                if (typeof cached.response.confidence === 'number') result.confidence = cached.response.confidence;
+            }
+
+            return result;
         } catch (error) {
             return null;
         }
     }
 
-    async writeCachedOcrResult(imageUrl, ocrConfig, text, cacheHelpers) {
+    async writeCachedOcrResult(imageUrl, ocrConfig, responseData, cacheHelpers) {
         if (!ocrConfig.cacheEnabled || !this.isNode || !this.fs || !this.path || !this.ocrStorageDir) {
             return null;
         }
-        const resultText = String(text || '').trim();
+
+        let resultText = '';
+        let classification = null;
+        let confidence = null;
+
+        if (typeof responseData === 'object' && responseData !== null) {
+            resultText = String(responseData.text || '').trim();
+            classification = responseData.classification || null;
+            confidence = responseData.confidence || null;
+        } else {
+            resultText = String(responseData || '').trim();
+        }
+
         if (!resultText) return null;
+
         const { normalizedUrl, hostDir, fileName, signatureHash } = cacheHelpers.getOcrCachePathParts(imageUrl, ocrConfig);
         const hostDirPath = this.path.join(this.ocrStorageDir, hostDir);
         const cachePath = this.path.join(hostDirPath, fileName);
@@ -682,7 +703,9 @@ class WebAdapter {
                 }
             },
             response: {
-                text: resultText
+                text: resultText,
+                classification,
+                confidence
             }
         };
 

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -688,7 +688,7 @@ class WebAdapter {
         const payload = {
             url: normalizedUrl,
             cachedAt: new Date().toISOString(),
-            cacheKeyVersion: 1,
+            cacheKeyVersion: 2,
             request: {
                 endpoint: String(ocrConfig.endpoint || ''),
                 model: String(ocrConfig.model || ''),

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -34,8 +34,8 @@ class AiWebParser {
         };
         this.sendAiRequest = dependencies.sendAiRequest || null;
         this.loadImageAsBase64 = dependencies.loadImageAsBase64 || null;
-        this.readCachedOcrResult = dependencies.readCachedOcrResult || null;
-        this.writeCachedOcrResult = dependencies.writeCachedOcrResult || null;
+        this._readCachedOcrResult = dependencies.readCachedOcrResult || null;
+        this._writeCachedOcrResult = dependencies.writeCachedOcrResult || null;
         this.recordAiPrompt = dependencies.recordAiPrompt || null;
         this.consumeAiPromptHistory = dependencies.consumeAiPromptHistory || null;
 
@@ -118,7 +118,7 @@ class AiWebParser {
         this.likelyImageQueryRegex = /(?:^|[?&])(w|h|q|fit|crop|auto|fm|format|s)=/;
         this.inlineUrlPattern = /(?:https?:\/\/|\/)[^\s"'<>]+/gi;
         this.defaultOcrModel = 'qwen2.5vl:3b';
-        this.defaultOcrPrompt = "Please extract all text from this image exactly as it appears. Return a JSON object with a single key 'text' containing the full extracted text, preserving line breaks as \\n. Do not add commentary.";
+        this.defaultOcrPrompt = "Please extract all text from this image exactly as it appears. Also classify the image into one of these types: background image, title, ad, event promotional art, multi-event promotional art. Provide a confidence score between 0 and 1 for the classification. Return a JSON object with keys 'text', 'classification' (string), and 'confidence' (number). Do not add commentary.";
         this.defaultOcrRequestConfig = {
             timeoutSeconds: 300,
             keepAlive: '5m',
@@ -1590,15 +1590,15 @@ class AiWebParser {
     }
 
     async readCachedOcrResult(imageUrl, ocrConfig = {}) {
-        if (typeof this.readCachedOcrResult !== 'function' || this.readCachedOcrResult === null) return null;
-        return this.readCachedOcrResult(imageUrl, ocrConfig, {
+        if (typeof this._readCachedOcrResult !== 'function') return null;
+        return this._readCachedOcrResult(imageUrl, ocrConfig, {
             getOcrCachePathParts: this.getOcrCachePathParts.bind(this)
         });
     }
 
-    async writeCachedOcrResult(imageUrl, ocrConfig = {}, text = '') {
-        if (typeof this.writeCachedOcrResult !== 'function' || this.writeCachedOcrResult === null) return null;
-        return this.writeCachedOcrResult(imageUrl, ocrConfig, text, {
+    async writeCachedOcrResult(imageUrl, ocrConfig = {}, responseData = null) {
+        if (typeof this._writeCachedOcrResult !== 'function') return null;
+        return this._writeCachedOcrResult(imageUrl, ocrConfig, responseData, {
             getOcrCachePathParts: this.getOcrCachePathParts.bind(this)
         });
     }
@@ -1617,11 +1617,19 @@ class AiWebParser {
 
     parseOcrResponse(rawText) {
         const parsed = this.parseAiEventResponse(rawText);
-        const text = parsed && typeof parsed.text === 'string' ? parsed.text : '';
+        if (!parsed) return null;
+        const text = typeof parsed.text === 'string' ? parsed.text : '';
         const normalizedText = text
             .replace(/\r\n?/g, '\n')
             .trim();
-        return this.isLikelyEmptyOcrText(normalizedText) ? '' : normalizedText;
+        const classification = typeof parsed.classification === 'string' ? parsed.classification.toLowerCase().trim() : 'unknown';
+        const confidence = typeof parsed.confidence === 'number' ? parsed.confidence : 0;
+
+        return {
+            text: this.isLikelyEmptyOcrText(normalizedText) ? '' : normalizedText,
+            classification,
+            confidence
+        };
     }
 
     isLikelyEmptyOcrText(text) {
@@ -1651,18 +1659,36 @@ class AiWebParser {
         return candidates.slice(0, Math.max(1, Number(ocrConfig.maxImages) || 1));
     }
 
-    buildOcrSnippet(imageUrl, text) {
-        return [
-            `OCR_IMAGE_URL: ${String(imageUrl || '').trim()}`,
-            'OCR_IMAGE_TEXT',
-            String(text || '').trim()
-        ].filter(Boolean).join('\n');
+    buildOcrSnippet(imageUrl, ocrResult) {
+        const text = typeof ocrResult === 'string' ? ocrResult : (ocrResult?.text || '');
+        const classification = typeof ocrResult === 'object' ? ocrResult.classification : null;
+        const confidence = typeof ocrResult === 'object' ? ocrResult.confidence : null;
+
+        const parts = [
+            `OCR_IMAGE_URL: ${String(imageUrl || '').trim()}`
+        ];
+        if (classification) {
+            const confidenceSuffix = typeof confidence === 'number' ? ` (confidence: ${confidence.toFixed(2)})` : '';
+            parts.push(`OCR_IMAGE_CLASSIFICATION: ${classification}${confidenceSuffix}`);
+        }
+        parts.push('OCR_IMAGE_TEXT');
+        parts.push(String(text).trim());
+
+        return parts.filter(Boolean).join('\n');
     }
 
     async getOcrTextForImage(imageUrl, ocrConfig = {}, passLabel = 'ocr') {
         const cached = await this.readCachedOcrResult(imageUrl, ocrConfig);
-        if (cached && cached.text) {
+        if (cached && (cached.text || (cached.response && cached.response.text))) {
             console.log(`🤖 AI Web: OCR cache hit for ${cached.imageUrl || imageUrl}`);
+            // Backward compatibility for old cache entries that were just text
+            if (typeof cached.text === 'string' && !cached.classification) {
+                return {
+                    ...cached,
+                    classification: 'unknown',
+                    confidence: 0
+                };
+            }
             return cached;
         }
 
@@ -1684,15 +1710,15 @@ class AiWebParser {
         };
         const rawResponse = await this.sendAiRequest(ocrConfig, payload, passLabel, ocrConfig.prompt);
         if (!rawResponse) return null;
-        const text = this.parseOcrResponse(rawResponse);
-        if (!text) {
+        const ocrResult = this.parseOcrResponse(rawResponse);
+        if (!ocrResult || !ocrResult.text) {
             console.warn(`🤖 AI Web: OCR response for ${imageUrl} did not include text`);
             return null;
         }
-        const cachePath = await this.writeCachedOcrResult(imageUrl, ocrConfig, text);
+        const cachePath = await this.writeCachedOcrResult(imageUrl, ocrConfig, ocrResult);
         return {
             imageUrl,
-            text,
+            ...ocrResult,
             cachePath,
             cached: false
         };
@@ -1761,15 +1787,22 @@ class AiWebParser {
                     });
                     continue;
                 }
-                const trimmedText = ocrResult.text.length > ocrConfig.maxTextChars
-                    ? `${ocrResult.text.slice(0, ocrConfig.maxTextChars)}…`
-                    : ocrResult.text;
-                snippets.push(this.buildOcrSnippet(imageUrl, trimmedText));
+                const text = ocrResult.text || '';
+                const trimmedText = text.length > ocrConfig.maxTextChars
+                    ? `${text.slice(0, ocrConfig.maxTextChars)}…`
+                    : text;
+                const snippetOcrResult = {
+                    ...ocrResult,
+                    text: trimmedText
+                };
+                snippets.push(this.buildOcrSnippet(imageUrl, snippetOcrResult));
                 diagnostics.processedImageCount += 1;
                 if (ocrResult.cached) diagnostics.cacheHits += 1;
                 diagnostics.images.push({
                     url: imageUrl,
                     textChars: trimmedText.length,
+                    classification: ocrResult.classification || 'unknown',
+                    confidence: ocrResult.confidence || 0,
                     cached: Boolean(ocrResult.cached),
                     status: 'ok'
                 });

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1546,6 +1546,7 @@ class AiWebParser {
         } catch (_) {}
         const parsed = this.parseUrlComponents(normalizedUrl);
         const requestSignature = JSON.stringify({
+            version: 2,
             model: String(ocrConfig.model || ''),
             prompt: String(ocrConfig.prompt || ''),
             options: {
@@ -1681,14 +1682,6 @@ class AiWebParser {
         const cached = await this.readCachedOcrResult(imageUrl, ocrConfig);
         if (cached && (cached.text || (cached.response && cached.response.text))) {
             console.log(`🤖 AI Web: OCR cache hit for ${cached.imageUrl || imageUrl}`);
-            // Backward compatibility for old cache entries that were just text
-            if (typeof cached.text === 'string' && !cached.classification) {
-                return {
-                    ...cached,
-                    classification: 'unknown',
-                    confidence: 0
-                };
-            }
             return cached;
         }
 


### PR DESCRIPTION
Comprehensive update to OCR processing. It fixes a critical shadowing bug in `AiWebParser` where injected cache methods were hiding prototype methods that provided necessary `cacheHelpers`. It also updates the OCR strategy to classify images by type (e.g., promotional art vs. ads) and include confidence scores, enhancing the context provided to the downstream extraction model. This includes updates to both Scriptable and Web adapters for consistent caching behavior.

---
*PR created automatically by Jules for task [10858679831993873930](https://jules.google.com/task/10858679831993873930) started by @stanleyrya*