### PR TITLE
feat(scriptable): optional AI second opinion for page classification

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -343,11 +343,12 @@ const scraperConfig = {
         think: false,
         timeoutSeconds: 120,
         keepAlive: "5m",
-        // AI page classification second opinion. When the deterministic classifiers
-        // (URL rules, JSON-LD Event markup) have no answer, the crude month-count
-        // heuristic decides — enabling this asks the text model instead (one small
-        // request per crawled page). URL rules and JSON-LD always take precedence.
-        classifyPages: false,
+        // AI page classification second opinion (default: true). When the deterministic
+        // classifiers (URL rules, JSON-LD Event markup) have no answer, the text model
+        // classifies the page instead of the crude month-count heuristic (one small
+        // request per weak-signal page). URL rules and JSON-LD always take precedence.
+        // Set to false to fall back to the month-count heuristic only.
+        classifyPages: true,
         // OCR settings live inside `ai` (getOcrConfig reads parserConfig.ai.ocr; a
         // top-level `ocr` block is accepted as fallback, but this is the canonical spot).
         ocr: {

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -343,6 +343,11 @@ const scraperConfig = {
         think: false,
         timeoutSeconds: 120,
         keepAlive: "5m",
+        // AI page classification second opinion. When the deterministic classifiers
+        // (URL rules, JSON-LD Event markup) have no answer, the crude month-count
+        // heuristic decides — enabling this asks the text model instead (one small
+        // request per crawled page). URL rules and JSON-LD always take precedence.
+        classifyPages: false,
         // OCR settings live inside `ai` (getOcrConfig reads parserConfig.ai.ocr; a
         // top-level `ocr` block is accepted as fallback, but this is the canonical spot).
         ocr: {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -168,11 +168,18 @@ class SharedCore {
      * @returns {'event-page'|'link-aggregator'|'multi-event-page'|'ad'|'unknown'}
      */
     classifyPage(url, html) {
+        return this.classifyPageWithSignal(url, html).classification;
+    }
+
+    // Like classifyPage, but also reports WHICH tier decided ('url-rule', 'json-ld',
+    // 'heuristic', 'none') so callers can treat text-heuristic results as weak and
+    // optionally re-check them with AI.
+    classifyPageWithSignal(url, html) {
         // 1. URL pattern rules (deterministic, no HTML needed)
         if (url) {
             for (const rule of this.pageClassificationRules) {
                 if (this.pageClassificationRuleMatchesUrl(rule, url)) {
-                    return rule.classification;
+                    return { classification: rule.classification, signal: 'url-rule' };
                 }
             }
 
@@ -184,8 +191,8 @@ class SharedCore {
         //    landing in the segment-discovery path that finds nothing.
         if (html) {
             const jsonLdEventCount = this.extractJsonLdEventNodes(html).length;
-            if (jsonLdEventCount === 1) return 'event-page';
-            if (jsonLdEventCount >= 2) return 'multi-event-page';
+            if (jsonLdEventCount === 1) return { classification: 'event-page', signal: 'json-ld' };
+            if (jsonLdEventCount >= 2) return { classification: 'multi-event-page', signal: 'json-ld' };
         }
 
         // 3. HTML heuristics for unknown URLs
@@ -199,12 +206,89 @@ class SharedCore {
             const numericDateMatches = html.match(this.pageClassificationNumericDatePattern) || [];
 
             if (monthMatches.length >= this.pageClassificationMultiEventThreshold ||
-                numericDateMatches.length >= this.pageClassificationMultiEventThreshold) return 'multi-event-page';
+                numericDateMatches.length >= this.pageClassificationMultiEventThreshold) {
+                return { classification: 'multi-event-page', signal: 'heuristic' };
+            }
             if (monthMatches.length >= this.pageClassificationEventPageThreshold ||
-                numericDateMatches.length >= this.pageClassificationEventPageThreshold) return 'event-page';
+                numericDateMatches.length >= this.pageClassificationEventPageThreshold) {
+                return { classification: 'event-page', signal: 'heuristic' };
+            }
         }
 
-        return 'unknown';
+        return { classification: 'unknown', signal: 'none' };
+    }
+
+    // Compact text summary of a page for the AI classification prompt: title, meta
+    // description, and the first chunk of visible body text.
+    summarizePageForClassification(html, maxTextChars = 2500) {
+        const source = String(html || '');
+        const titleMatch = source.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+        const metaMatch = source.match(/<meta[^>]+name\s*=\s*["']description["'][^>]*content\s*=\s*["']([^"']*)["']/i)
+            || source.match(/<meta[^>]+content\s*=\s*["']([^"']*)["'][^>]*name\s*=\s*["']description["']/i);
+        const bodyMatch = source.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+        const cleanText = (value) => String(value || '')
+            .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+            .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+            .replace(/<[^>]+>/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        return {
+            title: cleanText(titleMatch ? titleMatch[1] : ''),
+            metaDescription: cleanText(metaMatch ? metaMatch[1] : ''),
+            bodyText: cleanText(bodyMatch ? bodyMatch[1] : source).slice(0, maxTextChars)
+        };
+    }
+
+    // Ask the text model to classify a page. Used only when the deterministic tiers
+    // (URL rules, JSON-LD) had no answer and the month-count heuristic is all we have.
+    // Returns { classification, confidence, reason } or null when the response is
+    // unusable — callers should keep their heuristic answer in that case.
+    async classifyPageWithAi(url, html, aiConfig, httpAdapter) {
+        if (!aiConfig || !httpAdapter) return null;
+        const validLabels = ['event-page', 'multi-event-page', 'link-aggregator', 'ad', 'unknown'];
+        const summary = this.summarizePageForClassification(html);
+        if (!summary.bodyText && !summary.title) return null;
+
+        const prompt = [
+            'You are classifying a web page for an event scraper.',
+            '',
+            `URL: ${url || 'unknown'}`,
+            `PAGE_TITLE: ${summary.title || 'none'}`,
+            `META_DESCRIPTION: ${summary.metaDescription || 'none'}`,
+            `PAGE_TEXT (truncated): ${summary.bodyText || 'none'}`,
+            '',
+            'Classify the page into exactly ONE category:',
+            '- event-page: describes ONE event (one date or continuous range, one venue, one ticket flow)',
+            '- multi-event-page: lists TWO OR MORE distinct events with different dates or tickets',
+            '- link-aggregator: a hub of links (linktree-style, venue/city hub) without event details of its own',
+            '- ad: advertisement or promo page with no concrete event details',
+            '- unknown: cannot tell from the text',
+            '',
+            'Return JSON only: {"classification": "<category>", "confidence": 0-100, "reason": "<one sentence>"}'
+        ].join('\n');
+
+        // Classification needs a short answer — cap generation regardless of the
+        // extraction config's budget.
+        const classifyConfig = { ...aiConfig, numPredict: Math.min(Number(aiConfig.numPredict) || 300, 300) };
+        const rawResponse = await this.callAiGenerate(classifyConfig, prompt, 'classify-page', httpAdapter);
+        if (!rawResponse) return null;
+
+        let parsed = null;
+        try {
+            parsed = JSON.parse(this.extractFirstJsonObject(rawResponse) || rawResponse);
+        } catch (_) {
+            return null;
+        }
+        if (!parsed || typeof parsed !== 'object') return null;
+        const classification = String(parsed.classification || '').trim().toLowerCase();
+        if (!validLabels.includes(classification) || classification === 'unknown') return null;
+        const confidence = Number(parsed.confidence);
+        if (Number.isFinite(confidence) && confidence < 60) return null;
+        return {
+            classification,
+            confidence: Number.isFinite(confidence) ? confidence : null,
+            reason: typeof parsed.reason === 'string' ? parsed.reason : ''
+        };
     }
 
     // Schema.org Event and its subtypes (MusicEvent, DanceEvent, Festival, ...).
@@ -910,7 +994,32 @@ class SharedCore {
         logParserSwitch = true,
         httpAdapter
     }) {
-        const pageClassification = this.classifyPage(url, htmlData.html);
+        let { classification: pageClassification, signal: classificationSignal } = this.classifyPageWithSignal(url, htmlData.html);
+
+        // Optional AI second opinion (parserConfig.ai.classifyPages) — only when the
+        // deterministic tiers (URL rules, JSON-LD) had no answer and we are relying on
+        // the crude month-count heuristic. Costs one small text-model request per page.
+        const aiClassifyEnabled = Boolean(parserConfig && parserConfig.ai && parserConfig.ai.classifyPages === true);
+        const weakSignal = classificationSignal === 'heuristic' || classificationSignal === 'none';
+        if (aiClassifyEnabled && weakSignal) {
+            const aiParser = parsers && parsers['ai-web'];
+            const aiConfig = aiParser && typeof aiParser.getAiConfig === 'function'
+                ? aiParser.getAiConfig(parserConfig)
+                : null;
+            try {
+                const aiResult = await this.classifyPageWithAi(url, htmlData.html, aiConfig, httpAdapter);
+                if (aiResult && aiResult.classification && aiResult.classification !== pageClassification) {
+                    await displayAdapter.logInfo(`SYSTEM: AI reclassified ${url} → ${aiResult.classification} (was ${pageClassification} via ${classificationSignal}, confidence ${aiResult.confidence === null ? 'n/a' : aiResult.confidence}: ${aiResult.reason})`);
+                    pageClassification = aiResult.classification;
+                    classificationSignal = 'ai';
+                } else if (aiResult && aiResult.classification) {
+                    classificationSignal = 'ai-confirmed';
+                }
+            } catch (error) {
+                console.warn(`⚠️ SharedCore: AI page classification failed for ${url}: ${error.message}`);
+            }
+        }
+
         if (logClassification) {
             await displayAdapter.logInfo(`SYSTEM: Classified ${url} → ${pageClassification}`);
         }

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -244,7 +244,7 @@ class SharedCore {
     // Returns { classification, confidence, reason } or null when the response is
     // unusable — callers should keep their heuristic answer in that case.
     async classifyPageWithAi(url, html, aiConfig, httpAdapter) {
-        if (!aiConfig || !httpAdapter) return null;
+        if (!aiConfig || aiConfig.enabled === false || !httpAdapter) return null;
         const validLabels = ['event-page', 'multi-event-page', 'link-aggregator', 'ad', 'unknown'];
         const summary = this.summarizePageForClassification(html);
         if (!summary.bodyText && !summary.title) return null;
@@ -996,10 +996,11 @@ class SharedCore {
     }) {
         let { classification: pageClassification, signal: classificationSignal } = this.classifyPageWithSignal(url, htmlData.html);
 
-        // Optional AI second opinion (parserConfig.ai.classifyPages) — only when the
-        // deterministic tiers (URL rules, JSON-LD) had no answer and we are relying on
-        // the crude month-count heuristic. Costs one small text-model request per page.
-        const aiClassifyEnabled = Boolean(parserConfig && parserConfig.ai && parserConfig.ai.classifyPages === true);
+        // AI second opinion (default on; disable with parserConfig.ai.classifyPages: false)
+        // — only when the deterministic tiers (URL rules, JSON-LD) had no answer and we
+        // are relying on the crude month-count heuristic. Costs one small text-model
+        // request per weak-signal page.
+        const aiClassifyEnabled = !(parserConfig && parserConfig.ai && parserConfig.ai.classifyPages === false);
         const weakSignal = classificationSignal === 'heuristic' || classificationSignal === 'none';
         if (aiClassifyEnabled && weakSignal) {
             const aiParser = parsers && parsers['ai-web'];

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -227,3 +227,144 @@ test('classifyPage prefers JSON-LD Event count over the month-name heuristic', (
   ]);
   assert.equal(ruledCore.classifyPage('https://sickening.example/e/bearracuda', singleEventHtml), 'multi-event-page');
 });
+
+test('classifyPageWithSignal reports which tier decided', () => {
+  const core = createCore();
+
+  const jsonLdHtml = '<script type="application/ld+json">{"@type":"MusicEvent","name":"X","startDate":"2026-07-17T21:00:00-07:00"}</script>';
+  assert.deepEqual(core.classifyPageWithSignal('https://x.example/e/x', jsonLdHtml), { classification: 'event-page', signal: 'json-ld' });
+
+  assert.deepEqual(
+    core.classifyPageWithSignal('https://x.example/party', '<body>July 17 party</body>'),
+    { classification: 'event-page', signal: 'heuristic' }
+  );
+  assert.deepEqual(core.classifyPageWithSignal('https://x.example/', '<body>no dates here</body>'), { classification: 'unknown', signal: 'none' });
+
+  const ruledCore = createCore();
+  ruledCore.pageClassificationRules = ruledCore.normalizePageClassificationRules([
+    { pattern: 'x\\.example/hub', classification: 'link-aggregator' }
+  ]);
+  assert.deepEqual(ruledCore.classifyPageWithSignal('https://x.example/hub', jsonLdHtml), { classification: 'link-aggregator', signal: 'url-rule' });
+});
+
+test('classifyPageWithAi accepts confident valid labels and rejects everything else', async () => {
+  const core = createCore();
+  const aiConfig = {
+    provider: 'openai',
+    endpoint: 'http://rybook.example:8000/v1/chat/completions',
+    model: 'test-model',
+    temperature: 0,
+    numPredict: 2000,
+    timeoutSeconds: 120,
+    openai: {}
+  };
+  const html = '<html><head><title>Big Party</title></head><body>One night only at The Eagle, July 17.</body></html>';
+  const adapterReturning = (content) => ({
+    postJson: async () => ({
+      ok: true,
+      status: 200,
+      text: JSON.stringify({ choices: [{ message: { role: 'assistant', content }, finish_reason: 'stop' }] })
+    })
+  });
+
+  const good = await core.classifyPageWithAi('https://x.example/party', html, aiConfig,
+    adapterReturning('{"classification": "event-page", "confidence": 92, "reason": "single event"}'));
+  assert.equal(good.classification, 'event-page');
+  assert.equal(good.confidence, 92);
+
+  // The numPredict cap should apply to the classification request
+  let sentPayload = null;
+  const capturingAdapter = {
+    postJson: async (endpoint, payload) => {
+      sentPayload = payload;
+      return { ok: true, status: 200, text: JSON.stringify({ choices: [{ message: { content: '{"classification": "ad", "confidence": 99}' } }] }) };
+    }
+  };
+  await core.classifyPageWithAi('https://x.example/party', html, aiConfig, capturingAdapter);
+  assert.equal(sentPayload.max_tokens, 300);
+
+  // Low confidence → keep the heuristic answer
+  const lowConfidence = await core.classifyPageWithAi('https://x.example/party', html, aiConfig,
+    adapterReturning('{"classification": "multi-event-page", "confidence": 30, "reason": "unsure"}'));
+  assert.equal(lowConfidence, null);
+
+  // Invalid or unknown labels → null
+  assert.equal(await core.classifyPageWithAi('https://x.example/party', html, aiConfig,
+    adapterReturning('{"classification": "unknown", "confidence": 95}')), null);
+  assert.equal(await core.classifyPageWithAi('https://x.example/party', html, aiConfig,
+    adapterReturning('{"classification": "banana", "confidence": 95}')), null);
+  assert.equal(await core.classifyPageWithAi('https://x.example/party', html, aiConfig,
+    adapterReturning('not json')), null);
+
+  // Missing config/adapter → null without throwing
+  assert.equal(await core.classifyPageWithAi('https://x.example/party', html, null, adapterReturning('{}')), null);
+  assert.equal(await core.classifyPageWithAi('https://x.example/party', html, aiConfig, null), null);
+});
+
+test('parsePageForCrawl uses the AI second opinion only for weak signals when enabled', async () => {
+  const core = createCore();
+  const displayAdapter = { logInfo: async () => {} };
+  const monthNoise = '<body>January February March April May June July August</body>';
+  const receivedClassifications = [];
+  const parsers = {
+    'ai-web': {
+      getAiConfig: () => ({
+        provider: 'openai',
+        endpoint: 'http://rybook.example:8000/v1/chat/completions',
+        model: 'test-model',
+        temperature: 0,
+        numPredict: 2000,
+        timeoutSeconds: 120,
+        openai: {}
+      }),
+      parseEvents: async (htmlData, parserConfig, cities, classification) => {
+        receivedClassifications.push(classification);
+        return { events: [], additionalLinks: [] };
+      }
+    }
+  };
+  const aiAdapter = {
+    postJson: async () => ({
+      ok: true,
+      status: 200,
+      text: JSON.stringify({ choices: [{ message: { content: '{"classification": "event-page", "confidence": 90, "reason": "one event"}' } }] })
+    })
+  };
+
+  // Heuristic says multi-event-page (8 month names); AI overrides to event-page
+  await core.parsePageForCrawl({
+    url: 'https://x.example/party',
+    htmlData: { url: 'https://x.example/party', html: monthNoise },
+    parsers,
+    parserConfig: { ai: { classifyPages: true } },
+    displayAdapter,
+    httpAdapter: aiAdapter
+  });
+  assert.deepEqual(receivedClassifications, ['event-page']);
+
+  // Flag off → heuristic result stands, no AI request
+  receivedClassifications.length = 0;
+  const explodingAdapter = { postJson: async () => { throw new Error('AI must not be called when classifyPages is off'); } };
+  await core.parsePageForCrawl({
+    url: 'https://x.example/party',
+    htmlData: { url: 'https://x.example/party', html: monthNoise },
+    parsers,
+    parserConfig: {},
+    displayAdapter,
+    httpAdapter: explodingAdapter
+  });
+  assert.deepEqual(receivedClassifications, ['multi-event-page']);
+
+  // Strong signal (JSON-LD) → no AI request even when enabled
+  receivedClassifications.length = 0;
+  const jsonLdHtml = '<script type="application/ld+json">{"@type":"MusicEvent","name":"X","startDate":"2026-07-17T21:00:00-07:00"}</script>';
+  await core.parsePageForCrawl({
+    url: 'https://x.example/e/x',
+    htmlData: { url: 'https://x.example/e/x', html: jsonLdHtml },
+    parsers,
+    parserConfig: { ai: { classifyPages: true } },
+    displayAdapter,
+    httpAdapter: explodingAdapter
+  });
+  assert.deepEqual(receivedClassifications, ['event-page']);
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -331,38 +331,57 @@ test('parsePageForCrawl uses the AI second opinion only for weak signals when en
     })
   };
 
-  // Heuristic says multi-event-page (8 month names); AI overrides to event-page
-  await core.parsePageForCrawl({
-    url: 'https://x.example/party',
-    htmlData: { url: 'https://x.example/party', html: monthNoise },
-    parsers,
-    parserConfig: { ai: { classifyPages: true } },
-    displayAdapter,
-    httpAdapter: aiAdapter
-  });
-  assert.deepEqual(receivedClassifications, ['event-page']);
-
-  // Flag off → heuristic result stands, no AI request
-  receivedClassifications.length = 0;
-  const explodingAdapter = { postJson: async () => { throw new Error('AI must not be called when classifyPages is off'); } };
+  // Default (no config): heuristic says multi-event-page (8 month names);
+  // AI overrides to event-page
   await core.parsePageForCrawl({
     url: 'https://x.example/party',
     htmlData: { url: 'https://x.example/party', html: monthNoise },
     parsers,
     parserConfig: {},
     displayAdapter,
+    httpAdapter: aiAdapter
+  });
+  assert.deepEqual(receivedClassifications, ['event-page']);
+
+  // Explicitly disabled → heuristic result stands, no AI request
+  receivedClassifications.length = 0;
+  const explodingAdapter = { postJson: async () => { throw new Error('AI must not be called when classifyPages is off'); } };
+  await core.parsePageForCrawl({
+    url: 'https://x.example/party',
+    htmlData: { url: 'https://x.example/party', html: monthNoise },
+    parsers,
+    parserConfig: { ai: { classifyPages: false } },
+    displayAdapter,
     httpAdapter: explodingAdapter
   });
   assert.deepEqual(receivedClassifications, ['multi-event-page']);
 
-  // Strong signal (JSON-LD) → no AI request even when enabled
+  // ai.enabled: false (AI extraction disabled) → no classification request either
+  receivedClassifications.length = 0;
+  const disabledAiParsers = {
+    'ai-web': {
+      getAiConfig: () => ({ enabled: false }),
+      parseEvents: parsers['ai-web'].parseEvents
+    }
+  };
+  await core.parsePageForCrawl({
+    url: 'https://x.example/party',
+    htmlData: { url: 'https://x.example/party', html: monthNoise },
+    parsers: disabledAiParsers,
+    parserConfig: {},
+    displayAdapter,
+    httpAdapter: explodingAdapter
+  });
+  assert.deepEqual(receivedClassifications, ['multi-event-page']);
+
+  // Strong signal (JSON-LD) → no AI request even though classification is enabled
   receivedClassifications.length = 0;
   const jsonLdHtml = '<script type="application/ld+json">{"@type":"MusicEvent","name":"X","startDate":"2026-07-17T21:00:00-07:00"}</script>';
   await core.parsePageForCrawl({
     url: 'https://x.example/e/x',
     htmlData: { url: 'https://x.example/e/x', html: jsonLdHtml },
     parsers,
-    parserConfig: { ai: { classifyPages: true } },
+    parserConfig: {},
     displayAdapter,
     httpAdapter: explodingAdapter
   });


### PR DESCRIPTION
**Stacked on #1449** (uses its `classifyPage` JSON-LD tier) — GitHub will retarget this to `main` when that merges.

## What

When neither URL rules nor JSON-LD Event markup can classify a page, classification currently falls to counting month names in the HTML — the heuristic that sent single-event ticketing pages down the fruitless segment path. Now (by default) those weak-signal pages get a second opinion from the existing text model instead.

## How

- `classifyPage` → `classifyPageWithSignal`, which also reports the deciding tier (`url-rule` | `json-ld` | `heuristic` | `none`). The public `classifyPage` contract is unchanged.
- `SharedCore.classifyPageWithAi(url, html, aiConfig, httpAdapter)`: compact prompt (page title + meta description + first 2500 chars of visible text, scripts/styles stripped) with the five classification labels defined; generation capped at 300 tokens regardless of the extraction config. Only valid labels with confidence ≥ 60 are accepted — "unknown", low confidence, bad JSON, or request failure all keep the heuristic answer.
- `parsePageForCrawl` consults the AI **only** when the deterministic tiers had no answer. Strong signals (URL rules, JSON-LD) never trigger an AI call. Reclassifications log the old label, tier, confidence, and the model's reason.
- **On by default**: disable with `ai.classifyPages: false`, or it stays off automatically when the parser's AI is disabled (`ai.enabled: false`). Costs one small text-model request per weak-signal crawled page.

## Testing

`node --test scripts/parsers/ai-web-parser.test.js scripts/shared-core.test.js scripts/normalizers.test.js` → **43/43 pass** (signal reporting, AI acceptance/rejection matrix incl. the 300-token cap, and `parsePageForCrawl` integration proving: default-on override, explicit opt-out, ai.enabled:false suppression, and no AI call on strong signals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)