### PR TITLE
fix(scraper): Scriptable-safe URL stripping, weekday-pinned years, smaller first OCR pass

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1007,7 +1007,11 @@ class ScriptableAdapter {
     return Number.isFinite(statusCode) ? statusCode : null;
   }
 
-  async fetchImageAsBase64(url, timeoutSeconds = 30, maxDimension = 1568) {
+  // Default maxDimension of 1024 matches what the OCR overflow-retry path uses:
+  // first attempts at ~1568px reliably overflowed the vision model's context
+  // (0 tokens, finish_reason "length") and only succeeded after retrying ≤1024,
+  // so every large image paid a wasted round trip.
+  async fetchImageAsBase64(url, timeoutSeconds = 30, maxDimension = 1024) {
     try {
       const request = new Request(url);
       request.timeoutInterval = timeoutSeconds;

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -256,8 +256,10 @@ class AiWebParser {
         this.defaultOcrModel = 'qwen3-vl:4b-instruct';
         this.defaultOcrPrompt = "You are performing OCR on an event flyer.\n\nSTEP 1: OCR\nExtract ALL visible text from the image.\n\nRules:\n- Copy text exactly as shown.\n- Preserve line breaks when possible.\n- Do not summarize.\n- Do not interpret.\n- Do not correct spelling.\n- Do not infer missing words.\n\nSTEP 2: Classification\n\nClassify the image into ONE category:\n\nad-banner: Advertisement or promotional banner (usually has \"buy\", \"get tickets\", \"sale\")\nevent-flyer: Single event poster/flyer - ONE primary event with ONE title, ONE venue, and ONE date or continuous date range. May contain schedules, activities, DJs, performers, or sub-events that are clearly part of the same event. Examples: Bear Week, Bear Weekend, Pride Festival, Camp Weekend, Resort Weekend Package.\nmulti-event-flyer: Two or more independent events with different titles, different dates/times, and separate ticketing. Often appears as a calendar, event listing, or monthly schedule.\nlogo: Brand or organization logo (minimal text, just brand name)\nthumbnail: Small preview image (low detail)\nhero-banner: Large header/banner image (prominent on page)\n\nDecision rule: If there is ONE overarching event name and the listed activities appear to belong to that event, classify as event-flyer. Only classify as multi-event-flyer when multiple independent events are advertised that require separate tickets.\n\nIMPORTANT CONTEXT: This is for a gay bear community travel guide. Events may be part of:\n- \"Bear Week\" or \"Bear Weekend\" themed events\n- Annual bear gatherings (e.g., \"Puerto Vallarta Bear Week\", \"Sitges Bear Week\")\n- Regular bear-themed parties or meetups\n- Events at bear-owned businesses or bear-friendly venues\n\nSTEP 3: Event Analysis\n\nDetermine:\n- eventName: The primary event title\n- venue: The venue or venue group name\n- startDate: Start date/time if visible\n- endDate: End date/time if visible\n\nUse only information visible in the image.\n\nSTEP 4: Summary\n\nCreate a concise summary describing:\n- event name\n- venue\n- date/time\n- why it may be relevant to the bear community\n\nReturn JSON only with these fields:\n{\n  \"text\": \"full extracted text\",\n  \"imageClassification\": \"ad-banner|event-flyer|multi-event-flyer|logo|thumbnail|hero-banner\",\n  \"eventSummary\": \"a concise 1-2 sentence summary of the event including: event name, venue, date/time, and any bear-week context if applicable. Focus on what makes this event notable for the bear community.\",\n  \"confidence\": 0-100,\n  \"reason\": \"brief explanation for classification\"\n}";
         // When an image overflows the vision model's context, retry once at this
-        // longest-side cap (the adapter's default first-pass cap is 1568px).
-        this.ocrOverflowRetryMaxDimension = 1024;
+        // longest-side cap. The adapter's default first-pass cap is 1024px (the
+        // value overflow retries used to succeed at), so this safety net steps
+        // down further and should rarely fire.
+        this.ocrOverflowRetryMaxDimension = 768;
         this.defaultOcrRequestConfig = {
             // With requests serialized (maxConcurrentRequests), anything slower than
             // 2 minutes on the local vision model is stuck, not slow.
@@ -2010,69 +2012,94 @@ class AiWebParser {
      * Strip size-related parameters from image URLs for deduplication.
      * Removes width/height parameters like w=1920, h=1080, w_296,h_370, etc.
      * to identify the same image at different resolutions.
+     * Built entirely on string/regex parsing — the URL global does not exist in
+     * Scriptable (iOS JavaScriptCore), and a URL-based implementation silently
+     * no-oped there, which broke OCR↔segment image matching (every segment
+     * logged "failed to match any of the N OCR results").
      */
     stripSizeParams(url, unwrapDepth = 0) {
         if (!url) return url;
-        try {
-            const parsed = new URL(url);
+        const text = String(url);
 
-            // Image proxies like img.evbuc.com wrap the source URL inside the path
-            // (img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2F...) with per-variant crop
-            // and signature query params, so no amount of param stripping makes two
-            // variants equal. Dedup on the decoded inner URL instead.
-            if (unwrapDepth < this.maxUrlUnwrapDepth) {
-                const encodedPathMatch = parsed.pathname.match(/^\/(https?%3a%2f%2f.+)$/i);
-                if (encodedPathMatch) {
-                    try {
-                        const innerUrl = decodeURIComponent(encodedPathMatch[1]);
-                        return this.stripSizeParams(innerUrl, unwrapDepth + 1);
-                    } catch (_) {}
-                }
+        // Split hash and query off the scheme://host/path part manually.
+        let withoutHash = text;
+        let hash = '';
+        const hashIndex = withoutHash.indexOf('#');
+        if (hashIndex >= 0) {
+            hash = withoutHash.slice(hashIndex);
+            withoutHash = withoutHash.slice(0, hashIndex);
+        }
+        let base = withoutHash;
+        let queryText = '';
+        const queryIndex = base.indexOf('?');
+        if (queryIndex >= 0) {
+            queryText = base.slice(queryIndex + 1);
+            base = base.slice(0, queryIndex);
+        }
+
+        const baseMatch = base.match(/^(https?:\/\/[^/]+)(\/.*)?$/i);
+        if (!baseMatch) {
+            // Not an absolute http(s) URL — nothing safe to strip.
+            return url;
+        }
+        const origin = baseMatch[1];
+        let pathname = baseMatch[2] || '';
+
+        // Image proxies like img.evbuc.com wrap the source URL inside the path
+        // (img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2F...) with per-variant crop
+        // and signature query params, so no amount of param stripping makes two
+        // variants equal. Dedup on the decoded inner URL instead.
+        if (unwrapDepth < this.maxUrlUnwrapDepth) {
+            const encodedPathMatch = pathname.match(/^\/(https?%3a%2f%2f.+)$/i);
+            if (encodedPathMatch) {
+                try {
+                    const innerUrl = decodeURIComponent(encodedPathMatch[1]);
+                    return this.stripSizeParams(innerUrl, unwrapDepth + 1);
+                } catch (_) {}
             }
+        }
 
-            let pathname = parsed.pathname;
+        // Remove size patterns from pathname (e.g., /w_296,h_370/ or /1920x1080/)
+        // Handle Wix-style /v1/fill/w_296,h_370,.../<name> transform paths: everything
+        // from /v1/fill/ onward is transform params plus a duplicate filename, so the
+        // whole tail is stripped and the bare asset URL remains.
+        pathname = pathname.replace(/\/v1\/(?:fill|crop|fit)\/.*$/i, '');  // Wix transform path
+        pathname = pathname.replace(/\/\d+[xX]\d+\/?/g, '/');  // 1920x1080 patterns
+        pathname = pathname.replace(/\/w_\d+(?:,h_\d+)?\/?/i, '/');  // w_296,h_370 patterns
+        pathname = pathname.replace(/\/h_\d+(?:,w_\d+)?\/?/i, '/');  // h_370,w_296 patterns
+        pathname = pathname.replace(/\/(?:w|h|width|height|wpx|hpx)=\d+\/?/gi, '/');  // /w=1920/ patterns
 
-            // Remove size patterns from pathname (e.g., /w_296,h_370/ or /1920x1080/)
-            // Handle Wix-style /v1/fill/w_296,h_370,.../ patterns
-            pathname = pathname.replace(/\/v1\/(?:fill|crop|fit)\/.*$/i, '');  // Wix transform path
-            pathname = pathname.replace(/\/\d+[xX]\d+\/?/g, '/');  // 1920x1080 patterns
-            pathname = pathname.replace(/\/w_\d+(?:,h_\d+)?\/?/i, '/');  // w_296,h_370 patterns
-            pathname = pathname.replace(/\/h_\d+(?:,w_\d+)?\/?/i, '/');  // h_370,w_296 patterns
-            pathname = pathname.replace(/\/(?:w|h|width|height|wpx|hpx)=\d+\/?/gi, '/');  // ?w=1920 patterns
-
-            if (pathname !== parsed.pathname) {
-                parsed.pathname = pathname;
-            }
-
-            // Remove size query parameters (both w=1920 and w_296,h_370 formats)
-            const searchParams = parsed.searchParams;
-            const keysToRemove = [];
-            for (const key of searchParams.keys()) {
-                const lowerKey = key.toLowerCase();
+        // Remove size query parameters (both w=1920 and w_296,h_370 formats).
+        const keptPairs = [];
+        if (queryText) {
+            for (const pair of queryText.split('&')) {
+                if (!pair) continue;
+                const separatorIndex = pair.indexOf('=');
+                const rawKey = separatorIndex >= 0 ? pair.slice(0, separatorIndex) : pair;
+                const rawValue = separatorIndex >= 0 ? pair.slice(separatorIndex + 1) : '';
+                let key = rawKey;
+                try {
+                    key = decodeURIComponent(rawKey.replace(/\+/g, ' '));
+                } catch (_) {}
+                let value = rawValue;
+                try {
+                    value = decodeURIComponent(rawValue.replace(/\+/g, ' '));
+                } catch (_) {}
                 // Match standard size params: w, h, width, height, wpx, hpx, scale, size, res, resolution
-                if (/^(w|h|width|height|wpx|hpx|scale|size|res|resolution|x|y)$/.test(lowerKey)) {
-                    keysToRemove.push(key);
+                if (/^(w|h|width|height|wpx|hpx|scale|size|res|resolution|x|y)$/.test(key.toLowerCase())) {
+                    continue;
                 }
                 // Match Wix-style params like w_296,h_370 (the key is 'v1' or similar, value contains size info)
                 // Check if the value contains size patterns like w_\d+, h_\d+, or \d+x\d+
-                const value = searchParams.get(key);
                 if (value && (/\d+[xX]\d+/.test(value) || /w_\d+(?:,h_\d+)?/.test(value) || /h_\d+(?:,w_\d+)?/.test(value))) {
-                    keysToRemove.push(key);
+                    continue;
                 }
+                keptPairs.push(pair);
             }
-            for (const key of keysToRemove) {
-                searchParams.delete(key);
-            }
-
-            // Clean up empty search params
-            if (parsed.search === '?') {
-                parsed.search = '';
-            }
-
-            return parsed.toString();
-        } catch (_) {
-            return url;
         }
+
+        const search = keptPairs.length > 0 ? `?${keptPairs.join('&')}` : '';
+        return `${origin}${pathname}${search}${hash}`;
     }
 
     /**
@@ -2978,12 +3005,20 @@ class AiWebParser {
                 .filter(Boolean)
         );
 
-        // Strip sizes for more robust comparison
-        const strippedSegmentImageSet = new Set(
-            Array.from(normalizedSegmentImageSet)
-                .map(u => this.stripSizeParams(u))
-                .filter(Boolean)
-        );
+        // Strip sizes for more robust comparison. Each URL is also run through
+        // upgradeCdnThumbnailUrl first: OCR results are keyed by the upgraded bare
+        // asset URL, so segment thumbnail variants must collapse to the same key
+        // even if a future transform shape slips past stripSizeParams.
+        const strippedSegmentImageSet = new Set();
+        for (const u of normalizedSegmentImageSet) {
+            const stripped = this.stripSizeParams(u);
+            if (stripped) strippedSegmentImageSet.add(stripped);
+            const upgraded = this.upgradeCdnThumbnailUrl(u);
+            if (upgraded && upgraded !== u) {
+                const strippedUpgraded = this.stripSizeParams(upgraded);
+                if (strippedUpgraded) strippedSegmentImageSet.add(strippedUpgraded);
+            }
+        }
 
         console.log(`🤖 AI Web: Filtering OCR results against ${normalizedSegmentImageSet.size} segment images (${strippedSegmentImageSet.size} stripped)`);
 
@@ -4664,6 +4699,16 @@ class AiWebParser {
         const schema = this.getEventSchema();
         Object.keys(nextEvent).forEach(key => {
             const value = nextEvent[key];
+            // Weekday-pin flags from different passes cover different date fields
+            // (e.g. startDate from one pass, endDate from a retry) — union them
+            // instead of letting the first pass's flags shadow later ones.
+            if (key === '__weekdayPinnedYears' && value && typeof value === 'object') {
+                merged.__weekdayPinnedYears = {
+                    ...(merged.__weekdayPinnedYears && typeof merged.__weekdayPinnedYears === 'object' ? merged.__weekdayPinnedYears : {}),
+                    ...value
+                };
+                return;
+            }
             if (!this.isUsableAiFieldValue(value)) return;
             const normalizedName = this.normalizePromptFieldName(key);
             if (this.hasResolvedFieldValue(merged, normalizedName)) return;
@@ -5651,7 +5696,23 @@ TEXT:
                         console.log(`🤖 AI Web: Dropping field ${key} due to low confidence (${confidence})`);
                         continue; // Drop it
                     }
-                    filteredEvent[key] = fieldData.value;
+                    let value = fieldData.value;
+                    // Weekday-pinned year inference: the evidence string is only
+                    // available here (it is discarded when field objects flatten to
+                    // scalars), so this is the seam where "Sat, Aug 22" can pin the
+                    // year the model hallucinated. See resolveWeekdayPinnedYear.
+                    const pinBucket = this.getDateFieldPinBucket(key);
+                    if (pinBucket) {
+                        const pinResult = this.resolveWeekdayPinnedYear(value, fieldData.evidence);
+                        if (pinResult) {
+                            value = pinResult.value;
+                            if (!filteredEvent.__weekdayPinnedYears || typeof filteredEvent.__weekdayPinnedYears !== 'object') {
+                                filteredEvent.__weekdayPinnedYears = {};
+                            }
+                            filteredEvent.__weekdayPinnedYears[pinBucket] = true;
+                        }
+                    }
+                    filteredEvent[key] = value;
                 } else {
                     // Fallback in case AI doesn't follow the format perfectly
                     filteredEvent[key] = fieldData;
@@ -6903,7 +6964,20 @@ TEXT:
             }
         }
 
-        const { startDate, endDate } = this.normalizeEventDates(finalStartDate, finalEndDate);
+        // Weekday-pinned years (see resolveWeekdayPinnedYear) are deterministic and
+        // must not be re-adjusted toward the window. An end that was derived from
+        // the start (no end info of its own) inherits the start's pin so the pair
+        // cannot be split across years, and vice versa for a start that fell back
+        // to the end value.
+        const weekdayPinnedYears = aiEvent.__weekdayPinnedYears && typeof aiEvent.__weekdayPinnedYears === 'object'
+            ? aiEvent.__weekdayPinnedYears
+            : {};
+        const effectivePinnedYears = {
+            start: Boolean(weekdayPinnedYears.start) || (!combinedStartDate && Boolean(weekdayPinnedYears.end)),
+            end: Boolean(weekdayPinnedYears.end) || (!endProvided && !endDateRaw && Boolean(weekdayPinnedYears.start))
+        };
+
+        const { startDate, endDate } = this.normalizeEventDates(finalStartDate, finalEndDate, effectivePinnedYears);
         console.log(`🤖 AI Web: Normalized dates — startDate=${startDate instanceof Date ? startDate.toISOString() : startDate}, endDate=${endDate instanceof Date ? endDate.toISOString() : endDate}`);
 
         if (!title || !startDate) {
@@ -7253,9 +7327,141 @@ TEXT:
         }
     }
 
-    normalizeEventDates(startDate, endDate) {
-        const adjustedStart = this.adjustLikelyEventYear(startDate);
-        const adjustedEnd = this.adjustLikelyEventYear(endDate);
+    // Clock hook — production always uses the real clock; tests override this to
+    // freeze "now" for deterministic year-window and weekday-pinning assertions.
+    now() {
+        return new Date();
+    }
+
+    // Which weekday-pin bucket an AI date field key belongs to ('start'/'end'),
+    // or null for non-date fields. Keys arrive canonical ("startDate") or
+    // lowercased ("startdate") depending on the pass that produced them.
+    getDateFieldPinBucket(key) {
+        const normalized = String(key || '').trim().toLowerCase();
+        if (normalized === 'startdate' || normalized === 'start') return 'start';
+        if (normalized === 'enddate' || normalized === 'end') return 'end';
+        return null;
+    }
+
+    // Extract a weekday stated adjacent to a date in free text ("Sat, Aug 22",
+    // "Aug 22, Saturday", "Sat 8/22"). Returns the JS day index (0=Sunday) or
+    // null when no weekday sits next to a date-looking token.
+    extractStatedWeekdayAdjacentToDate(text) {
+        const raw = String(text || '');
+        if (!raw) return null;
+        const weekday = '(sun(?:day)?|mon(?:day)?|tue(?:s(?:day)?)?|wed(?:s|nesday)?|thu(?:r(?:s(?:day)?)?)?|fri(?:day)?|sat(?:urday)?)';
+        const month = '(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)';
+        const dayNum = '\\d{1,2}(?:st|nd|rd|th)?';
+        const dateToken = `(?:${month}\\.?\\s*${dayNum}|${dayNum}\\s*(?:of\\s+)?${month}|\\d{1,2}[\\/.\\-]\\d{1,2})`;
+        const weekdayThenDate = new RegExp(`\\b${weekday}\\b\\.?,?\\s*${dateToken}`, 'i');
+        const dateThenWeekday = new RegExp(`${dateToken}\\s*,?\\s*\\(?\\b${weekday}\\b`, 'i');
+        const match = raw.match(weekdayThenDate) || raw.match(dateThenWeekday);
+        if (!match) return null;
+        const dayIndexByPrefix = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
+        const prefix = String(match[1] || '').slice(0, 3).toLowerCase();
+        return Object.prototype.hasOwnProperty.call(dayIndexByPrefix, prefix) ? dayIndexByPrefix[prefix] : null;
+    }
+
+    // Build one candidate for weekday pinning: the field value with its 4-digit
+    // year replaced by `year`. Date-only/ISO-leading values use UTC weekday math;
+    // other parseable strings use the host-local weekday (matching how they will
+    // later be parsed). Returns { year, text, date, weekday, iso } or null.
+    buildWeekdayPinCandidate(valueText, yearMatch, year) {
+        const candidateText = valueText.slice(0, yearMatch.index)
+            + String(year)
+            + valueText.slice(yearMatch.index + yearMatch[0].length);
+        const isoMatch = candidateText.match(/^\s*(\d{4})-(\d{1,2})-(\d{1,2})(?:[T\s]|$)/);
+        if (isoMatch) {
+            const month = Number(isoMatch[2]);
+            const day = Number(isoMatch[3]);
+            const utcDate = new Date(Date.UTC(year, month - 1, day));
+            if (utcDate.getUTCFullYear() !== year || utcDate.getUTCMonth() !== month - 1 || utcDate.getUTCDate() !== day) {
+                return null; // e.g. Feb 29 in a non-leap candidate year
+            }
+            return {
+                year,
+                text: candidateText,
+                date: utcDate,
+                weekday: utcDate.getUTCDay(),
+                iso: utcDate.toISOString().slice(0, 10)
+            };
+        }
+        const parsed = new Date(candidateText);
+        if (Number.isNaN(parsed.getTime()) || parsed.getFullYear() !== year) return null;
+        return {
+            year,
+            text: candidateText,
+            date: parsed,
+            weekday: parsed.getDay(),
+            iso: `${parsed.getFullYear()}-${String(parsed.getMonth() + 1).padStart(2, '0')}-${String(parsed.getDate()).padStart(2, '0')}`
+        };
+    }
+
+    // Deterministic weekday→year pinning. Listing/flyer text often states a
+    // weekday but no year ("Sat, Aug 22"); the extraction model then hallucinates
+    // one, and window-based repair (adjustLikelyEventYear) can land on the wrong
+    // weekday (2025-08-22 is a Friday). When the field's own evidence names a
+    // weekday adjacent to the date AND carries no explicit 4-digit year, the year
+    // is derivable: try currentYear−1…currentYear+2 and keep candidates whose
+    // actual weekday matches; prefer one inside the year window, else the nearest
+    // to now. Past dates are intentionally allowed — past events must stay
+    // datable so the downstream past-filter can drop them (never force future).
+    // Returns { value, pinnedYear, aiYear } or null when pinning does not apply
+    // (no weekday, explicit year in evidence, unparseable value, or no candidate
+    // matches the stated weekday — e.g. bad OCR).
+    resolveWeekdayPinnedYear(rawValue, evidenceText) {
+        if (typeof rawValue !== 'string') return null;
+        const valueText = rawValue.trim();
+        if (!valueText) return null;
+        const yearMatch = valueText.match(/\b(?:19|20)\d{2}\b/);
+        if (!yearMatch) return null;
+        const evidence = String(evidenceText || '').trim();
+        if (!evidence || /\b(?:19|20)\d{2}\b/.test(evidence)) return null;
+        const statedWeekday = this.extractStatedWeekdayAdjacentToDate(evidence);
+        if (statedWeekday === null) return null;
+
+        const aiYear = Number(yearMatch[0]);
+        const now = this.now();
+        const currentYear = now.getFullYear();
+        const matches = [];
+        for (let year = currentYear - 1; year <= currentYear + 2; year++) {
+            const candidate = this.buildWeekdayPinCandidate(valueText, yearMatch, year);
+            if (candidate && candidate.weekday === statedWeekday) {
+                matches.push(candidate);
+            }
+        }
+        if (matches.length === 0) return null;
+
+        let chosen = matches[0];
+        if (matches.length > 1) {
+            const dayMs = this.extractionLimits.millisPerDay;
+            const windowStart = new Date(now.getTime() - (this.extractionLimits.yearWindowPastDays * dayMs));
+            const windowEnd = new Date(now.getTime() + (this.extractionLimits.yearWindowFutureDays * dayMs));
+            const inWindow = matches.filter(candidate => candidate.date >= windowStart && candidate.date <= windowEnd);
+            const pool = inWindow.length > 0 ? inWindow : matches;
+            chosen = pool.reduce((best, candidate) => {
+                if (!best) return candidate;
+                return Math.abs(candidate.date.getTime() - now.getTime()) < Math.abs(best.date.getTime() - now.getTime())
+                    ? candidate
+                    : best;
+            }, null);
+        }
+        if (chosen.year !== aiYear) {
+            console.log(`🤖 AI Web: Weekday-pinned year: "${this.trimToMaxLength(evidence, 80)}" → ${chosen.iso} (AI said ${aiYear})`);
+        }
+        return { value: chosen.text, pinnedYear: chosen.year, aiYear };
+    }
+
+    normalizeEventDates(startDate, endDate, weekdayPinnedYears = null) {
+        const pinned = weekdayPinnedYears && typeof weekdayPinnedYears === 'object' ? weekdayPinnedYears : {};
+        // A weekday-pinned year is deterministic — never "repair" it toward the
+        // window (that is exactly the wrong-weekday failure pinning prevents).
+        const adjustedStart = pinned.start && startDate instanceof Date && !Number.isNaN(startDate.getTime())
+            ? new Date(startDate)
+            : this.adjustLikelyEventYear(startDate);
+        const adjustedEnd = pinned.end && endDate instanceof Date && !Number.isNaN(endDate.getTime())
+            ? new Date(endDate)
+            : this.adjustLikelyEventYear(endDate);
         if (!adjustedStart) {
             return { startDate: null, endDate: null };
         }
@@ -7268,7 +7474,7 @@ TEXT:
 
     adjustLikelyEventYear(date) {
         if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null;
-        const now = new Date();
+        const now = this.now();
         const dayMs = this.extractionLimits.millisPerDay;
         const windowStart = new Date(now.getTime() - (this.extractionLimits.yearWindowPastDays * dayMs));
         const windowEnd = new Date(now.getTime() + (this.extractionLimits.yearWindowFutureDays * dayMs));
@@ -7282,7 +7488,21 @@ TEXT:
             candidate.setFullYear(candidateYear);
             return candidate;
         });
-        const inWindow = candidates.filter(candidate => candidate >= windowStart && candidate <= windowEnd);
+        let inWindow = candidates.filter(candidate => candidate >= windowStart && candidate <= windowEnd);
+        if (inWindow.length === 0) {
+            // Hallucinated years can be more than ±1 off ("Sat, Aug 22" guessed as
+            // 2024 when the window wants 2026) — re-anchor candidates on the current
+            // year before giving up.
+            const currentYear = now.getFullYear();
+            const currentYearCandidates = [];
+            for (let candidateYear = currentYear - 1; candidateYear <= currentYear + 2; candidateYear++) {
+                if (candidateYear >= year - 1 && candidateYear <= year + 1) continue; // already tried
+                const candidate = new Date(date);
+                candidate.setFullYear(candidateYear);
+                currentYearCandidates.push(candidate);
+            }
+            inWindow = currentYearCandidates.filter(candidate => candidate >= windowStart && candidate <= windowEnd);
+        }
         if (inWindow.length === 0) {
             console.warn(`🤖 AI Web: Date ${date.toISOString()} is outside window [${windowStart.toISOString()}, ${windowEnd.toISOString()}] and no candidate year was in window.`);
         }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1723,3 +1723,141 @@ test('normalizeAiEvent upgrades a blurred CDN thumbnail image field', () => {
     'the stored image must never be the blurred thumbnail'
   );
 });
+
+// ---------------------------------------------------------------------------
+// Scriptable-safe stripSizeParams (2026-07-12 run findings: the URL global does
+// not exist in Scriptable, so URL-based stripping silently no-oped and every
+// segment logged "failed to match any of the N OCR results")
+// ---------------------------------------------------------------------------
+
+test('stripSizeParams strips Wix transforms and unwraps proxies without the URL global (Scriptable)', () => {
+  const parser = createParser();
+  const asset = 'https://static.wixstatic.com/media/8e6e19_16d4c264742a4b0e93a445f2f04e2170~mv2.jpg';
+  const variant = `${asset}/v1/fill/w_147,h_184,al_c,q_80,usm_0.66_1.00_0.01,blur_2,enc_auto/8e6e19_16d4c264742a4b0e93a445f2f04e2170~mv2.jpg`;
+  const inner = 'https://cdn.evbuc.com/images/1184410354/185013722403/1/original.20260512-160408';
+  const wrapped = `https://img.evbuc.com/${encodeURIComponent(inner)}?crop=focalpoint&fit=crop&w=940&auto=format%2Ccompress&q=75&s=79b82ef9b2961bb09d52102535747556`;
+
+  const RealURL = global.URL;
+  global.URL = undefined;
+  try {
+    assert.equal(parser.stripSizeParams(variant), asset, 'Wix transform variant must strip to the bare asset URL');
+    assert.equal(parser.stripSizeParams(asset), asset, 'bare asset URL must pass through unchanged');
+    assert.equal(parser.stripSizeParams(wrapped), inner, 'evbuc path-wrapped proxy must unwrap to the inner URL');
+    assert.equal(
+      parser.stripSizeParams('https://x.example/img.jpg?w=1920&h=1080&fit=crop'),
+      'https://x.example/img.jpg?fit=crop',
+      'size query params must be dropped while other params survive'
+    );
+    assert.equal(
+      parser.stripSizeParams('https://x.example/photos/1920x1080/flyer.jpg'),
+      'https://x.example/photos/flyer.jpg',
+      'dimension path segments must be dropped'
+    );
+  } finally {
+    global.URL = RealURL;
+  }
+});
+
+test('filterOcrResultsForSegment matches bare-asset OCR keys to transform-variant segment images without the URL global', () => {
+  const parser = createParser();
+  const asset = 'https://static.wixstatic.com/media/8e6e19_16d4c264742a4b0e93a445f2f04e2170~mv2.jpg';
+  const variant = `${asset}/v1/fill/w_147,h_184,al_c,q_80,usm_0.66_1.00_0.01,blur_2,enc_auto/8e6e19_16d4c264742a4b0e93a445f2f04e2170~mv2.jpg`;
+  const ocrResults = [
+    { url: asset, text: 'FLYER TEXT', imageClassification: 'event-flyer' },
+    { url: 'https://static.wixstatic.com/media/aaaa11_ffffffffffffffffffffffffffffffff~mv2.jpg', text: 'OTHER FLYER', imageClassification: 'event-flyer' }
+  ];
+  const segment = { html: '', lines: ['SAT, AUG 22 BEAR NIGHT'], imageHintUrls: [variant] };
+
+  const RealURL = global.URL;
+  global.URL = undefined;
+  try {
+    const matched = parser.filterOcrResultsForSegment(ocrResults, segment, 'https://wix-site.example/events');
+    assert.equal(matched.length, 1, 'exactly the segment\'s own flyer OCR must match');
+    assert.equal(matched[0].url, asset);
+  } finally {
+    global.URL = RealURL;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Weekday-pinned year inference (2026-07-12 run findings: listing text stated a
+// weekday but no year, the model hallucinated one, and window repair landed on
+// the wrong weekday — e.g. "Sat, Aug 22" → 2025-08-22, a Friday)
+// ---------------------------------------------------------------------------
+
+const FROZEN_NOW = () => new Date(Date.UTC(2026, 6, 13, 12, 0, 0)); // 2026-07-13
+
+test('resolveWeekdayPinnedYear pins hallucinated years to the stated weekday', () => {
+  const parser = createParser();
+  parser.now = FROZEN_NOW;
+  // The four real failures from the 2026-07-12 run:
+  assert.equal(parser.resolveWeekdayPinnedYear('2024-08-22', 'Sat, Aug 22').value, '2026-08-22');
+  assert.equal(parser.resolveWeekdayPinnedYear('2026-10-11', 'Sat, Oct 11').value, '2025-10-11', 'past dates are allowed so the past-filter can drop them');
+  assert.equal(parser.resolveWeekdayPinnedYear('2027-01-17', 'Sat, Jan 17').value, '2026-01-17');
+  assert.equal(parser.resolveWeekdayPinnedYear('2026-12-31', 'Wed, Dec 31').value, '2025-12-31');
+});
+
+test('weekday pinning leaves explicit years and weekday-less evidence alone', () => {
+  const parser = createParser();
+  parser.now = FROZEN_NOW;
+  assert.equal(parser.resolveWeekdayPinnedYear('2024-08-22', 'Sat, Aug 22, 2024'), null, 'an explicit year in evidence is trusted');
+  assert.equal(parser.resolveWeekdayPinnedYear('2024-08-22', 'Aug 22'), null, 'no weekday falls through to existing behavior');
+  assert.equal(parser.resolveWeekdayPinnedYear('2024-08-22', ''), null, 'missing evidence falls through');
+  assert.equal(parser.resolveWeekdayPinnedYear('Aug 22', 'Sat, Aug 22'), null, 'a value without a 4-digit year cannot be rewritten');
+  assert.equal(parser.resolveWeekdayPinnedYear('2026-08-22', 'Saturday party vibes'), null, 'a weekday with no adjacent date does not pin');
+});
+
+test('adjustLikelyEventYear re-anchors on the current year when hallucinated-year ±1 misses the window', () => {
+  const parser = createParser();
+  parser.now = FROZEN_NOW;
+  // "Sat, Aug 22" guessed as 2024: 2023/2024/2025 are all outside the window,
+  // but the current-year anchor finds 2026-08-22.
+  const adjusted = parser.adjustLikelyEventYear(new Date(Date.UTC(2024, 7, 22)));
+  assert.equal(adjusted.toISOString().slice(0, 10), '2026-08-22');
+  // In-window dates are untouched.
+  const inWindow = parser.adjustLikelyEventYear(new Date(Date.UTC(2026, 8, 4)));
+  assert.equal(inWindow.toISOString().slice(0, 10), '2026-09-04');
+});
+
+test('normalizeEventDates keeps weekday-pinned past dates instead of repairing them into the window', () => {
+  const parser = createParser();
+  parser.now = FROZEN_NOW;
+  const pinnedStart = new Date(Date.UTC(2025, 9, 11, 22, 0, 0)); // Sat 2025-10-11, outside the window
+  const pinnedResult = parser.normalizeEventDates(new Date(pinnedStart), new Date(pinnedStart), { start: true, end: true });
+  assert.equal(pinnedResult.startDate.toISOString(), '2025-10-11T22:00:00.000Z');
+  assert.equal(pinnedResult.endDate.toISOString(), '2025-10-11T22:00:00.000Z');
+  // Without the pin the old window repair still applies (and picks 2026-10-11).
+  const unpinnedResult = parser.normalizeEventDates(new Date(pinnedStart), new Date(pinnedStart));
+  assert.equal(unpinnedResult.startDate.toISOString().slice(0, 10), '2026-10-11');
+});
+
+test('extraction flattens field objects through weekday pinning and normalizeAiEvent honors the pin', async () => {
+  global.EventSchema = EventSchema; // earlier tests leak a mocked schema — pin the real one
+  const parser = createParser();
+  parser.now = FROZEN_NOW;
+  const response = JSON.stringify({
+    title: { value: 'BEAR NIGHT', evidence: 'BEAR NIGHT', confidence: 95 },
+    startDate: { value: '2026-10-11', evidence: 'Sat, Oct 11', confidence: 90 }
+  });
+  parser.core.callAiGenerate = async () => response;
+
+  const event = await parser.extractEventWithTwoPassAi(
+    { html: '<p>Sat, Oct 11 BEAR NIGHT</p>', url: 'https://x.example/events' },
+    {}, null, {}, ['title', 'startDate'], 'Sat, Oct 11 BEAR NIGHT', 'test',
+    { dataFlags: { jsonLd: true } }
+  );
+  assert.equal(event.startDate, '2025-10-11', 'the AI year must be overridden by the stated weekday');
+  assert.deepEqual(event.__weekdayPinnedYears, { start: true });
+
+  // normalizeAiEvent must keep the pinned (past) year, and the derived end date
+  // inherits the pin so the pair is not split across years.
+  const normalized = parser.normalizeAiEvent({
+    title: 'BEAR NIGHT',
+    startDate: '2025-10-11',
+    startTime: '21:00',
+    __weekdayPinnedYears: { start: true }
+  }, {}, null, null, null);
+  assert.ok(normalized);
+  assert.equal(normalized.startDate.toISOString().slice(0, 10), '2025-10-11');
+  assert.equal(normalized.endDate.toISOString().slice(0, 10), '2025-10-11');
+});


### PR DESCRIPTION
Fixes the three root causes behind the 2026-07-13 CHUNK run's wrong dates, phantom future events, and missing segment↔detail merges.

## 1. Scriptable-safe `stripSizeParams` (restores OCR text to segments)

`stripSizeParams` was built on `new URL()`, which doesn't exist in Scriptable's JavaScriptCore — on-device it threw, the catch returned the URL unchanged, and OCR↔segment matching silently broke the moment OCR results became keyed by upgraded bare Wix asset URLs. Every segment logged `Segment failed to match any of the 22 OCR results`, so extraction ran on 2 lines of listing text with no year/venue/time.

- Rewritten regex-first with zero URL-global dependence (manual `#`/`?` splitting, origin/path regex, hand-filtered size query params). evbuc encoded-path unwrap preserved.
- `filterOcrResultsForSegment` additionally feeds segment URLs through `upgradeCdnThumbnailUrl` so thumbnail variants collapse to the same key as OCR results.

## 2. Weekday-pinned year inference (kills phantom resurrections)

Listing segments state a weekday but no year ("Sat, Aug 22"); the model hallucinates a year and `adjustLikelyEventYear` repaired it toward the scrape window with no weekday check. Real damage from the run: `Sat, Oct 11` → 2026-10-11 (a Sunday — phantom), `Sat, Jan 17` → 2027-01-17 (Sunday — phantom), `Wed, Dec 31` → 2026-12-31 (Thursday — phantom), `Sat, Aug 22` → 2025-08-22 (Friday — real future event killed as past).

- When a date field's evidence names a weekday adjacent to the date and carries no explicit year, the year is resolved deterministically: candidates currentYear−1…+2 filtered by actual weekday, window-preferred, nearest-to-now. Past dates intentionally allowed so the past-filter can do its job.
- Pinned dates bypass window repair (`normalizeEventDates`); an end derived from a pinned start inherits the pin.
- `adjustLikelyEventYear` also now re-anchors candidates on the current year when hallucinated-year ±1 misses the window entirely.
- New log: `🤖 AI Web: Weekday-pinned year: "Sat, Aug 22" → 2026-08-22 (AI said 2024)`.

With both fixes, segment and detail records agree on dates again, so the same-URL merge pairs re-form.

## 3. Smaller first OCR pass

Every large image paid a guaranteed-to-fail ~1568px first request (0 tokens, finish_reason `length`) before succeeding at ≤1024 on retry. First-pass cap is now 1024 (`fetchImageAsBase64`), overflow retry steps down to 768 as the safety net. Saves ~1.5–4s per large image.

## Tests

7 new tests in `ai-web-parser.test.js`, including Wix/evbuc stripping and OCR↔segment matching with `global.URL` deleted (simulating Scriptable), and the four real weekday-pin cases with a frozen clock. Full suite: 285 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP