### PR TITLE
Test suite expansion + CI: event-schema, orchestrator, automation filtering

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+name: Scraper Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      # The scraper tests are dependency-free (node:test + node:assert only),
+      # so no npm install is needed.
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A modern static website for chunky.dad",
   "main": "index.html",
   "scripts": {
+    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js",
     "start": "python3 -m http.server 8000",
     "serve": "python3 -m http.server 8000",
     "dev": "python3 -m http.server 8000",

--- a/scripts/bear-event-scraper-unified.test.js
+++ b/scripts/bear-event-scraper-unified.test.js
@@ -1,0 +1,197 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// Requiring the orchestrator must NOT auto-execute a scrape: the auto-run IIFE is
+// guarded by require.main === module. The fact this file loads without network or
+// calendar side effects is itself part of the regression lock (see last test).
+const { BearEventScraperOrchestrator } = require('./bear-event-scraper-unified');
+const { SharedCore } = require('./shared-core');
+const { EventSchema } = require('./event-schema');
+
+const CITIES = {
+  dallas: { timezone: 'America/Chicago', patterns: ['dallas'] }
+};
+
+class StubNormalizerPipeline {
+  setCore() {}
+}
+
+function buildConfig(overrides = {}) {
+  return {
+    cities: CITIES,
+    config: {},
+    parsers: [],
+    ...overrides
+  };
+}
+
+// Adapter class factory: run() instantiates the class twice (bootstrap + final),
+// so recorded calls live in a closure shared by all instances.
+function createStubAdapter({ config, executeError = null, omitExecute = false } = {}) {
+  const calls = { executeCalendarActions: [], displayResults: [], showError: [] };
+
+  class StubAdapter {
+    constructor(options = {}) {
+      this.options = options;
+    }
+    async loadConfiguration() {
+      return config;
+    }
+    async displayResults(results) {
+      calls.displayResults.push(results);
+    }
+    async showError(title, message) {
+      calls.showError.push({ title, message });
+    }
+  }
+
+  if (!omitExecute) {
+    StubAdapter.prototype.executeCalendarActions = async function executeCalendarActions(events, cfg) {
+      calls.executeCalendarActions.push({ events, config: cfg });
+      if (executeError) throw executeError;
+      return events.length;
+    };
+  }
+
+  return { StubAdapter, calls };
+}
+
+// Subclass (never prototype mutation) so each test gets an isolated SharedCore
+// whose event-production stages are canned while run()'s real branching executes.
+function createSharedCoreStub(events) {
+  return class StubSharedCore extends SharedCore {
+    async processEvents() {
+      return {
+        totalEvents: events.length,
+        rawBearEvents: events.length,
+        bearEvents: events.length,
+        duplicatesRemoved: 0,
+        errors: [],
+        parserResults: [],
+        allProcessedEvents: [...events]
+      };
+    }
+    async deduplicateEvents(evts) {
+      return evts;
+    }
+    async prepareEventsForCalendar(evts) {
+      return evts;
+    }
+  };
+}
+
+function createOrchestrator({ config, events = [], adapterOptions = {}, isScriptable = true } = {}) {
+  const { StubAdapter, calls } = createStubAdapter({ config, ...adapterOptions });
+  const orch = new BearEventScraperOrchestrator();
+  orch.isInitialized = true;
+  orch.isScriptable = isScriptable;
+  orch.isWeb = false;
+  orch.modules = {
+    SharedCore: createSharedCoreStub(events),
+    EventSchema,
+    NormalizerPipeline: StubNormalizerPipeline,
+    adapter: StubAdapter,
+    parsers: {}
+  };
+  return { orch, calls };
+}
+
+function buildEvents() {
+  return [
+    { title: 'Live Event', startDate: new Date('2026-08-01T21:00:00.000Z'), _parserConfig: { name: 'Live Parser', dryRun: false } },
+    { title: 'Dry Event', startDate: new Date('2026-08-01T22:00:00.000Z'), _parserConfig: { name: 'Dry Parser', dryRun: true } }
+  ];
+}
+
+test('automation run executes calendar actions, excluding dry-run-parser events', async () => {
+  const config = buildConfig({ runtime: { automationRun: true }, config: { dryRun: false } });
+  const { orch, calls } = createOrchestrator({ config, events: buildEvents() });
+
+  const results = await orch.run();
+
+  assert.equal(calls.executeCalendarActions.length, 1, 'automation executes without a UI prompt');
+  assert.deepEqual(
+    calls.executeCalendarActions[0].events.map(e => e.title),
+    ['Live Event'],
+    'filterEventsForExecution strips events from dryRun parsers'
+  );
+  assert.equal(results.calendarEvents, 1);
+  assert.equal(results.analyzedEvents.length, 2, 'analysis still covers dry-run events');
+  assert.equal(calls.displayResults.length, 1);
+});
+
+test('display mode (scriptable, manual) leaves execution to the display layer', async () => {
+  const config = buildConfig({ config: { dryRun: false } });
+  const { orch, calls } = createOrchestrator({ config, events: buildEvents() });
+
+  const results = await orch.run();
+
+  assert.equal(calls.executeCalendarActions.length, 0, 'orchestrator must not execute in display mode');
+  assert.equal(results.calendarEvents, 0);
+  assert.equal(results.analyzedEvents.length, 2, 'events are still analyzed for review');
+  assert.equal(calls.displayResults.length, 1);
+});
+
+test('global dryRun true never executes calendar actions, even in automation', async () => {
+  const config = buildConfig({ runtime: { automationRun: true }, config: { dryRun: true } });
+  const { orch, calls } = createOrchestrator({ config, events: buildEvents() });
+
+  const results = await orch.run();
+
+  assert.equal(calls.executeCalendarActions.length, 0);
+  assert.equal(results.calendarEvents, 0);
+  assert.equal(results.analyzedEvents.length, 2, 'dry run still produces the analysis');
+});
+
+test('an adapter without executeCalendarActions is tolerated', async () => {
+  const config = buildConfig({ runtime: { automationRun: true }, config: { dryRun: false } });
+  const { orch, calls } = createOrchestrator({
+    config,
+    events: buildEvents(),
+    adapterOptions: { omitExecute: true }
+  });
+
+  const results = await orch.run();
+
+  assert.equal(results.calendarEvents, 0);
+  assert.equal(calls.displayResults.length, 1, 'results are still displayed');
+});
+
+test('executeCalendarActions failures land in results.errors and run() still returns', async () => {
+  const config = buildConfig({ runtime: { automationRun: true }, config: { dryRun: false } });
+  const { orch, calls } = createOrchestrator({
+    config,
+    events: buildEvents(),
+    adapterOptions: { executeError: new Error('calendar exploded') }
+  });
+
+  const results = await orch.run();
+
+  assert.equal(calls.executeCalendarActions.length, 1, 'the attempt was made');
+  assert.deepEqual(results.errors, ['Calendar processing failed: calendar exploded']);
+  assert.equal(results.calendarEvents, 0, 'nothing was recorded as processed');
+  assert.equal(calls.displayResults.length, 1, 'the run completes and displays results');
+  assert.equal(calls.showError.length, 0, 'a calendar failure is not a fatal orchestrator error');
+});
+
+test('zero events found short-circuits the calendar stage', async () => {
+  const config = buildConfig({ runtime: { automationRun: true }, config: { dryRun: false } });
+  const { orch, calls } = createOrchestrator({ config, events: [] });
+
+  const results = await orch.run();
+
+  assert.equal(results.calendarEvents, 0);
+  assert.deepEqual(results.analyzedEvents, []);
+  assert.equal(calls.executeCalendarActions.length, 0);
+  assert.equal(calls.displayResults.length, 1);
+});
+
+test('require() exports the orchestrator without auto-executing', () => {
+  // If the guarded IIFE had fired on require, module load would have attempted the
+  // real module loading + scrape and this file would have failed long before now.
+  assert.equal(typeof BearEventScraperOrchestrator, 'function');
+  assert.equal(typeof BearEventScraperOrchestrator.execute, 'function');
+  const fresh = new BearEventScraperOrchestrator();
+  assert.equal(fresh.isInitialized, false);
+  assert.equal(fresh.isNode, true);
+});

--- a/scripts/event-schema.test.js
+++ b/scripts/event-schema.test.js
@@ -1,0 +1,204 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { EventSchema } = require('./event-schema');
+
+// ---------------------------------------------------------------------------
+// formatEventNotes → parseNotesIntoFields round-trip
+// ---------------------------------------------------------------------------
+
+test('notes round-trip: colons, backslashes, and newlines in values survive exactly', () => {
+  const event = {
+    title: 'FURBALL', // excluded from notes; keys below are canonical notes keys
+    description: 'Doors: 9pm sharp\nDress code \\ leather welcome',
+    bar: 'The Eagle: Backroom',
+    shortName: 'FUR\\BALL: DALLAS',
+    cover: '$10'
+  };
+
+  const notes = EventSchema.formatEventNotes(event);
+  const parsed = EventSchema.parseNotesIntoFields(notes);
+
+  assert.equal(parsed.description, 'Doors: 9pm sharp\nDress code \\ leather welcome');
+  assert.equal(parsed.bar, 'The Eagle: Backroom');
+  assert.equal(parsed.shortName, 'FUR\\BALL: DALLAS');
+  assert.equal(parsed.cover, '$10');
+  assert.equal(parsed.title, undefined, 'excluded fields never enter the notes');
+});
+
+test('notes round-trip: URL-like values keep their unescaped colons', () => {
+  const event = {
+    ticketUrl: 'https://tickets.example/e/furball?time=21:00',
+    website: 'https://x.example/party'
+  };
+  const notes = EventSchema.formatEventNotes(event);
+  assert.match(notes, /ticketUrl: https:\/\/tickets\.example\/e\/furball\?time=21:00/,
+    'URL fields are written verbatim, not colon-escaped');
+
+  const parsed = EventSchema.parseNotesIntoFields(notes);
+  assert.equal(parsed.ticketUrl, 'https://tickets.example/e/furball?time=21:00');
+  assert.equal(parsed.website, 'https://x.example/party');
+});
+
+test('parseNotesIntoFields: a value line that looks like "key: value" stays part of the value', () => {
+  // The multi-line description contains an escaped "Doors\: 9pm" line; it must not
+  // be promoted to its own field.
+  const event = { description: 'Big party\nDoors: 9pm\nCover: cheap' };
+  const notes = EventSchema.formatEventNotes(event);
+  const parsed = EventSchema.parseNotesIntoFields(notes);
+  assert.deepEqual(parsed, { description: 'Big party\nDoors: 9pm\nCover: cheap' });
+});
+
+test('parseNotesIntoFields canonicalizes aliased keys (notes context maps location → bar)', () => {
+  const parsed = EventSchema.parseNotesIntoFields([
+    'venue: The Eagle',
+    'location: STATION 4',
+    'tickets: https://t.example/x'
+  ].join('\n'));
+  assert.equal(parsed.bar, 'STATION 4', 'both venue and location canonicalize to bar; last one wins');
+  assert.equal(parsed.ticketUrl, 'https://t.example/x');
+});
+
+test('parseNotesIntoFields tolerates empty and non-string input', () => {
+  assert.deepEqual(EventSchema.parseNotesIntoFields(''), {});
+  assert.deepEqual(EventSchema.parseNotesIntoFields(null), {});
+  assert.deepEqual(EventSchema.parseNotesIntoFields(undefined), {});
+  assert.deepEqual(EventSchema.parseNotesIntoFields(42), {});
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeEventKey
+// ---------------------------------------------------------------------------
+
+test('canonicalizeEventKey normalizes casing, spaces, dashes, and underscores', () => {
+  assert.equal(EventSchema.canonicalizeEventKey('Start Date'), 'startDate');
+  assert.equal(EventSchema.canonicalizeEventKey('start_date'), 'startDate');
+  assert.equal(EventSchema.canonicalizeEventKey('START-DATE'), 'startDate');
+  assert.equal(EventSchema.canonicalizeEventKey('Short Name'), 'shortName');
+});
+
+test('canonicalizeEventKey resolves aliases to canonical fields', () => {
+  assert.equal(EventSchema.canonicalizeEventKey('venue'), 'bar');
+  assert.equal(EventSchema.canonicalizeEventKey('name'), 'title');
+  assert.equal(EventSchema.canonicalizeEventKey('summary'), 'title');
+  assert.equal(EventSchema.canonicalizeEventKey('url'), 'website');
+  assert.equal(EventSchema.canonicalizeEventKey('link'), 'website');
+  assert.equal(EventSchema.canonicalizeEventKey('tickets'), 'ticketUrl');
+  assert.equal(EventSchema.canonicalizeEventKey('insta'), 'instagram');
+  assert.equal(EventSchema.canonicalizeEventKey('rrule'), 'recurrence');
+  assert.equal(EventSchema.canonicalizeEventKey('id'), 'identifier');
+  assert.equal(EventSchema.canonicalizeEventKey('duration'), 'durationMinutes');
+});
+
+test('canonicalizeEventKey maps location → bar only in the notes context', () => {
+  assert.equal(EventSchema.canonicalizeEventKey('location'), 'location');
+  assert.equal(EventSchema.canonicalizeEventKey('location', { context: 'notes' }), 'bar');
+  // Other keys are unaffected by the notes context
+  assert.equal(EventSchema.canonicalizeEventKey('venue', { context: 'notes' }), 'bar');
+});
+
+test('canonicalizeEventKey passes unknown and falsy keys through unchanged', () => {
+  assert.equal(EventSchema.canonicalizeEventKey('someCustomField'), 'someCustomField');
+  assert.equal(EventSchema.canonicalizeEventKey(''), '');
+  assert.equal(EventSchema.canonicalizeEventKey(null), null);
+  assert.equal(EventSchema.canonicalizeEventKey(undefined), undefined);
+  assert.equal(EventSchema.canonicalizeEventKey(0), 0);
+});
+
+// ---------------------------------------------------------------------------
+// findUnescaped / unescapeText
+// ---------------------------------------------------------------------------
+
+test('findUnescaped finds the first unescaped delimiter and skips escaped ones', () => {
+  assert.equal(EventSchema.findUnescaped('bar: The Eagle', ':'), 3);
+  // 'a\:b:c' — the first colon is escaped, the second is not
+  assert.equal(EventSchema.findUnescaped('a\\:b:c', ':'), 4);
+  // 'a\\:b' — double backslash escapes itself, so the colon IS unescaped
+  assert.equal(EventSchema.findUnescaped('a\\\\:b', ':'), 3);
+  // 'a\\\:b' — three backslashes: pair + escape, so the colon is escaped
+  assert.equal(EventSchema.findUnescaped('a\\\\\\:b', ':'), -1);
+});
+
+test('findUnescaped honors startIndex and missing-delimiter cases', () => {
+  assert.equal(EventSchema.findUnescaped('a:b:c', ':', 2), 3);
+  assert.equal(EventSchema.findUnescaped('no delimiter here', ':'), -1);
+  assert.equal(EventSchema.findUnescaped('', ':'), -1);
+  assert.equal(EventSchema.findUnescaped(null, ':'), -1);
+  assert.equal(EventSchema.findUnescaped('abc', ''), -1);
+});
+
+test('unescapeText reverses escapeText', () => {
+  assert.equal(EventSchema.unescapeText('Doors\\: 9pm'), 'Doors: 9pm');
+  assert.equal(EventSchema.unescapeText('back\\\\slash'), 'back\\slash');
+  assert.equal(EventSchema.unescapeText('plain text'), 'plain text');
+  assert.equal(EventSchema.unescapeText(123), 123, 'non-strings pass through');
+
+  const original = 'a:b\\c: d';
+  assert.equal(EventSchema.unescapeText(EventSchema.escapeText(original)), original);
+});
+
+// ---------------------------------------------------------------------------
+// isValidMetadataKey
+// ---------------------------------------------------------------------------
+
+test('isValidMetadataKey accepts letter-led alphanumeric keys (spaces allowed inside)', () => {
+  assert.equal(EventSchema.isValidMetadataKey('bar'), true);
+  assert.equal(EventSchema.isValidMetadataKey('ticketUrl'), true);
+  assert.equal(EventSchema.isValidMetadataKey('short name'), true);
+  assert.equal(EventSchema.isValidMetadataKey('a1'), true);
+  assert.equal(EventSchema.isValidMetadataKey('  bar  '), true, 'surrounding whitespace is trimmed');
+});
+
+test('isValidMetadataKey rejects garbage', () => {
+  assert.equal(EventSchema.isValidMetadataKey(''), false);
+  assert.equal(EventSchema.isValidMetadataKey(null), false);
+  assert.equal(EventSchema.isValidMetadataKey(undefined), false);
+  assert.equal(EventSchema.isValidMetadataKey(42), false);
+  assert.equal(EventSchema.isValidMetadataKey('a'), false, 'too short');
+  assert.equal(EventSchema.isValidMetadataKey('9lives'), false, 'must start with a letter');
+  assert.equal(EventSchema.isValidMetadataKey('has-dash'), false);
+  assert.equal(EventSchema.isValidMetadataKey('under_score'), false);
+  assert.equal(EventSchema.isValidMetadataKey('https://x.example'), false);
+  assert.equal(EventSchema.isValidMetadataKey('x'.repeat(31)), false, 'max 30 chars');
+  assert.equal(EventSchema.isValidMetadataKey('x'.repeat(30)), true);
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_NOTES_EXCLUDED_FIELDS
+// ---------------------------------------------------------------------------
+
+test('formatEventNotes omits default-excluded fields, underscore fields, and empty values', () => {
+  const event = {
+    title: 'FURBALL',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    city: 'dallas',
+    source: 'ai-web',
+    url: 'https://x.example',
+    notes: 'pre-existing notes',
+    matchKey: 'furball|2026-07-05',
+    _parserConfig: { name: 'secret' },
+    emptyField: '',
+    nullField: null,
+    bar: 'STATION 4'
+  };
+  const notes = EventSchema.formatEventNotes(event);
+  assert.equal(notes, 'bar: STATION 4', 'only the non-excluded, non-empty field remains');
+});
+
+test('DEFAULT_NOTES_EXCLUDED_FIELDS covers the calendar-native and internal fields', () => {
+  const excluded = EventSchema.DEFAULT_NOTES_EXCLUDED_FIELDS;
+  ['title', 'startDate', 'endDate', 'location', 'notes', 'url', 'city', 'source',
+    'coordinates', 'lat', 'lng', 'matchKey', 'recurrence'].forEach(field => {
+    assert.equal(excluded.has(field), true, `${field} should be excluded from notes`);
+  });
+  ['bar', 'address', 'shortName', 'ticketUrl', 'timezone', 'cover'].forEach(field => {
+    assert.equal(excluded.has(field), false, `${field} should be allowed in notes`);
+  });
+});
+
+test('formatEventNotes honors a custom excludeFields set', () => {
+  const event = { bar: 'STATION 4', cover: '$10' };
+  const notes = EventSchema.formatEventNotes(event, { excludeFields: new Set(['cover']) });
+  assert.equal(notes, 'bar: STATION 4');
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -787,3 +787,271 @@ test('filterEventsForExecution tolerates non-array input', () => {
   assert.deepEqual(SharedCore.filterEventsForExecution(null), []);
   assert.deepEqual(SharedCore.filterEventsForExecution(undefined), []);
 });
+
+// ---------------------------------------------------------------------------
+// Automation filtering (resolveAutomationContext / evaluateAutomationForParser)
+// ---------------------------------------------------------------------------
+
+test('resolveAutomationContext detects automation runs from runtime flags', () => {
+  const core = createCore();
+  assert.deepEqual(
+    core.resolveAutomationContext({ runtime: { automationRun: true } }),
+    { automationRun: true, filterParsers: true }
+  );
+  assert.deepEqual(
+    core.resolveAutomationContext({ runtime: { type: 'automated' } }),
+    { automationRun: true, filterParsers: true }
+  );
+  // Legacy fallback: runContext is consulted when runtime is absent
+  assert.deepEqual(
+    core.resolveAutomationContext({ runContext: { automationRun: true } }),
+    { automationRun: true, filterParsers: true }
+  );
+});
+
+test('resolveAutomationContext: automationFilter false disables parser filtering', () => {
+  const core = createCore();
+  assert.deepEqual(
+    core.resolveAutomationContext({ runtime: { automationRun: true, automationFilter: false } }),
+    { automationRun: true, filterParsers: false }
+  );
+});
+
+test('resolveAutomationContext treats manual and empty configs as non-automation', () => {
+  const core = createCore();
+  assert.deepEqual(core.resolveAutomationContext({}), { automationRun: false, filterParsers: false });
+  assert.deepEqual(core.resolveAutomationContext(null), { automationRun: false, filterParsers: false });
+  assert.deepEqual(
+    core.resolveAutomationContext({ runtime: { automationRun: false } }),
+    { automationRun: false, filterParsers: false }
+  );
+});
+
+test('evaluateAutomationForParser requires an explicit automationEnabled: true under filtering', () => {
+  const core = createCore();
+  const filtering = { automationRun: true, filterParsers: true };
+  assert.deepEqual(
+    core.evaluateAutomationForParser({ automationEnabled: true }, filtering),
+    { shouldRun: true, reason: null }
+  );
+  assert.deepEqual(
+    core.evaluateAutomationForParser({ automationEnabled: false }, filtering),
+    { shouldRun: false, reason: 'automation-disabled' }
+  );
+  assert.deepEqual(
+    core.evaluateAutomationForParser({ name: 'No Flag' }, filtering),
+    { shouldRun: false, reason: 'automation-disabled' }
+  );
+  assert.deepEqual(
+    core.evaluateAutomationForParser(null, filtering),
+    { shouldRun: false, reason: 'automation-disabled' }
+  );
+});
+
+test('evaluateAutomationForParser lets everything run when filtering is off', () => {
+  const core = createCore();
+  const noFiltering = { automationRun: false, filterParsers: false };
+  assert.deepEqual(core.evaluateAutomationForParser({ automationEnabled: false }, noFiltering), { shouldRun: true, reason: null });
+  assert.deepEqual(core.evaluateAutomationForParser({}, noFiltering), { shouldRun: true, reason: null });
+  assert.deepEqual(core.evaluateAutomationForParser({}, null), { shouldRun: true, reason: null });
+});
+
+// ---------------------------------------------------------------------------
+// processEvents automation behavior
+// ---------------------------------------------------------------------------
+
+function createDisplayAdapterStub() {
+  const logs = [];
+  const log = async (message) => { logs.push(message); };
+  return { logs, logInfo: log, logWarn: log, logError: log, logSuccess: log };
+}
+
+// Parser configs with no URLs exercise the real processParser without HTTP:
+// the crawl loop is a no-op, so only the enable/skip branching is under test.
+// The 'ai-web' entry exists because parser-less configs fall back to it.
+const STUB_PARSERS = { 'ai-web': {} };
+
+test('processEvents: enabled:false + automationEnabled:true RUNS in automation mode (intentional rule)', async () => {
+  const core = createCore();
+  const display = createDisplayAdapterStub();
+  const config = {
+    runtime: { automationRun: true },
+    parsers: [
+      { name: 'Disabled But Automated', enabled: false, automationEnabled: true, urls: [] },
+      { name: 'No Automation Flag', enabled: true, urls: [] }
+    ]
+  };
+
+  const results = await core.processEvents(config, {}, display, STUB_PARSERS);
+
+  assert.deepEqual(results.parserResults.map(r => r.name), ['Disabled But Automated'],
+    '"enabled" is a manual-run switch; automation only honors automationEnabled');
+  assert.deepEqual(results.automationSkippedParsers,
+    [{ name: 'No Automation Flag', reason: 'automation-disabled' }]);
+});
+
+test('processEvents: manual runs honor enabled and ignore automationEnabled', async () => {
+  const core = createCore();
+  const display = createDisplayAdapterStub();
+  const config = {
+    parsers: [
+      { name: 'Disabled But Automated', enabled: false, automationEnabled: true, urls: [] },
+      { name: 'Plain Manual Parser', urls: [] }
+    ]
+  };
+
+  const results = await core.processEvents(config, {}, display, STUB_PARSERS);
+
+  assert.deepEqual(results.parserResults.map(r => r.name), ['Plain Manual Parser']);
+  assert.equal(results.automationSkippedParsers, undefined, 'no automation bookkeeping on manual runs');
+});
+
+test('processEvents: automationFilter false runs every parser except manually-disabled ones', async () => {
+  const core = createCore();
+  const display = createDisplayAdapterStub();
+  const config = {
+    runtime: { automationRun: true, automationFilter: false },
+    parsers: [
+      { name: 'No Automation Flag', urls: [] },
+      { name: 'Manually Disabled', enabled: false, urls: [] }
+    ]
+  };
+
+  const results = await core.processEvents(config, {}, display, STUB_PARSERS);
+  assert.deepEqual(results.parserResults.map(r => r.name), ['No Automation Flag'],
+    'with filtering off, enabled:false applies again and automationEnabled is not required');
+});
+
+test('processEvents returns empty results when no parsers are configured', async () => {
+  const core = createCore();
+  const display = createDisplayAdapterStub();
+  const results = await core.processEvents({ parsers: [] }, {}, display, STUB_PARSERS);
+  assert.equal(results.totalEvents, 0);
+  assert.deepEqual(results.allProcessedEvents, []);
+  assert.deepEqual(results.parserResults, []);
+});
+
+// ---------------------------------------------------------------------------
+// createEventKey / keyTemplate
+// ---------------------------------------------------------------------------
+
+test('createEventKey substitutes ${date}, ${city}, ${venue}, and ${normalizedTitle}', () => {
+  const core = createCore();
+  const event = {
+    title: 'MEGA WOOF! / Dallas',
+    bar: ' The Eagle ',
+    city: 'dallas',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    _parserConfig: { keyTemplate: 'promo-${date}-${city}-${venue}' }
+  };
+  assert.equal(core.createEventKey(event), 'promo-2026-08-01-dallas-the eagle');
+
+  const normalized = core.createEventKey(event, '${normalizedTitle}');
+  assert.equal(normalized, 'mega-woof-dallas', 'specials between words collapse to hyphens');
+});
+
+test('createEventKey falls back to normalizedTitle|date|venue without a keyTemplate', () => {
+  const core = createCore();
+  const event = {
+    title: 'Bear Night',
+    bar: 'The Eagle',
+    city: 'dallas',
+    startDate: new Date('2026-08-01T21:00:00.000Z')
+  };
+  assert.equal(core.createEventKey(event), 'bear-night|2026-08-01|the eagle');
+});
+
+test('createEventKey title normalization strips trailing punctuation and collapses runs', () => {
+  const core = createCore();
+  const key = (title) => core.createEventKey({ title, startDate: new Date('2026-08-01T00:00:00.000Z') }, '${normalizedTitle}');
+  assert.equal(key('Party!!!'), 'party');
+  assert.equal(key('BEARRACUDA:  Invasion'), 'bearracuda-invasion');
+  assert.equal(key('  spaced   out  '), 'spaced-out');
+  assert.equal(key('a...b'), 'a-b');
+});
+
+test('createEventKey uses originalTitle over title and the UTC date of startDate', () => {
+  const core = createCore();
+  const event = {
+    title: 'Renamed Event',
+    originalTitle: 'Original Name',
+    bar: 'Somewhere',
+    startDate: '2026-08-02T01:00:00.000Z' // string input; late-night UTC date is kept as-is
+  };
+  assert.equal(core.createEventKey(event), 'original-name|2026-08-02|somewhere');
+});
+
+// ---------------------------------------------------------------------------
+// filterFutureEvents
+// ---------------------------------------------------------------------------
+
+test('filterFutureEvents drops past events unless allowPastEvents is set', () => {
+  const core = createCore();
+  const past = { title: 'Yesterday', startDate: new Date(Date.now() - 24 * 60 * 60 * 1000) };
+  const future = { title: 'Tomorrow', startDate: new Date(Date.now() + 24 * 60 * 60 * 1000) };
+
+  assert.deepEqual(core.filterFutureEvents([past, future]).map(e => e.title), ['Tomorrow']);
+  assert.deepEqual(
+    core.filterFutureEvents([past, future], null, true).map(e => e.title),
+    ['Yesterday', 'Tomorrow'],
+    'allowPastEvents keeps past events'
+  );
+});
+
+test('filterFutureEvents enforces the daysToLookAhead cutoff', () => {
+  const core = createCore();
+  const inWindow = { title: 'Soon', startDate: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000) };
+  const beyond = { title: 'Too Far', startDate: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000) };
+
+  assert.deepEqual(core.filterFutureEvents([inWindow, beyond], 5).map(e => e.title), ['Soon']);
+  assert.deepEqual(core.filterFutureEvents([inWindow, beyond]).map(e => e.title), ['Soon', 'Too Far'],
+    'no cutoff without daysToLookAhead');
+});
+
+test('filterFutureEvents drops events with missing or invalid startDate', () => {
+  const core = createCore();
+  const events = [
+    { title: 'No Date' },
+    { title: 'Bad Date', startDate: 'not-a-date' },
+    { title: 'Good', startDate: new Date(Date.now() + 60 * 60 * 1000) }
+  ];
+  assert.deepEqual(core.filterFutureEvents(events).map(e => e.title), ['Good']);
+});
+
+// ---------------------------------------------------------------------------
+// filterBearEvents
+// ---------------------------------------------------------------------------
+
+test('filterBearEvents: alwaysBear keeps everything and stamps isBearEvent', () => {
+  const core = createCore();
+  const events = [
+    { title: 'Techno Tuesday' },
+    { title: 'Wine Tasting' }
+  ];
+  const result = core.filterBearEvents(events, { alwaysBear: true });
+  assert.equal(result.length, 2);
+  assert.ok(result.every(e => e.isBearEvent === true));
+});
+
+test('filterBearEvents matches bear keywords in title, description, or bar', () => {
+  const core = createCore();
+  const events = [
+    { title: 'Bear Night' },
+    { title: 'Saturday Social', description: 'hosted by your favorite cub DJ' },
+    { title: 'Happy Hour', bar: 'Woof Lounge' },
+    { title: 'Techno Tuesday', description: 'four to the floor' }
+  ];
+  const result = core.filterBearEvents(events, {});
+  assert.deepEqual(result.map(e => e.title), ['Bear Night', 'Saturday Social', 'Happy Hour']);
+});
+
+test('filterBearEvents: requireKeywords + allowlist gates keyword matching', () => {
+  const core = createCore();
+  const events = [
+    { title: 'Bear Night at the Eagle' },
+    { title: 'FURBALL Bear Bash' }
+  ];
+  // Both match bear keywords, but only the allowlisted one passes the gate
+  const result = core.filterBearEvents(events, { allowlist: ['furball'], requireKeywords: true });
+  assert.deepEqual(result.map(e => e.title), ['FURBALL Bear Bash']);
+});


### PR DESCRIPTION
Third PR from the unified-scraper review: locks in the behaviors the review found untested, and finally wires the suite into CI — until now nothing ran the tests automatically.

## New tests (68 → 111 passing)

- **`scripts/event-schema.test.js` (new, 17):** first tests ever for event-schema despite it being a hard module-load requirement — `formatEventNotes` → `parseNotesIntoFields` round-trip with colons/newlines/escape characters, `canonicalizeEventKey` casing/aliases (including notes-context `location`→`bar`), `findUnescaped`/`unescapeText` escape semantics, `isValidMetadataKey`, and `DEFAULT_NOTES_EXCLUDED_FIELDS` exclusion.
- **`scripts/shared-core.test.js` (+19):** automation filtering (`resolveAutomationContext`, `evaluateAutomationForParser`, and the intentional `processEvents` rule that a parser with `enabled: false` but `automationEnabled: true` still runs on automation while one without `automationEnabled` is skipped), `createEventKey`/keyTemplate substitution and title normalization, `filterFutureEvents` (past events, `allowPastEvents`, `daysToLookAhead`), `filterBearEvents` (`alwaysBear`, keywords, allowlist).
- **`scripts/bear-event-scraper-unified.test.js` (new, 7):** possible now that #1457 made the orchestrator require-safe. Execution-mode matrix with stub adapters and a canned SharedCore subclass: automation runs execute calendar actions and filter out dry-run parsers' events; display mode defers execution; global dryRun blocks it; adapters without `executeCalendarActions` don't throw; an executor error lands in `results.errors` without killing the run; zero events yields `calendarEvents: 0`; and `require()` produces no side effects.

## CI

- `package.json` gains a `"test"` script listing the five test files explicitly — deliberately not directory mode, because node's default pattern would also pick up `scripts/test-ai-prompt.js`, a Scriptable utility that makes live AI HTTP requests on load.
- `.github/workflows/tests.yml`: runs `npm test` on every PR and push to main (node 22, no install step — the tests are dependency-free).

No genuine bugs surfaced; all assertions lock current behavior. One nuance documented in the tests: when notes contain both `venue:` and `location:` lines, both canonicalize to `bar` and the last one wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)