### PR TITLE
Fix recurring event end date expansion

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2114,6 +2114,10 @@ class DynamicCalendarLoader extends CalendarCore {
                     originalStartDate: event.startDate // Keep reference to original
                 };
                 
+                if (event.endDate && event.startDate) {
+                    const duration = new Date(event.endDate).getTime() - new Date(event.startDate).getTime();
+                    expandedEvent.endDate = new Date(occurrence.getTime() + duration);
+                }
                 
                 expandedEvents.push(expandedEvent);
             }


### PR DESCRIPTION
This commit fixes a bug where recurring events were not properly expanding on the calendar because their `endDate` was not being updated alongside their `startDate`. The `endDate` is now correctly shifted based on the original event's duration.

---
*PR created automatically by Jules for task [6237320691209204530](https://jules.google.com/task/6237320691209204530) started by @stanleyrya*