### PR TITLE
Improve event deduplication by matching on date and location instead of title/shortName

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -6116,40 +6116,6 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       .toLowerCase()
       .trim();
 
-    // Check shortNames as well
-    const existingShortName = (
-      existingEvent.shortName ||
-      parsedExistingNotes.shortName ||
-      ""
-    )
-      .toLowerCase()
-      .trim();
-    const newShortName = (newEvent.shortName || "").toLowerCase().trim();
-
-    console.log(`📱 Scriptable: Checking merge eligibility:`);
-    console.log(`   Existing: "${existingTitle}"`);
-    console.log(`   New: "${newTitle}"`);
-    if (newOriginalTitle) {
-      console.log(`   New (original): "${newOriginalTitle}"`);
-    }
-    if (existingShortName || newShortName) {
-      console.log(
-        `   ShortNames - Existing: "${existingShortName}", New: "${newShortName}"`,
-      );
-    }
-
-    // Exact shortName match
-    if (
-      existingShortName &&
-      newShortName &&
-      existingShortName === newShortName
-    ) {
-      console.log(
-        `📱 Scriptable: Exact shortName match - should merge: "${existingShortName}"`,
-      );
-      return true;
-    }
-
     // Exact address and coordinates match
     const existingAddress = existingEvent.address || parsedExistingNotes.address;
     const addressMatch =
@@ -6157,6 +6123,16 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       newEvent.address &&
       existingAddress.toLowerCase().trim() ===
         newEvent.address.toLowerCase().trim();
+
+    const normalizeVenue = (value) => {
+        if (!value) return '';
+        return String(value).toLowerCase().replace(/[^a-z0-9]/g, '').trim();
+    };
+
+    const existingBar = existingEvent.location || parsedExistingNotes.bar || parsedExistingNotes.venue;
+    const newBar = newEvent.bar || newEvent.venue || newEvent.location;
+    const barMatch = existingBar && newBar && normalizeVenue(existingBar) === normalizeVenue(newBar);
+
     const coordMatch =
       existingEvent.coordinates &&
       newEvent.coordinates &&
@@ -6164,13 +6140,13 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       existingEvent.coordinates.lng === newEvent.coordinates.lng;
 
     // Check times using getTime() because we're in Scriptable realm
+    // Allow up to 6 hours difference for time overlap matching
     const timeMatch =
       existingEvent.startDate &&
       newEvent.startDate &&
-      new Date(existingEvent.startDate).getTime() ===
-        new Date(newEvent.startDate).getTime();
+      Math.abs(new Date(existingEvent.startDate).getTime() - new Date(newEvent.startDate).getTime()) <= (6 * 60 * 60 * 1000);
 
-    if (timeMatch && (addressMatch || coordMatch)) {
+    if (timeMatch && (addressMatch || coordMatch || barMatch)) {
       console.log(
         `📱 Scriptable: Location and time match - should merge: "${existingEvent.title || existingEvent.name}" vs "${newTitle}"`,
       );

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2877,7 +2877,7 @@ class SharedCore {
         // Check for exact or similar duplicates
         const exactMatch = existingEventsData.find(existing => 
             this.areTitlesSimilar(existing.title, event.title) &&
-            this.areDatesEqual(existing.startDate, event.startDate, 1)
+            this.areDatesEqual(existing.startDate, event.startDate, 60)
         );
         
         if (exactMatch) {
@@ -2894,8 +2894,9 @@ class SharedCore {
         
         // Check for overlapping events - only merge when time and title/venue are similar
         const timeConflicts = existingEventsData.filter(existing => 
-            this.doDatesOverlap(existing.startDate, existing.endDate, 
-                               event.startDate, event.endDate || event.startDate)
+            this.doDatesOverlap(existing.startDate, existing.endDate || existing.startDate,
+                               event.startDate, event.endDate || event.startDate) ||
+            this.areDatesEqual(existing.startDate, event.startDate, 6 * 60) // within 6 hours
         );
         
         if (timeConflicts.length > 0) {
@@ -2910,11 +2911,10 @@ class SharedCore {
                 return existingVenue && existingVenue === newVenue;
             };
             
-            const timeSimilar = (existing) => this.areDatesEqual(existing.startDate, event.startDate, 60);
+            const timeSimilar = (existing) => this.areDatesEqual(existing.startDate, event.startDate, 6 * 60);
             
             const mergeableConflict = timeConflicts.find(existing =>
-                timeSimilar(existing) &&
-                (this.areTitlesSimilar(existing.title, event.title) || venuesSimilar(existing))
+                timeSimilar(existing) && venuesSimilar(existing)
             );
             
             if (mergeableConflict) {
@@ -3337,7 +3337,7 @@ class SharedCore {
     
     // Check if two date ranges overlap (pure logic)
     doDatesOverlap(start1, end1, start2, end2) {
-        return start1 < end2 && end1 > start2;
+        return start1 <= end2 && end1 >= start2;
     }
     
     // Fuzzy title matching to handle variations


### PR DESCRIPTION
This ensures events like "FURBALL" and "DALLAS FREEDOM TEA" which occur at the exact same location and similar time (e.g. 21:00 and 22:00) merge appropriately instead of creating duplicates.

Changes:
- **shared-core.js (`analyzeEventAction`)**: Now allows events overlapping or within 6 hours of each other to be merged if their venues are the same, instead of strictly relying on title matching.
- **scriptable-adapter.js (`shouldMergeTimeConflict`)**: Dropped checking `shortName` fields completely for consistency. Now merges any events that overlap within a 6-hour window and share the same address, coordinates, or normalized venue (bar) name.

---
*PR created automatically by Jules for task [11483415348226223781](https://jules.google.com/task/11483415348226223781) started by @stanleyrya*