### PR TITLE
fix: selected map markers moving to the left edge

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2727,7 +2727,6 @@ body.index-page main {
 
 .marker-selected {
     z-index: 1010 !important;
-    position: relative !important;
 }
 
 .marker-dimmed {


### PR DESCRIPTION
- Removed `position: relative !important;` from the `.marker-selected` class in `styles.css`.
- This ensures MapLibre GL JS can maintain its internal absolute positioning for map markers, resolving an issue where selecting an event caused its map marker to incorrectly jump to the left edge of the screen.

---
*PR created automatically by Jules for task [3911985644604172596](https://jules.google.com/task/3911985644604172596) started by @stanleyrya*