### PR TITLE
Fix event shifting to previous day by correcting `getLocalHour`

### DIFF
--- a/data/calendars/seattle.ics
+++ b/data/calendars/seattle.ics
@@ -42,9 +42,57 @@ RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
 END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
+DTSTART:20250927T040000Z
+DTEND:20250927T100000Z
+DTSTAMP:20260617T154048Z
+UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
+CREATED:20250825T034004Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to choose your own ADVENTURE! Now our guys can grab a wristband when you 
+ walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp\; TIGERBE
+ ATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: Amer
+ ica/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover
+ : $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/up
+ loads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/even
+ ts/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail
+ -seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https:/
+ /www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?a
+ pi=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearrac
+ uda-2025-09-27-seattle
+LAST-MODIFIED:20250920T210916Z
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail: SEATTLE
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260509T040000Z
+DTEND:20260509T100000Z
+DTSTAMP:20260617T154048Z
+UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
+CREATED:20260507T001637Z
+DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
+ • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
+ e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
+ da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
+ com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
+ uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
+ ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
+  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
+ ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
+LAST-MODIFIED:20260507T001638Z
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
 DTSTART:20260614T040000Z
 DTEND:20260614T100000Z
-DTSTAMP:20260617T131420Z
+DTSTAMP:20260617T154048Z
 UID:762BAD4A-F1D8-4519-BAC3-D755EF9BA263
 CREATED:20260514T005858Z
 DESCRIPTION:description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. 
@@ -73,9 +121,132 @@ X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20260614T000000
+DTEND;TZID=America/New_York:20260614T060000
+DTSTAMP:20260617T154048Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+RECURRENCE-ID;TZID=America/New_York:20260614T140000
+CREATED:20250712T180301Z
+DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
+ am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
+ /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
+ -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
+ 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
+ \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
+ rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
+ 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
+ ttle
+LAST-MODIFIED:20260507T001639Z
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Seattle GLOW
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+BEGIN:VALARM
+ACTION:NONE
+TRIGGER;VALUE=DATE-TIME:19760401T005545Z
+END:VALARM
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251011T040000Z
+DTEND:20251011T100000Z
+DTSTAMP:20260617T154048Z
+UID:9DF93D82-1411-44C0-BE63-00037416BB38
+CREATED:20250817T231654Z
+DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
+  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
+ nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
+ ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
+ eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
+ 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
+ erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
+ nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
+ ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
+ https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
+ arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
+ bearracuda-2025-10-11-seattle
+LAST-MODIFIED:20251001T141832Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:2
+STATUS:CONFIRMED
+SUMMARY:Bearracuda Seattle: SERIOUS WOOD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20250706T140000
+DTEND;TZID=America/New_York:20250706T190000
+RRULE:FREQ=WEEKLY;BYDAY=SU
+DTSTAMP:20260617T154048Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
+ ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
+ rtName: South Seattle Social
+LAST-MODIFIED:20260507T001639Z
+LOCATION:47.51652271569908\, -122.35487284211817
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:South Seattle Bear Social
+TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260308T050000Z
+DTEND:20260308T100000Z
+DTSTAMP:20260617T154048Z
+UID:3DCE764F-EC21-459C-8791-745DE1731298
+CREATED:20260123T030754Z
+DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
+ TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
+ A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
+ seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
+ 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
+ : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
+ 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
+ earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
+ C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
+ -seattle
+LAST-MODIFIED:20260126T235324Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle:TRAIL HEAD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251122T050000Z
+DTEND:20251122T110000Z
+DTSTAMP:20260617T154048Z
+UID:3D70DFD0-9501-434E-A015-10F01A25DA09
+CREATED:20250930T014035Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
+ tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
+ ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
+ 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
+ sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
+ a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
+ ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
+ reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
+ -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
+ oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
+ =101730401\nkey: bearracuda-2025-11-22-seattle
+LAST-MODIFIED:20251001T225002Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle: Wish BONED!
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
 DTSTART:20260201T050000Z
 DTEND:20260201T110000Z
-DTSTAMP:20260617T131420Z
+DTSTAMP:20260617T154048Z
 UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
 CREATED:20260123T030739Z
 DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
@@ -101,7 +272,7 @@ BEGIN:VEVENT
 DTSTART;TZID=America/Los_Angeles:20250717T190000
 DTEND;TZID=America/Los_Angeles:20250718T020000
 RRULE:FREQ=MONTHLY;BYDAY=3TH
-DTSTAMP:20260617T131420Z
+DTSTAMP:20260617T154048Z
 UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
 CREATED:20250712T180301Z
 DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
@@ -117,176 +288,5 @@ SEQUENCE:1
 STATUS:CONFIRMED
 SUMMARY:Leather Night
 TRANSP:OPAQUE
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20251011T040000Z
-DTEND:20251011T100000Z
-DTSTAMP:20260617T131420Z
-UID:9DF93D82-1411-44C0-BE63-00037416BB38
-CREATED:20250817T231654Z
-DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
-  nut huggers\, flannel\, suspenders\, beanies & overalls! Hot Go-Go’s\, Chu
- nky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: M
- ASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: America/Los_Ang
- eles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.
- 54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/s
- erioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\
- nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-ti
- ckets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: 
- https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/se
- arch/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: 
- bearracuda-2025-10-11-seattle
-LAST-MODIFIED:20251001T141832Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:2
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle: SERIOUS WOOD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20251122T050000Z
-DTEND:20251122T110000Z
-DTSTAMP:20260617T131420Z
-UID:3D70DFD0-9501-434E-A015-10F01A25DA09
-CREATED:20250930T014035Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
- tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
- ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
- 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
- sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
- a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
- ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
- reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
- -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
- oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
- =101730401\nkey: bearracuda-2025-11-22-seattle
-LAST-MODIFIED:20251001T225002Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle: Wish BONED!
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20250706T140000
-DTEND;TZID=America/New_York:20250706T190000
-RRULE:FREQ=WEEKLY;BYDAY=SU
-DTSTAMP:20260617T131420Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
- ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
- rtName: South Seattle Social
-LAST-MODIFIED:20260507T001639Z
-LOCATION:47.51652271569908\, -122.35487284211817
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:South Seattle Bear Social
-TRANSP:OPAQUE
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260308T050000Z
-DTEND:20260308T100000Z
-DTSTAMP:20260617T131420Z
-UID:3DCE764F-EC21-459C-8791-745DE1731298
-CREATED:20260123T030754Z
-DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
- TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
- A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
- seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
- 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
- : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
- 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
- earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
- C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
- -seattle
-LAST-MODIFIED:20260126T235324Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle:TRAIL HEAD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20250927T040000Z
-DTEND:20250927T100000Z
-DTSTAMP:20260617T131420Z
-UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
-CREATED:20250825T034004Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to choose your own ADVENTURE! Now our guys can grab a wristband when you 
- walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp\; TIGERBE
- ATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: Amer
- ica/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover
- : $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/up
- loads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/even
- ts/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail
- -seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https:/
- /www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?a
- pi=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearrac
- uda-2025-09-27-seattle
-LAST-MODIFIED:20250920T210916Z
-SEQUENCE:1
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail: SEATTLE
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260509T040000Z
-DTEND:20260509T100000Z
-DTSTAMP:20260617T131420Z
-UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
-CREATED:20260507T001637Z
-DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
- • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
- e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
- da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
- com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
- uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
- ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
-  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
- ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
-LAST-MODIFIED:20260507T001638Z
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20260614T000000
-DTEND;TZID=America/New_York:20260614T060000
-DTSTAMP:20260617T131420Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-RECURRENCE-ID;TZID=America/New_York:20260614T140000
-CREATED:20250712T180301Z
-DESCRIPTION:description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 
- am\nbar: MASSIVE\naddress: 619 E. Pine St\, Seattle\, WA\ntimezone: America
- /Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda
- -seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548
- 258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow
- \nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bea
- rracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%
- 20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-sea
- ttle
-LAST-MODIFIED:20260507T001639Z
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Seattle GLOW
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-BEGIN:VALARM
-ACTION:NONE
-TRIGGER;VALUE=DATE-TIME:19760401T005545Z
-END:VALARM
 END:VEVENT
 END:VCALENDAR

--- a/data/calendars/update-summary.json
+++ b/data/calendars/update-summary.json
@@ -1,159 +1,159 @@
 {
-  "lastUpdated": "2026-06-17T13:14:20.952Z",
+  "lastUpdated": "2026-06-17T15:40:49.382Z",
   "cities": {
     "nyc": {
       "name": "New York",
       "status": "success",
       "dataLength": 12154,
       "eventCount": 14,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "seattle": {
       "name": "Seattle",
       "status": "success",
       "dataLength": 12362,
       "eventCount": 10,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "la": {
       "name": "Los Angeles",
       "status": "success",
       "dataLength": 8423,
       "eventCount": 7,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "toronto": {
       "name": "Toronto",
       "status": "success",
       "dataLength": 197,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "london": {
       "name": "London",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "chicago": {
       "name": "Chicago",
       "status": "success",
       "dataLength": 13565,
       "eventCount": 12,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "berlin": {
       "name": "Berlin",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "palm-springs": {
       "name": "Palm Springs",
       "status": "success",
       "dataLength": 1487,
       "eventCount": 1,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "denver": {
       "name": "Denver",
       "status": "success",
       "dataLength": 6856,
       "eventCount": 6,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "dallas": {
       "name": "Dallas",
       "status": "success",
       "dataLength": 195,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "dc": {
       "name": "DC",
       "status": "success",
       "dataLength": 1503,
       "eventCount": 1,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "vegas": {
       "name": "Las Vegas",
       "status": "success",
       "dataLength": 4410,
       "eventCount": 3,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "atlanta": {
       "name": "Atlanta",
       "status": "success",
       "dataLength": 4933,
       "eventCount": 4,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "nola": {
       "name": "New Orleans",
       "status": "success",
       "dataLength": 2367,
       "eventCount": 2,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "sf": {
       "name": "San Francisco",
       "status": "success",
       "dataLength": 15367,
       "eventCount": 12,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "portland": {
       "name": "Portland",
       "status": "success",
       "dataLength": 18474,
       "eventCount": 14,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "sitges": {
       "name": "Sitges",
       "status": "success",
       "dataLength": 193,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "boston": {
       "name": "Boston",
       "status": "success",
       "dataLength": 196,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "phoenix": {
       "name": "Phoenix",
       "status": "success",
       "dataLength": 2874,
       "eventCount": 2,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "ptown": {
       "name": "Provincetown",
       "status": "success",
       "dataLength": 202,
       "eventCount": 0,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "san-diego": {
       "name": "San Diego",
       "status": "success",
       "dataLength": 4073,
       "eventCount": 3,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     },
     "philly": {
       "name": "Philadelphia",
       "status": "success",
       "dataLength": 4689,
       "eventCount": 3,
-      "lastUpdated": "2026-06-17T13:14:20.952Z"
+      "lastUpdated": "2026-06-17T15:40:49.382Z"
     }
   }
 }

--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -1506,18 +1506,9 @@ class CalendarCore {
 
     getLocalHour(dateObj, timezone) {
         if (!dateObj || Number.isNaN(dateObj.getTime())) return null;
-        if (!timezone) return dateObj.getUTCHours();
-        try {
-            const formatter = new Intl.DateTimeFormat('en-US', {
-                timeZone: timezone,
-                hour: 'numeric',
-                hourCycle: 'h23'
-            });
-            const hourStr = formatter.format(dateObj);
-            return parseInt(hourStr, 10);
-        } catch (e) {
-            return dateObj.getUTCHours();
-        }
+        // Event dates are stored as local Date objects representing their calendar's local time,
+        // so getHours() directly gives the correct local hour without secondary timezone conversion.
+        return dateObj.getHours();
     }
 
     // Get logical start date for event (shifts late-night events < 6am to previous day)


### PR DESCRIPTION
Fix event shifting to previous day by correcting `getLocalHour`

Modified `getLocalHour` in `js/calendar-core.js` to return `dateObj.getHours()` directly instead of parsing via `Intl.DateTimeFormat`. Calendar events are instantiated as local Date objects representing their timezone, so extracting the hour via `getHours()` prevents erroneous timezone conversions that shifted evening events to late-night events and caused them to display on the previous day.

---
*PR created automatically by Jules for task [17695134569964500291](https://jules.google.com/task/17695134569964500291) started by @stanleyrya*