### PR TITLE
fix(scraper): geocode retry ladder, self-healing geocode cache, location preserve-on-empty

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1101,9 +1101,16 @@ class ScriptableAdapter {
         pageCacheConfig.enabled &&
         (options.method || "GET").toUpperCase() === "GET" &&
         !options.body;
+      // Optional caller hook (options.isCacheableResponse): a response it
+      // rejects is neither served from the disk cache nor written to it —
+      // used by the geocode path so an empty Nominatim body can't poison a
+      // venue for the whole TTL. Callers that don't pass it are unaffected.
+      const isCacheableResponse = (responseData) =>
+        typeof options.isCacheableResponse !== "function" ||
+        options.isCacheableResponse(responseData) !== false;
       if (canUseCache) {
         const cachedPage = await this.readCachedPage(url, pageCacheConfig);
-        if (cachedPage) {
+        if (cachedPage && isCacheableResponse(cachedPage)) {
           return cachedPage;
         }
       }
@@ -1138,7 +1145,7 @@ class ScriptableAdapter {
           headers: request.response ? request.response.headers : {},
         };
 
-        if (canUseCache) {
+        if (canUseCache && isCacheableResponse(responseData)) {
           await this.writeCachedPage(url, responseData, pageCacheConfig);
         }
 
@@ -1154,6 +1161,57 @@ class ScriptableAdapter {
       const errorMessage = `📱 Scriptable: ✗ HTTP request failed for ${url}: ${error.message}`;
       console.log(errorMessage);
       throw new Error(`HTTP request failed for ${url}: ${error.message}`);
+    }
+  }
+
+  // Native reverse geocode via Scriptable's Location API (Apple's geocoding
+  // service — no network quota, no Nominatim rate-limit budget). Returns a
+  // "street, city, state zip" string or null when nothing usable comes back.
+  // normalizers.js calls this hook only when it exists; all Scriptable API
+  // usage stays in this adapter (pure-module rule).
+  async reverseGeocode(lat, lon) {
+    if (
+      typeof Location === "undefined" ||
+      typeof Location.reverseGeocode !== "function"
+    ) {
+      return null;
+    }
+    try {
+      const placemarks = await Location.reverseGeocode(lat, lon);
+      const mark =
+        Array.isArray(placemarks) && placemarks.length > 0
+          ? placemarks[0]
+          : null;
+      if (!mark || typeof mark !== "object") {
+        return null;
+      }
+      const postal =
+        mark.postalAddress && typeof mark.postalAddress === "object"
+          ? mark.postalAddress
+          : {};
+      const clean = (value) =>
+        typeof value === "string" || typeof value === "number"
+          ? String(value).trim()
+          : "";
+      let street = clean(postal.street);
+      if (!street) {
+        street = [clean(mark.subThoroughfare), clean(mark.thoroughfare)]
+          .filter((part) => part.length > 0)
+          .join(" ");
+      }
+      const city = clean(postal.city) || clean(mark.locality);
+      const state = clean(postal.state) || clean(mark.administrativeArea);
+      const zip = clean(postal.postalCode) || clean(mark.postalCode);
+      const stateZip = [state, zip].filter((part) => part.length > 0).join(" ");
+      const parts = [street, city, stateZip].filter(
+        (part) => part.length > 0,
+      );
+      return parts.length > 0 ? parts.join(", ") : null;
+    } catch (error) {
+      console.log(
+        `📱 Scriptable: Native reverse geocode failed for ${lat},${lon}: ${error.message}`,
+      );
+      return null;
     }
   }
 

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -238,9 +238,15 @@ class WebAdapter {
         try {
             const pageCacheConfig = this.getPageCacheConfig();
             const canUseCache = pageCacheConfig.enabled && (options.method || 'GET').toUpperCase() === 'GET' && !options.body;
+            // Optional caller hook (options.isCacheableResponse): a response it
+            // rejects is neither served from the disk cache nor written to it —
+            // used by the geocode path so an empty Nominatim body can't poison a
+            // venue for the whole TTL. Callers that don't pass it are unaffected.
+            const isCacheableResponse = (responseData) =>
+                typeof options.isCacheableResponse !== 'function' || options.isCacheableResponse(responseData) !== false;
             if (canUseCache) {
                 const cachedPage = await this.readCachedPage(url, pageCacheConfig);
-                if (cachedPage) {
+                if (cachedPage && isCacheableResponse(cachedPage)) {
                     return cachedPage;
                 }
             }
@@ -279,7 +285,7 @@ class WebAdapter {
                     headers: Object.fromEntries(response.headers.entries())
                 };
 
-                if (canUseCache) {
+                if (canUseCache && isCacheableResponse(responseData)) {
                     await this.writeCachedPage(url, responseData, pageCacheConfig);
                 }
 

--- a/scripts/metrics-sections.js
+++ b/scripts/metrics-sections.js
@@ -46,9 +46,11 @@ const GUARD_LABELS = [
     { key: 'taglineRejected', label: 'Site tagline rejected as description' },
     { key: 'geocodePicked', label: 'Geocode candidate picked by distance' },
     { key: 'geocodeRejected', label: 'Geocode rejected (outside event city)' },
+    { key: 'geocodeNoResults', label: 'Geocode found no results (address unresolvable)' },
     { key: 'degenerateEndCaught', label: 'Degenerate end date caught' },
     { key: 'coordsPreserved', label: 'Calendar coordinates preserved' },
-    { key: 'barPreserved', label: 'Calendar venue preserved' }
+    { key: 'barPreserved', label: 'Calendar venue preserved' },
+    { key: 'locationPreserved', label: 'Calendar location preserved' }
 ];
 
 const SIGNALS_PASS_ORDER = ['extraction', 'context-prep', 'repair', 'merge-arbitration', 'ocr'];

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -727,6 +727,25 @@ class LocationNormalizer extends BaseNormalizer {
 // rejected: a candidate 50+ km away is a same-named street/place in another city.
 const CITY_CENTER_RADIUS_KM = 50;
 
+// Hard cap on Nominatim requests per event for the forward-geocode retry
+// ladder. Never raise this without revisiting the rate-limit budget.
+const MAX_GEOCODE_QUERIES_PER_EVENT = 3;
+
+// Street-type words a trailing directional can follow ("Cheshire Bridge Rd NE").
+const GEOCODE_STREET_TYPE_WORDS = 'Street|St|Road|Rd|Avenue|Ave|Boulevard|Blvd|Drive|Dr|Lane|Ln|Way|Place|Pl|Court|Ct|Parkway|Pkwy|Highway|Hwy';
+// Longest alternatives first so "Northeast" matches before "North".
+const GEOCODE_DIRECTIONAL_WORDS = 'Northeast|Northwest|Southeast|Southwest|North|South|East|West|NE|NW|SE|SW|N|S|E|W';
+// A directional that FOLLOWS a street-type word and ends the address or a
+// comma-separated segment ("...Cheshire Bridge Rd NE", "...Road Northeast,
+// Atlanta"). Nominatim's free-text parser returns 0 results for these
+// (verified live 2026-07-12). Directional PREFIXES that are part of the
+// street name ("3702 N Halsted", "722 E Burnside") never match: there the
+// directional precedes the name instead of following a street type.
+const GEOCODE_TRAILING_DIRECTIONAL_RE = new RegExp(
+    `\\b((?:${GEOCODE_STREET_TYPE_WORDS})\\.?)\\s+(?:${GEOCODE_DIRECTIONAL_WORDS})\\.?(?=\\s*(?:,|$))`,
+    'gi'
+);
+
 class OpenStreetMapNormalizer extends BaseNormalizer {
     constructor(core) {
         super(core);
@@ -778,17 +797,63 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         return null;
     }
 
+    // Usable geocode payload: a non-empty array (forward search) or an object
+    // (reverse lookup). An empty array is Nominatim's "no results" — a transient
+    // bad fetch of one must never be served from the persistent cache for its
+    // whole TTL (observed 2026-07-12: cached empty bodies silently skipped
+    // Chicago and Provincetown venues that geocode fine live).
+    isUsableGeocodeData(data) {
+        if (Array.isArray(data)) return data.length > 0;
+        return data !== null && data !== undefined && typeof data === 'object';
+    }
+
+    // Cache-worthiness hook handed to the adapters via options.isCacheableResponse:
+    // an empty-array or unparseable Nominatim body must not be written to the disk
+    // cache, and a previously cached one is treated as a miss (self-heals poisoned
+    // entries from earlier runs). Adapters apply this generically; only the
+    // geocode fetch path passes it, so website page caching is untouched.
+    isCacheableGeocodeResponse(responseData) {
+        const body = responseData && typeof responseData.html === 'string'
+            ? responseData.html
+            : (typeof responseData === 'string' ? responseData : null);
+        if (body === null) return true; // unknown shape — leave generic caching alone
+        try {
+            return this.isUsableGeocodeData(JSON.parse(body));
+        } catch (e) {
+            return false;
+        }
+    }
+
+    // Human-readable label for cache-bypass logging: the decoded q= parameter
+    // when present, else the URL itself (reverse lookups have no q=).
+    describeGeocodeQuery(url) {
+        const match = /[?&]q=([^&]*)/.exec(String(url || ''));
+        if (match) {
+            try {
+                return decodeURIComponent(match[1]);
+            } catch (e) {
+                return match[1];
+            }
+        }
+        return String(url || '');
+    }
+
     async fetchDataWithCacheAndRateLimit(url, options, httpAdapter) {
-        // 1. Check in-memory cache
+        // 1. Check in-memory cache (per-run: a live-fetched empty result stays
+        //    here so the same address is never re-queried within one run)
         if (this.memoryCache[url]) {
             return this.memoryCache[url];
         }
 
-        // 2. Check persistent cache
+        // 2. Check persistent cache. A cached empty/unusable geocode body is a
+        //    poisoned entry from an earlier run — treat it as a miss and refetch.
         const persistentData = await this.checkPersistentCache(url, httpAdapter);
         if (persistentData) {
-            this.memoryCache[url] = persistentData;
-            return persistentData;
+            if (this.isUsableGeocodeData(persistentData)) {
+                this.memoryCache[url] = persistentData;
+                return persistentData;
+            }
+            console.log(`🗺️ OpenStreetMapNormalizer: Ignoring cached empty geocode result for "${this.describeGeocodeQuery(url)}" — refetching`);
         }
 
         // 3. Not cached, so we must fetch. Delay for rate limit first.
@@ -892,6 +957,53 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         return nearest;
     }
 
+    // Strip directionals that FOLLOW a street-type word — at the end of the
+    // address or before a comma. "2069 Cheshire Bridge Rd NE" → "2069 Cheshire
+    // Bridge Rd"; "…Road Northeast, Atlanta, GA" → "…Road, Atlanta, GA".
+    // Directional prefixes ("3702 N Halsted", "722 E Burnside") pass through
+    // unchanged (see GEOCODE_TRAILING_DIRECTIONAL_RE).
+    stripTrailingDirectionals(address) {
+        return String(address || '')
+            .replace(GEOCODE_TRAILING_DIRECTIONAL_RE, '$1')
+            .replace(/\s+,/g, ',')
+            .trim();
+    }
+
+    // Forward-geocode retry ladder: deduped, ordered query strings, hard-capped
+    // at MAX_GEOCODE_QUERIES_PER_EVENT. Order:
+    //   1. The query exactly as built today (city-anchored when the address
+    //      doesn't already contain the city).
+    //   2. The address with trailing directionals stripped (same anchoring) —
+    //      Nominatim's free-text parser chokes on "Rd NE" / "Road Northeast".
+    //   3. "<bar>, <city>" — venue-name lookup rescues venues OSM knows by name.
+    buildGeocodeQueryVariants(address, eventCity, bar) {
+        const city = typeof eventCity === 'string' ? eventCity.trim() : '';
+        const anchorToCity = (text) => {
+            const includesCity = city && text.toLowerCase().includes(city.toLowerCase());
+            return city && !includesCity ? `${text}, ${city}` : text;
+        };
+        const variants = [];
+        const seen = new Set();
+        const push = (query) => {
+            const trimmed = typeof query === 'string' ? query.trim() : '';
+            if (!trimmed) return;
+            const key = trimmed.toLowerCase();
+            if (seen.has(key)) return; // skip variants identical to an earlier one
+            seen.add(key);
+            variants.push(trimmed);
+        };
+
+        const baseAddress = String(address || '').trim();
+        push(anchorToCity(baseAddress));
+        push(anchorToCity(this.stripTrailingDirectionals(baseAddress)));
+        const barName = typeof bar === 'string' ? bar.trim() : '';
+        if (barName && city) {
+            push(`${barName}, ${city}`);
+        }
+
+        return variants.slice(0, MAX_GEOCODE_QUERIES_PER_EVENT);
+    }
+
     async normalizeAsync(event, httpAdapter) {
         if (!event || !httpAdapter || typeof httpAdapter.fetchData !== 'function') return event;
 
@@ -903,7 +1015,11 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         const options = {
             headers: {
                 'User-Agent': 'ChunkyDadScraper/1.0 (https://github.com/chunkeydad)'
-            }
+            },
+            // Cache-worthiness hook honored by the adapters' fetchData: never
+            // persist an empty/unparseable Nominatim body to the disk cache and
+            // treat an already-cached one as a miss (see isCacheableGeocodeResponse).
+            isCacheableResponse: (responseData) => this.isCacheableGeocodeResponse(responseData)
         };
 
         if (hasAddress && !hasLocation) {
@@ -917,39 +1033,58 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             // fall back to rejecting results whose address details don't mention the city.
             const eventCity = typeof event.city === 'string' ? event.city.trim() : '';
             const cityCenter = this.getCityCenterCoordinates(eventCity);
-            const addressIncludesCity = eventCity && address.toLowerCase().includes(eventCity.toLowerCase());
-            const queryText = eventCity && !addressIncludesCity ? `${address}, ${eventCity}` : address;
-            const query = encodeURIComponent(queryText);
             const cityValidationParam = eventCity ? '&addressdetails=1' : '';
             const resultLimit = cityCenter ? 5 : 1;
-            const url = `https://nominatim.openstreetmap.org/search?format=json&q=${query}&limit=${resultLimit}${cityValidationParam}`;
 
-            try {
-                const data = await this.fetchDataWithCacheAndRateLimit(url, options, httpAdapter);
-                if (Array.isArray(data) && data.length > 0) {
-                    if (cityCenter) {
-                        // Distance-ranked selection: nearest candidate within the radius wins
-                        const picked = this.pickNearestGeocodeCandidate(data, cityCenter, eventCity, address);
-                        if (picked) {
-                            event.location = `${picked.lat}, ${picked.lon}`;
-                            modified = true;
-                            console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
-                        }
-                    } else {
-                        const firstResult = data[0];
-                        if (firstResult.lat && firstResult.lon) {
-                            if (eventCity && !this.geocodeResultMatchesCity(firstResult, eventCity)) {
-                                console.warn(`🗺️ OpenStreetMapNormalizer: Geocode for "${event.address}" resolved outside event city "${eventCity}" ("${firstResult.display_name || 'no display name'}") — ignoring coordinates`);
-                            } else {
-                                event.location = `${firstResult.lat}, ${firstResult.lon}`;
-                                modified = true;
-                                console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
+            // Retry ladder: when a query returns 0 candidates (or every candidate
+            // is rejected by the distance/city checks), retry with progressively
+            // simplified queries. Every attempt goes through
+            // fetchDataWithCacheAndRateLimit (rate-limited AND cached) and the
+            // ladder is hard-capped at MAX_GEOCODE_QUERIES_PER_EVENT requests.
+            const queryVariants = this.buildGeocodeQueryVariants(address, eventCity, event.bar);
+            let attempts = 0;
+            let resolvedLocation = null;
+            for (let i = 0; i < queryVariants.length && !resolvedLocation; i++) {
+                const queryText = queryVariants[i];
+                const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(queryText)}&limit=${resultLimit}${cityValidationParam}`;
+                attempts += 1;
+                try {
+                    const data = await this.fetchDataWithCacheAndRateLimit(url, options, httpAdapter);
+                    if (Array.isArray(data) && data.length > 0) {
+                        if (cityCenter) {
+                            // Distance-ranked selection: nearest candidate within the radius wins
+                            const picked = this.pickNearestGeocodeCandidate(data, cityCenter, eventCity, queryText);
+                            if (picked) {
+                                resolvedLocation = `${picked.lat}, ${picked.lon}`;
+                            }
+                        } else {
+                            const firstResult = data[0];
+                            if (firstResult.lat && firstResult.lon) {
+                                if (eventCity && !this.geocodeResultMatchesCity(firstResult, eventCity)) {
+                                    console.warn(`🗺️ OpenStreetMapNormalizer: Geocode for "${queryText}" resolved outside event city "${eventCity}" ("${firstResult.display_name || 'no display name'}") — ignoring coordinates`);
+                                } else {
+                                    resolvedLocation = `${firstResult.lat}, ${firstResult.lon}`;
+                                }
                             }
                         }
+                    } else if (i < queryVariants.length - 1) {
+                        console.log(`🗺️ OpenStreetMapNormalizer: 0 geocode results for "${queryText}" — trying next variant`);
+                    }
+                } catch (err) {
+                    console.log(`🗺️ OpenStreetMapNormalizer: Failed to geocode address "${event.address}": ${err.message}`);
+                }
+                if (resolvedLocation) {
+                    event.location = resolvedLocation;
+                    modified = true;
+                    console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
+                    if (i > 0) {
+                        console.log(`🗺️ OpenStreetMapNormalizer: Geocoded via simplified query "${queryText}"`);
                     }
                 }
-            } catch (err) {
-                console.log(`🗺️ OpenStreetMapNormalizer: Failed to geocode address "${event.address}": ${err.message}`);
+            }
+            if (!resolvedLocation) {
+                // Exact shape counted by run-log-summary's geocodeNoResults guard.
+                console.warn(`🗺️ OpenStreetMapNormalizer: No geocode results for "${address}" (${eventCity || 'no city'}) after ${attempts} ${attempts === 1 ? 'query' : 'queries'} — leaving location empty`);
             }
         } else if (hasLocation && !hasAddress) {
             const parts = event.location.split(',').map(p => p.trim());
@@ -958,16 +1093,33 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 const lon = parseFloat(parts[1]);
 
                 if (!isNaN(lat) && !isNaN(lon)) {
-                    const url = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}`;
-                    try {
-                        const data = await this.fetchDataWithCacheAndRateLimit(url, options, httpAdapter);
-                        if (data && data.display_name) {
-                            event.address = data.display_name;
-                            modified = true;
-                            console.log(`🗺️ OpenStreetMapNormalizer: Found address for coordinates "${event.location}" -> ${event.address}`);
+                    // Prefer the adapter's native reverse geocoder when it exposes
+                    // one (Scriptable's Location.reverseGeocode — no network quota,
+                    // no Nominatim rate-limit budget). Nominatim stays the fallback.
+                    let nativeAddress = null;
+                    if (typeof httpAdapter.reverseGeocode === 'function') {
+                        try {
+                            nativeAddress = await httpAdapter.reverseGeocode(lat, lon);
+                        } catch (err) {
+                            console.log(`🗺️ OpenStreetMapNormalizer: Native reverse geocode failed for "${event.location}": ${err.message}`);
                         }
-                    } catch (err) {
-                        console.log(`🗺️ OpenStreetMapNormalizer: Failed to reverse geocode location "${event.location}": ${err.message}`);
+                    }
+                    if (typeof nativeAddress === 'string' && nativeAddress.trim().length > 0) {
+                        event.address = nativeAddress.trim();
+                        modified = true;
+                        console.log(`🗺️ OpenStreetMapNormalizer: Found address for coordinates "${event.location}" -> ${event.address} (native reverse geocode)`);
+                    } else {
+                        const url = `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}`;
+                        try {
+                            const data = await this.fetchDataWithCacheAndRateLimit(url, options, httpAdapter);
+                            if (data && data.display_name) {
+                                event.address = data.display_name;
+                                modified = true;
+                                console.log(`🗺️ OpenStreetMapNormalizer: Found address for coordinates "${event.location}" -> ${event.address}`);
+                            }
+                        } catch (err) {
+                            console.log(`🗺️ OpenStreetMapNormalizer: Failed to reverse geocode location "${event.location}": ${err.message}`);
+                        }
                     }
                 }
             }

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -231,6 +231,246 @@ test('haversineDistanceKm sanity: Portland→Seattle ≈ 233 km, identical point
   assert.equal(normalizer.haversineDistanceKm(45.5, -122.6, 45.5, -122.6), 0);
 });
 
+// ---------------------------------------------------------------------------
+// Forward-geocode retry ladder (2026-07-12 run findings: Nominatim returns 0
+// results for "2069 CHESHIRE BRIDGE RD NE" — its free-text parser chokes on a
+// trailing directional after a street type — while "2069 Cheshire Bridge Rd,
+// Atlanta" and "The Heretic, Atlanta" both resolve to the right venue)
+// ---------------------------------------------------------------------------
+
+const CITIES_WITH_ATLANTA = {
+  atlanta: {
+    timezone: 'America/New_York',
+    patterns: ['atlanta', 'atl'],
+    coordinates: { lat: 33.749, lng: -84.388 }
+  }
+};
+
+function createOsmNormalizerWithAtlanta() {
+  const core = new SharedCore(CITIES_WITH_ATLANTA, { eventSchema: EventSchema });
+  return new OpenStreetMapNormalizer(core);
+}
+
+// Stub httpAdapter that returns one canned Nominatim result set per request,
+// in order (the last one repeats if more requests arrive).
+function createSequencedStubAdapter(responses) {
+  const requests = [];
+  return {
+    requests,
+    fetchData: async (url) => {
+      requests.push(url);
+      const index = Math.min(requests.length - 1, responses.length - 1);
+      return JSON.stringify(responses[index]);
+    }
+  };
+}
+
+function decodeQueryParam(url) {
+  const match = /[?&]q=([^&]*)/.exec(url);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+// The Heretic, ~8 km from the Atlanta city center.
+const HERETIC_RESULT = {
+  lat: '33.8226',
+  lon: '-84.3510',
+  display_name: 'The Heretic, 2069, Cheshire Bridge Road Northeast, Atlanta, Fulton County, Georgia, 30324, United States',
+  address: { city: 'Atlanta', county: 'Fulton County', state: 'Georgia' }
+};
+
+test('stripTrailingDirectionals strips only directionals that follow a street type', () => {
+  const normalizer = createOsmNormalizerWithAtlanta();
+  assert.equal(
+    normalizer.stripTrailingDirectionals('2069 CHESHIRE BRIDGE RD NE'),
+    '2069 CHESHIRE BRIDGE RD'
+  );
+  assert.equal(
+    normalizer.stripTrailingDirectionals('2069 Cheshire Bridge Road Northeast, Atlanta, GA, 30324'),
+    '2069 Cheshire Bridge Road, Atlanta, GA, 30324',
+    'a mid-address directional before a comma must also be stripped'
+  );
+  // Directional PREFIXES are part of the street name and must pass through
+  assert.equal(normalizer.stripTrailingDirectionals('3702 N Halsted'), '3702 N Halsted');
+  assert.equal(normalizer.stripTrailingDirectionals('722 E Burnside'), '722 E Burnside');
+  assert.equal(normalizer.stripTrailingDirectionals('355 W 41st St'), '355 W 41st St');
+});
+
+test('buildGeocodeQueryVariants orders, dedupes and caps the ladder', () => {
+  const normalizer = createOsmNormalizerWithAtlanta();
+
+  const full = normalizer.buildGeocodeQueryVariants('2069 CHESHIRE BRIDGE RD NE', 'atlanta', 'The Heretic');
+  assert.deepEqual(full, [
+    '2069 CHESHIRE BRIDGE RD NE, atlanta',
+    '2069 CHESHIRE BRIDGE RD, atlanta',
+    'The Heretic, atlanta'
+  ]);
+  assert.ok(full.length <= 3, 'hard cap: at most 3 queries per event');
+
+  // No strippable directional and no bar → the ladder collapses to one query
+  assert.deepEqual(
+    normalizer.buildGeocodeQueryVariants('3702 N Halsted', 'chicago', ''),
+    ['3702 N Halsted, chicago']
+  );
+  assert.deepEqual(
+    normalizer.buildGeocodeQueryVariants('722 E Burnside', 'portland', null),
+    ['722 E Burnside, portland']
+  );
+
+  // Address already containing the city is not re-anchored (today's behavior)
+  assert.deepEqual(
+    normalizer.buildGeocodeQueryVariants('2069 Cheshire Bridge Road Northeast, Atlanta, GA, 30324', 'atlanta', 'The Heretic'),
+    [
+      '2069 Cheshire Bridge Road Northeast, Atlanta, GA, 30324',
+      '2069 Cheshire Bridge Road, Atlanta, GA, 30324',
+      'The Heretic, atlanta'
+    ]
+  );
+});
+
+test('retry ladder: 0 results retries with the directional stripped, rate-limited per request', async () => {
+  const normalizer = createOsmNormalizerWithAtlanta();
+  let delays = 0;
+  normalizer.delayForRateLimit = async () => { delays += 1; };
+  const httpAdapter = createSequencedStubAdapter([[], [HERETIC_RESULT]]);
+  const event = { title: 'ATL BEAR NIGHT', address: '2069 CHESHIRE BRIDGE RD NE', city: 'atlanta', bar: 'The Heretic' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.location, '33.8226, -84.3510');
+  assert.equal(httpAdapter.requests.length, 2, 'exactly one retry after the empty first response');
+  assert.equal(decodeQueryParam(httpAdapter.requests[0]), '2069 CHESHIRE BRIDGE RD NE, atlanta');
+  assert.equal(
+    decodeQueryParam(httpAdapter.requests[1]),
+    '2069 CHESHIRE BRIDGE RD, atlanta',
+    'the second query must have the trailing directional stripped'
+  );
+  assert.equal(delays, 2, 'every live request must pass through the rate limiter');
+});
+
+test('retry ladder: falls back to bar+city and stops at the hard cap of 3 requests', async () => {
+  const normalizer = createOsmNormalizerWithAtlanta();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createSequencedStubAdapter([[], [], [HERETIC_RESULT]]);
+  const event = { title: 'ATL BEAR NIGHT', address: '2069 CHESHIRE BRIDGE RD NE', city: 'atlanta', bar: 'The Heretic' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(httpAdapter.requests.length, 3);
+  assert.equal(decodeQueryParam(httpAdapter.requests[2]), 'The Heretic, atlanta');
+  assert.equal(event.location, '33.8226, -84.3510', 'the venue-name lookup must rescue the event');
+});
+
+test('retry ladder: distance validation still applies to fallback variants', async () => {
+  const normalizer = createOsmNormalizerWithAtlanta();
+  normalizer.delayForRateLimit = async () => {};
+  // Variant 2 returns a candidate ~1000 km from Atlanta — must be rejected, ladder continues
+  const httpAdapter = createSequencedStubAdapter([[], [PORTLAND_MICHIGAN_RESULT], []]);
+  const event = { title: 'ATL BEAR NIGHT', address: '2069 CHESHIRE BRIDGE RD NE', city: 'atlanta', bar: 'The Heretic' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.location, undefined, 'a far-away candidate from a simplified query must not win');
+  assert.equal(httpAdapter.requests.length, 3, 'rejection counts as failure and the ladder continues to the cap');
+});
+
+test('retry ladder: identical variants are deduped so no duplicate request is sent', async () => {
+  const normalizer = createOsmNormalizerWithAtlanta();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createSequencedStubAdapter([[]]);
+  // No strippable directional, no bar → a single query, then exhaustion
+  const event = { title: 'CHI BEAR NIGHT', address: '3702 N Halsted', city: 'atlanta' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(httpAdapter.requests.length, 1, 'the stripped variant equals the original and must be skipped');
+  assert.equal(event.location, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Geocode cache poisoning (2026-07-12 run findings: cached empty Nominatim
+// bodies silently skipped venues that geocode fine live)
+// ---------------------------------------------------------------------------
+
+test('geocode requests carry a cache predicate that rejects empty/unparseable bodies', async () => {
+  const normalizer = createOsmNormalizer();
+  let capturedOptions = null;
+  const httpAdapter = {
+    fetchData: async (url, options) => {
+      capturedOptions = options;
+      return JSON.stringify([WRONG_CITY_RESULT]);
+    }
+  };
+  const event = { title: 'MYSTERY EVENT', address: '922 E. BURNSIDE' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(typeof capturedOptions.isCacheableResponse, 'function', 'the adapters gate disk-cache writes on this hook');
+  assert.equal(capturedOptions.isCacheableResponse({ html: '[]' }), false, 'an empty result set must never reach the disk cache');
+  assert.equal(capturedOptions.isCacheableResponse({ html: 'not json at all' }), false, 'an unparseable body must never reach the disk cache');
+  assert.equal(capturedOptions.isCacheableResponse({ html: JSON.stringify([WRONG_CITY_RESULT]) }), true);
+  assert.equal(capturedOptions.isCacheableResponse({ html: JSON.stringify({ display_name: 'reverse result' }) }), true);
+});
+
+test('a cached empty geocode body is treated as a miss and refetched live', async () => {
+  const normalizer = createOsmNormalizerWithCoords();
+  const requests = [];
+  const httpAdapter = {
+    getPageCacheConfig: () => ({ enabled: true, ttlDays: 7 }),
+    readCachedPage: async () => ({ html: '[]' }),
+    fetchData: async (url) => {
+      requests.push(url);
+      return JSON.stringify([PORTLAND_RESULT]);
+    }
+  };
+  const event = { title: 'PRIDE FRIDAY', address: '722 E Burnside', city: 'portland' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(requests.length, 1, 'the poisoned cache entry must not satisfy the request');
+  assert.equal(event.location, '45.5230622, -122.6564816', 'the live refetch must fill the coordinates');
+});
+
+// ---------------------------------------------------------------------------
+// Native reverse geocode hook (Scriptable Location.reverseGeocode — the
+// normalizer prefers it over Nominatim when the adapter exposes it)
+// ---------------------------------------------------------------------------
+
+test('reverse geocode prefers the adapter native hook and skips Nominatim', async () => {
+  const normalizer = createOsmNormalizer();
+  const requests = [];
+  const httpAdapter = {
+    fetchData: async (url) => {
+      requests.push(url);
+      return JSON.stringify({ display_name: 'Nominatim must not be consulted' });
+    },
+    reverseGeocode: async () => '2069 Cheshire Bridge Rd NE, Atlanta, GA 30324'
+  };
+  const event = { title: 'ATL BEAR NIGHT', location: '33.8226, -84.3510' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.address, '2069 Cheshire Bridge Rd NE, Atlanta, GA 30324');
+  assert.equal(requests.length, 0, 'the native hook must avoid the Nominatim request entirely');
+});
+
+test('reverse geocode falls back to Nominatim when the native hook returns nothing', async () => {
+  const normalizer = createOsmNormalizer();
+  const requests = [];
+  const httpAdapter = {
+    fetchData: async (url) => {
+      requests.push(url);
+      return JSON.stringify({ display_name: '722 E Burnside St, Portland, OR' });
+    },
+    reverseGeocode: async () => null
+  };
+  const event = { title: 'PRIDE FRIDAY', location: '45.5230622, -122.6564816' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.address, '722 E Burnside St, Portland, OR');
+  assert.equal(requests.length, 1, 'Nominatim stays the fallback');
+});
+
 test('resolveWallClockDates ignores events without the wall-clock flag', () => {
   const normalizer = createLocationNormalizer();
   const event = {

--- a/scripts/run-log-summary.js
+++ b/scripts/run-log-summary.js
@@ -262,23 +262,28 @@ function countCrawlNodes(sources) {
 //       "🤖 AI Web: Stripping page brand from title "X" → "Y""
 //       "🤖 AI Web: Rejecting title "X" from <pass> pass — the whole title is the page organizer/brand; ..."
 //       "🤖 AI Web: Rejecting description from <pass|final normalization> — identical to the site's own tagline, ..."
-//   - normalizers.js distance-ranked geocoding (#1462):
+//   - normalizers.js distance-ranked geocoding (#1462) and retry-ladder exhaustion:
 //       "🗺️ OpenStreetMapNormalizer: 5 candidates for "922 E. BURNSIDE"; picked #1 (1.9 km from portland center)"
 //       "🗺️ OpenStreetMapNormalizer: Geocode for "X" resolved outside event city "Y" (...) — ignoring coordinates"
 //       "🗺️ OpenStreetMapNormalizer: All 3 geocode candidates for "X" fall outside 15 km of ... — ignoring coordinates"
-//   - shared-core merge guards (#1464 degenerate ends, coordinate/bar preservation):
+//       "🗺️ OpenStreetMapNormalizer: No geocode results for "X" (city) after 3 queries — leaving location empty"
+//   - shared-core merge guards (#1464 degenerate ends, coordinate/bar/location preservation):
 //       "⚠️ MERGE: "T" existing|incoming|scraped endDate <= startDate (zero duration) — treating as missing, ..."
 //       "📍 MERGE: "T" location kept calendar coordinates over scraped text/empty value"
 //       "📍 MERGE: "T" bar kept from calendar (scrape found no venue)"
+//       "📍 MERGE: "T" location kept from calendar (scrape found none)"
+//       "📍 MERGE: "T" location kept from existing (incoming scrape found none)"
 const GUARD_LINE_RES = {
     brandBarRejected: /🤖 AI Web: (?:Dropping|Rejecting) bar ".*?" (?:—|from .*? pass —) matches (?:the )?page/,
     brandTitleStripped: /🤖 AI Web: (?:Stripping page brand from title ".*?"|Rejecting title ".*?" from .*? pass)/,
     taglineRejected: /🤖 AI Web: Rejecting description from .*? — identical to the site's own tagline/,
     geocodePicked: /🗺️ \w*Normalizer: \d+ candidates? for ".*?"; picked #\d+/,
     geocodeRejected: /🗺️ \w*Normalizer: (?:Geocode for ".*?" resolved outside event city|All \d+ geocode candidates? for ".*?" fall outside)/,
+    geocodeNoResults: /🗺️ \w*Normalizer: No geocode results for ".*?" \(.*?\) after \d+ quer(?:y|ies) — leaving location empty/,
     degenerateEndCaught: /⚠️ MERGE: ".*?" \S+ endDate <= startDate/,
     coordsPreserved: /📍 MERGE: ".*?" location kept calendar coordinates/,
-    barPreserved: /📍 MERGE: ".*?" bar kept from calendar/
+    barPreserved: /📍 MERGE: ".*?" bar kept from calendar/,
+    locationPreserved: /📍 MERGE: ".*?" location kept from (?:calendar|existing)/
 };
 
 function createGuardCounts() {
@@ -587,6 +592,9 @@ function evaluateRunHealth(signals, context = {}) {
     }
     if ((guards.geocodeRejected || 0) > 0) {
         reasons.push(`geocode rejected ×${guards.geocodeRejected}`);
+    }
+    if ((guards.geocodeNoResults || 0) > 0) {
+        reasons.push(`geocode no-results ×${guards.geocodeNoResults}`);
     }
     const events = quality.events || 0;
     const withBar = quality.withBar || 0;

--- a/scripts/run-log-summary.test.js
+++ b/scripts/run-log-summary.test.js
@@ -213,10 +213,14 @@ const SIGNALS_FIXTURE = [
   '2026-07-13T09:00:16.000Z [INFO] 🗺️ OpenStreetMapNormalizer: 5 candidates for "922 E. BURNSIDE"; picked #1 (1.9 km from portland center)',
   '2026-07-13T09:00:17.000Z [WARN] 🗺️ OpenStreetMapNormalizer: Geocode for "Sanctuary" resolved outside event city "portland" ("Sanctuary, Denver, Colorado") — ignoring coordinates',
   '2026-07-13T09:00:18.000Z [WARN] 🗺️ OpenStreetMapNormalizer: All 3 geocode candidates for "123 Main St" fall outside 15 km of atlanta center (nearest is 42.0 km away) — ignoring coordinates',
-  // Merge-time guards: degenerate end, coordinate preservation, bar preservation
+  // Geocode retry-ladder exhaustion (address unresolvable after all variants)
+  '2026-07-13T09:00:18.500Z [WARN] 🗺️ OpenStreetMapNormalizer: No geocode results for "2069 CHESHIRE BRIDGE RD NE" (atlanta) after 3 queries — leaving location empty',
+  // Merge-time guards: degenerate end, coordinate/bar/location preservation
   '2026-07-13T09:00:19.000Z [WARN] ⚠️ MERGE: "BEARRACUDA: Portland" scraped endDate <= startDate (zero duration) — treating as missing, keeping calendar end',
   '2026-07-13T09:00:20.000Z [INFO] 📍 MERGE: "BEARRACUDA: Portland" location kept calendar coordinates over scraped text/empty value',
   '2026-07-13T09:00:21.000Z [INFO] 📍 MERGE: "BEARRACUDA: Portland" bar kept from calendar (scrape found no venue)',
+  '2026-07-13T09:00:21.300Z [INFO] 📍 MERGE: "BEARRACUDA: Atlanta" location kept from calendar (scrape found none)',
+  '2026-07-13T09:00:21.600Z [INFO] 📍 MERGE: "BEARRACUDA: Atlanta" location kept from existing (incoming scrape found none)',
   // AI merge arbitration: one calendar pick, one scraped pick, one bulk fallback
   '2026-07-13T09:00:22.000Z [INFO] 🤝 AI MERGE: "BEARRACUDA: Portland" field=bar chose calendar ("Sanctuary") over scraped ("BEARRACUDA") — venue, not the organizer',
   '2026-07-13T09:00:23.000Z [INFO] 🤝 AI MERGE: "BEARRACUDA: Portland" field=description chose scraped ("Doors at 9") over calendar ("TBD") — fresher source',
@@ -235,9 +239,11 @@ test('buildSummary counts each guard line type', () => {
     taglineRejected: 1,
     geocodePicked: 1,
     geocodeRejected: 2,       // outside-city + all-candidates-outside
+    geocodeNoResults: 1,      // retry-ladder exhaustion warn
     degenerateEndCaught: 1,
     coordsPreserved: 1,
-    barPreserved: 1
+    barPreserved: 1,
+    locationPreserved: 2      // "kept from calendar" + "kept from existing"
   });
 });
 
@@ -347,6 +353,12 @@ test('evaluateRunHealth: each warn trigger fires independently', () => {
   geocode.guards = Object.assign({}, geocode.guards, { geocodeRejected: 1 });
   health = evaluateRunHealth(geocode, { errorsCount: 0 });
   assert.deepEqual(health.reasons, ['geocode rejected ×1']);
+
+  // geocode retry-ladder exhaustion (address unresolvable)
+  const noResults = buildHealthySignals();
+  noResults.guards = Object.assign({}, noResults.guards, { geocodeNoResults: 2 });
+  health = evaluateRunHealth(noResults, { errorsCount: 0 });
+  assert.deepEqual(health.reasons, ['geocode no-results ×2']);
 
   // low venue coverage (only with >2 events)
   const lowVenue = buildHealthySignals();

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1734,6 +1734,28 @@ class SharedCore {
                     }
                     return;
                 }
+                // Neither side is coordinates: an empty side is an extraction
+                // gap, not data — it must never clear a non-empty location
+                // (observed 2026-07-12: an empty scrape wiped a calendar's text
+                // location). Mirrors the bar rule below; both-non-empty text
+                // still falls through to the normal priority resolution.
+                const existingLocationEmpty = isEmpty(existingValue);
+                const newLocationEmpty = isEmpty(newValue);
+                if (existingLocationEmpty !== newLocationEmpty) {
+                    const chosenValue = existingLocationEmpty ? newValue : existingValue;
+                    mergedEvent[fieldName] = chosenValue;
+                    if (!existingLocationEmpty) {
+                        console.log(`📍 MERGE: "${newEvent.title || existingEvent.title || 'event'}" location kept from existing (incoming scrape found none)`);
+                    }
+                    mergeDecisions.push({
+                        field: fieldName,
+                        existingValue: existingValue,
+                        newValue: newValue,
+                        chosenValue: chosenValue,
+                        reason: 'location kept from the non-empty side — an empty scrape must not clear a location'
+                    });
+                    return;
+                }
             }
 
             // bar mirrors the location rule in spirit: an empty side is an
@@ -2008,6 +2030,18 @@ class SharedCore {
                     if (scraperValue !== calendarValue) {
                         console.log(`📍 MERGE: "${mergeTitle}" location kept calendar coordinates over scraped text/empty value`);
                     }
+                    continue;
+                }
+                // Neither side is coordinates: an empty/whitespace scraped
+                // location is an extraction gap, not data — under clobber
+                // semantics it wiped a calendar's text location (observed
+                // 2026-07-12: "clobbered 4 fields (… location)" on the Atlanta
+                // event). Text-vs-text still falls through to the configured
+                // merge strategy below.
+                if (this.isEmptyArbitrationValue(scraperValue)
+                    && !this.isEmptyArbitrationValue(calendarValue)) {
+                    mergedObject[fieldName] = calendarValue;
+                    console.log(`📍 MERGE: "${mergeTitle}" location kept from calendar (scrape found none)`);
                     continue;
                 }
             }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -840,6 +840,105 @@ test('location merge is deterministic: coordinates always beat text/empty and ne
   assert.equal(adapterB.calls.length, 0, 'no location scenario may consult the AI');
 });
 
+test('location preserve-on-empty: an empty scrape never clears a calendar location (text or coords)', async () => {
+  // 2026-07-12 run findings: only calendar COORDINATES were protected — an empty
+  // scraped location CLEARED a calendar location holding text ("clobbered 4
+  // fields (startDate, endDate, url, location)" on the Atlanta event).
+  const core = createCore();
+  const buildScraped = (location) => ({
+    title: 'ATL BEAR NIGHT',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    location,
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  });
+  const buildExisting = (location) => ({
+    title: 'ATL BEAR NIGHT',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    location,
+    notes: ''
+  });
+  const adapter = buildArbitrationAdapter({});
+
+  // Calendar TEXT survives an empty scrape
+  const keptText = await core.createFinalEventObject(
+    buildExisting('2069 Cheshire Bridge Rd NE, Atlanta'),
+    buildScraped(''),
+    { httpAdapter: adapter }
+  );
+  assert.equal(keptText.location, '2069 Cheshire Bridge Rd NE, Atlanta', 'an empty scrape must not clear a text location');
+
+  // Whitespace-only counts as empty
+  const keptWhitespace = await core.createFinalEventObject(
+    buildExisting('2069 Cheshire Bridge Rd NE, Atlanta'),
+    buildScraped('   '),
+    { httpAdapter: adapter }
+  );
+  assert.equal(keptWhitespace.location, '2069 Cheshire Bridge Rd NE, Atlanta', 'a whitespace scrape must not clear a text location');
+
+  // Calendar COORDINATES survive an empty scrape (existing rule, unchanged)
+  const keptCoords = await core.createFinalEventObject(
+    buildExisting('33.8226, -84.3510'),
+    buildScraped(''),
+    { httpAdapter: adapter }
+  );
+  assert.equal(keptCoords.location, '33.8226, -84.3510');
+
+  // Non-empty scraped coordinates still win over calendar text (unchanged)
+  const coordsWin = await core.createFinalEventObject(
+    buildExisting('2069 Cheshire Bridge Rd NE, Atlanta'),
+    buildScraped('33.8226, -84.3510'),
+    { httpAdapter: adapter }
+  );
+  assert.equal(coordsWin.location, '33.8226, -84.3510', 'scraped coordinates must still replace calendar text');
+
+  assert.equal(adapter.calls.length, 0, 'location is never AI-arbitrated');
+});
+
+test('mergeParsedEvents: an empty location loses to the non-empty side (text and coordinates)', async () => {
+  const core = createCore();
+  const priorities = core.getResolvedFieldPriorities({});
+  const adapter = buildArbitrationAdapter({});
+  const buildEvent = (location) => ({
+    title: 'ATL BEAR NIGHT',
+    location,
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    source: 'ai-web',
+    _parserConfig: TEST_AI_PARSER_CONFIG,
+    _fieldPriorities: priorities
+  });
+
+  // Existing TEXT survives an empty incoming
+  const keptText = await core.mergeParsedEvents(
+    buildEvent('2069 Cheshire Bridge Rd NE, Atlanta'),
+    buildEvent(''),
+    { httpAdapter: adapter }
+  );
+  assert.equal(keptText.location, '2069 Cheshire Bridge Rd NE, Atlanta', 'an empty incoming location must not clear existing text');
+
+  // An empty existing is filled by incoming text
+  const filled = await core.mergeParsedEvents(
+    buildEvent(''),
+    buildEvent('2069 Cheshire Bridge Rd NE, Atlanta'),
+    { httpAdapter: adapter }
+  );
+  assert.equal(filled.location, '2069 Cheshire Bridge Rd NE, Atlanta');
+
+  // Existing COORDINATES survive an empty incoming (coordinate rule, unchanged)
+  const keptCoords = await core.mergeParsedEvents(
+    buildEvent('33.8226, -84.3510'),
+    buildEvent(''),
+    { httpAdapter: adapter }
+  );
+  assert.equal(keptCoords.location, '33.8226, -84.3510');
+
+  assert.equal(adapter.calls.length, 0, 'location resolves deterministically without AI');
+});
+
 test('mergeParsedEvents: coordinates beat text and degenerate ends lose, without AI', async () => {
   const core = createCore();
   const priorities = core.getResolvedFieldPriorities({});


### PR DESCRIPTION
## Problem (from the 2026-07-13 run)

**Bearracuda Atlanta 17 Year Anniversary ended up with no coordinates.** Verified live: Nominatim returns **0 results** for both address forms the scraper queried — `"2069 CHESHIRE BRIDGE RD NE, atlanta"` and `"2069 Cheshire Bridge Road Northeast, Atlanta, GA, 30324"` — its free-text parser chokes on the trailing directional. `"2069 Cheshire Bridge Rd, Atlanta"` and `"The Heretic, Atlanta"` both resolve to the exact venue. Three compounding bugs:
1. Zero geocode results were **completely silent** — no log, no metric.
2. Chicago (`3702 N Halsted`) and Provincetown (`247 Commercial St`) geocode fine live but were also silently skipped — **stale empty bodies cached on-device** poison lookups for the whole TTL.
3. The merge then let the empty scraped location **clear** the calendar's location value (`clobbered … location`) — only coordinates were protected from empty scrapes, not text.

## Fix

### Geocode retry ladder (normalizers.js)
On zero results (or all candidates rejected by distance/city checks), retry with progressively simplified queries, **hard-capped at 3 Nominatim requests per event**:
1. today's city-anchored query →
2. trailing directionals stripped — only a directional *following* a street-type word (`Cheshire Bridge Rd NE` → `Cheshire Bridge Rd`; prefixes like `N Halsted` / `E Burnside` are never touched) →
3. `"<bar>, <city>"` venue-name lookup.

Every attempt goes through the existing rate limiter (1.1s, untouched — spy-tested) and cache; identical distance-from-city-center validation on every variant. Success via a fallback logs `Geocoded via simplified query "…"`. Exhaustion warns loudly: `No geocode results for "<address>" (<city>) after N queries — leaving location empty`.

### Self-healing geocode cache (normalizers.js + both adapters)
New opt-in `options.isCacheableResponse` hook in both adapters' `fetchData`, passed **only** by the geocode path (website page caching byte-for-byte unchanged): empty/unparseable Nominatim bodies are never written to the disk cache, and an already-cached one is treated as a miss → live refetch (`Ignoring cached empty geocode result … — refetching`). Existing poisoned device entries heal on the next run — no manual purge. In-memory per-run cache still holds live empties so one run never re-queries the same address.

### Metrics + health (run-log-summary.js, metrics-sections.js)
New guards `geocodeNoResults` and `locationPreserved`; run health now warns on geocode no-results.

### Location preserve-on-empty (shared-core.js)
In both merge paths, an empty scraped location never clears a non-empty calendar/existing location — text or coordinates — mirroring the bar rule (`📍 MERGE: … location kept from calendar (scrape found none)`). Coordinate rules and text-vs-text strategy semantics unchanged.

### Bonus: native reverse geocode (scriptable-adapter.js)
`adapter.reverseGeocode(lat, lon)` wraps Scriptable's `Location.reverseGeocode` (Apple geocoding — no Nominatim quota); normalizers prefer it for the coords→address backfill when the hook exists, Nominatim stays the fallback. Pure-module rules intact.

## Tests
216 → **228**, all green. Covers ladder ordering/dedup/cap and exact request counts, prefix-directional safety, fallback distance validation, cache read+write gating incl. the poisoned-cache self-heal, preserve-on-empty in both merge paths, new guard counters + health reason, and the native reverse-geocode hook.

## Nominatim etiquette
Rate limiter and User-Agent untouched; ladder adds requests only after a zero-result attempt (normal addresses still cost exactly 1); cache-bypass costs one extra request per poisoned address, once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP