### PR TITLE
Fix sync-bars endless URL scraping by retaining metadata

### DIFF
--- a/data/bars/dallas.json
+++ b/data/bars/dallas.json
@@ -7,6 +7,7 @@
     "instagram": "https://www.instagram.com/s4dallas",
     "facebook": "https://www.facebook.com/S4Dallas",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJd6m0dcmeToYR3R7XzdFC07U",
-    "gayCities": "https://dallas.gaycities.com/bars/213-station"
+    "gayCities": "https://dallas.gaycities.com/bars/213-station",
+    "gayCitiesLastScrapedAt": "2026-06-26T15:16:43.357Z"
   }
 ]

--- a/data/bars/nyc.json
+++ b/data/bars/nyc.json
@@ -28,7 +28,8 @@
     "wikipedia": "https://en.wikipedia.org/wiki/Eagle_NYC",
     "gayCities": "https://newyork.gaycities.com/bars/400-eagle-nyc",
     "faviconBg": "#f0f0f0",
-    "faviconFg": "#565656"
+    "faviconFg": "#565656",
+    "wikipediaLastScrapedAt": "2026-06-26T15:16:42.784Z"
   },
   {
     "name": "3 Dollar Bill",

--- a/data/bars/ptown.json
+++ b/data/bars/ptown.json
@@ -46,6 +46,7 @@
     "coordinates": "42.0510476, -70.1876737",
     "instagram": "https://www.instagram.com/redroomptown",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJqbgqyVOn_IkRIAI-jRz2eak",
-    "gayCities": "https://ptown.gaycities.com/bars/309562-red-room"
+    "gayCities": "https://ptown.gaycities.com/bars/309562-red-room",
+    "gayCitiesLastScrapedAt": "2026-06-26T15:16:45.767Z"
   }
 ]

--- a/data/bars/seattle.json
+++ b/data/bars/seattle.json
@@ -7,7 +7,8 @@
     "wikipedia": "https://en.wikipedia.org/wiki/Diesel_(gay_bar)",
     "gayCities": "https://seattle.gaycities.com/bars/302690-diesel",
     "faviconBg": "#335a91",
-    "faviconFg": "#c3cbd4"
+    "faviconFg": "#c3cbd4",
+    "wikipediaLastScrapedAt": "2026-06-26T15:16:42.812Z"
   },
   {
     "name": "The Lumber Yard Bar",
@@ -34,7 +35,8 @@
     "coordinates": "47.61427, -122.32708",
     "website": "http://seattleeagle.com",
     "wikipedia": "https://en.wikipedia.org/wiki/Seattle_Eagle",
-    "gayCities": "https://seattle.gaycities.com/bars/506-seattle-eagle"
+    "gayCities": "https://seattle.gaycities.com/bars/506-seattle-eagle",
+    "wikipediaLastScrapedAt": "2026-06-26T15:16:42.842Z"
   },
   {
     "name": "CC’s Seattle",

--- a/tools/sync-bars.js
+++ b/tools/sync-bars.js
@@ -310,7 +310,24 @@ function mergeBars(sheetsBars, localBars) {
             const existing = merged.get(key);
             Object.entries(normalizedBar).forEach(([field, value]) => {
                 if (field === 'name' || field === 'city') return;
-                if (!hasMeaningfulValue(existing[field]) && hasMeaningfulValue(value)) {
+
+                // For extraction tracking metadata fields, we want to always preserve them from local files
+                // if they are not in the sheet (sheets won't have these fields)
+                const metadataFields = [
+                    'wikipediaExtractionFailureAt',
+                    'wikipediaExtractionFailureMessage',
+                    'gayCitiesExtractionFailureAt',
+                    'gayCitiesExtractionFailureMessage',
+                    'gayCitiesExtractionFailureCount',
+                    'gayCitiesLastScrapedAt',
+                    'wikipediaLastScrapedAt'
+                ];
+
+                if (metadataFields.includes(field)) {
+                    if (!existing[field] && value) {
+                        existing[field] = value;
+                    }
+                } else if (!hasMeaningfulValue(existing[field]) && hasMeaningfulValue(value)) {
                     existing[field] = value;
                 }
             });
@@ -345,7 +362,8 @@ function cleanBarObject(bar) {
         'gayCitiesExtractionFailureAt',
         'gayCitiesExtractionFailureMessage',
         'gayCitiesExtractionFailureCount',
-        'gayCitiesLastScrapedAt'
+        'gayCitiesLastScrapedAt',
+        'wikipediaLastScrapedAt'
     ];
     
     fieldsToKeep.forEach(field => {
@@ -365,17 +383,25 @@ function shouldScrapeWikipediaBar(bar, localBar) {
         return false;
     }
 
+    const lastScrapedAt = bar.wikipediaLastScrapedAt || localBar?.wikipediaLastScrapedAt;
+
+    // Check if URL changed from what we have saved locally
+    const urlChanged = bar.wikipedia && localBar?.wikipedia && bar.wikipedia !== localBar.wikipedia;
+    if (urlChanged) {
+        console.log(`🔄 ${bar.name} Wikipedia URL changed: ${localBar?.wikipedia} → ${bar.wikipedia}`);
+        return true;
+    }
+
+    if (lastScrapedAt && !urlChanged) {
+        // We've already successfully scraped this URL, any missing fields are truly missing
+        return false;
+    }
+
     const missingFields = [];
     
     if (!bar.address || bar.address.trim() === '') missingFields.push('address');
     if (!bar.coordinates || bar.coordinates.trim() === '') missingFields.push('coordinates');
     if (!bar.image || bar.image.trim() === '') missingFields.push('image');
-    
-    // Check if URL changed from what we have saved locally
-    if (bar.wikipedia && localBar?.wikipedia && bar.wikipedia !== localBar.wikipedia) {
-        console.log(`🔄 ${bar.name} Wikipedia URL changed: ${localBar.wikipedia} → ${bar.wikipedia}`);
-        return true;
-    }
     
     if (missingFields.length > 0) {
         console.log(`📋 ${bar.name} missing Wikipedia scrapable fields: ${missingFields.join(', ')}`);
@@ -484,11 +510,13 @@ async function enrichBarsWithExternalData(bars) {
                     enrichedBar.image = scrapedData.image;
                 }
 
+                enrichedBar.wikipediaLastScrapedAt = new Date().toISOString();
                 delete enrichedBar.wikipediaExtractionFailureAt;
                 delete enrichedBar.wikipediaExtractionFailureMessage;
                 
                 console.log(`✅ Enriched ${bar.name} with Wikipedia data`);
             } catch (error) {
+                enrichedBar.wikipediaExtractionFailureAt = new Date().toISOString();
                 enrichedBar.wikipediaExtractionFailureMessage = error.message;
                 extractionFailures.push({
                     bar: bar.name,
@@ -529,6 +557,7 @@ async function enrichBarsWithExternalData(bars) {
                     enrichedBar.googleMaps = scrapedData.googleMaps;
                 }
 
+                enrichedBar.gayCitiesLastScrapedAt = new Date().toISOString();
                 delete enrichedBar.gayCitiesExtractionFailureAt;
                 delete enrichedBar.gayCitiesExtractionFailureMessage;
                 delete enrichedBar.gayCitiesExtractionFailureCount;
@@ -536,6 +565,7 @@ async function enrichBarsWithExternalData(bars) {
                 console.log(`✅ Enriched ${bar.name} with GayCities data`);
             } catch (error) {
                 const previousCount = enrichedBar.gayCitiesExtractionFailureCount || localBar?.gayCitiesExtractionFailureCount || 0;
+                enrichedBar.gayCitiesExtractionFailureAt = new Date().toISOString();
                 enrichedBar.gayCitiesExtractionFailureMessage = error.message;
                 enrichedBar.gayCitiesExtractionFailureCount = previousCount + 1;
 


### PR DESCRIPTION
Update `mergeBars` in `tools/sync-bars.js` to ensure metadata tracking fields (`gayCitiesLastScrapedAt`, `wikipediaLastScrapedAt`, etc.) are preserved from local JSON states to prevent endless scraping and HTTP 403 blocks from external sites like Wikipedia and GayCities.

---
*PR created automatically by Jules for task [8071306640571555977](https://jules.google.com/task/8071306640571555977) started by @stanleyrya*