### PR TITLE
Fix recurring event time preservation during expansion

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2146,7 +2146,18 @@ class DynamicCalendarLoader extends CalendarCore {
         // Check each day in the period
         while (current <= end) {
             if (this.doesRecurringEventOccurOnDate(event, current)) {
-                occurrences.push(new Date(current));
+                const occurrenceDate = new Date(current);
+                const originalStart = new Date(event.startDate);
+
+                // Preserve the original event's local time components
+                occurrenceDate.setHours(
+                    originalStart.getHours(),
+                    originalStart.getMinutes(),
+                    originalStart.getSeconds(),
+                    originalStart.getMilliseconds()
+                );
+
+                occurrences.push(occurrenceDate);
             }
             current.setDate(current.getDate() + 1);
         }


### PR DESCRIPTION
Fixes an issue where evening recurring events were bleeding over into the previous day.

---
*PR created automatically by Jules for task [8209492517985849183](https://jules.google.com/task/8209492517985849183) started by @stanleyrya*