### PR TITLE
OG studio: real NEAT gradient, compact toolbar, denser comparison grid

### DIFF
--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -60,55 +60,42 @@
     .topbar .page-name { font-size: 14px; color: var(--text-dim); letter-spacing: 0.4px; }
     .topbar .page-name strong { color: var(--text); font-weight: 600; }
 
-    .shell { max-width: 1560px; margin: 0 auto; padding: 28px 28px 80px; }
+    .shell { max-width: 1720px; margin: 0 auto; padding: 14px 20px 60px; }
 
-    .hero { margin: 6px 0 22px; }
-    .hero h1 {
-      font-family: 'Sora', sans-serif;
-      font-size: clamp(26px, 3.4vw, 40px);
-      font-weight: 800; letter-spacing: -0.5px; line-height: 1.05;
-      margin: 0 0 8px;
-      background: linear-gradient(100deg, #fff 20%, #ffb08a 60%, var(--brand) 100%);
-      -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent;
-    }
-    .hero p { margin: 0; color: var(--text-dim); font-size: 15px; max-width: 760px; line-height: 1.55; }
-
-    /* ===== Controls ===== */
-    .controls {
-      display: grid;
-      grid-template-columns: 200px minmax(280px, 1.6fr) minmax(180px, 1fr) auto;
-      gap: 12px;
-      align-items: end;
+    /* ===== Compact toolbar ===== */
+    .toolbar {
+      position: sticky; top: 55px; z-index: 40;
+      display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
       background: var(--bg-raised);
       border: 1px solid var(--line);
-      border-radius: var(--radius);
-      padding: 16px;
-      margin-bottom: 14px;
+      border-radius: 12px;
+      padding: 8px 10px;
+      margin-bottom: 16px;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.35);
     }
-    .field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
-    .field label { font-size: 11px; font-weight: 600; letter-spacing: 1.2px; text-transform: uppercase; color: var(--text-dim); }
-    .field select, .field input[type="text"], .field input[type="url"] {
+    .ctl {
       appearance: none;
       -webkit-appearance: none;
-      width: 100%;
-      padding: 11px 13px;
+      padding: 7px 10px;
       background: var(--bg-input);
       border: 1px solid var(--line);
-      border-radius: 10px;
+      border-radius: 8px;
       color: var(--text);
-      font-family: inherit; font-size: 14px;
+      font-family: inherit; font-size: 13px;
+      min-width: 0;
       transition: border-color .15s, box-shadow .15s;
     }
-    .field select { background-image: linear-gradient(45deg, transparent 50%, var(--text-dim) 50%), linear-gradient(135deg, var(--text-dim) 50%, transparent 50%); background-position: calc(100% - 18px) 50%, calc(100% - 13px) 50%; background-size: 5px 5px; background-repeat: no-repeat; padding-right: 34px; }
-    .field select:focus, .field input:focus { outline: none; border-color: var(--brand); box-shadow: 0 0 0 3px rgba(255,107,53,0.18); }
-    .btn-row { display: flex; gap: 8px; }
+    select.ctl { background-image: linear-gradient(45deg, transparent 50%, var(--text-dim) 50%), linear-gradient(135deg, var(--text-dim) 50%, transparent 50%); background-position: calc(100% - 14px) 50%, calc(100% - 10px) 50%; background-size: 4px 4px; background-repeat: no-repeat; padding-right: 26px; }
+    .ctl:focus { outline: none; border-color: var(--brand); box-shadow: 0 0 0 3px rgba(255,107,53,0.18); }
+    .ctl.grow { flex: 1 1 240px; }
+    .ctl.md { width: 170px; }
     .btn {
-      padding: 11px 16px;
-      border-radius: 10px;
+      padding: 7px 11px;
+      border-radius: 8px;
       border: 1px solid var(--line-strong);
       background: var(--bg-input);
       color: var(--text);
-      font-family: inherit; font-size: 14px; font-weight: 600;
+      font-family: inherit; font-size: 13px; font-weight: 600;
       cursor: pointer;
       transition: transform .12s, background .15s, border-color .15s;
       white-space: nowrap;
@@ -116,49 +103,19 @@
     .btn:hover { background: #232331; transform: translateY(-1px); border-color: rgba(255,255,255,0.24); }
     .btn.primary { background: linear-gradient(120deg, var(--brand), var(--brand-2)); border: none; color: #16090a; }
     .btn.primary:hover { box-shadow: 0 6px 18px rgba(255,107,53,0.35); }
-
-    .controls-secondary {
-      display: flex; flex-wrap: wrap; gap: 20px; align-items: end;
-      background: var(--bg-raised);
-      border: 1px solid var(--line);
-      border-radius: var(--radius);
-      padding: 14px 16px;
-      margin-bottom: 26px;
-    }
-    .controls-secondary .field.grow { flex: 1 1 320px; }
-
-    /* Palette strip */
-    .palette-block { display: flex; flex-direction: column; gap: 6px; }
-    .palette-label { font-size: 11px; font-weight: 600; letter-spacing: 1.2px; text-transform: uppercase; color: var(--text-dim); }
-    .palette-strip { display: flex; align-items: center; gap: 10px; padding-bottom: 16px; }
-    .swatch {
-      width: 38px; height: 38px; border-radius: 10px;
-      border: 1px solid rgba(255,255,255,0.18);
-      position: relative; flex-shrink: 0;
-      box-shadow: inset 0 0 0 1px rgba(0,0,0,0.2);
-    }
-    .swatch::after {
-      content: attr(data-hex);
-      position: absolute; top: calc(100% + 5px); left: 50%; transform: translateX(-50%);
-      font-size: 9px; color: var(--text-dim); letter-spacing: 0.3px; white-space: nowrap;
-    }
-    .palette-source { font-size: 12px; color: var(--text-dim); }
-    .palette-source b { color: var(--text); font-weight: 600; }
-
-    .toggle-field { display: flex; align-items: center; gap: 8px; padding-bottom: 10px; }
-    .toggle-field input { accent-color: var(--brand); width: 16px; height: 16px; }
-    .toggle-field label { font-size: 13px; color: var(--text-dim); cursor: pointer; user-select: none; }
-    .color-mini { display: flex; gap: 8px; align-items: center; }
-    .color-mini input[type="color"] {
-      width: 42px; height: 38px; padding: 2px;
-      background: var(--bg-input); border: 1px solid var(--line); border-radius: 10px; cursor: pointer;
-    }
+    .sep-v { width: 1px; height: 22px; background: var(--line-strong); margin: 0 2px; flex-shrink: 0; }
+    .dots { display: inline-flex; gap: 4px; align-items: center; }
+    .dot { width: 18px; height: 18px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.25); flex-shrink: 0; }
+    .tiny { font-size: 11.5px; color: var(--text-dim); display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; cursor: pointer; user-select: none; }
+    .tiny input { accent-color: var(--brand); margin: 0; }
+    .tiny b { color: var(--text); font-weight: 600; }
+    input.mini[type="color"] { width: 26px; height: 26px; padding: 1px; background: var(--bg-input); border: 1px solid var(--line); border-radius: 6px; cursor: pointer; flex-shrink: 0; }
 
     /* ===== Sample grid ===== */
     .grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(600px, 1fr));
-      gap: 26px;
+      grid-template-columns: repeat(auto-fill, minmax(430px, 1fr));
+      gap: 16px;
     }
     .card {
       background: var(--bg-raised);
@@ -168,13 +125,13 @@
       transition: border-color .2s, transform .2s, box-shadow .2s;
     }
     .card:hover { border-color: var(--line-strong); transform: translateY(-2px); box-shadow: 0 18px 40px rgba(0,0,0,0.45); }
-    .card-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 13px 16px; }
-    .card-head .name { font-weight: 700; font-size: 14.5px; letter-spacing: 0.1px; }
-    .card-head .desc { font-size: 12px; color: var(--text-dim); margin-top: 2px; }
-    .chips { display: flex; gap: 6px; flex-shrink: 0; }
+    .card-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 12px; }
+    .card-head .name { font-weight: 700; font-size: 13px; letter-spacing: 0.1px; }
+    .card-head .desc { font-size: 11px; color: var(--text-dim); margin-top: 1px; }
+    .chips { display: flex; gap: 5px; flex-shrink: 0; }
     .chip {
-      font-size: 10.5px; font-weight: 600; letter-spacing: 0.6px; text-transform: uppercase;
-      padding: 4px 9px; border-radius: 100px;
+      font-size: 9.5px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase;
+      padding: 3px 7px; border-radius: 100px;
       border: 1px solid var(--line-strong); color: var(--text-dim);
     }
     .chip.on { border-color: rgba(255,107,53,0.5); color: #ffa77f; }
@@ -222,22 +179,24 @@
     .og-title.t-md { font-size: 72px; }
     .og-title.t-sm { font-size: 54px; letter-spacing: -1px; }
 
-    /* --- 1. Aurora Mesh (neat.firecms style) --- */
-    .l-aurora { background: var(--p-deep, #0a0a12); }
-    .l-aurora .blob { position: absolute; border-radius: 50%; filter: blur(90px); opacity: 0.85; }
-    .l-aurora .b1 { width: 900px; height: 900px; top: -420px; right: -260px; animation: drift1 16s ease-in-out infinite alternate; }
-    .l-aurora .b2 { width: 700px; height: 700px; bottom: -380px; left: -180px; animation: drift2 19s ease-in-out infinite alternate; }
+    /* --- 1. Neat (the actual NEAT gradient library) + Aurora Mesh (CSS approximation) --- */
+    .l-neat, .l-aurora { background: var(--p-deep, #0a0a12); }
+    .l-neat canvas { position: absolute; inset: 0; width: 100%; height: 100%; }
+    .l-neat .scrim { position: absolute; inset: 0; z-index: 2; background: linear-gradient(180deg, rgba(0,0,0,0.02) 40%, rgba(0,0,0,0.35) 100%); }
+    .l-neat .blob, .l-aurora .blob { position: absolute; border-radius: 50%; filter: blur(90px); opacity: 0.85; }
+    .l-neat .b1, .l-aurora .b1 { width: 900px; height: 900px; top: -420px; right: -260px; animation: drift1 16s ease-in-out infinite alternate; }
+    .l-neat .b2, .l-aurora .b2 { width: 700px; height: 700px; bottom: -380px; left: -180px; animation: drift2 19s ease-in-out infinite alternate; }
     .l-aurora .b3 { width: 560px; height: 560px; top: 30%; left: 34%; opacity: 0.6; animation: drift3 14s ease-in-out infinite alternate; }
     .l-aurora .b4 { width: 460px; height: 460px; bottom: -200px; right: 16%; opacity: 0.55; animation: drift2 22s ease-in-out infinite alternate-reverse; }
     @keyframes drift1 { from { transform: translate(0,0) scale(1); } to { transform: translate(-140px, 90px) scale(1.15); } }
     @keyframes drift2 { from { transform: translate(0,0) scale(1); } to { transform: translate(120px, -70px) scale(1.1); } }
     @keyframes drift3 { from { transform: translate(0,0) scale(1); } to { transform: translate(-90px, -110px) scale(1.25); } }
-    .l-aurora .content {
+    .l-neat .content, .l-aurora .content {
       position: absolute; inset: 70px 80px; z-index: 6;
       display: flex; flex-direction: column; justify-content: flex-end; gap: 28px;
     }
-    .l-aurora .brand-mark { position: absolute; top: 0; left: 0; }
-    .l-aurora .og-title { text-shadow: 0 6px 40px rgba(0,0,0,0.35); max-width: 950px; }
+    .l-neat .brand-mark, .l-aurora .brand-mark { position: absolute; top: 0; left: 0; }
+    .l-neat .og-title, .l-aurora .og-title { text-shadow: 0 6px 40px rgba(0,0,0,0.35); max-width: 950px; }
 
     /* --- 2. Silk Flow (WebGL shader) --- */
     .l-silk { background: var(--p-deep, #0a0a12); }
@@ -435,15 +394,12 @@
 
     footer.page-foot { margin-top: 40px; text-align: center; color: var(--text-dim); font-size: 13px; }
 
-    @media (max-width: 1400px) {
+    @media (max-width: 940px) {
       .grid { grid-template-columns: 1fr; }
     }
-    @media (max-width: 1100px) {
-      .controls { grid-template-columns: 1fr 1fr; }
-    }
     @media (max-width: 640px) {
-      .shell { padding: 18px 14px 60px; }
-      .controls { grid-template-columns: 1fr; }
+      .shell { padding: 12px 10px 50px; }
+      .toolbar { position: static; }
     }
   </style>
 </head>
@@ -455,59 +411,22 @@
   </header>
 
   <main class="shell">
-    <div class="hero">
-      <h1>OpenGraph Image Studio</h1>
-      <p>Six candidate designs for event share images (1200×630). Each sample pulls the selected event's promo image when one exists, and builds its palette from the favicon colors we scrape for the event or its venue.</p>
-    </div>
-
-    <div class="controls">
-      <div class="field">
-        <label for="citySelect">City</label>
-        <select id="citySelect"></select>
-      </div>
-      <div class="field">
-        <label for="eventSelect">Event</label>
-        <select id="eventSelect"></select>
-      </div>
-      <div class="field">
-        <label for="eventSearch">Filter</label>
-        <input id="eventSearch" type="text" placeholder="Type to filter events…">
-      </div>
-      <div class="btn-row">
-        <button id="randomBtn" class="btn primary">🎲 Random</button>
-        <button id="reloadBtn" class="btn" title="Reload events">↻</button>
-      </div>
-    </div>
-
-    <div class="controls-secondary">
-      <div class="palette-block">
-        <div class="palette-label">Palette</div>
-        <div class="palette-strip" id="paletteStrip"></div>
-        <div class="palette-source" id="paletteSource"></div>
-      </div>
-      <div class="field">
-        <label>Override colors</label>
-        <div class="color-mini">
-          <input id="overrideA" type="color" value="#ff6b35" title="Primary override">
-          <input id="overrideB" type="color" value="#f7931e" title="Secondary override">
-          <div class="toggle-field" style="padding-bottom:0;">
-            <input id="overrideOn" type="checkbox">
-            <label for="overrideOn">Use overrides</label>
-          </div>
-        </div>
-      </div>
-      <div class="field grow">
-        <label for="coverInput">Image URL override (blank = event image)</label>
-        <input id="coverInput" type="url" placeholder="https://example.com/promo.jpg">
-      </div>
-      <div class="field">
-        <label for="cssPatternSelect">Classic pattern bg</label>
-        <select id="cssPatternSelect"><option>Loading…</option></select>
-      </div>
-      <div class="toggle-field">
-        <input id="animsOn" type="checkbox" checked>
-        <label for="animsOn">Animate gradients</label>
-      </div>
+    <div class="toolbar">
+      <select id="citySelect" class="ctl" title="City"></select>
+      <select id="eventSelect" class="ctl grow" title="Event"></select>
+      <input id="eventSearch" class="ctl md" type="text" placeholder="Filter events…">
+      <button id="randomBtn" class="btn primary" title="Random event">🎲</button>
+      <button id="reloadBtn" class="btn" title="Reload events">↻</button>
+      <span class="sep-v"></span>
+      <span class="dots" id="paletteStrip"></span>
+      <span class="tiny" id="paletteSource"></span>
+      <span class="sep-v"></span>
+      <input id="overrideA" class="mini" type="color" value="#ff6b35" title="Override color 1">
+      <input id="overrideB" class="mini" type="color" value="#f7931e" title="Override color 2">
+      <label class="tiny" title="Use the override colors instead of scraped favicon colors"><input id="overrideOn" type="checkbox">override</label>
+      <input id="coverInput" class="ctl md" type="url" placeholder="Image URL (blank = event img)">
+      <select id="cssPatternSelect" class="ctl md" title="Classic pattern background"><option>Loading…</option></select>
+      <label class="tiny" title="Animate the gradient backgrounds"><input id="animsOn" type="checkbox" checked>animate</label>
     </div>
 
     <section class="grid" id="grid"></section>
@@ -515,6 +434,13 @@
     <footer class="page-foot">Artboards are true 1200×630 compositions scaled to fit — what you see is what the OG crop gets.</footer>
   </main>
 
+  <script type="module">
+    // The actual NEAT gradient library from neat.firecms.co (three.js bundled)
+    import("https://esm.sh/@firecms/neat@1.0.1")
+      .then(m => { window.NeatGradient = m.NeatGradient; })
+      .catch(e => console.warn('NEAT library failed to load — Neat sample falls back to CSS mesh', e))
+      .finally(() => window.dispatchEvent(new Event('neat-ready')));
+  </script>
   <script src="../js/logger.js"></script>
   <script src="../js/city-config.js"></script>
   <script src="../js/event-schema.js"></script>
@@ -875,6 +801,9 @@
         stopAnims() {
           this.anims.forEach(a => {
             if (a.raf) cancelAnimationFrame(a.raf);
+            if (a.neat) {
+              try { a.neat.destroy(); } catch (e) {}
+            }
             if (a.gl) {
               const ext = a.gl.getExtension('WEBGL_lose_context');
               if (ext) ext.loseContext();
@@ -885,9 +814,9 @@
 
         renderPaletteStrip(p) {
           paletteStrip.innerHTML = [p.bg, p.fg, p.c3, p.c4, p.deep]
-            .map(hex => `<div class="swatch" data-hex="${hex}" style="background:${hex}"></div>`)
+            .map(hex => `<div class="dot" title="${hex}" style="background:${hex}"></div>`)
             .join('');
-          paletteSource.innerHTML = `Source: <b>${escapeHtml(p.source)}</b>`;
+          paletteSource.innerHTML = `<b>${escapeHtml(p.source)}</b>`;
         }
 
         variants(data, p) {
@@ -906,9 +835,31 @@
 
           return [
             {
+              key: 'neat',
+              name: 'Neat',
+              desc: window.NeatGradient
+                ? 'The real NEAT gradient library (neat.firecms.co) in the scraped palette'
+                : 'NEAT library unavailable — CSS mesh stand-in',
+              chips: ['favicon colors', 'animated', 'neat lib'],
+              html: `
+                <div class="artboard l-neat" style="--p-deep:${p.deep}">
+                  ${window.NeatGradient
+                    ? '<canvas class="neat-canvas"></canvas>'
+                    : `<div class="blob b1" style="background:radial-gradient(circle at 40% 40%, ${p.c1}, transparent 70%)"></div>
+                       <div class="blob b2" style="background:radial-gradient(circle at 60% 40%, ${p.c4}, transparent 70%)"></div>`}
+                  <div class="scrim"></div>
+                  <div class="grain"></div>
+                  <div class="content">
+                    ${brand}
+                    <h2 class="og-title ${data.titleClass}">${escapeHtml(data.title)}</h2>
+                    ${metaPills}
+                  </div>
+                </div>`
+            },
+            {
               key: 'aurora',
               name: 'Aurora Mesh',
-              desc: 'Drifting mesh gradient built from the scraped palette (neat.firecms vibe)',
+              desc: 'Drifting CSS blob mesh built from the scraped palette',
               chips: ['favicon colors', 'animated'],
               html: `
                 <div class="artboard l-aurora" style="--p-deep:${p.deep}">
@@ -1180,6 +1131,7 @@
             + this.classics(data, p).map(cardHtml).join('');
 
           this.fitArtboards();
+          grid.querySelectorAll('.neat-canvas').forEach(canvas => this.initNeat(canvas, p));
           grid.querySelectorAll('.silk-canvas').forEach(canvas => this.initSilk(canvas, p));
           grid.querySelectorAll('.css-pattern-bg').forEach(el => this.applyCssPattern(el, p));
         }
@@ -1193,6 +1145,41 @@
               art.style.transform = `scale(${scale})`;
             });
           });
+        }
+
+        // ---------- NEAT gradient (real library from neat.firecms.co) ----------
+        initNeat(canvas, p) {
+          if (!window.NeatGradient) return;
+          try {
+            const neat = new window.NeatGradient({
+              ref: canvas,
+              colors: [
+                { color: p.c1, enabled: true },
+                { color: p.c2, enabled: true },
+                { color: p.c3, enabled: true },
+                { color: p.c4, enabled: true },
+                { color: p.deep, enabled: true }
+              ],
+              speed: animsOn.checked ? 4 : 0,
+              horizontalPressure: 3,
+              verticalPressure: 4,
+              waveFrequencyX: 2,
+              waveFrequencyY: 3,
+              waveAmplitude: 6,
+              shadows: 4,
+              highlights: 6,
+              colorSaturation: 2,
+              colorBrightness: 1,
+              colorBlending: 6,
+              wireframe: false,
+              backgroundColor: p.deep,
+              backgroundAlpha: 1,
+              resolution: 0.4
+            });
+            this.anims.push({ neat });
+          } catch (e) {
+            logger.componentError(COMPONENT, 'NEAT gradient init failed', e);
+          }
         }
 
         // ---------- WebGL flow-noise gradient (Silk Flow) ----------
@@ -1369,6 +1356,11 @@
           window.addEventListener('resize', () => {
             clearTimeout(resizeTimer);
             resizeTimer = setTimeout(() => this.fitArtboards(), 120);
+          });
+
+          // Re-render once the NEAT module finishes loading (it races with init)
+          window.addEventListener('neat-ready', () => {
+            if (this.selectedEvent) this.render();
           });
         }
 


### PR DESCRIPTION
Follow-up to #1441 based on feedback:

- **Real NEAT gradient**: the "Neat" sample now uses the actual [@firecms/neat](https://neat.firecms.co/) library (loaded from esm.sh, three.js bundled) with the scraped favicon palette — the flowing silk-wave look from their homepage, not a CSS approximation. Falls back to the CSS blob mesh if the module fails to load. The old blob version stays as "Aurora Mesh" for comparison.
- **WAY smaller controls**: the hero heading and two full-width control panels are collapsed into a single slim sticky toolbar (city / event / filter / random / palette dots with hex tooltips / color overrides / image URL / classic pattern / animate toggle). Samples now start basically at the top of the page.
- **More OG images per screen**: grid tightened to ~3 columns with slimmer card headers, so all 13 layouts (7 new + 6 classics) can be compared with far less scrolling.

Verified in headless Chrome: NEAT module loads and renders, all 13 artboards draw with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)