### PR TITLE
feat(scriptable): classification cache + automatic city/timezone from JSON-LD

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -290,7 +290,7 @@ class AiWebParser {
             // (sickening.events, tryst.events, Eventbrite) hand us complete structured
             // data — when it covers title + start + venue, OCR and AI extraction add
             // cost without adding trust, so use the structured data directly.
-            const jsonLdEvents = this.extractEventsFromJsonLd(html, sourceUrl);
+            const jsonLdEvents = this.extractEventsFromJsonLd(html, sourceUrl, cityConfig);
             const completeJsonLdEvents = jsonLdEvents.filter(event => event.bar || event.address);
             const useJsonLdEvents = parserConfig.discoveryOnly !== true
                 && pageClassification !== 'link-aggregator'
@@ -2056,20 +2056,28 @@ class AiWebParser {
     }
 
     getOcrCacheRuntime() {
+        return this.getCacheRuntime('ocr', this.config.ocrCacheDir);
+    }
+
+    getAiClassificationCacheRuntime() {
+        return this.getCacheRuntime('classification', this.config.classificationCacheDir);
+    }
+
+    getCacheRuntime(subdir, overrideDir = null) {
         if (typeof FileManager !== 'undefined') {
             try {
                 const fm = FileManager.iCloud();
                 const documentsDir = fm.documentsDirectory();
-                const baseDir = this.config.ocrCacheDir
-                    ? String(this.config.ocrCacheDir)
-                    : fm.joinPath(fm.joinPath(fm.joinPath(documentsDir, 'chunky-dad-scraper'), 'storage'), 'ocr');
+                const baseDir = overrideDir
+                    ? String(overrideDir)
+                    : fm.joinPath(fm.joinPath(fm.joinPath(documentsDir, 'chunky-dad-scraper'), 'storage'), subdir);
                 return {
                     type: 'scriptable',
                     fm,
                     baseDir
                 };
             } catch (error) {
-                console.log(`🤖 AI Web: OCR cache setup unavailable in Scriptable: ${error.message}`);
+                console.log(`🤖 AI Web: ${subdir} cache setup unavailable in Scriptable: ${error.message}`);
                 return null;
             }
         }
@@ -2078,9 +2086,9 @@ class AiWebParser {
                 const fs = require('fs');
                 const path = require('path');
                 const os = require('os');
-                const baseDir = this.config.ocrCacheDir
-                    ? String(this.config.ocrCacheDir)
-                    : path.join(os.homedir(), '.chunky-dad-scraper', 'storage', 'ocr');
+                const baseDir = overrideDir
+                    ? String(overrideDir)
+                    : path.join(os.homedir(), '.chunky-dad-scraper', 'storage', subdir);
                 return {
                     type: 'node',
                     fs,
@@ -2088,7 +2096,7 @@ class AiWebParser {
                     baseDir
                 };
             } catch (error) {
-                console.log(`🤖 AI Web: OCR cache setup unavailable in Node: ${error.message}`);
+                console.log(`🤖 AI Web: ${subdir} cache setup unavailable in Node: ${error.message}`);
                 return null;
             }
         }
@@ -2158,6 +2166,104 @@ class AiWebParser {
             fileName: `${this.hashCacheValue(`${normalizedUrl}|${signatureHash}`)}.json`,
             signatureHash
         };
+    }
+
+    // Persistent cache for AI page-classification outcomes. SharedCore stays free of
+    // filesystem access (see its header rules), so parsePageForCrawl injects this
+    // provider the same way it borrows getAiConfig. Keyed by URL + a signature of the
+    // page summary and model, so content or model changes invalidate naturally.
+    getAiClassificationCache() {
+        return {
+            read: (url, signature) => this.readCachedAiClassification(url, signature),
+            write: (url, signature, outcome) => this.writeCachedAiClassification(url, signature, outcome)
+        };
+    }
+
+    getAiClassificationCachePathParts(url, signature) {
+        const signatureHash = this.hashCacheValue(JSON.stringify(signature || {}));
+        const normalizedUrl = this.normalizeHttpUrlValue(url) || String(url || '');
+        const parsed = this.parseUrlComponents(normalizedUrl);
+        if (parsed) {
+            const hostDir = this.sanitizeCacheSegment(parsed.hostname || 'unknown-host');
+            const pathSegments = String(parsed.pathname || '/')
+                .split('/')
+                .filter(Boolean)
+                .map(segment => this.sanitizeCacheSegment(segment))
+                .filter(Boolean);
+            let fileBase = pathSegments.length > 0 ? pathSegments.join('__') : 'index';
+            if (parsed.search) {
+                fileBase += `--q-${this.hashCacheValue(parsed.search)}`;
+            }
+            fileBase += `--cls-${signatureHash}`;
+            if (fileBase.length > 140) {
+                fileBase = `${fileBase.slice(0, 96)}--${this.hashCacheValue(fileBase)}`;
+            }
+            return { normalizedUrl, hostDir, fileName: `${fileBase}.json` };
+        }
+        return {
+            normalizedUrl,
+            hostDir: 'unknown-host',
+            fileName: `${this.hashCacheValue(`${normalizedUrl}|${signatureHash}`)}.json`
+        };
+    }
+
+    async readCachedAiClassification(url, signature) {
+        const runtime = this.getAiClassificationCacheRuntime();
+        if (!runtime) return null;
+        const { hostDir, fileName } = this.getAiClassificationCachePathParts(url, signature);
+        try {
+            let rawPayload = null;
+            if (runtime.type === 'scriptable') {
+                const cachePath = runtime.fm.joinPath(runtime.fm.joinPath(runtime.baseDir, hostDir), fileName);
+                if (!runtime.fm.fileExists(cachePath)) return null;
+                try {
+                    await runtime.fm.downloadFileFromiCloud(cachePath);
+                } catch (_) {}
+                rawPayload = runtime.fm.readString(cachePath);
+            } else {
+                const cachePath = runtime.path.join(runtime.baseDir, hostDir, fileName);
+                rawPayload = await runtime.fs.promises.readFile(cachePath, 'utf8');
+            }
+            const cached = JSON.parse(rawPayload);
+            return cached && cached.outcome && typeof cached.outcome === 'object' ? cached.outcome : null;
+        } catch (error) {
+            const missingFile = error && (error.code === 'ENOENT' || /does not exist/i.test(String(error.message || '')));
+            if (!missingFile) {
+                console.log(`🤖 AI Web: classification cache read failed for ${url}: ${error.message}`);
+            }
+            return null;
+        }
+    }
+
+    async writeCachedAiClassification(url, signature, outcome) {
+        if (!outcome || typeof outcome !== 'object') return null;
+        const runtime = this.getAiClassificationCacheRuntime();
+        if (!runtime) return null;
+        const { normalizedUrl, hostDir, fileName } = this.getAiClassificationCachePathParts(url, signature);
+        const payload = {
+            url: normalizedUrl,
+            cachedAt: new Date().toISOString(),
+            signature: signature || {},
+            outcome
+        };
+        try {
+            if (runtime.type === 'scriptable') {
+                const hostDirPath = runtime.fm.joinPath(runtime.baseDir, hostDir);
+                if (!runtime.fm.fileExists(runtime.baseDir)) runtime.fm.createDirectory(runtime.baseDir, true);
+                if (!runtime.fm.fileExists(hostDirPath)) runtime.fm.createDirectory(hostDirPath, true);
+                const cachePath = runtime.fm.joinPath(hostDirPath, fileName);
+                runtime.fm.writeString(cachePath, JSON.stringify(payload, null, 2));
+                return cachePath;
+            }
+            const hostDirPath = runtime.path.join(runtime.baseDir, hostDir);
+            await runtime.fs.promises.mkdir(hostDirPath, { recursive: true });
+            const cachePath = runtime.path.join(hostDirPath, fileName);
+            await runtime.fs.promises.writeFile(cachePath, JSON.stringify(payload, null, 2), 'utf8');
+            return cachePath;
+        } catch (error) {
+            console.log(`🤖 AI Web: classification cache write failed for ${url}: ${error.message}`);
+            return null;
+        }
     }
 
     async readCachedOcrResult(imageUrl, ocrConfig = {}) {
@@ -2319,7 +2425,7 @@ class AiWebParser {
     // Build parser events from schema.org Event JSON-LD nodes. Ticketing pages
     // describe their event completely in structured data; using it directly is
     // exact (ISO dates carry timezone offsets) and costs no AI/OCR requests.
-    extractEventsFromJsonLd(html, sourceUrl) {
+    extractEventsFromJsonLd(html, sourceUrl, cityConfig = null) {
         if (!this.core || typeof this.core.extractJsonLdEventNodes !== 'function') return [];
         let nodes = [];
         try {
@@ -2331,7 +2437,7 @@ class AiWebParser {
         const events = [];
         const seen = new Set();
         for (const node of nodes) {
-            const event = this.buildEventFromJsonLdNode(node, sourceUrl);
+            const event = this.buildEventFromJsonLdNode(node, sourceUrl, cityConfig);
             if (!event) continue;
             const key = `${event.title.toLowerCase()}|${event.startDate.toISOString()}`;
             if (seen.has(key)) continue;
@@ -2341,7 +2447,7 @@ class AiWebParser {
         return events;
     }
 
-    buildEventFromJsonLdNode(node, sourceUrl) {
+    buildEventFromJsonLdNode(node, sourceUrl, cityConfig = null) {
         if (!node || typeof node !== 'object') return null;
         const clean = (value) => this.normalizeWhitespace(
             this.decodeBasicEntities(this.stripTags(String(value || ''))).replace(/&amp;/gi, '&')
@@ -2371,6 +2477,17 @@ class AiWebParser {
             image: this.pickJsonLdImage(node.image),
             source: this.config.source
         };
+        // The JSON-LD address carries the locality (e.g. "Portland, OR") — resolve city
+        // and timezone from it directly so nothing downstream has to guess. Address only:
+        // bar names produce false city matches ("Brooklyn Bowl" in Vegas).
+        if (address && cityConfig) {
+            const cityKey = this.findCityKeyInText(address, cityConfig);
+            if (cityKey) {
+                event.city = cityKey;
+                const timezone = this.getTimezoneForCity(cityKey, cityConfig);
+                if (timezone) event.timezone = timezone;
+            }
+        }
         // Dates without an explicit offset are wall-clock times anchored as UTC;
         // LocationNormalizer re-anchors them once the city/timezone is known.
         if (start.timezoneUnresolved || (end.date && end.timezoneUnresolved)) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -738,3 +738,34 @@ test('parseEvents falls through to AI extraction when JSON-LD is incomplete for 
   assert.equal(ocrRan, true, 'OCR should still run on the segment path');
   assert.equal(result.events.length, 0);
 });
+
+test('buildEventFromJsonLdNode resolves city and timezone from the address', () => {
+  const parser = createParser();
+  const cityConfig = {
+    portland: { timezone: 'America/Los_Angeles', patterns: ['portland', 'pdx'] },
+    nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc', 'brooklyn'] }
+  };
+
+  const events = parser.extractEventsFromJsonLd(SICKENING_JSONLD_HTML, 'https://sickening.events/e/x', cityConfig);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].city, 'portland');
+  assert.equal(events[0].timezone, 'America/Los_Angeles');
+
+  // Bar names must NOT drive city resolution — address only
+  const brooklynBowlVegas = parser.buildEventFromJsonLdNode({
+    '@type': 'MusicEvent',
+    name: 'Bear Night',
+    startDate: '2026-08-01T21:00:00-07:00',
+    location: {
+      '@type': 'Place',
+      name: 'Brooklyn Bowl',
+      address: { '@type': 'PostalAddress', streetAddress: '3545 S Las Vegas Blvd' }
+    }
+  }, 'https://x.example/e/bearnight', cityConfig);
+  assert.equal(brooklynBowlVegas.city, undefined);
+  assert.equal(brooklynBowlVegas.bar, 'Brooklyn Bowl');
+
+  // No cityConfig → no city fields, no crash
+  const bare = parser.extractEventsFromJsonLd(SICKENING_JSONLD_HTML, 'https://sickening.events/e/x');
+  assert.equal(bare[0].city, undefined);
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -243,11 +243,33 @@ class SharedCore {
     // (URL rules, JSON-LD) had no answer and the month-count heuristic is all we have.
     // Returns { classification, confidence, reason } or null when the response is
     // unusable — callers should keep their heuristic answer in that case.
-    async classifyPageWithAi(url, html, aiConfig, httpAdapter) {
+    // `cache` is an optional { read(url, signature), write(url, signature, outcome) }
+    // provider (persistence lives in the adapter/parser layer — this file stays pure);
+    // outcomes are cached per URL + page-summary + model so repeat runs over unchanged
+    // pages cost nothing.
+    async classifyPageWithAi(url, html, aiConfig, httpAdapter, cache = null) {
         if (!aiConfig || aiConfig.enabled === false || !httpAdapter) return null;
         const validLabels = ['event-page', 'multi-event-page', 'link-aggregator', 'ad', 'unknown'];
         const summary = this.summarizePageForClassification(html);
         if (!summary.bodyText && !summary.title) return null;
+
+        const cacheSignature = {
+            model: String(aiConfig.model || ''),
+            title: summary.title,
+            metaDescription: summary.metaDescription,
+            bodyText: summary.bodyText
+        };
+        if (cache && typeof cache.read === 'function') {
+            try {
+                const cachedOutcome = await cache.read(url, cacheSignature);
+                if (cachedOutcome && typeof cachedOutcome === 'object') {
+                    console.log(`🗂️ SharedCore: AI classification cache hit for ${url} → ${cachedOutcome.rejected ? 'rejected' : cachedOutcome.classification}`);
+                    return cachedOutcome.rejected ? null : cachedOutcome;
+                }
+            } catch (error) {
+                console.log(`🗂️ SharedCore: AI classification cache read failed for ${url}: ${error.message}`);
+            }
+        }
 
         const prompt = [
             'You are classifying a web page for an event scraper.',
@@ -277,18 +299,34 @@ class SharedCore {
         try {
             parsed = JSON.parse(this.extractFirstJsonObject(rawResponse) || rawResponse);
         } catch (_) {
+            // Unparseable response — could be a transient server problem, don't cache
             return null;
         }
         if (!parsed || typeof parsed !== 'object') return null;
+
+        // The model answered; both accepted and rejected outcomes are deterministic
+        // for this page+model (temperature 0) and worth caching.
         const classification = String(parsed.classification || '').trim().toLowerCase();
-        if (!validLabels.includes(classification) || classification === 'unknown') return null;
         const confidence = Number(parsed.confidence);
-        if (Number.isFinite(confidence) && confidence < 60) return null;
-        return {
-            classification,
-            confidence: Number.isFinite(confidence) ? confidence : null,
-            reason: typeof parsed.reason === 'string' ? parsed.reason : ''
-        };
+        let outcome;
+        if (!validLabels.includes(classification) || classification === 'unknown'
+            || (Number.isFinite(confidence) && confidence < 60)) {
+            outcome = { rejected: true };
+        } else {
+            outcome = {
+                classification,
+                confidence: Number.isFinite(confidence) ? confidence : null,
+                reason: typeof parsed.reason === 'string' ? parsed.reason : ''
+            };
+        }
+        if (cache && typeof cache.write === 'function') {
+            try {
+                await cache.write(url, cacheSignature, outcome);
+            } catch (error) {
+                console.log(`🗂️ SharedCore: AI classification cache write failed for ${url}: ${error.message}`);
+            }
+        }
+        return outcome.rejected ? null : outcome;
     }
 
     // Schema.org Event and its subtypes (MusicEvent, DanceEvent, Festival, ...).
@@ -1007,8 +1045,11 @@ class SharedCore {
             const aiConfig = aiParser && typeof aiParser.getAiConfig === 'function'
                 ? aiParser.getAiConfig(parserConfig)
                 : null;
+            const classificationCache = aiParser && typeof aiParser.getAiClassificationCache === 'function'
+                ? aiParser.getAiClassificationCache()
+                : null;
             try {
-                const aiResult = await this.classifyPageWithAi(url, htmlData.html, aiConfig, httpAdapter);
+                const aiResult = await this.classifyPageWithAi(url, htmlData.html, aiConfig, httpAdapter, classificationCache);
                 if (aiResult && aiResult.classification && aiResult.classification !== pageClassification) {
                     await displayAdapter.logInfo(`SYSTEM: AI reclassified ${url} → ${aiResult.classification} (was ${pageClassification} via ${classificationSignal}, confidence ${aiResult.confidence === null ? 'n/a' : aiResult.confidence}: ${aiResult.reason})`);
                     pageClassification = aiResult.classification;

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -387,3 +387,59 @@ test('parsePageForCrawl uses the AI second opinion only for weak signals when en
   });
   assert.deepEqual(receivedClassifications, ['event-page']);
 });
+
+test('classifyPageWithAi persists outcomes through an injected cache provider', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const { AiWebParser } = require('./parsers/ai-web-parser');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cls-cache-test-'));
+
+  const core = createCore();
+  const parser = new AiWebParser({
+    normalizeUrl: (u) => u,
+    classificationCacheDir: cacheDir
+  });
+  const cache = parser.getAiClassificationCache();
+  const aiConfig = {
+    provider: 'openai',
+    endpoint: 'http://rybook.example:8000/v1/chat/completions',
+    model: 'test-model',
+    temperature: 0,
+    numPredict: 2000,
+    timeoutSeconds: 120,
+    openai: {}
+  };
+  const html = '<html><head><title>Big Party</title></head><body>One night only, July 17.</body></html>';
+  const adapterReturning = (content) => ({
+    postJson: async () => ({
+      ok: true,
+      status: 200,
+      text: JSON.stringify({ choices: [{ message: { content } }] })
+    })
+  });
+  const explodingAdapter = { postJson: async () => { throw new Error('cached pages must not hit the AI'); } };
+
+  // Accepted outcome: first call hits the AI, second is served from cache
+  const first = await core.classifyPageWithAi('https://x.example/party', html, aiConfig,
+    adapterReturning('{"classification": "event-page", "confidence": 92, "reason": "one event"}'), cache);
+  assert.equal(first.classification, 'event-page');
+  const second = await core.classifyPageWithAi('https://x.example/party', html, aiConfig, explodingAdapter, cache);
+  assert.equal(second.classification, 'event-page');
+  assert.equal(second.confidence, 92);
+
+  // Rejected outcome (low confidence) is cached too — no repeat request, still null
+  const lowFirst = await core.classifyPageWithAi('https://x.example/other', html, aiConfig,
+    adapterReturning('{"classification": "multi-event-page", "confidence": 30}'), cache);
+  assert.equal(lowFirst, null);
+  const lowSecond = await core.classifyPageWithAi('https://x.example/other', html, aiConfig, explodingAdapter, cache);
+  assert.equal(lowSecond, null);
+
+  // Changed page content → different signature → cache miss, AI consulted again
+  const changedHtml = '<html><head><title>Big Party</title></head><body>Totally new lineup, August 20.</body></html>';
+  const changed = await core.classifyPageWithAi('https://x.example/party', changedHtml, aiConfig,
+    adapterReturning('{"classification": "multi-event-page", "confidence": 90, "reason": "many"}'), cache);
+  assert.equal(changed.classification, 'multi-event-page');
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
**Stacked on #1450** (which stacks on #1449) — GitHub retargets automatically as the stack merges. Merge order: #1449 → #1450 → this.

Two more steps toward "as automatic as possible":

## AI classification cache

Every AI page-classification outcome — accepted **and** rejected — is now cached persistently, keyed by URL + a signature of the page summary (title/meta/body text) + model. Repeat runs over unchanged pages cost **zero** classification requests; page content or model changes invalidate naturally through the signature hash.

- Persistence lives in `AiWebParser` (`storage/classification`, sibling of the OCR cache; `getOcrCacheRuntime` generalized to `getCacheRuntime(subdir)`) because `shared-core.js` is filesystem-free by architecture rule. `parsePageForCrawl` injects the cache provider into `classifyPageWithAi` the same way it borrows `getAiConfig`.
- Transient failures (no response, unparseable JSON) are **not** cached — only real model answers are.

## Automatic city/timezone from JSON-LD

JSON-LD events now resolve `city` and `timezone` directly from their `PostalAddress` — `addressLocality` ("Portland") is matched against the city config patterns. No parser config, no guessing downstream. Deliberately address-only: bar names cause false matches ("Brooklyn Bowl" in Vegas).

## Testing

`node --test scripts/parsers/ai-web-parser.test.js scripts/shared-core.test.js scripts/normalizers.test.js` → **45/45 pass** (2 new tests: real temp-dir cache round-trip covering accepted/rejected outcomes and content-change invalidation; city/timezone resolution incl. the Brooklyn Bowl guard and no-cityConfig safety)

🤖 Generated with [Claude Code](https://claude.com/claude-code)