### PR TITLE
Fix date normalization failure when timezone is missing

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -5938,12 +5938,12 @@ TEXT:
         const combinedStartDate = startProvided
             ? this.parseDateValue(aiEvent.start, timezone)
             : (startTimeRaw && startDateRaw
-                ? this.convertLocalDateTimeToUtc(startDateRaw.toISOString().split('T')[0] + ' ' + startTimeRaw, timezone)
+                ? (this.convertLocalDateTimeToUtc(startDateRaw.toISOString().split('T')[0] + ' ' + startTimeRaw, timezone) || combineDateAndTime(startDateRaw, startTimeRaw))
                 : (startTimeRaw && !startDateRaw ? this.parseDateValue(startTimeRaw, timezone) : startDateRaw));
         const combinedEndDate = endProvided
             ? this.parseDateValue(aiEvent.end, timezone)
             : (endTimeRaw && endDateRaw
-                ? this.convertLocalDateTimeToUtc(endDateRaw.toISOString().split('T')[0] + ' ' + endTimeRaw, timezone)
+                ? (this.convertLocalDateTimeToUtc(endDateRaw.toISOString().split('T')[0] + ' ' + endTimeRaw, timezone) || combineDateAndTime(endDateRaw, endTimeRaw))
                 : (endTimeRaw && !endDateRaw ? this.parseDateValue(endTimeRaw, timezone) : endDateRaw));
 
         console.log(`🤖 AI Web: Combined dates — combinedStartDate=${combinedStartDate instanceof Date ? combinedStartDate.toISOString() : combinedStartDate}, combinedEndDate=${combinedEndDate instanceof Date ? combinedEndDate.toISOString() : combinedEndDate}`);


### PR DESCRIPTION
This change fixes a bug in the `AiWebParser` where event normalization would fail entirely if the timezone or city information was missing, even if valid date and time values were successfully extracted by the AI.

Key changes:
- Updated `AiWebParser.prototype.normalizeAiEvent` in `scripts/parsers/ai-web-parser.js` to include a fallback mechanism for date combination.
- If `convertLocalDateTimeToUtc` fails (returning `null`), the code now uses `combineDateAndTime` to perform a basic UTC combination of the extracted date and time strings.
- This ensures that the parser remains robust and can still produce valid event objects even with incomplete location metadata.
- Verified the fix with a reproduction script and confirmed no regressions by running the existing test suite.

---
*PR created automatically by Jules for task [2478197881940140181](https://jules.google.com/task/2478197881940140181) started by @stanleyrya*