### PR TITLE
Improve map interface and button styles

### DIFF
--- a/js/bear-directory.js
+++ b/js/bear-directory.js
@@ -121,7 +121,7 @@ class BearDirectory {
                 this.applyTheme(this.map);
             });
             
-            this.map.addControl(new maplibregl.NavigationControl());
+            this.map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-left');
             
             logger.componentLoad('MAP', 'Directory map initialized');
         } catch (error) {

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2634,6 +2634,8 @@ class DynamicCalendarLoader extends CalendarCore {
                 }
             }
             map.addControl(new MyLocationControl(), 'top-left');
+            // Add navigation controls (zoom in/out)
+            map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-left');
             
             // Initialize location status
             updateLocationStatus();

--- a/styles.css
+++ b/styles.css
@@ -2680,8 +2680,8 @@ body.index-page main {
     background: var(--background-primary);
     border: 2px solid var(--border-light);
     border-radius: 8px;
-    width: 34px;
-    height: 34px;
+    width: 30px;
+    height: 25px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -5864,3 +5864,34 @@ body.loaded {
     transform: translateY(-5px);
 }
 
+
+
+/* Map controls icon adjustments */
+.map-control-btn i::before {
+    margin: 5px 0 0 0;
+}
+
+/* Icon-only button adjustments */
+.icon-only i::before {
+    margin: 1px 0 0 0;
+}
+
+.share-event-btn.icon-only i::before {
+    margin: -2px 0 0 0;
+}
+/* Maplibre Attribution Auto-Dismiss on Mobile */
+@media (max-width: 768px) {
+    .maplibregl-ctrl-attrib {
+        max-width: 150px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        transition: max-width 0.3s ease;
+    }
+
+    .maplibregl-ctrl-bottom-right:active .maplibregl-ctrl-attrib,
+    .maplibregl-ctrl-attrib:active {
+        max-width: none;
+        white-space: normal;
+    }
+}


### PR DESCRIPTION
The user requested a few UI enhancements for maps and buttons. 

1. **Map Button Styles**: Added constraints to `.map-control-btn` width and height and modified the `margin` of `i::before` pseudoelements to center the icons.
2. **Icon-only Buttons**: Modified the `.icon-only i::before` margin, with an exception for `.share-event-btn.icon-only i::before`.
3. **Map Zoom Interface**: Added `maplibregl.NavigationControl({ showCompass: false })` to both `js/dynamic-calendar-loader.js` and `js/bear-directory.js` to expose plus/minus zoom buttons, improving accessibility and addressing a zoom issue on desktop. 
4. **MapLibre Attribution Auto-dismiss**: Included responsive styles for `max-width: 768px` to restrict the attribution string width, allowing it to fully expand only when pressed (`:active`).

---
*PR created automatically by Jules for task [6980936301231488286](https://jules.google.com/task/6980936301231488286) started by @stanleyrya*