### PR TITLE
Automation-run safety + metrics durability fixes

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -161,7 +161,7 @@ const scraperConfig = {
       alwaysBear: true,      // Skip bear keyword filtering
       urlDiscoveryDepth: 1,  // Recursive crawl depth for discovered URLs (0 = no discovery crawl)
       maxAdditionalUrls: 20, // Optional: per-page cap for discovered URLs (uses parser default if omitted)
-      dryRun: false,         // Optional: override global dryRun setting for this parser
+      dryRun: true,          // Optional: never write this parser's events (global dryRun: true still blocks everything)
       allowlist: ["keyword1", "keyword2"],
       city: "nyc"
     },

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -474,7 +474,12 @@ class ScriptableAdapter {
     this.pageStorageDir = this.fm.joinPath(this.storageDir, "pages");
     this.cacheDir = this.fm.joinPath(this.baseDir, "cache");
 
-    this.runtimeContext = this.getScriptableRuntimeContext();
+    // Reuse a resolved run context (with automation overrides applied) when the
+    // orchestrator hands one over; otherwise detect it fresh
+    this.runtimeContext =
+      config.runtime && typeof config.runtime === "object"
+        ? { ...config.runtime }
+        : this.getScriptableRuntimeContext();
     this.runStartedAt = new Date();
     this.warnCount = 0;
     this.lastExecutionActionCounts = null;
@@ -540,6 +545,8 @@ class ScriptableAdapter {
 
   applyAutomationRunContext(runtimeContext, automationRun, automationOverride) {
     const updated = { ...(runtimeContext || {}) };
+    const hasOverride =
+      automationOverride !== null && automationOverride !== undefined;
     if (automationRun) {
       updated.type = "automated";
       if (
@@ -547,14 +554,13 @@ class ScriptableAdapter {
         updated.trigger === "app" ||
         updated.trigger === "unknown"
       ) {
-        updated.trigger =
-          automationOverride !== null ? "shortcut" : updated.trigger;
+        updated.trigger = hasOverride ? "shortcut" : updated.trigger;
       }
     } else if (automationOverride === false) {
       updated.type = "manual";
     }
     updated.automationRun = automationRun === true;
-    if (automationOverride !== null && automationOverride !== undefined) {
+    if (hasOverride) {
       updated.automationOverride = automationOverride;
     }
     return updated;
@@ -2407,13 +2413,17 @@ class ScriptableAdapter {
     if (results?._isDisplayingSavedRun || runContext?.type === "display") {
       return false;
     }
+    // Widgets can never present WebViews/alerts
+    if (runContext?.runsInWidget || this.runtimeContext?.runsInWidget) {
+      return true;
+    }
+    // Any automation run (scheduled, Siri, or automation=true override) must not
+    // block on UI — even when no parser is automationEnabled
     const automationRun =
-      Boolean(config?.runtime?.automationRun) ||
-      runContext?.type === "automated";
-    const hasAutomationParsers =
-      Array.isArray(config?.parsers) &&
-      config.parsers.some((parser) => parser?.automationEnabled === true);
-    return automationRun && hasAutomationParsers;
+      typeof config?.runtime?.automationRun === "boolean"
+        ? config.runtime.automationRun
+        : runContext?.type === "automated";
+    return automationRun;
   }
 
   // Results Display - Enhanced with calendar preview and comparison
@@ -2527,8 +2537,13 @@ class ScriptableAdapter {
       const automationRunForSave =
         Boolean(runtimeForSave.automationRun) ||
         runtimeForSave.type === "automated";
+      // Only apply the automationEnabled filter when the schedule filter was
+      // actually in effect — override runs (parserName/url input + automation=true)
+      // run other parsers and must still be saved for audit/metrics
+      const automationFilterForSave =
+        automationRunForSave && runtimeForSave.automationFilter !== false;
       const activeParsers = parserConfigs.filter((parser) => {
-        if (automationRunForSave) {
+        if (automationFilterForSave) {
           return parser?.automationEnabled === true;
         }
         return parser?.enabled !== false;
@@ -2555,7 +2570,7 @@ class ScriptableAdapter {
         const reason = results?._isDisplayingSavedRun
           ? "display mode"
           : !hasActiveParsers
-            ? automationRunForSave
+            ? automationFilterForSave
               ? "no automation-enabled parsers"
               : "no enabled parsers"
             : "missing analyzed events";
@@ -3177,14 +3192,8 @@ class ScriptableAdapter {
         !results._isDisplayingSavedRun
       ) {
         // Check if we have any events from non-dry-run parsers
-        const eventsFromActiveParsers = results.analyzedEvents.filter(
-          (event) => {
-            const parserConfig = results.config?.parsers?.find(
-              (p) => p.name === event._parserConfig?.name,
-            );
-            const isParserDryRun = parserConfig?.dryRun === true;
-            return !isParserDryRun;
-          },
+        const eventsFromActiveParsers = SharedCore.filterEventsForExecution(
+          results.analyzedEvents,
         );
 
         const globalDryRun = results.config?.config?.dryRun;
@@ -7482,16 +7491,35 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     const lines = existing.split("\n").filter((line) => line.trim().length > 0);
     const keptLines = [];
 
+    let corruptLines = 0;
     lines.forEach((line) => {
-      const parsed = JSON.parse(line);
+      let parsed = null;
+      try {
+        parsed = JSON.parse(line);
+      } catch (parseError) {
+        // A single corrupt line (interrupted write, partial sync) must not
+        // poison the whole file and block every future metrics append
+        corruptLines += 1;
+        return;
+      }
       const finishedAtMs = parsed?.finished_at
         ? new Date(parsed.finished_at).getTime()
         : null;
-      if (!finishedAtMs || !Number.isFinite(finishedAtMs)) return;
+      if (!Number.isFinite(finishedAtMs)) {
+        // Keep records without a parseable finished_at; only retention pruning
+        // is allowed to drop lines
+        keptLines.push(line);
+        return;
+      }
       if (!cutoffMs || finishedAtMs >= cutoffMs) {
         keptLines.push(line);
       }
     });
+    if (corruptLines > 0) {
+      console.warn(
+        `📱 Scriptable: Dropped ${corruptLines} corrupt metrics line(s) during append`,
+      );
+    }
 
     const line = JSON.stringify(record);
     keptLines.push(line);

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -246,6 +246,9 @@ class BearEventScraperOrchestrator {
                 finalAdapter = new this.modules.adapter({
                     cities: config.cities,
                     pageCache: config.config?.pageCache || null,
+                    // Carry the resolved run context (automation overrides) into the
+                    // instance that saves runs/metrics, not just the config object
+                    runtime: config.runtime || null,
                     ...this.config
                 });
             }
@@ -276,18 +279,19 @@ class BearEventScraperOrchestrator {
             // Process events using shared core
             const results = await sharedCore.processEvents(config, finalAdapter, finalAdapter, parsers);
             results.config = config;
+            results.calendarEvents = 0;
             if (!Array.isArray(results.analyzedEvents)) {
                 results.analyzedEvents = [];
             }
-            
+
             // Add to calendar if not dry run and we have events
             if (results.allProcessedEvents && results.allProcessedEvents.length > 0) {
                 console.log(`🐻 Orchestrator: Preparing ${results.allProcessedEvents.length} events for calendar...`);
-                
+
                 let calendarEvents = 0;
-                
+
                 // Check if we should add to calendar
-                const isDryRun = config.config.dryRun;
+                const isDryRun = Boolean(config.config?.dryRun);
                 
                 // Always prepare events for analysis (even in dry run mode) to show action types
                 // Perform cross-parser deduplication to merge events from different parsers
@@ -304,22 +308,28 @@ class BearEventScraperOrchestrator {
 
                 // Determine execution mode based on environment
                 const automationRun = Boolean(config?.runtime?.automationRun);
+                const isWidget = this.isScriptable && Boolean(config?.runtime?.runsInWidget);
                 const hasDisplay = (this.isScriptable || this.isWeb) && !automationRun;
-                const isWidget = this.isScriptable && config.widgetParameter;
                 if (automationRun) {
                     console.log('🐻 Orchestrator: Automation run detected - executing without UI prompt');
                 }
-                
+
                 if (!isDryRun && typeof finalAdapter.executeCalendarActions === 'function' && analyzedEvents) {
                     if (hasDisplay && !isWidget) {
                         // If we have a display (not widget), show results first and let user decide
                         console.log('🐻 Orchestrator: Display mode - review results before execution');
                         // The display will handle the execution decision
                     } else {
-                        // No display (widget mode) or explicit execution requested
-                        console.log(`🐻 Orchestrator: Executing calendar actions (${analyzedEvents.length} events)`);
+                        // No display (automation or widget mode) - execute directly,
+                        // excluding events from parsers marked dryRun
+                        const executableEvents = this.modules.SharedCore.filterEventsForExecution(analyzedEvents);
+                        const dryRunSkipped = analyzedEvents.length - executableEvents.length;
+                        if (dryRunSkipped > 0) {
+                            console.log(`🐻 Orchestrator: Excluding ${dryRunSkipped} events from dry-run parsers`);
+                        }
+                        console.log(`🐻 Orchestrator: Executing calendar actions (${executableEvents.length} events)`);
                         try {
-                            calendarEvents = await finalAdapter.executeCalendarActions(analyzedEvents, config);
+                            calendarEvents = await finalAdapter.executeCalendarActions(executableEvents, config);
                             console.log(`🐻 Orchestrator: ✓ Processed ${calendarEvents} events to calendar`);
                         } catch (error) {
                             console.error(`🐻 Orchestrator: ✗ Failed to process events to calendar: ${error.message}`);
@@ -329,10 +339,8 @@ class BearEventScraperOrchestrator {
                 } else {
                     console.log('🐻 Orchestrator: Skipping calendar execution (dry run or unsupported)');
                 }
-                
-            // Add calendar count and config to results
-            results.calendarEvents = calendarEvents;
-            results.config = config;
+
+                results.calendarEvents = calendarEvents;
             }
 
             // Display results
@@ -377,19 +385,29 @@ class BearEventScraperOrchestrator {
     }
 }
 
-// Auto-execute when loaded
-(async () => {
-    try {
-        const results = await BearEventScraperOrchestrator.execute();
-        console.log('🐻 Bear Event Scraper: Execution completed successfully');
-    } catch (error) {
-        console.error(`🐻 Bear Event Scraper: Execution failed: ${error}`);
-    } finally {
-        if (typeof Script !== 'undefined' && typeof Script.complete === 'function') {
-            Script.complete();
+// Auto-execute when loaded — but never on require(): in Node, only run when
+// invoked directly, so tests/tools can import the orchestrator without scraping.
+// Scriptable also defines a module global, so check importModule first.
+const isScriptableEnvironment = typeof importModule !== 'undefined';
+const isNodeEnvironment = !isScriptableEnvironment && typeof module !== 'undefined' && module.exports && typeof window === 'undefined';
+const isDirectNodeRun = isNodeEnvironment && typeof require !== 'undefined' && require.main === module;
+if (!isNodeEnvironment || isDirectNodeRun) {
+    (async () => {
+        try {
+            const results = await BearEventScraperOrchestrator.execute();
+            console.log('🐻 Bear Event Scraper: Execution completed successfully');
+        } catch (error) {
+            console.error(`🐻 Bear Event Scraper: Execution failed: ${error}`);
+            if (typeof process !== 'undefined') {
+                process.exitCode = 1;
+            }
+        } finally {
+            if (typeof Script !== 'undefined' && typeof Script.complete === 'function') {
+                Script.complete();
+            }
         }
-    }
-})();
+    })();
+}
 
 // Export for manual execution if needed
 if (typeof module !== 'undefined' && module.exports) {

--- a/scripts/display-run-metrics.js
+++ b/scripts/display-run-metrics.js
@@ -25,7 +25,8 @@ const CHART_STYLE = {
   padding: 6
 };
 
-const DEBUG_CHART_POINTS = true;
+// Off by default; enable per-render with ?debugCharts=1
+const DEBUG_CHART_POINTS = false;
 
 const CHART_AXIS_LABELS = {
   runs: 'Runs (oldest to newest)',
@@ -421,11 +422,12 @@ class MetricsDisplay {
       }
     });
 
-    records.sort((a, b) => {
-      const aTime = a?.finished_at ? new Date(a.finished_at).getTime() : 0;
-      const bTime = b?.finished_at ? new Date(b.finished_at).getTime() : 0;
-      return aTime - bTime;
-    });
+    const getFinishedTime = (record) => {
+      const time = record?.finished_at ? new Date(record.finished_at).getTime() : 0;
+      // A malformed finished_at yields NaN, which would corrupt the sort order
+      return Number.isFinite(time) ? time : 0;
+    };
+    records.sort((a, b) => getFinishedTime(a) - getFinishedTime(b));
 
     return records;
   }
@@ -452,19 +454,29 @@ class MetricsDisplay {
   }
 
   async loadRunDetails(record) {
-    const runPath = record?.run_file_path || null;
-    if (!runPath) return null;
-    if (!this.fm.fileExists(runPath)) {
-      return null;
+    // Prefer reconstructing the path from run_id: run_file_path is stored as a
+    // device-absolute path and goes stale across devices/container changes
+    const candidatePaths = [];
+    if (record?.run_id) {
+      const runsDir = this.fm.joinPath(this.baseDir, 'runs');
+      candidatePaths.push(this.fm.joinPath(runsDir, `${record.run_id}.json`));
     }
-    try {
-      await this.fm.downloadFileFromiCloud(runPath);
-      const content = this.fm.readString(runPath);
-      return JSON.parse(content);
-    } catch (error) {
-      console.log(`Metrics: Failed to load run details: ${error.message}`);
-      return null;
+    if (record?.run_file_path) {
+      candidatePaths.push(record.run_file_path);
     }
+    for (const runPath of candidatePaths) {
+      if (!this.fm.fileExists(runPath)) {
+        continue;
+      }
+      try {
+        await this.fm.downloadFileFromiCloud(runPath);
+        const content = this.fm.readString(runPath);
+        return JSON.parse(content);
+      } catch (error) {
+        console.log(`Metrics: Failed to load run details: ${error.message}`);
+      }
+    }
+    return null;
   }
 
   getConfiguredParsers() {
@@ -1993,10 +2005,15 @@ class MetricsDisplay {
     if (!view || view.mode !== 'runs') return null;
     const fromParam = this.getRunFiltersFromParam(this.runtime.widgetParameter);
     const fromQuery = this.getRunFiltersFromQuery(this.getQueryParams());
-    return {
-      ...fromParam,
-      ...fromQuery
-    };
+    // Query values win only when actually set — an empty query object returns
+    // all-null fields, which must not clobber widget-parameter filters
+    const merged = { ...fromParam };
+    Object.entries(fromQuery).forEach(([key, value]) => {
+      if (value !== null && value !== undefined) {
+        merged[key] = value;
+      }
+    });
+    return merged;
   }
 
   async resolveView() {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2812,6 +2812,13 @@ class SharedCore {
     // business logic lives in exactly one place.
     // -------------------------------------------------------------------------
 
+    // Events from parsers marked dryRun must never reach calendar writes,
+    // regardless of which path (automation or interactive prompt) executes them
+    static filterEventsForExecution(analyzedEvents) {
+        if (!Array.isArray(analyzedEvents)) return [];
+        return analyzedEvents.filter(event => event?._parserConfig?.dryRun !== true);
+    }
+
     static normalizeOverrideUid(value) {
         if (value === null || value === undefined) return '';
         return String(value).trim();

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -774,3 +774,16 @@ test('relaxed identity signal matches same-local-day despite degraded start time
   assert.equal(core.getSameEventIdentitySignal(a, b), null, 'strict signal requires close start times');
   assert.equal(core.getSameEventIdentitySignal(a, b, { requireCloseStartTimes: false }), 'place-day-name');
 });
+
+test('filterEventsForExecution excludes events from dry-run parsers', () => {
+  const live = { title: 'Live Event', _parserConfig: { name: 'Live Parser', dryRun: false } };
+  const dry = { title: 'Dry Event', _parserConfig: { name: 'Dry Parser', dryRun: true } };
+  const unstamped = { title: 'No Parser Config' };
+  const result = SharedCore.filterEventsForExecution([live, dry, unstamped]);
+  assert.deepEqual(result.map(e => e.title), ['Live Event', 'No Parser Config']);
+});
+
+test('filterEventsForExecution tolerates non-array input', () => {
+  assert.deepEqual(SharedCore.filterEventsForExecution(null), []);
+  assert.deepEqual(SharedCore.filterEventsForExecution(undefined), []);
+});


### PR DESCRIPTION
Safety-fix PR from the unified-scraper review (automation flow + metrics script). Three parallel reviewers audited the orchestrator, the automation path in scriptable-adapter, and display-run-metrics; this PR fixes everything ranked high/medium plus the small guaranteed-wins.

## Automation flow

- **Automation runs never block on UI.** `shouldSkipResultsUi` previously required a parser with `automationEnabled: true` to skip the WebView — so Siri/Shortcut runs with URL input (or any automation run without automation-enabled parsers) auto-wrote the calendar and then awaited `WebView.loadHTML` unattended, and could even present a second execution prompt for the same events. Now any automation run skips the UI, and widget contexts always skip it (widgets can't present).
- **Override-driven automation runs leave an audit trail.** Run-save gating filtered by `automationEnabled` whenever the run was automated, so `parserName=X&automation=true` runs wrote to the calendar with no saved run and no metrics. Gating now respects `runtime.automationFilter`, matching what shared-core actually executes.
- **Per-parser `dryRun: true` is honored in automation mode.** Previously only the interactive prompt filtered dry-run parsers' events; scheduled/widget runs would have written them. New `SharedCore.filterEventsForExecution` is used by both the orchestrator's automation path and the display path.
- **Forced automation runs are recorded as automated.** The orchestrator's second adapter instance rebuilt a raw run context, discarding automation overrides — saved runs and metrics labeled forced runs "Manual (app)". The resolved context is now passed into the final adapter.
- **Node entry point:** `require()` no longer kicks off a live scrape (making the orchestrator testable), and a failed direct run sets `process.exitCode = 1`.
- Orchestrator cleanups: dead `isWidget` check now reads `config.runtime.runsInWidget`, `config.config?.dryRun` guarded, `results.calendarEvents` defaults to 0 (no more "Added to Calendar: undefined"), duplicate `results.config` assignment removed.

## Metrics

- **Writer:** `appendMetricsRecord` no longer `JSON.parse`s blind — one corrupt NDJSON line (interrupted write/partial iCloud sync) used to make every future metrics append throw forever, while the dashboard silently rendered stale data. Corrupt lines are skipped with a warning; records without a parseable `finished_at` are kept instead of silently deleted.
- **Reader:** widget-parameter run filters (`view=runs|status=failed|days=7`) actually apply now — an empty query object's null fields were clobbering them. Record sort is NaN-safe. Run details load by `run_id` (device-portable) with the stored absolute path as fallback. Chart debug logging is off by default (`?debugCharts=1` to enable).

## Docs/tests

- README: parser `dryRun` doc now describes real behavior (parser-level opt-out; global `dryRun: true` still blocks everything — there is no parser-level opt-in override).
- 2 new tests for `filterEventsForExecution`; suite is 68/68. Verified `require()` no longer auto-runs and that the Scriptable path still auto-executes (Scriptable defines `module`, so the guard checks `importModule` first).

Follow-ups planned separately: dead-code deletion (~1,000 lines: UITable render path in display-run-metrics, orphaned saved-run helpers in the adapter) and the larger test-suite additions + CI wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)