### PR TITLE
fix(scraper): anchored dates beat wall-clock in merges, weekday-pin hardening, city-from-address guard

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -587,7 +587,18 @@ class LocationNormalizer extends BaseNormalizer {
         if (addressParts.length > 0) {
             const firstPart = addressParts[0].toLowerCase();
             const normalizedCity = this.normalizeCityName(firstPart);
-            return normalizedCity;
+            // Guard: normalizeCityName echoes unmapped input back (lowercased), so
+            // without this check a bare street address ("1192 folsom st") would
+            // masquerade as a city and poison timezone resolution and geocoding
+            // (observed 2026-07-13). Only return candidates that map to a known
+            // city; otherwise report no city found so callers fall through to the
+            // next strategy.
+            if (normalizedCity && (
+                (this.core.cities && Object.prototype.hasOwnProperty.call(this.core.cities, normalizedCity)) ||
+                Object.values(this.core.cityMappings).includes(normalizedCity)
+            )) {
+                return normalizedCity;
+            }
         }
 
         return null;
@@ -618,35 +629,11 @@ class LocationNormalizer extends BaseNormalizer {
     // Once the city is known here, convert those wall-clock values to real UTC instants.
     resolveWallClockDates(event) {
         if (!event || !event._timezoneUnresolved) return event;
-
-        const timezone = event.timezone
-            || (event.city && this.core && this.core.cities && this.core.cities[event.city]?.timezone)
-            || '';
-        if (!timezone || typeof this.core?.convertWallClockDateToUtc !== 'function') {
-            const title = event.title || 'unknown';
-            this.core?.warnOnce?.(
-                `wallclock:${title}`,
-                `🚨 LocationNormalizer: Could not resolve timezone for "${title}" (city: "${event.city || 'unknown'}") — dates remain wall-clock UTC and may be wrong`
-            );
-            return event;
-        }
-
-        const reanchor = (value) => {
-            if (!value) return value;
-            const converted = this.core.convertWallClockDateToUtc(value, timezone);
-            if (!converted || isNaN(converted.getTime())) return value;
-            return value instanceof Date ? converted : converted.toISOString();
-        };
-
-        const originalStart = event.startDate;
-        event.startDate = reanchor(event.startDate);
-        event.endDate = reanchor(event.endDate);
-        event.timezone = timezone;
-        delete event._timezoneUnresolved;
-
-        const format = (value) => value instanceof Date ? value.toISOString() : String(value);
-        console.log(`🗺️ LocationNormalizer: Re-anchored wall-clock dates to ${timezone} — start ${format(originalStart)} → ${format(event.startDate)}`);
-        return event;
+        // The conversion logic lives in SharedCore.resolveWallClockDates so the
+        // post-merge re-anchor pass in deduplicateEvents shares the exact same
+        // behavior (merges can resolve a city AFTER this normalizer already ran).
+        if (!this.core || typeof this.core.resolveWallClockDates !== 'function') return event;
+        return this.core.resolveWallClockDates(event);
     }
 
     extractCityFromEvent(event) {

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -67,6 +67,35 @@ test('resolveWallClockDates leaves dates untouched when the timezone stays unkno
 });
 
 // ---------------------------------------------------------------------------
+// City-from-address guard (2026-07-13 run findings: the flyer address
+// "1192 FOLSOM ST" has no city part and the fallback returned the lowercased
+// street address as the "city", blocking timezone resolution and breaking
+// geocoding)
+// ---------------------------------------------------------------------------
+
+test('extractCityFromAddress never returns a raw street address as a city', () => {
+  const core = new SharedCore(
+    {
+      sf: { timezone: 'America/Los_Angeles', patterns: ['sf', 'san francisco'] },
+      portland: { timezone: 'America/Los_Angeles', patterns: ['portland'] }
+    },
+    { eventSchema: EventSchema }
+  );
+  const normalizer = new LocationNormalizer(core);
+
+  assert.equal(normalizer.extractCityFromAddress('1192 FOLSOM ST'), null, 'an address without a city part yields no city');
+  assert.equal(
+    normalizer.extractCityFromEvent({ title: 'CHUNK', address: '1192 FOLSOM ST' }),
+    'unknown',
+    'the caller falls through to unknown instead of a garbage city'
+  );
+
+  // Legitimate addresses still resolve to their mapped city.
+  assert.equal(normalizer.extractCityFromAddress('722 E Burnside St, Portland, OR 97214, USA'), 'portland');
+  assert.equal(normalizer.extractCityFromAddress('1192 Folsom St, San Francisco, CA'), 'sf');
+});
+
+// ---------------------------------------------------------------------------
 // OpenStreetMapNormalizer forward-geocode city validation (2026-07-12 run
 // findings: flyer-OCR typo "922 E. BURNSIDE" geocoded to Burnside, Michigan
 // for an event in Portland)

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -5703,7 +5703,11 @@ TEXT:
                     // year the model hallucinated. See resolveWeekdayPinnedYear.
                     const pinBucket = this.getDateFieldPinBucket(key);
                     if (pinBucket) {
-                        const pinResult = this.resolveWeekdayPinnedYear(value, fieldData.evidence);
+                        // Pass the raw source content (not processedSnippet — the
+                        // helper-pass prefix is model output) so pinning can fall
+                        // back to a weekday the flyer states on the line above the
+                        // date when the model's evidence omits it.
+                        const pinResult = this.resolveWeekdayPinnedYear(value, fieldData.evidence, snippet);
                         if (pinResult) {
                             value = pinResult.value;
                             if (!filteredEvent.__weekdayPinnedYears || typeof filteredEvent.__weekdayPinnedYears !== 'object') {
@@ -7397,30 +7401,136 @@ TEXT:
         };
     }
 
+    // Month/day (1-based) of a date field value, for locating its token in source
+    // text. ISO-leading values are read positionally; other parseable strings go
+    // through Date (month/day are stable regardless of host timezone at noon-less
+    // date strings' local-midnight parse).
+    getMonthDayFromDateText(valueText) {
+        const raw = String(valueText || '').trim();
+        if (!raw) return null;
+        const isoMatch = raw.match(/^\s*(\d{4})-(\d{1,2})-(\d{1,2})(?:[T\s]|$)/);
+        if (isoMatch) {
+            return { month: Number(isoMatch[2]), day: Number(isoMatch[3]) };
+        }
+        const parsed = new Date(raw);
+        if (Number.isNaN(parsed.getTime())) return null;
+        return { month: parsed.getMonth() + 1, day: parsed.getDate() };
+    }
+
+    // Source-content fallback for weekday pinning: flyers often put the weekday on
+    // its own line directly above the date ("SATURDAY\nJANUARY 17TH"), and the
+    // model's evidence string quotes only the date line — no weekday, no pin.
+    // Search the pass's source content for the extracted month+day token and
+    // accept a weekday named in the preceding ~2 lines / ~40 chars, with nothing
+    // date-like (digits or another month name) between the weekday and the date.
+    // Conservative by design: pins only when the token match is unambiguous — the
+    // month+day appears exactly once, or every occurrence agrees on the adjacent
+    // weekday. Returns the JS day index (0=Sunday) or null.
+    extractWeekdayNearDateInSource(sourceText, valueText) {
+        const source = String(sourceText || '');
+        if (!source.trim()) return null;
+        const monthDay = this.getMonthDayFromDateText(valueText);
+        if (!monthDay || monthDay.month < 1 || monthDay.month > 12) return null;
+
+        const monthPatterns = [
+            'jan(?:uary)?', 'feb(?:ruary)?', 'mar(?:ch)?', 'apr(?:il)?', 'may', 'jun(?:e)?',
+            'jul(?:y)?', 'aug(?:ust)?', 'sep(?:t(?:ember)?)?', 'oct(?:ober)?', 'nov(?:ember)?', 'dec(?:ember)?'
+        ];
+        const monthPattern = monthPatterns[monthDay.month - 1];
+        const dayPattern = `${monthDay.day}(?:st|nd|rd|th)?`;
+        const dateTokenRegex = new RegExp(
+            `\\b(?:${monthPattern}\\.?\\s*${dayPattern}|${dayPattern}\\s*(?:of\\s+)?${monthPattern}|${monthDay.month}[\\/.\\-]${monthDay.day})\\b`,
+            'gi'
+        );
+        const weekdayPattern = '(sun(?:day)?|mon(?:day)?|tue(?:s(?:day)?)?|wed(?:s|nesday)?|thu(?:r(?:s(?:day)?)?)?|fri(?:day)?|sat(?:urday)?)';
+        const anyMonthRegex = new RegExp(`\\b(?:${monthPatterns.join('|')})\\b`, 'i');
+        const dayIndexByPrefix = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
+
+        const adjacentWeekdays = [];
+        let occurrenceCount = 0;
+        let tokenMatch;
+        while ((tokenMatch = dateTokenRegex.exec(source)) !== null) {
+            occurrenceCount++;
+            // Preceding window: tail of the current line plus up to two lines
+            // above, capped at 40 chars.
+            const before = source.slice(0, tokenMatch.index);
+            const context = before.split(/\r?\n/).slice(-3).join('\n').slice(-40);
+            // The weekday closest to the date token wins; require only non-date
+            // filler between them (no digits, no other month name).
+            const weekdayRegex = new RegExp(`\\b${weekdayPattern}\\b`, 'gi');
+            let lastWeekdayMatch = null;
+            let weekdayMatch;
+            while ((weekdayMatch = weekdayRegex.exec(context)) !== null) {
+                lastWeekdayMatch = weekdayMatch;
+            }
+            let adjacentWeekday = null;
+            if (lastWeekdayMatch) {
+                const between = context.slice(lastWeekdayMatch.index + lastWeekdayMatch[0].length);
+                if (!/\d/.test(between) && !anyMonthRegex.test(between)) {
+                    const prefix = String(lastWeekdayMatch[1] || '').slice(0, 3).toLowerCase();
+                    if (Object.prototype.hasOwnProperty.call(dayIndexByPrefix, prefix)) {
+                        adjacentWeekday = dayIndexByPrefix[prefix];
+                    }
+                }
+            }
+            adjacentWeekdays.push(adjacentWeekday);
+        }
+
+        if (occurrenceCount === 0) return null;
+        if (occurrenceCount === 1) return adjacentWeekdays[0];
+        const first = adjacentWeekdays[0];
+        if (first === null) return null;
+        return adjacentWeekdays.every(weekday => weekday === first) ? first : null;
+    }
+
     // Deterministic weekday→year pinning. Listing/flyer text often states a
     // weekday but no year ("Sat, Aug 22"); the extraction model then hallucinates
     // one, and window-based repair (adjustLikelyEventYear) can land on the wrong
-    // weekday (2025-08-22 is a Friday). When the field's own evidence names a
-    // weekday adjacent to the date AND carries no explicit 4-digit year, the year
-    // is derivable: try currentYear−1…currentYear+2 and keep candidates whose
-    // actual weekday matches; prefer one inside the year window, else the nearest
-    // to now. Past dates are intentionally allowed — past events must stay
-    // datable so the downstream past-filter can drop them (never force future).
+    // weekday (2025-08-22 is a Friday). When a weekday is stated adjacent to the
+    // date — in the field's own evidence, or (fallback) in the pass's source
+    // content just above the date token — the year is derivable:
+    //   - evidence carries an explicit 4-digit year too: verify weekday against
+    //     the value as extracted; on agreement pin it as-is (protects a correct
+    //     past date from window repair), on contradiction the weekday wins
+    //     (flyers state weekdays reliably; years leak from helper-pass output)
+    //     and the year is recomputed below;
+    //   - no explicit year: try currentYear−1…currentYear+2 and keep candidates
+    //     whose actual weekday matches; prefer one inside the year window, else
+    //     the nearest to now.
+    // Past dates are intentionally allowed — past events must stay datable so the
+    // downstream past-filter can drop them (never force future).
     // Returns { value, pinnedYear, aiYear } or null when pinning does not apply
-    // (no weekday, explicit year in evidence, unparseable value, or no candidate
-    // matches the stated weekday — e.g. bad OCR).
-    resolveWeekdayPinnedYear(rawValue, evidenceText) {
+    // (no weekday anywhere, unparseable value, or no candidate matches the stated
+    // weekday — e.g. bad OCR).
+    resolveWeekdayPinnedYear(rawValue, evidenceText, sourceText = '') {
         if (typeof rawValue !== 'string') return null;
         const valueText = rawValue.trim();
         if (!valueText) return null;
         const yearMatch = valueText.match(/\b(?:19|20)\d{2}\b/);
         if (!yearMatch) return null;
         const evidence = String(evidenceText || '').trim();
-        if (!evidence || /\b(?:19|20)\d{2}\b/.test(evidence)) return null;
-        const statedWeekday = this.extractStatedWeekdayAdjacentToDate(evidence);
+        if (!evidence) return null;
+        let statedWeekday = this.extractStatedWeekdayAdjacentToDate(evidence);
+        if (statedWeekday === null) {
+            statedWeekday = this.extractWeekdayNearDateInSource(sourceText, valueText);
+            if (statedWeekday !== null) {
+                console.log(`🤖 AI Web: Weekday for "${this.trimToMaxLength(valueText, 40)}" found in source content (evidence had none)`);
+            }
+        }
         if (statedWeekday === null) return null;
 
         const aiYear = Number(yearMatch[0]);
+        if (/\b(?:19|20)\d{2}\b/.test(evidence)) {
+            // Explicit year in evidence + stated weekday: verify them against each
+            // other instead of refusing to pin (helper-pass output leaks years into
+            // evidence strings). Agreement pins the date exactly as extracted.
+            const asExtracted = this.buildWeekdayPinCandidate(valueText, yearMatch, aiYear);
+            if (asExtracted && asExtracted.weekday === statedWeekday) {
+                return { value: asExtracted.text, pinnedYear: aiYear, aiYear };
+            }
+            // Contradiction (or unparseable value): fall through — the weekday
+            // recomputes the year via the candidate loop below.
+        }
         const now = this.now();
         const currentYear = now.getFullYear();
         const matches = [];

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1797,14 +1797,63 @@ test('resolveWeekdayPinnedYear pins hallucinated years to the stated weekday', (
   assert.equal(parser.resolveWeekdayPinnedYear('2026-12-31', 'Wed, Dec 31').value, '2025-12-31');
 });
 
-test('weekday pinning leaves explicit years and weekday-less evidence alone', () => {
+test('weekday pinning leaves weekday-less evidence and unparseable values alone', () => {
   const parser = createParser();
   parser.now = FROZEN_NOW;
-  assert.equal(parser.resolveWeekdayPinnedYear('2024-08-22', 'Sat, Aug 22, 2024'), null, 'an explicit year in evidence is trusted');
+  assert.equal(parser.resolveWeekdayPinnedYear('2024-08-22', 'Aug 22, 2024'), null, 'an explicit year with no weekday anywhere falls through');
   assert.equal(parser.resolveWeekdayPinnedYear('2024-08-22', 'Aug 22'), null, 'no weekday falls through to existing behavior');
   assert.equal(parser.resolveWeekdayPinnedYear('2024-08-22', ''), null, 'missing evidence falls through');
   assert.equal(parser.resolveWeekdayPinnedYear('Aug 22', 'Sat, Aug 22'), null, 'a value without a 4-digit year cannot be rewritten');
   assert.equal(parser.resolveWeekdayPinnedYear('2026-08-22', 'Saturday party vibes'), null, 'a weekday with no adjacent date does not pin');
+});
+
+test('weekday pinning verifies explicit evidence years against the stated weekday', () => {
+  const parser = createParser();
+  parser.now = FROZEN_NOW;
+  // NYE Chicago (2026-07-13 run): the helper pass leaked "2025" into the
+  // evidence string, so the old explicit-year guard refused to pin an extracted
+  // date that was CORRECT (but past) — window repair then invented a 2027
+  // phantom. The stated weekday matches the date+year as extracted → pin as-is.
+  const nye = parser.resolveWeekdayPinnedYear(
+    '2025-12-31',
+    'OCR_IMAGE_TEXT: "WEDNESDAY DECEMBER 31st" and PRE-PARSED HELPER DATA: "Core Event Date": "Wednesday, December 31, 2025"'
+  );
+  assert.ok(nye, 'matching weekday and year must pin the extracted date');
+  assert.equal(nye.value, '2025-12-31');
+  assert.equal(nye.pinnedYear, 2025);
+  // The pin must protect the correct past date from the year-window bump.
+  const normalized = parser.normalizeEventDates(
+    new Date(Date.UTC(2026, 0, 1, 3, 0, 0)), // combined 10PM CT on the pinned date
+    new Date(Date.UTC(2026, 0, 1, 3, 0, 0)),
+    { start: true, end: true }
+  );
+  assert.equal(normalized.startDate.toISOString(), '2026-01-01T03:00:00.000Z', 'pinned past instant stays past so the past-filter can drop it');
+  // Contradicting year: the weekday wins and the year is recomputed.
+  const contradicted = parser.resolveWeekdayPinnedYear('2024-08-22', 'Sat, Aug 22, 2024');
+  assert.equal(contradicted.value, '2026-08-22', '2024-08-22 is a Thursday; the stated Saturday pins 2026');
+  // Genuinely future date with agreeing year and weekday stays untouched.
+  const future = parser.resolveWeekdayPinnedYear('2026-08-22', 'Sat, Aug 22, 2026');
+  assert.equal(future.value, '2026-08-22');
+  assert.equal(future.pinnedYear, 2026);
+});
+
+test('weekday pinning falls back to the source content when evidence lacks a weekday', () => {
+  const parser = createParser();
+  parser.now = FROZEN_NOW;
+  // CHUNK SF Jan 17 (2026-07-13 run): the flyer put "SATURDAY" on its own line
+  // above "JANUARY 17TH", and the model's evidence quoted only the date line —
+  // no weekday, no pin, and 2025-01-17 was bumped to a phantom future date.
+  const source = 'CHUNK\nSATURDAY\nJANUARY 17TH\n9PM-2AM\n1192 FOLSOM ST';
+  const pinned = parser.resolveWeekdayPinnedYear('2025-01-17', 'JANUARY 17TH', source);
+  assert.ok(pinned, 'a weekday on the line above the date token must pin');
+  assert.equal(pinned.value, '2026-01-17', '2026-01-17 is the Saturday');
+  // No weekday anywhere near the date token → existing behavior (no pin).
+  assert.equal(parser.resolveWeekdayPinnedYear('2025-01-17', 'JANUARY 17TH', 'CHUNK\nJANUARY 17TH\n9PM-2AM'), null);
+  // Ambiguous: the date token appears twice with conflicting adjacent weekdays.
+  const ambiguous = 'FRIDAY\nJANUARY 17TH\nother party\nSATURDAY\nJANUARY 17TH';
+  assert.equal(parser.resolveWeekdayPinnedYear('2025-01-17', 'JANUARY 17TH', ambiguous), null);
+  // Date-like text between the weekday and the token breaks adjacency.
+  assert.equal(parser.resolveWeekdayPinnedYear('2025-01-17', 'JANUARY 17TH', 'SATURDAY DEC 13\nJANUARY 17TH'), null);
 });
 
 test('adjustLikelyEventYear re-anchors on the current year when hallucinated-year ±1 misses the window', () => {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1793,6 +1793,18 @@ class SharedCore {
             urlDeduplicated.push(event);
         }
 
+        // Post-merge re-anchor: a merge can resolve the city (e.g. AI arbitration
+        // picked the detail page's "sf") for an event whose dates are still
+        // wall-clock components labeled UTC (_timezoneUnresolved) — the normal
+        // LocationNormalizer re-anchor already ran before dedup and could not
+        // help. Convert those dates now that the timezone is knowable; events
+        // that stay unresolved keep the flag (and its warning).
+        for (const event of urlDeduplicated) {
+            if (event && event._timezoneUnresolved) {
+                this.resolveWallClockDates(event);
+            }
+        }
+
         // Log results for large batches
         if (logProgress) {
             const duplicatesFound = events.length - urlDeduplicated.length;
@@ -2046,6 +2058,32 @@ class SharedCore {
                 }
             }
 
+            // A record flagged _timezoneUnresolved stores wall-clock components
+            // labeled UTC (a possibly wrong instant); an unflagged record's dates
+            // are real timezone-anchored instants. When exactly one side is
+            // flagged, the anchored side's date wins deterministically — source
+            // priority/tie-breaks must never let a wall-clock value clobber a
+            // correct instant (observed 2026-07-13: a segment record's wall-clock
+            // 22:00Z beat the detail page's JSON-LD-anchored 05:00Z).
+            if ((fieldName === 'startDate' || fieldName === 'endDate')
+                && !isEmpty(existingValue) && !isEmpty(newValue)) {
+                const existingWallClock = Boolean(existingEvent._timezoneUnresolved);
+                const newWallClock = Boolean(newEvent._timezoneUnresolved);
+                if (existingWallClock !== newWallClock && String(existingValue) !== String(newValue)) {
+                    const chosenValue = existingWallClock ? newValue : existingValue;
+                    mergedEvent[fieldName] = chosenValue;
+                    console.log(`⏰ MERGE: "${mergeEventTitle}" kept timezone-anchored ${fieldName} over wall-clock value`);
+                    mergeDecisions.push({
+                        field: fieldName,
+                        existingValue: existingValue,
+                        newValue: newValue,
+                        chosenValue: chosenValue,
+                        reason: 'timezone-anchored date wins over wall-clock (_timezoneUnresolved) date'
+                    });
+                    return;
+                }
+            }
+
             const canArbitrate = this.isArbitrationEligibleField(fieldName)
                 && this.isGenuineFieldConflict(fieldName, existingValue, newValue);
 
@@ -2160,6 +2198,36 @@ class SharedCore {
                     chosenValue: chosenValue,
                     reason: decision ? `ai: ${decision.reason || `chose ${pick}`}` : conflict.fallbackReason
                 });
+            }
+        }
+
+        // _timezoneUnresolved must describe the merged event's DATES, not the base
+        // record: the `{ ...newEvent }` spread above copies newEvent's flag even
+        // when existing's anchored dates won, and drops existing's flag even when
+        // its wall-clock dates won (underscore fields are skipped by the field
+        // loop). Recompute the flag from whichever record supplied the final
+        // startDate/endDate so downstream re-anchoring still knows.
+        {
+            const existingWallClock = Boolean(existingEvent._timezoneUnresolved);
+            const newWallClock = Boolean(newEvent._timezoneUnresolved);
+            if (existingWallClock || newWallClock) {
+                const finalDateIsWallClock = (fieldName) => {
+                    const value = mergedEvent[fieldName];
+                    if (isEmpty(value)) return false;
+                    const fromExisting = value === existingEvent[fieldName];
+                    const fromNew = value === newEvent[fieldName];
+                    if (fromExisting && fromNew) return existingWallClock && newWallClock;
+                    if (fromExisting) return existingWallClock;
+                    if (fromNew) return newWallClock;
+                    // Values always come from one of the two records; fall back to
+                    // the base record's flag (mergedEvent started as { ...newEvent }).
+                    return newWallClock;
+                };
+                if (finalDateIsWallClock('startDate') || finalDateIsWallClock('endDate')) {
+                    mergedEvent._timezoneUnresolved = true;
+                } else {
+                    delete mergedEvent._timezoneUnresolved;
+                }
             }
         }
 
@@ -2708,7 +2776,48 @@ class SharedCore {
         }
         return new Date(utcMillis);
     }
-    
+
+    // The ai-web parser stores extracted local times as wall-clock components labeled
+    // UTC when it cannot resolve a timezone at parse time (flagged via
+    // event._timezoneUnresolved). Once a timezone/city is known — during normalization
+    // or resolved later by a merge — convert those wall-clock values to real UTC
+    // instants and clear the flag. Shared seam: LocationNormalizer.resolveWallClockDates
+    // delegates here, and deduplicateEvents runs it post-merge for events whose city
+    // was only resolved during merge arbitration. Log strings intentionally keep the
+    // LocationNormalizer prefix so existing log consumers keep working.
+    resolveWallClockDates(event) {
+        if (!event || !event._timezoneUnresolved) return event;
+
+        const timezone = event.timezone
+            || (event.city && this.cities && this.cities[event.city]?.timezone)
+            || '';
+        if (!timezone) {
+            const title = event.title || 'unknown';
+            this.warnOnce(
+                `wallclock:${title}`,
+                `🚨 LocationNormalizer: Could not resolve timezone for "${title}" (city: "${event.city || 'unknown'}") — dates remain wall-clock UTC and may be wrong`
+            );
+            return event;
+        }
+
+        const reanchor = (value) => {
+            if (!value) return value;
+            const converted = this.convertWallClockDateToUtc(value, timezone);
+            if (!converted || isNaN(converted.getTime())) return value;
+            return value instanceof Date ? converted : converted.toISOString();
+        };
+
+        const originalStart = event.startDate;
+        event.startDate = reanchor(event.startDate);
+        event.endDate = reanchor(event.endDate);
+        event.timezone = timezone;
+        delete event._timezoneUnresolved;
+
+        const format = (value) => value instanceof Date ? value.toISOString() : String(value);
+        console.log(`🗺️ LocationNormalizer: Re-anchored wall-clock dates to ${timezone} — start ${format(originalStart)} → ${format(event.startDate)}`);
+        return event;
+    }
+
     // Normalize event date using local or specified timezone
     normalizeEventDateLocal(dateInput, timezone = null) {
         if (!dateInput) return '';

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1346,6 +1346,107 @@ test('mergeParsedEvents: coordinates beat text and degenerate ends lose, without
 });
 
 // ---------------------------------------------------------------------------
+// Wall-clock vs timezone-anchored dates across merges (2026-07-13 run findings:
+// "BEARS IN SPACE" — the segment record's wall-clock 22:00Z survived the merge
+// with the detail page's JSON-LD-anchored 05:00Z, the _timezoneUnresolved flag
+// was dropped, and nothing re-anchored after dedup)
+// ---------------------------------------------------------------------------
+
+test('mergeParsedEvents: timezone-anchored dates beat wall-clock dates in both directions', async () => {
+  const core = createCore();
+  const priorities = core.getResolvedFieldPriorities({});
+  const adapter = buildArbitrationAdapter({});
+
+  const wallClock = {
+    title: 'BEARS IN SPACE',
+    startDate: new Date('2026-07-25T22:00:00.000Z'), // flyer said 10PM PT; stored as wall-clock UTC
+    endDate: new Date('2026-07-26T00:00:00.000Z'),
+    source: 'ai-web',
+    _timezoneUnresolved: true,
+    _fieldPriorities: priorities
+  };
+  const anchored = {
+    title: 'BEARS IN SPACE',
+    startDate: new Date('2026-07-26T05:00:00.000Z'), // 10PM PT as the real instant
+    endDate: new Date('2026-07-26T09:00:00.000Z'),
+    city: 'sf',
+    timezone: 'America/Los_Angeles',
+    source: 'ai-web',
+    _parserConfig: TEST_AI_PARSER_CONFIG,
+    _fieldPriorities: priorities
+  };
+
+  // Flagged record is EXISTING (the real failure: the same-priority tie-break
+  // kept the existing wall-clock dates)
+  const mergedA = await core.mergeParsedEvents({ ...wallClock }, { ...anchored }, { httpAdapter: adapter });
+  assert.equal(mergedA.startDate.toISOString(), '2026-07-26T05:00:00.000Z', 'anchored start wins over existing wall-clock');
+  assert.equal(mergedA.endDate.toISOString(), '2026-07-26T09:00:00.000Z', 'anchored end wins over existing wall-clock');
+  assert.equal(mergedA._timezoneUnresolved, undefined, 'the flag must not describe anchored dates');
+
+  // Flagged record is INCOMING (base spread would otherwise carry both the
+  // wall-clock dates and the flag)
+  const mergedB = await core.mergeParsedEvents({ ...anchored }, { ...wallClock }, { httpAdapter: adapter });
+  assert.equal(mergedB.startDate.toISOString(), '2026-07-26T05:00:00.000Z', 'anchored start wins over incoming wall-clock');
+  assert.equal(mergedB.endDate.toISOString(), '2026-07-26T09:00:00.000Z', 'anchored end wins over incoming wall-clock');
+  assert.equal(mergedB._timezoneUnresolved, undefined, 'the incoming flag must not survive onto anchored dates');
+
+  assert.equal(adapter.calls.length, 0, 'the wall-clock rule resolves deterministically without AI');
+});
+
+test('mergeParsedEvents: the wall-clock flag follows the record that supplied the dates', async () => {
+  const core = createCore();
+  const priorities = core.getResolvedFieldPriorities({});
+  const adapter = buildArbitrationAdapter({});
+
+  // Both records flagged: the merged dates are still wall-clock → flag stays.
+  const bothFlagged = await core.mergeParsedEvents(
+    { title: 'BEARS IN SPACE', startDate: new Date('2026-07-25T22:00:00.000Z'), source: 'ai-web', _timezoneUnresolved: true, _fieldPriorities: priorities },
+    { title: 'BEARS IN SPACE', startDate: new Date('2026-07-25T22:00:00.000Z'), source: 'ai-web', _timezoneUnresolved: true, _fieldPriorities: priorities },
+    { httpAdapter: adapter }
+  );
+  assert.equal(bothFlagged._timezoneUnresolved, true, 'both-flagged merges must keep the flag for downstream re-anchoring');
+
+  // Flagged side wins because the anchored side has no dates → flag propagates
+  // even though the base record (incoming) was unflagged.
+  const flaggedDatesWon = await core.mergeParsedEvents(
+    { title: 'BEARS IN SPACE', startDate: new Date('2026-07-25T22:00:00.000Z'), source: 'ai-web', _timezoneUnresolved: true, _fieldPriorities: priorities },
+    { title: 'BEARS IN SPACE', source: 'ai-web', _fieldPriorities: priorities },
+    { httpAdapter: adapter }
+  );
+  assert.equal(flaggedDatesWon.startDate.toISOString(), '2026-07-25T22:00:00.000Z', 'the only available date wins');
+  assert.equal(flaggedDatesWon._timezoneUnresolved, true, 'wall-clock dates keep their flag');
+  assert.equal(adapter.calls.length, 0);
+});
+
+test('deduplicateEvents re-anchors wall-clock dates once the merged event has a resolvable city', async () => {
+  const core = new SharedCore(
+    { sf: { timezone: 'America/Los_Angeles', patterns: ['sf', 'san francisco'] } },
+    { eventSchema: EventSchema }
+  );
+  // Two flagged records of the same event; only one knows the city (in the real
+  // run the city was resolved during merge arbitration). The merge keeps the
+  // wall-clock dates + flag, and the post-merge pass must convert them.
+  const segmentA = {
+    title: 'BEARS IN SPACE',
+    bar: 'The Stud',
+    startDate: new Date('2026-07-25T22:00:00.000Z'), // 10PM PT wall-clock
+    endDate: new Date('2026-07-26T00:00:00.000Z'),
+    source: 'ai-web',
+    _timezoneUnresolved: true
+  };
+  const segmentB = { ...segmentA, city: 'sf' };
+
+  const result = await core.deduplicateEvents([segmentA, segmentB], null);
+  assert.equal(result.length, 1, 'same key merges');
+  const merged = result[0];
+  // 10PM wall-clock in America/Los_Angeles (PDT, UTC-7) is 05:00Z the next day
+  assert.equal(merged.startDate.toISOString(), '2026-07-26T05:00:00.000Z');
+  assert.equal(merged.endDate.toISOString(), '2026-07-26T07:00:00.000Z');
+  assert.equal(merged.timezone, 'America/Los_Angeles');
+  assert.equal(merged._timezoneUnresolved, undefined, 're-anchoring must clear the flag');
+});
+
+// ---------------------------------------------------------------------------
 // Identity-verified cross-parser dedup (2026-07-12 run findings)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes the three bugs from the 2026-07-13 22:43 CHUNK run: the Dore Alley event landing at 3:00 PM instead of 10:00 PM, and the two remaining phantom future events (HOT GOGO BEARS 2027-01-17, NYE 2026-12-31).

## 1. Wall-clock dates must not survive merges as wrong instants

When the parser can't resolve a timezone (flyer has no city text), it stores local times as wall-clock components labeled UTC and flags `_timezoneUnresolved` for later re-anchoring. Three gaps let that wrong instant reach the calendar:

- The merge date tie-break let a wall-clock date beat the other record's correct JSON-LD-anchored date. New deterministic rule (modeled on the degenerate-end rule): when exactly one record is flagged, the timezone-anchored record's startDate/endDate wins. Logs `⏰ MERGE: "<title>" kept timezone-anchored <field> over wall-clock value`.
- The `{...newEvent}` spread copied/dropped the flag independent of whose dates won. The flag is now recomputed from whichever record supplied the final dates.
- Nothing re-anchored after merges, even when the merge itself resolved the city (AI arbitration picked "sf"). `deduplicateEvents` now runs a post-merge re-anchor pass; the conversion logic moved from `LocationNormalizer.resolveWallClockDates` into `SharedCore.resolveWallClockDates` (normalizer delegates; log strings byte-identical).

## 2. Weekday-pin hardening

- **Evidence with an explicit year + adjacent weekday** (year leaks from the helper pass into evidence strings) is now *verified* instead of refused: weekday agrees → pin as extracted (protects a correct past date like NYE's 2026-01-01T03:00Z from window repair); weekday contradicts → weekday wins and the year is recomputed.
- **Evidence without a weekday** falls back to searching the pass's raw source content for the date token with a weekday in the preceding ~2 lines / ~40 chars ("SATURDAY" on its own flyer line above "JANUARY 17TH"). Conservative: only pins when the token match is unambiguous and nothing date-like sits between weekday and date.

## 3. City-from-address guard

`extractCityFromAddress` returned the raw lowercased street address ("1192 folsom st") as the city when the address had no city part — poisoning timezone resolution and geocoding. Candidates must now map to a known city; otherwise the caller falls through to the next strategy.

## Tests

291 pass / 0 fail. New: both merge directions of wall-clock-vs-anchored, flag propagation, post-merge re-anchor with resolved city; NYE match/contradiction cases with frozen clock; Jan 17 source-line weekday pin plus ambiguity negatives; street-address-is-not-a-city with Portland/SF addresses still resolving.

One deliberate behavior change: `'Sat, Aug 22, 2024'` (weekday contradicts year) now pins to 2026-08-22 instead of leaving the AI year untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP