### PR TITLE
chore: add warning comments for new stateless GitHub App token format lengths

### DIFF
--- a/.github/workflows/bars-sync.yml
+++ b/.github/workflows/bars-sync.yml
@@ -18,6 +18,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        # Note: GitHub App installation tokens will soon use a new stateless format (ghs_...)
+        # and may be longer (~520 characters). Avoid adding hardcoded length assumptions.
         token: ${{ secrets.GITHUB_TOKEN }}
       
     - name: Set up Node.js

--- a/.github/workflows/directory-preview-sync.yml
+++ b/.github/workflows/directory-preview-sync.yml
@@ -14,6 +14,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        # Note: GitHub App installation tokens will soon use a new stateless format (ghs_...)
+        # and may be longer (~520 characters). Avoid adding hardcoded length assumptions.
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Node.js

--- a/.github/workflows/sync-beta-to-external-repo.yml
+++ b/.github/workflows/sync-beta-to-external-repo.yml
@@ -26,6 +26,8 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.ref }}
+        # Note: GitHub App installation tokens will soon use a new stateless format (ghs_...)
+        # and may be longer (~520 characters). Avoid adding hardcoded length assumptions.
         token: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Determine branch for workflow_dispatch
@@ -46,6 +48,8 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ steps.branch.outputs.branch }}
+        # Note: GitHub App installation tokens will soon use a new stateless format (ghs_...)
+        # and may be longer (~520 characters). Avoid adding hardcoded length assumptions.
         token: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Get current branch name
@@ -62,6 +66,8 @@ jobs:
     
     - name: Add external repository remote
       run: |
+        # Note: GitHub App installation tokens will soon use a new stateless format (ghs_...)
+        # and may be longer (~520 characters). Avoid adding hardcoded length assumptions.
         git remote add external https://${{ secrets.BETA_REPO_TOKEN }}@github.com/${{ secrets.BETA_REPO_OWNER }}/chunky-dad-beta.git || true
         git remote set-url external https://${{ secrets.BETA_REPO_TOKEN }}@github.com/${{ secrets.BETA_REPO_OWNER }}/chunky-dad-beta.git
     

--- a/.github/workflows/update-calendar-data.yml
+++ b/.github/workflows/update-calendar-data.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # Note: GitHub App installation tokens will soon use a new stateless format (ghs_...)
+          # and may be longer (~520 characters). Avoid adding hardcoded length assumptions.
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Setup Node.js


### PR DESCRIPTION
Added comments warning developers that GitHub App installation tokens will soon use a stateless format (ghs_...) and may be longer (~520 characters) above GITHUB_TOKEN usage across GitHub Actions workflows. This prevents developers from making hardcoded length assumptions.

---
*PR created automatically by Jules for task [13204822116316175952](https://jules.google.com/task/13204822116316175952) started by @stanleyrya*