### PR TITLE
OG studio: favicon in every layout, bigger type, natural-ratio editorial photo

### DIFF
--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -106,6 +106,8 @@
     .sep-v { width: 1px; height: 22px; background: var(--line-strong); margin: 0 2px; flex-shrink: 0; }
     .dots { display: inline-flex; gap: 4px; align-items: center; }
     .dot { width: 18px; height: 18px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.25); flex-shrink: 0; }
+    .favicon-chip { width: 22px; height: 22px; border-radius: 6px; border: 1px solid rgba(255,255,255,0.25); background: #fff; object-fit: contain; flex-shrink: 0; }
+    .favicon-chip[hidden] { display: none; }
     .tiny { font-size: 11.5px; color: var(--text-dim); display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; cursor: pointer; user-select: none; }
     .tiny input { accent-color: var(--brand); margin: 0; }
     .tiny b { color: var(--text); font-weight: 600; }
@@ -157,27 +159,27 @@
       opacity: 0.07; mix-blend-mode: overlay;
     }
     .brand-mark { display: inline-flex; align-items: center; gap: 12px; }
-    .brand-mark img { width: 44px; height: 44px; border-radius: 12px; }
-    .brand-mark span { font-size: 22px; font-weight: 700; letter-spacing: 0.2px; }
+    .brand-mark img { width: 52px; height: 52px; border-radius: 14px; }
+    .brand-mark span { font-size: 28px; font-weight: 700; letter-spacing: 0.2px; }
 
     .meta-row { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
     .meta-pill {
       display: inline-flex; align-items: center; gap: 8px;
       font-family: 'Space Grotesk', sans-serif;
-      font-size: 21px; font-weight: 600; letter-spacing: 0.3px;
-      padding: 10px 20px; border-radius: 100px;
+      font-size: 28px; font-weight: 600; letter-spacing: 0.3px;
+      padding: 13px 26px; border-radius: 100px;
       background: rgba(255,255,255,0.13);
       border: 1px solid rgba(255,255,255,0.22);
       backdrop-filter: blur(6px);
       -webkit-backdrop-filter: blur(6px);
       white-space: nowrap;
     }
-    .meta-plain { font-family: 'Space Grotesk', sans-serif; font-size: 23px; font-weight: 500; opacity: 0.92; }
+    .meta-plain { font-family: 'Space Grotesk', sans-serif; font-size: 30px; font-weight: 500; opacity: 0.92; }
 
     .og-title { font-weight: 800; letter-spacing: -1.5px; line-height: 1.02; margin: 0; text-wrap: balance; }
-    .og-title.t-lg { font-size: 92px; }
-    .og-title.t-md { font-size: 72px; }
-    .og-title.t-sm { font-size: 54px; letter-spacing: -1px; }
+    .og-title.t-lg { font-size: 110px; }
+    .og-title.t-md { font-size: 88px; }
+    .og-title.t-sm { font-size: 66px; letter-spacing: -1px; }
 
     /* --- 1. Neat (the actual NEAT gradient library) + Aurora Mesh (CSS approximation) --- */
     .l-neat, .l-aurora { background: var(--p-deep, #0a0a12); }
@@ -208,10 +210,10 @@
     }
     .l-silk .kicker {
       font-family: 'Space Grotesk', sans-serif;
-      font-size: 19px; font-weight: 700; letter-spacing: 5px; text-transform: uppercase; opacity: 0.9;
+      font-size: 25px; font-weight: 700; letter-spacing: 5px; text-transform: uppercase; opacity: 0.9;
       display: flex; align-items: center; gap: 16px;
     }
-    .l-silk .kicker img { width: 40px; height: 40px; border-radius: 11px; }
+    .l-silk .kicker img { width: 48px; height: 48px; border-radius: 13px; }
     .l-silk .og-title { text-shadow: 0 8px 50px rgba(0,0,0,0.45); }
 
     /* --- 3. Photo Split --- */
@@ -259,8 +261,8 @@
       -webkit-backdrop-filter: blur(8px);
       padding: 16px 22px; border-radius: 18px;
     }
-    .l-poster .date-tag .d1 { font-size: 15px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; opacity: 0.85; margin-bottom: 7px; }
-    .l-poster .date-tag .d2 { font-size: 30px; font-weight: 700; }
+    .l-poster .date-tag .d1 { font-size: 20px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; opacity: 0.85; margin-bottom: 7px; }
+    .l-poster .date-tag .d2 { font-size: 38px; font-weight: 700; }
     .l-poster .og-title { max-width: 900px; text-shadow: 0 6px 36px rgba(0,0,0,0.5); }
 
     /* --- 5. Editorial Minimal --- */
@@ -272,7 +274,7 @@
     .l-editorial .head { display: flex; justify-content: space-between; align-items: center; }
     .l-editorial .brand-mark span { color: #131217; }
     .l-editorial .city-tag {
-      font-family: 'Space Grotesk', sans-serif; font-size: 18px; font-weight: 700;
+      font-family: 'Space Grotesk', sans-serif; font-size: 24px; font-weight: 700;
       letter-spacing: 3px; text-transform: uppercase; color: #6d6a75;
     }
     .l-editorial .og-title { color: #131217; letter-spacing: -2.5px; }
@@ -285,9 +287,10 @@
       animation: drift3 18s ease-in-out infinite alternate;
     }
     .l-editorial .photo-chip {
-      position: absolute; right: 80px; top: 150px;
-      width: 300px; height: 300px; border-radius: 28px;
-      background-size: cover; background-position: center;
+      /* real <img> so the photo keeps its natural aspect ratio — no square crop */
+      position: absolute; right: 76px; top: 130px;
+      max-width: 400px; max-height: 380px; width: auto; height: auto;
+      display: block; border-radius: 28px;
       box-shadow: 0 30px 60px rgba(19,18,23,0.25);
       transform: rotate(3deg);
       border: 6px solid #fff;
@@ -329,10 +332,10 @@
     .l-c-split .left-side { position: absolute; left: 0; top: 0; bottom: 0; width: 55%; clip-path: polygon(0 0, 100% 0, 85% 100%, 0 100%); z-index: 1; }
     .l-c-split .left-side .cover { position: absolute; inset: 0; background-size: cover; background-position: center; opacity: 0.3; }
     .l-c-split .left-content { position: absolute; left: 60px; top: 60px; bottom: 60px; width: 420px; display: flex; flex-direction: column; justify-content: center; z-index: 2; }
-    .l-c-split .brand { font-size: 20px; font-weight: 700; text-transform: uppercase; letter-spacing: 3px; margin-bottom: 30px; opacity: 0.9; }
-    .l-c-split .event-title { font-size: 64px; line-height: 0.95; font-weight: 800; margin-bottom: 20px; text-shadow: 0 4px 20px rgba(0,0,0,0.5); }
-    .l-c-split .event-date { font-size: 24px; opacity: 0.9; margin-bottom: 10px; }
-    .l-c-split .venue { font-size: 20px; opacity: 0.8; }
+    .l-c-split .brand { font-size: 24px; font-weight: 700; text-transform: uppercase; letter-spacing: 3px; margin-bottom: 30px; opacity: 0.9; }
+    .l-c-split .event-title { font-size: 76px; line-height: 0.95; font-weight: 800; margin-bottom: 20px; text-shadow: 0 4px 20px rgba(0,0,0,0.5); }
+    .l-c-split .event-date { font-size: 30px; opacity: 0.9; margin-bottom: 10px; }
+    .l-c-split .venue { font-size: 26px; opacity: 0.8; }
     .l-c-split .right-side { position: absolute; right: 0; top: 0; bottom: 0; width: 50%; display: flex; align-items: center; justify-content: center; z-index: 0; }
     .l-c-split .event-image { width: 400px; height: 500px; background-size: cover; background-position: center; box-shadow: -20px 0 60px rgba(0,0,0,0.5); }
 
@@ -340,34 +343,34 @@
     .l-c-glass .cover { position: absolute; inset: 0; background-size: cover; background-position: center; filter: brightness(0.6); }
     .l-c-glass .glass { position: absolute; inset: 80px; background: rgba(255,255,255,0.12); border: 1px solid rgba(255,255,255,0.25); border-radius: 24px; backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
     .l-c-glass .glass .inner { position: absolute; inset: 0; padding: 40px; display: flex; flex-direction: column; justify-content: center; }
-    .l-c-glass .event-title { font-size: 72px; font-weight: 800; line-height: 0.95; text-shadow: 0 6px 30px rgba(0,0,0,0.6); }
-    .l-c-glass .event-date { margin-top: 16px; font-size: 26px; opacity: 0.95; }
-    .l-c-glass .venue { margin-top: 8px; font-size: 22px; opacity: 0.85; }
+    .l-c-glass .event-title { font-size: 84px; font-weight: 800; line-height: 0.95; text-shadow: 0 6px 30px rgba(0,0,0,0.6); }
+    .l-c-glass .event-date { margin-top: 16px; font-size: 32px; opacity: 0.95; }
+    .l-c-glass .venue { margin-top: 8px; font-size: 28px; opacity: 0.85; }
 
     /* Classic: Bold & Centered */
     .l-c-bold { display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 80px; }
-    .l-c-bold .event-title { font-size: 84px; font-weight: 800; line-height: 0.9; text-shadow: 0 8px 40px rgba(0,0,0,0.4); margin-bottom: 30px; }
-    .l-c-bold .event-details { font-size: 32px; opacity: 0.95; line-height: 1.4; margin-bottom: 20px; }
-    .l-c-bold .event-venue { font-size: 28px; opacity: 0.85; }
+    .l-c-bold .event-title { font-size: 98px; font-weight: 800; line-height: 0.9; text-shadow: 0 8px 40px rgba(0,0,0,0.4); margin-bottom: 30px; }
+    .l-c-bold .event-details { font-size: 38px; opacity: 0.95; line-height: 1.4; margin-bottom: 20px; }
+    .l-c-bold .event-venue { font-size: 32px; opacity: 0.85; }
     .l-c-bold .logo-stamp { position: absolute; bottom: 60px; right: 60px; width: 80px; height: 80px; object-fit: contain; opacity: 0.8; }
 
     /* Classic: Side by Side */
     .l-c-side { display: flex; }
     .l-c-side .left-panel { flex: 1; padding: 80px 60px; display: flex; flex-direction: column; justify-content: center; background: rgba(0,0,0,0.2); }
     .l-c-side .right-panel { flex: 1; padding: 80px 60px; display: flex; flex-direction: column; justify-content: center; }
-    .l-c-side .event-title { font-size: 56px; font-weight: 800; line-height: 1; margin-bottom: 24px; text-shadow: 0 4px 20px rgba(0,0,0,0.3); }
-    .l-c-side .event-date { font-size: 28px; opacity: 0.95; margin-bottom: 12px; }
-    .l-c-side .event-venue { font-size: 24px; opacity: 0.9; margin-bottom: 24px; }
-    .l-c-side .description { font-size: 20px; opacity: 0.85; line-height: 1.5; display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical; overflow: hidden; }
+    .l-c-side .event-title { font-size: 66px; font-weight: 800; line-height: 1; margin-bottom: 24px; text-shadow: 0 4px 20px rgba(0,0,0,0.3); }
+    .l-c-side .event-date { font-size: 34px; opacity: 0.95; margin-bottom: 12px; }
+    .l-c-side .event-venue { font-size: 28px; opacity: 0.9; margin-bottom: 24px; }
+    .l-c-side .description { font-size: 26px; opacity: 0.85; line-height: 1.45; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
     .l-c-side .chunky-logo { width: 120px; height: 120px; object-fit: contain; margin-bottom: 30px; }
 
     /* Classic: Banner */
     .l-c-banner .banner-bg { position: absolute; inset: 0; background-size: cover; background-position: center; filter: brightness(0.4) blur(2px); }
     .l-c-banner .banner-content { position: relative; z-index: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; text-align: center; padding: 80px; }
     .l-c-banner .brand-logo { width: 100px; height: 100px; object-fit: contain; margin-bottom: 40px; filter: drop-shadow(0 4px 12px rgba(0,0,0,0.3)); }
-    .l-c-banner .event-title { font-size: 72px; font-weight: 800; line-height: 0.95; margin-bottom: 30px; text-shadow: 0 6px 30px rgba(0,0,0,0.6); text-transform: uppercase; letter-spacing: -1px; }
-    .l-c-banner .event-info { font-size: 32px; opacity: 0.95; margin-bottom: 12px; font-weight: 600; }
-    .l-c-banner .event-cta { background: #fff; color: #111; padding: 16px 40px; border-radius: 50px; font-size: 24px; font-weight: 700; margin-top: 20px; box-shadow: 0 8px 24px rgba(0,0,0,0.3); }
+    .l-c-banner .event-title { font-size: 84px; font-weight: 800; line-height: 0.95; margin-bottom: 30px; text-shadow: 0 6px 30px rgba(0,0,0,0.6); text-transform: uppercase; letter-spacing: -1px; }
+    .l-c-banner .event-info { font-size: 38px; opacity: 0.95; margin-bottom: 12px; font-weight: 600; }
+    .l-c-banner .event-cta { background: #fff; color: #111; padding: 18px 46px; border-radius: 50px; font-size: 30px; font-weight: 700; margin-top: 20px; box-shadow: 0 8px 24px rgba(0,0,0,0.3); }
 
     /* Classic: CSS Pattern */
     .l-c-pattern { background: #000; }
@@ -379,10 +382,10 @@
       display: flex; flex-direction: column; justify-content: center;
       padding: 60px 72px;
     }
-    .l-c-pattern .brand { font-size: 15px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; margin-bottom: 18px; }
-    .l-c-pattern .event-title { font-size: 66px; line-height: 0.95; font-weight: 800; margin-bottom: 20px; }
-    .l-c-pattern .event-date { font-size: 26px; opacity: 0.9; margin-bottom: 8px; }
-    .l-c-pattern .event-venue { font-size: 22px; opacity: 0.8; }
+    .l-c-pattern .brand { font-size: 20px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; margin-bottom: 18px; }
+    .l-c-pattern .event-title { font-size: 78px; line-height: 0.95; font-weight: 800; margin-bottom: 20px; }
+    .l-c-pattern .event-date { font-size: 32px; opacity: 0.9; margin-bottom: 8px; }
+    .l-c-pattern .event-venue { font-size: 28px; opacity: 0.8; }
 
     /* pause all artboard animation when toggled off */
     body.anims-off .artboard * { animation-play-state: paused !important; }
@@ -418,6 +421,7 @@
       <button id="randomBtn" class="btn primary" title="Random event">🎲</button>
       <button id="reloadBtn" class="btn" title="Reload events">↻</button>
       <span class="sep-v"></span>
+      <img id="faviconChip" class="favicon-chip" alt="favicon" hidden>
       <span class="dots" id="paletteStrip"></span>
       <span class="tiny" id="paletteSource"></span>
       <span class="sep-v"></span>
@@ -465,6 +469,7 @@
       const cssPatternSelect = document.getElementById('cssPatternSelect');
       const paletteStrip = document.getElementById('paletteStrip');
       const paletteSource = document.getElementById('paletteSource');
+      const faviconChip = document.getElementById('faviconChip');
       const grid = document.getElementById('grid');
 
       // ---------- color utilities ----------
@@ -817,6 +822,38 @@
             .map(hex => `<div class="dot" title="${hex}" style="background:${hex}"></div>`)
             .join('');
           paletteSource.innerHTML = `<b>${escapeHtml(p.source)}</b>`;
+          this.renderFaviconChip();
+        }
+
+        // Resolve the locally-downloaded favicon for the selected event via the
+        // shared FilenameUtils (favicon field wins over website, same as the map markers)
+        getFaviconInfo(ev) {
+          if (!ev || !window.FilenameUtils) return null;
+          const raw = String(ev.favicon || ev.website || '').trim();
+          if (!raw) return null;
+          let url = raw;
+          if (!url.startsWith('http://') && !url.startsWith('https://')) url = 'https://' + url;
+          try {
+            return {
+              path: window.FilenameUtils.convertWebsiteUrlToFaviconPath(url, '../img/favicons'),
+              from: ev.favicon ? 'favicon field' : 'website field'
+            };
+          } catch (e) {
+            logger.debug(COMPONENT, 'Could not derive favicon path', { url: raw, error: e.message });
+            return null;
+          }
+        }
+
+        renderFaviconChip() {
+          const fav = this.getFaviconInfo(this.selectedEvent);
+          if (fav) {
+            faviconChip.hidden = false;
+            faviconChip.title = `${fav.path.split('/').pop()} (from ${fav.from})`;
+            faviconChip.src = fav.path;
+          } else {
+            faviconChip.hidden = true;
+            faviconChip.removeAttribute('src');
+          }
         }
 
         variants(data, p) {
@@ -950,7 +987,7 @@
               html: `
                 <div class="artboard l-editorial">
                   <div class="orb" style="background:radial-gradient(circle, ${p.c1}, transparent 70%)"></div>
-                  ${hasImage ? `<div class="photo-chip" style="background-image:url('${img}'), linear-gradient(145deg, ${p.c1}, ${p.c4})"></div>` : ''}
+                  ${hasImage ? `<img class="photo-chip" src="${escapeHtml(data.cover)}" alt="" style="background:linear-gradient(145deg, ${p.c1}, ${p.c4})" onerror="this.remove()">` : ''}
                   <div class="content">
                     <div class="head">
                       ${brand}
@@ -958,7 +995,7 @@
                     </div>
                     <div>
                       <div class="accent-bar" style="background:linear-gradient(90deg, ${p.bg}, ${p.c3})"></div>
-                      <h2 class="og-title ${data.titleClass}" style="max-width:${hasImage ? '760px' : '1000px'};">${escapeHtml(data.title)}</h2>
+                      <h2 class="og-title ${data.titleClass}" style="max-width:${hasImage ? '660px' : '1000px'};">${escapeHtml(data.title)}</h2>
                     </div>
                     <div class="meta-row">
                       <div class="meta-plain"><b>${escapeHtml(data.date)}</b>${data.time ? ' · ' + escapeHtml(data.time) : ''}</div>
@@ -1357,6 +1394,9 @@
             clearTimeout(resizeTimer);
             resizeTimer = setTimeout(() => this.fitArtboards(), 120);
           });
+
+          // Hide the favicon chip when the local file doesn't exist for this domain
+          faviconChip.addEventListener('error', () => { faviconChip.hidden = true; });
 
           // Re-render once the NEAT module finishes loading (it races with init)
           window.addEventListener('neat-ready', () => {

--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -176,6 +176,14 @@
     }
     .meta-plain { font-family: 'Space Grotesk', sans-serif; font-size: 30px; font-weight: 500; opacity: 0.92; }
 
+    /* Downloaded venue/event favicon shown beside the venue name in every layout */
+    .artboard .fav-ico {
+      width: 40px; height: 40px; border-radius: 10px;
+      background: #fff; object-fit: contain; padding: 2px;
+      vertical-align: -10px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+    }
+
     .og-title { font-weight: 800; letter-spacing: -1.5px; line-height: 1.02; margin: 0; text-wrap: balance; }
     .og-title.t-lg { font-size: 110px; }
     .og-title.t-md { font-size: 88px; }
@@ -798,7 +806,8 @@
             time: ev.time || '',
             city: getCityConfig(this.currentCity)?.name || 'City',
             description: ev.tea || 'Join us for an amazing bear community event!',
-            cover: (coverInput.value || '').trim() || (ev.image || '').trim()
+            cover: (coverInput.value || '').trim() || (ev.image || '').trim(),
+            favicon: (this.getFaviconInfo(ev) || {}).path || ''
           };
         }
 
@@ -864,10 +873,14 @@
               <img src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad">
               <span>chunky.dad</span>
             </div>`;
+          // The downloaded favicon stands in for the 📍 pin wherever the venue is named
+          const venueIco = data.favicon
+            ? `<img class="fav-ico" src="${escapeHtml(data.favicon)}" alt="" onerror="this.remove()">`
+            : '📍';
           const metaPills = `
             <div class="meta-row">
               <div class="meta-pill">📅 ${escapeHtml(data.date)}${data.time ? ' · ' + escapeHtml(data.time) : ''}</div>
-              <div class="meta-pill">📍 ${escapeHtml(data.venue)}</div>
+              <div class="meta-pill">${venueIco} ${escapeHtml(data.venue)}</div>
             </div>`;
 
           return [
@@ -943,7 +956,7 @@
                       <h2 class="og-title ${data.titleClass}">${escapeHtml(data.title)}</h2>
                       <div class="meta-row" style="flex-direction:column;align-items:flex-start;gap:10px;">
                         <div class="meta-plain">📅 ${escapeHtml(data.date)}${data.time ? ' · ' + escapeHtml(data.time) : ''}</div>
-                        <div class="meta-plain">📍 ${escapeHtml(data.venue)} · ${escapeHtml(data.city)}</div>
+                        <div class="meta-plain">${venueIco} ${escapeHtml(data.venue)} · ${escapeHtml(data.city)}</div>
                       </div>
                     </div>
                   </div>
@@ -974,7 +987,7 @@
                     </div>
                     <h2 class="og-title ${data.titleClass}">${escapeHtml(data.title)}</h2>
                     <div class="meta-row">
-                      <div class="meta-pill" style="border-color:${hexToRgba(p.c2, 0.6)}">📍 ${escapeHtml(data.venue)} · ${escapeHtml(data.city)}</div>
+                      <div class="meta-pill" style="border-color:${hexToRgba(p.c2, 0.6)}">${venueIco} ${escapeHtml(data.venue)} · ${escapeHtml(data.city)}</div>
                     </div>
                   </div>
                 </div>`
@@ -999,7 +1012,7 @@
                     </div>
                     <div class="meta-row">
                       <div class="meta-plain"><b>${escapeHtml(data.date)}</b>${data.time ? ' · ' + escapeHtml(data.time) : ''}</div>
-                      <div class="meta-plain">${escapeHtml(data.venue)}</div>
+                      <div class="meta-plain">${data.favicon ? venueIco + ' ' : ''}${escapeHtml(data.venue)}</div>
                     </div>
                   </div>
                 </div>`
@@ -1033,6 +1046,9 @@
           const img = cssUrl(data.cover);
           const grad = `linear-gradient(135deg, ${p.c1} 0%, ${p.c4} 100%)`;
           const when = `${escapeHtml(data.date)}${data.time ? ' · ' + escapeHtml(data.time) : ''}`;
+          const venueIco = data.favicon
+            ? `<img class="fav-ico" src="${escapeHtml(data.favicon)}" alt="" onerror="this.remove()"> `
+            : '';
 
           return [
             {
@@ -1048,7 +1064,7 @@
                     <div class="brand" style="color:${p.bg}">chunky.dad</div>
                     <div class="event-title">${escapeHtml(data.title)}</div>
                     <div class="event-date">${when}</div>
-                    <div class="event-venue">@ ${escapeHtml(data.venue)}</div>
+                    <div class="event-venue">${venueIco}@ ${escapeHtml(data.venue)}</div>
                   </div>
                 </div>`
             },
@@ -1061,7 +1077,7 @@
                 <div class="artboard l-c-bold" style="background:${grad}">
                   <div class="event-title">${escapeHtml(data.title)}</div>
                   <div class="event-details">${when}</div>
-                  <div class="event-venue">@ ${escapeHtml(data.venue)}</div>
+                  <div class="event-venue">${venueIco}@ ${escapeHtml(data.venue)}</div>
                   <img class="logo-stamp" src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" />
                 </div>`
             },
@@ -1078,7 +1094,7 @@
                   </div>
                   <div class="right-panel">
                     <div class="event-date">${escapeHtml(data.date)}</div>
-                    <div class="event-venue">@ ${escapeHtml(data.venue)}${data.time ? ' · ' + escapeHtml(data.time) : ''}</div>
+                    <div class="event-venue">${venueIco}@ ${escapeHtml(data.venue)}${data.time ? ' · ' + escapeHtml(data.time) : ''}</div>
                     <div class="description">${escapeHtml(data.description)}</div>
                   </div>
                 </div>`
@@ -1094,7 +1110,7 @@
                   <div class="banner-content">
                     <img class="brand-logo" src="../Rising_Star_Ryan_Head_Compressed.png" alt="chunky.dad" />
                     <div class="event-title">${escapeHtml(data.title)}</div>
-                    <div class="event-info">${when} · ${escapeHtml(data.venue)}</div>
+                    <div class="event-info">${when} · ${venueIco}${escapeHtml(data.venue)}</div>
                     <div class="event-cta">Get Tickets</div>
                   </div>
                 </div>`
@@ -1113,7 +1129,7 @@
                     <div class="brand">chunky.dad</div>
                     <div class="event-title">${escapeHtml(data.title)}</div>
                     <div class="event-date">${when}</div>
-                    <div class="venue">@ ${escapeHtml(data.venue)}</div>
+                    <div class="venue">${venueIco}@ ${escapeHtml(data.venue)}</div>
                   </div>
                   <div class="right-side">
                     <div class="event-image" style="background-image:${hasImage ? `url('${img}'), ` : ''}linear-gradient(160deg, ${p.c2}, ${p.c4})"></div>
@@ -1132,7 +1148,7 @@
                     <div class="inner">
                       <div class="event-title">${escapeHtml(data.title)}</div>
                       <div class="event-date">${when}</div>
-                      <div class="venue">@ ${escapeHtml(data.venue)}</div>
+                      <div class="venue">${venueIco}@ ${escapeHtml(data.venue)}</div>
                     </div>
                   </div>
                 </div>`


### PR DESCRIPTION
Follow-up to #1446 with the next round of feedback on the OG Image Studio (`testing/test-og-event-layouts-calendar.html`):

- **Favicon in the OG images**: every one of the 13 layouts now shows the venue's downloaded favicon as a small white-backed rounded chip beside the venue name — it replaces the 📍 pin in the new variants' meta pills and prefixes the `@ venue` line in the classics. Resolved via the shared `FilenameUtils.convertWebsiteUrlToFaviconPath()` with the event's hardcoded `favicon` field taking precedence over `website` (same rule as the map markers). If the local file is missing, the chip removes itself gracefully.
- **Toolbar favicon chip**: the resolved favicon also shows in the toolbar next to the palette dots, with a tooltip naming the file and which field it came from.
- **Bigger type**: font sizes bumped ~15–30% across all layouts (titles 110/88/66px, pills 28px, etc.) since OG images are mostly seen at thumbnail size in phone messaging apps.
- **Editorial Minimal photo**: now a real `<img>` that keeps the image's natural aspect ratio (capped 400×380px) instead of a 300px square crop — still in the rotated rounded white frame with shadow.

Verified in headless Chrome against NYC data with zero console errors, including the real NEAT gradient card and a forced 2:1 landscape image for the editorial aspect-ratio check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)