### PR TITLE
Add OpenAI support to AiWebParser

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -2670,20 +2670,7 @@ class AiWebParser {
 
         const base64Image = await this.loadImageAsBase64(imageUrl, ocrConfig.timeoutSeconds);
         console.log(`🤖 AI Web: OCR image attached via base64 payload (${base64Image.length} chars)`);
-        const payload = {
-            model: ocrConfig.model,
-            prompt: ocrConfig.prompt,
-            images: [base64Image],
-            format: 'json',
-            stream: false,
-            think: ocrConfig.think,
-            keep_alive: ocrConfig.keepAlive,
-            options: {
-                num_ctx: ocrConfig.numCtx,
-                num_predict: ocrConfig.numPredict,
-                temperature: ocrConfig.temperature
-            }
-        };
+        const payload = this.buildAiPayload(ocrConfig, ocrConfig.prompt, base64Image);
         const rawResponse = await this.sendAiRequest(ocrConfig, payload, passLabel, ocrConfig.prompt);
         if (!rawResponse) return null;
         const parsed = this.parseOcrResponseWithClassification(rawResponse);
@@ -3381,6 +3368,7 @@ class AiWebParser {
         const aiConfig = parserConfig && typeof parserConfig.ai === 'object' ? parserConfig.ai : {};
         return {
             enabled: aiConfig.enabled !== false,
+            provider: String(aiConfig.provider || 'ollama'),
             endpoint: String(aiConfig.endpoint || 'http://desktop.taila7523c.ts.net:11434/api/generate'),
             model: String(aiConfig.model || 'qwen3.5:4b'),
             payloadMode: this.normalizePayloadMode(aiConfig.payloadMode),
@@ -3390,7 +3378,9 @@ class AiWebParser {
             temperature: Number.isFinite(Number(aiConfig.temperature)) ? Number(aiConfig.temperature) : 0,
             think: Object.prototype.hasOwnProperty.call(aiConfig, 'think') ? Boolean(aiConfig.think) : false,
             timeoutSeconds: Number.isFinite(Number(aiConfig.timeoutSeconds)) ? Number(aiConfig.timeoutSeconds) : 120,
-            keepAlive: Object.prototype.hasOwnProperty.call(aiConfig, 'keepAlive') ? String(aiConfig.keepAlive) : '5m'
+            keepAlive: Object.prototype.hasOwnProperty.call(aiConfig, 'keepAlive') ? String(aiConfig.keepAlive) : '5m',
+            ollama: aiConfig.ollama && typeof aiConfig.ollama === 'object' ? aiConfig.ollama : {},
+            openai: aiConfig.openai && typeof aiConfig.openai === 'object' ? aiConfig.openai : {}
         };
     }
 
@@ -3418,6 +3408,7 @@ class AiWebParser {
         };
         return {
             enabled: rawOcr.enabled !== false,
+            provider: String(rawOcr.provider || baseAiConfig.provider || 'ollama'),
             endpoint: String(rawOcr.endpoint || baseAiConfig.endpoint || ''),
             model: String(rawOcr.model || this.defaultOcrModel),
             prompt: String(rawOcr.prompt || this.defaultOcrPrompt),
@@ -3430,7 +3421,9 @@ class AiWebParser {
             maxImages,
             maxTextChars,
             cacheEnabled: rawOcr.cache !== false,
-            requireMissingFields: rawOcr.requireMissingFields !== false
+            requireMissingFields: rawOcr.requireMissingFields !== false,
+            ollama: rawOcr.ollama && typeof rawOcr.ollama === 'object' ? rawOcr.ollama : (baseAiConfig.ollama || {}),
+            openai: rawOcr.openai && typeof rawOcr.openai === 'object' ? rawOcr.openai : (baseAiConfig.openai || {})
         };
     }
 
@@ -4818,7 +4811,7 @@ TEXT:
         if (prompt) {
             this.recordAiPrompt(prompt, passLabel, aiConfig);
         }
-        console.log(`🤖 AI Web: Sending AI request${label} to ${aiConfig.endpoint} — model: ${aiConfig.model}, stream: ${payload.stream}, prompt: ${promptChars} chars`);
+        console.log(`🤖 AI Web: Sending AI request${label} to ${aiConfig.endpoint} — model: ${aiConfig.model}, provider: ${aiConfig.provider}, prompt: ${promptChars} chars`);
         if (prompt) {
             console.log(`🤖 AI Web: Full prompt${label} (${promptChars} chars)\n${prompt}`);
         }
@@ -4859,10 +4852,11 @@ TEXT:
                 }
             }
             const elapsed = Date.now() - startTime;
-            if (responseJson && typeof responseJson.response === 'string' && responseJson.response.length > 0) {
-                console.log(`🤖 AI Web: AI request${label} succeeded in ${elapsed}ms — response: ${responseJson.response.length} chars`);
-                console.log(`🤖 AI Web: Model response text${label}\n${responseJson.response}`);
-                return responseJson.response;
+            const responseContent = this.extractAiResponse(aiConfig, responseJson);
+            if (responseContent && typeof responseContent === 'string' && responseContent.length > 0) {
+                console.log(`🤖 AI Web: AI request${label} succeeded in ${elapsed}ms — response: ${responseContent.length} chars`);
+                console.log(`🤖 AI Web: Model response text${label}\n${responseContent}`);
+                return responseContent;
             }
             const doneReason = responseJson && typeof responseJson.done_reason === 'string' ? responseJson.done_reason : 'n/a';
             console.warn(`🤖 AI Web: AI request${label} completed in ${elapsed}ms with empty response (done_reason: ${doneReason})`);
@@ -4878,21 +4872,85 @@ TEXT:
         }
     }
 
+    /**
+     * Maps common inputs, images, and provider-specific configurations into the exact payload.
+     * @param {Object} aiConfig - Your unified configuration object
+     * @param {string} prompt - The text extraction prompt
+     * @param {string|null} base64Image - Optional base64 image data string
+     */
+    buildAiPayload(aiConfig, prompt, base64Image = null) {
+        if (aiConfig.provider === 'ollama') {
+            const payload = {
+                model: aiConfig.model,
+                prompt: prompt,
+                format: "json",
+                stream: false,
+                think: aiConfig.think,
+                keep_alive: aiConfig.keepAlive,
+                options: {
+                    num_ctx: aiConfig.numCtx,
+                    num_predict: aiConfig.numPredict,
+                    temperature: aiConfig.temperature
+                }
+            };
+            if (base64Image) {
+                payload.images = [base64Image];
+            }
+            return payload;
+        }
+
+        if (aiConfig.provider === 'openai') {
+            let userContent;
+            if (base64Image) {
+                userContent = [
+                    { type: "text", text: prompt },
+                    {
+                        type: "image_url",
+                        image_url: {
+                            url: `data:image/png;base64,${base64Image}`
+                        }
+                    }
+                ];
+            } else {
+                userContent = prompt;
+            }
+
+            return {
+                model: aiConfig.model,
+                messages: [
+                    { role: "user", content: userContent }
+                ],
+                temperature: aiConfig.temperature,
+                max_tokens: aiConfig.numPredict,
+                response_format: aiConfig.openai?.responseFormat
+                    ? { type: aiConfig.openai.responseFormat }
+                    : { type: "json_object" }
+            };
+        }
+
+        throw new Error(`Unsupported AI provider: ${aiConfig.provider}`);
+    }
+
+    /**
+     * Extracts the raw string content out of varying provider response shapes.
+     */
+    extractAiResponse(aiConfig, responseBody) {
+        if (!responseBody) return null;
+
+        if (aiConfig.provider === 'ollama') {
+            return responseBody.response;
+        }
+
+        if (aiConfig.provider === 'openai') {
+            return responseBody.choices?.[0]?.message?.content;
+        }
+
+        throw new Error(`Unsupported AI provider: ${aiConfig.provider}`);
+    }
+
     async callAiGenerate(aiConfig, prompt, passLabel) {
         if (!prompt) return null;
-        const payload = {
-            model: aiConfig.model,
-            prompt,
-            format: 'json',
-            stream: false,
-            think: aiConfig.think,
-            keep_alive: aiConfig.keepAlive,
-            options: {
-                num_ctx: aiConfig.numCtx,
-                num_predict: aiConfig.numPredict,
-                temperature: aiConfig.temperature
-            }
-        };
+        const payload = this.buildAiPayload(aiConfig, prompt);
         return this.sendAiRequest(aiConfig, payload, passLabel, prompt);
     }
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -182,3 +182,52 @@ test('getAiPromptFields should group and sort split date/time fields correctly',
   const expectedOrder = ['title', 'startdate', 'starttime', 'enddate', 'endtime', 'city'];
   assert.deepEqual(normalizedFields, expectedOrder, 'Fields should be sorted according to EventSchema canonical order');
 });
+
+test('buildAiPayload and extractAiResponse support both Ollama and OpenAI', () => {
+  const parser = createParser();
+  const prompt = 'Extract event details';
+  const base64Image = 'base64data';
+
+  // Ollama Payload
+  const ollamaConfig = {
+    provider: 'ollama',
+    model: 'qwen3.5:4b',
+    numPredict: 512,
+    temperature: 0,
+    keepAlive: '5m'
+  };
+  const ollamaPayload = parser.buildAiPayload(ollamaConfig, prompt, base64Image);
+  assert.equal(ollamaPayload.model, 'qwen3.5:4b');
+  assert.equal(ollamaPayload.prompt, prompt);
+  assert.deepEqual(ollamaPayload.images, [base64Image]);
+  assert.equal(ollamaPayload.options.num_predict, 512);
+
+  // OpenAI Payload (Text only)
+  const openaiConfig = {
+    provider: 'openai',
+    model: 'gpt-4o',
+    numPredict: 1024,
+    temperature: 0.5
+  };
+  const openaiPayloadText = parser.buildAiPayload(openaiConfig, prompt);
+  assert.equal(openaiPayloadText.model, 'gpt-4o');
+  assert.equal(openaiPayloadText.messages[0].role, 'user');
+  assert.equal(openaiPayloadText.messages[0].content, prompt);
+  assert.equal(openaiPayloadText.max_tokens, 1024);
+  assert.deepEqual(openaiPayloadText.response_format, { type: 'json_object' });
+
+  // OpenAI Payload (Vision)
+  const openaiPayloadVision = parser.buildAiPayload(openaiConfig, prompt, base64Image);
+  assert.ok(Array.isArray(openaiPayloadVision.messages[0].content));
+  assert.equal(openaiPayloadVision.messages[0].content[0].type, 'text');
+  assert.equal(openaiPayloadVision.messages[0].content[0].text, prompt);
+  assert.equal(openaiPayloadVision.messages[0].content[1].type, 'image_url');
+  assert.equal(openaiPayloadVision.messages[0].content[1].image_url.url, `data:image/png;base64,${base64Image}`);
+
+  // Response Extraction
+  const ollamaResponse = { response: '{"title": "Ollama Event"}' };
+  assert.equal(parser.extractAiResponse(ollamaConfig, ollamaResponse), '{"title": "Ollama Event"}');
+
+  const openaiResponse = { choices: [{ message: { content: '{"title": "OpenAI Event"}' } }] };
+  assert.equal(parser.extractAiResponse(openaiConfig, openaiResponse), '{"title": "OpenAI Event"}');
+});

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -472,6 +472,56 @@ const scraperConfig = {
         ticketUrl: { priority: ["ai-web"], merge: "clobber" }
       },
       metadata: {}
+    },
+    {
+      name: "AI Web Parser (OpenAI Sample)",
+      iconUrl: "https://www.google.com/s2/favicons?domain=openai.com&sz=64",
+      enabled: false,
+      automation: {
+        automationEnabled: false
+      },
+      parser: "ai-web",
+      urls: ["https://example.com/openai-events"],
+      alwaysBear: false,
+      urlDiscoveryDepth: 1,
+      maxAdditionalUrls: 15,
+      dryRun: true,
+      ai: {
+        enabled: true,
+        provider: "openai",
+        endpoint: "https://api.openai.com/v1/chat/completions",
+        model: "gpt-4o",
+        numPredict: 1024,
+        temperature: 0,
+        openai: {
+          responseFormat: "json_object"
+        }
+      },
+      ocr: {
+        enabled: true,
+        provider: "openai",
+        endpoint: "https://api.openai.com/v1/chat/completions",
+        model: "gpt-4o-mini",
+        numPredict: 2000,
+        temperature: 0,
+        openai: {
+          responseFormat: "json_object"
+        }
+      },
+      fieldPriorities: {
+        title: { priority: ["ai-web"], merge: "clobber" },
+        description: { priority: ["ai-web"], merge: "clobber" },
+        bar: { priority: ["ai-web"], merge: "clobber" },
+        address: { priority: ["ai-web"], merge: "clobber" },
+        startDate: { priority: ["ai-web"], merge: "clobber" },
+        endDate: { priority: ["ai-web"], merge: "clobber" },
+        city: { priority: ["ai-web"], merge: "clobber" },
+        url: { priority: ["ai-web"], merge: "clobber" },
+        image: { priority: ["ai-web"], merge: "clobber" },
+        cover: { priority: ["ai-web"], merge: "clobber" },
+        ticketUrl: { priority: ["ai-web"], merge: "clobber" }
+      },
+      metadata: {}
     }
   ]
 };


### PR DESCRIPTION
This change adds support for OpenAI-compatible endpoints to the `AiWebParser` and its OCR functionality. 

Key changes:
- Introduced a modular adapter pattern with `buildAiPayload` and `extractAiResponse` methods.
- `buildAiPayload` handles the specific request structures for Ollama (root `prompt` and `images`) and OpenAI (`messages` array with content blocks for vision).
- `extractAiResponse` provides a unified way to get generated text from different response formats.
- Enhanced configuration to allow specifying the provider and nested provider-specific parameters.
- Updated all AI call sites to use these new unified methods.
- Added unit tests in `ai-web-parser.test.js` to verify correct payload construction and response parsing for both providers.

The implementation follows the requested modular architecture, keeping the core scraping logic provider-agnostic and avoiding complex fallback logic.

---
*PR created automatically by Jules for task [8665151422558404831](https://jules.google.com/task/8665151422558404831) started by @stanleyrya*