### PR TITLE
OG studio: clean up Editorial Minimal layout

### DIFF
--- a/testing/test-og-event-layouts-calendar.html
+++ b/testing/test-og-event-layouts-calendar.html
@@ -279,16 +279,10 @@
       position: absolute; inset: 64px 80px;
       display: flex; flex-direction: column; justify-content: space-between;
     }
-    .l-editorial .head { display: flex; justify-content: space-between; align-items: center; }
     .l-editorial .brand-mark span { color: #131217; }
-    .l-editorial .city-tag {
-      font-family: 'Space Grotesk', sans-serif; font-size: 24px; font-weight: 700;
-      letter-spacing: 3px; text-transform: uppercase; color: #6d6a75;
-    }
     .l-editorial .og-title { color: #131217; letter-spacing: -2.5px; }
-    .l-editorial .accent-bar { height: 12px; width: 220px; border-radius: 100px; margin-bottom: 34px; }
+    .l-editorial .info { display: flex; flex-direction: column; gap: 20px; margin-top: 44px; }
     .l-editorial .meta-plain { color: #3c3a44; }
-    .l-editorial .meta-row { gap: 26px; }
     .l-editorial .orb {
       position: absolute; width: 520px; height: 520px; border-radius: 50%;
       right: -160px; bottom: -220px; filter: blur(70px); opacity: 0.5; pointer-events: none;
@@ -296,11 +290,11 @@
     }
     .l-editorial .photo-chip {
       /* real <img> so the photo keeps its natural aspect ratio — no square crop */
-      position: absolute; right: 76px; top: 130px;
-      max-width: 400px; max-height: 380px; width: auto; height: auto;
+      position: absolute; right: 76px; top: 50%;
+      max-width: 400px; max-height: 400px; width: auto; height: auto;
       display: block; border-radius: 28px;
       box-shadow: 0 30px 60px rgba(19,18,23,0.25);
-      transform: rotate(3deg);
+      transform: translateY(-50%) rotate(3deg);
       border: 6px solid #fff;
     }
 
@@ -995,25 +989,21 @@
             {
               key: 'editorial',
               name: 'Editorial Minimal',
-              desc: 'Light, type-first layout with a single palette accent',
+              desc: 'Light, type-first layout — title up top, details stacked below',
               chips: hasImage ? ['favicon colors', 'event image'] : ['favicon colors'],
               html: `
                 <div class="artboard l-editorial">
                   <div class="orb" style="background:radial-gradient(circle, ${p.c1}, transparent 70%)"></div>
                   ${hasImage ? `<img class="photo-chip" src="${escapeHtml(data.cover)}" alt="" style="background:linear-gradient(145deg, ${p.c1}, ${p.c4})" onerror="this.remove()">` : ''}
                   <div class="content">
-                    <div class="head">
-                      ${brand}
-                      <div class="city-tag">${escapeHtml(data.city)}</div>
-                    </div>
                     <div>
-                      <div class="accent-bar" style="background:linear-gradient(90deg, ${p.bg}, ${p.c3})"></div>
-                      <h2 class="og-title ${data.titleClass}" style="max-width:${hasImage ? '660px' : '1000px'};">${escapeHtml(data.title)}</h2>
+                      <h2 class="og-title ${data.titleClass}" style="max-width:${hasImage ? '640px' : '1000px'};">${escapeHtml(data.title)}</h2>
+                      <div class="info" style="max-width:${hasImage ? '620px' : '1000px'};">
+                        <div class="meta-plain"><b>${escapeHtml(data.date)}</b>${data.time ? ' · ' + escapeHtml(data.time) : ''}</div>
+                        <div class="meta-plain">${data.favicon ? venueIco + ' ' : ''}${escapeHtml(data.venue)} · ${escapeHtml(data.city)}</div>
+                      </div>
                     </div>
-                    <div class="meta-row">
-                      <div class="meta-plain"><b>${escapeHtml(data.date)}</b>${data.time ? ' · ' + escapeHtml(data.time) : ''}</div>
-                      <div class="meta-plain">${data.favicon ? venueIco + ' ' : ''}${escapeHtml(data.venue)}</div>
-                    </div>
+                    ${brand}
                   </div>
                 </div>`
             },


### PR DESCRIPTION
Follow-up to #1469, cleaning up the Editorial Minimal sample in the OG Image Studio per feedback:

- **Accent bar removed** — the gradient line above the title read as random noise.
- **Title moved to the top** of the artboard.
- **Details stacked on their own lines** beneath the title: date · time, then venue (with its favicon) · city, then the chunky.dad mark anchored at the bottom.
- Photo chip now vertically centers on the right side, and the title/info column is width-capped so long venue lines wrap instead of running under the photo.

Verified in headless Chrome (NYC data, forced landscape image): no overlap, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)