### PR TITLE
Refactor map UI: enable city map zoom, simplify popups, update pins

### DIFF
--- a/js/bear-directory.js
+++ b/js/bear-directory.js
@@ -395,7 +395,21 @@ class BearDirectory {
                         </div>
                     `);
 
-                    const marker = new maplibregl.Marker()
+                    // Try to get a simple text marker (first letter or emoji based on type)
+                    let markerText = '🐻';
+                    if (item.type && item.type.toLowerCase().includes('bar')) markerText = '🍻';
+                    else if (item.type && item.type.toLowerCase().includes('gear')) markerText = '👕';
+                    else if (item.name) markerText = item.name.charAt(0).toUpperCase();
+
+                    const el = document.createElement('div');
+                    el.className = 'favicon-marker text-marker';
+                    el.innerHTML = `
+                        <div class="favicon-marker-container text-marker">
+                            <span class="marker-text" style="font-size: 16px;">${markerText}</span>
+                        </div>
+                    `;
+
+                    const marker = new maplibregl.Marker({ element: el, anchor: 'bottom' })
                         .setLngLat([lng, lat])
                         .setPopup(popup)
                         .addTo(this.map);

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2588,8 +2588,7 @@ class DynamicCalendarLoader extends CalendarCore {
                 style: 'https://tiles.openfreemap.org/styles/liberty',
                 center: [mapCenter[1], mapCenter[0]],
                 zoom: mapZoom,
-                renderWorldCopies: false,
-                scrollZoom: false
+                renderWorldCopies: false
             });
 
             map.on('style.load', () => {
@@ -2641,20 +2640,6 @@ class DynamicCalendarLoader extends CalendarCore {
             
             // Initialize location status
             updateLocationStatus();
-
-            // Enable scroll wheel zoom only when Ctrl is pressed
-            map.on('wheel', function(e) {
-                if (e.originalEvent.ctrlKey) {
-                    map.scrollWheelZoom.enable();
-                } else {
-                    map.scrollWheelZoom.disable();
-                }
-            });
-
-            // Disable scroll wheel zoom when mouse leaves map
-            map.on('mouseout', function() {
-                map.scrollWheelZoom.disable();
-            });
             
             let markersAdded = 0;
             const markers = []; // Store markers for fit all function

--- a/js/home-map.js
+++ b/js/home-map.js
@@ -93,9 +93,9 @@ class HomeMap {
                 if (!isNaN(lat) && !isNaN(lng)) {
                     const popup = new maplibregl.Popup({ offset: 25 }).setHTML(`
                         <div class="map-popup" style="text-align: center;">
-                            <h4 style="margin-bottom: 5px; color: var(--text-primary);">${city.emoji} ${city.name}</h4>
-                            <p style="margin-top: 5px; margin-bottom: 10px;">${city.tagline}</p>
-                            <a href="${city.key}/" style="display: inline-block; padding: 5px 10px; background-color: var(--primary-color); color: white; text-decoration: none; border-radius: 5px; font-size: 14px;">View City</a>
+                            <a href="${city.key}/" style="display: inline-block; color: var(--text-primary); text-decoration: none;">
+                                <h4 style="margin: 5px 0; font-size: 18px;">${city.emoji} ${city.name}</h4>
+                            </a>
                         </div>
                     `);
 


### PR DESCRIPTION
Addressed three primary map UI issues: 
1. City page maps are now fully interactive, with restrictions on scroll zoom removed. 
2. Home page map popups have been simplified to remove the clunky descriptive tagline.
3. The directory maps now leverage custom HTML markers containing emojis/text rather than the generic default SVGs, matching our visual identity.

---
*PR created automatically by Jules for task [7531403338099115194](https://jules.google.com/task/7531403338099115194) started by @stanleyrya*