### PR TITLE
Fix unknown city errors and add GayCities backoff

### DIFF
--- a/data/bars/bangkok.json
+++ b/data/bars/bangkok.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "BEEF.BKK",
+    "city": "bangkok",
+    "address": "9th Fl. SilomEdge Si Lom Rd, Suriya Wong, Bang Rak, Bangkok 10500, Thailand",
+    "coordinates": "13.729305880910303, 100.53569913387547",
+    "instagram": "https://www.instagram.com/beef.bkk",
+    "facebook": "https://www.facebook.com/beef.bkkbar/",
+    "googleMaps": "https://maps.app.goo.gl/zEYjJa9v8AJJGUNB6"
+  },
+  {
+    "name": "CAKE",
+    "city": "bangkok",
+    "address": "ตั้งอยู่ที่ 942/27 Rama IV Rd, Suriya Wong, Bang Rak, Bangkok 10500, Thailand",
+    "coordinates": "13.730338066694463, 100.53405491726055",
+    "instagram": "https://www.instagram.com/cake.bangkok",
+    "facebook": "https://www.facebook.com/CakeBangkokTH/",
+    "googleMaps": "https://maps.app.goo.gl/GrhBKQzDEFfvcUFn8"
+  },
+  {
+    "name": "BARBER.BAR",
+    "city": "bangkok",
+    "address": "ชั้น 2 109/111 Si Lom Rd, Khwaeng Suriya Wong, Khet Bang Rak, Bangkok 10500, Thailand",
+    "coordinates": "13.727938343038128, 100.53224466713601",
+    "instagram": "https://www.instagram.com/bar.ber.bar/",
+    "googleMaps": "https://maps.app.goo.gl/V96bZYM6qBm8tqQs5"
+  }
+]

--- a/data/bars/boston.json
+++ b/data/bars/boston.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "The Alley Bar",
+    "city": "boston",
+    "gayCities": "https://boston.gaycities.com/bars/127-the-alley-bar",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:07.283Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/chicago.json
+++ b/data/bars/chicago.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "Meeting House Tavern",
+    "city": "chicago",
+    "gayCities": "https://chicago.gaycities.com/bars/311263-meeting-house-tavern",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:06.765Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "The SoFo Tap",
+    "city": "chicago",
+    "address": "4923 N Clark St 1st floor, Chicago, IL 60640",
+    "coordinates": "41.9724308, -87.6676099",
+    "instagram": "https://www.instagram.com/thesofotap",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJUztUhCjSD4gRnZEajxMfo7Q",
+    "gayCities": "https://chicago.gaycities.com/bars/2076-the-sofo-tap",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:20.384Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Jackhammer",
+    "city": "chicago",
+    "gayCities": "https://chicago.gaycities.com/bars/176-jackhammer",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:07.070Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Touché",
+    "city": "chicago",
+    "address": "6412 N Clark St, Chicago, IL 60626",
+    "coordinates": "41.9985708, -87.670974",
+    "instagram": "https://www.instagram.com/?hl=en",
+    "facebook": "https://www.facebook.com/ToucheChicago",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJnwLkWrzRD4gREreJ-KlTEoU",
+    "gayCities": "https://chicago.gaycities.com/bars/184-touch%C3%A9"
+  },
+  {
+    "name": "Cell Block",
+    "city": "chicago",
+    "gayCities": "https://chicago.gaycities.com/bars/145-cell-block",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:08.721Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/fort-lauderdale.json
+++ b/data/bars/fort-lauderdale.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "Eagle",
+    "city": "fort-lauderdale",
+    "gayCities": "https://fortlauderdale.gaycities.com/bars/309115-eagle-wilton-manors",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:07.785Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Gym Sports Bar",
+    "city": "fort-lauderdale",
+    "address": "2287 Wilton Dr, Wilton Manors, FL 33305",
+    "coordinates": "26.1572257, -80.1373084",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJPUAeAZwB2YgRL0hklcfzn6A",
+    "gayCities": "https://fortlauderdale.gaycities.com/bars/309259-gym-sportsbar-wilton-manors",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:26.668Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "The Pub",
+    "city": "fort-lauderdale",
+    "gayCities": "https://fortlauderdale.gaycities.com/bars/304345-the-pub-wilton-manors",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:08.740Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Hunters",
+    "city": "fort-lauderdale",
+    "address": "2232-2238 Wilton Dr, Wilton Manors, FL 33305",
+    "coordinates": "26.1557905, -80.1381831",
+    "facebook": "https://www.facebook.com/huntersfl",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJde9xlp4B2YgRVl9hn3TriiI",
+    "gayCities": "https://fortlauderdale.gaycities.com/bars/247-hunters-nightclub-wilton-manors",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:32.819Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Scandals Saloon",
+    "city": "fort-lauderdale",
+    "gayCities": "https://fortlauderdale.gaycities.com/bars/256-scandals-saloon",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:14.184Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/hong-kong.json
+++ b/data/bars/hong-kong.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "Boo Bar",
+    "city": "hong-kong",
+    "address": "Hong Kong, Yau Ma Tei, Nathan Rd, 225號五樓 Pearl Oriental Tower",
+    "coordinates": "22.304447393688015, 114.17136209855921",
+    "instagram": "https://www.instagram.com/boobarhk",
+    "facebook": "https://www.facebook.com/boobar.hk/",
+    "googleMaps": "https://maps.app.goo.gl/jPTA9KhoNaEzNhCJA"
+  }
+]

--- a/data/bars/honolulu.json
+++ b/data/bars/honolulu.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "Hula's Bar and Lei Stand",
+    "city": "honolulu",
+    "gayCities": "https://hawaii.gaycities.com/bars/276-hulas-bar-lei-stand",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:15.559Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "In Between",
+    "city": "honolulu",
+    "address": "2155 Lauula St, Honolulu, HI 96815",
+    "coordinates": "21.2807141, -157.8297099",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJK93OZIptAHwRwR-r34F8Zj4",
+    "gayCities": "https://hawaii.gaycities.com/bars/277-in-between",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:42.207Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/la.json
+++ b/data/bars/la.json
@@ -7,7 +7,9 @@
     "instagram": "dirtybird_la",
     "facebook": "https://www.facebook.com/eagle.bar.la/",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJLwuhHU_HwoARdQQ1PfOn6B4",
-    "gayCities": "https://losangeles.gaycities.com/bars/357-eagle-la"
+    "gayCities": "https://losangeles.gaycities.com/bars/357-eagle-la",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:04.830Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   },
   {
     "name": "Precinct LA",
@@ -17,6 +19,29 @@
     "instagram": "https://www.instagram.com/precinctdtla",
     "facebook": "https://www.facebook.com/precinctdtla",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ16rgokvGwoARgLmCBWa28wI",
-    "gayCities": "https://losangeles.gaycities.com/bars/306866-precinct"
+    "gayCities": "https://losangeles.gaycities.com/bars/306866-precinct",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:08.016Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Akbar",
+    "city": "la",
+    "gayCities": "https://losangeles.gaycities.com/bars/359-akbar",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:06.594Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "The Falcon",
+    "city": "la",
+    "gayCities": "https://longbeach.gaycities.com/bars/1215-falcon",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:06.674Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "GYM Bar",
+    "city": "la",
+    "gayCities": "https://losangeles.gaycities.com/bars/309258-gym-bar-weho",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:14.234Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   }
 ]

--- a/data/bars/london.json
+++ b/data/bars/london.json
@@ -7,6 +7,34 @@
     "instagram": "https://www.instagram.com/rvtofficial",
     "facebook": "https://www.facebook.com/TheRVT",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJuYgA--wEdkgRD-0ylWTyMkw",
-    "gayCities": "https://london.gaycities.com/bars/1710-royal-vauxhall-tavern"
+    "gayCities": "https://london.gaycities.com/bars/1710-royal-vauxhall-tavern",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:05.525Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Duke of Wellington",
+    "city": "london",
+    "gayCities": "https://london.gaycities.com/bars/1704-the-duke-of-wellington",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:05.999Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Kings Arms",
+    "city": "london",
+    "address": "23 Poland St, London, England W1F 8QL",
+    "coordinates": "51.5151643, -0.1371827",
+    "instagram": "https://www.instagram.com/KingsArms.soho",
+    "facebook": "https://www.facebook.com/kingsarms.soho",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJBUDtIZcEdkgR0k-Xw7rA8wM",
+    "gayCities": "https://london.gaycities.com/bars/2046-the-kings-arms",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:17.284Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Eagle London",
+    "city": "london",
+    "gayCities": "https://london.gaycities.com/bars/1685-eagle-london",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:06.578Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   }
 ]

--- a/data/bars/montreal.json
+++ b/data/bars/montreal.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Le Stud",
+    "city": "montreal",
+    "gayCities": "https://montreal.gaycities.com/bars/724-le-stud",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:08.383Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Aigle Noir",
+    "city": "montreal",
+    "address": "1315 St Catherine St E, Montreal, QC H2L 2H4",
+    "coordinates": "45.519641, -73.555339",
+    "facebook": "https://www.facebook.com/Bar.Aigle.Noir/",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJEc7NGK4byUwR1QVPh5qsYCY",
+    "gayCities": "https://montreal.gaycities.com/bars/710-aigle-noir",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:29.766Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/nyc.json
+++ b/data/bars/nyc.json
@@ -6,7 +6,9 @@
     "coordinates": "40.7173904, -73.9493112",
     "instagram": "https://www.instagram.com/animal.nyc",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJdaGX6E9ZwokRrcrhq8cMM-8",
-    "gayCities": "https://newyork.gaycities.com/bars/312406-animal"
+    "gayCities": "https://newyork.gaycities.com/bars/312406-animal",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:02.885Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   },
   {
     "name": "Rockbar",
@@ -16,7 +18,9 @@
     "instagram": "https://www.instagram.com/rockbarnyc",
     "facebook": "https://www.facebook.com/Rockbar-NYC",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJlwfqXuxZwokRTlizRW_4cwc",
-    "gayCities": "https://newyork.gaycities.com/bars/3486-rockbar-nyc"
+    "gayCities": "https://newyork.gaycities.com/bars/3486-rockbar-nyc",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:43:58.506Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   },
   {
     "name": "Eagle NYC",
@@ -36,7 +40,9 @@
     "instagram": "https://www.instagram.com/3dollarbillbk",
     "facebook": "https://www.facebook.com/3dollarbillbk",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ7zm6H3JbwokR3ui1wTNr6Xc",
-    "gayCities": "https://newyork.gaycities.com/bars/309059-dollar-bill"
+    "gayCities": "https://newyork.gaycities.com/bars/309059-dollar-bill",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:03.601Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   },
   {
     "name": "Ty's",
@@ -46,7 +52,9 @@
     "instagram": "https://www.instagram.com/tysbar",
     "facebook": "https://www.facebook.com/TysNYC",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJaVvpXJNZwokRT3p02KL_TrY",
-    "gayCities": "https://newyork.gaycities.com/bars/388-tys-bar-nyc"
+    "gayCities": "https://newyork.gaycities.com/bars/388-tys-bar-nyc",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:01.708Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   },
   {
     "name": "Nowhere Bar",
@@ -56,6 +64,47 @@
     "instagram": "https://www.instagram.com/nowherenyc",
     "facebook": "https://www.facebook.com/nowherebar",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJZ1fMFZ5ZwokRkYrV85CZorY",
-    "gayCities": "https://newyork.gaycities.com/bars/415-nowhere-bar"
+    "gayCities": "https://newyork.gaycities.com/bars/415-nowhere-bar",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:03.933Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Albatross",
+    "city": "nyc",
+    "gayCities": "https://newyork.gaycities.com/bars/449-albatross-bar",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:05.543Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Gym Sports Bar",
+    "city": "nyc",
+    "gayCities": "https://newyork.gaycities.com/bars/394-gym-sportsbar",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:08.111Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "FLEX",
+    "city": "nyc",
+    "gayCities": "https://newyork.gaycities.com/bars/311127-flex",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:15.060Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Atlas Social Club",
+    "city": "nyc",
+    "address": "753 9th Ave, New York, NY 10019",
+    "coordinates": "40.7640829, -73.9889102",
+    "facebook": "https://www.facebook.com/atlassocialclub",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJSYrBMldYwokRuer87cJcwiw",
+    "gayCities": "https://newyork.gaycities.com/bars/305118-atlas-social-club",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:39.100Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "9th Avenue Saloon",
+    "city": "nyc",
+    "gayCities": "https://newyork.gaycities.com/bars/426-th-avenue-saloon",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:15.492Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   }
 ]

--- a/data/bars/palm-springs.json
+++ b/data/bars/palm-springs.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "Hunters",
+    "city": "palm-springs",
+    "gayCities": "https://palmsprings.gaycities.com/bars/588-hunters-palm-springs",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:14.133Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/paris.json
+++ b/data/bars/paris.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "Bear's Den",
+    "city": "paris",
+    "gayCities": "https://paris.gaycities.com/bars/1625-bears-den",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:05.684Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "El Hombre",
+    "city": "paris",
+    "address": "15 rue de la Reynie, Paris, France 75004",
+    "coordinates": "48.859861, 2.349458",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJsYcLoB5u5kcRvlZDfSyg7w4",
+    "gayCities": "https://paris.gaycities.com/bars/307921-el-hombre",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:14.181Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/portland.json
+++ b/data/bars/portland.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "CC Slaughters",
+    "city": "portland",
+    "gayCities": "https://portland.gaycities.com/bars/893-cc-slaughters-nightclub-and-lounge",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:08.216Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/ptown.json
+++ b/data/bars/ptown.json
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "A-House",
+    "city": "ptown",
+    "gayCities": "https://ptown.gaycities.com/bars/535-a-house",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:07.379Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Boatslip",
+    "city": "ptown",
+    "address": "161 Commercial St, Provincetown, MA 02657",
+    "coordinates": "42.0470329, -70.1901852",
+    "instagram": "https://www.instagram.com/boatslipresort",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ-fvjNIBY-4kRHNO3kg_G5Cc",
+    "gayCities": "https://ptown.gaycities.com/hotels/10272-boatslip-resort-beach-club",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:23.570Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Crown & Anchor",
+    "city": "ptown",
+    "gayCities": "https://ptown.gaycities.com/bars/541-crown-anchor",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:07.704Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Purgatory Gifford House",
+    "city": "ptown",
+    "gayCities": "https://ptown.gaycities.com/bars/543-purgatory-gifford-house",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:08.314Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/pv.json
+++ b/data/bars/pv.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "STUDS",
+    "city": "pv",
+    "gayCities": "https://vallarta.gaycities.com/bars/309956-studs-bear-bar",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:05.611Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "CC Slaughters",
+    "city": "pv",
+    "gayCities": "https://vallarta.gaycities.com/bars/302724-cc-slaughters",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:08.132Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/seattle.json
+++ b/data/bars/seattle.json
@@ -15,7 +15,9 @@
     "address": "9630 16th Ave SW, Seattle, WA 98106",
     "coordinates": "47.5165235, -122.3548059",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ-8uYrt9DkFQRXv1WZmNZ8F0",
-    "gayCities": "https://seattle.gaycities.com/bars/309627-the-lumber-yard-bar"
+    "gayCities": "https://seattle.gaycities.com/bars/309627-the-lumber-yard-bar",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:04.188Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   },
   {
     "name": "The Cuff Complex",
@@ -24,7 +26,9 @@
     "coordinates": "47.6150778, -122.3157208",
     "facebook": "https://www.facebook.com/thecuffcomplex",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJuQVbk81qkFQRkm6N_RnwHQY",
-    "gayCities": "https://seattle.gaycities.com/bars/514-the-cuff-complex"
+    "gayCities": "https://seattle.gaycities.com/bars/514-the-cuff-complex",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:04.862Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   },
   {
     "name": "Seattle Eagle",
@@ -41,7 +45,9 @@
     "coordinates": "47.6196626, -122.3233158",
     "facebook": "https://www.facebook.com/ccsseattle",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJk-Ws_tFqkFQRc2h8MPRvv5I",
-    "gayCities": "https://seattle.gaycities.com/bars/505-ccs-seattle"
+    "gayCities": "https://seattle.gaycities.com/bars/505-ccs-seattle",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:04.751Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   },
   {
     "name": "Madison Pub",
@@ -49,7 +55,9 @@
     "address": "1315 E Madison St, Seattle, WA 98122",
     "coordinates": "47.6133619, -122.3149054",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJB_-ecc5qkFQRS1xH4lgadrg",
-    "gayCities": "https://seattle.gaycities.com/bars/508-madison-pub"
+    "gayCities": "https://seattle.gaycities.com/bars/508-madison-pub",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:05.171Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   },
   {
     "name": "Pony",
@@ -57,6 +65,8 @@
     "address": "1221 E Madison St, Seattle, WA 98122",
     "coordinates": "47.6130663, -122.3157243",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJRUOyfc5qkFQRDZLLFj1Q264",
-    "gayCities": "https://seattle.gaycities.com/bars/2442-pony"
+    "gayCities": "https://seattle.gaycities.com/bars/2442-pony",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:11.084Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
   }
 ]

--- a/data/bars/sf.json
+++ b/data/bars/sf.json
@@ -1,0 +1,43 @@
+[
+  {
+    "name": "SF Eagle",
+    "city": "sf",
+    "gayCities": "https://sanfrancisco.gaycities.com/bars/304619-sf-eagle",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:14.304Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Powerhouse",
+    "city": "sf",
+    "address": "1347 Folsom St, San Francisco, CA 94103",
+    "coordinates": "37.773088, -122.412193",
+    "instagram": "https://www.instagram.com/sfpowerhouse",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJY_ioDSh-j4ARCCFmqIVhgZo",
+    "gayCities": "https://sanfrancisco.gaycities.com/bars/43-powerhouse",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:35.917Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Hole in the Wall Saloon",
+    "city": "sf",
+    "gayCities": "https://sanfrancisco.gaycities.com/bars/40-hole-in-the-wall-saloon",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:14.640Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "Lone Star Saloon",
+    "city": "sf",
+    "address": "1354 Harrison St, San Francisco, CA 94103",
+    "coordinates": "37.7721717, -122.410901",
+    "facebook": "https://www.facebook.com/lonestarsf",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ4yvd8Ch-j4ARGZFAn1jfTl8",
+    "gayCities": "https://sanfrancisco.gaycities.com/bars/42-lone-star-saloon"
+  },
+  {
+    "name": "440 Castro",
+    "city": "sf",
+    "gayCities": "https://sanfrancisco.gaycities.com/bars/3-castro",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:15.010Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/tokyo.json
+++ b/data/bars/tokyo.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "EAGLE TOKYO",
+    "city": "tokyo",
+    "gayCities": "https://tokyo.gaycities.com/bars/307927-eagle-tokyo",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:16.126Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  },
+  {
+    "name": "EAGLE TOKYO BLUE",
+    "city": "tokyo",
+    "address": "2 Chome−11−2 Casa Verde, 1階、地下1階, Shinjuku City, Tokyo 160-0022",
+    "coordinates": "35.690086, 139.7077713",
+    "instagram": "https://www.instagram.com/eagletokyojp",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJVVvvklSNGGAR4pCosef9zpQ",
+    "gayCities": "https://tokyo.gaycities.com/bars/312380-eagle-tokyo-blue",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:45.310Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/bars/vegas.json
+++ b/data/bars/vegas.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "Fun Hog Ranch",
+    "city": "vegas",
+    "gayCities": "https://lasvegas.gaycities.com/bars/1346-fun-hog-ranch",
+    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:08.295Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+  }
+]

--- a/data/calendars/seattle.ics
+++ b/data/calendars/seattle.ics
@@ -42,26 +42,131 @@ RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
 END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20250706T140000
-DTEND;TZID=America/New_York:20250706T190000
-RRULE:FREQ=WEEKLY;BYDAY=SU
-DTSTAMP:20260613T123544Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
+DTSTART;TZID=America/Los_Angeles:20250717T190000
+DTEND;TZID=America/Los_Angeles:20250718T020000
+RRULE:FREQ=MONTHLY;BYDAY=3TH
+DTSTAMP:20260613T145429Z
+UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
 CREATED:20250712T180301Z
-DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
- ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
- rtName: South Seattle Social
-LAST-MODIFIED:20260507T001639Z
-LOCATION:47.51652271569908\, -122.35487284211817
+DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
+ DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
+ <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
+ IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
+ ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
+ /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
+ a>
+LAST-MODIFIED:20250719T040329Z
+LOCATION:47.61337340244105\, -122.31441768029491
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:Leather Night
+TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251011T040000Z
+DTEND:20251011T100000Z
+DTSTAMP:20260613T145429Z
+UID:9DF93D82-1411-44C0-BE63-00037416BB38
+CREATED:20250817T231654Z
+DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
+  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
+ nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
+ ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
+ eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
+ 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
+ erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
+ nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
+ ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
+ https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
+ arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
+ bearracuda-2025-10-11-seattle
+LAST-MODIFIED:20251001T141832Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:2
+STATUS:CONFIRMED
+SUMMARY:Bearracuda Seattle: SERIOUS WOOD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260509T040000Z
+DTEND:20260509T100000Z
+DTSTAMP:20260613T145429Z
+UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
+CREATED:20260507T001637Z
+DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
+ • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
+ e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
+ da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
+ com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
+ uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
+ ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
+  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
+ ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
+LAST-MODIFIED:20260507T001638Z
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:South Seattle Bear Social
+SUMMARY:Treasure Trail Seattle
 TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251122T050000Z
+DTEND:20251122T110000Z
+DTSTAMP:20260613T145429Z
+UID:3D70DFD0-9501-434E-A015-10F01A25DA09
+CREATED:20250930T014035Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
+ tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
+ ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
+ 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
+ sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
+ a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
+ ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
+ reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
+ -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
+ oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
+ =101730401\nkey: bearracuda-2025-11-22-seattle
+LAST-MODIFIED:20251001T225002Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle: Wish BONED!
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260308T050000Z
+DTEND:20260308T100000Z
+DTSTAMP:20260613T145429Z
+UID:3DCE764F-EC21-459C-8791-745DE1731298
+CREATED:20260123T030754Z
+DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
+ TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
+ A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
+ seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
+ 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
+ : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
+ 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
+ earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
+ C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
+ -seattle
+LAST-MODIFIED:20260126T235324Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle:TRAIL HEAD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
 DTSTART:20260614T040000Z
 DTEND:20260614T100000Z
-DTSTAMP:20260613T123544Z
+DTSTAMP:20260613T145429Z
 UID:762BAD4A-F1D8-4519-BAC3-D755EF9BA263
 CREATED:20260514T005858Z
 DESCRIPTION:description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. 
@@ -90,78 +195,34 @@ X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
-DTSTART;TZID=America/Los_Angeles:20250717T190000
-DTEND;TZID=America/Los_Angeles:20250718T020000
-RRULE:FREQ=MONTHLY;BYDAY=3TH
-DTSTAMP:20260613T123544Z
-UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
- DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
- <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
- IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
- ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
- /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
- a>
-LAST-MODIFIED:20250719T040329Z
-LOCATION:47.61337340244105\, -122.31441768029491
+DTSTART:20250927T040000Z
+DTEND:20250927T100000Z
+DTSTAMP:20260613T145429Z
+UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
+CREATED:20250825T034004Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to choose your own ADVENTURE! Now our guys can grab a wristband when you 
+ walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp\; TIGERBE
+ ATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: Amer
+ ica/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover
+ : $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/up
+ loads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/even
+ ts/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail
+ -seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https:/
+ /www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?a
+ pi=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearrac
+ uda-2025-09-27-seattle
+LAST-MODIFIED:20250920T210916Z
 SEQUENCE:1
 STATUS:CONFIRMED
-SUMMARY:Leather Night
-TRANSP:OPAQUE
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260201T050000Z
-DTEND:20260201T110000Z
-DTSTAMP:20260613T123544Z
-UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
-CREATED:20260123T030739Z
-DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
- s by MATT STANDS &amp\; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine\, Sea
- ttle\, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com
- /events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025
- /12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/69805544976
- 5272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-bee
- f-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: http
- s://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search
- /?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey
- : bearracuda-2026-02-01-seattle
-LAST-MODIFIED:20260126T235314Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
+SUMMARY:Treasure Trail: SEATTLE
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260509T040000Z
-DTEND:20260509T100000Z
-DTSTAMP:20260613T123544Z
-UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
-CREATED:20260507T001637Z
-DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
- • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
- e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
- da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
- com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
- uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
- ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
-  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
- ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
-LAST-MODIFIED:20260507T001638Z
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
 DTSTART;TZID=America/New_York:20260614T000000
 DTEND;TZID=America/New_York:20260614T060000
-DTSTAMP:20260613T123544Z
+DTSTAMP:20260613T145429Z
 UID:6irujvg3effpkdu42krgr91osj@google.com
 RECURRENCE-ID;TZID=America/New_York:20260614T140000
 CREATED:20250712T180301Z
@@ -187,106 +248,45 @@ TRIGGER;VALUE=DATE-TIME:19760401T005545Z
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT
-DTSTART:20250927T040000Z
-DTEND:20250927T100000Z
-DTSTAMP:20260613T123544Z
-UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
-CREATED:20250825T034004Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to choose your own ADVENTURE! Now our guys can grab a wristband when you 
- walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp\; TIGERBE
- ATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: Amer
- ica/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover
- : $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/up
- loads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/even
- ts/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail
- -seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https:/
- /www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?a
- pi=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearrac
- uda-2025-09-27-seattle
-LAST-MODIFIED:20250920T210916Z
-SEQUENCE:1
+DTSTART;TZID=America/New_York:20250706T140000
+DTEND;TZID=America/New_York:20250706T190000
+RRULE:FREQ=WEEKLY;BYDAY=SU
+DTSTAMP:20260613T145429Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
+ ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
+ rtName: South Seattle Social
+LAST-MODIFIED:20260507T001639Z
+LOCATION:47.51652271569908\, -122.35487284211817
+SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Treasure Trail: SEATTLE
+SUMMARY:South Seattle Bear Social
 TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 END:VEVENT
 BEGIN:VEVENT
-DTSTART:20251122T050000Z
-DTEND:20251122T110000Z
-DTSTAMP:20260613T123544Z
-UID:3D70DFD0-9501-434E-A015-10F01A25DA09
-CREATED:20250930T014035Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
- tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
- ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
- 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
- sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
- a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
- ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
- reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
- -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
- oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
- =101730401\nkey: bearracuda-2025-11-22-seattle
-LAST-MODIFIED:20251001T225002Z
+DTSTART:20260201T050000Z
+DTEND:20260201T110000Z
+DTSTAMP:20260613T145429Z
+UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
+CREATED:20260123T030739Z
+DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
+ s by MATT STANDS &amp\; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine\, Sea
+ ttle\, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com
+ /events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025
+ /12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/69805544976
+ 5272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-bee
+ f-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: http
+ s://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search
+ /?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey
+ : bearracuda-2026-02-01-seattle
+LAST-MODIFIED:20260126T235314Z
 LOCATION:47.6150572\, -122.3236574
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle: Wish BONED!
+SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260308T050000Z
-DTEND:20260308T100000Z
-DTSTAMP:20260613T123544Z
-UID:3DCE764F-EC21-459C-8791-745DE1731298
-CREATED:20260123T030754Z
-DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
- TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
- A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
- seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
- 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
- : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
- 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
- earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
- C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
- -seattle
-LAST-MODIFIED:20260126T235324Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle:TRAIL HEAD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20251011T040000Z
-DTEND:20251011T100000Z
-DTSTAMP:20260613T123544Z
-UID:9DF93D82-1411-44C0-BE63-00037416BB38
-CREATED:20250817T231654Z
-DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
-  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
- nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
- ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
- eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
- 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
- erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
- nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
- ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
- https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
- arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
- bearracuda-2025-10-11-seattle
-LAST-MODIFIED:20251001T141832Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:2
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle: SERIOUS WOOD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 END:VEVENT
 END:VCALENDAR

--- a/data/calendars/update-summary.json
+++ b/data/calendars/update-summary.json
@@ -1,159 +1,159 @@
 {
-  "lastUpdated": "2026-06-13T12:35:45.347Z",
+  "lastUpdated": "2026-06-13T14:54:30.354Z",
   "cities": {
     "nyc": {
       "name": "New York",
       "status": "success",
       "dataLength": 10636,
       "eventCount": 11,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "seattle": {
       "name": "Seattle",
       "status": "success",
       "dataLength": 12362,
       "eventCount": 10,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "la": {
       "name": "Los Angeles",
       "status": "success",
       "dataLength": 8423,
       "eventCount": 7,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "toronto": {
       "name": "Toronto",
       "status": "success",
       "dataLength": 197,
       "eventCount": 0,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "london": {
       "name": "London",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "chicago": {
       "name": "Chicago",
       "status": "success",
       "dataLength": 13565,
       "eventCount": 12,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "berlin": {
       "name": "Berlin",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "palm-springs": {
       "name": "Palm Springs",
       "status": "success",
       "dataLength": 1487,
       "eventCount": 1,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "denver": {
       "name": "Denver",
       "status": "success",
       "dataLength": 6856,
       "eventCount": 6,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "dallas": {
       "name": "Dallas",
       "status": "success",
       "dataLength": 195,
       "eventCount": 0,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "dc": {
       "name": "DC",
       "status": "success",
       "dataLength": 1503,
       "eventCount": 1,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "vegas": {
       "name": "Las Vegas",
       "status": "success",
       "dataLength": 4410,
       "eventCount": 3,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "atlanta": {
       "name": "Atlanta",
       "status": "success",
       "dataLength": 4933,
       "eventCount": 4,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "nola": {
       "name": "New Orleans",
       "status": "success",
       "dataLength": 2367,
       "eventCount": 2,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "sf": {
       "name": "San Francisco",
       "status": "success",
       "dataLength": 15367,
       "eventCount": 12,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "portland": {
       "name": "Portland",
       "status": "success",
       "dataLength": 18474,
       "eventCount": 14,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "sitges": {
       "name": "Sitges",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "boston": {
       "name": "Boston",
       "status": "success",
       "dataLength": 196,
       "eventCount": 0,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "phoenix": {
       "name": "Phoenix",
       "status": "success",
       "dataLength": 2874,
       "eventCount": 2,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "ptown": {
       "name": "Provincetown",
       "status": "success",
       "dataLength": 202,
       "eventCount": 0,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "san-diego": {
       "name": "San Diego",
       "status": "success",
       "dataLength": 4073,
       "eventCount": 3,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     },
     "philly": {
       "name": "Philadelphia",
       "status": "success",
       "dataLength": 4689,
       "eventCount": 3,
-      "lastUpdated": "2026-06-13T12:35:45.347Z"
+      "lastUpdated": "2026-06-13T14:54:30.354Z"
     }
   }
 }

--- a/js/city-config.js
+++ b/js/city-config.js
@@ -179,7 +179,7 @@ const CITY_CONFIG = {
         calendarId: '2f2e6cde722236a41a43325818baaa3775288bd2b4796a98b943e158bf62eb81@group.calendar.google.com',
         calendar: 'chunky-dad-sf',
         timezone: 'America/Los_Angeles',
-        patterns: ['san francisco', 'sf', 'castro', 'san jose', 'oakland'],
+        patterns: ['san francisco', 'san fransisco', 'sf', 'castro', 'san jose', 'oakland'],
         coordinates: { lat: 37.7749, lng: -122.4194 },
         mapZoom: 10,
         visible: true
@@ -238,6 +238,9 @@ const CITY_CONFIG = {
         tagline: 'Cape Cod bear paradise',
         aliases: ['provincetown'],
         calendarId: '3b7c4ed1606370c70125e378cb3435fe8ab168161593b0f7dd3112ae56bc4db9@group.calendar.google.com',
+        calendar: 'chunky-dad-provincetown',
+        timezone: 'America/New_York',
+        patterns: ['provincetown', 'ptown'],
         coordinates: { lat: 42.0526, lng: -70.1865 },
         mapZoom: 12,
         visible: true
@@ -508,6 +511,42 @@ const CITY_CONFIG = {
         timezone: 'America/Bogota',
         patterns: ['bogota', 'bogotá'],
         coordinates: { lat: 4.7110, lng: -74.0721 },
+        mapZoom: 11,
+        visible: false
+    },
+    'honolulu': {
+        name: 'Honolulu',
+        emoji: '🌺',
+        tagline: 'Hawaiian bear paradise',
+        calendarId: '8b1cdc79cf18b1c20d5f4b8a49ad96a2890497d51b274e4c7cc9fe0779f1935f@group.calendar.google.com',
+        calendar: 'chunky-dad-honolulu',
+        timezone: 'Pacific/Honolulu',
+        patterns: ['honolulu', 'hawaii', 'oahu', 'waikiki'],
+        coordinates: { lat: 21.3069, lng: -157.8583 },
+        mapZoom: 11,
+        visible: false
+    },
+    'hong-kong': {
+        name: 'Hong Kong',
+        emoji: '🇭🇰',
+        tagline: 'Asian bear scene',
+        calendarId: '75b66a4ed30e33ee388ad32773157c2ceb380043cfdc3132434e43cf45a4bfb7@group.calendar.google.com',
+        calendar: 'chunky-dad-hongkong',
+        timezone: 'Asia/Hong_Kong',
+        patterns: ['hong kong', 'hk'],
+        coordinates: { lat: 22.3193, lng: 114.1694 },
+        mapZoom: 11,
+        visible: false
+    },
+    'tokyo': {
+        name: 'Tokyo',
+        emoji: '🗼',
+        tagline: 'Japanese bear scene',
+        calendarId: '55b5375e8476d1f78d4f8b7aace56322a4fd61a524cd613982534de8ac9fc566@group.calendar.google.com',
+        calendar: 'chunky-dad-tokyo',
+        timezone: 'Asia/Tokyo',
+        patterns: ['tokyo'],
+        coordinates: { lat: 35.6762, lng: 139.6503 },
         mapZoom: 11,
         visible: false
     }

--- a/scripts/scraper-cities.js
+++ b/scripts/scraper-cities.js
@@ -130,6 +130,7 @@ const scraperCities = {
     "timezone": "America/Los_Angeles",
     "patterns": [
       "san francisco",
+      "san fransisco",
       "sf",
       "castro",
       "san jose",
@@ -166,6 +167,14 @@ const scraperCities = {
     "timezone": "America/Phoenix",
     "patterns": [
       "phoenix"
+    ]
+  },
+  "ptown": {
+    "calendar": "chunky-dad-provincetown",
+    "timezone": "America/New_York",
+    "patterns": [
+      "provincetown",
+      "ptown"
     ]
   },
   "san-diego": {
@@ -336,6 +345,31 @@ const scraperCities = {
     "patterns": [
       "bogota",
       "bogotá"
+    ]
+  },
+  "honolulu": {
+    "calendar": "chunky-dad-honolulu",
+    "timezone": "Pacific/Honolulu",
+    "patterns": [
+      "honolulu",
+      "hawaii",
+      "oahu",
+      "waikiki"
+    ]
+  },
+  "hong-kong": {
+    "calendar": "chunky-dad-hongkong",
+    "timezone": "Asia/Hong_Kong",
+    "patterns": [
+      "hong kong",
+      "hk"
+    ]
+  },
+  "tokyo": {
+    "calendar": "chunky-dad-tokyo",
+    "timezone": "Asia/Tokyo",
+    "patterns": [
+      "tokyo"
     ]
   }
 };

--- a/tools/sync-bars.js
+++ b/tools/sync-bars.js
@@ -465,7 +465,7 @@ async function enrichBarsWithExternalData(bars) {
         } else if (needsGayCitiesScraping) {
             try {
                 console.log(`🔍 Scraping GayCities data for ${bar.name} from ${bar.gayCities}`);
-                const scrapedData = await scrapeGayCitiesData(bar.gayCities);
+                const scrapedData = await scrapeGayCitiesDataWithRetry(bar.gayCities);
                 
                 // Only update fields that are currently empty
                 if (!enrichedBar.address && scrapedData.address) {
@@ -602,6 +602,28 @@ async function scrapeWikipediaData(url) {
     // Wikipedia logo extraction removed - logos are now handled by the image download action
     
     return data;
+}
+
+
+async function scrapeGayCitiesDataWithRetry(url) {
+    const maxRetries = 2;
+    let lastError;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+            return await scrapeGayCitiesData(url);
+        } catch (error) {
+            lastError = error;
+            if (error.message.includes('403') && attempt < maxRetries) {
+                console.log(`    ⚠️ HTTP 403 on ${url}, retrying (${attempt + 1}/${maxRetries})...`);
+                // Exponential backoff: 2s, 4s, etc.
+                await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+            } else {
+                throw error;
+            }
+        }
+    }
+    throw lastError;
 }
 
 // Scrape GayCities data for a bar (simplified version)


### PR DESCRIPTION
Resolves the "Unknown city" errors for Provincetown, San Francisco, and Tokyo during the sync-bars.js execution. Also adds new cities (Honolulu, Hong Kong, Tokyo) as requested. Implements an exponential backoff to handle HTTP 403 errors while scraping GayCities.

---
*PR created automatically by Jules for task [5578188205092923259](https://jules.google.com/task/5578188205092923259) started by @stanleyrya*