### PR TITLE
Fix GitHub Actions calendar pre-processing missing event end-dates

### DIFF
--- a/tools/process-calendars.js
+++ b/tools/process-calendars.js
@@ -86,9 +86,24 @@ async function processCalendars() {
 
             const dateReplacer = function(key, value) {
                 if (this[key] instanceof Date) {
-                    const pad = (n) => n.toString().padStart(2, '0');
                     const date = this[key];
-                    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+                    const calendarTimezone = cityCalendar.calendarTimezone || "America/New_York";
+                    const formatter = new Intl.DateTimeFormat('en-CA', {
+                        timeZone: calendarTimezone,
+                        year: 'numeric', month: '2-digit', day: '2-digit',
+                        hour: '2-digit', minute: '2-digit', second: '2-digit',
+                        hour12: false
+                    });
+                    const parts = formatter.formatToParts(date);
+                    const y = parts.find(p => p.type === 'year')?.value;
+                    const mo = parts.find(p => p.type === 'month')?.value;
+                    const d = parts.find(p => p.type === 'day')?.value;
+                    let h = parts.find(p => p.type === 'hour')?.value;
+                    if (h === '24') h = '00';
+                    const mi = parts.find(p => p.type === 'minute')?.value;
+                    const s = parts.find(p => p.type === 'second')?.value;
+
+                    return `${y}-${mo}-${d}T${h}:${mi}:${s}`;
                 }
                 return value;
             };


### PR DESCRIPTION
Modified the Date Replacer logic utilized in pre-processed `.json` payload generation. Instead of locally extracting individual time components via `get*()` methods — which inconsistently revert to UTC boundaries across CI platforms — dates are definitively serialized mimicking their native local-time context by querying explicit internal offset structures parsed via `Intl.DateTimeFormat()`. This directly prevents occurrences from accidentally overlapping bounding-box filters by falsely rendering premature end-dates due to 24-hour subtraction artifacts.

---
*PR created automatically by Jules for task [17078690116034545974](https://jules.google.com/task/17078690116034545974) started by @stanleyrya*