### PR TITLE
fix(scriptable): OCR segment top-up and canonical response keys in ai-web parser

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -399,6 +399,9 @@ class AiWebParser {
         }
         console.log(`🤖 AI Web: multi-event-page split into ${segments.length} candidate segment${segments.length === 1 ? '' : 's'}`);
 
+        // OCR any segment images the capped page-level pass missed
+        await this.ensureSegmentOcrCoverage(segments, ocrResults, parserConfig, sourceUrl, httpAdapter);
+
         // Segments are unstructured data (page content + OCR), so always use split fields
         const segmentDataFlags = { ocr: true, segment: true };
         const segmentPromptFields = this.getAiPromptFields(parserConfig, segmentDataFlags);
@@ -2286,7 +2289,11 @@ class AiWebParser {
         const html = htmlData && typeof htmlData.html === 'string' ? htmlData.html : '';
 
         // Extract all image URLs from HTML
-        const allImageUrls = this.extractOrderedImageUrlsFromHtml(html, sourceUrl, 10);
+        const maxOcrImages = 10;
+        const allImageUrls = this.extractOrderedImageUrlsFromHtml(html, sourceUrl, maxOcrImages);
+        if (allImageUrls.length >= maxOcrImages) {
+            console.log(`🤖 AI Web: OCR page-level image cap (${maxOcrImages}) reached — images beyond the cap rely on segment top-up`);
+        }
 
         // Pre-filter out uninteresting images before OCR
         const imageUrls = allImageUrls.filter(url => !this.isLikelyUninterestingImageUrl(url));
@@ -2381,6 +2388,61 @@ class AiWebParser {
             reason,
             cacheHit: rawResult.cached || false
         };
+    }
+
+    // The page-level OCR pass caps how many images it reads, so flyers for later segments on
+    // long multi-event pages can miss OCR entirely. Top up: OCR the first usable image of any
+    // segment that has no OCR coverage yet, so every segment can contribute image text.
+    // Mutates ocrResults in place so callers holding the array see the new entries.
+    async ensureSegmentOcrCoverage(segments, ocrResults, parserConfig, sourceUrl = '', httpAdapter = null) {
+        if (!Array.isArray(segments) || segments.length === 0 || !Array.isArray(ocrResults)) {
+            return ocrResults;
+        }
+        const ocrConfig = this.getOcrConfig(parserConfig);
+        if (!ocrConfig.enabled) return ocrResults;
+
+        const coveredStrippedUrls = new Set(
+            ocrResults
+                .map(ocr => this.stripSizeParams(this.normalizeHttpUrlValue(ocr && ocr.url)))
+                .filter(Boolean)
+        );
+
+        const targets = [];
+        const targetStrippedUrls = new Set();
+        for (const segment of segments) {
+            const segmentImageUrls = [
+                ...this.extractOrderedImageUrlsFromHtml(
+                    segment && typeof segment.html === 'string' ? segment.html : '',
+                    sourceUrl,
+                    2
+                ),
+                ...(Array.isArray(segment && segment.imageHintUrls) ? segment.imageHintUrls : [])
+            ];
+            const normalizedUrls = segmentImageUrls
+                .map(url => this.normalizeHttpUrlValue(url))
+                .filter(Boolean);
+            const hasCoverage = normalizedUrls.some(url => coveredStrippedUrls.has(this.stripSizeParams(url)));
+            if (hasCoverage) continue;
+
+            const candidate = normalizedUrls.find(url => !this.isLikelyUninterestingImageUrl(url));
+            if (!candidate) continue;
+            const strippedCandidate = this.stripSizeParams(candidate);
+            if (targetStrippedUrls.has(strippedCandidate)) continue;
+            targetStrippedUrls.add(strippedCandidate);
+            targets.push(candidate);
+        }
+        if (targets.length === 0) return ocrResults;
+
+        console.log(`🤖 AI Web: OCR top-up for ${targets.length} segment image(s) missed by the page-level cap`);
+        const rawResults = await Promise.all(targets.map(url =>
+            this.getOcrTextForImage(url, ocrConfig, 'ocr-segment', httpAdapter).catch(() => null)
+        ));
+        for (const rawResult of rawResults) {
+            const normalized = this.normalizeOcrResult(rawResult);
+            if (!normalized || !normalized.text || normalized.text.trim().length === 0) continue;
+            ocrResults.push(normalized);
+        }
+        return ocrResults;
     }
 
     filterOcrResultsForSegment(ocrResults, segment, sourceUrl = '') {
@@ -4034,12 +4096,24 @@ class AiWebParser {
     mergeAiEventFields(currentEvent, nextEvent) {
         const merged = currentEvent && typeof currentEvent === 'object' ? { ...currentEvent } : {};
         if (!nextEvent || typeof nextEvent !== 'object') return merged;
+        const schema = this.getEventSchema();
         Object.keys(nextEvent).forEach(key => {
             const value = nextEvent[key];
             if (!this.isUsableAiFieldValue(value)) return;
             const normalizedName = this.normalizePromptFieldName(key);
             if (this.hasResolvedFieldValue(merged, normalizedName)) return;
-            merged[key] = value;
+            // Retry passes prompt with lowercased field names ("startdate") and the model echoes
+            // them back; store under the canonical schema key so downstream readers that expect
+            // camelCase (normalizeAiEvent) still find the value when the primary pass failed.
+            let targetKey = key;
+            if (!key.startsWith('__') && schema && typeof schema.canonicalizeEventKey === 'function') {
+                const lowered = String(key).trim().toLowerCase();
+                const canonical = schema.canonicalizeEventKey(lowered);
+                if (canonical && canonical !== lowered) {
+                    targetKey = canonical;
+                }
+            }
+            merged[targetKey] = value;
         });
         return merged;
     }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -300,3 +300,104 @@ test('normalizeAiEvent flags wall-clock dates when no timezone can be resolved',
   assert.equal(event.startDate.toISOString(), '2026-07-17T22:00:00.000Z');
   assert.equal(event._timezoneUnresolved, true);
 });
+
+test('mergeAiEventFields canonicalizes lowercase response keys to schema keys', () => {
+  const parser = createParser();
+  const merged = parser.mergeAiEventFields({}, {
+    startdate: '2026-07-17',
+    starttime: '22:00',
+    endtime: '02:00',
+    bar: 'ROCKBAR',
+    __internal: 'keep-raw'
+  });
+
+  assert.equal(merged.startDate, '2026-07-17');
+  assert.equal(merged.startTime, '22:00');
+  assert.equal(merged.endTime, '02:00');
+  assert.equal(merged.bar, 'ROCKBAR');
+  assert.equal(merged.__internal, 'keep-raw');
+  assert.equal(merged.startdate, undefined, 'lowercase key should not survive the merge');
+});
+
+test('mergeAiEventFields still prefers already-resolved fields over retry values', () => {
+  const parser = createParser();
+  const merged = parser.mergeAiEventFields(
+    { startDate: '2026-07-17' },
+    { startdate: '2026-01-01' }
+  );
+  assert.equal(merged.startDate, '2026-07-17', 'primary-pass value should win');
+});
+
+test('retry-only extraction (lowercase keys) survives date normalization', () => {
+  // Reproduces the segment-3 failure: primary pass timed out, retry pass returned
+  // perfect data under lowercase keys, and the event was dropped with startDate=null.
+  const parser = createParser();
+  const retryResponse = {
+    title: 'FURBALL',
+    startdate: '2026-07-17',
+    starttime: '22:00'
+  };
+  const merged = parser.mergeAiEventFields({}, retryResponse);
+  const event = parser.normalizeAiEvent(merged, {}, null, null, null);
+
+  assert.ok(event, 'event should survive normalization');
+  assert.ok(event.startDate instanceof Date && !isNaN(event.startDate.getTime()));
+  assert.equal(event.startDate.toISOString().slice(0, 10), '2026-07-17');
+});
+
+test('ensureSegmentOcrCoverage OCRs only segments the page-level pass missed', async () => {
+  const parser = createParser();
+  const coveredUrl = 'https://img.example/media/aaa~mv2.jpg/v1/fill/w_296,h_526/aaa~mv2.jpg';
+  const missedUrl = 'https://img.example/media/bbb~mv2.png/v1/fill/w_296,h_296/bbb~mv2.png';
+
+  const segments = [
+    { lines: [], html: '', imageHintUrls: [coveredUrl] },
+    { lines: [], html: '', imageHintUrls: [missedUrl] }
+  ];
+  const ocrResults = [
+    { url: coveredUrl, text: 'FLYER ONE TEXT', imageClassification: 'event-flyer' }
+  ];
+
+  const ocrCalls = [];
+  parser.getOcrTextForImage = async (url) => {
+    ocrCalls.push(url);
+    return { url, text: 'FURBALL AUSTIN @ 9PM', imageClassification: 'event-flyer' };
+  };
+
+  await parser.ensureSegmentOcrCoverage(segments, ocrResults, {}, 'https://img.example/', null);
+
+  assert.deepEqual(ocrCalls, [missedUrl], 'only the uncovered segment image should be OCRd');
+  assert.equal(ocrResults.length, 2);
+  assert.equal(ocrResults[1].url, missedUrl);
+  assert.equal(ocrResults[1].text, 'FURBALL AUSTIN @ 9PM');
+
+  // The topped-up result must now match the previously uncovered segment
+  const matched = parser.filterOcrResultsForSegment(ocrResults, segments[1], 'https://img.example/');
+  assert.equal(matched.length, 1);
+  assert.equal(matched[0].url, missedUrl);
+});
+
+test('ensureSegmentOcrCoverage is a no-op when OCR is disabled or coverage is complete', async () => {
+  const parser = createParser();
+  const url = 'https://img.example/media/ccc~mv2.jpg/v1/fill/w_296,h_526/ccc~mv2.jpg';
+  const segments = [{ lines: [], html: '', imageHintUrls: [url] }];
+
+  let called = false;
+  parser.getOcrTextForImage = async () => {
+    called = true;
+    return null;
+  };
+
+  // Coverage complete (same image at a different size counts via stripped-URL match)
+  const resizedUrl = 'https://img.example/media/ccc~mv2.jpg/v1/fill/w_592,h_1052/ccc~mv2.jpg';
+  const covered = [{ url: resizedUrl, text: 'TEXT', imageClassification: 'event-flyer' }];
+  await parser.ensureSegmentOcrCoverage(segments, covered, {}, 'https://img.example/', null);
+  assert.equal(called, false, 'covered segment should not trigger OCR');
+  assert.equal(covered.length, 1);
+
+  // OCR disabled
+  const empty = [];
+  await parser.ensureSegmentOcrCoverage(segments, empty, { ai: { ocr: { enabled: false } } }, 'https://img.example/', null);
+  assert.equal(called, false, 'disabled OCR should not trigger requests');
+  assert.equal(empty.length, 0);
+});


### PR DESCRIPTION
## Two bugs from one furball.nyc scrape

### Bug A — segment images beyond the 10-image OCR cap never get OCR'd

`extractOcrFromAllImages` collects page images via `extractOrderedImageUrlsFromHtml(html, sourceUrl, 10)` — a hard cap of 10 unique images in document order. The Furball page has 11 (hero, banner, calendar, logo, then 7 segment flyers), so the Austin flyer (segment 7/7, image #11) was never OCR'd: `Segment failed to match any of the 8 OCR results`. The extraction only saw page text ("August 29, 2026", no time) and the event landed at midnight local. The "OCR skipped 1 uninteresting images" log line was a red herring — that was the logo.

**Fix:** new `ensureSegmentOcrCoverage` runs after segment discovery in `extractEventsFromMultiEventPage`. For any segment whose images have zero OCR coverage (stripped-URL comparison, same as `filterOcrResultsForSegment`), it OCRs the first usable image (one per segment, uninteresting-URL filter applied) and appends the normalized results in place. The page-level cap stays at 10, and hitting it now logs so this failure mode is diagnosable from logs.

### Bug B — retry-pass responses use lowercase keys that date normalization can't read

Retry passes build their field list from `getRemainingPromptFields`, which lowercases names (`startdate`, `starttime`), and the model echoes those keys. `mergeAiEventFields` stored values under the raw response key while `normalizeAiEvent` reads only camelCase. Normally invisible because the primary pass supplies camelCase — but in this run the primary extraction for segment 3 (Rockbar) timed out, the retry succeeded with confidence-100 data, and the event was dropped with `Normalization failed — startDate=null`.

**Fix:** `mergeAiEventFields` now stores values under the canonical schema key via `EventSchema.canonicalizeEventKey` (`startdate` → `startDate`, etc.), leaving internal `__` keys untouched and keeping existing resolved-field precedence.

## Testing

- 5 new tests: key canonicalization, primary-pass precedence, the exact segment-3 repro (retry-only lowercase keys → event survives normalization), OCR top-up targeting only uncovered segments (with the result then matching via `filterOcrResultsForSegment`), and no-op behavior when coverage is complete or OCR is disabled.
- `node --test scripts/parsers/ai-web-parser.test.js` — 12/12 pass; `node --check` clean.
- Real-world check after merge: re-scrape furball.nyc — segment 7's prompts should contain `OCR_IMAGE_TEXT` for the Austin flyer and pick up its start time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)