### PR TITLE
Fix main page map aspect ratio on large screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
             </div>
 
             <div class="container">
-                <div id="homeMap" style="height: 400px; border-radius: 12px; margin-top: 20px;"></div>
+                <div id="homeMap" style="border-radius: 12px; margin-top: 20px;"></div>
             </div>
         </section>
 

--- a/styles.css
+++ b/styles.css
@@ -6041,3 +6041,11 @@ body.loaded {
     height: 100%;
     border: none;
 }
+
+/* Home Map responsive height */
+#homeMap {
+    width: 100%;
+    min-height: 400px;
+    max-height: 70vh;
+    aspect-ratio: 16 / 9;
+}


### PR DESCRIPTION
Fixes the issue where the main page map gets disproportionately wide and short on larger screen sizes. By using `aspect-ratio: 16 / 9` and a max-height constraint, the map correctly scales and fits the initial world view without clipping any countries.

---
*PR created automatically by Jules for task [10000494188140548350](https://jules.google.com/task/10000494188140548350) started by @stanleyrya*