### PR TITLE
Group startTime and endTime with date fields in AI prompt

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4565,6 +4565,22 @@ class AiWebParser {
             const fullDateFields = ['start', 'end'];
             selected = selected.filter(field => !fullDateFields.includes(field));
         }
+
+        // Ensure fields follow the canonical order from EventSchema
+        const schemaFields = this.getEventSchemaPromptFields();
+        const schemaOrderMap = new Map(schemaFields.map((field, index) => [field.normalizedName, index]));
+
+        selected.sort((a, b) => {
+            const indexA = schemaOrderMap.get(this.normalizePromptFieldName(a));
+            const indexB = schemaOrderMap.get(this.normalizePromptFieldName(b));
+
+            // If a field is not in the schema (e.g. city added manually), put it at the end
+            const sortA = indexA !== undefined ? indexA : 999;
+            const sortB = indexB !== undefined ? indexB : 999;
+
+            return sortA - sortB;
+        });
+
         const aiPromptFields = selected;
         const manuallyScrapedFields = new Set(['instagram', 'facebook', 'gmaps']);
         const filteredPromptFields = aiPromptFields.filter(field => !manuallyScrapedFields.has(this.normalizePromptFieldName(field)));

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -134,3 +134,51 @@ test('validateAiEventEvidence should NOT delete trusted or internal fields', () 
   );
   assert.ok(nonStrictResult.event.startDate, 'startDate should be kept when strict is false even if evidence is missing');
 });
+
+test('getAiPromptFields should group and sort split date/time fields correctly', () => {
+  // Mock EventSchema specifically for this test to ensure consistency
+  global.EventSchema = {
+    AI_PROMPT_FIELDS: [
+      { param: 'name',    desc: 'Name' },
+      { param: 'startDate', desc: 'Start Date' },
+      { param: 'startTime', desc: 'Start Time' },
+      { param: 'endDate', desc: 'End Date' },
+      { param: 'endTime', desc: 'End Time' },
+      { param: 'city', desc: 'City' }
+    ],
+    canonicalizeEventKey: (key) => {
+      const map = {
+        'name': 'title',
+        'title': 'title',
+        'startdate': 'startDate',
+        'starttime': 'startTime',
+        'enddate': 'endDate',
+        'endtime': 'endTime',
+        'city': 'city'
+      };
+      return map[key.toLowerCase()] || key;
+    }
+  };
+
+  const parser = createParser();
+
+  const parserConfig = {
+    fieldPriorities: {
+      'startTime': { priority: ['ai-web'] },
+      'endTime': { priority: ['ai-web'] },
+      'startDate': { priority: ['ai-web'] },
+      'endDate': { priority: ['ai-web'] },
+      'name': { priority: ['ai-web'] }
+    }
+  };
+
+  // Scenario 1: OCR enabled (dataFlags.ocr = true)
+  const fields = parser.getAiPromptFields(parserConfig, { ocr: true });
+
+  // Expected order based on our mock AI_PROMPT_FIELDS:
+  // name (title), startDate (startdate), startTime (starttime), endDate (enddate), endTime (endtime), city (city)
+  const normalizedFields = fields.map(f => parser.normalizePromptFieldName(f));
+
+  const expectedOrder = ['title', 'startdate', 'starttime', 'enddate', 'endtime', 'city'];
+  assert.deepEqual(normalizedFields, expectedOrder, 'Fields should be sorted according to EventSchema canonical order');
+});


### PR DESCRIPTION
Modified `getAiPromptFields` in `scripts/parsers/ai-web-parser.js` to sort the selected fields array based on the canonical order defined in `EventSchema.AI_PROMPT_FIELDS`. Added a new test case in `scripts/parsers/ai-web-parser.test.js` to verify the grouping and sorting of split date/time fields.

---
*PR created automatically by Jules for task [9600305123265141219](https://jules.google.com/task/9600305123265141219) started by @stanleyrya*