### PR TITLE
feat: automatically infer static and clobber priority for metadata fields

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -88,10 +88,7 @@ const scraperConfig = {
       maxAdditionalUrls: null,
       dryRun: false,
       fieldPriorities: {
-        title: { priority: ["static"], merge: "clobber" },
         shortName: { priority: ["static"], merge: "upsert" },
-        instagram: { priority: ["static"], merge: "clobber" },
-        url: { priority: ["static"], merge: "clobber" },
       },
       metadata: {
         title: { value: "MEGAWOOF" },
@@ -113,7 +110,6 @@ const scraperConfig = {
       dryRun: false,
       fieldPriorities: {
         shortName: { priority: ["static"], merge: "upsert" },
-        instagram: { priority: ["static"], merge: "clobber" },
       },
       metadata: {
         shortName: {
@@ -155,7 +151,6 @@ const scraperConfig = {
       fieldPriorities: {
         title: { priority: ["ai-web", "bearracuda"], merge: "clobber" },
         shortName: { priority: ["static"], merge: "upsert" },
-        instagram: { priority: ["static"], merge: "clobber" },
         description: { priority: ["bearracuda", "ai-web"], merge: "clobber" },
         bar: { priority: ["ai-web", "bearracuda"], merge: "clobber" },
         address: { priority: ["ai-web", "bearracuda"], merge: "clobber" },
@@ -198,7 +193,6 @@ const scraperConfig = {
       fieldPriorities: {
         title: { priority: ["chunk"], merge: "clobber" },
         shortName: { priority: ["static"], merge: "upsert" },
-        instagram: { priority: ["static"], merge: "clobber" },
         description: { priority: ["chunk"], merge: "clobber" },
         bar: { priority: ["chunk"], merge: "clobber" },
         address: { priority: ["chunk"], merge: "clobber" },
@@ -236,7 +230,6 @@ const scraperConfig = {
       fieldPriorities: {
         title: { priority: ["ai-web", "static"], merge: "clobber" },
         shortName: { priority: ["static"], merge: "upsert" },
-        instagram: { priority: ["static"], merge: "clobber" },
       },
       metadata: {
         title: { value: "FURBALL" },
@@ -263,7 +256,6 @@ const scraperConfig = {
       fieldPriorities: {
         title: { priority: ["ai-web", "linktree"], merge: "clobber" },
         shortName: { priority: ["static"], merge: "upsert" },
-        instagram: { priority: ["static"], merge: "clobber" },
         description: { priority: ["ai-web", "linktree"], merge: "clobber" },
         bar: { priority: ["ai-web", "linktree"], merge: "clobber" },
         address: { priority: ["ai-web", "linktree"], merge: "clobber" },
@@ -299,9 +291,6 @@ const scraperConfig = {
       // Field priorities for merging data from different sources
       fieldPriorities: {
         title: { priority: ["redeyetickets"], merge: "clobber" },
-        shortName: { priority: ["static"], merge: "clobber" },
-        shorterName: { priority: ["static"], merge: "clobber" },
-        instagram: { priority: ["static"], merge: "clobber" },
         description: { priority: ["redeyetickets"], merge: "clobber" },
         bar: { priority: ["redeyetickets"], merge: "clobber" },
         address: { priority: ["redeyetickets"], merge: "clobber" },
@@ -337,8 +326,6 @@ const scraperConfig = {
       dryRun: false,
       fieldPriorities: {
         shortName: { priority: ["static"], merge: "upsert" },
-        instagram: { priority: ["static"], merge: "clobber" },
-        facebook: { priority: ["static"], merge: "clobber" },
       },
       metadata: {
         shortName: { value: "TWIST-ED BEAR" },
@@ -358,9 +345,6 @@ const scraperConfig = {
       maxAdditionalUrls: null,
       dryRun: false,
       fieldPriorities: {
-        instagram: { priority: ["static"], merge: "clobber" },
-        facebook: { priority: ["static"], merge: "clobber" },
-        website: { priority: ["static"], merge: "clobber" },
       },
       metadata: {
         website: { value: "https://www.thedallaseagle.com" },

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2436,6 +2436,17 @@ class SharedCore {
     
     getResolvedFieldPriorities(parserConfig) {
         const explicitPriorities = parserConfig?.fieldPriorities || {};
+
+        // Auto-infer "static" with "clobber" for fields present in metadata but missing from explicitPriorities
+        const inferredPriorities = {};
+        if (parserConfig?.metadata) {
+            Object.keys(parserConfig.metadata).forEach(key => {
+                if (!explicitPriorities[key]) {
+                    inferredPriorities[key] = { priority: ["static"], merge: "clobber" };
+                }
+            });
+        }
+
         const defaultPriorities = {
             title: { priority: ["ai-web"], merge: "clobber" },
             instagram: { priority: ["ai-web"], merge: "clobber" },
@@ -2453,7 +2464,7 @@ class SharedCore {
             cover: { priority: ["ai-web"], merge: "clobber" },
             ticketUrl: { priority: ["ai-web"], merge: "clobber" }
         };
-        return { ...defaultPriorities, ...explicitPriorities };
+        return { ...defaultPriorities, ...inferredPriorities, ...explicitPriorities };
     }
 
     // Apply field-level priority strategies from the parser config


### PR DESCRIPTION
This commit simplifies `scripts/scraper-input.js` by automatically inferring `{ priority: ["static"], merge: "clobber" }` for fields defined in the `metadata` object within `scripts/shared-core.js`. It removes the need to explicitly write these priority rules when metadata is present, reducing boilerplate and cleaning up the scriptable input configurations.

---
*PR created automatically by Jules for task [3872165938500393234](https://jules.google.com/task/3872165938500393234) started by @stanleyrya*