### PR TITLE
fix: null pointer error evaluating segment bounds matched records

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1180,7 +1180,7 @@ class AiWebParser {
 
         // Text similarity bonus - compare OCR text with segment content
         let similarity = 0;
-        if (ocrResult.text && Array.isArray(segmentBounds.matchedRecords) && segmentBounds.matchedRecords.length > 0) {
+        if (ocrResult.text && segmentBounds && Array.isArray(segmentBounds.matchedRecords) && segmentBounds.matchedRecords.length > 0) {
             const segmentText = segmentBounds.matchedRecords.map(r => r.text).join('\n');
             similarity = this.computeTextSimilarity(ocrResult.text, segmentText);
             if (similarity >= 0.15) {


### PR DESCRIPTION
Fixes a `TypeError` in `AiWebParser` occurring when `segmentBounds` is null. Added a safe access check before attempting to access `segmentBounds.matchedRecords` during image pairing cost calculations. This allows the process to gracefully handle OCR processing on pages with unstructured layouts where segment boundaries are not well-defined.

---
*PR created automatically by Jules for task [17256281803065036862](https://jules.google.com/task/17256281803065036862) started by @stanleyrya*