### PR TITLE
feat(tools): improve gaycities scraper with rate limits and exponential backoff

### DIFF
--- a/data/bars/la.json
+++ b/data/bars/la.json
@@ -8,8 +8,7 @@
     "facebook": "https://www.facebook.com/eagle.bar.la/",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJLwuhHU_HwoARdQQ1PfOn6B4",
     "gayCities": "https://losangeles.gaycities.com/bars/357-eagle-la",
-    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:04.830Z",
-    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+    "gayCitiesLastScrapedAt": "2026-06-13T15:14:53.360Z"
   },
   {
     "name": "Precinct LA",
@@ -20,8 +19,7 @@
     "facebook": "https://www.facebook.com/precinctdtla",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ16rgokvGwoARgLmCBWa28wI",
     "gayCities": "https://losangeles.gaycities.com/bars/306866-precinct",
-    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:08.016Z",
-    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+    "gayCitiesLastScrapedAt": "2026-06-13T15:14:55.610Z"
   },
   {
     "name": "Akbar",

--- a/data/bars/nyc.json
+++ b/data/bars/nyc.json
@@ -7,8 +7,9 @@
     "instagram": "https://www.instagram.com/animal.nyc",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJdaGX6E9ZwokRrcrhq8cMM-8",
     "gayCities": "https://newyork.gaycities.com/bars/312406-animal",
-    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:02.885Z",
-    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+    "gayCitiesExtractionFailureAt": "2026-06-13T15:10:55.777Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403",
+    "gayCitiesExtractionFailureCount": 1
   },
   {
     "name": "Rockbar",
@@ -19,8 +20,9 @@
     "facebook": "https://www.facebook.com/Rockbar-NYC",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJlwfqXuxZwokRTlizRW_4cwc",
     "gayCities": "https://newyork.gaycities.com/bars/3486-rockbar-nyc",
-    "gayCitiesExtractionFailureAt": "2026-06-13T14:43:58.506Z",
-    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+    "gayCitiesExtractionFailureAt": "2026-06-13T15:11:00.881Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403",
+    "gayCitiesExtractionFailureCount": 1
   },
   {
     "name": "Eagle NYC",
@@ -41,8 +43,9 @@
     "facebook": "https://www.facebook.com/3dollarbillbk",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ7zm6H3JbwokR3ui1wTNr6Xc",
     "gayCities": "https://newyork.gaycities.com/bars/309059-dollar-bill",
-    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:03.601Z",
-    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+    "gayCitiesExtractionFailureAt": "2026-06-13T15:11:06.105Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403",
+    "gayCitiesExtractionFailureCount": 1
   },
   {
     "name": "Ty's",
@@ -53,8 +56,9 @@
     "facebook": "https://www.facebook.com/TysNYC",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJaVvpXJNZwokRT3p02KL_TrY",
     "gayCities": "https://newyork.gaycities.com/bars/388-tys-bar-nyc",
-    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:01.708Z",
-    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+    "gayCitiesExtractionFailureAt": "2026-06-13T15:11:11.173Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403",
+    "gayCitiesExtractionFailureCount": 1
   },
   {
     "name": "Nowhere Bar",
@@ -65,8 +69,9 @@
     "facebook": "https://www.facebook.com/nowherebar",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJZ1fMFZ5ZwokRkYrV85CZorY",
     "gayCities": "https://newyork.gaycities.com/bars/415-nowhere-bar",
-    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:03.933Z",
-    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+    "gayCitiesExtractionFailureAt": "2026-06-13T15:11:16.233Z",
+    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403",
+    "gayCitiesExtractionFailureCount": 1
   },
   {
     "name": "Albatross",

--- a/data/bars/seattle.json
+++ b/data/bars/seattle.json
@@ -16,8 +16,7 @@
     "coordinates": "47.5165235, -122.3548059",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ-8uYrt9DkFQRXv1WZmNZ8F0",
     "gayCities": "https://seattle.gaycities.com/bars/309627-the-lumber-yard-bar",
-    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:04.188Z",
-    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+    "gayCitiesLastScrapedAt": "2026-06-13T15:14:46.563Z"
   },
   {
     "name": "The Cuff Complex",
@@ -27,8 +26,7 @@
     "facebook": "https://www.facebook.com/thecuffcomplex",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJuQVbk81qkFQRkm6N_RnwHQY",
     "gayCities": "https://seattle.gaycities.com/bars/514-the-cuff-complex",
-    "gayCitiesExtractionFailureAt": "2026-06-13T14:44:04.862Z",
-    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+    "gayCitiesLastScrapedAt": "2026-06-13T15:14:48.626Z"
   },
   {
     "name": "Seattle Eagle",
@@ -46,8 +44,7 @@
     "facebook": "https://www.facebook.com/ccsseattle",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJk-Ws_tFqkFQRc2h8MPRvv5I",
     "gayCities": "https://seattle.gaycities.com/bars/505-ccs-seattle",
-    "gayCitiesExtractionFailureAt": "2026-06-13T14:35:04.751Z",
-    "gayCitiesExtractionFailureMessage": "HTTP error! status: 403"
+    "gayCitiesLastScrapedAt": "2026-06-13T15:14:51.206Z"
   },
   {
     "name": "Madison Pub",

--- a/tools/sync-bars.js
+++ b/tools/sync-bars.js
@@ -335,11 +335,13 @@ function cleanBarObject(bar) {
         'wikipediaExtractionFailureAt',
         'wikipediaExtractionFailureMessage',
         'gayCitiesExtractionFailureAt',
-        'gayCitiesExtractionFailureMessage'
+        'gayCitiesExtractionFailureMessage',
+        'gayCitiesExtractionFailureCount',
+        'gayCitiesLastScrapedAt'
     ];
     
     fieldsToKeep.forEach(field => {
-        if (bar[field] && bar[field].toString().trim() !== '') {
+        if (bar[field] !== undefined && bar[field] !== null && bar[field].toString().trim() !== '') {
             cleaned[field] = bar[field];
         }
     });
@@ -378,8 +380,32 @@ function shouldScrapeWikipediaBar(bar, localBar) {
 // Check if a bar needs GayCities scraping based on missing data or URL changes
 function shouldScrapeGayCitiesBar(bar, localBar) {
     const priorFailureAt = bar.gayCitiesExtractionFailureAt || localBar?.gayCitiesExtractionFailureAt;
-    if (priorFailureAt) {
-        console.log(`🚫 Skipping GayCities scraping for ${bar.name} - previous extraction failed at ${priorFailureAt}; requires manual investigation`);
+    const priorFailureCount = bar.gayCitiesExtractionFailureCount || localBar?.gayCitiesExtractionFailureCount || 0;
+
+    // Check if URL changed from what we have saved locally
+    const urlChanged = bar.gayCities && localBar?.gayCities && bar.gayCities !== localBar.gayCities;
+
+    if (priorFailureAt && !urlChanged) {
+        if (priorFailureCount >= 3) {
+            console.log(`🚫 Skipping GayCities scraping for ${bar.name} - failed ${priorFailureCount} times, last at ${priorFailureAt}`);
+            return false;
+        } else {
+            // Exponential backoff
+            const failedDate = new Date(priorFailureAt);
+            const now = new Date();
+            const daysSinceFailure = (now - failedDate) / (1000 * 60 * 60 * 24);
+            const daysToWait = priorFailureCount; // wait 1 day for 1 failure, 2 days for 2 failures
+
+            if (daysSinceFailure < daysToWait) {
+                console.log(`⏳ Backing off GayCities scraping for ${bar.name} - waiting ${daysToWait} days after failure ${priorFailureCount}`);
+                return false;
+            }
+        }
+    }
+
+    const lastScrapedAt = bar.gayCitiesLastScrapedAt || localBar?.gayCitiesLastScrapedAt;
+    if (lastScrapedAt && !urlChanged) {
+        // We've already successfully scraped this URL, any missing fields are truly missing
         return false;
     }
 
@@ -392,8 +418,7 @@ function shouldScrapeGayCitiesBar(bar, localBar) {
     if (!bar.facebook || bar.facebook.trim() === '') missingFields.push('facebook');
     if (!bar.googleMaps || bar.googleMaps.trim() === '') missingFields.push('googleMaps');
     
-    // Check if URL changed from what we have saved locally
-    if (bar.gayCities && localBar?.gayCities && bar.gayCities !== localBar.gayCities) {
+    if (urlChanged) {
         console.log(`🔄 ${bar.name} GayCities URL changed: ${localBar.gayCities} → ${bar.gayCities}`);
         return true;
     }
@@ -410,6 +435,8 @@ function shouldScrapeGayCitiesBar(bar, localBar) {
 async function enrichBarsWithExternalData(bars) {
     const enrichedBars = [];
     const extractionFailures = [];
+    let gayCitiesScrapedCount = 0;
+    const MAX_GAYCITIES_SCRAPES = 5;
     
     for (const bar of bars) {
         let enrichedBar = { ...bar };
@@ -424,7 +451,11 @@ async function enrichBarsWithExternalData(bars) {
         const needsWikipediaScraping = bar.wikipedia && shouldScrapeWikipediaBar(bar, localBar);
         
         // Check if bar needs GayCities scraping
-        const needsGayCitiesScraping = bar.gayCities && shouldScrapeGayCitiesBar(bar, localBar);
+        let needsGayCitiesScraping = bar.gayCities && shouldScrapeGayCitiesBar(bar, localBar);
+        if (needsGayCitiesScraping && gayCitiesScrapedCount >= MAX_GAYCITIES_SCRAPES) {
+            console.log(`⏸️  Skipping GayCities scraping for ${bar.name} - reached session limit of ${MAX_GAYCITIES_SCRAPES}`);
+            needsGayCitiesScraping = false;
+        }
         
         if (needsWikipediaScraping) {
             try {
@@ -464,6 +495,12 @@ async function enrichBarsWithExternalData(bars) {
             }
         } else if (needsGayCitiesScraping) {
             try {
+                if (gayCitiesScrapedCount > 0) {
+                    console.log(`⏳ Waiting 2 seconds before next GayCities request...`);
+                    await new Promise(resolve => setTimeout(resolve, 2000));
+                }
+                gayCitiesScrapedCount++;
+
                 console.log(`🔍 Scraping GayCities data for ${bar.name} from ${bar.gayCities}`);
                 const scrapedData = await scrapeGayCitiesDataWithRetry(bar.gayCities);
                 
@@ -489,12 +526,17 @@ async function enrichBarsWithExternalData(bars) {
 
                 delete enrichedBar.gayCitiesExtractionFailureAt;
                 delete enrichedBar.gayCitiesExtractionFailureMessage;
+                delete enrichedBar.gayCitiesExtractionFailureCount;
+                enrichedBar.gayCitiesLastScrapedAt = new Date().toISOString();
                 
                 console.log(`✅ Enriched ${bar.name} with GayCities data`);
             } catch (error) {
                 const failedAt = new Date().toISOString();
+                const previousCount = enrichedBar.gayCitiesExtractionFailureCount || localBar?.gayCitiesExtractionFailureCount || 0;
                 enrichedBar.gayCitiesExtractionFailureAt = failedAt;
                 enrichedBar.gayCitiesExtractionFailureMessage = error.message;
+                enrichedBar.gayCitiesExtractionFailureCount = previousCount + 1;
+
                 extractionFailures.push({
                     bar: bar.name,
                     city: bar.city,
@@ -504,10 +546,6 @@ async function enrichBarsWithExternalData(bars) {
                 });
                 console.warn(`⚠️  Failed to scrape GayCities data for ${bar.name}:`, error.message);
             }
-        } else if (bar.wikipedia) {
-            console.log(`⏭️  Skipping Wikipedia scraping for ${bar.name} - already has valid data`);
-        } else if (bar.gayCities) {
-            console.log(`⏭️  Skipping GayCities scraping for ${bar.name} - already has valid data`);
         }
         
         enrichedBars.push(enrichedBar);


### PR DESCRIPTION
Improves scraping reliability and server politeness for the sync-bars.js script by setting strict session limits, 2s network request pauses, handling deduplication via last scraped timestamps, and tracking failure counts to orchestrate exponential backoffs.

---
*PR created automatically by Jules for task [6968036207762497542](https://jules.google.com/task/6968036207762497542) started by @stanleyrya*