### PR TITLE
Fix vertical alignment of today indicator in calendar views

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1865,7 +1865,7 @@ body.index-page main {
     color: var(--text-inverse) !important;
     width: 1.6em;
     height: 1.6em;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     border-radius: 50%;


### PR DESCRIPTION
Fixes a visual misalignment issue in the calendar component where the "today" indicator (purple circle) pushed the date number vertically lower than surrounding non-highlighted dates. Changed the `display` property of `.calendar-day.current .day-date` and `.calendar-day.current .day-number` from `flex` to `inline-flex`.

---
*PR created automatically by Jules for task [17651671113965531908](https://jules.google.com/task/17651671113965531908) started by @stanleyrya*