### PR TITLE
Fix non-deterministic ICS parsing in GitHub Actions causing false changes

### DIFF
--- a/.github/workflows/update-calendar-data.yml
+++ b/.github/workflows/update-calendar-data.yml
@@ -60,15 +60,12 @@ jobs:
               // Remove empty lines created by removing timestamps
               .replace(/\n\n+/g, '\n');
             
-            // Sort VEVENT blocks by UID so reordering doesn't count as a change
+            // Sort VEVENT blocks by their string content rather than just UID,
+            // because multiple events can have the same UID (e.g. recurrence overrides)
             const veventRegex = /BEGIN:VEVENT[\s\S]*?END:VEVENT/g;
             const vevents = normalized.match(veventRegex) || [];
             if (vevents.length > 0) {
-              vevents.sort((a, b) => {
-                const uidA = (a.match(/^UID:(.*)$/m) || ['', ''])[1].trim();
-                const uidB = (b.match(/^UID:(.*)$/m) || ['', ''])[1].trim();
-                return uidA.localeCompare(uidB);
-              });
+              vevents.sort((a, b) => a.localeCompare(b));
               let eventIndex = 0;
               normalized = normalized.replace(veventRegex, () => vevents[eventIndex++]);
             }


### PR DESCRIPTION
Update `normalizeICalData` in `update-calendar-data.yml` to sort `VEVENT` blocks using full string comparison (`localeCompare`) instead of extracting the `UID`. Google Calendar often exports recurring event overrides with the exact same `UID`, causing non-deterministic sorting if the fetch returns them in a different order. Comparing the full block content ensures stable, deterministic diffs and prevents unnecessary compute runs.

---
*PR created automatically by Jules for task [9436036126227070380](https://jules.google.com/task/9436036126227070380) started by @stanleyrya*