### PR TITLE
feat: Support multi-day events in city calendars

### DIFF
--- a/data/calendars/seattle.ics
+++ b/data/calendars/seattle.ics
@@ -42,128 +42,9 @@ RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
 END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART:20251011T040000Z
-DTEND:20251011T100000Z
-DTSTAMP:20260616T180218Z
-UID:9DF93D82-1411-44C0-BE63-00037416BB38
-CREATED:20250817T231654Z
-DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
-  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
- nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
- ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
- eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
- 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
- erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
- nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
- ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
- https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
- arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
- bearracuda-2025-10-11-seattle
-LAST-MODIFIED:20251001T141832Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:2
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle: SERIOUS WOOD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260509T040000Z
-DTEND:20260509T100000Z
-DTSTAMP:20260616T180218Z
-UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
-CREATED:20260507T001637Z
-DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
- • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
- e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
- da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
- com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
- uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
- ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
-  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
- ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
-LAST-MODIFIED:20260507T001638Z
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260308T050000Z
-DTEND:20260308T100000Z
-DTSTAMP:20260616T180218Z
-UID:3DCE764F-EC21-459C-8791-745DE1731298
-CREATED:20260123T030754Z
-DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
- TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
- A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
- seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
- 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
- : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
- 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
- earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
- C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
- -seattle
-LAST-MODIFIED:20260126T235324Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle:TRAIL HEAD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20250706T140000
-DTEND;TZID=America/New_York:20250706T190000
-RRULE:FREQ=WEEKLY;BYDAY=SU
-DTSTAMP:20260616T180218Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
- ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
- rtName: South Seattle Social
-LAST-MODIFIED:20260507T001639Z
-LOCATION:47.51652271569908\, -122.35487284211817
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:South Seattle Bear Social
-TRANSP:OPAQUE
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20260614T000000
-DTEND;TZID=America/New_York:20260614T060000
-DTSTAMP:20260616T180218Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-RECURRENCE-ID;TZID=America/New_York:20260614T140000
-CREATED:20250712T180301Z
-DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
- am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
- /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
- -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
- 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
- \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
- rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
- 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
- ttle
-LAST-MODIFIED:20260507T001639Z
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Seattle GLOW
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-BEGIN:VALARM
-ACTION:NONE
-TRIGGER;VALUE=DATE-TIME:19760401T005545Z
-END:VALARM
-END:VEVENT
-BEGIN:VEVENT
 DTSTART:20260614T040000Z
 DTEND:20260614T100000Z
-DTSTAMP:20260616T180218Z
+DTSTAMP:20260616T211221Z
 UID:762BAD4A-F1D8-4519-BAC3-D755EF9BA263
 CREATED:20260514T005858Z
 DESCRIPTION:description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. 
@@ -192,9 +73,81 @@ X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
+DTSTART;TZID=America/Los_Angeles:20250717T190000
+DTEND;TZID=America/Los_Angeles:20250718T020000
+RRULE:FREQ=MONTHLY;BYDAY=3TH
+DTSTAMP:20260616T211221Z
+UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
+ DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
+ <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
+ IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
+ ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
+ /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
+ a>
+LAST-MODIFIED:20250719T040329Z
+LOCATION:47.61337340244105\, -122.31441768029491
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:Leather Night
+TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20260614T000000
+DTEND;TZID=America/New_York:20260614T060000
+DTSTAMP:20260616T211221Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+RECURRENCE-ID;TZID=America/New_York:20260614T140000
+CREATED:20250712T180301Z
+DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
+ am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
+ /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
+ -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
+ 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
+ \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
+ rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
+ 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
+ ttle
+LAST-MODIFIED:20260507T001639Z
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Seattle GLOW
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+BEGIN:VALARM
+ACTION:NONE
+TRIGGER;VALUE=DATE-TIME:19760401T005545Z
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260509T040000Z
+DTEND:20260509T100000Z
+DTSTAMP:20260616T211221Z
+UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
+CREATED:20260507T001637Z
+DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
+ • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
+ e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
+ da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
+ com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
+ uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
+ ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
+  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
+ ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
+LAST-MODIFIED:20260507T001638Z
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
 DTSTART:20260201T050000Z
 DTEND:20260201T110000Z
-DTSTAMP:20260616T180218Z
+DTSTAMP:20260616T211221Z
 UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
 CREATED:20260123T030739Z
 DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
@@ -217,30 +170,85 @@ X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
-DTSTART;TZID=America/Los_Angeles:20250717T190000
-DTEND;TZID=America/Los_Angeles:20250718T020000
-RRULE:FREQ=MONTHLY;BYDAY=3TH
-DTSTAMP:20260616T180218Z
-UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
- DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
- <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
- IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
- ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
- /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
- a>
-LAST-MODIFIED:20250719T040329Z
-LOCATION:47.61337340244105\, -122.31441768029491
+DTSTART:20260308T050000Z
+DTEND:20260308T100000Z
+DTSTAMP:20260616T211221Z
+UID:3DCE764F-EC21-459C-8791-745DE1731298
+CREATED:20260123T030754Z
+DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
+ TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
+ A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
+ seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
+ 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
+ : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
+ 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
+ earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
+ C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
+ -seattle
+LAST-MODIFIED:20260126T235324Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle:TRAIL HEAD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20250927T040000Z
+DTEND:20250927T100000Z
+DTSTAMP:20260616T211221Z
+UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
+CREATED:20250825T034004Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to choose your own ADVENTURE! Now our guys can grab a wristband when you 
+ walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp\; TIGERBE
+ ATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: Amer
+ ica/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover
+ : $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/up
+ loads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/even
+ ts/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail
+ -seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https:/
+ /www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?a
+ pi=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearrac
+ uda-2025-09-27-seattle
+LAST-MODIFIED:20250920T210916Z
 SEQUENCE:1
 STATUS:CONFIRMED
-SUMMARY:Leather Night
+SUMMARY:Treasure Trail: SEATTLE
 TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251011T040000Z
+DTEND:20251011T100000Z
+DTSTAMP:20260616T211221Z
+UID:9DF93D82-1411-44C0-BE63-00037416BB38
+CREATED:20250817T231654Z
+DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
+  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
+ nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
+ ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
+ eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
+ 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
+ erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
+ nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
+ ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
+ https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
+ arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
+ bearracuda-2025-10-11-seattle
+LAST-MODIFIED:20251001T141832Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:2
+STATUS:CONFIRMED
+SUMMARY:Bearracuda Seattle: SERIOUS WOOD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 END:VEVENT
 BEGIN:VEVENT
 DTSTART:20251122T050000Z
 DTEND:20251122T110000Z
-DTSTAMP:20260616T180218Z
+DTSTAMP:20260616T211221Z
 UID:3D70DFD0-9501-434E-A015-10F01A25DA09
 CREATED:20250930T014035Z
 DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
@@ -265,28 +273,20 @@ X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
-DTSTART:20250927T040000Z
-DTEND:20250927T100000Z
-DTSTAMP:20260616T180218Z
-UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
-CREATED:20250825T034004Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to choose your own ADVENTURE! Now our guys can grab a wristband when you 
- walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp\; TIGERBE
- ATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: Amer
- ica/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover
- : $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/up
- loads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/even
- ts/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail
- -seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https:/
- /www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?a
- pi=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearrac
- uda-2025-09-27-seattle
-LAST-MODIFIED:20250920T210916Z
-SEQUENCE:1
+DTSTART;TZID=America/New_York:20250706T140000
+DTEND;TZID=America/New_York:20250706T190000
+RRULE:FREQ=WEEKLY;BYDAY=SU
+DTSTAMP:20260616T211221Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
+ ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
+ rtName: South Seattle Social
+LAST-MODIFIED:20260507T001639Z
+LOCATION:47.51652271569908\, -122.35487284211817
+SEQUENCE:0
 STATUS:CONFIRMED
-SUMMARY:Treasure Trail: SEATTLE
+SUMMARY:South Seattle Bear Social
 TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 END:VEVENT
 END:VCALENDAR

--- a/data/calendars/update-summary.json
+++ b/data/calendars/update-summary.json
@@ -1,159 +1,159 @@
 {
-  "lastUpdated": "2026-06-16T18:02:19.353Z",
+  "lastUpdated": "2026-06-16T21:12:21.917Z",
   "cities": {
     "nyc": {
       "name": "New York",
       "status": "success",
       "dataLength": 10992,
       "eventCount": 12,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "seattle": {
       "name": "Seattle",
       "status": "success",
       "dataLength": 12362,
       "eventCount": 10,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "la": {
       "name": "Los Angeles",
       "status": "success",
       "dataLength": 8423,
       "eventCount": 7,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "toronto": {
       "name": "Toronto",
       "status": "success",
       "dataLength": 197,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "london": {
       "name": "London",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "chicago": {
       "name": "Chicago",
       "status": "success",
       "dataLength": 13565,
       "eventCount": 12,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "berlin": {
       "name": "Berlin",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "palm-springs": {
       "name": "Palm Springs",
       "status": "success",
       "dataLength": 1487,
       "eventCount": 1,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "denver": {
       "name": "Denver",
       "status": "success",
       "dataLength": 6856,
       "eventCount": 6,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "dallas": {
       "name": "Dallas",
       "status": "success",
       "dataLength": 195,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "dc": {
       "name": "DC",
       "status": "success",
       "dataLength": 1503,
       "eventCount": 1,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "vegas": {
       "name": "Las Vegas",
       "status": "success",
       "dataLength": 4410,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "atlanta": {
       "name": "Atlanta",
       "status": "success",
       "dataLength": 4933,
       "eventCount": 4,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "nola": {
       "name": "New Orleans",
       "status": "success",
       "dataLength": 2367,
       "eventCount": 2,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "sf": {
       "name": "San Francisco",
       "status": "success",
       "dataLength": 15367,
       "eventCount": 12,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "portland": {
       "name": "Portland",
       "status": "success",
       "dataLength": 18474,
       "eventCount": 14,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "sitges": {
       "name": "Sitges",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "boston": {
       "name": "Boston",
       "status": "success",
       "dataLength": 196,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "phoenix": {
       "name": "Phoenix",
       "status": "success",
       "dataLength": 2874,
       "eventCount": 2,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "ptown": {
       "name": "Provincetown",
       "status": "success",
       "dataLength": 202,
       "eventCount": 0,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "san-diego": {
       "name": "San Diego",
       "status": "success",
       "dataLength": 4073,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     },
     "philly": {
       "name": "Philadelphia",
       "status": "success",
       "dataLength": 4689,
       "eventCount": 3,
-      "lastUpdated": "2026-06-16T18:02:19.353Z"
+      "lastUpdated": "2026-06-16T21:12:21.917Z"
     }
   }
 }

--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -1504,8 +1504,45 @@ class CalendarCore {
         return { start, end };
     }
 
+    // Check if event is a multi-day event
+    isMultiDay(event) {
+        if (!event.startDate || !event.endDate) return false;
+
+        const start = new Date(event.startDate);
+        const end = new Date(event.endDate);
+
+        // Use local dates to avoid timezone issues
+        const startKey = `${start.getFullYear()}-${start.getMonth()}-${start.getDate()}`;
+        const endKey = `${end.getFullYear()}-${end.getMonth()}-${end.getDate()}`;
+
+        // Account for end dates that are just exactly at midnight the next day
+        // Some all-day events are 2026-06-26 00:00:00 to 2026-06-27 00:00:00
+        if (startKey !== endKey) {
+            // Check if end date is exactly 12:00 AM
+            if (end.getHours() === 0 && end.getMinutes() === 0 && end.getSeconds() === 0) {
+                // Adjust end date back by 1 millisecond for comparison
+                const adjustedEnd = new Date(end.getTime() - 1);
+                const adjustedEndKey = `${adjustedEnd.getFullYear()}-${adjustedEnd.getMonth()}-${adjustedEnd.getDate()}`;
+                return startKey !== adjustedEndKey;
+            }
+            return true;
+        }
+        return false;
+    }
+
     // Check if event falls within a date range
-    isEventInPeriod(eventDate, start, end) {
+    isEventInPeriod(eventDate, start, end, eventEndDate = null) {
+        // If it's a multi-day event and we have an end date, check if any part of the event overlaps with the period
+        if (eventEndDate) {
+            // Adjust end date if it's exactly midnight, so it doesn't spill over to the next day
+            const adjustedEnd = new Date(eventEndDate);
+            if (adjustedEnd.getHours() === 0 && adjustedEnd.getMinutes() === 0) {
+                 adjustedEnd.setTime(adjustedEnd.getTime() - 1);
+            }
+            return (eventDate <= end && adjustedEnd >= start);
+        }
+
+        // Single day event
         return eventDate >= start && eventDate <= end;
     }
 
@@ -1558,7 +1595,8 @@ class CalendarCore {
     filterEventsByDateRange(events, startDate, endDate) {
         return events.filter(event => {
             const eventDate = new Date(event.startDate);
-            return this.isEventInPeriod(eventDate, startDate, endDate) ||
+            const eventEndDate = event.endDate ? new Date(event.endDate) : null;
+            return this.isEventInPeriod(eventDate, startDate, endDate, eventEndDate) ||
                    this.isRecurringEventInPeriod(event, startDate, endDate);
         });
     }

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1814,6 +1814,9 @@ class DynamicCalendarLoader extends CalendarCore {
         
         // Event badges
         const formatDayTime = (event) => {
+            if (this.isMultiDay(event) && window.formatEventDates) {
+                return window.formatEventDates(event);
+            }
             return this.getEnhancedDayTimeDisplay(event, this.currentView, periodBounds);
         };
         
@@ -2016,7 +2019,8 @@ class DynamicCalendarLoader extends CalendarCore {
             }
             
             // For all events (including expanded recurring events), check if they fall within the period
-            const isInPeriod = this.isEventInPeriod(event.startDate, start, end);
+            const eventEndDate = event.endDate ? new Date(event.endDate) : null;
+            const isInPeriod = this.isEventInPeriod(new Date(event.startDate), start, end, eventEndDate) : (new Date(event.startDate) >= start && new Date(event.startDate) <= end);
             logger.debug('CALENDAR', `🔍 FILTER: Event ${event.name}: ${isInPeriod ? 'INCLUDED' : 'EXCLUDED'}`, {
                 eventDate: new Date(event.startDate).toISOString(),
                 periodStart: start.toISOString(),
@@ -2035,8 +2039,21 @@ class DynamicCalendarLoader extends CalendarCore {
             const dateA = new Date(a.startDate);
             const dateB = new Date(b.startDate);
             
-            // If dates are the same, sort by start time
+            // If dates are the same, sort by start time/multi-day
             if (dateA.toDateString() === dateB.toDateString()) {
+                const aIsMultiDay = this.isMultiDay(a);
+                const bIsMultiDay = this.isMultiDay(b);
+                const aIsAllDay = !a.time;
+                const bIsAllDay = !b.time;
+
+                // 1. Multi-day events go first
+                if (aIsMultiDay && !bIsMultiDay) return -1;
+                if (!aIsMultiDay && bIsMultiDay) return 1;
+
+                // 2. All-day events go second
+                if (aIsAllDay && !bIsAllDay) return -1;
+                if (!aIsAllDay && bIsAllDay) return 1;
+
                 return dateA.getTime() - dateB.getTime();
             }
             
@@ -2334,12 +2351,29 @@ class DynamicCalendarLoader extends CalendarCore {
             const dayEvents = events.filter(event => {
                 if (!event.startDate) return false;
                 
+                // Set dayDate for comparisons
+                const dayDate = new Date(day);
+                dayDate.setHours(0, 0, 0, 0);
+
+                // Multi-day events check
+                if (this.isMultiDay(event)) {
+                    const eventDate = new Date(event.startDate);
+                    eventDate.setHours(0, 0, 0, 0);
+                    const eventEndDate = new Date(event.endDate);
+
+                    // Adjust end date if it's exactly midnight, so it doesn't spill over to the next day
+                    if (eventEndDate.getHours() === 0 && eventEndDate.getMinutes() === 0 && eventEndDate.getSeconds() === 0) {
+                        eventEndDate.setTime(eventEndDate.getTime() - 1);
+                    }
+                    eventEndDate.setHours(0, 0, 0, 0);
+
+                    return dayDate >= eventDate && dayDate <= eventEndDate;
+                }
+
                 // For already expanded recurring events, just check if the date matches
                 if (event.isExpanded) {
                     const eventDate = new Date(event.startDate);
                     eventDate.setHours(0, 0, 0, 0);
-                    const dayDate = new Date(day);
-                    dayDate.setHours(0, 0, 0, 0);
                     
                     return eventDate.getTime() === dayDate.getTime();
                 }
@@ -2352,8 +2386,6 @@ class DynamicCalendarLoader extends CalendarCore {
                 // For non-recurring events, check exact date match
                 const eventDate = new Date(event.startDate);
                 eventDate.setHours(0, 0, 0, 0);
-                const dayDate = new Date(day);
-                dayDate.setHours(0, 0, 0, 0);
                 
                 return eventDate.getTime() === dayDate.getTime();
             });
@@ -2363,10 +2395,34 @@ class DynamicCalendarLoader extends CalendarCore {
 
             const eventsHtml = filteredDayEvents.length > 0 
                 ? filteredDayEvents.map(event => {
-                    const mobileTime = event.time ? this.formatTimeForMobile(event.time) : null;
+                    const isMultiDay = this.isMultiDay(event);
+                    const mobileTime = isMultiDay && window.formatEventDates ? window.formatEventDates(event) : (event.time ? this.formatTimeForMobile(event.time) : null);
+
+                    // Determine multi-day flow class
+                    let flowClass = '';
+                    if (isMultiDay) {
+                        const eventStart = new Date(event.startDate);
+                        eventStart.setHours(0, 0, 0, 0);
+                        const eventEnd = new Date(event.endDate);
+                        if (eventEnd.getHours() === 0 && eventEnd.getMinutes() === 0 && eventEnd.getSeconds() === 0) {
+                            eventEnd.setTime(eventEnd.getTime() - 1);
+                        }
+                        eventEnd.setHours(0, 0, 0, 0);
+
+                        const dayDate = new Date(day);
+                        dayDate.setHours(0, 0, 0, 0);
+
+                        if (dayDate.getTime() === eventStart.getTime()) {
+                            flowClass = ' multi-day multi-day-start';
+                        } else if (dayDate.getTime() === eventEnd.getTime()) {
+                            flowClass = ' multi-day multi-day-end';
+                        } else {
+                            flowClass = ' multi-day multi-day-middle';
+                        }
+                    }
                     
                     return `
-                        <div class="event-item" data-event-slug="${event.slug}" title="${event.name} at ${event.bar || 'Location'}${event.time ? ' - ' + event.time : ''}">
+                        <div class="event-item${flowClass}" data-event-slug="${event.slug}" title="${event.name} at ${event.bar || 'Location'}${event.time ? ' - ' + event.time : ''}">
                             ${this.generateEventNameElements(event, hideEvents)}
                             ${mobileTime ? `<div class="event-time">${mobileTime}</div>` : ''}
                             <div class="event-venue">${event.bar || ''}</div>
@@ -2443,12 +2499,28 @@ class DynamicCalendarLoader extends CalendarCore {
             const dayEvents = events.filter(event => {
                 if (!event.startDate) return false;
                 
+                const dayDate = new Date(day);
+                dayDate.setHours(0, 0, 0, 0);
+
+                // Multi-day events check
+                if (this.isMultiDay(event)) {
+                    const eventDate = new Date(event.startDate);
+                    eventDate.setHours(0, 0, 0, 0);
+                    const eventEndDate = new Date(event.endDate);
+
+                    // Adjust end date if it's exactly midnight, so it doesn't spill over to the next day
+                    if (eventEndDate.getHours() === 0 && eventEndDate.getMinutes() === 0 && eventEndDate.getSeconds() === 0) {
+                        eventEndDate.setTime(eventEndDate.getTime() - 1);
+                    }
+                    eventEndDate.setHours(0, 0, 0, 0);
+
+                    return dayDate >= eventDate && dayDate <= eventEndDate;
+                }
+
                 // For already expanded recurring events, just check if the date matches
                 if (event.isExpanded) {
                     const eventDate = new Date(event.startDate);
                     eventDate.setHours(0, 0, 0, 0);
-                    const dayDate = new Date(day);
-                    dayDate.setHours(0, 0, 0, 0);
                     
                     const matches = eventDate.getTime() === dayDate.getTime();
                     if (matches) {
@@ -2479,8 +2551,6 @@ class DynamicCalendarLoader extends CalendarCore {
                 // For non-recurring events, check exact date match
                 const eventDate = new Date(event.startDate);
                 eventDate.setHours(0, 0, 0, 0);
-                const dayDate = new Date(day);
-                dayDate.setHours(0, 0, 0, 0);
                 
                 return eventDate.getTime() === dayDate.getTime();
             });
@@ -2500,10 +2570,34 @@ class DynamicCalendarLoader extends CalendarCore {
             
             const eventsHtml = eventsToShow.length > 0 
                 ? eventsToShow.map(event => {
-                    const mobileTime = event.time ? this.formatTimeForMobile(event.time) : null;
+                    const isMultiDay = this.isMultiDay(event);
+                    const mobileTime = isMultiDay && window.formatEventDates ? window.formatEventDates(event) : (event.time ? this.formatTimeForMobile(event.time) : null);
+
+                    // Determine multi-day flow class
+                    let flowClass = '';
+                    if (isMultiDay) {
+                        const eventStart = new Date(event.startDate);
+                        eventStart.setHours(0, 0, 0, 0);
+                        const eventEnd = new Date(event.endDate);
+                        if (eventEnd.getHours() === 0 && eventEnd.getMinutes() === 0 && eventEnd.getSeconds() === 0) {
+                            eventEnd.setTime(eventEnd.getTime() - 1);
+                        }
+                        eventEnd.setHours(0, 0, 0, 0);
+
+                        const dayDate = new Date(day);
+                        dayDate.setHours(0, 0, 0, 0);
+
+                        if (dayDate.getTime() === eventStart.getTime()) {
+                            flowClass = ' multi-day multi-day-start';
+                        } else if (dayDate.getTime() === eventEnd.getTime()) {
+                            flowClass = ' multi-day multi-day-end';
+                        } else {
+                            flowClass = ' multi-day multi-day-middle';
+                        }
+                    }
                     
                     return `
-                        <div class="event-item" data-event-slug="${event.slug}" title="${event.name} at ${event.bar || 'Location'}${event.time ? ' - ' + event.time : ''}">
+                        <div class="event-item${flowClass}" data-event-slug="${event.slug}" title="${event.name} at ${event.bar || 'Location'}${event.time ? ' - ' + event.time : ''}">
                             ${this.generateEventNameElements(event, hideEvents)}
                             ${mobileTime ? `<div class="event-time">${mobileTime}</div>` : ''}
                             <div class="event-venue">${event.bar || ''}</div>

--- a/js/today-events.js
+++ b/js/today-events.js
@@ -195,7 +195,11 @@ class TodayEventsAggregator extends DynamicCalendarLoader {
     // Use inherited CalendarCore methods for consistent event badges
     const timeDisplay = document.createElement('div');
     timeDisplay.className = 'event-day';
-    timeDisplay.textContent = this.getEnhancedDayTimeDisplay(ev);
+    if (this.isMultiDay(ev) && window.formatEventDates) {
+      timeDisplay.textContent = window.formatEventDates(ev);
+    } else {
+      timeDisplay.textContent = this.getEnhancedDayTimeDisplay(ev);
+    }
     meta.appendChild(timeDisplay);
 
     const recurringBadgeContent = this.getRecurringBadgeContent(ev);

--- a/nyc/index.html
+++ b/nyc/index.html
@@ -85,7 +85,7 @@
   <meta property="og:title" content="New York - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to New York - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/nyc/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=d0882e5a">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=9a6c126b">
 </head>
 <body>
         <header>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^5.1.0",
+        "playwright": "^1.61.0",
         "puppeteer": "^22.15.0",
         "sharp": "^0.33.0"
       }
@@ -1226,6 +1227,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1735,6 +1750,36 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "^5.1.0",
+    "playwright": "^1.61.0",
     "puppeteer": "^22.15.0",
     "sharp": "^0.33.0"
   }

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Seattle - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Seattle - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/seattle/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=29b89813">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=3193440a">
 </head>
 <body>
         <header>

--- a/styles.css
+++ b/styles.css
@@ -1928,6 +1928,45 @@ body.index-page main {
     line-height: 1.3;
 }
 
+/* Multi-day Event Flow Styling */
+.event-item.multi-day-start {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: none;
+    margin-right: -10px; /* Overlap the gap */
+    padding-right: 12px;
+    position: relative;
+    z-index: 1;
+}
+
+.event-item.multi-day-middle {
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    margin-left: -10px;
+    margin-right: -10px;
+    padding-left: 12px;
+    padding-right: 12px;
+    position: relative;
+    z-index: 1;
+}
+
+.event-item.multi-day-end {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: none;
+    margin-left: -10px;
+    padding-left: 12px;
+    position: relative;
+    z-index: 1;
+}
+
+/* Ensure multi-day events cover the parent calendar day paddings/gaps */
+.calendar-day .daily-events,
+.calendar-day .day-events {
+    overflow: visible; /* Needed to allow negative margins to bleed out */
+}
+
 /* Hover effects only on non-touch devices */
 @media (hover: hover) and (pointer: fine) {
     .event-item:hover {


### PR DESCRIPTION
Added support for multi-day events on city pages.
- Format event time as a date range (e.g. 6/21-6/26) instead of time for multi-day events on cards and calendar grid
- Add logic to correctly bound multi-day events to not bleed incorrectly past midnight
- Prioritize multi-day events to sort to the top of the day
- Add styling for continuous multi-day events to flow across the month/week calendar grid visually with negative margins and specific border radii.

---
*PR created automatically by Jules for task [8026410548798493670](https://jules.google.com/task/8026410548798493670) started by @stanleyrya*