### PR TITLE
fix: restore map marker selection styling after maplibre migration

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -606,9 +606,9 @@ class DynamicCalendarLoader extends CalendarCore {
             logger.debug('MAP', 'Selected event has no map marker, dimming all markers', { eventSlug });
             // Dim all markers since selection is active but no marker is selected
             Object.values(window.eventsMapMarkersBySlug).forEach(marker => {
-                if (marker._icon) {
-                    marker._icon.classList.remove('marker-selected');
-                    marker._icon.classList.add('marker-dimmed');
+                if (marker.getElement()) {
+                    marker.getElement().classList.remove('marker-selected');
+                    marker.getElement().classList.add('marker-dimmed');
                 }
             });
             logger.userInteraction('MAP', 'All markers dimmed (selection active but no marker selected)', { eventSlug });
@@ -618,16 +618,16 @@ class DynamicCalendarLoader extends CalendarCore {
         // Use CSS classes instead of inline styles
         if (window.eventsMapMarkersBySlug) {
             Object.entries(window.eventsMapMarkersBySlug).forEach(([slug, marker]) => {
-                if (marker._icon) {
+                if (marker.getElement()) {
                     // Remove all marker state classes
-                    marker._icon.classList.remove('marker-selected', 'marker-dimmed');
+                    marker.getElement().classList.remove('marker-selected', 'marker-dimmed');
                     
                     if (slug === eventSlug) {
                         // Highlight the selected marker
-                        marker._icon.classList.add('marker-selected');
+                        marker.getElement().classList.add('marker-selected');
                     } else {
                         // Dim unselected markers
-                        marker._icon.classList.add('marker-dimmed');
+                        marker.getElement().classList.add('marker-dimmed');
                     }
                 }
             });
@@ -642,9 +642,9 @@ class DynamicCalendarLoader extends CalendarCore {
         if (window.eventsMapMarkersBySlug) {
             const markerCount = Object.keys(window.eventsMapMarkersBySlug).length;
             Object.values(window.eventsMapMarkersBySlug).forEach(marker => {
-                if (marker._icon) {
+                if (marker.getElement()) {
                     // Remove all marker state classes
-                    marker._icon.classList.remove('marker-selected', 'marker-dimmed');
+                    marker.getElement().classList.remove('marker-selected', 'marker-dimmed');
                 }
             });
             logger.debug('MAP', 'All markers reset to normal appearance', { markerCount });

--- a/styles.css
+++ b/styles.css
@@ -2710,27 +2710,27 @@ body.index-page main {
 
 
 /* Map Marker Selection States */
-.leaflet-marker-icon.marker-selected .favicon-marker-container {
+.marker-selected .favicon-marker-container {
     border-color: var(--primary-color) !important;
     border-width: 2px !important;
     position: relative !important;
     overflow: hidden !important;
 }
 
-.leaflet-marker-icon.marker-selected .favicon-marker-container:hover {
+.marker-selected .favicon-marker-container:hover {
 }
 
-.leaflet-marker-icon.marker-selected .favicon-marker-icon {
+.marker-selected .favicon-marker-icon {
     transform: none !important;
     position: relative !important;
 }
 
-.leaflet-marker-icon.marker-selected {
+.marker-selected {
     z-index: 1010 !important;
     position: relative !important;
 }
 
-.leaflet-marker-icon.marker-dimmed {
+.marker-dimmed {
     opacity: 0.6 !important;
     z-index: 1000 !important;
 }


### PR DESCRIPTION
Fixes a regression introduced by the MapLibre migration where selecting an event on the city page map or list no longer visually highlighted the selected marker or dimmed the others. This updates the JS to use `marker.getElement()` instead of the legacy Leaflet `marker._icon` property, and updates the CSS classes to remove Leaflet scoping.

---
*PR created automatically by Jules for task [3231107599974883433](https://jules.google.com/task/3231107599974883433) started by @stanleyrya*