### PR TITLE
feat(event-builder): show favicon in preview card

### DIFF
--- a/testing/event-builder.html
+++ b/testing/event-builder.html
@@ -1634,8 +1634,23 @@
       color: var(--accent);
     }
 
-    .preview-title {
+    .preview-title-container {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
       margin: 0.35rem 0 0.45rem;
+    }
+
+    .preview-favicon {
+      width: 24px;
+      height: 24px;
+      border-radius: 4px;
+      object-fit: cover;
+      flex-shrink: 0;
+    }
+
+    .preview-title {
+      margin: 0;
       font-size: 1.1rem;
       color: var(--text-primary);
     }
@@ -2624,7 +2639,10 @@
             </div>
             <div class="preview-body">
               <div class="preview-city" id="preview-city">City</div>
-              <h3 class="preview-title" id="preview-title">Untitled event</h3>
+              <div class="preview-title-container">
+                <img id="preview-favicon" class="preview-favicon is-hidden" alt="" loading="lazy" onerror="this.classList.add('is-hidden')">
+                <h3 class="preview-title" id="preview-title">Untitled event</h3>
+              </div>
               <p class="preview-time" id="preview-time">Add start and end times to preview timing.</p>
               <p class="preview-venue" id="preview-venue">Venue TBA</p>
               <p class="preview-address" id="preview-address">Address TBD</p>
@@ -3151,6 +3169,7 @@
         dom.previewMedia = document.getElementById('preview-media');
         dom.previewImage = document.getElementById('preview-image');
         dom.previewCity = document.getElementById('preview-city');
+        dom.previewFavicon = document.getElementById('preview-favicon');
         dom.previewTitle = document.getElementById('preview-title');
         dom.previewTime = document.getElementById('preview-time');
         dom.previewVenue = document.getElementById('preview-venue');
@@ -9145,6 +9164,16 @@ Example output:
           } else {
             dom.previewImage.removeAttribute('src');
             dom.previewImage.alt = '';
+          }
+        }
+        const faviconUrl = (state.favicon || '').trim();
+        if (dom.previewFavicon) {
+          if (faviconUrl) {
+            dom.previewFavicon.src = faviconUrl;
+            dom.previewFavicon.classList.remove('is-hidden');
+          } else {
+            dom.previewFavicon.removeAttribute('src');
+            dom.previewFavicon.classList.add('is-hidden');
           }
         }
         const recurrenceLabel = getRecurrenceChipLabel(event.recurrence);


### PR DESCRIPTION
The `event-builder` page allows users to set an `event.favicon` override property for an event (specifically intended for map marker icon generation and cross-module identification). However, the "Live Preview" preview card panel did not visually display the selected favicon, meaning the user couldn't verify if it successfully loaded or how it looked unless they checked the actual live website preview map flow.

This change modifies `testing/event-builder.html` to add a new `img` element next to the preview title. When the user pastes or inputs a `Favicon URL`, `updatePreviewCard` dynamically assigns it to the image source. If the link is invalid, it falls back gracefully using an `onerror` handler to hide itself.

---
*PR created automatically by Jules for task [14006949560680221356](https://jules.google.com/task/14006949560680221356) started by @stanleyrya*