### PR TITLE
Fix merge conflicts caused by dynamic timestamps in data generation

### DIFF
--- a/.github/workflows/update-calendar-data.yml
+++ b/.github/workflows/update-calendar-data.yml
@@ -180,7 +180,7 @@ jobs:
               }
               
               const summary = {
-                lastUpdated: new Date().toISOString(),
+
                 cities: {}
               };
               
@@ -193,7 +193,7 @@ jobs:
                     name: result.config.name,
                     status: 'error',
                     error: result.error,
-                    lastUpdated: new Date().toISOString()
+
                   };
                   errorCount++;
                 } else {
@@ -202,12 +202,19 @@ jobs:
                     status: 'success',
                     dataLength: result.icalData.length,
                     eventCount: (result.icalData.match(/BEGIN:VEVENT/g) || []).length,
-                    lastUpdated: new Date().toISOString()
+
                   };
                   successCount++;
                 }
               });
               
+              // Sort cities alphabetically
+              const sortedCities = Object.keys(summary.cities).sort().reduce((acc, key) => {
+                acc[key] = summary.cities[key];
+                return acc;
+              }, {});
+              summary.cities = sortedCities;
+
               // Save summary
               fs.writeFileSync('data/calendars/update-summary.json', JSON.stringify(summary, null, 2));
               

--- a/data/calendars/seattle.ics
+++ b/data/calendars/seattle.ics
@@ -42,122 +42,9 @@ RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
 END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
-DTSTART:20260201T050000Z
-DTEND:20260201T110000Z
-DTSTAMP:20260623T212530Z
-UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
-CREATED:20260123T030739Z
-DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
- s by MATT STANDS &amp\; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine\, Sea
- ttle\, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com
- /events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025
- /12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/69805544976
- 5272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-bee
- f-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: http
- s://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search
- /?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey
- : bearracuda-2026-02-01-seattle
-LAST-MODIFIED:20260126T235314Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
-TRANSP:OPAQUE
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/New_York:20250706T140000
-DTEND;TZID=America/New_York:20250706T190000
-RRULE:FREQ=WEEKLY;BYDAY=SU
-DTSTAMP:20260623T212530Z
-UID:6irujvg3effpkdu42krgr91osj@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
- ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
- rtName: South Seattle Social
-LAST-MODIFIED:20260507T001639Z
-LOCATION:47.51652271569908\, -122.35487284211817
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:South Seattle Bear Social
-TRANSP:OPAQUE
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20251122T050000Z
-DTEND:20251122T110000Z
-DTSTAMP:20260623T212530Z
-UID:3D70DFD0-9501-434E-A015-10F01A25DA09
-CREATED:20250930T014035Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
- tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
- ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
- 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
- sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
- a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
- ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
- reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
- -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
- oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
- =101730401\nkey: bearracuda-2025-11-22-seattle
-LAST-MODIFIED:20251001T225002Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle: Wish BONED!
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART;TZID=America/Los_Angeles:20250717T190000
-DTEND;TZID=America/Los_Angeles:20250718T020000
-RRULE:FREQ=MONTHLY;BYDAY=3TH
-DTSTAMP:20260623T212530Z
-UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
-CREATED:20250712T180301Z
-DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
- DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
- <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
- IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
- ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
- /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
- a>
-LAST-MODIFIED:20250719T040329Z
-LOCATION:47.61337340244105\, -122.31441768029491
-SEQUENCE:1
-STATUS:CONFIRMED
-SUMMARY:Leather Night
-TRANSP:OPAQUE
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20250927T040000Z
-DTEND:20250927T100000Z
-DTSTAMP:20260623T212530Z
-UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
-CREATED:20250825T034004Z
-DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
- u to choose your own ADVENTURE! Now our guys can grab a wristband when you 
- walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp\; TIGERBE
- ATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: Amer
- ica/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover
- : $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/up
- loads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/even
- ts/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail
- -seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https:/
- /www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?a
- pi=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearrac
- uda-2025-09-27-seattle
-LAST-MODIFIED:20250920T210916Z
-SEQUENCE:1
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail: SEATTLE
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-END:VEVENT
-BEGIN:VEVENT
 DTSTART:20260614T040000Z
 DTEND:20260614T100000Z
-DTSTAMP:20260623T212530Z
+DTSTAMP:20260624T031825Z
 UID:762BAD4A-F1D8-4519-BAC3-D755EF9BA263
 CREATED:20260514T005858Z
 DESCRIPTION:description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. 
@@ -186,57 +73,9 @@ X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
 X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
 END:VEVENT
 BEGIN:VEVENT
-DTSTART:20260308T050000Z
-DTEND:20260308T100000Z
-DTSTAMP:20260623T212530Z
-UID:3DCE764F-EC21-459C-8791-745DE1731298
-CREATED:20260123T030754Z
-DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
- TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
- A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
- seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
- 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
- : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
- 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
- earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
- C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
- -seattle
-LAST-MODIFIED:20260126T235324Z
-LOCATION:47.6150572\, -122.3236574
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle:TRAIL HEAD
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
-DTSTART:20260509T040000Z
-DTEND:20260509T100000Z
-DTSTAMP:20260623T212530Z
-UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
-CREATED:20260507T001637Z
-DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
- • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
- e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
- da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
- com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
- uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
- ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
-  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
- ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
-LAST-MODIFIED:20260507T001638Z
-SEQUENCE:0
-STATUS:CONFIRMED
-SUMMARY:Treasure Trail Seattle
-TRANSP:OPAQUE
-X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
-X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
-END:VEVENT
-BEGIN:VEVENT
 DTSTART;TZID=America/New_York:20260614T000000
 DTEND;TZID=America/New_York:20260614T060000
-DTSTAMP:20260623T212530Z
+DTSTAMP:20260624T031825Z
 UID:6irujvg3effpkdu42krgr91osj@google.com
 RECURRENCE-ID;TZID=America/New_York:20260614T140000
 CREATED:20250712T180301Z
@@ -262,9 +101,59 @@ TRIGGER;VALUE=DATE-TIME:19760401T005545Z
 END:VALARM
 END:VEVENT
 BEGIN:VEVENT
+DTSTART:20260201T050000Z
+DTEND:20260201T110000Z
+DTSTAMP:20260624T031825Z
+UID:33B9EEB8-F6D3-4068-9A20-64B8DE33B103
+CREATED:20260123T030739Z
+DESCRIPTION:description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat
+ s by MATT STANDS &amp\; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine\, Sea
+ ttle\, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com
+ /events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025
+ /12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/69805544976
+ 5272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-bee
+ f-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: http
+ s://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search
+ /?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey
+ : bearracuda-2026-02-01-seattle
+LAST-MODIFIED:20260126T235314Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Bearracuda Seattle Winter Beef Ball 2026!
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260308T050000Z
+DTEND:20260308T100000Z
+DTSTAMP:20260624T031825Z
+UID:3DCE764F-EC21-459C-8791-745DE1731298
+CREATED:20260123T030754Z
+DESCRIPTION:description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA
+ TT STANDS &amp\; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, W
+ A 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/
+ seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-
+ 4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl
+ : https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-198
+ 0435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/b
+ earracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2
+ C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08
+ -seattle
+LAST-MODIFIED:20260126T235324Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle:TRAIL HEAD
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
 DTSTART:20251011T040000Z
 DTEND:20251011T100000Z
-DTSTAMP:20260623T212530Z
+DTSTAMP:20260624T031825Z
 UID:9DF93D82-1411-44C0-BE63-00037416BB38
 CREATED:20250817T231654Z
 DESCRIPTION:description: SERIOUS WOOD Show off your boots\, plaid\, jeans\,
@@ -286,5 +175,118 @@ STATUS:CONFIRMED
 SUMMARY:Bearracuda Seattle: SERIOUS WOOD
 TRANSP:OPAQUE
 X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20260509T040000Z
+DTEND:20260509T100000Z
+DTSTAMP:20260624T031825Z
+UID:C2EDB500-501A-4F94-9060-3A0EEE8AC165
+CREATED:20260507T001637Z
+DESCRIPTION:description: Clothes check available\n\nMusic & Entertainment\n
+ • Beats by MATT STANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pin
+ e St\, Seattle\, WA\ntimezone: America/Los_Angeles\nimage: https://bearracu
+ da.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.
+ com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearrac
+ uda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: h
+ ttps://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps:
+  https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pi
+ ne%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle
+LAST-MODIFIED:20260507T001638Z
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20251122T050000Z
+DTEND:20251122T110000Z
+DTSTAMP:20260624T031825Z
+UID:3D70DFD0-9501-434E-A015-10F01A25DA09
+CREATED:20250930T014035Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to GET STUFFED at our Pre-Thanksgiving Romp! Now our guys can grab a wris
+ tband when you walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by MATT ST
+ ANDS &amp\; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98
+ 122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/trea
+ sureseattle/\ncover: $15.65 - $30.54 (as of 10/1)\nimage: https://bearracud
+ a.com/wp-content/uploads/2025/04/treasurenov.jpg\nfacebook: https://www.fac
+ ebook.com/events/784739777742843\nticketUrl: https://www.eventbrite.com/e/t
+ reasure-trail-seattle-wish-boned-tickets-1754983576119\nshortName: Bear-rac
+ -uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.g
+ oogle.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id
+ =101730401\nkey: bearracuda-2025-11-22-seattle
+LAST-MODIFIED:20251001T225002Z
+LOCATION:47.6150572\, -122.3236574
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail Seattle: Wish BONED!
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+X-APPLE-CREATOR-TEAM-IDENTITY:8NQFWJHC63
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/Los_Angeles:20250717T190000
+DTEND;TZID=America/Los_Angeles:20250718T020000
+RRULE:FREQ=MONTHLY;BYDAY=3TH
+DTSTAMP:20260624T031825Z
+UID:1dl55f6fm4qqv42go7r3nj5st9@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Bar: Diesel<br>Google Maps: <a href="https://maps.app.goo.gl/yD
+ DhdkV7M7p2mYEP7">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: 
+ <a href="https://dieselseattle.com/DIESEL.html">https://dieselseattle.com/D
+ IESEL.html</a><br>Facebook: <a href="https://www.facebook.com/DieselSeattle
+ ">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href="https:/
+ /www.instagram.com/dieselseattle">https://www.instagram.com/dieselseattle</
+ a>
+LAST-MODIFIED:20250719T040329Z
+LOCATION:47.61337340244105\, -122.31441768029491
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:Leather Night
+TRANSP:OPAQUE
+END:VEVENT
+BEGIN:VEVENT
+DTSTART:20250927T040000Z
+DTEND:20250927T100000Z
+DTSTAMP:20260624T031825Z
+UID:19A871C3-E891-4C93-BF2E-A0234C04BF1E
+CREATED:20250825T034004Z
+DESCRIPTION:description: Treasure Trail returns to Seattle and we invite yo
+ u to choose your own ADVENTURE! Now our guys can grab a wristband when you 
+ walk in\\:\n\nMusic & Entertainment\n• Hard Tunes by BIG SIR &amp\; TIGERBE
+ ATZ\nbar: MASSIVE\naddress: 619 E Pine\, Seattle\, WA 98122\ntimezone: Amer
+ ica/Los_Angeles\nurl: https://bearracuda.com/events/treasureseattle/\ncover
+ : $15.65 - $30.54 (as of 9/20)\nimage: https://bearracuda.com/wp-content/up
+ loads/2025/04/treasuretrailweb.jpg\nfacebook: https://www.facebook.com/even
+ ts/1113055394051303\nticketUrl: https://www.eventbrite.com/e/treasure-trail
+ -seattle-tickets-1497840042889\nshortName: Bear-rac-uda\ninstagram: https:/
+ /www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?a
+ pi=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearrac
+ uda-2025-09-27-seattle
+LAST-MODIFIED:20250920T210916Z
+SEQUENCE:1
+STATUS:CONFIRMED
+SUMMARY:Treasure Trail: SEATTLE
+TRANSP:OPAQUE
+X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;TZID=America/New_York:20250706T140000
+DTEND;TZID=America/New_York:20250706T190000
+RRULE:FREQ=WEEKLY;BYDAY=SU
+DTSTAMP:20260624T031825Z
+UID:6irujvg3effpkdu42krgr91osj@google.com
+CREATED:20250712T180301Z
+DESCRIPTION:Instagram: https://www.instagram.com/southseattlebearsocial/\nB
+ ar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nSho
+ rtName: South Seattle Social
+LAST-MODIFIED:20260507T001639Z
+LOCATION:47.51652271569908\, -122.35487284211817
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:South Seattle Bear Social
+TRANSP:OPAQUE
 END:VEVENT
 END:VCALENDAR

--- a/data/calendars/seattle.json
+++ b/data/calendars/seattle.json
@@ -22,101 +22,351 @@
   },
   "events": [
     {
-      "name": "Bearracuda Seattle Winter Beef Ball 2026!",
+      "name": "Bearracuda Seattle GLOW PARTY",
       "day": "Saturday",
       "time": "9PM-3AM",
       "eventType": "routine",
       "recurring": false,
-      "coordinates": {
-        "lat": 47.61337340244105,
-        "lng": -122.31441768029491
-      },
-      "startDate": "2025-07-17T19:00:00",
-      "endDate": "2025-07-18T02:00:00",
-      "unprocessedDescription": "Bar: Diesel<br>Google Maps: <a href=\"https://maps.app.goo.gl/yD\rDhdkV7M7p2mYEP7\">https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7</a><br>Website: <a href=\"https://dieselseattle.com/DIESEL.html\">https://dieselseattle.com/DIESEL.html</a><br>Facebook: <a href=\"https://www.facebook.com/DieselSeattle\">https://www.facebook.com/DieselSeattle</a><br>Instagram: <a href=\"https://www.instagram.com/dieselseattle\">https://www.instagram.com/dieselseattle</a>",
-      "startTimezone": "America/Los_Angeles",
-      "endTimezone": "America/Los_Angeles",
+      "recurrence": null,
+      "startDate": "2026-06-13T21:00:00",
+      "endDate": "2026-06-14T03:00:00",
+      "unprocessedDescription": "description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. \rPine SATURDAY, June 13th Doors at 9pm, Party til 3am! Hot Go-Go&rsquo;s, Chunky Visuals Decor by James Sharinghousen, Photos by Matt Hoffman, Hosted by Matt Bearracuda DJs Matt Stands DISCOUNTED tix for those in UV/Neon Attire Our GLOW PARTY is coming to Seattle! We are offering DEEPLY discounted tickets for those wearing UV Reactive or Neon Attire. Bearracuda resident DJ, Matt Stands spins all night with Hot GoGos, Decor by James Sharinghousen…\nbar: MASSIVE\naddress: 619 E. Pine\nticketUrl: https://www.sickening.events/e/bearracuda-seattle-glow/tickets\ninstagram: https://www.instagram.com/bearracuda\nimage: https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1776554715/saas/logos/image_1776554705644_n8exy3gc9.webp\ncover: DISCOUNTED tix for those in UV/Neon Attire\nshortName: South Seattle Social\nwebsite: https://bearracuda.com/events/seattle-glow/\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine\nkey: bearracuda-2026-06-14-seattle\ntimezone: America/Los_Angeles\noverrideUid: 6irujvg3effpkdu42krgr91osj@google.com\noverrideRecurrenceId: 20260614T180000Z",
+      "startTimezone": null,
+      "endTimezone": null,
       "calendarTimezone": "America/Los_Angeles",
-      "wasUTC": false,
-      "sourceUid": "1dl55f6fm4qqv42go7r3nj5st9@google.com",
-      "uid": "1dl55f6fm4qqv42go7r3nj5st9@google.com",
-      "recurrenceId": null,
+      "wasUTC": true,
+      "sourceUid": "762BAD4A-F1D8-4519-BAC3-D755EF9BA263",
+      "uid": "6irujvg3effpkdu42krgr91osj@google.com",
+      "recurrenceId": "2026-06-14T11:00:00",
       "recurrenceIdTimezone": null,
-      "sequence": 1,
-      "overrideIdentityType": null,
-      "bar": "Diesel",
-      "address": null,
-      "website": "https://dieselseattle.com/DIESEL.html",
-      "instagram": "https://www.instagram.com/dieselseattle",
-      "facebook": "https://www.facebook.com/DieselSeattle",
-      "gmaps": "https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7",
+      "sequence": 0,
+      "overrideIdentityType": "custom",
+      "bar": "MASSIVE",
+      "cover": "DISCOUNTED tix for those in UV/Neon Attire",
+      "image": "https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1776554715/saas/logos/image_1776554705644_n8exy3gc9.webp",
+      "tea": "Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. Pine SATURDAY, June 13th Doors at 9pm, Party til 3am! Hot Go-Go&rsquo;s, Chunky Visuals Decor by James Sharinghousen, Photos by Matt Hoffman, Hosted by Matt Bearracuda DJs Matt Stands DISCOUNTED tix for those in UV/Neon Attire Our GLOW PARTY is coming to Seattle! We are offering DEEPLY discounted tickets for those wearing UV Reactive or Neon Attire. Bearracuda resident DJ, Matt Stands spins all night with Hot GoGos, Decor by James Sharinghousen…",
+      "address": "619 E. Pine",
+      "website": "https://bearracuda.com/events/seattle-glow/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine",
+      "ticketUrl": "https://www.sickening.events/e/bearracuda-seattle-glow/tickets",
+      "shortName": "South Seattle Social",
       "links": [
         {
           "type": "website",
-          "url": "https://dieselseattle.com/DIESEL.html",
+          "url": "https://bearracuda.com/events/seattle-glow/",
           "label": "🌐 Website"
         },
         {
           "type": "instagram",
-          "url": "https://www.instagram.com/dieselseattle",
+          "url": "https://www.instagram.com/bearracuda",
           "label": "📷 Instagram"
         },
         {
-          "type": "facebook",
-          "url": "https://www.facebook.com/DieselSeattle",
-          "label": "📘 Facebook"
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine",
+          "label": "🗺️ Google Maps"
         },
         {
-          "type": "gmaps",
-          "url": "https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7",
-          "label": "🗺️ Google Maps"
+          "type": "tickets",
+          "url": "https://www.sickening.events/e/bearracuda-seattle-glow/tickets",
+          "label": "🎫 Tickets"
         }
       ],
-      "slug": "leather-night-51e2ca8d"
+      "slug": "bearracuda-seattle-glow-party-43d1597b"
     },
     {
-      "name": "South Seattle Bear Social",
-      "day": "Sunday",
-      "time": "11AM-4PM",
-      "eventType": "weekly",
-      "recurring": true,
-      "recurrence": "FREQ=WEEKLY;BYDAY=SU",
-      "coordinates": {
-        "lat": 47.51652271569908,
-        "lng": -122.35487284211817
-      },
-      "startDate": "2025-07-06T11:00:00",
-      "endDate": "2025-07-06T16:00:00",
-      "unprocessedDescription": "Instagram: https://www.instagram.com/southseattlebearsocial/\nB\rar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nShortName: South Seattle Social",
+      "name": "Seattle GLOW",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-06-13T21:00:00",
+      "endDate": "2026-06-14T03:00:00",
+      "unprocessedDescription": "description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 \ram\nbar: MASSIVE\naddress: 619 E. Pine St, Seattle, WA\ntimezone: America/Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda-seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow\nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-seattle",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
       "calendarTimezone": "America/Los_Angeles",
       "wasUTC": false,
       "sourceUid": "6irujvg3effpkdu42krgr91osj@google.com",
       "uid": "6irujvg3effpkdu42krgr91osj@google.com",
-      "recurrenceId": null,
-      "recurrenceIdTimezone": null,
+      "recurrenceId": "2026-06-14T11:00:00",
+      "recurrenceIdTimezone": "America/New_York",
       "sequence": 0,
-      "overrideIdentityType": null,
-      "bar": "Lumberyard",
-      "address": null,
+      "overrideIdentityType": "legacy",
+      "bar": "MASSIVE",
+      "image": "https://bearracuda.com/wp-content/uploads/2026/04/cuda-seattle-june2026-web-1.jpg",
+      "tea": "Doors Open at 9:00 pm - Party Goes Until 3:00 am",
+      "address": "619 E. Pine St, Seattle, WA",
       "website": null,
-      "instagram": "https://www.instagram.com/southseattlebearsocial/",
-      "gmaps": "https://maps.app.goo.gl/SDUbV4qsRpivNiX39",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1548258503329527",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
+      "ticketUrl": "https://sickening.events/e/bearracuda-seattle-glow",
       "shortName": "South Seattle Social",
       "links": [
         {
           "type": "instagram",
-          "url": "https://www.instagram.com/southseattlebearsocial/",
+          "url": "https://www.instagram.com/bearracuda",
           "label": "📷 Instagram"
         },
         {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1548258503329527",
+          "label": "📘 Facebook"
+        },
+        {
           "type": "gmaps",
-          "url": "https://maps.app.goo.gl/SDUbV4qsRpivNiX39",
+          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
           "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://sickening.events/e/bearracuda-seattle-glow",
+          "label": "🎫 Tickets"
         }
       ],
-      "slug": "south-seattle-bear-social-3b330fb1"
+      "slug": "seattle-glow-3b330fb1"
+    },
+    {
+      "name": "Bearracuda Seattle Winter Beef Ball 2026!",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 47.6150572,
+        "lng": -122.3236574
+      },
+      "startDate": "2026-01-31T21:00:00",
+      "endDate": "2026-02-01T03:00:00",
+      "unprocessedDescription": "description: WINTER BEEF BALL!\n\nMusic & Entertainment\n• Beat\rs by MATT STANDS &amp; FREDDY KOP\nbar: MASSIVE\naddress: 619 E Pine, Seattle, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/seattlebeef/\nimage: https://bearracuda.com/wp-content/uploads/2025/12/seattlejan26.jpg\nfacebook: https://www.facebook.com/events/698055449765272\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-winter-beef-ball-2026-tickets-1977102214947\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-02-01-seattle",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "33B9EEB8-F6D3-4068-9A20-64B8DE33B103",
+      "uid": "33B9EEB8-F6D3-4068-9A20-64B8DE33B103",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "MASSIVE",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/12/seattlejan26.jpg",
+      "tea": "WINTER BEEF BALL!",
+      "address": "619 E Pine, Seattle, WA 98122",
+      "website": "https://bearracuda.com/events/seattlebeef/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/698055449765272",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-seattle-winter-beef-ball-2026-tickets-1977102214947",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/seattlebeef/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/698055449765272",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-seattle-winter-beef-ball-2026-tickets-1977102214947",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-seattle-winter-beef-ball-2026-5d3a67cd"
+    },
+    {
+      "name": "Treasure Trail Seattle:TRAIL HEAD",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 47.6150572,
+        "lng": -122.3236574
+      },
+      "startDate": "2026-03-07T21:00:00",
+      "endDate": "2026-03-08T03:00:00",
+      "unprocessedDescription": "description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA\rTT STANDS &amp; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine, Seattle, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl: https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-1980435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08-seattle",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "3DCE764F-EC21-459C-8791-745DE1731298",
+      "uid": "3DCE764F-EC21-459C-8791-745DE1731298",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "MASSIVE",
+      "image": "https://bearracuda.com/wp-content/uploads/2026/01/11x17-4.jpg",
+      "tea": "TRAIL HEAD",
+      "address": "619 E Pine, Seattle, WA 98122",
+      "website": "https://bearracuda.com/events/seattlett/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/857466110421715",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
+      "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-1980435540012",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/seattlett/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/857466110421715",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-1980435540012",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-seattletrail-head-5f63386f"
+    },
+    {
+      "name": "Bearracuda Seattle: SERIOUS WOOD",
+      "day": "Friday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 47.6150572,
+        "lng": -122.3236574
+      },
+      "startDate": "2025-10-10T21:00:00",
+      "endDate": "2025-10-11T03:00:00",
+      "unprocessedDescription": "description: SERIOUS WOOD Show off your boots, plaid, jeans,\r nut huggers, flannel, suspenders, beanies & overalls! Hot Go-Go’s, Chunky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: MASSIVE\naddress: 619 E Pine, Seattle, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/serioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-tickets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearracuda-2025-10-11-seattle",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "9DF93D82-1411-44C0-BE63-00037416BB38",
+      "uid": "9DF93D82-1411-44C0-BE63-00037416BB38",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 2,
+      "overrideIdentityType": null,
+      "bar": "MASSIVE",
+      "cover": "$24.89 - $30.54 (as of 10/1)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/08/serioiusweb.jpg",
+      "tea": "SERIOUS WOOD Show off your boots, plaid, jeans, nut huggers, flannel, suspenders, beanies & overalls! Hot Go-Go’s, Chunky Visuals!",
+      "address": "619 E Pine, Seattle, WA 98122",
+      "website": "https://bearracuda.com/events/seattlewood/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1210500617554659",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-tickets-1565073299369?aff=oddtdtcreator",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/seattlewood/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1210500617554659",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-tickets-1565073299369?aff=oddtdtcreator",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-seattle-serious-wood-4a1720dd"
+    },
+    {
+      "name": "Treasure Trail Seattle",
+      "day": "Friday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-05-08T21:00:00",
+      "endDate": "2026-05-09T03:00:00",
+      "unprocessedDescription": "description: Clothes check available\n\nMusic & Entertainment\n\r• Beats by MATT STANDS &amp; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pine St, Seattle, WA\ntimezone: America/Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearracuda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "C2EDB500-501A-4F94-9060-3A0EEE8AC165",
+      "uid": "C2EDB500-501A-4F94-9060-3A0EEE8AC165",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "MASSIVE",
+      "image": "https://bearracuda.com/wp-content/uploads/2026/01/45-2.jpg",
+      "tea": "Clothes check available",
+      "address": "619 E. Pine St, Seattle, WA",
+      "website": null,
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1574328850293138/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
+      "ticketUrl": "https://sickening.events/e/bearracuda-treasure-trail-seattle-4/tickets",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1574328850293138/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://sickening.events/e/bearracuda-treasure-trail-seattle-4/tickets",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-seattle-7e9ae5d5"
     },
     {
       "name": "Treasure Trail Seattle: Wish BONED!",
@@ -295,289 +545,48 @@
       "slug": "treasure-trail-seattle-4a6fa455"
     },
     {
-      "name": "Bearracuda Seattle GLOW PARTY",
-      "day": "Saturday",
-      "time": "9PM-3AM",
-      "eventType": "routine",
-      "recurring": false,
-      "recurrence": null,
-      "startDate": "2026-06-13T21:00:00",
-      "endDate": "2026-06-14T03:00:00",
-      "unprocessedDescription": "description: Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. \rPine SATURDAY, June 13th Doors at 9pm, Party til 3am! Hot Go-Go&rsquo;s, Chunky Visuals Decor by James Sharinghousen, Photos by Matt Hoffman, Hosted by Matt Bearracuda DJs Matt Stands DISCOUNTED tix for those in UV/Neon Attire Our GLOW PARTY is coming to Seattle! We are offering DEEPLY discounted tickets for those wearing UV Reactive or Neon Attire. Bearracuda resident DJ, Matt Stands spins all night with Hot GoGos, Decor by James Sharinghousen…\nbar: MASSIVE\naddress: 619 E. Pine\nticketUrl: https://www.sickening.events/e/bearracuda-seattle-glow/tickets\ninstagram: https://www.instagram.com/bearracuda\nimage: https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1776554715/saas/logos/image_1776554705644_n8exy3gc9.webp\ncover: DISCOUNTED tix for those in UV/Neon Attire\nshortName: South Seattle Social\nwebsite: https://bearracuda.com/events/seattle-glow/\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine\nkey: bearracuda-2026-06-14-seattle\ntimezone: America/Los_Angeles\noverrideUid: 6irujvg3effpkdu42krgr91osj@google.com\noverrideRecurrenceId: 20260614T180000Z",
-      "startTimezone": null,
-      "endTimezone": null,
-      "calendarTimezone": "America/Los_Angeles",
-      "wasUTC": true,
-      "sourceUid": "762BAD4A-F1D8-4519-BAC3-D755EF9BA263",
-      "uid": "6irujvg3effpkdu42krgr91osj@google.com",
-      "recurrenceId": "2026-06-14T11:00:00",
-      "recurrenceIdTimezone": null,
-      "sequence": 0,
-      "overrideIdentityType": "custom",
-      "bar": "MASSIVE",
-      "cover": "DISCOUNTED tix for those in UV/Neon Attire",
-      "image": "https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1776554715/saas/logos/image_1776554705644_n8exy3gc9.webp",
-      "tea": "Bearracuda Seattle GLOW PARTY at MASSIVE - 619 E. Pine SATURDAY, June 13th Doors at 9pm, Party til 3am! Hot Go-Go&rsquo;s, Chunky Visuals Decor by James Sharinghousen, Photos by Matt Hoffman, Hosted by Matt Bearracuda DJs Matt Stands DISCOUNTED tix for those in UV/Neon Attire Our GLOW PARTY is coming to Seattle! We are offering DEEPLY discounted tickets for those wearing UV Reactive or Neon Attire. Bearracuda resident DJ, Matt Stands spins all night with Hot GoGos, Decor by James Sharinghousen…",
-      "address": "619 E. Pine",
-      "website": "https://bearracuda.com/events/seattle-glow/",
-      "instagram": "https://www.instagram.com/bearracuda",
-      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine",
-      "ticketUrl": "https://www.sickening.events/e/bearracuda-seattle-glow/tickets",
-      "shortName": "South Seattle Social",
-      "links": [
-        {
-          "type": "website",
-          "url": "https://bearracuda.com/events/seattle-glow/",
-          "label": "🌐 Website"
-        },
-        {
-          "type": "instagram",
-          "url": "https://www.instagram.com/bearracuda",
-          "label": "📷 Instagram"
-        },
-        {
-          "type": "gmaps",
-          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine",
-          "label": "🗺️ Google Maps"
-        },
-        {
-          "type": "tickets",
-          "url": "https://www.sickening.events/e/bearracuda-seattle-glow/tickets",
-          "label": "🎫 Tickets"
-        }
-      ],
-      "slug": "bearracuda-seattle-glow-party-43d1597b"
-    },
-    {
-      "name": "Treasure Trail Seattle:TRAIL HEAD",
-      "day": "Saturday",
-      "time": "9PM-3AM",
-      "eventType": "routine",
-      "recurring": false,
+      "name": "South Seattle Bear Social",
+      "day": "Sunday",
+      "time": "11AM-4PM",
+      "eventType": "weekly",
+      "recurring": true,
+      "recurrence": "FREQ=WEEKLY;BYDAY=SU",
       "coordinates": {
-        "lat": 47.6150572,
-        "lng": -122.3236574
+        "lat": 47.51652271569908,
+        "lng": -122.35487284211817
       },
-      "startDate": "2026-03-07T21:00:00",
-      "endDate": "2026-03-08T03:00:00",
-      "unprocessedDescription": "description: TRAIL HEAD\n\nMusic & Entertainment\n• Beats by MA\rTT STANDS &amp; DOBERMANN\nbar: MASSIVE\naddress: 619 E Pine, Seattle, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/seattlett/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/11x17-4.jpg\nfacebook: https://www.facebook.com/events/857466110421715\nticketUrl: https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-1980435540012\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122\nkey: bearracuda-2026-03-08-seattle",
-      "startTimezone": null,
-      "endTimezone": null,
-      "calendarTimezone": "America/Los_Angeles",
-      "wasUTC": true,
-      "sourceUid": "3DCE764F-EC21-459C-8791-745DE1731298",
-      "uid": "3DCE764F-EC21-459C-8791-745DE1731298",
-      "recurrenceId": null,
-      "recurrenceIdTimezone": null,
-      "sequence": 0,
-      "overrideIdentityType": null,
-      "bar": "MASSIVE",
-      "image": "https://bearracuda.com/wp-content/uploads/2026/01/11x17-4.jpg",
-      "tea": "TRAIL HEAD",
-      "address": "619 E Pine, Seattle, WA 98122",
-      "website": "https://bearracuda.com/events/seattlett/",
-      "instagram": "https://www.instagram.com/bearracuda",
-      "facebook": "https://www.facebook.com/events/857466110421715",
-      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
-      "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-1980435540012",
-      "shortName": "Bear-rac-uda",
-      "links": [
-        {
-          "type": "website",
-          "url": "https://bearracuda.com/events/seattlett/",
-          "label": "🌐 Website"
-        },
-        {
-          "type": "instagram",
-          "url": "https://www.instagram.com/bearracuda",
-          "label": "📷 Instagram"
-        },
-        {
-          "type": "facebook",
-          "url": "https://www.facebook.com/events/857466110421715",
-          "label": "📘 Facebook"
-        },
-        {
-          "type": "gmaps",
-          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
-          "label": "🗺️ Google Maps"
-        },
-        {
-          "type": "tickets",
-          "url": "https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-1980435540012",
-          "label": "🎫 Tickets"
-        }
-      ],
-      "slug": "treasure-trail-seattletrail-head-5f63386f"
-    },
-    {
-      "name": "Treasure Trail Seattle",
-      "day": "Friday",
-      "time": "9PM-3AM",
-      "eventType": "routine",
-      "recurring": false,
-      "startDate": "2026-05-08T21:00:00",
-      "endDate": "2026-05-09T03:00:00",
-      "unprocessedDescription": "description: Clothes check available\n\nMusic & Entertainment\n\r• Beats by MATT STANDS &amp; TIGERBEATZ\nbar: MASSIVE\naddress: 619 E. Pine St, Seattle, WA\ntimezone: America/Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/01/45-2.jpg\nfacebook: https://www.facebook.com/events/1574328850293138/\nticketUrl: https://sickening.events/e/bearracuda-treasure-trail-seattle-4/tickets\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\n_staticFields: [object Object]\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-05-09-seattle",
-      "startTimezone": null,
-      "endTimezone": null,
-      "calendarTimezone": "America/Los_Angeles",
-      "wasUTC": true,
-      "sourceUid": "C2EDB500-501A-4F94-9060-3A0EEE8AC165",
-      "uid": "C2EDB500-501A-4F94-9060-3A0EEE8AC165",
-      "recurrenceId": null,
-      "recurrenceIdTimezone": null,
-      "sequence": 0,
-      "overrideIdentityType": null,
-      "bar": "MASSIVE",
-      "image": "https://bearracuda.com/wp-content/uploads/2026/01/45-2.jpg",
-      "tea": "Clothes check available",
-      "address": "619 E. Pine St, Seattle, WA",
-      "website": null,
-      "instagram": "https://www.instagram.com/bearracuda",
-      "facebook": "https://www.facebook.com/events/1574328850293138/",
-      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
-      "ticketUrl": "https://sickening.events/e/bearracuda-treasure-trail-seattle-4/tickets",
-      "shortName": "Bear-rac-uda",
-      "links": [
-        {
-          "type": "instagram",
-          "url": "https://www.instagram.com/bearracuda",
-          "label": "📷 Instagram"
-        },
-        {
-          "type": "facebook",
-          "url": "https://www.facebook.com/events/1574328850293138/",
-          "label": "📘 Facebook"
-        },
-        {
-          "type": "gmaps",
-          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
-          "label": "🗺️ Google Maps"
-        },
-        {
-          "type": "tickets",
-          "url": "https://sickening.events/e/bearracuda-treasure-trail-seattle-4/tickets",
-          "label": "🎫 Tickets"
-        }
-      ],
-      "slug": "treasure-trail-seattle-7e9ae5d5"
-    },
-    {
-      "name": "Seattle GLOW",
-      "day": "Saturday",
-      "time": "9PM-3AM",
-      "eventType": "routine",
-      "recurring": false,
-      "startDate": "2026-06-13T21:00:00",
-      "endDate": "2026-06-14T03:00:00",
-      "unprocessedDescription": "description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 \ram\nbar: MASSIVE\naddress: 619 E. Pine St, Seattle, WA\ntimezone: America/Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/04/cuda-seattle-june2026-web-1.jpg\nfacebook: https://www.facebook.com/events/1548258503329527\nticketUrl: https://sickening.events/e/bearracuda-seattle-glow\nshortName: South Seattle Social\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA\nkey: bearracuda-2026-06-14-seattle",
+      "startDate": "2025-07-06T11:00:00",
+      "endDate": "2025-07-06T16:00:00",
+      "unprocessedDescription": "Instagram: https://www.instagram.com/southseattlebearsocial/\nB\rar: Lumberyard\nGoogle Maps: https://maps.app.goo.gl/SDUbV4qsRpivNiX39\nShortName: South Seattle Social",
       "startTimezone": "America/New_York",
       "endTimezone": "America/New_York",
       "calendarTimezone": "America/Los_Angeles",
       "wasUTC": false,
       "sourceUid": "6irujvg3effpkdu42krgr91osj@google.com",
       "uid": "6irujvg3effpkdu42krgr91osj@google.com",
-      "recurrenceId": "2026-06-14T11:00:00",
-      "recurrenceIdTimezone": "America/New_York",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
       "sequence": 0,
-      "overrideIdentityType": "legacy",
-      "bar": "MASSIVE",
-      "image": "https://bearracuda.com/wp-content/uploads/2026/04/cuda-seattle-june2026-web-1.jpg",
-      "tea": "Doors Open at 9:00 pm - Party Goes Until 3:00 am",
-      "address": "619 E. Pine St, Seattle, WA",
+      "overrideIdentityType": null,
+      "bar": "Lumberyard",
+      "address": null,
       "website": null,
-      "instagram": "https://www.instagram.com/bearracuda",
-      "facebook": "https://www.facebook.com/events/1548258503329527",
-      "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
-      "ticketUrl": "https://sickening.events/e/bearracuda-seattle-glow",
+      "instagram": "https://www.instagram.com/southseattlebearsocial/",
+      "gmaps": "https://maps.app.goo.gl/SDUbV4qsRpivNiX39",
       "shortName": "South Seattle Social",
       "links": [
         {
           "type": "instagram",
-          "url": "https://www.instagram.com/bearracuda",
+          "url": "https://www.instagram.com/southseattlebearsocial/",
           "label": "📷 Instagram"
         },
         {
-          "type": "facebook",
-          "url": "https://www.facebook.com/events/1548258503329527",
-          "label": "📘 Facebook"
-        },
-        {
           "type": "gmaps",
-          "url": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
+          "url": "https://maps.app.goo.gl/SDUbV4qsRpivNiX39",
           "label": "🗺️ Google Maps"
-        },
-        {
-          "type": "tickets",
-          "url": "https://sickening.events/e/bearracuda-seattle-glow",
-          "label": "🎫 Tickets"
         }
       ],
-      "slug": "seattle-glow-3b330fb1"
-    },
-    {
-      "name": "Bearracuda Seattle: SERIOUS WOOD",
-      "day": "Friday",
-      "time": "9PM-3AM",
-      "eventType": "routine",
-      "recurring": false,
-      "coordinates": {
-        "lat": 47.6150572,
-        "lng": -122.3236574
-      },
-      "startDate": "2025-10-10T21:00:00",
-      "endDate": "2025-10-11T03:00:00",
-      "unprocessedDescription": "description: SERIOUS WOOD Show off your boots, plaid, jeans,\r nut huggers, flannel, suspenders, beanies & overalls! Hot Go-Go’s, Chunky Visuals!\n\nMusic & Entertainment\n• Matt Consola\n• Freddy KOP\nbar: MASSIVE\naddress: 619 E Pine, Seattle, WA 98122\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/seattlewood/\ncover: $24.89 - $30.54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/serioiusweb.jpg\nfacebook: https://www.facebook.com/events/1210500617554659\nticketUrl: https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-tickets-1565073299369?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401\nkey: bearracuda-2025-10-11-seattle",
-      "startTimezone": null,
-      "endTimezone": null,
-      "calendarTimezone": "America/Los_Angeles",
-      "wasUTC": true,
-      "sourceUid": "9DF93D82-1411-44C0-BE63-00037416BB38",
-      "uid": "9DF93D82-1411-44C0-BE63-00037416BB38",
-      "recurrenceId": null,
-      "recurrenceIdTimezone": null,
-      "sequence": 2,
-      "overrideIdentityType": null,
-      "bar": "MASSIVE",
-      "cover": "$24.89 - $30.54 (as of 10/1)",
-      "image": "https://bearracuda.com/wp-content/uploads/2025/08/serioiusweb.jpg",
-      "tea": "SERIOUS WOOD Show off your boots, plaid, jeans, nut huggers, flannel, suspenders, beanies & overalls! Hot Go-Go’s, Chunky Visuals!",
-      "address": "619 E Pine, Seattle, WA 98122",
-      "website": "https://bearracuda.com/events/seattlewood/",
-      "instagram": "https://www.instagram.com/bearracuda",
-      "facebook": "https://www.facebook.com/events/1210500617554659",
-      "gmaps": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
-      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-tickets-1565073299369?aff=oddtdtcreator",
-      "shortName": "Bear-rac-uda",
-      "links": [
-        {
-          "type": "website",
-          "url": "https://bearracuda.com/events/seattlewood/",
-          "label": "🌐 Website"
-        },
-        {
-          "type": "instagram",
-          "url": "https://www.instagram.com/bearracuda",
-          "label": "📷 Instagram"
-        },
-        {
-          "type": "facebook",
-          "url": "https://www.facebook.com/events/1210500617554659",
-          "label": "📘 Facebook"
-        },
-        {
-          "type": "gmaps",
-          "url": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
-          "label": "🗺️ Google Maps"
-        },
-        {
-          "type": "tickets",
-          "url": "https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-tickets-1565073299369?aff=oddtdtcreator",
-          "label": "🎫 Tickets"
-        }
-      ],
-      "slug": "bearracuda-seattle-serious-wood-4a1720dd"
+      "slug": "south-seattle-bear-social-3b330fb1"
     }
   ]
 }

--- a/data/calendars/update-summary.json
+++ b/data/calendars/update-summary.json
@@ -1,159 +1,136 @@
 {
-  "lastUpdated": "2026-06-23T21:25:30.901Z",
   "cities": {
-    "nyc": {
-      "name": "New York",
+    "atlanta": {
+      "name": "Atlanta",
       "status": "success",
-      "dataLength": 10992,
-      "eventCount": 12,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "seattle": {
-      "name": "Seattle",
-      "status": "success",
-      "dataLength": 12362,
-      "eventCount": 10,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "la": {
-      "name": "Los Angeles",
-      "status": "success",
-      "dataLength": 8423,
-      "eventCount": 7,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "toronto": {
-      "name": "Toronto",
-      "status": "success",
-      "dataLength": 197,
-      "eventCount": 0,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "london": {
-      "name": "London",
-      "status": "success",
-      "dataLength": 193,
-      "eventCount": 0,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "chicago": {
-      "name": "Chicago",
-      "status": "success",
-      "dataLength": 13565,
-      "eventCount": 12,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
+      "dataLength": 4933,
+      "eventCount": 4
     },
     "berlin": {
       "name": "Berlin",
       "status": "success",
       "dataLength": 193,
-      "eventCount": 0,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "palm-springs": {
-      "name": "Palm Springs",
-      "status": "success",
-      "dataLength": 1487,
-      "eventCount": 1,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "denver": {
-      "name": "Denver",
-      "status": "success",
-      "dataLength": 6856,
-      "eventCount": 6,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "dallas": {
-      "name": "Dallas",
-      "status": "success",
-      "dataLength": 195,
-      "eventCount": 0,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "dc": {
-      "name": "DC",
-      "status": "success",
-      "dataLength": 1503,
-      "eventCount": 1,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "vegas": {
-      "name": "Las Vegas",
-      "status": "success",
-      "dataLength": 4410,
-      "eventCount": 3,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "atlanta": {
-      "name": "Atlanta",
-      "status": "success",
-      "dataLength": 4933,
-      "eventCount": 4,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "nola": {
-      "name": "New Orleans",
-      "status": "success",
-      "dataLength": 2367,
-      "eventCount": 2,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "sf": {
-      "name": "San Francisco",
-      "status": "success",
-      "dataLength": 15367,
-      "eventCount": 12,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "portland": {
-      "name": "Portland",
-      "status": "success",
-      "dataLength": 18474,
-      "eventCount": 14,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
-    },
-    "sitges": {
-      "name": "Sitges",
-      "status": "success",
-      "dataLength": 193,
-      "eventCount": 0,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
+      "eventCount": 0
     },
     "boston": {
       "name": "Boston",
       "status": "success",
       "dataLength": 196,
-      "eventCount": 0,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
+      "eventCount": 0
     },
-    "phoenix": {
-      "name": "Phoenix",
+    "chicago": {
+      "name": "Chicago",
       "status": "success",
-      "dataLength": 2874,
-      "eventCount": 2,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
+      "dataLength": 13565,
+      "eventCount": 12
     },
-    "ptown": {
-      "name": "Provincetown",
+    "dallas": {
+      "name": "Dallas",
       "status": "success",
-      "dataLength": 202,
-      "eventCount": 0,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
+      "dataLength": 195,
+      "eventCount": 0
     },
-    "san-diego": {
-      "name": "San Diego",
+    "dc": {
+      "name": "DC",
       "status": "success",
-      "dataLength": 4073,
-      "eventCount": 3,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
+      "dataLength": 1503,
+      "eventCount": 1
+    },
+    "denver": {
+      "name": "Denver",
+      "status": "success",
+      "dataLength": 6856,
+      "eventCount": 6
+    },
+    "la": {
+      "name": "Los Angeles",
+      "status": "success",
+      "dataLength": 8423,
+      "eventCount": 7
+    },
+    "london": {
+      "name": "London",
+      "status": "success",
+      "dataLength": 193,
+      "eventCount": 0
+    },
+    "nola": {
+      "name": "New Orleans",
+      "status": "success",
+      "dataLength": 2367,
+      "eventCount": 2
+    },
+    "nyc": {
+      "name": "New York",
+      "status": "success",
+      "dataLength": 10992,
+      "eventCount": 12
+    },
+    "palm-springs": {
+      "name": "Palm Springs",
+      "status": "success",
+      "dataLength": 1487,
+      "eventCount": 1
     },
     "philly": {
       "name": "Philadelphia",
       "status": "success",
       "dataLength": 4689,
-      "eventCount": 3,
-      "lastUpdated": "2026-06-23T21:25:30.901Z"
+      "eventCount": 3
+    },
+    "phoenix": {
+      "name": "Phoenix",
+      "status": "success",
+      "dataLength": 2874,
+      "eventCount": 2
+    },
+    "portland": {
+      "name": "Portland",
+      "status": "success",
+      "dataLength": 18474,
+      "eventCount": 14
+    },
+    "ptown": {
+      "name": "Provincetown",
+      "status": "success",
+      "dataLength": 202,
+      "eventCount": 0
+    },
+    "san-diego": {
+      "name": "San Diego",
+      "status": "success",
+      "dataLength": 4073,
+      "eventCount": 3
+    },
+    "seattle": {
+      "name": "Seattle",
+      "status": "success",
+      "dataLength": 12362,
+      "eventCount": 10
+    },
+    "sf": {
+      "name": "San Francisco",
+      "status": "success",
+      "dataLength": 15367,
+      "eventCount": 12
+    },
+    "sitges": {
+      "name": "Sitges",
+      "status": "success",
+      "dataLength": 193,
+      "eventCount": 0
+    },
+    "toronto": {
+      "name": "Toronto",
+      "status": "success",
+      "dataLength": 197,
+      "eventCount": 0
+    },
+    "vegas": {
+      "name": "Las Vegas",
+      "status": "success",
+      "dataLength": 4410,
+      "eventCount": 3
     }
   }
 }

--- a/scripts/fetch-calendar-data.js
+++ b/scripts/fetch-calendar-data.js
@@ -83,7 +83,7 @@ async function fetchCalendarData() {
         const results = await Promise.all(fetchPromises);
         
         const summary = {
-            lastUpdated: new Date().toISOString(),
+
             cities: {}
         };
         
@@ -96,7 +96,7 @@ async function fetchCalendarData() {
                     name: result.config.name,
                     status: 'error',
                     error: result.error,
-                    lastUpdated: new Date().toISOString()
+
                 };
                 errorCount++;
             } else {
@@ -105,12 +105,19 @@ async function fetchCalendarData() {
                     status: 'success',
                     dataLength: result.icalData.length,
                     eventCount: (result.icalData.match(/BEGIN:VEVENT/g) || []).length,
-                    lastUpdated: new Date().toISOString()
+
                 };
                 successCount++;
             }
         });
         
+        // Sort cities alphabetically
+        const sortedCities = Object.keys(summary.cities).sort().reduce((acc, key) => {
+            acc[key] = summary.cities[key];
+            return acc;
+        }, {});
+        summary.cities = sortedCities;
+
         // Save summary
         const summaryPath = path.join(dataDir, 'update-summary.json');
         fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2));

--- a/testing/generate-manifest.js
+++ b/testing/generate-manifest.js
@@ -42,7 +42,6 @@ const files = fs.readdirSync(testingDir)
     
     return {
       name: file,
-      size: stats.size,
       icon: metadata.icon,
       description: metadata.description
       // Removed modified timestamp to prevent unnecessary changes during CI

--- a/testing/manifest.json
+++ b/testing/manifest.json
@@ -2,49 +2,41 @@
   "files": [
     {
       "name": "event-builder.html",
-      "size": 422857,
       "icon": "🛠️",
       "description": "Build chunky.dad calendar events and preview them instantly."
     },
     {
       "name": "index.html",
-      "size": 25825,
       "icon": "📄",
       "description": "Test file"
     },
     {
       "name": "test-calendar-logging.html",
-      "size": 68633,
       "icon": "🔍",
       "description": "Debug Scope - Look deep inside calendar processing (magnify those logs)"
     },
     {
       "name": "test-city-landscapes.html",
-      "size": 23118,
       "icon": "🌄",
       "description": "City landscapes tester"
     },
     {
       "name": "test-google-sheets-loader.html",
-      "size": 43013,
       "icon": "📊",
       "description": "Sheet Metal Worker - Loads and shapes Google Sheets data"
     },
     {
       "name": "test-og-event-layouts-calendar.html",
-      "size": 76657,
       "icon": "📅",
       "description": "Old School Blueprint - Classic event layouts, tried and true"
     },
     {
       "name": "test-unified-scraper.html",
-      "size": 46169,
       "icon": "🪛",
       "description": "Scraper Tool - Extract that data, nice and smooth"
     },
     {
       "name": "ultimate-style-tester.html",
-      "size": 65988,
       "icon": "🔨",
       "description": "The Big Hammer - Pound your styles into perfect shape with live preview"
     }

--- a/tools/download-images.js
+++ b/tools/download-images.js
@@ -43,7 +43,6 @@ function adjustEventbriteImageUrl(imageUrl) {
       // Remove any query parameters to get the uncropped version
       const innerUrlObj = new URL(innerUrl);
       const uncroppedUrl = `${innerUrlObj.protocol}//${innerUrlObj.host}${innerUrlObj.pathname}`;
-      
       console.log(`🎫 Eventbrite: Adjusted image URL from cropped to uncropped: ${imageUrl} -> ${uncroppedUrl}`);
       return uncroppedUrl;
     }
@@ -157,33 +156,27 @@ async function downloadEventImage(imageUrl, eventInfo) {
     // If we got a different content type, regenerate filename with correct extension
     if (downloadResult.contentType) {
       const actualExtension = detectFileExtension(adjustedUrl, downloadResult.contentType);
-      
       if (actualExtension !== detectedExtension) {
         console.log(`🔄 Content type detected different extension: ${actualExtension} (was ${detectedExtension})`);
-        
-        // Generate new filename with correct extension
+          // Generate new filename with correct extension
         const correctFilename = generateEventFilename(adjustedUrl, eventInfo, actualExtension);
         const correctPath = path.join(dir, correctFilename);
         const correctMetadataPath = correctPath + '.meta';
-        
-        // Move the file to the correct name
+          // Move the file to the correct name
         if (fs.existsSync(localPath)) {
           fs.renameSync(localPath, correctPath);
           if (fs.existsSync(metadataPath)) {
             fs.renameSync(metadataPath, correctMetadataPath);
           }
         }
-        
-        // Update variables to use correct paths
+          // Update variables to use correct paths
         const finalFilename = correctFilename;
         const finalPath = correctPath;
         const finalMetadataPath = correctMetadataPath;
-        
-        // Save metadata with event information
+          // Save metadata with event information
         const metadata = {
           originalUrl: imageUrl,
           adjustedUrl: adjustedUrl,
-          downloadedAt: new Date().toISOString(),
           type: 'event',
           filename: finalFilename,
           contentType: downloadResult.contentType,
@@ -194,10 +187,8 @@ async function downloadEventImage(imageUrl, eventInfo) {
             recurring: eventInfo.recurring
           }
         };
-        
-        fs.writeFileSync(finalMetadataPath, JSON.stringify(metadata, null, 2));
-        
-        console.log(`✅ Downloaded event image: ${finalFilename} (${actualExtension})`);
+          fs.writeFileSync(finalMetadataPath, JSON.stringify(metadata, null, 2));
+          console.log(`✅ Downloaded event image: ${finalFilename} (${actualExtension})`);
         return { success: true, skipped: false, filename: finalFilename, localPath: finalPath };
       }
     }
@@ -206,7 +197,6 @@ async function downloadEventImage(imageUrl, eventInfo) {
     const metadata = {
       originalUrl: imageUrl,
       adjustedUrl: adjustedUrl,
-      downloadedAt: new Date().toISOString(),
       type: 'event',
       filename: filename,
       contentType: downloadResult.contentType,
@@ -230,7 +220,6 @@ async function downloadEventImage(imageUrl, eventInfo) {
     try {
       const failureMetadata = {
         originalUrl: imageUrl,
-        failedAt: new Date().toISOString(),
         error: error.message,
         type: 'event'
       };
@@ -324,24 +313,19 @@ async function fetchPageContent(url) {
       }
     }, (response) => {
       let stream = response;
-      
       // Handle gzip/deflate decompression
       if (response.headers['content-encoding'] === 'gzip') {
         stream = response.pipe(zlib.createGunzip());
       } else if (response.headers['content-encoding'] === 'deflate') {
         stream = response.pipe(zlib.createInflate());
       }
-      
       let data = '';
-      
       stream.on('data', (chunk) => {
         data += chunk;
       });
-      
       stream.on('end', () => {
         resolve(data);
       });
-      
       stream.on('error', (err) => {
         reject(err);
       });
@@ -410,10 +394,8 @@ function downloadFile(url, outputPath, timeout = 30000, maxRedirects = 5) {
         reject(new Error(`Too many redirects (max: ${maxRedirects})`));
         return;
       }
-      
       const parsedUrl = new URL(currentUrl);
       const client = parsedUrl.protocol === 'https:' ? https : http;
-      
       const request = client.get(currentUrl, {
         timeout: timeout,
         headers: {
@@ -428,11 +410,9 @@ function downloadFile(url, outputPath, timeout = 30000, maxRedirects = 5) {
           downloadWithRedirects(redirectUrl, redirectCount + 1);
           return;
         }
-        
-        if (response.statusCode >= 200 && response.statusCode < 300) {
+          if (response.statusCode >= 200 && response.statusCode < 300) {
           const fileStream = fs.createWriteStream(outputPath);
           response.pipe(fileStream);
-          
           fileStream.on('finish', () => {
             fileStream.close();
             // Return content type information
@@ -441,7 +421,6 @@ function downloadFile(url, outputPath, timeout = 30000, maxRedirects = 5) {
               contentLength: response.headers['content-length']
             });
           });
-          
           fileStream.on('error', (err) => {
             fs.unlink(outputPath, () => {}); // Delete partial file
             reject(err);
@@ -450,7 +429,6 @@ function downloadFile(url, outputPath, timeout = 30000, maxRedirects = 5) {
           reject(new Error(`HTTP ${response.statusCode}: ${response.statusMessage}`));
         }
       });
-      
       request.on('error', reject);
       request.on('timeout', () => {
         request.destroy();
@@ -470,13 +448,11 @@ function generateFilename(url, type = 'event', size = null) {
             // Check if filename already contains a size suffix to avoid double suffixes
             const ext = path.extname(baseFilename);
             const nameWithoutExt = path.basename(baseFilename, ext);
-            
-            // If the filename already contains a size suffix (like -64px), don't add another one
+              // If the filename already contains a size suffix (like -64px), don't add another one
             if (nameWithoutExt.includes('-64px') || nameWithoutExt.includes('-32px') || nameWithoutExt.includes('-256px')) {
                 return baseFilename;
             }
-            
-            // Add size suffix for higher quality favicons
+              // Add size suffix for higher quality favicons
             return `${nameWithoutExt}-${size}px${ext}`;
         }
         return baseFilename;
@@ -509,14 +485,11 @@ async function downloadImageWithCustomFilename(imageUrl, customFilename, type = 
     if (isLinktreeProfile && type === 'favicon') {
       const tempPath = localPath + '.temp';
       const optimizedPath = localPath + '.optimized';
-      
       try {
         // Move original to temp location
         fs.renameSync(localPath, tempPath);
-        
         // Process and optimize the image
         const processed = await processProfilePicture(tempPath, optimizedPath, targetSize);
-        
         if (processed) {
           // Replace original with optimized version
           fs.renameSync(optimizedPath, localPath);
@@ -525,7 +498,6 @@ async function downloadImageWithCustomFilename(imageUrl, customFilename, type = 
           // Fallback: restore original if processing failed
           fs.renameSync(tempPath, localPath);
         }
-        
         // Clean up temp file
         if (fs.existsSync(tempPath)) {
           fs.unlinkSync(tempPath);
@@ -545,7 +517,6 @@ async function downloadImageWithCustomFilename(imageUrl, customFilename, type = 
     // Save metadata
     const metadata = {
       originalUrl: imageUrl,
-      downloadedAt: new Date().toISOString(),
       type: type,
       filename: customFilename,
       contentType: downloadResult.contentType,
@@ -567,7 +538,6 @@ async function downloadImageWithCustomFilename(imageUrl, customFilename, type = 
       ensureDir(dir);
       const failureMetadata = {
         originalUrl: imageUrl,
-        failedAt: new Date().toISOString(),
         error: error.message,
         type: type,
         filename: customFilename
@@ -674,7 +644,6 @@ async function downloadImageWithSize(imageUrl, type = 'event', size = null) {
     // Save metadata
     const metadata = {
       originalUrl: imageUrl,
-      downloadedAt: new Date().toISOString(),
       type: type,
       filename: filename,
       size: size,
@@ -697,7 +666,6 @@ async function downloadImageWithSize(imageUrl, type = 'event', size = null) {
       ensureDir(dir);
       const failureMetadata = {
         originalUrl: imageUrl,
-        failedAt: new Date().toISOString(),
         error: error.message,
         type: type,
         filename: filename,
@@ -738,14 +706,11 @@ async function downloadImage(imageUrl, type = 'event', isLinktreeProfile = false
     if (isLinktreeProfile && type === 'favicon') {
       const tempPath = localPath + '.temp';
       const optimizedPath = localPath + '.optimized';
-      
       try {
         // Move original to temp location
         fs.renameSync(localPath, tempPath);
-        
         // Process and optimize the image
         const processed = await processProfilePicture(tempPath, optimizedPath, targetSize);
-        
         if (processed) {
           // Replace original with optimized version
           fs.renameSync(optimizedPath, localPath);
@@ -754,7 +719,6 @@ async function downloadImage(imageUrl, type = 'event', isLinktreeProfile = false
           // Fallback: restore original if processing failed
           fs.renameSync(tempPath, localPath);
         }
-        
         // Clean up temp file
         if (fs.existsSync(tempPath)) {
           fs.unlinkSync(tempPath);
@@ -774,7 +738,6 @@ async function downloadImage(imageUrl, type = 'event', isLinktreeProfile = false
     // Save metadata
     const metadata = {
       originalUrl: imageUrl,
-      downloadedAt: new Date().toISOString(),
       type: type,
       filename: filename,
       contentType: downloadResult.contentType,
@@ -797,7 +760,6 @@ async function downloadImage(imageUrl, type = 'event', isLinktreeProfile = false
       ensureDir(dir);
       const failureMetadata = {
         originalUrl: imageUrl,
-        failedAt: new Date().toISOString(),
         error: error.message,
         type: type,
         filename: filename
@@ -832,11 +794,9 @@ function processWebsiteUrl(url, context = '') {
       // Use Google's favicon service for regular domains with multiple sizes
       const faviconUrl64 = `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
       const faviconUrl256 = `https://www.google.com/s2/favicons?domain=${domain}&sz=256`;
-      
       console.log(`🌐 Found website for favicons${context}: ${domain}`);
       console.log(`   🗺️  Map HD (64px): ${faviconUrl64}`);
       console.log(`   🎨 Cards/OG (256px): ${faviconUrl256}`);
-      
       return { type: 'favicon', urls: { favicon64: faviconUrl64, favicon256: faviconUrl256 } };
     }
   } catch (error) {
@@ -905,7 +865,6 @@ async function extractImageUrls() {
         if (cleanUrl.startsWith('http') && cleanUrl.includes('.')) {
           // Adjust Eventbrite image URLs to get uncropped versions
           const adjustedUrl = adjustEventbriteImageUrl(cleanUrl);
-          
           // Store event with its image URL
           imageUrls.eventsWithInfo.push({
             imageUrl: adjustedUrl,
@@ -919,7 +878,6 @@ async function extractImageUrls() {
           }
         }
       }
-      
       // Extract website URLs for favicons
       if (event.favicon) {
         const result = processWebsiteUrl(event.favicon, ` (favicon override for ${event.name})`);
@@ -942,9 +900,7 @@ async function extractImageUrls() {
     for (const file of barFiles) {
       const filePath = path.join(barsDir, file);
       const bars = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-      
       console.log(`📋 Processing bar file: ${file} (${bars.length} bars)`);
-      
       for (const bar of bars) {
         if (bar.favicon) {
           const result = processWebsiteUrl(bar.favicon, ` (favicon override for ${bar.name})`);
@@ -1115,19 +1071,15 @@ async function main() {
       try {
         // Extract profile picture URL from Linktree page
         const profilePictureUrl = await extractLinktreeProfilePicture(linktreeUrl);
-        
         if (profilePictureUrl) {
           // Generate multiple sizes for Linktree profile pictures
           const sizes = [
             { size: '64', targetSize: 64, description: 'Map markers (64px)' },
             { size: '256', targetSize: 256, description: 'Cards/OG images (256px)' }
           ];
-          
           for (const { size, targetSize, description } of sizes) {
             const linktreeFilename = generateLinktreeFaviconFilename(linktreeUrl, size);
-            
             console.log(`📥 Processing Linktree ${description}: ${linktreeFilename}`);
-            
             // Download and process the profile picture with the custom filename
             const result = await downloadImageWithCustomFilename(profilePictureUrl, linktreeFilename, 'favicon', true, targetSize);
             if (result.success) {
@@ -1158,19 +1110,15 @@ async function main() {
       try {
         // Extract logo URL from Wikipedia page
         const logoUrl = await extractWikipediaLogo(wikipediaUrl);
-        
         if (logoUrl) {
           // Generate multiple sizes for Wikipedia logos
           const sizes = [
             { size: '64', targetSize: 64, description: 'Map markers (64px)' },
             { size: '256', targetSize: 256, description: 'Cards/OG images (256px)' }
           ];
-          
           for (const { size, targetSize, description } of sizes) {
             const wikipediaFilename = generateWikipediaFaviconFilename(wikipediaUrl, size);
-            
             console.log(`📥 Processing Wikipedia ${description}: ${wikipediaFilename}`);
-            
             // Download and process the logo with the custom filename
             const result = await downloadImageWithCustomFilename(logoUrl, wikipediaFilename, 'favicon', true, targetSize);
             if (result.success) {

--- a/tools/sync-bars.js
+++ b/tools/sync-bars.js
@@ -63,7 +63,7 @@ async function syncBars() {
         if (extractionFailures.length > 0) {
             console.error(`❌ External extraction failed for ${extractionFailures.length} bars:`);
             extractionFailures.forEach((failure) => {
-                console.error(`   - [${failure.source}] ${failure.bar} (${failure.city}) at ${failure.failedAt}: ${failure.error}`);
+                console.error(`   - [${failure.source}] ${failure.bar} (${failure.city}) at ${failure.error}`);
             });
             throw new Error('One or more external extractions failed. Check extraction failure fields in saved bars data, investigate source pages/logs, then trigger a new bars sync run.');
         }
@@ -489,14 +489,11 @@ async function enrichBarsWithExternalData(bars) {
                 
                 console.log(`✅ Enriched ${bar.name} with Wikipedia data`);
             } catch (error) {
-                const failedAt = new Date().toISOString();
-                enrichedBar.wikipediaExtractionFailureAt = failedAt;
                 enrichedBar.wikipediaExtractionFailureMessage = error.message;
                 extractionFailures.push({
                     bar: bar.name,
                     city: bar.city,
                     source: 'Wikipedia',
-                    failedAt,
                     error: error.message
                 });
                 console.warn(`⚠️  Failed to scrape Wikipedia data for ${bar.name}:`, error.message);
@@ -535,13 +532,10 @@ async function enrichBarsWithExternalData(bars) {
                 delete enrichedBar.gayCitiesExtractionFailureAt;
                 delete enrichedBar.gayCitiesExtractionFailureMessage;
                 delete enrichedBar.gayCitiesExtractionFailureCount;
-                enrichedBar.gayCitiesLastScrapedAt = new Date().toISOString();
                 
                 console.log(`✅ Enriched ${bar.name} with GayCities data`);
             } catch (error) {
-                const failedAt = new Date().toISOString();
                 const previousCount = enrichedBar.gayCitiesExtractionFailureCount || localBar?.gayCitiesExtractionFailureCount || 0;
-                enrichedBar.gayCitiesExtractionFailureAt = failedAt;
                 enrichedBar.gayCitiesExtractionFailureMessage = error.message;
                 enrichedBar.gayCitiesExtractionFailureCount = previousCount + 1;
 
@@ -549,7 +543,6 @@ async function enrichBarsWithExternalData(bars) {
                     bar: bar.name,
                     city: bar.city,
                     source: 'GayCities',
-                    failedAt,
                     error: error.message
                 });
                 console.warn(`⚠️  Failed to scrape GayCities data for ${bar.name}:`, error.message);


### PR DESCRIPTION
Removes dynamic properties (such as timestamp and file sizes) from auto-generated metadata to prevent noisy merge conflicts when no actual data logic changes. Fixes apply to `download-images.js`, `sync-bars.js`, `fetch-calendar-data.js`, `update-calendar-data.yml`, and `generate-manifest.js`.

---
*PR created automatically by Jules for task [11325979803873680660](https://jules.google.com/task/11325979803873680660) started by @stanleyrya*