### PR TITLE
Fix calendar week/month views and late-night day shifting

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -1504,12 +1504,29 @@ class CalendarCore {
         return { start, end };
     }
 
+    getLocalHour(dateObj, timezone) {
+        if (!dateObj || Number.isNaN(dateObj.getTime())) return null;
+        if (!timezone) return dateObj.getUTCHours();
+        try {
+            const formatter = new Intl.DateTimeFormat('en-US', {
+                timeZone: timezone,
+                hour: 'numeric',
+                hourCycle: 'h23'
+            });
+            const hourStr = formatter.format(dateObj);
+            return parseInt(hourStr, 10);
+        } catch (e) {
+            return dateObj.getUTCHours();
+        }
+    }
+
     // Get logical start date for event (shifts late-night events < 6am to previous day)
     getLogicalStartDate(event) {
         if (!event.startDate) return null;
         const logicalDate = new Date(event.startDate);
         const isAllDay = event.time === null;
-        if (!isAllDay && logicalDate.getHours() < 6) {
+        const localHour = this.getLocalHour(logicalDate, this.calendarTimezone);
+        if (!isAllDay && localHour !== null && localHour < 6) {
             logicalDate.setDate(logicalDate.getDate() - 1);
         }
         return logicalDate;
@@ -1521,11 +1538,15 @@ class CalendarCore {
         const logicalDate = new Date(event.endDate);
         const isAllDay = event.time === null;
 
-        if (logicalDate.getHours() === 0 && logicalDate.getMinutes() === 0 && logicalDate.getSeconds() === 0) {
+        let localHour = this.getLocalHour(logicalDate, this.calendarTimezone);
+
+        if (localHour !== null && localHour === 0 && logicalDate.getMinutes() === 0 && logicalDate.getSeconds() === 0) {
             logicalDate.setTime(logicalDate.getTime() - 1);
+            // Recalculate localHour after the 1-second adjustment
+            localHour = this.getLocalHour(logicalDate, this.calendarTimezone);
         }
 
-        if (!isAllDay && logicalDate.getHours() < 6) {
+        if (!isAllDay && localHour !== null && localHour < 6) {
             logicalDate.setDate(logicalDate.getDate() - 1);
         }
         return logicalDate;

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2439,10 +2439,12 @@ class DynamicCalendarLoader extends CalendarCore {
                         }
 
                         const eventId = event.uid || event.slug;
-                        if (seenMultiDayEvents.has(eventId)) {
+                        // Track occurrences uniquely by appending the eventStart timestamp
+                        const occurrenceId = `${eventId}_${eventStart.getTime()}`;
+                        if (seenMultiDayEvents.has(occurrenceId)) {
                             showTitle = false;
                         } else {
-                            seenMultiDayEvents.add(eventId);
+                            seenMultiDayEvents.add(occurrenceId);
                         }
                     }
                     
@@ -2638,10 +2640,12 @@ class DynamicCalendarLoader extends CalendarCore {
                         }
 
                         const eventId = event.uid || event.slug;
-                        if (seenMultiDayEvents.has(eventId)) {
+                        // Track occurrences uniquely by appending the eventStart timestamp
+                        const occurrenceId = `${eventId}_${eventStart.getTime()}`;
+                        if (seenMultiDayEvents.has(occurrenceId)) {
                             showTitle = false;
                         } else {
-                            seenMultiDayEvents.add(eventId);
+                            seenMultiDayEvents.add(occurrenceId);
                         }
                     }
                     


### PR DESCRIPTION
Fix calendar week/month views and late-night day shifting

- Add getLocalHour utility to calendar-core.js to accurately check if an event starts/ends before 6am in the target calendar's local timezone instead of the system/UTC timezone, fixing evening events from incorrectly shifting backwards by a day.
- Adjust getLogicalEndDate to recalculate localHour after the millisecond backward adjustment for midnight events, preventing double-subtraction.
- In dynamic-calendar-loader.js week/month views, change seenMultiDayEvents set to track unique occurrence combinations (eventId + eventStart) to prevent titles from being wrongly hidden on subsequent occurrences of weekly multi-day events.

---
*PR created automatically by Jules for task [16753644840342485081](https://jules.google.com/task/16753644840342485081) started by @stanleyrya*