### PR TITLE
Fix AI web parser URL evidence check dropping valid websites

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4999,7 +4999,7 @@ TEXT:
             else if (normalizedField === 'cover') mode = 'cover';
             else if (normalizedField === 'description') mode = validationConfig.fuzzyDescription ? 'fuzzy' : 'exact';
             else if (normalizedField === 'image') mode = 'image';
-            else if (normalizedField === 'url' || normalizedField === 'ticketurl' || normalizedField === 'instagram' || normalizedField === 'facebook' || normalizedField === 'gmaps') mode = 'url';
+            else if (normalizedField === 'url' || normalizedField === 'website' || normalizedField === 'ticketurl' || normalizedField === 'instagram' || normalizedField === 'facebook' || normalizedField === 'gmaps') mode = 'url';
             else mode = 'exact';
         }
 
@@ -5120,6 +5120,18 @@ TEXT:
         if (!normalized) return false;
         if (this.hasExactEvidence(evidenceContext, normalized)) {
             return true;
+        }
+        if (typeof normalized === 'string') {
+            const withoutProtocol = normalized.replace(/^https?:\/\//i, '');
+            if (this.hasExactEvidence(evidenceContext, withoutProtocol)) {
+                return true;
+            }
+            if (withoutProtocol.startsWith('www.')) {
+                const withoutWww = withoutProtocol.replace(/^www\./i, '');
+                if (this.hasExactEvidence(evidenceContext, withoutWww)) {
+                    return true;
+                }
+            }
         }
         return this.hasExactEvidence(evidenceContext, String(value || '').trim());
     }


### PR DESCRIPTION
The AI web parser evidence check was previously dropping the `website` field when the extracted URL (e.g., `https://www.furball.nyc`) didn't exactly match the OCR text (e.g., `WWW.FURBALL.NYC`). This issue occurred because `website` wasn't mapped to the `url` validation mode, and the `url` validation mode didn't account for missing protocols or `www.` prefixes in the source text.

This patch addresses the issue by mapping the `website` field to the `url` mode and modifying the `hasUrlEvidence` method to strip `http(s)://` and `www.` before checking against the evidence context. A safety type check was also added to prevent exceptions on unexpected inputs.

---
*PR created automatically by Jules for task [17948525022844776741](https://jules.google.com/task/17948525022844776741) started by @stanleyrya*