### PR TITLE
fix: calendar not showing Sunday recurring events

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -849,7 +849,7 @@ class CalendarCore {
         
         // Extract just the day part if the dayCode includes occurrence (e.g., "-1SA" -> "SA")
         const dayPart = dayCode.replace(/^-?\d+/, '');
-        return dayMap[dayPart] || -1;
+        return dayMap[dayPart] !== undefined ? dayMap[dayPart] : -1;
     }
 
     // Helper method to get occurrence number from day code (e.g., "2TU" -> 2)


### PR DESCRIPTION
Fixed a bug in `CalendarCore.getDayIndexFromCode` where the zero-indexed value for Sunday was being incorrectly evaluated as falsy, preventing Sunday recurring events from rendering on the calendar.

---
*PR created automatically by Jules for task [210653982013852836](https://jules.google.com/task/210653982013852836) started by @stanleyrya*