### PR TITLE
feat: improve test event builder preview capabilities

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1159,7 +1159,7 @@ class DynamicCalendarLoader extends CalendarCore {
                     if (!url.startsWith('http://') && !url.startsWith('https://')) {
                         url = 'https://' + url;
                     }
-                    if (this.dataSource === 'cached') {
+                    if (this.dataSource === 'cached' && !event.isTestEvent) {
                         faviconUrl = window.FilenameUtils.convertWebsiteUrlToFaviconPath(url, '/img/favicons');
                     } else {
                         faviconUrl = url;
@@ -3703,6 +3703,29 @@ class DynamicCalendarLoader extends CalendarCore {
     addTestEvent(testEventData) {
         logger.info('CALENDAR', 'Test event added from test interface', testEventData);
         
+        // Change header when in testing flow
+        const headerBrandText = document.querySelector('.logo .brand-text');
+        if (headerBrandText) {
+            headerBrandText.textContent = 'TESTING NEW EVENT';
+            headerBrandText.style.color = '#ff7b2f';
+        } else {
+            const headerLinks = document.querySelectorAll('.logo a');
+            headerLinks.forEach(link => {
+                // If there's an image, keep it, just replace text nodes or add a span
+                const img = link.querySelector('img');
+                link.innerHTML = '';
+                if (img) link.appendChild(img);
+                const span = document.createElement('span');
+                span.textContent = 'TESTING NEW EVENT';
+                span.style.fontWeight = 'bold';
+                span.style.color = '#ff7b2f';
+                span.style.letterSpacing = '1px';
+                span.style.marginLeft = '0.5rem';
+                link.appendChild(span);
+                link.href = '#';
+            });
+        }
+
         if (!testEventData || typeof testEventData !== 'object') {
             logger.warn('CALENDAR', 'Invalid test event payload received from test interface', { testEventData });
             return;
@@ -3926,6 +3949,7 @@ class DynamicCalendarLoader extends CalendarCore {
         logger.info('CALENDAR', 'Initializing DynamicCalendarLoader...');
         
         try {
+
             // Add timeout to prevent hanging initialization - 30s to account for delays + timeouts + slow networks
             const initPromise = this.renderCityPage();
             const timeoutPromise = new Promise((_, reject) => {
@@ -3936,6 +3960,21 @@ class DynamicCalendarLoader extends CalendarCore {
             this.isInitialized = true;
             logger.componentLoad('CALENDAR', 'Dynamic CalendarLoader initialization completed successfully');
             
+            // Check for testEvent in sessionStorage
+            try {
+                const testEventParam = sessionStorage.getItem('testEventPayload');
+                if (testEventParam) {
+                    const testEventData = JSON.parse(testEventParam);
+                    logger.info('CALENDAR', 'Found test event in sessionStorage', testEventData);
+                    // Clear it so it doesn't persist across random navigations in the same tab later
+                    // (But keep it if they just reload? Let's not clear it so reload works,
+                    // they can close the tab to clear it)
+                    this.addTestEvent(testEventData);
+                }
+            } catch (e) {
+                logger.error('CALENDAR', 'Failed to parse testEvent from sessionStorage', e);
+            }
+
             if (window.parent && window.parent !== window) {
                 try {
                     window.parent.postMessage({

--- a/testing/event-builder.html
+++ b/testing/event-builder.html
@@ -2663,7 +2663,13 @@
         <div class="calendar-preview-card">
           <div class="preview-header">
             <h2>Website Preview</h2>
-            <span id="calendar-status" class="status-badge status-loading">Loading calendar…</span>
+            <div style="display: flex; gap: 0.5rem; align-items: center;">
+              <button type="button" class="ghost-button action-button is-compact" id="open-preview-new-tab" aria-label="Open Preview in New Tab" style="border-color: rgba(255, 162, 74, 0.4); background: rgba(255, 162, 74, 0.1);">
+                <i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>
+                <span>Open Tab</span>
+              </button>
+              <span id="calendar-status" class="status-badge status-loading">Loading calendar…</span>
+            </div>
           </div>
           <iframe id="calendar-preview" title="chunky.dad calendar preview" src="../city.html?city=nyc"></iframe>
         </div>
@@ -3166,6 +3172,7 @@
         dom.existingClearSummaryButton = document.getElementById('existing-clear-summary');
         dom.calendarIframe = document.getElementById('calendar-preview');
         dom.calendarStatus = document.getElementById('calendar-status');
+        dom.openPreviewNewTabButton = document.getElementById('open-preview-new-tab');
         dom.previewMedia = document.getElementById('preview-media');
         dom.previewImage = document.getElementById('preview-image');
         dom.previewCity = document.getElementById('preview-city');
@@ -7669,6 +7676,19 @@ Example output:
         if (dom.copyShareButton) {
           dom.copyShareButton.addEventListener('click', () => {
             openTellDadEmail(dom.copyShareButton);
+          });
+        }
+        if (dom.openPreviewNewTabButton) {
+          dom.openPreviewNewTabButton.addEventListener('click', () => {
+            const payload = buildMessagePayload();
+            if (!payload) {
+              showToast('Add start & end times to preview.', 'warn');
+              return;
+            }
+            sessionStorage.setItem('testEventPayload', JSON.stringify(payload));
+            const targetCity = state.city || 'nyc';
+            const newWindowUrl = `../city.html?city=${encodeURIComponent(targetCity)}`;
+            window.open(newWindowUrl, '_blank');
           });
         }
         if (dom.addToCalendarButton) {


### PR DESCRIPTION
feat: improve test event builder preview capabilities

- Render user-provided favicon properly on maps without local caching behavior when in testing flow
- Modify city page header logic to show 'TESTING NEW EVENT' explicitly during injected previews
- Add 'Open Tab' button in event-builder to open test event payload directly in a new window securely via sessionStorage

---
*PR created automatically by Jules for task [13831181076326981400](https://jules.google.com/task/13831181076326981400) started by @stanleyrya*