### PR TITLE
Fix ai-web-parser not using default field priorities

### DIFF
--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -246,9 +246,11 @@ class BearEventScraperOrchestrator {
                             eventSchema: this.modules.EventSchema
                         });
                     } else if (name === 'ai-web') {
-                        parsers[name] = new ParserClass({
+                        const aiParser = new ParserClass({
                             normalizeUrl: sharedCore.normalizeUrl.bind(sharedCore)
                         });
+                        aiParser.core = sharedCore;
+                        parsers[name] = aiParser;
                     } else {
                         parsers[name] = new ParserClass();
                     }

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4501,9 +4501,7 @@ class AiWebParser {
     }
 
     getAiPromptFields(parserConfig = {}, dataFlags = {}) {
-        const priorities = parserConfig && parserConfig.fieldPriorities && typeof parserConfig.fieldPriorities === 'object'
-            ? parserConfig.fieldPriorities
-            : {};
+        const priorities = this.core.getResolvedFieldPriorities(parserConfig);
         const metadata = parserConfig && parserConfig.metadata && typeof parserConfig.metadata === 'object'
             ? parserConfig.metadata
             : {};

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -20,6 +20,7 @@ function createParser() {
 
 test('pairs nearby row-split event images to the matching multi-event segments', () => {
   const parser = createParser();
+  parser.core = { getResolvedFieldPriorities: (config) => config?.fieldPriorities || {} };
   const sourceUrl = 'https://furball.example/events';
   const html = `
     <html>
@@ -161,6 +162,7 @@ test('getAiPromptFields should group and sort split date/time fields correctly',
   };
 
   const parser = createParser();
+  parser.core = { getResolvedFieldPriorities: (config) => config?.fieldPriorities || {} };
 
   const parserConfig = {
     fieldPriorities: {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2832,13 +2832,7 @@ class SharedCore {
         return normalized;
     }
     
-    // Apply field-level priority strategies from the parser config
-    // This determines which parser's data to trust for each field
-    applyFieldPriorities(event, parserConfig, mainConfig) {
-        // Always attach parser config
-        event._parserConfig = parserConfig;
-        
-        // Get the field priorities configuration from this parser's config
+    getResolvedFieldPriorities(parserConfig) {
         const explicitPriorities = parserConfig?.fieldPriorities || {};
         const defaultPriorities = {
             title: { priority: ["ai-web"], merge: "clobber" },
@@ -2858,7 +2852,17 @@ class SharedCore {
             cover: { priority: ["ai-web"], merge: "clobber" },
             ticketUrl: { priority: ["ai-web"], merge: "clobber" }
         };
-        const fieldPriorities = { ...defaultPriorities, ...explicitPriorities };
+        return { ...defaultPriorities, ...explicitPriorities };
+    }
+
+    // Apply field-level priority strategies from the parser config
+    // This determines which parser's data to trust for each field
+    applyFieldPriorities(event, parserConfig, mainConfig) {
+        // Always attach parser config
+        event._parserConfig = parserConfig;
+
+        // Get the field priorities configuration from this parser's config
+        const fieldPriorities = this.getResolvedFieldPriorities(parserConfig);
         
         // Field priorities loaded from parser configuration
         


### PR DESCRIPTION
Fix ai-web-parser not using default field priorities

Extracts the logic to resolve default field priorities and configuration
overrides into `SharedCore.getResolvedFieldPriorities`. This allows the
`ai-web-parser` to properly fall back to the defaults (e.g. `merge: "clobber"`)
as expected without over-engineering fallback behaviors, aligning its
behavior with other components consuming parser configuration.

---
*PR created automatically by Jules for task [6432777107510142062](https://jules.google.com/task/6432777107510142062) started by @stanleyrya*