### PR TITLE
feat(scriptable): deterministic event extraction from schema.org JSON-LD

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -286,6 +286,30 @@ class AiWebParser {
             const sourceUrl = htmlData && htmlData.url ? htmlData.url : '';
             const additionalLinks = this.extractAdditionalUrls(html, sourceUrl, parserConfig);
 
+            // Deterministic extraction from schema.org Event JSON-LD. Ticketing pages
+            // (sickening.events, tryst.events, Eventbrite) hand us complete structured
+            // data — when it covers title + start + venue, OCR and AI extraction add
+            // cost without adding trust, so use the structured data directly.
+            const jsonLdEvents = this.extractEventsFromJsonLd(html, sourceUrl);
+            const completeJsonLdEvents = jsonLdEvents.filter(event => event.bar || event.address);
+            const useJsonLdEvents = parserConfig.discoveryOnly !== true
+                && pageClassification !== 'link-aggregator'
+                && completeJsonLdEvents.length > 0
+                // A multi-event page with a single JSON-LD node likely marks up only its
+                // featured event — fall through to segment extraction for full coverage.
+                && (pageClassification !== 'multi-event-page' || completeJsonLdEvents.length >= 2);
+            if (useJsonLdEvents) {
+                console.log(`🤖 AI Web: Extracted ${completeJsonLdEvents.length} event(s) from JSON-LD structured data — skipping OCR and AI extraction`);
+                return {
+                    events: completeJsonLdEvents,
+                    additionalLinks: additionalLinks,
+                    discoveredSegments: null,
+                    ocrResults: [],
+                    source: this.config.source,
+                    url: sourceUrl
+                };
+            }
+
             // Extract OCR from ALL images FIRST - we need it for consistent segment-to-image
             // mapping. Multi-event pages always need OCR (segment pairing runs even in
             // discoveryOnly mode); pages whose extraction will be skipped (link-aggregators,
@@ -336,6 +360,12 @@ class AiWebParser {
 
             // Skip AI extraction in discoveryOnly mode or for link-aggregator pages
             if (parserConfig.discoveryOnly === true || pageClassification === 'link-aggregator') {
+                // Discovery drops events, but JSON-LD event data still tells the user
+                // what the page is about — surface it as segments in the discovery tree.
+                if (!discoveredSegments && jsonLdEvents.length > 0) {
+                    discoveredSegments = this.describeJsonLdEventsAsSegments(jsonLdEvents);
+                    console.log(`🤖 AI Web: JSON-LD provided ${discoveredSegments.length} event segment(s) for discovery`);
+                }
                 console.log(`🤖 AI Web: Link-finding mode (${parserConfig.discoveryOnly ? 'discoveryOnly' : 'link-aggregator'}) found ${additionalLinks.length} additional links`);
                 return {
                     events: [],
@@ -2280,6 +2310,158 @@ class AiWebParser {
             confidence: confidenceMatch ? Number(confidenceMatch[1]) : null,
             reason: 'salvaged-from-truncated-response'
         };
+    }
+
+    // ============================================================================
+    // JSON-LD DETERMINISTIC EVENT EXTRACTION
+    // ============================================================================
+
+    // Build parser events from schema.org Event JSON-LD nodes. Ticketing pages
+    // describe their event completely in structured data; using it directly is
+    // exact (ISO dates carry timezone offsets) and costs no AI/OCR requests.
+    extractEventsFromJsonLd(html, sourceUrl) {
+        if (!this.core || typeof this.core.extractJsonLdEventNodes !== 'function') return [];
+        let nodes = [];
+        try {
+            nodes = this.core.extractJsonLdEventNodes(html);
+        } catch (error) {
+            console.warn(`🤖 AI Web: JSON-LD event extraction failed: ${error.message}`);
+            return [];
+        }
+        const events = [];
+        const seen = new Set();
+        for (const node of nodes) {
+            const event = this.buildEventFromJsonLdNode(node, sourceUrl);
+            if (!event) continue;
+            const key = `${event.title.toLowerCase()}|${event.startDate.toISOString()}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            events.push(event);
+        }
+        return events;
+    }
+
+    buildEventFromJsonLdNode(node, sourceUrl) {
+        if (!node || typeof node !== 'object') return null;
+        const clean = (value) => this.normalizeWhitespace(
+            this.decodeBasicEntities(this.stripTags(String(value || ''))).replace(/&amp;/gi, '&')
+        );
+        const title = clean(node.name);
+        const start = this.parseJsonLdDateValue(node.startDate);
+        if (!title || !start.date) return null;
+        const end = this.parseJsonLdDateValue(node.endDate);
+
+        const place = this.pickJsonLdPlace(node.location);
+        const bar = place ? clean(place.name) : '';
+        const address = place ? this.formatJsonLdAddress(place.address, clean) : '';
+
+        const offer = Array.isArray(node.offers) ? node.offers[0] : node.offers;
+        const offerUrl = offer && typeof offer === 'object' ? this.normalizeHttpUrlValue(offer.url) : '';
+        const ticketUrl = offerUrl || this.normalizeHttpUrlValue(node.url) || '';
+
+        const event = {
+            title,
+            description: clean(node.description),
+            startDate: start.date,
+            endDate: end.date || null,
+            bar,
+            address,
+            url: sourceUrl,
+            ticketUrl,
+            image: this.pickJsonLdImage(node.image),
+            source: this.config.source
+        };
+        // Dates without an explicit offset are wall-clock times anchored as UTC;
+        // LocationNormalizer re-anchors them once the city/timezone is known.
+        if (start.timezoneUnresolved || (end.date && end.timezoneUnresolved)) {
+            event._timezoneUnresolved = true;
+        }
+        return event;
+    }
+
+    parseJsonLdDateValue(value) {
+        const raw = String(value || '').trim();
+        if (!raw) return { date: null, timezoneUnresolved: false };
+        // Explicit offset or UTC marker → exact instant
+        if (/(?:Z|[+-]\d{2}:?\d{2})$/i.test(raw)) {
+            const date = new Date(raw);
+            return Number.isNaN(date.getTime())
+                ? { date: null, timezoneUnresolved: false }
+                : { date, timezoneUnresolved: false };
+        }
+        // No offset → wall-clock local time. Anchor as UTC (never the device timezone,
+        // which JS would otherwise silently use) and flag for normalizer re-anchoring.
+        const match = raw.match(/^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?$/);
+        if (!match) return { date: null, timezoneUnresolved: false };
+        const date = new Date(Date.UTC(
+            Number(match[1]), Number(match[2]) - 1, Number(match[3]),
+            Number(match[4] || 0), Number(match[5] || 0), Number(match[6] || 0)
+        ));
+        return Number.isNaN(date.getTime())
+            ? { date: null, timezoneUnresolved: false }
+            : { date, timezoneUnresolved: true };
+    }
+
+    pickJsonLdPlace(location) {
+        const candidates = Array.isArray(location) ? location : [location];
+        for (const candidate of candidates) {
+            if (candidate && typeof candidate === 'object') {
+                if (/virtual/i.test(String(candidate['@type'] || ''))) continue;
+                return candidate;
+            }
+            if (typeof candidate === 'string' && candidate.trim()) {
+                return { name: candidate };
+            }
+        }
+        return null;
+    }
+
+    formatJsonLdAddress(address, clean) {
+        if (!address) return '';
+        if (typeof address === 'string') return clean(address);
+        if (Array.isArray(address)) return this.formatJsonLdAddress(address[0], clean);
+        if (typeof address === 'object') {
+            return [address.streetAddress, address.addressLocality, address.addressRegion, address.postalCode]
+                .map(part => clean(part))
+                .filter(Boolean)
+                .join(', ');
+        }
+        return '';
+    }
+
+    pickJsonLdImage(image) {
+        const candidates = Array.isArray(image) ? image : [image];
+        for (const candidate of candidates) {
+            if (typeof candidate === 'string' && candidate.trim()) {
+                return this.normalizeHttpUrlValue(candidate) || '';
+            }
+            if (candidate && typeof candidate === 'object' && typeof candidate.url === 'string') {
+                return this.normalizeHttpUrlValue(candidate.url) || '';
+            }
+        }
+        return '';
+    }
+
+    // Discovery mode drops events, but the discovery tree should still show what a
+    // page is about — surface JSON-LD events in the same shape as discovered segments.
+    describeJsonLdEventsAsSegments(jsonLdEvents) {
+        const events = Array.isArray(jsonLdEvents) ? jsonLdEvents : [];
+        return events.map((event, i) => {
+            const lines = [
+                event.title,
+                event.startDate ? event.startDate.toISOString() : '',
+                event.bar,
+                event.address,
+                event.ticketUrl ? `TICKET_URL: ${event.ticketUrl}` : ''
+            ].filter(Boolean);
+            return {
+                index: i + 1,
+                lineCount: lines.length,
+                preview: lines.slice(0, 3).join(' | '),
+                imageUrls: event.image ? [event.image] : [],
+                resourceLines: event.image ? [`SEGMENT_IMAGE_URL: ${event.image}`] : []
+            };
+        });
     }
 
     // OCR is only worth paying for when something consumes it: segment pairing on

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -617,3 +617,124 @@ test('getUrlDedupeKey treats www and bare-host variants as the same URL', () => 
     parser.getUrlDedupeKey('https://tryst.events/e/bearracuda/tickets')
   );
 });
+
+const SICKENING_JSONLD_HTML = `
+  <html><head>
+    <script type="application/ld+json">
+      {"@context":"http://schema.org","@type":"MusicEvent",
+       "name":"Bearracuda Portland:PRIDE FRIDAY",
+       "url":"https://www.sickening.events/e/bearracuda-portland-pridefriday/tickets",
+       "startDate":"2026-07-17T21:00:00-07:00",
+       "endDate":"2026-07-18T03:00:00-07:00",
+       "eventStatus":"https://schema.org/EventScheduled",
+       "description":"<p>Harnesses, Jockstraps &amp; Fetish Gear encouraged.</p>",
+       "image":["https://res.cloudinary.example/cover.webp"],
+       "organizer":{"@type":"Organization","name":"Crown &amp; Anchor"},
+       "location":{"@type":"Place","name":"Nova PDX",
+         "address":{"@type":"PostalAddress","streetAddress":"722 East Burnside Street","addressLocality":"Portland","addressRegion":"OR","postalCode":"97214"}},
+       "offers":{"@type":"Offer","url":"https://www.sickening.events/e/bearracuda-portland-pridefriday/tickets","availability":"https://schema.org/InStock"}}
+    </script>
+  </head><body>January February March April May June July August related events footer</body></html>`;
+
+test('extractEventsFromJsonLd builds a complete event from ticketing-page structured data', () => {
+  const parser = createParser();
+  const events = parser.extractEventsFromJsonLd(SICKENING_JSONLD_HTML, 'https://sickening.events/e/bearracuda-portland-pridefriday');
+
+  assert.equal(events.length, 1);
+  const event = events[0];
+  assert.equal(event.title, 'Bearracuda Portland:PRIDE FRIDAY');
+  // Offset-carrying ISO dates are exact instants — no timezone ambiguity
+  assert.equal(event.startDate.toISOString(), '2026-07-18T04:00:00.000Z');
+  assert.equal(event.endDate.toISOString(), '2026-07-18T10:00:00.000Z');
+  assert.equal(event._timezoneUnresolved, undefined);
+  assert.equal(event.bar, 'Nova PDX');
+  assert.equal(event.address, '722 East Burnside Street, Portland, OR, 97214');
+  assert.equal(event.ticketUrl, 'https://www.sickening.events/e/bearracuda-portland-pridefriday/tickets');
+  assert.equal(event.image, 'https://res.cloudinary.example/cover.webp');
+  assert.match(event.description, /Harnesses, Jockstraps & Fetish Gear/);
+  assert.ok(!/<p>/.test(event.description), 'HTML tags should be stripped');
+  assert.equal(event.url, 'https://sickening.events/e/bearracuda-portland-pridefriday');
+});
+
+test('parseJsonLdDateValue anchors offset-less dates as wall-clock UTC and flags them', () => {
+  const parser = createParser();
+
+  const exact = parser.parseJsonLdDateValue('2026-07-17T21:00:00-07:00');
+  assert.equal(exact.timezoneUnresolved, false);
+  assert.equal(exact.date.toISOString(), '2026-07-18T04:00:00.000Z');
+
+  // No offset: must NOT be parsed in the device timezone — anchored as UTC + flagged
+  const wallClock = parser.parseJsonLdDateValue('2026-07-17T21:00:00');
+  assert.equal(wallClock.timezoneUnresolved, true);
+  assert.equal(wallClock.date.toISOString(), '2026-07-17T21:00:00.000Z');
+
+  const dateOnly = parser.parseJsonLdDateValue('2026-07-17');
+  assert.equal(dateOnly.timezoneUnresolved, true);
+  assert.equal(dateOnly.date.toISOString(), '2026-07-17T00:00:00.000Z');
+
+  assert.equal(parser.parseJsonLdDateValue('not a date').date, null);
+  assert.equal(parser.parseJsonLdDateValue('').date, null);
+});
+
+test('parseEvents returns JSON-LD events directly and skips OCR and AI extraction', async () => {
+  const parser = createParser();
+  parser.extractOcrFromAllImages = async () => {
+    throw new Error('OCR should not run when JSON-LD covers the event');
+  };
+  parser.core.callAiGenerate = async () => {
+    throw new Error('AI should not be called when JSON-LD covers the event');
+  };
+
+  const result = await parser.parseEvents(
+    { url: 'https://sickening.events/e/bearracuda-portland-pridefriday', html: SICKENING_JSONLD_HTML },
+    {},
+    null,
+    'event-page',
+    null
+  );
+
+  assert.equal(result.events.length, 1);
+  assert.equal(result.events[0].title, 'Bearracuda Portland:PRIDE FRIDAY');
+  assert.equal(result.events[0].bar, 'Nova PDX');
+});
+
+test('parseEvents surfaces JSON-LD events as segments in discovery mode', async () => {
+  const parser = createParser();
+  const result = await parser.parseEvents(
+    { url: 'https://sickening.events/e/bearracuda-portland-pridefriday', html: SICKENING_JSONLD_HTML },
+    { discoveryOnly: true },
+    null,
+    'event-page',
+    null
+  );
+
+  assert.equal(result.events.length, 0, 'discovery mode never returns events');
+  assert.ok(Array.isArray(result.discoveredSegments));
+  assert.equal(result.discoveredSegments.length, 1);
+  assert.match(result.discoveredSegments[0].preview, /Bearracuda Portland:PRIDE FRIDAY/);
+  assert.deepEqual(result.discoveredSegments[0].imageUrls, ['https://res.cloudinary.example/cover.webp']);
+});
+
+test('parseEvents falls through to AI extraction when JSON-LD is incomplete for the page type', async () => {
+  const parser = createParser();
+  // Multi-event page with only ONE JSON-LD event: likely just the featured event is
+  // marked up, so the segment path must still run for full coverage.
+  let ocrRan = false;
+  parser.extractOcrFromAllImages = async () => {
+    ocrRan = true;
+    return [];
+  };
+  parser.extractEventsFromMultiEventPage = async () => [];
+  parser.getDataFlagsForHtml = parser.getDataFlagsForHtml || (() => ({}));
+
+  const result = await parser.parseEvents(
+    { url: 'https://x.example/calendar', html: SICKENING_JSONLD_HTML },
+    {},
+    null,
+    'multi-event-page',
+    null
+  );
+
+  assert.equal(ocrRan, true, 'OCR should still run on the segment path');
+  assert.equal(result.events.length, 0);
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -178,7 +178,17 @@ class SharedCore {
 
         }
 
-        // 2. HTML heuristics for unknown URLs
+        // 2. Schema.org Event JSON-LD (deterministic). Ticketing pages (sickening.events,
+        //    tryst.events) describe exactly one event in structured data but trip the
+        //    month-count heuristic below with related-event footers and calendars,
+        //    landing in the segment-discovery path that finds nothing.
+        if (html) {
+            const jsonLdEventCount = this.extractJsonLdEventNodes(html).length;
+            if (jsonLdEventCount === 1) return 'event-page';
+            if (jsonLdEventCount >= 2) return 'multi-event-page';
+        }
+
+        // 3. HTML heuristics for unknown URLs
         if (html) {
             // Reset lastIndex since the patterns are reused across calls (global flag)
             this.pageClassificationMonthPattern.lastIndex = 0;
@@ -195,6 +205,55 @@ class SharedCore {
         }
 
         return 'unknown';
+    }
+
+    // Schema.org Event and its subtypes (MusicEvent, DanceEvent, Festival, ...).
+    // EventSeries is excluded: a series node describes many dates, not one event.
+    isJsonLdEventType(typeValue) {
+        const types = Array.isArray(typeValue) ? typeValue : [typeValue];
+        return types.some(value => {
+            const name = String(value || '').replace(/^https?:\/\/schema\.org\//i, '').trim();
+            if (!name || /^EventSeries$/i.test(name)) return false;
+            return /Event$/i.test(name) || /^Festival$/i.test(name);
+        });
+    }
+
+    // Collect JSON-LD nodes that describe a concrete event: an Event-typed node
+    // with both a name and a startDate. Walks @graph/list containers so wrapped
+    // and nested markup (WordPress @graph, ItemList, festival subEvents) is found.
+    extractJsonLdEventNodes(html) {
+        const nodes = [];
+        const source = String(html || '');
+        if (!source.includes('ld+json')) return nodes;
+        const scriptPattern = /<script[^>]*type\s*=\s*["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+        let match;
+        while ((match = scriptPattern.exec(source)) !== null) {
+            let parsed;
+            try {
+                parsed = JSON.parse(match[1].trim());
+            } catch (_) {
+                continue;
+            }
+            this.collectJsonLdEventNodes(parsed, nodes, 0);
+        }
+        return nodes;
+    }
+
+    collectJsonLdEventNodes(node, results, depth) {
+        if (!node || depth > 6) return;
+        if (Array.isArray(node)) {
+            for (const child of node) this.collectJsonLdEventNodes(child, results, depth + 1);
+            return;
+        }
+        if (typeof node !== 'object') return;
+        const hasName = typeof node.name === 'string' && node.name.trim().length > 0;
+        const hasStartDate = typeof node.startDate === 'string' && node.startDate.trim().length > 0;
+        if (this.isJsonLdEventType(node['@type']) && hasName && hasStartDate) {
+            results.push(node);
+        }
+        for (const key of ['@graph', 'mainEntity', 'subEvent', 'itemListElement', 'item', 'events']) {
+            if (node[key]) this.collectJsonLdEventNodes(node[key], results, depth + 1);
+        }
     }
 
     normalizePageClassificationRules(rules) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -158,3 +158,72 @@ test('callAiGenerate flags zero-token finish_reason=length image requests as con
   await core.callAiGenerate(aiConfig, 'text prompt', 'extract', overflowAdapter, null, null, textDiag);
   assert.equal(textDiag.failureKind, undefined);
 });
+
+test('extractJsonLdEventNodes finds Event nodes in plain, @graph, and list containers', () => {
+  const core = createCore();
+
+  const musicEventHtml = `
+    <html><head>
+      <script type="application/ld+json">
+        {"@context":"http://schema.org","@type":"MusicEvent","name":"BEARRACUDA","startDate":"2026-07-17T21:00:00-07:00","url":"https://www.tryst.events/e/bearracuda/tickets"}
+      </script>
+    </head><body></body></html>`;
+  const musicNodes = core.extractJsonLdEventNodes(musicEventHtml);
+  assert.equal(musicNodes.length, 1);
+  assert.equal(musicNodes[0].name, 'BEARRACUDA');
+
+  const graphHtml = `
+    <script type="application/ld+json">
+      {"@context":"https://schema.org","@graph":[
+        {"@type":"WebPage","name":"Some Page","url":"https://x.example/"},
+        {"@type":"DanceEvent","name":"Party One","startDate":"2026-08-01T22:00:00-05:00"},
+        {"@type":"Event","name":"Party Two","startDate":"2026-08-02"}
+      ]}
+    </script>`;
+  const graphNodes = core.extractJsonLdEventNodes(graphHtml);
+  assert.equal(graphNodes.length, 2);
+
+  // Nodes without a startDate or name are references, not concrete events
+  const incompleteHtml = `
+    <script type="application/ld+json">{"@type":"MusicEvent","name":"No Date Here"}</script>
+    <script type="application/ld+json">{"@type":"EventSeries","name":"Weekly Series","startDate":"2026-01-01"}</script>
+    <script type="application/ld+json">{"@type":"Organization","name":"Not An Event"}</script>`;
+  assert.equal(core.extractJsonLdEventNodes(incompleteHtml).length, 0);
+
+  // Malformed JSON in one script must not break others
+  const mixedHtml = `
+    <script type="application/ld+json">{not valid json</script>
+    <script type="application/ld+json">{"@type":"MusicEvent","name":"Survivor","startDate":"2026-09-04T21:00:00-05:00"}</script>`;
+  assert.equal(core.extractJsonLdEventNodes(mixedHtml).length, 1);
+});
+
+test('classifyPage prefers JSON-LD Event count over the month-name heuristic', () => {
+  const core = createCore();
+
+  // A ticketing page: one MusicEvent in JSON-LD, but a related-events footer full of
+  // month names that would trip the multi-event heuristic.
+  const monthNoise = 'January February March April May June July August September';
+  const singleEventHtml = `
+    <html><head>
+      <script type="application/ld+json">{"@type":"MusicEvent","name":"BEARRACUDA","startDate":"2026-07-17T21:00:00-07:00"}</script>
+    </head><body>${monthNoise}</body></html>`;
+  assert.equal(core.classifyPage('https://sickening.example/e/bearracuda', singleEventHtml), 'event-page');
+
+  const multiEventHtml = `
+    <script type="application/ld+json">[
+      {"@type":"Event","name":"Show A","startDate":"2026-08-01"},
+      {"@type":"Event","name":"Show B","startDate":"2026-08-08"}
+    ]</script>`;
+  assert.equal(core.classifyPage('https://x.example/calendar', multiEventHtml), 'multi-event-page');
+
+  // No JSON-LD events → the month heuristic still applies
+  assert.equal(core.classifyPage('https://x.example/events', `<body>${monthNoise}</body>`), 'multi-event-page');
+  assert.equal(core.classifyPage('https://x.example/party', '<body>July 17 party</body>'), 'event-page');
+
+  // Explicit URL rules still win over JSON-LD
+  const ruledCore = new SharedCore(CITIES, { eventSchema: EventSchema });
+  ruledCore.pageClassificationRules = ruledCore.normalizePageClassificationRules([
+    { pattern: 'sickening\\.example', classification: 'multi-event-page' }
+  ]);
+  assert.equal(ruledCore.classifyPage('https://sickening.example/e/bearracuda', singleEventHtml), 'multi-event-page');
+});


### PR DESCRIPTION
## Problem

Every sickening.events/tryst.events page in the 2026-07-12 Bearracuda run carried a complete schema.org `MusicEvent` JSON-LD block (name, ISO start/end with timezone offsets, venue, address, ticket URL) — and the pipeline ignored it for everything except link discovery. Worse, the month-count classification heuristic tripped on related-events footers and classified these single-event pages as `multi-event-page`, sending them down the segment-discovery path that found 0 segments on 4 of 7 pages.

## Changes

**Classification** (`classifyPage` in shared-core): new deterministic tier between explicit URL rules and the month heuristic — exactly one concrete JSON-LD Event node (Event subtype + `name` + `startDate`) → `event-page`; two or more → `multi-event-page`. Walks `@graph`/`itemListElement`/`subEvent` containers; `EventSeries` excluded. URL-pattern rules still take precedence.

**Extraction** (`parseEvents` in ai-web-parser): when JSON-LD provides a complete event (title + start + venue or address), it's returned directly and OCR + AI extraction are skipped for that page — the structured data is verbatim, exact, and free. Details:
- ISO dates with offsets → exact UTC instants (no timezone bug possible)
- offset-less dates → anchored wall-clock-as-UTC with `_timezoneUnresolved`, re-anchored by LocationNormalizer (the #1439 machinery)
- `ticketUrl` from `offers.url`, venue/address from `location`/`PostalAddress`, HTML entities decoded and tags stripped
- a `multi-event-page` with only ONE JSON-LD node (featured-event-only markup) still falls through to segment extraction so the other events aren't lost
- incomplete JSON-LD falls through to the existing AI path unchanged (which already sees JSON-LD as `JSON_LD_PRIMARY` in its prompt)

**Discovery mode**: JSON-LD events surface as discovered segments (title/date/venue/ticket URL/image), so the discovery tree keeps showing event details — previously that visibility came accidentally from the misclassification.

## Impact on the analyzed run

All 7 sickening/tryst pages would classify `event-page` and yield full events (exact times, venue, address, ticket URL) with **zero OCR or AI requests** on those pages.

## Testing

`node --test scripts/parsers/ai-web-parser.test.js scripts/shared-core.test.js scripts/normalizers.test.js` → **40/40 pass** (7 new tests: node collection across container shapes, classification priority incl. URL-rule precedence, full field mapping from a real sickening.events-shaped payload, wall-clock anchoring, skip-AI/OCR path, discovery segments, multi-event fall-through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)