### PR TITLE
Pre-process ICS calendars to JSON for NYC and Seattle

### DIFF
--- a/.github/workflows/update-calendar-data.yml
+++ b/.github/workflows/update-calendar-data.yml
@@ -230,6 +230,11 @@ jobs:
             });
           EOF
       
+
+      - name: Process calendars into JSON
+        run: |
+          node tools/process-calendars.js
+
       - name: Commit updated calendar data
         run: |
           git config --local user.email "action@github.com"

--- a/data/calendars/nyc.json
+++ b/data/calendars/nyc.json
@@ -1,0 +1,580 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/New_York",
+    "timezoneData": {
+      "tzid": "America/New_York",
+      "location": "America/New_York",
+      "daylight": {
+        "offsetFrom": "-0500",
+        "offsetTo": "-0400",
+        "name": "EDT",
+        "dtstart": "19700308T020000",
+        "rrule": "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU"
+      },
+      "standard": {
+        "offsetFrom": "-0400",
+        "offsetTo": "-0500",
+        "name": "EST",
+        "dtstart": "19701101T020000",
+        "rrule": "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU"
+      }
+    }
+  },
+  "events": [
+    {
+      "name": "CHUNK Brooklyn 7/4",
+      "day": "Saturday",
+      "time": "10PM-4AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 40.68830519999999,
+        "lng": -73.9569221
+      },
+      "startDate": "2026-07-05T02:00:00.000Z",
+      "endDate": "2026-07-05T08:00:00.000Z",
+      "unprocessedDescription": "description: CHUNK BROOKLYN Presents DC Legend KEENAN ORR with \rsupport from CHUNK Residents DICAP & DJ JAMES MICHELIN STAR BEARD HOT GOGO BEARS ALL NIGHT LONG // Hosted by JEREMY & BRIAN & BIG CLAUDE C'MON EVERYBODY // 325 FRANKLIN AVE // 10PM - CLOSE\nbar: C'mon Everybody\naddress: 325 Franklin Ave, Brooklyn, NY 11238, USA\nticketUrl: https://www.chunk-party.com/event-details/chunk-brooklyn-7-4\ncover: $20.50 - $30.75\nimage: https://static.wixstatic.com/media/42b6cb_74e11f57fc96460782c469ff9f79f25d~mv2.jpg/v1/fill/w_1240,h_1550,al_c,q_85/42b6cb_74e11f57fc96460782c469ff9f79f25d~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\nwebsite: https://www.chunk-party.com\ngmaps: https://www.google.com/maps/search/?api=1&query=C'mon%20Everybody%2C%20325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA\nkey: chunk-brooklyn-7/4|2026-07-05|c'mon everybody",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "AAC4129A-BE69-4DDF-87BE-D788FA75C0CC",
+      "uid": "AAC4129A-BE69-4DDF-87BE-D788FA75C0CC",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "C'mon Everybody",
+      "cover": "$20.50 - $30.75",
+      "image": "https://static.wixstatic.com/media/42b6cb_74e11f57fc96460782c469ff9f79f25d~mv2.jpg/v1/fill/w_1240,h_1550,al_c,q_85/42b6cb_74e11f57fc96460782c469ff9f79f25d~mv2.jpg",
+      "tea": "CHUNK BROOKLYN Presents DC Legend KEENAN ORR with support from CHUNK Residents DICAP & DJ JAMES MICHELIN STAR BEARD HOT GOGO BEARS ALL NIGHT LONG // Hosted by JEREMY & BRIAN & BIG CLAUDE C'MON EVERYBODY // 325 FRANKLIN AVE // 10PM - CLOSE",
+      "address": "325 Franklin Ave, Brooklyn, NY 11238, USA",
+      "website": "https://www.chunk-party.com",
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=C'mon%20Everybody%2C%20325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-brooklyn-7-4",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.chunk-party.com",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=C'mon%20Everybody%2C%20325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-brooklyn-7-4",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-brooklyn-74-31b4fb03"
+    },
+    {
+      "name": "Bears Are Animals",
+      "day": "Thursday",
+      "time": "7PM-10PM",
+      "eventType": "weekly",
+      "recurring": true,
+      "recurrence": "FREQ=WEEKLY",
+      "coordinates": {
+        "lat": 40.71739735291992,
+        "lng": -73.94930680925715
+      },
+      "startDate": "2025-07-10T23:00:00.000Z",
+      "endDate": "2025-07-11T02:00:00.000Z",
+      "unprocessedDescription": "Bar: Animal\nWebsite: https://animal.nyc\nInstagram: https://ww\rw.instagram.com/bearsareanimals\nGoogle Maps: https://maps.app.goo.gl/XvrwkXqQApYfaj6h9\nNickname: Animal\nShorter: BAA\nTea: Popular happy hour for those that want to go out in Brooklyn. Patio space and goes a bit later.",
+      "startTimezone": "America/New_York",
+      "endTimezone": "America/New_York",
+      "calendarTimezone": "America/New_York",
+      "wasUTC": false,
+      "sourceUid": "v12lqkpglh2iupk54ttds6pcmg@google.com",
+      "uid": "v12lqkpglh2iupk54ttds6pcmg@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Animal",
+      "tea": "Popular happy hour for those that want to go out in Brooklyn. Patio space and goes a bit later.",
+      "address": null,
+      "website": "https://animal.nyc",
+      "instagram": "https://www.instagram.com/bearsareanimals",
+      "gmaps": "https://maps.app.goo.gl/XvrwkXqQApYfaj6h9",
+      "shortName": "Animal",
+      "shorterName": "BAA",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://animal.nyc",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearsareanimals",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.app.goo.gl/XvrwkXqQApYfaj6h9",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "bears-are-animals-4cf796ee"
+    },
+    {
+      "name": "Bears Night Out",
+      "day": "Saturday",
+      "time": "10PM-4AM",
+      "eventType": "monthly",
+      "recurring": true,
+      "recurrence": "FREQ=MONTHLY;BYDAY=1SA",
+      "coordinates": {
+        "lat": 40.7326824,
+        "lng": -74.0097099
+      },
+      "startDate": "2025-07-06T02:00:00.000Z",
+      "endDate": "2025-07-06T08:00:00.000Z",
+      "unprocessedDescription": "Tea: Go-Go Bears, Cubs and LOTS of other fun things to grab on\rto!\nCover: $10\nWebsite: https://www.theurbanbear.com/\nInstagram: https://www.instagram.com/urbanbearnyc\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nBar: Rockbar\nShorter: BNO",
+      "startTimezone": "America/New_York",
+      "endTimezone": "America/New_York",
+      "calendarTimezone": "America/New_York",
+      "wasUTC": false,
+      "sourceUid": "suljenhlak65mplsbrft5rgcd0@google.com",
+      "uid": "suljenhlak65mplsbrft5rgcd0@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 2,
+      "overrideIdentityType": null,
+      "bar": "Rockbar",
+      "cover": "$10",
+      "tea": "Go-Go Bears, Cubs and LOTS of other fun things to grab onto!",
+      "address": null,
+      "website": "https://www.theurbanbear.com/",
+      "instagram": "https://www.instagram.com/urbanbearnyc",
+      "gmaps": "https://maps.app.goo.gl/3WsBUpQjekPZUW4u7",
+      "shorterName": "BNO",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.theurbanbear.com/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/urbanbearnyc",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.app.goo.gl/3WsBUpQjekPZUW4u7",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "bears-night-out-3d00f897"
+    },
+    {
+      "name": "Fat dad",
+      "day": "Saturday",
+      "time": null,
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-06-20T04:00:00.000Z",
+      "endDate": "2026-06-21T04:00:00.000Z",
+      "unprocessedDescription": null,
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": false,
+      "sourceUid": "t9c4ekcr125qg5chcflc59is5c@google.com",
+      "uid": "t9c4ekcr125qg5chcflc59is5c@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "website": null,
+      "slug": "fat-dad-54af58a5"
+    },
+    {
+      "name": "CHUNK Brooklyn - 5/9",
+      "day": "Saturday",
+      "time": "10PM-4AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 40.68830519999999,
+        "lng": -73.9569221
+      },
+      "startDate": "2026-05-10T02:00:00.000Z",
+      "endDate": "2026-05-10T08:00:00.000Z",
+      "unprocessedDescription": "description: CHUNK returns to Brooklyn Saturday May 9th CHUNK p\rresents SPRFRK w/ support from residents DICAP & THCKRTANKER // GOGO BEARS all night long // Hosted by Damiano // C'MON EVERYBODY 325 Franklin Ave // 10pm - close\nbar: C'mon Everybody\naddress: 325 Franklin Ave, Brooklyn, NY 11238, USA\nticketUrl: https://www.chunk-party.com/event-details/chunk-brooklyn-5-9\ncover: $15.38 - $25.63\nimage: https://static.wixstatic.com/media/42b6cb_81911c51814244bb9b559e72ce040b43~mv2.jpg/v1/fill/w_1360,h_1700,al_c,q_90/42b6cb_81911c51814244bb9b559e72ce040b43~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\ngmaps: https://www.google.com/maps/search/?api=1&query=C'mon%20Everybody%2C%20325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA\nkey: chunk-brooklyn-5/9|2026-05-10|c'mon everybody",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "90FA8B9E-8070-4539-B1B9-BF76B041D037",
+      "uid": "90FA8B9E-8070-4539-B1B9-BF76B041D037",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "C'mon Everybody",
+      "cover": "$15.38 - $25.63",
+      "image": "https://static.wixstatic.com/media/42b6cb_81911c51814244bb9b559e72ce040b43~mv2.jpg/v1/fill/w_1360,h_1700,al_c,q_90/42b6cb_81911c51814244bb9b559e72ce040b43~mv2.jpg",
+      "tea": "CHUNK returns to Brooklyn Saturday May 9th CHUNK presents SPRFRK w/ support from residents DICAP & THCKRTANKER // GOGO BEARS all night long // Hosted by Damiano // C'MON EVERYBODY 325 Franklin Ave // 10pm - close",
+      "address": "325 Franklin Ave, Brooklyn, NY 11238, USA",
+      "website": null,
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=C'mon%20Everybody%2C%20325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-brooklyn-5-9",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=C'mon%20Everybody%2C%20325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-brooklyn-5-9",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-brooklyn-59-7ffcc74a"
+    },
+    {
+      "name": "Rockstrap",
+      "day": "Friday",
+      "time": "10PM-4AM",
+      "eventType": "monthly",
+      "recurring": true,
+      "recurrence": "FREQ=MONTHLY;BYDAY=1FR",
+      "coordinates": {
+        "lat": 40.7326824,
+        "lng": -74.0097099
+      },
+      "startDate": "2025-07-05T02:00:00.000Z",
+      "endDate": "2025-07-05T08:00:00.000Z",
+      "unprocessedDescription": "Tea: Jockstraps encouraged, clothes check available!\nCover: $\r10 entry, $1 clothes check\nInstagram: https://www.instagram.com/rockbarny\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nNickname: Rock-strap\nBar: Rockbar\nShorter: RBR",
+      "startTimezone": "America/New_York",
+      "endTimezone": "America/New_York",
+      "calendarTimezone": "America/New_York",
+      "wasUTC": false,
+      "sourceUid": "bdstnukmpv6keg7pon3fram2qg@google.com",
+      "uid": "bdstnukmpv6keg7pon3fram2qg@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Rockbar",
+      "cover": "$10 entry, $1 clothes check",
+      "tea": "Jockstraps encouraged, clothes check available!",
+      "address": null,
+      "website": null,
+      "instagram": "https://www.instagram.com/rockbarny",
+      "gmaps": "https://maps.app.goo.gl/3WsBUpQjekPZUW4u7",
+      "shortName": "Rock-strap",
+      "shorterName": "RBR",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/rockbarny",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.app.goo.gl/3WsBUpQjekPZUW4u7",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "rockstrap-42266312"
+    },
+    {
+      "name": "Pride",
+      "day": "Friday",
+      "time": null,
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-06-26T04:00:00.000Z",
+      "endDate": "2026-06-29T04:00:00.000Z",
+      "unprocessedDescription": null,
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": false,
+      "sourceUid": "706B8093-375B-4E8C-8FBE-58F5CF949246",
+      "uid": "706B8093-375B-4E8C-8FBE-58F5CF949246",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "website": null,
+      "slug": "pride-059058a4"
+    },
+    {
+      "name": "GOLDILOXX MDW",
+      "day": "Saturday",
+      "time": "9PM-4AM",
+      "eventType": "routine",
+      "recurring": false,
+      "recurrence": null,
+      "coordinates": {
+        "lat": 40.75775322645565,
+        "lng": -73.99257438113817
+      },
+      "startDate": "2026-05-24T01:00:00.000Z",
+      "endDate": "2026-05-24T08:00:00.000Z",
+      "unprocessedDescription": "description: GOLDILOXX is an NYC based monthly bear party for b\rears and their admirers. When you arrive you get to select a color coded cup for whatever your mood is. Follow us on instagram for more updates ! @goldiloxx__ 🩵Blue Cup=DTF 🩷Pink Cup=Kiss 🧡Orange Cup=Side 💚Green Cup=Watch The party has two floors with two different vibes. Upstairs is flirty/dance/mingle Downstairs is ;););) Sexy Beefy Gogos all night **CLOTHING CHECK AVAILABLE**\nbar: Red Eye NY\naddress: 355 West 41st Street, New York NY 10036\nimage: https://redeye-event-flyers.s3.us-east-2.amazonaws.com/artwork/events/live/landscape_cover/8d628768-dd07-417e-8a43-b8e0669a624e/561602dc-734a-4e1a-aed8-f8baaee3c52d/a99044f121e5cedc1ec9a411/gl_5_23_26_scruff_eb75.jpg?v=a99044f121e5cedc1ec9a411397e16db9727cb379509afa5bcdb83516ffa7031\nticketUrl: https://redeyetickets.com/events/goldiloxx-mdw\ncover: $15 - $30 (as of 5/20)\nshortName: GOLDI-LOXX\nshorterName: GLX\ninstagram: https://www.instagram.com/goldiloxx__\ngmaps: https://www.google.com/maps/search/?api=1&query=Red%20Eye%20NY%2C%20355%20West%2041st%20Street%2C%20New%20York%20NY%2010036\nkey: goldiloxx-mdw|2026-05-24|red eye ny\noverrideUid: 88ctfpug1icbk4iofj0kgj4u78@google.com\noverrideRecurrenceId: 20260531T010000Z",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "B44747B4-59F4-4410-A7CB-A7DDA263B4B6",
+      "uid": "88ctfpug1icbk4iofj0kgj4u78@google.com",
+      "recurrenceId": "2026-05-31T01:00:00.000Z",
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": "custom",
+      "bar": "Red Eye NY",
+      "cover": "$15 - $30 (as of 5/20)",
+      "image": "https://redeye-event-flyers.s3.us-east-2.amazonaws.com/artwork/events/live/landscape_cover/8d628768-dd07-417e-8a43-b8e0669a624e/561602dc-734a-4e1a-aed8-f8baaee3c52d/a99044f121e5cedc1ec9a411/gl_5_23_26_scruff_eb75.jpg?v=a99044f121e5cedc1ec9a411397e16db9727cb379509afa5bcdb83516ffa7031",
+      "tea": "GOLDILOXX is an NYC based monthly bear party for bears and their admirers. When you arrive you get to select a color coded cup for whatever your mood is. Follow us on instagram for more updates ! @goldiloxx__ 🩵Blue Cup=DTF 🩷Pink Cup=Kiss 🧡Orange Cup=Side 💚Green Cup=Watch The party has two floors with two different vibes. Upstairs is flirty/dance/mingle Downstairs is ;););) Sexy Beefy Gogos all night **CLOTHING CHECK AVAILABLE**",
+      "address": "355 West 41st Street, New York NY 10036",
+      "website": null,
+      "instagram": "https://www.instagram.com/goldiloxx__",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Red%20Eye%20NY%2C%20355%20West%2041st%20Street%2C%20New%20York%20NY%2010036",
+      "ticketUrl": "https://redeyetickets.com/events/goldiloxx-mdw",
+      "shortName": "GOLDI-LOXX",
+      "shorterName": "GLX",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/goldiloxx__",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Red%20Eye%20NY%2C%20355%20West%2041st%20Street%2C%20New%20York%20NY%2010036",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://redeyetickets.com/events/goldiloxx-mdw",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "goldiloxx-mdw-43e392ec"
+    },
+    {
+      "name": "CHUNK BROOKLYN - The Return!",
+      "day": "Saturday",
+      "time": "10:30PM-4AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 40.68830519999999,
+        "lng": -73.9569221
+      },
+      "startDate": "2026-02-15T03:30:00.000Z",
+      "endDate": "2026-02-15T09:00:00.000Z",
+      "unprocessedDescription": "description: CHUNK returns to NY - Saturday February 14th // fe\raturing DJs RON LIKE HELL (Wrecked) & residents DICAP & MR PICKLES // HOT GOGO BEARS // C'MON EVERYBODY - 325 Franklin Ave - 10\\:30pm - 4am\nbar: Brooklyn\naddress: 325 Franklin Ave, Brooklyn, NY 11238, USA\ntimezone: America/New_York\nurl: https://www.chunk-party.com/event-details/chunk-brooklyn-the-return\nticketUrl: https://www.chunk-party.com/event-details/chunk-brooklyn-the-return\ncover: $15.38 - $25.63\nimage: https://static.wixstatic.com/media/42b6cb_253e0a5bd34945d9876e03eabd5eaabb~mv2.jpg/v1/fill/w_1344,h_1345,al_c,q_85/42b6cb_253e0a5bd34945d9876e03eabd5eaabb~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\ngmaps: https://www.google.com/maps/search/?api=1&query=325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA\nkey: chunk-brooklyn-the-return|2026-02-15|brooklyn",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "6DD23624-8818-401B-9BC1-13BB87366576",
+      "uid": "6DD23624-8818-401B-9BC1-13BB87366576",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Brooklyn",
+      "cover": "$15.38 - $25.63",
+      "image": "https://static.wixstatic.com/media/42b6cb_253e0a5bd34945d9876e03eabd5eaabb~mv2.jpg/v1/fill/w_1344,h_1345,al_c,q_85/42b6cb_253e0a5bd34945d9876e03eabd5eaabb~mv2.jpg",
+      "tea": "CHUNK returns to NY - Saturday February 14th // featuring DJs RON LIKE HELL (Wrecked) & residents DICAP & MR PICKLES // HOT GOGO BEARS // C'MON EVERYBODY - 325 Franklin Ave - 10:30pm - 4am",
+      "address": "325 Franklin Ave, Brooklyn, NY 11238, USA",
+      "website": "https://www.chunk-party.com/event-details/chunk-brooklyn-the-return",
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-brooklyn-the-return",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.chunk-party.com/event-details/chunk-brooklyn-the-return",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-brooklyn-the-return",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-brooklyn-the-return-5dd73bae"
+    },
+    {
+      "name": "Beer Blast",
+      "day": "Sunday",
+      "time": "5PM-4AM",
+      "eventType": "weekly",
+      "recurring": true,
+      "recurrence": "FREQ=WEEKLY",
+      "coordinates": {
+        "lat": 40.75168692425323,
+        "lng": -74.00431317114098
+      },
+      "startDate": "2025-07-06T21:00:00.000Z",
+      "endDate": "2025-07-07T08:00:00.000Z",
+      "unprocessedDescription": "Name: Beer Blast\nBar: Eagle NYC \nCover: No cover till 9PM, $\r20 cover at 9PM\nWebsite: https://eagle-ny.com\nGoogle Maps: https://maps.app.goo.gl/8N8zpGGAYwXJjgsGA\nNickname: Eagle\nShorter: EGL",
+      "startTimezone": "America/New_York",
+      "endTimezone": "America/New_York",
+      "calendarTimezone": "America/New_York",
+      "wasUTC": false,
+      "sourceUid": "96d0b400rgfpagk14sc2bd1aks@google.com",
+      "uid": "96d0b400rgfpagk14sc2bd1aks@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Eagle NYC",
+      "cover": "No cover till 9PM, $20 cover at 9PM",
+      "address": null,
+      "website": "https://eagle-ny.com",
+      "gmaps": "https://maps.app.goo.gl/8N8zpGGAYwXJjgsGA",
+      "shortName": "Eagle",
+      "shorterName": "EGL",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://eagle-ny.com",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.app.goo.gl/8N8zpGGAYwXJjgsGA",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "beer-blast-15963ca2"
+    },
+    {
+      "name": "Bear Happy Hour",
+      "day": "Thursday",
+      "time": "5PM-9PM",
+      "eventType": "weekly",
+      "recurring": true,
+      "recurrence": "FREQ=WEEKLY",
+      "startDate": "2025-07-10T21:00:00.000Z",
+      "endDate": "2025-07-11T01:00:00.000Z",
+      "unprocessedDescription": "Bar: Check instagram for this week’s location.\nTea: Popular ha\rppy hour that changes location every week in Manhattan.\nInstagram: https://www.instagram.com/bearhappyhournyc\nShorter: BHH\nWeb: https://linktr.ee/bearhappyhour",
+      "startTimezone": "America/New_York",
+      "endTimezone": "America/New_York",
+      "calendarTimezone": "America/New_York",
+      "wasUTC": false,
+      "sourceUid": "6thhos5ct3pllq5kmvsp7infd8@google.com",
+      "uid": "6thhos5ct3pllq5kmvsp7infd8@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Check instagram for this week’s location.",
+      "tea": "Popular happy hour that changes location every week in Manhattan.",
+      "address": null,
+      "website": "https://linktr.ee/bearhappyhour",
+      "instagram": "https://www.instagram.com/bearhappyhournyc",
+      "shorterName": "BHH",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/bearhappyhour",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearhappyhournyc",
+          "label": "📷 Instagram"
+        }
+      ],
+      "slug": "bear-happy-hour-66e240de"
+    },
+    {
+      "name": "FUZZY",
+      "day": "Friday",
+      "time": "10PM-4AM",
+      "eventType": "monthly",
+      "recurring": true,
+      "recurrence": "FREQ=MONTHLY;BYDAY=4FR",
+      "coordinates": {
+        "lat": 40.7316977,
+        "lng": -73.9841737
+      },
+      "startDate": "2022-02-26T03:00:00.000Z",
+      "endDate": "2022-02-26T09:00:00.000Z",
+      "unprocessedDescription": "shortName: FUZZY\ntea: A monthly social for NYC’s friendly faun\ra. Serving pop, house, rock, new wave and disco dusted with pink glitter.\ncover: $5\nbar: Nowhere Bar\naddress: 322 E 14th St, New York, NY 10003\ntimezone: America/New_York\nuid: fuzzy-20260503T203532Z@chunky.dad\nwebsite: https://fuzzy.nyc/\ninstagram: https://instagram.com/fuzzy_nyc\nfacebook: https://www.facebook.com/fuzzy.nyc\ngmaps: https://www.google.com/maps/place/?q=place_id:ChIJZ1fMFZ5ZwokRkYrV85CZorY",
+      "startTimezone": "America/New_York",
+      "endTimezone": "America/New_York",
+      "calendarTimezone": "America/New_York",
+      "wasUTC": false,
+      "sourceUid": "fuzzy-20260503T203532Z@chunky.dad",
+      "uid": "fuzzy-20260503T203532Z@chunky.dad",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 7,
+      "overrideIdentityType": null,
+      "bar": "Nowhere Bar",
+      "cover": "$5",
+      "tea": "A monthly social for NYC’s friendly fauna. Serving pop, house, rock, new wave and disco dusted with pink glitter.",
+      "address": "322 E 14th St, New York, NY 10003",
+      "website": "https://fuzzy.nyc/",
+      "instagram": "https://instagram.com/fuzzy_nyc",
+      "facebook": "https://www.facebook.com/fuzzy.nyc",
+      "gmaps": "https://www.google.com/maps/place/?q=place_id:ChIJZ1fMFZ5ZwokRkYrV85CZorY",
+      "shortName": "FUZZY",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://fuzzy.nyc/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://instagram.com/fuzzy_nyc",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/fuzzy.nyc",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/place/?q=place_id:ChIJZ1fMFZ5ZwokRkYrV85CZorY",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "fuzzy-0380f9f1"
+    }
+  ]
+}

--- a/data/calendars/nyc.json
+++ b/data/calendars/nyc.json
@@ -141,7 +141,7 @@
         "lng": -74.0097099
       },
       "startDate": "2025-07-06T02:00:00.000Z",
-      "endDate": "2025-07-06T08:00:00.000Z",
+      "endDate": "2025-07-05T08:00:00.000Z",
       "unprocessedDescription": "Tea: Go-Go Bears, Cubs and LOTS of other fun things to grab on\rto!\nCover: $10\nWebsite: https://www.theurbanbear.com/\nInstagram: https://www.instagram.com/urbanbearnyc\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nBar: Rockbar\nShorter: BNO",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
@@ -266,7 +266,7 @@
         "lng": -74.0097099
       },
       "startDate": "2025-07-05T02:00:00.000Z",
-      "endDate": "2025-07-05T08:00:00.000Z",
+      "endDate": "2025-07-04T08:00:00.000Z",
       "unprocessedDescription": "Tea: Jockstraps encouraged, clothes check available!\nCover: $\r10 entry, $1 clothes check\nInstagram: https://www.instagram.com/rockbarny\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nNickname: Rock-strap\nBar: Rockbar\nShorter: RBR",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
@@ -446,7 +446,7 @@
         "lng": -74.00431317114098
       },
       "startDate": "2025-07-06T21:00:00.000Z",
-      "endDate": "2025-07-07T08:00:00.000Z",
+      "endDate": "2025-07-06T08:00:00.000Z",
       "unprocessedDescription": "Name: Beer Blast\nBar: Eagle NYC \nCover: No cover till 9PM, $\r20 cover at 9PM\nWebsite: https://eagle-ny.com\nGoogle Maps: https://maps.app.goo.gl/8N8zpGGAYwXJjgsGA\nNickname: Eagle\nShorter: EGL",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",

--- a/data/calendars/seattle.json
+++ b/data/calendars/seattle.json
@@ -1,0 +1,592 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Los_Angeles",
+    "timezoneData": {
+      "tzid": "America/Los_Angeles",
+      "location": "America/Los_Angeles",
+      "daylight": {
+        "offsetFrom": "-0800",
+        "offsetTo": "-0700",
+        "name": "PDT",
+        "dtstart": "19700308T020000",
+        "rrule": "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU"
+      },
+      "standard": {
+        "offsetFrom": "-0700",
+        "offsetTo": "-0800",
+        "name": "PST",
+        "dtstart": "19701101T020000",
+        "rrule": "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU"
+      }
+    }
+  },
+  "events": [
+    {
+      "name": "Bearracuda Seattle: SERIOUS WOOD",
+      "day": "Friday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 47.6150572,
+        "lng": -122.3236574
+      },
+      "startDate": "2025-10-11T04:00:00.000Z",
+      "endDate": "2025-10-11T10:00:00.000Z",
+      "unprocessedDescription": "description: SERIOUS WOOD Show off your boots, plaid, jeans,\r nut huggers, flannel, suspenders, beanies & overalls! Hot Go-Go’s, Chunky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: MASSIVE\naddress: 619 E Pine, Seattle, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/serioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-tickets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearracuda-2025-10-11-seattle",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "9DF93D82-1411-44C0-BE63-00037416BB38",
+      "uid": "9DF93D82-1411-44C0-BE63-00037416BB38",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 2,
+      "overrideIdentityType": null,
+      "bar": "MASSIVE",
+      "cover": "$24.89 - $30.54 (as of 10/1)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/08/serioiusweb.jpg",
+      "tea": "SERIOUS WOOD Show off your boots, plaid, jeans, nut huggers, flannel, suspenders, beanies & overalls! Hot Go-Go’s, Chunky Visuals!",
+      "address": "619 E Pine, Seattle, WA 98122",
+      "website": "https://bearracuda.com/events/seattlewood/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1210500617554659",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-tickets-1565073299369?aff=oddtdtcreator",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/seattlewood/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1210500617554659",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-tickets-1565073299369?aff=oddtdtcreator",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-seattle-serious-wood-4a1720dd"
+    },
+    {
+      "name": "Treasure Trail Seattle:TRAIL HEAD",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 47.6150572,
+        "lng": -122.3236574
+      },
+      "startDate": "2026-03-08T05:00:00.000Z",
+      "endDate": "2026-03-08T10:00:00.000Z",
+      "unprocessedDescription": "description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA\rTT STANDS &amp; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine, Seattle, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl: https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-1980435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08-seattle",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "3DCE764F-EC21-459C-8791-745DE1731298",
+      "uid": "3DCE764F-EC21-459C-8791-745DE1731298",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "MASSIVE",
+      "image": "https://bearracuda.com/wp-content/uploads/2026/01/11x17-4.jpg",
+      "tea": "TRAIL HEAD",
+      "address": "619 E Pine, Seattle, WA 98122",
+      "website": "https://bearracuda.com/events/seattlett/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/857466110421715",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
+      "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-1980435540012",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/seattlett/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/857466110421715",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-1980435540012",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-seattletrail-head-5f63386f"
+    },
+    {
+      "name": "Treasure Trail Seattle",
+      "day": "Friday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-05-09T04:00:00.000Z",
+      "endDate": "2026-05-09T10:00:00.000Z",
+      "unprocessedDescription": "description: Clothes check available\n\nMusic & Entertainment\n\r• Beats by MATT STANDS &amp; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pine St, Seattle, WA\ntimezone: America/Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearracuda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "C2EDB500-501A-4F94-9060-3A0EEE8AC165",
+      "uid": "C2EDB500-501A-4F94-9060-3A0EEE8AC165",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "MASSIVE",
+      "image": "https://bearracuda.com/wp-content/uploads/2026/01/45-2.jpg",
+      "tea": "Clothes check available",
+      "address": "619 E. Pine St, Seattle, WA",
+      "website": null,
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1574328850293138/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
+      "ticketUrl": "https://sickening.events/e/bearracuda-treasure-trail-seattle-4/tickets",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1574328850293138/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://sickening.events/e/bearracuda-treasure-trail-seattle-4/tickets",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-seattle-7e9ae5d5"
+    },
+    {
+      "name": "South Seattle Bear Social",
+      "day": "Sunday",
+      "time": "11AM-4PM",
+      "eventType": "weekly",
+      "recurring": true,
+      "recurrence": "FREQ=WEEKLY;BYDAY=SU",
+      "coordinates": {
+        "lat": 47.51652271569908,
+        "lng": -122.35487284211817
+      },
+      "startDate": "2025-07-06T18:00:00.000Z",
+      "endDate": "2025-07-06T23:00:00.000Z",
+      "unprocessedDescription": "Instagram: https://www.instagram.com/southseattlebearsocial/\nB\rar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nShortName: South Seattle Social",
+      "startTimezone": "America/New_York",
+      "endTimezone": "America/New_York",
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": false,
+      "sourceUid": "6irujvg3effpkdu42krgr91osj@google.com",
+      "uid": "6irujvg3effpkdu42krgr91osj@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Lumberyard",
+      "address": null,
+      "website": null,
+      "instagram": "https://www.instagram.com/southseattlebearsocial/",
+      "gmaps": "https://maps.app.goo.gl/SDUbV4qsRpivNiX39",
+      "shortName": "South Seattle Social",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/southseattlebearsocial/",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.app.goo.gl/SDUbV4qsRpivNiX39",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "south-seattle-bear-social-3b330fb1"
+    },
+    {
+      "name": "Seattle GLOW",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-06-14T04:00:00.000Z",
+      "endDate": "2026-06-14T10:00:00.000Z",
+      "unprocessedDescription": "description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 \ram\nbar: MASSIVE\naddress: 619 E. Pine St, Seattle, WA\ntimezone: America/Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda-seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow\nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-seattle",
+      "startTimezone": "America/New_York",
+      "endTimezone": "America/New_York",
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": false,
+      "sourceUid": "6irujvg3effpkdu42krgr91osj@google.com",
+      "uid": "6irujvg3effpkdu42krgr91osj@google.com",
+      "recurrenceId": "2026-06-14T18:00:00.000Z",
+      "recurrenceIdTimezone": "America/New_York",
+      "sequence": 0,
+      "overrideIdentityType": "legacy",
+      "bar": "MASSIVE",
+      "image": "https://bearracuda.com/wp-content/uploads/2026/04/cuda-seattle-june2026-web-1.jpg",
+      "tea": "Doors Open at 9:00 pm - Party Goes Until 3:00 am",
+      "address": "619 E. Pine St, Seattle, WA",
+      "website": null,
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1548258503329527",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
+      "ticketUrl": "https://sickening.events/e/bearracuda-seattle-glow",
+      "shortName": "South Seattle Social",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1548258503329527",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://sickening.events/e/bearracuda-seattle-glow",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "seattle-glow-3b330fb1"
+    },
+    {
+      "name": "Leather Night",
+      "day": "Thursday",
+      "time": "7PM-2AM",
+      "eventType": "monthly",
+      "recurring": true,
+      "recurrence": "FREQ=MONTHLY;BYDAY=3TH",
+      "coordinates": {
+        "lat": 47.61337340244105,
+        "lng": -122.31441768029491
+      },
+      "startDate": "2025-07-18T02:00:00.000Z",
+      "endDate": "2025-07-18T09:00:00.000Z",
+      "unprocessedDescription": "Bar: Diesel<br>Google Maps: <a href=\"https://maps.app.goo.gl/yD\rDhdkV7M7p2mYEP7\">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: <a href=\"https://dieselseattle.com/DIESEL.html\">https://dieselseattle.com/DIESEL.html</a><br>Facebook: <a href=\"https://www.facebook.com/DieselSeattle\">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href=\"https://www.instagram.com/dieselseattle\">https://www.instagram.com/dieselseattle</a>",
+      "startTimezone": "America/Los_Angeles",
+      "endTimezone": "America/Los_Angeles",
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": false,
+      "sourceUid": "1dl55f6fm4qqv42go7r3nj5st9@google.com",
+      "uid": "1dl55f6fm4qqv42go7r3nj5st9@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Diesel",
+      "address": null,
+      "website": "https://dieselseattle.com/DIESEL.html",
+      "instagram": "https://www.instagram.com/dieselseattle",
+      "facebook": "https://www.facebook.com/DieselSeattle",
+      "gmaps": "https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://dieselseattle.com/DIESEL.html",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/dieselseattle",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/DieselSeattle",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "leather-night-51e2ca8d"
+    },
+    {
+      "name": "Bearracuda Seattle GLOW PARTY",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "recurrence": null,
+      "startDate": "2026-06-14T04:00:00.000Z",
+      "endDate": "2026-06-14T10:00:00.000Z",
+      "unprocessedDescription": "description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. \rPine SATURDAY, June 13th Doors at 9pm, Party til 3am! Hot Go-Go&rsquo;s, Chunky Visuals Decor by James Sharinghousen, Photos by Matt Hoffman, Hosted by Matt Bearracuda DJs Matt Stands DISCOUNTED tix for those in UV/Neon Attire Our GLOW PARTY is coming to Seattle! We are offering DEEPLY discounted tickets for those wearing UV Reactive or Neon Attire. Bearracuda resident DJ, Matt Stands spins all night with Hot GoGos, Decor by James Sharinghousen…\nbar: MASSIVE\naddress: 619 E. Pine\nticketUrl: https://www.sickening.events/e/bearracuda-seattle-glow/tickets\ninstagram: https://www.instagram.com/bearracuda\nimage: https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1776554715/saas/logos/image_1776554705644_n8exy3gc9.webp\ncover: DISCOUNTED tix for those in UV/Neon Attire\nshortName: South Seattle Social\nwebsite: https://bearracuda.com/events/seattle-glow/\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine\nkey: bearracuda-2026-06-14-seattle\ntimezone: America/Los_Angeles\noverrideUid: 6irujvg3effpkdu42krgr91osj@google.com\noverrideRecurrenceId: 20260614T180000Z",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "762BAD4A-F1D8-4519-BAC3-D755EF9BA263",
+      "uid": "6irujvg3effpkdu42krgr91osj@google.com",
+      "recurrenceId": "2026-06-14T18:00:00.000Z",
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": "custom",
+      "bar": "MASSIVE",
+      "cover": "DISCOUNTED tix for those in UV/Neon Attire",
+      "image": "https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1776554715/saas/logos/image_1776554705644_n8exy3gc9.webp",
+      "tea": "Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. Pine SATURDAY, June 13th Doors at 9pm, Party til 3am! Hot Go-Go&rsquo;s, Chunky Visuals Decor by James Sharinghousen, Photos by Matt Hoffman, Hosted by Matt Bearracuda DJs Matt Stands DISCOUNTED tix for those in UV/Neon Attire Our GLOW PARTY is coming to Seattle! We are offering DEEPLY discounted tickets for those wearing UV Reactive or Neon Attire. Bearracuda resident DJ, Matt Stands spins all night with Hot GoGos, Decor by James Sharinghousen…",
+      "address": "619 E. Pine",
+      "website": "https://bearracuda.com/events/seattle-glow/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine",
+      "ticketUrl": "https://www.sickening.events/e/bearracuda-seattle-glow/tickets",
+      "shortName": "South Seattle Social",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/seattle-glow/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.sickening.events/e/bearracuda-seattle-glow/tickets",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-seattle-glow-party-43d1597b"
+    },
+    {
+      "name": "Treasure Trail: SEATTLE",
+      "day": "Friday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2025-09-27T04:00:00.000Z",
+      "endDate": "2025-09-27T10:00:00.000Z",
+      "unprocessedDescription": "description: Treasure Trail returns to Seattle and we invite yo\ru to choose your own ADVENTURE! Now our guys can grab a wristband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine, Seattle, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover: $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/uploads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/events/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail-seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearracuda-2025-09-27-seattle",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "19A871C3-E891-4C93-BF2E-A0234C04BF1E",
+      "uid": "19A871C3-E891-4C93-BF2E-A0234C04BF1E",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "MASSIVE",
+      "cover": "$15.65 - $30.54 (as of 9/20)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/04/treasuretrailweb.jpg",
+      "tea": "Treasure Trail returns to Seattle and we invite you to choose your own ADVENTURE! Now our guys can grab a wristband when you walk in:",
+      "address": "619 E Pine, Seattle, WA 98122",
+      "website": "https://bearracuda.com/events/treasureseattle/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1113055394051303",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
+      "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-seattle-tickets-1497840042889",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/treasureseattle/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1113055394051303",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/treasure-trail-seattle-tickets-1497840042889",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-seattle-4a6fa455"
+    },
+    {
+      "name": "Bearracuda Seattle Winter Beef Ball 2026!",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 47.6150572,
+        "lng": -122.3236574
+      },
+      "startDate": "2026-02-01T05:00:00.000Z",
+      "endDate": "2026-02-01T11:00:00.000Z",
+      "unprocessedDescription": "description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat\rs by MATT STANDS &amp; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine, Seattle, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025/12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/698055449765272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-beef-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-02-01-seattle",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "33B9EEB8-F6D3-4068-9A20-64B8DE33B103",
+      "uid": "33B9EEB8-F6D3-4068-9A20-64B8DE33B103",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "MASSIVE",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/12/seattlejan26.jpg",
+      "tea": "WINTER BEEF BALL!",
+      "address": "619 E Pine, Seattle, WA 98122",
+      "website": "https://bearracuda.com/events/seattlebeef/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/698055449765272",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-seattle-winter-beef-ball-2026-tickets-1977102214947",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/seattlebeef/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/698055449765272",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-seattle-winter-beef-ball-2026-tickets-1977102214947",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-seattle-winter-beef-ball-2026-5d3a67cd"
+    },
+    {
+      "name": "Treasure Trail Seattle: Wish BONED!",
+      "day": "Friday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 47.6150572,
+        "lng": -122.3236574
+      },
+      "startDate": "2025-11-22T05:00:00.000Z",
+      "endDate": "2025-11-22T11:00:00.000Z",
+      "unprocessedDescription": "description: Treasure Trail returns to Seattle and we invite yo\ru to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wristband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT STANDS &amp; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine, Seattle, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.facebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/treasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearracuda-2025-11-22-seattle",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "3D70DFD0-9501-434E-A015-10F01A25DA09",
+      "uid": "3D70DFD0-9501-434E-A015-10F01A25DA09",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "MASSIVE",
+      "cover": "$15.65 - $30.54 (as of 10/1)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/04/treasurenov.jpg",
+      "tea": "Treasure Trail returns to Seattle and we invite you to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wristband when you walk in:",
+      "address": "619 E Pine, Seattle, WA 98122",
+      "website": "https://bearracuda.com/events/treasureseattle/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/784739777742843",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
+      "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-seattle-wish-boned-tickets-1754983576119",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/treasureseattle/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/784739777742843",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/treasure-trail-seattle-wish-boned-tickets-1754983576119",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-seattle-wish-boned-422a1406"
+    }
+  ]
+}

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1400,8 +1400,34 @@ class DynamicCalendarLoader extends CalendarCore {
             return this.loadCalendarDataFallback(cityKey, cityConfig);
         }
         
+        // Helper function to process dates recursively
+        const reviveDates = (obj) => {
+            if (obj === null || typeof obj !== 'object') return obj;
+            if (Array.isArray(obj)) return obj.map(reviveDates);
+
+            const revived = {};
+            for (const key of Object.keys(obj)) {
+                if ((key === 'startDate' || key === 'endDate' || key === 'recurrenceId') && obj[key] !== null) {
+                    const d = new Date(obj[key]);
+                    revived[key] = d;
+                } else {
+                    revived[key] = reviveDates(obj[key]);
+                }
+            }
+
+            // Re-apply `_wasUTC` on Date objects if `wasUTC` property exists on the event level
+            if (revived.wasUTC !== undefined) {
+                if (revived.startDate) revived.startDate._wasUTC = revived.wasUTC;
+                if (revived.endDate) revived.endDate._wasUTC = revived.wasUTC;
+            }
+            return revived;
+        };
+
+        const isJsonCity = (cityKey === 'nyc' || cityKey === 'seattle');
+        const ext = isJsonCity ? 'json' : 'ics';
+
         // Normal flow: Try to load cached calendar data first
-        const cachedDataUrl = this.buildLocalCalendarUrl(cityKey);
+        const cachedDataUrl = this.buildLocalCalendarUrl(cityKey, ext);
         
         try {
             logger.debug('CALENDAR', `Attempting to load cached calendar data`, {
@@ -1416,7 +1442,7 @@ class DynamicCalendarLoader extends CalendarCore {
             const response = await fetch(cachedDataUrl, {
                 method: 'GET',
                 headers: {
-                    'Accept': 'text/calendar,text/plain,*/*'
+                    'Accept': isJsonCity ? 'application/json' : 'text/calendar,text/plain,*/*'
                 },
                 cache: 'default' // Use browser cache for efficiency
             });
@@ -1425,46 +1451,71 @@ class DynamicCalendarLoader extends CalendarCore {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
             }
             
-            const icalText = await response.text();
-            
-            // Validate that we got actual iCal data
-            if (!icalText || !icalText.includes('BEGIN:VCALENDAR')) {
-                throw new Error('Invalid iCal data in cached file');
+            if (isJsonCity) {
+                const jsonData = await response.json();
+
+                logger.debug('CALENDAR', `Cached JSON data retrieved, reviving...`, {
+                    eventsLength: jsonData.events?.length
+                });
+
+                const events = reviveDates(jsonData.events);
+
+                this.allEvents = events;
+
+                // Set metadata to class properties so they are accessible
+                if (jsonData.metadata) {
+                    this.calendarTimezone = jsonData.metadata.calendarTimezone;
+                    this.timezoneData = jsonData.metadata.timezoneData;
+                }
+
+                this.eventsData = {
+                    cityConfig,
+                    events,
+                    calendarTimezone: this.calendarTimezone,
+                    timezoneData: this.timezoneData
+                };
+            } else {
+                const icalText = await response.text();
+
+                // Validate that we got actual iCal data
+                if (!icalText || !icalText.includes('BEGIN:VCALENDAR')) {
+                    throw new Error('Invalid iCal data in cached file');
+                }
+
+                logger.apiCall('CALENDAR', `Successfully loaded cached calendar data`, {
+                    dataLength: icalText.length,
+                    city: cityConfig.name,
+                    url: cachedDataUrl,
+                    method: 'cached_data_success'
+                });
+
+                // Log sample of the fetched data for debugging
+                logger.debug('CALENDAR', 'Cached iCal data validation', {
+                    firstLine: icalText.split('\n')[0],
+                    hasEvents: icalText.includes('BEGIN:VEVENT'),
+                    eventCount: (icalText.match(/BEGIN:VEVENT/g) || []).length,
+                    calendarName: icalText.match(/X-WR-CALNAME:(.+)/)?.[1]?.trim() || 'Unknown',
+                    encoding: icalText.includes('BEGIN:VCALENDAR') ? 'Valid iCal' : 'Invalid format',
+                    dataSize: `${(icalText.length / 1024).toFixed(1)}KB`,
+                    source: 'cached_github_actions'
+                });
+
+                const events = this.parseICalData(icalText);
+
+                // Store all events for filtering
+                this.allEvents = events;
+
+                this.eventsData = {
+                    cityConfig,
+                    events,
+                    calendarTimezone: this.calendarTimezone,
+                    timezoneData: this.timezoneData
+                };
             }
-            
-            logger.apiCall('CALENDAR', `Successfully loaded cached calendar data`, {
-                dataLength: icalText.length,
-                city: cityConfig.name,
-                url: cachedDataUrl,
-                method: 'cached_data_success'
-            });
-            
-            // Log sample of the fetched data for debugging
-            logger.debug('CALENDAR', 'Cached iCal data validation', {
-                firstLine: icalText.split('\n')[0],
-                hasEvents: icalText.includes('BEGIN:VEVENT'),
-                eventCount: (icalText.match(/BEGIN:VEVENT/g) || []).length,
-                calendarName: icalText.match(/X-WR-CALNAME:(.+)/)?.[1]?.trim() || 'Unknown',
-                encoding: icalText.includes('BEGIN:VCALENDAR') ? 'Valid iCal' : 'Invalid format',
-                dataSize: `${(icalText.length / 1024).toFixed(1)}KB`,
-                source: 'cached_github_actions'
-            });
-            
-            const events = this.parseICalData(icalText);
-            
-            // Store all events for filtering
-            this.allEvents = events;
-            
-            this.eventsData = {
-                cityConfig,
-                events,
-                calendarTimezone: this.calendarTimezone,
-                timezoneData: this.timezoneData
-            };
             
             logger.timeEnd('CALENDAR', `Loading ${cityConfig.name} calendar data`);
             logger.componentLoad('CALENDAR', `Successfully processed cached calendar data for ${cityConfig.name}`, {
-                eventCount: events.length,
+                eventCount: this.allEvents.length,
                 cityKey,
                 calendarTimezone: this.calendarTimezone,
                 hasTimezoneData: !!this.timezoneData,
@@ -1550,13 +1601,13 @@ class DynamicCalendarLoader extends CalendarCore {
 
 
     // Resolve correct local calendar URL depending on current page location
-    buildLocalCalendarUrl(cityKey) {
+    buildLocalCalendarUrl(cityKey, ext = 'ics') {
         try {
             const pathname = window.location.pathname || '';
             
             // Use PathUtils if available for consistent path resolution
             if (window.pathUtils) {
-                return window.pathUtils.resolvePath(`data/calendars/${cityKey}.ics`);
+                return window.pathUtils.resolvePath(`data/calendars/${cityKey}.${ext}`);
             }
             
             // Fallback logic for path detection
@@ -1572,7 +1623,7 @@ class DynamicCalendarLoader extends CalendarCore {
             const needsParentPath = isTesting || isInCitySubdirectory;
             const prefix = needsParentPath ? '../' : '';
             
-            return `${prefix}data/calendars/${cityKey}.ics`;
+            return `${prefix}data/calendars/${cityKey}.${ext}`;
         } catch (e) {
             // Safe fallback
             return `data/calendars/${cityKey}.ics`;

--- a/tools/process-calendars.js
+++ b/tools/process-calendars.js
@@ -1,0 +1,102 @@
+const fs = require('fs');
+const path = require('path');
+
+// Resolve project root
+const ROOT = path.resolve(__dirname, '..');
+
+// Provide basic logging to satisfy dependencies
+global.logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: console.error,
+    componentInit: () => {},
+    componentLoad: () => {},
+    componentError: () => {},
+    time: () => {},
+    timeEnd: () => {},
+    apiCall: () => {},
+    performance: () => {}
+};
+
+// Load EventSchema and CalendarCore
+const evSch = require(path.join(ROOT, 'js', 'event-schema.js'));
+global.EventSchema = evSch.EventSchema;
+const CalendarCore = require(path.join(ROOT, 'js', 'calendar-core.js'));
+
+const calendar = new CalendarCore();
+
+// Load CITY_CONFIG
+let CITY_CONFIG;
+try {
+    const cityModule = require(path.join(ROOT, 'js', 'city-config.js'));
+    CITY_CONFIG = cityModule.CITY_CONFIG || {};
+} catch (e) {
+    console.error('Failed to load CITY_CONFIG:', e.message);
+    process.exit(1);
+}
+
+// Target cities to test the new JSON logic with
+const TARGET_CITIES = ['nyc', 'seattle'];
+
+async function processCalendars() {
+    let successCount = 0;
+    let errorCount = 0;
+
+    const calendarsDir = path.join(ROOT, 'data', 'calendars');
+
+    for (const cityKey of TARGET_CITIES) {
+        if (!CITY_CONFIG[cityKey] || CITY_CONFIG[cityKey].visible === false) {
+            console.log(`Skipping ${cityKey} (not in config or not visible)`);
+            continue;
+        }
+
+        const icsPath = path.join(calendarsDir, `${cityKey}.ics`);
+        const jsonPath = path.join(calendarsDir, `${cityKey}.json`);
+
+        if (!fs.existsSync(icsPath)) {
+            console.log(`Skipping ${cityKey} (no ICS file found at ${icsPath})`);
+            continue;
+        }
+
+        try {
+            const icalText = fs.readFileSync(icsPath, 'utf8');
+
+            // Re-instantiate calendar core to ensure a clean state
+            const cityCalendar = new CalendarCore();
+
+            // Set timezone environment for Node to parse dates accurately if needed, though CalendarCore should handle it
+            try {
+                const tzMatch = icalText.match(/X-WR-TIMEZONE:(.+)/);
+                if (tzMatch && tzMatch[1]) {
+                    process.env.TZ = tzMatch[1].trim();
+                }
+            } catch (_) {}
+
+            const events = cityCalendar.parseICalData(icalText) || [];
+
+            // Also store calendar metadata in the JSON if available
+            const output = {
+                metadata: {
+                    calendarTimezone: cityCalendar.calendarTimezone,
+                    timezoneData: cityCalendar.timezoneData,
+                },
+                events: events
+            };
+
+            fs.writeFileSync(jsonPath, JSON.stringify(output, null, 2));
+            console.log(`✓ Processed ${cityKey}.ics -> ${cityKey}.json (${events.length} events)`);
+            successCount++;
+        } catch (error) {
+            console.error(`✗ Error processing ${cityKey}:`, error);
+            errorCount++;
+        }
+    }
+
+    console.log(`\nProcessing complete: ${successCount} successful, ${errorCount} failed.`);
+    if (errorCount > 0) {
+        process.exit(1);
+    }
+}
+
+processCalendars();


### PR DESCRIPTION
Creates a process-calendars.js script which runs in GitHub actions and parses ICS data into a JSON file for explicitly targeted cities. Modifies dynamic-calendar-loader.js to load this JSON data on page load for those specific cities, correctly reviving Date objects from ISO strings so that legacy date functionality (like recurring event generation and filtering) remains intact.

---
*PR created automatically by Jules for task [17137337798488563515](https://jules.google.com/task/17137337798488563515) started by @stanleyrya*