### PR TITLE
feat(scraper): Wix server-data enrichment (coords, timezone, prices) + OSM geocode hardening

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -715,13 +715,27 @@ class LocationNormalizer extends BaseNormalizer {
 const CITY_CENTER_RADIUS_KM = 50;
 
 // Hard cap on Nominatim requests per event for the forward-geocode retry
-// ladder. Never raise this without revisiting the rate-limit budget.
-const MAX_GEOCODE_QUERIES_PER_EVENT = 3;
+// ladder. 4 covers the full ladder (canonical address, postal/country strip,
+// directional strip, venue-name rescue); every request stays 1.1s-throttled
+// and later rungs only fire after earlier ones return nothing usable. Never
+// raise this without revisiting the rate-limit budget.
+const MAX_GEOCODE_QUERIES_PER_EVENT = 4;
 
 // Street-type words a trailing directional can follow ("Cheshire Bridge Rd NE").
 const GEOCODE_STREET_TYPE_WORDS = 'Street|St|Road|Rd|Avenue|Ave|Boulevard|Blvd|Drive|Dr|Lane|Ln|Way|Place|Pl|Court|Ct|Parkway|Pkwy|Highway|Hwy';
 // Longest alternatives first so "Northeast" matches before "North".
 const GEOCODE_DIRECTIONAL_WORDS = 'Northeast|Northwest|Southeast|Southwest|North|South|East|West|NE|NW|SE|SW|N|S|E|W';
+// Nominatim result kinds that are administrative areas rather than a concrete
+// venue or address. A simplified/fallback query reduced to a place name (e.g.
+// "Brooklyn, nyc") happily matches the admin area itself; its centroid is a
+// wrong-but-plausible coordinate that wins merges downstream — worse than no
+// coordinates at all (observed 2026-07-14: "325 Franklin Ave, Brooklyn, NY
+// 11238, USA" stored the Brooklyn borough centroid, ~4 km from the venue).
+const GEOCODE_ADMIN_AREA_TYPES = [
+    'city', 'borough', 'suburb', 'neighbourhood', 'quarter', 'town', 'village',
+    'state', 'county', 'municipality', 'district', 'city_district', 'postcode'
+];
+
 // A directional that FOLLOWS a street-type word and ends the address or a
 // comma-separated segment ("...Cheshire Bridge Rd NE", "...Road Northeast,
 // Atlanta"). Nominatim's free-text parser returns 0 results for these
@@ -944,6 +958,42 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         return nearest;
     }
 
+    // True when a Nominatim result is an administrative area (city/borough/
+    // suburb/neighbourhood...) rather than a concrete venue or address. Venue
+    // matches (class=amenity, addresstype=amenity) are never admin areas.
+    isAdminAreaGeocodeResult(result) {
+        if (!result || typeof result !== 'object') return false;
+        const resultClass = String(result.class || '').toLowerCase();
+        const resultType = String(result.type || '').toLowerCase();
+        if (resultClass === 'boundary' && resultType === 'administrative') return true;
+        if (resultClass === 'place' && GEOCODE_ADMIN_AREA_TYPES.includes(resultType)) return true;
+        return GEOCODE_ADMIN_AREA_TYPES.includes(String(result.addresstype || '').toLowerCase());
+    }
+
+    // Canonical addresses ("1192 Folsom St, San Francisco, CA 94103, USA") return
+    // 0 Nominatim results while "1192 Folsom St, San Francisco" resolves — the
+    // postal-code/country decoration chokes the free-text parser (verified live
+    // 2026-07-14). Drops the trailing country token plus any state/zip tokens
+    // before it, keeping street + city. Returns '' when the address carries no
+    // country decoration (looser addresses already geocode and the ladder budget
+    // is tight) or when stripping would leave a bare place token — that query
+    // could only match an admin centroid, so it must never be issued.
+    stripPostalCodeAndCountry(address) {
+        const parts = String(address || '').split(',').map(part => part.trim()).filter(Boolean);
+        if (parts.length < 2 || !/^(USA|US|United States)$/i.test(parts[parts.length - 1])) return '';
+        parts.pop();
+        while (parts.length > 0) {
+            const tail = parts[parts.length - 1];
+            const isStateZip = /^[A-Z]{2}\s+\d{5}(-\d{4})?$/.test(tail);
+            const isBareZip = /^\d{5}(-\d{4})?$/.test(tail);
+            const isLoneStateCode = /^[A-Z]{2}$/.test(tail);
+            if (!isStateZip && !isBareZip && !isLoneStateCode) break;
+            parts.pop();
+        }
+        if (parts.length === 0 || (parts.length === 1 && !/\d/.test(parts[0]))) return '';
+        return parts.join(', ');
+    }
+
     // Strip directionals that FOLLOW a street-type word — at the end of the
     // address or before a comma. "2069 Cheshire Bridge Rd NE" → "2069 Cheshire
     // Bridge Rd"; "…Road Northeast, Atlanta, GA" → "…Road, Atlanta, GA".
@@ -960,9 +1010,11 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     // at MAX_GEOCODE_QUERIES_PER_EVENT. Order:
     //   1. The query exactly as built today (city-anchored when the address
     //      doesn't already contain the city).
-    //   2. The address with trailing directionals stripped (same anchoring) —
+    //   2. The address with postal-code/country decoration stripped (same
+    //      anchoring) — Nominatim chokes on "…, CA 94103, USA" endings.
+    //   3. The address with trailing directionals stripped (same anchoring) —
     //      Nominatim's free-text parser chokes on "Rd NE" / "Road Northeast".
-    //   3. "<bar>, <city>" — venue-name lookup rescues venues OSM knows by name.
+    //   4. "<bar>, <city>" — venue-name lookup rescues venues OSM knows by name.
     buildGeocodeQueryVariants(address, eventCity, bar) {
         const city = typeof eventCity === 'string' ? eventCity.trim() : '';
         const anchorToCity = (text) => {
@@ -982,6 +1034,8 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
 
         const baseAddress = String(address || '').trim();
         push(anchorToCity(baseAddress));
+        const postalStripped = this.stripPostalCodeAndCountry(baseAddress);
+        if (postalStripped) push(anchorToCity(postalStripped));
         push(anchorToCity(this.stripTrailingDirectionals(baseAddress)));
         const barName = typeof bar === 'string' ? bar.trim() : '';
         if (barName && city) {
@@ -1037,15 +1091,28 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 attempts += 1;
                 try {
                     const data = await this.fetchDataWithCacheAndRateLimit(url, options, httpAdapter);
-                    if (Array.isArray(data) && data.length > 0) {
+                    // Simplified/fallback queries can degrade to a bare place name and
+                    // match the admin area itself — reject those centroids. The first
+                    // (full-address) query keeps today's behavior: a full address that
+                    // resolves to an admin boundary is a different failure mode.
+                    let candidates = Array.isArray(data) ? data : [];
+                    if (i > 0 && candidates.length > 0) {
+                        candidates = candidates.filter(result => {
+                            if (!this.isAdminAreaGeocodeResult(result)) return true;
+                            const kind = result.addresstype || result.type || 'unknown';
+                            console.warn(`🗺️ OpenStreetMapNormalizer: Rejected admin-area result for "${queryText}" (type=${kind}) — not a venue/address`);
+                            return false;
+                        });
+                    }
+                    if (candidates.length > 0) {
                         if (cityCenter) {
                             // Distance-ranked selection: nearest candidate within the radius wins
-                            const picked = this.pickNearestGeocodeCandidate(data, cityCenter, eventCity, queryText);
+                            const picked = this.pickNearestGeocodeCandidate(candidates, cityCenter, eventCity, queryText);
                             if (picked) {
                                 resolvedLocation = `${picked.lat}, ${picked.lon}`;
                             }
                         } else {
-                            const firstResult = data[0];
+                            const firstResult = candidates[0];
                             if (firstResult.lat && firstResult.lon) {
                                 if (eventCity && !this.geocodeResultMatchesCity(firstResult, eventCity)) {
                                     console.warn(`🗺️ OpenStreetMapNormalizer: Geocode for "${queryText}" resolved outside event city "${eventCity}" ("${firstResult.display_name || 'no display name'}") — ignoring coordinates`);
@@ -1054,7 +1121,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                                 }
                             }
                         }
-                    } else if (i < queryVariants.length - 1) {
+                    } else if ((!Array.isArray(data) || data.length === 0) && i < queryVariants.length - 1) {
                         console.log(`🗺️ OpenStreetMapNormalizer: 0 geocode results for "${queryText}" — trying next variant`);
                     }
                 } catch (err) {

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -416,6 +416,175 @@ test('retry ladder: identical variants are deduped so no duplicate request is se
 });
 
 // ---------------------------------------------------------------------------
+// Geocoder hardening (2026-07-14 run findings): the simplified-query fallback
+// for "325 Franklin Ave, Brooklyn, NY 11238, USA" eventually queried
+// "Brooklyn, nyc", matched the borough itself and stored its centroid (~4 km
+// from the venue); and full canonical addresses ("1192 Folsom St, San
+// Francisco, CA 94103, USA") return 0 results while the street+city core
+// resolves fine — the postal-code/country decoration chokes Nominatim.
+// ---------------------------------------------------------------------------
+
+const CITIES_NYC_WITH_COORDS = {
+  nyc: {
+    timezone: 'America/New_York',
+    patterns: ['new york', 'nyc', 'brooklyn'],
+    coordinates: { lat: 40.7128, lng: -74.006 }
+  }
+};
+
+function createOsmNormalizerWithNyc() {
+  const core = new SharedCore(CITIES_NYC_WITH_COORDS, { eventSchema: EventSchema });
+  return new OpenStreetMapNormalizer(core);
+}
+
+// The borough of Brooklyn itself — inside the 50 km radius, so only the
+// admin-area check can reject it.
+const BROOKLYN_BOROUGH_RESULT = {
+  lat: '40.6526006',
+  lon: '-73.9497211',
+  class: 'boundary',
+  type: 'administrative',
+  addresstype: 'borough',
+  display_name: 'Brooklyn, Kings County, City of New York, New York, United States',
+  address: { borough: 'Brooklyn', city: 'City of New York', state: 'New York' }
+};
+
+// The venue as Nominatim returns it for a name lookup — an amenity, not an
+// administrative area.
+const CMON_EVERYBODY_RESULT = {
+  lat: '40.6791213',
+  lon: '-73.9556999',
+  class: 'amenity',
+  type: 'bar',
+  addresstype: 'amenity',
+  display_name: "C'mon Everybody, 325, Franklin Avenue, Brooklyn, Kings County, City of New York, New York, 11238, United States",
+  address: { city: 'City of New York', county: 'Kings County', state: 'New York' }
+};
+
+test('stripPostalCodeAndCountry keeps street + city and drops postal/country decoration', () => {
+  const normalizer = createOsmNormalizerWithNyc();
+  assert.equal(
+    normalizer.stripPostalCodeAndCountry('1192 Folsom St, San Francisco, CA 94103, USA'),
+    '1192 Folsom St, San Francisco'
+  );
+  assert.equal(
+    normalizer.stripPostalCodeAndCountry('325 Franklin Ave, Brooklyn, NY 11238, USA'),
+    '325 Franklin Ave, Brooklyn'
+  );
+  assert.equal(
+    normalizer.stripPostalCodeAndCountry('722 E Burnside St, Portland, OR 97214, United States'),
+    '722 E Burnside St, Portland'
+  );
+  // No country decoration → not a canonical address, leave the ladder alone
+  assert.equal(normalizer.stripPostalCodeAndCountry('2069 Cheshire Bridge Road Northeast, Atlanta, GA, 30324'), '');
+  assert.equal(normalizer.stripPostalCodeAndCountry('1192 FOLSOM ST'), '');
+  // Stripping must never leave a bare place token — that query can only match
+  // an admin centroid (the "Brooklyn, nyc" poisoning)
+  assert.equal(normalizer.stripPostalCodeAndCountry('Brooklyn, NY 11238, USA'), '');
+});
+
+test('buildGeocodeQueryVariants tries the postal/country-stripped core after the full address', () => {
+  const normalizer = createOsmNormalizerWithNyc();
+  assert.deepEqual(
+    normalizer.buildGeocodeQueryVariants('325 Franklin Ave, Brooklyn, NY 11238, USA', 'nyc', "C'mon Everybody"),
+    [
+      '325 Franklin Ave, Brooklyn, NY 11238, USA, nyc',
+      '325 Franklin Ave, Brooklyn, nyc',
+      "C'mon Everybody, nyc"
+    ]
+  );
+  // With a strippable directional too, the full 4-rung ladder fits the cap and
+  // the venue-name rescue is never evicted
+  const atlanta = createOsmNormalizerWithAtlanta();
+  assert.deepEqual(
+    atlanta.buildGeocodeQueryVariants('2069 Cheshire Bridge Rd NE, Atlanta, GA 30324, USA', 'atlanta', 'The Heretic'),
+    [
+      '2069 Cheshire Bridge Rd NE, Atlanta, GA 30324, USA',
+      '2069 Cheshire Bridge Rd NE, Atlanta',
+      '2069 Cheshire Bridge Rd, Atlanta, GA 30324, USA',
+      'The Heretic, atlanta'
+    ]
+  );
+});
+
+test('a simplified-query admin-area match is rejected instead of poisoning coordinates', async () => {
+  const normalizer = createOsmNormalizerWithNyc();
+  normalizer.delayForRateLimit = async () => {};
+  // Full address → 0 results; stripped variant → the borough itself; venue → 0
+  const httpAdapter = createSequencedStubAdapter([[], [BROOKLYN_BOROUGH_RESULT], []]);
+  const event = { title: 'BEAR NIGHT', address: '325 Franklin Ave, Brooklyn, NY 11238, USA', city: 'nyc', bar: "C'mon Everybody" };
+  const warns = [];
+  const realWarn = console.warn;
+  console.warn = (message) => { warns.push(String(message)); };
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    console.warn = realWarn;
+  }
+
+  assert.equal(event.location, undefined, 'a borough centroid must never become the event location');
+  assert.ok(
+    warns.some(w => w.includes('Rejected admin-area result') && w.includes('type=borough')),
+    `the rejection must be logged: ${warns.join(' | ')}`
+  );
+  assert.equal(httpAdapter.requests.length, 3, 'the ladder continues past the rejected result');
+});
+
+test('a venue-name simplified query still resolves through an amenity result', async () => {
+  const normalizer = createOsmNormalizerWithNyc();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createSequencedStubAdapter([[], [], [CMON_EVERYBODY_RESULT]]);
+  const event = { title: 'BEAR NIGHT', address: '325 Franklin Ave, Brooklyn, NY 11238, USA', city: 'nyc', bar: "C'mon Everybody" };
+  const logs = [];
+  const realLog = console.log;
+  console.log = (message) => { logs.push(String(message)); };
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    console.log = realLog;
+  }
+
+  assert.equal(event.location, '40.6791213, -73.9556999', 'the amenity match must keep working');
+  assert.ok(
+    logs.some(l => l.includes('Geocoded via simplified query "C\'mon Everybody, nyc"')),
+    `the simplified-query success log must be preserved: ${logs.join(' | ')}`
+  );
+});
+
+const CITIES_SF_WITH_COORDS = {
+  sf: {
+    timezone: 'America/Los_Angeles',
+    patterns: ['sf', 'san francisco'],
+    coordinates: { lat: 37.7749, lng: -122.4194 }
+  }
+};
+
+const FOLSOM_RESULT = {
+  lat: '37.7756941',
+  lon: '-122.4103049',
+  display_name: '1192, Folsom Street, San Francisco, California, 94103, United States',
+  address: { city: 'San Francisco', county: 'San Francisco', state: 'California' }
+};
+
+test('a canonical address that only resolves without postal/country decoration is rescued by the new variant', async () => {
+  const core = new SharedCore(CITIES_SF_WITH_COORDS, { eventSchema: EventSchema });
+  const normalizer = new OpenStreetMapNormalizer(core);
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createSequencedStubAdapter([[], [FOLSOM_RESULT]]);
+  const event = { title: 'CHUNK', address: '1192 Folsom St, San Francisco, CA 94103, USA', city: 'sf' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.location, '37.7756941, -122.4103049');
+  assert.equal(httpAdapter.requests.length, 2);
+  assert.equal(
+    decodeQueryParam(httpAdapter.requests[1]),
+    '1192 Folsom St, San Francisco, sf',
+    'the second query must be the postal/country-stripped core'
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Geocode cache poisoning (2026-07-12 run findings: cached empty Nominatim
 // bodies silently skipped venues that geocode fine live)
 // ---------------------------------------------------------------------------

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -355,6 +355,9 @@ class AiWebParser {
                         }
                     });
                 }
+                // Enrichment only: fills empty fields from the Wix warmup blob,
+                // never skips or replaces an extraction step.
+                this.applyWixServerDataEnrichment(completeJsonLdEvents, htmlData, cityConfig);
                 await this.applyJsonLdGapFill(completeJsonLdEvents, htmlData, parserConfig, cityConfig, httpAdapter);
                 return {
                     events: completeJsonLdEvents,
@@ -442,6 +445,10 @@ class AiWebParser {
             const events = pageClassification === 'multi-event-page'
                 ? await this.extractEventsFromMultiEventPage(htmlData, parserConfig, cityConfig, promptFields, ocrResults, httpAdapter)
                 : await this.extractEventsFromSinglePage(htmlData, parserConfig, cityConfig, promptFields, ocrResults, httpAdapter);
+
+            // Enrichment only: fills empty fields on the finished AI/OCR events
+            // from the Wix warmup blob, never skips or replaces an extraction step.
+            this.applyWixServerDataEnrichment(events, htmlData, cityConfig);
 
             return {
                 events,
@@ -2805,6 +2812,206 @@ class AiWebParser {
                 resourceLines: event.image ? [`SEGMENT_IMAGE_URL: ${event.image}`] : []
             };
         });
+    }
+
+    // ============================================================================
+    // WIX SERVER-DATA (warmup-data) EVENT ENRICHMENT
+    // ============================================================================
+
+    // Wix event pages embed authoritative server state in
+    // <script type="application/json" id="wix-warmup-data">: exact UTC instants,
+    // an IANA timezone, venue coordinates and ticket prices. Returns a normalized
+    // record or null; any absent/unparseable/odd-shaped blob means "no server
+    // data" and leaves the extraction flow untouched.
+    extractWixServerEventData(html) {
+        if (!html || typeof html !== 'string') return null;
+        try {
+            const startMatch = html.match(/<script\b[^>]*\bid=["']wix-warmup-data["'][^>]*>/i);
+            if (!startMatch) return null;
+            const jsonString = this.extractJsonObject(html, startMatch.index + startMatch[0].length);
+            if (!jsonString) return null;
+            const eventNode = this.findWixWarmupEventNode(JSON.parse(jsonString));
+            return eventNode ? this.buildWixServerEventRecord(eventNode) : null;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    // The events-app GUID key inside appsWarmupData is deployment-specific —
+    // iterate every app's state and take the first EventsPageInitialState event.
+    findWixWarmupEventNode(warmup) {
+        if (!warmup || typeof warmup !== 'object') return null;
+        const apps = warmup.appsWarmupData && typeof warmup.appsWarmupData === 'object'
+            ? Object.values(warmup.appsWarmupData)
+            : [warmup];
+        for (const app of apps) {
+            if (!app || typeof app !== 'object') continue;
+            const state = app.EventsPageInitialState;
+            if (!state || typeof state !== 'object') continue;
+            const wrapper = state.event;
+            if (!wrapper || typeof wrapper !== 'object') continue;
+            // Observed shape nests the event once more (state.event.event); accept
+            // the flat shape too in case other app versions skip the wrapper.
+            if (wrapper.event && typeof wrapper.event === 'object') return wrapper.event;
+            if (wrapper.title || wrapper.scheduling) return wrapper;
+        }
+        return null;
+    }
+
+    buildWixServerEventRecord(node) {
+        const clean = (value) => typeof value === 'string' ? this.normalizeWhitespace(value) : '';
+        const location = node.location && typeof node.location === 'object' ? node.location : {};
+        const fullAddress = location.fullAddress && typeof location.fullAddress === 'object' ? location.fullAddress : {};
+        const geocode = fullAddress.geocode && typeof fullAddress.geocode === 'object' ? fullAddress.geocode : {};
+        const coords = location.coordinates && typeof location.coordinates === 'object' ? location.coordinates : {};
+
+        const pickCoordinatePair = (latValue, lngValue) => {
+            const lat = Number(latValue);
+            const lng = Number(lngValue);
+            return Number.isFinite(lat) && Number.isFinite(lng) ? { lat, lng } : null;
+        };
+        const pair = pickCoordinatePair(coords.lat, coords.lng)
+            || pickCoordinatePair(geocode.latitude, geocode.longitude);
+
+        const scheduling = node.scheduling && node.scheduling.config && typeof node.scheduling.config === 'object'
+            ? node.scheduling.config
+            : {};
+        const timeZoneId = clean(scheduling.timeZoneId);
+        const ticketing = node.registration && node.registration.ticketing && typeof node.registration.ticketing === 'object'
+            ? node.registration.ticketing
+            : {};
+
+        const record = {
+            title: clean(node.title) || null,
+            slug: clean(node.slug) || null,
+            // OpenStreetMapNormalizer stores event.location as `${lat}, ${lng}` —
+            // match it byte-for-byte so merge comparisons treat both the same.
+            coordinates: pair ? `${pair.lat}, ${pair.lng}` : null,
+            timezone: /^[A-Za-z]+\/[A-Za-z_\-+0-9]+/.test(timeZoneId) ? timeZoneId : null,
+            startDateUtc: this.parseWixExactInstant(scheduling.startDate),
+            endDateUtc: this.parseWixExactInstant(scheduling.endDate),
+            address: clean(location.address) || clean(fullAddress.formattedAddress) || null,
+            city: clean(fullAddress.city).toLowerCase() || null,
+            cover: this.formatWixTicketPriceRange(ticketing)
+        };
+        return Object.values(record).some(value => value !== null) ? record : null;
+    }
+
+    // Only explicit-offset/Z timestamps are exact instants; wall-clock strings
+    // are ignored (the normal pipeline handles those with re-anchoring).
+    parseWixExactInstant(value) {
+        const raw = String(value || '').trim();
+        if (!raw || !/(?:Z|[+-]\d{2}:?\d{2})$/i.test(raw)) return null;
+        const date = new Date(raw);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+
+    // "$20.50-$30.75" from the Wix ticketing block, collapsing equal bounds to a
+    // single value. Sold-out events keep their price — sold-out handling is a
+    // separate concern.
+    formatWixTicketPriceRange(ticketing) {
+        const formatAmount = (price) => {
+            if (!price || typeof price !== 'object') return '';
+            const amount = String(price.amount || '').trim();
+            if (!amount || !Number.isFinite(Number(amount))) return '';
+            const currency = String(price.currency || '').trim().toUpperCase();
+            return currency === 'USD' ? `$${amount}` : (currency ? `${amount} ${currency}` : amount);
+        };
+        const formattedText = (value) => typeof value === 'string' ? value.trim() : '';
+        const low = formattedText(ticketing.lowestTicketPriceFormatted) || formatAmount(ticketing.lowestTicketPrice);
+        const high = formattedText(ticketing.highestTicketPriceFormatted) || formatAmount(ticketing.highestTicketPrice);
+        if (low && high) return low === high ? low : `${low}-${high}`;
+        return low || high || null;
+    }
+
+    // ENRICHMENT ONLY — runs on the parser's finished events just before they
+    // are returned (both the JSON-LD fast path and the AI-extraction path) and
+    // never influences which extraction steps run. Each field fills only when
+    // currently empty; values from JSON-LD/AI/OCR are never overwritten. The
+    // sole date exception: wall-clock dates (_timezoneUnresolved) are unanchored
+    // guesses, so the blob's exact UTC instants replace them and clear the flag.
+    applyWixServerDataEnrichment(events, htmlData, cityConfig) {
+        try {
+            if (!Array.isArray(events) || events.length === 0) return events;
+            const html = htmlData && typeof htmlData.html === 'string' ? htmlData.html : '';
+            const sourceUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
+            const record = this.extractWixServerEventData(html);
+            if (!record) return events;
+
+            const filledFields = new Set();
+            let enrichedCount = 0;
+            for (const event of events) {
+                if (!event || typeof event !== 'object') continue;
+                if (!this.wixServerRecordMatchesEvent(record, event, sourceUrl, events.length)) continue;
+                const filled = this.fillEventFromWixServerRecord(event, record, cityConfig);
+                if (filled.length > 0) {
+                    enrichedCount += 1;
+                    filled.forEach(field => filledFields.add(field));
+                }
+            }
+            if (filledFields.size > 0) {
+                console.log(`🤖 AI Web: Wix server data enriched ${enrichedCount} event(s) for ${sourceUrl}: filled=[${Array.from(filledFields).join(', ')}]`);
+            } else {
+                console.log(`🤖 AI Web: Wix server data present for ${sourceUrl} but no empty fields to fill`);
+            }
+        } catch (error) {
+            console.warn(`🤖 AI Web: Wix server data enrichment failed — events unchanged: ${error.message}`);
+        }
+        return events;
+    }
+
+    // Conservative same-event check: the warmup blob describes ONE event, so it
+    // applies only when the slug appears in the page URL, the titles match, or a
+    // single-event event-details page leaves no other candidate. Ambiguity means
+    // no enrichment.
+    wixServerRecordMatchesEvent(record, event, sourceUrl, eventCount) {
+        const url = String(sourceUrl || '').toLowerCase();
+        const slug = record.slug ? record.slug.toLowerCase() : '';
+        if (slug && url.includes(slug)) return true;
+        if (record.title && event && event.title
+            && this.normalizeEvidenceText(record.title) === this.normalizeEvidenceText(event.title)) return true;
+        // An event-details URL naming a DIFFERENT slug is a mismatch, not ambiguity.
+        if (slug && /\/event-details\//.test(url)) return false;
+        return eventCount === 1 && /\/event-details\//.test(url);
+    }
+
+    fillEventFromWixServerRecord(event, record, cityConfig) {
+        const filled = [];
+        const isEmpty = (value) => value === null || value === undefined || String(value).trim() === '';
+        const fill = (field, value) => {
+            if (value && isEmpty(event[field])) {
+                event[field] = value;
+                filled.push(field);
+            }
+        };
+        fill('location', record.coordinates);
+        fill('timezone', record.timezone);
+        fill('cover', record.cover);
+        fill('address', record.address);
+        if (record.city && isEmpty(event.city)) {
+            // Only configured city keys, resolved through the same alias matching
+            // the rest of the parser uses — never invent a key from raw Wix text.
+            const cityKey = this.findCityKeyInText(record.city, cityConfig);
+            if (cityKey) {
+                event.city = cityKey;
+                filled.push('city');
+            }
+        }
+        // Replacing wall-clock dates needs an end instant whenever the event has
+        // an end date, so the pair is never split across anchoring schemes. When
+        // instants are missing but the timezone was filled above, the flag stays
+        // set and LocationNormalizer re-anchors with that timezone as usual.
+        if (event._timezoneUnresolved && record.startDateUtc
+            && (record.endDateUtc || isEmpty(event.endDate))) {
+            event.startDate = record.startDateUtc;
+            filled.push('startDate');
+            if (record.endDateUtc) {
+                event.endDate = record.endDateUtc;
+                filled.push('endDate');
+            }
+            delete event._timezoneUnresolved;
+        }
+        return filled;
     }
 
     // Event property that carries a prompt field on JSON-LD-built events: split

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1912,6 +1912,251 @@ test('extraction flattens field objects through weekday pinning and normalizeAiE
 });
 
 // ---------------------------------------------------------------------------
+// Wix server-data (warmup-data) enrichment: the wix-warmup-data blob carries
+// authoritative coordinates, timezone, exact UTC instants and ticket prices.
+// Enrichment ONLY — it fills empty fields on the finished events and never
+// causes any extraction step (JSON-LD path, OCR, AI) to be skipped.
+// ---------------------------------------------------------------------------
+
+// Trimmed real structure from chunk-party.com (the app GUID is deliberately
+// NOT the production events-app GUID — the extractor must iterate keys).
+const WIX_WARMUP_HTML = `
+<html><head>
+<script type="application/json" id="wix-warmup-data">{"appsWarmupData":{"deadbeef-0000-4000-8000-000000000000":{"EventsPageInitialState":{"event":{"event":{
+  "id":"2a06f832-0000-4000-8000-000000000000",
+  "location":{"name":"Nova PDX","coordinates":{"lat":45.52281000000001,"lng":-122.6581342},"address":"722 E Burnside St, Portland, OR 97214, USA","fullAddress":{"country":"US","subdivision":"OR","city":"Portland","postalCode":"97214-1219","formattedAddress":"722 E Burnside St, Portland, OR 97214, USA","geocode":{"latitude":45.52281000000001,"longitude":-122.6581342}}},
+  "scheduling":{"config":{"startDate":"2026-08-23T04:00:00.000Z","endDate":"2026-08-23T09:00:00.000Z","timeZoneId":"America/Los_Angeles"}},
+  "title":"CHUNK Portland - SUMMER BLOW OUT!","slug":"chunk-portland-summer-blow-out",
+  "registration":{"ticketing":{"lowestTicketPrice":{"amount":"20.50","currency":"USD"},"highestTicketPrice":{"amount":"30.75","currency":"USD"},"lowestTicketPriceFormatted":"$20.50","highestTicketPriceFormatted":"$30.75","soldOut":false}}
+}}}}}}</script>
+</head><body>CHUNK Portland - SUMMER BLOW OUT!</body></html>`;
+
+const CHUNK_PAGE_URL = 'https://www.chunk-party.com/event-details/chunk-portland-summer-blow-out';
+
+const PORTLAND_CITY_CONFIG = {
+  portland: { timezone: 'America/Los_Angeles', patterns: ['portland', 'pdx'] }
+};
+
+test('extractWixServerEventData parses the warmup blob without the URL global (Scriptable)', () => {
+  const parser = createParser();
+  const RealURL = global.URL;
+  global.URL = undefined;
+  try {
+    const record = parser.extractWixServerEventData(WIX_WARMUP_HTML);
+    assert.ok(record, 'the blob must parse even though its app GUID is unknown');
+    assert.equal(record.title, 'CHUNK Portland - SUMMER BLOW OUT!');
+    assert.equal(record.slug, 'chunk-portland-summer-blow-out');
+    // Byte-for-byte the OpenStreetMapNormalizer location format: "<lat>, <lng>"
+    assert.equal(record.coordinates, '45.52281000000001, -122.6581342');
+    assert.equal(record.timezone, 'America/Los_Angeles');
+    assert.equal(record.startDateUtc.toISOString(), '2026-08-23T04:00:00.000Z');
+    assert.equal(record.endDateUtc.toISOString(), '2026-08-23T09:00:00.000Z');
+    assert.equal(record.address, '722 E Burnside St, Portland, OR 97214, USA');
+    assert.equal(record.city, 'portland');
+    assert.equal(record.cover, '$20.50-$30.75');
+  } finally {
+    global.URL = RealURL;
+  }
+});
+
+test('extractWixServerEventData yields null for absent, garbage or event-less blobs', () => {
+  const parser = createParser();
+  const RealURL = global.URL;
+  global.URL = undefined;
+  try {
+    assert.equal(parser.extractWixServerEventData('<html><body>no blob here</body></html>'), null);
+    assert.equal(parser.extractWixServerEventData(''), null);
+    assert.equal(parser.extractWixServerEventData(null), null);
+    assert.equal(
+      parser.extractWixServerEventData('<script type="application/json" id="wix-warmup-data">{not json at all'),
+      null
+    );
+    assert.equal(
+      parser.extractWixServerEventData('<script type="application/json" id="wix-warmup-data">{"appsWarmupData":{"x":{"SomethingElse":{}}}}</script>'),
+      null,
+      'a warmup blob without an EventsPageInitialState event is not server data'
+    );
+  } finally {
+    global.URL = RealURL;
+  }
+});
+
+test('extractWixServerEventData ignores wall-clock scheduling dates and bogus timezone ids', () => {
+  const parser = createParser();
+  // Same shape, but offset-less dates and a non-IANA timezone
+  const html = WIX_WARMUP_HTML
+    .replace('2026-08-23T04:00:00.000Z', '2026-08-22T21:00:00')
+    .replace('2026-08-23T09:00:00.000Z', '2026-08-23T02:00:00')
+    .replace('America/Los_Angeles', 'PST');
+  const record = parser.extractWixServerEventData(html);
+  assert.ok(record);
+  assert.equal(record.startDateUtc, null, 'offset-less dates are not exact instants');
+  assert.equal(record.endDateUtc, null);
+  assert.equal(record.timezone, null, 'a non-IANA id must not pass through');
+  // Explicit-offset (non-Z) instants are exact too
+  const offsetRecord = parser.extractWixServerEventData(
+    WIX_WARMUP_HTML.replace('2026-08-23T04:00:00.000Z', '2026-08-22T21:00:00-07:00')
+  );
+  assert.equal(offsetRecord.startDateUtc.toISOString(), '2026-08-23T04:00:00.000Z');
+});
+
+test('applyWixServerDataEnrichment fills only empty fields on a matching event', () => {
+  const parser = createParser();
+  // AI-extraction shape: dates resolved (no wall-clock flag), gaps elsewhere
+  const events = [{
+    title: 'CHUNK Portland - SUMMER BLOW OUT!',
+    startDate: new Date('2026-08-23T04:00:00.000Z'),
+    endDate: new Date('2026-08-23T09:00:00.000Z'),
+    bar: 'Nova PDX',
+    address: '',
+    location: '',
+    city: '',
+    timezone: '',
+    cover: ''
+  }];
+
+  parser.applyWixServerDataEnrichment(events, { url: CHUNK_PAGE_URL, html: WIX_WARMUP_HTML }, PORTLAND_CITY_CONFIG);
+
+  const event = events[0];
+  assert.equal(event.location, '45.52281000000001, -122.6581342');
+  assert.equal(event.timezone, 'America/Los_Angeles');
+  assert.equal(event.cover, '$20.50-$30.75');
+  assert.equal(event.address, '722 E Burnside St, Portland, OR 97214, USA');
+  assert.equal(event.city, 'portland', 'the raw Wix city resolves through the configured city keys');
+  assert.equal(event.bar, 'Nova PDX', 'existing values stay untouched');
+});
+
+test('applyWixServerDataEnrichment never overwrites non-empty fields', () => {
+  const parser = createParser();
+  const events = [{
+    title: 'CHUNK Portland - SUMMER BLOW OUT!',
+    startDate: new Date('2026-08-23T05:00:00.000Z'),
+    endDate: new Date('2026-08-23T10:00:00.000Z'),
+    location: '45.5, -122.6',
+    timezone: 'America/New_York',
+    cover: '$15',
+    address: '123 Somewhere Else St',
+    city: 'nyc'
+  }];
+
+  parser.applyWixServerDataEnrichment(events, { url: CHUNK_PAGE_URL, html: WIX_WARMUP_HTML }, PORTLAND_CITY_CONFIG);
+
+  const event = events[0];
+  assert.equal(event.location, '45.5, -122.6');
+  assert.equal(event.timezone, 'America/New_York');
+  assert.equal(event.cover, '$15');
+  assert.equal(event.address, '123 Somewhere Else St');
+  assert.equal(event.city, 'nyc');
+  assert.equal(event.startDate.toISOString(), '2026-08-23T05:00:00.000Z', 'anchored dates are trusted data');
+});
+
+test('applyWixServerDataEnrichment replaces wall-clock dates with exact UTC instants and clears the flag', () => {
+  const parser = createParser();
+  // Wall-clock 9pm local stored as 9pm UTC by the timezone-less fallback
+  const events = [{
+    title: 'CHUNK Portland - SUMMER BLOW OUT!',
+    startDate: new Date('2026-08-22T21:00:00.000Z'),
+    endDate: new Date('2026-08-23T02:00:00.000Z'),
+    _timezoneUnresolved: true
+  }];
+
+  parser.applyWixServerDataEnrichment(events, { url: CHUNK_PAGE_URL, html: WIX_WARMUP_HTML }, PORTLAND_CITY_CONFIG);
+
+  const event = events[0];
+  assert.equal(event.startDate.toISOString(), '2026-08-23T04:00:00.000Z');
+  assert.equal(event.endDate.toISOString(), '2026-08-23T09:00:00.000Z');
+  assert.equal(event._timezoneUnresolved, undefined, 'authoritative instants resolve the wall-clock gap');
+});
+
+test('applyWixServerDataEnrichment applies nothing when the slug and title both mismatch', () => {
+  const parser = createParser();
+  const events = [{
+    title: 'A COMPLETELY DIFFERENT PARTY',
+    startDate: new Date('2026-09-01T04:00:00.000Z'),
+    endDate: new Date('2026-09-01T09:00:00.000Z'),
+    location: '',
+    cover: ''
+  }];
+
+  parser.applyWixServerDataEnrichment(
+    events,
+    { url: 'https://www.chunk-party.com/event-details/some-other-party', html: WIX_WARMUP_HTML },
+    PORTLAND_CITY_CONFIG
+  );
+
+  assert.equal(events[0].location, '', 'an event-details URL naming a different slug must not be enriched');
+  assert.equal(events[0].cover, '');
+});
+
+test('parseEvents enriches the JSON-LD fast-path result from Wix server data without running OCR or AI', async () => {
+  const parser = createParser();
+  parser.extractOcrFromAllImages = async () => {
+    throw new Error('OCR should not run when JSON-LD covers the event');
+  };
+  parser.core.callAiGenerate = async () => {
+    throw new Error('AI should not be called when JSON-LD covers the event');
+  };
+  // Complete JSON-LD (title + start + venue) with exact instants that differ
+  // from the warmup instants — enrichment must not touch them.
+  const html = `
+    <html><head>
+      <script type="application/ld+json">
+        {"@context":"http://schema.org","@type":"MusicEvent",
+         "name":"CHUNK Portland - SUMMER BLOW OUT!",
+         "startDate":"2026-08-22T21:00:00-07:00","endDate":"2026-08-23T02:00:00-07:00",
+         "location":{"@type":"Place","name":"Nova PDX",
+           "address":{"@type":"PostalAddress","streetAddress":"722 E Burnside St","addressLocality":"Portland","addressRegion":"OR"}}}
+      </script>
+    ${WIX_WARMUP_HTML.replace('<html><head>', '')}`;
+
+  const result = await parser.parseEvents(
+    { url: CHUNK_PAGE_URL, html },
+    {},
+    PORTLAND_CITY_CONFIG,
+    'event-page',
+    null
+  );
+
+  assert.equal(result.events.length, 1);
+  const event = result.events[0];
+  assert.equal(event.bar, 'Nova PDX');
+  // Enrichment filled the JSON-LD gaps...
+  assert.equal(event.location, '45.52281000000001, -122.6581342');
+  assert.equal(event.cover, '$20.50-$30.75');
+  // ...but never overwrote what JSON-LD provided
+  assert.equal(event.startDate.toISOString(), '2026-08-23T04:00:00.000Z');
+  assert.equal(event.address, '722 E Burnside St, Portland, OR');
+});
+
+test('warmup presence never skips extraction steps: OCR and AI still run when JSON-LD is incomplete', async () => {
+  const parser = createParser();
+  let ocrRan = false;
+  let aiExtractionRan = false;
+  parser.extractOcrFromAllImages = async () => {
+    ocrRan = true;
+    return [];
+  };
+  parser.extractEventsFromMultiEventPage = async () => {
+    aiExtractionRan = true;
+    return [];
+  };
+
+  // Multi-event page whose single JSON-LD node does NOT take the fast path —
+  // the warmup blob is present but must not short-circuit anything.
+  const result = await parser.parseEvents(
+    { url: CHUNK_PAGE_URL, html: `${SICKENING_JSONLD_HTML}${WIX_WARMUP_HTML}` },
+    {},
+    PORTLAND_CITY_CONFIG,
+    'multi-event-page',
+    null
+  );
+
+  assert.equal(ocrRan, true, 'OCR must still run with warmup data present');
+  assert.equal(aiExtractionRan, true, 'AI extraction must still run with warmup data present');
+  assert.equal(result.events.length, 0);
+});
+
+// ---------------------------------------------------------------------------
 // JSON-LD offers → cover + fast-path coverage/gap-fill (chunk-party.com event
 // pages: the JSON-LD carries a complete offers block and the body shows
 // prices, but fast-path events never got a cover because the AI never ran)


### PR DESCRIPTION
Two fixes from the 2026-07-14 CHUNK run failure analysis. Companion to #1481 (independent branches; see merge-order note below).

## 1. Wix server-data (warmup-data) enrichment
Wix event pages embed authoritative server state in `<script id="wix-warmup-data">`: exact venue coordinates, IANA timezone, exact UTC start/end instants, structured address, and ticket prices. We already parsed this blob for URL discovery — now event fields use it too.

**Enrichment only, never a bypass** (explicit design rule): it runs on the parser's finished events immediately before return, on BOTH paths (JSON-LD fast path and AI extraction). It cannot skip any extraction step, fills only empty fields, and never overwrites JSON-LD/AI/OCR values. Sole exception: wall-clock dates (`_timezoneUnresolved` — admitted guesses) are replaced by the blob's exact UTC instants and the flag cleared. Conservative same-event matching (slug in URL / title equality / single-event detail page); ambiguity applies nothing; any error leaves events unchanged.

Impact: venue coordinates come from the page instead of OSM geocoding (which failed twice this run, leaving Dore Alley's location empty), timezone stated instead of inferred, prices as a second source alongside #1481's JSON-LD offers.

## 2. OSM geocoder hardening
- **Reject admin-area centroids on fallback queries**: "325 Franklin Ave, Brooklyn, NY 11238, USA" failed → the venue-name variant "Brooklyn, nyc" (garbage bar name) matched the borough itself → Brooklyn's centroid (~4 km off) was stored as venue coords. Wrong-but-plausible coordinates win merges downstream — worse than none. Fallback-query results that are boundaries/city/borough/suburb/neighbourhood-level matches are now rejected (logged); legitimate venue-name lookups ("C'mon Everybody, nyc") keep working, covered by test.
- **New query variant — strip postal/country decoration**: "1192 Folsom St, San Francisco, CA 94103, USA" gets 0 Nominatim results while "1192 Folsom St, San Francisco" resolves (verified live). New ladder rung after the full address drops the country token plus state/zip tokens; never emits a bare place token. Query budget 3→4 so the venue-name rescue rung isn't evicted (all requests stay 1.1s-throttled, later rungs fire only after earlier ones fail).

## Tests
305 pass (291 on main + 14 new, in existing files): warmup blob parsing (GUID-agnostic, garbage-safe), fill-only-empty semantics, no-overwrite, wall-clock replacement, slug mismatch → no-op, OCR/AI still run with blob present (bypass regression guard), Scriptable `global.URL = undefined` pattern; admin-area rejection, venue-name acceptance preserved, postal-strip variant, existing geocode tests unchanged.

## Merge-order note
If #1481 merges first, this branch needs a trivial rebase (both insert a call before the same fast-path return). The right final order at that site is enrichment → gap-fill, so warmup-filled fields don't trigger unnecessary gap-fill AI requests. I'll handle the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP