### PR TITLE
fix(scraper): end-time rollover, degenerate endDate guard, date arbitration routing, location=coordinates

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -6534,7 +6534,16 @@ TEXT:
                 combinedEndDate = combinedStartDate ? new Date(combinedStartDate) : endDateRaw;
             }
         } else if (endTimeRaw) {
-            combinedEndDate = this.parseDateValue(endTimeRaw, timezone);
+            // End time with no end date ("Party Goes Until 2:00 am!" — the next-day
+            // endDate is never verbatim on the page, so the evidence gate drops it):
+            // anchor the end time to the START's date. The past-midnight rollover
+            // below moves it to the next day when it lands before the start.
+            if (startDateRaw) {
+                combinedEndDate = this.convertLocalDateTimeToUtc(startDateRaw.toISOString().split('T')[0] + ' ' + endTimeRaw, timezone) || combineDateAndTime(startDateRaw, endTimeRaw) || null;
+            }
+            if (!combinedEndDate) {
+                combinedEndDate = this.parseDateValue(endTimeRaw, timezone);
+            }
         }
 
         // If we only have a start date and no end date info at all, match the end exactly to the start

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -832,6 +832,39 @@ test('normalizeAiEvent rolls past-midnight end times to the next day', () => {
   assert.equal(sameDay.endDate.toISOString(), '2026-07-12T00:00:00.000Z'); // 8pm EDT
 });
 
+test('normalizeAiEvent anchors an end time with NO end date to the start date', () => {
+  const parser = createParser();
+  const cityConfig = { nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc'] } };
+
+  // "Party Goes Until 2:00 am!" — the page never prints the next-day date, so the
+  // evidence gate drops the inferred endDate and only rawEndTime=02:00 survives.
+  // The end must anchor to the START's date and roll past midnight, not go null
+  // and collapse the event to zero duration.
+  const lateNight = parser.normalizeAiEvent({
+    title: 'NEW ORLEANS',
+    startDate: '2026-09-04',
+    startTime: '21:00',
+    endTime: '02:00',
+    address: '800 Bourbon St, New York, NY'
+  }, {}, null, cityConfig, null);
+  assert.ok(lateNight);
+  assert.equal(lateNight.startDate.toISOString(), '2026-09-05T01:00:00.000Z'); // 9pm EDT
+  assert.equal(lateNight.endDate.toISOString(), '2026-09-05T06:00:00.000Z', 'end must land at 2am the NEXT day');
+  assert.equal(lateNight.endDate - lateNight.startDate, 5 * 60 * 60 * 1000, 'the 5-hour duration must survive');
+
+  // An end time AFTER the start time (still no end date) stays on the same day
+  const sameDay = parser.normalizeAiEvent({
+    title: 'TEA DANCE',
+    startDate: '2026-09-04',
+    startTime: '14:00',
+    endTime: '18:00',
+    address: '800 Bourbon St, New York, NY'
+  }, {}, null, cityConfig, null);
+  assert.ok(sameDay);
+  assert.equal(sameDay.startDate.toISOString(), '2026-09-04T18:00:00.000Z'); // 2pm EDT
+  assert.equal(sameDay.endDate.toISOString(), '2026-09-04T22:00:00.000Z', 'same-day end must not roll over');
+});
+
 test('getAiPromptFields default branch still requests split time fields', () => {
   const parser = createParser();
   // No OCR, no JSON-LD, no meta — the branch that previously dropped startTime/endTime

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -341,7 +341,41 @@ class SharedCore {
     isArbitrationEligibleField(fieldName) {
         const name = String(fieldName || '');
         if (!name || name.startsWith('_')) return false;
-        return name !== 'key' && name !== 'notes' && name !== 'source';
+        // location is never arbitrated: it is ALWAYS coordinates (the calendar is
+        // used as a database), so merges resolve it deterministically via
+        // isCoordinatePair — human-readable text belongs in address/bar.
+        return name !== 'key' && name !== 'notes' && name !== 'source' && name !== 'location';
+    }
+
+    // "lat, lng" / "lat,lng": two finite floats with lat in [-90, 90] and lng in
+    // [-180, 180]. The location field is ALWAYS coordinates — the normalization
+    // layer fills it with coordinates, and merges must never let address text or
+    // an empty scrape displace them.
+    isCoordinatePair(value) {
+        if (typeof value !== 'string') return false;
+        const match = value.trim().match(/^(-?\d{1,3}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)$/);
+        if (!match) return false;
+        const lat = Number(match[1]);
+        const lng = Number(match[2]);
+        return Number.isFinite(lat) && Number.isFinite(lng)
+            && Math.abs(lat) <= 90 && Math.abs(lng) <= 180;
+    }
+
+    // Date-or-ISO-string → epoch milliseconds, or null when absent/unparseable.
+    toEpochMillis(value) {
+        if (value === null || value === undefined || value === '') return null;
+        const date = value instanceof Date ? value : new Date(value);
+        const time = date.getTime();
+        return Number.isNaN(time) ? null : time;
+    }
+
+    // endDate <= startDate (compared as instants) is a normalization artifact
+    // (e.g. an evidence-dropped end date collapsing an event to zero duration),
+    // not data. Degenerate ends must never displace a positive-duration end.
+    hasDegenerateEnd(event) {
+        const startMs = this.toEpochMillis(event && event.startDate);
+        const endMs = this.toEpochMillis(event && event.endDate);
+        return startMs !== null && endMs !== null && endMs <= startMs;
     }
 
     isEmptyArbitrationValue(value) {
@@ -1677,6 +1711,52 @@ class SharedCore {
             const newValue = newEvent[fieldName];
             const existingSource = existingEvent.source;
             const newSource = newEvent.source;
+
+            // location is ALWAYS coordinates: when exactly one side has a
+            // coordinate pair it wins deterministically — text or an empty value
+            // never displaces coordinates. Both-or-neither coordinates falls
+            // through to the normal priority resolution below (never AI:
+            // location is excluded from arbitration eligibility).
+            if (fieldName === 'location') {
+                const existingIsCoordinates = this.isCoordinatePair(existingValue);
+                const newIsCoordinates = this.isCoordinatePair(newValue);
+                if (existingIsCoordinates !== newIsCoordinates) {
+                    const chosenValue = existingIsCoordinates ? existingValue : newValue;
+                    mergedEvent[fieldName] = chosenValue;
+                    if (existingValue !== newValue) {
+                        mergeDecisions.push({
+                            field: fieldName,
+                            existingValue: existingValue,
+                            newValue: newValue,
+                            chosenValue: chosenValue,
+                            reason: 'location must be coordinates — coordinates win over text/empty'
+                        });
+                    }
+                    return;
+                }
+            }
+
+            // A degenerate end (endDate <= that record's own startDate) is a
+            // normalization artifact, not data — when exactly one side's end is
+            // degenerate, the positive-duration end wins deterministically.
+            if (fieldName === 'endDate' && !isEmpty(existingValue) && !isEmpty(newValue)) {
+                const existingEndDegenerate = this.hasDegenerateEnd(existingEvent);
+                const newEndDegenerate = this.hasDegenerateEnd(newEvent);
+                if (existingEndDegenerate !== newEndDegenerate) {
+                    const chosenValue = existingEndDegenerate ? newValue : existingValue;
+                    mergedEvent[fieldName] = chosenValue;
+                    console.warn(`⚠️ MERGE: "${newEvent.title || existingEvent.title || 'event'}" ${existingEndDegenerate ? 'existing' : 'incoming'} endDate <= startDate (zero duration) — treating as missing, keeping the positive-duration end`);
+                    mergeDecisions.push({
+                        field: fieldName,
+                        existingValue: existingValue,
+                        newValue: newValue,
+                        chosenValue: chosenValue,
+                        reason: 'degenerate end (endDate <= startDate) treated as missing'
+                    });
+                    return;
+                }
+            }
+
             const canArbitrate = this.isArbitrationEligibleField(fieldName)
                 && this.isGenuineFieldConflict(fieldName, existingValue, newValue);
 
@@ -1855,6 +1935,19 @@ class SharedCore {
         // Genuine conflicts deferred to AI arbitration (strategy "ai")
         const pendingAiConflicts = [];
 
+        const mergeTitle = scraperObject.title || calendarObject.title || 'event';
+
+        // A scraped endDate that is <= the scraped startDate (zero/negative duration)
+        // is a normalization artifact, not data — it must never replace a calendar
+        // end that yields positive duration, and it never even becomes a conflict.
+        const calendarStartMs = this.toEpochMillis(calendarObject.startDate);
+        const calendarEndMs = this.toEpochMillis(calendarObject.endDate);
+        const keepCalendarEndOverDegenerateScrape = this.hasDegenerateEnd(scraperObject)
+            && calendarStartMs !== null && calendarEndMs !== null && calendarEndMs > calendarStartMs;
+        if (keepCalendarEndOverDegenerateScrape) {
+            console.warn(`⚠️ MERGE: "${mergeTitle}" scraped endDate <= startDate (zero duration) — treating as missing, keeping calendar end`);
+        }
+
         // Apply merge logic for each field
         for (const fieldName of allFields) {
             // Skip internal fields
@@ -1864,6 +1957,50 @@ class SharedCore {
             const mergeStrategy = priorityConfig?.merge || 'upsert';
             const scraperValue = scraperObject[fieldName];
             const calendarValue = calendarObject[fieldName];
+
+            if (fieldName === 'endDate' && keepCalendarEndOverDegenerateScrape) {
+                mergedObject[fieldName] = calendarValue;
+                continue;
+            }
+
+            if (fieldName === 'location') {
+                // location is ALWAYS coordinates (the calendar is the database; the
+                // normalization layer fills this field with coordinates). Resolve it
+                // deterministically — never via AI: scraped coordinates win; else
+                // calendar coordinates are KEPT (an empty or text scrape must not
+                // wipe them); when neither side is coordinates, fall through to the
+                // configured merge strategy (clobber semantics today).
+                if (this.isCoordinatePair(scraperValue)) {
+                    mergedObject[fieldName] = scraperValue;
+                    if (scraperValue !== calendarValue) {
+                        clobberedFields.push(fieldName);
+                    }
+                    continue;
+                }
+                if (this.isCoordinatePair(calendarValue)) {
+                    mergedObject[fieldName] = calendarValue;
+                    if (scraperValue !== calendarValue) {
+                        console.log(`📍 MERGE: "${mergeTitle}" location kept calendar coordinates over scraped text/empty value`);
+                    }
+                    continue;
+                }
+            }
+
+            // Dates are calendar-critical: a genuinely different startDate/endDate is
+            // arbitrated even when a parser config says clobber — silently overwriting
+            // a differing calendar date is how good ends get destroyed. A failed
+            // arbitration still falls back to the scraped value (exactly clobber).
+            const routeDateConflictToAi = (fieldName === 'startDate' || fieldName === 'endDate')
+                && mergeStrategy === 'clobber'
+                && this.isArbitrationEligibleField(fieldName)
+                && this.isGenuineFieldConflict(fieldName, calendarValue, scraperValue);
+            if (routeDateConflictToAi) {
+                pendingAiConflicts.push({
+                    field: fieldName,
+                    values: { calendar: calendarValue, scraped: scraperValue }
+                });
+                continue;
+            }
 
             switch (mergeStrategy) {
                 case 'ai':

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -676,6 +676,200 @@ test('resolveAiConfig defaults and the arbitrateMerges flag', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Degenerate ends, date arbitration routing, and the location=coordinates rule
+// ---------------------------------------------------------------------------
+
+const TEST_AI_PARSER_CONFIG = { ai: { provider: 'ollama', endpoint: 'http://ai.example/api/generate', model: 'test-model' } };
+
+test('a degenerate scraped endDate (== startDate) never clobbers a positive-duration calendar end', async () => {
+  const core = createCore();
+  const scraped = {
+    title: 'New Orleans',
+    startDate: new Date('2026-09-05T02:00:00.000Z'),
+    endDate: new Date('2026-09-05T02:00:00.000Z'), // zero duration — a normalization artifact, not data
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const existing = {
+    title: 'New Orleans',
+    startDate: new Date('2026-09-05T02:00:00.000Z'),
+    endDate: new Date('2026-09-05T07:00:00.000Z'), // "party until 2am" — 5h duration
+    notes: ''
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'a degenerate end must never even become an arbitration conflict');
+  assert.equal(finalEvent.endDate.toISOString(), '2026-09-05T07:00:00.000Z', 'the calendar end must survive');
+});
+
+test('genuinely differing dates reach arbitration even under an explicit merge:"clobber" config', async () => {
+  const core = createCore();
+  // Bearracuda-style per-parser override: merge "clobber" for dates. This exact
+  // config made date conflicts bypass isGenuineFieldConflict entirely and
+  // silently overwrite calendar dates.
+  const clobberPriorities = core.getResolvedFieldPriorities({
+    fieldPriorities: {
+      startDate: { priority: ['ai-web', 'bearracuda'], merge: 'clobber' },
+      endDate: { priority: ['ai-web', 'bearracuda'], merge: 'clobber' }
+    }
+  });
+
+  // Calendar endDate as a Date instance AND as an ISO string — both must route.
+  for (const calendarEnd of [new Date('2026-09-05T07:00:00.000Z'), '2026-09-05T07:00:00.000Z']) {
+    const scraped = {
+      title: 'New Orleans',
+      startDate: new Date('2026-09-05T01:00:00.000Z'),
+      endDate: new Date('2026-09-05T06:00:00.000Z'), // valid positive duration, but differs from calendar
+      source: 'ai-web',
+      _fieldPriorities: clobberPriorities,
+      _parserConfig: TEST_AI_PARSER_CONFIG
+    };
+    const existing = {
+      title: 'New Orleans',
+      startDate: new Date('2026-09-05T01:00:00.000Z'),
+      endDate: calendarEnd,
+      notes: ''
+    };
+    const adapter = buildArbitrationAdapter({
+      endDate: { pick: 'calendar', value: '2026-09-05T07:00:00.000Z', reason: 'calendar end matches the flyer' }
+    });
+
+    const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+    assert.equal(adapter.calls.length, 1, 'the endDate conflict must reach the arbitration prompt despite merge:"clobber"');
+    assert.match(adapter.calls[0].prompt, /endDate/);
+    assert.match(adapter.calls[0].prompt, /2026-09-05T07:00:00\.000Z/, 'the calendar candidate is serialized as ISO in the prompt');
+    assert.match(adapter.calls[0].prompt, /2026-09-05T06:00:00\.000Z/, 'the scraped candidate is serialized as ISO in the prompt');
+    // The verbatim ISO answer is accepted and the picked side's ORIGINAL value is applied
+    assert.equal(finalEvent.endDate, calendarEnd, 'the calendar side keeps its original value (Date or ISO string)');
+  }
+});
+
+test('clobber fallback still applies when date arbitration is unavailable', async () => {
+  const core = createCore();
+  const clobberPriorities = core.getResolvedFieldPriorities({
+    fieldPriorities: { endDate: { priority: ['ai-web'], merge: 'clobber' } }
+  });
+  const scraped = {
+    title: 'New Orleans',
+    startDate: new Date('2026-09-05T01:00:00.000Z'),
+    endDate: new Date('2026-09-05T06:00:00.000Z'),
+    source: 'ai-web',
+    _fieldPriorities: clobberPriorities,
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const existing = {
+    title: 'New Orleans',
+    startDate: new Date('2026-09-05T01:00:00.000Z'),
+    endDate: new Date('2026-09-05T07:00:00.000Z'),
+    notes: ''
+  };
+  const adapter = buildArbitrationAdapter({}, { fail: true });
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(finalEvent.endDate.toISOString(), '2026-09-05T06:00:00.000Z', 'failed arbitration degrades to exactly the clobber behavior');
+});
+
+test('isCoordinatePair recognizes lat/lng strings only', () => {
+  const core = createCore();
+  assert.equal(core.isCoordinatePair('45.52, -122.65'), true);
+  assert.equal(core.isCoordinatePair('45.52,-122.65'), true);
+  assert.equal(core.isCoordinatePair('722 East Burnside Street'), false);
+  assert.equal(core.isCoordinatePair('portland'), false);
+  assert.equal(core.isCoordinatePair(''), false);
+  assert.equal(core.isCoordinatePair('91, 10'), false, 'latitude out of range');
+  assert.equal(core.isCoordinatePair('45, 181'), false, 'longitude out of range');
+  assert.equal(core.isCoordinatePair(null), false);
+  assert.equal(core.isCoordinatePair(undefined), false);
+});
+
+test('location merge is deterministic: coordinates always beat text/empty and never reach the AI', async () => {
+  const core = createCore();
+  const buildScraped = (location) => ({
+    title: 'FURBALL',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    location,
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  });
+  const buildExisting = (location) => ({
+    title: 'FURBALL',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    location,
+    notes: ''
+  });
+
+  // (a) calendar has address text, scraped has coordinates → coordinates win, no AI call
+  const adapterA = buildArbitrationAdapter({});
+  const a = await core.createFinalEventObject(
+    buildExisting('722 East Burnside Street, Portland'),
+    buildScraped('45.52, -122.65'),
+    { httpAdapter: adapterA }
+  );
+  assert.equal(a.location, '45.52, -122.65');
+  assert.equal(adapterA.calls.length, 0, 'location must never be AI-arbitrated');
+
+  // (b) calendar coordinates are preserved against an empty scrape and a text scrape
+  const adapterB = buildArbitrationAdapter({});
+  const bEmpty = await core.createFinalEventObject(
+    buildExisting('45.52,-122.65'),
+    buildScraped(''),
+    { httpAdapter: adapterB }
+  );
+  assert.equal(bEmpty.location, '45.52,-122.65', 'an empty scrape must not wipe calendar coordinates');
+  const bText = await core.createFinalEventObject(
+    buildExisting('45.52,-122.65'),
+    buildScraped('portland'),
+    { httpAdapter: adapterB }
+  );
+  assert.equal(bText.location, '45.52,-122.65', 'scraped text must not displace calendar coordinates');
+
+  // (c) both sides are coordinates but differ → the scraped (fresher) fix wins
+  const cResult = await core.createFinalEventObject(
+    buildExisting('40.7128, -74.0060'),
+    buildScraped('45.52, -122.65'),
+    { httpAdapter: adapterB }
+  );
+  assert.equal(cResult.location, '45.52, -122.65', 'scraped coordinates win over differing calendar coordinates');
+  assert.equal(adapterB.calls.length, 0, 'no location scenario may consult the AI');
+});
+
+test('mergeParsedEvents: coordinates beat text and degenerate ends lose, without AI', async () => {
+  const core = createCore();
+  const priorities = core.getResolvedFieldPriorities({});
+  const adapter = buildArbitrationAdapter({});
+
+  const existing = {
+    title: 'FURBALL',
+    location: '45.52, -122.65',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-05T22:00:00.000Z'), // degenerate: end == start
+    source: 'ai-web',
+    _fieldPriorities: priorities
+  };
+  const incoming = {
+    title: 'FURBALL',
+    location: '722 East Burnside Street',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    source: 'ai-web',
+    _parserConfig: TEST_AI_PARSER_CONFIG,
+    _fieldPriorities: priorities
+  };
+
+  const merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+  assert.equal(merged.location, '45.52, -122.65', 'coordinates beat text regardless of which side has them');
+  assert.equal(merged.endDate.toISOString(), '2026-07-06T02:00:00.000Z', 'the positive-duration end wins');
+  assert.equal(adapter.calls.length, 0, 'both rules resolve deterministically without AI');
+});
+
+// ---------------------------------------------------------------------------
 // Identity-verified cross-parser dedup (2026-07-12 run findings)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes the two issues from the 2026-07-13 run report (zero-duration New Orleans end clobbering the calendar's correct 2:00 AM end; address-vs-coordinates `location` arbitration), per the owner's direction that **`location` is always coordinates** — the calendar is a database.

## 1. End time without an end date (ai-web-parser.js ~6536)
"Party Goes Until 2:00 am!" pages never print the next-day date, so the evidence gate rightly drops the inferred `endDate`, leaving only `endTime`. That branch used to produce `null` → `endDate = startDate` (zero-duration event). It now anchors the end time to the start's date and lets the existing past-midnight rollover move it to the next day. NOLA case now yields the correct 5-hour duration.

## 2. Degenerate-end guard (createFinalEventObject + mergeParsedEvents)
A scraped `endDate <= startDate` is treated as **missing data**: it can never replace a calendar end with positive duration, and never becomes an arbitration conflict. Same principle in cross-parser merges (the positive-duration side wins, with a warn log).

## 3. Date arbitration routing — root cause was config, fix is in routing
Dates were configured `merge: "ai"` by default, but the live parser config explicitly sets `startDate`/`endDate` (and url/location/facebook) to `merge: "clobber"` — matching exactly the 5 fields the run log shows silently clobbered. Rather than requiring config edits, genuinely-differing start/end dates are now routed to AI arbitration **even under a clobber config**, with failed/absent arbitration falling back to the scraped value (i.e. exactly clobber). Dates are calendar-critical; silent date clobbers are how good ends get destroyed.

## 4. `location` = coordinates, deterministically (no AI)
`location` is removed from arbitration eligibility. New `isCoordinatePair` helper; resolution order in both merge paths: scraped coordinates win → else calendar coordinates are **kept** (an empty or text scrape can never wipe coordinates out of the database) → only when neither side is coordinates does the configured strategy apply. The inconsistent address-vs-coords AI picks from the last run can't happen anymore.

## Tests
161 → 168, all green. New coverage: the exact NOLA normalization repro (21:00→02:00 rollover, plus the same-day no-rollover case), degenerate end preserved against calendar + excluded from arbitration, differing valid dates reaching the arbitration prompt (Date and ISO-string calendar values), coordinates-beat-text in both merge paths, coordinate-pair validation. Pre-fix sanity: 6 of 7 new tests fail without the source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)