### PR TITLE
feat(scraper): JSON-LD offers→cover, targeted gap-fill, page-cache hit logging

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -951,6 +951,7 @@ class ScriptableAdapter {
         statusCode: cached.statusCode || 200,
         headers: cached.headers || {},
         fetchedAt: cached.fetchedAt || null,
+        modifiedAtMs: modifiedAt ? modifiedAt.getTime() : null,
         cachePath,
       };
     } catch (error) {
@@ -962,6 +963,33 @@ class ScriptableAdapter {
       );
       return null;
     }
+  }
+
+  // Hours below 24h ("5.3h"), days otherwise ("2.1d"); null when unknown.
+  formatPageCacheAge(ageMs) {
+    if (!Number.isFinite(ageMs) || ageMs < 0) {
+      return null;
+    }
+    const hours = ageMs / (60 * 60 * 1000);
+    return hours < 24 ? `${hours.toFixed(1)}h` : `${(hours / 24).toFixed(1)}d`;
+  }
+
+  // Cache hits were previously silent, hiding why a page showed stale content.
+  logPageCacheHit(url, cachedPage, pageCacheConfig) {
+    const fetchedAtMs = cachedPage.fetchedAt
+      ? Date.parse(cachedPage.fetchedAt)
+      : NaN;
+    const baseMs = Number.isFinite(fetchedAtMs)
+      ? fetchedAtMs
+      : Number(cachedPage.modifiedAtMs);
+    const age =
+      Number.isFinite(baseMs) && baseMs > 0
+        ? this.formatPageCacheAge(Date.now() - baseMs)
+        : null;
+    const agePart = age ? `age ${age}, ` : "";
+    console.log(
+      `📱 Scriptable: Page cache hit (${agePart}ttl ${pageCacheConfig.ttlDays}d) for ${url}`,
+    );
   }
 
   async writeCachedPage(url, responseData, pageCacheConfig) {
@@ -1116,6 +1144,7 @@ class ScriptableAdapter {
       if (canUseCache) {
         const cachedPage = await this.readCachedPage(url, pageCacheConfig);
         if (cachedPage && isCacheableResponse(cachedPage)) {
+          this.logPageCacheHit(url, cachedPage, pageCacheConfig);
           return cachedPage;
         }
       }

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -176,6 +176,7 @@ class WebAdapter {
                 statusCode: cached.statusCode || 200,
                 headers: cached.headers || {},
                 fetchedAt: cached.fetchedAt || null,
+                modifiedAtMs: Number.isFinite(stats.mtimeMs) ? stats.mtimeMs : null,
                 cachePath
             };
         } catch (error) {
@@ -187,6 +188,24 @@ class WebAdapter {
             }
             return null;
         }
+    }
+
+    // Hours below 24h ("5.3h"), days otherwise ("2.1d"); null when unknown.
+    formatPageCacheAge(ageMs) {
+        if (!Number.isFinite(ageMs) || ageMs < 0) {
+            return null;
+        }
+        const hours = ageMs / (60 * 60 * 1000);
+        return hours < 24 ? `${hours.toFixed(1)}h` : `${(hours / 24).toFixed(1)}d`;
+    }
+
+    // Cache hits were previously silent, hiding why a page showed stale content.
+    logPageCacheHit(url, cachedPage, pageCacheConfig) {
+        const fetchedAtMs = cachedPage.fetchedAt ? Date.parse(cachedPage.fetchedAt) : NaN;
+        const baseMs = Number.isFinite(fetchedAtMs) ? fetchedAtMs : Number(cachedPage.modifiedAtMs);
+        const age = Number.isFinite(baseMs) && baseMs > 0 ? this.formatPageCacheAge(Date.now() - baseMs) : null;
+        const agePart = age ? `age ${age}, ` : '';
+        console.log(`🟢 Node.js: Page cache hit (${agePart}ttl ${pageCacheConfig.ttlDays}d) for ${url}`);
     }
 
     async writeCachedPage(url, responseData, pageCacheConfig) {
@@ -247,6 +266,7 @@ class WebAdapter {
             if (canUseCache) {
                 const cachedPage = await this.readCachedPage(url, pageCacheConfig);
                 if (cachedPage && isCacheableResponse(cachedPage)) {
+                    this.logPageCacheHit(url, cachedPage, pageCacheConfig);
                     return cachedPage;
                 }
             }

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -285,6 +285,14 @@ class AiWebParser {
             'href',
             'link'
         ];
+        // JSON-LD fast-path gap-fill signals: normalized prompt field → regexes a
+        // VISIBLE-page-text match of which justifies one targeted AI extraction for
+        // that field. Data-driven so future fields just add an entry; only plain
+        // string event fields may appear here (never startDate/endDate — those are
+        // Date-typed on JSON-LD events).
+        this.jsonLdGapFillSignals = {
+            cover: [/[$€£]\s?\d/, /\b\d+(?:\.\d{2})?\s?(?:USD|EUR|GBP)\b/i]
+        };
         if (typeof this.config.normalizeUrl !== 'function') {
             throw new Error('AiWebParser requires config.normalizeUrl from SharedCore');
         }
@@ -347,6 +355,7 @@ class AiWebParser {
                         }
                     });
                 }
+                await this.applyJsonLdGapFill(completeJsonLdEvents, htmlData, parserConfig, cityConfig, httpAdapter);
                 return {
                     events: completeJsonLdEvents,
                     additionalLinks: additionalLinks,
@@ -2604,6 +2613,7 @@ class AiWebParser {
         const offer = Array.isArray(node.offers) ? node.offers[0] : node.offers;
         const offerUrl = offer && typeof offer === 'object' ? this.normalizeHttpUrlValue(offer.url) : '';
         const ticketUrl = offerUrl || this.normalizeHttpUrlValue(node.url) || '';
+        const cover = this.formatJsonLdOffersCover(node.offers);
 
         const event = {
             title,
@@ -2617,6 +2627,7 @@ class AiWebParser {
             image: this.pickJsonLdImage(node.image),
             source: this.config.source
         };
+        if (cover) event.cover = cover;
         // The JSON-LD address carries the locality (e.g. "Portland, OR") — resolve city
         // and timezone from it directly so nothing downstream has to guess. Address only:
         // bar names produce false city matches ("Brooklyn Bowl" in Vegas).
@@ -2701,6 +2712,79 @@ class AiWebParser {
         return '';
     }
 
+    // Cover (price) from schema.org offers: a single offer object, a plain offer
+    // array, or an AggregateOffer wrapping tier offers. Tiers still on sale
+    // (availability without "SoldOut") define the honest walk-up range; when every
+    // tier is sold out or unpriced, fall back to all tier prices, then to the
+    // AggregateOffer lowPrice/highPrice. Defensive like the sibling pickJsonLd*
+    // helpers: malformed offers must never break the JSON-LD fast path.
+    formatJsonLdOffersCover(offers) {
+        try {
+            const tierOffers = [];
+            const aggregateOffers = [];
+            const collect = (node, depth) => {
+                if (!node || depth > 3) return;
+                if (Array.isArray(node)) {
+                    node.forEach(item => collect(item, depth + 1));
+                    return;
+                }
+                if (typeof node !== 'object') return;
+                if (node.offers || /aggregate/i.test(String(node['@type'] || ''))) {
+                    aggregateOffers.push(node);
+                    collect(node.offers, depth + 1);
+                    return;
+                }
+                tierOffers.push(node);
+            };
+            collect(offers, 0);
+
+            // Prices of 0, negative, or unparseable never make a cover.
+            const parsePrice = (value) => {
+                if (value === null || value === undefined || value === '') return null;
+                const amount = Number(String(value).trim());
+                return Number.isFinite(amount) && amount > 0 ? amount : null;
+            };
+            const priced = tierOffers
+                .map(offer => ({
+                    amount: parsePrice(offer.price),
+                    currency: offer.priceCurrency,
+                    soldOut: /soldout/i.test(String(offer.availability || ''))
+                }))
+                .filter(entry => entry.amount !== null);
+            let selected = priced.filter(entry => !entry.soldOut);
+            if (selected.length === 0) selected = priced;
+            if (selected.length === 0) {
+                for (const aggregate of aggregateOffers) {
+                    const amounts = [parsePrice(aggregate.lowPrice), parsePrice(aggregate.highPrice)]
+                        .filter(amount => amount !== null);
+                    if (amounts.length > 0) {
+                        selected = amounts.map(amount => ({ amount, currency: aggregate.priceCurrency }));
+                        break;
+                    }
+                }
+            }
+            if (selected.length === 0) return '';
+
+            const amounts = selected.map(entry => entry.amount);
+            const min = Math.min(...amounts);
+            const max = Math.max(...amounts);
+            // Whole-dollar values render without trailing ".00"; anything with cents
+            // always gets two decimals ("20.5" → "$20.50").
+            const formatAmount = (amount) => Number.isInteger(amount) ? String(amount) : amount.toFixed(2);
+            const firstCurrency = selected.find(entry => entry.currency && String(entry.currency).trim());
+            const currency = firstCurrency ? String(firstCurrency.currency).trim().toUpperCase() : '';
+            if (!currency || currency === 'USD' || currency === '$') {
+                return min === max ? `$${formatAmount(min)}` : `$${formatAmount(min)}-$${formatAmount(max)}`;
+            }
+            return min === max
+                ? `${formatAmount(min)} ${currency}`
+                : `${formatAmount(min)}-${formatAmount(max)} ${currency}`;
+        } catch (error) {
+            console.warn(`🤖 AI Web: JSON-LD offers→cover mapping failed: ${error && error.message ? error.message : error}`);
+            return '';
+        }
+    }
+
     // Discovery mode drops events, but the discovery tree should still show what a
     // page is about — surface JSON-LD events in the same shape as discovered segments.
     describeJsonLdEventsAsSegments(jsonLdEvents) {
@@ -2721,6 +2805,130 @@ class AiWebParser {
                 resourceLines: event.image ? [`SEGMENT_IMAGE_URL: ${event.image}`] : []
             };
         });
+    }
+
+    // Event property that carries a prompt field on JSON-LD-built events: split
+    // and full date fields all land in startDate/endDate, and the page URL
+    // satisfies website. Everything else maps through the schema's canonical key.
+    getJsonLdEventKeyForPromptField(promptField) {
+        const normalized = this.normalizePromptFieldName(promptField);
+        if (normalized === 'start' || normalized === 'startdate' || normalized === 'starttime') return 'startDate';
+        if (normalized === 'end' || normalized === 'enddate' || normalized === 'endtime') return 'endDate';
+        if (normalized === 'website') return 'url';
+        const schema = this.getEventSchema();
+        if (schema && typeof schema.canonicalizeEventKey === 'function') {
+            const canonical = schema.canonicalizeEventKey(normalized);
+            if (canonical) return canonical;
+        }
+        return normalized;
+    }
+
+    hasJsonLdEventValue(event, eventKey) {
+        const value = event ? event[eventKey] : null;
+        if (value instanceof Date) return !Number.isNaN(value.getTime());
+        if (typeof value === 'string') return value.trim().length > 0;
+        return value !== null && value !== undefined;
+    }
+
+    // First usable value in an AI pass result for a prompt field, tolerating the
+    // lowercased key echoes the retry-style prompts produce.
+    getUsableAiFieldValueForPromptField(aiEvent, promptField) {
+        if (!aiEvent || typeof aiEvent !== 'object') return null;
+        const normalizedField = this.normalizePromptFieldName(promptField);
+        for (const key of Object.keys(aiEvent)) {
+            if (this.isInternalAiFieldKey(key)) continue;
+            if (this.normalizePromptFieldName(key) !== normalizedField) continue;
+            if (this.isUsableAiFieldValue(aiEvent[key])) return aiEvent[key];
+        }
+        return null;
+    }
+
+    // JSON-LD fast-path coverage + targeted gap-fill. The fast path skips AI
+    // entirely, so fields the structured data never carries (cover on most
+    // ticketing pages) were silently lost even when the visible page shows them.
+    // A missing field triggers ONE restricted AI extraction only when the page
+    // text matches its jsonLdGapFillSignals entry; validated results fill ONLY
+    // empty fields — a JSON-LD-provided value is never overwritten. Any failure
+    // degrades to the previous behavior (events returned unchanged).
+    async applyJsonLdGapFill(events, htmlData, parserConfig, cityConfig, httpAdapter) {
+        const sourceUrl = htmlData && htmlData.url ? htmlData.url : '';
+        try {
+            const promptFields = this.getAiPromptFields(parserConfig, { jsonLd: true }, sourceUrl);
+            const seenKeys = new Set();
+            const entries = [];
+            for (const promptField of promptFields) {
+                const eventKey = this.getJsonLdEventKeyForPromptField(promptField);
+                if (seenKeys.has(eventKey)) continue;
+                seenKeys.add(eventKey);
+                entries.push({
+                    promptField,
+                    eventKey,
+                    provided: events.every(event => this.hasJsonLdEventValue(event, eventKey))
+                });
+            }
+            const provided = entries.filter(entry => entry.provided).map(entry => entry.eventKey);
+            const missing = entries.filter(entry => !entry.provided).map(entry => entry.eventKey);
+            console.log(`🤖 AI Web: JSON-LD coverage for ${sourceUrl}: provided=[${provided.join(', ')}], missing=[${missing.join(', ')}]`);
+            if (missing.length === 0) return;
+
+            // A page-level text match can't be attributed to a specific event when
+            // the fast path returned several — gap-fill only for single-event pages.
+            if (events.length !== 1) return;
+
+            const pageText = this.extractBodyParts(htmlData && htmlData.html ? htmlData.html : '').join('\n');
+            const requested = entries.filter(entry => {
+                if (entry.provided) return false;
+                // Date fields are Date-typed on JSON-LD events; gap-fill writes plain
+                // strings, so they can never be requested even if signal-mapped.
+                if (entry.eventKey === 'startDate' || entry.eventKey === 'endDate') return false;
+                const signals = this.jsonLdGapFillSignals[this.normalizePromptFieldName(entry.promptField)];
+                return Array.isArray(signals) && pageText && signals.some(regex => regex.test(pageText));
+            });
+            if (requested.length === 0) return;
+            const requestedNames = requested.map(entry => entry.eventKey);
+
+            const aiConfig = this.getAiConfig(parserConfig);
+            const maxHtmlChars = Math.max(500, Number(aiConfig.maxHtmlChars));
+            const sectionBundle = this.getPromptSectionBundle(htmlData && htmlData.html ? htmlData.html : '', aiConfig);
+            // One targeted request: first content snippet only. dataFlags carry
+            // jsonLd (true for this page) so the two-pass extractor skips its
+            // context-prep round-trip.
+            const contentSnippets = sectionBundle.content
+                ? this.buildPromptSnippets([], [sectionBundle.content], maxHtmlChars).slice(0, 1)
+                : [];
+            if (!aiConfig.enabled || contentSnippets.length === 0) {
+                console.log(`🤖 AI Web: JSON-LD gap-fill for ${sourceUrl}: requested=[${requestedNames.join(', ')}], filled=[] (${aiConfig.enabled ? 'no page text to extract from' : 'AI disabled'})`);
+                return;
+            }
+            const partial = await this.extractFieldsAcrossSnippets(
+                htmlData,
+                aiConfig,
+                cityConfig,
+                parserConfig,
+                requested.map(entry => entry.promptField),
+                contentSnippets,
+                'jsonld gap-fill',
+                null,
+                { partitionLabel: 'content', dataFlags: { jsonLd: true, content: true } },
+                httpAdapter
+            );
+
+            const filled = [];
+            for (const entry of requested) {
+                const value = this.getUsableAiFieldValueForPromptField(partial, entry.promptField);
+                if (typeof value !== 'string' || !value.trim()) continue;
+                let filledAny = false;
+                for (const event of events) {
+                    if (this.hasJsonLdEventValue(event, entry.eventKey)) continue;
+                    event[entry.eventKey] = value.trim();
+                    filledAny = true;
+                }
+                if (filledAny) filled.push(entry.eventKey);
+            }
+            console.log(`🤖 AI Web: JSON-LD gap-fill for ${sourceUrl}: requested=[${requestedNames.join(', ')}], filled=[${filled.join(', ')}]`);
+        } catch (error) {
+            console.warn(`🤖 AI Web: JSON-LD gap-fill failed for ${sourceUrl} — keeping JSON-LD events unchanged: ${error && error.message ? error.message : error}`);
+        }
     }
 
     // OCR is only worth paying for when something consumes it: segment pairing on

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1910,3 +1910,245 @@ test('extraction flattens field objects through weekday pinning and normalizeAiE
   assert.equal(normalized.startDate.toISOString().slice(0, 10), '2025-10-11');
   assert.equal(normalized.endDate.toISOString().slice(0, 10), '2025-10-11');
 });
+
+// ---------------------------------------------------------------------------
+// JSON-LD offers → cover + fast-path coverage/gap-fill (chunk-party.com event
+// pages: the JSON-LD carries a complete offers block and the body shows
+// prices, but fast-path events never got a cover because the AI never ran)
+// ---------------------------------------------------------------------------
+
+const CHUNK_OFFERS = {
+  '@type': 'AggregateOffer', highPrice: '30.75', lowPrice: '20.50',
+  offerCount: '3', priceCurrency: 'USD',
+  availability: 'https://schema.org/InStock',
+  url: 'https://tix.example/chunk-pdx',
+  offers: [
+    { '@type': 'offer', name: 'Early Bird GA', price: '20.5', priceCurrency: 'USD', availability: 'https://schema.org/SoldOut', url: 'https://tix.example/chunk-pdx' },
+    { '@type': 'offer', name: 'Tier 1 GA', price: '25.63', priceCurrency: 'USD', availability: 'https://schema.org/InStock', url: 'https://tix.example/chunk-pdx' },
+    { '@type': 'offer', name: 'Tier 2 GA', price: '30.75', priceCurrency: 'USD', availability: 'https://schema.org/InStock', url: 'https://tix.example/chunk-pdx' }
+  ]
+};
+
+const CHUNK_JSONLD_HTML = `
+  <html><head>
+    <script type="application/ld+json">
+      {"@context":"https://schema.org","@type":"Event",
+       "name":"CHUNK Portland Summer Blow Out",
+       "startDate":"2026-08-22T21:00:00-07:00",
+       "endDate":"2026-08-23T02:00:00-07:00",
+       "description":"CHUNK returns to Portland.",
+       "image":"https://static.example/chunk-pdx.jpg",
+       "location":{"@type":"Place","name":"Bossanova Ballroom",
+         "address":{"@type":"PostalAddress","streetAddress":"722 E Burnside St","addressLocality":"Portland","addressRegion":"OR"}},
+       "offers":${JSON.stringify(CHUNK_OFFERS)}}
+    </script>
+  </head><body>CHUNK Portland Summer Blow Out at Bossanova Ballroom. Tickets from $20.50 to $30.75.</body></html>`;
+
+test('formatJsonLdOffersCover maps schema.org offer shapes to display prices (Scriptable-safe)', () => {
+  global.EventSchema = EventSchema; // earlier tests leak a mocked schema
+  const parser = createParser();
+  const RealURL = global.URL;
+  global.URL = undefined;
+  try {
+    // AggregateOffer with tiers: the sold-out early bird is excluded from the range
+    assert.equal(parser.formatJsonLdOffersCover(CHUNK_OFFERS), '$25.63-$30.75');
+
+    // Every tier sold out → all tier prices back the range
+    const allSoldOut = {
+      ...CHUNK_OFFERS,
+      offers: CHUNK_OFFERS.offers.map(offer => ({ ...offer, availability: 'https://schema.org/SoldOut' }))
+    };
+    assert.equal(parser.formatJsonLdOffersCover(allSoldOut), '$20.50-$30.75');
+
+    // Tiers without usable prices → AggregateOffer lowPrice/highPrice fallback
+    const unpricedTiers = { ...CHUNK_OFFERS, offers: [{ '@type': 'offer', name: 'GA' }] };
+    assert.equal(parser.formatJsonLdOffersCover(unpricedTiers), '$20.50-$30.75');
+    const bareAggregate = { '@type': 'AggregateOffer', lowPrice: '20.50', highPrice: '30.75' };
+    assert.equal(parser.formatJsonLdOffersCover(bareAggregate), '$20.50-$30.75');
+
+    // Single offer object and plain offer arrays
+    assert.equal(parser.formatJsonLdOffersCover({ price: '25.63', priceCurrency: 'USD' }), '$25.63');
+    assert.equal(parser.formatJsonLdOffersCover([{ price: '20.5' }, { price: '30.75' }]), '$20.50-$30.75');
+
+    // Whole-dollar values render without ".00"; cents always get two decimals
+    assert.equal(parser.formatJsonLdOffersCover({ price: '20' }), '$20');
+    assert.equal(parser.formatJsonLdOffersCover({ price: '20.5' }), '$20.50');
+
+    // Non-USD currencies render as amount + space + code
+    assert.equal(parser.formatJsonLdOffersCover({ price: '25.63', priceCurrency: 'EUR' }), '25.63 EUR');
+    assert.equal(
+      parser.formatJsonLdOffersCover([{ price: '20.5', priceCurrency: 'EUR' }, { price: '30.75', priceCurrency: 'EUR' }]),
+      '20.50-30.75 EUR'
+    );
+
+    // Zero/negative/unparseable prices and absent offers yield no cover
+    assert.equal(parser.formatJsonLdOffersCover({ price: '0' }), '');
+    assert.equal(parser.formatJsonLdOffersCover({ price: '-5' }), '');
+    assert.equal(parser.formatJsonLdOffersCover({ price: 'TBD' }), '');
+    assert.equal(parser.formatJsonLdOffersCover(undefined), '');
+    assert.equal(parser.formatJsonLdOffersCover(null), '');
+    assert.equal(parser.formatJsonLdOffersCover('not-an-offer'), '');
+    assert.equal(parser.formatJsonLdOffersCover([]), '');
+  } finally {
+    global.URL = RealURL;
+  }
+});
+
+test('the JSON-LD fast path sets cover from offers and needs no gap-fill AI request', async () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  let aiCalls = 0;
+  parser.core.callAiGenerate = async () => {
+    aiCalls++;
+    return '{}';
+  };
+
+  const result = await parser.parseEvents(
+    { url: 'https://www.chunk-party.example/event-details/chunk-portland-summer-blow-out', html: CHUNK_JSONLD_HTML },
+    {},
+    null,
+    'event-page',
+    null
+  );
+
+  assert.equal(result.events.length, 1, 'the structured-data fast path must be used');
+  assert.equal(result.events[0].title, 'CHUNK Portland Summer Blow Out');
+  assert.equal(result.events[0].cover, '$25.63-$30.75', 'in-stock tier range from the offers block');
+  assert.equal(aiCalls, 0, 'offers already provided cover, so the page price signal must not trigger gap-fill');
+
+  // The offers block without nested tiers still maps through extractEventsFromJsonLd
+  const events = parser.extractEventsFromJsonLd(CHUNK_JSONLD_HTML, 'https://www.chunk-party.example/e/x');
+  assert.equal(events.length, 1);
+  assert.equal(events[0].cover, '$25.63-$30.75');
+  assert.equal(events[0].ticketUrl, 'https://tix.example/chunk-pdx', 'offers.url → ticketUrl is unchanged');
+});
+
+const GAPFILL_JSONLD_HTML = `
+  <html><head>
+    <script type="application/ld+json">
+      {"@context":"https://schema.org","@type":"Event",
+       "name":"UNDERBEAR Lounge",
+       "startDate":"2026-08-22T21:00:00-04:00",
+       "location":{"@type":"Place","name":"Rockbar NYC",
+         "address":{"@type":"PostalAddress","streetAddress":"185 Christopher St","addressLocality":"New York","addressRegion":"NY"}}}
+    </script>
+  </head><body>
+    <p>UNDERBEAR Lounge at Rockbar NYC.</p>
+    <p>Party with the bears all night long downstairs.</p>
+    <p>$15 cover at the door.</p>
+  </body></html>`;
+
+test('JSON-LD gap-fill pays exactly one restricted AI request when the page shows a price signal', async () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  const aiCalls = [];
+  parser.core.callAiGenerate = async (config, prompt, label) => {
+    aiCalls.push(label);
+    return JSON.stringify({
+      cover: { value: '$15', evidence: '$15 cover at the door', confidence: 95 },
+      // A field JSON-LD already provided must never win, even if the model returns it
+      title: { value: 'AI Title That Must Not Win', evidence: 'UNDERBEAR Lounge', confidence: 95 }
+    });
+  };
+  const requestedFieldLists = [];
+  const originalExtract = parser.extractFieldsAcrossSnippets.bind(parser);
+  parser.extractFieldsAcrossSnippets = (htmlData, aiConfig, cityConfig, parserConfig, fields, ...rest) => {
+    requestedFieldLists.push(fields.slice());
+    return originalExtract(htmlData, aiConfig, cityConfig, parserConfig, fields, ...rest);
+  };
+
+  const result = await parser.parseEvents(
+    { url: 'https://underbear.example/party', html: GAPFILL_JSONLD_HTML },
+    {},
+    null,
+    'event-page',
+    null
+  );
+
+  assert.equal(result.events.length, 1, 'the fast path must still return the JSON-LD event');
+  assert.deepEqual(aiCalls, ['extraction'], 'exactly one AI request, no context-prep/repair round-trips');
+  assert.deepEqual(requestedFieldLists, [['cover']], 'the request must be restricted to the missing signal-matched field');
+  assert.equal(result.events[0].cover, '$15', 'the validated AI cover must fill the empty field');
+  assert.equal(result.events[0].title, 'UNDERBEAR Lounge', 'a JSON-LD-provided value must never be overwritten');
+  assert.equal(result.events[0].bar, 'Rockbar NYC');
+});
+
+test('JSON-LD gap-fill makes no AI request when no missing field has a page signal', async () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  let aiCalls = 0;
+  parser.core.callAiGenerate = async () => {
+    aiCalls++;
+    return '{}';
+  };
+
+  const html = GAPFILL_JSONLD_HTML.replace('$15 cover at the door.', 'Free entry before ten.');
+  const result = await parser.parseEvents(
+    { url: 'https://underbear.example/party', html },
+    {},
+    null,
+    'event-page',
+    null
+  );
+
+  assert.equal(result.events.length, 1);
+  assert.equal(aiCalls, 0, 'no price signal in the page text → no AI request at all');
+  assert.equal(result.events[0].cover, undefined);
+});
+
+test('JSON-LD gap-fill errors degrade to returning the JSON-LD events unchanged', async () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.core.callAiGenerate = async () => {
+    throw new Error('AI endpoint down');
+  };
+
+  const result = await parser.parseEvents(
+    { url: 'https://underbear.example/party', html: GAPFILL_JSONLD_HTML },
+    {},
+    null,
+    'event-page',
+    null
+  );
+
+  assert.equal(result.events.length, 1, 'a gap-fill failure must never fail the page');
+  assert.equal(result.events[0].title, 'UNDERBEAR Lounge');
+  assert.equal(result.events[0].bar, 'Rockbar NYC');
+  assert.equal(result.events[0].cover, undefined, 'the event is returned exactly as JSON-LD built it');
+});
+
+test('the fast path logs a JSON-LD coverage line and a gap-fill outcome line', async () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.core.callAiGenerate = async () => JSON.stringify({
+    cover: { value: '$15', evidence: '$15 cover at the door', confidence: 95 }
+  });
+
+  const lines = [];
+  const realLog = console.log;
+  console.log = (...args) => {
+    lines.push(args.map(String).join(' '));
+  };
+  try {
+    await parser.parseEvents(
+      { url: 'https://underbear.example/party', html: GAPFILL_JSONLD_HTML },
+      {},
+      null,
+      'event-page',
+      null
+    );
+  } finally {
+    console.log = realLog;
+  }
+
+  const coverageLine = lines.find(line => line.includes('JSON-LD coverage for https://underbear.example/party'));
+  assert.ok(coverageLine, 'a coverage line must always be logged on the fast path');
+  assert.match(coverageLine, /provided=\[[^\]]*\btitle\b/);
+  assert.match(coverageLine, /provided=\[[^\]]*\bbar\b/);
+  assert.match(coverageLine, /missing=\[[^\]]*\bcover\b/);
+
+  const gapFillLine = lines.find(line => line.includes('JSON-LD gap-fill for https://underbear.example/party'));
+  assert.ok(gapFillLine, 'the gap-fill outcome must be logged');
+  assert.match(gapFillLine, /requested=\[cover\]/);
+  assert.match(gapFillLine, /filled=\[cover\]/);
+});


### PR DESCRIPTION
Closes the field-coverage gap in the JSON-LD fast path found via the 2026-07-14 CHUNK run (prices never captured), and makes the fast-path/caching decisions observable.

## 1. Map JSON-LD offers → cover
The fast path ("skipping OCR and AI extraction") built events from JSON-LD but ignored the `offers` block except for its URL — so ticket prices sitting in the structured data were silently dropped on every ticketing page. `buildEventFromJsonLdNode` now maps offers to `cover`:
- Handles single offer, plain offer arrays, and AggregateOffer with nested tiers.
- In-stock tiers preferred (honest walk-up range, e.g. `$25.63-$30.75` when Early Bird is sold out); falls back to all tiers, then AggregateOffer lowPrice/highPrice.
- Skips 0/negative/unparseable prices; `$20` / `$20.50` / `$20.50-$30.75`; non-USD renders `25.63 EUR`. Never throws.

## 2. JSON-LD coverage log + targeted gap-fill
Bear sites are inconsistent — structured data sometimes has a field, sometimes only the page body does. The fast path now:
- Always logs per page: `🤖 AI Web: JSON-LD coverage for <url>: provided=[...], missing=[...]` — routine visibility into how each site's structured data is shaped.
- When a missing field has a matching signal in the VISIBLE page text (data-driven map; v1: price patterns for `cover`), runs ONE restricted AI extraction for just those fields, with full evidence/confidence validation. Fills only empty fields — JSON-LD values are never overwritten. No signal → no AI request. Single-event pages only (a page-level price can't be attributed on multi-event pages). Errors degrade to previous behavior.

## 3. Page-cache hit logging (both adapters)
The local page cache (ttl 3d) served pages silently — this morning's run missed a newly-added event because the homepage came from a days-old cache entry with zero log evidence. Hits now log `📱 Scriptable: Page cache hit (age 2.1d, ttl 3d) for <url>` (and `🟢 Node.js:` in the web adapter), age from fetchedAt with mtime fallback.

## Tests
297 pass (291 on main + 6 new, in existing test files): offers→cover matrix (sold-out exclusion, aggregate fallback, currencies, whole-dollar rendering) under the `global.URL = undefined` Scriptable-safety pattern; fast-path integration (cover set, zero AI calls); gap-fill exactly-one-request restricted to missing fields, no-overwrite, no-signal → zero requests, AI-error → unchanged; log-line assertions.

No load-bearing log shapes changed; no `new URL` in the diff; scraper-input.js untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP