### PR TITLE
Remove mastodon field from ai-web-parser

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -361,13 +361,11 @@ const scraperConfig = {
         instagram: { priority: ["static"], merge: "clobber" },
         facebook: { priority: ["static"], merge: "clobber" },
         website: { priority: ["static"], merge: "clobber" },
-        mastodon: { priority: ["static"], merge: "clobber" },
       },
       metadata: {
         website: { value: "https://www.thedallaseagle.com" },
         facebook: { value: "https://www.facebook.com/lonestareagle" },
         instagram: { value: "https://www.instagram.com/thedallaseagle/" },
-        mastodon: { value: "https://mastodon.social/@dallaseagle" }
       }
     },
     {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2441,7 +2441,6 @@ class SharedCore {
             instagram: { priority: ["ai-web"], merge: "clobber" },
             facebook: { priority: ["ai-web"], merge: "clobber" },
             website: { priority: ["ai-web"], merge: "clobber" },
-            mastodon: { priority: ["ai-web"], merge: "clobber" },
             description: { priority: ["ai-web"], merge: "clobber" },
             bar: { priority: ["ai-web"], merge: "clobber" },
             address: { priority: ["ai-web"], merge: "clobber" },


### PR DESCRIPTION
Removes `mastodon` from `ai-web-parser` defaults to stop the AI from trying to extract it. This field is not currently supported/requested.

---
*PR created automatically by Jules for task [14509165304614183068](https://jules.google.com/task/14509165304614183068) started by @stanleyrya*