### PR TITLE
Fix BarDataNormalizer venue assignment from description

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -196,7 +196,7 @@ class BarDataNormalizer extends BaseNormalizer {
             let modified = false;
 
             // Set bar name if not already set (since we matched by address/location/description)
-            if (matchedBar.name && (!event.bar || event.bar.trim() === '')) {
+            if (matchedBar.name && (!event.bar || event.bar.trim() === '' || descriptionWasVenue)) {
                 event.bar = matchedBar.name;
                 modified = true;
             }


### PR DESCRIPTION
Fix for BarDataNormalizer where mistakenly placed venue names in the description were not updating the actual `bar` field of the event when the field wasn't strictly empty.

---
*PR created automatically by Jules for task [4424882883215560249](https://jules.google.com/task/4424882883215560249) started by @stanleyrya*