### PR TITLE
fix(scriptable): resolve event times to local timezone when city evidence is an alias

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -307,6 +307,9 @@ class LocationNormalizer extends BaseNormalizer {
             );
         }
 
+        // Re-anchor wall-clock dates now that the city (and thus timezone) may be resolved
+        this.resolveWallClockDates(event);
+
         // Check if venue name indicates TBA/placeholder
         const isTBAVenue = event.bar && (
                           event.bar.toLowerCase().includes('tba') ||
@@ -610,6 +613,42 @@ class LocationNormalizer extends BaseNormalizer {
     }
 
     // Extract city from event data or URL
+    // The ai-web parser stores extracted local times as wall-clock components labeled UTC when
+    // it cannot resolve a timezone at parse time (flagged via event._timezoneUnresolved).
+    // Once the city is known here, convert those wall-clock values to real UTC instants.
+    resolveWallClockDates(event) {
+        if (!event || !event._timezoneUnresolved) return event;
+
+        const timezone = event.timezone
+            || (event.city && this.core && this.core.cities && this.core.cities[event.city]?.timezone)
+            || '';
+        if (!timezone || typeof this.core?.convertWallClockDateToUtc !== 'function') {
+            const title = event.title || 'unknown';
+            this.core?.warnOnce?.(
+                `wallclock:${title}`,
+                `🚨 LocationNormalizer: Could not resolve timezone for "${title}" (city: "${event.city || 'unknown'}") — dates remain wall-clock UTC and may be wrong`
+            );
+            return event;
+        }
+
+        const reanchor = (value) => {
+            if (!value) return value;
+            const converted = this.core.convertWallClockDateToUtc(value, timezone);
+            if (!converted || isNaN(converted.getTime())) return value;
+            return value instanceof Date ? converted : converted.toISOString();
+        };
+
+        const originalStart = event.startDate;
+        event.startDate = reanchor(event.startDate);
+        event.endDate = reanchor(event.endDate);
+        event.timezone = timezone;
+        delete event._timezoneUnresolved;
+
+        const format = (value) => value instanceof Date ? value.toISOString() : String(value);
+        console.log(`🗺️ LocationNormalizer: Re-anchored wall-clock dates to ${timezone} — start ${format(originalStart)} → ${format(event.startDate)}`);
+        return event;
+    }
+
     extractCityFromEvent(event) {
         if (event.city) {
             const normalizedCity = this.normalizeCityName(String(event.city));

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -1,0 +1,81 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { LocationNormalizer } = require('./normalizers');
+const { SharedCore } = require('./shared-core');
+const { EventSchema } = require('./event-schema');
+
+const CITIES = {
+  nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc'] }
+};
+
+function createLocationNormalizer() {
+  const core = new SharedCore(CITIES, { eventSchema: EventSchema });
+  return new LocationNormalizer(core);
+}
+
+test('resolveWallClockDates re-anchors flagged dates once the city timezone is known', () => {
+  const normalizer = createLocationNormalizer();
+  const event = {
+    title: 'UNDERBEAR',
+    city: 'nyc',
+    // Wall-clock 10pm local stored as 10pm UTC by the parser's timezone-less fallback
+    startDate: new Date('2026-07-17T22:00:00.000Z'),
+    endDate: new Date('2026-07-17T22:00:00.000Z'),
+    _timezoneUnresolved: true
+  };
+
+  normalizer.resolveWallClockDates(event);
+
+  // 10pm EDT (UTC-4) is 2am UTC the next day
+  assert.equal(event.startDate.toISOString(), '2026-07-18T02:00:00.000Z');
+  assert.equal(event.endDate.toISOString(), '2026-07-18T02:00:00.000Z');
+  assert.equal(event.timezone, 'America/New_York');
+  assert.equal(event._timezoneUnresolved, undefined);
+});
+
+test('resolveWallClockDates preserves ISO string date types', () => {
+  const normalizer = createLocationNormalizer();
+  const event = {
+    title: 'UNDERBEAR',
+    city: 'nyc',
+    startDate: '2026-07-17T22:00:00.000Z',
+    endDate: '2026-07-17T22:00:00.000Z',
+    _timezoneUnresolved: true
+  };
+
+  normalizer.resolveWallClockDates(event);
+
+  assert.equal(event.startDate, '2026-07-18T02:00:00.000Z');
+  assert.equal(typeof event.startDate, 'string');
+});
+
+test('resolveWallClockDates leaves dates untouched when the timezone stays unknown', () => {
+  const normalizer = createLocationNormalizer();
+  const event = {
+    title: 'MYSTERY EVENT',
+    city: 'unknown',
+    startDate: new Date('2026-07-17T22:00:00.000Z'),
+    endDate: new Date('2026-07-17T22:00:00.000Z'),
+    _timezoneUnresolved: true
+  };
+
+  normalizer.resolveWallClockDates(event);
+
+  assert.equal(event.startDate.toISOString(), '2026-07-17T22:00:00.000Z');
+  assert.equal(event._timezoneUnresolved, true, 'flag should remain so the gap stays visible');
+});
+
+test('resolveWallClockDates ignores events without the wall-clock flag', () => {
+  const normalizer = createLocationNormalizer();
+  const event = {
+    title: 'ALREADY ANCHORED',
+    city: 'nyc',
+    startDate: new Date('2026-07-18T02:00:00.000Z')
+  };
+
+  normalizer.resolveWallClockDates(event);
+
+  assert.equal(event.startDate.toISOString(), '2026-07-18T02:00:00.000Z');
+  assert.equal(event.timezone, undefined);
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -466,7 +466,8 @@ class AiWebParser {
             trustedFields: aiEvent && Array.isArray(aiEvent.__preValidatedFields) ? aiEvent.__preValidatedFields : [],
             evidenceContext: evidenceContext,
             validationContext: {
-                imageEvidenceUrls: imageEvidenceUrls
+                imageEvidenceUrls: imageEvidenceUrls,
+                cityConfig: cityConfig
             }
         });
         const event = this.normalizeAiEvent(validationResult.event, parserConfig, promptHtmlData, cityConfig, promptFields);
@@ -4132,7 +4133,7 @@ class AiWebParser {
             // Validate extracted fields
             const validatedPartial = this.validateAiEventEvidence(partial, htmlData, parserConfig, remainingFields, {
                 evidenceContext: snippetEvidenceContext,
-                validationContext: { imageEvidenceUrls: snippetImageEvidence }
+                validationContext: { imageEvidenceUrls: snippetImageEvidence, cityConfig: cityConfig }
             }).event || {};
 
             // Track field sources for traceability
@@ -5044,6 +5045,7 @@ TEXT:
             else if (normalizedField === 'location') mode = 'coords';
             else if (normalizedField === 'cover') mode = 'cover';
             else if (normalizedField === 'description') mode = validationConfig.fuzzyDescription ? 'fuzzy' : 'exact';
+            else if (normalizedField === 'city') mode = 'city';
             else if (normalizedField === 'image') mode = 'image';
             else if (normalizedField === 'url' || normalizedField === 'website' || normalizedField === 'ticketurl' || normalizedField === 'instagram' || normalizedField === 'facebook' || normalizedField === 'gmaps') mode = 'url';
             else mode = 'exact';
@@ -5558,6 +5560,8 @@ TEXT:
                 return this.hasCoverEvidence(evidenceContext, valueText);
             case 'fuzzy':
                 return this.hasFuzzyEvidence(evidenceContext, valueText);
+            case 'city':
+                return this.hasCityEvidence(evidenceContext, valueText, validationContext);
             case 'url':
                 return this.hasUrlEvidence(evidenceContext, valueText);
             case 'image':
@@ -5769,6 +5773,9 @@ TEXT:
             this.getResolvedParserMetadataFieldValue(parserConfig, ['timezone'], aiEvent),
             this.getTimezoneForCity(city, cityConfig),
             this.getTimezoneForCity(parserConfig && parserConfig.city, cityConfig),
+            // Fallback: the address often names the city even when the city field was
+            // dropped by evidence validation (e.g. flyer only says "NYC").
+            this.getTimezoneForCity(this.findCityKeyInText(address, cityConfig), cityConfig),
             ''
         );
         const url = this.firstNonEmpty(
@@ -5884,6 +5891,17 @@ TEXT:
             combinedEndDate = new Date(combinedStartDate);
         }
 
+        // Without a timezone, combineDateAndTime stored the extracted local time as wall-clock
+        // components labeled UTC (a wrong instant). Flag the event so LocationNormalizer can
+        // re-anchor it once the city/timezone resolve downstream. Full datetime strings
+        // (startProvided/endProvided) are excluded because Date parsing already anchored them.
+        const usedWallClockFallback = !timezone && !startProvided && !endProvided && Boolean(startDateRaw || endDateRaw);
+        if (usedWallClockFallback) {
+            console.warn(`🚨 AI Web: No timezone resolved for "${title}" — storing local time as wall-clock UTC and flagging for downstream re-anchoring (startTime=${startTimeRaw || 'none'})`);
+        } else if (!timezone && (startProvided || endProvided)) {
+            console.warn(`🚨 AI Web: No timezone resolved for "${title}" — full datetime was parsed in the host timezone and may be wrong`);
+        }
+
         console.log(`🤖 AI Web: Combined dates — combinedStartDate=${combinedStartDate instanceof Date ? combinedStartDate.toISOString() : combinedStartDate}, combinedEndDate=${combinedEndDate instanceof Date ? combinedEndDate.toISOString() : combinedEndDate}`);
 
         // For single-day events, if startDate is missing but endDate exists, use endDate as start
@@ -5937,6 +5955,9 @@ TEXT:
             source: this.config.source,
             isBearEvent: false
         };
+        if (usedWallClockFallback) {
+            event._timezoneUnresolved = true;
+        }
 
         if (aiPrompts.length > 0) {
             event._aiPrompts = aiPrompts;
@@ -6069,6 +6090,73 @@ TEXT:
         const matched = map[matchedKey];
         if (!matched || typeof matched !== 'object' || typeof matched.timezone !== 'string') return '';
         return matched.timezone.trim();
+    }
+
+    // All names that refer to a configured city: its key, display name, patterns, and aliases.
+    getCityAliasList(cityKey, cityData) {
+        const aliases = new Set();
+        const add = value => {
+            const text = String(value || '').trim().toLowerCase();
+            if (text) aliases.add(text);
+        };
+        add(cityKey);
+        if (cityData && typeof cityData === 'object') {
+            add(cityData.name);
+            if (Array.isArray(cityData.patterns)) cityData.patterns.forEach(add);
+            if (Array.isArray(cityData.aliases)) cityData.aliases.forEach(add);
+        }
+        return Array.from(aliases);
+    }
+
+    findCityConfigEntry(cityValue, cityConfig) {
+        const map = this.getCityConfigMap(cityConfig);
+        if (!map || typeof map !== 'object') return null;
+        const normalizedCity = String(cityValue || '').trim().toLowerCase();
+        if (!normalizedCity) return null;
+        for (const [key, cityData] of Object.entries(map)) {
+            const aliases = this.getCityAliasList(key, cityData);
+            if (aliases.includes(normalizedCity)) {
+                return { key, aliases };
+            }
+        }
+        return null;
+    }
+
+    textContainsCityAlias(normalizedText, alias) {
+        const normalizedAlias = this.normalizeEvidenceText(alias);
+        if (!normalizedAlias) return false;
+        const escaped = normalizedAlias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const pattern = new RegExp(`(^|[^a-z0-9])${escaped}($|[^a-z0-9])`);
+        return pattern.test(normalizedText);
+    }
+
+    // The AI canonicalizes city names (e.g. "NYC" -> "new york"), so verbatim evidence
+    // matching fails whenever the page only uses an alias. Accept evidence for any
+    // configured alias of the same city. Aliases under 3 chars are skipped to avoid
+    // substring-style false positives from short codes.
+    hasCityEvidence(evidenceContext, value, validationContext = null) {
+        if (this.hasExactEvidence(evidenceContext, value)) return true;
+        const cityConfig = validationContext && validationContext.cityConfig ? validationContext.cityConfig : null;
+        const entry = this.findCityConfigEntry(value, cityConfig);
+        if (!entry) return false;
+        return entry.aliases.some(alias =>
+            alias.length >= 3 && this.textContainsCityAlias(evidenceContext.normalized, alias)
+        );
+    }
+
+    // Find a configured city referenced inside free text (e.g. a street address).
+    findCityKeyInText(text, cityConfig) {
+        const map = this.getCityConfigMap(cityConfig);
+        if (!map || typeof map !== 'object') return '';
+        const normalizedText = this.normalizeEvidenceText(text);
+        if (!normalizedText) return '';
+        for (const [key, cityData] of Object.entries(map)) {
+            const matched = this.getCityAliasList(key, cityData).some(alias =>
+                alias.length >= 3 && this.textContainsCityAlias(normalizedText, alias)
+            );
+            if (matched) return key;
+        }
+        return '';
     }
 
     hasExplicitTimezoneInfo(dateValue) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -237,3 +237,66 @@ test('buildAiPayload and extractAiResponse support both Ollama and OpenAI', () =
   const openaiResponse = { choices: [{ message: { content: '{"title": "OpenAI Event"}' } }] };
   assert.equal(parser.core.extractAiResponse(openaiConfig, openaiResponse), '{"title": "OpenAI Event"}');
 });
+
+test('city survives evidence validation when the page only uses a configured alias', () => {
+  const parser = createParser();
+  const cityConfig = {
+    nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc', 'brooklyn'] },
+    chicago: { timezone: 'America/Chicago', patterns: ['chicago'] }
+  };
+  const evidenceContext = parser.buildAiEvidenceContextFromText('FURBALL PRESENTS UNDERBEAR ROCKBAR NYC 125 CHRISTOPHER ST NYC');
+  const validationContext = { imageEvidenceUrls: new Set(), cityConfig };
+
+  const result = parser.validateAiEventEvidence(
+    { city: 'new york' },
+    { html: 'irrelevant' },
+    {},
+    null,
+    { evidenceContext, validationContext }
+  );
+  assert.equal(result.event.city, 'new york', 'canonical city should be kept via its "nyc" alias evidence');
+
+  const mismatch = parser.validateAiEventEvidence(
+    { city: 'chicago' },
+    { html: 'irrelevant' },
+    {},
+    null,
+    { evidenceContext, validationContext }
+  );
+  assert.equal(mismatch.event.city, undefined, 'city with no alias in evidence should still be dropped');
+});
+
+test('normalizeAiEvent falls back to the address to resolve the timezone', () => {
+  const parser = createParser();
+  const cityConfig = {
+    nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc'] }
+  };
+  const aiEvent = {
+    title: 'UNDERBEAR',
+    startDate: '2026-07-17',
+    startTime: '22:00',
+    address: '125 Christopher St, New York, NY 10014'
+  };
+
+  const event = parser.normalizeAiEvent(aiEvent, {}, null, cityConfig, null);
+  assert.ok(event, 'event should normalize');
+  // 10pm EDT (UTC-4) on July 17 is 2am UTC on July 18
+  assert.equal(event.startDate.toISOString(), '2026-07-18T02:00:00.000Z');
+  assert.equal(event.timezone, 'America/New_York');
+  assert.equal(event._timezoneUnresolved, undefined);
+});
+
+test('normalizeAiEvent flags wall-clock dates when no timezone can be resolved', () => {
+  const parser = createParser();
+  const aiEvent = {
+    title: 'UNDERBEAR',
+    startDate: '2026-07-17',
+    startTime: '22:00'
+  };
+
+  const event = parser.normalizeAiEvent(aiEvent, {}, null, null, null);
+  assert.ok(event, 'event should normalize');
+  // Wall-clock fallback: local 10pm stored as 10pm UTC, flagged for downstream re-anchoring
+  assert.equal(event.startDate.toISOString(), '2026-07-17T22:00:00.000Z');
+  assert.equal(event._timezoneUnresolved, true);
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1759,6 +1759,48 @@ class SharedCore {
     normalizeEventDate(dateInput) {
         return SharedCore.normalizeEventDate(dateInput);
     }
+
+    // Offset (in minutes) of `timezone` from UTC at the given instant
+    getTimezoneOffsetMinutes(date, timezone) {
+        if (!date || !timezone) return null;
+        try {
+            const formatter = new Intl.DateTimeFormat('en', {
+                timeZone: timezone,
+                timeZoneName: 'longOffset'
+            });
+            const parts = formatter.formatToParts(date);
+            const offsetPart = parts.find(part => part.type === 'timeZoneName');
+            const offsetText = offsetPart && typeof offsetPart.value === 'string' ? offsetPart.value : '';
+            const offsetMatch = offsetText.match(/GMT([+-])(\d{2}):(\d{2})/);
+            if (!offsetMatch) return null;
+            const sign = offsetMatch[1] === '+' ? 1 : -1;
+            const hours = parseInt(offsetMatch[2], 10);
+            const minutes = parseInt(offsetMatch[3], 10);
+            return sign * ((hours * 60) + minutes);
+        } catch (_) {
+            return null;
+        }
+    }
+
+    // Reinterpret a date whose UTC components actually hold local wall-clock time in `timezone`
+    // (the ai-web parser's timezone-less fallback stores dates that way, flagged via
+    // event._timezoneUnresolved) as the real UTC instant. Iterates because the offset guess
+    // can be wrong near DST transitions.
+    convertWallClockDateToUtc(dateInput, timezone) {
+        if (!dateInput || !timezone) return null;
+        const date = new Date(dateInput);
+        if (isNaN(date.getTime())) return null;
+        const baseUtcMillis = date.getTime();
+        let utcMillis = baseUtcMillis;
+        for (let i = 0; i < 4; i++) {
+            const offsetMinutes = this.getTimezoneOffsetMinutes(new Date(utcMillis), timezone);
+            if (!Number.isFinite(offsetMinutes)) return null;
+            const nextUtcMillis = baseUtcMillis - (offsetMinutes * 60 * 1000);
+            if (nextUtcMillis === utcMillis) break;
+            utcMillis = nextUtcMillis;
+        }
+        return new Date(utcMillis);
+    }
     
     // Normalize event date using local or specified timezone
     normalizeEventDateLocal(dateInput, timezone = null) {


### PR DESCRIPTION
## Problem

Events like Furball's UNDERBEAR (flyer: "FRIDAY JULY 17 @ 10PM ... ROCKBAR NYC") were saved as `2026-07-17T22:00:00.000Z` — 10pm **UTC**, which displays as 6pm ET.

Root cause chain:
1. The extraction prompt asks for a canonical city name (`e.g. "new york"`), but evidence validation requires the value **verbatim** in the source. The flyer only says "NYC", so the correctly-extracted `city: "new york"` was dropped (`Dropped 1 field(s) lacking source evidence: city`).
2. With no city, the timezone chain in `normalizeAiEvent` resolved to `''`.
3. `convertLocalDateTimeToUtc` bails without a timezone, so `combineDateAndTime` silently combined the local time via `Date.UTC()` — producing a wall-clock time mislabeled as UTC.
4. `LocationNormalizer` later inferred `city: "nyc"` from the address, but the date was already baked.

## Fix (three layers)

**Alias-aware city validation** — `city` gets its own evidence mode: if the exact value isn't in the source, any configured alias/pattern of the same city counts ("new york" ↔ "nyc", "brooklyn", ...). Word-boundary matched with a 3-char minimum so short codes like "la" can't false-positive inside other words.

**Address→timezone fallback** — the timezone chain now also scans the extracted address for a configured city ("125 Christopher St, New York, NY" → nyc → America/New_York). Bar names are deliberately not scanned (Brooklyn Bowl is in Vegas).

**Wall-clock flag + downstream re-anchor** — when no timezone resolves, the parser warns loudly (🚨) and sets `_timezoneUnresolved`. Since the UTC fallback already stores exact wall-clock components, `LocationNormalizer.resolveWallClockDates()` converts them to the real instant once city inference resolves the timezone (new DST-safe `SharedCore.convertWallClockDateToUtc`). Worst case (city never resolves) is identical to previous behavior, plus a visible warning. This also fixes date-only events without a timezone landing on the previous local day in dedup keys.

## Testing

- 11/11 tests pass: `node --test scripts/parsers/ai-web-parser.test.js scripts/normalizers.test.js` (3 new parser tests, new `normalizers.test.js` with 4 tests)
- End-to-end repro with the real `scraper-cities.js` config: city `"new york"` survives validation against "ROCKBAR NYC" evidence, and the event lands at `2026-07-18T02:00:00.000Z` = 10pm EDT ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)