### PR TITLE
Fix multi-day calendar event logic for late night single-day events

### DIFF
--- a/data/calendars/seattle.ics
+++ b/data/calendars/seattle.ics
@@ -42,226 +42,9 @@ RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
 END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20260614T000000
-DTEND;TZID=America/New_York:20260614T060000
-DTSTAMP:20260617T004525Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-RECURRENCE-ID;TZID=America/New_York:20260614T140000
-CREATED:20250712T180301Z
-DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
- am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
- /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
- -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
- 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
- \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
- rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
- 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
- ttle
-LAST-MODIFIED:20260507T001639Z
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Seattle GLOW
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-BEGIN:VALARM
-ACTION:NONE
-TRIGGER;VALUE=DATE-TIME:19760401T005545Z
-END:VALARM
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20250927T040000Z
-DTEND:20250927T100000Z
-DTSTAMP:20260617T004525Z
-UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
-CREATED:20250825T034004Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to choose your own ADVENTURE! Now our guys can grab a wristband when you 
- walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp\; TIGERBE
- ATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: Amer
- ica/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover
- : $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/up
- loads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/even
- ts/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail
- -seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https:/
- /www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?a
- pi=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearrac
- uda-2025-09-27-seattle
-LAST-MODIFIED:20250920T210916Z
-SEQUENCE:1
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail: SEATTLE
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20251011T040000Z
-DTEND:20251011T100000Z
-DTSTAMP:20260617T004525Z
-UID:9DF93D82-1411-44C0-BE63-00037416BB38
-CREATED:20250817T231654Z
-DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
-  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
- nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
- ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
- eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
- 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
- erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
- nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
- ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
- https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
- arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
- bearracuda-2025-10-11-seattle
-LAST-MODIFIED:20251001T141832Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:2
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle: SERIOUS WOOD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260201T050000Z
-DTEND:20260201T110000Z
-DTSTAMP:20260617T004525Z
-UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
-CREATED:20260123T030739Z
-DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
- s by MATT STANDS &amp\; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine\, Sea
- ttle\, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com
- /events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025
- /12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/69805544976
- 5272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-bee
- f-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: http
- s://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search
- /?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey
- : bearracuda-2026-02-01-seattle
-LAST-MODIFIED:20260126T235314Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/Los_Angeles:20250717T190000
-DTEND;TZID=America/Los_Angeles:20250718T020000
-RRULE:FREQ=MONTHLY;BYDAY=3TH
-DTSTAMP:20260617T004525Z
-UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
- DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
- <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
- IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
- ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
- /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
- a>
-LAST-MODIFIED:20250719T040329Z
-LOCATION:47.61337340244105\, -122.31441768029491
-SEQUENCE:1
-STATUS:CONFIRMED
-SUMMARY:Leather Night
-TRANSP:OPAQUE
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20251122T050000Z
-DTEND:20251122T110000Z
-DTSTAMP:20260617T004525Z
-UID:3D70DFD0-9501-434E-A015-10F01A25DA09
-CREATED:20250930T014035Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
- tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
- ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
- 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
- sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
- a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
- ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
- reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
- -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
- oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
- =101730401\nkey: bearracuda-2025-11-22-seattle
-LAST-MODIFIED:20251001T225002Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle: Wish BONED!
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20250706T140000
-DTEND;TZID=America/New_York:20250706T190000
-RRULE:FREQ=WEEKLY;BYDAY=SU
-DTSTAMP:20260617T004525Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
- ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
- rtName: South Seattle Social
-LAST-MODIFIED:20260507T001639Z
-LOCATION:47.51652271569908\, -122.35487284211817
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:South Seattle Bear Social
-TRANSP:OPAQUE
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260308T050000Z
-DTEND:20260308T100000Z
-DTSTAMP:20260617T004525Z
-UID:3DCE764F-EC21-459C-8791-745DE1731298
-CREATED:20260123T030754Z
-DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
- TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
- A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
- seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
- 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
- : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
- 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
- earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
- C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
- -seattle
-LAST-MODIFIED:20260126T235324Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle:TRAIL HEAD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260509T040000Z
-DTEND:20260509T100000Z
-DTSTAMP:20260617T004525Z
-UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
-CREATED:20260507T001637Z
-DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
- • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
- e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
- da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
- com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
- uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
- ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
-  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
- ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
-LAST-MODIFIED:20260507T001638Z
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
 DTSTART:20260614T040000Z
 DTEND:20260614T100000Z
-DTSTAMP:20260617T004525Z
+DTSTAMP:20260617T043551Z
 UID:762BAD4A-F1D8-4519-BAC3-D755EF9BA263
 CREATED:20260514T005858Z
 DESCRIPTION:description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. 
@@ -288,5 +71,222 @@ SUMMARY:Bearracuda Seattle GLOW PARTY
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260509T040000Z
+DTEND:20260509T100000Z
+DTSTAMP:20260617T043551Z
+UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
+CREATED:20260507T001637Z
+DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
+ • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
+ e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
+ da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
+ com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
+ uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
+ ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
+  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
+ ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
+LAST-MODIFIED:20260507T001638Z
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251011T040000Z
+DTEND:20251011T100000Z
+DTSTAMP:20260617T043551Z
+UID:9DF93D82-1411-44C0-BE63-00037416BB38
+CREATED:20250817T231654Z
+DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
+  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
+ nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
+ ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
+ eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
+ 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
+ erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
+ nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
+ ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
+ https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
+ arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
+ bearracuda-2025-10-11-seattle
+LAST-MODIFIED:20251001T141832Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:2
+STATUS:CONFIRMED
+SUMMARY:Bearracuda Seattle: SERIOUS WOOD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260308T050000Z
+DTEND:20260308T100000Z
+DTSTAMP:20260617T043551Z
+UID:3DCE764F-EC21-459C-8791-745DE1731298
+CREATED:20260123T030754Z
+DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
+ TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
+ A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
+ seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
+ 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
+ : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
+ 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
+ earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
+ C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
+ -seattle
+LAST-MODIFIED:20260126T235324Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle:TRAIL HEAD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260201T050000Z
+DTEND:20260201T110000Z
+DTSTAMP:20260617T043551Z
+UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
+CREATED:20260123T030739Z
+DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
+ s by MATT STANDS &amp\; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine\, Sea
+ ttle\, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com
+ /events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025
+ /12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/69805544976
+ 5272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-bee
+ f-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: http
+ s://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search
+ /?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey
+ : bearracuda-2026-02-01-seattle
+LAST-MODIFIED:20260126T235314Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20250927T040000Z
+DTEND:20250927T100000Z
+DTSTAMP:20260617T043551Z
+UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
+CREATED:20250825T034004Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to choose your own ADVENTURE! Now our guys can grab a wristband when you 
+ walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp\; TIGERBE
+ ATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: Amer
+ ica/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover
+ : $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/up
+ loads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/even
+ ts/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail
+ -seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https:/
+ /www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?a
+ pi=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearrac
+ uda-2025-09-27-seattle
+LAST-MODIFIED:20250920T210916Z
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail: SEATTLE
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20250706T140000
+DTEND;TZID=America/New_York:20250706T190000
+RRULE:FREQ=WEEKLY;BYDAY=SU
+DTSTAMP:20260617T043551Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
+ ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
+ rtName: South Seattle Social
+LAST-MODIFIED:20260507T001639Z
+LOCATION:47.51652271569908\, -122.35487284211817
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:South Seattle Bear Social
+TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Los_Angeles:20250717T190000
+DTEND;TZID=America/Los_Angeles:20250718T020000
+RRULE:FREQ=MONTHLY;BYDAY=3TH
+DTSTAMP:20260617T043551Z
+UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
+ DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
+ <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
+ IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
+ ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
+ /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
+ a>
+LAST-MODIFIED:20250719T040329Z
+LOCATION:47.61337340244105\, -122.31441768029491
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:Leather Night
+TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251122T050000Z
+DTEND:20251122T110000Z
+DTSTAMP:20260617T043551Z
+UID:3D70DFD0-9501-434E-A015-10F01A25DA09
+CREATED:20250930T014035Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
+ tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
+ ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
+ 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
+ sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
+ a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
+ ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
+ reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
+ -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
+ oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
+ =101730401\nkey: bearracuda-2025-11-22-seattle
+LAST-MODIFIED:20251001T225002Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle: Wish BONED!
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20260614T000000
+DTEND;TZID=America/New_York:20260614T060000
+DTSTAMP:20260617T043551Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+RECURRENCE-ID;TZID=America/New_York:20260614T140000
+CREATED:20250712T180301Z
+DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
+ am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
+ /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
+ -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
+ 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
+ \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
+ rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
+ 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
+ ttle
+LAST-MODIFIED:20260507T001639Z
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Seattle GLOW
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+BEGIN:VALARM
+ACTION:NONE
+TRIGGER;VALUE=DATE-TIME:19760401T005545Z
+END:VALARM
 END:VEVENT
 END:VCALENDAR

--- a/data/calendars/update-summary.json
+++ b/data/calendars/update-summary.json
@@ -1,159 +1,159 @@
 {
-  "lastUpdated": "2026-06-17T03:07:42.532Z",
+  "lastUpdated": "2026-06-17T04:35:52.157Z",
   "cities": {
     "nyc": {
       "name": "New York",
       "status": "success",
       "dataLength": 12154,
       "eventCount": 14,
-      "lastUpdated": "2026-06-17T03:07:42.532Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "seattle": {
       "name": "Seattle",
       "status": "success",
       "dataLength": 12362,
       "eventCount": 10,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "la": {
       "name": "Los Angeles",
       "status": "success",
       "dataLength": 8423,
       "eventCount": 7,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "toronto": {
       "name": "Toronto",
       "status": "success",
       "dataLength": 197,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "london": {
       "name": "London",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "chicago": {
       "name": "Chicago",
       "status": "success",
       "dataLength": 13565,
       "eventCount": 12,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "berlin": {
       "name": "Berlin",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "palm-springs": {
       "name": "Palm Springs",
       "status": "success",
       "dataLength": 1487,
       "eventCount": 1,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "denver": {
       "name": "Denver",
       "status": "success",
       "dataLength": 6856,
       "eventCount": 6,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "dallas": {
       "name": "Dallas",
       "status": "success",
       "dataLength": 195,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "dc": {
       "name": "DC",
       "status": "success",
       "dataLength": 1503,
       "eventCount": 1,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "vegas": {
       "name": "Las Vegas",
       "status": "success",
       "dataLength": 4410,
       "eventCount": 3,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "atlanta": {
       "name": "Atlanta",
       "status": "success",
       "dataLength": 4933,
       "eventCount": 4,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "nola": {
       "name": "New Orleans",
       "status": "success",
       "dataLength": 2367,
       "eventCount": 2,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "sf": {
       "name": "San Francisco",
       "status": "success",
       "dataLength": 15367,
       "eventCount": 12,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "portland": {
       "name": "Portland",
       "status": "success",
       "dataLength": 18474,
       "eventCount": 14,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "sitges": {
       "name": "Sitges",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "boston": {
       "name": "Boston",
       "status": "success",
       "dataLength": 196,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "phoenix": {
       "name": "Phoenix",
       "status": "success",
       "dataLength": 2874,
       "eventCount": 2,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "ptown": {
       "name": "Provincetown",
       "status": "success",
       "dataLength": 202,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "san-diego": {
       "name": "San Diego",
       "status": "success",
       "dataLength": 4073,
       "eventCount": 3,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     },
     "philly": {
       "name": "Philadelphia",
       "status": "success",
       "dataLength": 4689,
       "eventCount": 3,
-      "lastUpdated": "2026-06-17T03:07:42.533Z"
+      "lastUpdated": "2026-06-17T04:35:52.157Z"
     }
   }
 }

--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -1504,30 +1504,44 @@ class CalendarCore {
         return { start, end };
     }
 
+    // Get logical start date for event (shifts late-night events < 6am to previous day)
+    getLogicalStartDate(event) {
+        if (!event.startDate) return null;
+        const logicalDate = new Date(event.startDate);
+        const isAllDay = event.time === null;
+        if (!isAllDay && logicalDate.getHours() < 6) {
+            logicalDate.setDate(logicalDate.getDate() - 1);
+        }
+        return logicalDate;
+    }
+
+    // Get logical end date for event
+    getLogicalEndDate(event) {
+        if (!event.endDate) return null;
+        const logicalDate = new Date(event.endDate);
+        const isAllDay = event.time === null;
+
+        if (logicalDate.getHours() === 0 && logicalDate.getMinutes() === 0 && logicalDate.getSeconds() === 0) {
+            logicalDate.setTime(logicalDate.getTime() - 1);
+        }
+
+        if (!isAllDay && logicalDate.getHours() < 6) {
+            logicalDate.setDate(logicalDate.getDate() - 1);
+        }
+        return logicalDate;
+    }
+
     // Check if event is a multi-day event
     isMultiDay(event) {
         if (!event.startDate || !event.endDate) return false;
 
-        const start = new Date(event.startDate);
-        const end = new Date(event.endDate);
+        const logicalStart = this.getLogicalStartDate(event);
+        const logicalEnd = this.getLogicalEndDate(event);
 
-        // Use local dates to avoid timezone issues
-        const startKey = `${start.getFullYear()}-${start.getMonth()}-${start.getDate()}`;
-        const endKey = `${end.getFullYear()}-${end.getMonth()}-${end.getDate()}`;
+        const startKey = `${logicalStart.getFullYear()}-${logicalStart.getMonth()}-${logicalStart.getDate()}`;
+        const endKey = `${logicalEnd.getFullYear()}-${logicalEnd.getMonth()}-${logicalEnd.getDate()}`;
 
-        // Account for end dates that are just exactly at midnight the next day
-        // Some all-day events are 2026-06-26 00:00:00 to 2026-06-27 00:00:00
-        if (startKey !== endKey) {
-            // Check if end date is exactly 12:00 AM
-            if (end.getHours() === 0 && end.getMinutes() === 0 && end.getSeconds() === 0) {
-                // Adjust end date back by 1 millisecond for comparison
-                const adjustedEnd = new Date(end.getTime() - 1);
-                const adjustedEndKey = `${adjustedEnd.getFullYear()}-${adjustedEnd.getMonth()}-${adjustedEnd.getDate()}`;
-                return startKey !== adjustedEndKey;
-            }
-            return true;
-        }
-        return false;
+        return startKey !== endKey;
     }
 
     // Check if event falls within a date range

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2019,8 +2019,8 @@ class DynamicCalendarLoader extends CalendarCore {
             }
             
             // For all events (including expanded recurring events), check if they fall within the period
-            const eventEndDate = event.endDate ? new Date(event.endDate) : null;
-            const isInPeriod = this.isEventInPeriod(new Date(event.startDate), start, end, eventEndDate);
+            const eventEndDate = this.getLogicalEndDate(event);
+            const isInPeriod = this.isEventInPeriod(this.getLogicalStartDate(event), start, end, eventEndDate);
             logger.debug('CALENDAR', `🔍 FILTER: Event ${event.name}: ${isInPeriod ? 'INCLUDED' : 'EXCLUDED'}`, {
                 eventDate: new Date(event.startDate).toISOString(),
                 periodStart: start.toISOString(),
@@ -2363,14 +2363,9 @@ class DynamicCalendarLoader extends CalendarCore {
 
                 // Multi-day events check
                 if (this.isMultiDay(event)) {
-                    const eventDate = new Date(event.startDate);
+                    const eventDate = this.getLogicalStartDate(event);
                     eventDate.setHours(0, 0, 0, 0);
-                    const eventEndDate = new Date(event.endDate);
-
-                    // Adjust end date if it's exactly midnight, so it doesn't spill over to the next day
-                    if (eventEndDate.getHours() === 0 && eventEndDate.getMinutes() === 0 && eventEndDate.getSeconds() === 0) {
-                        eventEndDate.setTime(eventEndDate.getTime() - 1);
-                    }
+                    const eventEndDate = this.getLogicalEndDate(event);
                     eventEndDate.setHours(0, 0, 0, 0);
 
                     return dayDate >= eventDate && dayDate <= eventEndDate;
@@ -2378,7 +2373,7 @@ class DynamicCalendarLoader extends CalendarCore {
 
                 // For already expanded recurring events, just check if the date matches
                 if (event.isExpanded) {
-                    const eventDate = new Date(event.startDate);
+                    const eventDate = this.getLogicalStartDate(event);
                     eventDate.setHours(0, 0, 0, 0);
                     
                     return eventDate.getTime() === dayDate.getTime();
@@ -2390,7 +2385,7 @@ class DynamicCalendarLoader extends CalendarCore {
                 }
                 
                 // For non-recurring events, check exact date match
-                const eventDate = new Date(event.startDate);
+                const eventDate = this.getLogicalStartDate(event);
                 eventDate.setHours(0, 0, 0, 0);
                 
                 return eventDate.getTime() === dayDate.getTime();
@@ -2427,12 +2422,9 @@ class DynamicCalendarLoader extends CalendarCore {
                     let showTitle = true;
 
                     if (isMultiDay) {
-                        const eventStart = new Date(event.startDate);
+                        const eventStart = this.getLogicalStartDate(event);
                         eventStart.setHours(0, 0, 0, 0);
-                        const eventEnd = new Date(event.endDate);
-                        if (eventEnd.getHours() === 0 && eventEnd.getMinutes() === 0 && eventEnd.getSeconds() === 0) {
-                            eventEnd.setTime(eventEnd.getTime() - 1);
-                        }
+                        const eventEnd = this.getLogicalEndDate(event);
                         eventEnd.setHours(0, 0, 0, 0);
 
                         const dayDate = new Date(day);
@@ -2542,14 +2534,9 @@ class DynamicCalendarLoader extends CalendarCore {
 
                 // Multi-day events check
                 if (this.isMultiDay(event)) {
-                    const eventDate = new Date(event.startDate);
+                    const eventDate = this.getLogicalStartDate(event);
                     eventDate.setHours(0, 0, 0, 0);
-                    const eventEndDate = new Date(event.endDate);
-
-                    // Adjust end date if it's exactly midnight, so it doesn't spill over to the next day
-                    if (eventEndDate.getHours() === 0 && eventEndDate.getMinutes() === 0 && eventEndDate.getSeconds() === 0) {
-                        eventEndDate.setTime(eventEndDate.getTime() - 1);
-                    }
+                    const eventEndDate = this.getLogicalEndDate(event);
                     eventEndDate.setHours(0, 0, 0, 0);
 
                     return dayDate >= eventDate && dayDate <= eventEndDate;
@@ -2557,7 +2544,7 @@ class DynamicCalendarLoader extends CalendarCore {
 
                 // For already expanded recurring events, just check if the date matches
                 if (event.isExpanded) {
-                    const eventDate = new Date(event.startDate);
+                    const eventDate = this.getLogicalStartDate(event);
                     eventDate.setHours(0, 0, 0, 0);
                     
                     const matches = eventDate.getTime() === dayDate.getTime();
@@ -2587,7 +2574,7 @@ class DynamicCalendarLoader extends CalendarCore {
                 }
                 
                 // For non-recurring events, check exact date match
-                const eventDate = new Date(event.startDate);
+                const eventDate = this.getLogicalStartDate(event);
                 eventDate.setHours(0, 0, 0, 0);
                 
                 return eventDate.getTime() === dayDate.getTime();
@@ -2634,12 +2621,9 @@ class DynamicCalendarLoader extends CalendarCore {
                     let showTitle = true;
 
                     if (isMultiDay) {
-                        const eventStart = new Date(event.startDate);
+                        const eventStart = this.getLogicalStartDate(event);
                         eventStart.setHours(0, 0, 0, 0);
-                        const eventEnd = new Date(event.endDate);
-                        if (eventEnd.getHours() === 0 && eventEnd.getMinutes() === 0 && eventEnd.getSeconds() === 0) {
-                            eventEnd.setTime(eventEnd.getTime() - 1);
-                        }
+                        const eventEnd = this.getLogicalEndDate(event);
                         eventEnd.setHours(0, 0, 0, 0);
 
                         const dayDate = new Date(day);


### PR DESCRIPTION
Fixes issue where events ending slightly into the next day (e.g. before 6am) are incorrectly styled as multi-day events. Also shifts events completely within 12am-6am to display on the previous day.

---
*PR created automatically by Jules for task [14083581302642425454](https://jules.google.com/task/14083581302642425454) started by @stanleyrya*