### PR TITLE
Enable JSON calendar mode for all cities

### DIFF
--- a/.github/workflows/update-calendar-data.yml
+++ b/.github/workflows/update-calendar-data.yml
@@ -10,6 +10,7 @@ on:
       - 'js/city-config.js'
       - '.github/workflows/update-calendar-data.yml'
       - 'tools/generate-event-pages.js'
+      - 'tools/process-calendars.js'
       - 'tools/generate-og-images.js'
       - 'tools/download-images.js'
       - 'tools/extract-favicon-colors.js'

--- a/data/calendars/atlanta.json
+++ b/data/calendars/atlanta.json
@@ -1,0 +1,245 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/New_York",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "Bearracuda Atlanta: Bulges & Jocks",
+      "day": "Saturday",
+      "time": "10PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33.81158,
+        "lng": -84.3554
+      },
+      "startDate": "2025-11-08T22:00:00",
+      "endDate": "2025-11-09T03:00:00",
+      "unprocessedDescription": "description: Doors Open at 10\\:00 pm - Party Goes Until 3\\:00\r am\nbar: Heretic\naddress: 2069 Cheshire Bridge Rd NE, Atlanta, GA 30324\ntimezone: America/New_York\nurl: https://bearracuda.com/events/atlbulge/\ncover: $20.73 - $26.82 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/04/cuda-atlanta-nov_2025-web.jpg\nfacebook: https://www.facebook.com/events/645075138661917/\nticketUrl: https://www.eventbrite.com/e/bearracuda-atlanta-bulges-jocks-tickets-1751306507909\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://maps.google.com/?q=33.81158,-84.3554\nkey: bearracuda-2025-11-09-atlanta",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "2BF0CBE2-B7B0-4042-BD0F-3835C9D751AE",
+      "uid": "2BF0CBE2-B7B0-4042-BD0F-3835C9D751AE",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Heretic",
+      "cover": "$20.73 - $26.82 (as of 10/1)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/04/cuda-atlanta-nov_2025-web.jpg",
+      "tea": "Doors Open at 10:00 pm - Party Goes Until 3:00 am",
+      "address": "2069 Cheshire Bridge Rd NE, Atlanta, GA 30324",
+      "website": "https://bearracuda.com/events/atlbulge/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/645075138661917/",
+      "gmaps": "https://maps.google.com/?q=33.81158,-84.3554",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-atlanta-bulges-jocks-tickets-1751306507909",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/atlbulge/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/645075138661917/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.google.com/?q=33.81158,-84.3554",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-atlanta-bulges-jocks-tickets-1751306507909",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-atlanta-bulges-jocks-4b843b95"
+    },
+    {
+      "name": "Bearracuda Atlanta 16 Year Anniversary!",
+      "day": "Saturday",
+      "time": "10PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33.81158,
+        "lng": -84.3554
+      },
+      "startDate": "2025-08-23T22:00:00",
+      "endDate": "2025-08-24T03:00:00",
+      "unprocessedDescription": "description: 16 YEAR ANNIVERSARY\nwebsite: https://www.eventbri\rte.com/e/bearracuda-atlanta-16-year-anniversary-tickets-1364601091599\ncover: $20.73 - $26.82 (as of 8/20)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1030030273%2F301420936599%2F1%2Foriginal.20250513-190933?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.0142045454545&fp-y=0.478571428571&s=3ecb099cc8f9d16e98d8ea2b078ddca7\ngmaps: https://www.google.com/maps/search/?api=1&query=33.81158%2C-84.3554&query_place_id=ChIJHfQbk9cF9YgRffpBbinNqZk\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\nkey: bearracuda-2025-08-24-atlanta\nurl: https://www.eventbrite.com/e/bearracuda-atlanta-16-year-anniversary-tickets-1364601091599",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "6603D191-FFD6-4D13-89CE-03BD5C0A3D4F",
+      "uid": "6603D191-FFD6-4D13-89CE-03BD5C0A3D4F",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "cover": "$20.73 - $26.82 (as of 8/20)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1030030273%2F301420936599%2F1%2Foriginal.20250513-190933?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.0142045454545&fp-y=0.478571428571&s=3ecb099cc8f9d16e98d8ea2b078ddca7",
+      "tea": "16 YEAR ANNIVERSARY",
+      "address": null,
+      "website": "https://www.eventbrite.com/e/bearracuda-atlanta-16-year-anniversary-tickets-1364601091599",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=33.81158%2C-84.3554&query_place_id=ChIJHfQbk9cF9YgRffpBbinNqZk",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.eventbrite.com/e/bearracuda-atlanta-16-year-anniversary-tickets-1364601091599",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=33.81158%2C-84.3554&query_place_id=ChIJHfQbk9cF9YgRffpBbinNqZk",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "bearracuda-atlanta-16-year-anniversary-520590b4"
+    },
+    {
+      "name": "Bearracuda Atlanta Bear Pride 2026!",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33.81158,
+        "lng": -84.3554
+      },
+      "startDate": "2026-04-25T21:00:00",
+      "endDate": "2026-04-26T03:00:00",
+      "unprocessedDescription": "description: Doors Open at 9\\:00 pm - Party Goes Until 3\\:00 \ram\nbar: Heretic\naddress: 2069 Cheshire Bridge Rd NE, Atlanta, GA 30324\ntimezone: America/New_York\nurl: https://bearracuda.com/events/atlantabearpride/\nimage: https://bearracuda.com/wp-content/uploads/2025/12/cuda-atlanta-april_2026-web.jpg\nfacebook: https://www.facebook.com/events/3839124786219875/\nticketUrl: https://www.eventbrite.com/e/bearracuda-atlanta-bear-pride-2026-tickets-1978849934423\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=Heretic%2C%202069%20Cheshire%20Bridge%20Rd%20NE%2C%20Atlanta%2C%20GA%2030324\nkey: bearracuda-2026-04-26-atlanta",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "26189CDE-B43B-4E65-9A46-35472A1B1374",
+      "uid": "26189CDE-B43B-4E65-9A46-35472A1B1374",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Heretic",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/12/cuda-atlanta-april_2026-web.jpg",
+      "tea": "Doors Open at 9:00 pm - Party Goes Until 3:00 am",
+      "address": "2069 Cheshire Bridge Rd NE, Atlanta, GA 30324",
+      "website": "https://bearracuda.com/events/atlantabearpride/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/3839124786219875/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Heretic%2C%202069%20Cheshire%20Bridge%20Rd%20NE%2C%20Atlanta%2C%20GA%2030324",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-atlanta-bear-pride-2026-tickets-1978849934423",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/atlantabearpride/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/3839124786219875/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Heretic%2C%202069%20Cheshire%20Bridge%20Rd%20NE%2C%20Atlanta%2C%20GA%2030324",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-atlanta-bear-pride-2026-tickets-1978849934423",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-atlanta-bear-pride-2026-3ac2015f"
+    },
+    {
+      "name": "NEW DATE: Bearracuda Atlanta❄️Winter Beef Ball: Jock & Underwear Pa\rrty!",
+      "day": "Saturday",
+      "time": "10PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33.81158,
+        "lng": -84.3554
+      },
+      "startDate": "2026-02-07T22:00:00",
+      "endDate": "2026-02-08T03:00:00",
+      "unprocessedDescription": "description: Doors Open at 10\\:00 pm - Party Goes Until 3\\:00\r am\nbar: Heretic\naddress: 2069 Cheshire Bridge Rd NE, Atlanta, GA 30324\ntimezone: America/New_York\nurl: https://bearracuda.com/events/atlbulge/\nimage: https://bearracuda.com/wp-content/uploads/2025/04/cuda-atlanta-january_2026-v1.jpg\nfacebook: https://www.facebook.com/events/871622958626464\nticketUrl: https://www.eventbrite.com/e/bearracuda-atlantawinter-beef-ball-jock-underwear-party-tickets-1967115296806?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=Heretic%2C%202069%20Cheshire%20Bridge%20Rd%20NE%2C%20Atlanta%2C%20GA%2030324\nkey: bearracuda-2026-02-08-atlanta",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "B66760F4-84C2-4D7B-88FA-86483970980A",
+      "uid": "B66760F4-84C2-4D7B-88FA-86483970980A",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Heretic",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/04/cuda-atlanta-january_2026-v1.jpg",
+      "tea": "Doors Open at 10:00 pm - Party Goes Until 3:00 am",
+      "address": "2069 Cheshire Bridge Rd NE, Atlanta, GA 30324",
+      "website": "https://bearracuda.com/events/atlbulge/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/871622958626464",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Heretic%2C%202069%20Cheshire%20Bridge%20Rd%20NE%2C%20Atlanta%2C%20GA%2030324",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-atlantawinter-beef-ball-jock-underwear-party-tickets-1967115296806?aff=oddtdtcreator",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/atlbulge/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/871622958626464",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Heretic%2C%202069%20Cheshire%20Bridge%20Rd%20NE%2C%20Atlanta%2C%20GA%2030324",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-atlantawinter-beef-ball-jock-underwear-party-tickets-1967115296806?aff=oddtdtcreator",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "new-date-bearracuda-atlantawinter-beef-ball-jock-underwear-pa-rty-3d2076fd"
+    }
+  ]
+}

--- a/data/calendars/berlin.json
+++ b/data/calendars/berlin.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "calendarTimezone": "Europe/Berlin",
+    "timezoneData": null
+  },
+  "events": []
+}

--- a/data/calendars/boston.json
+++ b/data/calendars/boston.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/New_York",
+    "timezoneData": null
+  },
+  "events": []
+}

--- a/data/calendars/chicago.json
+++ b/data/calendars/chicago.json
@@ -1,0 +1,737 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Chicago",
+    "timezoneData": {
+      "tzid": "America/Chicago",
+      "location": "America/Chicago",
+      "daylight": {
+        "offsetFrom": "-0600",
+        "offsetTo": "-0500",
+        "name": "CDT",
+        "dtstart": "19700308T020000",
+        "rrule": "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU"
+      },
+      "standard": {
+        "offsetFrom": "-0500",
+        "offsetTo": "-0600",
+        "name": "CST",
+        "dtstart": "19701101T020000",
+        "rrule": "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU"
+      }
+    }
+  },
+  "events": [
+    {
+      "name": "CHUNK CHICAGO presents SPRING THAW!",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.9493756,
+        "lng": -87.64979
+      },
+      "startDate": "2026-03-21T21:00:00",
+      "endDate": "2026-03-22T03:00:00",
+      "unprocessedDescription": "description: LET'S GO! - DJs DICAP B2B w/ THCKRTANKER and HOLE \rTEA HOT GOGO BEARS all night long! Cell Block 9-3\nbar: Cell Block Chicago\naddress: 3702 N Halsted St, Chicago, IL 60613, USA\ntimezone: America/Chicago\nurl: https://www.chunk-party.com/event-details/chunk-chicago-presents-spring-thaw\nticketUrl: https://www.chunk-party.com/event-details/chunk-chicago-presents-spring-thaw\ncover: $20.50 - $30.75\nimage: https://static.wixstatic.com/media/42b6cb_d962047a65cf4cc092599b13282ae872~mv2.jpg/v1/fill/w_843,h_1303,al_c,q_85/42b6cb_d962047a65cf4cc092599b13282ae872~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\ngmaps: https://www.google.com/maps/search/?api=1&query=Cell%20Block%20Chicago%2C%203702%20N%20Halsted%20St%2C%20Chicago%2C%20IL%2060613%2C%20USA\nkey: chunk-chicago-presents-spring-thaw|2026-03-22|cell block chicago",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "9C1D2EFD-AB1A-4084-A6DF-108E782DD7C8",
+      "uid": "9C1D2EFD-AB1A-4084-A6DF-108E782DD7C8",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Cell Block Chicago",
+      "cover": "$20.50 - $30.75",
+      "image": "https://static.wixstatic.com/media/42b6cb_d962047a65cf4cc092599b13282ae872~mv2.jpg/v1/fill/w_843,h_1303,al_c,q_85/42b6cb_d962047a65cf4cc092599b13282ae872~mv2.jpg",
+      "tea": "LET'S GO! - DJs DICAP B2B w/ THCKRTANKER and HOLE TEA HOT GOGO BEARS all night long! Cell Block 9-3",
+      "address": "3702 N Halsted St, Chicago, IL 60613, USA",
+      "website": "https://www.chunk-party.com/event-details/chunk-chicago-presents-spring-thaw",
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Cell%20Block%20Chicago%2C%203702%20N%20Halsted%20St%2C%20Chicago%2C%20IL%2060613%2C%20USA",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-chicago-presents-spring-thaw",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.chunk-party.com/event-details/chunk-chicago-presents-spring-thaw",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Cell%20Block%20Chicago%2C%203702%20N%20Halsted%20St%2C%20Chicago%2C%20IL%2060613%2C%20USA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-chicago-presents-spring-thaw",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-chicago-presents-spring-thaw-572f1025"
+    },
+    {
+      "name": "Coach After Dark: Market Days",
+      "day": "Saturday",
+      "time": "9PM-5AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.998402,
+        "lng": -87.6709808
+      },
+      "startDate": "2026-08-08T21:00:00",
+      "endDate": "2026-08-09T05:00:00",
+      "unprocessedDescription": "description: It's the BIGGEST Coach After Dark ever! 4 DJs, 8 \rsexy hot jock go-gos, and 8 hours to gear up and sweat it out on the dance floor!\nbar: Jackhammer\naddress: 6406 North Clark Street, Chicago, IL 60626\ntimezone: America/Chicago\nticketUrl: https://www.eventbrite.com/e/coach-after-dark-market-days-tickets-1991246880021\ninstagram: https://www.instagram.com/coachafterdark\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1186284656%2F2198683436473%2F1%2Foriginal.20260606-002206?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.151&fp-y=0.461&s=b79d377a24d50af51114d1726ef8548d\ncover: $32.78-$54.13\nshortName: COACH\nwebsite: https://www.eventbrite.com/o/bear-happy-hour-87043830313\ngmaps: https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626\nkey: coach-after-dark-market-days|2026-08-09|jackhammer",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "12390A71-5BE8-463A-BB22-806B533B7C1F",
+      "uid": "12390A71-5BE8-463A-BB22-806B533B7C1F",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Jackhammer",
+      "cover": "$32.78-$54.13",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1186284656%2F2198683436473%2F1%2Foriginal.20260606-002206?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.151&fp-y=0.461&s=b79d377a24d50af51114d1726ef8548d",
+      "tea": "It's the BIGGEST Coach After Dark ever! 4 DJs, 8 sexy hot jock go-gos, and 8 hours to gear up and sweat it out on the dance floor!",
+      "address": "6406 North Clark Street, Chicago, IL 60626",
+      "website": "https://www.eventbrite.com/o/bear-happy-hour-87043830313",
+      "instagram": "https://www.instagram.com/coachafterdark",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626",
+      "ticketUrl": "https://www.eventbrite.com/e/coach-after-dark-market-days-tickets-1991246880021",
+      "shortName": "COACH",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.eventbrite.com/o/bear-happy-hour-87043830313",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/coachafterdark",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/coach-after-dark-market-days-tickets-1991246880021",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "coach-after-dark-market-days-1945e994"
+    },
+    {
+      "name": "Coach After Dark: Chicago",
+      "day": "Saturday",
+      "time": "9PM-5AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.998402,
+        "lng": -87.6709808
+      },
+      "startDate": "2026-05-09T21:00:00",
+      "endDate": "2026-05-10T05:00:00",
+      "unprocessedDescription": "description: The Sports Gear Disco returns to Jackhammer Saturd\ray May 9th! Come gear up and sweat it out on the dance floor!\nbar: Jackhammer\naddress: 6406 North Clark Street, Chicago, IL 60626\ntimezone: America/Chicago\nticketUrl: https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1987165553664\ninstagram: https://www.instagram.com/coachafterdark\ncover: $20.00-$30.65\nwebsite: https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1987165553664\ngmaps: https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626\nkey: coach-after-dark-chicago|2026-05-10|jackhammer",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "FA8478FF-3F78-4E27-AAB4-B71F3FA40171",
+      "uid": "FA8478FF-3F78-4E27-AAB4-B71F3FA40171",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Jackhammer",
+      "cover": "$20.00-$30.65",
+      "tea": "The Sports Gear Disco returns to Jackhammer Saturday May 9th! Come gear up and sweat it out on the dance floor!",
+      "address": "6406 North Clark Street, Chicago, IL 60626",
+      "website": "https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1987165553664",
+      "instagram": "https://www.instagram.com/coachafterdark",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626",
+      "ticketUrl": "https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1987165553664",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1987165553664",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/coachafterdark",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1987165553664",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "coach-after-dark-chicago-45a4a493"
+    },
+    {
+      "name": "Furball Market Days",
+      "day": "Friday",
+      "time": "10:30PM-4AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.9498139,
+        "lng": -87.6588771
+      },
+      "startDate": "2025-08-08T22:30:00",
+      "endDate": "2025-08-09T04:00:00",
+      "unprocessedDescription": "Google Maps: https://maps.app.goo.gl/Gwxy5yMhZhZFEfsBA?g_st=ipc\r\nWebsite: https://www.furball.nyc/\nCover: ~$30\nBar: Metro\nShort: Furball\nShorter: FUR",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "anpebtqveq4fqmniffj10p0j5o@google.com",
+      "uid": "anpebtqveq4fqmniffj10p0j5o@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Metro",
+      "cover": "~$30",
+      "address": null,
+      "website": "https://www.furball.nyc/",
+      "gmaps": "https://maps.app.goo.gl/Gwxy5yMhZhZFEfsBA?g_st=ipc",
+      "shortName": "Furball",
+      "shorterName": "FUR",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.furball.nyc/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.app.goo.gl/Gwxy5yMhZhZFEfsBA?g_st=ipc",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "furball-market-days-78310803"
+    },
+    {
+      "name": "Bearracuda Chicago Jockstrap Party: Tix at the DOOR",
+      "day": "Friday",
+      "time": "9PM-4AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2025-08-29T21:00:00",
+      "endDate": "2025-08-30T04:00:00",
+      "unprocessedDescription": "description: Music & Entertainment\n• DJ Tim Arnold (Main Floor\r)\n• REDUX (The HOLE)\nbar: The Jackhammer Complex\naddress: 6406 N Clark St, Chicago, IL 60626\ntimezone: America/Chicago\nurl: https://bearracuda.com/events/chicagoaug/\ncover: $19.24 - $24.89 (as of 8/29)\nimage: https://bearracuda.com/wp-content/uploads/2025/04/chicagoaugustweb.jpg\nfacebook: https://www.facebook.com/events/1227123952423945/\nticketUrl: https://www.eventbrite.com/e/bearracuda-chicago-labor-day-jockstrap-party-tickets-1412963053529?aff=oddtdtcreator\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://maps.google.com/?q=41.99842,-87.67112\nkey: bearracuda-2025-08-30-chicago",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "EA39ACFC-8AE4-4766-9C7C-C310633622D9",
+      "uid": "EA39ACFC-8AE4-4766-9C7C-C310633622D9",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "The Jackhammer Complex",
+      "cover": "$19.24 - $24.89 (as of 8/29)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/04/chicagoaugustweb.jpg",
+      "tea": "Music & Entertainment",
+      "address": "6406 N Clark St, Chicago, IL 60626",
+      "website": "https://bearracuda.com/events/chicagoaug/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1227123952423945/",
+      "gmaps": "https://maps.google.com/?q=41.99842,-87.67112",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-chicago-labor-day-jockstrap-party-tickets-1412963053529?aff=oddtdtcreator",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/chicagoaug/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1227123952423945/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.google.com/?q=41.99842,-87.67112",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-chicago-labor-day-jockstrap-party-tickets-1412963053529?aff=oddtdtcreator",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-chicago-jockstrap-party-tix-at-the-door-17cea9ba"
+    },
+    {
+      "name": "Market Day 1",
+      "day": "Friday",
+      "time": "5PM-10PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.9436009,
+        "lng": -87.6494458
+      },
+      "startDate": "2025-08-08T17:00:00",
+      "endDate": "2025-08-08T22:00:00",
+      "unprocessedDescription": "Website: <a href=\"https://northalsted.com/main-events/northalst\red-market-days/\" target=\"_blank\">https://northalsted.com/main-events/northalsted-market-days/</a><br>Tea: Live music street festival with a queer focus. Friday’s top artists are Saucy Santana and Monét X Change. See the website for more artists and entry info.<br>Instagram: <a href=\"https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1\" target=\"_blank\">https://www.instagram.com/marketdayschicago</a><br>Cover: $20 suggested donation<br>Maps: <a href=\"https://maps.app.goo.gl/TmSKcmCvv6WZizMeA?g_st=ipc\">https://maps.app.goo.gl/TmSKcmCvv6WZizMeA?g_st=ipc</a><br>Bar: Halsted St. from Belmont to Addison",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "50pmdk0ccoramq9nd5615m8ueh@google.com",
+      "uid": "50pmdk0ccoramq9nd5615m8ueh@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Halsted St. from Belmont to Addison",
+      "cover": "$20 suggested donation",
+      "tea": "Live music street festival with a queer focus. Friday’s top artists are Saucy Santana and Monét X Change. See the website for more artists and entry info.",
+      "address": null,
+      "website": "https://northalsted.com/main-events/northalsted-market-days/",
+      "instagram": "https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://northalsted.com/main-events/northalsted-market-days/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1",
+          "label": "📷 Instagram"
+        }
+      ],
+      "slug": "market-day-1-35c3f1a2"
+    },
+    {
+      "name": "Market Day 2",
+      "day": "Saturday",
+      "time": "11AM-10PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.9436009,
+        "lng": -87.6494458
+      },
+      "startDate": "2025-08-09T11:00:00",
+      "endDate": "2025-08-09T22:00:00",
+      "unprocessedDescription": "Website: <a href=\"https://northalsted.com/main-events/northalst\red-market-days/\" target=\"_blank\">https://northalsted.com/main-events/northalsted-market-days/</a><br>Tea: Live music street festival with a queer focus. Saturday’s top artists are Keke Palmer, Keisha, Same Star, and Brooke Eden. See the website for more artists and entry info.<br>Instagram: <a href=\"https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1\" target=\"_blank\">https://www.instagram.com/marketdayschicago</a><br>Cover: $20 suggested donation<br>Maps: <a href=\"https://maps.app.goo.gl/TmSKcmCvv6WZizMeA?g_st=ipc\" target=\"_blank\">https://maps.app.goo.gl/TmSKcmCvv6WZizMeA?g_st=ipc</a><br>Bar: Halsted St. from Belmont to Addison",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "0nfdrio58lobhrsarq4dgge2p7@google.com",
+      "uid": "0nfdrio58lobhrsarq4dgge2p7@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Halsted St. from Belmont to Addison",
+      "cover": "$20 suggested donation",
+      "tea": "Live music street festival with a queer focus. Saturday’s top artists are Keke Palmer, Keisha, Same Star, and Brooke Eden. See the website for more artists and entry info.",
+      "address": null,
+      "website": "https://northalsted.com/main-events/northalsted-market-days/",
+      "instagram": "https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://northalsted.com/main-events/northalsted-market-days/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1",
+          "label": "📷 Instagram"
+        }
+      ],
+      "slug": "market-day-2-115ee9f1"
+    },
+    {
+      "name": "Belly Up",
+      "day": "Saturday",
+      "time": "9PM-5AM",
+      "eventType": "monthly",
+      "recurring": true,
+      "recurrence": "FREQ=MONTHLY;BYDAY=1SA",
+      "coordinates": {
+        "lat": 41.9983961,
+        "lng": -87.6709779
+      },
+      "startDate": "2025-09-06T21:00:00",
+      "endDate": "2025-09-07T05:00:00",
+      "unprocessedDescription": "tea: 🎧 Live DJs and Dancers bringing the energy\ncover: Before\r 10pm\\: FREE, 10pm-2\\:30am\\: $10, 2\\:30am-Last call\\: $5\nbar: Jackhammer\naddress: 6406 N Clark St, Chicago, IL 60626\nuid: qo8nfeeu512fe74ng1o3jmoqt0@google.com\nwebsite: https://jackhammerchicago.com/belly-up\nfacebook: https://www.facebook.com/chijackhammer/events\ngmaps: https://maps.app.goo.gl/Groc2oBnZyjMU2cJA",
+      "startTimezone": "America/Chicago",
+      "endTimezone": "America/Chicago",
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": false,
+      "sourceUid": "qo8nfeeu512fe74ng1o3jmoqt0@google.com",
+      "uid": "qo8nfeeu512fe74ng1o3jmoqt0@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 2,
+      "overrideIdentityType": null,
+      "bar": "Jackhammer",
+      "cover": "Before 10pm: FREE, 10pm-2:30am: $10, 2:30am-Last call: $5",
+      "tea": "🎧 Live DJs and Dancers bringing the energy",
+      "address": "6406 N Clark St, Chicago, IL 60626",
+      "website": "https://jackhammerchicago.com/belly-up",
+      "facebook": "https://www.facebook.com/chijackhammer/events",
+      "gmaps": "https://maps.app.goo.gl/Groc2oBnZyjMU2cJA",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://jackhammerchicago.com/belly-up",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/chijackhammer/events",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.app.goo.gl/Groc2oBnZyjMU2cJA",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "belly-up-3e6c6e9e"
+    },
+    {
+      "name": "CHUNK CHICAGO presents SAUSAGE PARTY!",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.9493756,
+        "lng": -87.64979
+      },
+      "startDate": "2025-10-11T21:00:00",
+      "endDate": "2025-10-12T03:00:00",
+      "unprocessedDescription": "description: BEEF, DADS, BBQ, SAUSAGES, WEINERS - WHATS NOT\r TO LOVE?!? NYC DJ LEGEND DICAP AND CHUNK RESIDENT MR PICKLES HOSTED BY COACH MIKEY HOT GOGO BEARS ALL NIGHT LONG CELL BLOCK // 3702 N HALSTED ST // HEART OF BOYSTOWN // CHICAGO // 9P\nbar: CELL BLOCK\naddress: 3702 N Halsted St, Chicago, IL 60613, USA\ntimezone: America/Chicago\nurl: https://www.chunk-party.com/event-details/chunk-chicago-presents-sausage-party\nticketUrl: https://www.chunk-party.com/event-details/chunk-chicago-presents-sausage-party\ncover: $20.50 - $25.63\nimage: https://static.wixstatic.com/media/42b6cb_356df9ed11594c12b5bb6c45d0661e05~mv2.jpg/v1/fill/w_1874,h_2342,al_c,q_90/42b6cb_356df9ed11594c12b5bb6c45d0661e05~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\ngmaps: https://maps.google.com/?q=41.9493756,-87.64979\nkey: chunk-chicago-presents-sausage-party|2025-10-12|cell block|chunk",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "8E2BF651-F6BA-4564-B5F9-7C014070614B",
+      "uid": "8E2BF651-F6BA-4564-B5F9-7C014070614B",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "CELL BLOCK",
+      "cover": "$20.50 - $25.63",
+      "image": "https://static.wixstatic.com/media/42b6cb_356df9ed11594c12b5bb6c45d0661e05~mv2.jpg/v1/fill/w_1874,h_2342,al_c,q_90/42b6cb_356df9ed11594c12b5bb6c45d0661e05~mv2.jpg",
+      "tea": "BEEF, DADS, BBQ, SAUSAGES, WEINERS - WHATS NOT TO LOVE?!? NYC DJ LEGEND DICAP AND CHUNK RESIDENT MR PICKLES HOSTED BY COACH MIKEY HOT GOGO BEARS ALL NIGHT LONG CELL BLOCK // 3702 N HALSTED ST // HEART OF BOYSTOWN // CHICAGO // 9P",
+      "address": "3702 N Halsted St, Chicago, IL 60613, USA",
+      "website": "https://www.chunk-party.com/event-details/chunk-chicago-presents-sausage-party",
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://maps.google.com/?q=41.9493756,-87.64979",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-chicago-presents-sausage-party",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.chunk-party.com/event-details/chunk-chicago-presents-sausage-party",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.google.com/?q=41.9493756,-87.64979",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-chicago-presents-sausage-party",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-chicago-presents-sausage-party-55be49fe"
+    },
+    {
+      "name": "MEGAWOOF CHICAGO - JULY - BEARWATCH",
+      "day": "Saturday",
+      "time": "9PM-5AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.998402,
+        "lng": -87.6709808
+      },
+      "startDate": "2026-07-11T21:00:00",
+      "endDate": "2026-07-12T05:00:00",
+      "unprocessedDescription": "description: CHICAGO MEGAWOOF CHICAGO - JULY - SPECIAL OFFER\nb\rar: Jackhammer\naddress: 6406 North Clark Street, Chicago, IL 60626\ntimezone: America/Chicago\nticketUrl: https://www.eventbrite.com/e/megawoof-chicago-july-bearwatch-tickets-1987363318183\ninstagram: https://www.instagram.com/megawoof_america\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1184410354%2F185013722403%2F1%2Foriginal.20260512-160408?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=79b82ef9b2961bb09d52102535747556\ncover: $11.58-$21.05\nshortName: MEGA-WOOF\nwebsite: https://linktr.ee/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626\nkey: megawoof-chicago-july-bearwatch|2026-07-12|jackhammer",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "7536DF8E-6246-479E-8FF7-E711B6A04177",
+      "uid": "7536DF8E-6246-479E-8FF7-E711B6A04177",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Jackhammer",
+      "cover": "$11.58-$21.05",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1184410354%2F185013722403%2F1%2Foriginal.20260512-160408?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=79b82ef9b2961bb09d52102535747556",
+      "tea": "CHICAGO MEGAWOOF CHICAGO - JULY - SPECIAL OFFER",
+      "address": "6406 North Clark Street, Chicago, IL 60626",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-chicago-july-bearwatch-tickets-1987363318183",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-chicago-july-bearwatch-tickets-1987363318183",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-chicago-july-bearwatch-7afede0c"
+    },
+    {
+      "name": "FURBALL CHICAGO MARKET DAYS",
+      "day": "Friday",
+      "time": "10:30PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.9497837,
+        "lng": -87.6590034
+      },
+      "startDate": "2026-08-07T22:30:00",
+      "unprocessedDescription": "description: MUSIC\nJESSE MERCADO\n(CHICAGO)\nTONY MORAN\nbar: \rMetro\naddress: 3730 N CLARK ST\ntimezone: America/Chicago\nticketUrl: https://www.etix.com/ticket/p/54403374/?partner_id=100&_gl=1*1bmryzt*_ga*MTI5NjI5MTA1OS4xNzgzNzA5NzI5*_ga_Z3MV4KFJMN*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGgxNzA5NTE2OTA5*_ga_DSG080VB8M*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGg3NjY5MDM0NTA.*_ga_68TT1Q537T*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGg5NTk4NTE2Njg.*_ga_MCR6RT8ZB7*czE3ODM3MDk3MzAkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGgw&_ga=2.96391708.1430242853.1783709730-1296291059.1783709729\ninstagram: https://instagram.com/furballnyc/\nimage: https://static.wixstatic.com/media/238fae_166133fdfd194d6aa28343c55418296e~mv2.jpg/v1/fill/w_296,h_494,al_c,q_80,usm_0.66_1.00_0.01,enc_avif,quality_auto/238fae_166133fdfd194d6aa28343c55418296e~mv2.jpg\nshortName: FUR-BALL\nfavicon: https://linktr.ee/furballnyc\nwebsite: https://www.furball.nyc\ngmaps: https://www.google.com/maps/search/?api=1&query=Metro%2C%203730%20N%20CLARK%20ST\nkey: furball-chicago-market-days|2026-08-08|metro",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "33540850-F538-4592-BB59-A8A672F2F796",
+      "uid": "33540850-F538-4592-BB59-A8A672F2F796",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Metro",
+      "image": "https://static.wixstatic.com/media/238fae_166133fdfd194d6aa28343c55418296e~mv2.jpg/v1/fill/w_296,h_494,al_c,q_80,usm_0.66_1.00_0.01,enc_avif,quality_auto/238fae_166133fdfd194d6aa28343c55418296e~mv2.jpg",
+      "favicon": "https://linktr.ee/furballnyc",
+      "tea": "MUSIC",
+      "address": "3730 N CLARK ST",
+      "website": "https://www.furball.nyc",
+      "instagram": "https://instagram.com/furballnyc/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Metro%2C%203730%20N%20CLARK%20ST",
+      "ticketUrl": "https://www.etix.com/ticket/p/54403374/?partner_id=100&_gl=1*1bmryzt*_ga*MTI5NjI5MTA1OS4xNzgzNzA5NzI5*_ga_Z3MV4KFJMN*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGgxNzA5NTE2OTA5*_ga_DSG080VB8M*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGg3NjY5MDM0NTA.*_ga_68TT1Q537T*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGg5NTk4NTE2Njg.*_ga_MCR6RT8ZB7*czE3ODM3MDk3MzAkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGgw&_ga=2.96391708.1430242853.1783709730-1296291059.1783709729",
+      "shortName": "FUR-BALL",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.furball.nyc",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://instagram.com/furballnyc/",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Metro%2C%203730%20N%20CLARK%20ST",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.etix.com/ticket/p/54403374/?partner_id=100&_gl=1*1bmryzt*_ga*MTI5NjI5MTA1OS4xNzgzNzA5NzI5*_ga_Z3MV4KFJMN*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGgxNzA5NTE2OTA5*_ga_DSG080VB8M*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGg3NjY5MDM0NTA.*_ga_68TT1Q537T*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGg5NTk4NTE2Njg.*_ga_MCR6RT8ZB7*czE3ODM3MDk3MzAkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGgw&_ga=2.96391708.1430242853.1783709730-1296291059.1783709729",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "furball-chicago-market-days-4ca14ebb"
+    },
+    {
+      "name": "Market Day 3",
+      "day": "Sunday",
+      "time": "11AM-10PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.9436009,
+        "lng": -87.6494458
+      },
+      "startDate": "2025-08-10T11:00:00",
+      "endDate": "2025-08-10T22:00:00",
+      "unprocessedDescription": "Website: <a href=\"https://northalsted.com/main-events/northalst\red-market-days/\" target=\"_blank\">https://northalsted.com/main-events/northalsted-market-days/</a><br>Tea: Live music street festival with a queer focus. Sunday’s top artists are David Archuleta, Joe Dombrowski, and Sasha Colby. See the website for more artists and entry info.<br>Instagram: <a href=\"https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1\" target=\"_blank\">https://www.instagram.com/marketdayschicago</a><br>Cover: $20 suggested donation<br>Maps: <a href=\"https://maps.app.goo.gl/TmSKcmCvv6WZizMeA?g_st=ipc\" target=\"_blank\">https://maps.app.goo.gl/TmSKcmCvv6WZizMeA?g_st=ipc</a><br>Bar: Halsted St. from Belmont to Addison",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "1bs4hde34sb2o62dtr2sl85ild@google.com",
+      "uid": "1bs4hde34sb2o62dtr2sl85ild@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Halsted St. from Belmont to Addison",
+      "cover": "$20 suggested donation",
+      "tea": "Live music street festival with a queer focus. Sunday’s top artists are David Archuleta, Joe Dombrowski, and Sasha Colby. See the website for more artists and entry info.",
+      "address": null,
+      "website": "https://northalsted.com/main-events/northalsted-market-days/",
+      "instagram": "https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://northalsted.com/main-events/northalsted-market-days/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1",
+          "label": "📷 Instagram"
+        }
+      ],
+      "slug": "market-day-3-691a9a51"
+    },
+    {
+      "name": "Coach After Dark: Chicago",
+      "day": "Saturday",
+      "time": "9PM-5AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 41.998402,
+        "lng": -87.6709808
+      },
+      "startDate": "2026-02-14T21:00:00",
+      "endDate": "2026-02-15T05:00:00",
+      "unprocessedDescription": "description: This Valentine's Day Coach After Dark\\: The Sport\rs Gear Disco returns to Jackhammer in Chicago!\nbar: Jackhammer\naddress: 6406 North Clark Street, Chicago, IL 60626\ntimezone: America/Chicago\nticketUrl: https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1980995304282\ncover: $20 - $30.65 (as of 1/28)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1175333561%2F2198683436473%2F1%2Foriginal.20260120-135628?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=70ef3f1bebb0d6754418e16fe06236bd\ninstagram: https://www.instagram.com/coachafterdark\ngmaps: https://www.google.com/maps/search/?api=1&query=41.998402%2C-87.6709808&query_place_id=ChIJ44RAWrzRD4gRDGoLchD_2SI\nkey: coach-after-dark-chicago|2026-02-15|jackhammer",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "0AD1679F-26DC-4355-ABDC-8F79B5C3552A",
+      "uid": "0AD1679F-26DC-4355-ABDC-8F79B5C3552A",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Jackhammer",
+      "cover": "$20 - $30.65 (as of 1/28)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1175333561%2F2198683436473%2F1%2Foriginal.20260120-135628?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=70ef3f1bebb0d6754418e16fe06236bd",
+      "tea": "This Valentine's Day Coach After Dark: The Sports Gear Disco returns to Jackhammer in Chicago!",
+      "address": "6406 North Clark Street, Chicago, IL 60626",
+      "website": null,
+      "instagram": "https://www.instagram.com/coachafterdark",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=41.998402%2C-87.6709808&query_place_id=ChIJ44RAWrzRD4gRDGoLchD_2SI",
+      "ticketUrl": "https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1980995304282",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/coachafterdark",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=41.998402%2C-87.6709808&query_place_id=ChIJ44RAWrzRD4gRDGoLchD_2SI",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1980995304282",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "coach-after-dark-chicago-78fe7aea"
+    },
+    {
+      "name": "Bear Happy Hour",
+      "day": "Thursday",
+      "time": "5PM-9PM",
+      "eventType": "weekly",
+      "recurring": true,
+      "recurrence": "FREQ=WEEKLY",
+      "startDate": "2025-07-10T17:00:00",
+      "endDate": "2025-07-10T21:00:00",
+      "unprocessedDescription": "Bar: Check instagram for this week’s location.\nTea: Popular ha\rppy hour that changes location every week.\nInstagram: https://www.instagram.com/bearhappyhourchi\nShorter: BHH\nWeb: https://linktr.ee/bearhappyhour",
+      "startTimezone": "America/North_Dakota/New_Salem",
+      "endTimezone": "America/North_Dakota/New_Salem",
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": false,
+      "sourceUid": "gntkupiisd0hb2k7uptg7j855g@google.com",
+      "uid": "gntkupiisd0hb2k7uptg7j855g@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Check instagram for this week’s location.",
+      "tea": "Popular happy hour that changes location every week.",
+      "address": null,
+      "website": "https://linktr.ee/bearhappyhour",
+      "instagram": "https://www.instagram.com/bearhappyhourchi",
+      "shorterName": "BHH",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/bearhappyhour",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearhappyhourchi",
+          "label": "📷 Instagram"
+        }
+      ],
+      "slug": "bear-happy-hour-50e80e42"
+    }
+  ]
+}

--- a/data/calendars/dallas.json
+++ b/data/calendars/dallas.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Chicago",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "FURBALL",
+      "day": "Sunday",
+      "time": "5PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 32.810535,
+        "lng": -96.8110709
+      },
+      "startDate": "2026-07-05T17:00:00",
+      "unprocessedDescription": "bar: STATION 4\naddress: 3911 Cedar Springs Rd, Dallas, TX 75\r219\ntimezone: America/Chicago\nticketUrl: https://events.ticketleap.com/tickets/furballnyc/furball-dallas-freedom-tea-2026\ninstagram: https://instagram.com/furballnyc/\nimage: https://static.wixstatic.com/media/238fae_335eacf0ca204c35bff2a6a6b4994fc5~mv2.jpg/v1/fill/w_296,h_525,al_c,q_80,usm_0.66_1.00_0.01,enc_avif,quality_auto/238fae_335eacf0ca204c35bff2a6a6b4994fc5~mv2.jpg\nshortName: FUR-BALL\nwebsite: https://www.furball.nyc\ngmaps: https://www.google.com/maps/search/?api=1&query=STATION%204%2C%20391%20Cedar%20Springs%20Rd",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "53B4DABD-D3AE-47EC-AE4A-7D8C33A7652D",
+      "uid": "53B4DABD-D3AE-47EC-AE4A-7D8C33A7652D",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "STATION 4",
+      "image": "https://static.wixstatic.com/media/238fae_335eacf0ca204c35bff2a6a6b4994fc5~mv2.jpg/v1/fill/w_296,h_525,al_c,q_80,usm_0.66_1.00_0.01,enc_avif,quality_auto/238fae_335eacf0ca204c35bff2a6a6b4994fc5~mv2.jpg",
+      "address": "3911 Cedar Springs Rd, Dallas, TX 75219",
+      "website": "https://www.furball.nyc",
+      "instagram": "https://instagram.com/furballnyc/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=STATION%204%2C%20391%20Cedar%20Springs%20Rd",
+      "ticketUrl": "https://events.ticketleap.com/tickets/furballnyc/furball-dallas-freedom-tea-2026",
+      "shortName": "FUR-BALL",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.furball.nyc",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://instagram.com/furballnyc/",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=STATION%204%2C%20391%20Cedar%20Springs%20Rd",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://events.ticketleap.com/tickets/furballnyc/furball-dallas-freedom-tea-2026",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "furball-442f8415"
+    }
+  ]
+}

--- a/data/calendars/dc.json
+++ b/data/calendars/dc.json
@@ -1,0 +1,65 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/New_York",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "MEGAWOOF",
+      "day": "Friday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 38.9162081,
+        "lng": -77.0213011
+      },
+      "startDate": "2026-02-13T21:00:00",
+      "endDate": "2026-02-14T03:00:00",
+      "unprocessedDescription": "description: MEGAWOOF AMERICA - S.VALENTINE + President Day Wee\rkend\nbar: Uproar Lounge & Restaurant\naddress: 639 Florida Avenue Northwest, Washington, DC 20001\ntimezone: America/New_York\nticketUrl: https://www.eventbrite.com/e/megawoof-america-svalentine-weekend-tickets-1981048053055\ncover: $11.58 - $22.10 (as of 2/8)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1175380239%2F185013722403%2F1%2Foriginal.20260120-203950?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=8fcf2a3b96dea4876485890a59c19bba\nshortName: MEGA-WOOF\ninstagram: https://www.instagram.com/megawoof_america\nurl: https://linktr.ee/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=38.9162081%2C-77.0213011&query_place_id=ChIJvfMkyPq3t4kRztqpgf-qNEc\nkey: megawoof|2026-02-14|uproar lounge & restaurant",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "C32DBFE5-FAB5-4B93-B65E-FEEAAC41B2BC",
+      "uid": "C32DBFE5-FAB5-4B93-B65E-FEEAAC41B2BC",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Uproar Lounge & Restaurant",
+      "cover": "$11.58 - $22.10 (as of 2/8)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1175380239%2F185013722403%2F1%2Foriginal.20260120-203950?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=8fcf2a3b96dea4876485890a59c19bba",
+      "tea": "MEGAWOOF AMERICA - S.VALENTINE + President Day Weekend",
+      "address": "639 Florida Avenue Northwest, Washington, DC 20001",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=38.9162081%2C-77.0213011&query_place_id=ChIJvfMkyPq3t4kRztqpgf-qNEc",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-svalentine-weekend-tickets-1981048053055",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=38.9162081%2C-77.0213011&query_place_id=ChIJvfMkyPq3t4kRztqpgf-qNEc",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-america-svalentine-weekend-tickets-1981048053055",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-5e604137"
+    }
+  ]
+}

--- a/data/calendars/denver.json
+++ b/data/calendars/denver.json
@@ -1,0 +1,349 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Denver",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "DENVER",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-03-14T21:00:00",
+      "endDate": "2026-03-15T02:00:00",
+      "unprocessedDescription": "description: Doors Open at 9\\:00 pm - Party Goes Until 2\\:00 \ram\nbar: Ophelia's\naddress: 1215 20th Street, Denver, CO\ntimezone: America/Denver\nurl: https://bearracuda.com/events/denvermarch/\nimage: https://bearracuda.com/wp-content/uploads/2026/01/denvernew2.jpg\nfacebook: https://www.facebook.com/events/1959773034896673\nticketUrl: https://www.ticketmaster.com/bearracuda-denver-colorado-03-14-2026/event/1E0064260CAC881B\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=Ophelia's%2C%201215%2020th%20Street%2C%20Denver%2C%20CO\nkey: bearracuda-2026-03-15-denver",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Denver",
+      "wasUTC": true,
+      "sourceUid": "CEB40CFA-CC09-4975-8972-54CF6AC84812",
+      "uid": "CEB40CFA-CC09-4975-8972-54CF6AC84812",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Ophelia's",
+      "image": "https://bearracuda.com/wp-content/uploads/2026/01/denvernew2.jpg",
+      "tea": "Doors Open at 9:00 pm - Party Goes Until 2:00 am",
+      "address": "1215 20th Street, Denver, CO",
+      "website": "https://bearracuda.com/events/denvermarch/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1959773034896673",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Ophelia's%2C%201215%2020th%20Street%2C%20Denver%2C%20CO",
+      "ticketUrl": "https://www.ticketmaster.com/bearracuda-denver-colorado-03-14-2026/event/1E0064260CAC881B",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/denvermarch/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1959773034896673",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Ophelia's%2C%201215%2020th%20Street%2C%20Denver%2C%20CO",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.ticketmaster.com/bearracuda-denver-colorado-03-14-2026/event/1E0064260CAC881B",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "denver-42126767"
+    },
+    {
+      "name": "Bearracuda",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2025-09-06T21:00:00",
+      "endDate": "2025-09-07T02:00:00",
+      "unprocessedDescription": "description: 16 YEAR ANNIVERSARY\nDoors Open at 9\\:00 pm - Par\rty Goes Until 2\\:00 am\nbar: Summit\naddress: 1902 Blake St, Denver, CO 80202\ntimezone: America/Denver\nurl: https://bearracuda.com/events/denverpride/\nimage: https://bearracuda.com/wp-content/uploads/2025/01/den16web.jpg\nfacebook: https://www.facebook.com/events/747044714674555\nticketUrl: https://www.ticketmaster.com/event/1E0062E79CD214B2\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://maps.google.com/?q=1902%20Blake%20St%2C%20Denver%2C%20CO%2080202\nkey: bearracuda-2025-09-07-denver",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Denver",
+      "wasUTC": true,
+      "sourceUid": "2EADF29C-DD45-4A7C-938D-D57E62DB56F7",
+      "uid": "2EADF29C-DD45-4A7C-938D-D57E62DB56F7",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Summit",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/01/den16web.jpg",
+      "tea": "16 YEAR ANNIVERSARY",
+      "address": "1902 Blake St, Denver, CO 80202",
+      "website": "https://bearracuda.com/events/denverpride/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/747044714674555",
+      "gmaps": "https://maps.google.com/?q=1902%20Blake%20St%2C%20Denver%2C%20CO%2080202",
+      "ticketUrl": "https://www.ticketmaster.com/event/1E0062E79CD214B2",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/denverpride/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/747044714674555",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.google.com/?q=1902%20Blake%20St%2C%20Denver%2C%20CO%2080202",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.ticketmaster.com/event/1E0062E79CD214B2",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-0f2c13d7"
+    },
+    {
+      "name": "TWISTED BEAR DENVER - feat. DJ/Producer MATT CONSOLA",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 39.7402498,
+        "lng": -104.9790098
+      },
+      "startDate": "2026-05-09T21:00:00",
+      "endDate": "2026-05-10T02:00:00",
+      "unprocessedDescription": "description: Excited to return to Denver with a debut party at \rX Bar\nbar: X BAR\naddress: 629 East Colfax Avenue, Denver, CO 80203\nticketUrl: https://www.eventbrite.com/e/twisted-bear-denver-feat-djproducer-matt-consola-tickets-1985473771498\ncover: $17.85 - $23.18 (as of 4/12)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1180182811%2F1088207912863%2F1%2Foriginal.20260318-214151?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=b3cb8f1090035f0405afc6acb5b357f5\nshortName: TWIST-ED BEAR\ninstagram: https://www.instagram.com/twistedbearparty\nfacebook: https://www.facebook.com/twistedglobal/\ngmaps: https://www.google.com/maps/search/?api=1&query=39.7402498%2C-104.9790098&query_place_id=ChIJw4sroyx5bIcR5jU8EDoneGU\nkey: twisted-bear-denver-feat-dj-producer-matt-consola|2026-05-10|x bar",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Denver",
+      "wasUTC": true,
+      "sourceUid": "5CAA4C7D-1DF7-4658-A7DA-92DB96234ABB",
+      "uid": "5CAA4C7D-1DF7-4658-A7DA-92DB96234ABB",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "X BAR",
+      "cover": "$17.85 - $23.18 (as of 4/12)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1180182811%2F1088207912863%2F1%2Foriginal.20260318-214151?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=b3cb8f1090035f0405afc6acb5b357f5",
+      "tea": "Excited to return to Denver with a debut party at X Bar",
+      "address": "629 East Colfax Avenue, Denver, CO 80203",
+      "website": null,
+      "instagram": "https://www.instagram.com/twistedbearparty",
+      "facebook": "https://www.facebook.com/twistedglobal/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=39.7402498%2C-104.9790098&query_place_id=ChIJw4sroyx5bIcR5jU8EDoneGU",
+      "ticketUrl": "https://www.eventbrite.com/e/twisted-bear-denver-feat-djproducer-matt-consola-tickets-1985473771498",
+      "shortName": "TWIST-ED BEAR",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/twistedbearparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/twistedglobal/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=39.7402498%2C-104.9790098&query_place_id=ChIJw4sroyx5bIcR5jU8EDoneGU",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/twisted-bear-denver-feat-djproducer-matt-consola-tickets-1985473771498",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "twisted-bear-denver-feat-djproducer-matt-consola-0fcf1526"
+    },
+    {
+      "name": "DENVER",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2025-11-08T21:00:00",
+      "endDate": "2025-11-09T02:00:00",
+      "unprocessedDescription": "description: Doors Open at 9\\:00 pm - Party Goes Until 2\\:00 \ram\nbar: Ophelia's\naddress: 1215 20th Street, Denver, CO 80202\ntimezone: America/Denver\nurl: https://bearracuda.com/events/denverjockstrap/\nimage: https://bearracuda.com/wp-content/uploads/2025/01/denvernov1.jpg\nfacebook: https://www.facebook.com/events/940668894946715\nticketUrl: https://www.ticketmaster.com/event/1E00632CA5D027C6\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://maps.google.com/?q=1215%2020th%20Street%2C%20Denver%2C%20CO%2080202\nkey: bearracuda-2025-11-09-denver",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Denver",
+      "wasUTC": true,
+      "sourceUid": "C7EE5AFD-D875-467B-903D-095E6C0F0F61",
+      "uid": "C7EE5AFD-D875-467B-903D-095E6C0F0F61",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Ophelia's",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/01/denvernov1.jpg",
+      "tea": "Doors Open at 9:00 pm - Party Goes Until 2:00 am",
+      "address": "1215 20th Street, Denver, CO 80202",
+      "website": "https://bearracuda.com/events/denverjockstrap/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/940668894946715",
+      "gmaps": "https://maps.google.com/?q=1215%2020th%20Street%2C%20Denver%2C%20CO%2080202",
+      "ticketUrl": "https://www.ticketmaster.com/event/1E00632CA5D027C6",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/denverjockstrap/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/940668894946715",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.google.com/?q=1215%2020th%20Street%2C%20Denver%2C%20CO%2080202",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.ticketmaster.com/event/1E00632CA5D027C6",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "denver-39553322"
+    },
+    {
+      "name": "DENVER PRIDE",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-06-27T21:00:00",
+      "endDate": "2026-06-28T02:00:00",
+      "unprocessedDescription": "description: Music & Entertainment\n• TONY MORAN\n• Mateo Segad\re (Sold Pink Disco)\nbar: SUMMIT\naddress: 1302 Blake St, Denver, CO\ntimezone: America/Denver\nimage: https://bearracuda.com/wp-content/uploads/2025/01/tonydenverstory.jpg\nfacebook: https://www.facebook.com/events/3431582900333796/\nticketUrl: https://www.ticketmaster.com/event/1E00642CF2CCADDC\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\nwebsite: https://bearracuda.com/events/denverpride26/\ngmaps: https://www.google.com/maps/search/?api=1&query=SUMMIT%2C%201302%20Blake%20St%2C%20Denver%2C%20CO\nkey: bearracuda-2026-06-28-denver",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Denver",
+      "wasUTC": true,
+      "sourceUid": "945D4169-D1D1-494F-AABB-A7A87C364566",
+      "uid": "945D4169-D1D1-494F-AABB-A7A87C364566",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "SUMMIT",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/01/tonydenverstory.jpg",
+      "tea": "Music & Entertainment",
+      "address": "1302 Blake St, Denver, CO",
+      "website": "https://bearracuda.com/events/denverpride26/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/3431582900333796/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=SUMMIT%2C%201302%20Blake%20St%2C%20Denver%2C%20CO",
+      "ticketUrl": "https://www.ticketmaster.com/event/1E00642CF2CCADDC",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/denverpride26/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/3431582900333796/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=SUMMIT%2C%201302%20Blake%20St%2C%20Denver%2C%20CO",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.ticketmaster.com/event/1E00642CF2CCADDC",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "denver-pride-2021bba4"
+    },
+    {
+      "name": "MEGAWOOF",
+      "day": "Saturday",
+      "time": "9PM-4:30AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 39.7239346,
+        "lng": -104.9987819
+      },
+      "startDate": "2025-08-23T21:00:00",
+      "endDate": "2025-08-24T04:30:00",
+      "unprocessedDescription": "url: https://www.eventbrite.com/e/megawoof-america-denver-massi\rve-2-parties-1-ticket-tickets-1381219547849\nkey: megawoof|2025-08-24|trade|eventbrite\ndescription: Get ready for the ultimate party experience at MEGAWOOF AMERICA DENVER: MASSIVE 2 Parties 1 Ticket - double the fun, double the excitement!\nbar: Trade\naddress: 475 Santa Fe Drive, Denver, CO 80204\ncover: $16.84 - $27.37 (as of 8/23)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1042921273%2F185013722403%2F1%2Foriginal.20250531-143913?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.005&fp-y=0.005&s=c06443fa220ad17e09684daaac345928\nshortName: MEGA-WOOF\ninstagram: https://www.instagram.com/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=39.7239346%2C-104.9987819&query_place_id=ChIJly0oIDt_bIcRWYKaXvlNsQY",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Denver",
+      "wasUTC": true,
+      "sourceUid": "FA8F22C5-9B06-4F8D-B6DC-EB06F50184FF",
+      "uid": "FA8F22C5-9B06-4F8D-B6DC-EB06F50184FF",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Trade",
+      "cover": "$16.84 - $27.37 (as of 8/23)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1042921273%2F185013722403%2F1%2Foriginal.20250531-143913?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.005&fp-y=0.005&s=c06443fa220ad17e09684daaac345928",
+      "tea": "Get ready for the ultimate party experience at MEGAWOOF AMERICA DENVER: MASSIVE 2 Parties 1 Ticket - double the fun, double the excitement!",
+      "address": "475 Santa Fe Drive, Denver, CO 80204",
+      "website": "https://www.eventbrite.com/e/megawoof-america-denver-massive-2-parties-1-ticket-tickets-1381219547849",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=39.7239346%2C-104.9987819&query_place_id=ChIJly0oIDt_bIcRWYKaXvlNsQY",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.eventbrite.com/e/megawoof-america-denver-massive-2-parties-1-ticket-tickets-1381219547849",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=39.7239346%2C-104.9987819&query_place_id=ChIJly0oIDt_bIcRWYKaXvlNsQY",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "megawoof-37fcce1a"
+    }
+  ]
+}

--- a/data/calendars/la.json
+++ b/data/calendars/la.json
@@ -1,0 +1,423 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Los_Angeles",
+    "timezoneData": {
+      "tzid": "America/Los_Angeles",
+      "location": "America/Los_Angeles",
+      "daylight": {
+        "offsetFrom": "-0800",
+        "offsetTo": "-0700",
+        "name": "PDT",
+        "dtstart": "19700308T020000",
+        "rrule": "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU"
+      },
+      "standard": {
+        "offsetFrom": "-0700",
+        "offsetTo": "-0800",
+        "name": "PST",
+        "dtstart": "19701101T020000",
+        "rrule": "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU"
+      }
+    }
+  },
+  "events": [
+    {
+      "name": "MEGAWOOF PRIDE - FREE - JUNE 6th FREE TKTS @The Globe",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 34.044092,
+        "lng": -118.2542355
+      },
+      "startDate": "2026-06-06T21:00:00",
+      "endDate": "2026-06-07T02:00:00",
+      "unprocessedDescription": "description: MEGAWOOF PRIDE - FIRST 200 TICKETS FREE -\nbar: Th\re Globe\naddress: 740 South Broadway, Los Angeles, CA 90014\nticketUrl: https://www.eventbrite.com/e/megawoof-pride-free-june-6th-free-tkts-the-globe-tickets-1987743346859\ninstagram: https://www.instagram.com/megawoof_america\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1183615730%2F185013722403%2F1%2Foriginal.20260503-000457?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=bffadc80cfbaa15ecbe0f81f67bae150\ncover: FREE\nshortName: MEGA-WOOF\n_aiPrompts\\: [object Object],[object Object]\n_aiValidation\\: [object Object]\nwebsite: https://linktr.ee/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=The%20Globe%2C%20740%20South%20Broadway%2C%20Los%20Angeles%2C%20CA%2090014\nkey: megawoof-pride-free-june-6th-free-tkts-the-globe|2026-06-07|the globe",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "FC6AD30A-ABEE-4135-91A0-18E30D96674D",
+      "uid": "FC6AD30A-ABEE-4135-91A0-18E30D96674D",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "The Globe",
+      "cover": "FREE",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1183615730%2F185013722403%2F1%2Foriginal.20260503-000457?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=bffadc80cfbaa15ecbe0f81f67bae150",
+      "tea": "MEGAWOOF PRIDE - FIRST 200 TICKETS FREE -",
+      "address": "740 South Broadway, Los Angeles, CA 90014",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Globe%2C%20740%20South%20Broadway%2C%20Los%20Angeles%2C%20CA%2090014",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-pride-free-june-6th-free-tkts-the-globe-tickets-1987743346859",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=The%20Globe%2C%20740%20South%20Broadway%2C%20Los%20Angeles%2C%20CA%2090014",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-pride-free-june-6th-free-tkts-the-globe-tickets-1987743346859",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-pride-free-june-6th-free-tkts-the-globe-0bb27076"
+    },
+    {
+      "name": "Club Chub",
+      "day": "Sunday",
+      "time": "3PM-9PM",
+      "eventType": "monthly",
+      "recurring": true,
+      "recurrence": "FREQ=MONTHLY;BYDAY=3SU",
+      "coordinates": {
+        "lat": 34.0498043,
+        "lng": -118.2493258
+      },
+      "startDate": "2025-07-20T15:00:00",
+      "endDate": "2025-07-20T21:00:00",
+      "unprocessedDescription": "Bar: Precinct DTLA\nGoogle Maps: https://maps.app.goo.gl/pfwrr6\roMcbTvdFtx7?g_st=ipc\nInstagram: https://www.instagram.com/clubchubparty?igsh=MWxjZHprZnl6NWc0NQ==",
+      "startTimezone": "America/Los_Angeles",
+      "endTimezone": "America/Los_Angeles",
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": false,
+      "sourceUid": "44n2vcp54ehl3nlh4b3o61ndm0@google.com",
+      "uid": "44n2vcp54ehl3nlh4b3o61ndm0@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Precinct DTLA",
+      "address": null,
+      "website": null,
+      "instagram": "https://www.instagram.com/clubchubparty?igsh=MWxjZHprZnl6NWc0NQ==",
+      "gmaps": "https://maps.app.goo.gl/pfwrr6oMcbTvdFtx7?g_st=ipc",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/clubchubparty?igsh=MWxjZHprZnl6NWc0NQ==",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.app.goo.gl/pfwrr6oMcbTvdFtx7?g_st=ipc",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "club-chub-0e67a66c"
+    },
+    {
+      "name": "MEGAWOOF",
+      "day": "Saturday",
+      "time": "10PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33.9139036,
+        "lng": -118.2805709
+      },
+      "startDate": "2025-08-16T22:00:00",
+      "endDate": "2025-08-17T03:00:00",
+      "unprocessedDescription": "description: Location TBA, but likely in a dark DTLA warehouse\r 😈 Be sure to follow them on IG for location, updates, and more!\ninstagram: https://www.instagram.com/megawoof_america\nkey: megawoof|2025-08-17|tba|eventbrite\nbar: Sanctuary Studios\nurl: https://www.eventbrite.com/e/duro-summer-night-foam-edition-tickets-1446957562019\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1096137783%2F185013722403%2F1%2Foriginal.20250814-194101?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.005&fp-y=0.005&s=f20000487492df90f51bb44fe04473cb\nshortName: MEGA-WOOF\nwebsite: https://www.eventbrite.com/e/duro-summer-night-foam-edition-tickets-1446957562019\ncover: $11.58 - $36.83 (as of 8/16)\ngmaps: https://www.google.com/maps/search/?api=1&query=33.9139036%2C-118.2805709&query_place_id=ChIJg2cOgOq2woAR8bONfuIJg_k",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "1o1kijpavt9mfq2f5bbtcj4jng@google.com",
+      "uid": "1o1kijpavt9mfq2f5bbtcj4jng@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Sanctuary Studios",
+      "cover": "$11.58 - $36.83 (as of 8/16)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1096137783%2F185013722403%2F1%2Foriginal.20250814-194101?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.005&fp-y=0.005&s=f20000487492df90f51bb44fe04473cb",
+      "tea": "Location TBA, but likely in a dark DTLA warehouse 😈 Be sure to follow them on IG for location, updates, and more!",
+      "address": null,
+      "website": "https://www.eventbrite.com/e/duro-summer-night-foam-edition-tickets-1446957562019",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=33.9139036%2C-118.2805709&query_place_id=ChIJg2cOgOq2woAR8bONfuIJg_k",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.eventbrite.com/e/duro-summer-night-foam-edition-tickets-1446957562019",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=33.9139036%2C-118.2805709&query_place_id=ChIJg2cOgOq2woAR8bONfuIJg_k",
+          "label": "🗺️ Google Maps"
+        }
+      ],
+      "slug": "megawoof-69e037bc"
+    },
+    {
+      "name": "Bear Happy Hour",
+      "day": "Thursday",
+      "time": "5PM-9PM",
+      "eventType": "weekly",
+      "recurring": true,
+      "recurrence": "FREQ=WEEKLY",
+      "startDate": "2025-07-17T17:00:00",
+      "endDate": "2025-07-17T21:00:00",
+      "unprocessedDescription": "Bar: Check instagram for this week’s location.\nTea: Popular ha\rppy hour that changes location every week.\nShorter: BHH\nInstagram: https://www.instagram.com/bearhappyhourla\nWeb: https://linktr.ee/bearhappyhour",
+      "startTimezone": "America/Vancouver",
+      "endTimezone": "America/Vancouver",
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": false,
+      "sourceUid": "9vnvsm6kjpievu62279lco139k@google.com",
+      "uid": "9vnvsm6kjpievu62279lco139k@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Check instagram for this week’s location.",
+      "tea": "Popular happy hour that changes location every week.",
+      "address": null,
+      "website": "https://linktr.ee/bearhappyhour",
+      "instagram": "https://www.instagram.com/bearhappyhourla",
+      "shorterName": "BHH",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/bearhappyhour",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearhappyhourla",
+          "label": "📷 Instagram"
+        }
+      ],
+      "slug": "bear-happy-hour-67a26f5d"
+    },
+    {
+      "name": "MEGAWOOF AMERICA - LONG BEACH PRIDE",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33.874454,
+        "lng": -118.1680614
+      },
+      "startDate": "2026-05-16T21:00:00",
+      "endDate": "2026-05-17T02:00:00",
+      "unprocessedDescription": "description: MEGAWOOF AMERICA - LONG BEACH PRIDE\nbar: Falcon N\rorth\naddress: 2020 East Artesia Boulevard, Long Beach, CA 90805\nticketUrl: https://www.eventbrite.com/e/megawoof-america-long-beach-pride-tickets-1986926425425\ninstagram: https://www.instagram.com/megawoof_america\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1181624525%2F185013722403%2F1%2Foriginal.20260407-190035?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=251ea205299011add78dbf1d4b7fe8bd\ncover: $11.58-$22.09\nshortName: MEGA-WOOF\n_aiPrompts\\: [object Object],[object Object],[object Object]\n_aiValidation\\: [object Object]\nwebsite: https://linktr.ee/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=Falcon%20North%2C%202020%20East%20Artesia%20Boulevard%2C%20Long%20Beach%2C%20CA%2090805\nkey: megawoof-america-long-beach-pride|2026-05-17|falcon north",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "F5435015-D350-4B57-8C02-6227EB96FDE1",
+      "uid": "F5435015-D350-4B57-8C02-6227EB96FDE1",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Falcon North",
+      "cover": "$11.58-$22.09",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1181624525%2F185013722403%2F1%2Foriginal.20260407-190035?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=251ea205299011add78dbf1d4b7fe8bd",
+      "tea": "MEGAWOOF AMERICA - LONG BEACH PRIDE",
+      "address": "2020 East Artesia Boulevard, Long Beach, CA 90805",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Falcon%20North%2C%202020%20East%20Artesia%20Boulevard%2C%20Long%20Beach%2C%20CA%2090805",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-long-beach-pride-tickets-1986926425425",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Falcon%20North%2C%202020%20East%20Artesia%20Boulevard%2C%20Long%20Beach%2C%20CA%2090805",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-america-long-beach-pride-tickets-1986926425425",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-america-long-beach-pride-152ddd6b"
+    },
+    {
+      "name": "D>U>R>O is back NEW OUTDOOR LOCATION _ NIGHT FOAM PARTY and SPECIAL\r GUEST",
+      "day": "Saturday",
+      "time": "10PM-4:30AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-08-01T22:00:00",
+      "endDate": "2026-08-02T04:30:00",
+      "unprocessedDescription": "description: D>U>R>O is back NEW OUTDOOR LOCATION _ NIGHT FOAM \rPARTY and SPECIAL GUEST\nbar: TBA\ntimezone: America/Los_Angeles\nticketUrl: https://www.eventbrite.com/e/duro-is-back-new-outdoor-location-night-foam-party-and-special-guest-tickets-1991255145744\ninstagram: https://www.instagram.com/megawoof_america\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1188494288%2F185013722403%2F1%2Foriginal.20260708-215523?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=fe83a13945d2758b3e20c2c7e84a0aa1\ncover: $22.10 - $39.98\nshortName: MEGA-WOOF\nwebsite: https://linktr.ee/megawoof_america\nkey: d-u>r-o-is-back-new-outdoor-location-night-foam-party-and-special-guest|2026-08-02|tba",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "A3B037C4-449C-4785-82BF-811EB8890D67",
+      "uid": "A3B037C4-449C-4785-82BF-811EB8890D67",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "TBA",
+      "cover": "$22.10 - $39.98",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1188494288%2F185013722403%2F1%2Foriginal.20260708-215523?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=fe83a13945d2758b3e20c2c7e84a0aa1",
+      "tea": "D>U>R>O is back NEW OUTDOOR LOCATION _ NIGHT FOAM PARTY and SPECIAL GUEST",
+      "address": null,
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "ticketUrl": "https://www.eventbrite.com/e/duro-is-back-new-outdoor-location-night-foam-party-and-special-guest-tickets-1991255145744",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/duro-is-back-new-outdoor-location-night-foam-party-and-special-guest-tickets-1991255145744",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "duro-is-back-new-outdoor-location-night-foam-party-and-special-guest-5bba8406"
+    },
+    {
+      "name": "MEGAWOOF",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33.87445400000001,
+        "lng": -118.1680614
+      },
+      "startDate": "2025-08-30T21:00:00",
+      "endDate": "2025-08-31T02:00:00",
+      "unprocessedDescription": "description: LONG BEACH — WE’RE BACK! \n The bears of MEGAWOOF \r\nreturn to close out the Summer Tour in you —\nSATURDAY, AUGUST 30th  and it’s all goin\nbar: Falcon North\naddress: 2020 East Artesia Boulevard, Long Beach, CA 90805\ntimezone: America/Los_Angeles\nurl: https://www.eventbrite.com/e/megawoof-america-bear-watchers-long-beach-tickets-1520432868639\nticketUrl: https://www.eventbrite.com/e/megawoof-america-bear-watchers-long-beach-tickets-1520432868639\ncover: $11.58 - $20 (as of 8/30)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1080748773%2F185013722403%2F1%2Foriginal.20250724-190615?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.005&fp-y=0.005&s=6b2534b07c6687d67975f54c65af5b3a\nshortName: MEGA-WOOF\ninstagram: https://www.instagram.com/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=33.87445400000001%2C-118.1680614&query_place_id=ChIJ91NzVy4z3YARBNuS8BZHBGg\nkey: megawoof|2025-08-31|falcon north|eventbrite",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "848D15A3-27B4-4F56-AAD0-9D7D66DD12A1",
+      "uid": "848D15A3-27B4-4F56-AAD0-9D7D66DD12A1",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Falcon North",
+      "cover": "$11.58 - $20 (as of 8/30)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1080748773%2F185013722403%2F1%2Foriginal.20250724-190615?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.005&fp-y=0.005&s=6b2534b07c6687d67975f54c65af5b3a",
+      "tea": "LONG BEACH — WE’RE BACK!",
+      "address": "2020 East Artesia Boulevard, Long Beach, CA 90805",
+      "website": "https://www.eventbrite.com/e/megawoof-america-bear-watchers-long-beach-tickets-1520432868639",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=33.87445400000001%2C-118.1680614&query_place_id=ChIJ91NzVy4z3YARBNuS8BZHBGg",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-bear-watchers-long-beach-tickets-1520432868639",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.eventbrite.com/e/megawoof-america-bear-watchers-long-beach-tickets-1520432868639",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=33.87445400000001%2C-118.1680614&query_place_id=ChIJ91NzVy4z3YARBNuS8BZHBGg",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-america-bear-watchers-long-beach-tickets-1520432868639",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-6062add7"
+    },
+    {
+      "name": "MEGAWOOF",
+      "day": "Saturday",
+      "time": "10PM-5AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2025-10-25T22:00:00",
+      "endDate": "2025-10-26T05:00:00",
+      "unprocessedDescription": "description: D>U>R>O  - MEGAWOOF AMERICA 10 YEAR ANNIVERSARY ED\rITION\ntimezone: America/Los_Angeles\nurl: https://linktr.ee/megawoof_america\nticketUrl: https://www.eventbrite.com/e/duro-megawoof-america-10-year-anniversary-edition-tickets-1688815666119\ncover: $22.10 - $39.98 (as of 10/1)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1121300433%2F185013722403%2F1%2Foriginal.20250911-154733?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=999820b38fc33236aa167ad0d4ea5f7a\nshortName: MEGA-WOOF\ninstagram: https://www.instagram.com/megawoof_america\nkey: megawoof|2025-10-26||eventbrite",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "342C3C24-21CD-4149-8634-E60F5CB0A57A",
+      "uid": "342C3C24-21CD-4149-8634-E60F5CB0A57A",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "cover": "$22.10 - $39.98 (as of 10/1)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1121300433%2F185013722403%2F1%2Foriginal.20250911-154733?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=999820b38fc33236aa167ad0d4ea5f7a",
+      "tea": "D>U>R>O  - MEGAWOOF AMERICA 10 YEAR ANNIVERSARY EDITION",
+      "address": null,
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "ticketUrl": "https://www.eventbrite.com/e/duro-megawoof-america-10-year-anniversary-edition-tickets-1688815666119",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/duro-megawoof-america-10-year-anniversary-edition-tickets-1688815666119",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-33341c08"
+    }
+  ]
+}

--- a/data/calendars/london.json
+++ b/data/calendars/london.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "calendarTimezone": "Europe/London",
+    "timezoneData": null
+  },
+  "events": []
+}

--- a/data/calendars/nola.json
+++ b/data/calendars/nola.json
@@ -1,0 +1,124 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Chicago",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "NEW ORLEANS",
+      "day": "Friday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2025-08-29T21:00:00",
+      "endDate": "2025-08-30T02:00:00",
+      "unprocessedDescription": "description: Music & Entertainment\n• Matt Stands &amp; Freddy\r King of Pants (Seattle)\n• Decor &amp; Photos by Dusti Cunningham\nbar: Joy Theatre\naddress: 1200 Canal St, New Orleans, LA 70112\ntimezone: America/Chicago\nurl: https://bearracuda.com/events/new-orleans/\nimage: https://bearracuda.com/wp-content/uploads/2025/04/cuda-nola-august-2025-web.jpg\nfacebook: https://www.facebook.com/share/1EZ2P4X4Ek/\nticketUrl: https://www.ticketmaster.com/bearracuda-new-orleans-louisiana-08-29-2025/event/1B006275D3607BD4\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://maps.google.com/?q=1200%20Canal%20St%2C%20New%20Orleans%2C%20LA%2070112\nkey: bearracuda-2025-08-30-new-orleans",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "96ED5A57-14F4-4189-81C5-1AA44B8E365F",
+      "uid": "96ED5A57-14F4-4189-81C5-1AA44B8E365F",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Joy Theatre",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/04/cuda-nola-august-2025-web.jpg",
+      "tea": "Music & Entertainment",
+      "address": "1200 Canal St, New Orleans, LA 70112",
+      "website": "https://bearracuda.com/events/new-orleans/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/share/1EZ2P4X4Ek/",
+      "gmaps": "https://maps.google.com/?q=1200%20Canal%20St%2C%20New%20Orleans%2C%20LA%2070112",
+      "ticketUrl": "https://www.ticketmaster.com/bearracuda-new-orleans-louisiana-08-29-2025/event/1B006275D3607BD4",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/new-orleans/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/share/1EZ2P4X4Ek/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.google.com/?q=1200%20Canal%20St%2C%20New%20Orleans%2C%20LA%2070112",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.ticketmaster.com/bearracuda-new-orleans-louisiana-08-29-2025/event/1B006275D3607BD4",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "new-orleans-605b589e"
+    },
+    {
+      "name": "New Orleans⚜️",
+      "day": "Friday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-09-04T21:00:00",
+      "endDate": "2026-09-05T02:00:00",
+      "unprocessedDescription": "description: Music & Entertainment\n• DJ MATEO SEGADE\n• KELLY \r(Shoes) LIVE!\nbar: Joy Theater\naddress: 1200 Canal Street, New Orleans, LA\ntimezone: America/Chicago\nimage: https://bearracuda.com/wp-content/uploads/2026/03/webnola-2.jpg\nfacebook: https://www.facebook.com/events/839699329141079\nticketUrl: https://www.ticketmaster.com/event/1B006454A32CE162\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\nwebsite: https://bearracuda.com/events/decadence/\ngmaps: https://www.google.com/maps/search/?api=1&query=Joy%20Theater%2C%201200%20Canal%20Street%2C%20New%20Orleans%2C%20LA\nkey: bearracuda-2026-09-05-nola",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Chicago",
+      "wasUTC": true,
+      "sourceUid": "74648B34-07A1-4BD2-8E78-D67B991A920E",
+      "uid": "74648B34-07A1-4BD2-8E78-D67B991A920E",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Joy Theater",
+      "image": "https://bearracuda.com/wp-content/uploads/2026/03/webnola-2.jpg",
+      "tea": "Music & Entertainment",
+      "address": "1200 Canal Street, New Orleans, LA",
+      "website": "https://bearracuda.com/events/decadence/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/839699329141079",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Joy%20Theater%2C%201200%20Canal%20Street%2C%20New%20Orleans%2C%20LA",
+      "ticketUrl": "https://www.ticketmaster.com/event/1B006454A32CE162",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/decadence/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/839699329141079",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Joy%20Theater%2C%201200%20Canal%20Street%2C%20New%20Orleans%2C%20LA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.ticketmaster.com/event/1B006454A32CE162",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "new-orleans-578ac888"
+    }
+  ]
+}

--- a/data/calendars/palm-springs.json
+++ b/data/calendars/palm-springs.json
@@ -1,0 +1,65 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Los_Angeles",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "MEGAWOOF",
+      "day": "Saturday",
+      "time": "9PM-12PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33.8189101,
+        "lng": -116.5470896
+      },
+      "startDate": "2026-02-21T21:00:00",
+      "endDate": "2026-02-22T12:00:00",
+      "unprocessedDescription": "description: SHINY DISCO BALLS IBC WEEKEND\nbar: Palm Springs\n\raddress: 333 S Palm Canyon Dr Unit, Palm Springs, CA 92262\ntimezone: America/Los_Angeles\nticketUrl: https://www.eventbrite.com/e/shiny-disco-balls-ibc-weekend-mlk-special-early-bird-15-tickets-1976070697651\ncover: $16.84 - $43.15 (as of 2/8)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1175105336%2F185013722403%2F1%2Foriginal.20260117-003934?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=5e6fb763c38a115a60476dbf25ac3ad3\nshortName: MEGA-WOOF\ninstagram: https://www.instagram.com/megawoof_america\nurl: https://linktr.ee/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=33.8189101%2C-116.5470896&query_place_id=ChIJs-Xb_9Qa24ARfHntwodp5aE\nkey: megawoof|2026-02-22|palm springs",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "88686A1C-DD82-4C9B-A917-74B3647FD814",
+      "uid": "88686A1C-DD82-4C9B-A917-74B3647FD814",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Palm Springs",
+      "cover": "$16.84 - $43.15 (as of 2/8)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1175105336%2F185013722403%2F1%2Foriginal.20260117-003934?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=5e6fb763c38a115a60476dbf25ac3ad3",
+      "tea": "SHINY DISCO BALLS IBC WEEKEND",
+      "address": "333 S Palm Canyon Dr Unit, Palm Springs, CA 92262",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=33.8189101%2C-116.5470896&query_place_id=ChIJs-Xb_9Qa24ARfHntwodp5aE",
+      "ticketUrl": "https://www.eventbrite.com/e/shiny-disco-balls-ibc-weekend-mlk-special-early-bird-15-tickets-1976070697651",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=33.8189101%2C-116.5470896&query_place_id=ChIJs-Xb_9Qa24ARfHntwodp5aE",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/shiny-disco-balls-ibc-weekend-mlk-special-early-bird-15-tickets-1976070697651",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-22570191"
+    }
+  ]
+}

--- a/data/calendars/philly.json
+++ b/data/calendars/philly.json
@@ -1,0 +1,172 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/New_York",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "CUBHOUSE PHILLY VALENTINE'S DANCE PARTY",
+      "day": "Friday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 39.9470542,
+        "lng": -75.161054
+      },
+      "startDate": "2026-02-13T21:00:00",
+      "endDate": "2026-02-14T02:00:00",
+      "unprocessedDescription": "description: CUBHOUSE returns for dancing with your VALENTINE'S\r sweet hearts at 254!\nCome paired or single and ready to mingle.   Keep a close eye on our Instagram for info regarding specials, guests, and special treats for all your hearts desires.\n Advance tickets are on sale now!\nbar: 254\naddress: 254 South 12th Street, Philadelphia, PA 19107\ntimezone: America/New_York\nticketUrl: https://www.eventbrite.com/e/cubhouse-philly-valentines-dance-party-tickets-1936787556719\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1167639013%2F2544065821071%2F1%2Foriginal.20251031-205615?crop=focalpoint&fit=crop&w=600&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=1d9da9d1c175b79fa1fc9ec4afcac0c2\nshortName: CUB-HOUSE\ninstagram: https://www.instagram.com/cubhouse.philly\nurl: https://linktr.ee/cubhouse\ngmaps: https://www.google.com/maps/search/?api=1&query=254%20South%2012th%20Street%2C%20Philadelphia%2C%20PA%2019107\nkey: cubhouse-philly-valentine-s-dance-party|2026-02-14|254",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "C9791D00-2BAB-4EB3-8347-4823E6C75F4A",
+      "uid": "C9791D00-2BAB-4EB3-8347-4823E6C75F4A",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "254",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1167639013%2F2544065821071%2F1%2Foriginal.20251031-205615?crop=focalpoint&fit=crop&w=600&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=1d9da9d1c175b79fa1fc9ec4afcac0c2",
+      "tea": "CUBHOUSE returns for dancing with your VALENTINE'S sweet hearts at 254!",
+      "address": "254 South 12th Street, Philadelphia, PA 19107",
+      "website": "https://linktr.ee/cubhouse",
+      "instagram": "https://www.instagram.com/cubhouse.philly",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=254%20South%2012th%20Street%2C%20Philadelphia%2C%20PA%2019107",
+      "ticketUrl": "https://www.eventbrite.com/e/cubhouse-philly-valentines-dance-party-tickets-1936787556719",
+      "shortName": "CUB-HOUSE",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/cubhouse",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/cubhouse.philly",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=254%20South%2012th%20Street%2C%20Philadelphia%2C%20PA%2019107",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/cubhouse-philly-valentines-dance-party-tickets-1936787556719",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "cubhouse-philly-valentines-dance-party-33f308ba"
+    },
+    {
+      "name": "CUBHOUSE PHILLY PRIDE  2026 KICKOFF DANCE PARTY",
+      "day": "Friday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 39.9470542,
+        "lng": -75.161054
+      },
+      "startDate": "2026-06-05T21:00:00",
+      "endDate": "2026-06-06T02:00:00",
+      "unprocessedDescription": "description: CUBHOUSE is back, and bigger than ever for it's 2\rnd annual PRIDE KICKOFF PARTY on June 5th at 254!  🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈\nWe’ll have the same friends and specials you love, as well as a few surprises to make sure your Pride weekend goes off with a bang. Follow us on Instagram @cubhouse.philly for updates as they’re revealed!\nTickets are now on sale, get them before the price goes up or we sell out!\nbar: 254\naddress: 254 South 12th Street, Philadelphia, PA 19107\ntimezone: America/New_York\nticketUrl: https://www.eventbrite.com/e/cubhouse-philly-pride-2026-kickoff-dance-party-tickets-1987102314514\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1181833880%2F2544065821071%2F1%2Foriginal.20260410-000607?crop=focalpoint&fit=crop&w=600&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.958&fp-y=0.532&s=44ef0d7ee0e22cbda267e0f163efc161\nshortName: CUB-HOUSE\ninstagram: https://www.instagram.com/cubhouse.philly\n_staticFields: [object Object]\ngmaps: https://www.google.com/maps/search/?api=1&query=254%20South%2012th%20Street%2C%20Philadelphia%2C%20PA%2019107\nkey: cubhouse-philly-pride-2026-kickoff-dance-party|2026-06-06|254",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "CBB60667-F22B-4146-A728-88011305369F",
+      "uid": "CBB60667-F22B-4146-A728-88011305369F",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "254",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1181833880%2F2544065821071%2F1%2Foriginal.20260410-000607?crop=focalpoint&fit=crop&w=600&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.958&fp-y=0.532&s=44ef0d7ee0e22cbda267e0f163efc161",
+      "tea": "CUBHOUSE is back, and bigger than ever for it's 2nd annual PRIDE KICKOFF PARTY on June 5th at 254!  🏳️‍🌈🏳️‍🌈🏳️‍🌈🏳️‍🌈",
+      "address": "254 South 12th Street, Philadelphia, PA 19107",
+      "website": null,
+      "instagram": "https://www.instagram.com/cubhouse.philly",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=254%20South%2012th%20Street%2C%20Philadelphia%2C%20PA%2019107",
+      "ticketUrl": "https://www.eventbrite.com/e/cubhouse-philly-pride-2026-kickoff-dance-party-tickets-1987102314514",
+      "shortName": "CUB-HOUSE",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/cubhouse.philly",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=254%20South%2012th%20Street%2C%20Philadelphia%2C%20PA%2019107",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/cubhouse-philly-pride-2026-kickoff-dance-party-tickets-1987102314514",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "cubhouse-philly-pride-2026-kickoff-dance-party-242e4df9"
+    },
+    {
+      "name": "CUBHOUSE PHILLY HALLOWEEN DANCE PARTY",
+      "day": "Friday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 39.9470542,
+        "lng": -75.161054
+      },
+      "startDate": "2025-10-31T21:00:00",
+      "endDate": "2025-11-01T02:00:00",
+      "unprocessedDescription": "description: CUBHOUSE returns on October 31st for a HALLOWEEN D\rANCE PART!\nbar: 254\naddress: 254 South 12th Street, Philadelphia, PA 19107\ntimezone: America/New_York\nticketUrl: https://www.eventbrite.com/e/cubhouse-philly-halloween-dance-party-tickets-1633106779339\ncover: $18.09 - $29.14 (as of 10/11)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1107233553%2F2544065821071%2F1%2Foriginal.20250828-015122?crop=focalpoint&fit=crop&w=600&auto=format%2Ccompress&q=75&sharp=10&fp-x=4.75680933852e-05&fp-y=8.98832684825e-05&s=af53a251c09f02c722723a1a4c940b29\nshortName: CUB-HOUSE\ninstagram: https://www.instagram.com/cubhouse.philly\nurl: https://linktr.ee/cubhouse\ngmaps: https://www.google.com/maps/search/?api=1&query=39.9470542%2C-75.161054&query_place_id=101718083\nkey: cubhouse-philly-halloween-dance-party|2025-11-01|254|eventbrite",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "3D97C917-CD83-44B2-A03C-0F6095F987D2",
+      "uid": "3D97C917-CD83-44B2-A03C-0F6095F987D2",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "254",
+      "cover": "$18.09 - $29.14 (as of 10/11)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1107233553%2F2544065821071%2F1%2Foriginal.20250828-015122?crop=focalpoint&fit=crop&w=600&auto=format%2Ccompress&q=75&sharp=10&fp-x=4.75680933852e-05&fp-y=8.98832684825e-05&s=af53a251c09f02c722723a1a4c940b29",
+      "tea": "CUBHOUSE returns on October 31st for a HALLOWEEN DANCE PART!",
+      "address": "254 South 12th Street, Philadelphia, PA 19107",
+      "website": "https://linktr.ee/cubhouse",
+      "instagram": "https://www.instagram.com/cubhouse.philly",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=39.9470542%2C-75.161054&query_place_id=101718083",
+      "ticketUrl": "https://www.eventbrite.com/e/cubhouse-philly-halloween-dance-party-tickets-1633106779339",
+      "shortName": "CUB-HOUSE",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/cubhouse",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/cubhouse.philly",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=39.9470542%2C-75.161054&query_place_id=101718083",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/cubhouse-philly-halloween-dance-party-tickets-1633106779339",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "cubhouse-philly-halloween-dance-party-7f59fc8c"
+    }
+  ]
+}

--- a/data/calendars/phoenix.json
+++ b/data/calendars/phoenix.json
@@ -1,0 +1,178 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Phoenix",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "Bearracuda Phoenix RELAUNCH Party!",
+      "day": "Saturday",
+      "time": "9:30PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 3110,
+        "lng": null
+      },
+      "startDate": "2026-05-23T21:30:00",
+      "unprocessedDescription": "description: Bearracuda PhoenixRELAUNCH PARTYSaturday, May 23t\rh, 2026DJ Freddy King of Pants (Seattle) Hosted by JP Hardy Kobalt - 3110 N. Central AveHOT GoGos All nightAdv. tix at Bearracuda.com - Doors at 9\\:30pmBearracuda is back in PHOENIX after a 6 year hiatus! Now at Kobalt! Join 100s of guys dancing til late, with sexy GoGos, chunky visuals and YOU!\nbar: Kobalt\naddress: 3110 N Central Ave\nticketUrl: https://www.sickening.events/e/bearracuda-phoenix-relaunch-party/tickets\ninstagram: https://www.instagram.com/bearracuda\nimage: https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1775591376/saas/logos/image_1775591369401_a4demr8jg.webp\ncover: EARLY BEAR\nshortName: Bear-rac-uda\nwebsite: https://bearracuda.com/events/phoenix/\ngmaps: https://www.google.com/maps/search/?api=1&query=Kobalt%2C%203110%20N%20Central%20Ave\nkey: bearracuda-2026-05-24-phoenix\ntimezone: America/Phoenix",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Phoenix",
+      "wasUTC": true,
+      "sourceUid": "9165A83C-32B2-497F-A522-7C5ADF7B9A2A",
+      "uid": "9165A83C-32B2-497F-A522-7C5ADF7B9A2A",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Kobalt",
+      "cover": "EARLY BEAR",
+      "image": "https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1775591376/saas/logos/image_1775591369401_a4demr8jg.webp",
+      "tea": "Bearracuda PhoenixRELAUNCH PARTYSaturday, May 23th, 2026DJ Freddy King of Pants (Seattle) Hosted by JP Hardy Kobalt - 3110 N. Central AveHOT GoGos All nightAdv. tix at Bearracuda.com - Doors at 9:30pmBearracuda is back in PHOENIX after a 6 year hiatus! Now at Kobalt! Join 100s of guys dancing til late, with sexy GoGos, chunky visuals and YOU!",
+      "address": "3110 N Central Ave",
+      "website": "https://bearracuda.com/events/phoenix/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Kobalt%2C%203110%20N%20Central%20Ave",
+      "ticketUrl": "https://www.sickening.events/e/bearracuda-phoenix-relaunch-party/tickets",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/phoenix/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Kobalt%2C%203110%20N%20Central%20Ave",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.sickening.events/e/bearracuda-phoenix-relaunch-party/tickets",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-phoenix-relaunch-party-320faa75"
+    },
+    {
+      "name": "MEGAWOOF",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33.4833086,
+        "lng": -112.0754149
+      },
+      "startDate": "2025-10-04T21:00:00",
+      "endDate": "2025-10-05T02:00:00",
+      "unprocessedDescription": "description: MEGAWOOF 10 YEAR ANNIVERSARY \\: PHOENIX KICK OFF\\\rnbar: Kobalt\naddress: 3110 North Central Avenue, Phoenix, AZ 85012\ntimezone: America/Phoenix\nurl: https://linktr.ee/megawoof_america\nticketUrl: https://www.eventbrite.com/e/megawoof-10-year-anniversary-phoenix-kick-off-tickets-1675720327609\ncover: $11.58 - $22.10 (as of 10/1)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1117518673%2F185013722403%2F1%2Foriginal.20250908-150401?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=3aac96e3f15ffea9f7cc53f0c3a8efa5\nshortName: MEGA-WOOF\ninstagram: https://www.instagram.com/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=33.4833086%2C-112.0754149&query_place_id=ChIJkRBEr18SK4cR8jynbFt5fPM\nkey: megawoof|2025-10-05|kobalt|eventbrite",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Phoenix",
+      "wasUTC": true,
+      "sourceUid": "F6548399-1DB6-4C62-9F75-A6045BF3884F",
+      "uid": "F6548399-1DB6-4C62-9F75-A6045BF3884F",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Kobalt",
+      "cover": "$11.58 - $22.10 (as of 10/1)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1117518673%2F185013722403%2F1%2Foriginal.20250908-150401?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=3aac96e3f15ffea9f7cc53f0c3a8efa5",
+      "tea": "MEGAWOOF 10 YEAR ANNIVERSARY : PHOENIX KICK OFF",
+      "address": "3110 North Central Avenue, Phoenix, AZ 85012",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=33.4833086%2C-112.0754149&query_place_id=ChIJkRBEr18SK4cR8jynbFt5fPM",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-10-year-anniversary-phoenix-kick-off-tickets-1675720327609",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=33.4833086%2C-112.0754149&query_place_id=ChIJkRBEr18SK4cR8jynbFt5fPM",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-10-year-anniversary-phoenix-kick-off-tickets-1675720327609",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-2f8a9cb8"
+    },
+    {
+      "name": "MEGAWOOF AMERICA - PHOENIX - SUMMER WOOFERS",
+      "day": "Saturday",
+      "time": "9:30PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33.4833086,
+        "lng": -112.0754149
+      },
+      "startDate": "2026-08-08T21:30:00",
+      "endDate": "2026-08-09T02:00:00",
+      "unprocessedDescription": "description: MEGAWOOF AMERICA - PHOENIX - SUMMER WOOFERS\nbar: \rKobalt\naddress: 3110 North Central Avenue, #175, Phoenix, AZ 85012\ntimezone: America/Phoenix\nticketUrl: https://www.eventbrite.com/e/megawoof-america-phoenix-summer-woofers-tickets-1992064021112\ninstagram: https://www.instagram.com/megawoof_america\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1187117356%2F185013722403%2F1%2Foriginal.20260617-155633?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=1c3fca6f7a04cb401339bb4a31cace61\ncover: $11.58-$22.10\nshortName: MEGA-WOOF\nwebsite: https://linktr.ee/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=Kobalt%2C%203110%20North%20Central%20Avenue%2C%20%23175%2C%20Phoenix%2C%20AZ%2085012\nkey: megawoof-america-phoenix-summer-woofers|2026-08-09|kobalt",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Phoenix",
+      "wasUTC": true,
+      "sourceUid": "DBB2B903-E956-45AE-8645-08B4C4A8A455",
+      "uid": "DBB2B903-E956-45AE-8645-08B4C4A8A455",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Kobalt",
+      "cover": "$11.58-$22.10",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1187117356%2F185013722403%2F1%2Foriginal.20260617-155633?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=1c3fca6f7a04cb401339bb4a31cace61",
+      "tea": "MEGAWOOF AMERICA - PHOENIX - SUMMER WOOFERS",
+      "address": "3110 North Central Avenue, #175, Phoenix, AZ 85012",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Kobalt%2C%203110%20North%20Central%20Avenue%2C%20%23175%2C%20Phoenix%2C%20AZ%2085012",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-phoenix-summer-woofers-tickets-1992064021112",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Kobalt%2C%203110%20North%20Central%20Avenue%2C%20%23175%2C%20Phoenix%2C%20AZ%2085012",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-america-phoenix-summer-woofers-tickets-1992064021112",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-america-phoenix-summer-woofers-007d0b12"
+    }
+  ]
+}

--- a/data/calendars/portland.json
+++ b/data/calendars/portland.json
@@ -1,0 +1,832 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Los_Angeles",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "TREASURE TRAIL Portland: Saturday, Jan. 24th!",
+      "day": "Saturday",
+      "time": "3PM-7PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 45.5235017,
+        "lng": -122.6802365
+      },
+      "startDate": "2026-01-24T15:00:00",
+      "endDate": "2026-01-24T19:00:00",
+      "unprocessedDescription": "description: Treasure Trail returns to Portland!\n\nMusic & Ent\rertainment\n• Clothes Check Available\nbar: Sanctuary Club\naddress: 33 Northwest 9th Avenue, Portland, OR 97209\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/treasurepdx/\nimage: https://bearracuda.com/wp-content/uploads/2025/11/1ttfuuuck.jpg\nfacebook: https://www.facebook.com/events/1185664703019614\nticketUrl: https://www.eventbrite.com/e/treasure-trail-portland-saturday-jan-24th-tickets-1976421422679\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://maps.google.com/?q=45.5235017,-122.6802365\nkey: bearracuda-2026-01-24-portland",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "2F092079-A18B-4B2D-B790-F9BB1BC5B388",
+      "uid": "2F092079-A18B-4B2D-B790-F9BB1BC5B388",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Sanctuary Club",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/11/1ttfuuuck.jpg",
+      "tea": "Treasure Trail returns to Portland!",
+      "address": "33 Northwest 9th Avenue, Portland, OR 97209",
+      "website": "https://bearracuda.com/events/treasurepdx/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1185664703019614",
+      "gmaps": "https://maps.google.com/?q=45.5235017,-122.6802365",
+      "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-portland-saturday-jan-24th-tickets-1976421422679",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/treasurepdx/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1185664703019614",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.google.com/?q=45.5235017,-122.6802365",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/treasure-trail-portland-saturday-jan-24th-tickets-1976421422679",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-portland-saturday-jan-24th-50c8389e"
+    },
+    {
+      "name": "Bearracuda Portland: CROTCH CARNIVAL!",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 45.5227415,
+        "lng": -122.6580938
+      },
+      "startDate": "2026-02-21T21:00:00",
+      "endDate": "2026-02-22T02:00:00",
+      "unprocessedDescription": "description: Doors Open at 9\\:00 pm - Party Goes Until 2\\:00 \ram\nbar: Bossanova Ballroom\naddress: 722 E Burnside, Portland, OR 97213\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/portlandfeb/\nimage: https://bearracuda.com/wp-content/uploads/2025/12/feb2026pdx.jpg\nfacebook: https://www.facebook.com/events/892528969904085\nticketUrl: https://www.eventbrite.com/e/bearracuda-portland-crotch-carnival-tickets-1979122152635\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=Bossanova%20Ballroom%2C%20722%20E%20Burnside%2C%20Portland%2C%20OR%2097213\nkey: bearracuda-2026-02-22-portland",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "22C75FCB-8CF5-426C-A2B3-01EBE0EEBF62",
+      "uid": "22C75FCB-8CF5-426C-A2B3-01EBE0EEBF62",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Bossanova Ballroom",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/12/feb2026pdx.jpg",
+      "tea": "Doors Open at 9:00 pm - Party Goes Until 2:00 am",
+      "address": "722 E Burnside, Portland, OR 97213",
+      "website": "https://bearracuda.com/events/portlandfeb/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/892528969904085",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Bossanova%20Ballroom%2C%20722%20E%20Burnside%2C%20Portland%2C%20OR%2097213",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-portland-crotch-carnival-tickets-1979122152635",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/portlandfeb/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/892528969904085",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Bossanova%20Ballroom%2C%20722%20E%20Burnside%2C%20Portland%2C%20OR%2097213",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-portland-crotch-carnival-tickets-1979122152635",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-portland-crotch-carnival-553c66fc"
+    },
+    {
+      "name": "Bearracuda Portland BONER GARAGE",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-05-16T21:00:00",
+      "endDate": "2026-05-17T02:00:00",
+      "unprocessedDescription": "description: Slide into the Boner Garage\\: ourfetish night at \rBearracuda Portland. We want to see your harnesses, latex, leather, rubber, jocks, pups, dom, sub, switch, spankers, suckers, cockrings, plugs, collars, hankies, hoods, dads, denim, voyeurism, feet, role play. Consent is always mandatory. Nick Bertossi spins all night with Hot GoGos, Visuals by Aaron Altemose, Decor by James Sharinghousen and YOU!\nbar: Nova PDX\naddress: 722 East Burnside Street\nticketUrl: https://www.sickening.events/e/bearracuda-portland-gearnight/tickets\ninstagram: https://www.instagram.com/bearracuda\nimage: https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1776291822/saas/logos/image_1776291814711_301fgtoxn.webp\ncover: $20-$30\nshortName: Bear-rac-uda\nwebsite: https://bearracuda.com/events/portland-gear/\ngmaps: https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20East%20Burnside%20Street\nkey: bearracuda-2026-05-17-portland\ntimezone: America/Los_Angeles",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "5D2FF721-0E32-4318-8CA8-391B11299303",
+      "uid": "5D2FF721-0E32-4318-8CA8-391B11299303",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Nova PDX",
+      "cover": "$20-$30",
+      "image": "https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1776291822/saas/logos/image_1776291814711_301fgtoxn.webp",
+      "tea": "Slide into the Boner Garage: ourfetish night at Bearracuda Portland. We want to see your harnesses, latex, leather, rubber, jocks, pups, dom, sub, switch, spankers, suckers, cockrings, plugs, collars, hankies, hoods, dads, denim, voyeurism, feet, role play. Consent is always mandatory. Nick Bertossi spins all night with Hot GoGos, Visuals by Aaron Altemose, Decor by James Sharinghousen and YOU!",
+      "address": "722 East Burnside Street",
+      "website": "https://bearracuda.com/events/portland-gear/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20East%20Burnside%20Street",
+      "ticketUrl": "https://www.sickening.events/e/bearracuda-portland-gearnight/tickets",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/portland-gear/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20East%20Burnside%20Street",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.sickening.events/e/bearracuda-portland-gearnight/tickets",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-portland-boner-garage-3e1b185e"
+    },
+    {
+      "name": "TREASURE TRAIL Portland PRIDE",
+      "day": "Friday",
+      "time": "8PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-07-17T20:00:00",
+      "endDate": "2026-07-18T02:00:00",
+      "unprocessedDescription": "description: TREASURE TRAIL Choose Your own Adventure! A Portla\rnd PRIDE Play Party\\: FRIDAY, July 17th, starting at 8pm. 33 NW 9th AveJP Hardy & Matt Bearracuda present TREASURE TRAIL Choose your own ADVENTURE! We've noticed a few shy guys at the party and some that needed a bit of a push for social interaction. Now our guys can grab a wristband when you walk in\\: Red wristband TOP Blue wristband VERS Green wristband BOTTOM White wristband SIDE Grab one at the door! Treasure Trail is a sexy and intimate p…\nbar: Sanctuary Club\naddress: 33 Northwest 9th Avenue\nticketUrl: https://www.sickening.events/e/bearracuda-treasure-trail-portland-pride/tickets\ninstagram: https://www.instagram.com/bearracuda\nimage: https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1775182350/saas/logos/image_1775182340772_kfkh3vpzm.webp\ncover: 20.00\nshortName: Bear-rac-uda\nwebsite: https://bearracuda.com/events/portland-pridefriday/\ngmaps: https://www.google.com/maps/search/?api=1&query=Sanctuary%20Club%2C%2033%20Northwest%209th%20Avenue\nkey: bearracuda-2026-07-18-portland\ntimezone: America/Los_Angeles",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "73CEC27F-15A9-46A4-B46D-495DFD3A0F01",
+      "uid": "73CEC27F-15A9-46A4-B46D-495DFD3A0F01",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Sanctuary Club",
+      "cover": "20.00",
+      "image": "https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1775182350/saas/logos/image_1775182340772_kfkh3vpzm.webp",
+      "tea": "TREASURE TRAIL Choose Your own Adventure! A Portland PRIDE Play Party: FRIDAY, July 17th, starting at 8pm. 33 NW 9th AveJP Hardy & Matt Bearracuda present TREASURE TRAIL Choose your own ADVENTURE! We've noticed a few shy guys at the party and some that needed a bit of a push for social interaction. Now our guys can grab a wristband when you walk in: Red wristband TOP Blue wristband VERS Green wristband BOTTOM White wristband SIDE Grab one at the door! Treasure Trail is a sexy and intimate p…",
+      "address": "33 Northwest 9th Avenue",
+      "website": "https://bearracuda.com/events/portland-pridefriday/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Sanctuary%20Club%2C%2033%20Northwest%209th%20Avenue",
+      "ticketUrl": "https://www.sickening.events/e/bearracuda-treasure-trail-portland-pride/tickets",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/portland-pridefriday/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Sanctuary%20Club%2C%2033%20Northwest%209th%20Avenue",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.sickening.events/e/bearracuda-treasure-trail-portland-pride/tickets",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-portland-pride-0c12f2cc"
+    },
+    {
+      "name": "CHUNK Portland - 5/23",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 45.52281000000001,
+        "lng": -122.6581342
+      },
+      "startDate": "2026-05-23T21:00:00",
+      "endDate": "2026-05-24T02:00:00",
+      "unprocessedDescription": "description: CHUNK Portland returns - SPRING HAS SPRUNG AND SO \rARE WE CHUNK presents DR. TIME - THE OG BIG BOY DJ & residents THCKRTANKER & BIRTHDAY GURL DECOR by BEARPAD ART!!!!! HOT GOGO BEARS ALL NIGHT // Hosted by AIRICK & CURTIS  9-close // NOVA PDX // 722 E Burnside Street\nbar: Nova PDX\naddress: 722 E Burnside St, Portland, OR 97214, USA\nticketUrl: https://www.chunk-party.com/event-details/chunk-portland-5-23\ncover: $20.50 - $35.88\nimage: https://static.wixstatic.com/media/42b6cb_90823e634f7740779eff0353f0bd4624~mv2.jpg/v1/fill/w_792,h_990,al_c,q_85/42b6cb_90823e634f7740779eff0353f0bd4624~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\nwebsite: https://www.chunk-party.com\ngmaps: https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20E%20Burnside%20St%2C%20Portland%2C%20OR%2097214%2C%20USA\nkey: chunk-portland-5/23|2026-05-24|nova pdx",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "D7550033-CDDB-49E1-9469-74BFA5A7CFB2",
+      "uid": "D7550033-CDDB-49E1-9469-74BFA5A7CFB2",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Nova PDX",
+      "cover": "$20.50 - $35.88",
+      "image": "https://static.wixstatic.com/media/42b6cb_90823e634f7740779eff0353f0bd4624~mv2.jpg/v1/fill/w_792,h_990,al_c,q_85/42b6cb_90823e634f7740779eff0353f0bd4624~mv2.jpg",
+      "tea": "CHUNK Portland returns - SPRING HAS SPRUNG AND SO ARE WE CHUNK presents DR. TIME - THE OG BIG BOY DJ & residents THCKRTANKER & BIRTHDAY GURL DECOR by BEARPAD ART!!!!! HOT GOGO BEARS ALL NIGHT // Hosted by AIRICK & CURTIS  9-close // NOVA PDX // 722 E Burnside Street",
+      "address": "722 E Burnside St, Portland, OR 97214, USA",
+      "website": "https://www.chunk-party.com",
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20E%20Burnside%20St%2C%20Portland%2C%20OR%2097214%2C%20USA",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-portland-5-23",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.chunk-party.com",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20E%20Burnside%20St%2C%20Portland%2C%20OR%2097214%2C%20USA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-portland-5-23",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-portland-523-12aa4185"
+    },
+    {
+      "name": "Bearracuda Portland: The Great Blumpkin!",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 45.5227415,
+        "lng": -122.6580938
+      },
+      "startDate": "2025-10-18T21:00:00",
+      "endDate": "2025-10-19T02:00:00",
+      "unprocessedDescription": "description: Doors Open at 9\\:00 pm - Party Goes Until 2\\:00 \ram\nbar: Bossanova Ballroom\naddress: 722 E Burnside, Portland, OR 97213\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/pdx16/\ncover: $16.81 - $36.19 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/04/1portlandoct.jpg\nfacebook: https://www.facebook.com/events/1006781098176826\nticketUrl: https://www.eventbrite.com/e/bearracuda-portland-the-great-blumpkin-tickets-1681430587149\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829\nkey: bearracuda-2025-10-19-portland",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "BC5FA8C9-8A54-4155-99F7-E782ADD15904",
+      "uid": "BC5FA8C9-8A54-4155-99F7-E782ADD15904",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Bossanova Ballroom",
+      "cover": "$16.81 - $36.19 (as of 10/1)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/04/1portlandoct.jpg",
+      "tea": "Doors Open at 9:00 pm - Party Goes Until 2:00 am",
+      "address": "722 E Burnside, Portland, OR 97213",
+      "website": "https://bearracuda.com/events/pdx16/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1006781098176826",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-portland-the-great-blumpkin-tickets-1681430587149",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/pdx16/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1006781098176826",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-portland-the-great-blumpkin-tickets-1681430587149",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-portland-the-great-blumpkin-341d5959"
+    },
+    {
+      "name": "Bearracuda Portland 16 YEAR Anniversary",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 45.5227415,
+        "lng": -122.6580938
+      },
+      "startDate": "2025-09-13T21:00:00",
+      "endDate": "2025-09-14T02:00:00",
+      "unprocessedDescription": "description: 16 YEAR ANNIVERSARY\n\nMusic & Entertainment\n• DJ\r CACTUSHEAD (BEEFMINCE UK)\n• DJ Matt Stands\nbar: Bossanova Ballroom\naddress: 722 E Burnside, Portland, OR 97213\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/pdx16/\ncover: $20.27 - $29.99 (as of 9/13)\nimage: https://bearracuda.com/wp-content/uploads/2025/04/cuda-portland-september_2025-web.jpg\nfacebook: https://www.facebook.com/events/751830650923430/\nticketUrl: https://www.eventbrite.com/e/bearracuda-portland-16-year-anniversary-tickets-1546221061819\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829\nkey: bearracuda-2025-09-14-portland",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "E0BA6861-892D-456D-9D6E-B53C61A7BF4C",
+      "uid": "E0BA6861-892D-456D-9D6E-B53C61A7BF4C",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 2,
+      "overrideIdentityType": null,
+      "bar": "Bossanova Ballroom",
+      "cover": "$20.27 - $29.99 (as of 9/13)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/04/cuda-portland-september_2025-web.jpg",
+      "tea": "16 YEAR ANNIVERSARY",
+      "address": "722 E Burnside, Portland, OR 97213",
+      "website": "https://bearracuda.com/events/pdx16/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/751830650923430/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-portland-16-year-anniversary-tickets-1546221061819",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/pdx16/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/751830650923430/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-portland-16-year-anniversary-tickets-1546221061819",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-portland-16-year-anniversary-21be21f0"
+    },
+    {
+      "name": "CHUNK PORTLAND - Friday November 7th",
+      "day": "Friday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 45.52281000000001,
+        "lng": -122.6581342
+      },
+      "startDate": "2025-11-07T21:00:00",
+      "endDate": "2025-11-08T02:00:00",
+      "unprocessedDescription": "description: We're BACK BACK BACK AGAIN! CHUNK Portland - THE R\rETURN DJ's MR PICKLES (CHUNK Resident) & Special Guest DJ FIVE (SF) HOT GOGO BEARS ALL NIGHT LONG State of the Art SOUND, LIGHTING, and VISUAL Friday November 7th // NOVA PDX // 722 E Burnside St // 9pm - close // 21+ // Gov ID RQ'D\nbar: NOVA PDX\naddress: 722 E Burnside St, Portland, OR 97214, USA\ntimezone: America/Los_Angeles\nurl: https://www.chunk-party.com/event-details/chunk-portland-friday-november-7th\nticketUrl: https://www.chunk-party.com/event-details/chunk-portland-friday-november-7th\ncover: $20.50 - $30.75\nimage: https://static.wixstatic.com/media/42b6cb_50aa142b23a0490483e13ef2902c67e3~mv2.jpg/v1/fill/w_1735,h_1735,al_c,q_90/42b6cb_50aa142b23a0490483e13ef2902c67e3~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\ngmaps: https://maps.google.com/?q=45.52281000000001,-122.6581342\nkey: chunk-portland-friday-november-7th|2025-11-08|nova pdx|chunk",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "E12CE81D-29DC-48FB-B1B3-DD5718366903",
+      "uid": "E12CE81D-29DC-48FB-B1B3-DD5718366903",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "NOVA PDX",
+      "cover": "$20.50 - $30.75",
+      "image": "https://static.wixstatic.com/media/42b6cb_50aa142b23a0490483e13ef2902c67e3~mv2.jpg/v1/fill/w_1735,h_1735,al_c,q_90/42b6cb_50aa142b23a0490483e13ef2902c67e3~mv2.jpg",
+      "tea": "We're BACK BACK BACK AGAIN! CHUNK Portland - THE RETURN DJ's MR PICKLES (CHUNK Resident) & Special Guest DJ FIVE (SF) HOT GOGO BEARS ALL NIGHT LONG State of the Art SOUND, LIGHTING, and VISUAL Friday November 7th // NOVA PDX // 722 E Burnside St // 9pm - close // 21+ // Gov ID RQ'D",
+      "address": "722 E Burnside St, Portland, OR 97214, USA",
+      "website": "https://www.chunk-party.com/event-details/chunk-portland-friday-november-7th",
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://maps.google.com/?q=45.52281000000001,-122.6581342",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-portland-friday-november-7th",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.chunk-party.com/event-details/chunk-portland-friday-november-7th",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.google.com/?q=45.52281000000001,-122.6581342",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-portland-friday-november-7th",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-portland-friday-november-7th-34a929ef"
+    },
+    {
+      "name": "CHUNK Portland - The RETURN! Saturday March 14th",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 45.52281000000001,
+        "lng": -122.6581342
+      },
+      "startDate": "2026-03-14T21:00:00",
+      "endDate": "2026-03-15T02:00:00",
+      "unprocessedDescription": "description: CHUNK PDX Presents E. FELD from Palm Springs DJ Co\rllective DRY HEAT! w/ support from MR PICKLES & BIRTHDAY GURL  HOT GOGO BEARS ALL NIGHT LONG State of the Art SOUND, LIGHTING, and VISUAL Saturday March 14th // NOVA PDX // 722 E Burnside St // 9pm - close // 21+ // Gov ID RQ'D\nbar: Portland\naddress: 722 E Burnside St, Portland, OR 97214, USA\ntimezone: America/Los_Angeles\nurl: https://www.chunk-party.com/event-details/chunk-portland-the-return-saturday-march-14th\nticketUrl: https://www.chunk-party.com/event-details/chunk-portland-the-return-saturday-march-14th\ncover: $20.50 - $25.63\nimage: https://static.wixstatic.com/media/42b6cb_f271f3bdec9c48aa995d105eff972004~mv2.jpg/v1/fill/w_847,h_1059,al_c,q_85/42b6cb_f271f3bdec9c48aa995d105eff972004~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\ngmaps: https://www.google.com/maps/search/?api=1&query=722%20E%20Burnside%20St%2C%20Portland%2C%20OR%2097214%2C%20USA\nkey: chunk-portland-the-return-saturday-march-14th|2026-03-15|portland",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "385E4388-7978-4649-B234-5C44D1C6F954",
+      "uid": "385E4388-7978-4649-B234-5C44D1C6F954",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Portland",
+      "cover": "$20.50 - $25.63",
+      "image": "https://static.wixstatic.com/media/42b6cb_f271f3bdec9c48aa995d105eff972004~mv2.jpg/v1/fill/w_847,h_1059,al_c,q_85/42b6cb_f271f3bdec9c48aa995d105eff972004~mv2.jpg",
+      "tea": "CHUNK PDX Presents E. FELD from Palm Springs DJ Collective DRY HEAT! w/ support from MR PICKLES & BIRTHDAY GURL  HOT GOGO BEARS ALL NIGHT LONG State of the Art SOUND, LIGHTING, and VISUAL Saturday March 14th // NOVA PDX // 722 E Burnside St // 9pm - close // 21+ // Gov ID RQ'D",
+      "address": "722 E Burnside St, Portland, OR 97214, USA",
+      "website": "https://www.chunk-party.com/event-details/chunk-portland-the-return-saturday-march-14th",
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=722%20E%20Burnside%20St%2C%20Portland%2C%20OR%2097214%2C%20USA",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-portland-the-return-saturday-march-14th",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.chunk-party.com/event-details/chunk-portland-the-return-saturday-march-14th",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=722%20E%20Burnside%20St%2C%20Portland%2C%20OR%2097214%2C%20USA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-portland-the-return-saturday-march-14th",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-portland-the-return-saturday-march-14th-47dcb647"
+    },
+    {
+      "name": "TREASURE TRAIL Portland: BACKCOUNTRY",
+      "day": "Sunday",
+      "time": "3PM-7PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 33,
+        "lng": null
+      },
+      "startDate": "2026-05-24T15:00:00",
+      "endDate": "2026-05-24T19:00:00",
+      "unprocessedDescription": "description: TREASURE TRAIL\\: Backcountry! A Portland Play Par\rty Saturday afternoon/evening, 3pm-7pm 33 NW 9th AveJP Hardy & Matt Bearracuda present TREASURE TRAIL Choose your own ADVENTURE! We've noticed a few shy guys at the party and some that needed a bit of a push for social interaction. Now our guys can grab a wristband when you walk in\\: Red wristband TOP Blue wristband VERS Green wristband BOTTOM White wristband SIDE Grab one at the door! Get ready for the RETURN of Bearracuda play parties, in con…\nbar: Sanctuary Club\naddress: 33 Northwest 9th Avenue\nticketUrl: https://www.sickening.events/e/bearracuda-treasure-trail-portland-back/tickets\ninstagram: https://www.instagram.com/bearracuda\nimage: https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1775609196/saas/logos/image_1775609187773_sy1lyd8mh.webp\ncover: $15-$20\nshortName: CHUNK\nwebsite: https://bearracuda.com/events/treasure-trail-portland/\ngmaps: https://www.google.com/maps/search/?api=1&query=Sanctuary%20Club%2C%2033%20Northwest%209th%20Avenue\nkey: bearracuda-2026-05-24-portland\ntimezone: America/Los_Angeles",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "DB562BB7-0556-4089-AF0D-63FA88FAC8C8",
+      "uid": "DB562BB7-0556-4089-AF0D-63FA88FAC8C8",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Sanctuary Club",
+      "cover": "$15-$20",
+      "image": "https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1775609196/saas/logos/image_1775609187773_sy1lyd8mh.webp",
+      "tea": "TREASURE TRAIL: Backcountry! A Portland Play Party Saturday afternoon/evening, 3pm-7pm 33 NW 9th AveJP Hardy & Matt Bearracuda present TREASURE TRAIL Choose your own ADVENTURE! We've noticed a few shy guys at the party and some that needed a bit of a push for social interaction. Now our guys can grab a wristband when you walk in: Red wristband TOP Blue wristband VERS Green wristband BOTTOM White wristband SIDE Grab one at the door! Get ready for the RETURN of Bearracuda play parties, in con…",
+      "address": "33 Northwest 9th Avenue",
+      "website": "https://bearracuda.com/events/treasure-trail-portland/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Sanctuary%20Club%2C%2033%20Northwest%209th%20Avenue",
+      "ticketUrl": "https://www.sickening.events/e/bearracuda-treasure-trail-portland-back/tickets",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/treasure-trail-portland/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Sanctuary%20Club%2C%2033%20Northwest%209th%20Avenue",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.sickening.events/e/bearracuda-treasure-trail-portland-back/tickets",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-portland-backcountry-33f45281"
+    },
+    {
+      "name": "HOT TAKE Portland",
+      "day": "Saturday",
+      "time": "8PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-05-30T20:00:00",
+      "endDate": "2026-05-31T02:00:00",
+      "unprocessedDescription": "description: HOT TAKE welcomes RuPaul&#8217;s Drag Race Season\r 18 Star\\: JANE DON&#8217;T!\n\nMusic & Entertainment\n• DJ Freddy King of Pants\nbar: NOVA PDX\naddress: 722 E Burnside, Portland, OR\ntimezone: America/Los_Angeles\nimage: https://bearracuda.com/wp-content/uploads/2026/05/hottake_may2026-igposter_v2-820x1024.jpg\nfacebook: https://www.facebook.com/events/891426833700451\nticketUrl: https://sickening.events/e/hot-take\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\nwebsite: https://bearracuda.com/events/hottakepdx/\ngmaps: https://www.google.com/maps/search/?api=1&query=NOVA%20PDX%2C%20722%20E%20Burnside%2C%20Portland%2C%20OR\nkey: bearracuda-2026-05-31-portland",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "B675ACB0-9AEC-419E-B6AD-335E72EA5F1E",
+      "uid": "B675ACB0-9AEC-419E-B6AD-335E72EA5F1E",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "NOVA PDX",
+      "image": "https://bearracuda.com/wp-content/uploads/2026/05/hottake_may2026-igposter_v2-820x1024.jpg",
+      "tea": "HOT TAKE welcomes RuPaul&#8217;s Drag Race Season 18 Star: JANE DON&#8217;T!",
+      "address": "722 E Burnside, Portland, OR",
+      "website": "https://bearracuda.com/events/hottakepdx/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/891426833700451",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=NOVA%20PDX%2C%20722%20E%20Burnside%2C%20Portland%2C%20OR",
+      "ticketUrl": "https://sickening.events/e/hot-take",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/hottakepdx/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/891426833700451",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=NOVA%20PDX%2C%20722%20E%20Burnside%2C%20Portland%2C%20OR",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://sickening.events/e/hot-take",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "hot-take-portland-46ec04ba"
+    },
+    {
+      "name": "TREASURE TRAIL: Portland",
+      "day": "Sunday",
+      "time": "3PM-8PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 45.5235017,
+        "lng": -122.6802365
+      },
+      "startDate": "2025-10-26T15:00:00",
+      "endDate": "2025-10-26T20:00:00",
+      "unprocessedDescription": "description: JP Hardy & Matt Bearracuda present TREASURE TRAIL \rAn Portland Play Party\nbar: Sanctuary Club\naddress: 33 Northwest 9th Avenue, Portland, OR 97209\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/treasure-trailpdx/\ncover: $19.24 - $30.54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/newtreasureweb.jpg\nfacebook: https://www.facebook.com/events/1054827773490040/\nticketUrl: https://www.eventbrite.com/e/treasure-trail-portland-tickets-1559975281059\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=45.5235017%2C-122.6802365&query_place_id=101715829\nkey: bearracuda-2025-10-26-portland",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "6C4ECC86-011F-4128-8CF0-9841CB2D8EED",
+      "uid": "6C4ECC86-011F-4128-8CF0-9841CB2D8EED",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Sanctuary Club",
+      "cover": "$19.24 - $30.54 (as of 10/1)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/08/newtreasureweb.jpg",
+      "tea": "JP Hardy & Matt Bearracuda present TREASURE TRAIL An Portland Play Party",
+      "address": "33 Northwest 9th Avenue, Portland, OR 97209",
+      "website": "https://bearracuda.com/events/treasure-trailpdx/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/1054827773490040/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=45.5235017%2C-122.6802365&query_place_id=101715829",
+      "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-portland-tickets-1559975281059",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/treasure-trailpdx/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/1054827773490040/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=45.5235017%2C-122.6802365&query_place_id=101715829",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/treasure-trail-portland-tickets-1559975281059",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-portland-1043b353"
+    },
+    {
+      "name": "Bearracuda Portland: PRIDE SATURDAY",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 722,
+        "lng": null
+      },
+      "startDate": "2026-07-18T21:00:00",
+      "endDate": "2026-07-19T03:00:00",
+      "unprocessedDescription": "description: PRIDE SATURDAY\\: COMMANDONo undies, Just Undies \ror Stripped bare! Less is MORE!\nbar: Nova PDX\naddress: 722 East Burnside Street\nticketUrl: https://www.sickening.events/e/bearracuda-portland-pridesaturday/tickets\ninstagram: https://www.instagram.com/bearracuda\nimage: https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1777525663/saas/logos/image_1777525655749_xz9b575vz.webp\nshortName: Bear-rac-uda\nwebsite: https://bearracuda.com/events/portland-pride-saturday/\ngmaps: https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20East%20Burnside%20Street\nkey: bearracuda-2026-07-19-portland\ntimezone: America/Los_Angeles",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "C1BB949C-3075-4731-BA5C-08112CA578ED",
+      "uid": "C1BB949C-3075-4731-BA5C-08112CA578ED",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Nova PDX",
+      "image": "https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1777525663/saas/logos/image_1777525655749_xz9b575vz.webp",
+      "tea": "PRIDE SATURDAY: COMMANDONo undies, Just Undies or Stripped bare! Less is MORE!",
+      "address": "722 East Burnside Street",
+      "website": "https://bearracuda.com/events/portland-pride-saturday/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20East%20Burnside%20Street",
+      "ticketUrl": "https://www.sickening.events/e/bearracuda-portland-pridesaturday/tickets",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/portland-pride-saturday/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20East%20Burnside%20Street",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.sickening.events/e/bearracuda-portland-pridesaturday/tickets",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-portland-pride-saturday-17cdfbd9"
+    },
+    {
+      "name": "Bearracuda Portland - Saturday, November 15th",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 45.5227415,
+        "lng": -122.6580938
+      },
+      "startDate": "2025-11-15T21:00:00",
+      "endDate": "2025-11-16T02:00:00",
+      "unprocessedDescription": "description: Music & Entertainment\n• DJ Freddy King of Pants &\ramp; DJ Matt Stands\n• MC - CHRISTEENE\n• Show with Barbin, Kharisma, Mulan Alexander &amp; Special Guests\nbar: Bossanova Ballroom\naddress: 722 E Burnside, Portland, OR 97213\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/portland-50/\ncover: $24.89 - $30.54 (as of 10/1)\nimage: https://bearracuda.com/wp-content/uploads/2025/08/bday2025.jpg\nfacebook: https://www.facebook.com/events/706971042315329\nticketUrl: https://www.eventbrite.com/e/bearracuda-portland-saturday-november-15th-tickets-1557485975479\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829\nkey: bearracuda-2025-11-16-portland",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "CA92B055-AF3F-4794-BF90-54987559FE94",
+      "uid": "CA92B055-AF3F-4794-BF90-54987559FE94",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Bossanova Ballroom",
+      "cover": "$24.89 - $30.54 (as of 10/1)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/08/bday2025.jpg",
+      "tea": "Music & Entertainment",
+      "address": "722 E Burnside, Portland, OR 97213",
+      "website": "https://bearracuda.com/events/portland-50/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/706971042315329",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-portland-saturday-november-15th-tickets-1557485975479",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/portland-50/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/706971042315329",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-portland-saturday-november-15th-tickets-1557485975479",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-portland-saturday-november-15th-1d72aa2a"
+    }
+  ]
+}

--- a/data/calendars/ptown.json
+++ b/data/calendars/ptown.json
@@ -1,0 +1,122 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/New_York",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "Riptide",
+      "day": "Thursday",
+      "time": "10PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 42.0510476,
+        "lng": -70.1876737
+      },
+      "startDate": "2026-07-16T22:00:00",
+      "unprocessedDescription": "description: MUSIC\\:\nGSP + HARLOW\nJOCKS · UNDERWEAR · GEAR\n\rLIMITED CLOTHES CHECK (FIRST COME, FIRST SERVED)\n$5 DISCOUNT WITH BEAR TAGS\nbar: REDROOM\naddress: 258 Commercial St, Provincetown, MA 02657\ntimezone: America/New_York\nticketUrl: https://events.ticketleap.com/tickets/furballnyc/UnderbearNYC-bear-week-2026\ninstagram: https://instagram.com/furballnyc/\nimage: https://static.wixstatic.com/media/238fae_ccecfe5565134a15b54c70f056f0e4c0~mv2.png/v1/fill/w_296,h_476,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/238fae_ccecfe5565134a15b54c70f056f0e4c0~mv2.png\ncover: $5 DISCOUNT WITH BEAR TAGS\nshortName: FUR-BALL\nfavicon: https://linktr.ee/furballnyc\nwebsite: https://www.furball.nyc\ngmaps: https://www.google.com/maps/search/?api=1&query=REDROOM%2C%20258%20COMMERCIAL%20ST%2C%20PROVINCETOWN%2C%20MA\nkey: riptide|2026-07-17|redroom",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "EA8572E1-44B4-47B7-A8F3-9D128EE5C5A5",
+      "uid": "EA8572E1-44B4-47B7-A8F3-9D128EE5C5A5",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "REDROOM",
+      "cover": "$5 DISCOUNT WITH BEAR TAGS",
+      "image": "https://static.wixstatic.com/media/238fae_ccecfe5565134a15b54c70f056f0e4c0~mv2.png/v1/fill/w_296,h_476,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/238fae_ccecfe5565134a15b54c70f056f0e4c0~mv2.png",
+      "favicon": "https://linktr.ee/furballnyc",
+      "tea": "MUSIC:",
+      "address": "258 Commercial St, Provincetown, MA 02657",
+      "website": "https://www.furball.nyc",
+      "instagram": "https://instagram.com/furballnyc/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=REDROOM%2C%20258%20COMMERCIAL%20ST%2C%20PROVINCETOWN%2C%20MA",
+      "ticketUrl": "https://events.ticketleap.com/tickets/furballnyc/UnderbearNYC-bear-week-2026",
+      "shortName": "FUR-BALL",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.furball.nyc",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://instagram.com/furballnyc/",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=REDROOM%2C%20258%20COMMERCIAL%20ST%2C%20PROVINCETOWN%2C%20MA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://events.ticketleap.com/tickets/furballnyc/UnderbearNYC-bear-week-2026",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "riptide-3342cdd1"
+    },
+    {
+      "name": "FURBALL",
+      "day": "Saturday",
+      "time": "10PM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 42.0470329,
+        "lng": -70.1901852
+      },
+      "startDate": "2026-07-11T22:00:00",
+      "unprocessedDescription": "description: PROVINCETOWN BEAR WEEK OFFICIAL 26TH ANNIVERSARY O\rPENING PARTY\nbar: Boatslip\naddress: 161 Commercial St, Provincetown, MA 02657\ntimezone: America/New_York\nticketUrl: https://events.ticketleap.com/tickets/furballnyc/furball-official-bear-week-underwear-opening-party-2026\ninstagram: https://instagram.com/furballnyc/\nimage: https://static.wixstatic.com/media/238fae_4a9e61a8ba4b43bd857ed15af7901591~mv2.jpg/v1/fill/w_560,h_700,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/238fae_4a9e61a8ba4b43bd857ed15af7901591~mv2.jpg\ncover: FREE FOR BEAR WEEK PACKAGE REGISTRANTS\nshortName: FUR-BALL\nfavicon: https://linktr.ee/furballnyc\nwebsite: https://www.furball.nyc\ngmaps: https://www.google.com/maps/search/?api=1&query=Boatslip%2C%20161%20Commercial%20St\nkey: furball|2026-07-12|boatslip",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/New_York",
+      "wasUTC": true,
+      "sourceUid": "D0D6C7F9-24C0-48F2-B9AB-8F785BF13389",
+      "uid": "D0D6C7F9-24C0-48F2-B9AB-8F785BF13389",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Boatslip",
+      "cover": "FREE FOR BEAR WEEK PACKAGE REGISTRANTS",
+      "image": "https://static.wixstatic.com/media/238fae_4a9e61a8ba4b43bd857ed15af7901591~mv2.jpg/v1/fill/w_560,h_700,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/238fae_4a9e61a8ba4b43bd857ed15af7901591~mv2.jpg",
+      "favicon": "https://linktr.ee/furballnyc",
+      "tea": "PROVINCETOWN BEAR WEEK OFFICIAL 26TH ANNIVERSARY OPENING PARTY",
+      "address": "161 Commercial St, Provincetown, MA 02657",
+      "website": "https://www.furball.nyc",
+      "instagram": "https://instagram.com/furballnyc/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Boatslip%2C%20161%20Commercial%20St",
+      "ticketUrl": "https://events.ticketleap.com/tickets/furballnyc/furball-official-bear-week-underwear-opening-party-2026",
+      "shortName": "FUR-BALL",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.furball.nyc",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://instagram.com/furballnyc/",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Boatslip%2C%20161%20Commercial%20St",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://events.ticketleap.com/tickets/furballnyc/furball-official-bear-week-underwear-opening-party-2026",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "furball-51be4236"
+    }
+  ]
+}

--- a/data/calendars/san-diego.json
+++ b/data/calendars/san-diego.json
@@ -1,0 +1,179 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Los_Angeles",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "MEGAWOOF",
+      "day": "Friday",
+      "time": "9PM-4AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 32.7468303,
+        "lng": -117.1607394
+      },
+      "startDate": "2025-10-31T21:00:00",
+      "endDate": "2025-11-01T04:00:00",
+      "unprocessedDescription": "description: MEGAWOOF AMERICA - 10 YEAR SAN DIEGO DEBUT -  INTE\rRNATIONAL HALLOWOOF\nbar: The Rail\naddress: 3796 Fifth Avenue, San Diego, CA 92103\ntimezone: America/Los_Angeles\nurl: https://linktr.ee/megawoof_america\nticketUrl: https://www.eventbrite.com/e/megawoof-america-10-year-san-diego-debut-international-hallowoof-tickets-1692702351299\ncover: $16.84 - $22.10 (as of 10/1)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1123525053%2F185013722403%2F1%2Foriginal.20250914-145257?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=5e-17&fp-y=5e-17&s=74a16cfb724650fcf4bf026281197f19\nshortName: MEGA-WOOF\ninstagram: https://www.instagram.com/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=32.7468303%2C-117.1607394&query_place_id=ChIJwdJrt9pU2YARYuac9G61qQE\nkey: megawoof|2025-11-01|the rail|eventbrite",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "192064B4-BCA8-491B-97A9-36BDF7A5A725",
+      "uid": "192064B4-BCA8-491B-97A9-36BDF7A5A725",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "The Rail",
+      "cover": "$16.84 - $22.10 (as of 10/1)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1123525053%2F185013722403%2F1%2Foriginal.20250914-145257?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=5e-17&fp-y=5e-17&s=74a16cfb724650fcf4bf026281197f19",
+      "tea": "MEGAWOOF AMERICA - 10 YEAR SAN DIEGO DEBUT -  INTERNATIONAL HALLOWOOF",
+      "address": "3796 Fifth Avenue, San Diego, CA 92103",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=32.7468303%2C-117.1607394&query_place_id=ChIJwdJrt9pU2YARYuac9G61qQE",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-10-year-san-diego-debut-international-hallowoof-tickets-1692702351299",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=32.7468303%2C-117.1607394&query_place_id=ChIJwdJrt9pU2YARYuac9G61qQE",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-america-10-year-san-diego-debut-international-hallowoof-tickets-1692702351299",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-7025d33f"
+    },
+    {
+      "name": "MEGAWOOF AMERICA - SAN DIEGO",
+      "day": "Friday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 32.7468303,
+        "lng": -117.1607394
+      },
+      "startDate": "2026-05-15T21:00:00",
+      "endDate": "2026-05-16T02:00:00",
+      "unprocessedDescription": "description: SAN DIEGO Here we go again… MEGAWOOF is BACK and r\ready to keep you sweaty, sexy, and beefy.\nbar: The Brass Rail\naddress: 3796 Fifth Avenue, San Diego, CA 92103\nticketUrl: https://www.eventbrite.com/e/megawoof-america-san-diego-tickets-1986666861061\ninstagram: https://www.instagram.com/megawoof_america\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1181921091%2F185013722403%2F1%2Foriginal.20260411-040157?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=3319257efa3598b3e12a398447de4622\ncover: $16.84-$22.10\nshortName: MEGA-WOOF\nwebsite: https://linktr.ee/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=The%20Brass%20Rail%2C%203796%20Fifth%20Avenue%2C%20San%20Diego%2C%20CA%2092103\nkey: megawoof-america-san-diego|2026-05-16|the brass rail",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "5B8DF162-E146-4A77-87D2-D03C226F55B4",
+      "uid": "5B8DF162-E146-4A77-87D2-D03C226F55B4",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "The Brass Rail",
+      "cover": "$16.84-$22.10",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1181921091%2F185013722403%2F1%2Foriginal.20260411-040157?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=3319257efa3598b3e12a398447de4622",
+      "tea": "SAN DIEGO Here we go again… MEGAWOOF is BACK and ready to keep you sweaty, sexy, and beefy.",
+      "address": "3796 Fifth Avenue, San Diego, CA 92103",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Brass%20Rail%2C%203796%20Fifth%20Avenue%2C%20San%20Diego%2C%20CA%2092103",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-san-diego-tickets-1986666861061",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=The%20Brass%20Rail%2C%203796%20Fifth%20Avenue%2C%20San%20Diego%2C%20CA%2092103",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-america-san-diego-tickets-1986666861061",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-america-san-diego-7cd96d30"
+    },
+    {
+      "name": "MEGAWOOF",
+      "day": "Friday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 32.7468303,
+        "lng": -117.1607394
+      },
+      "startDate": "2026-02-06T21:00:00",
+      "endDate": "2026-02-07T02:00:00",
+      "unprocessedDescription": "description: MEGAWOOF SAN DIEGO - Feb 6th\nbar: The Rail\naddre\rss: 3796 Fifth Avenue, San Diego, CA 92103\ntimezone: America/Los_Angeles\nticketUrl: https://www.eventbrite.com/e/megawoof-san-diego-feb-6th-tickets-1979742608435\ncover: $11.58 - $16.84 (as of 2/2)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1174012983%2F185013722403%2F1%2Foriginal.20260105-163247?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=ac5e775082450ea31daa858d20720acc\nshortName: MEGA-WOOF\ninstagram: https://www.instagram.com/megawoof_america\nurl: https://linktr.ee/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=32.7468303%2C-117.1607394&query_place_id=ChIJwdJrt9pU2YARYuac9G61qQE\nkey: megawoof|2026-02-07|the rail",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "72BA7733-05A0-4516-93E3-FCFD336AB92E",
+      "uid": "72BA7733-05A0-4516-93E3-FCFD336AB92E",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "The Rail",
+      "cover": "$11.58 - $16.84 (as of 2/2)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1174012983%2F185013722403%2F1%2Foriginal.20260105-163247?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=ac5e775082450ea31daa858d20720acc",
+      "tea": "MEGAWOOF SAN DIEGO - Feb 6th",
+      "address": "3796 Fifth Avenue, San Diego, CA 92103",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=32.7468303%2C-117.1607394&query_place_id=ChIJwdJrt9pU2YARYuac9G61qQE",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-san-diego-feb-6th-tickets-1979742608435",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=32.7468303%2C-117.1607394&query_place_id=ChIJwdJrt9pU2YARYuac9G61qQE",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-san-diego-feb-6th-tickets-1979742608435",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-4faca4f4"
+    }
+  ]
+}

--- a/data/calendars/sf.json
+++ b/data/calendars/sf.json
@@ -1,0 +1,680 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Los_Angeles",
+    "timezoneData": {
+      "tzid": "America/Los_Angeles",
+      "location": "America/Los_Angeles",
+      "daylight": {
+        "offsetFrom": "-0800",
+        "offsetTo": "-0700",
+        "name": "PDT",
+        "dtstart": "19700308T020000",
+        "rrule": "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU"
+      },
+      "standard": {
+        "offsetFrom": "-0700",
+        "offsetTo": "-0800",
+        "name": "PST",
+        "dtstart": "19701101T020000",
+        "rrule": "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU"
+      }
+    }
+  },
+  "events": [
+    {
+      "name": "Bearracuda SF presents: HORSE MEAT DISCO",
+      "day": "Friday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 37.7689137,
+        "lng": -122.4192514
+      },
+      "startDate": "2025-09-26T21:00:00",
+      "endDate": "2025-09-27T03:00:00",
+      "unprocessedDescription": "description: Music & Entertainment\n• Main Floor - Horse Meat D\risco\n• Upstairs - Mateo Segade (LA)\n• Decor and photos by Dusti Cunningham\nbar: The Public Works SF\naddress: 161 Erie Street, San Francisco, CA 94103\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/flsm-friday/\ncover: $57.79 - $99.99 (as of 9/20)\nimage: https://bearracuda.com/wp-content/uploads/2025/05/hmd2025.jpg\nfacebook: https://www.facebook.com/events/564754916670823/\nticketUrl: https://www.eventbrite.com/e/bearracuda-sf-flsm-friday-tickets-1370410668199\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=37.7689137%2C-122.4192514&query_place_id=85922583\nkey: bearracuda-2025-09-27-sf",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "5E26BD3A-6828-47B9-9E16-D6D7D4970A79",
+      "uid": "5E26BD3A-6828-47B9-9E16-D6D7D4970A79",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 2,
+      "overrideIdentityType": null,
+      "bar": "The Public Works SF",
+      "cover": "$57.79 - $99.99 (as of 9/20)",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/05/hmd2025.jpg",
+      "tea": "Music & Entertainment",
+      "address": "161 Erie Street, San Francisco, CA 94103",
+      "website": "https://bearracuda.com/events/flsm-friday/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/564754916670823/",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=37.7689137%2C-122.4192514&query_place_id=85922583",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-sf-flsm-friday-tickets-1370410668199",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/flsm-friday/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/564754916670823/",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=37.7689137%2C-122.4192514&query_place_id=85922583",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-sf-flsm-friday-tickets-1370410668199",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-sf-presents-horse-meat-disco-151154b5"
+    },
+    {
+      "name": "CHUNK DORE ALLEY - Saturday July 25th",
+      "day": "Saturday",
+      "time": "10PM-4AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 37.77526599999999,
+        "lng": -122.4100374
+      },
+      "startDate": "2026-07-25T22:00:00",
+      "endDate": "2026-07-26T04:00:00",
+      "unprocessedDescription": "description: THE PREMIER BEAR/CUB SATURDAY MAIN EVENT! CHUNK SF\r Presents BEARS IN SPACE With DICAP & NICK MOSS & THCKRTANKER & OMNIBOT GOGO FETISH BEARS // Hosted By ROSS & BIG CLAUDE & More f8 NIGHTCLUB // 1192 FOLSOM ST // 10pm - 4am\nbar: F8 Nightclub & Bar\naddress: 1192 Folsom St, San Francisco, CA 94103, USA\nticketUrl: https://www.chunk-party.com/event-details/chunk-dore-alley-saturday-july-25th\ncover: $25.63 - $61.50\nimage: https://static.wixstatic.com/media/42b6cb_fc05a5a5ac4046eba761fbc4463286b9~mv2.jpg/v1/fill/w_3300,h_4125,al_c,q_90/42b6cb_fc05a5a5ac4046eba761fbc4463286b9~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\nwebsite: https://www.chunk-party.com\ngmaps: https://www.google.com/maps/search/?api=1&query=F8%20Nightclub%20%26%20Bar%2C%201192%20Folsom%20St%2C%20San%20Francisco%2C%20CA%2094103%2C%20USA\nkey: chunk-dore-alley-saturday-july-25th|2026-07-26|f8 nightclub & bar",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "CEC90038-7CD1-4FA5-9BA7-1353A769AEB8",
+      "uid": "CEC90038-7CD1-4FA5-9BA7-1353A769AEB8",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "F8 Nightclub & Bar",
+      "cover": "$25.63 - $61.50",
+      "image": "https://static.wixstatic.com/media/42b6cb_fc05a5a5ac4046eba761fbc4463286b9~mv2.jpg/v1/fill/w_3300,h_4125,al_c,q_90/42b6cb_fc05a5a5ac4046eba761fbc4463286b9~mv2.jpg",
+      "tea": "THE PREMIER BEAR/CUB SATURDAY MAIN EVENT! CHUNK SF Presents BEARS IN SPACE With DICAP & NICK MOSS & THCKRTANKER & OMNIBOT GOGO FETISH BEARS // Hosted By ROSS & BIG CLAUDE & More f8 NIGHTCLUB // 1192 FOLSOM ST // 10pm - 4am",
+      "address": "1192 Folsom St, San Francisco, CA 94103, USA",
+      "website": "https://www.chunk-party.com",
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=F8%20Nightclub%20%26%20Bar%2C%201192%20Folsom%20St%2C%20San%20Francisco%2C%20CA%2094103%2C%20USA",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-dore-alley-saturday-july-25th",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.chunk-party.com",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=F8%20Nightclub%20%26%20Bar%2C%201192%20Folsom%20St%2C%20San%20Francisco%2C%20CA%2094103%2C%20USA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-dore-alley-saturday-july-25th",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-dore-alley-saturday-july-25th-3bf852a2"
+    },
+    {
+      "name": "CHUNK presents FOLSOM '25",
+      "day": "Saturday",
+      "time": "10PM-4AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 37.77526599999999,
+        "lng": -122.4100374
+      },
+      "startDate": "2025-09-27T22:00:00",
+      "endDate": "2025-09-28T04:00:00",
+      "unprocessedDescription": "description: CHUNK SF presents BEARS IN SPACE (LA/CDMX) 5 DJS /\r/ 2 ROOMS // CAVALCADE OF GOGO BEARS DJS - DICAP (NYC) // MR PICKLES (CHUNK RESIDENT) // DR TIME (Palm Springs) // FREDDY KOP (Seattle)  f8 NIGHTCLUB // 1192 FOLSOM ST // 10PM - CLOSE // 21+ // ID RQ'D\nbar: f8 NIGHTCLUB\naddress: 1192 Folsom St, San Francisco\ntimezone: America/Los_Angeles\nurl: https://www.chunk-party.com/event-details/chunk-presents-folsom-25\nticketUrl: https://www.chunk-party.com/event-details/chunk-presents-folsom-25\ncover: $25.63 - $66.63\nimage: https://static.wixstatic.com/media/42b6cb_4273bbd8298849f09e8b04906a809d02~mv2.jpg/v1/fill/w_3300,h_4125,al_c,q_90/42b6cb_4273bbd8298849f09e8b04906a809d02~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\ngmaps: https://maps.google.com/?q=37.77526599999999,-122.4100374\nkey: chunk-presents-folsom-'25|2025-09-28|f8 nightclub|chunk",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "9D1A1197-0811-4645-ABAE-ECF5464CC76F",
+      "uid": "9D1A1197-0811-4645-ABAE-ECF5464CC76F",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "f8 NIGHTCLUB",
+      "cover": "$25.63 - $66.63",
+      "image": "https://static.wixstatic.com/media/42b6cb_4273bbd8298849f09e8b04906a809d02~mv2.jpg/v1/fill/w_3300,h_4125,al_c,q_90/42b6cb_4273bbd8298849f09e8b04906a809d02~mv2.jpg",
+      "tea": "CHUNK SF presents BEARS IN SPACE (LA/CDMX) 5 DJS // 2 ROOMS // CAVALCADE OF GOGO BEARS DJS - DICAP (NYC) // MR PICKLES (CHUNK RESIDENT) // DR TIME (Palm Springs) // FREDDY KOP (Seattle)  f8 NIGHTCLUB // 1192 FOLSOM ST // 10PM - CLOSE // 21+ // ID RQ'D",
+      "address": "1192 Folsom St, San Francisco",
+      "website": "https://www.chunk-party.com/event-details/chunk-presents-folsom-25",
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://maps.google.com/?q=37.77526599999999,-122.4100374",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-presents-folsom-25",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.chunk-party.com/event-details/chunk-presents-folsom-25",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.google.com/?q=37.77526599999999,-122.4100374",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-presents-folsom-25",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-presents-folsom-25-6a09272f"
+    },
+    {
+      "name": "Bearracuda SF: BEEFCAKE Pride",
+      "day": "Friday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-06-26T21:00:00",
+      "endDate": "2026-06-27T03:00:00",
+      "unprocessedDescription": "description: Bearracuda SF Pride! Friday, June 26th, 2026 wit\rh TONY MORANBEEFCAKE\nbar: Public Works\naddress: 161 Erie Street\nticketUrl: https://www.sickening.events/e/bearracuda-sf-pride-2026-beefcakes/tickets\ninstagram: https://www.instagram.com/bearracuda\nimage: https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1776730474/saas/logos/image_1776730463946_w2htw6xrh.webp\ncover: General Admission $40.00-$50.00\nshortName: Bear-rac-uda\nwebsite: https://bearracuda.com/events/sf-pride/\ngmaps: https://www.google.com/maps/search/?api=1&query=Public%20Works%2C%20161%20Erie%20Street\nkey: bearracuda-2026-06-27-sf\ntimezone: America/Los_Angeles",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "77CEB24A-C15A-4D66-82A3-E51D9C5804D4",
+      "uid": "77CEB24A-C15A-4D66-82A3-E51D9C5804D4",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Public Works",
+      "cover": "General Admission $40.00-$50.00",
+      "image": "https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1776730474/saas/logos/image_1776730463946_w2htw6xrh.webp",
+      "tea": "Bearracuda SF Pride! Friday, June 26th, 2026 with TONY MORANBEEFCAKE",
+      "address": "161 Erie Street",
+      "website": "https://bearracuda.com/events/sf-pride/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Public%20Works%2C%20161%20Erie%20Street",
+      "ticketUrl": "https://www.sickening.events/e/bearracuda-sf-pride-2026-beefcakes/tickets",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/sf-pride/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Public%20Works%2C%20161%20Erie%20Street",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.sickening.events/e/bearracuda-sf-pride-2026-beefcakes/tickets",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-sf-beefcake-pride-2d1a3a4d"
+    },
+    {
+      "name": "CHUNK SF presents FATHER FIGURE",
+      "day": "Saturday",
+      "time": "10PM-3:30AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 37.77526599999999,
+        "lng": -122.4100374
+      },
+      "startDate": "2026-05-02T22:00:00",
+      "endDate": "2026-05-03T03:30:00",
+      "unprocessedDescription": "description: New Orleans DADDY Father Figure joins us for CHUNK\r'S OFFICIAL SPRING THAW. Support from the BAPTIST and CHUNK residents MISS PIGGY & BEN FONIK. GOGO BEARS ALL NIGHT LONG\nbar: F8 Nightclub & Bar\naddress: 1192 Folsom St, San Francisco, CA 94103, USA\nticketUrl: https://www.chunk-party.com/event-details/chunk-sf-presents-father-figure\ncover: $20.50 - $35.88\nimage: https://static.wixstatic.com/media/42b6cb_c906b540fe2743aab81be9b8019fb0a4~mv2.jpg/v1/fill/w_792,h_1224,al_c,q_85/42b6cb_c906b540fe2743aab81be9b8019fb0a4~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\ngmaps: https://www.google.com/maps/search/?api=1&query=F8%20Nightclub%20%26%20Bar%2C%201192%20Folsom%20St%2C%20San%20Francisco%2C%20CA%2094103%2C%20USA\nkey: chunk-sf-presents-father-figure|2026-05-03|f8 nightclub & bar",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "56CFF5FC-B1E1-4512-8FBC-EDBD2064A2E6",
+      "uid": "56CFF5FC-B1E1-4512-8FBC-EDBD2064A2E6",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "F8 Nightclub & Bar",
+      "cover": "$20.50 - $35.88",
+      "image": "https://static.wixstatic.com/media/42b6cb_c906b540fe2743aab81be9b8019fb0a4~mv2.jpg/v1/fill/w_792,h_1224,al_c,q_85/42b6cb_c906b540fe2743aab81be9b8019fb0a4~mv2.jpg",
+      "tea": "New Orleans DADDY Father Figure joins us for CHUNK'S OFFICIAL SPRING THAW. Support from the BAPTIST and CHUNK residents MISS PIGGY & BEN FONIK. GOGO BEARS ALL NIGHT LONG",
+      "address": "1192 Folsom St, San Francisco, CA 94103, USA",
+      "website": null,
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=F8%20Nightclub%20%26%20Bar%2C%201192%20Folsom%20St%2C%20San%20Francisco%2C%20CA%2094103%2C%20USA",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-sf-presents-father-figure",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=F8%20Nightclub%20%26%20Bar%2C%201192%20Folsom%20St%2C%20San%20Francisco%2C%20CA%2094103%2C%20USA",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-sf-presents-father-figure",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-sf-presents-father-figure-305593c7"
+    },
+    {
+      "name": "MEGAWOOF AMERICA SAN FRANCISCO",
+      "day": "Friday",
+      "time": "9:30PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 37.7761825,
+        "lng": -122.4083567
+      },
+      "startDate": "2026-07-03T21:30:00",
+      "endDate": "2026-07-04T02:00:00",
+      "unprocessedDescription": "description: MEGAWOOF AMERICA RETURNS to SAN FRANCISCO\nbar: Th\re Stud\naddress: 1123 Folsom Street, San Francisco, CA 94103\nticketUrl: https://www.eventbrite.com/e/megawoof-america-san-francisco-tickets-1988522943654\ninstagram: https://www.instagram.com/megawoof_america\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1184030413%2F185013722403%2F1%2Foriginal.20260507-154720?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=69d71feb01b7e2d1a442a2d027def793\ncover: $11.58-$22.1\nshortName: MEGA-WOOF\n_aiPrompts\\: [object Object],[object Object],[object Object]\n_aiValidation\\: [object Object]\nwebsite: https://linktr.ee/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103\nkey: megawoof-america-san-francisco|2026-07-04|the stud",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "1FB109E7-0355-4D65-AB9C-85F56D1E2502",
+      "uid": "1FB109E7-0355-4D65-AB9C-85F56D1E2502",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "The Stud",
+      "cover": "$11.58-$22.1",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1184030413%2F185013722403%2F1%2Foriginal.20260507-154720?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=69d71feb01b7e2d1a442a2d027def793",
+      "tea": "MEGAWOOF AMERICA RETURNS to SAN FRANCISCO",
+      "address": "1123 Folsom Street, San Francisco, CA 94103",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-san-francisco-tickets-1988522943654",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-america-san-francisco-tickets-1988522943654",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-america-san-francisco-25d83ad3"
+    },
+    {
+      "name": "Bear Happy Hour",
+      "day": "Thursday",
+      "time": "5PM-9PM",
+      "eventType": "weekly",
+      "recurring": true,
+      "recurrence": "FREQ=WEEKLY",
+      "startDate": "2025-10-02T17:00:00",
+      "endDate": "2025-10-02T21:00:00",
+      "unprocessedDescription": "Bar: Check instagram for this week’s location.\nTea: Popular ha\rppy hour that changes location every week.\nInstagram: https://www.instagram.com/bearhappyhoursf\nShorter: BHH\nWeb: https://linktr.ee/bearhappyhour",
+      "startTimezone": "America/Los_Angeles",
+      "endTimezone": "America/Los_Angeles",
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": false,
+      "sourceUid": "dkep613fqcsi8tlh6bfsp12h50@google.com",
+      "uid": "dkep613fqcsi8tlh6bfsp12h50@google.com",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Check instagram for this week’s location.",
+      "tea": "Popular happy hour that changes location every week.",
+      "address": null,
+      "website": "https://linktr.ee/bearhappyhour",
+      "instagram": "https://www.instagram.com/bearhappyhoursf",
+      "shorterName": "BHH",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/bearhappyhour",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearhappyhoursf",
+          "label": "📷 Instagram"
+        }
+      ],
+      "slug": "bear-happy-hour-67a521bf"
+    },
+    {
+      "name": "CHUNK San Francisco - Saturday January 17th",
+      "day": "Saturday",
+      "time": "10PM-4AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 37.77526599999999,
+        "lng": -122.4100374
+      },
+      "startDate": "2026-01-17T22:00:00",
+      "endDate": "2026-01-18T04:00:00",
+      "unprocessedDescription": "description: CHUNK SF celebrates MLK JR Weekend  - Atlanta LEGE\rND Vicki Powell from DEEP SOUTH DJ Collective. Resident DJs MR PICKLES & DR TIME & BEN FONIK. Cavalcade of HOT GOGO BEARS - 2 rooms f8 NIGHTCLUB 10-4am\nbar: San Francisco\naddress: 1192 Folsom St, San Francisco, CA 94103, USA\ntimezone: America/Los_Angeles\nurl: https://www.chunk-party.com/event-details/chunk-san-francisco-saturday-january-17th\nticketUrl: https://www.chunk-party.com/event-details/chunk-san-francisco-saturday-january-17th\ncover: $20.50 - $41.00\nimage: https://static.wixstatic.com/media/42b6cb_846622553967483cb81ea3b1a938bc04~mv2.jpg/v1/fill/w_809,h_1012,al_c,q_85/42b6cb_846622553967483cb81ea3b1a938bc04~mv2.jpg\nshortName: CHUNK\ninstagram: https://www.instagram.com/chunkparty\ngmaps: https://maps.google.com/?q=37.77526599999999,-122.4100374\nkey: chunk-san-francisco-saturday-january-17th|2026-01-18|san francisco|chunk",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "7F66ECD5-BDAB-4CA8-BBC0-AAC031F6E4DB",
+      "uid": "7F66ECD5-BDAB-4CA8-BBC0-AAC031F6E4DB",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "San Francisco",
+      "cover": "$20.50 - $41.00",
+      "image": "https://static.wixstatic.com/media/42b6cb_846622553967483cb81ea3b1a938bc04~mv2.jpg/v1/fill/w_809,h_1012,al_c,q_85/42b6cb_846622553967483cb81ea3b1a938bc04~mv2.jpg",
+      "tea": "CHUNK SF celebrates MLK JR Weekend  - Atlanta LEGEND Vicki Powell from DEEP SOUTH DJ Collective. Resident DJs MR PICKLES & DR TIME & BEN FONIK. Cavalcade of HOT GOGO BEARS - 2 rooms f8 NIGHTCLUB 10-4am",
+      "address": "1192 Folsom St, San Francisco, CA 94103, USA",
+      "website": "https://www.chunk-party.com/event-details/chunk-san-francisco-saturday-january-17th",
+      "instagram": "https://www.instagram.com/chunkparty",
+      "gmaps": "https://maps.google.com/?q=37.77526599999999,-122.4100374",
+      "ticketUrl": "https://www.chunk-party.com/event-details/chunk-san-francisco-saturday-january-17th",
+      "shortName": "CHUNK",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.chunk-party.com/event-details/chunk-san-francisco-saturday-january-17th",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/chunkparty",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://maps.google.com/?q=37.77526599999999,-122.4100374",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.chunk-party.com/event-details/chunk-san-francisco-saturday-january-17th",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "chunk-san-francisco-saturday-january-17th-227d733c"
+    },
+    {
+      "name": "BEEFWITCH",
+      "day": "Friday",
+      "time": "10PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 37.7761825,
+        "lng": -122.4083567
+      },
+      "startDate": "2026-05-15T22:00:00",
+      "endDate": "2026-05-16T02:00:00",
+      "unprocessedDescription": "description: The Occult Leather Party Returns to The Stud Frida\ry May 15. Are you ready to live deliciously?\nbar: The Stud\naddress: 1123 Folsom Street, San Francisco, CA 94103\nticketUrl: https://www.eventbrite.com/e/beefwitch-tickets-1988340517011\ninstagram: https://www.instagram.com/thebeefwitch\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1183146702%2F2198683436473%2F1%2Foriginal.20260427-173849?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=d4ebc964c2b00b6625c9a810da2199de\ncover: $10.38-$17.85\nshortName: BEEFWITCH\ngmaps: https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103\nkey: beefwitch|2026-05-16|the stud",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "BBE7F872-30A1-40EC-AB3C-BCDAF9342658",
+      "uid": "BBE7F872-30A1-40EC-AB3C-BCDAF9342658",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "The Stud",
+      "cover": "$10.38-$17.85",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1183146702%2F2198683436473%2F1%2Foriginal.20260427-173849?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=d4ebc964c2b00b6625c9a810da2199de",
+      "tea": "The Occult Leather Party Returns to The Stud Friday May 15. Are you ready to live deliciously?",
+      "address": "1123 Folsom Street, San Francisco, CA 94103",
+      "website": null,
+      "instagram": "https://www.instagram.com/thebeefwitch",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103",
+      "ticketUrl": "https://www.eventbrite.com/e/beefwitch-tickets-1988340517011",
+      "shortName": "BEEFWITCH",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/thebeefwitch",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/beefwitch-tickets-1988340517011",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "beefwitch-0e685674"
+    },
+    {
+      "name": "Treasure Trail: San Francisco",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "startDate": "2026-06-13T21:00:00",
+      "endDate": "2026-06-14T02:00:00",
+      "unprocessedDescription": "description: Saturday, June 13th, 2025 Doors at 9pm, Party t\ril 2amClothes Check encouraged1123 FOLSOMSteamy Go-Go&rsquo;s, Heavy CruisingHard Sounds by Paul Goodyear Hosted byJP Hardy➲➲https\\://www.jphardyofficial.comSPRING has sprung and we are ready to strip down! Grab a wristband when you walk in\\: Red Wristband TOP Blue Wristband VERS Green Wristband BOTTOM White Wristband SIDE You can choose one when you purchase tix and are free to change your mind (or go without a wristband) when you arrive.\nbar: The Stud\naddress: 1123 Folsom Street\nticketUrl: https://www.sickening.events/e/treasuresf/tickets\ninstagram: https://www.instagram.com/bearracuda\nimage: https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1777842694/saas/logos/image_1777842674799_zsjr6b8zx.webp\ncover: 15.00\nshortName: Bear-rac-uda\nwebsite: https://bearracuda.com/events/treasure-trail-sf/\ngmaps: https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street\nkey: bearracuda-2026-06-14-sf\ntimezone: America/Los_Angeles",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "C0CE53B6-54E8-4E7E-AD3D-95DF514E0382",
+      "uid": "C0CE53B6-54E8-4E7E-AD3D-95DF514E0382",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "The Stud",
+      "cover": "15.00",
+      "image": "https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1777842694/saas/logos/image_1777842674799_zsjr6b8zx.webp",
+      "tea": "Saturday, June 13th, 2025 Doors at 9pm, Party til 2amClothes Check encouraged1123 FOLSOMSteamy Go-Go&rsquo;s, Heavy CruisingHard Sounds by Paul Goodyear Hosted byJP Hardy➲➲https://www.jphardyofficial.comSPRING has sprung and we are ready to strip down! Grab a wristband when you walk in: Red Wristband TOP Blue Wristband VERS Green Wristband BOTTOM White Wristband SIDE You can choose one when you purchase tix and are free to change your mind (or go without a wristband) when you arrive.",
+      "address": "1123 Folsom Street",
+      "website": "https://bearracuda.com/events/treasure-trail-sf/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street",
+      "ticketUrl": "https://www.sickening.events/e/treasuresf/tickets",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/treasure-trail-sf/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.sickening.events/e/treasuresf/tickets",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "treasure-trail-san-francisco-1a2ef0fe"
+    },
+    {
+      "name": "Bearracuda SF:  20 YEAR ANNIVERSARY!",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 37.7761062,
+        "lng": -122.4083888
+      },
+      "startDate": "2026-03-28T21:00:00",
+      "endDate": "2026-03-29T02:00:00",
+      "unprocessedDescription": "description: Photos & Decor by Dusti Cunningham\nbar: THE STUD\\\rnaddress: 1123 Folsom Street, San Francisco, CA 94103\ntimezone: America/Los_Angeles\nurl: https://bearracuda.com/events/sf20/\nimage: https://bearracuda.com/wp-content/uploads/2025/11/insta-3.jpg\nfacebook: https://www.facebook.com/events/753717904452981\nticketUrl: https://www.eventbrite.com/e/bearracuda-sf-20-year-anniversary-tickets-1976399528192\nshortName: Bear-rac-uda\ninstagram: https://www.instagram.com/bearracuda\ngmaps: https://www.google.com/maps/search/?api=1&query=THE%20STUD%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103\nkey: bearracuda-2026-03-29-sf",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "9D681FB7-DEDE-43CA-82D9-23985C241DAD",
+      "uid": "9D681FB7-DEDE-43CA-82D9-23985C241DAD",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "THE STUD",
+      "image": "https://bearracuda.com/wp-content/uploads/2025/11/insta-3.jpg",
+      "tea": "Photos & Decor by Dusti Cunningham",
+      "address": "1123 Folsom Street, San Francisco, CA 94103",
+      "website": "https://bearracuda.com/events/sf20/",
+      "instagram": "https://www.instagram.com/bearracuda",
+      "facebook": "https://www.facebook.com/events/753717904452981",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=THE%20STUD%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103",
+      "ticketUrl": "https://www.eventbrite.com/e/bearracuda-sf-20-year-anniversary-tickets-1976399528192",
+      "shortName": "Bear-rac-uda",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://bearracuda.com/events/sf20/",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/bearracuda",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "facebook",
+          "url": "https://www.facebook.com/events/753717904452981",
+          "label": "📘 Facebook"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=THE%20STUD%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/bearracuda-sf-20-year-anniversary-tickets-1976399528192",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "bearracuda-sf-20-year-anniversary-4ae69009"
+    },
+    {
+      "name": "BEEFWITCH",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 37.7761825,
+        "lng": -122.4083567
+      },
+      "startDate": "2025-10-18T21:00:00",
+      "endDate": "2025-10-19T02:00:00",
+      "unprocessedDescription": "description: The Occult Underwear Party returns to SF for Bearr\rison Weekend!  Featuring a LIVE floor show and witchy girl pop by DJ NaughtyBoyy.\nbar: The Stud\naddress: 1123 Folsom Street, San Francisco, CA 94103\ntimezone: America/Los_Angeles\nticketUrl: https://www.eventbrite.com/e/beefwitch-tickets-1728182092159\ncover: $12.51 - $17.85 (as of 10/1)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1131139693%2F2198683436473%2F1%2Foriginal.20250922-081325?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=64b5e194843ee640607400ec97184904\ninstagram: https://www.instagram.com/coachafterdark\ngmaps: https://www.google.com/maps/search/?api=1&query=37.7761825%2C-122.4083567&query_place_id=ChIJBWia_yh-j4ARczXTRg2RGCs\nkey: beefwitch|2025-10-19|the stud|eventbrite\nshortName: Coach After Dark",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "3F9230E0-3F04-4F12-98C1-311ACA95E3D8",
+      "uid": "3F9230E0-3F04-4F12-98C1-311ACA95E3D8",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "The Stud",
+      "cover": "$12.51 - $17.85 (as of 10/1)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1131139693%2F2198683436473%2F1%2Foriginal.20250922-081325?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=64b5e194843ee640607400ec97184904",
+      "tea": "The Occult Underwear Party returns to SF for Bearrison Weekend!  Featuring a LIVE floor show and witchy girl pop by DJ NaughtyBoyy.",
+      "address": "1123 Folsom Street, San Francisco, CA 94103",
+      "website": null,
+      "instagram": "https://www.instagram.com/coachafterdark",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=37.7761825%2C-122.4083567&query_place_id=ChIJBWia_yh-j4ARczXTRg2RGCs",
+      "ticketUrl": "https://www.eventbrite.com/e/beefwitch-tickets-1728182092159",
+      "shortName": "Coach After Dark",
+      "links": [
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/coachafterdark",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=37.7761825%2C-122.4083567&query_place_id=ChIJBWia_yh-j4ARczXTRg2RGCs",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/beefwitch-tickets-1728182092159",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "beefwitch-06eb5e73"
+    }
+  ]
+}

--- a/data/calendars/sitges.json
+++ b/data/calendars/sitges.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "calendarTimezone": "Europe/Madrid",
+    "timezoneData": null
+  },
+  "events": []
+}

--- a/data/calendars/toronto.json
+++ b/data/calendars/toronto.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/New_York",
+    "timezoneData": null
+  },
+  "events": []
+}

--- a/data/calendars/vegas.json
+++ b/data/calendars/vegas.json
@@ -1,0 +1,179 @@
+{
+  "metadata": {
+    "calendarTimezone": "America/Los_Angeles",
+    "timezoneData": null
+  },
+  "events": [
+    {
+      "name": "MEGAWOOF",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 36.1214368,
+        "lng": -115.144945
+      },
+      "startDate": "2025-08-30T21:00:00",
+      "endDate": "2025-08-31T02:00:00",
+      "unprocessedDescription": "description: MEGAWOOF AMERICA - LAS VEGAS - LABOR DAY WEEKEND :\r BEARS AT WORK\nbar: Dust Las Vegas\naddress: 855 East Twain Avenue, Las Vegas, NV 89169\ntimezone: America/Los_Angeles\nurl: https://www.eventbrite.com/e/megawoof-america-las-vegas-labor-day-weekend-bears-at-work-tickets-1531257726079\nticketUrl: https://www.eventbrite.com/e/megawoof-america-las-vegas-labor-day-weekend-bears-at-work-tickets-1531257726079\ncover: $11.58 - $23.14 (as of 8/30)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1081598603%2F185013722403%2F1%2Foriginal.20250725-224704?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=73fd269e7d0c3aa5168b99f977aba5d7\nshortName: MEGA-WOOF\ninstagram: https://www.instagram.com/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=36.1214368%2C-115.144945&query_place_id=ChIJxfTt6N_FyIARvHYdOaAV7t8\nkey: megawoof|2025-08-31|dust las vegas|eventbrite",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "A6BB3951-52D8-4124-B6CD-3E5AC290BBBF",
+      "uid": "A6BB3951-52D8-4124-B6CD-3E5AC290BBBF",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Dust Las Vegas",
+      "cover": "$11.58 - $23.14 (as of 8/30)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1081598603%2F185013722403%2F1%2Foriginal.20250725-224704?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=73fd269e7d0c3aa5168b99f977aba5d7",
+      "tea": "MEGAWOOF AMERICA - LAS VEGAS - LABOR DAY WEEKEND : BEARS AT WORK",
+      "address": "855 East Twain Avenue, Las Vegas, NV 89169",
+      "website": "https://www.eventbrite.com/e/megawoof-america-las-vegas-labor-day-weekend-bears-at-work-tickets-1531257726079",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=36.1214368%2C-115.144945&query_place_id=ChIJxfTt6N_FyIARvHYdOaAV7t8",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-las-vegas-labor-day-weekend-bears-at-work-tickets-1531257726079",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://www.eventbrite.com/e/megawoof-america-las-vegas-labor-day-weekend-bears-at-work-tickets-1531257726079",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=36.1214368%2C-115.144945&query_place_id=ChIJxfTt6N_FyIARvHYdOaAV7t8",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-america-las-vegas-labor-day-weekend-bears-at-work-tickets-1531257726079",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-00b39ef8"
+    },
+    {
+      "name": "MEGAWOOF",
+      "day": "Saturday",
+      "time": "9PM-3AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 36.1214368,
+        "lng": -115.144945
+      },
+      "startDate": "2025-11-01T21:00:00",
+      "endDate": "2025-11-02T03:00:00",
+      "unprocessedDescription": "description: MEGAWOOF - 10 YEAR US ANNIVERSARY - INTERNATIONAL \rHALLOWOOF  LAS VEGAS. FULL DETAILS COMING SOON\nbar: Dust Las Vegas\naddress: 855 East Twain Avenue, Las Vegas, NV 89169\ntimezone: America/Los_Angeles\nurl: https://linktr.ee/megawoof_america\nticketUrl: https://www.eventbrite.com/e/megawoof-10-year-us-anniversary-international-hallowoof-las-vegas-tickets-1636556246789\ncover: $14.73 - $32.63 (as of 10/1)\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1119746233%2F185013722403%2F1%2Foriginal.20250910-090426?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.00562374813779&fp-y=0.00392996108949&s=b5b7632d3b98e604c53a0466d40046ce\nshortName: MEGA-WOOF\ninstagram: https://www.instagram.com/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=36.1214368%2C-115.144945&query_place_id=ChIJxfTt6N_FyIARvHYdOaAV7t8\nkey: megawoof|2025-11-02|dust las vegas|eventbrite",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "CD1401F3-1C01-4716-8C0D-4BCDC8CB458C",
+      "uid": "CD1401F3-1C01-4716-8C0D-4BCDC8CB458C",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 0,
+      "overrideIdentityType": null,
+      "bar": "Dust Las Vegas",
+      "cover": "$14.73 - $32.63 (as of 10/1)",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1119746233%2F185013722403%2F1%2Foriginal.20250910-090426?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.00562374813779&fp-y=0.00392996108949&s=b5b7632d3b98e604c53a0466d40046ce",
+      "tea": "MEGAWOOF - 10 YEAR US ANNIVERSARY - INTERNATIONAL HALLOWOOF  LAS VEGAS. FULL DETAILS COMING SOON",
+      "address": "855 East Twain Avenue, Las Vegas, NV 89169",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=36.1214368%2C-115.144945&query_place_id=ChIJxfTt6N_FyIARvHYdOaAV7t8",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-10-year-us-anniversary-international-hallowoof-las-vegas-tickets-1636556246789",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=36.1214368%2C-115.144945&query_place_id=ChIJxfTt6N_FyIARvHYdOaAV7t8",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-10-year-us-anniversary-international-hallowoof-las-vegas-tickets-1636556246789",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-0bc51ff7"
+    },
+    {
+      "name": "MEGAWOOF - LAS VEGAS - MEMORIAL DAY WEEKEND -",
+      "day": "Saturday",
+      "time": "9PM-2AM",
+      "eventType": "routine",
+      "recurring": false,
+      "coordinates": {
+        "lat": 36.1214368,
+        "lng": -115.144945
+      },
+      "startDate": "2026-05-23T21:00:00",
+      "endDate": "2026-05-24T02:00:00",
+      "unprocessedDescription": "description: MEGAWOOF - LAS VEGAS - MEMORIAL DAY WEEKEND -\nbar\r: Dust Las Vegas\naddress: 855 East Twain Avenue, #UNIT 114, Las Vegas, NV 89169\nticketUrl: https://www.eventbrite.com/e/megawoof-las-vegas-memorial-day-weekend--tickets-1987462465736\ninstagram: https://www.instagram.com/megawoof_america\nimage: https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1182286369%2F185013722403%2F1%2Foriginal.20260416-004205?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=6d1d711a41d7f0c27ae9f39b1b91241d\ncover: $11.58-$22.10\nshortName: MEGA-WOOF\n_aiPrompts\\: [object Object],[object Object],[object Object]\n_aiValidation\\: [object Object]\nwebsite: https://linktr.ee/megawoof_america\ngmaps: https://www.google.com/maps/search/?api=1&query=Dust%20Las%20Vegas%2C%20855%20East%20Twain%20Avenue%2C%20%23UNIT%20114%2C%20Las%20Vegas%2C%20NV%2089169\nkey: megawoof-las-vegas-memorial-day-weekend|2026-05-24|dust las vegas",
+      "startTimezone": null,
+      "endTimezone": null,
+      "calendarTimezone": "America/Los_Angeles",
+      "wasUTC": true,
+      "sourceUid": "88E347BD-4E10-44E2-966A-19CAACE20C42",
+      "uid": "88E347BD-4E10-44E2-966A-19CAACE20C42",
+      "recurrenceId": null,
+      "recurrenceIdTimezone": null,
+      "sequence": 1,
+      "overrideIdentityType": null,
+      "bar": "Dust Las Vegas",
+      "cover": "$11.58-$22.10",
+      "image": "https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1182286369%2F185013722403%2F1%2Foriginal.20260416-004205?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.5&fp-y=0.5&s=6d1d711a41d7f0c27ae9f39b1b91241d",
+      "tea": "MEGAWOOF - LAS VEGAS - MEMORIAL DAY WEEKEND -",
+      "address": "855 East Twain Avenue, #UNIT 114, Las Vegas, NV 89169",
+      "website": "https://linktr.ee/megawoof_america",
+      "instagram": "https://www.instagram.com/megawoof_america",
+      "gmaps": "https://www.google.com/maps/search/?api=1&query=Dust%20Las%20Vegas%2C%20855%20East%20Twain%20Avenue%2C%20%23UNIT%20114%2C%20Las%20Vegas%2C%20NV%2089169",
+      "ticketUrl": "https://www.eventbrite.com/e/megawoof-las-vegas-memorial-day-weekend--tickets-1987462465736",
+      "shortName": "MEGA-WOOF",
+      "links": [
+        {
+          "type": "website",
+          "url": "https://linktr.ee/megawoof_america",
+          "label": "🌐 Website"
+        },
+        {
+          "type": "instagram",
+          "url": "https://www.instagram.com/megawoof_america",
+          "label": "📷 Instagram"
+        },
+        {
+          "type": "gmaps",
+          "url": "https://www.google.com/maps/search/?api=1&query=Dust%20Las%20Vegas%2C%20855%20East%20Twain%20Avenue%2C%20%23UNIT%20114%2C%20Las%20Vegas%2C%20NV%2089169",
+          "label": "🗺️ Google Maps"
+        },
+        {
+          "type": "tickets",
+          "url": "https://www.eventbrite.com/e/megawoof-las-vegas-memorial-day-weekend--tickets-1987462465736",
+          "label": "🎫 Tickets"
+        }
+      ],
+      "slug": "megawoof-las-vegas-memorial-day-weekend--741892f2"
+    }
+  ]
+}

--- a/img/favicons/favicon-bigfunco.myshopify.com-256px.ico.meta
+++ b/img/favicons/favicon-bigfunco.myshopify.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-bigfunco.myshopify.com-256px.ico",
   "size": "256",
-  "failureCount": 4
+  "failureCount": 5
 }

--- a/img/favicons/favicon-bigfunco.myshopify.com-64px.ico.meta
+++ b/img/favicons/favicon-bigfunco.myshopify.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-bigfunco.myshopify.com-64px.ico",
   "size": "64",
-  "failureCount": 4
+  "failureCount": 5
 }

--- a/img/favicons/favicon-noxsatvrn.carrd.co-256px.ico.meta
+++ b/img/favicons/favicon-noxsatvrn.carrd.co-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-noxsatvrn.carrd.co-256px.ico",
   "size": "256",
-  "failureCount": 4
+  "failureCount": 5
 }

--- a/img/favicons/favicon-noxsatvrn.carrd.co-64px.ico.meta
+++ b/img/favicons/favicon-noxsatvrn.carrd.co-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-noxsatvrn.carrd.co-64px.ico",
   "size": "64",
-  "failureCount": 4
+  "failureCount": 5
 }

--- a/img/favicons/favicon-seattleeagle.com-256px.ico.meta
+++ b/img/favicons/favicon-seattleeagle.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-seattleeagle.com-256px.ico",
   "size": "256",
-  "failureCount": 4
+  "failureCount": 5
 }

--- a/img/favicons/favicon-seattleeagle.com-64px.ico.meta
+++ b/img/favicons/favicon-seattleeagle.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-seattleeagle.com-64px.ico",
   "size": "64",
-  "failureCount": 4
+  "failureCount": 5
 }

--- a/img/favicons/favicon-theoldbaby.com-256px.ico.meta
+++ b/img/favicons/favicon-theoldbaby.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-theoldbaby.com-256px.ico",
   "size": "256",
-  "failureCount": 4
+  "failureCount": 5
 }

--- a/img/favicons/favicon-theoldbaby.com-64px.ico.meta
+++ b/img/favicons/favicon-theoldbaby.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-theoldbaby.com-64px.ico",
   "size": "64",
-  "failureCount": 4
+  "failureCount": 5
 }

--- a/img/favicons/favicon-yeahbuzzy.com-256px.ico.meta
+++ b/img/favicons/favicon-yeahbuzzy.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-yeahbuzzy.com-256px.ico",
   "size": "256",
-  "failureCount": 4
+  "failureCount": 5
 }

--- a/img/favicons/favicon-yeahbuzzy.com-64px.ico.meta
+++ b/img/favicons/favicon-yeahbuzzy.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-yeahbuzzy.com-64px.ico",
   "size": "64",
-  "failureCount": 4
+  "failureCount": 5
 }

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1400,8 +1400,8 @@ class DynamicCalendarLoader extends CalendarCore {
             return this.loadCalendarDataFallback(cityKey, cityConfig);
         }
         
-        // Helper function to process dates recursively
-        const isJsonCity = (cityKey === 'nyc' || cityKey === 'seattle');
+        // All cities use pre-processed JSON calendar data
+        const isJsonCity = true;
         const ext = isJsonCity ? 'json' : 'ics';
 
         // Normal flow: Try to load cached calendar data first

--- a/tools/process-calendars.js
+++ b/tools/process-calendars.js
@@ -46,8 +46,8 @@ try {
     process.exit(1);
 }
 
-// Target cities to test the new JSON logic with
-const TARGET_CITIES = ['nyc', 'seattle'];
+// JSON mode is enabled for all configured cities
+const TARGET_CITIES = Object.keys(CITY_CONFIG);
 
 async function processCalendars() {
     let successCount = 0;


### PR DESCRIPTION
## Summary
- `tools/process-calendars.js` now generates JSON for every visible city in `CITY_CONFIG` instead of only `nyc` and `seattle`
- `js/dynamic-calendar-loader.js` now fetches `.json` (instead of `.ics`) for all cities; existing proxy/direct fallbacks still apply if a JSON file is ever missing
- Added `tools/process-calendars.js` to the Update Calendar Data workflow's push trigger paths so it re-runs when the tool changes
- Committed the generated JSON for all 22 visible cities so there's no gap before the next scheduled workflow run (regenerating nyc/seattle produced zero diff, confirming determinism)

## Testing
- Ran `node tools/process-calendars.js` locally: 22 successful, 0 failed
- Spot-checked `la.json`: correct `America/Los_Angeles` timezone and local-time date strings without `Z`, matching the frontend `dateReviver` expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)