### PR TITLE
fix(scraper): re-request brand-rejected fields, site-tagline guard, preserve venue on empty scrape

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4600,6 +4600,48 @@ class AiWebParser {
         return merged;
     }
 
+    // Per-pass organizer-brand / site-tagline guard. Values rejected here never
+    // enter the accumulated event, so the field stays in later passes' request
+    // lists. Deliberately narrow:
+    // - bar: rejected when it matches a page brand name (same test as the
+    //   normalizeAiEvent backstop).
+    // - title: rejected ONLY when the WHOLE title is a brand name — a title
+    //   merely containing the brand ("Provincetown⚓ | BEARRACUDA") is kept;
+    //   the suffix strip happens at the end (stripPageBrandFromTitle).
+    // - description: rejected ONLY when exactly equal (trimmed, whitespace-
+    //   collapsed, case-insensitive) to the site's own JSON-LD
+    //   WebSite.description. No fuzzy matching — genuine event taglines must
+    //   never be dropped.
+    rejectBrandLikePassFields(partial, htmlData, passLabel = '') {
+        if (!partial || typeof partial !== 'object') return partial;
+        const brandNames = this.getPageBrandNames(htmlData);
+        const siteTaglines = this.getPageSiteTaglines(htmlData);
+        if (brandNames.length === 0 && siteTaglines.length === 0) return partial;
+        const guarded = { ...partial };
+        const passName = String(passLabel || '').trim() || 'extraction';
+        Object.keys(guarded).forEach(key => {
+            if (this.isInternalAiFieldKey(key)) return;
+            const value = guarded[key];
+            if (typeof value !== 'string' || !value.trim()) return;
+            const normalizedField = this.normalizePromptFieldName(key);
+            if (normalizedField === 'bar' && brandNames.length > 0 && this.matchesPageBrandName(value, brandNames)) {
+                console.log(`🤖 AI Web: Rejecting bar "${value}" from ${passName} pass — matches page organizer/brand; keeping field open for later passes`);
+                delete guarded[key];
+                return;
+            }
+            if (normalizedField === 'title' && brandNames.length > 0 && this.matchesPageBrandName(value, brandNames)) {
+                console.log(`🤖 AI Web: Rejecting title "${value}" from ${passName} pass — the whole title is the page organizer/brand; keeping field open for later passes`);
+                delete guarded[key];
+                return;
+            }
+            if (normalizedField === 'description' && this.matchesSiteTagline(value, siteTaglines)) {
+                console.log(`🤖 AI Web: Rejecting description from ${passName} pass — identical to the site's own tagline, not event-specific`);
+                delete guarded[key];
+            }
+        });
+        return guarded;
+    }
+
     getBestModePromptGroups(sectionBundle) {
         const jsonGroup = sectionBundle && sectionBundle.jsonLd
             ? { label: 'jsonld', sections: [sectionBundle.jsonLd] }
@@ -4687,10 +4729,19 @@ class AiWebParser {
             const partial = await this.extractEventWithTwoPassAi(htmlData, aiConfig, cityConfig, parserConfig, remainingFields, snippetText, passLabel, { ...options, dataFlags }, httpAdapter);
 
             // Validate extracted fields
-            const validatedPartial = this.validateAiEventEvidence(partial, htmlData, parserConfig, remainingFields, {
+            let validatedPartial = this.validateAiEventEvidence(partial, htmlData, parserConfig, remainingFields, {
                 evidenceContext: snippetEvidenceContext,
                 validationContext: { imageEvidenceUrls: snippetImageEvidence, cityConfig: cityConfig }
             }).event || {};
+
+            // Reject organizer-brand / site-tagline values AT PASS-RESULT TIME:
+            // an accepted value consumes the field slot (later passes only ask for
+            // still-missing fields via getRemainingPromptFields), so a junk meta
+            // answer like bar:"BEARRACUDA" would permanently block the correct
+            // value even when a later content pass could find it. Rejecting here
+            // keeps the field open; normalizeAiEvent keeps the same guards as an
+            // end-of-pipeline backstop.
+            validatedPartial = this.rejectBrandLikePassFields(validatedPartial, htmlData, passLabel);
 
             // Track field sources for traceability
             const validatedFields = validationState ? validationState.validatedFields : new Set();
@@ -6366,12 +6417,12 @@ TEXT:
             aiEvent.summary,
             this.getResolvedParserMetadataFieldValue(parserConfig, ['title', 'name', 'summary'], aiEvent)
         );
-        const description = this.firstNonEmpty(
-            aiEvent.description,
-            aiEvent.desc,
+        const aiDescription = this.firstNonEmpty(aiEvent.description, aiEvent.desc, '');
+        const configDescription = this.firstNonEmpty(
             this.getResolvedParserMetadataFieldValue(parserConfig, ['description', 'desc'], aiEvent),
             ''
         );
+        let description = aiDescription || configDescription;
         const aiBar = this.firstNonEmpty(aiEvent.bar, aiEvent.venue, '');
         const configBar = this.firstNonEmpty(
             this.getResolvedParserMetadataFieldValue(parserConfig, ['bar', 'venue'], aiEvent),
@@ -6398,6 +6449,16 @@ TEXT:
                 console.log(`🤖 AI Web: Stripping page brand from title "${title}" → "${strippedTitle}"`);
                 title = strippedTitle;
             }
+        }
+        // Site-tagline backstop (the primary guard runs at pass-result time in
+        // rejectBrandLikePassFields): an AI-extracted description that exactly
+        // equals the site's own JSON-LD WebSite.description is the site blurb,
+        // not an event description. Only the AI value is guarded — a configured
+        // metadata description is a deliberate override and survives.
+        if (description && description === aiDescription
+            && this.matchesSiteTagline(description, this.getPageSiteTaglines(htmlData))) {
+            console.log(`🤖 AI Web: Rejecting description from final normalization — identical to the site's own tagline, not event-specific`);
+            description = configDescription;
         }
         const address = this.firstNonEmpty(
             aiEvent.address,
@@ -7120,6 +7181,72 @@ TEXT:
             if (contentMatch) addName(this.sanitizeMetaContent('og:site_name', contentMatch[1]));
         }
         return Array.from(names);
+    }
+
+    // The page's site-level tagline(s): JSON-LD WebSite.description ONLY.
+    // Promoter sites repeat the same site blurb on every event page (e.g.
+    // bearracuda.com's "A Safe and Inclusive Space for Furry Friends and Their
+    // Admirers!") and extraction can return it as the event description.
+    // og:description and Event/WebPage-level descriptions are deliberately NOT
+    // collected — those can legitimately be event-specific, and genuine event
+    // taglines must never be dropped. Cached per page like getPageBrandNames.
+    getPageSiteTaglines(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object') return [];
+        if (Array.isArray(htmlData.pageSiteTaglines)) return htmlData.pageSiteTaglines;
+        const taglines = this.extractPageSiteTaglines(typeof htmlData.html === 'string' ? htmlData.html : '');
+        if (Object.isExtensible(htmlData)) {
+            htmlData.pageSiteTaglines = taglines;
+        }
+        return taglines;
+    }
+
+    extractPageSiteTaglines(html) {
+        const source = String(html || '').slice(0, 500000);
+        const taglines = new Set();
+        const addTagline = value => {
+            const text = this.normalizeWhitespace(this.decodeBasicEntities(String(value || '')));
+            if (text) taglines.add(text);
+        };
+        const collectWebSiteNodes = (node, depth) => {
+            if (!node || depth > 6) return;
+            if (Array.isArray(node)) {
+                node.forEach(child => collectWebSiteNodes(child, depth + 1));
+                return;
+            }
+            if (typeof node !== 'object') return;
+            const types = Array.isArray(node['@type']) ? node['@type'] : [node['@type']];
+            const isWebSite = types.some(type =>
+                /^WebSite$/i.test(String(type || '').replace(/^https?:\/\/schema\.org\//i, '').trim()));
+            if (isWebSite && typeof node.description === 'string') addTagline(node.description);
+            // Same traversal rule as extractPageBrandNames: only descend through
+            // graph containers — descriptions nested inside Event nodes are the
+            // event's own data, never a site tagline.
+            if (node['@graph']) collectWebSiteNodes(node['@graph'], depth + 1);
+        };
+        const scriptRegex = /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+        let match;
+        while ((match = scriptRegex.exec(source)) !== null) {
+            const text = this.normalizeWhitespace(this.decodeBasicEntities(match[1] || ''));
+            if (!text) continue;
+            let parsed = null;
+            try {
+                parsed = JSON.parse(text);
+            } catch (_) {
+                continue;
+            }
+            collectWebSiteNodes(parsed, 0);
+        }
+        return Array.from(taglines);
+    }
+
+    // Exact match only, after trimming + whitespace-collapsing (case-insensitive).
+    // No fuzzy or substring matching whatsoever: an event tagline that merely
+    // resembles the site blurb must survive.
+    matchesSiteTagline(value, taglines) {
+        const normalized = this.normalizeWhitespace(String(value || '')).toLowerCase();
+        if (!normalized) return false;
+        return (Array.isArray(taglines) ? taglines : []).some(tagline =>
+            this.normalizeWhitespace(String(tagline || '')).toLowerCase() === normalized);
     }
 
     // Comparable variants of a brand-ish name: lowercased, punctuation stripped,

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1109,3 +1109,168 @@ test('getPageBrandNames caches the brand extraction on htmlData', () => {
   assert.equal(second, first, 'repeat lookups return the cached array');
   assert.deepEqual(viaSpread, first, 'spread copies (segments/OCR) inherit the cache');
 });
+// ---------------------------------------------------------------------------
+// Pass-result guards (2026-07-13 run findings: a junk meta-pass answer — bar:
+// "BEARRACUDA" from og:title — consumed the field slot, later passes never
+// re-requested bar, and the end-of-pipeline guard left the event with NO bar
+// even though the page body named the venue. Same mechanism for the site-level
+// WebSite.description tagline leaking in as the event description.)
+// ---------------------------------------------------------------------------
+
+const BEARRACUDA_TAGLINE_HTML = `
+  <html>
+    <head>
+      <meta property="og:site_name" content="BEARRACUDA" />
+      <script type="application/ld+json">
+        {"@context":"https://schema.org","@graph":[
+          {"@type":"Organization","name":"Bearracuda, Inc.","alternateName":"Bearracuda"},
+          {"@type":"WebSite","name":"BEARRACUDA","description":"A Safe and Inclusive Space for Furry Friends and Their Admirers!"},
+          {"@type":"Event","name":"Treasure Trail Portland PRIDE","description":"One night only at Sanctuary."}
+        ]}
+      </script>
+    </head>
+    <body><p>Treasure Trail Portland PRIDE — 🪩 Sanctuary, 📍 Map → Sanctuary</p></body>
+  </html>
+`;
+
+const SITE_TAGLINE = 'A Safe and Inclusive Space for Furry Friends and Their Admirers!';
+
+// Drives extractFieldsAcrossSnippets — the seam where per-pass results are
+// merged (mergeAiEventFields) and later passes are narrowed to still-missing
+// fields (getRemainingPromptFields) — with one stubbed AI answer per snippet.
+async function runPassSequence(parser, htmlData, fields, passResults) {
+  const requestedFieldsPerPass = [];
+  parser.extractEventWithTwoPassAi = async (hd, aiConfig, cityConfig, parserConfig, requestedFields) => {
+    requestedFieldsPerPass.push(requestedFields.slice());
+    return passResults[requestedFieldsPerPass.length - 1] || {};
+  };
+  // Evidence validation is exercised elsewhere; pass results through untouched.
+  parser.validateAiEventEvidence = (partial) => ({ event: partial || {}, report: { dropped: [] } });
+  const snippets = passResults.map((_, index) => `SNIPPET ${index + 1}`);
+  const merged = await parser.extractFieldsAcrossSnippets(
+    htmlData, {}, null, {}, fields, snippets, 'test');
+  return { merged, requestedFieldsPerPass };
+}
+
+test('a brand bar is rejected at pass time and the field is re-requested in later passes', async () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_TAGLINE_HTML, url: 'https://bearracuda.com/events/treasurepdx/' };
+
+  const { merged, requestedFieldsPerPass } = await runPassSequence(parser, htmlData, ['title', 'bar'], [
+    { title: 'Treasure Trail Portland PRIDE', bar: 'BEARRACUDA' }, // meta-style pass: brand leak
+    { bar: 'Sanctuary' }                                            // content-style pass: real venue
+  ]);
+
+  assert.deepEqual(requestedFieldsPerPass[0], ['title', 'bar']);
+  assert.deepEqual(requestedFieldsPerPass[1], ['bar'],
+    'bar must stay in the next pass\'s field list after the brand rejection (title resolved, so only bar remains)');
+  assert.equal(merged.bar, 'Sanctuary', 'the later pass\'s real venue must be accepted');
+  assert.equal(merged.title, 'Treasure Trail Portland PRIDE');
+
+  // ...and it survives to the final event through normalizeAiEvent
+  const event = parser.normalizeAiEvent(
+    { ...merged, startDate: '2026-07-18', startTime: '21:00' }, {}, htmlData, null, null);
+  assert.equal(event.bar, 'Sanctuary');
+});
+
+test('a non-brand bar from an early pass is accepted and NOT re-requested', async () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_TAGLINE_HTML, url: 'https://bearracuda.com/events/treasurepdx/' };
+
+  const { merged, requestedFieldsPerPass } = await runPassSequence(parser, htmlData, ['title', 'bar'], [
+    { bar: 'Sanctuary' },
+    { title: 'Treasure Trail Portland PRIDE', bar: 'Some Other Venue' }
+  ]);
+
+  assert.deepEqual(requestedFieldsPerPass[0], ['title', 'bar']);
+  assert.deepEqual(requestedFieldsPerPass[1], ['title'], 'an accepted bar must not be requested again');
+  assert.equal(merged.bar, 'Sanctuary', 'the first accepted value wins');
+});
+
+test('a title that IS the brand is rejected at pass time; a brand-suffixed title is kept', async () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_TAGLINE_HTML, url: 'https://bearracuda.com/events/ptown/' };
+
+  const { merged, requestedFieldsPerPass } = await runPassSequence(parser, htmlData, ['title'], [
+    { title: 'BEARRACUDA' },                 // whole title is the brand → rejected
+    { title: 'Provincetown⚓ | BEARRACUDA' }  // brand suffix only → kept at pass time
+  ]);
+
+  assert.deepEqual(requestedFieldsPerPass[1], ['title'], 'title must be re-requested after the brand-only rejection');
+  assert.equal(merged.title, 'Provincetown⚓ | BEARRACUDA',
+    'a title merely containing the brand is kept at pass time (suffix strip happens at the end)');
+});
+
+test('extractPageSiteTaglines reads only WebSite.description, never Event descriptions', () => {
+  const parser = createParser();
+  const taglines = parser.extractPageSiteTaglines(BEARRACUDA_TAGLINE_HTML);
+  assert.deepEqual(taglines, [SITE_TAGLINE]);
+  assert.ok(!taglines.includes('One night only at Sanctuary.'),
+    'Event-level descriptions are never treated as site taglines');
+  assert.deepEqual(parser.extractPageSiteTaglines(BEARRACUDA_HTML), [],
+    'a WebSite node without a description yields no taglines');
+});
+
+test('a site-tagline description is rejected at pass time and later passes can recover the real one', async () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_TAGLINE_HTML, url: 'https://bearracuda.com/events/neworleans/' };
+
+  const { merged, requestedFieldsPerPass } = await runPassSequence(parser, htmlData, ['description'], [
+    // Differing whitespace and case must still match exactly after normalization
+    { description: '  a safe  and inclusive space for furry friends and their admirers!  ' },
+    { description: 'One night only at Sanctuary.' }
+  ]);
+
+  assert.deepEqual(requestedFieldsPerPass[1], ['description'],
+    'description must stay open after the tagline rejection');
+  assert.equal(merged.description, 'One night only at Sanctuary.');
+});
+
+test('normalizeAiEvent drops a site-tagline description as a final backstop', () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_TAGLINE_HTML, url: 'https://bearracuda.com/events/neworleans/' };
+
+  const event = parser.normalizeAiEvent(
+    { title: 'Bearracuda New Orleans', description: SITE_TAGLINE, startDate: '2026-08-01' },
+    {}, htmlData, null, null);
+  assert.equal(event.description, '', 'the site blurb must not survive as the event description');
+
+  // A configured metadata description is a deliberate override and survives,
+  // including as the fallback when the AI tagline is dropped.
+  const configured = parser.normalizeAiEvent(
+    { title: 'Bearracuda New Orleans', description: SITE_TAGLINE, startDate: '2026-08-01' },
+    { metadata: { description: 'Bearracuda takes over NOLA.' } }, htmlData, null, null);
+  assert.equal(configured.description, 'Bearracuda takes over NOLA.');
+});
+
+test('genuine event taglines are never dropped, even ones containing brand words', async () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_TAGLINE_HTML, url: 'https://bearracuda.com/events/ptown/' };
+
+  const { merged } = await runPassSequence(parser, htmlData, ['description'], [
+    { description: 'BEAR WEEK KICK OFF' }
+  ]);
+  assert.equal(merged.description, 'BEAR WEEK KICK OFF', 'distinct event taglines are kept at pass time');
+
+  const event = parser.normalizeAiEvent(
+    { title: 'Bearracuda Provincetown', description: 'BEAR WEEK KICK OFF', startDate: '2026-07-11' },
+    {}, htmlData, null, null);
+  assert.equal(event.description, 'BEAR WEEK KICK OFF', 'distinct event taglines survive the final guard');
+});
+
+test('the description guard is inert on pages with no WebSite.description', async () => {
+  const parser = createParser();
+  // BEARRACUDA_HTML declares WebSite/Organization names but no description
+  const htmlData = { html: BEARRACUDA_HTML, url: 'https://bearracuda.com/events/portland' };
+
+  const { merged, requestedFieldsPerPass } = await runPassSequence(parser, htmlData, ['description'], [
+    { description: SITE_TAGLINE }
+  ]);
+  assert.equal(requestedFieldsPerPass.length, 1, 'nothing left to re-request');
+  assert.equal(merged.description, SITE_TAGLINE, 'no site tagline on the page → nothing to reject');
+
+  const event = parser.normalizeAiEvent(
+    { title: 'Portland PRIDE FRIDAY', description: SITE_TAGLINE, startDate: '2026-07-17' },
+    {}, htmlData, null, null);
+  assert.equal(event.description, SITE_TAGLINE, 'final guard is inert without a page tagline');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1736,6 +1736,32 @@ class SharedCore {
                 }
             }
 
+            // bar mirrors the location rule in spirit: an empty side is an
+            // extraction gap, not data — when exactly one record has a venue it
+            // wins deterministically, regardless of source priority. (The
+            // priority path below only prefers the non-empty side when BOTH
+            // sources are in the priority list; without that, an empty incoming
+            // bar could clear a venue.) Both-non-empty falls through to the
+            // normal resolution below.
+            if (fieldName === 'bar') {
+                const existingBarEmpty = isEmpty(existingValue);
+                const newBarEmpty = isEmpty(newValue);
+                if (existingBarEmpty !== newBarEmpty) {
+                    const chosenValue = existingBarEmpty ? newValue : existingValue;
+                    mergedEvent[fieldName] = chosenValue;
+                    if (existingValue !== newValue) {
+                        mergeDecisions.push({
+                            field: fieldName,
+                            existingValue: existingValue,
+                            newValue: newValue,
+                            chosenValue: chosenValue,
+                            reason: 'bar kept from the non-empty side — an empty scrape must not clear a venue'
+                        });
+                    }
+                    return;
+                }
+            }
+
             // A degenerate end (endDate <= that record's own startDate) is a
             // normalization artifact, not data — when exactly one side's end is
             // degenerate, the positive-duration end wins deterministically.
@@ -1984,6 +2010,19 @@ class SharedCore {
                     }
                     continue;
                 }
+            }
+
+            // An empty scraped bar is an extraction gap, not data (e.g. the venue
+            // was rejected by the organizer-brand guard and never recovered) — it
+            // must never clear the calendar's venue, even under clobber/ai
+            // clear-on-empty-scrape semantics. A non-empty scraped bar keeps
+            // today's behavior exactly (strategy/arbitration below).
+            if (fieldName === 'bar'
+                && this.isEmptyArbitrationValue(scraperValue)
+                && !this.isEmptyArbitrationValue(calendarValue)) {
+                mergedObject[fieldName] = calendarValue;
+                console.log(`📍 MERGE: "${mergeTitle}" bar kept from calendar (scrape found no venue)`);
+                continue;
             }
 
             // Dates are calendar-critical: a genuinely different startDate/endDate is

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1489,3 +1489,80 @@ test('applyGlobalAiExtraContext: global applies unless the parser defines its ow
   const untouched = { name: 'p' };
   assert.equal(core.applyGlobalAiExtraContext(untouched, {}), untouched, 'no global → config object passes through');
 });
+
+// ---------------------------------------------------------------------------
+// Empty scraped bar must never clear a calendar venue (2026-07-13 run findings:
+// the brand guard left extraction with NO bar and the ai-strategy merge's
+// clear-on-empty-scrape semantics wiped the calendar's correct venue)
+// ---------------------------------------------------------------------------
+
+test('an empty scraped bar keeps the calendar venue and never reaches arbitration', async () => {
+  const core = createCore();
+  const scraped = {
+    title: 'Treasure Trail Portland PRIDE',
+    startDate: new Date('2026-07-18T21:00:00.000Z'),
+    bar: '', // brand-guarded away, never recovered — an extraction gap, not data
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const existing = {
+    title: 'Treasure Trail Portland PRIDE',
+    startDate: new Date('2026-07-18T21:00:00.000Z'),
+    notes: 'bar: Sanctuary Club'
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'empty vs non-empty bar is not a conflict — no arbitration request');
+  assert.equal(core.parseNotesIntoFields(finalEvent.notes).bar, 'Sanctuary Club',
+    'the calendar venue must survive an empty scrape');
+});
+
+test('a non-empty scraped bar keeps today\'s behavior: genuine conflicts still route to arbitration', async () => {
+  const core = createCore();
+  const scraped = {
+    title: 'Treasure Trail Portland PRIDE',
+    startDate: new Date('2026-07-18T21:00:00.000Z'),
+    bar: 'Sanctuary',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const existing = {
+    title: 'Treasure Trail Portland PRIDE',
+    startDate: new Date('2026-07-18T21:00:00.000Z'),
+    notes: 'bar: Sanctuary Club'
+  };
+  const adapter = buildArbitrationAdapter({
+    bar: { pick: 'calendar', value: 'Sanctuary Club', reason: 'full venue name' }
+  });
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1, 'a genuine bar conflict still reaches arbitration exactly as today');
+  assert.match(adapter.calls[0].prompt, /field: bar/);
+  assert.equal(core.parseNotesIntoFields(finalEvent.notes).bar, 'Sanctuary Club');
+});
+
+test('mergeParsedEvents: an empty bar loses to the non-empty side regardless of priorities', async () => {
+  const core = createCore();
+
+  // No priority config at all: previously the incoming (empty) bar won via the
+  // newEvent spread and wiped the existing venue.
+  const merged = await core.mergeParsedEvents(
+    { title: 'Treasure Trail', bar: 'Sanctuary Club', source: 'bearracuda', _fieldPriorities: {} },
+    { title: 'Treasure Trail', bar: '', source: 'ai-web', _fieldPriorities: {} },
+    {});
+  assert.equal(merged.bar, 'Sanctuary Club', 'existing venue survives an empty incoming bar');
+
+  // Reverse direction: an incoming venue fills an existing empty bar even when
+  // only the existing source is in the priority list (previously kept empty).
+  const priorities = { bar: { priority: ['bearracuda'], merge: 'upsert' } };
+  const filled = await core.mergeParsedEvents(
+    { title: 'Treasure Trail', bar: '', source: 'bearracuda', _fieldPriorities: priorities },
+    { title: 'Treasure Trail', bar: 'Sanctuary', source: 'ai-web', _fieldPriorities: priorities },
+    {});
+  assert.equal(filled.bar, 'Sanctuary', 'a real venue fills an empty bar across parsers');
+});


### PR DESCRIPTION
Closes out the findings from the 2026-07-13 12:45 run review ("why did Sanctuary get dropped when it's on the page?").

## 1. Junk pass answers no longer block the right answer (root cause of the missing venue)
Extraction narrows each pass to still-missing fields. On treasurepdx the meta pass returned `bar: "BEARRACUDA"` (confidence 70 → accepted), so the content pass **never asked for `bar`** — and the end-of-pipeline organizer guard then dropped the junk value, leaving the field empty even though "🪩 Sanctuary" was in the body text. The organizer-brand guard now also runs **at pass-result time** (`rejectBrandLikePassFields`, wired in before the field-slot is consumed): a brand-matching `bar` is rejected immediately with a log line, the field stays open, and the later content pass finds the real venue. Runtime-verified against a stubbed reproduction of the exact log sequence (meta BEARRACUDA → rejection → content re-request → final `bar: "Sanctuary"`). `title` is rejected per-pass only when the *whole* title is the brand; suffix stripping stays at the end. The normalizeAiEvent guards remain as backstops.

## 2. Site-tagline guard for `description` — deliberately narrow
The New Orleans page returned the site's own blurb ("A Safe and Inclusive Space for Furry Friends and Their Admirers!") as the event description — that's bearracuda.com's JSON-LD `WebSite.description`, identical on every page. The guard collects taglines from `WebSite.description` **only** (never og:description, never Event/WebPage descriptions) and rejects an AI-extracted description **only on exact match** (trim/whitespace-collapse/case-insensitive — no fuzzy or substring matching), at pass time and as a final backstop. Genuine event taglines cannot collide by construction; a test locks in that "BEAR WEEK KICK OFF" survives. Configured metadata descriptions always survive.

## 3. Empty scraped `bar` never clears a calendar venue
Mirrors the location=coordinates rule: in calendar merges, an empty scraped bar preserves the calendar's venue (logged) instead of clear-on-empty clobbering it. Verification found `mergeParsedEvents` had the same hole (an incoming empty bar could win via spread when no priority config was decisive), so the symmetric one-side-empty rule was added there too; both-non-empty conflicts route exactly as before.

## Tests
168 → 179, all green. Coverage includes the full pass-narrowing repro at the real seam (`extractFieldsAcrossSnippets`), tagline exact-match acceptance/rejection edges, no-tagline pages, and bar preservation in both merge paths with unchanged genuine-conflict routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)