### PR TITLE
test(scraper): golden pipeline fixtures, replay tool, calendar-contract tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A modern static website for chunky.dad",
   "main": "index.html",
   "scripts": {
-    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/metrics-sections.test.js scripts/adapters/scriptable-adapter.test.js",
+    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/metrics-sections.test.js scripts/adapters/scriptable-adapter.test.js scripts/golden-pipeline.test.js scripts/calendar-contract.test.js scripts/replay-run.test.js",
     "start": "python3 -m http.server 8000",
     "serve": "python3 -m http.server 8000",
     "dev": "python3 -m http.server 8000",

--- a/scripts/calendar-contract.test.js
+++ b/scripts/calendar-contract.test.js
@@ -1,0 +1,304 @@
+// ============================================================================
+// CALENDAR-AS-DATABASE CONTRACT TESTS
+// ============================================================================
+// The calendar IS the database: events are persisted as calendar entries whose
+// `location` field is ALWAYS a coordinate pair and whose `notes` field is a
+// key/value codec (event-schema.js) that must round-trip losslessly. These
+// property-style checks pin those invariants over a table of representative
+// events, including the nasty real cases from production runs (emoji titles,
+// addresses with commas, coordinates with leading whitespace).
+// ============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { SharedCore } = require('./shared-core');
+const { EventSchema } = require('./event-schema');
+
+const CITIES = {
+  nola: { calendar: 'chunky-dad-nola', timezone: 'America/Chicago', patterns: ['new orleans', 'nola'] },
+  sf: { calendar: 'chunky-dad-sf', timezone: 'America/Los_Angeles', patterns: ['san francisco', 'sf'] },
+  portland: { calendar: 'chunky-dad-portland', timezone: 'America/Los_Angeles', patterns: ['portland', 'pdx'] }
+};
+
+function createCore() {
+  return new SharedCore(CITIES, { eventSchema: EventSchema });
+}
+
+const epoch = (value) => (value instanceof Date ? value : new Date(value)).getTime();
+
+// Representative events, straight from production pain: emoji titles, address
+// text where coordinates belong, coordinates with leading whitespace.
+const PORTLAND_COORDS = '45.52, -122.65';
+const PORTLAND_COORDS_LEADING_SPACE = ' 45.52, -122.65';
+const NOLA_COORDS = '29.9611, -90.0645';
+
+function buildScrapedEvent(overrides = {}) {
+  return {
+    title: 'New Orleans⚜️',
+    description: 'FIXTURE PRESENTS',
+    startDate: new Date('2026-09-05T02:00:00.000Z'),
+    endDate: new Date('2026-09-05T07:00:00.000Z'),
+    bar: 'Oak Barrel Saloon',
+    address: '800 Bourbon St, New Orleans, LA, 70116',
+    city: 'nola',
+    timezone: 'America/Chicago',
+    location: NOLA_COORDS,
+    source: 'ai-web',
+    ...overrides
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Invariant 1: location is ALWAYS coordinates. Whenever either merge input
+// carries a coordinate location, the merged output's location must satisfy
+// isCoordinatePair — address text or an empty scrape must never displace it.
+// ---------------------------------------------------------------------------
+
+test('contract: mergeParsedEvents never lets text or empty values displace coordinate locations', async () => {
+  const core = createCore();
+
+  const table = [
+    {
+      name: 'existing coordinates vs incoming address text',
+      existing: buildScrapedEvent({ location: NOLA_COORDS }),
+      incoming: buildScrapedEvent({ location: '800 Bourbon St, New Orleans, LA, 70116', source: 'bearracuda' })
+    },
+    {
+      name: 'existing address text vs incoming coordinates',
+      existing: buildScrapedEvent({ location: '800 Bourbon St, New Orleans, LA, 70116' }),
+      incoming: buildScrapedEvent({ location: NOLA_COORDS, source: 'bearracuda' })
+    },
+    {
+      name: 'existing coordinates vs incoming empty location',
+      existing: buildScrapedEvent({ location: NOLA_COORDS }),
+      incoming: buildScrapedEvent({ location: '', source: 'bearracuda' })
+    },
+    {
+      name: 'incoming coordinates with leading whitespace vs existing empty',
+      existing: buildScrapedEvent({ location: undefined }),
+      incoming: buildScrapedEvent({ title: 'SF⛓️ FLSM', location: PORTLAND_COORDS_LEADING_SPACE, source: 'bearracuda' })
+    },
+    {
+      name: 'both sides coordinates',
+      existing: buildScrapedEvent({ location: NOLA_COORDS }),
+      incoming: buildScrapedEvent({ location: PORTLAND_COORDS, source: 'bearracuda' })
+    }
+  ];
+
+  for (const { name, existing, incoming } of table) {
+    // No httpAdapter → AI arbitration disabled → deterministic paths only
+    const merged = await core.mergeParsedEvents(existing, incoming, {});
+    assert.ok(
+      core.isCoordinatePair(merged.location),
+      `${name}: merged location must be a coordinate pair, got "${merged.location}"`
+    );
+    assert.ok(
+      !/bourbon/i.test(String(merged.location)),
+      `${name}: address text must never become the location`
+    );
+  }
+});
+
+test('contract: createFinalEventObject keeps location as coordinates against the calendar', async () => {
+  const core = createCore();
+
+  const calendarWithCoords = {
+    title: 'New Orleans⚜️',
+    startDate: new Date('2026-09-05T02:00:00.000Z'),
+    endDate: new Date('2026-09-05T07:00:00.000Z'),
+    location: PORTLAND_COORDS_LEADING_SPACE, // legacy record saved with a leading space
+    notes: 'bar: Oak Barrel Saloon\naddress: 800 Bourbon St, New Orleans, LA, 70116'
+  };
+
+  const table = [
+    {
+      name: 'scraped coordinates replace calendar coordinates',
+      existing: calendarWithCoords,
+      scraped: buildScrapedEvent({ location: NOLA_COORDS }),
+      expected: NOLA_COORDS
+    },
+    {
+      name: 'scraped address text must NOT wipe calendar coordinates',
+      existing: calendarWithCoords,
+      scraped: buildScrapedEvent({ location: '800 Bourbon St, New Orleans, LA, 70116' }),
+      expected: PORTLAND_COORDS_LEADING_SPACE
+    },
+    {
+      name: 'empty scrape must NOT wipe calendar coordinates',
+      existing: calendarWithCoords,
+      scraped: buildScrapedEvent({ location: '' }),
+      expected: PORTLAND_COORDS_LEADING_SPACE
+    },
+    {
+      name: 'scraped coordinates fill a calendar event without any',
+      existing: { ...calendarWithCoords, location: '' },
+      scraped: buildScrapedEvent({ location: NOLA_COORDS }),
+      expected: NOLA_COORDS
+    }
+  ];
+
+  for (const { name, existing, scraped, expected } of table) {
+    const finalEvent = await core.createFinalEventObject(existing, scraped, {});
+    assert.equal(finalEvent.location, expected, name);
+    assert.ok(
+      core.isCoordinatePair(finalEvent.location),
+      `${name}: final location must be a coordinate pair, got "${finalEvent.location}"`
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Invariant 2: the notes codec round-trips every standard field losslessly.
+// The field set is derived from event-schema.js itself (canonical alias
+// targets that are not excluded from notes), so schema additions are covered
+// automatically.
+// ---------------------------------------------------------------------------
+
+function getNotesRoundTrippableFields() {
+  const canonicalTargets = new Set(Object.values(EventSchema.EVENT_KEY_ALIASES));
+  return [...canonicalTargets].filter(field =>
+    !EventSchema.DEFAULT_NOTES_EXCLUDED_FIELDS.has(field) &&
+    EventSchema.canonicalizeEventKey(field, { context: 'notes' }) === field
+  );
+}
+
+test('contract: formatEventNotes → parseNotesIntoFields round-trips every standard field', () => {
+  const fields = getNotesRoundTrippableFields();
+  assert.ok(fields.includes('bar') && fields.includes('address') && fields.includes('ticketUrl'),
+    'sanity: the canonical field set must include the core metadata fields');
+
+  // Every standard field gets a value with a colon — the classic breaker.
+  const event = {};
+  for (const field of fields) {
+    event[field] = `${field} value: with colon`;
+  }
+  // Overlay the nasty real-world values on the usual suspects.
+  Object.assign(event, {
+    description: 'Doors: 9 PM\nAfterparty: TBD\nDress code — harness: encouraged',
+    bar: 'STATION 4: THE BASEMENT',
+    address: '3911 Cedar Springs Rd, Dallas, TX 75219',
+    shortName: 'SF⛓️ FLSM',
+    ticketUrl: 'https://events.ticketleap.example/tickets/furball?date=2026-09-04&aff=ig',
+    website: 'https://fixturepromoter.example/events/new-orleans',
+    gmaps: 'https://www.google.com/maps/search/?api=1&query=29.9611%2C-90.0645',
+    timezone: 'America/Chicago',
+    startTime: '21:00',
+    endTime: '02:00'
+  });
+
+  const notes = EventSchema.formatEventNotes(event);
+  const parsed = EventSchema.parseNotesIntoFields(notes);
+
+  for (const field of fields) {
+    assert.equal(parsed[field], event[field], `field "${field}" must round-trip losslessly`);
+  }
+});
+
+test('contract: multi-line values never swallow the fields that follow them', () => {
+  const event = {
+    description: 'Line one\nhttps://sneaky.example/not-a-key\nLine three: still description',
+    bar: 'Oak Barrel Saloon',
+    ticketUrl: 'https://tickets.example/e/fixture-new-orleans/tickets'
+  };
+  const parsed = EventSchema.parseNotesIntoFields(EventSchema.formatEventNotes(event));
+  assert.equal(parsed.description, event.description);
+  assert.equal(parsed.bar, event.bar);
+  assert.equal(parsed.ticketUrl, event.ticketUrl);
+});
+
+// ---------------------------------------------------------------------------
+// Invariant 3: event keys are non-empty, stable, and safe for the notes codec.
+// ---------------------------------------------------------------------------
+
+test('contract: createEventKey is non-empty, stable, and never breaks the notes format', () => {
+  const core = createCore();
+
+  const table = [
+    buildScrapedEvent(),
+    buildScrapedEvent({ title: 'New Orleans⚜️', bar: '' }),
+    buildScrapedEvent({ title: 'SF⛓️ FLSM', bar: 'SF Eagle', city: 'sf' }),
+    buildScrapedEvent({ title: 'Portland PRIDE FRIDAY | Late Night', bar: 'Nova PDX', city: 'portland' }),
+    buildScrapedEvent({ title: 'BEAR NIGHT: THE RETURN!', bar: 'STATION 4: THE BASEMENT' }),
+    buildScrapedEvent({ title: '  padded  title  ', bar: ' padded bar ' }),
+    // Custom key template, as configured by real parsers
+    buildScrapedEvent({ _parserConfig: { keyTemplate: 'fixture-${date}-${city}' } })
+  ];
+
+  for (const event of table) {
+    const key = core.createEventKey(event);
+    assert.equal(typeof key, 'string');
+    assert.ok(key.trim().length > 0, `key must be non-empty for "${event.title}"`);
+    assert.ok(!key.includes('\n') && !key.includes('\r'),
+      `key must not contain newlines (would corrupt notes): "${key}"`);
+
+    // Stability: identical input yields the identical key.
+    const clone = JSON.parse(JSON.stringify({ ...event, startDate: event.startDate.toISOString(), endDate: event.endDate.toISOString() }));
+    clone.startDate = new Date(clone.startDate);
+    clone.endDate = new Date(clone.endDate);
+    assert.equal(core.createEventKey(clone), key, `key must be stable for "${event.title}"`);
+
+    // Notes-codec safety: the key survives a notes round-trip verbatim and
+    // does not swallow the field written after it.
+    const notes = EventSchema.formatEventNotes({ key, shortName: 'AFTER-KEY' });
+    const parsed = EventSchema.parseNotesIntoFields(notes);
+    assert.equal(parsed.key, key, `key must round-trip through notes: "${key}"`);
+    assert.equal(parsed.shortName, 'AFTER-KEY');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Invariant 4: a merged event never ends before it starts.
+// ---------------------------------------------------------------------------
+
+test('contract: merged events never end before they start', async () => {
+  const core = createCore();
+
+  const positive = buildScrapedEvent();
+  const degenerate = buildScrapedEvent({
+    // endDate collapsed onto startDate — the classic evidence-dropped-end artifact
+    endDate: new Date('2026-09-05T02:00:00.000Z'),
+    source: 'bearracuda'
+  });
+  const inverted = buildScrapedEvent({
+    // endDate before startDate — worst-case upstream data
+    endDate: new Date('2026-09-04T23:00:00.000Z'),
+    source: 'bearracuda'
+  });
+
+  const parsedPairs = [
+    { name: 'degenerate incoming end', existing: positive, incoming: degenerate },
+    { name: 'degenerate existing end', existing: degenerate, incoming: positive },
+    { name: 'inverted incoming end', existing: positive, incoming: inverted },
+    { name: 'inverted existing end', existing: inverted, incoming: positive },
+    { name: 'both positive', existing: positive, incoming: buildScrapedEvent({ source: 'bearracuda' }) }
+  ];
+  for (const { name, existing, incoming } of parsedPairs) {
+    const merged = await core.mergeParsedEvents(existing, incoming, {});
+    assert.ok(merged.startDate && merged.endDate, `${name}: merged event must keep both dates`);
+    assert.ok(
+      epoch(merged.endDate) >= epoch(merged.startDate),
+      `${name}: merged event must not end before it starts (${merged.startDate} → ${merged.endDate})`
+    );
+  }
+
+  const calendarEvent = {
+    title: 'New Orleans⚜️',
+    startDate: new Date('2026-09-05T02:00:00.000Z'),
+    endDate: new Date('2026-09-05T07:00:00.000Z'),
+    location: NOLA_COORDS,
+    notes: 'bar: Oak Barrel Saloon'
+  };
+  const finalPairs = [
+    { name: 'degenerate scrape vs positive calendar', scraped: degenerate },
+    { name: 'inverted scrape vs positive calendar', scraped: inverted },
+    { name: 'positive scrape vs positive calendar', scraped: positive }
+  ];
+  for (const { name, scraped } of finalPairs) {
+    const finalEvent = await core.createFinalEventObject(calendarEvent, scraped, {});
+    assert.ok(
+      epoch(finalEvent.endDate) >= epoch(finalEvent.startDate),
+      `${name}: final event must not end before it starts (${finalEvent.startDate} → ${finalEvent.endDate})`
+    );
+  }
+});

--- a/scripts/fixtures/fixture-promoter/event-new-orleans.html
+++ b/scripts/fixtures/fixture-promoter/event-new-orleans.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>New Orleans Party | FIXTURE</title>
+  <meta property="og:site_name" content="FIXTURE" />
+  <meta property="og:title" content="New Orleans Party | FIXTURE" />
+  <meta property="og:description" content="FIXTURE takes over Bourbon Street for one night only." />
+  <meta property="og:url" content="https://fixturepromoter.example/events/new-orleans" />
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@graph":[
+      {"@type":"Organization","name":"Fixture Promoter, Inc.","alternateName":"FIXTURE"},
+      {"@type":"WebSite","name":"FIXTURE"},
+      {"@type":"WebPage","name":"New Orleans Party | FIXTURE","url":"https://fixturepromoter.example/events/new-orleans"}
+    ]}
+  </script>
+</head>
+<body>
+  <h1>New Orleans Party</h1>
+  <p>Presented by FIXTURE</p>
+  <p>🪩 Oak Barrel Saloon</p>
+  <p>📅 Friday, September 4, 2026</p>
+  <p>Doors Open at 9:00 pm</p>
+  <p>Party Goes Until 2:00 am!</p>
+  <p>800 Bourbon St, New Orleans, LA, 70116</p>
+  <p><a href="https://tickets.example/e/fixture-new-orleans/tickets">Get Tickets</a></p>
+</body>
+</html>

--- a/scripts/fixtures/fixture-promoter/event-san-francisco.html
+++ b/scripts/fixtures/fixture-promoter/event-san-francisco.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>San Francisco Party | FIXTURE</title>
+  <meta property="og:site_name" content="FIXTURE" />
+  <meta property="og:title" content="San Francisco Party | FIXTURE" />
+  <meta property="og:description" content="FIXTURE hits Polk Street. Furry chests encouraged." />
+  <meta property="og:url" content="https://fixturepromoter.example/events/san-francisco" />
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@graph":[
+      {"@type":"Organization","name":"Fixture Promoter, Inc.","alternateName":"FIXTURE"},
+      {"@type":"WebSite","name":"FIXTURE"},
+      {"@type":"WebPage","name":"San Francisco Party | FIXTURE","url":"https://fixturepromoter.example/events/san-francisco"}
+    ]}
+  </script>
+</head>
+<body>
+  <h1>San Francisco Party</h1>
+  <p>Presented by FIXTURE</p>
+  <p>📅 Friday, September 11, 2026</p>
+  <p>Doors Open at 9:00 pm</p>
+  <p>Party Goes Until 2:00 am!</p>
+  <p>1548 Polk St, San Francisco, CA 94109</p>
+</body>
+</html>

--- a/scripts/fixtures/fixture-promoter/landing.html
+++ b/scripts/fixtures/fixture-promoter/landing.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>FIXTURE - Bear Dance Parties</title>
+  <meta property="og:site_name" content="FIXTURE" />
+  <meta property="og:title" content="FIXTURE - Bear Dance Parties" />
+  <meta property="og:description" content="The bear dance party. Choose your city below." />
+  <meta property="og:url" content="https://fixturepromoter.example/" />
+  <script type="application/ld+json">
+    {"@context":"https://schema.org","@graph":[
+      {"@type":"Organization","name":"Fixture Promoter, Inc.","alternateName":"FIXTURE","url":"https://fixturepromoter.example"},
+      {"@type":"WebSite","name":"FIXTURE","url":"https://fixturepromoter.example"},
+      {"@type":"WebPage","name":"FIXTURE - Bear Dance Parties","url":"https://fixturepromoter.example/"}
+    ]}
+  </script>
+</head>
+<body>
+  <h1>FIXTURE</h1>
+  <p>The bear dance party. Choose your city.</p>
+  <nav>
+    <a href="/events/new-orleans">New Orleans</a>
+    <a href="/events/san-francisco">San Francisco</a>
+    <a href="https://tickets.example/e/fixture-new-orleans/tickets">New Orleans Tickets</a>
+  </nav>
+</body>
+</html>

--- a/scripts/fixtures/fixture-promoter/tickets-new-orleans.html
+++ b/scripts/fixtures/fixture-promoter/tickets-new-orleans.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>New Orleans Party Tickets</title>
+  <script type="application/ld+json">
+    {"@context":"http://schema.org","@type":"MusicEvent",
+     "name":"New Orleans Party",
+     "url":"https://tickets.example/e/fixture-new-orleans/tickets",
+     "startDate":"2026-09-04T21:00:00-05:00",
+     "endDate":"2026-09-05T02:00:00-05:00",
+     "eventStatus":"https://schema.org/EventScheduled",
+     "description":"<p>FIXTURE takes over Bourbon Street. Harnesses &amp; fur encouraged.</p>",
+     "image":["https://cdn.tickets.example/fixture-new-orleans-cover.webp"],
+     "organizer":{"@type":"Organization","name":"Fixture Promoter, Inc."},
+     "location":{"@type":"Place","name":"Oak Barrel Saloon",
+       "address":{"@type":"PostalAddress","streetAddress":"800 Bourbon St","addressLocality":"New Orleans","addressRegion":"LA","postalCode":"70116"}},
+     "offers":{"@type":"Offer","url":"https://tickets.example/e/fixture-new-orleans/tickets","availability":"https://schema.org/InStock"}}
+  </script>
+</head>
+<body>Related events footer with more parties every weekend.</body>
+</html>

--- a/scripts/golden-pipeline.test.js
+++ b/scripts/golden-pipeline.test.js
@@ -1,0 +1,314 @@
+// ============================================================================
+// GOLDEN PIPELINE TEST
+// ============================================================================
+// Drives the REAL scraping pipeline end-to-end over a small hand-crafted
+// promoter site (scripts/fixtures/fixture-promoter/, modeled on the
+// bearracuda.com structure seen in production):
+//
+//   landing page (link-aggregator, JSON-LD @graph Organization/WebSite)
+//     ├── /events/new-orleans      (event page, og:title "… | FIXTURE")
+//     ├── /events/san-francisco    (event page, organizer-as-bar AI leak)
+//     └── tickets.example/…        (third-party ticketing page whose MusicEvent
+//                                   JSON-LD describes the SAME event as
+//                                   /events/new-orleans → dedup + merge)
+//
+// The AI endpoint, the page fetches, and the Nominatim geocoder are all served
+// by in-test stubs, so the run is fully offline and deterministic. The whole
+// stack is real: SharedCore.processParser → crawl → classifyPage(+AI) →
+// AiWebParser.parseEvents → NormalizerPipeline (incl. geocoding) →
+// SharedCore.deduplicateEvents.
+//
+// IMPORTANT: assertions cover FINAL OUTPUT ONLY — never request counts, pass
+// ordering, or prompt text. The AI stub matches requests on the *kind of answer
+// being requested* (classification / arbitration / extraction) and on which
+// fixture page's content is present, so changes to pass mechanics (extra
+// passes, reordered passes, prompt rewording) must not break this test.
+// ============================================================================
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { SharedCore } = require('./shared-core');
+const { EventSchema } = require('./event-schema');
+const { NormalizerPipeline } = require('./normalizers');
+const { AiWebParser } = require('./parsers/ai-web-parser');
+
+const FIXTURE_DIR = path.join(__dirname, 'fixtures', 'fixture-promoter');
+const readFixture = (name) => fs.readFileSync(path.join(FIXTURE_DIR, name), 'utf8');
+
+const SITE = 'https://fixturepromoter.example';
+const TICKETS_URL = 'https://tickets.example/e/fixture-new-orleans/tickets';
+
+const PAGES = {
+  [`${SITE}/`]: 'landing.html',
+  [`${SITE}/events/new-orleans`]: 'event-new-orleans.html',
+  [`${SITE}/events/san-francisco`]: 'event-san-francisco.html',
+  [TICKETS_URL]: 'tickets-new-orleans.html'
+};
+
+// Cities config mirrors scraper-cities.js entries (patterns + timezone +
+// center coordinates, which the geocoder uses for candidate distance ranking).
+const CITIES = {
+  nola: {
+    calendar: 'chunky-dad-nola',
+    timezone: 'America/Chicago',
+    patterns: ['new orleans', 'nola'],
+    coordinates: { lat: 29.9511, lng: -90.0715 }
+  },
+  sf: {
+    calendar: 'chunky-dad-sf',
+    timezone: 'America/Los_Angeles',
+    patterns: ['san francisco', 'sf'],
+    coordinates: { lat: 37.7749, lng: -122.4194 }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Canned AI responses (per-field evidence+confidence format, exactly what the
+// local model returns in production). Every value is verbatim on the fixture
+// page so the evidence-validation gate keeps it.
+// ---------------------------------------------------------------------------
+
+// New Orleans event page: a clean extraction. The venue matches the ticketing
+// page's JSON-LD venue so the dedup merge is deterministic regardless of which
+// record the crawl encounters first.
+const NOLA_EXTRACTION = JSON.stringify({
+  name: { value: 'New Orleans Party | FIXTURE', evidence: 'og:title New Orleans Party | FIXTURE', confidence: 95 },
+  venue: { value: 'Oak Barrel Saloon', evidence: '🪩 Oak Barrel Saloon', confidence: 95 },
+  addr: { value: '800 Bourbon St, New Orleans, LA, 70116', evidence: '800 Bourbon St, New Orleans, LA, 70116', confidence: 95 },
+  city: { value: 'new orleans', evidence: 'New Orleans', confidence: 90 },
+  startDate: { value: '2026-09-04', evidence: 'Friday, September 4, 2026', confidence: 95 },
+  startTime: { value: '21:00', evidence: 'Doors Open at 9:00 pm', confidence: 90 },
+  endTime: { value: '02:00', evidence: 'Party Goes Until 2:00 am!', confidence: 90 },
+  tickets: { value: TICKETS_URL, evidence: 'Get Tickets', confidence: 90 },
+  // Low-confidence hallucination: must be dropped by the confidence filter.
+  cover: { value: '$15', evidence: '', confidence: 20 }
+});
+
+// San Francisco event page: the organizer-as-bar leak seen in production
+// bearracuda.com runs — the page has no venue text, and the model returns the
+// promoter brand as the venue. The brand guard must drop it end-to-end.
+const SF_EXTRACTION = JSON.stringify({
+  name: { value: 'San Francisco Party | FIXTURE', evidence: 'og:title San Francisco Party | FIXTURE', confidence: 95 },
+  venue: { value: 'FIXTURE', evidence: 'Presented by FIXTURE', confidence: 60 },
+  addr: { value: '1548 Polk St, San Francisco, CA 94109', evidence: '1548 Polk St, San Francisco, CA 94109', confidence: 95 },
+  city: { value: 'san francisco', evidence: 'San Francisco', confidence: 90 },
+  startDate: { value: '2026-09-11', evidence: 'Friday, September 11, 2026', confidence: 95 },
+  startTime: { value: '21:00', evidence: 'Doors Open at 9:00 pm', confidence: 90 },
+  endTime: { value: '02:00', evidence: 'Party Goes Until 2:00 am!', confidence: 90 }
+});
+
+const classifyAnswer = (classification) => JSON.stringify({
+  classification,
+  confidence: 92,
+  reason: 'fixture classification'
+});
+
+// Scripted Nominatim forward-geocode candidates (first candidate is inside the
+// city-center acceptance radius).
+const GEOCODE_RESULTS = [
+  {
+    match: /bourbon/i,
+    results: [
+      { lat: '29.9611', lon: '-90.0645', display_name: '800, Bourbon Street, French Quarter, New Orleans, LA', address: { city: 'New Orleans' } }
+    ]
+  },
+  {
+    match: /polk/i,
+    results: [
+      // A same-named street in the wrong state, ranked out by distance…
+      { lat: '38.5816', lon: '-121.4944', display_name: 'Polk Street, Sacramento, CA', address: { city: 'Sacramento' } },
+      // …and the real candidate near the SF city center.
+      { lat: '37.7935', lon: '-122.4217', display_name: '1548, Polk Street, San Francisco, CA', address: { city: 'San Francisco' } }
+    ]
+  }
+];
+
+// ---------------------------------------------------------------------------
+// Stub adapters
+// ---------------------------------------------------------------------------
+
+// Decide what a prompt is asking for by the shape of the answer it requests,
+// then answer based on which fixture page's content is in the prompt. This is
+// intentionally independent of pass names, pass order, and request counts.
+function respondToPrompt(prompt) {
+  const text = String(prompt || '');
+
+  // Page-classification requests ask for {"classification": …}
+  if (text.includes('"classification"')) {
+    if (text.includes('/events/new-orleans') || text.includes('/events/san-francisco')) {
+      return classifyAnswer('event-page');
+    }
+    return classifyAnswer('link-aggregator');
+  }
+
+  // Merge-arbitration requests ask for {"pick": …} — decline so the
+  // deterministic fallback path is exercised (no model dependency).
+  if (text.includes('"pick"')) {
+    return '';
+  }
+
+  // Extraction-ish requests (extraction, context-prep, repair, retries):
+  // answer with the page's scripted event, whichever pass is asking.
+  if (text.includes('Oak Barrel Saloon') || text.includes('New Orleans')) {
+    return NOLA_EXTRACTION;
+  }
+  if (text.includes('Polk St') || text.includes('San Francisco')) {
+    return SF_EXTRACTION;
+  }
+  return '';
+}
+
+function createStubHttpAdapter() {
+  const adapter = {
+    aiRequests: [],
+    fetchedUrls: [],
+
+    async fetchData(url) {
+      adapter.fetchedUrls.push(url);
+      const fixture = PAGES[url] || PAGES[String(url).replace(/\/$/, '')];
+      if (fixture) {
+        return { url, html: readFixture(fixture), statusCode: 200, headers: {} };
+      }
+      throw new Error(`Unexpected fetch in golden test: ${url}`);
+    },
+
+    // The geocoder reads Nominatim responses through the page-cache hooks
+    // before ever calling fetchData — serving them here keeps the test
+    // offline AND skips the 1.1s/request Nominatim rate-limit delay.
+    getPageCacheConfig() {
+      return { enabled: true, ttlDays: 1 };
+    },
+    async readCachedPage(url) {
+      if (!/nominatim\.openstreetmap\.org\/search/.test(url)) return null;
+      const query = decodeURIComponent(url);
+      const entry = GEOCODE_RESULTS.find(candidate => candidate.match.test(query));
+      return { html: JSON.stringify(entry ? entry.results : []) };
+    },
+
+    async postJson(endpoint, payload) {
+      // Works for both providers: openai chat payloads and ollama generate payloads.
+      const prompt = payload && Array.isArray(payload.messages)
+        ? (typeof payload.messages[0].content === 'string'
+          ? payload.messages[0].content
+          : payload.messages[0].content.map(part => part.text || '').join('\n'))
+        : String(payload && payload.prompt || '');
+      adapter.aiRequests.push(prompt);
+      const content = respondToPrompt(prompt);
+      return {
+        ok: true,
+        status: 200,
+        text: JSON.stringify({ choices: [{ message: { content } }] })
+      };
+    }
+  };
+  return adapter;
+}
+
+function createStubDisplayAdapter() {
+  const lines = [];
+  const log = (level) => async (message) => { lines.push(`[${level}] ${message}`); };
+  return {
+    lines,
+    logInfo: log('info'),
+    logWarn: log('warn'),
+    logError: log('error'),
+    logSuccess: log('success')
+  };
+}
+
+// Mirrors the orchestrator wiring in bear-event-scraper-unified.js run().
+function createPipeline() {
+  const normalizerPipeline = new NormalizerPipeline();
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    normalizerPipeline,
+    bars: {}
+  });
+  normalizerPipeline.setCore(core);
+
+  const aiParser = new AiWebParser({ normalizeUrl: core.normalizeUrl.bind(core) });
+  aiParser.core = core;
+
+  return { core, parsers: { 'ai-web': aiParser } };
+}
+
+const PARSER_CONFIG = {
+  name: 'Fixture Promoter',
+  parser: 'ai-web',
+  enabled: true,
+  urls: [`${SITE}/`],
+  alwaysBear: true,
+  allowPastEvents: true, // fixture dates are fixed — keep the test time-independent
+  urlDiscoveryDepth: 1,
+  ai: {
+    enabled: true,
+    provider: 'openai',
+    endpoint: 'http://ai.fixture.test/v1/chat/completions',
+    model: 'fixture-test-model',
+    timeoutSeconds: 5,
+    ocr: { enabled: false }
+  }
+};
+
+const MAIN_CONFIG = {
+  config: { dryRun: true },
+  cities: CITIES
+};
+
+test('golden pipeline: fixture promoter site crawls, extracts, geocodes, and dedups to the final merged events', async () => {
+  const { core, parsers } = createPipeline();
+  const httpAdapter = createStubHttpAdapter();
+  const displayAdapter = createStubDisplayAdapter();
+
+  const result = await core.processParser(PARSER_CONFIG, MAIN_CONFIG, httpAdapter, displayAdapter, parsers, new Set());
+
+  // ---- Final output only from here on ----
+  const events = [...result.events].sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
+
+  // Three records were scraped (two event pages + the ticketing page); the two
+  // records describing the same New Orleans event must merge into one.
+  assert.equal(events.length, 2, `expected 2 final events, got ${events.length}: ${events.map(e => e.title).join(' / ')}`);
+  assert.equal(result.duplicatesRemoved, 1, 'exactly one duplicate record must be merged away');
+
+  const [nola, sf] = events;
+
+  // --- New Orleans: merged from the event page + ticketing JSON-LD ---
+  assert.equal(nola.title, 'New Orleans Party', 'brand suffix must be stripped from the title');
+  assert.equal(nola.bar, 'Oak Barrel Saloon', 'bar must be the venue');
+  assert.equal(nola.address, '800 Bourbon St, New Orleans, LA, 70116');
+  assert.equal(nola.city, 'nola', 'city must resolve to the canonical city key');
+  assert.equal(nola.timezone, 'America/Chicago');
+  assert.equal(nola.ticketUrl, TICKETS_URL);
+  // 9pm CDT with "until 2:00 am" — the end must roll over to the NEXT day and
+  // agree with the ticketing page's explicit offsets.
+  assert.equal(new Date(nola.startDate).toISOString(), '2026-09-05T02:00:00.000Z');
+  assert.equal(new Date(nola.endDate).toISOString(), '2026-09-05T07:00:00.000Z');
+  // location is ALWAYS coordinates (stubbed geocoder), never address text
+  assert.ok(core.isCoordinatePair(nola.location), `nola location must be coordinates, got "${nola.location}"`);
+  assert.equal(nola.location, '29.9611, -90.0645');
+  assert.equal(nola.isBearEvent, true);
+
+  // --- San Francisco: organizer-as-bar leak must be stopped by the guard ---
+  assert.equal(sf.title, 'San Francisco Party', 'brand suffix must be stripped from the title');
+  assert.equal(sf.bar || '', '', 'the promoter brand must never survive as the venue');
+  assert.equal(sf.address, '1548 Polk St, San Francisco, CA 94109');
+  assert.equal(sf.city, 'sf');
+  assert.equal(sf.timezone, 'America/Los_Angeles');
+  // 9pm PDT with "until 2:00 am" — rolled-over end on the next local day
+  assert.equal(new Date(sf.startDate).toISOString(), '2026-09-12T04:00:00.000Z');
+  assert.equal(new Date(sf.endDate).toISOString(), '2026-09-12T09:00:00.000Z');
+  // Distance ranking must pick the candidate near the SF center, not Sacramento
+  assert.ok(core.isCoordinatePair(sf.location), `sf location must be coordinates, got "${sf.location}"`);
+  assert.equal(sf.location, '37.7935, -122.4217');
+
+  // The promoter brand must not leak into any final field on any event.
+  for (const event of events) {
+    assert.ok(!/fixture/i.test(event.bar || ''), `bar leaked the organizer brand: "${event.bar}"`);
+    assert.ok(!/\|\s*FIXTURE/i.test(event.title || ''), `title kept the brand suffix: "${event.title}"`);
+    assert.equal(event.cover || '', '', 'the low-confidence cover hallucination must not survive');
+    assert.equal(event.source, 'ai-web');
+  }
+});

--- a/scripts/replay-run.test.js
+++ b/scripts/replay-run.test.js
@@ -1,0 +1,307 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('node:child_process');
+
+const {
+  replayRun,
+  collectScrapedEvents,
+  buildCalendarEventFromSnapshot,
+  reviveEventDates,
+  diffEvents,
+  formatReplayReport
+} = require('../tools/replay-run');
+
+const REPLAY_CLI = path.join(__dirname, '..', 'tools', 'replay-run.js');
+
+// ---------------------------------------------------------------------------
+// Embedded fixture run: the shape written by ScriptableAdapter.saveRun()
+// (scripts/adapters/scriptable-adapter.js — version 2 payload). Three scraped
+// records: two are the same Dallas event (shared ticketUrl, different titles →
+// identity-scan dedup), one is independent. The first analyzed event carries a
+// calendar snapshot (_original.calendar), so replay exercises both
+// deduplicateEvents and createFinalEventObject. The analyzedEvents below are
+// the frozen deterministic outcome of that merge (AI arbitration disabled).
+// ---------------------------------------------------------------------------
+
+const TICKET_URL = 'https://events.ticketleap.example/furball-dallas-freedom-tea';
+
+const SCRAPED_A1 = {
+  title: 'DALLAS FREEDOM TEA',
+  startDate: '2026-07-05T22:00:00.000Z',
+  endDate: '2026-07-06T03:00:00.000Z',
+  bar: 'STATION 4',
+  address: '3911 Cedar Springs Rd, Dallas, TX 75219',
+  city: 'dallas',
+  timezone: 'America/Chicago',
+  ticketUrl: TICKET_URL,
+  shortName: 'FUR-BALL',
+  source: 'ai-web',
+  isBearEvent: true
+};
+
+const SCRAPED_A2 = {
+  title: 'FURBALL DALLAS',
+  description: 'FURBALL PRESENTS',
+  startDate: '2026-07-05T22:00:00.000Z',
+  endDate: '2026-07-06T03:00:00.000Z',
+  bar: 'STATION 4',
+  address: '3911 Cedar Springs Rd, Dallas, TX 75219',
+  city: 'dallas',
+  timezone: 'America/Chicago',
+  ticketUrl: TICKET_URL,
+  source: 'ai-web',
+  isBearEvent: true
+};
+
+const SCRAPED_B = {
+  title: 'BEAR HAPPY HOUR',
+  startDate: '2026-07-08T23:00:00.000Z',
+  endDate: '2026-07-09T02:00:00.000Z',
+  bar: 'HIDDEN DOOR',
+  address: '5025 Bowser Ave, Dallas, TX 75209',
+  city: 'dallas',
+  timezone: 'America/Chicago',
+  source: 'ai-web',
+  isBearEvent: true
+};
+
+const CALENDAR_NOTES = [
+  'bar: STATION 4',
+  'address: 3911 Cedar Springs Rd, Dallas, TX 75219',
+  'timezone: America/Chicago',
+  `ticketUrl: ${TICKET_URL}`,
+  'shortName: FUR-BALL'
+].join('\n');
+
+const CALENDAR_SNAPSHOT = {
+  bar: 'STATION 4',
+  address: '3911 Cedar Springs Rd, Dallas, TX 75219',
+  timezone: 'America/Chicago',
+  ticketUrl: TICKET_URL,
+  shortName: 'FUR-BALL',
+  title: 'FURBALL',
+  startDate: '2026-07-05T21:00:00.000Z',
+  endDate: '2026-07-06T02:00:00.000Z',
+  location: '32.810535, -96.8110709',
+  notes: CALENDAR_NOTES,
+  url: 'https://furball.example'
+};
+
+// Frozen deterministic outcome of dedup(A1, A2) + createFinalEventObject
+// against CALENDAR_SNAPSHOT.
+const SAVED_MERGED_A = {
+  title: 'FURBALL',
+  startDate: '2026-07-05T21:00:00.000Z',
+  endDate: '2026-07-06T02:00:00.000Z',
+  location: '32.810535, -96.8110709',
+  notes: [
+    'description: FURBALL PRESENTS',
+    'bar: STATION 4',
+    'address: 3911 Cedar Springs Rd, Dallas, TX 75219',
+    'timezone: America/Chicago',
+    `ticketUrl: ${TICKET_URL}`,
+    'key: dallas-freedom-tea|2026-07-05|station 4',
+    'shortName: FUR-BALL'
+  ].join('\n'),
+  url: 'https://furball.example',
+  description: 'FURBALL PRESENTS',
+  bar: 'STATION 4',
+  address: '3911 Cedar Springs Rd, Dallas, TX 75219',
+  city: 'dallas',
+  timezone: 'America/Chicago',
+  ticketUrl: TICKET_URL,
+  source: 'ai-web',
+  isBearEvent: true,
+  key: 'dallas-freedom-tea|2026-07-05|station 4',
+  shortName: 'FUR-BALL',
+  _action: 'merge',
+  _existingEvent: {
+    title: 'FURBALL',
+    startDate: '2026-07-05T21:00:00.000Z',
+    endDate: '2026-07-06T02:00:00.000Z',
+    location: '32.810535, -96.8110709',
+    url: 'https://furball.example',
+    notes: CALENDAR_NOTES
+  },
+  _original: {
+    scraper: { ...SCRAPED_A2, key: 'dallas-freedom-tea|2026-07-05|station 4' },
+    calendar: CALENDAR_SNAPSHOT,
+    merged: {}
+  }
+};
+
+const SAVED_NEW_B = {
+  ...SCRAPED_B,
+  key: 'bear-happy-hour|2026-07-08|hidden door',
+  notes: [
+    'bar: HIDDEN DOOR',
+    'address: 5025 Bowser Ave, Dallas, TX 75209',
+    'timezone: America/Chicago',
+    'key: bear-happy-hour|2026-07-08|hidden door'
+  ].join('\n'),
+  _action: 'new'
+};
+
+function buildFixtureRun() {
+  return JSON.parse(JSON.stringify({
+    version: 2,
+    summary: {
+      runId: '20260713-090000',
+      timestamp: '2026-07-13T09:00:00.000Z',
+      runContext: null,
+      totals: { totalEvents: 3, bearEvents: 2, calendarEvents: 0, errors: 0 },
+      parserSummaries: [{ name: 'Furball', bearEvents: 2, totalEvents: 3 }]
+    },
+    runContext: null,
+    config: {
+      config: { dryRun: true },
+      cities: {
+        dallas: { calendar: 'chunky-dad-dallas', timezone: 'America/Chicago', patterns: ['dallas'] }
+      }
+    },
+    analyzedEvents: [SAVED_MERGED_A, SAVED_NEW_B],
+    parserResults: [
+      { name: 'Furball', bearEvents: 2, totalEvents: 3, events: [SCRAPED_A1, SCRAPED_A2, SCRAPED_B] }
+    ],
+    errors: []
+  }));
+}
+
+test('replayRun reproduces a saved run with zero differences', async () => {
+  const report = await replayRun(buildFixtureRun());
+
+  assert.equal(report.scrapedSource, 'parserResults');
+  assert.equal(report.counts.scraped, 3);
+  assert.equal(report.counts.replayed, 2, 'the two same-event records must dedup into one');
+  assert.equal(report.counts.saved, 2);
+  assert.equal(report.counts.matched, 2);
+  assert.deepEqual(report.unmatchedSaved, []);
+  assert.deepEqual(report.unmatchedReplayed, []);
+  assert.equal(report.counts.withDifferences, 0);
+  assert.equal(report.ok, true);
+
+  const merged = report.events.find(entry => entry.title === 'FURBALL');
+  assert.ok(merged, 'the calendar-merged event must be matched');
+  assert.equal(merged.mergedWithCalendar, true);
+});
+
+test('replayRun surfaces per-field differences when the saved outcome no longer matches', async () => {
+  const run = buildFixtureRun();
+  // Simulate a historical run produced by older merge logic: the saved outcome
+  // kept a different bar and a different end date than today's code produces.
+  run.analyzedEvents[0].bar = 'THE OLD VENUE';
+  run.analyzedEvents[0].endDate = '2026-07-06T05:00:00.000Z';
+
+  const report = await replayRun(run);
+  assert.equal(report.ok, false);
+  assert.equal(report.counts.withDifferences, 1);
+
+  const merged = report.events.find(entry => entry.title === 'FURBALL');
+  const fields = merged.differences.map(diff => diff.field).sort();
+  assert.deepEqual(fields, ['bar', 'endDate']);
+
+  const barDiff = merged.differences.find(diff => diff.field === 'bar');
+  assert.equal(barDiff.saved, 'THE OLD VENUE');
+  assert.equal(barDiff.replayed, 'STATION 4');
+
+  const text = formatReplayReport(report);
+  assert.match(text, /FURBALL/);
+  assert.match(text, /bar:/);
+  assert.match(text, /THE OLD VENUE/);
+  assert.match(text, /STATION 4/);
+});
+
+test('replayRun reports events the replay adds or removes', async () => {
+  const run = buildFixtureRun();
+  // A saved event the replay can no longer produce (e.g. its scraped records
+  // were pruned from the run) must be reported, not crash the diff.
+  run.analyzedEvents.push({
+    title: 'GHOST EVENT',
+    startDate: '2026-07-10T01:00:00.000Z',
+    key: 'ghost-event|2026-07-10|'
+  });
+
+  const report = await replayRun(run);
+  assert.equal(report.ok, false);
+  assert.equal(report.unmatchedSaved.length, 1);
+  assert.equal(report.unmatchedSaved[0].title, 'GHOST EVENT');
+  assert.match(formatReplayReport(report), /GHOST EVENT/);
+});
+
+test('replayRun handles older/partial runs gracefully', async () => {
+  // Old runs: no parserResults events — fall back to the merge snapshots on
+  // analyzedEvents (_original.scraper), then to the events themselves.
+  const run = buildFixtureRun();
+  run.parserResults = [{ name: 'Furball', bearEvents: 2, totalEvents: 3 }];
+  delete run.config.cities;
+
+  const report = await replayRun(run);
+  assert.equal(report.scrapedSource, 'analyzedEvents');
+  assert.equal(report.counts.scraped, 2);
+  assert.ok(report.warnings.some(warning => /cities/.test(warning)), 'missing cities config must be surfaced as a warning');
+
+  // Fully empty run: no events anywhere — warn, do not throw.
+  const empty = await replayRun({ version: 1 });
+  assert.equal(empty.counts.scraped, 0);
+  assert.equal(empty.counts.saved, 0);
+  assert.ok(empty.warnings.some(warning => /no scraped events/i.test(warning)));
+
+  await assert.rejects(() => replayRun(null), /empty or not an object/);
+});
+
+test('collectScrapedEvents and snapshot/date helpers cover the saved-run shapes', () => {
+  const fromAnalyzed = collectScrapedEvents({
+    analyzedEvents: [
+      { _original: { scraper: { title: 'A', startDate: '2026-07-05T22:00:00.000Z' } } },
+      { title: 'B', startDate: '2026-07-06T22:00:00.000Z', _action: 'new' }
+    ]
+  });
+  assert.equal(fromAnalyzed.source, 'analyzedEvents');
+  assert.equal(fromAnalyzed.events.length, 2);
+  assert.ok(fromAnalyzed.events[0].startDate instanceof Date, 'ISO strings must be revived to Dates');
+  assert.equal(fromAnalyzed.events[1].title, 'B');
+  assert.equal(fromAnalyzed.events[1]._action, undefined, 'analysis fields must be stripped');
+
+  const calendarEvent = buildCalendarEventFromSnapshot(CALENDAR_SNAPSHOT);
+  assert.equal(calendarEvent.title, 'FURBALL');
+  assert.equal(calendarEvent.notes, CALENDAR_NOTES);
+  assert.ok(calendarEvent.startDate instanceof Date);
+  assert.equal(buildCalendarEventFromSnapshot(null), null);
+
+  const revived = reviveEventDates({ startDate: 'not a date', endDate: '2026-07-06T03:00:00.000Z' });
+  assert.equal(revived.startDate, 'not a date', 'unparseable dates stay untouched');
+  assert.ok(revived.endDate instanceof Date);
+
+  // Date-object vs ISO-string must not count as a difference
+  assert.deepEqual(
+    diffEvents(
+      { title: 'X', startDate: '2026-07-05T22:00:00.000Z' },
+      { title: 'X', startDate: new Date('2026-07-05T22:00:00.000Z') }
+    ),
+    []
+  );
+});
+
+test('replay-run CLI prints a readable diff and supports --json', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'replay-run-test-'));
+  const runPath = path.join(tmpDir, 'run.json');
+  try {
+    fs.writeFileSync(runPath, JSON.stringify(buildFixtureRun()));
+
+    const text = execFileSync(process.execPath, [REPLAY_CLI, runPath], { encoding: 'utf8' });
+    assert.match(text, /Replayed 3 scraped event\(s\)/);
+    assert.match(text, /no differences/);
+
+    const json = JSON.parse(execFileSync(process.execPath, [REPLAY_CLI, runPath, '--json'], { encoding: 'utf8' }));
+    assert.equal(json.ok, true);
+    assert.equal(json.counts.replayed, 2);
+
+    const help = execFileSync(process.execPath, [REPLAY_CLI, '--help'], { encoding: 'utf8' });
+    assert.match(help, /Usage: node tools\/replay-run\.js/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tools/replay-run.js
+++ b/tools/replay-run.js
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+// ============================================================================
+// replay-run.js - Replay a saved scraper run's merge/dedup layer (CLI)
+//
+// Takes a run JSON written by the Scriptable adapter's saveRun()
+// (Documents/chunky-dad-scraper/runs/<runId>.json, shape:
+//   { version, summary, runContext, config, analyzedEvents, parserResults, errors })
+// and re-runs the DETERMINISTIC merge/dedup layer over the saved scraped
+// events:
+//
+//   1. SharedCore.deduplicateEvents over the scraped event records
+//      (parserResults[].events, falling back to analyzedEvents' _original.scraper)
+//   2. SharedCore.createFinalEventObject against the saved calendar snapshot
+//      (_original.calendar) for events the run merged into the calendar
+//
+// AI arbitration is DISABLED (no HTTP adapter → arbitration returns null →
+// the deterministic fallback paths run), so the replay needs no network and
+// no model. The tool then diffs the replayed outcome against what the saved
+// run recorded, making it a regression harness for merge changes against
+// real historical runs.
+//
+// Usage:
+//   node tools/replay-run.js <run.json>          readable diff
+//   node tools/replay-run.js <run.json> --json   machine-readable diff
+//   node tools/replay-run.js --help
+// ============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const { SharedCore } = require('../scripts/shared-core');
+const { EventSchema } = require('../scripts/event-schema');
+
+const HELP = `Replay the deterministic merge/dedup layer of a saved scraper run.
+
+Usage: node tools/replay-run.js <run.json> [options]
+
+The input is a run record written by the Scriptable adapter (saveRun):
+Documents/chunky-dad-scraper/runs/<runId>.json.
+
+The scraped events saved in the run are pushed back through
+SharedCore.deduplicateEvents and (for events the run merged into the calendar)
+SharedCore.createFinalEventObject, with AI arbitration disabled, and the
+result is diffed against the outcome the run recorded. Zero differences means
+the current merge code reproduces the historical run.
+
+Options:
+  --json    print the diff as JSON
+  --help    show this help
+`;
+
+// Fields compared between the saved outcome and the replayed outcome.
+// notes is included deliberately: it is the calendar-as-database payload.
+const COMPARED_FIELDS = [
+  'title', 'startDate', 'endDate', 'location', 'bar', 'address', 'city',
+  'timezone', 'ticketUrl', 'url', 'website', 'description', 'shortName',
+  'image', 'cover', 'gmaps', 'instagram', 'facebook', 'notes'
+];
+
+function createCore(run) {
+  const cities = run && run.config && run.config.cities && typeof run.config.cities === 'object'
+    ? run.config.cities
+    : {};
+  return new SharedCore(cities, { eventSchema: EventSchema });
+}
+
+// Saved runs are JSON, so Dates arrive as ISO strings. Revive the two date
+// fields the merge layer compares as instants.
+function reviveEventDates(event) {
+  if (!event || typeof event !== 'object') return event;
+  const revived = { ...event };
+  for (const field of ['startDate', 'endDate']) {
+    const value = revived[field];
+    if (typeof value === 'string' && value) {
+      const date = new Date(value);
+      if (!Number.isNaN(date.getTime())) revived[field] = date;
+    }
+  }
+  return revived;
+}
+
+function stripAnalysisFields(event) {
+  const cleaned = {};
+  for (const key of Object.keys(event || {})) {
+    if (key.startsWith('_')) continue;
+    cleaned[key] = event[key];
+  }
+  return cleaned;
+}
+
+// Collect the scraped (pre-cross-parser-dedup) event records from a saved run.
+// Newer runs carry them in parserResults[].events; older/partial runs fall
+// back to the merge snapshots on analyzedEvents (_original.scraper), and
+// finally to the analyzed events themselves.
+function collectScrapedEvents(run) {
+  const fromParserResults = [];
+  if (run && Array.isArray(run.parserResults)) {
+    for (const parserResult of run.parserResults) {
+      if (parserResult && Array.isArray(parserResult.events)) {
+        fromParserResults.push(...parserResult.events.filter(Boolean));
+      }
+    }
+  }
+  if (fromParserResults.length > 0) {
+    return { events: fromParserResults.map(reviveEventDates), source: 'parserResults' };
+  }
+
+  const analyzed = run && Array.isArray(run.analyzedEvents) ? run.analyzedEvents.filter(Boolean) : [];
+  if (analyzed.length > 0) {
+    const events = analyzed.map(event => {
+      const scraper = event && event._original && event._original.scraper;
+      return reviveEventDates(scraper && typeof scraper === 'object' ? scraper : stripAnalysisFields(event));
+    });
+    return { events, source: 'analyzedEvents' };
+  }
+
+  return { events: [], source: 'none' };
+}
+
+// Rebuild the existing-calendar event that createFinalEventObject expects from
+// the calendar snapshot the run saved in _original.calendar.
+function buildCalendarEventFromSnapshot(calendarSnapshot) {
+  if (!calendarSnapshot || typeof calendarSnapshot !== 'object') return null;
+  return reviveEventDates({
+    title: calendarSnapshot.title,
+    startDate: calendarSnapshot.startDate,
+    endDate: calendarSnapshot.endDate,
+    location: calendarSnapshot.location,
+    url: calendarSnapshot.url,
+    notes: calendarSnapshot.notes || ''
+  });
+}
+
+function serializeFieldValue(value) {
+  if (value === null || value === undefined) return '';
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    // Normalize date-like strings so Date-object vs ISO-string is not a diff
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(trimmed)) {
+      const date = new Date(trimmed);
+      if (!Number.isNaN(date.getTime())) return date.toISOString();
+    }
+    return trimmed;
+  }
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch (_) {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+function matchIdentity(core, event) {
+  const title = String(event && (event.title || event.name) || '').trim().toLowerCase();
+  const day = core.normalizeEventDate(event && event.startDate);
+  return `${title}|${day}`;
+}
+
+// Pair saved outcome events with replayed events: by saved key first, then by
+// normalized title + start day.
+function pairEvents(core, savedEvents, replayedEvents) {
+  const pairs = [];
+  const unmatchedReplayed = [...replayedEvents];
+
+  for (const saved of savedEvents) {
+    let index = -1;
+    if (saved && saved.key) {
+      index = unmatchedReplayed.findIndex(candidate => candidate && candidate.key === saved.key);
+    }
+    if (index === -1) {
+      const identity = matchIdentity(core, saved);
+      index = unmatchedReplayed.findIndex(candidate => matchIdentity(core, candidate) === identity);
+    }
+    if (index === -1) {
+      pairs.push({ saved, replayed: null });
+    } else {
+      pairs.push({ saved, replayed: unmatchedReplayed[index] });
+      unmatchedReplayed.splice(index, 1);
+    }
+  }
+
+  return { pairs, unmatchedReplayed };
+}
+
+function diffEvents(saved, replayed) {
+  const differences = [];
+  for (const field of COMPARED_FIELDS) {
+    const savedValue = serializeFieldValue(saved ? saved[field] : undefined);
+    const replayedValue = serializeFieldValue(replayed ? replayed[field] : undefined);
+    if (savedValue !== replayedValue) {
+      differences.push({ field, saved: savedValue, replayed: replayedValue });
+    }
+  }
+  return differences;
+}
+
+// Re-run the deterministic merge/dedup layer over a saved run and diff the
+// replayed outcome against the recorded one.
+// Returns { ok, scrapedSource, counts, events, unmatchedSaved, unmatchedReplayed, warnings }
+async function replayRun(run) {
+  const warnings = [];
+  if (!run || typeof run !== 'object') {
+    throw new Error('Run record is empty or not an object');
+  }
+
+  const core = createCore(run);
+  if (!run.config || !run.config.cities) {
+    warnings.push('Run has no saved cities config — keys and local-day matching may differ from the original run.');
+  }
+
+  const { events: scrapedEvents, source: scrapedSource } = collectScrapedEvents(run);
+  if (scrapedEvents.length === 0) {
+    warnings.push('Run contains no scraped events (no parserResults[].events and no analyzedEvents).');
+  }
+
+  // 1. Deterministic cross-parser dedup. No httpAdapter → AI arbitration is
+  //    skipped and every conflict takes its deterministic fallback.
+  const globalConfig = run.config && run.config.config ? run.config.config : null;
+  const deduplicated = await core.deduplicateEvents(scrapedEvents.map(event => ({ ...event })), null, globalConfig);
+
+  // 2. Replay the calendar merge for events the run compared against an
+  //    existing calendar event (saved snapshot in _original.calendar).
+  const savedEvents = Array.isArray(run.analyzedEvents) ? run.analyzedEvents.filter(Boolean) : [];
+  const calendarSnapshotsByIdentity = new Map();
+  for (const saved of savedEvents) {
+    const snapshot = saved && saved._original && saved._original.calendar;
+    const calendarEvent = buildCalendarEventFromSnapshot(snapshot);
+    if (calendarEvent) {
+      calendarSnapshotsByIdentity.set(matchIdentity(core, saved), calendarEvent);
+      if (saved.key) calendarSnapshotsByIdentity.set(`key:${saved.key}`, calendarEvent);
+    }
+  }
+
+  const replayedEvents = [];
+  for (const event of deduplicated) {
+    const calendarEvent = (event.key && calendarSnapshotsByIdentity.get(`key:${event.key}`))
+      || calendarSnapshotsByIdentity.get(matchIdentity(core, event));
+    if (calendarEvent) {
+      replayedEvents.push(await core.createFinalEventObject(calendarEvent, event, {}));
+    } else {
+      const finalEvent = { ...event };
+      if (!finalEvent.notes) finalEvent.notes = core.formatEventNotes(finalEvent);
+      replayedEvents.push(finalEvent);
+    }
+  }
+
+  // 3. Diff replayed outcome vs the saved outcome.
+  const { pairs, unmatchedReplayed } = pairEvents(core, savedEvents, replayedEvents);
+  const eventReports = [];
+  const unmatchedSaved = [];
+  for (const { saved, replayed } of pairs) {
+    if (!replayed) {
+      unmatchedSaved.push({ title: saved.title || saved.name || '(untitled)', key: saved.key || null });
+      continue;
+    }
+    const differences = diffEvents(saved, replayed);
+    eventReports.push({
+      title: saved.title || saved.name || '(untitled)',
+      key: saved.key || replayed.key || null,
+      action: saved._action || null,
+      mergedWithCalendar: Boolean(saved._original && saved._original.calendar),
+      differences
+    });
+  }
+
+  const differingEvents = eventReports.filter(report => report.differences.length > 0);
+  return {
+    ok: unmatchedSaved.length === 0 && unmatchedReplayed.length === 0 && differingEvents.length === 0,
+    scrapedSource,
+    counts: {
+      scraped: scrapedEvents.length,
+      replayed: replayedEvents.length,
+      saved: savedEvents.length,
+      matched: eventReports.length,
+      withDifferences: differingEvents.length
+    },
+    events: eventReports,
+    unmatchedSaved,
+    unmatchedReplayed: unmatchedReplayed.map(event => ({ title: event.title || '(untitled)', key: event.key || null })),
+    warnings
+  };
+}
+
+function formatReplayReport(report) {
+  const lines = [];
+  lines.push(`Replayed ${report.counts.scraped} scraped event(s) (${report.scrapedSource}) → ${report.counts.replayed} after dedup/merge; run recorded ${report.counts.saved}.`);
+  for (const warning of report.warnings) {
+    lines.push(`⚠ ${warning}`);
+  }
+  if (report.ok) {
+    lines.push('✓ Replay matches the saved run — no differences.');
+    return lines.join('\n');
+  }
+  for (const entry of report.unmatchedSaved) {
+    lines.push(`✖ Saved event has no replayed counterpart: "${entry.title}"${entry.key ? ` (key: ${entry.key})` : ''}`);
+  }
+  for (const entry of report.unmatchedReplayed) {
+    lines.push(`✖ Replay produced an event the run did not record: "${entry.title}"${entry.key ? ` (key: ${entry.key})` : ''}`);
+  }
+  for (const eventReport of report.events) {
+    if (eventReport.differences.length === 0) continue;
+    lines.push(`✖ "${eventReport.title}"${eventReport.action ? ` [${eventReport.action}]` : ''} — ${eventReport.differences.length} field difference(s):`);
+    for (const diff of eventReport.differences) {
+      lines.push(`    ${diff.field}:`);
+      lines.push(`      saved:    ${JSON.stringify(diff.saved)}`);
+      lines.push(`      replayed: ${JSON.stringify(diff.replayed)}`);
+    }
+  }
+  const unchanged = report.events.filter(entry => entry.differences.length === 0).length;
+  lines.push(`${unchanged} event(s) identical, ${report.counts.withDifferences} with differences.`);
+  return lines.join('\n');
+}
+
+function loadRunFile(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function main(argv) {
+  const args = argv.slice(2);
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(HELP);
+    return args.length === 0 ? 1 : 0;
+  }
+  const jsonOutput = args.includes('--json');
+  const filePath = args.find(arg => !arg.startsWith('--'));
+  if (!filePath) {
+    process.stderr.write('Missing run file path.\n\n');
+    process.stderr.write(HELP);
+    return 1;
+  }
+
+  let run;
+  try {
+    run = loadRunFile(filePath);
+  } catch (error) {
+    process.stderr.write(`Failed to read run file: ${error.message}\n`);
+    return 1;
+  }
+
+  // The merge layer logs heavily via console.log/warn; keep the CLI output to
+  // the diff itself. Set VERBOSE_REPLAY=1 to see the merge-layer logging.
+  const silenced = {};
+  if (!process.env.VERBOSE_REPLAY) {
+    for (const level of ['log', 'info', 'debug', 'warn']) {
+      silenced[level] = console[level];
+      console[level] = () => {};
+    }
+  }
+  let report;
+  try {
+    report = await replayRun(run);
+  } finally {
+    for (const level of Object.keys(silenced)) {
+      console[level] = silenced[level];
+    }
+  }
+  if (jsonOutput) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatReplayReport(report)}\n`);
+  }
+  return report.ok ? 0 : 2;
+}
+
+if (require.main === module) {
+  main(process.argv).then(
+    code => { process.exitCode = code; },
+    error => {
+      process.stderr.write(`replay-run failed: ${error.message}\n`);
+      process.exitCode = 1;
+    }
+  );
+}
+
+module.exports = {
+  replayRun,
+  collectScrapedEvents,
+  buildCalendarEventFromSnapshot,
+  reviveEventDates,
+  diffEvents,
+  formatReplayReport,
+  COMPARED_FIELDS
+};


### PR DESCRIPTION
## What

Test infrastructure round: lock in end-to-end behavior and make historical runs replayable.

### Golden pipeline test (`scripts/golden-pipeline.test.js` + `scripts/fixtures/fixture-promoter/`)
A hand-crafted 4-page promoter site modeled on bearracuda.com (landing link-aggregator with JSON-LD Organization, two event pages, a third-party ticketing page whose MusicEvent JSON-LD describes the same event as one of them) driven through the **real** stack — `SharedCore.processParser` → crawl → classify → `AiWebParser.parseEvents` → normalizer pipeline with stubbed Nominatim → `deduplicateEvents`. Fully offline and deterministic (verified across 5 consecutive runs).

Assertions cover **final output only** — never request counts, pass order, or prompt text. The AI stub answers by the *kind of answer requested* (classification / arbitration / extraction) and by page content, so pass-mechanics changes can't break it. It locks in the whole bug-fix history end-to-end: brand-stripped titles, organizer-as-bar guard, distance-ranked geocoding (rejects a Sacramento decoy for a Polk St address), coordinates-in-`location`, past-midnight end rollover in two timezones, 3 scraped records → 2 final events with exactly 1 dedup merge, low-confidence field filtering.

### Replay tool (`tools/replay-run.js` + tests)
`node tools/replay-run.js <saved-run.json>` re-runs the deterministic dedup/merge layer over a saved run's scraped events (AI arbitration disabled → fallback paths) and diffs against what the run recorded — a regression harness for merge changes against real historical runs. Exit 0 = identical, exit 2 = per-event field diffs. `--json` for machine-readable output; older run shapes fall back to `analyzedEvents`' `_original.scraper`.

### Calendar-contract tests (`scripts/calendar-contract.test.js`)
Table-driven round-trip invariants for the calendar-as-database payload: emoji titles, comma-laden addresses, coordinate `location` strings, colon/newline/URL values through `formatEventNotes`/`parseNotesIntoFields`, with the field set derived programmatically from `event-schema.js` so new fields are covered automatically.

## Notes
- Zero runtime-file changes — every entry point was already exported; only `package.json`'s explicit test list grows (directory mode still avoided).
- 199/199 tests after rebasing onto main (+13).
- Trivially conflicts with #1467 on the `package.json` test line — whichever merges second needs a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP