### PR TITLE
Fix truncated AI JSON generation by increasing numPredict limits

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -3375,7 +3375,7 @@ class AiWebParser {
             payloadMode: this.normalizePayloadMode(aiConfig.payloadMode),
             maxHtmlChars: Number.isFinite(Number(aiConfig.maxHtmlChars)) ? Number(aiConfig.maxHtmlChars) : 6000,
             numCtx: Number.isFinite(Number(aiConfig.numCtx)) ? Number(aiConfig.numCtx) : 8192,
-            numPredict: Number.isFinite(Number(aiConfig.numPredict)) ? Number(aiConfig.numPredict) : 512,
+            numPredict: Number.isFinite(Number(aiConfig.numPredict)) ? Number(aiConfig.numPredict) : 2000,
             temperature: Number.isFinite(Number(aiConfig.temperature)) ? Number(aiConfig.temperature) : 0,
             think: Object.prototype.hasOwnProperty.call(aiConfig, 'think') ? Boolean(aiConfig.think) : false,
             timeoutSeconds: Number.isFinite(Number(aiConfig.timeoutSeconds)) ? Number(aiConfig.timeoutSeconds) : 120,

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -43,7 +43,7 @@ const scraperConfig = {
       payloadMode: "best",
       maxHtmlChars: 6000,
       numCtx: 2048,
-      numPredict: 512,
+      numPredict: 2000,
       temperature: 0,
       think: false,
       timeoutSeconds: 120,
@@ -374,7 +374,7 @@ const scraperConfig = {
         payloadMode: "best",
         maxHtmlChars: 6000,
         numCtx: 2048,
-        numPredict: 512,
+        numPredict: 2000,
         temperature: 0,
         think: false,
         timeoutSeconds: 120,
@@ -414,7 +414,7 @@ const scraperConfig = {
         provider: "openai",
         endpoint: "https://api.openai.com/v1/chat/completions",
         model: "gpt-4o",
-        numPredict: 1024,
+        numPredict: 2000,
         temperature: 0,
         openai: {
           responseFormat: "json_object"


### PR DESCRIPTION
This commit fixes a bug where the `ai-web-parser` would log a truncated response (containing a single property instead of the full JSON wrapper) because the `numPredict` (which controls `max_tokens`) was artificially low (512 or 1024). I updated `scripts/scraper-input.js` and the default inside `scripts/shared-core.js` to 2000 to match working manual payload sizes.

---
*PR created automatically by Jules for task [14045103458897086737](https://jules.google.com/task/14045103458897086737) started by @stanleyrya*