### PR TITLE
fix: handle readonly event objects in shared-core

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -334,7 +334,11 @@ class SharedCore {
                 // Collect all processed events
                 if (parserResult.events && parserResult.events.length > 0) {
                     // Add parser config reference to each event for later use
-                    parserResult.events.forEach(event => {
+                    parserResult.events.forEach((event, index, arr) => {
+                        if (!Object.isExtensible(event)) {
+                            event = { ...event };
+                            arr[index] = event;
+                        }
                         event._parserConfig = parserConfig;
                     });
                     results.allProcessedEvents.push(...parserResult.events);


### PR DESCRIPTION
Resolves an issue where processing pages crashes with an "Attempted to assign to readonly property" error when attempting to assign `_parserConfig` to frozen event objects retrieved from the cache. We now check if the event is extensible and clone it if necessary.

---
*PR created automatically by Jules for task [5434407332643633552](https://jules.google.com/task/5434407332643633552) started by @stanleyrya*