### PR TITLE
Support favicon field in bar syncing and image download flows

### DIFF
--- a/data/calendars/seattle.ics
+++ b/data/calendars/seattle.ics
@@ -42,58 +42,102 @@ RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
 END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20260614T000000
-DTEND;TZID=America/New_York:20260614T060000
-DTSTAMP:20260616T114645Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-RECURRENCE-ID;TZID=America/New_York:20260614T140000
-CREATED:20250712T180301Z
-DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
- am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
- /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
- -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
- 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
- \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
- rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
- 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
- ttle
-LAST-MODIFIED:20260507T001639Z
+DTSTART:20260509T040000Z
+DTEND:20260509T100000Z
+DTSTAMP:20260616T130352Z
+UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
+CREATED:20260507T001637Z
+DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
+ • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
+ e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
+ da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
+ com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
+ uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
+ ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
+  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
+ ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
+LAST-MODIFIED:20260507T001638Z
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Seattle GLOW
+SUMMARY:Treasure Trail Seattle
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-BEGIN:VALARM
-ACTION:NONE
-TRIGGER;VALUE=DATE-TIME:19760401T005545Z
-END:VALARM
 END:VEVENT
 BEGIN:VEVENT
-DTSTART;TZID=America/Los_Angeles:20250717T190000
-DTEND;TZID=America/Los_Angeles:20250718T020000
-RRULE:FREQ=MONTHLY;BYDAY=3TH
-DTSTAMP:20260616T114645Z
-UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
+DTSTART;TZID=America/New_York:20250706T140000
+DTEND;TZID=America/New_York:20250706T190000
+RRULE:FREQ=WEEKLY;BYDAY=SU
+DTSTAMP:20260616T130352Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
 CREATED:20250712T180301Z
-DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
- DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
- <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
- IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
- ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
- /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
- a>
-LAST-MODIFIED:20250719T040329Z
-LOCATION:47.61337340244105\, -122.31441768029491
-SEQUENCE:1
+DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
+ ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
+ rtName: South Seattle Social
+LAST-MODIFIED:20260507T001639Z
+LOCATION:47.51652271569908\, -122.35487284211817
+SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Leather Night
+SUMMARY:South Seattle Bear Social
 TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251122T050000Z
+DTEND:20251122T110000Z
+DTSTAMP:20260616T130352Z
+UID:3D70DFD0-9501-434E-A015-10F01A25DA09
+CREATED:20250930T014035Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
+ tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
+ ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
+ 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
+ sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
+ a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
+ ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
+ reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
+ -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
+ oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
+ =101730401\nkey: bearracuda-2025-11-22-seattle
+LAST-MODIFIED:20251001T225002Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle: Wish BONED!
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251011T040000Z
+DTEND:20251011T100000Z
+DTSTAMP:20260616T130352Z
+UID:9DF93D82-1411-44C0-BE63-00037416BB38
+CREATED:20250817T231654Z
+DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
+  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
+ nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
+ ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
+ eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
+ 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
+ erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
+ nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
+ ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
+ https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
+ arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
+ bearracuda-2025-10-11-seattle
+LAST-MODIFIED:20251001T141832Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:2
+STATUS:CONFIRMED
+SUMMARY:Bearracuda Seattle: SERIOUS WOOD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 END:VEVENT
 BEGIN:VEVENT
 DTSTART:20250927T040000Z
 DTEND:20250927T100000Z
-DTSTAMP:20260616T114645Z
+DTSTAMP:20260616T130352Z
 UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
 CREATED:20250825T034004Z
 DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
@@ -116,9 +160,55 @@ TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 END:VEVENT
 BEGIN:VEVENT
+DTSTART:20260308T050000Z
+DTEND:20260308T100000Z
+DTSTAMP:20260616T130352Z
+UID:3DCE764F-EC21-459C-8791-745DE1731298
+CREATED:20260123T030754Z
+DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
+ TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
+ A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
+ seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
+ 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
+ : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
+ 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
+ earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
+ C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
+ -seattle
+LAST-MODIFIED:20260126T235324Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle:TRAIL HEAD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Los_Angeles:20250717T190000
+DTEND;TZID=America/Los_Angeles:20250718T020000
+RRULE:FREQ=MONTHLY;BYDAY=3TH
+DTSTAMP:20260616T130352Z
+UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
+ DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
+ <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
+ IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
+ ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
+ /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
+ a>
+LAST-MODIFIED:20250719T040329Z
+LOCATION:47.61337340244105\, -122.31441768029491
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:Leather Night
+TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
 DTSTART:20260614T040000Z
 DTEND:20260614T100000Z
-DTSTAMP:20260616T114645Z
+DTSTAMP:20260616T130352Z
 UID:762BAD4A-F1D8-4519-BAC3-D755EF9BA263
 CREATED:20260514T005858Z
 DESCRIPTION:description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. 
@@ -147,36 +237,37 @@ X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
-DTSTART:20251122T050000Z
-DTEND:20251122T110000Z
-DTSTAMP:20260616T114645Z
-UID:3D70DFD0-9501-434E-A015-10F01A25DA09
-CREATED:20250930T014035Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
- tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
- ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
- 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
- sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
- a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
- ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
- reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
- -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
- oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
- =101730401\nkey: bearracuda-2025-11-22-seattle
-LAST-MODIFIED:20251001T225002Z
-LOCATION:47.6150572\, -122.3236574
+DTSTART;TZID=America/New_York:20260614T000000
+DTEND;TZID=America/New_York:20260614T060000
+DTSTAMP:20260616T130352Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+RECURRENCE-ID;TZID=America/New_York:20260614T140000
+CREATED:20250712T180301Z
+DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
+ am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
+ /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
+ -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
+ 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
+ \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
+ rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
+ 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
+ ttle
+LAST-MODIFIED:20260507T001639Z
 SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle: Wish BONED!
+SUMMARY:Seattle GLOW
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+BEGIN:VALARM
+ACTION:NONE
+TRIGGER;VALUE=DATE-TIME:19760401T005545Z
+END:VALARM
 END:VEVENT
 BEGIN:VEVENT
 DTSTART:20260201T050000Z
 DTEND:20260201T110000Z
-DTSTAMP:20260616T114645Z
+DTSTAMP:20260616T130352Z
 UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
 CREATED:20260123T030739Z
 DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
@@ -194,97 +285,6 @@ LOCATION:47.6150572\, -122.3236574
 SEQUENCE:0
 STATUS:CONFIRMED
 SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20250706T140000
-DTEND;TZID=America/New_York:20250706T190000
-RRULE:FREQ=WEEKLY;BYDAY=SU
-DTSTAMP:20260616T114645Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
- ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
- rtName: South Seattle Social
-LAST-MODIFIED:20260507T001639Z
-LOCATION:47.51652271569908\, -122.35487284211817
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:South Seattle Bear Social
-TRANSP:OPAQUE
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260509T040000Z
-DTEND:20260509T100000Z
-DTSTAMP:20260616T114645Z
-UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
-CREATED:20260507T001637Z
-DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
- • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
- e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
- da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
- com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
- uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
- ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
-  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
- ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
-LAST-MODIFIED:20260507T001638Z
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20251011T040000Z
-DTEND:20251011T100000Z
-DTSTAMP:20260616T114645Z
-UID:9DF93D82-1411-44C0-BE63-00037416BB38
-CREATED:20250817T231654Z
-DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
-  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
- nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
- ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
- eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
- 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
- erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
- nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
- ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
- https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
- arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
- bearracuda-2025-10-11-seattle
-LAST-MODIFIED:20251001T141832Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:2
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle: SERIOUS WOOD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260308T050000Z
-DTEND:20260308T100000Z
-DTSTAMP:20260616T114645Z
-UID:3DCE764F-EC21-459C-8791-745DE1731298
-CREATED:20260123T030754Z
-DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
- TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
- A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
- seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
- 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
- : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
- 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
- earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
- C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
- -seattle
-LAST-MODIFIED:20260126T235324Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle:TRAIL HEAD
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63

--- a/data/calendars/update-summary.json
+++ b/data/calendars/update-summary.json
@@ -1,159 +1,159 @@
 {
-  "lastUpdated": "2026-06-16T11:46:46.563Z",
+  "lastUpdated": "2026-06-16T13:03:52.980Z",
   "cities": {
     "nyc": {
       "name": "New York",
       "status": "success",
       "dataLength": 10636,
       "eventCount": 11,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "seattle": {
       "name": "Seattle",
       "status": "success",
       "dataLength": 12362,
       "eventCount": 10,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "la": {
       "name": "Los Angeles",
       "status": "success",
       "dataLength": 8423,
       "eventCount": 7,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "toronto": {
       "name": "Toronto",
       "status": "success",
       "dataLength": 197,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "london": {
       "name": "London",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "chicago": {
       "name": "Chicago",
       "status": "success",
       "dataLength": 13565,
       "eventCount": 12,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "berlin": {
       "name": "Berlin",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "palm-springs": {
       "name": "Palm Springs",
       "status": "success",
       "dataLength": 1487,
       "eventCount": 1,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "denver": {
       "name": "Denver",
       "status": "success",
       "dataLength": 6856,
       "eventCount": 6,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "dallas": {
       "name": "Dallas",
       "status": "success",
       "dataLength": 195,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "dc": {
       "name": "DC",
       "status": "success",
       "dataLength": 1503,
       "eventCount": 1,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "vegas": {
       "name": "Las Vegas",
       "status": "success",
       "dataLength": 4410,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "atlanta": {
       "name": "Atlanta",
       "status": "success",
       "dataLength": 4933,
       "eventCount": 4,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "nola": {
       "name": "New Orleans",
       "status": "success",
       "dataLength": 2367,
       "eventCount": 2,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "sf": {
       "name": "San Francisco",
       "status": "success",
       "dataLength": 15367,
       "eventCount": 12,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "portland": {
       "name": "Portland",
       "status": "success",
       "dataLength": 18474,
       "eventCount": 14,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "sitges": {
       "name": "Sitges",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "boston": {
       "name": "Boston",
       "status": "success",
       "dataLength": 196,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "phoenix": {
       "name": "Phoenix",
       "status": "success",
       "dataLength": 2874,
       "eventCount": 2,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "ptown": {
       "name": "Provincetown",
       "status": "success",
       "dataLength": 202,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "san-diego": {
       "name": "San Diego",
       "status": "success",
       "dataLength": 4073,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     },
     "philly": {
       "name": "Philadelphia",
       "status": "success",
       "dataLength": 4689,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T11:46:46.563Z"
+      "lastUpdated": "2026-06-16T13:03:52.980Z"
     }
   }
 }

--- a/img/favicons/favicon-seattleeagle.com-256px.ico.meta
+++ b/img/favicons/favicon-seattleeagle.com-256px.ico.meta
@@ -1,0 +1,9 @@
+{
+  "originalUrl": "https://www.google.com/s2/favicons?domain=seattleeagle.com&sz=256",
+  "failedAt": "2026-06-16T13:04:02.550Z",
+  "error": "HTTP 404: Not Found",
+  "type": "favicon",
+  "filename": "favicon-seattleeagle.com-256px.ico",
+  "size": "256",
+  "failureCount": 1
+}

--- a/img/favicons/favicon-seattleeagle.com-64px.ico.meta
+++ b/img/favicons/favicon-seattleeagle.com-64px.ico.meta
@@ -1,0 +1,9 @@
+{
+  "originalUrl": "https://www.google.com/s2/favicons?domain=seattleeagle.com&sz=64",
+  "failedAt": "2026-06-16T13:04:02.469Z",
+  "error": "HTTP 404: Not Found",
+  "type": "favicon",
+  "filename": "favicon-seattleeagle.com-64px.ico",
+  "size": "64",
+  "failureCount": 1
+}

--- a/testing/manifest.json
+++ b/testing/manifest.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "name": "event-builder.html",
-      "size": 419378,
+      "size": 420316,
       "icon": "🛠️",
       "description": "Build chunky.dad calendar events and preview them instantly."
     },

--- a/tools/download-images.js
+++ b/tools/download-images.js
@@ -946,13 +946,19 @@ async function extractImageUrls() {
       console.log(`📋 Processing bar file: ${file} (${bars.length} bars)`);
       
       for (const bar of bars) {
-        // Process Wikipedia URLs for bar logos (prioritize over website favicons)
+        if (bar.favicon) {
+          const result = processWebsiteUrl(bar.favicon, ` (favicon override for ${bar.name})`);
+          addProcessedUrl(imageUrls, result);
+        }
+
+        // Process Wikipedia URLs for bar logos
         if (bar.wikipedia) {
           const result = processWebsiteUrl(bar.wikipedia, ` for ${bar.name}`);
           addProcessedUrl(imageUrls, result);
-          console.log(`📚 Using Wikipedia logo for ${bar.name} (skipping website favicon)`);
-        } else if (bar.website) {
-          // Only process website URLs for favicons if no Wikipedia URL exists
+        }
+
+        // Process website URLs for favicons
+        if (bar.website) {
           const result = processWebsiteUrl(bar.website, ` for ${bar.name}`);
           addProcessedUrl(imageUrls, result);
         }

--- a/tools/sync-bars.js
+++ b/tools/sync-bars.js
@@ -102,6 +102,12 @@ function parseGoogleSheetsData(json) {
     const rows = json.table.rows;
     const data = [];
     
+    if (rows.length === 0) return data;
+
+    // Parse header to dynamically find columns if they exist beyond the hardcoded ones
+    const headers = rows[0].c.map(cell => cell?.v?.toLowerCase().trim());
+    const faviconIdx = headers.indexOf('favicon');
+
     // Skip header row
     for (let i = 1; i < rows.length; i++) {
         const row = rows[i];
@@ -128,7 +134,8 @@ function parseGoogleSheetsData(json) {
             instagram: cells[7]?.v || '',      // H: instagram
             website: cells[8]?.v || '',        // I: website
             facebook: cells[9]?.v || '',       // J: facebook
-            image: ''                          // K: twitter (not used, image field empty for now)
+            image: '',                         // K: twitter (not used, image field empty for now)
+            favicon: faviconIdx !== -1 ? (cells[faviconIdx]?.v || '') : ''
         };
         
         // Clean Instagram username - remove @ symbol and trim
@@ -330,6 +337,7 @@ function cleanBarObject(bar) {
         'image',
         'wikipedia',
         'gayCities',
+        'favicon',
         'faviconBg',
         'faviconFg',
         'wikipediaExtractionFailureAt',


### PR DESCRIPTION
- Updated `tools/sync-bars.js` to parse the new `favicon` field by looking at the Google Sheet response headers dynamically, and added it to `fieldsToKeep` so it retains its value locally during merges.
- Modified `tools/download-images.js` to parse `bar.favicon` overrides for downloads and updated processing logic to ensure `bar.website` and `bar.wikipedia` URLs are still processed even when other URL fields are present, instead of mutually exclusively.
- All modifications pass the required code review logic.

---
*PR created automatically by Jules for task [3712937435524948941](https://jules.google.com/task/3712937435524948941) started by @stanleyrya*