### PR TITLE
feat(scriptable): merge renamed events via shared same-event identity detection

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -6096,152 +6096,41 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     return events;
   }
 
-  // Helper method to determine if time conflicts should be merged
+  // Helper method to determine if time conflicts should be merged.
+  // Delegates to SharedCore's same-event identity detection so this report always
+  // agrees with the merge decision made in analyzeEventAction.
   shouldMergeTimeConflict(existingEvent, newEvent) {
-    // Extract parsed fields from notes because existingEvent is a CalendarEvent
-    const parsedExistingNotes = this.parseNotesIntoFields(
-      existingEvent.notes || "",
+    const core = this.getIdentityCore();
+    if (!core) {
+      console.log(
+        "📱 Scriptable: Merge eligibility unavailable (identity core failed to initialize)",
+      );
+      return false;
+    }
+    const signal = core.getSameEventIdentitySignal(newEvent, existingEvent);
+    const existingLabel = existingEvent.title || existingEvent.name || "";
+    const newLabel = newEvent.title || newEvent.name || "";
+    console.log(
+      `📱 Scriptable: Merge eligibility ${signal ? `match (${signal})` : "no match"} — "${existingLabel}" vs "${newLabel}"`,
     );
+    return Boolean(signal);
+  }
 
-    // Check if both events are similar enough to be the same event
-    const existingTitle = (existingEvent.title || existingEvent.name || "")
-      .toLowerCase()
-      .trim();
-
-    // For new events, check both the current title and original title (if title was overridden)
-    const newTitle = (newEvent.title || newEvent.name || "")
-      .toLowerCase()
-      .trim();
-    const newOriginalTitle = (newEvent.originalTitle || "")
-      .toLowerCase()
-      .trim();
-
-    // Check shortNames as well
-    const existingShortName = (
-      existingEvent.shortName ||
-      parsedExistingNotes.shortName ||
-      ""
-    )
-      .toLowerCase()
-      .trim();
-    const newShortName = (newEvent.shortName || "").toLowerCase().trim();
-
-    console.log(`📱 Scriptable: Checking merge eligibility:`);
-    console.log(`   Existing: "${existingTitle}"`);
-    console.log(`   New: "${newTitle}"`);
-    if (newOriginalTitle) {
-      console.log(`   New (original): "${newOriginalTitle}"`);
-    }
-    if (existingShortName || newShortName) {
-      console.log(
-        `   ShortNames - Existing: "${existingShortName}", New: "${newShortName}"`,
-      );
-    }
-
-    // Exact shortName match
-    if (
-      existingShortName &&
-      newShortName &&
-      existingShortName === newShortName
-    ) {
-      console.log(
-        `📱 Scriptable: Exact shortName match - should merge: "${existingShortName}"`,
-      );
-      return true;
-    }
-
-    // Exact address and coordinates match
-    const existingAddress = existingEvent.address || parsedExistingNotes.address;
-    const addressMatch =
-      existingAddress &&
-      newEvent.address &&
-      existingAddress.toLowerCase().trim() ===
-        newEvent.address.toLowerCase().trim();
-    const coordMatch =
-      existingEvent.coordinates &&
-      newEvent.coordinates &&
-      existingEvent.coordinates.lat === newEvent.coordinates.lat &&
-      existingEvent.coordinates.lng === newEvent.coordinates.lng;
-
-    // Check times using getTime() because we're in Scriptable realm
-    const timeMatch =
-      existingEvent.startDate &&
-      newEvent.startDate &&
-      new Date(existingEvent.startDate).getTime() ===
-        new Date(newEvent.startDate).getTime();
-
-    if (timeMatch && (addressMatch || coordMatch)) {
-      console.log(
-        `📱 Scriptable: Location and time match - should merge: "${existingEvent.title || existingEvent.name}" vs "${newTitle}"`,
-      );
-      return true;
-    }
-
-    // Generic pattern detection for events with complex text formatting
-    // This helps merge events that have variations like "A>B>C", "A-B-C", "A B C"
-    const hasComplexPattern = (text) => {
-      // Check if text has letters separated by special characters
-      return /[a-z][\s\>\<\-\.\,\!\@\#\$\%\^\&\*\(\)\_\+\=\{\}\[\]\|\\\:\;\"\'\?\/]+[a-z]/i.test(
-        text,
-      );
-    };
-
-    const normalizeComplexText = (text) => {
-      return (
-        text
-          // Replace sequences of special chars between letters with a single hyphen
-          .replace(
-            /([a-z])[\s\>\<\-\.\,\!\@\#\$\%\^\&\*\(\)\_\+\=\{\}\[\]\|\\\:\;\"\'\?\/]+([a-z])/gi,
-            "$1-$2",
-          )
-          // Remove trailing special characters after words
-          .replace(
-            /([a-z])[\!\@\#\$\%\^\&\*\(\)\_\+\=\{\}\[\]\|\\\:\;\"\'\?\,\.]+(?=\s|$)/gi,
-            "$1",
-          )
-          // Collapse multiple spaces/hyphens into single hyphen
-          .replace(/[\s\-]+/g, "-")
-          // Remove leading/trailing hyphens
-          .replace(/^-+|-+$/g, "")
-      );
-    };
-
-    // Check if both titles have complex patterns that normalize to the same value
-    if (
-      hasComplexPattern(existingTitle) ||
-      hasComplexPattern(newTitle) ||
-      hasComplexPattern(newOriginalTitle)
-    ) {
-      const normalizedExisting = normalizeComplexText(existingTitle);
-      const normalizedNew = normalizeComplexText(newTitle);
-      const normalizedNewOriginal = normalizeComplexText(newOriginalTitle);
-
-      if (
-        normalizedExisting === normalizedNew ||
-        normalizedExisting === normalizedNewOriginal
-      ) {
-        console.log(
-          `📱 Scriptable: Complex pattern match detected - should merge:`,
+  // Lazily build a SharedCore instance for identity checks
+  getIdentityCore() {
+    if (this._identityCore === undefined) {
+      try {
+        this._identityCore = new SharedCore(this.cities || {}, {
+          eventSchema: SharedEventSchema,
+        });
+      } catch (error) {
+        console.warn(
+          `📱 Scriptable: Could not initialize identity core: ${error}`,
         );
-        console.log(`   Normalized existing: "${normalizedExisting}"`);
-        console.log(`   Normalized new: "${normalizedNew}"`);
-        return true;
+        this._identityCore = null;
       }
     }
-
-    // Check for exact title matches (case insensitive) - check both titles
-    if (
-      existingTitle === newTitle ||
-      (newOriginalTitle && existingTitle === newOriginalTitle)
-    ) {
-      console.log(
-        `📱 Scriptable: Exact title match - should merge: "${existingEvent.title || existingEvent.name}" vs "${newTitle}"`,
-      );
-      return true;
-    }
-
-    console.log(`📱 Scriptable: No merge criteria met`);
-    return false;
+    return this._identityCore;
   }
 
   // Helper method to calculate title similarity

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2875,11 +2875,11 @@ class SharedCore {
         }
         
         // Check for exact or similar duplicates
-        const exactMatch = existingEventsData.find(existing => 
-            this.areTitlesSimilar(existing.title, event.title) &&
+        const exactMatch = existingEventsData.find(existing =>
+            this.areTitlesSimilar(existing.title || existing.name, event.title) &&
             this.areDatesEqual(existing.startDate, event.startDate, 1)
         );
-        
+
         if (exactMatch) {
             const recurringMergeDecision = this.resolveRecurringMergeCandidate(existingEventsData, exactMatch);
             if (recurringMergeDecision) {
@@ -2891,7 +2891,24 @@ class SharedCore {
                 existingEvent: exactMatch
             });
         }
-        
+
+        // Identity-based match: catches renamed events ("FURBALL" vs "DALLAS FREEDOM TEA")
+        // and zero-duration or hour-shifted records that the interval-overlap check below
+        // misses (a start==end range can never satisfy doDatesOverlap).
+        for (const existing of existingEventsData) {
+            const identitySignal = this.getSameEventIdentitySignal(event, existing);
+            if (!identitySignal) continue;
+            const recurringMergeDecision = this.resolveRecurringMergeCandidate(existingEventsData, existing);
+            if (recurringMergeDecision) {
+                return finalize(recurringMergeDecision);
+            }
+            return finalize({
+                action: 'merge',
+                reason: `Same event identity (${identitySignal})`,
+                existingEvent: existing
+            });
+        }
+
         // Check for overlapping events - only merge when time and title/venue are similar
         const timeConflicts = existingEventsData.filter(existing => 
             this.doDatesOverlap(existing.startDate, existing.endDate, 
@@ -2914,7 +2931,7 @@ class SharedCore {
             
             const mergeableConflict = timeConflicts.find(existing =>
                 timeSimilar(existing) &&
-                (this.areTitlesSimilar(existing.title, event.title) || venuesSimilar(existing))
+                (this.areTitlesSimilar(existing.title || existing.name, event.title) || venuesSimilar(existing))
             );
             
             if (mergeableConflict) {
@@ -3370,10 +3387,155 @@ class SharedCore {
         
         const eventName1 = extractEventName(title1);
         const eventName2 = extractEventName(title2);
-        
+
         return eventName1 === eventName2;
     }
-    
+
+    // === Same-event identity detection ===
+    // Decides whether a newly scraped event and an existing record describe the same
+    // underlying event even when their titles differ (e.g. "DALLAS FREEDOM TEA" vs
+    // "FURBALL"). Used by analyzeEventAction and the scriptable adapter so the merge
+    // decision and the calendar-check report can never disagree.
+
+    normalizeIdentityText(value) {
+        return String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    }
+
+    normalizeTicketUrlForIdentity(url) {
+        const text = String(url || '').trim().toLowerCase();
+        if (!text) return '';
+        const withoutProtocol = text.replace(/^https?:\/\//, '').replace(/^www\./, '');
+        const withoutHash = withoutProtocol.split('#')[0];
+        const [path, query] = withoutHash.split('?');
+        const cleanPath = path.replace(/\/+$/, '');
+        if (!query) return cleanPath;
+        const keptParams = query.split('&').filter(param => {
+            const key = param.split('=')[0];
+            return key && !this.trackingParamPattern.test(key);
+        });
+        return keptParams.length > 0 ? `${cleanPath}?${keptParams.sort().join('&')}` : cleanPath;
+    }
+
+    parseCoordinatesForIdentity(event, fields) {
+        const fromObject = event && event.coordinates;
+        if (fromObject && Number.isFinite(fromObject.lat) && Number.isFinite(fromObject.lng)) {
+            return { lat: fromObject.lat, lng: fromObject.lng };
+        }
+        const candidates = [event && event.location, fields && fields.location];
+        for (const candidate of candidates) {
+            const text = String(candidate || '').trim();
+            const match = text.match(/^(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)$/);
+            if (match) {
+                return { lat: parseFloat(match[1]), lng: parseFloat(match[2]) };
+            }
+        }
+        return null;
+    }
+
+    // Normalize scraped events and calendar events (which carry `name` instead of `title`
+    // and stash extra fields in notes) into one comparable shape.
+    buildIdentityComparisonShape(event) {
+        const fields = this.parseNotesIntoFields((event && (event.notes || event.unprocessedDescription)) || '');
+        const names = [event.title, event.name, event.originalTitle, event.shortName, fields.shortName]
+            .map(value => String(value || '').trim())
+            .filter(Boolean);
+        return {
+            startDate: event.startDate instanceof Date ? event.startDate : this.parseDate(event.startDate),
+            timezone: event.timezone
+                || fields.timezone
+                || event.calendarTimezone
+                || (event.city && this.cities[event.city]?.timezone)
+                || null,
+            ticketUrl: this.normalizeTicketUrlForIdentity(event.ticketUrl || fields.ticketUrl),
+            names: [...new Set(names)],
+            bar: String(event.bar || fields.bar || '').trim(),
+            address: String(event.address || fields.address || '').trim(),
+            locationText: typeof event.location === 'string' ? event.location : '',
+            coordinates: this.parseCoordinatesForIdentity(event, fields)
+        };
+    }
+
+    areIdentityDatesOnSameLocalDay(shapeA, shapeB) {
+        if (!shapeA.startDate || !shapeB.startDate) return false;
+        const timezone = shapeA.timezone || shapeB.timezone || null;
+        const dayA = this.normalizeEventDateLocal(shapeA.startDate, timezone);
+        const dayB = this.normalizeEventDateLocal(shapeB.startDate, timezone);
+        return Boolean(dayA) && dayA === dayB;
+    }
+
+    areIdentityNamesSimilar(shapeA, shapeB) {
+        for (const nameA of shapeA.names) {
+            for (const nameB of shapeB.names) {
+                if (this.areTitlesSimilar(nameA, nameB)) return true;
+            }
+        }
+        return false;
+    }
+
+    areIdentityPlacesSimilar(shapeA, shapeB) {
+        const barA = this.normalizeIdentityText(shapeA.bar);
+        const barB = this.normalizeIdentityText(shapeB.bar);
+        if (barA && barB) {
+            if (barA === barB) return true;
+            if (barA.length >= 4 && barB.length >= 4 && (barA.includes(barB) || barB.includes(barA))) return true;
+        }
+
+        // Calendar events often carry the venue inside a free-form location string
+        // ("STATION 4\n3911 Cedar Springs Rd...") rather than a bar field.
+        const locationA = this.normalizeIdentityText(shapeA.locationText);
+        const locationB = this.normalizeIdentityText(shapeB.locationText);
+        if (barA && barA.length >= 4 && locationB.includes(barA)) return true;
+        if (barB && barB.length >= 4 && locationA.includes(barB)) return true;
+
+        const addressA = this.normalizeIdentityText(shapeA.address);
+        const addressB = this.normalizeIdentityText(shapeB.address);
+        if (addressA.length >= 10 && addressB.length >= 10 &&
+            (addressA === addressB || addressA.includes(addressB) || addressB.includes(addressA))) {
+            return true;
+        }
+
+        if (shapeA.coordinates && shapeB.coordinates &&
+            Math.abs(shapeA.coordinates.lat - shapeB.coordinates.lat) <= 0.002 &&
+            Math.abs(shapeA.coordinates.lng - shapeB.coordinates.lng) <= 0.002) {
+            return true;
+        }
+
+        return false;
+    }
+
+    // Returns the name of the matched identity signal for logging, or null when the
+    // events look distinct. Signals are ordered strongest-first.
+    getSameEventIdentitySignal(newEvent, existingEvent) {
+        if (!newEvent || typeof newEvent !== 'object' || !existingEvent || typeof existingEvent !== 'object') {
+            return null;
+        }
+        const incoming = this.buildIdentityComparisonShape(newEvent);
+        const existing = this.buildIdentityComparisonShape(existingEvent);
+
+        // Every signal requires the same local calendar day — even a shared ticket URL
+        // could otherwise refer to a different night of the same run.
+        if (!this.areIdentityDatesOnSameLocalDay(incoming, existing)) return null;
+
+        // A shared ticket URL is a near-unique event identifier.
+        if (incoming.ticketUrl && existing.ticketUrl && incoming.ticketUrl === existing.ticketUrl) {
+            return 'ticket-url';
+        }
+
+        // Same place, roughly the same start time (tolerant of legacy wall-clock offsets),
+        // and any pair of name-ish fields (title/name/shortName) similar.
+        if (this.areDatesEqual(incoming.startDate, existing.startDate, 120) &&
+            this.areIdentityPlacesSimilar(incoming, existing) &&
+            this.areIdentityNamesSimilar(incoming, existing)) {
+            return 'place-time-name';
+        }
+
+        return null;
+    }
+
+    areEventsSameIdentity(newEvent, existingEvent) {
+        return Boolean(this.getSameEventIdentitySignal(newEvent, existingEvent));
+    }
+
     // Process event with conflicts - extract and merge based on strategies
     processEventWithConflicts(event) {
         if (!event._conflicts || event._conflicts.length === 0) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1,0 +1,110 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { SharedCore } = require('./shared-core');
+const { EventSchema } = require('./event-schema');
+
+const CITIES = {
+  dallas: { timezone: 'America/Chicago', patterns: ['dallas'] }
+};
+
+function createCore() {
+  return new SharedCore(CITIES, { eventSchema: EventSchema });
+}
+
+// Real-world pair: freshly scraped event vs the calendar record it should merge into.
+// Titles differ ("DALLAS FREEDOM TEA" vs "FURBALL") and the stored time is an hour off
+// (legacy wall-clock data), but shortName, venue, address, and ticketUrl all agree.
+function buildScrapedEvent(overrides = {}) {
+  return {
+    title: 'DALLAS FREEDOM TEA',
+    description: 'FURBALL PRESENTS',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-05T22:00:00.000Z'),
+    bar: 'STATION 4',
+    address: '3911 Cedar Springs Rd, Dallas, TX 75219',
+    city: 'dallas',
+    timezone: 'America/Chicago',
+    ticketUrl: 'https://events.ticketleap.com/tickets/furballnyc/furball-dallas-freedom-tea-2026',
+    shortName: 'FUR-BALL',
+    source: 'ai-web',
+    ...overrides
+  };
+}
+
+function buildCalendarEvent(overrides = {}, notesOverride = null) {
+  const notes = notesOverride !== null ? notesOverride : [
+    'bar: STATION 4',
+    'address: 3911 Cedar Springs Rd, Dallas, TX 75219',
+    'timezone: America/Chicago',
+    'ticketUrl: https://events.ticketleap.com/tickets/furballnyc/furball-dallas-freedom-tea-2026',
+    'shortName: FUR-BALL'
+  ].join('\n');
+  return {
+    name: 'FURBALL',
+    startDate: new Date('2026-07-05T21:00:00.000Z'),
+    endDate: new Date('2026-07-05T21:00:00.000Z'),
+    coordinates: { lat: 32.810535, lng: -96.8110709 },
+    calendarTimezone: 'America/Chicago',
+    notes,
+    ...overrides
+  };
+}
+
+test('identity: shared ticketUrl on the same local day matches', () => {
+  const core = createCore();
+  const signal = core.getSameEventIdentitySignal(buildScrapedEvent(), buildCalendarEvent());
+  assert.equal(signal, 'ticket-url');
+});
+
+test('identity: place + close time + similar name matches without ticketUrl', () => {
+  const core = createCore();
+  const scraped = buildScrapedEvent({ ticketUrl: '' });
+  const existing = buildCalendarEvent({}, [
+    'bar: STATION 4',
+    'address: 3911 Cedar Springs Rd, Dallas, TX 75219',
+    'shortName: FUR-BALL'
+  ].join('\n'));
+  // shortName "FUR-BALL" vs name "FURBALL" is the similar-name link
+  const signal = core.getSameEventIdentitySignal(scraped, existing);
+  assert.equal(signal, 'place-time-name');
+});
+
+test('identity: same venue and time but unrelated names do not match', () => {
+  const core = createCore();
+  const scraped = buildScrapedEvent({ ticketUrl: '', shortName: '', title: 'BEAR HAPPY HOUR' });
+  const existing = buildCalendarEvent({}, 'bar: STATION 4\naddress: 3911 Cedar Springs Rd, Dallas, TX 75219');
+  assert.equal(core.getSameEventIdentitySignal(scraped, existing), null);
+});
+
+test('identity: shared ticketUrl on different local days does not match', () => {
+  const core = createCore();
+  const scraped = buildScrapedEvent({ startDate: new Date('2026-07-06T22:00:00.000Z') });
+  assert.equal(core.getSameEventIdentitySignal(scraped, buildCalendarEvent()), null);
+});
+
+test('identity: ticketUrl comparison ignores protocol, www, and tracking params', () => {
+  const core = createCore();
+  const scraped = buildScrapedEvent({
+    ticketUrl: 'http://www.events.ticketleap.com/tickets/furballnyc/furball-dallas-freedom-tea-2026/?utm_source=ig'
+  });
+  assert.equal(core.getSameEventIdentitySignal(scraped, buildCalendarEvent()), 'ticket-url');
+});
+
+test('analyzeEventAction merges renamed same-day events via identity signals', () => {
+  const core = createCore();
+  const analysis = core.analyzeEventAction(buildScrapedEvent(), [buildCalendarEvent()]);
+  assert.equal(analysis.action, 'merge');
+  assert.match(analysis.reason, /Same event identity/);
+});
+
+test('analyzeEventAction keeps genuinely different same-venue events separate', () => {
+  const core = createCore();
+  const scraped = buildScrapedEvent({
+    title: 'UNDERWEAR NIGHT',
+    shortName: '',
+    ticketUrl: 'https://events.ticketleap.com/tickets/other-promoter/underwear-night'
+  });
+  const analysis = core.analyzeEventAction(scraped, [buildCalendarEvent()]);
+  assert.equal(analysis.action, 'new');
+});


### PR DESCRIPTION
## Problem

A freshly scraped **"DALLAS FREEDOM TEA"** and the existing calendar record **"FURBALL"** — same night, same Station 4, same address, identical ticketleap URL — were not merged. Four stacked gaps:

1. The primary match key is `title|date|venue`, and the titles differ.
2. The shortName-aware merge logic from #1433/#1435 (`shouldMergeTimeConflict`) was only called in the calendar-check *report* path, where its verdict is printed as "(merge)/(no merge)" — `analyzeEventAction`, which makes the real decision, never consulted it.
3. `analyzeEventAction`'s fallbacks compared `existing.title` (calendar events carry `name`), required interval overlap that zero-duration events (`endDate === startDate`, the ai-web ambiguous-end convention) can never satisfy, and the stored time was an hour off from legacy wall-clock data.
4. The venue check strict-equaled the bar name against the raw calendar location string, which never matches.

## Fix

One shared identity engine in `SharedCore`, used by both the decision path and the report path, ordered strongest-signal-first:

- **Gate:** both events must be on the same **local calendar day** (timezone-aware) — nothing merges across days.
- **Signal 1 — `ticket-url`:** shared ticket URL (normalized: protocol/www/hash/trailing-slash stripped, tracking params removed). A ticket link is a near-unique event identifier.
- **Signal 2 — `place-time-name`:** same place (bar similarity, bar-inside-location-string, normalized address containment, or coords within ~200m) **and** start times within 2h (tolerant of legacy hour-shifted data) **and** any similar name-ish pair across title/name/shortName — pulled from the event or its notes.

Wiring:
- `analyzeEventAction` runs the identity pass after the exact-duplicate check, reporting `Same event identity (<signal>)` as the merge reason.
- The adapter's `shouldMergeTimeConflict` now delegates to the same function, so the calendar-check report and the actual merge decision can never disagree again.
- Fallback title comparisons now use `existing.title || existing.name`.

## Testing

- New `scripts/shared-core.test.js` built around the real Furball/Station-4 pair: ticket-url match, place-time-name match via shortName↔name, unrelated names at the same venue stay separate, same ticket URL on different days stays separate, URL normalization, and end-to-end `analyzeEventAction` merge + negative case.
- `node --test scripts/shared-core.test.js scripts/parsers/ai-web-parser.test.js` — 11/11 pass; both changed files pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)