### PR TITLE
Fix event properties overwritten in normalizers

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -198,7 +198,7 @@ class BarDataNormalizer extends BaseNormalizer {
             }
 
             if (modified && typeof this.core.formatEventNotes === 'function') {
-                event = this.core.formatEventNotes(event);
+                event.notes = this.core.formatEventNotes(event);
             }
         }
 
@@ -749,7 +749,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         }
 
         if (modified && this.core && typeof this.core.formatEventNotes === 'function') {
-            event = this.core.formatEventNotes(event);
+            event.notes = this.core.formatEventNotes(event);
         }
 
         return event;


### PR DESCRIPTION
Fixed an issue in `scripts/normalizers.js` where `event` was overwritten by `this.core.formatEventNotes(event)`, causing `startDate` and other fields to be dropped. Changed it to `event.notes = this.core.formatEventNotes(event)` to only update the notes field.

---
*PR created automatically by Jules for task [6557852368054724141](https://jules.google.com/task/6557852368054724141) started by @stanleyrya*