### PR TITLE
fix(scraper): a bare city name is not an event title — prefix the known organizer

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -328,7 +328,17 @@ class AiWebParser {
             if (useJsonLdEvents) {
                 console.log(`🤖 AI Web: Extracted ${completeJsonLdEvents.length} event(s) from JSON-LD structured data — skipping OCR and AI extraction`);
                 if (pageBrandNames.length > 0) {
-                    completeJsonLdEvents.forEach(event => { event._organizer = pageBrandNames[0]; });
+                    completeJsonLdEvents.forEach(event => {
+                        event._organizer = pageBrandNames[0];
+                        // JSON-LD events skip normalizeAiEvent, so the bare-city
+                        // title rule (organizer prefix) is applied here too.
+                        const prefixedTitle = this.buildOrganizerPrefixedTitle(
+                            event.title, event.city, pageBrandNames, htmlData, cityConfig);
+                        if (prefixedTitle) {
+                            console.log(`🤖 AI Web: Title "${event.title}" is just the event's city — prefixed known organizer → "${prefixedTitle}"`);
+                            event.title = prefixedTitle;
+                        }
+                    });
                 }
                 return {
                     events: completeJsonLdEvents,
@@ -6633,6 +6643,17 @@ TEXT:
                 ''
             )
         );
+        // A bare city is not an event name — after the brand strip above (which
+        // is what exposes the bare city), prefix the page's known organizer:
+        // "New Orleans⚜️" → "BEARRACUDA: New Orleans⚜️". Titles already naming
+        // the organizer or a real event are untouched.
+        if (pageBrandNames.length > 0 && city) {
+            const prefixedTitle = this.buildOrganizerPrefixedTitle(title, city, pageBrandNames, htmlData, cityConfig);
+            if (prefixedTitle) {
+                console.log(`🤖 AI Web: Title "${title}" is just the event's city — prefixed known organizer → "${prefixedTitle}"`);
+                title = prefixedTitle;
+            }
+        }
         const timezone = this.firstNonEmpty(
             aiEvent.timezone,
             this.getResolvedParserMetadataFieldValue(parserConfig, ['timezone'], aiEvent),
@@ -7443,6 +7464,132 @@ TEXT:
         while (kept.length > 1 && this.matchesPageBrandName(kept[0], brandNames)) kept.shift();
         if (kept.length === parts.length) return text;
         return kept.join(' | ');
+    }
+
+    // Emoji/pictograph-stripped view of a title — identical to SharedCore's
+    // stripEmojiForTitleTwin (parsers are standalone and cannot import shared
+    // code, so the regex is deliberately duplicated; keep the two in sync).
+    // Conservative on purpose: ASCII and real punctuation are never stripped.
+    stripEmojiFromTitle(value) {
+        return String(value)
+            .replace(/[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0E}\u{FE0F}\u{20E3}\u{200D}]/gu, '')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
+    // First og-style meta content for a key (e.g. 'og:title', 'og:site_name'),
+    // entity-decoded and whitespace-collapsed. '' when absent.
+    extractOgMetaContent(html, keyName) {
+        const source = String(html || '').slice(0, 500000);
+        const metaRegex = /<meta\b[^>]*>/gi;
+        let match;
+        while ((match = metaRegex.exec(source)) !== null) {
+            const tag = match[0];
+            const nameMatch = tag.match(/\b(?:name|property)\s*=\s*["']([^"']+)["']/i);
+            if (!nameMatch || this.normalizeWhitespace(nameMatch[1]).toLowerCase() !== keyName) continue;
+            const contentMatch = tag.match(/\bcontent\s*=\s*["']([^"']+)["']/i);
+            if (!contentMatch) continue;
+            const value = this.normalizeWhitespace(this.decodeBasicEntities(contentMatch[1]));
+            if (value) return value;
+        }
+        return '';
+    }
+
+    // Cached per page like getPageBrandNames (segment/OCR copies spread
+    // htmlData and inherit the cache).
+    getPageOgTitle(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object') return '';
+        if (typeof htmlData.pageOgTitle === 'string') return htmlData.pageOgTitle;
+        const ogTitle = this.extractOgMetaContent(typeof htmlData.html === 'string' ? htmlData.html : '', 'og:title');
+        if (Object.isExtensible(htmlData)) {
+            htmlData.pageOgTitle = ogTitle;
+        }
+        return ogTitle;
+    }
+
+    getPageOgSiteName(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object') return '';
+        if (typeof htmlData.pageOgSiteName === 'string') return htmlData.pageOgSiteName;
+        const siteName = this.extractOgMetaContent(typeof htmlData.html === 'string' ? htmlData.html : '', 'og:site_name');
+        if (Object.isExtensible(htmlData)) {
+            htmlData.pageOgSiteName = siteName;
+        }
+        return siteName;
+    }
+
+    // A bare city name is not an event name. True when the title — after
+    // stripping emoji, collapsing whitespace, and case-folding — exactly equals
+    // any configured name of the event's resolved city (key, display name,
+    // patterns, aliases; dashes/underscores in a candidate read as spaces).
+    // Whole-title match only: "Hot Take Portland" is a real event name.
+    // Missing/unknown cities are never city-only. Mirrors
+    // SharedCore.isCityOnlyTitle, which drives the deterministic merge rule.
+    isCityOnlyTitle(title, cityValue, cityConfig) {
+        if (!title || !cityValue) return false;
+        const entry = this.findCityConfigEntry(cityValue, cityConfig);
+        if (!entry) return false;
+        const normalizedTitle = this.stripEmojiFromTitle(title).toLowerCase();
+        if (!normalizedTitle) return false;
+        return entry.aliases.some(alias => {
+            const collapsed = this.normalizeWhitespace(alias).toLowerCase();
+            return collapsed === normalizedTitle
+                || collapsed.replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim() === normalizedTitle;
+        });
+    }
+
+    // Word-level brand containment (matchesPageBrandName is whole-value
+    // equality only): "Bearracuda Atlanta 17 Year Anniversary" CONTAINS the
+    // "Bearracuda" brand and must never be organizer-prefixed again.
+    titleContainsPageBrandName(title, brandNames) {
+        const normalizedTitle = String(title || '')
+            .toLowerCase()
+            .replace(/[^a-z0-9&\s]/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        if (!normalizedTitle) return false;
+        const paddedTitle = ` ${normalizedTitle} `;
+        return (Array.isArray(brandNames) ? brandNames : []).some(brand => {
+            for (const variant of this.getBrandNameVariants(brand)) {
+                if (paddedTitle.includes(` ${variant} `)) return true;
+            }
+            return false;
+        });
+    }
+
+    // A bare city is not an event name: bearracuda.com names its event pages
+    // after the city (og:title "New Orleans⚜️ | BEARRACUDA" → brand strip
+    // leaves "New Orleans⚜️"). When the extracted title is exactly the event's
+    // resolved city and the page declares a known organizer, return
+    // "<ORGANIZER>: <city title>" so the calendar title names the party; ''
+    // when the rule doesn't apply. Everything is derived from page metadata +
+    // the cities config — no per-site rules.
+    // - organizerDisplay: og:site_name (how the site displays its own brand,
+    //   e.g. "BEARRACUDA") when present, else the primary extracted brand name
+    //   (the same value the _organizer stamp uses).
+    // - baseTitle: models often strip emoji ("New Orleans" from og:title
+    //   "New Orleans⚜️ | BEARRACUDA"), so when the brand-stripped og:title is
+    //   an emoji-richer variant of the title (equal after emoji-strip +
+    //   case-fold), the og:title variant is used to preserve the emoji.
+    buildOrganizerPrefixedTitle(title, cityValue, pageBrandNames, htmlData, cityConfig) {
+        if (!title || !cityValue) return '';
+        if (!Array.isArray(pageBrandNames) || pageBrandNames.length === 0) return '';
+        if (!this.isCityOnlyTitle(title, cityValue, cityConfig)) return '';
+        if (this.titleContainsPageBrandName(title, pageBrandNames)) return '';
+        const ogSiteName = this.getPageOgSiteName(htmlData);
+        const organizerDisplay = ogSiteName && this.matchesPageBrandName(ogSiteName, pageBrandNames)
+            ? ogSiteName
+            : pageBrandNames[0];
+        let baseTitle = title;
+        const ogTitle = this.getPageOgTitle(htmlData);
+        if (ogTitle) {
+            const ogStripped = this.stripPageBrandFromTitle(ogTitle, pageBrandNames);
+            const ogWithoutEmoji = this.stripEmojiFromTitle(ogStripped);
+            if (ogStripped !== ogWithoutEmoji
+                && ogWithoutEmoji.toLowerCase() === this.stripEmojiFromTitle(title).toLowerCase()) {
+                baseTitle = ogStripped;
+            }
+        }
+        return `${organizerDisplay}: ${baseTitle}`;
     }
 
     extractBodyParts(html) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1092,6 +1092,130 @@ test('normalizeAiEvent stamps the derived organizer as internal _organizer metad
 });
 
 // ---------------------------------------------------------------------------
+// Bare-city titles (2026-07-12 run: bearracuda.com names its event pages after
+// the city — og:title "New Orleans⚜️ | BEARRACUDA" → brand strip leaves just
+// the city, which is not an event name)
+// ---------------------------------------------------------------------------
+
+const CITY_TITLE_CITY_CONFIG = {
+  nola: { timezone: 'America/Chicago', patterns: ['new orleans', 'nola'] },
+  atlanta: { timezone: 'America/New_York', patterns: ['atlanta'] },
+  portland: { timezone: 'America/Los_Angeles', patterns: ['portland', 'pdx'] }
+};
+
+const BEARRACUDA_NOLA_HTML = `
+  <html>
+    <head>
+      <meta property="og:site_name" content="BEARRACUDA" />
+      <meta property="og:title" content="New Orleans⚜️ | BEARRACUDA" />
+      <script type="application/ld+json">
+        {"@context":"https://schema.org","@graph":[
+          {"@type":"Organization","name":"Bearracuda, Inc.","alternateName":"Bearracuda"},
+          {"@type":"WebSite","name":"BEARRACUDA"}
+        ]}
+      </script>
+    </head>
+    <body><p>Bearracuda New Orleans at the Metropolitan</p></body>
+  </html>
+`;
+
+test('normalizeAiEvent prefixes the organizer onto a bare-city title, restoring emoji from og:title', () => {
+  const parser = createParser();
+  const htmlData = { html: BEARRACUDA_NOLA_HTML, url: 'https://bearracuda.com/events/neworleans' };
+
+  // The model usually drops the emoji: "New Orleans" from og:title "New Orleans⚜️ | BEARRACUDA"
+  const event = parser.normalizeAiEvent(
+    { title: 'New Orleans', city: 'new orleans', startDate: '2026-10-11', startTime: '22:00' },
+    {}, htmlData, CITY_TITLE_CITY_CONFIG, null);
+  assert.ok(event, 'event should normalize');
+  assert.equal(event.title, 'BEARRACUDA: New Orleans⚜️',
+    'organizer prefixed and the emoji-richer og:title variant used as the base');
+
+  // The emoji variant surviving extraction ends the same way (brand strip → prefix)
+  const emojiEvent = parser.normalizeAiEvent(
+    { title: 'New Orleans⚜️ | BEARRACUDA', city: 'nola', startDate: '2026-10-11', startTime: '22:00' },
+    {}, { html: BEARRACUDA_NOLA_HTML, url: 'https://bearracuda.com/events/neworleans' }, CITY_TITLE_CITY_CONFIG, null);
+  assert.equal(emojiEvent.title, 'BEARRACUDA: New Orleans⚜️');
+});
+
+test('normalizeAiEvent leaves titles that already name the organizer or a real event untouched', () => {
+  const parser = createParser();
+
+  // Title already contains the organizer (Atlanta got rescued by its ticketing page)
+  const named = parser.normalizeAiEvent(
+    { title: 'Bearracuda Atlanta 17 Year Anniversary', city: 'atlanta', startDate: '2026-10-11' },
+    {}, { html: BEARRACUDA_NOLA_HTML, url: 'https://bearracuda.com/events/atlanta' }, CITY_TITLE_CITY_CONFIG, null);
+  assert.equal(named.title, 'Bearracuda Atlanta 17 Year Anniversary');
+
+  // An already-prefixed title is not city-only — the rule is idempotent
+  const prefixed = parser.normalizeAiEvent(
+    { title: 'BEARRACUDA: New Orleans⚜️', city: 'nola', startDate: '2026-10-11' },
+    {}, { html: BEARRACUDA_NOLA_HTML, url: 'https://bearracuda.com/events/neworleans' }, CITY_TITLE_CITY_CONFIG, null);
+  assert.equal(prefixed.title, 'BEARRACUDA: New Orleans⚜️', 'never double-prefixed');
+
+  // A title that merely CONTAINS the city is a real event name
+  const containsCity = parser.normalizeAiEvent(
+    { title: 'Hot Take Portland', city: 'portland', startDate: '2026-10-11' },
+    {}, { html: BEARRACUDA_NOLA_HTML, url: 'https://bearracuda.com/events/portland' }, CITY_TITLE_CITY_CONFIG, null);
+  assert.equal(containsCity.title, 'Hot Take Portland');
+
+  // Word-level containment backs the never-double-prefix guard
+  assert.equal(parser.titleContainsPageBrandName('Bearracuda Atlanta 17 Year Anniversary', ['Bearracuda, Inc.', 'BEARRACUDA']), true);
+  assert.equal(parser.titleContainsPageBrandName('Bearracuda Portland:PRIDE FRIDAY', ['BEARRACUDA']), true);
+  assert.equal(parser.titleContainsPageBrandName('New Orleans⚜️', ['BEARRACUDA']), false);
+});
+
+test('normalizeAiEvent keeps a bare-city title when no organizer or no city is known', () => {
+  const parser = createParser();
+
+  // No page brand → nothing to prefix with
+  const noBrand = parser.normalizeAiEvent(
+    { title: 'New Orleans', city: 'nola', startDate: '2026-10-11' },
+    {}, { html: '<html><body><p>party page with no brand markup</p></body></html>', url: 'https://example.com/nola' },
+    CITY_TITLE_CITY_CONFIG, null);
+  assert.equal(noBrand.title, 'New Orleans');
+
+  // No resolved city → the title cannot be judged city-only
+  const noCity = parser.normalizeAiEvent(
+    { title: 'New Orleans', startDate: '2026-10-11' },
+    {}, { html: BEARRACUDA_NOLA_HTML, url: 'https://bearracuda.com/events/neworleans' }, CITY_TITLE_CITY_CONFIG, null);
+  assert.equal(noCity.title, 'New Orleans');
+
+  // Unknown city value → defensive false
+  const unknownCity = parser.normalizeAiEvent(
+    { title: 'Denver', city: 'denver', startDate: '2026-10-11' },
+    {}, { html: BEARRACUDA_NOLA_HTML, url: 'https://bearracuda.com/events/denver' }, CITY_TITLE_CITY_CONFIG, null);
+  assert.equal(unknownCity.title, 'Denver');
+});
+
+test('the JSON-LD fast path applies the bare-city organizer prefix too', async () => {
+  const parser = createParser();
+  const html = `
+    <html>
+      <head>
+        <meta property="og:site_name" content="BEARRACUDA" />
+        <meta property="og:title" content="New Orleans⚜️ | BEARRACUDA" />
+        <script type="application/ld+json">
+          {"@context":"https://schema.org","@graph":[
+            {"@type":"Organization","name":"Bearracuda, Inc.","alternateName":"Bearracuda"},
+            {"@type":"Event","name":"New Orleans⚜️","startDate":"2026-10-11T22:00:00-05:00",
+             "location":{"@type":"Place","name":"The Metropolitan",
+               "address":{"@type":"PostalAddress","streetAddress":"310 Andrew Higgins Blvd","addressLocality":"New Orleans","addressRegion":"LA"}}}
+          ]}
+        </script>
+      </head>
+      <body><p>Bearracuda New Orleans</p></body>
+    </html>
+  `;
+
+  const result = await parser.parseEvents(
+    { html, url: 'https://bearracuda.com/events/neworleans' }, {}, CITY_TITLE_CITY_CONFIG, 'event-page', null);
+  assert.equal(result.events.length, 1, 'the structured-data fast path should be used');
+  assert.equal(result.events[0].title, 'BEARRACUDA: New Orleans⚜️');
+  assert.equal(result.events[0]._organizer, 'Bearracuda, Inc.');
+});
+
+// ---------------------------------------------------------------------------
 // Wasted-AI-call cuts (2026-07-13 run findings): Event-less JSON-LD passes,
 // duplicate context-prep round-trips, and repair passes for evidence-only
 // JSON breakage.

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -443,11 +443,41 @@ class SharedCore {
             .trim();
     }
 
+    // A bare city name is not an event name (bearracuda.com titles its event
+    // pages after the city: og:title "New Orleans⚜️ | BEARRACUDA" → the brand
+    // strip leaves "New Orleans⚜️"). True when the title — after stripping
+    // emoji (stripEmojiForTitleTwin), collapsing whitespace, and case-folding —
+    // exactly equals the resolved city's key (dashes/underscores read as
+    // spaces), its display name, or ANY configured pattern/alias ("new
+    // orleans", "nola"). Whole-title match only: "Hot Take Portland" is a real
+    // event name. Missing/unknown cities are never city-only.
+    isCityOnlyTitle(title, cityKey) {
+        if (!title || !cityKey || !this.cities || typeof this.cities !== 'object') return false;
+        const normalizedKey = String(cityKey).trim().toLowerCase();
+        const cityData = this.cities[cityKey] || this.cities[normalizedKey];
+        if (!cityData || typeof cityData !== 'object') return false;
+        const normalizedTitle = this.stripEmojiForTitleTwin(title).replace(/\s+/g, ' ').trim().toLowerCase();
+        if (!normalizedTitle) return false;
+        const candidates = new Set();
+        const addCandidate = value => {
+            const text = String(value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+            if (!text) return;
+            candidates.add(text);
+            candidates.add(text.replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim());
+        };
+        addCandidate(normalizedKey);
+        addCandidate(cityData.name);
+        if (Array.isArray(cityData.patterns)) cityData.patterns.forEach(addCandidate);
+        if (Array.isArray(cityData.aliases)) cityData.aliases.forEach(addCandidate);
+        return candidates.has(normalizedTitle);
+    }
+
     // Deterministic conflict resolution consulted by BOTH merge paths
     // (createFinalEventObject and mergeParsedEvents) before a field is queued
     // for AI arbitration. Returns { winner: 'a'|'b', reason } or null (→
-    // arbitrate as usual). Callers map a/b onto their own labels.
-    resolveConflictDeterministically(fieldName, valueA, valueB) {
+    // arbitrate as usual). Callers map a/b onto their own labels and thread
+    // event context (currently { cityKey }) for the city-aware title rule.
+    resolveConflictDeterministically(fieldName, valueA, valueB, context = null) {
         const urlA = this.getUrlRuleParts(valueA);
         const urlB = this.getUrlRuleParts(valueB);
         if (urlA && urlB) {
@@ -492,6 +522,23 @@ class SharedCore {
                     reason: 'emoji title variant beats its emoji-stripped twin'
                 };
             }
+            // A bare city is not an event name: when exactly one side's title is
+            // just the event's city (per isCityOnlyTitle), the named side wins.
+            // MUST run after the emoji-twin rule above — twins like "New Orleans"
+            // vs "New Orleans⚜️" are BOTH city-only, and the emoji variant should
+            // win there rather than tie through this rule. Two named titles (or
+            // two bare-city titles) still arbitrate.
+            const cityKey = context && context.cityKey;
+            if (cityKey) {
+                const cityOnlyA = this.isCityOnlyTitle(valueA, cityKey);
+                const cityOnlyB = this.isCityOnlyTitle(valueB, cityKey);
+                if (cityOnlyA !== cityOnlyB) {
+                    return {
+                        winner: cityOnlyA ? 'b' : 'a',
+                        reason: 'named title beats bare city title'
+                    };
+                }
+            }
         }
         return null;
     }
@@ -532,6 +579,7 @@ class SharedCore {
             '- "bar" must be the physical venue where the event takes place — never the promoter, organizer, or brand whose name appears in page titles.',
             organizer ? `- KNOWN ORGANIZER: ${JSON.stringify(String(organizer))} — never pick a bar value equal to the organizer.` : '',
             '- For "title", prefer the actual event name — do not prefer a variant just because it appends status text (e.g. sold-out notices) or site branding.',
+            '- For "title", a bare city name is not an event name — prefer the variant that names the event or its organizer.',
             '- For "image", prefer event-specific promotional artwork over site or ticketing-service logos.',
             `- "pick" must be "${labelA}" or "${labelB}".`,
             'Return JSON only:',
@@ -1792,8 +1840,12 @@ class SharedCore {
         // run before a conflict is queued for AI — both merge paths consult
         // resolveConflictDeterministically so behavior is identical.
         const mergeEventTitle = newEvent.title || existingEvent.title || 'event';
+        // City context for the city-aware title rule (a bare city title loses
+        // to a named title) — both records describe the same event, so either
+        // side's resolved city works.
+        const mergeContext = { cityKey: newEvent.city || existingEvent.city || '' };
         const queueArbitrationConflict = (fieldName, existingValue, newValue, fallbackPick, fallbackReason) => {
-            const resolved = this.resolveConflictDeterministically(fieldName, existingValue, newValue);
+            const resolved = this.resolveConflictDeterministically(fieldName, existingValue, newValue, mergeContext);
             if (!resolved) {
                 pendingAiConflicts.push({
                     field: fieldName,
@@ -2091,8 +2143,12 @@ class SharedCore {
         // Deterministic pre-arbitration rules (URL shape / emoji-twin titles)
         // run before a conflict is queued for AI — both merge paths consult
         // resolveConflictDeterministically so behavior is identical.
+        // City context for the city-aware title rule (a bare city title loses
+        // to a named title) — the scraper object carries the resolved city; the
+        // calendar object may carry one parsed from its notes.
+        const mergeContext = { cityKey: scraperObject.city || calendarObject.city || '' };
         const queueArbitrationConflict = (fieldName, calendarValue, scraperValue) => {
-            const resolved = this.resolveConflictDeterministically(fieldName, calendarValue, scraperValue);
+            const resolved = this.resolveConflictDeterministically(fieldName, calendarValue, scraperValue, mergeContext);
             if (!resolved) {
                 pendingAiConflicts.push({
                     field: fieldName,

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -794,6 +794,146 @@ test('guardrail: emoji twin detection covers ⚜️, ⚓ and ⛓️ in both dire
   assert.equal(core.resolveConflictDeterministically('title', '🐻', '⚓'), null, 'pure-emoji titles are not twins');
 });
 
+// ---------------------------------------------------------------------------
+// Bare-city titles (2026-07-12 run: bearracuda.com pages are named after the
+// city — "New Orleans⚜️ | BEARRACUDA" → brand strip leaves just the city)
+// ---------------------------------------------------------------------------
+
+const CITY_TITLE_CITIES = {
+  nola: { timezone: 'America/Chicago', patterns: ['new orleans', 'nola'] },
+  ptown: { timezone: 'America/New_York', patterns: ['provincetown', 'ptown'] },
+  sf: { timezone: 'America/Los_Angeles', name: 'San Francisco', patterns: ['sf'] },
+  'new-york': { timezone: 'America/New_York', patterns: [] },
+  portland: { timezone: 'America/Los_Angeles', patterns: ['portland', 'pdx'] },
+  chicago: { timezone: 'America/Chicago', patterns: ['chicago'] },
+  atlanta: { timezone: 'America/New_York', patterns: ['atlanta'] }
+};
+
+function createCityTitleCore() {
+  return new SharedCore(CITY_TITLE_CITIES, { eventSchema: EventSchema });
+}
+
+test('isCityOnlyTitle matches key, display name, patterns, and emoji variants — whole title only', () => {
+  const core = createCityTitleCore();
+  // Key, patterns, and case-folding
+  assert.equal(core.isCityOnlyTitle('nola', 'nola'), true, 'the city key itself');
+  assert.equal(core.isCityOnlyTitle('New Orleans', 'nola'), true, 'configured pattern');
+  assert.equal(core.isCityOnlyTitle('NOLA', 'nola'), true, 'pattern is case-folded');
+  assert.equal(core.isCityOnlyTitle('  new   orleans ', 'nola'), true, 'whitespace collapsed');
+  // Emoji/pictograph variants
+  assert.equal(core.isCityOnlyTitle('New Orleans⚜️', 'nola'), true, 'emoji is stripped before matching');
+  assert.equal(core.isCityOnlyTitle('Provincetown⚓', 'ptown'), true);
+  // Display name and dashed keys read as spaces
+  assert.equal(core.isCityOnlyTitle('San Francisco', 'sf'), true, 'display name counts');
+  assert.equal(core.isCityOnlyTitle('New York', 'new-york'), true, 'key dashes read as spaces');
+  // Whole-title match only: a title that merely CONTAINS the city is a real name
+  assert.equal(core.isCityOnlyTitle('Hot Take Portland', 'portland'), false);
+  assert.equal(core.isCityOnlyTitle('Treasure Trail Chicago', 'chicago'), false);
+  assert.equal(core.isCityOnlyTitle('Atlanta 17 Year', 'atlanta'), false);
+  assert.equal(core.isCityOnlyTitle('Bearracuda Atlanta 17 Year Anniversary', 'atlanta'), false);
+  // Defensive: unknown/missing city or empty title is never city-only
+  assert.equal(core.isCityOnlyTitle('Denver', 'denver'), false, 'unknown city key');
+  assert.equal(core.isCityOnlyTitle('New Orleans', ''), false, 'missing city key');
+  assert.equal(core.isCityOnlyTitle('', 'nola'), false, 'empty title');
+  assert.equal(core.isCityOnlyTitle('⚜️', 'nola'), false, 'pure-emoji title strips to nothing');
+});
+
+test('guardrail: a named title beats a bare city title in both directions; ties still arbitrate', () => {
+  const core = createCityTitleCore();
+  const context = { cityKey: 'nola' };
+  assert.deepEqual(
+    core.resolveConflictDeterministically('title', 'BEARRACUDA: New Orleans⚜️', 'New Orleans⚜️', context),
+    { winner: 'a', reason: 'named title beats bare city title' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('title', 'New Orleans⚜️', 'BEARRACUDA: New Orleans⚜️', context),
+    { winner: 'b', reason: 'named title beats bare city title' });
+  // Emoji-twin rule runs FIRST: two city-only twins keep the emoji variant
+  assert.deepEqual(
+    core.resolveConflictDeterministically('title', 'New Orleans⚜️', 'New Orleans', context),
+    { winner: 'a', reason: 'emoji title variant beats its emoji-stripped twin' });
+  // Two named titles (or two bare-city titles) are still a genuine question
+  assert.equal(core.resolveConflictDeterministically('title', 'FURBALL', 'MEGAWOOF', context), null);
+  assert.equal(core.resolveConflictDeterministically('title', 'New Orleans⚜️', 'NOLA', context), null,
+    'two bare-city variants still arbitrate');
+  // No city context → the rule never fires
+  assert.equal(core.resolveConflictDeterministically('title', 'FURBALL', 'New Orleans'), null);
+});
+
+test('guardrail: calendar bare-city title loses to the scraped named title without AI', async () => {
+  const core = createCore(); // dallas cities config — 'Dallas' is city-only
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.title = 'BEARRACUDA: Dallas';
+  existing.title = 'Dallas';
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'the only conflict resolved deterministically — no AI request at all');
+  assert.equal(finalEvent.title, 'BEARRACUDA: Dallas');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['title']);
+  assert.ok(logLines.includes(
+    '🔒 MERGE: "BEARRACUDA: Dallas" field=title resolved deterministically — named title beats bare city title'
+  ), `stable 🔒 log line expected, got: ${JSON.stringify(logLines)}`);
+});
+
+test('guardrail: scraped bare-city title loses to the calendar named title without AI', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.title = 'Dallas';
+  existing.title = 'FURBALL DALLAS';
+  const adapter = buildArbitrationAdapter({});
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'zero AI calls when the city rule decides the only conflict');
+  assert.equal(finalEvent.title, 'FURBALL DALLAS', 'the named calendar title wins');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['title']);
+});
+
+test('mergeParsedEvents: named-vs-bare-city titles resolve deterministically in both directions', async () => {
+  const core = createCityTitleCore();
+  const priorities = { title: { priority: ['ai-web'], merge: 'ai' } };
+  const aiParserConfig = { ai: { provider: 'ollama', endpoint: 'http://ai.example', model: 'm' } };
+  const base = { city: 'nola', source: 'ai-web', _fieldPriorities: priorities };
+
+  // Incoming bare city vs existing named title
+  const adapterA = buildArbitrationAdapter({});
+  const mergedA = await core.mergeParsedEvents(
+    { ...base, title: 'BEARRACUDA: New Orleans⚜️' },
+    { ...base, title: 'New Orleans⚜️', _parserConfig: aiParserConfig },
+    { httpAdapter: adapterA });
+  assert.equal(adapterA.calls.length, 0, 'zero AI calls — the city rule decides');
+  assert.equal(mergedA.title, 'BEARRACUDA: New Orleans⚜️');
+
+  // Incoming named title vs existing bare city
+  const adapterB = buildArbitrationAdapter({});
+  const mergedB = await core.mergeParsedEvents(
+    { ...base, title: 'New Orleans⚜️' },
+    { ...base, title: 'BEARRACUDA: New Orleans⚜️', _parserConfig: aiParserConfig },
+    { httpAdapter: adapterB });
+  assert.equal(adapterB.calls.length, 0);
+  assert.equal(mergedB.title, 'BEARRACUDA: New Orleans⚜️');
+
+  // Two named titles remain a genuine AI question
+  const adapterC = buildArbitrationAdapter({
+    title: { pick: 'existing', value: 'FURBALL', reason: 'canonical name' }
+  });
+  const mergedC = await core.mergeParsedEvents(
+    { ...base, title: 'FURBALL' },
+    { ...base, title: 'MEGAWOOF', _parserConfig: aiParserConfig },
+    { httpAdapter: adapterC });
+  assert.equal(adapterC.calls.length, 1, 'two named titles still arbitrate');
+  assert.equal(mergedC.title, 'FURBALL');
+});
+
 test('guardrail: logo-path image loses to event artwork in both directions; both-logo goes to AI', async () => {
   const core = createCore();
   const logo = 'https://res.cloudinary.com/eventservice/image/upload/w_600/saas/logos/image_abc.webp';


### PR DESCRIPTION
## Problem (from tonight's run)

bearracuda.com titles its event pages after the **city** (og:title `New Orleans⚜️ | BEARRACUDA`, `Atlanta | BEARRACUDA`), so after the organizer guard correctly strips the brand, the event title is just the city. Atlanta got rescued by its ticketing page's `Bearracuda Atlanta 17 Year Anniversary`; New Orleans has no ticketing page, so the calendar title ended up as `New Orleans⚜️` — a place, not an event.

## Fix (page-derived + cities-config-derived — no per-site rules)

1. **`SharedCore.isCityOnlyTitle(title, cityKey)`** — true only when the whole title, emoji-stripped/case-folded/whitespace-collapsed, equals the resolved city's key (dashes/underscores as spaces), display name, or any configured pattern/alias ("new orleans", "nola"). "Hot Take Portland" / "Treasure Trail Chicago" / unknown cities → false.
2. **Organizer prefix at extraction** (ai-web-parser, both the AI path in `normalizeAiEvent` and the JSON-LD fast path): city-only title + KNOWN ORGANIZER → `BEARRACUDA: New Orleans⚜️`. The display prefix comes from og:site_name ("BEARRACUDA"); the **emoji is recovered from the brand-stripped og:title** when the model dropped it. Titles already containing the organizer are never double-prefixed.
   ```
   🤖 AI Web: Title "New Orleans" is just the event's city — prefixed known organizer → "BEARRACUDA: New Orleans⚜️"
   ```
3. **Deterministic merge rule** (extends #1471's resolver with threaded `{cityKey}` context in both merge paths): when exactly one conflicting title is city-only, the named side wins — no AI call, counted by the existing `arbitrationDeterministic` guard:
   ```
   🔒 MERGE: "…" field=title resolved deterministically — named title beats bare city title
   ```
   Ordered **after** the emoji-twin rule so `"New Orleans"` vs `"New Orleans⚜️"` (both city-only) still keeps the emoji variant. Two named titles still arbitrate, with a new prompt rule as backstop: *"a bare city name is not an event name — prefer the variant that names the event or its organizer."*

## Expected on the next device run
Scraped title becomes `BEARRACUDA: New Orleans⚜️`; the calendar's stale `New Orleans⚜️` loses deterministically, so the stored title self-upgrades. Provincetown⚓ and any future city-named page from any promoter get the same treatment; `Bearracuda Atlanta 17 Year Anniversary`, `Bearracuda Portland:PRIDE FRIDAY`, and `Hot Take Portland` are untouched (covered by tests).

## Tests
254 → **263**, all green: pattern/key/alias/emoji matching and negatives, prefixing incl. emoji recovery and no-double-prefix, JSON-LD path, deterministic rule in both merge paths/directions with zero AI calls, emoji-twin precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP