### PR TITLE
fix(scriptable): validate rapid-mlx OCR setup and fix the sample OCR config

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -3493,9 +3493,11 @@ class AiWebParser {
         const parserAiConfig = parserConfig && parserConfig.ai && typeof parserConfig.ai === 'object'
             ? parserConfig.ai
             : {};
+        // Canonical location is parserConfig.ai.ocr; accept a top-level parserConfig.ocr
+        // as fallback so a mis-nested block configures OCR instead of being silently ignored.
         const rawOcr = parserAiConfig.ocr && typeof parserAiConfig.ocr === 'object'
             ? parserAiConfig.ocr
-            : {};
+            : (parserConfig && parserConfig.ocr && typeof parserConfig.ocr === 'object' ? parserConfig.ocr : {});
         const maxImages = Number.isFinite(Number(rawOcr.maxImages))
             ? Math.max(1, Math.min(4, Math.floor(Number(rawOcr.maxImages))))
             : 2;
@@ -3527,8 +3529,11 @@ class AiWebParser {
                 : 'http://desktop.taila7523c.ts.net:11434/api/generate';
         }
 
+        // OCR requires a VISION model. OpenAI-compatible servers (rapid-mlx) reject image
+        // content on text models ("Model ... does not support image, video, or audio inputs"),
+        // so never default to the text/coder model used for extraction.
         const defaultModel = provider === 'openai'
-            ? 'lmstudio-community/Qwen3-Coder-Next-MLX-6bit'
+            ? 'mlx-community/Qwen3-VL-4B-Instruct-4bit'
             : this.defaultOcrModel;
 
         return {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -222,13 +222,20 @@ test('buildAiPayload and extractAiResponse support both Ollama and OpenAI', () =
   assert.equal(openaiPayloadText.max_tokens, 1024);
   assert.deepEqual(openaiPayloadText.response_format, { type: 'json_object' });
 
-  // OpenAI Payload (Vision)
+  // OpenAI Payload (Vision) — unknown magic bytes fall back to png
   const openaiPayloadVision = parser.core.buildAiPayload(openaiConfig, prompt, base64Image);
   assert.ok(Array.isArray(openaiPayloadVision.messages[0].content));
   assert.equal(openaiPayloadVision.messages[0].content[0].type, 'text');
   assert.equal(openaiPayloadVision.messages[0].content[0].text, prompt);
   assert.equal(openaiPayloadVision.messages[0].content[1].type, 'image_url');
   assert.equal(openaiPayloadVision.messages[0].content[1].image_url.url, `data:image/png;base64,${base64Image}`);
+
+  // OpenAI Payload (Vision) — mime detected from base64 magic bytes
+  const jpegBase64 = '/9j/4AAQSkZJRgABAQAAAQ';
+  const openaiPayloadJpeg = parser.core.buildAiPayload(openaiConfig, prompt, jpegBase64);
+  assert.equal(openaiPayloadJpeg.messages[0].content[1].image_url.url, `data:image/jpeg;base64,${jpegBase64}`);
+  assert.equal(parser.core.detectBase64ImageMimeType('iVBORw0KGgoAAAANSUhEUg'), 'image/png');
+  assert.equal(parser.core.detectBase64ImageMimeType('UklGRh4AAABXRUJQVlA4'), 'image/webp');
 
   // Response Extraction
   const ollamaResponse = { response: '{"title": "Ollama Event"}' };
@@ -473,4 +480,23 @@ test('extractOcrFromAllImages respects maxImages without letting uninteresting i
   assert.ok(ocrCalls.every(url => url.includes('flyer')), 'the uninteresting logo should not consume a slot');
   assert.equal(maxInFlight, 1, 'requests should be serialized');
   assert.equal(results.length, 2);
+});
+
+test('getOcrConfig defaults the openai provider to a vision model and accepts top-level ocr blocks', () => {
+  const parser = createParser();
+
+  // openai provider must never default to the text/coder extraction model
+  const openaiOcr = parser.getOcrConfig({ ai: { ocr: { provider: 'openai' } } });
+  assert.equal(openaiOcr.provider, 'openai');
+  assert.match(openaiOcr.model, /VL/i, 'openai OCR default must be a vision model');
+  assert.equal(openaiOcr.endpoint, 'http://rybook.taila7523c.ts.net:8000/v1/chat/completions');
+
+  // A mis-nested top-level ocr block should still configure OCR (fallback)...
+  const topLevel = parser.getOcrConfig({ ocr: { maxImages: 3, concurrency: 2 } });
+  assert.equal(topLevel.maxImages, 3);
+  assert.equal(topLevel.maxConcurrentRequests, 2);
+
+  // ...but the canonical ai.ocr block wins when both exist
+  const both = parser.getOcrConfig({ ai: { ocr: { maxImages: 4 } }, ocr: { maxImages: 3 } });
+  assert.equal(both.maxImages, 4);
 });

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -343,21 +343,33 @@ const scraperConfig = {
         think: false,
         timeoutSeconds: 120,
         keepAlive: "5m",
-      },
-      ocr: {
-        enabled: true,
-        endpoint: "http://desktop.taila7523c.ts.net:11434/api/generate",
-        model: "qwen3-vl:4b-instruct", // OCR model - defaults to qwen3-vl:4b-instruct
-        timeoutSeconds: 300,
-        numCtx: 8192,
-        numPredict: 2000,
-        temperature: 0,
-        think: false,
-        keepAlive: "5m",
-        maxImages: 2,
-        maxTextChars: 4000,
-        cacheEnabled: true,
-        requireMissingFields: true,
+        // OCR settings live inside `ai` (getOcrConfig reads parserConfig.ai.ocr; a
+        // top-level `ocr` block is accepted as fallback, but this is the canonical spot).
+        ocr: {
+          enabled: true,
+          // --- Option A (default): Ollama vision model on desktop ---
+          provider: "ollama",
+          endpoint: "http://desktop.taila7523c.ts.net:11434/api/generate",
+          model: "qwen3-vl:4b-instruct", // OCR requires a VISION model
+          // --- Option B: rapid-mlx (OpenAI-compatible, Apple Silicon) on rybook ---
+          // rapid-mlx must be serving a VISION (VLM) model — text models reject image
+          // input with "Model ... does not support image, video, or audio inputs."
+          // Check what's served: http://rybook.taila7523c.ts.net:8000/v1/models
+          // provider: "openai",
+          // endpoint: "http://rybook.taila7523c.ts.net:8000/v1/chat/completions",
+          // model: "mlx-community/Qwen3-VL-4B-Instruct-4bit",
+          timeoutSeconds: 120,
+          numCtx: 8192,
+          numPredict: 2000,
+          temperature: 0,
+          think: false,
+          keepAlive: "5m",
+          maxImages: 2, // Per-page OCR budget on single-event pages (multi-event pages use 10 + segment top-up)
+          concurrency: 1, // Concurrent OCR requests; keep 1 for a single local GPU
+          maxTextChars: 4000,
+          cache: true, // OCR result cache (key is `cache`, not `cacheEnabled`)
+          requireMissingFields: true,
+        },
       },
       // Comprehensive example of fieldPriorities for merging data from different sources
       fieldPriorities: {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -3703,6 +3703,17 @@ class SharedCore {
     // AI ORCHESTRATION HELPERS
     // ============================================================================
 
+    // Detect the image mime type from base64 magic bytes so OpenAI-compatible servers
+    // that trust the data-URL label (instead of sniffing bytes) decode correctly.
+    detectBase64ImageMimeType(base64Image) {
+        const text = String(base64Image || '');
+        if (text.startsWith('/9j/')) return 'image/jpeg';
+        if (text.startsWith('iVBOR')) return 'image/png';
+        if (text.startsWith('R0lGO')) return 'image/gif';
+        if (text.startsWith('UklGR')) return 'image/webp';
+        return 'image/png';
+    }
+
     buildAiPayload(aiConfig, prompt, base64Image = null) {
         if (aiConfig.provider === 'ollama') {
             const payload = {
@@ -3732,7 +3743,7 @@ class SharedCore {
                     {
                         type: "image_url",
                         image_url: {
-                            url: `data:image/png;base64,${base64Image}`
+                            url: `data:${this.detectBase64ImageMimeType(base64Image)};base64,${base64Image}`
                         }
                     }
                 ];


### PR DESCRIPTION
(Re-created cleanly off main — the original commit landed on `fix/ocr-performance` just after #1445 merged, so it wasn't part of any open PR.)

## Context

Validated the openai-provider OCR path against the live rapid-mlx endpoint (`rybook:8000`):

- **Our payload shape is correct.** rapid-mlx's OpenAPI spec documents exactly the multimodal format `buildAiPayload` produces (`content: [{type:"text"},{type:"image_url",image_url:{url:"data:..."}}]`), plus `max_tokens` and `response_format:{type:"json_object"}`. A live probe request was parsed and answered.
- **OCR against rybook can't work until a vision model is served there.** The only model currently loaded is `lmstudio-community/Qwen3-Coder-Next-MLX-6bit`, and rapid-mlx rejects image input on text models: `"Model ... does not support image, video, or audio inputs."` (Clean 4xx; `callAiGenerate` logs the error body, so it's diagnosable.)

## Fixes

1. **The sample parser's `ocr` block was entirely dead**: it sat at the parser top level while `getOcrConfig` only reads `parserConfig.ai.ocr`, and it used `cacheEnabled` where the real key is `cache`. The sample now nests `ocr` inside `ai` with corrected keys, current defaults (120s timeout, `concurrency`, `maxImages` semantics), and a commented **Option B** showing the exact rapid-mlx settings: `provider: "openai"`, the `/v1/chat/completions` endpoint, and a **vision** model (`mlx-community/Qwen3-VL-4B-Instruct-4bit` — verified on HF; the MLX analog of the ollama default `qwen3-vl:4b-instruct`), plus a pointer to check `/v1/models` for what's actually served.
2. `getOcrConfig` accepts a top-level `ocr` block as fallback, so a mis-nested config configures OCR instead of being silently ignored.
3. The openai OCR **default model was the Qwen3-Coder text model** — a guaranteed rejection for image input. It now defaults to the Qwen3-VL 4-bit MLX model.
4. Data URLs hardcoded `image/png` regardless of actual bytes; the mime is now detected from base64 magic bytes (jpeg/png/gif/webp, png fallback).

## Testing

- New tests: openai OCR default resolves to a vision model + rybook endpoint, top-level `ocr` fallback (and `ai.ocr` precedence), mime detection from jpeg/png/webp magic bytes.
- `node --test scripts/parsers/ai-web-parser.test.js scripts/shared-core.test.js scripts/normalizers.test.js` — 28/28 pass; `scripts/scraper-input.js` passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)