### PR TITLE
Add direct image URL parsing support to favicon downloader

### DIFF
--- a/data/calendars/seattle.ics
+++ b/data/calendars/seattle.ics
@@ -42,62 +42,132 @@ RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
 END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART;TZID=America/Los_Angeles:20250717T190000
-DTEND;TZID=America/Los_Angeles:20250718T020000
-RRULE:FREQ=MONTHLY;BYDAY=3TH
-DTSTAMP:20260616T040542Z
-UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
- DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
- <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
- IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
- ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
- /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
- a>
-LAST-MODIFIED:20250719T040329Z
-LOCATION:47.61337340244105\, -122.31441768029491
-SEQUENCE:1
+DTSTART:20260201T050000Z
+DTEND:20260201T110000Z
+DTSTAMP:20260616T042508Z
+UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
+CREATED:20260123T030739Z
+DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
+ s by MATT STANDS &amp\; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine\, Sea
+ ttle\, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com
+ /events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025
+ /12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/69805544976
+ 5272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-bee
+ f-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: http
+ s://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search
+ /?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey
+ : bearracuda-2026-02-01-seattle
+LAST-MODIFIED:20260126T235314Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Leather Night
+SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
 TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20250706T140000
-DTEND;TZID=America/New_York:20250706T190000
-RRULE:FREQ=WEEKLY;BYDAY=SU
-DTSTAMP:20260616T040542Z
+DTSTART;TZID=America/New_York:20260614T000000
+DTEND;TZID=America/New_York:20260614T060000
+DTSTAMP:20260616T042508Z
 UID:6irujvg3effpkdu42krgr91osj@google.com
+RECURRENCE-ID;TZID=America/New_York:20260614T140000
 CREATED:20250712T180301Z
-DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
- ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
- rtName: South Seattle Social
+DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
+ am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
+ /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
+ -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
+ 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
+ \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
+ rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
+ 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
+ ttle
 LAST-MODIFIED:20260507T001639Z
-LOCATION:47.51652271569908\, -122.35487284211817
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:South Seattle Bear Social
+SUMMARY:Seattle GLOW
 TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+BEGIN:VALARM
+ACTION:NONE
+TRIGGER;VALUE=DATE-TIME:19760401T005545Z
+END:VALARM
 END:VEVENT
 BEGIN:VEVENT
-DTSTART:20260509T040000Z
-DTEND:20260509T100000Z
-DTSTAMP:20260616T040542Z
-UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
-CREATED:20260507T001637Z
-DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
- • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
- e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
- da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
- com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
- uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
- ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
-  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
- ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
-LAST-MODIFIED:20260507T001638Z
+DTSTART:20260308T050000Z
+DTEND:20260308T100000Z
+DTSTAMP:20260616T042508Z
+UID:3DCE764F-EC21-459C-8791-745DE1731298
+CREATED:20260123T030754Z
+DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
+ TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
+ A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
+ seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
+ 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
+ : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
+ 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
+ earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
+ C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
+ -seattle
+LAST-MODIFIED:20260126T235324Z
+LOCATION:47.6150572\, -122.3236574
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle
+SUMMARY:Treasure Trail Seattle:TRAIL HEAD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251011T040000Z
+DTEND:20251011T100000Z
+DTSTAMP:20260616T042508Z
+UID:9DF93D82-1411-44C0-BE63-00037416BB38
+CREATED:20250817T231654Z
+DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
+  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
+ nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
+ ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
+ eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
+ 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
+ erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
+ nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
+ ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
+ https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
+ arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
+ bearracuda-2025-10-11-seattle
+LAST-MODIFIED:20251001T141832Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:2
+STATUS:CONFIRMED
+SUMMARY:Bearracuda Seattle: SERIOUS WOOD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251122T050000Z
+DTEND:20251122T110000Z
+DTSTAMP:20260616T042508Z
+UID:3D70DFD0-9501-434E-A015-10F01A25DA09
+CREATED:20250930T014035Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
+ tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
+ ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
+ 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
+ sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
+ a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
+ ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
+ reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
+ -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
+ oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
+ =101730401\nkey: bearracuda-2025-11-22-seattle
+LAST-MODIFIED:20251001T225002Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle: Wish BONED!
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
@@ -105,7 +175,7 @@ END:VEVENT
 BEGIN:VEVENT
 DTSTART:20250927T040000Z
 DTEND:20250927T100000Z
-DTSTAMP:20260616T040542Z
+DTSTAMP:20260616T042508Z
 UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
 CREATED:20250825T034004Z
 DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
@@ -130,7 +200,7 @@ END:VEVENT
 BEGIN:VEVENT
 DTSTART:20260614T040000Z
 DTEND:20260614T100000Z
-DTSTAMP:20260616T040542Z
+DTSTAMP:20260616T042508Z
 UID:762BAD4A-F1D8-4519-BAC3-D755EF9BA263
 CREATED:20260514T005858Z
 DESCRIPTION:description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. 
@@ -159,132 +229,62 @@ X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
-DTSTART:20251122T050000Z
-DTEND:20251122T110000Z
-DTSTAMP:20260616T040542Z
-UID:3D70DFD0-9501-434E-A015-10F01A25DA09
-CREATED:20250930T014035Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
- tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
- ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
- 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
- sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
- a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
- ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
- reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
- -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
- oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
- =101730401\nkey: bearracuda-2025-11-22-seattle
-LAST-MODIFIED:20251001T225002Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle: Wish BONED!
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260308T050000Z
-DTEND:20260308T100000Z
-DTSTAMP:20260616T040542Z
-UID:3DCE764F-EC21-459C-8791-745DE1731298
-CREATED:20260123T030754Z
-DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
- TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
- A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
- seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
- 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
- : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
- 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
- earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
- C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
- -seattle
-LAST-MODIFIED:20260126T235324Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle:TRAIL HEAD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20260614T000000
-DTEND;TZID=America/New_York:20260614T060000
-DTSTAMP:20260616T040542Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-RECURRENCE-ID;TZID=America/New_York:20260614T140000
+DTSTART;TZID=America/Los_Angeles:20250717T190000
+DTEND;TZID=America/Los_Angeles:20250718T020000
+RRULE:FREQ=MONTHLY;BYDAY=3TH
+DTSTAMP:20260616T042508Z
+UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
 CREATED:20250712T180301Z
-DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
- am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
- /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
- -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
- 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
- \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
- rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
- 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
- ttle
+DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
+ DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
+ <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
+ IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
+ ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
+ /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
+ a>
+LAST-MODIFIED:20250719T040329Z
+LOCATION:47.61337340244105\, -122.31441768029491
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:Leather Night
+TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20250706T140000
+DTEND;TZID=America/New_York:20250706T190000
+RRULE:FREQ=WEEKLY;BYDAY=SU
+DTSTAMP:20260616T042508Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
+ ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
+ rtName: South Seattle Social
 LAST-MODIFIED:20260507T001639Z
+LOCATION:47.51652271569908\, -122.35487284211817
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Seattle GLOW
+SUMMARY:South Seattle Bear Social
 TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-BEGIN:VALARM
-ACTION:NONE
-TRIGGER;VALUE=DATE-TIME:19760401T005545Z
-END:VALARM
 END:VEVENT
 BEGIN:VEVENT
-DTSTART:20251011T040000Z
-DTEND:20251011T100000Z
-DTSTAMP:20260616T040542Z
-UID:9DF93D82-1411-44C0-BE63-00037416BB38
-CREATED:20250817T231654Z
-DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
-  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
- nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
- ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
- eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
- 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
- erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
- nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
- ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
- https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
- arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
- bearracuda-2025-10-11-seattle
-LAST-MODIFIED:20251001T141832Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:2
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle: SERIOUS WOOD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260201T050000Z
-DTEND:20260201T110000Z
-DTSTAMP:20260616T040542Z
-UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
-CREATED:20260123T030739Z
-DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
- s by MATT STANDS &amp\; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine\, Sea
- ttle\, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com
- /events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025
- /12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/69805544976
- 5272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-bee
- f-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: http
- s://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search
- /?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey
- : bearracuda-2026-02-01-seattle
-LAST-MODIFIED:20260126T235314Z
-LOCATION:47.6150572\, -122.3236574
+DTSTART:20260509T040000Z
+DTEND:20260509T100000Z
+DTSTAMP:20260616T042508Z
+UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
+CREATED:20260507T001637Z
+DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
+ • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
+ e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
+ da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
+ com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
+ uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
+ ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
+  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
+ ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
+LAST-MODIFIED:20260507T001638Z
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
+SUMMARY:Treasure Trail Seattle
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63

--- a/data/calendars/seattle.ics
+++ b/data/calendars/seattle.ics
@@ -42,132 +42,62 @@ RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
 END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART:20260201T050000Z
-DTEND:20260201T110000Z
-DTSTAMP:20260616T042508Z
-UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
-CREATED:20260123T030739Z
-DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
- s by MATT STANDS &amp\; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine\, Sea
- ttle\, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com
- /events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025
- /12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/69805544976
- 5272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-bee
- f-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: http
- s://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search
- /?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey
- : bearracuda-2026-02-01-seattle
-LAST-MODIFIED:20260126T235314Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20260614T000000
-DTEND;TZID=America/New_York:20260614T060000
-DTSTAMP:20260616T042508Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-RECURRENCE-ID;TZID=America/New_York:20260614T140000
+DTSTART;TZID=America/Los_Angeles:20250717T190000
+DTEND;TZID=America/Los_Angeles:20250718T020000
+RRULE:FREQ=MONTHLY;BYDAY=3TH
+DTSTAMP:20260616T040542Z
+UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
 CREATED:20250712T180301Z
-DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
- am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
- /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
- -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
- 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
- \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
- rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
- 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
- ttle
+DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
+ DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
+ <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
+ IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
+ ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
+ /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
+ a>
+LAST-MODIFIED:20250719T040329Z
+LOCATION:47.61337340244105\, -122.31441768029491
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:Leather Night
+TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20250706T140000
+DTEND;TZID=America/New_York:20250706T190000
+RRULE:FREQ=WEEKLY;BYDAY=SU
+DTSTAMP:20260616T040542Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
+ ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
+ rtName: South Seattle Social
 LAST-MODIFIED:20260507T001639Z
+LOCATION:47.51652271569908\, -122.35487284211817
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Seattle GLOW
+SUMMARY:South Seattle Bear Social
 TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-BEGIN:VALARM
-ACTION:NONE
-TRIGGER;VALUE=DATE-TIME:19760401T005545Z
-END:VALARM
 END:VEVENT
 BEGIN:VEVENT
-DTSTART:20260308T050000Z
-DTEND:20260308T100000Z
-DTSTAMP:20260616T042508Z
-UID:3DCE764F-EC21-459C-8791-745DE1731298
-CREATED:20260123T030754Z
-DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
- TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
- A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
- seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
- 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
- : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
- 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
- earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
- C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
- -seattle
-LAST-MODIFIED:20260126T235324Z
-LOCATION:47.6150572\, -122.3236574
+DTSTART:20260509T040000Z
+DTEND:20260509T100000Z
+DTSTAMP:20260616T040542Z
+UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
+CREATED:20260507T001637Z
+DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
+ • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
+ e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
+ da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
+ com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
+ uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
+ ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
+  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
+ ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
+LAST-MODIFIED:20260507T001638Z
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle:TRAIL HEAD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20251011T040000Z
-DTEND:20251011T100000Z
-DTSTAMP:20260616T042508Z
-UID:9DF93D82-1411-44C0-BE63-00037416BB38
-CREATED:20250817T231654Z
-DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
-  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
- nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
- ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
- eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
- 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
- erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
- nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
- ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
- https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
- arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
- bearracuda-2025-10-11-seattle
-LAST-MODIFIED:20251001T141832Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:2
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle: SERIOUS WOOD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20251122T050000Z
-DTEND:20251122T110000Z
-DTSTAMP:20260616T042508Z
-UID:3D70DFD0-9501-434E-A015-10F01A25DA09
-CREATED:20250930T014035Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
- tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
- ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
- 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
- sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
- a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
- ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
- reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
- -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
- oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
- =101730401\nkey: bearracuda-2025-11-22-seattle
-LAST-MODIFIED:20251001T225002Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle: Wish BONED!
+SUMMARY:Treasure Trail Seattle
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
@@ -175,7 +105,7 @@ END:VEVENT
 BEGIN:VEVENT
 DTSTART:20250927T040000Z
 DTEND:20250927T100000Z
-DTSTAMP:20260616T042508Z
+DTSTAMP:20260616T040542Z
 UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
 CREATED:20250825T034004Z
 DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
@@ -200,7 +130,7 @@ END:VEVENT
 BEGIN:VEVENT
 DTSTART:20260614T040000Z
 DTEND:20260614T100000Z
-DTSTAMP:20260616T042508Z
+DTSTAMP:20260616T040542Z
 UID:762BAD4A-F1D8-4519-BAC3-D755EF9BA263
 CREATED:20260514T005858Z
 DESCRIPTION:description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. 
@@ -229,62 +159,132 @@ X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
-DTSTART;TZID=America/Los_Angeles:20250717T190000
-DTEND;TZID=America/Los_Angeles:20250718T020000
-RRULE:FREQ=MONTHLY;BYDAY=3TH
-DTSTAMP:20260616T042508Z
-UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
- DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
- <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
- IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
- ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
- /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
- a>
-LAST-MODIFIED:20250719T040329Z
-LOCATION:47.61337340244105\, -122.31441768029491
-SEQUENCE:1
+DTSTART:20251122T050000Z
+DTEND:20251122T110000Z
+DTSTAMP:20260616T040542Z
+UID:3D70DFD0-9501-434E-A015-10F01A25DA09
+CREATED:20250930T014035Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
+ tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
+ ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
+ 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
+ sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
+ a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
+ ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
+ reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
+ -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
+ oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
+ =101730401\nkey: bearracuda-2025-11-22-seattle
+LAST-MODIFIED:20251001T225002Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Leather Night
+SUMMARY:Treasure Trail Seattle: Wish BONED!
 TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20250706T140000
-DTEND;TZID=America/New_York:20250706T190000
-RRULE:FREQ=WEEKLY;BYDAY=SU
-DTSTAMP:20260616T042508Z
+DTSTART:20260308T050000Z
+DTEND:20260308T100000Z
+DTSTAMP:20260616T040542Z
+UID:3DCE764F-EC21-459C-8791-745DE1731298
+CREATED:20260123T030754Z
+DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
+ TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
+ A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
+ seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
+ 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
+ : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
+ 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
+ earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
+ C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
+ -seattle
+LAST-MODIFIED:20260126T235324Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle:TRAIL HEAD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20260614T000000
+DTEND;TZID=America/New_York:20260614T060000
+DTSTAMP:20260616T040542Z
 UID:6irujvg3effpkdu42krgr91osj@google.com
+RECURRENCE-ID;TZID=America/New_York:20260614T140000
 CREATED:20250712T180301Z
-DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
- ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
- rtName: South Seattle Social
+DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00
+ am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
+ /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
+ -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
+ 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
+ \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
+ rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
+ 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
+ ttle
 LAST-MODIFIED:20260507T001639Z
-LOCATION:47.51652271569908\, -122.35487284211817
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:South Seattle Bear Social
+SUMMARY:Seattle GLOW
 TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+BEGIN:VALARM
+ACTION:NONE
+TRIGGER;VALUE=DATE-TIME:19760401T005545Z
+END:VALARM
 END:VEVENT
 BEGIN:VEVENT
-DTSTART:20260509T040000Z
-DTEND:20260509T100000Z
-DTSTAMP:20260616T042508Z
-UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
-CREATED:20260507T001637Z
-DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
- • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
- e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
- da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
- com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
- uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
- ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
-  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
- ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
-LAST-MODIFIED:20260507T001638Z
+DTSTART:20251011T040000Z
+DTEND:20251011T100000Z
+DTSTAMP:20260616T040542Z
+UID:9DF93D82-1411-44C0-BE63-00037416BB38
+CREATED:20250817T231654Z
+DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
+  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
+ nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
+ ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
+ eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
+ 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
+ erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
+ nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
+ ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram:
+ https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
+ arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey:
+ bearracuda-2025-10-11-seattle
+LAST-MODIFIED:20251001T141832Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:2
+STATUS:CONFIRMED
+SUMMARY:Bearracuda Seattle: SERIOUS WOOD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260201T050000Z
+DTEND:20260201T110000Z
+DTSTAMP:20260616T040542Z
+UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
+CREATED:20260123T030739Z
+DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
+ s by MATT STANDS &amp\; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine\, Sea
+ ttle\, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com
+ /events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025
+ /12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/69805544976
+ 5272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-bee
+ f-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: http
+ s://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search
+ /?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey
+ : bearracuda-2026-02-01-seattle
+LAST-MODIFIED:20260126T235314Z
+LOCATION:47.6150572\, -122.3236574
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle
+SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63

--- a/data/calendars/update-summary.json
+++ b/data/calendars/update-summary.json
@@ -1,159 +1,159 @@
 {
-  "lastUpdated": "2026-06-16T04:25:09.216Z",
+  "lastUpdated": "2026-06-16T04:05:42.959Z",
   "cities": {
     "nyc": {
       "name": "New York",
       "status": "success",
       "dataLength": 10636,
       "eventCount": 11,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "seattle": {
       "name": "Seattle",
       "status": "success",
       "dataLength": 12362,
       "eventCount": 10,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "la": {
       "name": "Los Angeles",
       "status": "success",
       "dataLength": 8423,
       "eventCount": 7,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "toronto": {
       "name": "Toronto",
       "status": "success",
       "dataLength": 197,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "london": {
       "name": "London",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "chicago": {
       "name": "Chicago",
       "status": "success",
       "dataLength": 13565,
       "eventCount": 12,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "berlin": {
       "name": "Berlin",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "palm-springs": {
       "name": "Palm Springs",
       "status": "success",
       "dataLength": 1487,
       "eventCount": 1,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "denver": {
       "name": "Denver",
       "status": "success",
       "dataLength": 6856,
       "eventCount": 6,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "dallas": {
       "name": "Dallas",
       "status": "success",
       "dataLength": 195,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "dc": {
       "name": "DC",
       "status": "success",
       "dataLength": 1503,
       "eventCount": 1,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "vegas": {
       "name": "Las Vegas",
       "status": "success",
       "dataLength": 4410,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "atlanta": {
       "name": "Atlanta",
       "status": "success",
       "dataLength": 4933,
       "eventCount": 4,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "nola": {
       "name": "New Orleans",
       "status": "success",
       "dataLength": 2367,
       "eventCount": 2,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "sf": {
       "name": "San Francisco",
       "status": "success",
       "dataLength": 15367,
       "eventCount": 12,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "portland": {
       "name": "Portland",
       "status": "success",
       "dataLength": 18474,
       "eventCount": 14,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "sitges": {
       "name": "Sitges",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "boston": {
       "name": "Boston",
       "status": "success",
       "dataLength": 196,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "phoenix": {
       "name": "Phoenix",
       "status": "success",
       "dataLength": 2874,
       "eventCount": 2,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "ptown": {
       "name": "Provincetown",
       "status": "success",
       "dataLength": 202,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "san-diego": {
       "name": "San Diego",
       "status": "success",
       "dataLength": 4073,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     },
     "philly": {
       "name": "Philadelphia",
       "status": "success",
       "dataLength": 4689,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T04:25:09.216Z"
+      "lastUpdated": "2026-06-16T04:05:42.959Z"
     }
   }
 }

--- a/data/calendars/update-summary.json
+++ b/data/calendars/update-summary.json
@@ -1,159 +1,159 @@
 {
-  "lastUpdated": "2026-06-16T04:05:42.959Z",
+  "lastUpdated": "2026-06-16T04:25:09.216Z",
   "cities": {
     "nyc": {
       "name": "New York",
       "status": "success",
       "dataLength": 10636,
       "eventCount": 11,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "seattle": {
       "name": "Seattle",
       "status": "success",
       "dataLength": 12362,
       "eventCount": 10,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "la": {
       "name": "Los Angeles",
       "status": "success",
       "dataLength": 8423,
       "eventCount": 7,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "toronto": {
       "name": "Toronto",
       "status": "success",
       "dataLength": 197,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "london": {
       "name": "London",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "chicago": {
       "name": "Chicago",
       "status": "success",
       "dataLength": 13565,
       "eventCount": 12,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "berlin": {
       "name": "Berlin",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "palm-springs": {
       "name": "Palm Springs",
       "status": "success",
       "dataLength": 1487,
       "eventCount": 1,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "denver": {
       "name": "Denver",
       "status": "success",
       "dataLength": 6856,
       "eventCount": 6,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "dallas": {
       "name": "Dallas",
       "status": "success",
       "dataLength": 195,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "dc": {
       "name": "DC",
       "status": "success",
       "dataLength": 1503,
       "eventCount": 1,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "vegas": {
       "name": "Las Vegas",
       "status": "success",
       "dataLength": 4410,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "atlanta": {
       "name": "Atlanta",
       "status": "success",
       "dataLength": 4933,
       "eventCount": 4,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "nola": {
       "name": "New Orleans",
       "status": "success",
       "dataLength": 2367,
       "eventCount": 2,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "sf": {
       "name": "San Francisco",
       "status": "success",
       "dataLength": 15367,
       "eventCount": 12,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "portland": {
       "name": "Portland",
       "status": "success",
       "dataLength": 18474,
       "eventCount": 14,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "sitges": {
       "name": "Sitges",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "boston": {
       "name": "Boston",
       "status": "success",
       "dataLength": 196,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "phoenix": {
       "name": "Phoenix",
       "status": "success",
       "dataLength": 2874,
       "eventCount": 2,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "ptown": {
       "name": "Provincetown",
       "status": "success",
       "dataLength": 202,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "san-diego": {
       "name": "San Diego",
       "status": "success",
       "dataLength": 4073,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     },
     "philly": {
       "name": "Philadelphia",
       "status": "success",
       "dataLength": 4689,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T04:05:42.959Z"
+      "lastUpdated": "2026-06-16T04:25:09.216Z"
     }
   }
 }

--- a/js/filename-utils.js
+++ b/js/filename-utils.js
@@ -226,6 +226,21 @@ function convertFaviconUrlToLocalPath(faviconUrl, basePath = 'img/favicons') {
 }
 
 /**
+ * Return true if the URL points to a direct image file.
+ * @param {string} url - The URL to check
+ * @returns {boolean}
+ */
+function isImageUrl(url) {
+    if (!url) return false;
+    try {
+        const parsedUrl = new URL(url);
+        return /\.(png|jpg|jpeg|gif|webp|svg|ico|bmp|tiff)$/i.test(parsedUrl.pathname);
+    } catch {
+        return false;
+    }
+}
+
+/**
  * Return true if the URL is a Linktree page.
  * @param {string} url - The URL to check
  * @returns {boolean}
@@ -294,6 +309,10 @@ function generateWikipediaFaviconFilename(wikipediaUrl, size = '32') {
  * @returns {string} - The local file path
  */
 function convertWebsiteUrlToFaviconPath(websiteUrl, basePath = 'img/favicons') {
+    if (isImageUrl(websiteUrl)) {
+        return convertFaviconUrlToLocalPath(websiteUrl, basePath);
+    }
+
     const parsedUrl = new URL(websiteUrl);
     
     // Check if it's a Linktree URL
@@ -392,7 +411,8 @@ if (typeof module !== 'undefined' && module.exports) {
         generateWikipediaFaviconFilename,
         detectFileExtension,
         slugify,
-        simpleHash
+        simpleHash,
+        isImageUrl
     };
 }
 
@@ -413,6 +433,7 @@ if (typeof window !== 'undefined') {
         generateWikipediaFaviconFilename,
         detectFileExtension,
         slugify,
-        simpleHash
+        simpleHash,
+        isImageUrl
     };
 }

--- a/tools/download-images.js
+++ b/tools/download-images.js
@@ -7,7 +7,7 @@ const http = require('http');
 const { URL } = require('url');
 
 // Import shared filename utilities
-const { generateFilenameFromUrl, generateFaviconFilename, generateEventFilename, cleanImageUrl, getEventDirectoryPath, convertImageUrlToLocalPath, detectFileExtension, isLinktreeUrl, isWikipediaUrl, generateLinktreeFaviconFilename, generateWikipediaFaviconFilename } = require('../js/filename-utils.js');
+const { generateFilenameFromUrl, generateFaviconFilename, generateEventFilename, cleanImageUrl, getEventDirectoryPath, convertImageUrlToLocalPath, detectFileExtension, isLinktreeUrl, isWikipediaUrl, generateLinktreeFaviconFilename, generateWikipediaFaviconFilename, isImageUrl } = require('../js/filename-utils.js');
 
 /**
  * Adjust Eventbrite image URLs to get uncropped versions
@@ -814,6 +814,11 @@ async function downloadImage(imageUrl, type = 'event', isLinktreeProfile = false
 // Process a website URL and add it to the appropriate collection
 function processWebsiteUrl(url, context = '') {
   try {
+    if (isImageUrl(url)) {
+      console.log(`🖼️  Found direct image URL${context}: ${url}`);
+      return { type: 'favicon_direct', url };
+    }
+
     const domain = new URL(url).hostname;
     
     // Check if it's a Linktree URL
@@ -853,6 +858,9 @@ function addProcessedUrl(imageUrls, result) {
   } else if (result.type === 'favicon') {
     imageUrls.favicons64.add(result.urls.favicon64);
     imageUrls.favicons256.add(result.urls.favicon256);
+  } else if (result.type === 'favicon_direct') {
+    imageUrls.faviconsDirect = imageUrls.faviconsDirect || new Set();
+    imageUrls.faviconsDirect.add(result.url);
   }
 }
 
@@ -862,6 +870,7 @@ async function extractImageUrls() {
     eventsWithInfo: [],  // Changed to array of event objects with image info
     favicons64: new Set(),  // Higher quality for map markers
     favicons256: new Set(),   // High quality for cards/OG
+    faviconsDirect: new Set(), // Direct image favicons
     linktreeUrls: new Set(),
     wikipediaUrls: new Set()
   };
@@ -912,8 +921,12 @@ async function extractImageUrls() {
       }
       
       // Extract website URLs for favicons
+      if (event.favicon) {
+        const result = processWebsiteUrl(event.favicon, ` (favicon override for ${event.name})`);
+        addProcessedUrl(imageUrls, result);
+      }
       if (event.website) {
-        const result = processWebsiteUrl(event.website);
+        const result = processWebsiteUrl(event.website, ` for ${event.name}`);
         addProcessedUrl(imageUrls, result);
       }
     }
@@ -1071,6 +1084,24 @@ async function main() {
     }
   }
   
+  // Download direct image favicons
+  if (imageUrls.faviconsDirect && imageUrls.faviconsDirect.size > 0) {
+    console.log('\n🖼️  Downloading direct image favicons...');
+    for (const url of imageUrls.faviconsDirect) {
+      // Use size '64' so it generates the consistent -64px.ext filename expected by convertWebsiteUrlToFaviconPath
+      const result = await downloadImageWithSize(url, 'favicon', '64');
+      if (result.success) {
+        if (result.skipped) {
+          totalSkipped++;
+        } else {
+          totalDownloaded++;
+        }
+      } else {
+        totalFailed++;
+      }
+    }
+  }
+
   // Process Linktree profile pictures with multiple sizes
   if (imageUrls.linktreeUrls && imageUrls.linktreeUrls.size > 0) {
     console.log('\n🔗 Processing Linktree profile pictures with multiple sizes...');


### PR DESCRIPTION
This change adds support for "favicon override" fields which contain a direct image URL. It intelligently detects if a given favicon URL is a direct image (`isImageUrl`) and updates the `download-images` script and frontend path builders to treat it accordingly, while continuing to fallback to the existing Google Favicon service for website domains.

---
*PR created automatically by Jules for task [5109295464750747646](https://jules.google.com/task/5109295464750747646) started by @stanleyrya*