### PR TITLE
Refine OCR summary selection flow

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2535,6 +2535,18 @@ class ScriptableAdapter {
         return this.unwrapImageProxyUrl(wrappedNormalized, unwrapDepth + 1);
     }
 
+    getImageProxyPathPrefixes() {
+        return ['/e/_next/image?', '/_next/image?'];
+    }
+
+    getLikelyImageRegex() {
+        return /(^|\/)(image|images|img|photo|photos|poster)(\/|$)/i;
+    }
+
+    getLikelyImageQueryRegex() {
+        return /(?:^|[?&])(w|h|q|fit|crop|auto|fm|format|s)=/;
+    }
+
     // Check if URL ends with a supported image extension
     hasSupportedImageFilenameAtEnd(url) {
         const parsed = this.parseUrlComponents(url);

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2302,11 +2302,41 @@ class ScriptableAdapter {
         return automationRun && hasAutomationParsers;
     }
 
+    normalizeOcrSourceInput(source) {
+        if (source && typeof source === 'object' && !Array.isArray(source)) {
+            return {
+                html: typeof source.html === 'string' ? source.html : '',
+                url: typeof source.url === 'string' ? source.url : '',
+                imageUrls: Array.isArray(source.imageUrls) ? source.imageUrls : [],
+                summaryKey: typeof source.summaryKey === 'string' ? source.summaryKey : ''
+            };
+        }
+        return {
+            html: typeof source === 'string' ? source : '',
+            url: '',
+            imageUrls: [],
+            summaryKey: ''
+        };
+    }
+
+    normalizeOcrImageUrls(imageUrls, sourceUrl = '') {
+        const normalizedUrls = new Set();
+        (Array.isArray(imageUrls) ? imageUrls : []).forEach(imageUrl => {
+            this.addImageUrlIfValid(imageUrl, sourceUrl, normalizedUrls);
+        });
+        return Array.from(normalizedUrls);
+    }
+
     // Simple OCR: Extract all images from HTML and run OCR on them
-    async runOcrOnAllImages(html, ocrConfig = {}) {
+    async runOcrOnAllImages(source, ocrConfig = {}) {
         try {
-            // Find all image URLs in HTML using the same patterns as ai-web-parser.js
-            const imageUrls = this.extractImageUrlsFromHtml(html);
+            const sourceInput = this.normalizeOcrSourceInput(source);
+            const html = sourceInput.html;
+            const sourceUrl = sourceInput.url;
+            const summaryKey = sourceInput.summaryKey || sourceUrl || html;
+            const imageUrls = sourceInput.imageUrls.length > 0
+                ? this.normalizeOcrImageUrls(sourceInput.imageUrls, sourceUrl)
+                : this.extractImageUrlsFromHtml(html, sourceUrl);
 
             if (!imageUrls || imageUrls.length === 0) {
                 console.log(`🤖 OCR: No images found in HTML`);
@@ -2315,7 +2345,7 @@ class ScriptableAdapter {
 
             // Check if we have a cached summary
             if (ocrConfig.cacheEnabled) {
-                const cachedSummary = await this.readCachedOcrSummary(html, ocrConfig, this);
+                const cachedSummary = await this.readCachedOcrSummary(summaryKey, ocrConfig, this);
                 if (cachedSummary && cachedSummary.results && cachedSummary.results.length > 0) {
                     console.log(`🤖 OCR: Using cached summary (${cachedSummary.successful}/${cachedSummary.imageCount} successful)`);
                     return cachedSummary.results;
@@ -2372,9 +2402,11 @@ class ScriptableAdapter {
                         images: [base64Image],
                         format: 'json',
                         stream: false,
+                        think: Boolean(ocrConfig.think),
+                        keep_alive: String(ocrConfig.keepAlive || ''),
                         options: {
-                            numCtx: Number(ocrConfig.numCtx) || 32000,
-                            numPredict: Number(ocrConfig.numPredict) || 2048,
+                            num_ctx: Number(ocrConfig.numCtx) || 32000,
+                            num_predict: Number(ocrConfig.numPredict) || 2048,
                             temperature: Number(ocrConfig.temperature) || 0.2
                         }
                     };
@@ -2417,7 +2449,7 @@ class ScriptableAdapter {
             // Cache the summary if we have results
             if (ocrConfig.cacheEnabled && ocrResults.length > 0) {
                 try {
-                    await this.writeCachedOcrSummary(html, ocrConfig, ocrResults, this);
+                    await this.writeCachedOcrSummary(summaryKey, ocrConfig, ocrResults, this);
                 } catch (error) {
                     console.log(`🤖 OCR: Failed to cache summary: ${error.message}`);
                 }
@@ -2432,11 +2464,10 @@ class ScriptableAdapter {
     }
 
     // Extract image URLs from HTML using the same patterns as ai-web-parser.js
-    extractImageUrlsFromHtml(html) {
+    extractImageUrlsFromHtml(html, sourceUrl = '') {
         if (!html) return [];
 
         const imageUrls = new Set();
-        const sourceUrl = ''; // Not available in this simple version
 
         // Extract URLs from image tags (src, data-src, data-lazy-src, poster, content)
         const attrPatterns = [

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -965,11 +965,41 @@ class WebAdapter {
         }
     }
 
+    normalizeOcrSourceInput(source) {
+        if (source && typeof source === 'object' && !Array.isArray(source)) {
+            return {
+                html: typeof source.html === 'string' ? source.html : '',
+                url: typeof source.url === 'string' ? source.url : '',
+                imageUrls: Array.isArray(source.imageUrls) ? source.imageUrls : [],
+                summaryKey: typeof source.summaryKey === 'string' ? source.summaryKey : ''
+            };
+        }
+        return {
+            html: typeof source === 'string' ? source : '',
+            url: '',
+            imageUrls: [],
+            summaryKey: ''
+        };
+    }
+
+    normalizeOcrImageUrls(imageUrls, sourceUrl = '') {
+        const normalizedUrls = new Set();
+        (Array.isArray(imageUrls) ? imageUrls : []).forEach(imageUrl => {
+            this.addImageUrlIfValid(imageUrl, sourceUrl, normalizedUrls);
+        });
+        return Array.from(normalizedUrls);
+    }
+
     // Simple OCR: Extract all images from HTML and run OCR on them
-    async runOcrOnAllImages(html, ocrConfig = {}) {
+    async runOcrOnAllImages(source, ocrConfig = {}) {
         try {
-            // Find all image URLs in HTML using the same patterns as ai-web-parser.js
-            const imageUrls = this.extractImageUrlsFromHtml(html);
+            const sourceInput = this.normalizeOcrSourceInput(source);
+            const html = sourceInput.html;
+            const sourceUrl = sourceInput.url;
+            const summaryKey = sourceInput.summaryKey || sourceUrl || html;
+            const imageUrls = sourceInput.imageUrls.length > 0
+                ? this.normalizeOcrImageUrls(sourceInput.imageUrls, sourceUrl)
+                : this.extractImageUrlsFromHtml(html, sourceUrl);
 
             if (!imageUrls || imageUrls.length === 0) {
                 console.log(`🤖 OCR: No images found in HTML`);
@@ -978,7 +1008,7 @@ class WebAdapter {
 
             // Check if we have a cached summary
             if (ocrConfig.cacheEnabled && this.isNode && this.fs && this.path && this.ocrStorageDir) {
-                const cachedSummary = await this.readCachedOcrSummary(html, ocrConfig, this);
+                const cachedSummary = await this.readCachedOcrSummary(summaryKey, ocrConfig, this);
                 if (cachedSummary && cachedSummary.results && cachedSummary.results.length > 0) {
                     console.log(`🤖 OCR: Using cached summary (${cachedSummary.successful}/${cachedSummary.imageCount} successful)`);
                     return cachedSummary.results;
@@ -1035,6 +1065,8 @@ class WebAdapter {
                         images: [base64Image],
                         format: 'json',
                         stream: false,
+                        think: Boolean(ocrConfig.think),
+                        keep_alive: String(ocrConfig.keepAlive || ''),
                         options: {
                             num_ctx: Number(ocrConfig.numCtx) || 32000,
                             num_predict: Number(ocrConfig.numPredict) || 2048,
@@ -1080,7 +1112,7 @@ class WebAdapter {
             // Cache the summary if we have results
             if (ocrConfig.cacheEnabled && this.isNode && this.fs && this.path && this.ocrStorageDir && ocrResults.length > 0) {
                 try {
-                    await this.writeCachedOcrSummary(html, ocrConfig, ocrResults, this);
+                    await this.writeCachedOcrSummary(summaryKey, ocrConfig, ocrResults, this);
                 } catch (error) {
                     console.log(`🤖 OCR: Failed to cache summary: ${error.message}`);
                 }
@@ -1095,11 +1127,10 @@ class WebAdapter {
     }
 
     // Extract image URLs from HTML using the same patterns as ai-web-parser.js
-    extractImageUrlsFromHtml(html) {
+    extractImageUrlsFromHtml(html, sourceUrl = '') {
         if (!html) return [];
 
         const imageUrls = new Set();
-        const sourceUrl = ''; // Not available in this simple version
 
         // Extract URLs from image tags (src, data-src, data-lazy-src, poster, content)
         const attrPatterns = [

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -1198,6 +1198,18 @@ class WebAdapter {
         return this.unwrapImageProxyUrl(wrappedNormalized, unwrapDepth + 1);
     }
 
+    getImageProxyPathPrefixes() {
+        return ['/e/_next/image?', '/_next/image?'];
+    }
+
+    getLikelyImageRegex() {
+        return /(^|\/)(image|images|img|photo|photos|poster)(\/|$)/i;
+    }
+
+    getLikelyImageQueryRegex() {
+        return /(?:^|[?&])(w|h|q|fit|crop|auto|fm|format|s)=/;
+    }
+
     // Check if URL ends with a supported image extension
     hasSupportedImageFilenameAtEnd(url) {
         const parsed = this.parseUrlComponents(url);

--- a/scripts/adapters/web-adapter.test.js
+++ b/scripts/adapters/web-adapter.test.js
@@ -1,0 +1,40 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { WebAdapter } = require('./web-adapter');
+
+test('runOcrOnAllImages uses the source URL as the OCR summary cache key', async () => {
+  const adapter = new WebAdapter();
+  let summaryKey = null;
+
+  adapter.readCachedOcrSummary = async key => {
+    summaryKey = key;
+    return {
+      successful: 1,
+      imageCount: 1,
+      results: [
+        {
+          src: 'https://furball.example/images/event-poster.jpg',
+          text: 'FURBALL BLACKOUT July 10 2026'
+        }
+      ]
+    };
+  };
+
+  const results = await adapter.runOcrOnAllImages(
+    {
+      html: '<img src="/images/event-poster.jpg" alt="Poster" />',
+      url: 'https://furball.example/events',
+      imageUrls: ['/images/event-poster.jpg']
+    },
+    { cacheEnabled: true }
+  );
+
+  assert.equal(summaryKey, 'https://furball.example/events');
+  assert.deepEqual(results, [
+    {
+      src: 'https://furball.example/images/event-poster.jpg',
+      text: 'FURBALL BLACKOUT July 10 2026'
+    }
+  ]);
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1640,36 +1640,161 @@ class AiWebParser {
         return normalized === 'text' || normalized === 'ocr text';
     }
 
-    async collectOcrCandidateImageUrls(htmlData, ocrConfig = {}) {
-        const maxImages = Number(ocrConfig.maxImages) || 1;
+    resolveOcrMaxImages(ocrConfig = {}) {
+        const parsedMaxImages = Number(ocrConfig.maxImages);
+        if (Number.isFinite(parsedMaxImages) && parsedMaxImages > 0) {
+            return Math.max(1, Math.floor(parsedMaxImages));
+        }
+        return 1;
+    }
 
-        // Extract ALL image URLs (without maxImages limit)
-        const allImages = this.buildImageEvidenceContext(htmlData);
-        const allImageUrls = Array.from(allImages);
+    extractSegmentHintImageUrls(htmlData) {
+        const html = htmlData && typeof htmlData.html === 'string' ? htmlData.html : '';
+        if (!html) return [];
 
-        // Call runOcrOnAllImages to process ALL images (uses caching internally)
-        const ocrResults = await this._runOcrOnAllImages(htmlData.html || '', ocrConfig);
+        const hintedUrls = [];
+        const seen = new Set();
+        const pattern = /^SEGMENT_IMAGE(?:_HINT)?_URL:\s*(\S+)/gim;
+        let match;
+        while ((match = pattern.exec(html)) !== null) {
+            const rawUrl = String(match[1] || '').trim();
+            const normalized = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(rawUrl) || rawUrl);
+            if (!normalized || seen.has(normalized)) continue;
+            seen.add(normalized);
+            hintedUrls.push(normalized);
+        }
+        return hintedUrls;
+    }
 
-        if (!Array.isArray(ocrResults) || ocrResults.length === 0) {
-            return [];
+    normalizeOcrRecoveryResult(result) {
+        if (!result || typeof result !== 'object') return null;
+        const imageUrl = String(result.imageUrl || result.src || result.url || '').trim();
+        return {
+            ...result,
+            imageUrl,
+            src: imageUrl || String(result.src || '').trim()
+        };
+    }
+
+    async collectOcrCandidateResults(htmlData, ocrConfig = {}) {
+        const maxImages = this.resolveOcrMaxImages(ocrConfig);
+        const segmentHintUrls = this.extractSegmentHintImageUrls(htmlData);
+
+        if (segmentHintUrls.length > 0) {
+            const hintedResults = [];
+            const selectedUrls = segmentHintUrls.slice(0, maxImages);
+            for (let index = 0; index < selectedUrls.length; index++) {
+                const imageUrl = selectedUrls[index];
+                try {
+                    const ocrResult = await this.getOcrTextForImage(imageUrl, ocrConfig, `segment ocr ${index + 1}/${selectedUrls.length}`);
+                    if (ocrResult) {
+                        hintedResults.push(this.normalizeOcrRecoveryResult(ocrResult));
+                    } else {
+                        hintedResults.push(this.normalizeOcrRecoveryResult({ imageUrl, src: imageUrl, text: '' }));
+                    }
+                } catch (error) {
+                    hintedResults.push(this.normalizeOcrRecoveryResult({
+                        imageUrl,
+                        src: imageUrl,
+                        text: '',
+                        error: error && error.message ? error.message : String(error || ''),
+                        cached: false
+                    }));
+                }
+            }
+            return {
+                selectionSource: 'segment-image-hints',
+                candidateImageCount: selectedUrls.length,
+                summaryImageCount: 0,
+                results: hintedResults
+            };
         }
 
-        // Sort by classification relevance (event/promo > title > multi-event > ad > background)
-        const sortedResults = this.sortOcrResultsByRelevance(ocrResults, htmlData, ocrConfig);
+        const allImageUrls = Array.from(this.buildImageEvidenceContext(htmlData));
+        if (typeof this._runOcrOnAllImages === 'function') {
+            const ocrResults = await this._runOcrOnAllImages({
+                html: htmlData && typeof htmlData.html === 'string' ? htmlData.html : '',
+                url: htmlData && typeof htmlData.url === 'string' ? htmlData.url : '',
+                imageUrls: allImageUrls
+            }, ocrConfig);
 
-        // Extract just the image URLs, limited to maxImages
-        const selectedUrls = sortedResults
+            if (!Array.isArray(ocrResults) || ocrResults.length === 0) {
+                return {
+                    selectionSource: 'summary',
+                    candidateImageCount: allImageUrls.length,
+                    summaryImageCount: 0,
+                    results: []
+                };
+            }
+
+            const sortedResults = this.sortOcrResultsByRelevance(ocrResults, htmlData, ocrConfig);
+            const preferredResults = sortedResults.filter(result => String(result && result.text ? result.text : '').trim());
+            const selectionPool = preferredResults.length > 0 ? preferredResults : sortedResults;
+            return {
+                selectionSource: 'summary',
+                candidateImageCount: allImageUrls.length,
+                summaryImageCount: ocrResults.length,
+                results: selectionPool
+                    .slice(0, maxImages)
+                    .map(result => this.normalizeOcrRecoveryResult(result))
+                    .filter(Boolean)
+            };
+        }
+
+        const fallbackResults = [];
+        const selectedFallbackUrls = allImageUrls.slice(0, maxImages);
+        for (let index = 0; index < selectedFallbackUrls.length; index++) {
+            const imageUrl = selectedFallbackUrls[index];
+            try {
+                const ocrResult = await this.getOcrTextForImage(imageUrl, ocrConfig, `ocr ${index + 1}/${selectedFallbackUrls.length}`);
+                if (ocrResult) {
+                    fallbackResults.push(this.normalizeOcrRecoveryResult(ocrResult));
+                } else {
+                    fallbackResults.push(this.normalizeOcrRecoveryResult({ imageUrl, src: imageUrl, text: '' }));
+                }
+            } catch (error) {
+                fallbackResults.push(this.normalizeOcrRecoveryResult({
+                    imageUrl,
+                    src: imageUrl,
+                    text: '',
+                    error: error && error.message ? error.message : String(error || ''),
+                    cached: false
+                }));
+            }
+        }
+        return {
+            selectionSource: 'direct-image-ocr',
+            candidateImageCount: selectedFallbackUrls.length,
+            summaryImageCount: 0,
+            results: fallbackResults
+        };
+    }
+
+    async collectOcrCandidateImageUrls(htmlData, ocrConfig = {}) {
+        const maxImages = this.resolveOcrMaxImages(ocrConfig);
+        const ocrSelection = await this.collectOcrCandidateResults(htmlData, ocrConfig);
+        return (ocrSelection.results || [])
             .slice(0, maxImages)
-            .map(result => result.src || result.imageUrl || result.url)
+            .map(result => result.imageUrl || result.src || result.url)
             .filter(url => url);
-
-        return selectedUrls;
     }
 
     sortOcrResultsByRelevance(ocrResults, htmlData, ocrConfig = {}) {
         const sorted = [...ocrResults];
 
         sorted.sort((a, b) => {
+            const hasTextA = String(a && a.text ? a.text : '').trim() ? 1 : 0;
+            const hasTextB = String(b && b.text ? b.text : '').trim() ? 1 : 0;
+            if (hasTextB !== hasTextA) {
+                return hasTextB - hasTextA;
+            }
+
+            const hasErrorA = a && a.error ? 1 : 0;
+            const hasErrorB = b && b.error ? 1 : 0;
+            if (hasErrorA !== hasErrorB) {
+                return hasErrorA - hasErrorB;
+            }
+
             const scoreA = this.scoreOcrResultByClassification(a, htmlData, ocrConfig);
             const scoreB = this.scoreOcrResultByClassification(b, htmlData, ocrConfig);
 
@@ -1781,9 +1906,12 @@ class AiWebParser {
             attemptedFields: [],
             recoveredFields: [],
             attemptedImageCount: 0,
+            candidateImageCount: 0,
+            summaryImageCount: 0,
             processedImageCount: 0,
             cacheHits: 0,
             images: [],
+            selectionSource: null,
             skippedReason: null
         };
         if (!ocrConfig.enabled) {
@@ -1810,23 +1938,39 @@ class AiWebParser {
             diagnostics.skippedReason = 'no-target-fields-missing';
             return { merged: mergedEvent, diagnostics };
         }
-        const imageUrls = await this.collectOcrCandidateImageUrls(htmlData, ocrConfig);
-        diagnostics.attemptedImageCount = imageUrls?.length || 0;
-        if (imageUrls.length === 0) {
+        const ocrSelection = await this.collectOcrCandidateResults(htmlData, ocrConfig);
+        const selectedResults = Array.isArray(ocrSelection && ocrSelection.results) ? ocrSelection.results : [];
+        diagnostics.selectionSource = ocrSelection && ocrSelection.selectionSource ? ocrSelection.selectionSource : null;
+        diagnostics.candidateImageCount = Number(ocrSelection && ocrSelection.candidateImageCount) || 0;
+        diagnostics.summaryImageCount = Number(ocrSelection && ocrSelection.summaryImageCount) || 0;
+        diagnostics.attemptedImageCount = selectedResults.length;
+        if (selectedResults.length === 0) {
             diagnostics.skippedReason = 'no-image-candidates';
             return { merged: mergedEvent, diagnostics };
         }
 
         const snippets = [];
-        for (let index = 0; index < imageUrls.length; index++) {
-            const imageUrl = imageUrls[index];
+        for (let index = 0; index < selectedResults.length; index++) {
+            const ocrResult = this.normalizeOcrRecoveryResult(selectedResults[index]);
+            const imageUrl = ocrResult && (ocrResult.imageUrl || ocrResult.src || ocrResult.url)
+                ? String(ocrResult.imageUrl || ocrResult.src || ocrResult.url).trim()
+                : '';
             try {
-                const ocrResult = await this.getOcrTextForImage(imageUrl, ocrConfig, `ocr ${index + 1}/${imageUrls.length}`);
+                if (ocrResult && ocrResult.error) {
+                    diagnostics.images.push({
+                        url: imageUrl,
+                        textChars: 0,
+                        cached: Boolean(ocrResult.cached),
+                        status: 'error',
+                        error: ocrResult.error
+                    });
+                    continue;
+                }
                 if (!ocrResult || !ocrResult.text) {
                     diagnostics.images.push({
                         url: imageUrl,
                         textChars: 0,
-                        cached: false,
+                        cached: Boolean(ocrResult && ocrResult.cached),
                         status: 'empty'
                     });
                     continue;

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1654,7 +1654,7 @@ class AiWebParser {
 
         const hintedUrls = [];
         const seen = new Set();
-        const pattern = /^SEGMENT_IMAGE(?:_HINT)?_URL:\s*(\S+)/gim;
+        const pattern = /^\s*SEGMENT_IMAGE(?:_HINT)?_URL:\s*(\S+)/gim;
         let match;
         while ((match = pattern.exec(html)) !== null) {
             const rawUrl = String(match[1] || '').trim();

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -14,8 +14,8 @@ function normalizeUrl(url, baseUrl = 'https://furball.example/events') {
   }
 }
 
-function createParser() {
-  return new AiWebParser({ normalizeUrl });
+function createParser(dependencies = {}) {
+  return new AiWebParser({ normalizeUrl }, dependencies);
 }
 
 test('pairs nearby row-split event images to the matching multi-event segments', () => {
@@ -85,4 +85,159 @@ test('pairs nearby row-split event images to the matching multi-event segments',
     ['https://furball.example/images/event-2.jpg']
   ]);
   assert.deepEqual(segments.slice(2).map(segment => segment.imageHintUrls || null), [null, null]);
+});
+
+test('reuses bulk OCR summary results to select the best recovery image', async () => {
+  let runOcrOnAllImagesCalls = 0;
+  let singleImageOcrCalls = 0;
+  let receivedSnippets = [];
+
+  const parser = createParser({
+    runOcrOnAllImages: async source => {
+      runOcrOnAllImagesCalls += 1;
+      assert.equal(source.url, 'https://furball.example/events');
+      assert.deepEqual(source.imageUrls, [
+        'https://furball.example/images/hero.jpg',
+        'https://furball.example/images/event-poster.jpg'
+      ]);
+      return [
+        {
+          src: 'https://furball.example/images/hero.jpg',
+          text: 'Welcome to Furball',
+          classification: 'background image',
+          confidence: 0.95
+        },
+        {
+          src: 'https://furball.example/images/event-poster.jpg',
+          text: 'FURBALL BLACKOUT July 10 2026 3 Dollar Bill',
+          classification: 'event promotional art',
+          confidence: 0.88,
+          cached: true
+        }
+      ];
+    }
+  });
+
+  parser.getOcrTextForImage = async () => {
+    singleImageOcrCalls += 1;
+    throw new Error('single-image OCR should not run when summary results already exist');
+  };
+  parser.extractFieldsAcrossSnippets = async (htmlData, aiConfig, cityConfig, parserConfig, promptFields, snippets) => {
+    receivedSnippets = snippets;
+    return { description: 'Recovered from OCR summary' };
+  };
+  parser.mergeAiEventFields = (existing, partial) => ({ ...existing, ...partial });
+
+  const result = await parser.recoverMissingFieldsFromImages(
+    {
+      html: `
+        <img src="/images/hero.jpg" alt="Hero" />
+        <img src="/images/event-poster.jpg" alt="Poster" />
+      `,
+      url: 'https://furball.example/events'
+    },
+    { endpoint: 'http://localhost:11434/api/generate', model: 'qwen3.5:4b' },
+    {},
+    {
+      ai: {
+        ocr: {
+          enabled: true,
+          endpoint: 'http://localhost:11434/api/generate',
+          model: 'qwen2.5vl:3b',
+          cache: true
+        }
+      }
+    },
+    ['description'],
+    {
+      title: 'FURBALL BLACKOUT',
+      startDate: '2026-07-10T20:00:00-04:00'
+    },
+    { validatedFields: new Set() },
+    null
+  );
+
+  assert.equal(runOcrOnAllImagesCalls, 1);
+  assert.equal(singleImageOcrCalls, 0);
+  assert.equal(result.merged.description, 'Recovered from OCR summary');
+  assert.equal(result.diagnostics.selectionSource, 'summary');
+  assert.equal(result.diagnostics.candidateImageCount, 2);
+  assert.equal(result.diagnostics.summaryImageCount, 2);
+  assert.equal(result.diagnostics.processedImageCount, 1);
+  assert.equal(result.diagnostics.cacheHits, 1);
+  assert.deepEqual(result.diagnostics.recoveredFields, ['description']);
+  assert.equal(receivedSnippets.length, 1);
+  assert.match(receivedSnippets[0], /OCR_IMAGE_URL: https:\/\/furball\.example\/images\/event-poster\.jpg/);
+});
+
+test('uses segment hinted image URLs directly for OCR recovery', async () => {
+  let runOcrOnAllImagesCalls = 0;
+  const singleImageOcrCalls = [];
+  let receivedSnippets = [];
+
+  const parser = createParser({
+    runOcrOnAllImages: async () => {
+      runOcrOnAllImagesCalls += 1;
+      return [];
+    }
+  });
+
+  parser.getOcrTextForImage = async imageUrl => {
+    singleImageOcrCalls.push(imageUrl);
+    return {
+      imageUrl,
+      text: 'FURBALL POOL PARTY July 24 2026 Elsewhere Rooftop',
+      classification: 'event promotional art',
+      confidence: 0.92,
+      cached: true
+    };
+  };
+  parser.extractFieldsAcrossSnippets = async (htmlData, aiConfig, cityConfig, parserConfig, promptFields, snippets) => {
+    receivedSnippets = snippets;
+    return { description: 'Recovered from segment OCR' };
+  };
+  parser.mergeAiEventFields = (existing, partial) => ({ ...existing, ...partial });
+
+  const result = await parser.recoverMissingFieldsFromImages(
+    {
+      html: `
+        SEGMENT_INDEX: 2/4
+        SEGMENT_IMAGE_HINT_URL: https://furball.example/images/event-2.jpg
+        <article class="event-card-copy">
+          <p>July 24, 2026</p>
+          <h3>FURBALL POOL PARTY</h3>
+        </article>
+      `,
+      url: 'https://furball.example/events'
+    },
+    { endpoint: 'http://localhost:11434/api/generate', model: 'qwen3.5:4b' },
+    {},
+    {
+      ai: {
+        ocr: {
+          enabled: true,
+          endpoint: 'http://localhost:11434/api/generate',
+          model: 'qwen2.5vl:3b'
+        }
+      }
+    },
+    ['description'],
+    {
+      title: 'FURBALL POOL PARTY',
+      startDate: '2026-07-24T20:00:00-04:00'
+    },
+    { validatedFields: new Set() },
+    null
+  );
+
+  assert.equal(runOcrOnAllImagesCalls, 0);
+  assert.deepEqual(singleImageOcrCalls, ['https://furball.example/images/event-2.jpg']);
+  assert.equal(result.merged.description, 'Recovered from segment OCR');
+  assert.equal(result.diagnostics.selectionSource, 'segment-image-hints');
+  assert.equal(result.diagnostics.candidateImageCount, 1);
+  assert.equal(result.diagnostics.summaryImageCount, 0);
+  assert.equal(result.diagnostics.processedImageCount, 1);
+  assert.equal(result.diagnostics.cacheHits, 1);
+  assert.equal(receivedSnippets.length, 1);
+  assert.match(receivedSnippets[0], /OCR_IMAGE_URL: https:\/\/furball\.example\/images\/event-2\.jpg/);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reuse bulk OCR summary results when selecting recovery images instead of OCRing the chosen image twice
- prefer segment image hints for multi-event recovery while keying OCR summaries off the page URL in both adapters
- align bulk OCR request payloads across web and Scriptable and add focused OCR flow tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31515edd-2aad-4784-8d43-d61f21b54e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31515edd-2aad-4784-8d43-d61f21b54e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

