### PR TITLE
Fix overnight event truncation during JSON calendar processing

### DIFF
--- a/data/calendars/nyc.json
+++ b/data/calendars/nyc.json
@@ -141,7 +141,7 @@
         "lng": -74.0097099
       },
       "startDate": "2025-07-05T22:00:00",
-      "endDate": "2025-07-05T04:00:00",
+      "endDate": "2025-07-06T04:00:00",
       "unprocessedDescription": "Tea: Go-Go Bears, Cubs and LOTS of other fun things to grab on\rto!\nCover: $10\nWebsite: https://www.theurbanbear.com/\nInstagram: https://www.instagram.com/urbanbearnyc\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nBar: Rockbar\nShorter: BNO",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
@@ -266,7 +266,7 @@
         "lng": -74.0097099
       },
       "startDate": "2025-07-04T22:00:00",
-      "endDate": "2025-07-04T04:00:00",
+      "endDate": "2025-07-05T04:00:00",
       "unprocessedDescription": "Tea: Jockstraps encouraged, clothes check available!\nCover: $\r10 entry, $1 clothes check\nInstagram: https://www.instagram.com/rockbarny\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nNickname: Rock-strap\nBar: Rockbar\nShorter: RBR",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
@@ -446,7 +446,7 @@
         "lng": -74.00431317114098
       },
       "startDate": "2025-07-06T17:00:00",
-      "endDate": "2025-07-06T04:00:00",
+      "endDate": "2025-07-07T04:00:00",
       "unprocessedDescription": "Name: Beer Blast\nBar: Eagle NYC \nCover: No cover till 9PM, $\r20 cover at 9PM\nWebsite: https://eagle-ny.com\nGoogle Maps: https://maps.app.goo.gl/8N8zpGGAYwXJjgsGA\nNickname: Eagle\nShorter: EGL",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",

--- a/tools/process-calendars.js
+++ b/tools/process-calendars.js
@@ -90,37 +90,26 @@ async function processCalendars() {
             const dateReplacer = function(key, value) {
                 if (this[key] instanceof Date) {
                     const date = this[key];
-                    const calendarTimezone = cityCalendar.calendarTimezone || "America/New_York";
 
-                    console.log(`\n[DateReplacer - ${key || 'root'}] Original Date object (ISO): ${date.toISOString()}`);
-                    console.log(`[DateReplacer - ${key || 'root'}] Original Date object (Local): ${date.toString()}`);
-                    console.log(`[DateReplacer - ${key || 'root'}] Intended target timezone: ${calendarTimezone}`);
+                    // Dates parsed by CalendarCore are constructed using local Date components
+                    // that directly correspond to the target timezone's time.
+                    // For example, an event starting at 5:00 PM EDT is parsed into a Date object
+                    // such that date.getFullYear(), date.getMonth(), and date.getHours() (which is 17)
+                    // directly match the EDT time.
+                    // Therefore, we must format it using its raw local methods rather than
+                    // applying an Intl.DateTimeFormat conversion, which would treat the local system's
+                    // offset as UTC/another timezone and mistakenly shift it again.
 
-                    const formatter = new Intl.DateTimeFormat('en-CA', {
-                        timeZone: calendarTimezone,
-                        year: 'numeric', month: '2-digit', day: '2-digit',
-                        hour: '2-digit', minute: '2-digit', second: '2-digit',
-                        hour12: false
-                    });
-                    const parts = formatter.formatToParts(date);
-                    console.log(`[DateReplacer - ${key || 'root'}] Formatter parts:`, JSON.stringify(parts));
-
-                    const y = parts.find(p => p.type === 'year')?.value;
-                    const mo = parts.find(p => p.type === 'month')?.value;
-                    const d = parts.find(p => p.type === 'day')?.value;
-                    let h = parts.find(p => p.type === 'hour')?.value;
-
-                    console.log(`[DateReplacer - ${key || 'root'}] Extracted hour before 24 check: ${h}`);
-                    if (h === '24') {
-                        console.log(`[DateReplacer - ${key || 'root'}] Hour is 24, adjusting to 00`);
-                        h = '00';
-                    }
-
-                    const mi = parts.find(p => p.type === 'minute')?.value;
-                    const s = parts.find(p => p.type === 'second')?.value;
+                    const pad = (n) => n.toString().padStart(2, '0');
+                    const y = date.getFullYear();
+                    const mo = pad(date.getMonth() + 1);
+                    const d = pad(date.getDate());
+                    const h = pad(date.getHours());
+                    const mi = pad(date.getMinutes());
+                    const s = pad(date.getSeconds());
 
                     const finalString = `${y}-${mo}-${d}T${h}:${mi}:${s}`;
-                    console.log(`[DateReplacer - ${key || 'root'}] Final serialized string: ${finalString}`);
+
                     return finalString;
                 }
                 return value;


### PR DESCRIPTION
Resolves issue where multiple events (e.g. "Beer Blast", "Rockstrap") were not rendering correctly because their JSON `endDate` output ended before or exactly when they started, due to `Intl.DateTimeFormat(..., { hour12: false })` outputting `24:00` for midnight while maintaining the same date index. Using `.getFullYear()`, `.getMonth()`, `.getHours()` etc correctly captures the date object's inherently mapped local values across midnight boundaries.

---
*PR created automatically by Jules for task [3396414878546842734](https://jules.google.com/task/3396414878546842734) started by @stanleyrya*