### PR TITLE
fix(scraper): canonicalize url/website as one field in calendar merge, honest clobber logging

### DIFF
--- a/scripts/replay-run.test.js
+++ b/scripts/replay-run.test.js
@@ -91,7 +91,9 @@ const CALENDAR_SNAPSHOT = {
 };
 
 // Frozen deterministic outcome of dedup(A1, A2) + createFinalEventObject
-// against CALENDAR_SNAPSHOT.
+// against CALENDAR_SNAPSHOT. The snapshot's native url folds into the canonical
+// website field (url/website are one logical field) and round-trips via the
+// "website:" notes line.
 const SAVED_MERGED_A = {
   title: 'FURBALL',
   startDate: '2026-07-05T21:00:00.000Z',
@@ -104,9 +106,11 @@ const SAVED_MERGED_A = {
     'timezone: America/Chicago',
     `ticketUrl: ${TICKET_URL}`,
     'key: dallas-freedom-tea|2026-07-05|station 4',
-    'shortName: FUR-BALL'
+    'shortName: FUR-BALL',
+    'website: https://furball.example'
   ].join('\n'),
   url: 'https://furball.example',
+  website: 'https://furball.example',
   description: 'FURBALL PRESENTS',
   bar: 'STATION 4',
   address: '3911 Cedar Springs Rd, Dallas, TX 75219',

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -369,6 +369,22 @@ class SharedCore {
         return Number.isNaN(time) ? null : time;
     }
 
+    // Value equality for clobber TRACKING/logging only — never for choosing a
+    // winner. Two Dates (or a Date vs ISO string) naming the same instant are
+    // the same value; everything else compares strictly. Keeps identical-instant
+    // startDate/endDate re-reads out of the `🔄 MERGE: ... clobbered N fields`
+    // log, which previously listed them on every run because each run builds
+    // fresh Date objects that fail the `!==` identity check.
+    mergeValuesEqualForTracking(a, b) {
+        if (a === b) return true;
+        if (a instanceof Date || b instanceof Date) {
+            const aMs = this.toEpochMillis(a);
+            const bMs = this.toEpochMillis(b);
+            return aMs !== null && aMs === bMs;
+        }
+        return false;
+    }
+
     // endDate <= startDate (compared as instants) is a normalization artifact
     // (e.g. an evidence-dropped end date collapsing an event to zero duration),
     // not data. Degenerate ends must never displace a positive-duration end.
@@ -2248,9 +2264,21 @@ class SharedCore {
 
     // Create complete merged event object that represents exactly what will be saved
     // Following the 6-step process: 1) scraper object, 2) calendar object, 3) simple merge, 4) gmaps, 5) notes, 6) display
+    //
+    // url vs website: they are ONE logical field. Notes persist only a "website:"
+    // line (url is notes-excluded) and Scriptable cannot read or write the native
+    // CalendarEvent.url property, so `website` is the canonical field that merges
+    // and round-trips; `url` is just an output view of it (set after the merge).
+    // Merging url as a separate field made every Scriptable run see an "empty"
+    // calendar url vs a scraped url and flag/clobber url forever.
     async createFinalEventObject(existingEvent, newEvent, options = {}) {
         // STEP 1: Build scraper object using priority list (already done - newEvent)
         const scraperObject = { ...newEvent };
+        // Fold a scraped url into the canonical website field when the parser
+        // found no website, so the one canonical field carries it into the merge.
+        if (this.isEmptyArbitrationValue(scraperObject.website) && scraperObject.url) {
+            scraperObject.website = scraperObject.url;
+        }
 
         // STEP 2: Build calendar object using calendar data
         const calendarObject = {
@@ -2264,6 +2292,13 @@ class SharedCore {
             notes: existingEvent.notes,
             url: existingEvent.url,
         };
+        // The notes-parsed website is canonical. A native url (readable on the
+        // web/Node adapter) only fills in when the notes carry no website —
+        // Scriptable always reports url as empty, and that empty value must not
+        // shadow the notes-parsed website.
+        if (this.isEmptyArbitrationValue(calendarObject.website) && existingEvent.url) {
+            calendarObject.website = existingEvent.url;
+        }
 
         // STEP 3: Simple merge - respect merge logic, grab from correct object
         const fieldPriorities = newEvent._fieldPriorities || {};
@@ -2302,7 +2337,7 @@ class SharedCore {
             }
             const chosenValue = resolved.winner === 'a' ? calendarValue : scraperValue;
             mergedObject[fieldName] = chosenValue;
-            if (resolved.winner === 'b' && scraperValue !== calendarValue) {
+            if (resolved.winner === 'b' && !this.mergeValuesEqualForTracking(scraperValue, calendarValue)) {
                 clobberedFields.push(fieldName);
             }
             console.log(`🔒 MERGE: "${mergeTitle}" field=${fieldName} resolved deterministically — ${resolved.reason}`);
@@ -2329,8 +2364,10 @@ class SharedCore {
 
         // Apply merge logic for each field
         for (const fieldName of allFields) {
-            // Skip internal fields
-            if (fieldName.startsWith('_') || fieldName === 'notes') continue;
+            // Skip internal fields. 'url' is an alias/view of 'website' (folded
+            // into website above) — it must never merge, clobber, or be logged
+            // as a separate field; website is the only field that merges.
+            if (fieldName.startsWith('_') || fieldName === 'notes' || fieldName === 'url') continue;
 
             const priorityConfig = fieldPriorities[fieldName];
             const mergeStrategy = priorityConfig?.merge || 'upsert';
@@ -2351,7 +2388,7 @@ class SharedCore {
                 // configured merge strategy (clobber semantics today).
                 if (this.isCoordinatePair(scraperValue)) {
                     mergedObject[fieldName] = scraperValue;
-                    if (scraperValue !== calendarValue) {
+                    if (!this.mergeValuesEqualForTracking(scraperValue, calendarValue)) {
                         clobberedFields.push(fieldName);
                     }
                     continue;
@@ -2413,14 +2450,14 @@ class SharedCore {
                     // No genuine conflict → clobber semantics (today's default),
                     // including clear-on-empty-scrape
                     mergedObject[fieldName] = scraperValue;
-                    if (scraperValue !== calendarValue) {
+                    if (!this.mergeValuesEqualForTracking(scraperValue, calendarValue)) {
                         clobberedFields.push(fieldName);
                     }
                     break;
                 case 'clobber':
                     mergedObject[fieldName] = scraperValue;
                     // Track when clobber actually changes a value
-                    if (scraperValue !== calendarValue) {
+                    if (!this.mergeValuesEqualForTracking(scraperValue, calendarValue)) {
                         clobberedFields.push(fieldName);
                     }
                     break;
@@ -2466,7 +2503,7 @@ class SharedCore {
                 if (decision) {
                     const otherPick = decision.pick === 'calendar' ? 'scraped' : 'calendar';
                     mergedObject[conflict.field] = conflict.values[decision.pick];
-                    if (decision.pick === 'scraped' && conflict.values.scraped !== conflict.values.calendar) {
+                    if (decision.pick === 'scraped' && !this.mergeValuesEqualForTracking(conflict.values.scraped, conflict.values.calendar)) {
                         clobberedFields.push(conflict.field);
                     }
                     console.log(`🤝 AI MERGE: "${eventTitle}" field=${conflict.field} chose ${decision.pick} ("${preview(conflict.values[decision.pick])}") over ${otherPick} ("${preview(conflict.values[otherPick])}")${decision.reason ? ` — ${decision.reason}` : ''}`);
@@ -2480,7 +2517,9 @@ class SharedCore {
                     });
                 } else {
                     mergedObject[conflict.field] = conflict.values.scraped;
-                    clobberedFields.push(conflict.field);
+                    if (!this.mergeValuesEqualForTracking(conflict.values.scraped, conflict.values.calendar)) {
+                        clobberedFields.push(conflict.field);
+                    }
                     aiDecisionRecords.push({
                         field: conflict.field,
                         existingValue: conflict.values.calendar,
@@ -2517,7 +2556,11 @@ class SharedCore {
             endDate: mergedObject.endDate || calendarObject.endDate,
             location: mergedObject.location || calendarObject.location,
             notes: newNotes,
-            url: mergedObject.url || calendarObject.url || calendarObject.website,
+            // url is a VIEW of the canonical merged website (one logical field) —
+            // kept because the web adapter and display read event.url; it is
+            // never independently stored ('url' is skipped by the merge loop, so
+            // the mergedObject spread below cannot override this).
+            url: mergedObject.website || '',
             
             // Copy all merged fields to final event
             ...mergedObject,
@@ -2561,9 +2604,13 @@ class SharedCore {
         if (!this.datesEqualForDisplay(finalEvent.startDate, existingEvent.startDate)) changes.push('startDate');
         if (!this.datesEqualForDisplay(finalEvent.endDate, existingEvent.endDate)) changes.push('endDate');
         if (finalEvent.location !== existingEvent.location) changes.push('location');
-        // url and website are aliases - treat existingEvent.url and calendarObject.website as the same
-        const existingUrl = existingEvent.url || calendarObject.website;
-        if (finalEvent.url !== existingUrl) changes.push('url');
+        // url is an output view of website (one logical field): compare the
+        // canonical merged website against the calendar's canonical website
+        // (which already folds in a real native url when the notes had none).
+        // The 'url' label is kept for display continuity. Comparing a scraped
+        // url against Scriptable's always-empty native url flagged 'url' on
+        // every run.
+        if (finalEvent.url !== (calendarObject.website || '')) changes.push('url');
         if (finalEvent.notes !== existingEvent.notes) changes.push('notes');
         
         finalEvent._changes = changes;

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -795,6 +795,114 @@ test('guardrail: emoji twin detection covers ⚜️, ⚓ and ⛓️ in both dire
 });
 
 // ---------------------------------------------------------------------------
+// url/website canonicalization (ONE logical field: website is canonical and
+// round-trips via the "website:" notes line; url is an output view of it) and
+// honest clobber logging (same-instant Dates are not "clobbered")
+// ---------------------------------------------------------------------------
+
+test('url/website are one field: a scraped url persists as website and goes quiet on re-run', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  const detailUrl = 'https://bearracuda.com/events/dallas-freedom-tea/';
+  scraped.url = detailUrl; // parser found no separate website
+  existing.url = ''; // Scriptable can never read the native CalendarEvent.url
+
+  const firstRun = await core.createFinalEventObject(existing, scraped, {});
+  assert.equal(firstRun.website, detailUrl, 'the scraped url folds into the canonical website field');
+  assert.equal(firstRun.url, detailUrl, 'url is a view of the merged website');
+  assert.equal(core.parseNotesIntoFields(firstRun.notes).website, detailUrl,
+    'the url round-trips through the website: notes line');
+  assert.ok(!/^url:/m.test(firstRun.notes), 'notes never carry a separate url: line');
+  assert.ok(firstRun._changes.includes('url'), 'the first run legitimately flags the newly stored website');
+
+  // Re-run with identical scraped data against the saved notes (Scriptable
+  // read-back: the native url is still empty) — everything must go quiet.
+  const readBack = { ...existing, notes: firstRun.notes, url: '' };
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let secondRun;
+  try {
+    secondRun = await core.createFinalEventObject(readBack, scraped, {});
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(secondRun.url, detailUrl);
+  assert.ok(!secondRun._changes.includes('url'), 'an identical re-scrape must not flag url');
+  assert.ok(!secondRun._changes.includes('notes'), 'notes are stable across identical runs');
+  assert.ok(!logLines.some(line => line.startsWith('🔄 MERGE:')),
+    `no clobber log on an identical re-run, got: ${JSON.stringify(logLines)}`);
+});
+
+test('url/website: a real scraped website wins over the detail url and nothing churns', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.url = 'https://tickets.example/detail/123';
+  scraped.website = 'https://furball.nyc/'; // page metadata website — url must not displace it
+  existing.notes += '\ndescription: FURBALL PRESENTS\nwebsite: https://furball.nyc/';
+  existing.url = '';
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, {});
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(finalEvent.website, 'https://furball.nyc/');
+  assert.equal(finalEvent.url, 'https://furball.nyc/', 'the url view mirrors the canonical website');
+  assert.equal(core.parseNotesIntoFields(finalEvent.notes).website, 'https://furball.nyc/');
+  assert.ok(!/^url:/m.test(finalEvent.notes), 'no url: line even when the scrape carried both fields');
+  assert.ok(!finalEvent._changes.includes('url'), 'matching stored website → url never flagged');
+  assert.ok(!logLines.some(line => line.startsWith('🔄 MERGE:')),
+    `url must not be merged/clobbered as its own field, got: ${JSON.stringify(logLines)}`);
+});
+
+test('clobber tracking: same-instant Date objects are not reported clobbered; differing instants are', async () => {
+  const core = createCore();
+  const buildExisting = () => ({
+    title: 'FURBALL',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    url: '',
+    notes: ''
+  });
+  const scraped = {
+    title: 'FURBALL',
+    startDate: new Date('2026-07-05T22:00:00.000Z'), // fresh objects, same instants
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    source: 'ai-web',
+    _fieldPriorities: { startDate: { merge: 'clobber' }, endDate: { merge: 'clobber' } }
+  };
+
+  const capture = async (existingEvent, scrapedEvent) => {
+    const logLines = [];
+    const originalLog = console.log;
+    console.log = (message) => { logLines.push(String(message)); };
+    try {
+      await core.createFinalEventObject(existingEvent, scrapedEvent, {});
+    } finally {
+      console.log = originalLog;
+    }
+    return logLines;
+  };
+
+  const quietLines = await capture(buildExisting(), scraped);
+  assert.ok(!quietLines.some(line => line.startsWith('🔄 MERGE:')),
+    `identical instants must not count as clobbered, got: ${JSON.stringify(quietLines)}`);
+
+  const scrapedLater = { ...scraped, startDate: new Date('2026-07-05T23:00:00.000Z') };
+  const clobberLines = await capture(buildExisting(), scrapedLater);
+  const clobberLog = clobberLines.find(line => line.startsWith('🔄 MERGE:'));
+  assert.ok(clobberLog, `a genuinely different instant is still reported, got: ${JSON.stringify(clobberLines)}`);
+  assert.match(clobberLog, /clobbered 1 field \(startDate\)/);
+});
+
+// ---------------------------------------------------------------------------
 // Bare-city titles (2026-07-12 run: bearracuda.com pages are named after the
 // city — "New Orleans⚜️ | BEARRACUDA" → brand strip leaves just the city)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Stops the perpetual url/website "change" flagged on every Scriptable run.

## Root cause
`url` and `website` are ONE logical field: notes persist only a `website:` line (url is notes-excluded), and Scriptable cannot read or write the native CalendarEvent.url property. But `createFinalEventObject` merged `url` as its own field — so every Scriptable run compared the scraped url against an always-empty calendar url, clobbered it, and flagged 'url' in `_changes` forever. The event-detail URL the merge picked was then silently dropped on save anyway.

## Fix (all in createFinalEventObject; event-schema untouched)
- Scraped `url` folds into canonical `website` when the parser found no website; the notes-parsed website is canonical on the calendar side, with a readable native url (web/Node adapter) filling in only when notes carry none — Scriptable's empty native url can never shadow it.
- The merge loop skips `url` entirely (like `notes`); `website` is the only field that merges. `finalEvent.url` is set as a view of the merged website afterward.
- Change detection compares canonical website; the first run after this lands legitimately flags one notes/url change, then goes quiet.
- New `mergeValuesEqualForTracking` (epoch-millis equality for Dates) applied to every `clobberedFields` push — the `clobbered N fields` log stops listing identical-instant startDate/endDate re-reads that fresh Date objects produced every run. Winner selection unchanged.

Cross-parser merging (`mergeParsedEvents`) intentionally untouched: `BasicDataNormalizer.syncUrlAndWebsiteFields` already ensures every scraped event carries website whenever it has url, so only website reaches the calendar merge.

## Tests
314 pass (3 new): url-only scrape → website canonicalized, notes carry a single `website:` line, identical Scriptable re-run produces zero changes; url + metadata website → website wins, no churn; same-instant Dates not reported clobbered, differing instants still are. One replay fixture updated to the intended new deterministic outcome (native url round-trips into website).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP