### PR TITLE
perf(scriptable): stop OCR-ing duplicate image variants and serialize OCR requests

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -247,7 +247,9 @@ class AiWebParser {
         this.defaultOcrModel = 'qwen3-vl:4b-instruct';
         this.defaultOcrPrompt = "You are performing OCR on an event flyer.\n\nSTEP 1: OCR\nExtract ALL visible text from the image.\n\nRules:\n- Copy text exactly as shown.\n- Preserve line breaks when possible.\n- Do not summarize.\n- Do not interpret.\n- Do not correct spelling.\n- Do not infer missing words.\n\nSTEP 2: Classification\n\nClassify the image into ONE category:\n\nad-banner: Advertisement or promotional banner (usually has \"buy\", \"get tickets\", \"sale\")\nevent-flyer: Single event poster/flyer - ONE primary event with ONE title, ONE venue, and ONE date or continuous date range. May contain schedules, activities, DJs, performers, or sub-events that are clearly part of the same event. Examples: Bear Week, Bear Weekend, Pride Festival, Camp Weekend, Resort Weekend Package.\nmulti-event-flyer: Two or more independent events with different titles, different dates/times, and separate ticketing. Often appears as a calendar, event listing, or monthly schedule.\nlogo: Brand or organization logo (minimal text, just brand name)\nthumbnail: Small preview image (low detail)\nhero-banner: Large header/banner image (prominent on page)\n\nDecision rule: If there is ONE overarching event name and the listed activities appear to belong to that event, classify as event-flyer. Only classify as multi-event-flyer when multiple independent events are advertised that require separate tickets.\n\nIMPORTANT CONTEXT: This is for a gay bear community travel guide. Events may be part of:\n- \"Bear Week\" or \"Bear Weekend\" themed events\n- Annual bear gatherings (e.g., \"Puerto Vallarta Bear Week\", \"Sitges Bear Week\")\n- Regular bear-themed parties or meetups\n- Events at bear-owned businesses or bear-friendly venues\n\nSTEP 3: Event Analysis\n\nDetermine:\n- eventName: The primary event title\n- venue: The venue or venue group name\n- startDate: Start date/time if visible\n- endDate: End date/time if visible\n\nUse only information visible in the image.\n\nSTEP 4: Summary\n\nCreate a concise summary describing:\n- event name\n- venue\n- date/time\n- why it may be relevant to the bear community\n\nReturn JSON only with these fields:\n{\n  \"text\": \"full extracted text\",\n  \"imageClassification\": \"ad-banner|event-flyer|multi-event-flyer|logo|thumbnail|hero-banner\",\n  \"eventSummary\": \"a concise 1-2 sentence summary of the event including: event name, venue, date/time, and any bear-week context if applicable. Focus on what makes this event notable for the bear community.\",\n  \"confidence\": 0-100,\n  \"reason\": \"brief explanation for classification\"\n}";
         this.defaultOcrRequestConfig = {
-            timeoutSeconds: 300,
+            // With requests serialized (maxConcurrentRequests), anything slower than
+            // 2 minutes on the local vision model is stuck, not slow.
+            timeoutSeconds: 120,
             keepAlive: '5m',
             numCtx: 8192,
             numPredict: 2000,
@@ -287,8 +289,12 @@ class AiWebParser {
             // Extract OCR from ALL images FIRST - we need it for consistent segment-to-image mapping
             // regardless of whether discoveryOnly mode is enabled
             const ocrConfig = this.getOcrConfig(parserConfig);
+            // Multi-event pages need broad coverage (one flyer per segment, with the
+            // segment top-up as backstop); single-event pages only need the main flyer,
+            // so respect the configured per-page image budget there.
+            const ocrImageCap = pageClassification === 'multi-event-page' ? 10 : ocrConfig.maxImages;
             ocrResults = ocrConfig.enabled
-                ? await this.extractOcrFromAllImages(htmlData, ocrConfig, httpAdapter)
+                ? await this.extractOcrFromAllImages(htmlData, ocrConfig, httpAdapter, ocrImageCap)
                 : [];
             if (ocrResults.length > 0) {
                 console.log(`🤖 AI Web: Extracted OCR from ${ocrResults.length} image(s)`);
@@ -1899,10 +1905,25 @@ class AiWebParser {
      * Removes width/height parameters like w=1920, h=1080, w_296,h_370, etc.
      * to identify the same image at different resolutions.
      */
-    stripSizeParams(url) {
+    stripSizeParams(url, unwrapDepth = 0) {
         if (!url) return url;
         try {
             const parsed = new URL(url);
+
+            // Image proxies like img.evbuc.com wrap the source URL inside the path
+            // (img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2F...) with per-variant crop
+            // and signature query params, so no amount of param stripping makes two
+            // variants equal. Dedup on the decoded inner URL instead.
+            if (unwrapDepth < this.maxUrlUnwrapDepth) {
+                const encodedPathMatch = parsed.pathname.match(/^\/(https?%3a%2f%2f.+)$/i);
+                if (encodedPathMatch) {
+                    try {
+                        const innerUrl = decodeURIComponent(encodedPathMatch[1]);
+                        return this.stripSizeParams(innerUrl, unwrapDepth + 1);
+                    } catch (_) {}
+                }
+            }
+
             let pathname = parsed.pathname;
 
             // Remove size patterns from pathname (e.g., /w_296,h_370/ or /1920x1080/)
@@ -2277,6 +2298,7 @@ class AiWebParser {
             'cache-',         // Cached images
             'thumb',          // Thumbnails (already handled by classification)
             'thumbnail',      // Thumbnails
+            '/_next/static/', // Next.js build assets (map placeholders, UI chrome)
         ];
         for (const pattern of uninterestingPatterns) {
             if (lowerUrl.includes(pattern)) return true;
@@ -2284,29 +2306,47 @@ class AiWebParser {
         return false;
     }
 
-    async extractOcrFromAllImages(htmlData, ocrConfig = {}, httpAdapter = null) {
+    // Run an async task over items with at most `limit` in flight. Local vision models
+    // serve one request well; parallel requests just push each other into timeouts.
+    async mapWithConcurrencyLimit(items, limit, task) {
+        const list = Array.isArray(items) ? items : [];
+        const results = new Array(list.length);
+        let nextIndex = 0;
+        const workerCount = Math.max(1, Math.min(Math.floor(Number(limit) || 1), list.length || 1));
+        const workers = Array.from({ length: workerCount }, async () => {
+            while (nextIndex < list.length) {
+                const index = nextIndex++;
+                results[index] = await task(list[index], index);
+            }
+        });
+        await Promise.all(workers);
+        return results;
+    }
+
+    async extractOcrFromAllImages(htmlData, ocrConfig = {}, httpAdapter = null, maxImages = 10) {
         const sourceUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
         const html = htmlData && typeof htmlData.html === 'string' ? htmlData.html : '';
 
-        // Extract all image URLs from HTML
-        const maxOcrImages = 10;
-        const allImageUrls = this.extractOrderedImageUrlsFromHtml(html, sourceUrl, maxOcrImages);
-        if (allImageUrls.length >= maxOcrImages) {
-            console.log(`🤖 AI Web: OCR page-level image cap (${maxOcrImages}) reached — images beyond the cap rely on segment top-up`);
-        }
+        // Gather more candidates than we intend to OCR so uninteresting images
+        // (logos, icons, static assets) don't consume slots meant for real flyers.
+        const maxCandidates = Math.max(10, maxImages);
+        const candidateUrls = this.extractOrderedImageUrlsFromHtml(html, sourceUrl, maxCandidates);
 
         // Pre-filter out uninteresting images before OCR
-        const imageUrls = allImageUrls.filter(url => !this.isLikelyUninterestingImageUrl(url));
-
-        if (imageUrls.length < allImageUrls.length) {
-            console.log(`🤖 AI Web: OCR skipped ${allImageUrls.length - imageUrls.length} uninteresting images`);
+        const interestingUrls = candidateUrls.filter(url => !this.isLikelyUninterestingImageUrl(url));
+        if (interestingUrls.length < candidateUrls.length) {
+            console.log(`🤖 AI Web: OCR skipped ${candidateUrls.length - interestingUrls.length} uninteresting images`);
         }
 
-        // Batch OCR requests using Promise.all
-        const ocrPromises = imageUrls.map(url =>
+        const imageUrls = interestingUrls.slice(0, maxImages);
+        if (imageUrls.length < interestingUrls.length || candidateUrls.length >= maxCandidates) {
+            console.log(`🤖 AI Web: OCR image cap (${maxImages}) applied — images beyond the cap rely on segment top-up`);
+        }
+
+        // Batch OCR requests with limited concurrency
+        const results = await this.mapWithConcurrencyLimit(imageUrls, ocrConfig.maxConcurrentRequests || 1, url =>
             this.getOcrTextForImage(url, ocrConfig, 'ocr-all', httpAdapter).catch(err => null)
         );
-        const results = await Promise.all(ocrPromises);
 
         const ocrResults = results
             .filter(r => r !== undefined)
@@ -2434,9 +2474,9 @@ class AiWebParser {
         if (targets.length === 0) return ocrResults;
 
         console.log(`🤖 AI Web: OCR top-up for ${targets.length} segment image(s) missed by the page-level cap`);
-        const rawResults = await Promise.all(targets.map(url =>
+        const rawResults = await this.mapWithConcurrencyLimit(targets, ocrConfig.maxConcurrentRequests || 1, url =>
             this.getOcrTextForImage(url, ocrConfig, 'ocr-segment', httpAdapter).catch(() => null)
-        ));
+        );
         for (const rawResult of rawResults) {
             const normalized = this.normalizeOcrResult(rawResult);
             if (!normalized || !normalized.text || normalized.text.trim().length === 0) continue;
@@ -3462,6 +3502,11 @@ class AiWebParser {
         const maxTextChars = Number.isFinite(Number(rawOcr.maxTextChars))
             ? Math.max(250, Math.floor(Number(rawOcr.maxTextChars)))
             : 4000;
+        // Concurrent vision requests contend for the same local GPU and push each other
+        // into timeouts, so requests are serialized by default.
+        const maxConcurrentRequests = Number.isFinite(Number(rawOcr.concurrency))
+            ? Math.max(1, Math.min(4, Math.floor(Number(rawOcr.concurrency))))
+            : 1;
         const ocrConfigTemplate = {
             timeoutSeconds: this.defaultOcrRequestConfig.timeoutSeconds,
             keepAlive: this.defaultOcrRequestConfig.keepAlive,
@@ -3500,6 +3545,7 @@ class AiWebParser {
             ),
             maxImages,
             maxTextChars,
+            maxConcurrentRequests,
             cacheEnabled: rawOcr.cache !== false,
             requireMissingFields: rawOcr.requireMissingFields !== false,
             ollama: rawOcr.ollama && typeof rawOcr.ollama === 'object' ? rawOcr.ollama : (baseAiConfig.ollama || {}),

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -401,3 +401,76 @@ test('ensureSegmentOcrCoverage is a no-op when OCR is disabled or coverage is co
   assert.equal(called, false, 'disabled OCR should not trigger requests');
   assert.equal(empty.length, 0);
 });
+
+test('stripSizeParams collapses path-wrapped image proxy variants (img.evbuc.com)', () => {
+  const parser = createParser();
+  const inner = 'https://cdn.evbuc.com/images/1184410354/185013722403/1/original.20260512-160408';
+  const encoded = encodeURIComponent(inner);
+  const variantA = `https://img.evbuc.com/${encoded}?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&s=79b82ef9b2961bb09d52102535747556`;
+  const variantB = `https://img.evbuc.com/${encoded}?crop=focalpoint&fit=crop&w=1880&auto=format%2Ccompress&q=75&s=deadbeefdeadbeefdeadbeefdeadbeef`;
+
+  const strippedA = parser.stripSizeParams(variantA);
+  const strippedB = parser.stripSizeParams(variantB);
+  const strippedInner = parser.stripSizeParams(inner);
+
+  assert.equal(strippedA, strippedB, 'differently-sized/signed variants should collapse');
+  assert.equal(strippedA, strippedInner, 'wrapped variants should collapse to the inner URL');
+
+  const html = `
+    <img src="${variantA}">
+    <img src="${variantB}">
+  `;
+  const records = parser.extractOrderedImageRecordsFromHtml(html, 'https://www.eventbrite.com/e/test');
+  assert.equal(records.length, 1, 'proxy variants of the same image should dedupe to one record');
+  assert.equal(records[0].url, variantA, 'first (smaller) variant should win');
+});
+
+test('mapWithConcurrencyLimit bounds in-flight tasks and preserves order', async () => {
+  const parser = createParser();
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const items = [1, 2, 3, 4, 5];
+  const results = await parser.mapWithConcurrencyLimit(items, 2, async (item) => {
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise(resolve => setTimeout(resolve, 5));
+    inFlight--;
+    return item * 10;
+  });
+  assert.deepEqual(results, [10, 20, 30, 40, 50]);
+  assert.equal(maxInFlight, 2, 'no more than `limit` tasks should run at once');
+});
+
+test('extractOcrFromAllImages respects maxImages without letting uninteresting images consume slots', async () => {
+  const parser = createParser();
+  const html = `
+    <img src="https://x.example/logo-header.png">
+    <img src="https://x.example/images/flyer-one.jpg">
+    <img src="https://x.example/images/flyer-two.jpg">
+    <img src="https://x.example/images/flyer-three.jpg">
+  `;
+
+  const ocrCalls = [];
+  let inFlight = 0;
+  let maxInFlight = 0;
+  parser.getOcrTextForImage = async (url) => {
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise(resolve => setTimeout(resolve, 2));
+    inFlight--;
+    ocrCalls.push(url);
+    return { url, text: `TEXT FROM ${url}`, imageClassification: 'event-flyer' };
+  };
+
+  const results = await parser.extractOcrFromAllImages(
+    { url: 'https://x.example/', html },
+    { maxConcurrentRequests: 1 },
+    null,
+    2
+  );
+
+  assert.equal(ocrCalls.length, 2, 'only maxImages should be OCRd');
+  assert.ok(ocrCalls.every(url => url.includes('flyer')), 'the uninteresting logo should not consume a slot');
+  assert.equal(maxInFlight, 1, 'requests should be serialized');
+  assert.equal(results.length, 2);
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -3810,16 +3810,19 @@ class SharedCore {
     }
 
     parseAiEventResponse(rawText) {
+        // Arrays are rejected: a garbage response like "[0]" would otherwise be
+        // processed as an event object with numeric field keys.
+        const isUsableEventObject = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
         if (!rawText) return null;
         try {
             const parsed = JSON.parse(rawText);
-            return parsed && typeof parsed === 'object' ? parsed : null;
+            return isUsableEventObject(parsed) ? parsed : null;
         } catch (parseError) {
             const jsonObject = this.extractFirstJsonObject(rawText);
             if (!jsonObject) return null;
             try {
                 const parsed = JSON.parse(jsonObject);
-                return parsed && typeof parsed === 'object' ? parsed : null;
+                return isUsableEventObject(parsed) ? parsed : null;
             } catch (jsonError) {
                 return null;
             }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -108,3 +108,10 @@ test('analyzeEventAction keeps genuinely different same-venue events separate', 
   const analysis = core.analyzeEventAction(scraped, [buildCalendarEvent()]);
   assert.equal(analysis.action, 'new');
 });
+
+test('parseAiEventResponse rejects array responses', () => {
+  const core = createCore();
+  assert.equal(core.parseAiEventResponse('[0]'), null, 'bare arrays are not event objects');
+  assert.equal(core.parseAiEventResponse('[{"title": "x"}]'), null);
+  assert.deepEqual(core.parseAiEventResponse('{"title": "x"}'), { title: 'x' });
+});


### PR DESCRIPTION
## Problem

A single Megawoof run (5 Eventbrite event pages) took **~27 minutes, ~24 of them in OCR**, with 7 requests dying at exactly the 300s timeout. Two compounding causes visible in the logs:

1. **The same flyer was OCR'd 2–3× at different sizes.** `img.evbuc.com` wraps the source URL in its *path* (`img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2F...?w=940&s=<sig>`) with per-variant crop/signature params — `unwrapImageProxyUrl` only handles `?url=` proxies and `stripSizeParams` can't make two variants equal, so dedup failed. The base64 payloads tell the story: ≤1.3M chars succeeded (70–260s), the 2.4–3.3M variants always timed out. Two requests on the Megamilk page had byte-identical payload sizes — same image, two URLs.
2. **All OCR requests fired in parallel (`Promise.all`) against one local Ollama GPU**, so concurrent vision requests pushed each other into the 300s timeout.

## Changes

- **Variant dedup**: `stripSizeParams` now decodes path-wrapped proxy URLs (bounded by `maxUrlUnwrapDepth`) so every variant of an image collapses to the inner source URL for dedup. Document order means the og:image (940px) variant wins as the fetch URL — the smallest one.
- **Serialized OCR**: new `mapWithConcurrencyLimit` runs OCR requests with bounded concurrency (default 1, configurable via `ai.ocr.concurrency`, clamped 1–4) in both the page-level pass and the segment top-up.
- **Timeout 300s → 120s**: with serialized requests, anything slower than 2 minutes on the 4B vision model is stuck, not slow.
- **`ocrConfig.maxImages` finally wired in**: the existing config knob (default 2, clamped 1–4) now caps single-event pages; multi-event pages keep the 10-image cap with the segment top-up as backstop. Uninteresting images are filtered *before* the cap so logos can't consume flyer slots.
- **Riders**: `/_next/static/` build assets (the Eventbrite map placeholder OCR'd on every first encounter) marked uninteresting; `parseAiEventResponse` rejects array responses — a garbage `[0]` reply was previously processed as an event with field key `"0"`.

Expected effect on the logged run: each event page drops from ~5 min of OCR (1 success + 2 timeouts) to one ~60–90s request — roughly **27 min → 3–5 min** for the parser.

## Testing

- 4 new tests: proxy-variant collapse (`stripSizeParams` + one deduped record from HTML), concurrency limiter bounds in-flight tasks and preserves order, `extractOcrFromAllImages` respects `maxImages`/serialization without letting uninteresting images consume slots, and array-response rejection.
- Full suite: `node --test scripts/parsers/ai-web-parser.test.js scripts/shared-core.test.js scripts/normalizers.test.js` — 27/27 pass; both changed files pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)