### PR TITLE
Enhance city calendar sorting, selection, and multi-day visual presentation

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2351,6 +2351,8 @@ class DynamicCalendarLoader extends CalendarCore {
             hideEvents
         });
 
+        let seenMultiDayEvents = new Set();
+
         return days.map(day => {
             const dayEvents = events.filter(event => {
                 if (!event.startDate) return false;
@@ -2394,8 +2396,26 @@ class DynamicCalendarLoader extends CalendarCore {
                 return eventDate.getTime() === dayDate.getTime();
             });
             
-            // Events are already deduplicated in getFilteredEvents, so use them directly
-            const filteredDayEvents = dayEvents;
+            // Events are already deduplicated in getFilteredEvents, but need to be sorted for the day
+            const filteredDayEvents = dayEvents.sort((a, b) => {
+                const aIsMultiDay = this.isMultiDay(a);
+                const bIsMultiDay = this.isMultiDay(b);
+                const aIsAllDay = !a.time;
+                const bIsAllDay = !b.time;
+
+                // 1. Multi-day events go first
+                if (aIsMultiDay && !bIsMultiDay) return -1;
+                if (!aIsMultiDay && bIsMultiDay) return 1;
+
+                // 2. All-day events go second
+                if (aIsAllDay && !bIsAllDay) return -1;
+                if (!aIsAllDay && bIsAllDay) return 1;
+
+                // 3. Sort by start time
+                const dateA = new Date(a.startDate);
+                const dateB = new Date(b.startDate);
+                return dateA.getTime() - dateB.getTime();
+            });
 
             const eventsHtml = filteredDayEvents.length > 0 
                 ? filteredDayEvents.map(event => {
@@ -2404,6 +2424,8 @@ class DynamicCalendarLoader extends CalendarCore {
 
                     // Determine multi-day flow class
                     let flowClass = '';
+                    let showTitle = true;
+
                     if (isMultiDay) {
                         const eventStart = new Date(event.startDate);
                         eventStart.setHours(0, 0, 0, 0);
@@ -2423,11 +2445,18 @@ class DynamicCalendarLoader extends CalendarCore {
                         } else {
                             flowClass = ' multi-day multi-day-middle';
                         }
+
+                        const eventId = event.uid || event.slug;
+                        if (seenMultiDayEvents.has(eventId)) {
+                            showTitle = false;
+                        } else {
+                            seenMultiDayEvents.add(eventId);
+                        }
                     }
                     
                     return `
                         <div class="event-item${flowClass}" data-event-slug="${event.slug}" title="${event.name} at ${event.bar || 'Location'}${event.time ? ' - ' + event.time : ''}">
-                            ${this.generateEventNameElements(event, hideEvents)}
+                            ${showTitle ? this.generateEventNameElements(event, hideEvents) : ''}
                             ${mobileTime ? `<div class="event-time">${mobileTime}</div>` : ''}
                             <div class="event-venue">${event.bar || ''}</div>
                         </div>
@@ -2499,7 +2528,12 @@ class DynamicCalendarLoader extends CalendarCore {
             hideEvents
         });
 
+        let seenMultiDayEvents = new Set();
+
         const daysHtml = days.map(day => {
+            if (day.getDay() === 0) {
+                seenMultiDayEvents.clear();
+            }
             const dayEvents = events.filter(event => {
                 if (!event.startDate) return false;
                 
@@ -2559,8 +2593,26 @@ class DynamicCalendarLoader extends CalendarCore {
                 return eventDate.getTime() === dayDate.getTime();
             });
             
-            // Events are already deduplicated in getFilteredEvents, so use them directly
-            const filteredDayEvents = dayEvents;
+            // Events are already deduplicated in getFilteredEvents, but need to be sorted for the day
+            const filteredDayEvents = dayEvents.sort((a, b) => {
+                const aIsMultiDay = this.isMultiDay(a);
+                const bIsMultiDay = this.isMultiDay(b);
+                const aIsAllDay = !a.time;
+                const bIsAllDay = !b.time;
+
+                // 1. Multi-day events go first
+                if (aIsMultiDay && !bIsMultiDay) return -1;
+                if (!aIsMultiDay && bIsMultiDay) return 1;
+
+                // 2. All-day events go second
+                if (aIsAllDay && !bIsAllDay) return -1;
+                if (!aIsAllDay && bIsAllDay) return 1;
+
+                // 3. Sort by start time
+                const dateA = new Date(a.startDate);
+                const dateB = new Date(b.startDate);
+                return dateA.getTime() - dateB.getTime();
+            });
 
             const isToday = day.getTime() === today.getTime();
             const isCurrentMonth = day.getMonth() === start.getMonth();
@@ -2579,6 +2631,8 @@ class DynamicCalendarLoader extends CalendarCore {
 
                     // Determine multi-day flow class
                     let flowClass = '';
+                    let showTitle = true;
+
                     if (isMultiDay) {
                         const eventStart = new Date(event.startDate);
                         eventStart.setHours(0, 0, 0, 0);
@@ -2598,11 +2652,18 @@ class DynamicCalendarLoader extends CalendarCore {
                         } else {
                             flowClass = ' multi-day multi-day-middle';
                         }
+
+                        const eventId = event.uid || event.slug;
+                        if (seenMultiDayEvents.has(eventId)) {
+                            showTitle = false;
+                        } else {
+                            seenMultiDayEvents.add(eventId);
+                        }
                     }
                     
                     return `
                         <div class="event-item${flowClass}" data-event-slug="${event.slug}" title="${event.name} at ${event.bar || 'Location'}${event.time ? ' - ' + event.time : ''}">
-                            ${this.generateEventNameElements(event, hideEvents)}
+                            ${showTitle ? this.generateEventNameElements(event, hideEvents) : ''}
                             ${mobileTime ? `<div class="event-time">${mobileTime}</div>` : ''}
                             <div class="event-venue">${event.bar || ''}</div>
                         </div>

--- a/styles.css
+++ b/styles.css
@@ -3347,6 +3347,13 @@ footer {
         display: none;
     }
 
+    /* Force event time to display for multi-day events on mobile to show date range */
+    .event-item.enhanced.multi-day-start .event-time,
+    .event-item.enhanced.multi-day-middle .event-time,
+    .event-item.enhanced.multi-day-end .event-time {
+        display: block;
+    }
+
     .event-item.enhanced .event-venue {
         display: none;
     }
@@ -3983,23 +3990,28 @@ footer {
 }
 
 /* Calendar Event Item Selected State */
-.event-item.selected {
-    background: var(--primary-color) !important;
-    color: white !important;
+.event-item.selected,
+.event-item.enhanced.selected {
+    background-color: var(--primary-color) !important;
+    color: var(--text-inverse) !important;
     font-weight: bold;
     border-radius: 4px;
 }
 
 /* Selected event text colors */
-.event-item.selected .event-name {
+.event-item.selected .event-name,
+.event-item.enhanced.selected .event-name {
     color: var(--text-inverse) !important;
 }
 
-.event-item.selected .event-time {
+.event-item.selected .event-time,
+.event-item.enhanced.selected .event-time {
     color: var(--text-inverse) !important;
 }
 
-.event-item.selected .venue {
+.event-item.selected .venue,
+.event-item.selected .event-venue,
+.event-item.enhanced.selected .event-venue {
     color: var(--text-inverse) !important;
 }
 


### PR DESCRIPTION
Fixes 4 issues raised with the city calendar page:
1. Re-introduces chronological sorting (with all-day/multi-day hoisted) within each calendar day bucket instead of relying on default data order.
2. Fixes bug where clicking a multi-day event on a larger screen caused a broken selection UI. Enhanced events now fully inherit the selected background/text color correctly.
3. Dedupes consecutive multi-day event titles within the same row/week so it no longer repeats "Pride Pride Pride".
4. Adjusts CSS to display the time/date block for multi-day events on week/month views for desktop, which was previously suppressed.

---
*PR created automatically by Jules for task [10481256484811671853](https://jules.google.com/task/10481256484811671853) started by @stanleyrya*