### PR TITLE
Fix default OCR config in AiWebParser to prevent model mismatch on OpenAI endpoint

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -3381,7 +3381,7 @@ class AiWebParser {
 
     getAiConfig(parserConfig = {}) {
         const aiConfig = parserConfig && typeof parserConfig.ai === 'object' ? parserConfig.ai : {};
-        const provider = String(aiConfig.provider || 'ollama');
+        const provider = String(aiConfig.provider || 'openai');
         const defaultEndpoint = provider === 'openai'
             ? 'https://api.openai.com/v1/chat/completions'
             : 'http://desktop.taila7523c.ts.net:11434/api/generate';
@@ -3429,11 +3429,27 @@ class AiWebParser {
             temperature: this.defaultOcrRequestConfig.temperature,
             think: this.defaultOcrRequestConfig.think
         };
+        const provider = String(rawOcr.provider || 'ollama');
+
+        let defaultEndpoint;
+        if (provider === 'openai') {
+            defaultEndpoint = 'https://api.openai.com/v1/chat/completions';
+        } else {
+            // If the base AI config is also ollama, inherit its endpoint so custom endpoints aren't lost
+            defaultEndpoint = baseAiConfig.provider === 'ollama' && baseAiConfig.endpoint
+                ? baseAiConfig.endpoint
+                : 'http://desktop.taila7523c.ts.net:11434/api/generate';
+        }
+
+        const defaultModel = provider === 'openai'
+            ? 'gpt-4o'
+            : this.defaultOcrModel;
+
         return {
             enabled: rawOcr.enabled !== false,
-            provider: String(rawOcr.provider || baseAiConfig.provider || 'ollama'),
-            endpoint: String(rawOcr.endpoint || baseAiConfig.endpoint || ''),
-            model: String(rawOcr.model || this.defaultOcrModel),
+            provider: provider,
+            endpoint: String(rawOcr.endpoint || defaultEndpoint),
+            model: String(rawOcr.model || defaultModel),
             prompt: String(rawOcr.prompt || this.defaultOcrPrompt),
             ...Object.fromEntries(
                 Object.entries(ocrConfigTemplate).map(([key, defaultValue]) => [


### PR DESCRIPTION
Fixes an error where the default OCR settings would inherit the text prompt configurations (which recently changed to OpenAI), resulting in sending Ollama OCR models to the OpenAI endpoint. The text prompts' provider has been officially defaulted to `openai`, but `ocr` will now safely default to `ollama` with its specific tailscale endpoint instead of crashing.

---
*PR created automatically by Jules for task [14203542128442929963](https://jules.google.com/task/14203542128442929963) started by @stanleyrya*