### PR TITLE
refactor(scraper): dynamically compute favicon URLs instead of hardcoding iconUrl

### DIFF
--- a/scripts/display-run-metrics.js
+++ b/scripts/display-run-metrics.js
@@ -487,8 +487,43 @@ class MetricsDisplay {
       const overrides = {};
       parsers.forEach(parser => {
         const name = parser?.name ? String(parser.name).toLowerCase() : '';
-        const iconUrl = parser?.iconUrl || parser?.faviconUrl || null;
-        if (!name || !iconUrl) return;
+        if (!name) return;
+
+        let iconUrl = parser?.iconUrl || parser?.faviconUrl || null;
+
+        if (!iconUrl && parser.urls && parser.urls.length > 0) {
+          const url = parser.urls[0];
+          try {
+            // Very simple parser for URLs since Scriptable has limited URL class features
+            // but we'll use regex for hostname and pathname
+            const match = url.match(/^https?:\/\/([^\/]+)(\/.*)?$/);
+            if (match) {
+              const hostname = match[1];
+              const pathname = match[2] || '/';
+
+              let filename;
+              if (hostname === 'linktr.ee' || hostname === 'www.linktr.ee') {
+                const cleanPath = pathname.substring(1)
+                  .replace(/[^a-zA-Z0-9._-]/g, '-')
+                  .replace(/-+/g, '-')
+                  .replace(/^-|-$/g, '');
+                filename = `favicon-linktr.ee-${cleanPath}-64px.png`;
+              } else {
+                const cleanDomain = hostname
+                  .replace(/^www\./, '')
+                  .replace(/[^a-zA-Z0-9.-]/g, '-')
+                  .replace(/-+/g, '-')
+                  .replace(/^-|-$/g, '');
+                filename = `favicon-${cleanDomain}-64px.ico`;
+              }
+              iconUrl = `https://chunky.dad/img/favicons/${filename}`;
+            }
+          } catch (e) {
+            // ignore
+          }
+        }
+
+        if (!iconUrl) return;
         overrides[name] = String(iconUrl);
       });
       return overrides;

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -78,7 +78,6 @@ const scraperConfig = {
   parsers: [
     {
       name: "Megawoof America",
-      iconUrl: "https://ugc.production.linktr.ee/YY9vP9AGQ9OTFY9iXiDi_hcmot5ynjOsfwPWJ?io=true&size=avatar-v3_0",
       enabled: true,
       automation: {
         automationEnabled: true
@@ -103,7 +102,6 @@ const scraperConfig = {
     },
     {
       name: "Coach After Dark",
-      iconUrl: "https://www.google.com/s2/favicons?domain=www.eventbrite.com&sz=64",
       enabled: true,
       automation: {
         automationEnabled: true
@@ -140,7 +138,6 @@ const scraperConfig = {
     },
     {
       name: "Bearracuda Events",
-      iconUrl: "https://www.google.com/s2/favicons?domain=bearracuda.com&sz=64",
       enabled: true,
       parser: "ai-web",
       automation: {
@@ -180,7 +177,6 @@ const scraperConfig = {
     },
     {
       name: "CHUNK",
-      iconUrl: "https://www.google.com/s2/favicons?domain=www.chunk-party.com&sz=64",
       enabled: true,
       automation: {
         automationEnabled: true
@@ -224,7 +220,6 @@ const scraperConfig = {
     },
     {
       name: "Furball",
-      iconUrl: "https://www.google.com/s2/favicons?domain=www.furball.nyc&sz=64",
       enabled: true,
       automation: {
         automationEnabled: false
@@ -251,7 +246,6 @@ const scraperConfig = {
     },
     {
       name: "Cubhouse",
-      iconUrl: "https://ugc.production.linktr.ee/48e9facd-5c7d-41e3-a7d0-04752baa27f1_IMG-5519.jpeg?io=true&size=avatar-v3_0",
       enabled: true,
       automation: {
         automationEnabled: true
@@ -292,7 +286,6 @@ const scraperConfig = {
     },
     {
       name: "Goldiloxx",
-      iconUrl: "https://www.google.com/s2/favicons?domain=redeyetickets.com&sz=64",
       enabled: true,
       automation: {
         automationEnabled: true
@@ -333,7 +326,6 @@ const scraperConfig = {
     },
     {
       name: "Twisted Bear",
-      iconUrl: "https://www.google.com/s2/favicons?domain=www.eventbrite.com&sz=64",
       enabled: true,
       automation: {
         automationEnabled: true
@@ -356,7 +348,6 @@ const scraperConfig = {
     },
     {
       name: "Dallas Eagle",
-      iconUrl: "https://www.google.com/s2/favicons?domain=www.eventbrite.com&sz=64",
       enabled: true,
       automation: {
         automationEnabled: false
@@ -381,7 +372,6 @@ const scraperConfig = {
     },
     {
       name: "AI Web Parser (Sample)",
-      iconUrl: "https://www.google.com/s2/favicons?domain=example.com&sz=64",
       enabled: false,
       automation: {
         automationEnabled: false
@@ -427,7 +417,6 @@ const scraperConfig = {
     },
     {
       name: "AI Web Parser (OpenAI Sample)",
-      iconUrl: "https://www.google.com/s2/favicons?domain=openai.com&sz=64",
       enabled: false,
       automation: {
         automationEnabled: false

--- a/scripts/stale-parsers.js
+++ b/scripts/stale-parsers.js
@@ -164,10 +164,43 @@ class StaleParsersChecker {
       const parsers = Array.isArray(scraperConfig?.parsers) ? scraperConfig.parsers : [];
       return parsers
         .filter(parser => parser && parser.name)
-        .map(parser => ({
-          name: parser.name,
-          iconUrl: parser.iconUrl || parser.faviconUrl || null
-        }));
+        .map(parser => {
+          let iconUrl = parser.iconUrl || parser.faviconUrl || null;
+
+          if (!iconUrl && parser.urls && parser.urls.length > 0) {
+            const url = parser.urls[0];
+            try {
+              const match = url.match(/^https?:\/\/([^\/]+)(\/.*)?$/);
+              if (match) {
+                const hostname = match[1];
+                const pathname = match[2] || '/';
+                let filename;
+                if (hostname === 'linktr.ee' || hostname === 'www.linktr.ee') {
+                  const cleanPath = pathname.substring(1)
+                    .replace(/[^a-zA-Z0-9._-]/g, '-')
+                    .replace(/-+/g, '-')
+                    .replace(/^-|-$/g, '');
+                  filename = `favicon-linktr.ee-${cleanPath}-64px.png`;
+                } else {
+                  const cleanDomain = hostname
+                    .replace(/^www\./, '')
+                    .replace(/[^a-zA-Z0-9.-]/g, '-')
+                    .replace(/-+/g, '-')
+                    .replace(/^-|-$/g, '');
+                  filename = `favicon-${cleanDomain}-64px.ico`;
+                }
+                iconUrl = `https://chunky.dad/img/favicons/${filename}`;
+              }
+            } catch (e) {
+              // ignore
+            }
+          }
+
+          return {
+            name: parser.name,
+            iconUrl: iconUrl
+          };
+        });
     } catch (error) {
       console.log(`StaleParsers: Could not load scraper-input: ${error.message}`);
       return [];


### PR DESCRIPTION
Removes hardcoded `iconUrl` overrides from `scripts/scraper-input.js` configurations to simplify parser setup. Updates the Scriptable UI dashboards (`scripts/display-run-metrics.js` and `scripts/stale-parsers.js`) to dynamically compute the `https://chunky.dad/img/favicons/...` URL using the parser's first website URL (`urls[0]`), bringing them in line with the standard `convertWebsiteUrlToFaviconPath` logic found in `js/filename-utils.js`.

---
*PR created automatically by Jules for task [916794372812764050](https://jules.google.com/task/916794372812764050) started by @stanleyrya*