### PR TITLE
Fix OCR mapping for segments with resized image URLs

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -2418,10 +2418,28 @@ class AiWebParser {
                 .filter(Boolean)
         );
 
+        // Strip sizes for more robust comparison
+        const strippedSegmentImageSet = new Set(
+            Array.from(normalizedSegmentImageSet)
+                .map(u => this.stripSizeParams(u))
+                .filter(Boolean)
+        );
+
+        console.log(`🤖 AI Web: Filtering OCR results against ${normalizedSegmentImageSet.size} segment images (${strippedSegmentImageSet.size} stripped)`);
+
         // Filter OCR results to match segment images
         return ocrResults.filter(ocr => {
             const ocrUrl = this.normalizeHttpUrlValue(ocr.url);
-            return normalizedSegmentImageSet.has(ocrUrl);
+            const strippedOcrUrl = this.stripSizeParams(ocrUrl);
+
+            const exactMatch = normalizedSegmentImageSet.has(ocrUrl);
+            const strippedMatch = strippedOcrUrl && strippedSegmentImageSet.has(strippedOcrUrl);
+
+            if (exactMatch || strippedMatch) {
+                console.log(`🤖 AI Web: Segment matched OCR result via ${exactMatch ? 'exact' : 'stripped'} URL: ${ocrUrl}`);
+                return true;
+            }
+            return false;
         });
     }
 

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -911,7 +911,8 @@ class AiWebParser {
             sourceUrl,
             Math.max(sourceSegments.length * 4, sourceSegments.length + 6)
         );
-        if (pageImageRecords.length < 2) return sourceSegments;
+        // Even if there's only 1 image on the page, we still want to match it to a segment using OCR
+        if (pageImageRecords.length === 0) return sourceSegments;
 
         const primarySegmentImages = sourceSegments.map(segment => {
             const images = this.extractOrderedImageUrlsFromHtml(
@@ -2428,19 +2429,30 @@ class AiWebParser {
         console.log(`🤖 AI Web: Filtering OCR results against ${normalizedSegmentImageSet.size} segment images (${strippedSegmentImageSet.size} stripped)`);
 
         // Filter OCR results to match segment images
-        return ocrResults.filter(ocr => {
+        const matchedOcrResults = ocrResults.filter(ocr => {
             const ocrUrl = this.normalizeHttpUrlValue(ocr.url);
             const strippedOcrUrl = this.stripSizeParams(ocrUrl);
 
             const exactMatch = normalizedSegmentImageSet.has(ocrUrl);
             const strippedMatch = strippedOcrUrl && strippedSegmentImageSet.has(strippedOcrUrl);
 
-            if (exactMatch || strippedMatch) {
-                console.log(`🤖 AI Web: Segment matched OCR result via ${exactMatch ? 'exact' : 'stripped'} URL: ${ocrUrl}`);
+            if (exactMatch) {
+                console.log(`🤖 AI Web: Segment matched OCR result via exact URL: ${ocrUrl}`);
+                return true;
+            } else if (strippedMatch) {
+                console.log(`🤖 AI Web: Segment matched OCR result via stripped URL: ${ocrUrl} -> ${strippedOcrUrl}`);
                 return true;
             }
             return false;
         });
+
+        if (matchedOcrResults.length === 0 && ocrResults.length > 0 && normalizedSegmentImageSet.size > 0) {
+            console.log(`🤖 AI Web: Segment failed to match any of the ${ocrResults.length} OCR results.`);
+            console.log(`🤖 AI Web: First segment image (stripped): ${Array.from(strippedSegmentImageSet)[0] || 'none'}`);
+            console.log(`🤖 AI Web: First OCR image (stripped): ${this.stripSizeParams(this.normalizeHttpUrlValue(ocrResults[0].url)) || 'none'}`);
+        }
+
+        return matchedOcrResults;
     }
 
     buildOcrSnippet(imageUrl, text, eventSummary = null) {


### PR DESCRIPTION
Used `stripSizeParams` to allow differently sized images to properly match up. Added `console.log` lines to indicate what gets matched or stripped to ease further debugging.

---
*PR created automatically by Jules for task [17096431512926783071](https://jules.google.com/task/17096431512926783071) started by @stanleyrya*