### PR TITLE
feat(scriptable): run-insight sections in the results and saved-run displays

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A modern static website for chunky.dad",
   "main": "index.html",
   "scripts": {
-    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js",
+    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/adapters/scriptable-adapter.test.js",
     "start": "python3 -m http.server 8000",
     "serve": "python3 -m http.server 8000",
     "dev": "python3 -m http.server 8000",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,7 @@ scripts/
 ├── scraper-input.js                    # Runtime configuration
 ├── bear-event-scraper-unified.js       # Lightweight orchestrator (environment detection only)
 ├── shared-core.js                      # Pure JavaScript business logic (NO environment code)
+├── run-log-summary.js                  # Pure run-log parsing/summarizing (used by displays + tools CLI)
 ├── adapters/                           # Environment-specific implementations
 │   ├── scriptable-adapter.js           # iOS/Scriptable ONLY code
 │   └── web-adapter.js                  # Browser/Web ONLY code

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -378,6 +378,7 @@ const HEADER_LOGO_CACHE_FILE = "logo-hero.png";
 const HEADER_LOGO_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const { EventSchema: SharedEventSchema } = importModule("event-schema");
 const { SharedCore } = importModule("shared-core");
+const { RunLogSummary } = importModule("run-log-summary");
 
 if (
   !SharedEventSchema ||
@@ -3187,6 +3188,11 @@ class ScriptableAdapter {
     const logSectionHtml = shouldShowLogs
       ? this.buildRunLogSectionHtml(runLogInfo, runPromptInfo)
       : "";
+    const runInsights = this.loadRunInsightsForDisplay(results, runLogInfo);
+    const insightSectionsHtml = this.buildRunInsightSectionsHtml(
+      runInsights,
+      results,
+    );
     const headerLogoData = await this.loadHeaderLogoData();
     const headerLogoSrc = headerLogoData || HEADER_LOGO_URL;
 
@@ -4171,6 +4177,29 @@ class ScriptableAdapter {
             color: var(--text-secondary);
             font-size: 14px;
         }
+
+        .insight-subtitle {
+            font-weight: 600;
+            font-size: 13px;
+            margin: 12px 0 4px;
+            color: var(--text-primary);
+        }
+
+        .insight-list {
+            margin: 0;
+            padding-left: 18px;
+            font-size: 12px;
+            font-family: monospace;
+            line-height: 1.5;
+            color: var(--text-primary);
+            word-break: break-word;
+        }
+
+        .insight-note {
+            color: var(--text-secondary);
+            font-size: 12px;
+            margin: 4px 0;
+        }
         
         .event-card.raw-mode .event-details,
         .event-card.raw-mode .event-metadata,
@@ -4437,6 +4466,8 @@ class ScriptableAdapter {
     }
 
     ${this.generateDiscoverySection(results)}
+
+    ${insightSectionsHtml}
 
     ${logSectionHtml}
     
@@ -5120,6 +5151,194 @@ class ScriptableAdapter {
         </details>
     </div>
         `;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Run-insight sections ("What Happened" crawl tree / "What We Did" decisions)
+  // ---------------------------------------------------------------------------
+
+  // Parse a run log into the structured insight summary (business logic lives
+  // in the shared run-log-summary module; this is just the environment glue).
+  buildRunInsightsFromLogText(text) {
+    try {
+      const trimmed = typeof text === "string" ? text : "";
+      if (!trimmed.trim()) {
+        return {
+          available: false,
+          reason: "No log lines captured for this run.",
+          summary: null,
+        };
+      }
+      return {
+        available: true,
+        reason: null,
+        summary: RunLogSummary.summarizeLogText(trimmed),
+      };
+    } catch (error) {
+      return {
+        available: false,
+        reason: `Log summary failed: ${error.message}`,
+        summary: null,
+      };
+    }
+  }
+
+  // Choose the insight data source: the saved run's log file when re-displaying
+  // a saved run, otherwise the FileLogger's in-memory entries for the live run.
+  loadRunInsightsForDisplay(results, logInfo = null) {
+    try {
+      if (results?._isDisplayingSavedRun) {
+        if (logInfo?.exists) {
+          return this.buildRunInsightsFromLogText(
+            logInfo.fullText || logInfo.text || "",
+          );
+        }
+        const runLabel = logInfo?.runId ? `run ${logInfo.runId}` : "this run";
+        return {
+          available: false,
+          reason: `Log not found for ${runLabel} — crawl and decision details from the log are unavailable.`,
+          summary: null,
+        };
+      }
+      return this.buildRunInsightsFromLogText(
+        logger.getLogText({ mode: "full" }),
+      );
+    } catch (error) {
+      return {
+        available: false,
+        reason: `Log summary failed: ${error.message}`,
+        summary: null,
+      };
+    }
+  }
+
+  // Structured per-event decisions from the analyzed results (preferred over
+  // log-derived data where both exist).
+  collectEventDecisionLines(results) {
+    const events = Array.isArray(results?.analyzedEvents)
+      ? results.analyzedEvents
+      : [];
+    return events.map((event) => {
+      const intent = this.normalizeIntentAction(event) || "other";
+      const write = this.getWriteActionFromEvent(event);
+      const title = event?.title || event?.name || "(untitled)";
+      const reason =
+        typeof event?._analysis?.reason === "string" &&
+        event._analysis.reason.trim()
+          ? ` — ${event._analysis.reason.trim()}`
+          : "";
+      return `${this.formatIntentActionLabel(intent)} → ${this.formatWriteActionLabel(write)}: "${title}"${reason}`;
+    });
+  }
+
+  // Capped, escaped <ul> for insight line lists (keeps total HTML size bounded).
+  buildInsightListHtml(lines, maxItems = 50) {
+    const allLines = Array.isArray(lines) ? lines : [];
+    if (allLines.length === 0) {
+      return `<div class="insight-note">(none)</div>`;
+    }
+    const shown = allLines.slice(0, maxItems);
+    const items = shown
+      .map((line) => `<li>${this.escapeHtml(line)}</li>`)
+      .join("");
+    const moreNote =
+      allLines.length > shown.length
+        ? `<div class="insight-note">… +${allLines.length - shown.length} more</div>`
+        : "";
+    return `<ul class="insight-list">${items}</ul>${moreNote}`;
+  }
+
+  // Two collapsed sections appended to the results display. Only summary lines
+  // are embedded — debug payload bodies (full AI prompts/responses) never are.
+  buildRunInsightSectionsHtml(insights, results) {
+    const summary = insights?.available ? insights.summary : null;
+    const unavailableNote = `<div class="insight-note">${this.escapeHtml(
+      insights?.reason || "Run log unavailable.",
+    )}</div>`;
+
+    // --- Section 1: What Happened (crawl/discovery tree) ---
+    const crawlSources = summary && Array.isArray(summary.crawl) ? summary.crawl : [];
+    const pageCount = RunLogSummary.countCrawlNodes(crawlSources);
+    let happenedBody;
+    if (!summary) {
+      happenedBody = unavailableNote;
+    } else {
+      const treeText =
+        crawlSources.length > 0
+          ? RunLogSummary.formatCrawlTreeText(crawlSources, { maxNodes: 50 })
+          : "";
+      const treeHtml = treeText
+        ? `<pre class="discovery-output">${this.escapeHtml(treeText)}</pre>`
+        : `<div class="insight-note">No crawl activity found in this run's log.</div>`;
+      const aiLines = (summary.aiRequestsByPass || []).map(
+        (stats) =>
+          `${stats.pass}: ${stats.sent} sent, ${stats.succeeded} succeeded, total ${stats.totalMs}ms, avg ${stats.avgMs}ms`,
+      );
+      const aiHtml =
+        aiLines.length > 0
+          ? `<div class="insight-subtitle">AI requests by pass</div>${this.buildInsightListHtml(aiLines)}`
+          : "";
+      const ocrHtml =
+        Array.isArray(summary.ocr) && summary.ocr.length > 0
+          ? `<div class="insight-subtitle">OCR activity</div>${this.buildInsightListHtml(summary.ocr)}`
+          : "";
+      happenedBody = `${treeHtml}${aiHtml}${ocrHtml}`;
+    }
+    const happenedSection = `
+    <div class="section insight-section">
+        <div class="section-header">
+            <span class="section-icon">🌳</span>
+            <span class="section-title">What Happened</span>
+            <span class="section-count">${pageCount}</span>
+        </div>
+        <details class="log-details">
+            <summary>Crawl &amp; extraction tree — tap to expand</summary>
+            ${happenedBody}
+        </details>
+    </div>
+        `;
+
+    // --- Section 2: What We Did (decisions) ---
+    const eventDecisions = this.collectEventDecisionLines(results);
+    const merges = summary ? summary.merges || [] : [];
+    const droppedFields = summary ? summary.droppedFields || [] : [];
+    const dedupeAndFilter = summary
+      ? [...(summary.dedupe || []), ...(summary.filtered || [])]
+      : [];
+    const problems = summary
+      ? (summary.problems || []).map(
+          (problem) => `[${problem.level.toUpperCase()}] ${problem.line}`,
+        )
+      : [];
+    const decisionCount = eventDecisions.length + merges.length;
+    const logOnlyParts = summary
+      ? `
+            <div class="insight-subtitle">AI merge decisions (${merges.length})</div>
+            ${this.buildInsightListHtml(merges)}
+            <div class="insight-subtitle">Dropped fields (${droppedFields.length})</div>
+            ${this.buildInsightListHtml(droppedFields)}
+            <div class="insight-subtitle">Dedup / filter</div>
+            ${this.buildInsightListHtml(dedupeAndFilter)}
+            <div class="insight-subtitle">Warnings &amp; errors (${problems.length})</div>
+            ${this.buildInsightListHtml(problems)}`
+      : unavailableNote;
+    const didSection = `
+    <div class="section insight-section">
+        <div class="section-header">
+            <span class="section-icon">🧭</span>
+            <span class="section-title">What We Did</span>
+            <span class="section-count">${decisionCount}</span>
+        </div>
+        <details class="log-details">
+            <summary>Decisions — actions, merges, drops — tap to expand</summary>
+            <div class="insight-subtitle">Event actions (${eventDecisions.length})</div>
+            ${this.buildInsightListHtml(eventDecisions)}
+            ${logOnlyParts}
+        </details>
+    </div>
+        `;
+
+    return `${happenedSection}${didSection}`;
   }
 
   // Generate HTML for the segments panel in discovery section
@@ -7724,6 +7943,9 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         runId,
         exists: true,
         text,
+        // Untruncated log content for the run-insight summary (parsed, never
+        // embedded in the HTML — only summary lines end up in the display).
+        fullText: content,
         totalLines,
         shownLines: displayLines.length,
         truncated,

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1,0 +1,151 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// ---------------------------------------------------------------------------
+// Headless load of the Scriptable adapter: stub the Scriptable globals the
+// module touches at require time (importModule, FileManager) so the pure
+// HTML-builder methods can be exercised under Node. WebView/Calendar/Device
+// are NOT stubbed on purpose — the methods under test must never touch them.
+// ---------------------------------------------------------------------------
+global.importModule = (name) => require(path.join(__dirname, '..', name));
+
+const fileManagerStub = {
+  documentsDirectory: () => '/tmp/chunky-dad-adapter-test',
+  joinPath: (a, b) => `${a}/${b}`,
+  fileExists: () => false,
+  isDirectory: () => false,
+  createDirectory: () => {},
+  fileName: (filePath) => String(filePath).split('/').pop(),
+  readString: () => null,
+  writeString: () => {},
+  downloadFileFromiCloud: async () => {}
+};
+global.FileManager = {
+  iCloud: () => fileManagerStub,
+  local: () => fileManagerStub
+};
+
+const { ScriptableAdapter } = require('./scriptable-adapter');
+
+const LOG_FIXTURE = [
+  '2026-07-12T03:00:00.000Z [INFO] SYSTEM: Bearracuda → bearracuda (1 URL): https://bearracuda.com/',
+  '2026-07-12T03:00:01.000Z [INFO] SYSTEM: Classified https://bearracuda.com/ → eventlist',
+  '2026-07-12T03:00:02.000Z [INFO] SYSTEM: Parsed https://bearracuda.com/ → 0 events, 2 links',
+  '2026-07-12T03:00:03.000Z [INFO] SYSTEM: Following 2 discovered URLs → 2 unique for crawl depth 1',
+  '2026-07-12T03:00:04.000Z [INFO] SYSTEM: Crawling 2 discovered URLs (depth 1/1)',
+  '2026-07-12T03:00:05.000Z [INFO] SYSTEM: Classified https://bearracuda.com/events/atlanta → event',
+  '2026-07-12T03:00:06.000Z [INFO] 🤖 AI Web: Running AI extraction for https://bearracuda.com/events/atlanta (12 fields)',
+  '2026-07-12T03:00:07.000Z [INFO] 🤖 AI Web: Sending AI request (extraction pass) to http://rybook.example:8000/v1/chat/completions — model: qwen, provider: openai, prompt: 4000 chars',
+  '2026-07-12T03:00:07.100Z [DEBUG] 🤖 AI Web: Full prompt (extraction pass) (4000 chars)',
+  'SECRET PAYLOAD BODY that must never be embedded in the display HTML',
+  '2026-07-12T03:00:09.000Z [INFO] 🤖 AI Web: AI request (extraction pass) succeeded in 2000ms — response: 400 chars',
+  '2026-07-12T03:00:10.000Z [INFO] SYSTEM: Parsed https://bearracuda.com/events/atlanta → 1 event',
+  '2026-07-12T03:00:11.000Z [INFO] SYSTEM: Classified https://bearracuda.com/events/seattle → event',
+  '2026-07-12T03:00:12.000Z [INFO] SYSTEM: Parsed https://bearracuda.com/events/seattle → 1 event',
+  '2026-07-12T03:00:13.000Z [INFO] SYSTEM: Event filtering complete: 2 → 2 future → 2 bear → 2 final',
+  '2026-07-12T03:00:14.000Z [INFO] 🤝 AI MERGE: "BEARRACUDA: Atlanta" field=bar chose scraped ("Heretic") over existing ("Heretic Atlanta") — fresher source',
+  '2026-07-12T03:00:15.000Z [WARN] 🤖 AI Web: Dropped 1 field(s) lacking source evidence: shortName'
+].join('\n');
+
+function buildResultsStub() {
+  return {
+    analyzedEvents: [
+      {
+        title: 'Bear <b>Night</b>',
+        _action: 'new',
+        startDate: '2026-08-01T02:00:00.000Z'
+      },
+      {
+        title: 'BEARRACUDA: Atlanta',
+        _action: 'merge',
+        _analysis: { reason: 'matched existing calendar event' }
+      }
+    ]
+  };
+}
+
+function buildAdapter() {
+  return new ScriptableAdapter({ cities: {} });
+}
+
+test('buildRunInsightSectionsHtml renders both collapsed sections from a run log', () => {
+  const adapter = buildAdapter();
+  const insights = adapter.buildRunInsightsFromLogText(LOG_FIXTURE);
+  assert.equal(insights.available, true);
+
+  const html = adapter.buildRunInsightSectionsHtml(insights, buildResultsStub());
+
+  // Both sections exist, with <details> collapsed by default
+  assert.ok(html.includes('What Happened'));
+  assert.ok(html.includes('What We Did'));
+  assert.equal((html.match(/<details class="log-details">/g) || []).length, 2);
+  assert.ok(!html.includes('<details open'));
+
+  // Crawl tree content: source, root and followed pages
+  assert.ok(html.includes('Bearracuda (bearracuda parser)'));
+  assert.ok(html.includes('https://bearracuda.com/ [eventlist]'));
+  assert.ok(html.includes('├─ https://bearracuda.com/events/atlanta'));
+
+  // Decisions: structured event actions + log-derived merge reason
+  assert.ok(html.includes('NEW → CREATE: &quot;Bear &lt;b&gt;Night&lt;/b&gt;&quot;'));
+  assert.ok(html.includes('MERGE → UPDATE: &quot;BEARRACUDA: Atlanta&quot; — matched existing calendar event'));
+  assert.ok(html.includes('fresher source'));
+  assert.ok(html.includes('Dropped 1 field(s)'));
+});
+
+test('run-insight HTML escapes markup and never embeds AI payload bodies', () => {
+  const adapter = buildAdapter();
+  const insights = adapter.buildRunInsightsFromLogText(LOG_FIXTURE);
+  const html = adapter.buildRunInsightSectionsHtml(insights, buildResultsStub());
+
+  assert.ok(!html.includes('SECRET PAYLOAD BODY'));
+  assert.ok(!html.includes('<b>Night</b>'));
+});
+
+test('saved run without a log file renders sections with a graceful note', () => {
+  const adapter = buildAdapter();
+  const insights = adapter.loadRunInsightsForDisplay(
+    { _isDisplayingSavedRun: true },
+    { runId: '20260101-000000', exists: false, reason: 'missing-log-file' }
+  );
+
+  assert.equal(insights.available, false);
+  assert.ok(insights.reason.includes('Log not found for run 20260101-000000'));
+
+  const html = adapter.buildRunInsightSectionsHtml(insights, buildResultsStub());
+  assert.ok(html.includes('What Happened'));
+  assert.ok(html.includes('What We Did'));
+  assert.ok(html.includes('Log not found for run 20260101-000000'));
+  // Structured event actions still render from the saved-run JSON
+  assert.ok(html.includes('NEW → CREATE: &quot;Bear &lt;b&gt;Night&lt;/b&gt;&quot;'));
+});
+
+test('saved run with a log file feeds its full text through the summary', () => {
+  const adapter = buildAdapter();
+  const insights = adapter.loadRunInsightsForDisplay(
+    { _isDisplayingSavedRun: true },
+    { runId: '20260101-000000', exists: true, fullText: LOG_FIXTURE, text: '' }
+  );
+
+  assert.equal(insights.available, true);
+  assert.equal(insights.summary.crawl.length, 1);
+  assert.equal(insights.summary.crawl[0].roots[0].children.length, 2);
+});
+
+test('long crawl lists are capped in the rendered HTML', () => {
+  const adapter = buildAdapter();
+  const manyPages = [
+    '2026-07-12T05:00:00.000Z [INFO] SYSTEM: Big source → ai-web (1 URL): https://big.example/',
+    '2026-07-12T05:00:01.000Z [INFO] SYSTEM: Parsed https://big.example/ → 0 events, 80 links',
+    '2026-07-12T05:00:02.000Z [INFO] SYSTEM: Crawling 80 discovered URLs (depth 1/1)'
+  ];
+  for (let i = 0; i < 80; i += 1) {
+    manyPages.push(`2026-07-12T05:00:03.000Z [INFO] SYSTEM: Parsed https://big.example/page-${i} → 1 event`);
+  }
+  const insights = adapter.buildRunInsightsFromLogText(manyPages.join('\n'));
+  const html = adapter.buildRunInsightSectionsHtml(insights, buildResultsStub());
+
+  assert.ok(html.includes('more page(s) not shown'));
+  assert.ok(!html.includes('page-79'));
+});

--- a/scripts/run-log-summary.js
+++ b/scripts/run-log-summary.js
@@ -1,0 +1,553 @@
+// ============================================================================
+// RUN LOG SUMMARY - PURE JAVASCRIPT LOG PARSING/SUMMARIZING
+// ============================================================================
+// ⚠️  AI ASSISTANT WARNING: This file contains PURE JavaScript business logic
+//
+// 🚨 CRITICAL RESTRICTIONS - NEVER ADD THESE TO THIS FILE:
+// ❌ NO Node-only APIs (fs, path, process) - the CLI wrapper in tools/ owns those
+// ❌ NO Scriptable APIs (FileManager, WebView, Alert) - adapters own those
+// ❌ NO DOM APIs (document, window)
+//
+// ✅ THIS FILE SHOULD ONLY CONTAIN:
+// ✅ Plain functions that take log text / entry arrays and return structured data
+//
+// Parses a run log written by the Scriptable adapter's FileLogger
+// (Documents/chunky-dad-scraper/logs/<runId>.log, format:
+//   2026-07-13T09:12:13.123Z [INFO] message
+// with multi-line messages) and also tolerates raw console-paste lines
+// (2026-07-13 09:12:13: message).
+//
+// Consumed by:
+//   - tools/analyze-scraper-log.js (Node CLI wrapper)
+//   - scripts/adapters/scriptable-adapter.js (run-insight sections in the
+//     results / saved-run WebView displays)
+//
+// 📖 READ scripts/README.md BEFORE EDITING - Contains full architecture rules
+// ============================================================================
+
+const FILE_ENTRY_RE = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z) \[([A-Z]+)\] (.*)$/;
+const PASTE_ENTRY_RE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?:\.\d+)?: (.*)$/;
+
+// Parse log text into entries: { ts, level, message } — message may be multi-line.
+function parseLog(text) {
+    const entries = [];
+    const lines = String(text || '').split(/\r?\n/);
+    for (const line of lines) {
+        let match = line.match(FILE_ENTRY_RE);
+        if (match) {
+            entries.push({ ts: match[1], level: match[2].toLowerCase(), message: match[3] });
+            continue;
+        }
+        match = line.match(PASTE_ENTRY_RE);
+        if (match) {
+            const message = match[2];
+            // Raw console pastes carry no level — infer warnings from emoji markers.
+            const level = /^(⚠️|🚨|❌)/.test(message) ? 'warn' : 'info';
+            entries.push({ ts: match[1], level, message });
+            continue;
+        }
+        if (entries.length > 0) {
+            entries[entries.length - 1].message += `\n${line}`;
+        } else if (line.trim()) {
+            entries.push({ ts: '', level: 'info', message: line });
+        }
+    }
+    return entries;
+}
+
+const URL_CONTEXT_RES = [
+    /🤖 AI Web: Running AI extraction for (\S+)/,
+    /🤖 AI Web: Fields for (\S+): \d+ selected/,
+    /🤖 AI Web: URL discovery stats for (\S+)/
+];
+
+// Annotate each entry with the page URL it belongs to (last URL-setting line wins).
+function annotateUrls(entries) {
+    let currentUrl = '';
+    for (const entry of entries) {
+        for (const re of URL_CONTEXT_RES) {
+            const match = entry.message.match(re);
+            if (match && match[1] && match[1] !== 'extraction' && match[1] !== 'unknown') {
+                currentUrl = match[1];
+                break;
+            }
+        }
+        entry.url = currentUrl;
+    }
+    return entries;
+}
+
+function normalizePass(raw) {
+    return String(raw || 'extraction').replace(/\s*pass$/i, '').trim() || 'extraction';
+}
+
+// ---------------------------------------------------------------------------
+// Crawl tree — reconstructed from shared-core's SYSTEM crawl/discovery lines
+// ---------------------------------------------------------------------------
+// Source start:   SYSTEM: <name> → <parserType> (N URLs)[: <url>]
+// Discovery mode: SYSTEM: <name> → Discovery only mode (depth N)
+// Classification: SYSTEM: Classified <url> → <type>
+// Page parsed:    SYSTEM: Parsed <url> → N events[, M links][, K segments]
+// Depth marker:   SYSTEM: Crawling N discovered URLs (depth d/max)
+// Failures:       SYSTEM: Failed to process URL <url>: msg
+//                 SYSTEM: Failed to process crawl page <url>: msg
+// Discovery end:  SYSTEM: Discovery complete: N URL(s) found across M link(s)...
+// Filter summary: SYSTEM: Event filtering complete: A → B future → C bear → D final
+const DISCOVERY_MODE_RE = /^SYSTEM: (.+?) → Discovery only mode \(depth (\d+)\)$/;
+const SOURCE_LINE_RE = /^SYSTEM: (.+?) → ([A-Za-z0-9_-]+) \((\d+) URLs?\)(?:: (\S+))?$/;
+const CLASSIFIED_RE = /^SYSTEM: Classified (\S+) → (\S+)$/;
+const PARSED_RE = /^SYSTEM: Parsed (\S+) → (\d+) events?(?:, (\d+) links?)?(?:, (\d+) segments?)?$/;
+const CRAWLING_RE = /^SYSTEM: Crawling (\d+) discovered URLs \(depth (\d+)\/(\d+)\)$/;
+const FAILED_URL_RE = /^SYSTEM: Failed to process (?:URL|crawl page) (\S+): (.*)$/;
+const DISCOVERY_COMPLETE_RE = /^SYSTEM: Discovery complete: (\d+) URL\(s\) found across (\d+) link\(s\)(.*)$/;
+const FILTERING_RE = /^SYSTEM: Event filtering complete: (\d+) → (\d+) future → (\d+) bear → (\d+) final$/;
+
+// Build per-source crawl trees. Returns an array of sources:
+// { name, parserType, urlCount, discoveryOnly, maxDepth, roots: [node],
+//   failures: [{url, error}], discovery: {urls, links, note} | null,
+//   filtering: {total, future, bear, final} | null }
+// where node = { url, classification, events, links, segments, depth, children: [node] }
+//
+// Depth attribution uses a frame stack keyed off the "Crawling N discovered URLs
+// (depth d/max)" markers: the crawl is depth-first, so the N pages parsed after a
+// depth-d marker are children of the page parsed immediately before it. Pages that
+// fail before their "Parsed" line make a frame under-consume; frames are also popped
+// whenever a shallower depth marker or a new source line arrives, so a lost page can
+// only mis-nest its own siblings, never a different source.
+function buildCrawlTree(entries) {
+    const sources = [];
+    const classifications = new Map();
+    let current = null;
+    let frames = null; // stack of { depth, remaining, parent }
+    let lastParsedNode = null;
+
+    const startFallbackSource = () => {
+        current = {
+            name: '(run)',
+            parserType: null,
+            urlCount: 0,
+            discoveryOnly: false,
+            maxDepth: null,
+            roots: [],
+            failures: [],
+            discovery: null,
+            filtering: null
+        };
+        sources.push(current);
+        frames = [{ depth: 0, remaining: Infinity, parent: null }];
+        lastParsedNode = null;
+    };
+
+    for (const entry of entries) {
+        const line = entry.message.split('\n', 1)[0];
+
+        let match = line.match(DISCOVERY_MODE_RE);
+        if (match) {
+            if (current && current.name === match[1]) {
+                current.discoveryOnly = true;
+                current.maxDepth = Number(match[2]);
+            }
+            continue;
+        }
+        match = line.match(SOURCE_LINE_RE);
+        if (match) {
+            current = {
+                name: match[1],
+                parserType: match[2],
+                urlCount: Number(match[3]),
+                discoveryOnly: false,
+                maxDepth: null,
+                roots: [],
+                failures: [],
+                discovery: null,
+                filtering: null
+            };
+            sources.push(current);
+            frames = [{ depth: 0, remaining: Infinity, parent: null }];
+            lastParsedNode = null;
+            continue;
+        }
+        match = line.match(CLASSIFIED_RE);
+        if (match) {
+            classifications.set(match[1], match[2]);
+            continue;
+        }
+        match = line.match(CRAWLING_RE);
+        if (match) {
+            if (!current) continue;
+            const depth = Number(match[2]);
+            while (frames.length > 1 && frames[frames.length - 1].depth >= depth) {
+                frames.pop();
+            }
+            frames.push({ depth, remaining: Number(match[1]), parent: lastParsedNode });
+            if (current.maxDepth === null) current.maxDepth = Number(match[3]);
+            continue;
+        }
+        match = line.match(PARSED_RE);
+        if (match) {
+            if (!current) startFallbackSource();
+            while (frames.length > 1 && frames[frames.length - 1].remaining <= 0) {
+                frames.pop();
+            }
+            const frame = frames[frames.length - 1];
+            const node = {
+                url: match[1],
+                classification: classifications.get(match[1]) || null,
+                events: Number(match[2]),
+                links: match[3] ? Number(match[3]) : 0,
+                segments: match[4] ? Number(match[4]) : 0,
+                depth: frame.depth,
+                children: []
+            };
+            if (frame.parent) {
+                frame.parent.children.push(node);
+            } else {
+                current.roots.push(node);
+            }
+            frame.remaining -= 1;
+            lastParsedNode = node;
+            continue;
+        }
+        match = line.match(FAILED_URL_RE);
+        if (match) {
+            if (current) current.failures.push({ url: match[1], error: match[2] });
+            continue;
+        }
+        match = line.match(DISCOVERY_COMPLETE_RE);
+        if (match) {
+            if (current) {
+                current.discovery = {
+                    urls: Number(match[1]),
+                    links: Number(match[2]),
+                    note: (match[3] || '').replace(/^,\s*/, '')
+                };
+            }
+            continue;
+        }
+        match = line.match(FILTERING_RE);
+        if (match) {
+            if (current) {
+                current.filtering = {
+                    total: Number(match[1]),
+                    future: Number(match[2]),
+                    bear: Number(match[3]),
+                    final: Number(match[4])
+                };
+            }
+            continue;
+        }
+    }
+
+    return sources;
+}
+
+function countCrawlNodes(sources) {
+    let count = 0;
+    const walk = (node) => {
+        count += 1;
+        for (const child of node.children || []) walk(child);
+    };
+    for (const source of Array.isArray(sources) ? sources : []) {
+        for (const root of source.roots || []) walk(root);
+    }
+    return count;
+}
+
+// Curated OCR activity lines (per-image cache/similarity chatter is excluded).
+const OCR_ACTIVITY_RES = [
+    /🤖 AI Web: Extracted OCR from \d+ image/,
+    /🤖 AI Web: Skipping OCR for /,
+    /🤖 AI Web: OCR skipped \d+ uninteresting/,
+    /🤖 AI Web: OCR image cap /,
+    /🤖 AI Web: Including OCR results /,
+    /🤖 AI Web: OCR top-up for /,
+    /🤖 AI Web: Skipped \d+ OCR result/,
+    /🤖 AI Web: Consolidated \d+ text-containing OCR results/
+];
+
+function buildSummary(entries) {
+    annotateUrls(entries);
+    const pages = new Map(); // url -> { events, passes:Set, aiMs, requests }
+    const aiByPass = new Map(); // pass -> { sent, succeeded, totalMs }
+    const merges = [];
+    const droppedFields = [];
+    const dedupe = [];
+    const filtered = [];
+    const calendar = [];
+    const ocr = [];
+    const problems = [];
+
+    const pageFor = (url) => {
+        const key = url || '(no url)';
+        if (!pages.has(key)) pages.set(key, { events: 0, passes: new Set(), aiMs: 0, requests: 0 });
+        return pages.get(key);
+    };
+
+    for (const entry of entries) {
+        const msg = entry.message;
+        const firstLine = msg.split('\n', 1)[0];
+
+        if (entry.level === 'warn' || entry.level === 'error') {
+            problems.push({ level: entry.level, line: firstLine });
+        }
+
+        let match = firstLine.match(/🤖 AI Web: Sending AI request(?: \(([^)]+)\))? to /);
+        if (match) {
+            const pass = normalizePass(match[1]);
+            if (!aiByPass.has(pass)) aiByPass.set(pass, { sent: 0, succeeded: 0, totalMs: 0 });
+            aiByPass.get(pass).sent += 1;
+            const page = pageFor(entry.url);
+            page.requests += 1;
+            page.passes.add(pass);
+            continue;
+        }
+        match = firstLine.match(/🤖 AI Web: AI request(?: \(([^)]+)\))? succeeded in (\d+)ms/);
+        if (match) {
+            const pass = normalizePass(match[1]);
+            if (!aiByPass.has(pass)) aiByPass.set(pass, { sent: 0, succeeded: 0, totalMs: 0 });
+            const stats = aiByPass.get(pass);
+            stats.succeeded += 1;
+            stats.totalMs += Number(match[2]);
+            pageFor(entry.url).aiMs += Number(match[2]);
+            continue;
+        }
+        match = firstLine.match(/🤖 AI Web: Extracted (\S+) →/);
+        if (match) {
+            pageFor(match[1]).events += 1;
+            continue;
+        }
+        if (firstLine.includes('🤖 AI Web: Running AI extraction for')) {
+            pageFor(entry.url);
+            continue;
+        }
+        if (/🤝 AI MERGE|🔄 PARSER MERGE|🔄 MERGE/.test(firstLine)) {
+            merges.push(firstLine);
+            continue;
+        }
+        if (/Dropped \d+ field\(s\) lacking source evidence|Dropping field .* low confidence/.test(firstLine)) {
+            droppedFields.push(firstLine);
+            continue;
+        }
+        match = firstLine.match(/🔄 SharedCore: Deduplicated (\d+) → (\d+)/);
+        if (match) {
+            dedupe.push(firstLine);
+            continue;
+        }
+        if (firstLine.includes('SharedCore: Filtering out event')) {
+            filtered.push(firstLine);
+            continue;
+        }
+        if (OCR_ACTIVITY_RES.some((re) => re.test(firstLine))) {
+            ocr.push(firstLine);
+            continue;
+        }
+        if (/^(📅|📊|🌍|🕐|✅ Found calendars|❌ Missing calendars)/.test(firstLine)) {
+            calendar.push(firstLine);
+        }
+    }
+
+    const crawl = buildCrawlTree(entries);
+    // Annotate tree nodes with per-page AI stats gathered above.
+    const annotateNode = (node) => {
+        const page = pages.get(node.url);
+        if (page) {
+            node.aiRequests = page.requests;
+            node.passes = Array.from(page.passes);
+            node.aiMs = page.aiMs;
+        }
+        for (const child of node.children || []) annotateNode(child);
+    };
+    for (const source of crawl) {
+        for (const root of source.roots || []) annotateNode(root);
+    }
+
+    return {
+        pages: Array.from(pages.entries()).map(([url, data]) => ({
+            url,
+            events: data.events,
+            aiRequests: data.requests,
+            passes: Array.from(data.passes),
+            aiMs: data.aiMs
+        })),
+        aiRequestsByPass: Array.from(aiByPass.entries()).map(([pass, s]) => ({
+            pass,
+            sent: s.sent,
+            succeeded: s.succeeded,
+            totalMs: s.totalMs,
+            avgMs: s.succeeded > 0 ? Math.round(s.totalMs / s.succeeded) : 0
+        })),
+        crawl,
+        ocr,
+        merges,
+        droppedFields,
+        dedupe,
+        filtered,
+        calendar,
+        problems
+    };
+}
+
+// Convenience: raw log text → structured summary.
+function summarizeLogText(text) {
+    return buildSummary(parseLog(text));
+}
+
+// Full AI payload dumps (debug channel): Full prompt / Model response text blocks.
+function extractAiPayloads(entries, passType = null) {
+    const payloads = [];
+    for (const entry of entries) {
+        const match = entry.message.match(/^🤖 AI Web: (Full prompt|Model response text)(?: \(([^)]+)\))?/);
+        if (!match) continue;
+        const pass = normalizePass(match[2]);
+        if (passType && pass !== normalizePass(passType)) continue;
+        payloads.push({ kind: match[1], pass, url: entry.url || '', text: entry.message });
+    }
+    return payloads;
+}
+
+// Render crawl trees as indented plain text (used by the CLI and, HTML-escaped,
+// by the Scriptable results display). options.maxNodes caps the total page nodes
+// rendered across all sources; the remainder collapses to a "+N more" line.
+function formatCrawlTreeText(sources, options = {}) {
+    const maxNodes = Number.isFinite(options.maxNodes) && options.maxNodes > 0
+        ? options.maxNodes
+        : Infinity;
+    const lines = [];
+    let rendered = 0;
+    let skipped = 0;
+
+    const nodeLabel = (node) => {
+        const parts = [];
+        parts.push(`${node.events} event${node.events === 1 ? '' : 's'}`);
+        if (node.links > 0) parts.push(`${node.links} link${node.links === 1 ? '' : 's'}`);
+        if (node.segments > 0) parts.push(`${node.segments} segment${node.segments === 1 ? '' : 's'}`);
+        if (node.aiRequests > 0) {
+            const passes = Array.isArray(node.passes) && node.passes.length > 0
+                ? `: ${node.passes.join(', ')}`
+                : '';
+            parts.push(`${node.aiRequests} AI call${node.aiRequests === 1 ? '' : 's'} (${node.aiMs}ms${passes})`);
+        }
+        const classification = node.classification ? ` [${node.classification}]` : '';
+        return `${node.url}${classification} → ${parts.join(', ')}`;
+    };
+
+    const walk = (node, prefix, isLast) => {
+        if (rendered >= maxNodes) {
+            skipped += 1 + countCrawlNodes([{ roots: node.children }]);
+            return;
+        }
+        rendered += 1;
+        const connector = prefix === '' ? '' : (isLast ? '└─ ' : '├─ ');
+        lines.push(`${prefix}${connector}${nodeLabel(node)}`);
+        const childPrefix = prefix === '' ? '   ' : `${prefix}${isLast ? '   ' : '│  '}`;
+        const children = node.children || [];
+        children.forEach((child, index) => walk(child, childPrefix, index === children.length - 1));
+    };
+
+    (Array.isArray(sources) ? sources : []).forEach((source, sourceIndex) => {
+        if (sourceIndex > 0) lines.push('');
+        const parserLabel = source.parserType ? ` (${source.parserType} parser)` : '';
+        const modeLabel = source.discoveryOnly
+            ? ` [discovery-only${source.maxDepth !== null ? `, depth ${source.maxDepth}` : ''}]`
+            : '';
+        lines.push(`${source.name}${parserLabel}${modeLabel}`);
+        (source.roots || []).forEach((root) => walk(root, '', true));
+        for (const failure of source.failures || []) {
+            lines.push(`   ✗ failed: ${failure.url} — ${failure.error}`);
+        }
+        if (source.discovery) {
+            lines.push(`   discovery: ${source.discovery.urls} URL(s) via ${source.discovery.links} link(s)${source.discovery.note ? `, ${source.discovery.note}` : ''}`);
+        }
+        if (source.filtering) {
+            lines.push(`   filtering: ${source.filtering.total} → ${source.filtering.future} future → ${source.filtering.bear} bear → ${source.filtering.final} final`);
+        }
+    });
+
+    if (skipped > 0) {
+        lines.push(`… +${skipped} more page(s) not shown`);
+    }
+    return lines.join('\n');
+}
+
+function formatSummary(summary) {
+    const out = [];
+    if (Array.isArray(summary.crawl) && summary.crawl.length > 0) {
+        out.push('=== CRAWL TREE ===');
+        out.push(formatCrawlTreeText(summary.crawl));
+        out.push('');
+    }
+    out.push('=== PAGES ===');
+    if (summary.pages.length === 0) out.push('  (none found)');
+    for (const page of summary.pages) {
+        out.push(`  ${page.url} → ${page.events} event(s), ${page.aiRequests} AI request(s) [${page.passes.join(', ')}], ${page.aiMs}ms AI time`);
+    }
+    out.push('', '=== AI REQUESTS BY PASS ===');
+    if (summary.aiRequestsByPass.length === 0) out.push('  (none found)');
+    for (const stats of summary.aiRequestsByPass) {
+        out.push(`  ${stats.pass}: ${stats.sent} sent, ${stats.succeeded} succeeded, total ${stats.totalMs}ms, avg ${stats.avgMs}ms`);
+    }
+    if (Array.isArray(summary.ocr) && summary.ocr.length > 0) {
+        out.push('', `=== OCR ACTIVITY (${summary.ocr.length}) ===`);
+        summary.ocr.forEach(line => out.push(`  ${line}`));
+    }
+    out.push('', `=== MERGE DECISIONS (${summary.merges.length}) ===`);
+    summary.merges.forEach(line => out.push(`  ${line}`));
+    if (summary.droppedFields.length > 0) {
+        out.push('', `=== DROPPED FIELDS (${summary.droppedFields.length}) ===`);
+        summary.droppedFields.forEach(line => out.push(`  ${line}`));
+    }
+    if (summary.dedupe.length > 0 || summary.filtered.length > 0) {
+        out.push('', '=== DEDUP / FILTER ===');
+        summary.dedupe.forEach(line => out.push(`  ${line}`));
+        summary.filtered.forEach(line => out.push(`  ${line}`));
+    }
+    if (summary.calendar.length > 0) {
+        out.push('', '=== CALENDAR ===');
+        summary.calendar.forEach(line => out.push(`  ${line}`));
+    }
+    out.push('', `=== WARNINGS / ERRORS (${summary.problems.length}) ===`);
+    summary.problems.forEach(problem => out.push(`  [${problem.level.toUpperCase()}] ${problem.line}`));
+    return out.join('\n');
+}
+
+function filterByUrl(entries, urlSubstring) {
+    const needle = String(urlSubstring || '');
+    return entries.filter(entry =>
+        (entry.url && entry.url.includes(needle)) || entry.message.includes(needle)
+    );
+}
+
+const RunLogSummary = {
+    parseLog,
+    annotateUrls,
+    buildSummary,
+    summarizeLogText,
+    buildCrawlTree,
+    countCrawlNodes,
+    formatCrawlTreeText,
+    extractAiPayloads,
+    formatSummary,
+    filterByUrl
+};
+
+// Export for both environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        RunLogSummary,
+        parseLog,
+        annotateUrls,
+        buildSummary,
+        summarizeLogText,
+        buildCrawlTree,
+        countCrawlNodes,
+        formatCrawlTreeText,
+        extractAiPayloads,
+        formatSummary,
+        filterByUrl
+    };
+} else if (typeof window !== 'undefined') {
+    window.RunLogSummary = RunLogSummary;
+} else {
+    // Scriptable environment
+    this.RunLogSummary = RunLogSummary;
+}

--- a/scripts/run-log-summary.test.js
+++ b/scripts/run-log-summary.test.js
@@ -1,0 +1,189 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  RunLogSummary,
+  parseLog,
+  buildSummary,
+  buildCrawlTree,
+  countCrawlNodes,
+  formatCrawlTreeText,
+  summarizeLogText
+} = require('./run-log-summary');
+
+// Bearracuda-shaped run: one source URL classified as an event list, which links
+// to per-event pages crawled at depth 1 (adapted from the analyze-scraper-log
+// fixture, extended with the shared-core SYSTEM crawl lines).
+const CRAWL_FIXTURE = [
+  '2026-07-12T03:00:00.000Z [INFO] SYSTEM: Bearracuda → bearracuda (1 URL): https://bearracuda.com/',
+  '2026-07-12T03:00:01.000Z [INFO] SYSTEM: Classified https://bearracuda.com/ → eventlist',
+  '2026-07-12T03:00:02.000Z [INFO] SYSTEM: Parsed https://bearracuda.com/ → 0 events, 3 links',
+  '2026-07-12T03:00:03.000Z [INFO] SYSTEM: Following 3 discovered URLs → 3 unique for crawl depth 1',
+  '2026-07-12T03:00:04.000Z [INFO] SYSTEM: Crawling 3 discovered URLs (depth 1/1)',
+  '2026-07-12T03:00:05.000Z [INFO] SYSTEM: Classified https://bearracuda.com/events/atlanta → event',
+  '2026-07-12T03:00:06.000Z [INFO] 🤖 AI Web: Running AI extraction for https://bearracuda.com/events/atlanta (12 fields)',
+  '2026-07-12T03:00:07.000Z [INFO] 🤖 AI Web: Sending AI request (extraction pass) to http://rybook.example:8000/v1/chat/completions — model: qwen, provider: openai, prompt: 4000 chars',
+  '2026-07-12T03:00:07.100Z [DEBUG] 🤖 AI Web: Full prompt (extraction pass) (4000 chars)',
+  'SECRET PAYLOAD BODY that must never reach the summary',
+  '2026-07-12T03:00:09.000Z [INFO] 🤖 AI Web: AI request (extraction pass) succeeded in 2000ms — response: 400 chars',
+  '2026-07-12T03:00:09.500Z [INFO] 🤖 AI Web: Extracted https://bearracuda.com/events/atlanta → title="BEARRACUDA: Atlanta", bar="Heretic", startDate=2026-08-01T02:00:00.000Z, city=atlanta',
+  '2026-07-12T03:00:10.000Z [INFO] SYSTEM: Parsed https://bearracuda.com/events/atlanta → 1 event',
+  '2026-07-12T03:00:11.000Z [INFO] SYSTEM: Classified https://bearracuda.com/events/seattle → event',
+  '2026-07-12T03:00:12.000Z [INFO] SYSTEM: Parsed https://bearracuda.com/events/seattle → 1 event',
+  '2026-07-12T03:00:13.000Z [ERROR] SYSTEM: Failed to process crawl page https://bearracuda.com/events/broken: HTTP 500',
+  '2026-07-12T03:00:14.000Z [INFO] SYSTEM: Event filtering complete: 2 → 2 future → 2 bear → 2 final',
+  '2026-07-12T03:00:15.000Z [INFO] 🤝 AI MERGE: "BEARRACUDA: Atlanta" field=bar chose scraped ("Heretic") over existing ("Heretic Atlanta") — fresher source',
+  '2026-07-12T03:00:16.000Z [INFO] 🔄 PARSER MERGE: "BEARRACUDA: Atlanta" (ai-web) + "BEARRACUDA: Atlanta" (bearracuda) → 2 fields updated (bar, ticketUrl)',
+  '2026-07-12T03:00:17.000Z [WARN] 🤖 AI Web: Dropped 1 field(s) lacking source evidence: shortName',
+  '2026-07-12T03:00:18.000Z [INFO] 🔄 SharedCore: Deduplicated 3 → 2 (1 duplicate merged)',
+  '2026-07-12T03:00:19.000Z [INFO] 🤖 AI Web: Extracted OCR from 4 image(s)'
+].join('\n');
+
+// Discovery-only run at depth 2: the tree must nest a depth-2 page under its
+// depth-1 parent, then correctly return to depth 1 for the next sibling.
+const DISCOVERY_FIXTURE = [
+  '2026-07-12T04:00:00.000Z [INFO] SYSTEM: Sitges discovery → ai-web (1 URL): https://sitges.example/',
+  '2026-07-12T04:00:01.000Z [INFO] SYSTEM: Sitges discovery → Discovery only mode (depth 2)',
+  '2026-07-12T04:00:02.000Z [INFO] SYSTEM: Classified https://sitges.example/ → eventlist',
+  '2026-07-12T04:00:03.000Z [INFO] SYSTEM: Parsed https://sitges.example/ → 0 events, 2 links, 2 segments',
+  '2026-07-12T04:00:04.000Z [INFO] SYSTEM: Following 2 discovered URLs → 2 unique for crawl depth 1',
+  '2026-07-12T04:00:05.000Z [INFO] SYSTEM: Crawling 2 discovered URLs (depth 1/2)',
+  '2026-07-12T04:00:06.000Z [INFO] SYSTEM: Classified https://sitges.example/a → event',
+  '2026-07-12T04:00:07.000Z [INFO] SYSTEM: Parsed https://sitges.example/a → 0 events, 1 link',
+  '2026-07-12T04:00:08.000Z [INFO] SYSTEM: Crawl page https://sitges.example/a found 1 URLs → 1 unique for depth 2',
+  '2026-07-12T04:00:09.000Z [INFO] SYSTEM: Crawling 1 discovered URLs (depth 2/2)',
+  '2026-07-12T04:00:10.000Z [INFO] SYSTEM: Parsed https://sitges.example/a/tickets → 0 events',
+  '2026-07-12T04:00:11.000Z [INFO] SYSTEM: Classified https://sitges.example/b → event',
+  '2026-07-12T04:00:12.000Z [INFO] SYSTEM: Parsed https://sitges.example/b → 0 events',
+  '2026-07-12T04:00:13.000Z [INFO] SYSTEM: Discovery complete: 4 URL(s) found across 3 link(s), 2 segment(s) on 1 multi-event page(s)'
+].join('\n');
+
+test('buildCrawlTree nests followed links under their source page', () => {
+  const sources = buildCrawlTree(parseLog(CRAWL_FIXTURE));
+
+  assert.equal(sources.length, 1);
+  const source = sources[0];
+  assert.equal(source.name, 'Bearracuda');
+  assert.equal(source.parserType, 'bearracuda');
+  assert.equal(source.urlCount, 1);
+  assert.equal(source.discoveryOnly, false);
+
+  assert.equal(source.roots.length, 1);
+  const root = source.roots[0];
+  assert.equal(root.url, 'https://bearracuda.com/');
+  assert.equal(root.classification, 'eventlist');
+  assert.equal(root.events, 0);
+  assert.equal(root.links, 3);
+  assert.equal(root.depth, 0);
+
+  assert.equal(root.children.length, 2);
+  const [atlanta, seattle] = root.children;
+  assert.equal(atlanta.url, 'https://bearracuda.com/events/atlanta');
+  assert.equal(atlanta.classification, 'event');
+  assert.equal(atlanta.events, 1);
+  assert.equal(atlanta.depth, 1);
+  assert.equal(seattle.url, 'https://bearracuda.com/events/seattle');
+
+  assert.deepEqual(source.failures, [
+    { url: 'https://bearracuda.com/events/broken', error: 'HTTP 500' }
+  ]);
+  assert.deepEqual(source.filtering, { total: 2, future: 2, bear: 2, final: 2 });
+  assert.equal(countCrawlNodes(sources), 3);
+});
+
+test('buildSummary annotates tree nodes with per-page AI stats and collects OCR', () => {
+  const summary = summarizeLogText(CRAWL_FIXTURE);
+
+  const atlanta = summary.crawl[0].roots[0].children[0];
+  assert.equal(atlanta.aiRequests, 1);
+  assert.deepEqual(atlanta.passes, ['extraction']);
+  assert.equal(atlanta.aiMs, 2000);
+
+  assert.equal(summary.ocr.length, 1);
+  assert.ok(summary.ocr[0].includes('Extracted OCR from 4 image(s)'));
+
+  // Debug payload bodies must never leak into the structured summary
+  assert.ok(!JSON.stringify(summary).includes('SECRET PAYLOAD BODY'));
+});
+
+test('buildSummary extracts merge decisions with their reasons', () => {
+  const summary = summarizeLogText(CRAWL_FIXTURE);
+
+  assert.equal(summary.merges.length, 2);
+  assert.ok(summary.merges[0].includes('chose scraped ("Heretic")'));
+  assert.ok(summary.merges[0].includes('fresher source'));
+  assert.ok(summary.merges[1].includes('2 fields updated (bar, ticketUrl)'));
+  assert.equal(summary.droppedFields.length, 1);
+  assert.equal(summary.dedupe.length, 1);
+});
+
+test('buildSummary collects warnings and errors', () => {
+  const summary = summarizeLogText(CRAWL_FIXTURE);
+
+  assert.equal(summary.problems.length, 2);
+  assert.equal(summary.problems.filter(p => p.level === 'error').length, 1);
+  assert.ok(summary.problems.some(p => p.line.includes('Failed to process crawl page')));
+  assert.ok(summary.problems.some(p => p.line.includes('Dropped 1 field(s)')));
+});
+
+test('buildCrawlTree handles discovery-only runs across depths', () => {
+  const sources = buildCrawlTree(parseLog(DISCOVERY_FIXTURE));
+
+  assert.equal(sources.length, 1);
+  const source = sources[0];
+  assert.equal(source.discoveryOnly, true);
+  assert.equal(source.maxDepth, 2);
+  assert.deepEqual(source.discovery, {
+    urls: 4,
+    links: 3,
+    note: '2 segment(s) on 1 multi-event page(s)'
+  });
+
+  const root = source.roots[0];
+  assert.equal(root.segments, 2);
+  assert.equal(root.children.length, 2);
+
+  const [a, b] = root.children;
+  assert.equal(a.url, 'https://sitges.example/a');
+  assert.equal(a.children.length, 1);
+  assert.equal(a.children[0].url, 'https://sitges.example/a/tickets');
+  assert.equal(a.children[0].depth, 2);
+  // After the depth-2 recursion, /b must return to depth 1 as a sibling of /a
+  assert.equal(b.url, 'https://sitges.example/b');
+  assert.equal(b.depth, 1);
+  assert.equal(b.children.length, 0);
+});
+
+test('formatCrawlTreeText renders a nested tree and caps node count', () => {
+  const sources = buildCrawlTree(parseLog(CRAWL_FIXTURE));
+  const text = formatCrawlTreeText(sources);
+
+  assert.ok(text.includes('Bearracuda (bearracuda parser)'));
+  assert.ok(text.includes('https://bearracuda.com/ [eventlist]'));
+  assert.ok(text.includes('├─ https://bearracuda.com/events/atlanta'));
+  assert.ok(text.includes('└─ https://bearracuda.com/events/seattle'));
+  assert.ok(text.includes('✗ failed: https://bearracuda.com/events/broken'));
+  assert.ok(text.includes('filtering: 2 → 2 future → 2 bear → 2 final'));
+
+  const capped = formatCrawlTreeText(sources, { maxNodes: 2 });
+  assert.ok(capped.includes('… +1 more page(s) not shown'));
+  assert.ok(!capped.includes('events/seattle'));
+});
+
+test('formatSummary includes the crawl tree section', () => {
+  const text = RunLogSummary.formatSummary(summarizeLogText(CRAWL_FIXTURE));
+  assert.ok(text.includes('=== CRAWL TREE ==='));
+  assert.ok(text.includes('=== PAGES ==='));
+  assert.ok(text.includes('=== OCR ACTIVITY (1) ==='));
+});
+
+test('gracefully handles empty and garbage input', () => {
+  for (const input of ['', null, undefined, 'random garbage\nno timestamps here\n{]']) {
+    const summary = buildSummary(parseLog(input));
+    assert.deepEqual(summary.crawl, []);
+    assert.deepEqual(summary.pages, []);
+    assert.deepEqual(summary.merges, []);
+    assert.equal(typeof RunLogSummary.formatSummary(summary), 'string');
+    assert.equal(formatCrawlTreeText(summary.crawl), '');
+  }
+});

--- a/tools/analyze-scraper-log.js
+++ b/tools/analyze-scraper-log.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 // ============================================================================
-// analyze-scraper-log.js - Summarize a bear-event-scraper run log
+// analyze-scraper-log.js - Summarize a bear-event-scraper run log (CLI)
+//
+// Thin Node wrapper (fs + args + printing) around the environment-agnostic
+// parsing/summarizing core in scripts/run-log-summary.js — the same module the
+// Scriptable displays use for their run-insight sections.
 //
 // Reads a run log written by the Scriptable adapter's FileLogger
 // (Documents/chunky-dad-scraper/logs/<runId>.log, format:
@@ -21,214 +25,14 @@
 'use strict';
 
 const fs = require('fs');
-
-const FILE_ENTRY_RE = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z) \[([A-Z]+)\] (.*)$/;
-const PASTE_ENTRY_RE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?:\.\d+)?: (.*)$/;
-
-// Parse log text into entries: { ts, level, message } — message may be multi-line.
-function parseLog(text) {
-    const entries = [];
-    const lines = String(text || '').split(/\r?\n/);
-    for (const line of lines) {
-        let match = line.match(FILE_ENTRY_RE);
-        if (match) {
-            entries.push({ ts: match[1], level: match[2].toLowerCase(), message: match[3] });
-            continue;
-        }
-        match = line.match(PASTE_ENTRY_RE);
-        if (match) {
-            const message = match[2];
-            // Raw console pastes carry no level — infer warnings from emoji markers.
-            const level = /^(⚠️|🚨|❌)/.test(message) ? 'warn' : 'info';
-            entries.push({ ts: match[1], level, message });
-            continue;
-        }
-        if (entries.length > 0) {
-            entries[entries.length - 1].message += `\n${line}`;
-        } else if (line.trim()) {
-            entries.push({ ts: '', level: 'info', message: line });
-        }
-    }
-    return entries;
-}
-
-const URL_CONTEXT_RES = [
-    /🤖 AI Web: Running AI extraction for (\S+)/,
-    /🤖 AI Web: Fields for (\S+): \d+ selected/,
-    /🤖 AI Web: URL discovery stats for (\S+)/
-];
-
-// Annotate each entry with the page URL it belongs to (last URL-setting line wins).
-function annotateUrls(entries) {
-    let currentUrl = '';
-    for (const entry of entries) {
-        for (const re of URL_CONTEXT_RES) {
-            const match = entry.message.match(re);
-            if (match && match[1] && match[1] !== 'extraction' && match[1] !== 'unknown') {
-                currentUrl = match[1];
-                break;
-            }
-        }
-        entry.url = currentUrl;
-    }
-    return entries;
-}
-
-function normalizePass(raw) {
-    return String(raw || 'extraction').replace(/\s*pass$/i, '').trim() || 'extraction';
-}
-
-function buildSummary(entries) {
-    annotateUrls(entries);
-    const pages = new Map(); // url -> { events, passes:Set, aiMs, requests }
-    const aiByPass = new Map(); // pass -> { sent, succeeded, totalMs }
-    const merges = [];
-    const droppedFields = [];
-    const dedupe = [];
-    const filtered = [];
-    const calendar = [];
-    const problems = [];
-
-    const pageFor = (url) => {
-        const key = url || '(no url)';
-        if (!pages.has(key)) pages.set(key, { events: 0, passes: new Set(), aiMs: 0, requests: 0 });
-        return pages.get(key);
-    };
-
-    for (const entry of entries) {
-        const msg = entry.message;
-        const firstLine = msg.split('\n', 1)[0];
-
-        if (entry.level === 'warn' || entry.level === 'error') {
-            problems.push({ level: entry.level, line: firstLine });
-        }
-
-        let match = firstLine.match(/🤖 AI Web: Sending AI request(?: \(([^)]+)\))? to /);
-        if (match) {
-            const pass = normalizePass(match[1]);
-            if (!aiByPass.has(pass)) aiByPass.set(pass, { sent: 0, succeeded: 0, totalMs: 0 });
-            aiByPass.get(pass).sent += 1;
-            const page = pageFor(entry.url);
-            page.requests += 1;
-            page.passes.add(pass);
-            continue;
-        }
-        match = firstLine.match(/🤖 AI Web: AI request(?: \(([^)]+)\))? succeeded in (\d+)ms/);
-        if (match) {
-            const pass = normalizePass(match[1]);
-            if (!aiByPass.has(pass)) aiByPass.set(pass, { sent: 0, succeeded: 0, totalMs: 0 });
-            const stats = aiByPass.get(pass);
-            stats.succeeded += 1;
-            stats.totalMs += Number(match[2]);
-            pageFor(entry.url).aiMs += Number(match[2]);
-            continue;
-        }
-        match = firstLine.match(/🤖 AI Web: Extracted (\S+) →/);
-        if (match) {
-            pageFor(match[1]).events += 1;
-            continue;
-        }
-        if (firstLine.includes('🤖 AI Web: Running AI extraction for')) {
-            pageFor(entry.url);
-            continue;
-        }
-        if (/🤝 AI MERGE|🔄 PARSER MERGE|🔄 MERGE/.test(firstLine)) {
-            merges.push(firstLine);
-            continue;
-        }
-        if (/Dropped \d+ field\(s\) lacking source evidence|Dropping field .* low confidence/.test(firstLine)) {
-            droppedFields.push(firstLine);
-            continue;
-        }
-        match = firstLine.match(/🔄 SharedCore: Deduplicated (\d+) → (\d+)/);
-        if (match) {
-            dedupe.push(firstLine);
-            continue;
-        }
-        if (firstLine.includes('SharedCore: Filtering out event')) {
-            filtered.push(firstLine);
-            continue;
-        }
-        if (/^(📅|📊|🌍|🕐|✅ Found calendars|❌ Missing calendars)/.test(firstLine)) {
-            calendar.push(firstLine);
-        }
-    }
-
-    return {
-        pages: Array.from(pages.entries()).map(([url, data]) => ({
-            url,
-            events: data.events,
-            aiRequests: data.requests,
-            passes: Array.from(data.passes),
-            aiMs: data.aiMs
-        })),
-        aiRequestsByPass: Array.from(aiByPass.entries()).map(([pass, s]) => ({
-            pass,
-            sent: s.sent,
-            succeeded: s.succeeded,
-            totalMs: s.totalMs,
-            avgMs: s.succeeded > 0 ? Math.round(s.totalMs / s.succeeded) : 0
-        })),
-        merges,
-        droppedFields,
-        dedupe,
-        filtered,
-        calendar,
-        problems
-    };
-}
-
-// Full AI payload dumps (debug channel): Full prompt / Model response text blocks.
-function extractAiPayloads(entries, passType = null) {
-    const payloads = [];
-    for (const entry of entries) {
-        const match = entry.message.match(/^🤖 AI Web: (Full prompt|Model response text)(?: \(([^)]+)\))?/);
-        if (!match) continue;
-        const pass = normalizePass(match[2]);
-        if (passType && pass !== normalizePass(passType)) continue;
-        payloads.push({ kind: match[1], pass, url: entry.url || '', text: entry.message });
-    }
-    return payloads;
-}
-
-function formatSummary(summary) {
-    const out = [];
-    out.push('=== PAGES ===');
-    if (summary.pages.length === 0) out.push('  (none found)');
-    for (const page of summary.pages) {
-        out.push(`  ${page.url} → ${page.events} event(s), ${page.aiRequests} AI request(s) [${page.passes.join(', ')}], ${page.aiMs}ms AI time`);
-    }
-    out.push('', '=== AI REQUESTS BY PASS ===');
-    if (summary.aiRequestsByPass.length === 0) out.push('  (none found)');
-    for (const stats of summary.aiRequestsByPass) {
-        out.push(`  ${stats.pass}: ${stats.sent} sent, ${stats.succeeded} succeeded, total ${stats.totalMs}ms, avg ${stats.avgMs}ms`);
-    }
-    out.push('', `=== MERGE DECISIONS (${summary.merges.length}) ===`);
-    summary.merges.forEach(line => out.push(`  ${line}`));
-    if (summary.droppedFields.length > 0) {
-        out.push('', `=== DROPPED FIELDS (${summary.droppedFields.length}) ===`);
-        summary.droppedFields.forEach(line => out.push(`  ${line}`));
-    }
-    if (summary.dedupe.length > 0 || summary.filtered.length > 0) {
-        out.push('', '=== DEDUP / FILTER ===');
-        summary.dedupe.forEach(line => out.push(`  ${line}`));
-        summary.filtered.forEach(line => out.push(`  ${line}`));
-    }
-    if (summary.calendar.length > 0) {
-        out.push('', '=== CALENDAR ===');
-        summary.calendar.forEach(line => out.push(`  ${line}`));
-    }
-    out.push('', `=== WARNINGS / ERRORS (${summary.problems.length}) ===`);
-    summary.problems.forEach(problem => out.push(`  [${problem.level.toUpperCase()}] ${problem.line}`));
-    return out.join('\n');
-}
-
-function filterByUrl(entries, urlSubstring) {
-    const needle = String(urlSubstring || '');
-    return entries.filter(entry =>
-        (entry.url && entry.url.includes(needle)) || entry.message.includes(needle)
-    );
-}
+const {
+    parseLog,
+    annotateUrls,
+    buildSummary,
+    extractAiPayloads,
+    formatSummary,
+    filterByUrl
+} = require('../scripts/run-log-summary');
 
 const HELP = `Analyze a bear-event-scraper run log.
 
@@ -238,8 +42,8 @@ Log files live in Scriptable's Documents/chunky-dad-scraper/logs/<runId>.log;
 raw console pastes ("2026-07-13 09:12:13: message") are also accepted.
 
 Options:
-  (none)            run summary: pages, AI timings, merges, dropped fields,
-                    dedup/filter results, calendar section, warnings/errors
+  (none)            run summary: crawl tree, pages, AI timings, merges, dropped
+                    fields, dedup/filter results, calendar section, warnings/errors
   --ai [passType]   print full AI prompt/response payloads (debug lines),
                     optionally only one pass type (extraction, context-prep,
                     repair, ocr, ...)
@@ -326,6 +130,7 @@ function main(argv) {
     return 0;
 }
 
+// Re-export the shared core so existing consumers/tests of this module keep working.
 module.exports = { parseLog, annotateUrls, buildSummary, extractAiPayloads, formatSummary, filterByUrl };
 
 if (require.main === module) {


### PR DESCRIPTION
On-phone run investigation, built into the displays that already exist. Two new sections in the results UI (and saved-run view), **collapsed by default** using the same tap-to-expand pattern as the existing Run Logs section — the default view is otherwise unchanged:

- **🌳 What Happened** — a crawl & extraction tree reconstructed from the run's own log: source → page classification → followed links by depth → events found per page with AI passes/timings, plus per-pass AI request stats, OCR activity, failed pages, and the dedup/filter funnel. Handles `discoveryOnly` runs (flags the source, shows links/segments per node and discovery totals).
- **🧭 What We Did** — per-event actions (NEW/MERGE/CONFLICT with write plan), AI merge-arbitration decisions *with the model's reasons*, parser merges, dropped fields, and warnings/errors.

## How it works
- New `scripts/run-log-summary.js`: environment-agnostic parsing/summarizing module (loads via Scriptable importModule and Node require). `tools/analyze-scraper-log.js` is now a thin CLI wrapper over it — desktop tool and phone display share one implementation.
- Live runs feed the sections from the adapter's in-memory captured log entries; saved runs load the matching `logs/<runId>.log` (missing log degrades gracefully — structured event actions still render).
- Full `[DEBUG]` payload bodies are never embedded in the HTML; long trees are capped with "+N more" notes; all content HTML-escaped.

## Tests
133 → 146, all green — including a new headless adapter test that stubs only `importModule`/`FileManager`, renders the real results HTML, and asserts: both sections present and collapsed, escaping correct, payload bodies absent, 80-page runs capped, and the missing-log saved-run path intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)