### PR TITLE
Fix multi-day event layout by maintaining consistent block height

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2456,7 +2456,7 @@ class DynamicCalendarLoader extends CalendarCore {
                     
                     return `
                         <div class="event-item${flowClass}" data-event-slug="${event.slug}" title="${event.name} at ${event.bar || 'Location'}${event.time ? ' - ' + event.time : ''}">
-                            ${showTitle ? this.generateEventNameElements(event, hideEvents) : ''}
+                            ${showTitle ? this.generateEventNameElements(event, hideEvents) : `<div style="visibility: hidden;">${this.generateEventNameElements(event, hideEvents)}</div>`}
                             ${mobileTime ? `<div class="event-time">${mobileTime}</div>` : ''}
                             <div class="event-venue">${event.bar || ''}</div>
                         </div>
@@ -2663,7 +2663,7 @@ class DynamicCalendarLoader extends CalendarCore {
                     
                     return `
                         <div class="event-item${flowClass}" data-event-slug="${event.slug}" title="${event.name} at ${event.bar || 'Location'}${event.time ? ' - ' + event.time : ''}">
-                            ${showTitle ? this.generateEventNameElements(event, hideEvents) : ''}
+                            ${showTitle ? this.generateEventNameElements(event, hideEvents) : `<div style="visibility: hidden;">${this.generateEventNameElements(event, hideEvents)}</div>`}
                             ${mobileTime ? `<div class="event-time">${mobileTime}</div>` : ''}
                             <div class="event-venue">${event.bar || ''}</div>
                         </div>


### PR DESCRIPTION
Resolves the layout issue on the city page calendar where subsequent days of a multi-day event would shrink in height because they lacked text content. By hiding the text using `visibility: hidden`, the layout height is preserved while avoiding visual repetition.

---
*PR created automatically by Jules for task [6790250911382291259](https://jules.google.com/task/6790250911382291259) started by @stanleyrya*