### PR TITLE
feat(scriptable): AI-arbitrated field merging with verbatim anti-hallucination gate

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -6483,6 +6483,31 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         // Both values are identical - no change needed
         flowIcon = "—";
         resultText = '<span style="color: #999;">SAME VALUE</span>';
+      } else if (strategy === "ai") {
+        // AI-arbitrated strategy — show which side the AI picked (or that it fell back)
+        const arbitration = event._original?.aiArbitration;
+        if (arbitration?.fallbacks?.includes(field)) {
+          flowIcon = "→";
+          resultText = '<span style="color: #ff9500;">AI FALLBACK (CLOBBERED)</span>';
+        } else if (arbitration?.arbitrated?.includes(field)) {
+          if (finalValue === existingValue && existingValue !== newValue) {
+            flowIcon = "←";
+            resultText = '<span style="color: #007aff;">🤝 AI CHOSE EXISTING</span>';
+          } else {
+            flowIcon = "→";
+            resultText = '<span style="color: #34c759;">🤝 AI CHOSE NEW</span>';
+          }
+        } else if (newValue !== undefined && finalValue === newValue) {
+          // No genuine conflict → clobber semantics applied
+          flowIcon = "→";
+          resultText = '<span style="color: #ff9500;">CLOBBERED</span>';
+        } else if (!newValue && !finalValue) {
+          flowIcon = "→";
+          resultText = '<span style="color: #ff9500;">CLEARED</span>';
+        } else {
+          flowIcon = "—";
+          resultText = '<span style="color: #999;">NO CHANGE</span>';
+        }
       } else if (strategy === "clobber") {
         // Clobber strategy - should always use new value (even if empty)
         // For clobber, we should trust that the merge logic worked correctly

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -291,7 +291,7 @@ class BearEventScraperOrchestrator {
                 
                 // Always prepare events for analysis (even in dry run mode) to show action types
                 // Perform cross-parser deduplication to merge events from different parsers
-                const deduplicatedEvents = await sharedCore.deduplicateEvents(results.allProcessedEvents, finalAdapter);
+                const deduplicatedEvents = await sharedCore.deduplicateEvents(results.allProcessedEvents, finalAdapter, config.config);
                 
                 const analyzedEvents = await sharedCore.prepareEventsForCalendar(deduplicatedEvents, finalAdapter, config.config);
                 console.log(`🐻 Orchestrator: Calendar analysis complete (${deduplicatedEvents.length} unique)`);

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -3842,32 +3842,11 @@ class AiWebParser {
         return prompts;
     }
 
+    // AI config resolution lives in SharedCore (resolveAiConfig) so the merge
+    // arbitration path can build the same config without reaching into the parser.
     getAiConfig(parserConfig = {}) {
-        const aiConfig = parserConfig && typeof parserConfig.ai === 'object' ? parserConfig.ai : {};
-        const provider = String(aiConfig.provider || 'openai');
-        const defaultEndpoint = provider === 'openai'
-            ? 'http://rybook.taila7523c.ts.net:8000/v1/chat/completions'
-            : 'http://desktop.taila7523c.ts.net:11434/api/generate';
-        const defaultModel = provider === 'openai'
-            ? 'lmstudio-community/Qwen3-Coder-Next-MLX-6bit'
-            : 'qwen3.5:4b';
-
-        return {
-            enabled: aiConfig.enabled !== false,
-            provider: provider,
-            endpoint: String(aiConfig.endpoint || defaultEndpoint),
-            model: String(aiConfig.model || defaultModel),
-            payloadMode: this.normalizePayloadMode(aiConfig.payloadMode),
-            maxHtmlChars: Number.isFinite(Number(aiConfig.maxHtmlChars)) ? Number(aiConfig.maxHtmlChars) : 6000,
-            numCtx: Number.isFinite(Number(aiConfig.numCtx)) ? Number(aiConfig.numCtx) : 8192,
-            numPredict: Number.isFinite(Number(aiConfig.numPredict)) ? Number(aiConfig.numPredict) : 2000,
-            temperature: Number.isFinite(Number(aiConfig.temperature)) ? Number(aiConfig.temperature) : 0,
-            think: Object.prototype.hasOwnProperty.call(aiConfig, 'think') ? Boolean(aiConfig.think) : false,
-            timeoutSeconds: Number.isFinite(Number(aiConfig.timeoutSeconds)) ? Number(aiConfig.timeoutSeconds) : 120,
-            keepAlive: Object.prototype.hasOwnProperty.call(aiConfig, 'keepAlive') ? String(aiConfig.keepAlive) : '5m',
-            ollama: aiConfig.ollama && typeof aiConfig.ollama === 'object' ? aiConfig.ollama : {},
-            openai: aiConfig.openai && typeof aiConfig.openai === 'object' ? aiConfig.openai : {}
-        };
+        const rawAi = parserConfig && typeof parserConfig.ai === 'object' ? parserConfig.ai : {};
+        return this.core.resolveAiConfig(rawAi);
     }
 
     getOcrConfig(parserConfig = {}, aiConfig = null) {
@@ -3941,9 +3920,7 @@ class AiWebParser {
     }
 
     normalizePayloadMode(mode) {
-        const normalized = String(mode || '').trim().toLowerCase();
-        if (normalized === 'exhaustive' || normalized === 'jsonld' || normalized === 'meta') return normalized;
-        return 'best';
+        return this.core.normalizePayloadMode(mode);
     }
 
     createPromptSection(label, parts) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -769,3 +769,14 @@ test('buildEventFromJsonLdNode resolves city and timezone from the address', () 
   const bare = parser.extractEventsFromJsonLd(SICKENING_JSONLD_HTML, 'https://sickening.events/e/x');
   assert.equal(bare[0].city, undefined);
 });
+
+test('getAiConfig delegates to SharedCore.resolveAiConfig', () => {
+  const parser = createParser();
+  const viaParser = parser.getAiConfig({ ai: { provider: 'ollama', numPredict: 1234 } });
+  const viaCore = parser.core.resolveAiConfig({ provider: 'ollama', numPredict: 1234 });
+  assert.deepEqual(viaParser, viaCore);
+  assert.equal(viaParser.numPredict, 1234);
+  assert.equal(viaParser.arbitrateMerges, true);
+  assert.equal(parser.normalizePayloadMode('jsonld'), 'jsonld');
+  assert.equal(parser.normalizePayloadMode('bogus'), 'best');
+});

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -47,6 +47,13 @@ const scraperConfig = {
       think: false,
       timeoutSeconds: 120,
       keepAlive: "5m",
+      // AI merge arbitration (default: true). When two records of the same event
+      // genuinely conflict on a field (both non-empty, different), the AI picks the
+      // better value — accepted only when its answer is a VERBATIM copy of one of
+      // the candidates; anything else falls back to the deterministic strategy
+      // (scraped clobbers). This global block also serves events from non-AI
+      // parsers; per-parser ai.arbitrateMerges overrides. Set false to disable.
+      arbitrateMerges: true,
     },
     ocr: {
       enabled: true,

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -329,6 +329,134 @@ class SharedCore {
         return outcome.rejected ? null : outcome;
     }
 
+    // ============================================================================
+    // AI MERGE ARBITRATION
+    // ============================================================================
+    // When two records of the same event both have a value for a field and the
+    // values differ, the AI picks the better one. The pick is only trusted when
+    // the returned value is a VERBATIM copy of one of the candidates — anything
+    // else falls back to the deterministic strategy, so a hallucinating (or dead)
+    // model can never make a merge worse than today.
+
+    isArbitrationEligibleField(fieldName) {
+        const name = String(fieldName || '');
+        if (!name || name.startsWith('_')) return false;
+        return name !== 'key' && name !== 'notes' && name !== 'source';
+    }
+
+    isEmptyArbitrationValue(value) {
+        return value === null || value === undefined || String(value).trim() === '';
+    }
+
+    serializeArbitrationValue(fieldName, value) {
+        if (value instanceof Date) return value.toISOString();
+        if ((fieldName === 'startDate' || fieldName === 'endDate') && value) {
+            const date = new Date(value);
+            if (!Number.isNaN(date.getTime())) return date.toISOString();
+        }
+        return String(value === null || value === undefined ? '' : value).trim();
+    }
+
+    // A genuine conflict: both sides non-empty primitives whose serialized forms
+    // differ. Same-instant Date vs ISO string is NOT a conflict.
+    isGenuineFieldConflict(fieldName, valueA, valueB) {
+        if (this.isEmptyArbitrationValue(valueA) || this.isEmptyArbitrationValue(valueB)) return false;
+        const isPrimitive = (v) => v instanceof Date || typeof v !== 'object';
+        if (!isPrimitive(valueA) || !isPrimitive(valueB)) return false;
+        return this.serializeArbitrationValue(fieldName, valueA) !== this.serializeArbitrationValue(fieldName, valueB);
+    }
+
+    arbitrationValuesEqual(fieldName, answerText, candidateText) {
+        if (answerText === candidateText) return true;
+        if (fieldName === 'startDate' || fieldName === 'endDate') {
+            const answerDate = new Date(answerText);
+            const candidateDate = new Date(candidateText);
+            return !Number.isNaN(answerDate.getTime()) && !Number.isNaN(candidateDate.getTime())
+                && answerDate.getTime() === candidateDate.getTime();
+        }
+        return false;
+    }
+
+    // One batched request per merged event. conflicts: [{ field, values: { <labelA>:
+    // raw, <labelB>: raw } }]. Returns { [field]: { pick, reason } } containing only
+    // fields whose answer survived the verbatim gate, or null when no usable response
+    // was obtained at all (caller falls back for everything).
+    async arbitrateMergeConflicts({ conflicts, labels, aiConfig, httpAdapter, eventContext = '' }) {
+        const list = Array.isArray(conflicts) ? conflicts.filter(Boolean) : [];
+        if (list.length === 0) return null;
+        if (!aiConfig || aiConfig.enabled === false || aiConfig.arbitrateMerges === false) return null;
+        if (!httpAdapter || typeof httpAdapter.postJson !== 'function') return null;
+        const [labelA, labelB] = labels;
+
+        const serializedByField = {};
+        const conflictLines = [];
+        for (const conflict of list) {
+            const serializedA = this.serializeArbitrationValue(conflict.field, conflict.values[labelA]);
+            const serializedB = this.serializeArbitrationValue(conflict.field, conflict.values[labelB]);
+            serializedByField[conflict.field] = { [labelA]: serializedA, [labelB]: serializedB };
+            conflictLines.push(`- field: ${conflict.field}\n  ${labelA}: ${JSON.stringify(serializedA)}\n  ${labelB}: ${JSON.stringify(serializedB)}`);
+        }
+
+        const prompt = [
+            'You are resolving merge conflicts between two records of the SAME event.',
+            eventContext ? `EVENT: ${eventContext}` : '',
+            `Record "${labelA}" and record "${labelB}" each provide a value for the fields below.`,
+            '',
+            'For each field, pick the value that is more correct, complete, and canonical',
+            '(official names, full addresses, complete URLs, correctly formatted values).',
+            '',
+            'CONFLICTS:',
+            ...conflictLines,
+            '',
+            'Rules:',
+            '- You MUST copy one of the two provided values EXACTLY. Never invent, edit, merge, or reformat a value.',
+            `- "pick" must be "${labelA}" or "${labelB}".`,
+            'Return JSON only:',
+            `{"choices": {"<field>": {"pick": "${labelA}" or "${labelB}", "value": "<exact copy of the chosen value>", "reason": "<one short sentence>"}}}`
+        ].filter(line => line !== '').join('\n');
+
+        const arbitrationConfig = { ...aiConfig, numPredict: Math.min(Number(aiConfig.numPredict) || 800, 800) };
+        const rawResponse = await this.callAiGenerate(arbitrationConfig, prompt, 'merge-arbitration', httpAdapter);
+        if (!rawResponse) return null;
+
+        let parsed = null;
+        try {
+            parsed = JSON.parse(this.extractFirstJsonObject(rawResponse) || rawResponse);
+        } catch (_) {
+            return null;
+        }
+        if (!parsed || typeof parsed !== 'object') return null;
+        const choices = parsed.choices && typeof parsed.choices === 'object' ? parsed.choices : parsed;
+
+        const results = {};
+        for (const conflict of list) {
+            const field = conflict.field;
+            const entry = choices[field];
+            const serialized = serializedByField[field];
+            if (!entry || typeof entry !== 'object') {
+                console.warn(`🤝 AI MERGE: no answer for field "${field}" — falling back`);
+                continue;
+            }
+            const answer = String(entry.value === null || entry.value === undefined ? '' : entry.value).trim();
+            const pick = String(entry.pick || '').trim();
+            const reason = typeof entry.reason === 'string' ? entry.reason : '';
+            const matchesA = this.arbitrationValuesEqual(field, answer, serialized[labelA]);
+            const matchesB = this.arbitrationValuesEqual(field, answer, serialized[labelB]);
+
+            if (labels.includes(pick) && this.arbitrationValuesEqual(field, answer, serialized[pick])) {
+                results[field] = { pick, reason };
+            } else if (matchesA !== matchesB) {
+                // Wrong/missing pick label but the value is provably one of the options
+                const recoveredPick = matchesA ? labelA : labelB;
+                console.warn(`🤝 AI MERGE: pick/value mismatch for "${field}" — trusting the verbatim value (${recoveredPick})`);
+                results[field] = { pick: recoveredPick, reason };
+            } else {
+                console.warn(`🤝 AI MERGE: rejected answer for "${field}" — not a verbatim copy of either option ("${answer.slice(0, 80)}") — falling back`);
+            }
+        }
+        return results;
+    }
+
     // Schema.org Event and its subtypes (MusicEvent, DanceEvent, Festival, ...).
     // EventSeries is excluded: a series node describes many dates, not one event.
     isJsonLdEventType(typeValue) {
@@ -634,7 +762,7 @@ class SharedCore {
         // Filter and process events
         const futureEvents = this.filterFutureEvents(allEvents, effectiveParserConfig.daysToLookAhead, effectiveParserConfig.allowPastEvents);
         const bearEvents = this.filterBearEvents(futureEvents, effectiveParserConfig);
-        const deduplicatedEvents = await this.deduplicateEvents(bearEvents, httpAdapter);
+        const deduplicatedEvents = await this.deduplicateEvents(bearEvents, httpAdapter, mainConfig?.config || mainConfig || null);
         
         // Calculate deduplication stats
         const duplicatesRemoved = bearEvents.length - deduplicatedEvents.length;
@@ -1301,7 +1429,7 @@ class SharedCore {
         return this.bearKeywords.some(keyword => searchText.includes(keyword));
     }
 
-    async deduplicateEvents(events, httpAdapter) {
+    async deduplicateEvents(events, httpAdapter, globalConfig = null) {
         const seen = new Map();
         const deduplicated = [];
         
@@ -1320,7 +1448,7 @@ class SharedCore {
             } else {
                 // Merge with existing event if needed
                 const existing = seen.get(key);
-                const merged = this.mergeParsedEvents(existing, event);
+                const merged = await this.mergeParsedEvents(existing, event, { httpAdapter, globalConfig });
                 merged.key = key; // Ensure merged event has the key
                 seen.set(key, merged);
                 
@@ -1420,48 +1548,64 @@ class SharedCore {
     }
 
     // Merge two parsed events based on field priorities (for deduplication)
-    mergeParsedEvents(existingEvent, newEvent) {
+    async mergeParsedEvents(existingEvent, newEvent, options = {}) {
         const fieldPriorities = newEvent._fieldPriorities || existingEvent._fieldPriorities || {};
-        
+
         // Start with newEvent as base to preserve metadata
         const mergedEvent = { ...newEvent };
-        
+
         // Helper function to check if a value is empty/null/undefined
         const isEmpty = (value) => {
-            return value === null || value === undefined || value === '' || 
+            return value === null || value === undefined || value === '' ||
                    (typeof value === 'string' && value.trim() === '');
         };
-        
+
         // Get all field names from both events
         const allFields = new Set([
             ...Object.keys(existingEvent),
             ...Object.keys(newEvent)
         ]);
-        
+
         // Track merge decisions for important fields
         const mergeDecisions = [];
-        
+        // Conflicts where the priority arrays are non-decisive — deferred to AI.
+        // Each carries the deterministic fallback so a failed arbitration reproduces
+        // today's behavior exactly.
+        const pendingAiConflicts = [];
+
         // Apply field priorities for each field
         allFields.forEach(fieldName => {
             if (fieldName.startsWith('_')) return; // Skip metadata fields
-            
+
             const priorityConfig = fieldPriorities[fieldName];
             const existingValue = existingEvent[fieldName];
             const newValue = newEvent[fieldName];
             const existingSource = existingEvent.source;
             const newSource = newEvent.source;
-            
+            const canArbitrate = this.isArbitrationEligibleField(fieldName)
+                && this.isGenuineFieldConflict(fieldName, existingValue, newValue);
+
             if (!priorityConfig || !priorityConfig.priority) {
-                return; // No priority config, keep newEvent value
+                // No priority config: keep newEvent value — unless it's a genuine
+                // conflict, in which case the AI gets to pick.
+                if (canArbitrate) {
+                    pendingAiConflicts.push({
+                        field: fieldName,
+                        values: { existing: existingValue, incoming: newValue },
+                        fallbackPick: 'incoming',
+                        fallbackReason: 'no priority config - keeping incoming'
+                    });
+                }
+                return;
             }
-            
+
             // Find which source has higher priority
             const existingIndex = priorityConfig.priority.indexOf(existingSource);
             const newIndex = priorityConfig.priority.indexOf(newSource);
-            
+
             let chosenValue = newValue; // Default
             let reason = 'default';
-            
+
             // If both sources are in the priority list, use the one with lower index (higher priority)
             if (existingIndex !== -1 && newIndex !== -1) {
                 if (existingIndex < newIndex) {
@@ -1485,7 +1629,17 @@ class SharedCore {
                         reason = `${newSource} has higher priority (index ${newIndex} vs ${existingIndex})`;
                     }
                 } else {
-                    // Same priority - preserve existing value to avoid overriding previous merges
+                    // Same priority — the priority array cannot decide. Defer genuine
+                    // conflicts to AI; otherwise preserve existing (today's behavior).
+                    if (canArbitrate) {
+                        pendingAiConflicts.push({
+                            field: fieldName,
+                            values: { existing: existingValue, incoming: newValue },
+                            fallbackPick: 'existing',
+                            fallbackReason: `same priority (index ${existingIndex} vs ${newIndex}) - preserving existing`
+                        });
+                        return;
+                    }
                     chosenValue = existingValue;
                     reason = `same priority (index ${existingIndex} vs ${newIndex}) - preserving existing`;
                 }
@@ -1497,10 +1651,19 @@ class SharedCore {
                 // Only new source is in priority list
                 chosenValue = newValue;
                 reason = `only ${newSource} in priority list`;
+            } else if (canArbitrate) {
+                // Neither source in the priority list — non-decisive, defer to AI
+                pendingAiConflicts.push({
+                    field: fieldName,
+                    values: { existing: existingValue, incoming: newValue },
+                    fallbackPick: 'incoming',
+                    fallbackReason: 'neither source in priority list - keeping incoming'
+                });
+                return;
             }
-            
+
             mergedEvent[fieldName] = chosenValue;
-            
+
             // Log decisions when values differ
             if (existingValue !== newValue) {
                 mergeDecisions.push({
@@ -1512,7 +1675,41 @@ class SharedCore {
                 });
             }
         });
-        
+
+        // AI arbitration for the non-decisive conflicts — one batched request
+        if (pendingAiConflicts.length > 0) {
+            const eventTitle = newEvent.title || existingEvent.title || 'event';
+            const aiConfig = this.getMergeArbitrationConfig(newEvent, options.globalConfig);
+            let arbitration = null;
+            try {
+                arbitration = await this.arbitrateMergeConflicts({
+                    conflicts: pendingAiConflicts,
+                    labels: ['existing', 'incoming'],
+                    aiConfig,
+                    httpAdapter: options.httpAdapter,
+                    eventContext: `"${eventTitle}" starting ${this.serializeArbitrationValue('startDate', newEvent.startDate || existingEvent.startDate) || 'unknown'} (record "existing" from ${existingEvent.source || 'unknown'}, record "incoming" from ${newEvent.source || 'unknown'})`
+                });
+            } catch (error) {
+                console.warn(`🤝 AI MERGE: arbitration failed for "${eventTitle}": ${error.message}`);
+            }
+            for (const conflict of pendingAiConflicts) {
+                const decision = arbitration ? arbitration[conflict.field] : null;
+                const pick = decision ? decision.pick : conflict.fallbackPick;
+                const chosenValue = conflict.values[pick];
+                mergedEvent[conflict.field] = chosenValue;
+                if (decision) {
+                    console.log(`🤝 AI MERGE: "${eventTitle}" field=${conflict.field} chose ${pick}${decision.reason ? ` — ${decision.reason}` : ''}`);
+                }
+                mergeDecisions.push({
+                    field: conflict.field,
+                    existingValue: conflict.values.existing,
+                    newValue: conflict.values.incoming,
+                    chosenValue: chosenValue,
+                    reason: decision ? `ai: ${decision.reason || `chose ${pick}`}` : conflict.fallbackReason
+                });
+            }
+        }
+
         if (mergeDecisions.length > 0) {
             const changedFields = Array.from(new Set(mergeDecisions.map(decision => decision.field)));
             const previewFields = changedFields.slice(0, 6);
@@ -1680,10 +1877,10 @@ class SharedCore {
 
     // Create complete merged event object that represents exactly what will be saved
     // Following the 6-step process: 1) scraper object, 2) calendar object, 3) simple merge, 4) gmaps, 5) notes, 6) display
-    createFinalEventObject(existingEvent, newEvent) {
+    async createFinalEventObject(existingEvent, newEvent, options = {}) {
         // STEP 1: Build scraper object using priority list (already done - newEvent)
         const scraperObject = { ...newEvent };
-        
+
         // STEP 2: Build calendar object using calendar data
         const calendarObject = {
             // Parse existing notes first so native fields below take precedence
@@ -1696,31 +1893,49 @@ class SharedCore {
             notes: existingEvent.notes,
             url: existingEvent.url,
         };
-        
+
         // STEP 3: Simple merge - respect merge logic, grab from correct object
         const fieldPriorities = newEvent._fieldPriorities || {};
         const mergedObject = {};
-        
+
         // Get all possible field names from both objects
         const allFields = new Set([
             ...Object.keys(scraperObject),
             ...Object.keys(calendarObject)
         ]);
-        
+
         // Track clobbered fields for summary logging
         const clobberedFields = [];
-        
+        // Genuine conflicts deferred to AI arbitration (strategy "ai")
+        const pendingAiConflicts = [];
+
         // Apply merge logic for each field
-        allFields.forEach(fieldName => {
+        for (const fieldName of allFields) {
             // Skip internal fields
-            if (fieldName.startsWith('_') || fieldName === 'notes') return;
-            
+            if (fieldName.startsWith('_') || fieldName === 'notes') continue;
+
             const priorityConfig = fieldPriorities[fieldName];
             const mergeStrategy = priorityConfig?.merge || 'upsert';
             const scraperValue = scraperObject[fieldName];
             const calendarValue = calendarObject[fieldName];
-            
+
             switch (mergeStrategy) {
+                case 'ai':
+                    if (this.isArbitrationEligibleField(fieldName)
+                        && this.isGenuineFieldConflict(fieldName, calendarValue, scraperValue)) {
+                        pendingAiConflicts.push({
+                            field: fieldName,
+                            values: { calendar: calendarValue, scraped: scraperValue }
+                        });
+                        break;
+                    }
+                    // No genuine conflict → clobber semantics (today's default),
+                    // including clear-on-empty-scrape
+                    mergedObject[fieldName] = scraperValue;
+                    if (scraperValue !== calendarValue) {
+                        clobberedFields.push(fieldName);
+                    }
+                    break;
                 case 'clobber':
                     mergedObject[fieldName] = scraperValue;
                     // Track when clobber actually changes a value
@@ -1736,8 +1951,67 @@ class SharedCore {
                     mergedObject[fieldName] = calendarValue;
                     break;
             }
-        });
-        
+        }
+
+        // STEP 3b: AI arbitration for genuine conflicts — one batched request.
+        // Any field the AI can't decide (or a dead/hallucinating model) falls back
+        // to clobber, i.e. exactly the pre-arbitration behavior.
+        const aiDecisionRecords = [];
+        if (pendingAiConflicts.length > 0) {
+            const eventTitle = scraperObject.title || calendarObject.title || 'event';
+            const aiConfig = this.getMergeArbitrationConfig(newEvent, options.globalConfig);
+            const eventContext = `"${eventTitle}" starting ${this.serializeArbitrationValue('startDate', scraperObject.startDate || calendarObject.startDate) || 'unknown'}`;
+            let arbitration = null;
+            try {
+                arbitration = await this.arbitrateMergeConflicts({
+                    conflicts: pendingAiConflicts,
+                    labels: ['calendar', 'scraped'],
+                    aiConfig,
+                    httpAdapter: options.httpAdapter,
+                    eventContext
+                });
+            } catch (error) {
+                console.warn(`🤝 AI MERGE: arbitration failed for "${eventTitle}": ${error.message}`);
+            }
+            if (!arbitration) {
+                console.warn(`🤝 AI MERGE: no arbitration result for "${eventTitle}" — falling back to scraped values for ${pendingAiConflicts.length} conflicted field(s)`);
+            }
+            const preview = (value) => {
+                const text = this.serializeArbitrationValue('', value);
+                return text.length > 60 ? `${text.slice(0, 57)}...` : text;
+            };
+            for (const conflict of pendingAiConflicts) {
+                const decision = arbitration ? arbitration[conflict.field] : null;
+                if (decision) {
+                    const otherPick = decision.pick === 'calendar' ? 'scraped' : 'calendar';
+                    mergedObject[conflict.field] = conflict.values[decision.pick];
+                    if (decision.pick === 'scraped' && conflict.values.scraped !== conflict.values.calendar) {
+                        clobberedFields.push(conflict.field);
+                    }
+                    console.log(`🤝 AI MERGE: "${eventTitle}" field=${conflict.field} chose ${decision.pick} ("${preview(conflict.values[decision.pick])}") over ${otherPick} ("${preview(conflict.values[otherPick])}")${decision.reason ? ` — ${decision.reason}` : ''}`);
+                    aiDecisionRecords.push({
+                        field: conflict.field,
+                        existingValue: conflict.values.calendar,
+                        newValue: conflict.values.scraped,
+                        chosenValue: conflict.values[decision.pick],
+                        reason: decision.reason || `ai chose ${decision.pick}`,
+                        source: 'ai'
+                    });
+                } else {
+                    mergedObject[conflict.field] = conflict.values.scraped;
+                    clobberedFields.push(conflict.field);
+                    aiDecisionRecords.push({
+                        field: conflict.field,
+                        existingValue: conflict.values.calendar,
+                        newValue: conflict.values.scraped,
+                        chosenValue: conflict.values.scraped,
+                        reason: 'ai unavailable/rejected — clobber fallback',
+                        source: 'fallback'
+                    });
+                }
+            }
+        }
+
         // Log summary of clobbered fields
         if (clobberedFields.length > 0) {
             const previewFields = clobberedFields.slice(0, 6);
@@ -1789,6 +2063,15 @@ class SharedCore {
             calendar: calendarObject,  // What was in the calendar
             merged: mergedObject       // What the merge logic produced
         };
+
+        // Expose AI arbitration outcomes for display/metrics
+        if (aiDecisionRecords.length > 0) {
+            finalEvent._mergeDecisions = aiDecisionRecords;
+            finalEvent._original.aiArbitration = {
+                arbitrated: aiDecisionRecords.filter(record => record.source === 'ai').map(record => record.field),
+                fallbacks: aiDecisionRecords.filter(record => record.source === 'fallback').map(record => record.field)
+            };
+        }
         
         // Simple change detection for display
         const changes = [];
@@ -2698,22 +2981,25 @@ class SharedCore {
             });
         }
 
+        // "ai" = AI-arbitrated on genuine conflicts, clobber semantics otherwise.
+        // Explicit fieldPriorities entries in the parser config override these —
+        // hardcoded config is the override, automation is the default.
         const defaultPriorities = {
-            title: { priority: ["ai-web"], merge: "clobber" },
-            instagram: { priority: ["ai-web"], merge: "clobber" },
-            facebook: { priority: ["ai-web"], merge: "clobber" },
-            website: { priority: ["ai-web"], merge: "clobber" },
-            description: { priority: ["ai-web"], merge: "clobber" },
-            bar: { priority: ["ai-web"], merge: "clobber" },
-            address: { priority: ["ai-web"], merge: "clobber" },
-            startDate: { priority: ["ai-web"], merge: "clobber" },
-            endDate: { priority: ["ai-web"], merge: "clobber" },
-            url: { priority: ["ai-web"], merge: "clobber" },
-            location: { priority: ["ai-web"], merge: "clobber" },
-            gmaps: { priority: ["ai-web"], merge: "clobber" },
-            image: { priority: ["ai-web"], merge: "clobber" },
-            cover: { priority: ["ai-web"], merge: "clobber" },
-            ticketUrl: { priority: ["ai-web"], merge: "clobber" }
+            title: { priority: ["ai-web"], merge: "ai" },
+            instagram: { priority: ["ai-web"], merge: "ai" },
+            facebook: { priority: ["ai-web"], merge: "ai" },
+            website: { priority: ["ai-web"], merge: "ai" },
+            description: { priority: ["ai-web"], merge: "ai" },
+            bar: { priority: ["ai-web"], merge: "ai" },
+            address: { priority: ["ai-web"], merge: "ai" },
+            startDate: { priority: ["ai-web"], merge: "ai" },
+            endDate: { priority: ["ai-web"], merge: "ai" },
+            url: { priority: ["ai-web"], merge: "ai" },
+            location: { priority: ["ai-web"], merge: "ai" },
+            gmaps: { priority: ["ai-web"], merge: "ai" },
+            image: { priority: ["ai-web"], merge: "ai" },
+            cover: { priority: ["ai-web"], merge: "ai" },
+            ticketUrl: { priority: ["ai-web"], merge: "ai" }
         };
         return { ...defaultPriorities, ...inferredPriorities, ...explicitPriorities };
     }
@@ -2840,7 +3126,7 @@ class SharedCore {
             // Handle merge action by creating complete final event object
             if (analysis.action === 'merge' && analysis.existingEvent) {
                 // Create final merged event that represents exactly what will be saved
-                analyzedEvent = this.createFinalEventObject(analysis.existingEvent, event);
+                analyzedEvent = await this.createFinalEventObject(analysis.existingEvent, event, { httpAdapter: calendarAdapter, globalConfig: config });
                 
                 // Calculate merge diff for display purposes
                 const originalFields = this.parseNotesIntoFields(analysis.existingEvent.notes || '');
@@ -2902,7 +3188,7 @@ class SharedCore {
                 const sourceMergeEvent = analysis.overrideIdentity
                     ? { ...event, ...analysis.overrideIdentity }
                     : event;
-                analyzedEvent = this.createFinalEventObject(analysis.sourceEvent, sourceMergeEvent);
+                analyzedEvent = await this.createFinalEventObject(analysis.sourceEvent, sourceMergeEvent, { httpAdapter: calendarAdapter, globalConfig: config });
                 delete analyzedEvent._existingEvent;
                 analyzedEvent._action = 'new';
 
@@ -3912,6 +4198,53 @@ class SharedCore {
     // ============================================================================
     // AI ORCHESTRATION HELPERS
     // ============================================================================
+
+    normalizePayloadMode(mode) {
+        const normalized = String(mode || '').trim().toLowerCase();
+        if (normalized === 'exhaustive' || normalized === 'jsonld' || normalized === 'meta') return normalized;
+        return 'best';
+    }
+
+    // Canonical AI config resolution (single source of truth — AiWebParser.getAiConfig
+    // delegates here). Takes the raw `ai` block from a parser or global config and
+    // returns the normalized shape callAiGenerate expects.
+    resolveAiConfig(rawAiConfig = {}) {
+        const aiConfig = rawAiConfig && typeof rawAiConfig === 'object' ? rawAiConfig : {};
+        const provider = String(aiConfig.provider || 'openai');
+        const defaultEndpoint = provider === 'openai'
+            ? 'http://rybook.taila7523c.ts.net:8000/v1/chat/completions'
+            : 'http://desktop.taila7523c.ts.net:11434/api/generate';
+        const defaultModel = provider === 'openai'
+            ? 'lmstudio-community/Qwen3-Coder-Next-MLX-6bit'
+            : 'qwen3.5:4b';
+
+        return {
+            enabled: aiConfig.enabled !== false,
+            provider: provider,
+            endpoint: String(aiConfig.endpoint || defaultEndpoint),
+            model: String(aiConfig.model || defaultModel),
+            payloadMode: this.normalizePayloadMode(aiConfig.payloadMode),
+            maxHtmlChars: Number.isFinite(Number(aiConfig.maxHtmlChars)) ? Number(aiConfig.maxHtmlChars) : 6000,
+            numCtx: Number.isFinite(Number(aiConfig.numCtx)) ? Number(aiConfig.numCtx) : 8192,
+            numPredict: Number.isFinite(Number(aiConfig.numPredict)) ? Number(aiConfig.numPredict) : 2000,
+            temperature: Number.isFinite(Number(aiConfig.temperature)) ? Number(aiConfig.temperature) : 0,
+            think: Object.prototype.hasOwnProperty.call(aiConfig, 'think') ? Boolean(aiConfig.think) : false,
+            timeoutSeconds: Number.isFinite(Number(aiConfig.timeoutSeconds)) ? Number(aiConfig.timeoutSeconds) : 120,
+            keepAlive: Object.prototype.hasOwnProperty.call(aiConfig, 'keepAlive') ? String(aiConfig.keepAlive) : '5m',
+            arbitrateMerges: aiConfig.arbitrateMerges !== false,
+            ollama: aiConfig.ollama && typeof aiConfig.ollama === 'object' ? aiConfig.ollama : {},
+            openai: aiConfig.openai && typeof aiConfig.openai === 'object' ? aiConfig.openai : {}
+        };
+    }
+
+    // AI config for merge arbitration: the event's own parser config wins, the global
+    // config.ai block covers events from non-AI parsers (bearracuda etc.).
+    getMergeArbitrationConfig(event, globalConfig = null) {
+        const rawAi = (event && event._parserConfig && event._parserConfig.ai && typeof event._parserConfig.ai === 'object' && event._parserConfig.ai)
+            || (globalConfig && globalConfig.ai && typeof globalConfig.ai === 'object' && globalConfig.ai)
+            || {};
+        return this.resolveAiConfig(rawAi);
+    }
 
     // Detect the image mime type from base64 magic bytes so OpenAI-compatible servers
     // that trust the data-URL label (instead of sniffing bytes) decode correctly.

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -443,3 +443,234 @@ test('classifyPageWithAi persists outcomes through an injected cache provider', 
 
   fs.rmSync(cacheDir, { recursive: true, force: true });
 });
+
+// ---------------------------------------------------------------------------
+// AI merge arbitration
+// ---------------------------------------------------------------------------
+
+function buildArbitrationPair() {
+  const core = createCore();
+  const scraped = {
+    title: 'FURBALL DALLAS',
+    description: 'FURBALL PRESENTS',
+    bar: 'S4',
+    address: '3911 Cedar Springs Rd, Dallas, TX 75219',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    ticketUrl: 'https://tickets.example/furball',
+    city: 'dallas',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: { ai: { provider: 'ollama', endpoint: 'http://ai.example/api/generate', model: 'test-model' } }
+  };
+  const existing = {
+    title: 'FURBALL',
+    startDate: new Date('2026-07-05T21:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    location: 'STATION 4, Dallas',
+    url: '',
+    notes: [
+      'bar: STATION 4',
+      'address: 3911 Cedar Springs Rd, Dallas, TX 75219',
+      'ticketUrl: https://tickets.example/furball'
+    ].join('\n')
+  };
+  // Genuine conflicts: title, bar, startDate. Equal fields (address, ticketUrl,
+  // endDate) and one-sided fields must never reach the AI.
+  return { scraped, existing };
+}
+
+function buildArbitrationAdapter(choices, options = {}) {
+  const calls = [];
+  return {
+    calls,
+    postJson: async (endpoint, payload) => {
+      calls.push(payload);
+      if (options.fail) throw new Error('AI endpoint down');
+      return {
+        ok: true,
+        status: 200,
+        text: JSON.stringify({ response: JSON.stringify({ choices }) })
+      };
+    }
+  };
+}
+
+test('field priority defaults are ai-arbitrated; explicit config and metadata stay deterministic', () => {
+  const core = createCore();
+  const resolved = core.getResolvedFieldPriorities({
+    fieldPriorities: { bar: { priority: ['static'], merge: 'preserve' } },
+    metadata: { shortName: { value: 'FUR-BALL' } }
+  });
+  assert.equal(resolved.title.merge, 'ai');
+  assert.equal(resolved.startDate.merge, 'ai');
+  assert.equal(resolved.ticketUrl.merge, 'ai');
+  assert.equal(resolved.bar.merge, 'preserve', 'explicit fieldPriorities override the ai default');
+  assert.equal(resolved.shortName.merge, 'clobber', 'metadata-inferred fields stay clobber');
+});
+
+test('createFinalEventObject applies verbatim-validated AI picks in ONE batched request', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildArbitrationPair();
+  const adapter = buildArbitrationAdapter({
+    title: { pick: 'scraped', value: 'FURBALL DALLAS', reason: 'more specific' },
+    bar: { pick: 'calendar', value: 'STATION 4', reason: 'official venue name' },
+    startDate: { pick: 'scraped', value: '2026-07-05T22:00:00.000Z', reason: 'flyer time' }
+  });
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1, 'all conflicts must batch into one AI request');
+  assert.match(adapter.calls[0].prompt, /2026-07-05T22:00:00\.000Z/, 'dates are serialized as ISO in the prompt');
+  assert.equal(finalEvent.title, 'FURBALL DALLAS');
+  assert.equal(finalEvent.bar, 'STATION 4', 'AI picked the calendar value');
+  assert.ok(finalEvent.startDate instanceof Date, 'winner keeps its original Date type');
+  assert.equal(finalEvent.startDate.toISOString(), '2026-07-05T22:00:00.000Z');
+  // Notes round-trip: the arbitrated bar survives formatEventNotes/parseNotesIntoFields
+  assert.equal(core.parseNotesIntoFields(finalEvent.notes).bar, 'STATION 4');
+  assert.deepEqual(finalEvent._original.aiArbitration.arbitrated.sort(), ['bar', 'startDate', 'title']);
+  assert.deepEqual(finalEvent._original.aiArbitration.fallbacks, []);
+});
+
+test('hallucinated or missing AI answers fall back to the scraped value (clobber)', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildArbitrationPair();
+  // bar: value matches NEITHER candidate → reject; title/startDate absent → fallback
+  const adapter = buildArbitrationAdapter({
+    bar: { pick: 'calendar', value: 'STATION FOUR', reason: 'made up' }
+  });
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(finalEvent.bar, 'S4', 'hallucinated answer falls back to scraped');
+  assert.equal(finalEvent.title, 'FURBALL DALLAS');
+  assert.equal(finalEvent.startDate.toISOString(), '2026-07-05T22:00:00.000Z');
+  assert.deepEqual(finalEvent._original.aiArbitration.arbitrated, []);
+  assert.deepEqual(finalEvent._original.aiArbitration.fallbacks.sort(), ['bar', 'startDate', 'title']);
+});
+
+test('a verbatim value with a wrong pick label is trusted via the value', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildArbitrationPair();
+  // pick says scraped but the value verbatim-equals the CALENDAR candidate
+  const adapter = buildArbitrationAdapter({
+    title: { pick: 'scraped', value: 'FURBALL DALLAS' },
+    bar: { pick: 'scraped', value: 'STATION 4' },
+    startDate: { pick: 'scraped', value: '2026-07-05T22:00:00.000Z' }
+  });
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(finalEvent.bar, 'STATION 4', 'the verbatim-matched candidate wins despite the mislabeled pick');
+});
+
+test('AI failure degrades to exactly the clobber behavior', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildArbitrationPair();
+  const adapter = buildArbitrationAdapter({}, { fail: true });
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(finalEvent.title, 'FURBALL DALLAS');
+  assert.equal(finalEvent.bar, 'S4');
+  assert.equal(finalEvent.startDate.toISOString(), '2026-07-05T22:00:00.000Z');
+  assert.equal(finalEvent._original.aiArbitration.fallbacks.length, 3);
+});
+
+test('no adapter or arbitrateMerges:false means zero AI requests', async () => {
+  const core = createCore();
+
+  const noAdapter = buildArbitrationPair();
+  const finalNoAdapter = await core.createFinalEventObject(noAdapter.existing, noAdapter.scraped, {});
+  assert.equal(finalNoAdapter.bar, 'S4', 'falls back to scraped without an adapter');
+
+  const optedOut = buildArbitrationPair();
+  optedOut.scraped._parserConfig.ai.arbitrateMerges = false;
+  const adapter = buildArbitrationAdapter({
+    bar: { pick: 'calendar', value: 'STATION 4' }
+  });
+  const finalOptedOut = await core.createFinalEventObject(optedOut.existing, optedOut.scraped, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 0, 'opt-out must not send AI requests');
+  assert.equal(finalOptedOut.bar, 'S4');
+});
+
+test('non-conflicts never reach the AI and keep clobber semantics', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildArbitrationPair();
+  // Remove all genuine conflicts: align title/bar/startDate, add a scraped-only field
+  existing.title = scraped.title;
+  existing.startDate = new Date(scraped.startDate.getTime());
+  existing.notes = existing.notes.replace('bar: STATION 4', 'bar: S4');
+  scraped.cover = '$10';
+  const adapter = buildArbitrationAdapter({});
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'no conflicts → no AI request');
+  assert.equal(finalEvent.cover, '$10', 'one-sided fields are added via clobber semantics');
+});
+
+test('same-instant Date vs ISO string is not a conflict; differing instants are', () => {
+  const core = createCore();
+  assert.equal(
+    core.isGenuineFieldConflict('startDate', new Date('2026-07-05T21:00:00.000Z'), '2026-07-05T21:00:00.000Z'),
+    false
+  );
+  assert.equal(
+    core.isGenuineFieldConflict('startDate', new Date('2026-07-05T21:00:00.000Z'), new Date('2026-07-05T22:00:00.000Z')),
+    true
+  );
+  assert.equal(core.isGenuineFieldConflict('bar', 'S4', ''), false, 'empty side is never a conflict');
+  assert.equal(core.isGenuineFieldConflict('coordinates', { lat: 1 }, { lat: 2 }), false, 'non-primitives are ineligible');
+});
+
+test('mergeParsedEvents: decisive priority skips AI, non-decisive conflicts consult it', async () => {
+  const core = createCore();
+  const priorities = {
+    bar: { priority: ['static', 'ai-web'], merge: 'ai' },
+    title: { priority: ['ai-web'], merge: 'ai' }
+  };
+  const aiParserConfig = { ai: { provider: 'ollama', endpoint: 'http://ai.example', model: 'm' } };
+
+  // Different sources: the priority arrays decide everything — zero AI requests
+  const staticExisting = { title: 'FURBALL', bar: 'STATION 4', source: 'static', _fieldPriorities: priorities };
+  const aiIncoming = { title: 'FURBALL DALLAS', bar: 'S4', source: 'ai-web', _parserConfig: aiParserConfig, _fieldPriorities: priorities };
+  const decisiveAdapter = buildArbitrationAdapter({});
+  const decisiveMerge = await core.mergeParsedEvents(staticExisting, aiIncoming, { httpAdapter: decisiveAdapter });
+  assert.equal(decisiveAdapter.calls.length, 0, 'decisive priority fields must not be arbitrated');
+  assert.equal(decisiveMerge.bar, 'STATION 4', 'static outranks ai-web for bar');
+  assert.equal(decisiveMerge.title, 'FURBALL DALLAS', 'only-listed source wins for title');
+
+  // Same source (duplicate from the same parser): same priority index → AI decides
+  const existing = { title: 'FURBALL', bar: 'STATION 4', source: 'ai-web', _fieldPriorities: priorities };
+  const incoming = { title: 'FURBALL DALLAS', bar: 'S4', source: 'ai-web', _parserConfig: aiParserConfig, _fieldPriorities: priorities };
+  const adapter = buildArbitrationAdapter({
+    title: { pick: 'existing', value: 'FURBALL', reason: 'canonical name' },
+    bar: { pick: 'incoming', value: 'S4', reason: 'newer listing' }
+  });
+  const merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 1, 'all same-priority conflicts batch into one request');
+  assert.equal(merged.title, 'FURBALL', 'AI decided the same-priority conflict');
+  assert.equal(merged.bar, 'S4');
+
+  // AI failure on a same-priority conflict → preserves existing (today's behavior)
+  const failingAdapter = buildArbitrationAdapter({}, { fail: true });
+  const mergedFallback = await core.mergeParsedEvents(existing, incoming, { httpAdapter: failingAdapter });
+  assert.equal(mergedFallback.title, 'FURBALL', 'same-priority fallback preserves existing');
+  assert.equal(mergedFallback.bar, 'STATION 4', 'same-priority fallback preserves existing');
+});
+
+test('resolveAiConfig defaults and the arbitrateMerges flag', () => {
+  const core = createCore();
+  const defaults = core.resolveAiConfig({});
+  assert.equal(defaults.enabled, true);
+  assert.equal(defaults.arbitrateMerges, true);
+  assert.equal(defaults.provider, 'openai');
+  assert.equal(defaults.endpoint, 'http://rybook.taila7523c.ts.net:8000/v1/chat/completions');
+  assert.equal(core.resolveAiConfig({ arbitrateMerges: false }).arbitrateMerges, false);
+
+  // getMergeArbitrationConfig: parser ai wins, global ai is the fallback
+  const fromParser = core.getMergeArbitrationConfig({ _parserConfig: { ai: { model: 'parser-model' } } }, { ai: { model: 'global-model' } });
+  assert.equal(fromParser.model, 'parser-model');
+  const fromGlobal = core.getMergeArbitrationConfig({ source: 'bearracuda' }, { ai: { model: 'global-model' } });
+  assert.equal(fromGlobal.model, 'global-model');
+});


### PR DESCRIPTION
## What

When two records of the same event merge (scraped vs calendar, or cross-parser duplicates) and a field **genuinely conflicts** (both sides non-empty, different), the AI now picks the better value. Its answer is only trusted when it is a **verbatim copy of one of the two candidates** — anything else falls back to today's exact behavior (scraped clobbers), so arbitration can only improve merges, never corrupt them.

## How

**One batched request per merged event** (`SharedCore.arbitrateMergeConflicts`): all conflicted fields with both candidates, response schema `{"choices": {"<field>": {"pick", "value", "reason"}}}`.

**The anti-hallucination gate**, per field:
| AI answer | Outcome |
|---|---|
| valid pick + value verbatim-equals that candidate | ✅ accepted |
| wrong/missing pick but value verbatim-equals exactly one candidate | ✅ that candidate (warn) |
| value matches neither / field missing / request failed | ⚠️ fallback to scraped (clobber), loud warn |

Only the pick label is consumed — the **original untouched value** is assigned (Dates stay Dates; no AI-generated string ever enters an event). Dates are compared as instants, so equivalent ISO renderings pass and same-instant `Date` vs ISO string is never even a conflict.

**Defaults flip to automation**: the 15 hardcoded per-field defaults in `getResolvedFieldPriorities` change `clobber` → `ai`. Explicit `fieldPriorities` in parser configs and metadata-inferred fields keep their configured strategies — hardcoded config is the override, per the no-more-hardcoding direction.

**Both merge engines wired** (each becomes async; propagation verified — all callers already async):
- `createFinalEventObject` (calendar merge): labels `calendar`/`scraped`; non-conflicts keep exact clobber semantics incl. clear-on-empty-scrape.
- `mergeParsedEvents` (cross-parser dedup): arbitrates **only** where priority arrays are non-decisive (same index — e.g. two events from the same parser — unlisted sources, or no config). Decisive priority config always wins.

**Config**: `ai.arbitrateMerges` (default **true**), per-parser or in the global `config.ai` block — which now also serves events from non-AI parsers (bearracuda etc.). aiConfig resolution moved to `SharedCore.resolveAiConfig` as the single source of truth; `AiWebParser.getAiConfig` delegates.

**Visibility**: `🤝 AI MERGE:` decision logs with the model's reason, `_mergeDecisions`/`_original.aiArbitration` records, and the Scriptable comparison table shows `🤝 AI CHOSE EXISTING/NEW` / `AI FALLBACK (CLOBBERED)`.

## Testing

`node --test scripts/parsers/ai-web-parser.test.js scripts/shared-core.test.js scripts/normalizers.test.js` → **56/56 pass** (11 new tests: default flip + override preservation, batching into one request, verbatim acceptance with notes round-trip, hallucination fallback, mislabeled-pick recovery, AI-failure = exact clobber output, opt-out/no-adapter zero requests, non-conflict/date-equivalence eligibility, decisive-vs-non-decisive dedup behavior, resolveAiConfig defaults + parser delegation parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)