### PR TITLE
fix(parsers): adjust ai web parser prompt format instructions

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4734,15 +4734,7 @@ ${String(snippet || '')}`;
         const templates = {
             default: `You are a data scraper. You are being provided part of a website that includes information about an event. You must check if any of the requested keys are within the provided scraped data and return it as ONLY valid JSON. If a requested key is not explicitly in the source text, skip and omit it.
 
-Format each extracted field as a JSON object containing "value", "evidence", and "confidence".
-Example:
-{
-  "title": {
-    "value": "Annual Bear Party",
-    "evidence": "Join us for the Annual Bear Party!",
-    "confidence": 95
-  }
-}
+Format the output as a single JSON object where each requested key maps to an object containing "value", "evidence", and "confidence".
 
 ${dataProvided}${sourceData}${additionalContext}Preferred keys:
 ${fieldContext}
@@ -4754,15 +4746,7 @@ Rules:
 `,
             alternate: `You are extracting specific event fields from web page source data. Carefully search the entire provided text for the listed fields — they may appear in metadata, structured data, or body text. Return only what you find as a single valid JSON object.
 
-Format each extracted field as a JSON object containing "value", "evidence", and "confidence".
-Example:
-{
-  "title": {
-    "value": "Annual Bear Party",
-    "evidence": "Join us for the Annual Bear Party!",
-    "confidence": 95
-  }
-}
+Format the output as a single JSON object where each requested key maps to an object containing "value", "evidence", and "confidence".
 
 ${dataProvided}${sourceData}${additionalContext}Fields to find:
 ${fieldContext}
@@ -4775,15 +4759,7 @@ Rules:
 `,
             repair: `Convert this text into one strict JSON object for an event.
 
-Format each extracted field as a JSON object containing "value", "evidence", and "confidence".
-Example:
-{
-  "title": {
-    "value": "Annual Bear Party",
-    "evidence": "Join us for the Annual Bear Party!",
-    "confidence": 95
-  }
-}
+Format the output as a single JSON object where each requested key maps to an object containing "value", "evidence", and "confidence".
 
 ${additionalContext}Preferred keys:
 ${fieldContext}


### PR DESCRIPTION
Fixes an issue where `AiWebParser` would only extract one field because the LLM was mimicking the single-field JSON example provided in the prompt.

---
*PR created automatically by Jules for task [11463609381036524159](https://jules.google.com/task/11463609381036524159) started by @stanleyrya*