### PR TITLE
feat: prioritize favicon override field in map markers

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1142,41 +1142,55 @@ class DynamicCalendarLoader extends CalendarCore {
 
     // Create marker icon with favicon or three letters
     createMarkerIcon(event) {
-        if (event.website) {
+        if (event.favicon || event.website) {
             try {
                 logger.debug('MAP', 'Creating favicon marker', {
                     eventName: event.name,
                     website: event.website,
+                    favicon: event.favicon,
                     dataSource: this.dataSource
                 });
                 
-                // Ensure URL has protocol
-                let url = event.website;
-                if (!url.startsWith('http://') && !url.startsWith('https://')) {
-                    url = 'https://' + url;
-                }
-                
                 let faviconUrl;
                 
-                // Convert to local favicon URL if using cached data
-                if (this.dataSource === 'cached') {
-                    faviconUrl = window.FilenameUtils.convertWebsiteUrlToFaviconPath(url, '/img/favicons');
-                    
-                    logger.debug('MAP', 'Using local favicon for cached data', {
-                        website: url,
-                        localPath: faviconUrl,
-                        dataSource: this.dataSource
-                    });
-                } else {
-                    // For live data, use Google favicon service with higher quality
-                    const hostname = new URL(url).hostname;
-                    faviconUrl = `https://www.google.com/s2/favicons?domain=${hostname}&sz=64`;
+                if (event.favicon) {
+                    let url = event.favicon;
+                    // Ensure URL has protocol
+                    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+                        url = 'https://' + url;
+                    }
+                    if (this.dataSource === 'cached') {
+                        faviconUrl = window.FilenameUtils.convertWebsiteUrlToFaviconPath(url, '/img/favicons');
+                    } else {
+                        faviconUrl = url;
+                    }
+                } else if (event.website) {
+                    let url = event.website;
+                    // Ensure URL has protocol
+                    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+                        url = 'https://' + url;
+                    }
+                    // Convert to local favicon URL if using cached data
+                    if (this.dataSource === 'cached') {
+                        faviconUrl = window.FilenameUtils.convertWebsiteUrlToFaviconPath(url, '/img/favicons');
+
+                        logger.debug('MAP', 'Using local favicon for cached data', {
+                            website: url,
+                            localPath: faviconUrl,
+                            dataSource: this.dataSource
+                        });
+                    } else {
+                        // For live data, use Google favicon service with higher quality
+                        const hostname = new URL(url).hostname;
+                        faviconUrl = `https://www.google.com/s2/favicons?domain=${hostname}&sz=64`;
+                    }
                 }
                 
                 const textFallback = this.getMarkerText(event);
                 
                 logger.debug('MAP', 'Favicon URL generated', {
-                    website: url,
+                    website: event.website,
+                    favicon: event.favicon,
                     faviconUrl,
                     textFallback,
                     dataSource: this.dataSource


### PR DESCRIPTION
Prioritizes the `favicon` field over `website` for marker generation in `js/dynamic-calendar-loader.js`. Direct image URLs bypass standard transformation paths, correctly acting as an explicit icon override while maintaining the standard website favicon behavior as a fallback.

---
*PR created automatically by Jules for task [16887308182336510755](https://jules.google.com/task/16887308182336510755) started by @stanleyrya*