### PR TITLE
Add pre-serialization check logs to calendar processing

### DIFF
--- a/data/calendars/nyc.json
+++ b/data/calendars/nyc.json
@@ -141,7 +141,7 @@
         "lng": -74.0097099
       },
       "startDate": "2025-07-05T22:00:00",
-      "endDate": "2025-07-06T04:00:00",
+      "endDate": "2025-07-05T04:00:00",
       "unprocessedDescription": "Tea: Go-Go Bears, Cubs and LOTS of other fun things to grab on\rto!\nCover: $10\nWebsite: https://www.theurbanbear.com/\nInstagram: https://www.instagram.com/urbanbearnyc\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nBar: Rockbar\nShorter: BNO",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
@@ -266,7 +266,7 @@
         "lng": -74.0097099
       },
       "startDate": "2025-07-04T22:00:00",
-      "endDate": "2025-07-05T04:00:00",
+      "endDate": "2025-07-04T04:00:00",
       "unprocessedDescription": "Tea: Jockstraps encouraged, clothes check available!\nCover: $\r10 entry, $1 clothes check\nInstagram: https://www.instagram.com/rockbarny\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nNickname: Rock-strap\nBar: Rockbar\nShorter: RBR",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
@@ -446,7 +446,7 @@
         "lng": -74.00431317114098
       },
       "startDate": "2025-07-06T17:00:00",
-      "endDate": "2025-07-07T04:00:00",
+      "endDate": "2025-07-06T04:00:00",
       "unprocessedDescription": "Name: Beer Blast\nBar: Eagle NYC \nCover: No cover till 9PM, $\r20 cover at 9PM\nWebsite: https://eagle-ny.com\nGoogle Maps: https://maps.app.goo.gl/8N8zpGGAYwXJjgsGA\nNickname: Eagle\nShorter: EGL",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",

--- a/data/calendars/nyc.json
+++ b/data/calendars/nyc.json
@@ -141,7 +141,7 @@
         "lng": -74.0097099
       },
       "startDate": "2025-07-05T22:00:00",
-      "endDate": "2025-07-05T04:00:00",
+      "endDate": "2025-07-06T04:00:00",
       "unprocessedDescription": "Tea: Go-Go Bears, Cubs and LOTS of other fun things to grab on\rto!\nCover: $10\nWebsite: https://www.theurbanbear.com/\nInstagram: https://www.instagram.com/urbanbearnyc\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nBar: Rockbar\nShorter: BNO",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
@@ -266,7 +266,7 @@
         "lng": -74.0097099
       },
       "startDate": "2025-07-04T22:00:00",
-      "endDate": "2025-07-04T04:00:00",
+      "endDate": "2025-07-05T04:00:00",
       "unprocessedDescription": "Tea: Jockstraps encouraged, clothes check available!\nCover: $\r10 entry, $1 clothes check\nInstagram: https://www.instagram.com/rockbarny\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nNickname: Rock-strap\nBar: Rockbar\nShorter: RBR",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
@@ -446,7 +446,7 @@
         "lng": -74.00431317114098
       },
       "startDate": "2025-07-06T17:00:00",
-      "endDate": "2025-07-06T04:00:00",
+      "endDate": "2025-07-07T04:00:00",
       "unprocessedDescription": "Name: Beer Blast\nBar: Eagle NYC \nCover: No cover till 9PM, $\r20 cover at 9PM\nWebsite: https://eagle-ny.com\nGoogle Maps: https://maps.app.goo.gl/8N8zpGGAYwXJjgsGA\nNickname: Eagle\nShorter: EGL",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",

--- a/tools/process-calendars.js
+++ b/tools/process-calendars.js
@@ -77,6 +77,15 @@ async function processCalendars() {
             const events = cityCalendar.parseICalData(icalText) || [];
             console.log(`[${cityKey}] Finished ICS parsing. Found ${events.length} events.`);
 
+            // Log raw parsed events before serialization specifically to check if they shifted
+            for (let i = 0; i < Math.min(5, events.length); i++) {
+                const e = events[i];
+                console.log(`\n[Pre-Serialization Check] Event: ${e.name}`);
+                console.log(`  Raw startDate: ${e.startDate ? e.startDate.toISOString() : null}`);
+                console.log(`  Raw endDate:   ${e.endDate ? e.endDate.toISOString() : null}`);
+                if (e.recurrence) console.log(`  Recurrence: ${e.recurrence}`);
+            }
+
             // Also store calendar metadata in the JSON if available
             const output = {
                 metadata: {
@@ -110,11 +119,17 @@ async function processCalendars() {
                     const d = parts.find(p => p.type === 'day')?.value;
                     let h = parts.find(p => p.type === 'hour')?.value;
 
+                    console.log(`[DateReplacer - ${key || 'root'}] Extracted components -> Year: ${y}, Month: ${mo}, Day: ${d}, Hour: ${h}`);
+
                     const mi = parts.find(p => p.type === 'minute')?.value;
                     const s = parts.find(p => p.type === 'second')?.value;
 
                     const finalString = `${y}-${mo}-${d}T${h}:${mi}:${s}`;
                     console.log(`[DateReplacer - ${key || 'root'}] Final serialized string: ${finalString}`);
+
+                    // Validate string isn't shifting unexpectedly due to Node bug or format
+                    console.log(`[DateReplacer - ${key || 'root'}] Final components mapping check -> ${finalString} matches extracted: ${y}-${mo}-${d}`);
+
                     return finalString;
                 }
                 return value;

--- a/tools/process-calendars.js
+++ b/tools/process-calendars.js
@@ -78,9 +78,9 @@ async function processCalendars() {
             console.log(`[${cityKey}] Finished ICS parsing. Found ${events.length} events.`);
 
             // Log raw parsed events before serialization specifically to check if they shifted
-            for (let i = 0; i < Math.min(5, events.length); i++) {
+            for (let i = 0; i < events.length; i++) {
                 const e = events[i];
-                console.log(`\n[Pre-Serialization Check] Event: ${e.name}`);
+                console.log(`\n[Pre-Serialization Check] Event: ${e.name} (UID: ${e.uid})`);
                 console.log(`  Raw startDate: ${e.startDate ? e.startDate.toISOString() : null}`);
                 console.log(`  Raw endDate:   ${e.endDate ? e.endDate.toISOString() : null}`);
                 if (e.recurrence) console.log(`  Recurrence: ${e.recurrence}`);
@@ -100,10 +100,11 @@ async function processCalendars() {
                 if (this[key] instanceof Date) {
                     const date = this[key];
                     const calendarTimezone = cityCalendar.calendarTimezone || "America/New_York";
+                    const eventIdentifier = this.name || this.uid || 'Unknown Event';
 
-                    console.log(`\n[DateReplacer - ${key || 'root'}] Original Date object (ISO): ${date.toISOString()}`);
-                    console.log(`[DateReplacer - ${key || 'root'}] Original Date object (Local): ${date.toString()}`);
-                    console.log(`[DateReplacer - ${key || 'root'}] Intended target timezone: ${calendarTimezone}`);
+                    console.log(`\n[DateReplacer - ${key || 'root'} for Event: ${eventIdentifier}] Original Date object (ISO): ${date.toISOString()}`);
+                    console.log(`[DateReplacer - ${key || 'root'} for Event: ${eventIdentifier}] Original Date object (Local): ${date.toString()}`);
+                    console.log(`[DateReplacer - ${key || 'root'} for Event: ${eventIdentifier}] Intended target timezone: ${calendarTimezone}`);
 
                     const formatter = new Intl.DateTimeFormat('en-CA', {
                         timeZone: calendarTimezone,
@@ -112,23 +113,23 @@ async function processCalendars() {
                         hourCycle: 'h23'
                     });
                     const parts = formatter.formatToParts(date);
-                    console.log(`[DateReplacer - ${key || 'root'}] Formatter parts:`, JSON.stringify(parts));
+                    console.log(`[DateReplacer - ${key || 'root'} for Event: ${eventIdentifier}] Formatter parts:`, JSON.stringify(parts));
 
                     const y = parts.find(p => p.type === 'year')?.value;
                     const mo = parts.find(p => p.type === 'month')?.value;
                     const d = parts.find(p => p.type === 'day')?.value;
                     let h = parts.find(p => p.type === 'hour')?.value;
 
-                    console.log(`[DateReplacer - ${key || 'root'}] Extracted components -> Year: ${y}, Month: ${mo}, Day: ${d}, Hour: ${h}`);
+                    console.log(`[DateReplacer - ${key || 'root'} for Event: ${eventIdentifier}] Extracted components -> Year: ${y}, Month: ${mo}, Day: ${d}, Hour: ${h}`);
 
                     const mi = parts.find(p => p.type === 'minute')?.value;
                     const s = parts.find(p => p.type === 'second')?.value;
 
                     const finalString = `${y}-${mo}-${d}T${h}:${mi}:${s}`;
-                    console.log(`[DateReplacer - ${key || 'root'}] Final serialized string: ${finalString}`);
+                    console.log(`[DateReplacer - ${key || 'root'} for Event: ${eventIdentifier}] Final serialized string: ${finalString}`);
 
                     // Validate string isn't shifting unexpectedly due to Node bug or format
-                    console.log(`[DateReplacer - ${key || 'root'}] Final components mapping check -> ${finalString} matches extracted: ${y}-${mo}-${d}`);
+                    console.log(`[DateReplacer - ${key || 'root'} for Event: ${eventIdentifier}] Final components mapping check -> ${finalString} matches extracted: ${y}-${mo}-${d}`);
 
                     return finalString;
                 }


### PR DESCRIPTION
Adding raw un-serialized Date logging for ICS events directly after parsing. This gives us visibility into whether the end date shift is happening during parsing (i.e. `calendarCore.getLogicalEndDate()`) or during the final `JSON.stringify` serialization steps, responding to the user's request for additional logs.

---
*PR created automatically by Jules for task [8081163659262628899](https://jules.google.com/task/8081163659262628899) started by @stanleyrya*