### PR TITLE
perf(scraper): deterministic case-only merge resolution + no location retries

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4448,11 +4448,21 @@ class AiWebParser {
             meta: new Set(),
             content: new Set()
         };
+        let excludedLocation = false;
         Object.keys(confidenceByField).forEach(field => {
             const confidence = confidenceByField[field];
             const expectation = expectations[field] || { expected: [], strong: [] };
             const hasContentExpected = expectation.expected && expectation.expected.includes('content');
             if (!confidence || confidence.level !== 'low') return;
+            // Never retry location (coordinates): across production runs the
+            // retry pass never legitimately recovered coordinates — the model
+            // fabricated them from the street address every time and the
+            // evidence gate dropped them. Main extraction passes still request
+            // location (a page could legitimately embed coordinates).
+            if (field === 'location') {
+                if (confidence.retryCandidates?.length || hasContentExpected) excludedLocation = true;
+                return;
+            }
             if (!confidence.retryCandidates?.length) {
                 // No retry candidates - if content is expected, add to content since OCR content might still have the field
                 if (hasContentExpected && grouped.content !== undefined) {
@@ -4466,6 +4476,9 @@ class AiWebParser {
                 });
             }
         });
+        if (excludedLocation) {
+            console.log('🤖 AI Web: Skipping location in confidence retry — never legitimately recovered on retry');
+        }
         return ['jsonld', 'meta', 'content']
             .map(partition => ({
                 partition,

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1594,3 +1594,65 @@ test('the description guard is inert on pages with no WebSite.description', asyn
     {}, htmlData, null, null);
   assert.equal(event.description, SITE_TAGLINE, 'final guard is inert without a page tagline');
 });
+
+// ---------------------------------------------------------------------------
+// Confidence retry: location (coordinates) is never re-requested (2026-07-12
+// run: the retry pass fabricated coordinates from the street address on nearly
+// every page, and the evidence gate dropped them every time)
+// ---------------------------------------------------------------------------
+
+test('the confidence-retry field list never contains location; main-pass selection still does', () => {
+  // Earlier tests install mock EventSchema globals; pin the real schema so
+  // the coords→location canonicalization is exercised for real.
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  const lowWithCandidates = (partitions) => ({
+    level: 'low',
+    reason: 'expected-strong-signal-missing-validated-value',
+    sourcePartition: null,
+    retryCandidates: partitions
+  });
+
+  // location and bar are both low-confidence retry candidates → only bar is planned
+  const diagnostics = {
+    fieldConfidence: {
+      title: { level: 'high', reason: 'expected-source-produced-validated-value', sourcePartition: 'jsonld' },
+      bar: lowWithCandidates(['content']),
+      location: lowWithCandidates(['jsonld', 'content'])
+    },
+    expectedSignals: {
+      title: { expected: ['jsonld'], strong: ['jsonld'] },
+      bar: { expected: ['content'], strong: ['content'] },
+      location: { expected: ['jsonld', 'content'], strong: ['jsonld'] }
+    }
+  };
+  const plan = parser.planConfidenceRetries(diagnostics, ['title', 'bar', 'location']);
+  const plannedFields = plan.flatMap(entry => entry.fields);
+  assert.ok(!plannedFields.includes('location'), `location must never appear in a retry plan, got: ${JSON.stringify(plan)}`);
+  assert.deepEqual(plan, [{ partition: 'content', fields: ['bar'] }], 'other low-confidence fields still retry');
+
+  // location as the ONLY low-confidence field → empty plan → the retry pass is skipped entirely
+  const locationOnly = {
+    fieldConfidence: { location: lowWithCandidates(['jsonld']) },
+    expectedSignals: { location: { expected: ['jsonld'], strong: ['jsonld'] } }
+  };
+  assert.deepEqual(parser.planConfidenceRetries(locationOnly, ['location']), [],
+    'a location-only retry plan must be empty (no zero-field request)');
+
+  // The no-candidates OCR-content fallback path must not re-add location either
+  const contentFallback = {
+    fieldConfidence: { location: { level: 'low', reason: 'no-validated-value', sourcePartition: null } },
+    expectedSignals: { location: { expected: ['content'], strong: [] } }
+  };
+  assert.deepEqual(parser.planConfidenceRetries(contentFallback, ['location']), [],
+    'the content-expected fallback must not resurrect location');
+
+  // Main-pass field selection is untouched: location is a schema prompt field
+  // and stays requested while missing (a page could legitimately embed coords)
+  const schemaFields = parser.getEventSchemaPromptFields().map(field => field.normalizedName);
+  assert.ok(schemaFields.includes('location'), 'the coords prompt field must still normalize to location');
+  assert.deepEqual(
+    parser.getRemainingPromptFields(['title', 'location'], { title: 'Treasure Trail Portland PRIDE' }),
+    ['location'],
+    'a missing location is still requested by the main extraction passes');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -540,6 +540,28 @@ class SharedCore {
                 }
             }
         }
+        // Case-only variants are not a real conflict: production runs burned
+        // 1.5–7s AI arbitrations on bar="NOVA PDX" vs "Nova PDX" and
+        // title="TREASURE TRAIL Portland PRIDE" vs "Treasure Trail Portland
+        // PRIDE" — and the model picked inconsistently between runs. When the
+        // two strings are identical after trimming, collapsing whitespace, and
+        // case-folding, keep the LESS-uppercased (less shouty) variant; on an
+        // uppercase-count tie keep valueA (the existing/calendar side, for
+        // stability). MUST run after the more specific rules above (URL depth,
+        // emoji-twin, city-only title, image logo) so those keep priority.
+        // Genuinely different text still arbitrates.
+        if (typeof valueA === 'string' && typeof valueB === 'string') {
+            const collapseWhitespace = value => value.replace(/\s+/g, ' ').trim();
+            const collapsedA = collapseWhitespace(valueA);
+            const collapsedB = collapseWhitespace(valueB);
+            if (collapsedA && collapsedB && collapsedA.toLowerCase() === collapsedB.toLowerCase()) {
+                const countUppercase = value => (value.match(/\p{Lu}/gu) || []).length;
+                return {
+                    winner: countUppercase(collapsedB) < countUppercase(collapsedA) ? 'b' : 'a',
+                    reason: 'case-only variants — kept less-uppercased form'
+                };
+            }
+        }
         return null;
     }
 

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -984,6 +984,58 @@ test('mergeParsedEvents: same-host root-vs-deep website resolves deterministical
   assert.equal(merged.website, 'https://bearracuda.com/events/portland-pridefriday/');
 });
 
+// ---------------------------------------------------------------------------
+// Case-only variants (2026-07-12 run: bar="NOVA PDX" vs "Nova PDX",
+// bar="MASSIVE" vs "Massive", title="Treasure Trail Portland PRIDE" vs
+// "TREASURE TRAIL Portland PRIDE" each burned a 1.5–7s AI arbitration, with
+// inconsistent picks between runs)
+// ---------------------------------------------------------------------------
+
+test('guardrail: case-only variants keep the less-uppercased form without AI', () => {
+  const core = createCore();
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'NOVA PDX', 'Nova PDX'),
+    { winner: 'b', reason: 'case-only variants — kept less-uppercased form' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('title', 'TREASURE TRAIL Portland PRIDE', 'Treasure Trail Portland PRIDE'),
+    { winner: 'b', reason: 'case-only variants — kept less-uppercased form' },
+    'the less-uppercased variant wins');
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Massive'),
+    { winner: 'b', reason: 'case-only variants — kept less-uppercased form' });
+  // Exact tie (whitespace-collapse-equal, same uppercase count) keeps valueA
+  // — the existing/calendar side, for stability
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'Nova PDX', 'Nova  PDX'),
+    { winner: 'a', reason: 'case-only variants — kept less-uppercased form' });
+  // Genuinely different values must still go to AI
+  assert.equal(core.resolveConflictDeterministically('bar', 'The Heretic', 'The Heretic Atlanta'), null);
+  assert.equal(core.resolveConflictDeterministically('address', '722 E Burnside', '722 East Burnside Street'), null);
+});
+
+test('guardrail: earlier deterministic rules keep priority over the case-only rule', () => {
+  const core = createCore();
+  // Emoji twins that are ALSO case-fold-equal (whitespace-only difference):
+  // the emoji-twin rule fires first — longer variant wins with the twin
+  // reason, where the case-only rule alone would have kept valueA on a tie.
+  assert.deepEqual(
+    core.resolveConflictDeterministically('title', 'Nova PDX 🔥', 'Nova  PDX 🔥'),
+    { winner: 'b', reason: 'emoji title variant beats its emoji-stripped twin' });
+  // Two bare-city case variants: the city rule needs exactly ONE city-only
+  // side so it stays silent, and the case-only rule now resolves what
+  // previously went to AI ("two bare-city variants still arbitrate" no longer
+  // applies when the variants differ only by case).
+  const cityCore = createCityTitleCore();
+  assert.deepEqual(
+    cityCore.resolveConflictDeterministically('title', 'NEW ORLEANS', 'New Orleans', { cityKey: 'nola' }),
+    { winner: 'b', reason: 'case-only variants — kept less-uppercased form' });
+  // A named-vs-bare-city pair keeps the city rule's reason (it can never be
+  // case-fold-equal, so the earlier rule always decides first)
+  assert.deepEqual(
+    cityCore.resolveConflictDeterministically('title', 'BEARRACUDA: New Orleans⚜️', 'New Orleans⚜️', { cityKey: 'nola' }),
+    { winner: 'a', reason: 'named title beats bare city title' });
+});
+
 test('resolveAiConfig defaults and the arbitrateMerges flag', () => {
   const core = createCore();
   const defaults = core.resolveAiConfig({});


### PR DESCRIPTION
## What

Two run-speed fixes from the 2026-07-13 16:33 production run review (~3m46s total, ~3min of it serialized local-AI inference):

1. **Case-only-variant deterministic tie-breaker** (`shared-core.js`): when two conflicting values are identical after trim + whitespace-collapse + case-fold (e.g. bar `"NOVA PDX"` vs `"Nova PDX"`, title `"TREASURE TRAIL Portland PRIDE"` vs `"Treasure Trail Portland PRIDE"`), resolve deterministically instead of burning a 1.5–7s AI arbitration call — the less-uppercased variant wins, `valueA` (existing/calendar side) on a tie. Ordered AFTER the URL-depth / emoji-twin / city-only-title / image-logo rules so those keep priority. Genuinely different values (`"The Heretic"` vs `"The Heretic Atlanta"`) still go to AI. Logs through the existing `🔒 MERGE:` line so the `arbitrationDeterministic` metrics counter picks it up unchanged.

2. **`location` excluded from confidence-retry extraction** (`ai-web-parser.js`): the retry pass re-requested coordinates on nearly every page and the model fabricated them from the street address every single time (all caught by the evidence gate — pure waste + hallucination surface). Retry plans now drop `location` (with a log line); a location-only plan skips the retry request entirely. Main extraction passes still request `location`.

Expected effect on a bearracuda run: several fewer merge-arbitration AI calls and ~1 fewer extraction call per page.

## Tests

266 pass / 0 fail with `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`. New coverage: less-uppercased winner, tie keeps existing side, whitespace-collapse equality, non-equal values fall through to AI, rule ordering vs emoji-twin, retry plan never contains location while main-pass selection still does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP