### PR TITLE
feat(scriptable): per-event provenance section + one-tap export-issue button

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A modern static website for chunky.dad",
   "main": "index.html",
   "scripts": {
-    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/metrics-sections.test.js scripts/adapters/scriptable-adapter.test.js scripts/golden-pipeline.test.js scripts/calendar-contract.test.js scripts/replay-run.test.js",
+    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/metrics-sections.test.js scripts/event-provenance.test.js scripts/adapters/scriptable-adapter.test.js scripts/golden-pipeline.test.js scripts/calendar-contract.test.js scripts/replay-run.test.js",
     "start": "python3 -m http.server 8000",
     "serve": "python3 -m http.server 8000",
     "dev": "python3 -m http.server 8000",

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -379,6 +379,7 @@ const HEADER_LOGO_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const { EventSchema: SharedEventSchema } = importModule("event-schema");
 const { SharedCore } = importModule("shared-core");
 const { RunLogSummary } = importModule("run-log-summary");
+const { EventProvenance } = importModule("event-provenance");
 
 if (
   !SharedEventSchema ||
@@ -3236,6 +3237,8 @@ class ScriptableAdapter {
     const runMetaLabel = runIdLabel
       ? `Run: ${runContextLabel} | ID: ${runIdLabel}`
       : `Run: ${runContextLabel}`;
+    // Run identity handed to each event card's provenance/export-issue section
+    const provenanceRunInfo = { runId: runIdLabel };
     const shouldShowLogs = results?._isDisplayingSavedRun === true;
     const runLogInfo = shouldShowLogs
       ? await this.loadRunLogsForDisplay(results)
@@ -4278,7 +4281,118 @@ class ScriptableAdapter {
             font-size: 12px;
             margin: 4px 0;
         }
-        
+
+        /* Per-event provenance section (built by event-provenance.js) */
+        .provenance-details {
+            margin-top: 12px;
+            border-top: 1px solid var(--border-color);
+            padding-top: 8px;
+        }
+
+        .provenance-details > summary {
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--primary-color);
+            padding: 5px 0;
+        }
+
+        .provenance-meta {
+            font-size: 11px;
+            color: var(--text-secondary);
+            margin: 4px 0;
+        }
+
+        .provenance-url {
+            font-family: monospace;
+            word-break: break-all;
+        }
+
+        .provenance-table-wrap {
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+            margin-top: 6px;
+        }
+
+        .provenance-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 11px;
+        }
+
+        .provenance-table th {
+            text-align: left;
+            padding: 4px 6px;
+            border-bottom: 1px solid var(--border-color);
+            color: var(--text-primary);
+            white-space: nowrap;
+        }
+
+        .provenance-table td {
+            padding: 4px 6px;
+            border-bottom: 1px solid var(--border-color);
+            color: var(--text-primary);
+            word-break: break-word;
+            vertical-align: top;
+        }
+
+        .provenance-table .provenance-field {
+            font-family: monospace;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .provenance-table .provenance-missing {
+            color: var(--text-secondary);
+        }
+
+        .provenance-table .provenance-decision {
+            color: var(--text-secondary);
+            font-style: italic;
+        }
+
+        .provenance-note {
+            color: var(--text-secondary);
+            font-size: 11px;
+            margin: 6px 0 0;
+        }
+
+        .provenance-export {
+            margin-top: 10px;
+        }
+
+        .provenance-export-btn {
+            padding: 4px 10px;
+            font-size: 11px;
+            background: var(--primary-color);
+            color: var(--text-inverse);
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            font-family: 'Poppins', sans-serif;
+            font-weight: 500;
+        }
+
+        .provenance-export-text {
+            width: 100%;
+            box-sizing: border-box;
+            margin-top: 8px;
+            font-family: monospace;
+            font-size: 10px;
+            background: var(--background-light);
+            color: var(--text-primary);
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 8px;
+        }
+
+        .provenance-export-status {
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--primary-color);
+            margin-top: 4px;
+        }
+
         .event-card.raw-mode .event-details,
         .event-card.raw-mode .event-metadata,
         .event-card.raw-mode .existing-info,
@@ -4473,7 +4587,7 @@ class ScriptableAdapter {
             <span class="section-title">New Events to Add</span>
             <span class="section-count">${newEvents.length}</span>
         </div>
-        ${newEvents.map((event) => this.generateEventCard(event)).join("")}
+        ${newEvents.map((event) => this.generateEventCard(event, provenanceRunInfo)).join("")}
     </div>
     `
         : ""
@@ -4488,7 +4602,7 @@ class ScriptableAdapter {
             <span class="section-title">Events to Merge (Adding Info)</span>
             <span class="section-count">${mergeEvents.length}</span>
         </div>
-        ${mergeEvents.map((event) => this.generateEventCard(event)).join("")}
+        ${mergeEvents.map((event) => this.generateEventCard(event, provenanceRunInfo)).join("")}
     </div>
     `
         : ""
@@ -4503,7 +4617,7 @@ class ScriptableAdapter {
                             <span class="section-title">Events Requiring Review</span>
             <span class="section-count">${conflictEvents.length}</span>
         </div>
-        ${conflictEvents.map((event) => this.generateEventCard(event)).join("")}
+        ${conflictEvents.map((event) => this.generateEventCard(event, provenanceRunInfo)).join("")}
     </div>
     `
         : ""
@@ -4974,6 +5088,46 @@ class ScriptableAdapter {
             filterEvents();
         }
         
+        // Per-event "Export issue" (provenance section). WKWebView has no
+        // reliable navigator.clipboard and no window.open, so: reveal a
+        // readonly textarea holding the JSON (auto-selects on focus), attempt
+        // the legacy execCommand copy, and tell the user which worked.
+        function exportProvenanceIssue(button) {
+            try {
+                const wrapper = button.closest ? button.closest('.provenance-export') : button.parentElement;
+                if (!wrapper) return;
+                const area = wrapper.querySelector('.provenance-export-area');
+                const textarea = wrapper.querySelector('.provenance-export-text');
+                const status = wrapper.querySelector('.provenance-export-status');
+                if (!area || !textarea || !status) return;
+
+                let text = '';
+                try {
+                    text = decodeURIComponent(button.getAttribute('data-payload') || '');
+                } catch (decodeError) {
+                    text = button.getAttribute('data-payload') || '';
+                }
+
+                area.style.display = 'block';
+                textarea.value = text;
+                textarea.focus();
+                textarea.select();
+                if (textarea.setSelectionRange) {
+                    textarea.setSelectionRange(0, textarea.value.length);
+                }
+
+                let copied = false;
+                try {
+                    copied = document.execCommand('copy');
+                } catch (copyError) {
+                    copied = false;
+                }
+                status.textContent = copied ? 'Copied ✓' : 'Select & copy above';
+            } catch (error) {
+                console.error('Export issue failed: ' + error);
+            }
+        }
+
         function copyEventJSON(button) {
             const eventJSON = button.getAttribute('data-event-json');
             
@@ -5315,6 +5469,26 @@ class ScriptableAdapter {
     }
   }
 
+  // Per-event "🔍 Provenance" section (field origins, merge decisions, and the
+  // export-issue payload). Builders live in the pure event-provenance module;
+  // this is just the environment glue. A failure here must never block an
+  // event card, so this degrades to an empty string (mirrors
+  // buildRunHealthBadgeHtml).
+  buildEventProvenanceHtml(event, runInfo = {}) {
+    try {
+      return EventProvenance.buildEventProvenanceSectionHtml(event, {
+        action: this.normalizeIntentAction(event),
+        runId: runInfo.runId || null,
+        timestamp: runInfo.timestamp || null,
+      });
+    } catch (error) {
+      console.log(
+        `📱 Scriptable: Provenance section build failed for "${event?.title || "unknown"}": ${error.message}`,
+      );
+      return "";
+    }
+  }
+
   // Structured per-event decisions from the analyzed results (preferred over
   // log-derived data where both exist).
   collectEventDecisionLines(results) {
@@ -5566,7 +5740,7 @@ class ScriptableAdapter {
   }
 
   // Generate HTML for individual event card
-  generateEventCard(event) {
+  generateEventCard(event, runInfo = {}) {
     const intentAction = this.normalizeIntentAction(event) || "other";
     const writeAction = this.getWriteActionFromEvent(event);
     const actionBadge =
@@ -5949,7 +6123,10 @@ class ScriptableAdapter {
                   })()
                 : ""
             }
-            
+
+            <!-- Per-event provenance (field origins + export-issue button) -->
+            ${this.buildEventProvenanceHtml(event, runInfo)}
+
             <!-- Simplified metadata -->
             ${
               event._action === "conflict" && event._conflicts

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -244,3 +244,78 @@ test('long crawl lists are capped in the rendered HTML', () => {
   assert.ok(html.includes('more page(s) not shown'));
   assert.ok(!html.includes('page-79'));
 });
+
+// ---------------------------------------------------------------------------
+// Per-event provenance section (event-provenance.js glue)
+// ---------------------------------------------------------------------------
+
+test('event cards embed the collapsed provenance section with the export control', () => {
+  const adapter = buildAdapter();
+  const event = {
+    title: 'BEARRACUDA: Atlanta',
+    startDate: '2026-08-01T02:00:00.000Z',
+    endDate: '2026-08-01T06:00:00.000Z',
+    url: 'https://bearracuda.com/events/atlanta',
+    source: 'bearracuda',
+    _action: 'merge',
+    _analysis: { action: 'merge' },
+    _original: {
+      scraper: { title: 'BEARRACUDA: Atlanta', endDate: '2026-08-01T04:00:00.000Z' },
+      calendar: { title: 'Bearracuda Atlanta', endDate: '2026-08-01T06:00:00.000Z' },
+      merged: {},
+      aiArbitration: { arbitrated: ['endDate'], fallbacks: [] }
+    },
+    _mergeDecisions: [{
+      field: 'endDate',
+      existingValue: '2026-08-01T06:00:00.000Z',
+      newValue: '2026-08-01T04:00:00.000Z',
+      chosenValue: '2026-08-01T06:00:00.000Z',
+      reason: 'calendar end matches doors-close time',
+      source: 'ai'
+    }]
+  };
+
+  const card = adapter.generateEventCard(event, { runId: '20260713-090000' });
+
+  assert.ok(card.includes('provenance-details'));
+  assert.ok(card.includes('🔍 Provenance'));
+  assert.ok(card.includes('Parser: bearracuda'));
+  assert.ok(card.includes('AI: calendar end matches doors-close time'));
+  assert.ok(card.includes('exportProvenanceIssue(this)'));
+
+  // The embedded export payload carries the run id passed through by the card
+  const payloadMatch = card.match(/data-payload="([^"]*)"/);
+  assert.ok(payloadMatch, 'export payload missing from card');
+  const payload = JSON.parse(decodeURIComponent(payloadMatch[1]));
+  assert.equal(payload.runId, '20260713-090000');
+  assert.equal(payload.mergeDecisions.length, 1);
+});
+
+test('a provenance build failure degrades to an empty section, never blocks the card', () => {
+  const adapter = buildAdapter();
+  const hostile = { title: 'Bad Event', startDate: '2026-08-01T02:00:00.000Z' };
+  Object.defineProperty(hostile, '_mergeDecisions', {
+    get() { throw new Error('boom'); },
+    enumerable: true
+  });
+
+  // The adapter wrapper swallows the throw and returns an empty section —
+  // the card build continues without provenance instead of dying.
+  assert.equal(adapter.buildEventProvenanceHtml(hostile), '');
+});
+
+test('generateRichHTML defines the exportProvenanceIssue page handler once', async () => {
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML({
+    totalEvents: 1,
+    bearEvents: 1,
+    calendarEvents: 0,
+    errors: [],
+    analyzedEvents: [{ title: 'Bear Night', startDate: '2026-08-01T02:00:00.000Z', _action: 'new' }],
+    parserResults: []
+  });
+
+  assert.equal((html.match(/function exportProvenanceIssue\(/g) || []).length, 1);
+  assert.ok(html.includes('provenance-details'));
+  assert.ok(html.includes('No provenance recorded'));
+});

--- a/scripts/event-provenance.js
+++ b/scripts/event-provenance.js
@@ -1,0 +1,458 @@
+// ============================================================================
+// EVENT PROVENANCE - PURE HTML/DATA BUILDERS FOR PER-EVENT FIELD PROVENANCE
+// ============================================================================
+// ⚠️  AI ASSISTANT WARNING: This file contains PURE JavaScript business logic
+//
+// 🚨 CRITICAL RESTRICTIONS - NEVER ADD THESE TO THIS FILE:
+// ❌ NO Node-only APIs (fs, path, process)
+// ❌ NO Scriptable APIs (FileManager, WebView, Alert) - adapters own those
+// ❌ NO DOM APIs (document, window) - this builds HTML strings only
+//
+// ✅ THIS FILE SHOULD ONLY CONTAIN:
+// ✅ Plain functions that take analyzed-event objects and return HTML strings
+//    or JSON-safe export payloads
+//
+// Builds the per-event "🔍 Provenance" <details> section shown inside each
+// event card of the results WebView and the saved-run display (both render
+// through ScriptableAdapter.generateEventCard), plus the "📤 Export issue"
+// JSON payload for handing one event's evidence to a debugging session.
+//
+// Input shape (all optional — old saved runs may carry none of it):
+//   event._original            { scraper, calendar, merged, aiArbitration }
+//   event._mergeDecisions      [{ field, existingValue, newValue, chosenValue,
+//                                 reason, source: 'ai'|'fallback' }]
+//   event.mergeDecisions       same record shape from cross-parser merges,
+//                              where present
+// Missing/partial data must render a graceful note — never throw. The click
+// handler for the export button (exportProvenanceIssue) is page JS defined by
+// the adapter's generateRichHTML script block, not by this module.
+//
+// Consumed by:
+//   - scripts/adapters/scriptable-adapter.js (event cards in the results and
+//     saved-run WebView displays; display-saved-run.js renders via the adapter)
+//   - scripts/event-provenance.test.js (headless Node tests)
+//
+// 📖 READ scripts/README.md BEFORE EDITING - Contains full architecture rules
+// ============================================================================
+
+// Fields worth tracing. Everything else is either internal (_-prefixed) or
+// derived (notes, gmaps) and is covered by the raw-JSON view instead.
+const PROVENANCE_FIELDS = [
+    'title', 'bar', 'address', 'location', 'city', 'startDate', 'endDate',
+    'description', 'ticketUrl', 'website', 'image', 'cover'
+];
+
+const VALUE_PREVIEW_MAX = 80;
+
+function escapeHtml(value) {
+    return String(value === null || value === undefined ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+// Empty-ish values (null/undefined/blank) all render as the same missing marker.
+function isMissingValue(value) {
+    return value === null || value === undefined
+        || (typeof value === 'string' && value.trim() === '');
+}
+
+// Render any field value as plain display text — objects/Dates/functions must
+// never leak raw into HTML or comparisons.
+function formatValueText(value) {
+    if (isMissingValue(value)) return '';
+    if (value instanceof Date) {
+        return Number.isFinite(value.getTime()) ? value.toISOString() : '';
+    }
+    if (typeof value === 'function') return '[function]';
+    if (typeof value === 'object') {
+        try {
+            return JSON.stringify(value);
+        } catch (error) {
+            return String(value);
+        }
+    }
+    return String(value);
+}
+
+function truncateText(text, maxLength = VALUE_PREVIEW_MAX) {
+    const str = String(text || '');
+    if (str.length <= maxLength) return str;
+    return `${str.slice(0, maxLength - 1)}…`;
+}
+
+// Field-aware equality: date fields compare by instant so a saved run's ISO
+// string equals the live Date object it was serialized from.
+function valuesEqual(fieldName, a, b) {
+    const aText = formatValueText(a);
+    const bText = formatValueText(b);
+    if (aText === bText) return true;
+    if (fieldName === 'startDate' || fieldName === 'endDate') {
+        const aMs = Date.parse(aText);
+        const bMs = Date.parse(bText);
+        if (Number.isFinite(aMs) && Number.isFinite(bMs)) return aMs === bMs;
+    }
+    return false;
+}
+
+// Recorded merge decisions keyed by field. _mergeDecisions (calendar-merge AI
+// arbitration records) is preferred; cross-parser mergeDecisions records are
+// folded in where present. Malformed entries are skipped, never thrown on.
+function collectDecisionsByField(event) {
+    const byField = {};
+    const lists = [];
+    if (event && Array.isArray(event._mergeDecisions)) lists.push(event._mergeDecisions);
+    if (event && Array.isArray(event.mergeDecisions)) lists.push(event.mergeDecisions);
+    for (const list of lists) {
+        for (const decision of list) {
+            if (!decision || typeof decision !== 'object') continue;
+            if (typeof decision.field !== 'string' || !decision.field) continue;
+            if (!byField[decision.field]) byField[decision.field] = [];
+            byField[decision.field].push(decision);
+        }
+    }
+    return byField;
+}
+
+// Human text for one recorded decision ({reason, source} record shape).
+function formatDecisionText(decision) {
+    if (!decision || typeof decision !== 'object') return '';
+    const reason = typeof decision.reason === 'string' ? decision.reason.trim() : '';
+    if (decision.source === 'ai') {
+        return reason ? `AI: ${reason}` : 'AI arbitration';
+    }
+    if (decision.source === 'fallback') {
+        return reason ? `AI fallback: ${reason}` : 'AI unavailable — fallback';
+    }
+    return reason || 'decision recorded';
+}
+
+// Derived decision text when values differ but no decision record exists
+// (e.g. plain clobber/upsert paths that never log a record).
+function deriveDecisionText(fieldName, finalValue, scraperValue, calendarValue, hasScraper, hasCalendar) {
+    const matchesScraper = hasScraper && !isMissingValue(scraperValue)
+        && valuesEqual(fieldName, finalValue, scraperValue);
+    const matchesCalendar = hasCalendar && !isMissingValue(calendarValue)
+        && valuesEqual(fieldName, finalValue, calendarValue);
+    if (matchesScraper && matchesCalendar) return 'both sources agree';
+    if (matchesScraper) {
+        return hasCalendar && isMissingValue(calendarValue)
+            ? 'took scraped value (calendar had none)'
+            : 'took scraped value';
+    }
+    if (matchesCalendar) {
+        return hasScraper && isMissingValue(scraperValue)
+            ? 'kept from calendar (scrape found none)'
+            : 'kept calendar value';
+    }
+    if (isMissingValue(finalValue)) return 'dropped during merge';
+    return 'value derived during merge';
+}
+
+// Short "AI arbitration: N arbitrated, M fallback" summary from
+// _original.aiArbitration { arbitrated: [fields], fallbacks: [fields] }.
+function formatArbitrationSummary(aiArbitration) {
+    if (!aiArbitration || typeof aiArbitration !== 'object') return '';
+    const arbitrated = Array.isArray(aiArbitration.arbitrated) ? aiArbitration.arbitrated.length : 0;
+    const fallbacks = Array.isArray(aiArbitration.fallbacks) ? aiArbitration.fallbacks.length : 0;
+    if (arbitrated === 0 && fallbacks === 0) return '';
+    const parts = [];
+    if (arbitrated > 0) parts.push(`${arbitrated} arbitrated`);
+    if (fallbacks > 0) parts.push(`${fallbacks} fallback${fallbacks === 1 ? '' : 's'}`);
+    return `AI arbitration: ${parts.join(', ')}`;
+}
+
+// Structured provenance model for one analyzed event — everything the HTML
+// builder and the export payload need, with no HTML in it. Never throws on
+// missing/partial data.
+function buildProvenanceModel(event, options = {}) {
+    const safeEvent = event && typeof event === 'object' ? event : {};
+    const original = safeEvent._original && typeof safeEvent._original === 'object'
+        ? safeEvent._original
+        : null;
+    const scraper = original && original.scraper && typeof original.scraper === 'object'
+        ? original.scraper
+        : null;
+    const calendar = original && original.calendar && typeof original.calendar === 'object'
+        ? original.calendar
+        : null;
+    const decisionsByField = collectDecisionsByField(safeEvent);
+    const hasDecisions = Object.keys(decisionsByField).length > 0;
+
+    const parserConfig = safeEvent._parserConfig && typeof safeEvent._parserConfig === 'object'
+        ? safeEvent._parserConfig
+        : null;
+    const parser = formatValueText(
+        options.parser || safeEvent.source || (parserConfig && (parserConfig.name || parserConfig.parser)) || ''
+    );
+    const sourceUrl = formatValueText(
+        safeEvent.url || safeEvent.website
+        || (scraper && (scraper.url || scraper.website)) || ''
+    );
+    const action = formatValueText(options.action || safeEvent._action || '');
+
+    const rows = [];
+    let unchangedCount = 0;
+    for (const field of PROVENANCE_FIELDS) {
+        const finalValue = safeEvent[field];
+        const scraperValue = scraper ? scraper[field] : undefined;
+        const calendarValue = calendar ? calendar[field] : undefined;
+        const decisions = decisionsByField[field] || [];
+
+        const allMissing = isMissingValue(finalValue)
+            && isMissingValue(scraperValue)
+            && isMissingValue(calendarValue);
+        if (allMissing && decisions.length === 0) continue;
+
+        const differs = (scraper && !valuesEqual(field, finalValue, scraperValue))
+            || (calendar && !valuesEqual(field, finalValue, calendarValue))
+            || (scraper && calendar && !valuesEqual(field, scraperValue, calendarValue));
+
+        if (!differs && decisions.length === 0) {
+            unchangedCount += 1;
+            continue;
+        }
+
+        const decisionText = decisions.length > 0
+            ? decisions.map(formatDecisionText).filter(Boolean).join('; ')
+            : deriveDecisionText(field, finalValue, scraperValue, calendarValue, Boolean(scraper), Boolean(calendar));
+
+        rows.push({
+            field,
+            finalValue,
+            scraperValue,
+            calendarValue,
+            decisionText,
+            recorded: decisions.length > 0
+        });
+    }
+
+    return {
+        parser,
+        sourceUrl,
+        action,
+        hasScraper: Boolean(scraper),
+        hasCalendar: Boolean(calendar),
+        // Whether any provenance data exists at all (vs. a bare final event
+        // from a new action or an old saved run)
+        hasProvenance: Boolean(scraper || calendar || hasDecisions),
+        arbitrationSummary: formatArbitrationSummary(original ? original.aiArbitration : null),
+        rows,
+        unchangedCount
+    };
+}
+
+// JSON-safe export payload for one event: everything a debugging session needs
+// to reproduce a field decision, and nothing internal beyond the listed keys.
+// Guaranteed serializable — functions and circular references are dropped.
+function buildExportIssuePayload(event, options = {}) {
+    const safeEvent = event && typeof event === 'object' ? event : {};
+    const model = buildProvenanceModel(safeEvent, options);
+    const original = safeEvent._original && typeof safeEvent._original === 'object'
+        ? safeEvent._original
+        : null;
+
+    // Deep-clone one field value into a JSON-safe form: functions dropped,
+    // Dates as ISO strings, circular references cut. Each value gets its own
+    // seen-set so shared references across payload sections survive intact.
+    const toJsonSafeValue = (value) => {
+        if (value === undefined || typeof value === 'function') return undefined;
+        if (value instanceof Date) return formatValueText(value) || null;
+        if (value === null || typeof value !== 'object') return value;
+        const seen = new WeakSet();
+        try {
+            return JSON.parse(JSON.stringify(value, (key, val) => {
+                if (typeof val === 'function') return undefined;
+                if (val && typeof val === 'object') {
+                    if (seen.has(val)) return undefined;
+                    seen.add(val);
+                }
+                return val;
+            }));
+        } catch (error) {
+            return formatValueText(value);
+        }
+    };
+
+    const pickFields = (source) => {
+        if (!source || typeof source !== 'object') return null;
+        const out = {};
+        for (const field of PROVENANCE_FIELDS) {
+            const value = toJsonSafeValue(source[field]);
+            if (value === undefined) continue;
+            out[field] = value;
+        }
+        return out;
+    };
+
+    const decisions = []
+        .concat(Array.isArray(safeEvent._mergeDecisions) ? safeEvent._mergeDecisions : [])
+        .concat(Array.isArray(safeEvent.mergeDecisions) ? safeEvent.mergeDecisions : [])
+        .filter((decision) => decision && typeof decision === 'object')
+        .map((decision) => ({
+            field: decision.field || null,
+            existingValue: formatValueText(decision.existingValue) || null,
+            newValue: formatValueText(decision.newValue) || null,
+            chosenValue: formatValueText(decision.chosenValue) || null,
+            reason: decision.reason || null,
+            source: decision.source || null
+        }));
+
+    const payload = {
+        runId: options.runId || null,
+        timestamp: options.timestamp || null,
+        parser: model.parser || null,
+        sourceUrl: model.sourceUrl || null,
+        action: model.action || null,
+        finalValues: pickFields(safeEvent) || {},
+        scraperValues: pickFields(original ? original.scraper : null),
+        calendarValues: pickFields(original ? original.calendar : null),
+        mergeDecisions: decisions,
+        aiArbitration: original && original.aiArbitration && typeof original.aiArbitration === 'object'
+            ? {
+                arbitrated: Array.isArray(original.aiArbitration.arbitrated) ? original.aiArbitration.arbitrated : [],
+                fallbacks: Array.isArray(original.aiArbitration.fallbacks) ? original.aiArbitration.fallbacks : []
+            }
+            : null
+    };
+
+    // Round-trip through JSON with a defensive replacer so the result is
+    // always serializable (functions dropped, circular references cut).
+    const seen = new WeakSet();
+    return JSON.parse(JSON.stringify(payload, (key, value) => {
+        if (typeof value === 'function') return undefined;
+        if (value && typeof value === 'object') {
+            if (seen.has(value)) return undefined;
+            seen.add(value);
+        }
+        return value;
+    }));
+}
+
+// Pretty-printed JSON string of the export payload (what lands in the
+// clipboard / textarea). Never throws — falls back to an error stub.
+function buildExportIssueJson(event, options = {}) {
+    try {
+        return JSON.stringify(buildExportIssuePayload(event, options), null, 2);
+    } catch (error) {
+        return JSON.stringify({ error: `Failed to build export payload: ${error.message}` }, null, 2);
+    }
+}
+
+// One value cell: truncated preview with the full value in title= for long
+// values, missing values as an em dash.
+function buildValueCellHtml(value) {
+    const text = formatValueText(value);
+    if (!text) {
+        return '<td class="provenance-missing">—</td>';
+    }
+    const preview = truncateText(text);
+    const titleAttr = preview === text ? '' : ` title="${escapeHtml(text)}"`;
+    return `<td${titleAttr}>${escapeHtml(preview)}</td>`;
+}
+
+// The "📤 Export issue" control: button + hidden readonly textarea. The
+// data-payload attribute carries the URI-encoded JSON; the page-side
+// exportProvenanceIssue() handler (defined by the display's script block)
+// reveals the textarea, selects it and attempts document.execCommand('copy').
+function buildExportControlsHtml(event, options = {}) {
+    const encoded = encodeURIComponent(buildExportIssueJson(event, options));
+    return `
+            <div class="provenance-export">
+                <button type="button" class="provenance-export-btn" onclick="exportProvenanceIssue(this)" data-payload="${escapeHtml(encoded)}">📤 Export issue</button>
+                <div class="provenance-export-area" style="display: none;">
+                    <textarea class="provenance-export-text" readonly rows="10" spellcheck="false" onfocus="this.select()"></textarea>
+                    <div class="provenance-export-status"></div>
+                </div>
+            </div>`;
+}
+
+// Full collapsed "🔍 Provenance" <details> section for one event card.
+// options: { action, parser, runId, timestamp } — all optional overrides the
+// adapter passes through (action from its intent normalization, run info for
+// the export payload). Degrades to an informative note on missing data.
+function buildEventProvenanceSectionHtml(event, options = {}) {
+    const model = buildProvenanceModel(event, options);
+
+    const metaParts = [];
+    if (model.parser) metaParts.push(`Parser: ${model.parser}`);
+    if (model.action) metaParts.push(`Action: ${model.action}`);
+    if (model.arbitrationSummary) metaParts.push(model.arbitrationSummary);
+    const metaLine = metaParts.length > 0
+        ? `<div class="provenance-meta">${escapeHtml(metaParts.join(' • '))}</div>`
+        : '';
+    const urlLine = model.sourceUrl
+        ? `<div class="provenance-meta provenance-url" title="${escapeHtml(model.sourceUrl)}">Source: ${escapeHtml(truncateText(model.sourceUrl))}</div>`
+        : '';
+
+    let body;
+    if (!model.hasProvenance) {
+        body = '<div class="provenance-note">No provenance recorded for this event (new event or older saved run).</div>';
+    } else if (model.rows.length === 0) {
+        body = `<div class="provenance-note">All ${model.unchangedCount} tracked field${model.unchangedCount === 1 ? '' : 's'} passed through unchanged.</div>`;
+    } else {
+        const calendarHeader = model.hasCalendar ? '<th>Calendar</th>' : '';
+        const rowsHtml = model.rows.map((row) => `
+                    <tr>
+                        <td class="provenance-field">${escapeHtml(row.field)}</td>
+                        ${buildValueCellHtml(row.finalValue)}
+                        ${buildValueCellHtml(row.scraperValue)}
+                        ${model.hasCalendar ? buildValueCellHtml(row.calendarValue) : ''}
+                        <td class="provenance-decision">${escapeHtml(row.decisionText)}</td>
+                    </tr>`).join('');
+        const unchangedNote = model.unchangedCount > 0
+            ? `<div class="provenance-note">${model.unchangedCount} field${model.unchangedCount === 1 ? '' : 's'} unchanged</div>`
+            : '';
+        body = `
+            <div class="provenance-table-wrap">
+                <table class="provenance-table">
+                    <tr><th>Field</th><th>Final</th><th>Scraper</th>${calendarHeader}<th>Decision</th></tr>
+                    ${rowsHtml}
+                </table>
+            </div>
+            ${unchangedNote}`;
+    }
+
+    return `
+        <details class="provenance-details">
+            <summary>🔍 Provenance</summary>
+            ${metaLine}
+            ${urlLine}
+            ${body}
+            ${buildExportControlsHtml(event, options)}
+        </details>`;
+}
+
+const EventProvenance = {
+    PROVENANCE_FIELDS,
+    escapeHtml,
+    formatValueText,
+    valuesEqual,
+    formatDecisionText,
+    buildProvenanceModel,
+    buildExportIssuePayload,
+    buildExportIssueJson,
+    buildEventProvenanceSectionHtml
+};
+
+// Export for both environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        EventProvenance,
+        escapeHtml,
+        formatValueText,
+        valuesEqual,
+        formatDecisionText,
+        buildProvenanceModel,
+        buildExportIssuePayload,
+        buildExportIssueJson,
+        buildEventProvenanceSectionHtml
+    };
+} else if (typeof window !== 'undefined') {
+    window.EventProvenance = EventProvenance;
+} else {
+    // Scriptable environment
+    this.EventProvenance = EventProvenance;
+}

--- a/scripts/event-provenance.test.js
+++ b/scripts/event-provenance.test.js
@@ -1,0 +1,313 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    EventProvenance,
+    buildProvenanceModel,
+    buildExportIssuePayload,
+    buildExportIssueJson,
+    buildEventProvenanceSectionHtml
+} = require('./event-provenance');
+
+// ---------------------------------------------------------------------------
+// Fixture shaped exactly like a calendar-merged analyzed event after
+// createFinalEventObject + sanitizeEventForRunSave (see shared-core.js
+// STEP 6 and the _mergeDecisions/aiArbitration records it attaches).
+// ---------------------------------------------------------------------------
+function buildMergedEventFixture() {
+    return {
+        title: 'BEARRACUDA: Atlanta',
+        bar: 'Heretic',
+        address: '2069 Cheshire Bridge Rd',
+        location: '33.823,-84.356',
+        city: 'atlanta',
+        startDate: '2026-08-01T02:00:00.000Z',
+        endDate: '2026-08-01T06:00:00.000Z',
+        description: 'Bear dance party',
+        url: 'https://bearracuda.com/events/atlanta',
+        source: 'bearracuda',
+        notes: 'internal notes blob',
+        _action: 'merge',
+        _parserConfig: { name: 'Bearracuda', parser: 'bearracuda' },
+        _fieldPriorities: { title: { merge: 'clobber' } },
+        _original: {
+            scraper: {
+                title: 'BEARRACUDA: Atlanta',
+                bar: 'Heretic',
+                address: '2069 Cheshire Bridge Rd',
+                city: 'atlanta',
+                startDate: '2026-08-01T02:00:00.000Z',
+                endDate: '2026-08-01T04:00:00.000Z',
+                description: 'Bear dance party',
+                url: 'https://bearracuda.com/events/atlanta'
+            },
+            calendar: {
+                title: 'Bearracuda Atlanta',
+                bar: 'Heretic',
+                address: '2069 Cheshire Bridge Rd',
+                location: '33.823,-84.356',
+                city: 'atlanta',
+                startDate: '2026-08-01T02:00:00.000Z',
+                endDate: '2026-08-01T06:00:00.000Z',
+                description: 'Bear dance party'
+            },
+            merged: {},
+            aiArbitration: { arbitrated: ['endDate'], fallbacks: ['title'] }
+        },
+        _mergeDecisions: [
+            {
+                field: 'endDate',
+                existingValue: '2026-08-01T06:00:00.000Z',
+                newValue: '2026-08-01T04:00:00.000Z',
+                chosenValue: '2026-08-01T06:00:00.000Z',
+                reason: 'calendar end matches doors-close time',
+                source: 'ai'
+            },
+            {
+                field: 'title',
+                existingValue: 'Bearracuda Atlanta',
+                newValue: 'BEARRACUDA: Atlanta',
+                chosenValue: 'BEARRACUDA: Atlanta',
+                reason: 'ai unavailable/rejected — clobber fallback',
+                source: 'fallback'
+            }
+        ]
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Interesting-row selection
+// ---------------------------------------------------------------------------
+
+test('provenance model keeps only interesting rows and counts pass-through fields', () => {
+    const model = buildProvenanceModel(buildMergedEventFixture());
+
+    // title (decision + calendar differs), location (scraper found none),
+    // endDate (decision + scraper differs) — in PROVENANCE_FIELDS order.
+    assert.deepEqual(model.rows.map(row => row.field), ['title', 'location', 'endDate']);
+    // bar, address, city, startDate, description are identical pass-throughs
+    assert.equal(model.unchangedCount, 5);
+    assert.equal(model.hasProvenance, true);
+    assert.equal(model.hasCalendar, true);
+    assert.equal(model.parser, 'bearracuda');
+    assert.equal(model.sourceUrl, 'https://bearracuda.com/events/atlanta');
+    assert.equal(model.action, 'merge');
+    assert.equal(model.arbitrationSummary, 'AI arbitration: 1 arbitrated, 1 fallback');
+});
+
+test('date fields compare by instant: a live Date equals its saved ISO string', () => {
+    const event = buildMergedEventFixture();
+    event.startDate = new Date('2026-08-01T02:00:00.000Z'); // live-run shape
+    const model = buildProvenanceModel(event);
+
+    assert.ok(!model.rows.some(row => row.field === 'startDate'),
+        'identical instants must not become a row');
+    assert.equal(EventProvenance.valuesEqual('startDate',
+        new Date('2026-08-01T02:00:00.000Z'), '2026-08-01T02:00:00.000Z'), true);
+    // Non-date fields stay strict
+    assert.equal(EventProvenance.valuesEqual('title', 'A', 'a'), false);
+});
+
+test('section HTML renders the rows, the unchanged note and the header line', () => {
+    const html = buildEventProvenanceSectionHtml(buildMergedEventFixture(), { runId: '20260713-090000' });
+
+    assert.ok(html.includes('<details class="provenance-details">'));
+    assert.ok(!html.includes('<details class="provenance-details" open'), 'must be collapsed by default');
+    assert.ok(html.includes('🔍 Provenance'));
+    assert.ok(html.includes('Parser: bearracuda'));
+    assert.ok(html.includes('Action: merge'));
+    assert.ok(html.includes('AI arbitration: 1 arbitrated, 1 fallback'));
+    assert.ok(html.includes('https://bearracuda.com/events/atlanta'));
+    assert.ok(html.includes('5 fields unchanged'));
+    assert.ok(html.includes('<th>Calendar</th>'), 'calendar column present for calendar merges');
+    assert.ok(html.includes('📤 Export issue'));
+});
+
+// ---------------------------------------------------------------------------
+// Decision-text rendering
+// ---------------------------------------------------------------------------
+
+test('recorded merge decisions render as AI / fallback decision text', () => {
+    const html = buildEventProvenanceSectionHtml(buildMergedEventFixture());
+
+    assert.ok(html.includes('AI: calendar end matches doors-close time'));
+    assert.ok(html.includes('AI fallback: ai unavailable/rejected — clobber fallback'));
+});
+
+test('fields without a recorded decision derive text from which side won', () => {
+    const model = buildProvenanceModel(buildMergedEventFixture());
+    const locationRow = model.rows.find(row => row.field === 'location');
+
+    assert.equal(locationRow.recorded, false);
+    assert.equal(locationRow.decisionText, 'kept from calendar (scrape found none)');
+});
+
+test('cross-parser mergeDecisions records (no source key) render their reason as-is', () => {
+    const event = {
+        title: 'FURBALL',
+        bar: 'Eagle NYC',
+        source: 'furball',
+        mergeDecisions: [{
+            field: 'bar',
+            existingValue: 'Eagle',
+            newValue: 'Eagle NYC',
+            chosenValue: 'Eagle NYC',
+            reason: 'furball has higher priority (index 0 vs 1)'
+        }]
+    };
+    const html = buildEventProvenanceSectionHtml(event);
+    assert.ok(html.includes('furball has higher priority (index 0 vs 1)'));
+});
+
+// ---------------------------------------------------------------------------
+// Graceful degradation
+// ---------------------------------------------------------------------------
+
+test('an event without _original or decisions renders a note, never throws', () => {
+    const html = buildEventProvenanceSectionHtml({
+        title: 'Bear Night',
+        startDate: '2026-08-01T02:00:00.000Z',
+        _action: 'new',
+        source: 'chunk'
+    });
+
+    assert.ok(html.includes('No provenance recorded'));
+    assert.ok(html.includes('Parser: chunk'));
+    assert.ok(html.includes('📤 Export issue'), 'export still available without provenance');
+});
+
+test('null / malformed inputs never throw', () => {
+    assert.ok(buildEventProvenanceSectionHtml(null).includes('No provenance recorded'));
+    assert.ok(buildEventProvenanceSectionHtml(undefined).includes('No provenance recorded'));
+    assert.ok(buildEventProvenanceSectionHtml('not-an-object').includes('No provenance recorded'));
+    assert.doesNotThrow(() => buildEventProvenanceSectionHtml({
+        _original: 'garbage',
+        _mergeDecisions: [null, 42, { noField: true }, { field: 7 }],
+        mergeDecisions: 'also-garbage'
+    }));
+    assert.doesNotThrow(() => buildExportIssuePayload(null));
+    assert.equal(typeof JSON.parse(buildExportIssueJson(null)), 'object');
+});
+
+test('an _original with only a scraper side renders without a calendar column', () => {
+    const event = {
+        title: 'CHUNK',
+        bar: 'Precinct',
+        _original: {
+            scraper: { title: 'CHUNK LA', bar: 'Precinct' }
+        }
+    };
+    const model = buildProvenanceModel(event);
+    assert.equal(model.hasCalendar, false);
+    assert.deepEqual(model.rows.map(row => row.field), ['title']);
+
+    const html = buildEventProvenanceSectionHtml(event);
+    assert.ok(!html.includes('<th>Calendar</th>'));
+});
+
+// ---------------------------------------------------------------------------
+// Export payload
+// ---------------------------------------------------------------------------
+
+test('export payload is valid JSON with the documented shape', () => {
+    const json = buildExportIssueJson(buildMergedEventFixture(), {
+        runId: '20260713-090000',
+        timestamp: '2026-07-13T09:00:00.000Z'
+    });
+    const payload = JSON.parse(json);
+
+    assert.equal(payload.runId, '20260713-090000');
+    assert.equal(payload.timestamp, '2026-07-13T09:00:00.000Z');
+    assert.equal(payload.parser, 'bearracuda');
+    assert.equal(payload.sourceUrl, 'https://bearracuda.com/events/atlanta');
+    assert.equal(payload.action, 'merge');
+    assert.equal(payload.finalValues.title, 'BEARRACUDA: Atlanta');
+    assert.equal(payload.scraperValues.endDate, '2026-08-01T04:00:00.000Z');
+    assert.equal(payload.calendarValues.title, 'Bearracuda Atlanta');
+    assert.equal(payload.mergeDecisions.length, 2);
+    assert.equal(payload.mergeDecisions[0].reason, 'calendar end matches doors-close time');
+    assert.equal(payload.mergeDecisions[0].source, 'ai');
+    assert.deepEqual(payload.aiArbitration, { arbitrated: ['endDate'], fallbacks: ['title'] });
+});
+
+test('export payload excludes internal fields and function values', () => {
+    const event = buildMergedEventFixture();
+    event.description = () => 'functions never belong in an export';
+    event._existingEvent = { identifier: 'ABC' };
+
+    const payload = buildExportIssuePayload(event, { runId: 'r1' });
+
+    for (const section of [payload.finalValues, payload.scraperValues, payload.calendarValues]) {
+        for (const key of Object.keys(section)) {
+            assert.ok(!key.startsWith('_'), `internal key leaked: ${key}`);
+            assert.ok(EventProvenance.PROVENANCE_FIELDS.includes(key), `unlisted key leaked: ${key}`);
+        }
+    }
+    assert.ok(!('description' in payload.finalValues), 'function value must be dropped');
+    assert.ok(!('notes' in payload.finalValues));
+    assert.ok(!JSON.stringify(payload).includes('_existingEvent'));
+});
+
+test('export payload survives Dates and circular references', () => {
+    const event = buildMergedEventFixture();
+    event.startDate = new Date('2026-08-01T02:00:00.000Z');
+    const circular = { note: 'loop' };
+    circular.self = circular;
+    event._original.scraper.description = circular;
+
+    const payload = JSON.parse(buildExportIssueJson(event));
+    assert.equal(payload.finalValues.startDate, '2026-08-01T02:00:00.000Z');
+    assert.equal(payload.scraperValues.description.note, 'loop');
+});
+
+// ---------------------------------------------------------------------------
+// HTML escaping & truncation
+// ---------------------------------------------------------------------------
+
+test('values with markup, quotes and emoji are escaped in the section HTML', () => {
+    const event = {
+        title: '<script>alert("pwned")</script>',
+        _original: {
+            scraper: { title: `Bear & "Cub's" 🐻 <b>Night</b>` },
+            calendar: { title: 'Bear Night' }
+        }
+    };
+    const html = buildEventProvenanceSectionHtml(event);
+
+    assert.ok(!html.includes('<script>alert'));
+    assert.ok(!html.includes('<b>Night</b>'));
+    assert.ok(html.includes('&lt;script&gt;'));
+    assert.ok(html.includes('&quot;'));
+    assert.ok(html.includes('&#39;'));
+    assert.ok(html.includes('🐻'), 'emoji pass through unmangled');
+});
+
+test('long values are truncated with the full value preserved in title=', () => {
+    const longValue = 'Woof! '.repeat(40).trim(); // ~240 chars
+    const event = {
+        description: longValue,
+        _original: {
+            scraper: { description: longValue },
+            calendar: { description: 'short' }
+        }
+    };
+    const html = buildEventProvenanceSectionHtml(event);
+
+    assert.ok(html.includes(`title="${EventProvenance.escapeHtml(longValue)}"`));
+    assert.ok(html.includes('…'));
+    assert.ok(!html.includes(`>${EventProvenance.escapeHtml(longValue)}<`), 'cell text must be truncated');
+});
+
+test('the export control embeds a URI-encoded payload the page JS can decode', () => {
+    const html = buildEventProvenanceSectionHtml(buildMergedEventFixture(), { runId: 'r1' });
+    const match = html.match(/data-payload="([^"]*)"/);
+    assert.ok(match, 'data-payload attribute missing');
+
+    const decoded = decodeURIComponent(match[1]);
+    const payload = JSON.parse(decoded);
+    assert.equal(payload.runId, 'r1');
+    assert.equal(payload.parser, 'bearracuda');
+    assert.ok(html.includes(`onclick="exportProvenanceIssue(this)"`));
+    assert.ok(html.includes('provenance-export-text'));
+    assert.ok(html.includes('onfocus="this.select()"'));
+});


### PR DESCRIPTION
## What

Debugging tooling built into the displays we already have: every event card (results WebView **and** saved-run display — both render through `generateEventCard`, so one insertion point covers both) gains a collapsed **🔍 Provenance** section:

- Header: parser, source page URL, action (new/merge), AI-arbitration summary (arbitrated/fallback counts)
- Field-by-field table — Final / Scraper / Calendar / Decision — showing **only rows where something happened** (values differed or a decision was recorded), with an "N fields unchanged" note for the rest. Decision text comes from the recorded `_mergeDecisions`/`mergeDecisions` ("AI: …", "AI fallback: …", "kept from calendar (scrape found none)", priority reasons). Long values truncate at 80 chars with the full value on the tooltip.
- **📤 Export issue** button: one tap produces a pretty-printed, self-contained JSON payload (runId, timestamp, parser, sourceUrl, action, final/scraper/calendar values, mergeDecisions, aiArbitration) in a readonly textarea with select-all + `execCommand('copy')` — "Copied ✓" on success, manual select as fallback. Verified in an actual WKWebView harness (collapse, tap, selection, valid JSON, copy success). Payload strips functions/circular refs, Dates→ISO, whitelisted fields only — no `_`-internals.

Old saved runs and events without `_original` render "No provenance recorded" — and the adapter wraps the builder in the same fail-safe pattern as the health badge, so a builder error can never break the results display (covered by a hostile-getter test).

## Placement
- `scripts/event-provenance.js` — **new pure module** (HTML/data builders only, same conventions as metrics-sections.js). ⚠️ New device file: copy to the Scriptable folder alongside the others.
- `scripts/adapters/scriptable-adapter.js` — glue only: fail-safe wrapper, CSS, page-side click handler, card insertion.
- `package.json` — new test file in the explicit test list.

## Tests
228 → **246**, all green: interesting-row selection, decision rendering from real-shaped records, date instant-equality (ISO string vs Date), graceful no-provenance handling, export payload shape/JSON validity, HTML escaping (emoji/quotes/angle brackets), adapter integration + fail-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP