### PR TITLE
fix(scriptable): OCR reliability — image downscaling, context-overflow detection, response salvage

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1060,11 +1060,31 @@ class ScriptableAdapter {
     return Number.isFinite(statusCode) ? statusCode : null;
   }
 
-  async fetchImageAsBase64(url, timeoutSeconds = 30) {
+  async fetchImageAsBase64(url, timeoutSeconds = 30, maxDimension = 1568) {
     try {
       const request = new Request(url);
       request.timeoutInterval = timeoutSeconds;
-      const image = await request.loadImage();
+      let image = await request.loadImage();
+      // Vision-model image tokens scale with pixel count, not file size. Oversized
+      // images overflow the model context and come back as empty responses with
+      // finish_reason "length", so cap the longest side before encoding.
+      const width = image.size ? image.size.width : 0;
+      const height = image.size ? image.size.height : 0;
+      const longestSide = Math.max(width, height);
+      if (maxDimension > 0 && longestSide > maxDimension) {
+        const scale = maxDimension / longestSide;
+        const newWidth = Math.max(1, Math.round(width * scale));
+        const newHeight = Math.max(1, Math.round(height * scale));
+        const context = new DrawContext();
+        context.size = new Size(newWidth, newHeight);
+        context.opaque = true;
+        context.respectScreenScale = false;
+        context.drawImageInRect(image, new Rect(0, 0, newWidth, newHeight));
+        image = context.getImage();
+        console.log(
+          `📱 Scriptable: Downscaled image ${Math.round(width)}x${Math.round(height)} → ${newWidth}x${newHeight} for OCR: ${url}`,
+        );
+      }
       const jpegData = Data.fromJPEG(image);
       return jpegData.toBase64String();
     } catch (error) {

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -286,14 +286,20 @@ class AiWebParser {
             const sourceUrl = htmlData && htmlData.url ? htmlData.url : '';
             const additionalLinks = this.extractAdditionalUrls(html, sourceUrl, parserConfig);
 
-            // Extract OCR from ALL images FIRST - we need it for consistent segment-to-image mapping
-            // regardless of whether discoveryOnly mode is enabled
+            // Extract OCR from ALL images FIRST - we need it for consistent segment-to-image
+            // mapping. Multi-event pages always need OCR (segment pairing runs even in
+            // discoveryOnly mode); pages whose extraction will be skipped (link-aggregators,
+            // or any page in discoveryOnly mode) have no OCR consumer, so skip the expense.
             const ocrConfig = this.getOcrConfig(parserConfig);
+            const runOcr = ocrConfig.enabled && this.shouldRunOcrForPage(parserConfig, pageClassification);
+            if (ocrConfig.enabled && !runOcr) {
+                console.log(`🤖 AI Web: Skipping OCR for ${pageClassification || 'unclassified'} page — no extraction will run (link-finding mode)`);
+            }
             // Multi-event pages need broad coverage (one flyer per segment, with the
             // segment top-up as backstop); single-event pages only need the main flyer,
             // so respect the configured per-page image budget there.
             const ocrImageCap = pageClassification === 'multi-event-page' ? 10 : ocrConfig.maxImages;
-            ocrResults = ocrConfig.enabled
+            ocrResults = runOcr
                 ? await this.extractOcrFromAllImages(htmlData, ocrConfig, httpAdapter, ocrImageCap)
                 : [];
             if (ocrResults.length > 0) {
@@ -1872,6 +1878,8 @@ class AiWebParser {
         try {
             const parsed = new URL(url);
             parsed.hash = '';
+            // www and bare-host variants of the same page are the same page
+            parsed.hostname = String(parsed.hostname || '').replace(/^www\./i, '');
             // Strip tracking/affiliate params so the same event with different tracking
             // suffixes (e.g. ?aff=ebdsoporgprofile, ?utm_source=…) deduplicates correctly.
             for (const key of [...parsed.searchParams.keys()]) {
@@ -2150,6 +2158,14 @@ class AiWebParser {
             if (responseText === undefined || responseText === null) return null;
 
             const parsed = JSON.parse(responseText);
+            if (parsed && typeof parsed === 'object' && parsed.failureKind) {
+                return {
+                    imageUrl: cached.url || normalizedUrl,
+                    failureKind: String(parsed.failureKind),
+                    cachePath,
+                    cached: true
+                };
+            }
             const normalized = this.normalizeOcrResult(parsed);
 
             return {
@@ -2224,7 +2240,7 @@ class AiWebParser {
 
     parseOcrResponseWithClassification(rawText) {
         const parsed = this.core.parseAiEventResponse(rawText);
-        if (!parsed) return null;
+        if (!parsed) return this.salvageTruncatedOcrResponse(rawText);
 
         return {
             text: parsed.text,
@@ -2233,6 +2249,46 @@ class AiWebParser {
             confidence: parsed.confidence,
             reason: parsed.reason
         };
+    }
+
+    // Vision models sometimes emit valid OCR text and then degenerate (e.g. endless
+    // newlines) until the token limit cuts the JSON off mid-string. The braces never
+    // balance so JSON.parse fails, but the "text" field is complete — pull it out
+    // rather than discarding a successful OCR pass.
+    salvageTruncatedOcrResponse(rawText) {
+        const source = String(rawText || '');
+        if (!source.includes('"text"')) return null;
+        const textMatch = source.match(/"text"\s*:\s*"((?:[^"\\]|\\.)*)/);
+        if (!textMatch || !textMatch[1]) return null;
+        let text;
+        try {
+            text = JSON.parse(`"${textMatch[1].replace(/\r?\n/g, '\\n')}"`);
+        } catch (_) {
+            text = textMatch[1].replace(/\\n/g, '\n').replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+        }
+        text = text.replace(/\n{3,}/g, '\n\n').trim();
+        if (!text) return null;
+
+        const classificationMatch = source.match(/"imageClassification"\s*:\s*"([^"\\]*)"/);
+        const summaryMatch = source.match(/"eventSummary"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+        const confidenceMatch = source.match(/"confidence"\s*:\s*(\d+)/);
+        console.warn(`🤖 AI Web: Salvaged OCR text (${text.length} chars) from a truncated/malformed JSON response`);
+        return {
+            text,
+            imageClassification: classificationMatch ? classificationMatch[1] : '',
+            eventSummary: summaryMatch ? summaryMatch[1] : null,
+            confidence: confidenceMatch ? Number(confidenceMatch[1]) : null,
+            reason: 'salvaged-from-truncated-response'
+        };
+    }
+
+    // OCR is only worth paying for when something consumes it: segment pairing on
+    // multi-event pages (which runs even in discoveryOnly mode), or AI extraction.
+    // Link-aggregators never extract, and discoveryOnly skips extraction everywhere.
+    shouldRunOcrForPage(parserConfig = {}, pageClassification = null) {
+        if (pageClassification === 'multi-event-page') return true;
+        if (pageClassification === 'link-aggregator') return false;
+        return parserConfig.discoveryOnly !== true;
     }
 
     isLikelyEmptyOcrText(text) {
@@ -2756,6 +2812,10 @@ class AiWebParser {
     async getOcrTextForImage(imageUrl, ocrConfig = {}, passLabel = 'ocr', httpAdapter = null) {
         const cached = await this.readCachedOcrResult(imageUrl, ocrConfig);
         if (cached) {
+            if (cached.failureKind) {
+                console.log(`🤖 AI Web: OCR negative cache hit (${cached.failureKind}) for ${cached.imageUrl || imageUrl} — skipping known-bad image`);
+                return null;
+            }
             console.log(`🤖 AI Web: OCR cache hit for ${cached.imageUrl || imageUrl}`);
             return cached;
         }
@@ -2765,10 +2825,29 @@ class AiWebParser {
         if (!normalizedUrl) {
             throw new Error('Missing image URL');
         }
-        const base64Image = await httpAdapter.fetchImageAsBase64(normalizedUrl, ocrConfig.timeoutSeconds);
-        console.log(`🤖 AI Web: OCR image attached via base64 payload (${base64Image.length} chars)`);
-        const rawResponse = await this.core.callAiGenerate(ocrConfig, ocrConfig.prompt, passLabel, httpAdapter, this.recordAiPrompt.bind(this), base64Image);
-        if (!rawResponse) return null;
+        const downloadStart = Date.now();
+        let base64Image;
+        try {
+            base64Image = await httpAdapter.fetchImageAsBase64(normalizedUrl, ocrConfig.timeoutSeconds);
+        } catch (error) {
+            console.warn(`🚨 AI Web: OCR image download failed for ${normalizedUrl} after ${Date.now() - downloadStart}ms: ${error.message}`);
+            throw error;
+        }
+        console.log(`🤖 AI Web: OCR image attached via base64 payload (${base64Image.length} chars) for ${normalizedUrl} (downloaded in ${Date.now() - downloadStart}ms)`);
+        const diagnostics = {};
+        const rawResponse = await this.core.callAiGenerate(ocrConfig, ocrConfig.prompt, passLabel, httpAdapter, this.recordAiPrompt.bind(this), base64Image, diagnostics);
+        if (!rawResponse) {
+            // Context overflow is deterministic for a given image+model — cache the
+            // failure so the same image is not re-downloaded and re-sent on every
+            // page (and every run) that references it.
+            if (diagnostics.failureKind === 'context-overflow') {
+                const cachePath = await this.writeCachedOcrResult(imageUrl, ocrConfig, JSON.stringify({ failureKind: diagnostics.failureKind }));
+                if (cachePath) {
+                    console.warn(`🤖 AI Web: Cached OCR failure (${diagnostics.failureKind}) for ${normalizedUrl} so it is not retried`);
+                }
+            }
+            return null;
+        }
         const parsed = this.parseOcrResponseWithClassification(rawResponse);
         if (!parsed) {
             console.warn(`🤖 AI Web: OCR response for ${imageUrl} did not include text`);
@@ -2927,6 +3006,10 @@ class AiWebParser {
             'kqzyfj.com',
             'sjv.io',
             'pxf.io',
+            // Bot-walled ticketing sites — always return HTTP 401/403 to non-browser
+            // clients, so crawling them only produces failure-cache entries
+            'ticketmaster.com',
+            'livenation.com',
             // External promotional / artist sites that are not event listing pages
             'jphardyofficial.com',
             'heymistr.com',

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -500,3 +500,120 @@ test('getOcrConfig defaults the openai provider to a vision model and accepts to
   const both = parser.getOcrConfig({ ai: { ocr: { maxImages: 4 } }, ocr: { maxImages: 3 } });
   assert.equal(both.maxImages, 4);
 });
+
+test('parseOcrResponseWithClassification salvages OCR text from truncated/degenerate JSON', () => {
+  const parser = createParser();
+
+  // Provincetown-style failure: valid text, then the model degenerates into endless
+  // newlines and the JSON never closes.
+  const truncated = '{\n  "text": "BEAR WEEK KICK OFF\\nBEARRACUDA\\nPROVINCETOWN\\n\\nBEATS BY\\nKELLY' +
+    '\n'.repeat(400);
+  const salvaged = parser.parseOcrResponseWithClassification(truncated);
+  assert.ok(salvaged, 'truncated response should be salvaged, not discarded');
+  assert.match(salvaged.text, /BEAR WEEK KICK OFF/);
+  assert.match(salvaged.text, /BEATS BY\nKELLY/);
+  assert.ok(!/\n{3,}/.test(salvaged.text), 'degenerate newline runs should be collapsed');
+  assert.equal(salvaged.reason, 'salvaged-from-truncated-response');
+
+  // Truncation after a complete text field still picks up classification/confidence
+  const cutLater = '{"text": "FURBALL NYC\\nSATURDAY 10PM", "imageClassification": "event-flyer", "confidence": 95, "eventSummary": "Furball';
+  const later = parser.parseOcrResponseWithClassification(cutLater);
+  assert.equal(later.text, 'FURBALL NYC\nSATURDAY 10PM');
+  assert.equal(later.imageClassification, 'event-flyer');
+  assert.equal(later.confidence, 95);
+
+  // Well-formed responses keep going through the normal parse path untouched
+  const complete = parser.parseOcrResponseWithClassification(
+    '{"text": "HOT TAKE", "imageClassification": "event-flyer", "eventSummary": "s", "confidence": 90, "reason": "r"}'
+  );
+  assert.equal(complete.text, 'HOT TAKE');
+  assert.equal(complete.reason, 'r');
+
+  // Garbage with no text field stays rejected
+  assert.equal(parser.parseOcrResponseWithClassification('not json at all'), null);
+  assert.equal(parser.parseOcrResponseWithClassification('{"foo": "bar"'), null);
+});
+
+test('shouldRunOcrForPage skips OCR when no extraction or segment pairing will consume it', () => {
+  const parser = createParser();
+
+  // Multi-event pages always OCR — segment pairing runs even in discoveryOnly mode
+  assert.equal(parser.shouldRunOcrForPage({ discoveryOnly: true }, 'multi-event-page'), true);
+  assert.equal(parser.shouldRunOcrForPage({}, 'multi-event-page'), true);
+
+  // Link-aggregators never extract events, so OCR has no consumer
+  assert.equal(parser.shouldRunOcrForPage({}, 'link-aggregator'), false);
+
+  // Event pages OCR only when extraction will actually run
+  assert.equal(parser.shouldRunOcrForPage({}, 'event-page'), true);
+  assert.equal(parser.shouldRunOcrForPage({ discoveryOnly: true }, 'event-page'), false);
+  assert.equal(parser.shouldRunOcrForPage({ discoveryOnly: true }, null), false);
+});
+
+test('getOcrTextForImage negative-caches context-overflow failures and skips them next time', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-cache-test-'));
+
+  const parser = new AiWebParser({ normalizeUrl, ocrCacheDir: cacheDir });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+
+  const imageUrl = 'https://cdn.example/huge-masthead.webp';
+  const ocrConfig = {
+    cacheEnabled: true,
+    model: 'mlx-community/Qwen3-VL-4B-Instruct-4bit',
+    prompt: 'ocr prompt',
+    timeoutSeconds: 120
+  };
+  const httpAdapter = { fetchImageAsBase64: async () => 'base64imagedata' };
+
+  // First call: the AI reports a context overflow via diagnostics
+  let aiCalls = 0;
+  parser.core.callAiGenerate = async (config, prompt, label, adapter, recorder, image, diagnostics) => {
+    aiCalls++;
+    if (diagnostics) diagnostics.failureKind = 'context-overflow';
+    return null;
+  };
+  const first = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', httpAdapter);
+  assert.equal(first, null);
+  assert.equal(aiCalls, 1);
+
+  // Second call: the cached failure short-circuits before download or AI request
+  parser.core.callAiGenerate = async () => {
+    throw new Error('AI should not be called for a negative-cached image');
+  };
+  const failingAdapter = {
+    fetchImageAsBase64: async () => {
+      throw new Error('image should not be re-downloaded for a negative-cached image');
+    }
+  };
+  const second = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', failingAdapter);
+  assert.equal(second, null);
+
+  // Transient failures (no failureKind) must NOT be cached
+  const otherUrl = 'https://cdn.example/other-flyer.jpg';
+  parser.core.callAiGenerate = async () => null;
+  await parser.getOcrTextForImage(otherUrl, ocrConfig, 'ocr-all', httpAdapter);
+  let retried = 0;
+  parser.core.callAiGenerate = async () => {
+    retried++;
+    return null;
+  };
+  await parser.getOcrTextForImage(otherUrl, ocrConfig, 'ocr-all', httpAdapter);
+  assert.equal(retried, 1, 'a transient empty response should be retried on the next call');
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+test('getUrlDedupeKey treats www and bare-host variants as the same URL', () => {
+  const parser = createParser();
+  assert.equal(
+    parser.getUrlDedupeKey('https://www.tryst.events/e/bearracuda/tickets'),
+    parser.getUrlDedupeKey('https://tryst.events/e/bearracuda/tickets')
+  );
+  assert.notEqual(
+    parser.getUrlDedupeKey('https://tryst.events/e/bearracuda'),
+    parser.getUrlDedupeKey('https://tryst.events/e/bearracuda/tickets')
+  );
+});

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -354,9 +354,11 @@ const scraperConfig = {
           // --- Option B: rapid-mlx (OpenAI-compatible, Apple Silicon) on rybook ---
           // rapid-mlx must be serving a VISION (VLM) model — text models reject image
           // input with "Model ... does not support image, video, or audio inputs."
-          // Check what's served: http://rybook.taila7523c.ts.net:8000/v1/models
+          // A rapid-mlx instance serves ONE model, so the vision server runs on its
+          // own port (e.g. 8001) alongside the text/extraction server on 8000.
+          // Check what's served: http://rybook.taila7523c.ts.net:8001/v1/models
           // provider: "openai",
-          // endpoint: "http://rybook.taila7523c.ts.net:8000/v1/chat/completions",
+          // endpoint: "http://rybook.taila7523c.ts.net:8001/v1/chat/completions",
           // model: "mlx-community/Qwen3-VL-4B-Instruct-4bit",
           timeoutSeconds: 120,
           numCtx: 8192,

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -3840,7 +3840,7 @@ class SharedCore {
         }
     }
 
-    async callAiGenerate(aiConfig, prompt, passLabel, httpAdapter, promptHistoryRecorder = null, base64Image = null) {
+    async callAiGenerate(aiConfig, prompt, passLabel, httpAdapter, promptHistoryRecorder = null, base64Image = null, diagnostics = null) {
         if (!prompt) return null;
         const payload = this.buildAiPayload(aiConfig, prompt, base64Image);
         const label = passLabel ? ` (${passLabel} pass)` : '';
@@ -3892,6 +3892,18 @@ class SharedCore {
             }
 
             const doneReason = responseJson && typeof responseJson.done_reason === 'string' ? responseJson.done_reason : 'n/a';
+            // OpenAI-compatible servers (rapid-mlx) report finish_reason "length" with zero
+            // tokens generated when the prompt+image alone overflow the model context —
+            // a deterministic failure that will recur on every retry with the same image.
+            const choice = responseJson && Array.isArray(responseJson.choices) ? responseJson.choices[0] : null;
+            const finishReason = choice && typeof choice.finish_reason === 'string' ? choice.finish_reason : null;
+            const completionTokens = responseJson && responseJson.usage ? Number(responseJson.usage.completion_tokens) : NaN;
+            if (base64Image && finishReason === 'length' && !(completionTokens > 0)) {
+                if (diagnostics && typeof diagnostics === 'object') {
+                    diagnostics.failureKind = 'context-overflow';
+                }
+                console.warn(`🚨 AI Web: AI request${label} generated 0 tokens with finish_reason "length" — the image (${base64Image.length} base64 chars) likely exceeds the model's context window. Downscale the image or raise the server's context limit.`);
+            }
             console.warn(`🤖 AI Web: AI request${label} completed in ${elapsed}ms with empty response (done_reason: ${doneReason})`);
             if (response.text) {
                 console.log(`🤖 AI Web: Raw response payload${label}\n${response.text}`);

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -115,3 +115,46 @@ test('parseAiEventResponse rejects array responses', () => {
   assert.equal(core.parseAiEventResponse('[{"title": "x"}]'), null);
   assert.deepEqual(core.parseAiEventResponse('{"title": "x"}'), { title: 'x' });
 });
+
+test('callAiGenerate flags zero-token finish_reason=length image requests as context overflow', async () => {
+  const core = createCore();
+  const overflowPayload = JSON.stringify({
+    id: 'chatcmpl-test',
+    object: 'chat.completion',
+    model: 'mlx-community/Qwen3-VL-4B-Instruct-4bit',
+    choices: [{ index: 0, message: { role: 'assistant' }, finish_reason: 'length' }],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+  });
+  const aiConfig = {
+    provider: 'openai',
+    endpoint: 'http://rybook.example:8001/v1/chat/completions',
+    model: 'mlx-community/Qwen3-VL-4B-Instruct-4bit',
+    temperature: 0,
+    numPredict: 2000,
+    timeoutSeconds: 120,
+    openai: {}
+  };
+
+  // Overflow signature: image attached, finish_reason "length", zero tokens generated
+  const overflowAdapter = { postJson: async () => ({ ok: true, status: 200, text: overflowPayload }) };
+  const diagnostics = {};
+  const result = await core.callAiGenerate(aiConfig, 'ocr prompt', 'ocr-all', overflowAdapter, null, 'base64image', diagnostics);
+  assert.equal(result, null);
+  assert.equal(diagnostics.failureKind, 'context-overflow');
+
+  // A truncated-but-nonempty response (tokens were generated) is NOT an overflow
+  const truncatedPayload = JSON.stringify({
+    choices: [{ index: 0, message: { role: 'assistant', content: '{"text": "PARTIAL' }, finish_reason: 'length' }],
+    usage: { prompt_tokens: 500, completion_tokens: 2000, total_tokens: 2500 }
+  });
+  const truncatedAdapter = { postJson: async () => ({ ok: true, status: 200, text: truncatedPayload }) };
+  const truncatedDiag = {};
+  const truncatedResult = await core.callAiGenerate(aiConfig, 'ocr prompt', 'ocr-all', truncatedAdapter, null, 'base64image', truncatedDiag);
+  assert.equal(truncatedResult, '{"text": "PARTIAL');
+  assert.equal(truncatedDiag.failureKind, undefined);
+
+  // Text-only requests (no image) never get the overflow flag
+  const textDiag = {};
+  await core.callAiGenerate(aiConfig, 'text prompt', 'extract', overflowAdapter, null, null, textDiag);
+  assert.equal(textDiag.failureKind, undefined);
+});


### PR DESCRIPTION
## Problem

In the 2026-07-12 Bearracuda run, **7 of ~13 live OCR requests failed** with empty responses (`finish_reason: "length"`, 0 tokens). Root cause: vision-model image tokens scale with **pixel count**, and large flyers overflow the model context — rapid-mlx then generates nothing. One 120KB webp masthead hit this deterministically and was retried on 5 different pages in one run. A separate flyer's OCR succeeded but degenerated into hundreds of newlines, truncating the JSON — the fully-extracted text was discarded. Two silent 1–2 minute stalls were unattributable image downloads.

## Changes

- **Downscale before sending** (Scriptable adapter): images over 1568px on the longest side are resized via DrawContext before JPEG encoding.
- **Context-overflow detection** (`callAiGenerate`): the `finish_reason: length` + zero-token + image-attached signature now logs a 🚨 warning naming the cause, and reports it through a new `diagnostics` out-param.
- **Negative caching**: context-overflow failures are cached per image+model so known-bad images are skipped instead of re-downloaded and re-sent every page/run. Transient failures are still retried.
- **Truncation salvage**: `salvageTruncatedOcrResponse` extracts the `text` field (plus classification/confidence when present) from unclosed JSON and collapses degenerate newline runs.
- **Download visibility**: OCR image attach lines now include the URL and download time; failures log URL + elapsed before propagating.
- **Skip OCR with no consumer**: link-aggregator pages, and non-multi-event pages in `discoveryOnly` mode, no longer OCR (segment pairing on multi-event pages still does). Cuts roughly half the OCR work in a discovery-only Bearracuda run.
- **Minor**: `ticketmaster.com`/`livenation.com` blocked from crawl discovery (always 401), www/bare-host variants dedupe, sample config comment reflects the vision server running on its own port (8001).

## Testing

- `node --test scripts/parsers/ai-web-parser.test.js scripts/shared-core.test.js scripts/normalizers.test.js` → **33/33 pass** (5 new tests: salvage, OCR gating matrix, negative-cache round-trip with real temp-dir cache, overflow-signature detection, www dedupe)
- `node --check` on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)