### PR TITLE
fix(parsers): Update date replacer to use hourCycle h23 to fix Node 24 parsing errors

### DIFF
--- a/tools/process-calendars.js
+++ b/tools/process-calendars.js
@@ -100,7 +100,7 @@ async function processCalendars() {
                         timeZone: calendarTimezone,
                         year: 'numeric', month: '2-digit', day: '2-digit',
                         hour: '2-digit', minute: '2-digit', second: '2-digit',
-                        hour12: false
+                        hourCycle: 'h23'
                     });
                     const parts = formatter.formatToParts(date);
                     console.log(`[DateReplacer - ${key || 'root'}] Formatter parts:`, JSON.stringify(parts));
@@ -109,12 +109,6 @@ async function processCalendars() {
                     const mo = parts.find(p => p.type === 'month')?.value;
                     const d = parts.find(p => p.type === 'day')?.value;
                     let h = parts.find(p => p.type === 'hour')?.value;
-
-                    console.log(`[DateReplacer - ${key || 'root'}] Extracted hour before 24 check: ${h}`);
-                    if (h === '24') {
-                        console.log(`[DateReplacer - ${key || 'root'}] Hour is 24, adjusting to 00`);
-                        h = '00';
-                    }
 
                     const mi = parts.find(p => p.type === 'minute')?.value;
                     const s = parts.find(p => p.type === 'second')?.value;


### PR DESCRIPTION
This PR updates `Intl.DateTimeFormat` configuration in `tools/process-calendars.js` to use `hourCycle: 'h23'` instead of `hour12: false`.

Node 24 (and modern V8) handles `hour12: false` differently depending on locale, occasionally outputting `24` for midnight. Changing this to `hourCycle: 'h23'` guarantees a strict 0-23 output.

Because of this, we can also remove the dirty `if (h === '24') { h = '00'; }` workaround previously used to fix the output on older Node versions. I verified this across Node 20 and Node 24 to ensure cross-compatibility in our processing script.

---
*PR created automatically by Jules for task [14770946493246315195](https://jules.google.com/task/14770946493246315195) started by @stanleyrya*