### PR TITLE
fix(scriptable): identity-verified dedup, end-time rollover, and OCR/evidence fixes

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -246,6 +246,9 @@ class AiWebParser {
         this.aiPromptHistory = [];
         this.defaultOcrModel = 'qwen3-vl:4b-instruct';
         this.defaultOcrPrompt = "You are performing OCR on an event flyer.\n\nSTEP 1: OCR\nExtract ALL visible text from the image.\n\nRules:\n- Copy text exactly as shown.\n- Preserve line breaks when possible.\n- Do not summarize.\n- Do not interpret.\n- Do not correct spelling.\n- Do not infer missing words.\n\nSTEP 2: Classification\n\nClassify the image into ONE category:\n\nad-banner: Advertisement or promotional banner (usually has \"buy\", \"get tickets\", \"sale\")\nevent-flyer: Single event poster/flyer - ONE primary event with ONE title, ONE venue, and ONE date or continuous date range. May contain schedules, activities, DJs, performers, or sub-events that are clearly part of the same event. Examples: Bear Week, Bear Weekend, Pride Festival, Camp Weekend, Resort Weekend Package.\nmulti-event-flyer: Two or more independent events with different titles, different dates/times, and separate ticketing. Often appears as a calendar, event listing, or monthly schedule.\nlogo: Brand or organization logo (minimal text, just brand name)\nthumbnail: Small preview image (low detail)\nhero-banner: Large header/banner image (prominent on page)\n\nDecision rule: If there is ONE overarching event name and the listed activities appear to belong to that event, classify as event-flyer. Only classify as multi-event-flyer when multiple independent events are advertised that require separate tickets.\n\nIMPORTANT CONTEXT: This is for a gay bear community travel guide. Events may be part of:\n- \"Bear Week\" or \"Bear Weekend\" themed events\n- Annual bear gatherings (e.g., \"Puerto Vallarta Bear Week\", \"Sitges Bear Week\")\n- Regular bear-themed parties or meetups\n- Events at bear-owned businesses or bear-friendly venues\n\nSTEP 3: Event Analysis\n\nDetermine:\n- eventName: The primary event title\n- venue: The venue or venue group name\n- startDate: Start date/time if visible\n- endDate: End date/time if visible\n\nUse only information visible in the image.\n\nSTEP 4: Summary\n\nCreate a concise summary describing:\n- event name\n- venue\n- date/time\n- why it may be relevant to the bear community\n\nReturn JSON only with these fields:\n{\n  \"text\": \"full extracted text\",\n  \"imageClassification\": \"ad-banner|event-flyer|multi-event-flyer|logo|thumbnail|hero-banner\",\n  \"eventSummary\": \"a concise 1-2 sentence summary of the event including: event name, venue, date/time, and any bear-week context if applicable. Focus on what makes this event notable for the bear community.\",\n  \"confidence\": 0-100,\n  \"reason\": \"brief explanation for classification\"\n}";
+        // When an image overflows the vision model's context, retry once at this
+        // longest-side cap (the adapter's default first-pass cap is 1568px).
+        this.ocrOverflowRetryMaxDimension = 1024;
         this.defaultOcrRequestConfig = {
             // With requests serialized (maxConcurrentRequests), anything slower than
             // 2 minutes on the local vision model is stuck, not slow.
@@ -2654,6 +2657,8 @@ class AiWebParser {
             'thumb',          // Thumbnails (already handled by classification)
             'thumbnail',      // Thumbnails
             '/_next/static/', // Next.js build assets (map placeholders, UI chrome)
+            'maps.google.com', // Embedded map iframes picked up as image candidates
+            'output=embed',   // Google Maps embed URLs — not images, always fail download
         ];
         for (const pattern of uninterestingPatterns) {
             if (lowerUrl.includes(pattern)) return true;
@@ -3134,7 +3139,28 @@ class AiWebParser {
         }
         console.log(`🤖 AI Web: OCR image attached via base64 payload (${base64Image.length} chars) for ${normalizedUrl} (downloaded in ${Date.now() - downloadStart}ms)`);
         const diagnostics = {};
-        const rawResponse = await this.core.callAiGenerate(ocrConfig, ocrConfig.prompt, passLabel, httpAdapter, this.recordAiPrompt.bind(this), base64Image, diagnostics);
+        let rawResponse = await this.core.callAiGenerate(ocrConfig, ocrConfig.prompt, passLabel, httpAdapter, this.recordAiPrompt.bind(this), base64Image, diagnostics);
+        if (!rawResponse && diagnostics.failureKind === 'context-overflow') {
+            // Vision tokens scale with pixels — retry once at a harder downscale before
+            // writing the image off (adapters without resize support return the same
+            // bytes, in which case we skip the pointless retry).
+            let retrySucceeded = false;
+            try {
+                const retryImage = await httpAdapter.fetchImageAsBase64(normalizedUrl, ocrConfig.timeoutSeconds, this.ocrOverflowRetryMaxDimension);
+                if (retryImage && retryImage.length < base64Image.length) {
+                    console.log(`🤖 AI Web: Retrying OCR at reduced resolution (${retryImage.length} chars, was ${base64Image.length}) for ${normalizedUrl}`);
+                    const retryDiagnostics = {};
+                    rawResponse = await this.core.callAiGenerate(ocrConfig, ocrConfig.prompt, passLabel, httpAdapter, this.recordAiPrompt.bind(this), retryImage, retryDiagnostics);
+                    retrySucceeded = Boolean(rawResponse);
+                    diagnostics.failureKind = retryDiagnostics.failureKind || (rawResponse ? null : diagnostics.failureKind);
+                }
+            } catch (error) {
+                console.warn(`🤖 AI Web: Reduced-resolution OCR retry failed for ${normalizedUrl}: ${error.message}`);
+            }
+            if (retrySucceeded) {
+                console.log(`🤖 AI Web: Reduced-resolution OCR retry succeeded for ${normalizedUrl}`);
+            }
+        }
         if (!rawResponse) {
             // Context overflow is deterministic for a given image+model — cache the
             // failure so the same image is not re-downloaded and re-sent on every
@@ -5078,7 +5104,33 @@ class AiWebParser {
             console.log('🤖 AI Web: Defaulting to split fields (no structured data or OCR context detected)');
             // Default to split fields (same as unstructured)
             const fullDateFields = ['start', 'end'];
+            const hasStartRequested = selected.some(field => this.normalizePromptFieldName(field) === 'start');
+            const hasEndRequested = selected.some(field => this.normalizePromptFieldName(field) === 'end');
             selected = selected.filter(field => !fullDateFields.includes(field));
+
+            // Same time companions as the OCR branch — plain page text can still carry
+            // times ("Doors Open at 9:00 pm") even when no OCR/structured signals exist.
+            // Without these, events from this branch get midnight defaults.
+            const hasStartDateSelected = selected.some(field => this.normalizePromptFieldName(field) === 'startdate');
+            const hasStartTimeSelected = selected.some(field => this.normalizePromptFieldName(field) === 'starttime');
+            if ((hasStartRequested || hasStartDateSelected) && !hasStartTimeSelected) {
+                selected.push('startTime');
+                console.log(`🤖 AI Web: Added split field => startTime (because ${hasStartRequested ? 'start' : 'startDate'} was selected)`);
+            }
+            if (hasStartRequested && !hasStartDateSelected) {
+                selected.push('startDate');
+                console.log('🤖 AI Web: Added split field => startDate (because start was selected)');
+            }
+            const hasEndDateSelected = selected.some(field => this.normalizePromptFieldName(field) === 'enddate');
+            const hasEndTimeSelected = selected.some(field => this.normalizePromptFieldName(field) === 'endtime');
+            if ((hasEndRequested || hasEndDateSelected) && !hasEndTimeSelected) {
+                selected.push('endTime');
+                console.log(`🤖 AI Web: Added split field => endTime (because ${hasEndRequested ? 'end' : 'endDate'} was selected)`);
+            }
+            if (hasEndRequested && !hasEndDateSelected) {
+                selected.push('endDate');
+                console.log('🤖 AI Web: Added split field => endDate (because end was selected)');
+            }
         }
 
         // Ensure fields follow the canonical order from EventSchema
@@ -5648,9 +5700,14 @@ TEXT:
     }
 
     hasUrlEvidence(evidenceContext, value) {
-        const normalized = this.normalizeHttpUrlValue(value);
-        if (!normalized) return false;
-        if (this.hasExactEvidence(evidenceContext, normalized)) {
+        const rawText = String(value || '').trim();
+        if (!rawText) return false;
+        // Bare-domain values ("WWW.MASSIVE.CLUB", "bearracuda.com") fail strict URL
+        // normalization but are still verifiable verbatim against the source —
+        // normalize them by prefixing a scheme instead of rejecting outright.
+        const normalized = this.normalizeHttpUrlValue(rawText)
+            || this.normalizeHttpUrlValue(`https://${rawText}`);
+        if (normalized && this.hasExactEvidence(evidenceContext, normalized)) {
             return true;
         }
         if (typeof normalized === 'string') {
@@ -5665,7 +5722,7 @@ TEXT:
                 }
             }
         }
-        return this.hasExactEvidence(evidenceContext, String(value || '').trim());
+        return this.hasExactEvidence(evidenceContext, rawText);
     }
 
     extractDateEvidenceParts(value) {
@@ -6373,6 +6430,19 @@ TEXT:
         // If we only have a start date and no end date info at all, match the end exactly to the start
         if (!endProvided && !endDateRaw && !endTimeRaw && combinedStartDate) {
             combinedEndDate = new Date(combinedStartDate);
+        }
+
+        // Past-midnight ends ("Party Goes Until 2:00 am!") usually arrive with the
+        // START's date because the next-day endDate isn't verbatim in the source and
+        // gets evidence-dropped. When an explicit end time lands before the start,
+        // roll it to the next day instead of collapsing the event to zero duration.
+        if (endTimeRaw && !endProvided
+            && combinedStartDate instanceof Date && !Number.isNaN(combinedStartDate.getTime())
+            && combinedEndDate instanceof Date && !Number.isNaN(combinedEndDate.getTime())
+            && combinedEndDate.getTime() < combinedStartDate.getTime()
+            && combinedStartDate.getTime() - combinedEndDate.getTime() < 24 * 60 * 60 * 1000) {
+            combinedEndDate = new Date(combinedEndDate.getTime() + 24 * 60 * 60 * 1000);
+            console.log(`🤖 AI Web: End time precedes start — assuming past-midnight end (+1 day): ${combinedEndDate.toISOString()}`);
         }
 
         // Without a timezone, combineDateAndTime stored the extracted local time as wall-clock

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -780,3 +780,105 @@ test('getAiConfig delegates to SharedCore.resolveAiConfig', () => {
   assert.equal(parser.normalizePayloadMode('jsonld'), 'jsonld');
   assert.equal(parser.normalizePayloadMode('bogus'), 'best');
 });
+
+test('hasUrlEvidence accepts bare-domain values found verbatim in the source', () => {
+  const parser = createParser();
+  const html = '<html><body>ADVANCED TIX AT WWW.MASSIVE.CLUB and TICKETS AT BEARRACUDA.COM</body></html>';
+  const ctx = parser.buildAiEvidenceContext({ html, url: 'https://x.example/' }, {});
+
+  assert.equal(parser.hasUrlEvidence(ctx, 'WWW.MASSIVE.CLUB'), true);
+  assert.equal(parser.hasUrlEvidence(ctx, 'bearracuda.com'), true);
+  assert.equal(parser.hasUrlEvidence(ctx, 'https://www.massive.club'), true);
+  assert.equal(parser.hasUrlEvidence(ctx, 'https://unrelated.example/tickets'), false);
+});
+
+test('embedded Google Maps URLs are uninteresting images', () => {
+  const parser = createParser();
+  assert.equal(
+    parser.isLikelyUninterestingImageUrl('https://maps.google.com/maps?q=722%20E%20Burnside&t=m&z=10&output=embed'),
+    true
+  );
+  assert.equal(parser.isLikelyUninterestingImageUrl('https://x.example/images/flyer.jpg'), false);
+});
+
+test('normalizeAiEvent rolls past-midnight end times to the next day', () => {
+  const parser = createParser();
+  const cityConfig = { nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc'] } };
+
+  // "Doors 9pm, party until 1am" — endDate arrives as the START's date because the
+  // next-day date is never verbatim in the source.
+  const lateNight = parser.normalizeAiEvent({
+    title: 'BEAR WEEK KICK OFF',
+    startDate: '2026-07-11',
+    startTime: '21:00',
+    endDate: '2026-07-11',
+    endTime: '01:00',
+    address: '247 Commercial St, New York, NY'
+  }, {}, null, cityConfig, null);
+  assert.ok(lateNight);
+  assert.equal(lateNight.startDate.toISOString(), '2026-07-12T01:00:00.000Z');
+  assert.equal(lateNight.endDate.toISOString(), '2026-07-12T05:00:00.000Z', 'end must roll to 1am the NEXT day');
+  assert.ok(lateNight.endDate > lateNight.startDate, 'event must not collapse to zero duration');
+
+  // Same-day ends stay untouched
+  const sameDay = parser.normalizeAiEvent({
+    title: 'TEA DANCE',
+    startDate: '2026-07-11',
+    startTime: '16:00',
+    endDate: '2026-07-11',
+    endTime: '20:00',
+    address: '247 Commercial St, New York, NY'
+  }, {}, null, cityConfig, null);
+  assert.equal(sameDay.endDate.toISOString(), '2026-07-12T00:00:00.000Z'); // 8pm EDT
+});
+
+test('getAiPromptFields default branch still requests split time fields', () => {
+  const parser = createParser();
+  // No OCR, no JSON-LD, no meta — the branch that previously dropped startTime/endTime
+  // and produced midnight-start events.
+  const fields = parser.getAiPromptFields({}, {});
+  const normalized = fields.map(f => parser.normalizePromptFieldName(f));
+  assert.ok(normalized.includes('startdate'), 'startDate expected');
+  assert.ok(normalized.includes('starttime'), 'startTime must accompany startDate');
+  assert.ok(normalized.includes('endtime'), 'endTime must accompany endDate');
+  assert.ok(!normalized.includes('start'), 'full datetime fields removed in split mode');
+});
+
+test('getOcrTextForImage retries overflowed images at reduced resolution before caching failure', async () => {
+  const parser = createParser();
+  const cacheWrites = [];
+  parser.writeCachedOcrResult = async (url, cfg, text) => {
+    cacheWrites.push(text);
+    return '/tmp/cache-path';
+  };
+  const ocrConfig = { cacheEnabled: false, prompt: 'ocr prompt', timeoutSeconds: 5 };
+  const adapter = {
+    fetchImageAsBase64: async (url, timeout, maxDimension) =>
+      maxDimension ? 'smallimg' : 'X'.repeat(500)
+  };
+
+  // First attempt overflows, reduced-resolution retry succeeds
+  let aiCalls = 0;
+  parser.core.callAiGenerate = async (cfg, prompt, label, http, rec, image, diagnostics) => {
+    aiCalls++;
+    if (image.length > 100) {
+      if (diagnostics) diagnostics.failureKind = 'context-overflow';
+      return null;
+    }
+    return JSON.stringify({ text: 'FLYER TEXT', imageClassification: 'event-flyer', eventSummary: 's', confidence: 90, reason: 'r' });
+  };
+  const result = await parser.getOcrTextForImage('https://x.example/big.png', ocrConfig, 'ocr-all', adapter);
+  assert.equal(aiCalls, 2, 'exactly one retry');
+  assert.equal(result.text, 'FLYER TEXT');
+  assert.ok(!cacheWrites.some(text => text.includes('failureKind')), 'no failure cached when the retry succeeds');
+
+  // Both attempts overflow → negative cache
+  cacheWrites.length = 0;
+  parser.core.callAiGenerate = async (cfg, prompt, label, http, rec, image, diagnostics) => {
+    if (diagnostics) diagnostics.failureKind = 'context-overflow';
+    return null;
+  };
+  const failed = await parser.getOcrTextForImage('https://x.example/huge.png', ocrConfig, 'ocr-all', adapter);
+  assert.equal(failed, null);
+  assert.ok(cacheWrites.some(text => text.includes('context-overflow')), 'persistent overflow is negative-cached');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1438,26 +1438,54 @@ class SharedCore {
 
         for (const event of events) {
             const key = this.createEventKey(event);
-            
+
             // Set the key on the event for later use
             event.key = key;
-            
-            if (!seen.has(key)) {
-                seen.set(key, event);
-                deduplicated.push(event);
-            } else {
-                // Merge with existing event if needed
-                const existing = seen.get(key);
+
+            const mergeIntoExisting = async (existing) => {
                 const merged = await this.mergeParsedEvents(existing, event, { httpAdapter, globalConfig });
-                merged.key = key; // Ensure merged event has the key
-                seen.set(key, merged);
-                
-                // Update in deduplicated array
-                const index = deduplicated.findIndex(e => e.key === key);
+                merged.key = existing.key;
+                seen.set(existing.key, merged);
+                const index = deduplicated.indexOf(existing);
                 if (index !== -1) {
                     deduplicated[index] = merged;
                 }
+            };
+
+            const keyMatch = seen.get(key);
+            if (keyMatch) {
+                // A key collision is a hint, not proof — loose key templates (e.g.
+                // "bearracuda-${date}-${city}") collide for two DIFFERENT events by the
+                // same promoter on the same night. Veto the merge when both records
+                // carry place info and the places don't match; merge otherwise
+                // (identity match or inconclusive = previous behavior).
+                if (this.areEventsDistinctByPlace(event, keyMatch)) {
+                    console.warn(`🔄 SharedCore: Key collision but different venues — keeping "${keyMatch.title || 'event'}" and "${event.title || 'event'}" as separate events`);
+                    let uniqueKey = key;
+                    let suffix = 2;
+                    while (seen.has(uniqueKey)) uniqueKey = `${key}--${suffix++}`;
+                    event.key = uniqueKey;
+                    seen.set(uniqueKey, event);
+                    deduplicated.push(event);
+                } else {
+                    await mergeIntoExisting(keyMatch);
+                }
+                continue;
             }
+
+            // No key match — degraded fields (e.g. a missing start time defaulting to
+            // midnight) make keys brittle, so scan for a same-event identity match
+            // before accepting the event as new.
+            const identityMatch = deduplicated.find(existing =>
+                this.getSameEventIdentitySignal(event, existing, { requireCloseStartTimes: false }));
+            if (identityMatch) {
+                console.log(`🔄 SharedCore: Identity match without key match — merging "${event.title || 'event'}" into "${identityMatch.title || 'event'}"`);
+                await mergeIntoExisting(identityMatch);
+                continue;
+            }
+
+            seen.set(key, event);
+            deduplicated.push(event);
         }
         
         // Log results for large batches
@@ -3946,12 +3974,17 @@ class SharedCore {
         const withoutHash = withoutProtocol.split('#')[0];
         const [path, query] = withoutHash.split('?');
         const cleanPath = path.replace(/\/+$/, '');
-        if (!query) return cleanPath;
+        // A bare-domain "ticket URL" (promoter homepage like bearracuda.com) carries no
+        // event-specific identity — two DIFFERENT events by the same promoter share it,
+        // so treating it as an identity signal causes false merges.
+        const hasEventSpecificPath = cleanPath.includes('/');
+        if (!query) return hasEventSpecificPath ? cleanPath : '';
         const keptParams = query.split('&').filter(param => {
             const key = param.split('=')[0];
             return key && !this.trackingParamPattern.test(key);
         });
-        return keptParams.length > 0 ? `${cleanPath}?${keptParams.sort().join('&')}` : cleanPath;
+        if (keptParams.length > 0) return `${cleanPath}?${keptParams.sort().join('&')}`;
+        return hasEventSpecificPath ? cleanPath : '';
     }
 
     parseCoordinatesForIdentity(event, fields) {
@@ -4043,10 +4076,15 @@ class SharedCore {
 
     // Returns the name of the matched identity signal for logging, or null when the
     // events look distinct. Signals are ordered strongest-first.
-    getSameEventIdentitySignal(newEvent, existingEvent) {
+    // options.requireCloseStartTimes (default true): the place-time-name signal demands
+    // start times within 2 hours. Cross-parser dedup relaxes this to same-local-day,
+    // because a degraded scrape (missing start time → midnight default) must still
+    // match its properly-timed twin from another source.
+    getSameEventIdentitySignal(newEvent, existingEvent, options = {}) {
         if (!newEvent || typeof newEvent !== 'object' || !existingEvent || typeof existingEvent !== 'object') {
             return null;
         }
+        const requireCloseStartTimes = options.requireCloseStartTimes !== false;
         const incoming = this.buildIdentityComparisonShape(newEvent);
         const existing = this.buildIdentityComparisonShape(existingEvent);
 
@@ -4061,13 +4099,24 @@ class SharedCore {
 
         // Same place, roughly the same start time (tolerant of legacy wall-clock offsets),
         // and any pair of name-ish fields (title/name/shortName) similar.
-        if (this.areDatesEqual(incoming.startDate, existing.startDate, 120) &&
+        if ((!requireCloseStartTimes || this.areDatesEqual(incoming.startDate, existing.startDate, 120)) &&
             this.areIdentityPlacesSimilar(incoming, existing) &&
             this.areIdentityNamesSimilar(incoming, existing)) {
-            return 'place-time-name';
+            return requireCloseStartTimes ? 'place-time-name' : 'place-day-name';
         }
 
         return null;
+    }
+
+    // Positive evidence that two records describe DIFFERENT events: both carry place
+    // information and the places do not match. Used to veto key-collision merges —
+    // a missing venue on either side stays inconclusive (returns false).
+    areEventsDistinctByPlace(eventA, eventB) {
+        const shapeA = this.buildIdentityComparisonShape(eventA);
+        const shapeB = this.buildIdentityComparisonShape(eventB);
+        const hasPlace = (shape) => Boolean(shape.bar || shape.address || shape.coordinates || shape.locationText);
+        if (!hasPlace(shapeA) || !hasPlace(shapeB)) return false;
+        return !this.areIdentityPlacesSimilar(shapeA, shapeB);
     }
 
     areEventsSameIdentity(newEvent, existingEvent) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -674,3 +674,103 @@ test('resolveAiConfig defaults and the arbitrateMerges flag', () => {
   const fromGlobal = core.getMergeArbitrationConfig({ source: 'bearracuda' }, { ai: { model: 'global-model' } });
   assert.equal(fromGlobal.model, 'global-model');
 });
+
+// ---------------------------------------------------------------------------
+// Identity-verified cross-parser dedup (2026-07-12 run findings)
+// ---------------------------------------------------------------------------
+
+test('normalizeTicketUrlForIdentity ignores bare-domain promoter homepages', () => {
+  const core = createCore();
+  // Two DIFFERENT events by the same promoter both list "bearracuda.com" — a bare
+  // domain must not act as an identity signal.
+  assert.equal(core.normalizeTicketUrlForIdentity('https://bearracuda.com'), '');
+  assert.equal(core.normalizeTicketUrlForIdentity('https://www.bearracuda.com/'), '');
+  assert.equal(
+    core.normalizeTicketUrlForIdentity('https://www.sickening.events/e/treasurechi/tickets'),
+    'sickening.events/e/treasurechi/tickets'
+  );
+  assert.equal(core.normalizeTicketUrlForIdentity('https://site.example?eventid=5'), 'site.example?eventid=5');
+});
+
+test('deduplicateEvents keeps different-venue events separate despite a key collision', async () => {
+  const core = createCore();
+  // Real scenario: Bearracuda ran TWO events in Portland on the same night, and the
+  // configured keyTemplate collapses to promoter+date+city for both.
+  const parserConfig = { keyTemplate: 'bearracuda-${date}-${city}' };
+  const treasureTrail = {
+    title: 'TREASURE TRAIL Portland PRIDE',
+    bar: 'Sanctuary',
+    address: '33 Northwest 9th Avenue, Portland, OR, 97209',
+    city: 'portland',
+    timezone: 'America/Los_Angeles',
+    startDate: new Date('2026-07-18T03:00:00.000Z'),
+    source: 'ai-web',
+    _parserConfig: parserConfig
+  };
+  const prideFriday = {
+    title: 'Portland PRIDE FRIDAY | BEARRACUDA',
+    bar: 'NOVA PDX',
+    address: '722 East Burnside Street, Portland, OR, 97214',
+    city: 'portland',
+    timezone: 'America/Los_Angeles',
+    startDate: new Date('2026-07-18T04:00:00.000Z'),
+    source: 'ai-web',
+    _parserConfig: parserConfig
+  };
+
+  const result = await core.deduplicateEvents([treasureTrail, prideFriday], null);
+  assert.equal(result.length, 2, 'different venues on the same night are different events');
+  assert.notEqual(result[0].key, result[1].key, 'the collision must be disambiguated');
+});
+
+test('deduplicateEvents merges the same event across parsers when keys diverge', async () => {
+  const core = createCore();
+  // Real scenario: the bearracuda.com scrape lost its start time (midnight default,
+  // UTC date July 25) while the sickening.events version had 9pm (UTC date July 26)
+  // — different keys, same event.
+  const degraded = {
+    title: 'Treasure Trail Chicago',
+    bar: 'Cell Block',
+    address: '3702 N Halsted',
+    city: 'chicago',
+    timezone: 'America/Chicago',
+    startDate: new Date('2026-07-25T05:00:00.000Z'), // midnight CDT
+    source: 'ai-web'
+  };
+  const complete = {
+    title: 'Treasure Trail Chicago LAUNCH PARTY',
+    bar: 'Cell Block',
+    address: '3702 North Halsted Street, Chicago, IL, 60613',
+    city: 'chicago',
+    timezone: 'America/Chicago',
+    startDate: new Date('2026-07-26T02:00:00.000Z'), // 9pm CDT, same local day
+    source: 'ai-web'
+  };
+
+  assert.notEqual(core.createEventKey(degraded), core.createEventKey(complete), 'precondition: keys diverge');
+  const result = await core.deduplicateEvents([degraded, complete], null);
+  assert.equal(result.length, 1, 'same venue + same local day + similar names must merge');
+});
+
+test('deduplicateEvents still merges plain key-collision duplicates', async () => {
+  const core = createCore();
+  const first = {
+    title: 'FURBALL DALLAS',
+    bar: 'STATION 4',
+    city: 'dallas',
+    timezone: 'America/Chicago',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    source: 'ai-web'
+  };
+  const second = { ...first, description: 'second copy' };
+  const result = await core.deduplicateEvents([first, second], null);
+  assert.equal(result.length, 1);
+});
+
+test('relaxed identity signal matches same-local-day despite degraded start times', () => {
+  const core = createCore();
+  const a = { title: 'Treasure Trail Chicago', bar: 'Cell Block', timezone: 'America/Chicago', startDate: new Date('2026-07-25T05:00:00.000Z') };
+  const b = { title: 'Treasure Trail Chicago LAUNCH PARTY', bar: 'Cell Block', timezone: 'America/Chicago', startDate: new Date('2026-07-26T02:00:00.000Z') };
+  assert.equal(core.getSameEventIdentitySignal(a, b), null, 'strict signal requires close start times');
+  assert.equal(core.getSameEventIdentitySignal(a, b, { requireCloseStartTimes: false }), 'place-day-name');
+});


### PR DESCRIPTION
Fixes everything surfaced by analyzing the 2026-07-12 Bearracuda run (the first run with the full JSON-LD + arbitration stack live).

## The merge bugs (both directions, one root cause)

Cross-parser dedup merged on **exact key match alone**, and the configured `keyTemplate: "bearracuda-${date}-${city}"` makes keys simultaneously too loose and too brittle:

- **Too loose — data loss**: Bearracuda ran two different Portland events on July 17 (Treasure Trail @ Sanctuary, Pride Friday @ NOVA PDX). Same key → blind merge → Treasure Trail Portland vanished, and merge arbitration confabulated justifications for it.
- **Too brittle — duplication**: Treasure Trail Chicago appeared twice. The bearracuda.com scrape lost its start time (midnight default → different UTC date in the key) so it never matched its sickening.events twin.

Dedup is now identity-verified in both directions using the #1440 identity machinery:

- **Key collision** → vetoed when both records carry place info and the venues don't match (`areEventsDistinctByPlace`); inconclusive collisions still merge as before.
- **No key match** → identity scan with a relaxed `place-day-name` signal (`requireCloseStartTimes: false`): same local day + same venue + similar names merges even when one side's start time degraded to midnight. The strict 2-hour window still applies everywhere else.
- **Bare-domain ticket URLs** (promoter homepages like `bearracuda.com`) no longer count as identity signals — two *different* events by one promoter share them, which would have re-introduced the Portland false-merge through the ticket-url signal.

## Every event collapsed to zero duration

"Party Goes Until 2:00 am!" produces an end time with the **start's** date (the next-day date is never verbatim in the source, so the model's inferred `endDate` gets evidence-dropped — correctly). Normalization then clamped end=start. An explicit end time that precedes the start now rolls forward one day (same logic the bearracuda-parser always had).

## Midnight-start events

Two stacked fixes for the Chicago "no start time" case:
- The no-OCR/no-structured-data field-selection branch never requested `startTime`/`endTime` — even though the page text said "Doors Open at 9:00 pm". It now adds the same time companions as the OCR branch.
- Context-overflowed OCR images get **one retry at 1024px** before being negative-cached (the Chicago flyer was 1111×1389 — under the 1568px first-pass cap — yet still overflowed as a 4.4M-char payload).

## Evidence & noise fixes

- `hasUrlEvidence` rejected bare-domain values (`WWW.MASSIVE.CLUB`, `bearracuda.com`) before any evidence check (strict URL normalization returns null → early false). Reproduced with a test harness, fixed by normalizing via an `https://` prefix — the verbatim gate itself is unchanged.
- Embedded Google Maps URLs (`maps.google.com`/`output=embed`) were attempted as OCR image downloads on every page (~500ms failure each, uncacheable). Now filtered as uninteresting.

## Testing

`node --test scripts/parsers/ai-web-parser.test.js scripts/shared-core.test.js scripts/normalizers.test.js` → **66/66 pass** (10 new tests, each reproducing a scenario from the run: the Portland collision veto, the Chicago cross-key merge, plain-collision regression, relaxed identity signal, bare-domain ticket URLs, late-night rollover + same-day non-rollover, default-branch time fields, bare-domain url evidence, maps-embed filtering, and the OCR retry/negative-cache flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)