### PR TITLE
Fix ICS end date parsing timezone offset for midnight events

### DIFF
--- a/data/calendars/nyc.json
+++ b/data/calendars/nyc.json
@@ -141,7 +141,7 @@
         "lng": -74.0097099
       },
       "startDate": "2025-07-05T22:00:00",
-      "endDate": "2025-07-05T04:00:00",
+      "endDate": "2025-07-06T04:00:00",
       "unprocessedDescription": "Tea: Go-Go Bears, Cubs and LOTS of other fun things to grab on\rto!\nCover: $10\nWebsite: https://www.theurbanbear.com/\nInstagram: https://www.instagram.com/urbanbearnyc\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nBar: Rockbar\nShorter: BNO",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
@@ -266,7 +266,7 @@
         "lng": -74.0097099
       },
       "startDate": "2025-07-04T22:00:00",
-      "endDate": "2025-07-04T04:00:00",
+      "endDate": "2025-07-05T04:00:00",
       "unprocessedDescription": "Tea: Jockstraps encouraged, clothes check available!\nCover: $\r10 entry, $1 clothes check\nInstagram: https://www.instagram.com/rockbarny\nGoogle Maps: https://maps.app.goo.gl/3WsBUpQjekPZUW4u7\nNickname: Rock-strap\nBar: Rockbar\nShorter: RBR",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
@@ -446,7 +446,7 @@
         "lng": -74.00431317114098
       },
       "startDate": "2025-07-06T17:00:00",
-      "endDate": "2025-07-06T04:00:00",
+      "endDate": "2025-07-07T04:00:00",
       "unprocessedDescription": "Name: Beer Blast\nBar: Eagle NYC \nCover: No cover till 9PM, $\r20 cover at 9PM\nWebsite: https://eagle-ny.com\nGoogle Maps: https://maps.app.goo.gl/8N8zpGGAYwXJjgsGA\nNickname: Eagle\nShorter: EGL",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",

--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -1230,7 +1230,7 @@ class CalendarCore {
                                 hour: '2-digit',
                                 minute: '2-digit',
                                 second: '2-digit',
-                                hour12: false
+                                hourCycle: 'h23'
                             });
                             const tzParts = tzFormatter.formatToParts(provisionalUTC);
                             const tzY = parseInt(tzParts.find(p => p.type === 'year')?.value);
@@ -1290,7 +1290,7 @@ class CalendarCore {
                                 hour: '2-digit',
                                 minute: '2-digit',
                                 second: '2-digit',
-                                hour12: false
+                                hourCycle: 'h23'
                             });
                             const cityParts = cityFormatter.formatToParts(date);
                             const localYear = parseInt(cityParts.find(p => p.type === 'year')?.value);

--- a/test_ics_tz.js
+++ b/test_ics_tz.js
@@ -1,0 +1,66 @@
+process.env.TZ = "America/New_York";
+global.logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: console.error,
+    componentInit: () => {},
+    componentLoad: () => {},
+    componentError: () => {},
+    time: () => {},
+    timeEnd: () => {},
+    apiCall: () => {},
+    performance: () => {}
+};
+
+const evSch = require('./js/event-schema.js');
+global.EventSchema = evSch.EventSchema;
+const CalendarCore = require('./js/calendar-core.js');
+
+const icalText = `BEGIN:VCALENDAR
+VERSION:2.0
+X-WR-CALNAME:NYC Calendar
+X-WR-TIMEZONE:America/New_York
+BEGIN:VTIMEZONE
+TZID:America/New_York
+X-LIC-LOCATION:America/New_York
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+TZNAME:EDT
+DTSTART:19700308T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+TZNAME:EST
+DTSTART:19701101T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20250704T220000
+DTEND;TZID=America/New_York:20250705T040000
+RRULE:FREQ=MONTHLY;BYDAY=1FR
+DTSTAMP:20260617T184850Z
+UID:bdstnukmpv6keg7pon3fram2qg@google.com
+CREATED:20250719T041643Z
+DESCRIPTION:Tea
+LAST-MODIFIED:20250723T045823Z
+LOCATION:40.7326824, -74.0097099
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Rockstrap
+TRANSP:OPAQUE
+END:VEVENT
+END:VCALENDAR`;
+
+const cityCalendar = new CalendarCore();
+const events = cityCalendar.parseICalData(icalText) || [];
+for (let i = 0; i < events.length; i++) {
+    const e = events[i];
+    console.log(`[Test Result] Event: ${e.name}`);
+    console.log(`  Start: ${e.startDate ? e.startDate.toISOString() : null}`);
+    console.log(`  End:   ${e.endDate ? e.endDate.toISOString() : null}`);
+}


### PR DESCRIPTION
This change addresses an issue where the `endDate` of events spanning midnight were incorrectly pushed backward by exactly 24 hours during ICS-to-JSON parsing. The root cause was that `Intl.DateTimeFormat` configured with `hour12: false` in `en-CA` locale formats midnight as `24:xx` (h24) instead of `00:xx` in newer Node.js versions. This caused `new Date(..., 24, ...)` to wrap to the next day when calculating the `provisionalUTC` difference, incorrectly subtracting 20 hours instead of adding 4. Changing `hour12: false` to `hourCycle: 'h23'` guarantees a 00-23 format and correct UTC offsets.

---
*PR created automatically by Jules for task [17259708309213915527](https://jules.google.com/task/17259708309213915527) started by @stanleyrya*