### PR TITLE
fix(scraper): resolve systematic merge conflicts deterministically before AI arbitration

### DIFF
--- a/scripts/metrics-sections.js
+++ b/scripts/metrics-sections.js
@@ -50,7 +50,8 @@ const GUARD_LABELS = [
     { key: 'degenerateEndCaught', label: 'Degenerate end date caught' },
     { key: 'coordsPreserved', label: 'Calendar coordinates preserved' },
     { key: 'barPreserved', label: 'Calendar venue preserved' },
-    { key: 'locationPreserved', label: 'Calendar location preserved' }
+    { key: 'locationPreserved', label: 'Calendar location preserved' },
+    { key: 'arbitrationDeterministic', label: 'Merge conflicts resolved deterministically' }
 ];
 
 const SIGNALS_PASS_ORDER = ['extraction', 'context-prep', 'repair', 'merge-arbitration', 'ocr'];

--- a/scripts/run-log-summary.js
+++ b/scripts/run-log-summary.js
@@ -273,6 +273,8 @@ function countCrawlNodes(sources) {
 //       "📍 MERGE: "T" bar kept from calendar (scrape found no venue)"
 //       "📍 MERGE: "T" location kept from calendar (scrape found none)"
 //       "📍 MERGE: "T" location kept from existing (incoming scrape found none)"
+//   - shared-core deterministic pre-arbitration rules (URL shape / emoji-twin titles):
+//       "🔒 MERGE: "T" field=website resolved deterministically — same-host deeper URL beats domain root"
 const GUARD_LINE_RES = {
     brandBarRejected: /🤖 AI Web: (?:Dropping|Rejecting) bar ".*?" (?:—|from .*? pass —) matches (?:the )?page/,
     brandTitleStripped: /🤖 AI Web: (?:Stripping page brand from title ".*?"|Rejecting title ".*?" from .*? pass)/,
@@ -283,7 +285,8 @@ const GUARD_LINE_RES = {
     degenerateEndCaught: /⚠️ MERGE: ".*?" \S+ endDate <= startDate/,
     coordsPreserved: /📍 MERGE: ".*?" location kept calendar coordinates/,
     barPreserved: /📍 MERGE: ".*?" bar kept from calendar/,
-    locationPreserved: /📍 MERGE: ".*?" location kept from (?:calendar|existing)/
+    locationPreserved: /📍 MERGE: ".*?" location kept from (?:calendar|existing)/,
+    arbitrationDeterministic: /🔒 MERGE: ".*?" field=\S+ resolved deterministically/
 };
 
 function createGuardCounts() {
@@ -377,7 +380,10 @@ function buildSummary(entries) {
             pageFor(entry.url);
             continue;
         }
-        if (/🤝 AI MERGE|🔄 PARSER MERGE|🔄 MERGE/.test(firstLine)) {
+        // 🔒 deterministic resolutions are merge decisions too (already counted
+        // as a guard above; they match none of the 🤝 AI MERGE signal regexes,
+        // so they never inflate the AI conflict/pick counters).
+        if (/🤝 AI MERGE|🔄 PARSER MERGE|🔄 MERGE|🔒 MERGE/.test(firstLine)) {
             merges.push(firstLine);
             continue;
         }

--- a/scripts/run-log-summary.test.js
+++ b/scripts/run-log-summary.test.js
@@ -225,6 +225,10 @@ const SIGNALS_FIXTURE = [
   '2026-07-13T09:00:22.000Z [INFO] 🤝 AI MERGE: "BEARRACUDA: Portland" field=bar chose calendar ("Sanctuary") over scraped ("BEARRACUDA") — venue, not the organizer',
   '2026-07-13T09:00:23.000Z [INFO] 🤝 AI MERGE: "BEARRACUDA: Portland" field=description chose scraped ("Doors at 9") over calendar ("TBD") — fresher source',
   '2026-07-13T09:00:24.000Z [WARN] 🤝 AI MERGE: no arbitration result for "Other Event" — falling back to scraped values for 2 conflicted field(s)',
+  // Deterministic pre-arbitration resolutions (🔒): counted as a guard, never
+  // as AI arbitration conflicts/picks
+  '2026-07-13T09:00:24.300Z [INFO] 🔒 MERGE: "BEARRACUDA: Portland" field=website resolved deterministically — same-host deeper URL beats domain root',
+  '2026-07-13T09:00:24.600Z [INFO] 🔒 MERGE: "New Orleans⚜️" field=title resolved deterministically — emoji title variant beats its emoji-stripped twin',
   // Dedup funnel
   '2026-07-13T09:00:25.000Z [INFO] SYSTEM: Event filtering complete: 18 → 16 future → 16 bear → 9 final',
   '2026-07-13T09:00:26.000Z [INFO] 🔄 SharedCore: Deduplicated 16 → 9 (removed 7)'
@@ -243,8 +247,13 @@ test('buildSummary counts each guard line type', () => {
     degenerateEndCaught: 1,
     coordsPreserved: 1,
     barPreserved: 1,
-    locationPreserved: 2      // "kept from calendar" + "kept from existing"
+    locationPreserved: 2,     // "kept from calendar" + "kept from existing"
+    arbitrationDeterministic: 2 // 🔒 website root-vs-deep + 🔒 emoji-twin title
   });
+
+  // 🔒 lines are merge decisions too: they must show up in the merges list
+  // (for --merges analysis) while only counting toward the guard above.
+  assert.equal(summary.merges.filter(line => line.includes('🔒 MERGE')).length, 2);
 });
 
 test('buildSummary tracks failed AI requests per pass', () => {
@@ -293,6 +302,9 @@ test('buildRunSignals aggregates ai, guards, arbitration, funnel and quality', (
   });
   assert.equal(signals.guards.brandBarRejected, 2);
   assert.equal(signals.guards.geocodeRejected, 2);
+  assert.equal(signals.guards.arbitrationDeterministic, 2);
+  // The two 🔒 lines count ONLY toward the guard above — the AI arbitration
+  // conflict/pick/fallback counters must not move.
   assert.deepEqual(signals.arbitration, {
     conflicts: 4,       // 2 decided picks + 2 fields in the bulk fallback
     calendarPicks: 1,

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -411,6 +411,91 @@ class SharedCore {
         return false;
     }
 
+    // ------------------------------------------------------------------
+    // Deterministic pre-arbitration rules. Production runs showed the
+    // arbitration model systematically misjudging three conflict shapes (with
+    // confabulated reasons); these generic signals — URL shape and string
+    // identity, never per-site rules — resolve them BEFORE the AI sees them:
+    // fewer AI calls and no model dependency. Everything else still arbitrates.
+    // ------------------------------------------------------------------
+
+    // Lowercased host without "www." plus path segments (trailing slashes
+    // ignored) for an http(s) URL string, or null when the value isn't one.
+    // Built on parseUrl (Scriptable-safe regex parsing — no URL global).
+    getUrlRuleParts(value) {
+        if (typeof value !== 'string') return null;
+        const parsed = this.parseUrl(value.trim());
+        if (!parsed || !parsed.host) return null;
+        const host = String(parsed.hostname || parsed.host).toLowerCase().replace(/^www\./, '');
+        if (!host) return null;
+        const segments = String(parsed.pathname || '/').split('/').filter(Boolean);
+        const hasQuery = String(parsed.search || '').length > 1;
+        return { host, segments, hasQuery };
+    }
+
+    // Emoji/pictograph-stripped view of a title: pictograph blocks, variation
+    // selectors, the keycap combiner and ZWJ removed, whitespace collapsed.
+    // Conservative on purpose: ASCII and real punctuation are never stripped.
+    stripEmojiForTitleTwin(value) {
+        return String(value)
+            .replace(/[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0E}\u{FE0F}\u{20E3}\u{200D}]/gu, '')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
+    // Deterministic conflict resolution consulted by BOTH merge paths
+    // (createFinalEventObject and mergeParsedEvents) before a field is queued
+    // for AI arbitration. Returns { winner: 'a'|'b', reason } or null (→
+    // arbitrate as usual). Callers map a/b onto their own labels.
+    resolveConflictDeterministically(fieldName, valueA, valueB) {
+        const urlA = this.getUrlRuleParts(valueA);
+        const urlB = this.getUrlRuleParts(valueB);
+        if (urlA && urlB) {
+            // Same-host root URL never beats a deeper path: the deeper URL is
+            // the event-specific one (observed: the model picked
+            // "https://bearracuda.com/" over ".../events/portland-pridefriday/").
+            // Different hosts, both deep, or both root still arbitrate.
+            if (urlA.host === urlB.host) {
+                const rootA = urlA.segments.length === 0 && !urlA.hasQuery;
+                const rootB = urlB.segments.length === 0 && !urlB.hasQuery;
+                if (rootA && !rootB && urlB.segments.length > 0) {
+                    return { winner: 'b', reason: 'same-host deeper URL beats domain root' };
+                }
+                if (rootB && !rootA && urlA.segments.length > 0) {
+                    return { winner: 'a', reason: 'same-host deeper URL beats domain root' };
+                }
+            }
+            // A logo-path image never beats a non-logo image: ticketing
+            // services attach their own ".../saas/logos/..." asset, which the
+            // model picked over the actual event poster. Matches path
+            // components only (never hostname or query); both-or-neither
+            // logo-ish still arbitrates (with a prompt rule as backstop).
+            if (fieldName === 'image') {
+                const hasLogoSegment = (parts) => parts.segments.some(segment => /logo/i.test(segment));
+                const logoA = hasLogoSegment(urlA);
+                const logoB = hasLogoSegment(urlB);
+                if (logoA !== logoB) {
+                    return { winner: logoA ? 'b' : 'a', reason: 'event artwork beats logo-path image' };
+                }
+            }
+        }
+        // Emoji-stripped title twins are not a conflict: calendar titles
+        // deliberately carry emoji (canonical per the calendar contract), so
+        // when both titles are identical after stripping emoji (case-sensitive
+        // otherwise) the variant WITH the emoji — the longer one — wins.
+        // Titles differing in real text still arbitrate.
+        if (fieldName === 'title' && typeof valueA === 'string' && typeof valueB === 'string') {
+            const strippedA = this.stripEmojiForTitleTwin(valueA);
+            if (strippedA && strippedA === this.stripEmojiForTitleTwin(valueB) && valueA.length !== valueB.length) {
+                return {
+                    winner: valueA.length > valueB.length ? 'a' : 'b',
+                    reason: 'emoji title variant beats its emoji-stripped twin'
+                };
+            }
+        }
+        return null;
+    }
+
     // One batched request per merged event. conflicts: [{ field, values: { <labelA>:
     // raw, <labelB>: raw } }]. Returns { [field]: { pick, reason } } containing only
     // fields whose answer survived the verbatim gate, or null when no usable response
@@ -447,6 +532,7 @@ class SharedCore {
             '- "bar" must be the physical venue where the event takes place — never the promoter, organizer, or brand whose name appears in page titles.',
             organizer ? `- KNOWN ORGANIZER: ${JSON.stringify(String(organizer))} — never pick a bar value equal to the organizer.` : '',
             '- For "title", prefer the actual event name — do not prefer a variant just because it appends status text (e.g. sold-out notices) or site branding.',
+            '- For "image", prefer event-specific promotional artwork over site or ticketing-service logos.',
             `- "pick" must be "${labelA}" or "${labelB}".`,
             'Return JSON only:',
             `{"choices": {"<field>": {"pick": "${labelA}" or "${labelB}", "value": "<exact copy of the chosen value>", "reason": "<one short sentence>"}}}`
@@ -1702,6 +1788,33 @@ class SharedCore {
         // today's behavior exactly.
         const pendingAiConflicts = [];
 
+        // Deterministic pre-arbitration rules (URL shape / emoji-twin titles)
+        // run before a conflict is queued for AI — both merge paths consult
+        // resolveConflictDeterministically so behavior is identical.
+        const mergeEventTitle = newEvent.title || existingEvent.title || 'event';
+        const queueArbitrationConflict = (fieldName, existingValue, newValue, fallbackPick, fallbackReason) => {
+            const resolved = this.resolveConflictDeterministically(fieldName, existingValue, newValue);
+            if (!resolved) {
+                pendingAiConflicts.push({
+                    field: fieldName,
+                    values: { existing: existingValue, incoming: newValue },
+                    fallbackPick,
+                    fallbackReason
+                });
+                return;
+            }
+            const chosenValue = resolved.winner === 'a' ? existingValue : newValue;
+            mergedEvent[fieldName] = chosenValue;
+            console.log(`🔒 MERGE: "${mergeEventTitle}" field=${fieldName} resolved deterministically — ${resolved.reason}`);
+            mergeDecisions.push({
+                field: fieldName,
+                existingValue: existingValue,
+                newValue: newValue,
+                chosenValue: chosenValue,
+                reason: `deterministic: ${resolved.reason}`
+            });
+        };
+
         // Apply field priorities for each field
         allFields.forEach(fieldName => {
             if (fieldName.startsWith('_')) return; // Skip metadata fields
@@ -1812,12 +1925,8 @@ class SharedCore {
                 // No priority config: keep newEvent value — unless it's a genuine
                 // conflict, in which case the AI gets to pick.
                 if (canArbitrate) {
-                    pendingAiConflicts.push({
-                        field: fieldName,
-                        values: { existing: existingValue, incoming: newValue },
-                        fallbackPick: 'incoming',
-                        fallbackReason: 'no priority config - keeping incoming'
-                    });
+                    queueArbitrationConflict(fieldName, existingValue, newValue,
+                        'incoming', 'no priority config - keeping incoming');
                 }
                 return;
             }
@@ -1855,12 +1964,8 @@ class SharedCore {
                     // Same priority — the priority array cannot decide. Defer genuine
                     // conflicts to AI; otherwise preserve existing (today's behavior).
                     if (canArbitrate) {
-                        pendingAiConflicts.push({
-                            field: fieldName,
-                            values: { existing: existingValue, incoming: newValue },
-                            fallbackPick: 'existing',
-                            fallbackReason: `same priority (index ${existingIndex} vs ${newIndex}) - preserving existing`
-                        });
+                        queueArbitrationConflict(fieldName, existingValue, newValue,
+                            'existing', `same priority (index ${existingIndex} vs ${newIndex}) - preserving existing`);
                         return;
                     }
                     chosenValue = existingValue;
@@ -1876,12 +1981,8 @@ class SharedCore {
                 reason = `only ${newSource} in priority list`;
             } else if (canArbitrate) {
                 // Neither source in the priority list — non-decisive, defer to AI
-                pendingAiConflicts.push({
-                    field: fieldName,
-                    values: { existing: existingValue, incoming: newValue },
-                    fallbackPick: 'incoming',
-                    fallbackReason: 'neither source in priority list - keeping incoming'
-                });
+                queueArbitrationConflict(fieldName, existingValue, newValue,
+                    'incoming', 'neither source in priority list - keeping incoming');
                 return;
             }
 
@@ -1982,8 +2083,38 @@ class SharedCore {
         const clobberedFields = [];
         // Genuine conflicts deferred to AI arbitration (strategy "ai")
         const pendingAiConflicts = [];
+        // Arbitration outcomes (deterministic, ai, fallback) for display/metrics
+        const aiDecisionRecords = [];
 
         const mergeTitle = scraperObject.title || calendarObject.title || 'event';
+
+        // Deterministic pre-arbitration rules (URL shape / emoji-twin titles)
+        // run before a conflict is queued for AI — both merge paths consult
+        // resolveConflictDeterministically so behavior is identical.
+        const queueArbitrationConflict = (fieldName, calendarValue, scraperValue) => {
+            const resolved = this.resolveConflictDeterministically(fieldName, calendarValue, scraperValue);
+            if (!resolved) {
+                pendingAiConflicts.push({
+                    field: fieldName,
+                    values: { calendar: calendarValue, scraped: scraperValue }
+                });
+                return;
+            }
+            const chosenValue = resolved.winner === 'a' ? calendarValue : scraperValue;
+            mergedObject[fieldName] = chosenValue;
+            if (resolved.winner === 'b' && scraperValue !== calendarValue) {
+                clobberedFields.push(fieldName);
+            }
+            console.log(`🔒 MERGE: "${mergeTitle}" field=${fieldName} resolved deterministically — ${resolved.reason}`);
+            aiDecisionRecords.push({
+                field: fieldName,
+                existingValue: calendarValue,
+                newValue: scraperValue,
+                chosenValue: chosenValue,
+                reason: resolved.reason,
+                source: 'deterministic'
+            });
+        };
 
         // A scraped endDate that is <= the scraped startDate (zero/negative duration)
         // is a normalization artifact, not data — it must never replace a calendar
@@ -2068,10 +2199,7 @@ class SharedCore {
                 && this.isArbitrationEligibleField(fieldName)
                 && this.isGenuineFieldConflict(fieldName, calendarValue, scraperValue);
             if (routeDateConflictToAi) {
-                pendingAiConflicts.push({
-                    field: fieldName,
-                    values: { calendar: calendarValue, scraped: scraperValue }
-                });
+                queueArbitrationConflict(fieldName, calendarValue, scraperValue);
                 continue;
             }
 
@@ -2079,10 +2207,7 @@ class SharedCore {
                 case 'ai':
                     if (this.isArbitrationEligibleField(fieldName)
                         && this.isGenuineFieldConflict(fieldName, calendarValue, scraperValue)) {
-                        pendingAiConflicts.push({
-                            field: fieldName,
-                            values: { calendar: calendarValue, scraped: scraperValue }
-                        });
+                        queueArbitrationConflict(fieldName, calendarValue, scraperValue);
                         break;
                     }
                     // No genuine conflict → clobber semantics (today's default),
@@ -2112,7 +2237,6 @@ class SharedCore {
         // STEP 3b: AI arbitration for genuine conflicts — one batched request.
         // Any field the AI can't decide (or a dead/hallucinating model) falls back
         // to clobber, i.e. exactly the pre-arbitration behavior.
-        const aiDecisionRecords = [];
         if (pendingAiConflicts.length > 0) {
             const eventTitle = scraperObject.title || calendarObject.title || 'event';
             const aiConfig = this.getMergeArbitrationConfig(newEvent, options.globalConfig);
@@ -2226,7 +2350,8 @@ class SharedCore {
             finalEvent._mergeDecisions = aiDecisionRecords;
             finalEvent._original.aiArbitration = {
                 arbitrated: aiDecisionRecords.filter(record => record.source === 'ai').map(record => record.field),
-                fallbacks: aiDecisionRecords.filter(record => record.source === 'fallback').map(record => record.field)
+                fallbacks: aiDecisionRecords.filter(record => record.source === 'fallback').map(record => record.field),
+                deterministic: aiDecisionRecords.filter(record => record.source === 'deterministic').map(record => record.field)
             };
         }
         

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -659,6 +659,191 @@ test('mergeParsedEvents: decisive priority skips AI, non-decisive conflicts cons
   assert.equal(mergedFallback.bar, 'STATION 4', 'same-priority fallback preserves existing');
 });
 
+// ---------------------------------------------------------------------------
+// Deterministic pre-arbitration guardrails (🔒)
+// ---------------------------------------------------------------------------
+
+// Arbitration pair with title/bar/startDate aligned so each guardrail test can
+// introduce exactly the conflicts it needs.
+function buildAlignedArbitrationPair() {
+  const { scraped, existing } = buildArbitrationPair();
+  existing.title = scraped.title;
+  existing.startDate = new Date(scraped.startDate.getTime());
+  existing.notes = existing.notes.replace('bar: STATION 4', 'bar: S4');
+  return { scraped, existing };
+}
+
+test('guardrail: same-host root URL never beats the deeper path — zero AI calls', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  // Observed production shape: the model picked the domain root over the event page
+  scraped.website = 'https://bearracuda.com/';
+  existing.notes += '\nwebsite: https://www.bearracuda.com/events/portland-pridefriday/';
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'the only conflict resolved deterministically — no AI request at all');
+  assert.equal(finalEvent.website, 'https://www.bearracuda.com/events/portland-pridefriday/',
+    'the winner keeps its original untouched value (www + trailing slash preserved)');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['website']);
+  assert.deepEqual(finalEvent._original.aiArbitration.fallbacks, [], 'resolved, not a fallback');
+  const record = finalEvent._mergeDecisions.find(decision => decision.field === 'website');
+  assert.equal(record.source, 'deterministic');
+  assert.equal(record.reason, 'same-host deeper URL beats domain root');
+  assert.ok(logLines.includes(
+    '🔒 MERGE: "FURBALL DALLAS" field=website resolved deterministically — same-host deeper URL beats domain root'
+  ), `stable 🔒 log line expected, got: ${JSON.stringify(logLines)}`);
+});
+
+test('guardrail: deterministic field is excluded from the AI batch; genuine conflicts still arbitrate', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildArbitrationPair(); // title/bar/startDate conflicts remain
+  scraped.website = 'https://bearracuda.com/events/portland-pridefriday/';
+  existing.notes += '\nwebsite: https://bearracuda.com/';
+  const adapter = buildArbitrationAdapter({
+    title: { pick: 'scraped', value: 'FURBALL DALLAS' },
+    bar: { pick: 'calendar', value: 'STATION 4' },
+    startDate: { pick: 'scraped', value: '2026-07-05T22:00:00.000Z' }
+  });
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1, 'the genuine conflicts still batch into one AI request');
+  assert.match(adapter.calls[0].prompt, /field: title/);
+  assert.ok(!adapter.calls[0].prompt.includes('website'), 'deterministically resolved fields must not reach the prompt');
+  assert.ok(!adapter.calls[0].prompt.includes('portland-pridefriday'));
+  assert.equal(finalEvent.website, 'https://bearracuda.com/events/portland-pridefriday/', 'scraped deep URL wins over the calendar root');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['website']);
+  assert.deepEqual(finalEvent._original.aiArbitration.arbitrated.sort(), ['bar', 'startDate', 'title']);
+});
+
+test('guardrail: cross-host root-vs-deep URLs still go to the AI', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.website = 'https://ticketmaster.com/';
+  existing.notes += '\nwebsite: https://bearracuda.com/events/portland-pridefriday/';
+  const adapter = buildArbitrationAdapter({
+    website: { pick: 'calendar', value: 'https://bearracuda.com/events/portland-pridefriday/' }
+  });
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1, 'different hosts are a genuine question for the AI');
+  assert.match(adapter.calls[0].prompt, /field: website/);
+  assert.equal(finalEvent.website, 'https://bearracuda.com/events/portland-pridefriday/');
+});
+
+test('guardrail: same-host deep-vs-deep and root-vs-root URLs still go to the AI', () => {
+  const core = createCore();
+  assert.equal(
+    core.resolveConflictDeterministically('ticketUrl',
+      'https://bearracuda.com/events/portland/', 'https://bearracuda.com/tickets/portland/'),
+    null, 'both deep → arbitrate');
+  assert.equal(
+    core.resolveConflictDeterministically('website',
+      'https://bearracuda.com/', 'http://www.bearracuda.com'),
+    null, 'both root → arbitrate');
+  assert.equal(
+    core.resolveConflictDeterministically('website',
+      'https://bearracuda.com/', 'https://bearracuda.com/?p=1'),
+    null, 'a query-only URL is not a deeper path');
+});
+
+test('guardrail: "New Orleans" vs "New Orleans⚜️" keeps the emoji title without AI', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.title = 'New Orleans';
+  existing.title = 'New Orleans⚜️';
+  const adapter = buildArbitrationAdapter({});
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'an emoji-stripped twin is not a conflict');
+  assert.equal(finalEvent.title, 'New Orleans⚜️', 'calendar emoji titles are canonical');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['title']);
+});
+
+test('guardrail: emoji twin detection covers ⚜️, ⚓ and ⛓️ in both directions', () => {
+  const core = createCore();
+  const twins = [
+    ['New Orleans⚜️', 'New Orleans'],
+    ['Anchor Bear Night ⚓', 'Anchor Bear Night'],
+    ['CHAINED⛓️', 'CHAINED']
+  ];
+  for (const [emojiTitle, plainTitle] of twins) {
+    assert.deepEqual(
+      core.resolveConflictDeterministically('title', emojiTitle, plainTitle),
+      { winner: 'a', reason: 'emoji title variant beats its emoji-stripped twin' });
+    assert.deepEqual(
+      core.resolveConflictDeterministically('title', plainTitle, emojiTitle),
+      { winner: 'b', reason: 'emoji title variant beats its emoji-stripped twin' });
+  }
+  // Real text differences (and case differences) still arbitrate; ASCII is never stripped
+  assert.equal(core.resolveConflictDeterministically('title', 'FURBALL', 'FURBALL DALLAS'), null);
+  assert.equal(core.resolveConflictDeterministically('title', 'New Orleans⚜️', 'NEW ORLEANS'), null, 'case-sensitive otherwise');
+  assert.equal(core.resolveConflictDeterministically('title', 'Bear-Night!', 'BearNight!'), null, 'ASCII punctuation is real text');
+  assert.equal(core.resolveConflictDeterministically('title', '🐻', '⚓'), null, 'pure-emoji titles are not twins');
+});
+
+test('guardrail: logo-path image loses to event artwork in both directions; both-logo goes to AI', async () => {
+  const core = createCore();
+  const logo = 'https://res.cloudinary.com/eventservice/image/upload/w_600/saas/logos/image_abc.webp';
+  const poster = 'https://bearracuda.com/wp-content/uploads/2026/05/45-3.png';
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image', logo, poster),
+    { winner: 'b', reason: 'event artwork beats logo-path image' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image', poster, logo),
+    { winner: 'a', reason: 'event artwork beats logo-path image' });
+  const otherLogo = 'https://cdn.tickets.example/assets/logo/brand.png';
+  assert.equal(core.resolveConflictDeterministically('image', logo, otherLogo), null, 'both logo-ish → arbitrate');
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image', 'https://a.example/logo-banners/x.png', poster),
+    { winner: 'b', reason: 'event artwork beats logo-path image' },
+    'a path component merely containing "logo" counts');
+  // "logo" in the hostname or query must NOT count
+  assert.equal(
+    core.resolveConflictDeterministically('image', 'https://logo.example/poster.png', 'https://bearracuda.com/poster2.png'),
+    null, 'hostname is never matched');
+  assert.equal(
+    core.resolveConflictDeterministically('image', 'https://a.example/img.png?from=logos', 'https://b.example/img2.png'),
+    null, 'querystring is never matched');
+
+  // End-to-end: a scraped ticketing-service logo never beats the calendar poster
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.image = logo;
+  existing.notes += `\nimage: ${poster}`;
+  const adapter = buildArbitrationAdapter({});
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 0);
+  assert.equal(finalEvent.image, poster);
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['image']);
+});
+
+test('mergeParsedEvents: same-host root-vs-deep website resolves deterministically too', async () => {
+  const core = createCore();
+  const priorities = { website: { priority: ['ai-web'], merge: 'ai' } };
+  const aiParserConfig = { ai: { provider: 'ollama', endpoint: 'http://ai.example', model: 'm' } };
+  // Same source → same priority index → normally a non-decisive AI conflict
+  const existing = { title: 'FURBALL', website: 'https://bearracuda.com/events/portland-pridefriday/', source: 'ai-web', _fieldPriorities: priorities };
+  const incoming = { title: 'FURBALL', website: 'https://bearracuda.com/', source: 'ai-web', _parserConfig: aiParserConfig, _fieldPriorities: priorities };
+  const adapter = buildArbitrationAdapter({});
+
+  const merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'deterministic resolution must skip AI in the parser-merge path too');
+  assert.equal(merged.website, 'https://bearracuda.com/events/portland-pridefriday/');
+});
+
 test('resolveAiConfig defaults and the arbitrateMerges flag', () => {
   const core = createCore();
   const defaults = core.resolveAiConfig({});


### PR DESCRIPTION
## Problem (from the 2026-07-13 run)

The AI merge arbitration made three systematic wrong picks, each with a confidently confabulated reason:
1. **`website`**: picked scraped `https://bearracuda.com/` over the calendar's `https://bearracuda.com/events/portland-pridefriday/`.
2. **`title`**: picked `"New Orleans"` over the calendar's `"New Orleans⚜️"` — same title minus the emoji the calendar carries deliberately (canonical per the calendar contract and covered by the calendar-contract tests).
3. **`image`** (twice): picked the ticketing service's `…/saas/logos/….webp` logo over the actual bearracuda event poster.

## Fix

New pure `resolveConflictDeterministically(field, a, b)` consulted by **both** merge paths (`mergeParsedEvents` and `createFinalEventObject`) before a field is queued for AI arbitration — generic signals only (URL shape, string identity), per the automation-over-hardcoding direction:

- **Same-host deeper URL beats domain root** — both values http(s) URLs on the same host (www./trailing-slash ignored), one is the bare root, the other has path segments → deeper wins, no AI. Cross-host (ticketmaster vs bearracuda), deep-vs-deep, root-vs-root, and query-only URLs still arbitrate.
- **Emoji title variant beats its emoji-stripped twin** — titles identical after stripping pictographs/variation selectors (case-sensitive otherwise) → the emoji-bearing variant wins, no AI. Real text differences still arbitrate; the existing status-text prompt rule stays.
- **Event artwork beats logo-path image** — exactly one image URL has a `logo`-containing path segment → the other wins, no AI. Both/neither logo-ish still arbitrates, backstopped by a new prompt rule: *"For image, prefer event-specific promotional artwork over site or ticketing-service logos."*

Wins apply exactly like an AI pick (original untouched value, recorded in mergeDecisions/`_mergeDecisions` with `deterministic: <reason>`, new `aiArbitration.deterministic` list — never counted as fallback) and log a stable line:
```
🔒 MERGE: "<title>" field=<field> resolved deterministically — <reason>
```
plus a new `arbitrationDeterministic` metrics guard (verified not to move the 🤝 AI conflict/pick/fallback counters). Verbatim gate, fallback semantics, location/bar/date rules, and config overrides untouched. Side benefit: each firing saves the field an AI-arbitration slot.

## Tests
228 → **236**, all green. Covers all three rules in both directions, both merge paths, mixed batches (deterministic field excluded from the AI prompt while genuine conflicts still arbitrate, zero AI calls when nothing remains), the deliberate non-matches (cross-host, both-logo, real-text title diffs, pure-emoji titles), and the metrics counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP