### PR TITLE
Fix about page header spacing and mobile layout backdrop clipping

### DIFF
--- a/about.html
+++ b/about.html
@@ -25,7 +25,7 @@
                 <div class="logo">
                     <h1><a href="index.html"><img src="favicons/favicon-192x192.png"
                                                   srcset="favicons/favicon-96x96.png 1x, favicons/favicon-192x192.png 2x, favicons/favicon-256x256.png 3x"
-                                                  alt="chunky.dad logo" class="logo-img"> chunky.dad / about</a></h1>
+                                                  alt="chunky.dad logo" class="logo-img">chunky.dad/about</a></h1>
                 </div>
                 <div class="hamburger">
                     <span></span>

--- a/styles.css
+++ b/styles.css
@@ -6106,6 +6106,9 @@ body.loaded {
         grid-template-columns: 1fr;
         gap: 40px;
     }
+    .about-image-wrapper {
+        margin-right: 15px;
+    }
     .about-image-backdrop {
         left: 15px;
         top: 15px;


### PR DESCRIPTION
Fixed the header text to correctly read "chunky.dad/about" without spaces on the about page. Additionally, corrected a CSS issue where the rectangular backdrop behind the image would hit the right edge of the screen on mobile devices by adjusting the container's margin within the responsive media query.

---
*PR created automatically by Jules for task [5731027385467407779](https://jules.google.com/task/5731027385467407779) started by @stanleyrya*