### PR TITLE
Fix missing test files in the /testing index fallback array

### DIFF
--- a/testing/index.html
+++ b/testing/index.html
@@ -842,7 +842,10 @@
               'multiline-breakpoint-test.html',
               'hyphenation-test.html',
               'simplified-hyphenation-test.html',
-              'test-event-abbreviation.html'
+              'test-event-abbreviation.html',
+              'test-city-landscapes.html',
+              'test-og-event-layouts-calendar.html',
+              'test-unified-scraper.html'
             ];
 
             const fileChecks = allKnownFiles.map(async (filename) => {


### PR DESCRIPTION
In the `/testing` interface, the directory listing utilizes a 3-tier loading strategy:
1. Fetching `manifest.json`.
2. Fetching directory index (`fetch('./')`), which fails because it resolves to `index.html`.
3. Probing a hardcoded `allKnownFiles` array using `HEAD` requests.

The `allKnownFiles` array was outdated, causing newly added tools (like unified scraper and city landscapes) to not appear in the testing directory when the fallback probe was triggered.

This PR updates the `allKnownFiles` array by explicitly appending `test-city-landscapes.html`, `test-og-event-layouts-calendar.html`, and `test-unified-scraper.html`. It preserves all historical files so the fallback probe does not regress on other branches. Tests and verification confirm the new tools now correctly show up when `manifest.json` is missing.

---
*PR created automatically by Jules for task [487914525238787018](https://jules.google.com/task/487914525238787018) started by @stanleyrya*