### PR TITLE
perf(scraper): skip Event-less JSON-LD pass, cache context-prep, salvage almost-valid AI responses

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -244,6 +244,10 @@ class AiWebParser {
         this.likelyImageQueryRegex = /(?:^|[?&])(w|h|q|fit|crop|auto|fm|format|s)=/;
         this.inlineUrlPattern = /(?:https?:\/\/|\/)[^\s"'<>]+/gi;
         this.aiPromptHistory = [];
+        // Context-prep responses keyed by prompt hash: confidence retries rebuild a
+        // byte-identical context-prep prompt, so the HTTP round-trip can be reused.
+        // In-memory only, scoped to this parser instance (one run).
+        this.contextPrepResponseCache = new Map();
         this.defaultOcrModel = 'qwen3-vl:4b-instruct';
         this.defaultOcrPrompt = "You are performing OCR on an event flyer.\n\nSTEP 1: OCR\nExtract ALL visible text from the image.\n\nRules:\n- Copy text exactly as shown.\n- Preserve line breaks when possible.\n- Do not summarize.\n- Do not interpret.\n- Do not correct spelling.\n- Do not infer missing words.\n\nSTEP 2: Classification\n\nClassify the image into ONE category:\n\nad-banner: Advertisement or promotional banner (usually has \"buy\", \"get tickets\", \"sale\")\nevent-flyer: Single event poster/flyer - ONE primary event with ONE title, ONE venue, and ONE date or continuous date range. May contain schedules, activities, DJs, performers, or sub-events that are clearly part of the same event. Examples: Bear Week, Bear Weekend, Pride Festival, Camp Weekend, Resort Weekend Package.\nmulti-event-flyer: Two or more independent events with different titles, different dates/times, and separate ticketing. Often appears as a calendar, event listing, or monthly schedule.\nlogo: Brand or organization logo (minimal text, just brand name)\nthumbnail: Small preview image (low detail)\nhero-banner: Large header/banner image (prominent on page)\n\nDecision rule: If there is ONE overarching event name and the listed activities appear to belong to that event, classify as event-flyer. Only classify as multi-event-flyer when multiple independent events are advertised that require separate tickets.\n\nIMPORTANT CONTEXT: This is for a gay bear community travel guide. Events may be part of:\n- \"Bear Week\" or \"Bear Weekend\" themed events\n- Annual bear gatherings (e.g., \"Puerto Vallarta Bear Week\", \"Sitges Bear Week\")\n- Regular bear-themed parties or meetups\n- Events at bear-owned businesses or bear-friendly venues\n\nSTEP 3: Event Analysis\n\nDetermine:\n- eventName: The primary event title\n- venue: The venue or venue group name\n- startDate: Start date/time if visible\n- endDate: End date/time if visible\n\nUse only information visible in the image.\n\nSTEP 4: Summary\n\nCreate a concise summary describing:\n- event name\n- venue\n- date/time\n- why it may be relevant to the bear community\n\nReturn JSON only with these fields:\n{\n  \"text\": \"full extracted text\",\n  \"imageClassification\": \"ad-banner|event-flyer|multi-event-flyer|logo|thumbnail|hero-banner\",\n  \"eventSummary\": \"a concise 1-2 sentence summary of the event including: event name, venue, date/time, and any bear-week context if applicable. Focus on what makes this event notable for the bear community.\",\n  \"confidence\": 0-100,\n  \"reason\": \"brief explanation for classification\"\n}";
         // When an image overflows the vision model's context, retry once at this
@@ -4642,6 +4646,26 @@ class AiWebParser {
         return guarded;
     }
 
+    // A jsonld extraction pass on a page whose JSON-LD carries no Event-typed node
+    // (WebPage/ImageObject/BreadcrumbList/Organization boilerplate) is a wasted AI
+    // request — the model has nothing to extract and returns {}. Detect Event-typed
+    // nodes (any @type containing "Event", schema.org URL prefixes included) over the
+    // same extractJsonLdParts output the jsonld pass would send, and cache the
+    // determination on htmlData (like getPageBrandNames) so re-parses are free.
+    // Pages WITH Event nodes keep today's behavior exactly: the deterministic
+    // JSON-LD path may not have fully extracted them, so the AI pass still runs.
+    pageHasEventTypedJsonLd(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object') return false;
+        if (typeof htmlData.hasEventTypedJsonLd === 'boolean') return htmlData.hasEventTypedJsonLd;
+        const html = typeof htmlData.html === 'string' ? htmlData.html : '';
+        const result = this.extractJsonLdParts(String(html).slice(0, 500000))
+            .some(part => this.containsEventType(part));
+        if (Object.isExtensible(htmlData)) {
+            htmlData.hasEventTypedJsonLd = result;
+        }
+        return result;
+    }
+
     getBestModePromptGroups(sectionBundle) {
         const jsonGroup = sectionBundle && sectionBundle.jsonLd
             ? { label: 'jsonld', sections: [sectionBundle.jsonLd] }
@@ -4776,6 +4800,13 @@ class AiWebParser {
         let merged = {};
 
         const runPartitionExtraction = async (fieldsToExtract, partition, passLabel, extractionOptions = {}) => {
+            // Skip the jsonld pass entirely when the page's JSON-LD has no Event-typed
+            // node: the payload is WebPage/Organization boilerplate the model can only
+            // answer with {} (observed on every bearracuda.com event page).
+            if (partition === 'jsonld' && sectionBundle.jsonLd && !this.pageHasEventTypedJsonLd(htmlData)) {
+                console.log('🤖 AI Web: Skipping jsonld extraction pass — no Event-typed JSON-LD on page');
+                return {};
+            }
             const sections = this.getSectionsForPartition(sectionBundle, partition);
             const snippets = this.buildPromptSnippets([], sections, maxHtmlChars);
             // Determine data flags based on partition and snippet content
@@ -5558,7 +5589,21 @@ TEXT:
         if (hasUnstructuredData && !hasStructuredData) {
             console.log(`🤖 AI Web: Running context pre-extraction pass${passSuffix}`);
             const contextPrompt = this.buildContextPrePrompt(snippet);
-            const contextResponse = await this.core.callAiGenerate(aiConfig, contextPrompt, 'context-prep', httpAdapter, this.recordAiPrompt.bind(this));
+            // Confidence retries re-run this pass with a byte-identical prompt (~1.2s
+            // each): reuse the previous successful response instead of paying twice.
+            const contextPromptHash = this.core && typeof this.core.hashString === 'function'
+                ? this.core.hashString(contextPrompt)
+                : null;
+            let contextResponse;
+            if (contextPromptHash !== null && this.contextPrepResponseCache.has(contextPromptHash)) {
+                contextResponse = this.contextPrepResponseCache.get(contextPromptHash);
+                console.log(`🤖 AI Web: context-prep cache hit (hash ${contextPromptHash}) — reusing previous result`);
+            } else {
+                contextResponse = await this.core.callAiGenerate(aiConfig, contextPrompt, 'context-prep', httpAdapter, this.recordAiPrompt.bind(this));
+                if (contextPromptHash !== null && contextResponse) {
+                    this.contextPrepResponseCache.set(contextPromptHash, contextResponse);
+                }
+            }
             if (contextResponse) {
                 const strippedContext = contextResponse.replace(/[^a-z0-9]/gi, '').trim();
                 if (strippedContext.length >= 5) {
@@ -5593,6 +5638,17 @@ TEXT:
             }
         }
 
+        // PASS 2.5: Deterministic salvage before paying for an AI repair round-trip.
+        // Most unparseable responses fail JSON.parse only because the model put raw
+        // quotes inside `evidence` strings — the values themselves are fine.
+        const salvagedEvent = this.salvageUnparseableAiResponse(rawResponse, fields);
+        if (salvagedEvent) {
+            const salvagedFieldCount = Object.keys(salvagedEvent).length;
+            console.log(`🤖 AI Web: Salvaged ${salvagedFieldCount} field(s) from unparseable response — skipping repair pass`);
+            event = parseAndFilterConfidence(JSON.stringify(salvagedEvent));
+            if (event) return event;
+        }
+
         // PASS 3: Try repair if extraction returned unparseable JSON
         console.warn(`🤖 AI Web: Extraction pass${passSuffix} returned unparseable JSON; attempting repair`);
         const repairPrompt = this.buildJsonRepairPrompt(rawResponse, aiConfig, cityConfig, parserConfig, fields, dataFlags, htmlData);
@@ -5606,6 +5662,103 @@ TEXT:
 
         console.warn(`🤖 AI Web: Extraction pass${passSuffix} failed (both standard and repair)`);
         return null;
+    }
+
+    // === Deterministic salvage of unparseable extraction responses ===
+    //
+    // Extraction responses frequently fail JSON.parse only because the model copies
+    // raw quotes into `evidence` strings, e.g.
+    //   "evidence": "name":"Treasure Trail Portland PRIDE | BEARRACUDA",
+    //   "evidence": "📅 August 15, 2026" and "SAT, AUG 15 / 9PM - LATE",
+    // The `value`/`confidence` entries are well-formed; only evidence is mangled.
+    // Recover per-field {value, evidence?, confidence} objects with a tolerant
+    // scanner instead of a full AI repair round-trip. Conservative by design:
+    // - only field keys among the requested prompt fields are accepted;
+    // - the value must be a strict JSON scalar terminated by an "evidence"/
+    //   "confidence" boundary (a value containing raw quotes is NOT trusted);
+    // - a numeric confidence must be present;
+    // - everything between "evidence": and the confidence entry is kept as
+    //   opaque best-effort evidence text.
+    // Returns null (fall through to the AI repair pass) unless at least one field
+    // salvages cleanly.
+    salvageUnparseableAiResponse(rawResponse, promptFields) {
+        const source = String(rawResponse || '');
+        if (!source) return null;
+        const knownFields = new Set(
+            (Array.isArray(promptFields) ? promptFields : [])
+                .map(field => this.normalizePromptFieldName(field))
+                .filter(Boolean)
+        );
+        if (knownFields.size === 0) return null;
+
+        // Field entries look like `"key": {"value": ...` — requiring the "value"
+        // key right after the brace keeps evidence garbage (e.g. quoted JSON-LD
+        // fragments) from being mistaken for a field boundary.
+        const anchorRegex = /"([A-Za-z][A-Za-z0-9_]*)"\s*:\s*\{\s*"value"\s*:/g;
+        const anchors = [];
+        let match;
+        while ((match = anchorRegex.exec(source)) !== null) {
+            anchors.push({ key: match[1], start: match.index, valueStart: anchorRegex.lastIndex });
+        }
+        if (anchors.length === 0) return null;
+
+        const salvaged = {};
+        const seenFields = new Set();
+        for (let i = 0; i < anchors.length; i++) {
+            const anchor = anchors[i];
+            const normalizedKey = this.normalizePromptFieldName(anchor.key);
+            if (!knownFields.has(normalizedKey) || seenFields.has(normalizedKey)) continue;
+            const chunkEnd = i + 1 < anchors.length ? anchors[i + 1].start : source.length;
+            const fieldData = this.salvageAiFieldChunk(source.slice(anchor.valueStart, chunkEnd));
+            if (!fieldData) continue;
+            seenFields.add(normalizedKey);
+            salvaged[anchor.key] = fieldData;
+        }
+        return seenFields.size >= 1 ? salvaged : null;
+    }
+
+    // Parse one field body starting right after `"value":`. Returns
+    // {value, evidence?, confidence} or null when the chunk is not trustworthy.
+    salvageAiFieldChunk(chunk) {
+        const scalarMatch = chunk.match(/^\s*("(?:[^"\\]|\\.)*"|-?\d+(?:\.\d+)?|true|false|null)/);
+        if (!scalarMatch) return null;
+        let value;
+        try {
+            value = JSON.parse(scalarMatch[1]);
+        } catch (_) {
+            return null;
+        }
+        if (value === null) return null;
+
+        // The scalar must terminate at a proper field boundary — otherwise the
+        // value itself may contain raw quotes and the capture is a truncation.
+        const afterValue = chunk.slice(scalarMatch[0].length);
+        const boundaryMatch = afterValue.match(/^\s*,\s*"(evidence|confidence)"\s*:/);
+        if (!boundaryMatch) return null;
+
+        const confidenceMatches = Array.from(chunk.matchAll(/"confidence"\s*:\s*(-?\d+(?:\.\d+)?)/g));
+        if (confidenceMatches.length === 0) return null;
+        const lastConfidence = confidenceMatches[confidenceMatches.length - 1];
+        const confidence = Number(lastConfidence[1]);
+        if (!Number.isFinite(confidence)) return null;
+
+        const fieldData = { value, confidence };
+        const evidenceMatch = afterValue.match(/^\s*,\s*"evidence"\s*:/);
+        if (evidenceMatch) {
+            // Best-effort: keep the mangled evidence text (minus wrapping quotes and
+            // the trailing comma) rather than discarding it.
+            const evidenceStart = scalarMatch[0].length + evidenceMatch[0].length;
+            const evidenceEnd = lastConfidence.index;
+            if (evidenceEnd > evidenceStart) {
+                const evidenceText = chunk.slice(evidenceStart, evidenceEnd)
+                    .trim()
+                    .replace(/[\s,]+$/, '')
+                    .replace(/^"|"$/g, '')
+                    .trim();
+                if (evidenceText) fieldData.evidence = evidenceText;
+            }
+        }
+        return fieldData;
     }
 
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1091,6 +1091,202 @@ test('normalizeAiEvent stamps the derived organizer as internal _organizer metad
   assert.equal(plain._organizer, undefined, 'no page brand → no organizer stamp');
 });
 
+// ---------------------------------------------------------------------------
+// Wasted-AI-call cuts (2026-07-13 run findings): Event-less JSON-LD passes,
+// duplicate context-prep round-trips, and repair passes for evidence-only
+// JSON breakage.
+// ---------------------------------------------------------------------------
+
+const NO_EVENT_JSONLD_HTML = `
+  <html>
+    <head>
+      <title>Atlanta | BEARRACUDA</title>
+      <meta property="og:title" content="Atlanta | BEARRACUDA" />
+      <meta property="og:description" content="Bearracuda returns to Atlanta for one night only" />
+      <script type="application/ld+json">
+        {"@context":"https://schema.org","@graph":[
+          {"@type":"WebPage","name":"Atlanta | BEARRACUDA","url":"https://bearracuda.com/events/atlanta"},
+          {"@type":"ImageObject","url":"https://bearracuda.com/images/atlanta.jpg"},
+          {"@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Events"}]},
+          {"@type":"WebSite","name":"BEARRACUDA"},
+          {"@type":"Organization","name":"Bearracuda, Inc."}
+        ]}
+      </script>
+    </head>
+    <body>
+      <h1>Bearracuda Atlanta</h1>
+      <p>Saturday August 15 at Future Atlanta, 9pm until late.</p>
+      <p>DJs all night long with the best bears in the South.</p>
+    </body>
+  </html>
+`;
+
+test('skips the jsonld extraction pass when the page has no Event-typed JSON-LD', async () => {
+  const parser = createParser();
+  const calls = [];
+  parser.core.callAiGenerate = async (config, prompt, label) => {
+    calls.push({ label, prompt });
+    return '{}';
+  };
+
+  const htmlData = { url: 'https://bearracuda.com/events/atlanta', html: NO_EVENT_JSONLD_HTML };
+  const aiConfig = parser.getAiConfig({});
+  await parser.extractEventWithAiStrategy(htmlData, aiConfig, null, {}, ['title', 'bar'], null);
+
+  assert.equal(htmlData.hasEventTypedJsonLd, false, 'the determination must be cached on htmlData');
+  assert.ok(calls.length > 0, 'meta/content passes must still run');
+  assert.ok(
+    !calls.some(call => call.prompt.includes('JSON_LD_PRIMARY')),
+    'no request may carry the Event-less JSON_LD_PRIMARY payload'
+  );
+  assert.ok(
+    calls.some(call => call.prompt.includes('META_PRIMARY')),
+    'the meta pass must be unchanged'
+  );
+  assert.ok(
+    calls.some(call => call.prompt.includes('CONTENT')),
+    'the content pass must be unchanged'
+  );
+});
+
+test('keeps the jsonld extraction pass when the page has an Event-typed JSON-LD node', async () => {
+  const parser = createParser();
+  const calls = [];
+  parser.core.callAiGenerate = async (config, prompt, label) => {
+    calls.push({ label, prompt });
+    return '{}';
+  };
+
+  const htmlData = { url: 'https://sickening.events/e/bearracuda-portland-pridefriday', html: SICKENING_JSONLD_HTML };
+  await parser.extractEventWithAiStrategy(htmlData, parser.getAiConfig({}), null, {}, ['title', 'bar'], null);
+
+  assert.equal(parser.pageHasEventTypedJsonLd(htmlData), true);
+  assert.ok(
+    calls.some(call => call.prompt.includes('JSON_LD_PRIMARY')),
+    'a MusicEvent node must keep the jsonld pass running as today'
+  );
+});
+
+test('context-prep responses are cached per identical prompt within a parser instance', async () => {
+  const parser = createParser();
+  let contextPrepCalls = 0;
+  const extractionPrompts = [];
+  parser.core.callAiGenerate = async (config, prompt, label) => {
+    if (label === 'context-prep') {
+      contextPrepCalls++;
+      return 'CORRECTIONS:\n- Cleaned Times: 9:00 PM\n- Core Event Date: August 15, 2026\n- Parent Festival Dates: None';
+    }
+    extractionPrompts.push(prompt);
+    return '{}';
+  };
+
+  const htmlData = { url: 'https://x.example/party', html: '<p>party</p>' };
+  const aiConfig = parser.getAiConfig({});
+  const options = { dataFlags: { content: true } };
+  const snippet = 'CONTENT\nSAT AUG 15 / 9PM - LATE at Future Atlanta';
+
+  await parser.extractEventWithTwoPassAi(htmlData, aiConfig, null, {}, ['title'], snippet, 'first', options, null);
+  await parser.extractEventWithTwoPassAi(htmlData, aiConfig, null, {}, ['title'], snippet, 'retry', options, null);
+
+  assert.equal(contextPrepCalls, 1, 'the identical context-prep prompt must be paid for exactly once');
+  assert.equal(extractionPrompts.length, 2);
+  assert.ok(
+    extractionPrompts.every(prompt => prompt.includes('PRE-PARSED HELPER DATA')),
+    'the cached context result must feed both extraction passes'
+  );
+
+  // Different content → a genuinely new context-prep request
+  await parser.extractEventWithTwoPassAi(htmlData, aiConfig, null, {}, ['title'], 'CONTENT\nA totally different page', 'other', options, null);
+  assert.equal(contextPrepCalls, 2, 'different content must not hit the cache');
+});
+
+// The exact breakage shapes from the 2026-07-13 Scriptable run logs: raw quotes
+// inside `evidence` strings are the only reason JSON.parse fails.
+const TREASUREPDX_BROKEN_RESPONSE = '{"title": {"value": "Treasure Trail Portland PRIDE", "evidence": "name":"Treasure Trail Portland PRIDE | BEARRACUDA", "confidence": 95}, "website": {"value": "https://treasurepdx.com", "evidence": "url":"https://treasurepdx.com/", "confidence": 90}}';
+const SEATTLE_BROKEN_RESPONSE = '{"startDate": {"value": "2026-08-15", "evidence": "📅 August 15, 2026" and "SAT, AUG 15 / 9PM - LATE", "confidence": 92}, "startTime": {"value": "21:00", "evidence": "9PM - LATE", "confidence": 88}}';
+
+test('salvages evidence-mangled extraction responses instead of running the repair pass', async () => {
+  const parser = createParser();
+  const labels = [];
+  parser.core.callAiGenerate = async (config, prompt, label) => {
+    labels.push(label);
+    return TREASUREPDX_BROKEN_RESPONSE;
+  };
+
+  const event = await parser.extractEventWithTwoPassAi(
+    { url: 'https://treasurepdx.com/', html: '<p>x</p>' },
+    parser.getAiConfig({}), null, {}, ['title', 'website'], 'SNIPPET', '', {}, null);
+
+  assert.deepEqual(labels, ['extraction'], 'no repair round-trip may be paid for');
+  assert.ok(event, 'the salvaged event must be returned');
+  assert.equal(event.title, 'Treasure Trail Portland PRIDE');
+  assert.equal(event.website, 'https://treasurepdx.com');
+});
+
+test('salvage recovers values, confidences and best-effort evidence from the Seattle payload', () => {
+  const parser = createParser();
+  assert.equal(parser.core.parseAiEventResponse(SEATTLE_BROKEN_RESPONSE), null, 'the payload must really be unparseable');
+
+  const salvaged = parser.salvageUnparseableAiResponse(SEATTLE_BROKEN_RESPONSE, ['startDate', 'startTime']);
+  assert.ok(salvaged);
+  assert.equal(salvaged.startDate.value, '2026-08-15');
+  assert.equal(salvaged.startDate.confidence, 92);
+  assert.match(salvaged.startDate.evidence, /August 15, 2026/, 'mangled evidence text is preserved best-effort');
+  assert.equal(salvaged.startTime.value, '21:00');
+  assert.equal(salvaged.startTime.confidence, 88);
+  assert.equal(salvaged.startTime.evidence, '9PM - LATE');
+
+  // Unknown field names never salvage
+  assert.equal(parser.salvageUnparseableAiResponse(SEATTLE_BROKEN_RESPONSE, ['title']), null);
+  // A value containing raw quotes is a truncation hazard, not a salvage
+  assert.equal(
+    parser.salvageUnparseableAiResponse('{"title": {"value": "The "Bear" Party", "evidence": "x", "confidence": 90}}', ['title']),
+    null
+  );
+});
+
+test('truly garbage responses still fall through to the AI repair pass', async () => {
+  const parser = createParser();
+  const labels = [];
+  parser.core.callAiGenerate = async (config, prompt, label) => {
+    labels.push(label);
+    if (label === 'repair') {
+      return '{"title": {"value": "Repaired Party", "evidence": "Repaired Party", "confidence": 90}}';
+    }
+    return 'not json at all &&&';
+  };
+
+  const event = await parser.extractEventWithTwoPassAi(
+    { url: 'https://x.example/', html: '<p>x</p>' },
+    parser.getAiConfig({}), null, {}, ['title'], 'SNIPPET', '', {}, null);
+
+  assert.deepEqual(labels, ['extraction', 'repair'], 'garbage must reach the repair pass exactly as today');
+  assert.equal(event.title, 'Repaired Party');
+});
+
+test('valid extraction responses never invoke salvage', async () => {
+  const parser = createParser();
+  let salvageCalls = 0;
+  const originalSalvage = parser.salvageUnparseableAiResponse.bind(parser);
+  parser.salvageUnparseableAiResponse = (...args) => {
+    salvageCalls++;
+    return originalSalvage(...args);
+  };
+  const labels = [];
+  parser.core.callAiGenerate = async (config, prompt, label) => {
+    labels.push(label);
+    return '{"title": {"value": "Clean Party", "evidence": "Clean Party", "confidence": 90}}';
+  };
+
+  const event = await parser.extractEventWithTwoPassAi(
+    { url: 'https://x.example/', html: '<p>x</p>' },
+    parser.getAiConfig({}), null, {}, ['title'], 'SNIPPET', '', {}, null);
+
+  assert.equal(event.title, 'Clean Party');
+  assert.equal(salvageCalls, 0, 'the happy path must not change');
+  assert.deepEqual(labels, ['extraction']);
+});
+
 test('getPageBrandNames caches the brand extraction on htmlData', () => {
   const parser = createParser();
   const htmlData = { html: BEARRACUDA_HTML, url: 'https://bearracuda.com/events/portland' };


### PR DESCRIPTION
Cuts roughly a third of AI requests per run with no behavior change on the happy path. Three independent optimizations, each evidenced in the 2026-07-13 run logs:

## 1. Skip the JSON-LD extraction pass when the page has no Event-typed JSON-LD
Every bearracuda event page sends a ~4.8KB JSON_LD_PRIMARY prompt containing only WebPage/Organization boilerplate and gets `{}` back. `pageHasEventTypedJsonLd` (any `@type` containing "Event", schema.org prefixes and `@graph` handled, cached per page) now gates the pass with a log line. The deterministic Event-node extraction path and pages that genuinely have Event JSON-LD are untouched.

## 2. Context-prep result cache
The confidence retry re-sends a byte-identical context-prep prompt — the log tiering already *detects* this (suppression lines) but the HTTP request was still paid (~1.2s × once per page). Successful responses are now cached per run keyed by prompt hash; the retry gets an instant cache hit.

## 3. Deterministic salvage before the AI repair pass
A large share of extraction responses fail JSON.parse only because the model writes raw quotes inside `evidence` strings — triggering a full repair round-trip that sometimes returns the same broken payload and discards the whole pass (the Treasure Trail Seattle case). A conservative salvage step now recovers `{value, confidence}` per requested field (strict scalar values, numeric confidence, unknown keys rejected, quote-ambiguous values rejected rather than truncated) and only falls through to AI repair when salvage yields nothing. Verified safe with the evidence gate: it validates values against the source snippet, never the model's evidence string.

Per bearracuda page: ~6 requests → ~4, plus 1-2 more saved on every page with a quote-mangled response.

## Tests
179 → 186, all green (rebased onto #1465; both changesets verified together). New coverage includes the exact broken payloads from production logs, cache hit/miss behavior, and pass-skipping with/without Event JSON-LD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)