### PR TITLE
Fix AiWebParser cross-prompt data merging bug

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -5569,7 +5569,11 @@ TEXT:
 
             // Check if field should be skipped/dropped/bypassed
             const status = this.getFieldValidationStatus(key, aiEvent, rule, requestedFields, trustedFields, report);
-            if (status === 'skip-internal' || status === 'drop-not-usable' || status === 'drop-not-requested' || status === 'bypass-strictness' || status === 'bypass-trusted') {
+            if (status === 'skip-internal' || status === 'bypass-strictness' || status === 'bypass-trusted') {
+                // Keep these fields without further evidence checks
+                return;
+            }
+            if (status === 'drop-not-usable' || status === 'drop-not-requested') {
                 delete validated[key];
                 return;
             }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -86,3 +86,51 @@ test('pairs nearby row-split event images to the matching multi-event segments',
   ]);
   assert.deepEqual(segments.slice(2).map(segment => segment.imageHintUrls || null), [null, null]);
 });
+
+test('validateAiEventEvidence should NOT delete trusted or internal fields', () => {
+  // Mock EventSchema for testing
+  global.EventSchema = {
+    AI_PROMPT_FIELDS: [
+      { param: 'title', desc: 'Event title' },
+      { param: 'startDate', desc: 'Start date' }
+    ],
+    canonicalizeEventKey: (key) => key.toLowerCase()
+  };
+
+  const parser = createParser();
+  const aiEvent = {
+    title: 'Furball',
+    startDate: '2026-07-11',
+    __internal: 'keep me'
+  };
+
+  const htmlData = { html: 'Some content' };
+  const evidenceContext = parser.buildAiEvidenceContextFromText('Some content');
+  const validationContext = { imageEvidenceUrls: new Set() };
+
+  // Test trusted fields
+  const result = parser.validateAiEventEvidence(aiEvent, htmlData, {}, null, {
+    evidenceContext,
+    validationContext,
+    trustedFields: ['title']
+  });
+
+  assert.ok(result.event.title, 'title should be kept because it is trusted');
+  assert.equal(result.event.title, 'Furball');
+
+  // Test internal fields
+  assert.ok(result.event.__internal, '__internal should be kept because it is internal');
+
+  // Test field not in evidence but NOT strict
+  const nonStrictResult = parser.validateAiEventEvidence(
+    { startDate: '2026-07-11' },
+    htmlData,
+    { ai: { validation: { strict: false } } },
+    null,
+    {
+      evidenceContext,
+      validationContext
+    }
+  );
+  assert.ok(nonStrictResult.event.startDate, 'startDate should be kept when strict is false even if evidence is missing');
+});


### PR DESCRIPTION
Fixed a bug in `AiWebParser` where cross-prompt data merging was broken. The `validateAiEventEvidence` function was incorrectly deleting fields that were already trusted, internal, or marked for strictness bypass. This caused the parser to lose critical event data like `title` and `startDate` during multi-pass extractions. Added a regression test to verify that these fields are now correctly preserved.

---
*PR created automatically by Jules for task [6255053344833235655](https://jules.google.com/task/6255053344833235655) started by @stanleyrya*