### PR TITLE
feat(scraper): organizer context in AI prompts + distance-ranked geocoding

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -723,6 +723,10 @@ class LocationNormalizer extends BaseNormalizer {
 }
 
 
+// Forward-geocode candidates farther than this from the event city's center are
+// rejected: a candidate 50+ km away is a same-named street/place in another city.
+const CITY_CENTER_RADIUS_KM = 50;
+
 class OpenStreetMapNormalizer extends BaseNormalizer {
     constructor(core) {
         super(core);
@@ -830,6 +834,64 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         return candidates.some(value => typeof value === 'string' && value.toLowerCase().includes(target));
     }
 
+    // Known city-center coordinates from the cities config (generated from
+    // js/city-config.js by tools/generate-scraper-cities.js). Returns
+    // { lat, lng } or null when the city is unknown or has no coordinates.
+    getCityCenterCoordinates(city) {
+        const key = String(city || '').trim();
+        if (!key || !this.core || !this.core.cities) return null;
+        const cityConfig = this.core.cities[key];
+        const coords = cityConfig && cityConfig.coordinates;
+        if (!coords) return null;
+        const lat = Number(coords.lat);
+        const lng = Number(coords.lng);
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+        return { lat, lng };
+    }
+
+    // Great-circle distance in kilometers between two lat/lon points.
+    haversineDistanceKm(lat1, lon1, lat2, lon2) {
+        const toRad = deg => (deg * Math.PI) / 180;
+        const earthRadiusKm = 6371;
+        const dLat = toRad(lat2 - lat1);
+        const dLon = toRad(lon2 - lon1);
+        const sinLat = Math.sin(dLat / 2);
+        const sinLon = Math.sin(dLon / 2);
+        const a = sinLat * sinLat + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * sinLon * sinLon;
+        return 2 * earthRadiusKm * Math.asin(Math.sqrt(Math.min(1, a)));
+    }
+
+    // Rank forward-geocode candidates by distance to the event city's center and
+    // return the nearest one inside the acceptance radius, or null. This
+    // supersedes the textual city check when center coordinates are known: a
+    // textual "portland" match can still be the wrong Portland — distance can't.
+    pickNearestGeocodeCandidate(candidates, cityCenter, eventCity, addressLabel) {
+        const ranked = [];
+        (Array.isArray(candidates) ? candidates : []).forEach((candidate, index) => {
+            if (!candidate) return;
+            const lat = Number(candidate.lat);
+            const lon = Number(candidate.lon);
+            if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+            ranked.push({
+                index,
+                lat: candidate.lat,
+                lon: candidate.lon,
+                distanceKm: this.haversineDistanceKm(lat, lon, cityCenter.lat, cityCenter.lng)
+            });
+        });
+        if (ranked.length === 0) return null;
+        ranked.sort((a, b) => a.distanceKm - b.distanceKm);
+        const nearest = ranked[0];
+        if (nearest.distanceKm > CITY_CENTER_RADIUS_KM) {
+            console.warn(`🗺️ OpenStreetMapNormalizer: All ${ranked.length} geocode candidate${ranked.length === 1 ? '' : 's'} for "${addressLabel}" fall outside ${CITY_CENTER_RADIUS_KM} km of ${eventCity} center (nearest is ${nearest.distanceKm.toFixed(1)} km away) — ignoring coordinates`);
+            return null;
+        }
+        if (ranked.length > 1) {
+            console.log(`🗺️ OpenStreetMapNormalizer: ${ranked.length} candidates for "${addressLabel}"; picked #${nearest.index + 1} (${nearest.distanceKm.toFixed(1)} km from ${eventCity} center)`);
+        }
+        return nearest;
+    }
+
     async normalizeAsync(event, httpAdapter) {
         if (!event || !httpAdapter || typeof httpAdapter.fetchData !== 'function') return event;
 
@@ -848,26 +910,41 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             const address = event.address.trim();
             // Bare street strings geocode anywhere on the planet: a flyer-OCR typo like
             // "922 E. BURNSIDE" (real address: 722 E Burnside, Portland) resolved to
-            // Burnside, Michigan. When the event knows its city, anchor the query to it
-            // and reject results that land outside that city.
+            // Burnside, Michigan. When the event knows its city, anchor the query to it.
+            // When the city also has known center coordinates, request several
+            // candidates and pick by distance to that center (textual matching alone
+            // false-accepts "Portland, Michigan" for a Portland OR event); otherwise
+            // fall back to rejecting results whose address details don't mention the city.
             const eventCity = typeof event.city === 'string' ? event.city.trim() : '';
+            const cityCenter = this.getCityCenterCoordinates(eventCity);
             const addressIncludesCity = eventCity && address.toLowerCase().includes(eventCity.toLowerCase());
             const queryText = eventCity && !addressIncludesCity ? `${address}, ${eventCity}` : address;
             const query = encodeURIComponent(queryText);
             const cityValidationParam = eventCity ? '&addressdetails=1' : '';
-            const url = `https://nominatim.openstreetmap.org/search?format=json&q=${query}&limit=1${cityValidationParam}`;
+            const resultLimit = cityCenter ? 5 : 1;
+            const url = `https://nominatim.openstreetmap.org/search?format=json&q=${query}&limit=${resultLimit}${cityValidationParam}`;
 
             try {
                 const data = await this.fetchDataWithCacheAndRateLimit(url, options, httpAdapter);
                 if (Array.isArray(data) && data.length > 0) {
-                    const firstResult = data[0];
-                    if (firstResult.lat && firstResult.lon) {
-                        if (eventCity && !this.geocodeResultMatchesCity(firstResult, eventCity)) {
-                            console.warn(`🗺️ OpenStreetMapNormalizer: Geocode for "${event.address}" resolved outside event city "${eventCity}" ("${firstResult.display_name || 'no display name'}") — ignoring coordinates`);
-                        } else {
-                            event.location = `${firstResult.lat}, ${firstResult.lon}`;
+                    if (cityCenter) {
+                        // Distance-ranked selection: nearest candidate within the radius wins
+                        const picked = this.pickNearestGeocodeCandidate(data, cityCenter, eventCity, address);
+                        if (picked) {
+                            event.location = `${picked.lat}, ${picked.lon}`;
                             modified = true;
                             console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
+                        }
+                    } else {
+                        const firstResult = data[0];
+                        if (firstResult.lat && firstResult.lon) {
+                            if (eventCity && !this.geocodeResultMatchesCity(firstResult, eventCity)) {
+                                console.warn(`🗺️ OpenStreetMapNormalizer: Geocode for "${event.address}" resolved outside event city "${eventCity}" ("${firstResult.display_name || 'no display name'}") — ignoring coordinates`);
+                            } else {
+                                event.location = `${firstResult.lat}, ${firstResult.lon}`;
+                                modified = true;
+                                console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
+                            }
                         }
                     }
                 }

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -159,6 +159,78 @@ test('forward geocode without an event city keeps the legacy query and accepts t
   );
 });
 
+// ---------------------------------------------------------------------------
+// OpenStreetMapNormalizer distance-ranked geocoding: when the event city has
+// known center coordinates, candidates are ranked by haversine distance to the
+// center (textual matching alone false-accepts "Portland, Michigan" for a
+// Portland OR event because the display name contains "portland").
+// ---------------------------------------------------------------------------
+
+const CITIES_WITH_COORDS = {
+  portland: {
+    timezone: 'America/Los_Angeles',
+    patterns: ['portland', 'pdx'],
+    coordinates: { lat: 45.5152, lng: -122.6784 }
+  }
+};
+
+function createOsmNormalizerWithCoords() {
+  const core = new SharedCore(CITIES_WITH_COORDS, { eventSchema: EventSchema });
+  return new OpenStreetMapNormalizer(core);
+}
+
+// Textually matches "portland" but is ~2800 km from Portland, Oregon.
+const PORTLAND_MICHIGAN_RESULT = {
+  lat: '42.8692006',
+  lon: '-84.9030517',
+  display_name: 'Portland, Ionia County, Michigan, United States',
+  address: { city: 'Portland', county: 'Ionia County', state: 'Michigan' }
+};
+
+test('distance ranking picks the candidate nearest the city center, not the first textual match', async () => {
+  const normalizer = createOsmNormalizerWithCoords();
+  // The wrong-state (but textually matching) candidate is listed FIRST
+  const httpAdapter = createStubHttpAdapter([PORTLAND_MICHIGAN_RESULT, PORTLAND_RESULT]);
+  const event = { title: 'PRIDE FRIDAY', address: '722 E Burnside', city: 'portland' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.location, '45.5230622, -122.6564816', 'the Oregon candidate must win by distance');
+  assert.ok(
+    httpAdapter.requests[0].includes('&limit=5'),
+    `known city coordinates must request 5 candidates: ${httpAdapter.requests[0]}`
+  );
+  assert.ok(httpAdapter.requests[0].includes('&addressdetails=1'), 'address details stay requested');
+});
+
+test('distance ranking rejects every candidate beyond the 50 km radius', async () => {
+  const normalizer = createOsmNormalizerWithCoords();
+  const httpAdapter = createStubHttpAdapter([WRONG_CITY_RESULT, PORTLAND_MICHIGAN_RESULT]);
+  const event = { title: 'PRIDE FRIDAY', address: '922 E. BURNSIDE', city: 'portland' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.location, undefined, 'candidates outside the radius must not set coordinates');
+});
+
+test('a configured city without coordinates keeps the textual validation path', async () => {
+  const normalizer = createOsmNormalizer(); // CITIES: nyc has no coordinates
+  const httpAdapter = createStubHttpAdapter([WRONG_CITY_RESULT]);
+  const event = { title: 'BEAR NIGHT', address: '355 W 41st St', city: 'nyc' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.location, undefined, 'textual city mismatch must still reject the result');
+  assert.ok(httpAdapter.requests[0].includes('&limit=1'), 'no coordinates → legacy single-result request');
+});
+
+test('haversineDistanceKm sanity: Portland→Seattle ≈ 233 km, identical points are 0', () => {
+  const normalizer = createOsmNormalizerWithCoords();
+  const distance = normalizer.haversineDistanceKm(45.5152, -122.6784, 47.6062, -122.3321);
+  assert.ok(Math.abs(distance - 233) < 5, `expected ~233 km, got ${distance}`);
+  assert.equal(normalizer.haversineDistanceKm(45.5, -122.6, 45.5, -122.6), 0);
+});
+
 test('resolveWallClockDates ignores events without the wall-clock flag', () => {
   const normalizer = createLocationNormalizer();
   const event = {

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -300,6 +300,15 @@ class AiWebParser {
             const sourceUrl = htmlData && htmlData.url ? htmlData.url : '';
             const additionalLinks = this.extractAdditionalUrls(html, sourceUrl, parserConfig);
 
+            // Derive the page's organizer/site brand ONCE per page (from JSON-LD
+            // Organization/WebSite and og:site_name). Extraction prompts, the
+            // post-extraction guard in normalizeAiEvent, and downstream merge
+            // arbitration all reuse this cached result instead of re-parsing HTML.
+            const pageBrandNames = this.getPageBrandNames(htmlData);
+            if (pageBrandNames.length > 0) {
+                console.log(`🤖 AI Web: Page organizer/brand derived from metadata: ${pageBrandNames.map(name => `"${name}"`).join(', ')}`);
+            }
+
             // Deterministic extraction from schema.org Event JSON-LD. Ticketing pages
             // (sickening.events, tryst.events, Eventbrite) hand us complete structured
             // data — when it covers title + start + venue, OCR and AI extraction add
@@ -314,6 +323,9 @@ class AiWebParser {
                 && (pageClassification !== 'multi-event-page' || completeJsonLdEvents.length >= 2);
             if (useJsonLdEvents) {
                 console.log(`🤖 AI Web: Extracted ${completeJsonLdEvents.length} event(s) from JSON-LD structured data — skipping OCR and AI extraction`);
+                if (pageBrandNames.length > 0) {
+                    completeJsonLdEvents.forEach(event => { event._organizer = pageBrandNames[0]; });
+                }
                 return {
                     events: completeJsonLdEvents,
                     additionalLinks: additionalLinks,
@@ -5319,6 +5331,27 @@ ${String(snippet || '')}`;
 `;
         }
 
+        // Page-level steering context, present in every extraction variant
+        // (default/alternate/repair): the organizer brand derived from the page's
+        // own metadata (prevention up front, complementing the post-extraction
+        // guard in normalizeAiEvent) plus any configured ai.extraContext override,
+        // which is appended verbatim.
+        let steeringContext = '';
+        const pageBrandNames = this.getPageBrandNames(htmlData);
+        if (pageBrandNames.length > 0) {
+            const aliasSuffix = pageBrandNames.length > 1
+                ? ` (also appears as ${pageBrandNames.slice(1).map(name => `"${name}"`).join(', ')})`
+                : '';
+            steeringContext += `KNOWN ORGANIZER (derived from page metadata): "${pageBrandNames[0]}"${aliasSuffix} — this is the event promoter/site brand, NOT the venue. Never return it as "bar", and do not treat its name in page titles as part of the event name.\n`;
+        }
+        const extraContext = aiConfig && typeof aiConfig.extraContext === 'string' ? aiConfig.extraContext.trim() : '';
+        if (extraContext) {
+            steeringContext += `${extraContext}\n`;
+        }
+        if (steeringContext) {
+            steeringContext += `\n`;
+        }
+
         const exampleOutput = `EXAMPLE OUTPUT FORMAT (structure only, not real data):\n{"city": {"value": "miami", "evidence": "Miami, FL", "confidence": 90}, "bar": {"value": "Eagle Bar", "evidence": "@ Eagle Bar", "confidence": 95}}`;
 
         const templates = {
@@ -5326,7 +5359,7 @@ ${String(snippet || '')}`;
 
 Format the output as a single JSON object where each requested key maps to an object containing "value", "evidence", and "confidence".
 
-${dataProvided}${sourceData}${additionalContext}Preferred keys:
+${dataProvided}${sourceData}${additionalContext}${steeringContext}Preferred keys:
 ${fieldContext}
 Rules:
 - Return a single JSON object only
@@ -5340,7 +5373,7 @@ ${exampleOutput}
 
 Format the output as a single JSON object where each requested key maps to an object containing "value", "evidence", and "confidence".
 
-${dataProvided}${sourceData}${additionalContext}Fields to find:
+${dataProvided}${sourceData}${additionalContext}${steeringContext}Fields to find:
 ${fieldContext}
 Rules:
 - Return a single JSON object only
@@ -5355,7 +5388,7 @@ ${exampleOutput}
 
 Format the output as a single JSON object where each requested key maps to an object containing "value", "evidence", and "confidence".
 
-${additionalContext}Preferred keys:
+${additionalContext}${steeringContext}Preferred keys:
 ${fieldContext}
 Rules:
 - JSON object only
@@ -5378,8 +5411,13 @@ TEXT:
         return this.buildExtractionPrompt(htmlData, aiConfig, cityConfig, parserConfig, fields, snippet, 'alternate', dataFlags);
     }
 
-    buildJsonRepairPrompt(rawResponse, aiConfig, cityConfig, parserConfig, fields, dataFlags = {}) {
-        return this.buildExtractionPrompt(null, aiConfig, cityConfig, parserConfig, fields, rawResponse, 'repair', dataFlags);
+    buildJsonRepairPrompt(rawResponse, aiConfig, cityConfig, parserConfig, fields, dataFlags = {}, htmlData = null) {
+        // The repair pass sees only the broken JSON text, but still needs the
+        // page-level steering context (organizer brand, ai.extraContext). Pass the
+        // cached brand names through WITHOUT the page html so the repair prompt
+        // stays free of page/OCR payload.
+        const contextHtmlData = htmlData ? { pageBrandNames: this.getPageBrandNames(htmlData) } : null;
+        return this.buildExtractionPrompt(contextHtmlData, aiConfig, cityConfig, parserConfig, fields, rawResponse, 'repair', dataFlags);
     }
 
     /**
@@ -5506,7 +5544,7 @@ TEXT:
 
         // PASS 3: Try repair if extraction returned unparseable JSON
         console.warn(`🤖 AI Web: Extraction pass${passSuffix} returned unparseable JSON; attempting repair`);
-        const repairPrompt = this.buildJsonRepairPrompt(rawResponse, aiConfig, cityConfig, parserConfig, fields, dataFlags);
+        const repairPrompt = this.buildJsonRepairPrompt(rawResponse, aiConfig, cityConfig, parserConfig, fields, dataFlags, htmlData);
         const repairResponse = await this.core.callAiGenerate(aiConfig, repairPrompt, 'repair', httpAdapter, this.recordAiPrompt.bind(this));
         if (!repairResponse) return null;
         event = parseAndFilterConfidence(repairResponse);
@@ -6345,9 +6383,8 @@ TEXT:
         // ("Portland PRIDE FRIDAY | BEARRACUDA") and extraction leaks it into
         // bar/title. The brand names are derived from the page's own markup —
         // see extractPageBrandNames — never from a hardcoded organizer list.
-        const pageBrandNames = this.extractPageBrandNames(
-            htmlData && typeof htmlData.html === 'string' ? htmlData.html : ''
-        );
+        // (Cached per page; parseEvents primes the cache on the original html.)
+        const pageBrandNames = this.getPageBrandNames(htmlData);
         if (pageBrandNames.length > 0) {
             // Only AI-extracted values are guarded: an explicitly configured bar is a
             // deliberate override and must survive even when it matches the site brand
@@ -6584,6 +6621,13 @@ TEXT:
         };
         if (usedWallClockFallback) {
             event._timezoneUnresolved = true;
+        }
+
+        // Stamp the derived organizer as internal metadata (underscore fields are
+        // excluded from calendar notes and merge field loops) so downstream merge
+        // arbitration can warn the model off picking the organizer as the venue.
+        if (pageBrandNames.length > 0) {
+            event._organizer = pageBrandNames[0];
         }
 
         if (aiPrompts.length > 0) {
@@ -7003,6 +7047,20 @@ TEXT:
     // it into bar/title; deriving the brand from the page keeps the guard generic
     // (no hardcoded organizer lists). og:site_name is deliberately excluded from
     // prompt meta parts (excludedMetaKeyRegexes), so it is read from the raw HTML.
+    // Cached per-page brand lookup: brand extraction re-parses the page's JSON-LD,
+    // so it is computed once per parsed page and carried on htmlData (segment and
+    // OCR copies spread htmlData, inheriting the cache). parseEvents primes the
+    // cache on the original page html before any per-pass copies are made.
+    getPageBrandNames(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object') return [];
+        if (Array.isArray(htmlData.pageBrandNames)) return htmlData.pageBrandNames;
+        const names = this.extractPageBrandNames(typeof htmlData.html === 'string' ? htmlData.html : '');
+        if (Object.isExtensible(htmlData)) {
+            htmlData.pageBrandNames = names;
+        }
+        return names;
+    }
+
     extractPageBrandNames(html) {
         const source = String(html || '').slice(0, 500000);
         const names = new Set();

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -989,3 +989,90 @@ test('matchesPageBrandName matches across trailing corporate suffixes and punctu
   assert.equal(parser.matchesPageBrandName('bearracuda inc', ['Bearracuda, Inc.']), true);
   assert.equal(parser.matchesPageBrandName('Nova PDX', ['Bearracuda, Inc.', 'BEARRACUDA']), false);
 });
+
+// ---------------------------------------------------------------------------
+// Organizer context in extraction prompts (prevention, complementing the
+// post-extraction guard) + the ai.extraContext override
+// ---------------------------------------------------------------------------
+
+test('extraction prompts carry the KNOWN ORGANIZER line when the page declares a brand', () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_HTML, url: 'https://bearracuda.com/events/portland' };
+  const aiConfig = parser.getAiConfig({});
+
+  for (const variant of ['default', 'alternate', 'repair']) {
+    const prompt = parser.buildExtractionPrompt(
+      htmlData, aiConfig, null, {}, ['title', 'bar'], 'SNIPPET', variant, { content: true });
+    assert.match(
+      prompt,
+      /KNOWN ORGANIZER \(derived from page metadata\): "Bearracuda, Inc\."/,
+      `${variant} variant must carry the organizer line`);
+    assert.match(prompt, /NOT the venue/, `${variant} variant must explain the brand is not the venue`);
+  }
+});
+
+test('extraction prompts omit the KNOWN ORGANIZER line when the page declares no brand', () => {
+  const parser = createParser();
+  const htmlData = { html: '<html><body><p>Bear Night at the Eagle</p></body></html>', url: 'https://eagle.example/events' };
+  const prompt = parser.buildExtractionPrompt(
+    htmlData, parser.getAiConfig({}), null, {}, ['title', 'bar'], 'SNIPPET', 'default', { content: true });
+  assert.ok(!/KNOWN ORGANIZER/.test(prompt), 'no page brand → no organizer line');
+});
+
+test('ai.extraContext is appended verbatim to the extraction prompt context', () => {
+  const parser = createParser();
+  const aiConfig = parser.getAiConfig({ ai: { extraContext: 'VENUE HINT: events here are always at Eagle NYC.' } });
+  assert.equal(aiConfig.extraContext, 'VENUE HINT: events here are always at Eagle NYC.');
+
+  const prompt = parser.buildExtractionPrompt(
+    { html: '<p>party</p>', url: 'https://eagle.example/events' },
+    aiConfig, null, {}, ['title', 'bar'], 'SNIPPET', 'default', { content: true });
+  assert.match(prompt, /VENUE HINT: events here are always at Eagle NYC\./);
+
+  const withoutOverride = parser.buildExtractionPrompt(
+    { html: '<p>party</p>', url: 'https://eagle.example/events' },
+    parser.getAiConfig({}), null, {}, ['title', 'bar'], 'SNIPPET', 'default', { content: true });
+  assert.ok(!/VENUE HINT/.test(withoutOverride), 'no override → nothing appended');
+});
+
+test('the repair prompt keeps the organizer context without the page payload', () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_HTML, url: 'https://bearracuda.com/events/portland' };
+  const prompt = parser.buildJsonRepairPrompt(
+    '{"title": broken', parser.getAiConfig({}), null, {}, ['title', 'bar'], {}, htmlData);
+  assert.match(prompt, /KNOWN ORGANIZER \(derived from page metadata\): "Bearracuda, Inc\."/);
+  assert.ok(!prompt.includes('Nova PDX, 722 E Burnside'), 'page body must not leak into the repair prompt');
+});
+
+test('normalizeAiEvent stamps the derived organizer as internal _organizer metadata', () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_HTML, url: 'https://bearracuda.com/events/portland' };
+  const event = parser.normalizeAiEvent(
+    { title: 'Portland PRIDE FRIDAY', bar: 'Nova PDX', startDate: '2026-07-17', startTime: '22:00' },
+    {}, htmlData, null, null);
+  assert.equal(event._organizer, 'Bearracuda, Inc.');
+
+  const plain = parser.normalizeAiEvent(
+    { title: 'Bear Night', startDate: '2026-07-17' },
+    {}, { html: '<p>no brand markup</p>', url: 'https://eagle.example' }, null, null);
+  assert.equal(plain._organizer, undefined, 'no page brand → no organizer stamp');
+});
+
+test('getPageBrandNames caches the brand extraction on htmlData', () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_HTML, url: 'https://bearracuda.com/events/portland' };
+  let extractCalls = 0;
+  const originalExtract = parser.extractPageBrandNames.bind(parser);
+  parser.extractPageBrandNames = (html) => {
+    extractCalls++;
+    return originalExtract(html);
+  };
+
+  const first = parser.getPageBrandNames(htmlData);
+  const second = parser.getPageBrandNames(htmlData);
+  const viaSpread = parser.getPageBrandNames({ ...htmlData, html: 'OCR TEXT\n' + htmlData.html });
+
+  assert.equal(extractCalls, 1, 'the page html must be parsed exactly once');
+  assert.equal(second, first, 'repeat lookups return the cached array');
+  assert.deepEqual(viaSpread, first, 'spread copies (segments/OCR) inherit the cache');
+});

--- a/scripts/scraper-cities.js
+++ b/scripts/scraper-cities.js
@@ -18,14 +18,22 @@ const scraperCities = {
       "brooklyn",
       "queens",
       "bronx"
-    ]
+    ],
+    "coordinates": {
+      "lat": 40.7831,
+      "lng": -73.9712
+    }
   },
   "seattle": {
     "calendar": "chunky-dad-seattle",
     "timezone": "America/Los_Angeles",
     "patterns": [
       "seattle"
-    ]
+    ],
+    "coordinates": {
+      "lat": 47.6062,
+      "lng": -122.3321
+    }
   },
   "la": {
     "calendar": "chunky-dad-la",
@@ -40,21 +48,33 @@ const scraperCities = {
       "long beach",
       "santa monica",
       "d>u>r>o"
-    ]
+    ],
+    "coordinates": {
+      "lat": 34.0522,
+      "lng": -118.2437
+    }
   },
   "toronto": {
     "calendar": "chunky-dad-toronto",
     "timezone": "America/Toronto",
     "patterns": [
       "toronto"
-    ]
+    ],
+    "coordinates": {
+      "lat": 43.6532,
+      "lng": -79.3832
+    }
   },
   "london": {
     "calendar": "chunky-dad-london",
     "timezone": "Europe/London",
     "patterns": [
       "london"
-    ]
+    ],
+    "coordinates": {
+      "lat": 51.5074,
+      "lng": -0.1278
+    }
   },
   "chicago": {
     "calendar": "chunky-dad-chicago",
@@ -62,35 +82,55 @@ const scraperCities = {
     "patterns": [
       "chicago",
       "chi"
-    ]
+    ],
+    "coordinates": {
+      "lat": 41.8781,
+      "lng": -87.6298
+    }
   },
   "berlin": {
     "calendar": "chunky-dad-berlin",
     "timezone": "Europe/Berlin",
     "patterns": [
       "berlin"
-    ]
+    ],
+    "coordinates": {
+      "lat": 52.52,
+      "lng": 13.405
+    }
   },
   "palm-springs": {
     "calendar": "chunky-dad-palm-springs",
     "timezone": "America/Los_Angeles",
     "patterns": [
       "palm springs"
-    ]
+    ],
+    "coordinates": {
+      "lat": 33.8303,
+      "lng": -116.5453
+    }
   },
   "denver": {
     "calendar": "chunky-dad-denver",
     "timezone": "America/Denver",
     "patterns": [
       "denver"
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.7392,
+      "lng": -104.9903
+    }
   },
   "dallas": {
     "calendar": "chunky-dad-dallas",
     "timezone": "America/Chicago",
     "patterns": [
       "dallas"
-    ]
+    ],
+    "coordinates": {
+      "lat": 32.7767,
+      "lng": -96.797
+    }
   },
   "dc": {
     "calendar": "chunky-dad-dc",
@@ -100,7 +140,11 @@ const scraperCities = {
       "washington, dc",
       "washington dc",
       "district of columbia"
-    ]
+    ],
+    "coordinates": {
+      "lat": 38.9072,
+      "lng": -77.0369
+    }
   },
   "vegas": {
     "calendar": "chunky-dad-vegas",
@@ -108,7 +152,11 @@ const scraperCities = {
     "patterns": [
       "las vegas",
       "vegas"
-    ]
+    ],
+    "coordinates": {
+      "lat": 36.1699,
+      "lng": -115.1398
+    }
   },
   "atlanta": {
     "calendar": "chunky-dad-atlanta",
@@ -116,14 +164,22 @@ const scraperCities = {
     "patterns": [
       "atlanta",
       "atl"
-    ]
+    ],
+    "coordinates": {
+      "lat": 33.749,
+      "lng": -84.388
+    }
   },
   "nola": {
     "calendar": "chunky-dad-new-orleans",
     "timezone": "America/Chicago",
     "patterns": [
       "new orleans"
-    ]
+    ],
+    "coordinates": {
+      "lat": 29.9511,
+      "lng": -90.0715
+    }
   },
   "sf": {
     "calendar": "chunky-dad-sf",
@@ -135,21 +191,33 @@ const scraperCities = {
       "castro",
       "san jose",
       "oakland"
-    ]
+    ],
+    "coordinates": {
+      "lat": 37.7749,
+      "lng": -122.4194
+    }
   },
   "portland": {
     "calendar": "chunky-dad-portland",
     "timezone": "America/Los_Angeles",
     "patterns": [
       "portland"
-    ]
+    ],
+    "coordinates": {
+      "lat": 45.5152,
+      "lng": -122.6784
+    }
   },
   "sitges": {
     "calendar": "chunky-dad-sitges",
     "timezone": "Europe/Madrid",
     "patterns": [
       "sitges"
-    ]
+    ],
+    "coordinates": {
+      "lat": 41.2379,
+      "lng": 1.8057
+    }
   },
   "boston": {
     "calendar": "chunky-dad-boston",
@@ -160,14 +228,22 @@ const scraperCities = {
       "bostom",
       "bostun",
       "bostan"
-    ]
+    ],
+    "coordinates": {
+      "lat": 42.3601,
+      "lng": -71.0589
+    }
   },
   "phoenix": {
     "calendar": "chunky-dad-phoenix",
     "timezone": "America/Phoenix",
     "patterns": [
       "phoenix"
-    ]
+    ],
+    "coordinates": {
+      "lat": 33.4484,
+      "lng": -112.074
+    }
   },
   "ptown": {
     "calendar": "chunky-dad-provincetown",
@@ -175,14 +251,22 @@ const scraperCities = {
     "patterns": [
       "provincetown",
       "ptown"
-    ]
+    ],
+    "coordinates": {
+      "lat": 42.0526,
+      "lng": -70.1865
+    }
   },
   "san-diego": {
     "calendar": "chunky-dad-san-diego",
     "timezone": "America/Los_Angeles",
     "patterns": [
       "san diego"
-    ]
+    ],
+    "coordinates": {
+      "lat": 32.7157,
+      "lng": -117.1611
+    }
   },
   "philly": {
     "calendar": "chunky-dad-philadelphia",
@@ -190,7 +274,11 @@ const scraperCities = {
     "patterns": [
       "philadelphia",
       "philly"
-    ]
+    ],
+    "coordinates": {
+      "lat": 39.9526,
+      "lng": -75.1652
+    }
   },
   "miami": {
     "calendar": "chunky-dad-miami",
@@ -200,7 +288,11 @@ const scraperCities = {
       "south beach",
       "miami beach",
       "key west"
-    ]
+    ],
+    "coordinates": {
+      "lat": 25.7617,
+      "lng": -80.1918
+    }
   },
   "pv": {
     "calendar": "chunky-dad-puerto-vallerta",
@@ -208,28 +300,44 @@ const scraperCities = {
     "patterns": [
       "puerto vallarta",
       "vallarta"
-    ]
+    ],
+    "coordinates": {
+      "lat": 20.6534,
+      "lng": -105.2253
+    }
   },
   "austin": {
     "calendar": "chunky-dad-austin",
     "timezone": "America/Chicago",
     "patterns": [
       "austin"
-    ]
+    ],
+    "coordinates": {
+      "lat": 30.2672,
+      "lng": -97.7431
+    }
   },
   "houston": {
     "calendar": "chunky-dad-houston",
     "timezone": "America/Chicago",
     "patterns": [
       "houston"
-    ]
+    ],
+    "coordinates": {
+      "lat": 29.7604,
+      "lng": -95.3698
+    }
   },
   "sacramento": {
     "calendar": "chunky-dad-sacramento",
     "timezone": "America/Los_Angeles",
     "patterns": [
       "sacramento"
-    ]
+    ],
+    "coordinates": {
+      "lat": 38.5816,
+      "lng": -121.4944
+    }
   },
   "poconos": {
     "calendar": "chunky-dad-poconos",
@@ -237,14 +345,22 @@ const scraperCities = {
     "patterns": [
       "poconos",
       "pocono"
-    ]
+    ],
+    "coordinates": {
+      "lat": 41.0339,
+      "lng": -75.3188
+    }
   },
   "torremolinos": {
     "calendar": "chunky-dad-torremolinos",
     "timezone": "Europe/Madrid",
     "patterns": [
       "torremolinos"
-    ]
+    ],
+    "coordinates": {
+      "lat": 36.6213,
+      "lng": -4.4998
+    }
   },
   "fort-lauderdale": {
     "calendar": "chunky-dad-fort-lauderdale",
@@ -253,14 +369,22 @@ const scraperCities = {
       "fort lauderdale",
       "fll",
       "ft lauderdale"
-    ]
+    ],
+    "coordinates": {
+      "lat": 26.1224,
+      "lng": -80.1373
+    }
   },
   "montreal": {
     "calendar": "chunky-dad-montreal",
     "timezone": "America/Toronto",
     "patterns": [
       "montreal"
-    ]
+    ],
+    "coordinates": {
+      "lat": 45.5019,
+      "lng": -73.5674
+    }
   },
   "fire-island": {
     "calendar": "chunky-dad-fire-island",
@@ -269,7 +393,11 @@ const scraperCities = {
       "fire island",
       "cherry grove",
       "fire island pines"
-    ]
+    ],
+    "coordinates": {
+      "lat": 40.6482,
+      "lng": -73.085
+    }
   },
   "vancouver": {
     "calendar": "chunky-dad-vancouver",
@@ -277,7 +405,11 @@ const scraperCities = {
     "patterns": [
       "vancouver",
       "yvr"
-    ]
+    ],
+    "coordinates": {
+      "lat": 49.2827,
+      "lng": -123.1207
+    }
   },
   "bangkok": {
     "calendar": "chunky-dad-bangkok",
@@ -285,14 +417,22 @@ const scraperCities = {
     "patterns": [
       "bangkok",
       "bkk"
-    ]
+    ],
+    "coordinates": {
+      "lat": 13.7563,
+      "lng": 100.5018
+    }
   },
   "paris": {
     "calendar": "chunky-dad-paris",
     "timezone": "Europe/Paris",
     "patterns": [
       "paris"
-    ]
+    ],
+    "coordinates": {
+      "lat": 48.8566,
+      "lng": 2.3522
+    }
   },
   "manchester": {
     "calendar": "chunky-dad-manchester",
@@ -300,14 +440,22 @@ const scraperCities = {
     "patterns": [
       "manchester",
       "mcr"
-    ]
+    ],
+    "coordinates": {
+      "lat": 53.4808,
+      "lng": -2.2426
+    }
   },
   "dublin": {
     "calendar": "chunky-dad-dublin",
     "timezone": "Europe/Dublin",
     "patterns": [
       "dublin"
-    ]
+    ],
+    "coordinates": {
+      "lat": 53.3498,
+      "lng": -6.2603
+    }
   },
   "mexico-city": {
     "calendar": "chunky-dad-mexico-city",
@@ -315,21 +463,33 @@ const scraperCities = {
     "patterns": [
       "mexico city",
       "cdmx"
-    ]
+    ],
+    "coordinates": {
+      "lat": 19.4326,
+      "lng": -99.1332
+    }
   },
   "madrid": {
     "calendar": "chunky-dad-madrid",
     "timezone": "Europe/Madrid",
     "patterns": [
       "madrid"
-    ]
+    ],
+    "coordinates": {
+      "lat": 40.4168,
+      "lng": -3.7038
+    }
   },
   "amsterdam": {
     "calendar": "chunky-dad-amsterdam",
     "timezone": "Europe/Amsterdam",
     "patterns": [
       "amsterdam"
-    ]
+    ],
+    "coordinates": {
+      "lat": 52.3676,
+      "lng": 4.9041
+    }
   },
   "sao-paulo": {
     "calendar": "chunky-dad-sao-paulo",
@@ -337,7 +497,11 @@ const scraperCities = {
     "patterns": [
       "sao paulo",
       "são paulo"
-    ]
+    ],
+    "coordinates": {
+      "lat": -23.5505,
+      "lng": -46.6333
+    }
   },
   "bogota": {
     "calendar": "chunky-dad-bogota",
@@ -345,7 +509,11 @@ const scraperCities = {
     "patterns": [
       "bogota",
       "bogotá"
-    ]
+    ],
+    "coordinates": {
+      "lat": 4.711,
+      "lng": -74.0721
+    }
   },
   "honolulu": {
     "calendar": "chunky-dad-honolulu",
@@ -355,7 +523,11 @@ const scraperCities = {
       "hawaii",
       "oahu",
       "waikiki"
-    ]
+    ],
+    "coordinates": {
+      "lat": 21.3069,
+      "lng": -157.8583
+    }
   },
   "hong-kong": {
     "calendar": "chunky-dad-hongkong",
@@ -363,14 +535,22 @@ const scraperCities = {
     "patterns": [
       "hong kong",
       "hk"
-    ]
+    ],
+    "coordinates": {
+      "lat": 22.3193,
+      "lng": 114.1694
+    }
   },
   "tokyo": {
     "calendar": "chunky-dad-tokyo",
     "timezone": "Asia/Tokyo",
     "patterns": [
       "tokyo"
-    ]
+    ],
+    "coordinates": {
+      "lat": 35.6762,
+      "lng": 139.6503
+    }
   }
 };
 

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -54,6 +54,14 @@ const scraperConfig = {
       // (scraped clobbers). This global block also serves events from non-AI
       // parsers; per-parser ai.arbitrateMerges overrides. Set false to disable.
       arbitrateMerges: true,
+      // extraContext (override-only): free-form text appended VERBATIM to the
+      // context of every AI extraction prompt. Organizer/brand context is
+      // normally derived automatically from each page's own metadata (JSON-LD
+      // Organization/WebSite nodes and og:site_name) — set this only when a
+      // page's markup declares nothing useful and the model needs a hint.
+      // Per-parser ai.extraContext overrides this global value ("" opts out).
+      // Default: "" (no extra context).
+      // extraContext: "",
       // Full AI prompt/response payloads normally go to the debug channel only:
       // captured into the run log file (logs/<runId>.log) but hidden from the
       // visible console. Set true to also mirror them to the live console while

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -381,7 +381,7 @@ class SharedCore {
     // raw, <labelB>: raw } }]. Returns { [field]: { pick, reason } } containing only
     // fields whose answer survived the verbatim gate, or null when no usable response
     // was obtained at all (caller falls back for everything).
-    async arbitrateMergeConflicts({ conflicts, labels, aiConfig, httpAdapter, eventContext = '' }) {
+    async arbitrateMergeConflicts({ conflicts, labels, aiConfig, httpAdapter, eventContext = '', organizer = '' }) {
         const list = Array.isArray(conflicts) ? conflicts.filter(Boolean) : [];
         if (list.length === 0) return null;
         if (!aiConfig || aiConfig.enabled === false || aiConfig.arbitrateMerges === false) return null;
@@ -411,6 +411,7 @@ class SharedCore {
             'Rules:',
             '- You MUST copy one of the two provided values EXACTLY. Never invent, edit, merge, or reformat a value.',
             '- "bar" must be the physical venue where the event takes place — never the promoter, organizer, or brand whose name appears in page titles.',
+            organizer ? `- KNOWN ORGANIZER: ${JSON.stringify(String(organizer))} — never pick a bar value equal to the organizer.` : '',
             '- For "title", prefer the actual event name — do not prefer a variant just because it appends status text (e.g. sold-out notices) or site branding.',
             `- "pick" must be "${labelA}" or "${labelB}".`,
             'Return JSON only:',
@@ -691,7 +692,10 @@ class SharedCore {
     }
 
     async processParser(parserConfig, mainConfig, httpAdapter, displayAdapter, parsers, globalProcessedUrls = new Set()) {
-        const effectiveParserConfig = this.applyGlobalAiConfidenceDefaults(parserConfig, mainConfig);
+        const effectiveParserConfig = this.applyGlobalAiExtraContext(
+            this.applyGlobalAiConfidenceDefaults(parserConfig, mainConfig),
+            mainConfig
+        );
 
         // Prefer explicit parser selection from config; otherwise auto-detect from URL.
         const configuredParserName = this.normalizeParserName(effectiveParserConfig && effectiveParserConfig.parser);
@@ -866,6 +870,27 @@ class SharedCore {
             ai: {
                 ...parserAi,
                 confidence: mergedConfidence
+            }
+        };
+    }
+
+    // Global ai.extraContext default (config.ai.extraContext): extra text appended
+    // verbatim to every extraction prompt. A parser's own ai.extraContext — even an
+    // explicit empty string — overrides the global value.
+    applyGlobalAiExtraContext(parserConfig, mainConfig) {
+        const parser = parserConfig && typeof parserConfig === 'object' ? parserConfig : {};
+        const globalAi = mainConfig && mainConfig.config && mainConfig.config.ai && typeof mainConfig.config.ai === 'object'
+            ? mainConfig.config.ai
+            : null;
+        const globalExtraContext = globalAi && typeof globalAi.extraContext === 'string' ? globalAi.extraContext : '';
+        if (!globalExtraContext) return parser;
+        const parserAi = parser.ai && typeof parser.ai === 'object' ? parser.ai : {};
+        if (typeof parserAi.extraContext === 'string') return parser;
+        return {
+            ...parser,
+            ai: {
+                ...parserAi,
+                extraContext: globalExtraContext
             }
         };
     }
@@ -1618,6 +1643,12 @@ class SharedCore {
         // Start with newEvent as base to preserve metadata
         const mergedEvent = { ...newEvent };
 
+        // Carry the derived organizer across merges: underscore fields are skipped
+        // by the field loop below, so an existing-only _organizer would be lost.
+        if (!mergedEvent._organizer && existingEvent && typeof existingEvent._organizer === 'string' && existingEvent._organizer) {
+            mergedEvent._organizer = existingEvent._organizer;
+        }
+
         // Helper function to check if a value is empty/null/undefined
         const isEmpty = (value) => {
             return value === null || value === undefined || value === '' ||
@@ -1751,7 +1782,8 @@ class SharedCore {
                     labels: ['existing', 'incoming'],
                     aiConfig,
                     httpAdapter: options.httpAdapter,
-                    eventContext: `"${eventTitle}" starting ${this.serializeArbitrationValue('startDate', newEvent.startDate || existingEvent.startDate) || 'unknown'} (record "existing" from ${existingEvent.source || 'unknown'}, record "incoming" from ${newEvent.source || 'unknown'})`
+                    eventContext: `"${eventTitle}" starting ${this.serializeArbitrationValue('startDate', newEvent.startDate || existingEvent.startDate) || 'unknown'} (record "existing" from ${existingEvent.source || 'unknown'}, record "incoming" from ${newEvent.source || 'unknown'})`,
+                    organizer: this.getKnownOrganizer(newEvent, existingEvent)
                 });
             } catch (error) {
                 console.warn(`🤝 AI MERGE: arbitration failed for "${eventTitle}": ${error.message}`);
@@ -1882,7 +1914,8 @@ class SharedCore {
                     labels: ['calendar', 'scraped'],
                     aiConfig,
                     httpAdapter: options.httpAdapter,
-                    eventContext
+                    eventContext,
+                    organizer: this.getKnownOrganizer(scraperObject, calendarObject)
                 });
             } catch (error) {
                 console.warn(`🤝 AI MERGE: arbitration failed for "${eventTitle}": ${error.message}`);
@@ -4216,10 +4249,24 @@ class SharedCore {
             timeoutSeconds: Number.isFinite(Number(aiConfig.timeoutSeconds)) ? Number(aiConfig.timeoutSeconds) : 120,
             keepAlive: Object.prototype.hasOwnProperty.call(aiConfig, 'keepAlive') ? String(aiConfig.keepAlive) : '5m',
             arbitrateMerges: aiConfig.arbitrateMerges !== false,
+            // Override-only: extra text appended verbatim to extraction prompt
+            // context. Organizer context is normally derived from page metadata.
+            extraContext: typeof aiConfig.extraContext === 'string' ? aiConfig.extraContext : '',
             verboseConsoleLogs: aiConfig.verboseConsoleLogs === true,
             ollama: aiConfig.ollama && typeof aiConfig.ollama === 'object' ? aiConfig.ollama : {},
             openai: aiConfig.openai && typeof aiConfig.openai === 'object' ? aiConfig.openai : {}
         };
+    }
+
+    // The organizer brand a parser derived from page metadata and stamped as
+    // internal metadata (_organizer, excluded from notes/merge field loops).
+    // First non-empty value across the given event records wins.
+    getKnownOrganizer(...events) {
+        for (const event of events) {
+            const organizer = event && typeof event._organizer === 'string' ? event._organizer.trim() : '';
+            if (organizer) return organizer;
+        }
+        return '';
     }
 
     // AI config for merge arbitration: the event's own parser config wins, the global

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1223,3 +1223,75 @@ test('logAiPayloadDebug logs different payloads in full', () => {
   assert.ok(captured.debug[1].includes('payload B'));
   assert.ok(!captured.debug[1].includes('suppressed'));
 });
+
+// ---------------------------------------------------------------------------
+// Organizer context in merge arbitration + ai.extraContext resolution
+// ---------------------------------------------------------------------------
+
+test('arbitration prompt includes the organizer line when an event carries _organizer', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildArbitrationPair();
+  scraped._organizer = 'Bearracuda';
+  const adapter = buildArbitrationAdapter({
+    bar: { pick: 'calendar', value: 'STATION 4', reason: 'venue' }
+  });
+
+  await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1);
+  assert.match(
+    adapter.calls[0].prompt,
+    /- KNOWN ORGANIZER: "Bearracuda" — never pick a bar value equal to the organizer\./
+  );
+});
+
+test('arbitration prompt omits the organizer line when no event carries _organizer', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildArbitrationPair();
+  const adapter = buildArbitrationAdapter({});
+
+  await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1);
+  assert.ok(!/KNOWN ORGANIZER/.test(adapter.calls[0].prompt));
+});
+
+test('mergeParsedEvents passes the organizer to arbitration and carries _organizer across merges', async () => {
+  const core = createCore();
+  const priorities = { title: { priority: ['ai-web'], merge: 'ai' } };
+  const aiParserConfig = { ai: { provider: 'ollama', endpoint: 'http://ai.example', model: 'm' } };
+  const existing = { title: 'FURBALL', source: 'ai-web', _organizer: 'Bearracuda', _fieldPriorities: priorities };
+  const incoming = { title: 'FURBALL DALLAS', source: 'ai-web', _parserConfig: aiParserConfig, _fieldPriorities: priorities };
+  const adapter = buildArbitrationAdapter({
+    title: { pick: 'incoming', value: 'FURBALL DALLAS', reason: 'more specific' }
+  });
+
+  const merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1);
+  assert.match(adapter.calls[0].prompt, /- KNOWN ORGANIZER: "Bearracuda" — never pick a bar value equal to the organizer\./);
+  assert.equal(merged._organizer, 'Bearracuda', 'an existing-only _organizer must survive the merge');
+});
+
+test('resolveAiConfig resolves extraContext (override-only, default empty)', () => {
+  const core = createCore();
+  assert.equal(core.resolveAiConfig({}).extraContext, '');
+  assert.equal(core.resolveAiConfig({ extraContext: 'HINT' }).extraContext, 'HINT');
+});
+
+test('applyGlobalAiExtraContext: global applies unless the parser defines its own', () => {
+  const core = createCore();
+  const mainConfig = { config: { ai: { extraContext: 'GLOBAL HINT' } } };
+
+  const inherited = core.applyGlobalAiExtraContext({ name: 'p' }, mainConfig);
+  assert.equal(inherited.ai.extraContext, 'GLOBAL HINT');
+
+  const overridden = core.applyGlobalAiExtraContext({ name: 'p', ai: { extraContext: 'MINE' } }, mainConfig);
+  assert.equal(overridden.ai.extraContext, 'MINE');
+
+  const optedOut = core.applyGlobalAiExtraContext({ name: 'p', ai: { extraContext: '' } }, mainConfig);
+  assert.equal(optedOut.ai.extraContext, '', 'an explicit empty string opts out of the global');
+
+  const untouched = { name: 'p' };
+  assert.equal(core.applyGlobalAiExtraContext(untouched, {}), untouched, 'no global → config object passes through');
+});

--- a/tools/generate-scraper-cities.js
+++ b/tools/generate-scraper-cities.js
@@ -25,9 +25,17 @@ if (!CITY_CONFIG || typeof CITY_CONFIG !== 'object') {
 const scraperCities = {};
 Object.entries(CITY_CONFIG).forEach(([cityKey, cityConfig]) => {
   if (!cityConfig) return;
-  const { calendar, timezone, patterns } = cityConfig;
+  const { calendar, timezone, patterns, coordinates } = cityConfig;
   if (!calendar || !timezone || !Array.isArray(patterns)) return;
   scraperCities[cityKey] = { calendar, timezone, patterns };
+  // City-center coordinates power distance-ranked geocode validation in the
+  // scraper's OpenStreetMapNormalizer.
+  if (coordinates && Number.isFinite(Number(coordinates.lat)) && Number.isFinite(Number(coordinates.lng))) {
+    scraperCities[cityKey].coordinates = {
+      lat: Number(coordinates.lat),
+      lng: Number(coordinates.lng)
+    };
+  }
 });
 
 if (Object.keys(scraperCities).length === 0) {


### PR DESCRIPTION
Follow-up to #1460 — moves the organizer fix from cleanup to prevention, and closes the same-named-city hole in geocode validation.

## Organizer context in AI prompts
- Extraction prompts (all passes, incl. repair) now carry a page-derived line: `KNOWN ORGANIZER (derived from page metadata): "Bearracuda, Inc." (also appears as "Bearracuda", "BEARRACUDA") — this is the event promoter/site brand, NOT the venue…`. Brand names come from the same JSON-LD Organization/WebSite + og:site_name extraction #1460 introduced, now computed once per page and cached.
- Events get an `_organizer` stamp (including on the deterministic JSON-LD shortcut path), and merge arbitration includes a `KNOWN ORGANIZER` rule so the model can't pick the promoter as `bar` during merges either.
- New `ai.extraContext` config (global or per-parser, per-parser wins, `""` opts out) for manual steering when a site's markup lies — override-only; the organizer line stays automatic. Documented in scraper-input.js.

## Distance-ranked geocoding
The textual city check from #1460 false-accepts same-named cities ("Portland, Michigan" contains "portland"). Now:
- `js/city-config.js` coordinates flow into the generated `scripts/scraper-cities.js` (generator updated; regeneration verified byte-identical) → SharedCore → OpenStreetMapNormalizer.
- When the event city has known center coordinates: request 5 Nominatim candidates and pick the **nearest within 50 km of the city center** (haversine), logging the choice (`3 candidates for "722 E Burnside"; picked #2 (1.9 km from portland center)`); all-outside-radius → no coordinates + warning with nearest distance.
- Cities without coordinates keep the textual check; events without a city keep the byte-identical legacy request.

## Tests
133 → 148, all green. Coverage includes: wrong-state candidate listed first loses to the true-city candidate, all-beyond-radius rejection, coordinate-less fallback, prompt contains/omits the organizer line, extraContext injection, `_organizer` stamping and arbitration rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)