### PR TITLE
fix: resolve syntax error in dynamic-calendar-loader.js

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2020,7 +2020,7 @@ class DynamicCalendarLoader extends CalendarCore {
             
             // For all events (including expanded recurring events), check if they fall within the period
             const eventEndDate = event.endDate ? new Date(event.endDate) : null;
-            const isInPeriod = this.isEventInPeriod(new Date(event.startDate), start, end, eventEndDate) : (new Date(event.startDate) >= start && new Date(event.startDate) <= end);
+            const isInPeriod = this.isEventInPeriod(new Date(event.startDate), start, end, eventEndDate);
             logger.debug('CALENDAR', `🔍 FILTER: Event ${event.name}: ${isInPeriod ? 'INCLUDED' : 'EXCLUDED'}`, {
                 eventDate: new Date(event.startDate).toISOString(),
                 periodStart: start.toISOString(),


### PR DESCRIPTION
Fixes a critical syntax error in `js/dynamic-calendar-loader.js` that was breaking city pages (e.g. `/nyc/index.html`). The issue was a stray colon from a broken ternary expression. The fix updates the assignment to just use the return value of `this.isEventInPeriod()` correctly.

Verified fix locally and ran parser tests.

---
*PR created automatically by Jules for task [15254172572574231091](https://jules.google.com/task/15254172572574231091) started by @stanleyrya*