### PR TITLE
fix: wrap unwrapped single-field AI responses in ai-web-parser

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4849,6 +4849,18 @@ TEXT:
             let event = this.core.parseAiEventResponse(rawResponse);
             if (!event) return null;
 
+            if (
+                typeof event === 'object' &&
+                'value' in event &&
+                Object.keys(event).every(k => ['value', 'evidence', 'confidence', 'reason'].includes(k)) &&
+                Array.isArray(fields) &&
+                fields.length === 1
+            ) {
+                const wrappedEvent = {};
+                wrappedEvent[fields[0]] = event;
+                event = wrappedEvent;
+            }
+
             const filteredEvent = {};
             for (const key in event) {
                 if (!Object.prototype.hasOwnProperty.call(event, key)) continue;


### PR DESCRIPTION
When requesting a single field in `ai-web-parser.js` (like during a retry), the AI model can sometimes return a flat JSON object (e.g., `{"value": "...", "evidence": "..."}`) instead of wrapping it in the requested field name. This causes the extraction loop to mistakenly drop the data because it iterates over `value` and `evidence` as if they were valid field keys lacking confidence.

This commit updates `parseAndFilterConfidence` to intercept this specific case by checking if exactly one field was requested and if the event contains only `value`, `evidence`, `confidence`, and/or `reason` keys. If so, it wraps the object under the correct field name before further processing.

---
*PR created automatically by Jules for task [3084502597205354907](https://jules.google.com/task/3084502597205354907) started by @stanleyrya*