### PR TITLE
Fix: Enforce exact match for AI web parser description validation

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4901,7 +4901,7 @@ TEXT:
         return {
             enabled: rawValidation.enabled !== false,
             strictDefault: rawValidation.strict !== false,
-            fuzzyDescription: rawValidation.fuzzyDescription !== false,
+            fuzzyDescription: rawValidation.fuzzyDescription === true,
             perField: rawValidation.perField && typeof rawValidation.perField === 'object'
                 ? rawValidation.perField
                 : {},


### PR DESCRIPTION
Closes the issue where AI-generated summaries were slipping into the event description field. By changing the validation mode for descriptions from `fuzzy` to `exact`, any non-verbatim extractions (like generated summaries) will be strictly rejected.

---
*PR created automatically by Jules for task [9928072819086733185](https://jules.google.com/task/9928072819086733185) started by @stanleyrya*