### PR TITLE
feat(scraper): OCR cache retention by last use — touch-on-hit, 90d auto-prune, per-scope broom defaults

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -747,6 +747,15 @@ class ScriptableAdapter {
     };
   }
 
+  // How long unused OCR/classification cache entries survive the end-of-run
+  // prune. Reads the global `ocr` block threaded in by the orchestrator (the
+  // same way pageCache is) — the single retention knob, everything else about
+  // cache retention is fixed policy.
+  getOcrCacheRetentionDays() {
+    const raw = Number(this.config.ocr?.cacheRetentionDays);
+    return Number.isFinite(raw) && raw > 0 ? raw : 90;
+  }
+
   normalizePageCacheUrl(url) {
     try {
       const normalized = new URL(String(url));
@@ -2651,6 +2660,52 @@ class ScriptableAdapter {
         } catch (metricsErr) {
           console.log(
             `📱 Scriptable: Metrics write failed: ${metricsErr.message}`,
+          );
+        }
+      }
+
+      if (!results?._isDisplayingSavedRun) {
+        // Prune persistent caches. Pages past their TTL are dead weight
+        // already (readCachedPage ignores them), so they only get a 1-day
+        // grace. OCR/classification entries are retained by LAST USE: cache
+        // hits rewrite ("touch") the entry at most every 7 days (see
+        // AiWebParser.touchCacheEntryOnHit), so a file's mtime tracks its
+        // last use to within that window — pruning works from mtime alone,
+        // no payload reads, with the touch interval added as grace.
+        try {
+          const pageTtlDays = this.getPageCacheConfig().ttlDays;
+          const prunedPages = await this.cleanupOldFiles(
+            "chunky-dad-scraper/storage/pages",
+            { maxAgeDays: pageTtlDays + 1, recurse: true },
+          );
+          if (prunedPages > 0) {
+            console.log(
+              `📱 Scriptable: Pruned ${prunedPages} expired page cache file(s) (ttl ${pageTtlDays}d)`,
+            );
+          }
+          const ocrRetentionDays = this.getOcrCacheRetentionDays();
+          const unusedCutoffDays = ocrRetentionDays + 7;
+          const prunedOcr = await this.cleanupOldFiles(
+            "chunky-dad-scraper/storage/ocr",
+            { maxAgeDays: unusedCutoffDays, recurse: true },
+          );
+          if (prunedOcr > 0) {
+            console.log(
+              `📱 Scriptable: Pruned ${prunedOcr} OCR cache entries unused for ${ocrRetentionDays}d`,
+            );
+          }
+          const prunedClassification = await this.cleanupOldFiles(
+            "chunky-dad-scraper/storage/classification",
+            { maxAgeDays: unusedCutoffDays, recurse: true },
+          );
+          if (prunedClassification > 0) {
+            console.log(
+              `📱 Scriptable: Pruned ${prunedClassification} classification cache entries unused for ${ocrRetentionDays}d`,
+            );
+          }
+        } catch (pruneErr) {
+          console.log(
+            `📱 Scriptable: Cache prune failed: ${pruneErr.message}`,
           );
         }
       }
@@ -7430,33 +7485,52 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
 
   async cleanupOldFiles(
     relDirPath,
-    { maxAgeDays = 30, keep = () => false, afterCleanup = null } = {},
+    { maxAgeDays = 30, keep = () => false, recurse = false, afterCleanup = null } = {},
   ) {
     // Use documents directory as base, not script directory
     const documentsDir = this.fm.documentsDirectory();
     const dirPath = this.fm.joinPath(documentsDir, relDirPath);
     const fm = this.fm || FileManager.iCloud();
-    if (!fm.fileExists(dirPath)) return;
+    if (!fm.fileExists(dirPath)) return 0;
     const now = Date.now();
     const cutoff = now - maxAgeDays * 24 * 60 * 60 * 1000;
-    const files = fm.listContents(dirPath) || [];
-    files.forEach((name) => {
-      if (keep(name)) return;
-      const path = fm.joinPath(dirPath, name);
-      let mtime = null;
-      try {
-        mtime = fm.modificationDate(path);
-      } catch (_) {}
-      const ms = mtime ? mtime.getTime() : null;
-      if (ms && ms < cutoff) {
+    const removeOldEntries = (currentDir) => {
+      let removed = 0;
+      const files = fm.listContents(currentDir) || [];
+      files.forEach((name) => {
+        if (keep(name)) return;
+        const path = fm.joinPath(currentDir, name);
+        // Nested cache layouts (storage/<scope>/<host>/<file>) opt into
+        // descending; flat dirs (runs/, logs/) keep the original behavior
+        if (recurse) {
+          let isDirectory = false;
+          try {
+            isDirectory = fm.isDirectory(path);
+          } catch (_) {}
+          if (isDirectory) {
+            removed += removeOldEntries(path);
+            return;
+          }
+        }
+        let mtime = null;
         try {
-          fm.remove(path);
+          mtime = fm.modificationDate(path);
         } catch (_) {}
-      }
-    });
+        const ms = mtime ? mtime.getTime() : null;
+        if (ms && ms < cutoff) {
+          try {
+            fm.remove(path);
+            removed += 1;
+          } catch (_) {}
+        }
+      });
+      return removed;
+    };
+    const removedCount = removeOldEntries(dirPath);
     if (typeof afterCleanup === "function") {
       await afterCleanup();
     }
+    return removedCount;
   }
 
   // Metrics helpers

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -319,3 +319,59 @@ test('generateRichHTML defines the exportProvenanceIssue page handler once', asy
   assert.ok(html.includes('provenance-details'));
   assert.ok(html.includes('No provenance recorded'));
 });
+
+// ---------------------------------------------------------------------------
+// End-of-run cache pruning: cleanupOldFiles recursion + retention config
+// ---------------------------------------------------------------------------
+
+test('cleanupOldFiles recurses into nested cache host dirs and reports the pruned count', async () => {
+  const adapter = buildAdapter();
+  const DAY = 24 * 60 * 60 * 1000;
+  const now = Date.now();
+  const base = '/tmp/chunky-dad-adapter-test/chunky-dad-scraper/storage/ocr';
+  const dirs = {
+    [base]: ['host-a', 'host-b'],
+    [`${base}/host-a`]: ['stale.json', 'fresh.json'],
+    [`${base}/host-b`]: ['ancient.json']
+  };
+  // Touch-on-hit rewrites entries on use, so mtime IS last use (within the
+  // 7-day rate limit) — the pruner never needs to read payloads
+  const mtimes = {
+    [`${base}/host-a/stale.json`]: new Date(now - 120 * DAY),
+    [`${base}/host-a/fresh.json`]: new Date(now - 5 * DAY),
+    [`${base}/host-b/ancient.json`]: new Date(now - 400 * DAY)
+  };
+  const removed = [];
+  adapter.fm = {
+    documentsDirectory: () => '/tmp/chunky-dad-adapter-test',
+    joinPath: (a, b) => `${a}/${b}`,
+    fileExists: (p) => Boolean(dirs[p]) || Boolean(mtimes[p]),
+    isDirectory: (p) => Boolean(dirs[p]),
+    listContents: (p) => dirs[p] || [],
+    modificationDate: (p) => mtimes[p] || null,
+    remove: (p) => removed.push(p)
+  };
+
+  const count = await adapter.cleanupOldFiles('chunky-dad-scraper/storage/ocr', {
+    maxAgeDays: 97, // 90d retention + 7d touch-interval grace
+    recurse: true
+  });
+
+  assert.equal(count, 2);
+  assert.deepEqual(removed.sort(), [
+    `${base}/host-a/stale.json`,
+    `${base}/host-b/ancient.json`
+  ]);
+});
+
+test('getOcrCacheRetentionDays reads config.ocr.cacheRetentionDays with a 90d default', () => {
+  assert.equal(buildAdapter().getOcrCacheRetentionDays(), 90);
+  assert.equal(
+    new ScriptableAdapter({ cities: {}, ocr: { cacheRetentionDays: 30 } }).getOcrCacheRetentionDays(),
+    30
+  );
+  assert.equal(
+    new ScriptableAdapter({ cities: {}, ocr: { cacheRetentionDays: 'bogus' } }).getOcrCacheRetentionDays(),
+    90
+  );
+});

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -246,6 +246,8 @@ class BearEventScraperOrchestrator {
                 finalAdapter = new this.modules.adapter({
                     cities: config.cities,
                     pageCache: config.config?.pageCache || null,
+                    // Global OCR block, for the end-of-run cache-retention prune
+                    ocr: config.config?.ocr || null,
                     // Carry the resolved run context (automation overrides) into the
                     // instance that saves runs/metrics, not just the config object
                     runtime: config.runtime || null,

--- a/scripts/page-cache-maintenance.js
+++ b/scripts/page-cache-maintenance.js
@@ -31,6 +31,11 @@ const LOGO_URL = 'https://chunky.dad/favicons/logo-hero.png';
 const LOGO_CACHE_TTL_DAYS = 7;
 const DEFAULT_PRUNE_DAYS = 7;
 const QUICK_DAY_OPTIONS = [3, 7, 14, 30, 60];
+// OCR results are expensive to regenerate (each one is a vision-model request)
+// and the scraper itself only prunes them after 90 days unused — the broom's
+// OCR scope gets matching, much longer defaults than the short-lived page cache.
+const OCR_DEFAULT_PRUNE_DAYS = 90;
+const OCR_QUICK_DAY_OPTIONS = [30, 60, 90, 180, 365];
 const MAX_HOST_ROWS = 40;
 
 class PageCacheMaintenance {
@@ -46,13 +51,19 @@ class PageCacheMaintenance {
         key: 'pages',
         label: 'Page cache',
         dir: this.pageStorageDir,
-        footerLabel: 'storage/pages'
+        footerLabel: 'storage/pages',
+        daysParam: 'days',
+        defaultDays: DEFAULT_PRUNE_DAYS,
+        quickDayOptions: QUICK_DAY_OPTIONS
       },
       {
         key: 'ocr',
         label: 'OCR cache',
         dir: this.ocrStorageDir,
-        footerLabel: 'storage/ocr'
+        footerLabel: 'storage/ocr',
+        daysParam: 'ocrDays',
+        defaultDays: OCR_DEFAULT_PRUNE_DAYS,
+        quickDayOptions: OCR_QUICK_DAY_OPTIONS
       }
     ];
     this.cacheDir = this.fm.joinPath(this.baseDir, 'cache');
@@ -89,16 +100,18 @@ class PageCacheMaintenance {
     return runtime;
   }
 
-  getConfiguredDefaultDays() {
+  getConfiguredDefaultDays(scope) {
     try {
       const scraperConfig = importModule('scraper-input');
-      const raw = scraperConfig?.config?.pageCache?.ttlDays;
+      const raw = scope.key === 'ocr'
+        ? scraperConfig?.config?.ocr?.cacheRetentionDays
+        : scraperConfig?.config?.pageCache?.ttlDays;
       const parsed = Number(raw);
       if (Number.isFinite(parsed) && parsed > 0) return Math.floor(parsed);
     } catch (error) {
       console.log(`PageCacheMaintenance: Could not load scraper-input: ${error.message}`);
     }
-    return DEFAULT_PRUNE_DAYS;
+    return scope.defaultDays;
   }
 
   parseDaysValue(value) {
@@ -128,12 +141,24 @@ class PageCacheMaintenance {
     return null;
   }
 
-  getSelectedDays() {
-    const queryDays = this.parseDaysParameter(this.runtime.queryParameters?.days);
+  getSelectedDaysForScope(scope) {
+    const queryDays = this.parseDaysParameter(this.runtime.queryParameters?.[scope.daysParam]);
     if (queryDays) return queryDays;
-    const widgetDays = this.parseDaysParameter(this.runtime.widgetParameter);
-    if (widgetDays) return widgetDays;
-    return this.getConfiguredDefaultDays();
+    // The widget parameter predates per-scope thresholds and keeps its original
+    // meaning: it only overrides the page-cache threshold
+    if (scope.key === 'pages') {
+      const widgetDays = this.parseDaysParameter(this.runtime.widgetParameter);
+      if (widgetDays) return widgetDays;
+    }
+    return this.getConfiguredDefaultDays(scope);
+  }
+
+  getSelectedDays() {
+    const daysByScope = {};
+    this.cacheScopes.forEach(scope => {
+      daysByScope[scope.key] = this.getSelectedDaysForScope(scope);
+    });
+    return daysByScope;
   }
 
   parseBoolean(value) {
@@ -438,6 +463,9 @@ class PageCacheMaintenance {
       key: scope.key,
       label: scope.label,
       dir: scope.dir,
+      days,
+      daysParam: scope.daysParam,
+      quickDayOptions: scope.quickDayOptions,
       exists: this.fm.fileExists(scope.dir),
       hostCount: hosts.length,
       totalFileCount: hosts.reduce((sum, host) => sum + host.totalFileCount, 0),
@@ -448,8 +476,8 @@ class PageCacheMaintenance {
     };
   }
 
-  async analyzePageCache(days) {
-    const scopePromises = this.cacheScopes.map(scope => this.analyzeCacheScope(scope, days));
+  async analyzePageCache(daysByScope) {
+    const scopePromises = this.cacheScopes.map(scope => this.analyzeCacheScope(scope, daysByScope[scope.key]));
     const scopes = await Promise.all(scopePromises);
     const hosts = scopes.reduce((allHosts, scope) => allHosts.concat(scope.hosts), []);
     hosts.sort((left, right) => {
@@ -463,7 +491,7 @@ class PageCacheMaintenance {
 
     return {
       generatedAt: new Date(),
-      days,
+      daysByScope,
       exists: scopes.some(scope => scope.exists),
       cacheScopes: scopes,
       hostCount: hosts.length,
@@ -478,9 +506,9 @@ class PageCacheMaintenance {
   async confirmPrune(analysis, deleteHosts) {
     const alert = new Alert();
     alert.title = deleteHosts ? 'Delete old files + empty hosts?' : 'Delete old files?';
-    const messageLines = [
-      `${analysis.oldFileCount} file(s) are older than ${analysis.days} day(s).`
-    ];
+    const messageLines = analysis.cacheScopes.map(scope =>
+      `${scope.label}: ${scope.oldFileCount} file(s) older than ${scope.days} day(s).`
+    );
     if (deleteHosts) {
       messageLines.push(`${analysis.removableHostCount} host folder(s) can be removed if empty after pruning.`);
     }
@@ -522,7 +550,7 @@ class PageCacheMaintenance {
     });
 
     return {
-      days: analysis.days,
+      daysByScope: analysis.daysByScope,
       deleteHosts,
       deletedFileCount: deletedFiles.length,
       deletedHostCount: deletedHosts.length,
@@ -533,17 +561,17 @@ class PageCacheMaintenance {
     };
   }
 
-  async maybeRunAction(days) {
+  async maybeRunAction(daysByScope) {
     const action = this.getActionFromQuery();
     if (action !== 'prune') return null;
 
     const deleteHosts = this.parseBoolean(
       this.runtime.queryParameters?.deleteHosts || this.runtime.queryParameters?.pruneHosts
     );
-    const analysis = await this.analyzePageCache(days);
+    const analysis = await this.analyzePageCache(daysByScope);
     if (analysis.oldFileCount === 0 && (!deleteHosts || analysis.removableHostCount === 0)) {
       return {
-        days,
+        daysByScope,
         deleteHosts,
         deletedFileCount: 0,
         deletedHostCount: 0,
@@ -558,7 +586,7 @@ class PageCacheMaintenance {
     const confirmed = await this.confirmPrune(analysis, deleteHosts);
     if (!confirmed) {
       return {
-        days,
+        daysByScope,
         deleteHosts,
         cancelled: true,
         deletedFileCount: 0,
@@ -685,16 +713,37 @@ class PageCacheMaintenance {
     const logoImage = await this.loadLogoImage();
     const logoDataUri = this.imageToDataUri(logoImage);
     const resultMessage = this.buildResultMessage(result);
-    const days = analysis.days;
-    const dayChips = QUICK_DAY_OPTIONS.map(option => {
-      const activeClass = option === days ? 'chip active' : 'chip';
-      const href = this.escapeHtml(this.buildSelfUrl({ days: option }));
-      return `<a class="${activeClass}" href="${href}">${this.escapeHtml(option)}d</a>`;
+    const daysByScope = analysis.daysByScope;
+    // Every self-link carries BOTH scope thresholds so changing one never
+    // resets the other back to its default
+    const buildDaysParams = (overrides = {}) => {
+      const params = {};
+      this.cacheScopes.forEach(scope => {
+        params[scope.daysParam] = overrides[scope.key] !== undefined
+          ? overrides[scope.key]
+          : daysByScope[scope.key];
+      });
+      return params;
+    };
+    const thresholdSections = analysis.cacheScopes.map(scope => {
+      const chips = scope.quickDayOptions.map(option => {
+        const activeClass = option === scope.days ? 'chip active' : 'chip';
+        const href = this.escapeHtml(this.buildSelfUrl(buildDaysParams({ [scope.key]: option })));
+        return `<a class="${activeClass}" href="${href}">${this.escapeHtml(option)}d</a>`;
+      }).join('');
+      return `
+        <div>
+          <h2 style="font-size: 14px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); margin-bottom: 12px;">${this.escapeHtml(scope.label)} threshold</h2>
+          <div class="chip-row">${chips}</div>
+        </div>`;
     }).join('');
+    const thresholdSummary = analysis.cacheScopes
+      .map(scope => `${scope.label}: ${scope.days}d`)
+      .join(' • ');
 
-    const pruneHref = this.escapeHtml(this.buildSelfUrl({ action: 'prune', days }));
-    const pruneHostsHref = this.escapeHtml(this.buildSelfUrl({ action: 'prune', days, deleteHosts: 1 }));
-    const refreshHref = this.escapeHtml(this.buildSelfUrl({ days }));
+    const pruneHref = this.escapeHtml(this.buildSelfUrl({ action: 'prune', ...buildDaysParams() }));
+    const pruneHostsHref = this.escapeHtml(this.buildSelfUrl({ action: 'prune', ...buildDaysParams(), deleteHosts: 1 }));
+    const refreshHref = this.escapeHtml(this.buildSelfUrl(buildDaysParams()));
 
     const activeModel = this.getModelFromQuery();
     const ocrScope = analysis.cacheScopes.find(s => s.key === 'ocr');
@@ -702,10 +751,10 @@ class PageCacheMaintenance {
     const availableModels = [...new Set(allOcrFiles.map(f => f.modelName).filter(Boolean))].sort();
 
     const modelChips = availableModels.length > 0 ? [
-      `<a class="chip ${!activeModel ? 'active' : ''}" href="${this.escapeHtml(this.buildSelfUrl({ days }))}">All models</a>`,
+      `<a class="chip ${!activeModel ? 'active' : ''}" href="${this.escapeHtml(this.buildSelfUrl(buildDaysParams()))}">All models</a>`,
       ...availableModels.map(m => {
         const activeClass = m === activeModel ? 'chip active' : 'chip';
-        const href = this.escapeHtml(this.buildSelfUrl({ days, model: m }));
+        const href = this.escapeHtml(this.buildSelfUrl({ ...buildDaysParams(), model: m }));
         return `<a class="${activeClass}" href="${href}">${this.escapeHtml(m)}</a>`;
       })
     ].join('') : '';
@@ -975,7 +1024,7 @@ class PageCacheMaintenance {
         </div>
       </div>
       <div class="meta">
-        Threshold: <strong>${this.escapeHtml(days)} day(s)</strong><br>
+        <strong>${this.escapeHtml(thresholdSummary)}</strong><br>
         Updated: ${this.escapeHtml(this.formatTimestamp(analysis.generatedAt))}
       </div>
     </div>
@@ -984,10 +1033,7 @@ class PageCacheMaintenance {
 
     <div class="panel controls">
       <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 24px;">
-        <div>
-          <h2 style="font-size: 14px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); margin-bottom: 12px;">Threshold</h2>
-          <div class="chip-row">${dayChips}</div>
-        </div>
+        ${thresholdSections}
         ${modelChips ? `
         <div>
           <h2 style="font-size: 14px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); margin-bottom: 12px;">Model Filter</h2>
@@ -1060,12 +1106,16 @@ class PageCacheMaintenance {
     await WebView.loadHTML(html, null, null, true);
   }
 
-  async renderWidget(days) {
-    const analysis = await this.analyzePageCache(days);
+  async renderWidget(daysByScope) {
+    const analysis = await this.analyzePageCache(daysByScope);
     const widget = new ListWidget();
     widget.backgroundColor = new Color(BRAND.primary);
     widget.setPadding(12, 12, 12, 12);
-    widget.url = this.buildSelfUrl({ days: analysis.days });
+    const widgetDaysParams = {};
+    this.cacheScopes.forEach(scope => {
+      widgetDaysParams[scope.daysParam] = daysByScope[scope.key];
+    });
+    widget.url = this.buildSelfUrl(widgetDaysParams);
 
     const title = widget.addText('Cache');
     title.font = Font.boldSystemFont(FONT_SIZES.widget.label);
@@ -1077,10 +1127,13 @@ class PageCacheMaintenance {
     count.font = Font.boldSystemFont(FONT_SIZES.widget.metric);
     count.textColor = new Color(analysis.oldFileCount > 0 ? BRAND.danger : BRAND.success);
 
+    const widgetThresholds = analysis.cacheScopes
+      .map(scope => `${scope.key} ${scope.days}d`)
+      .join(' • ');
     const detail = widget.addText(
       analysis.oldFileCount > 0
-        ? `${analysis.oldFileCount} old files > ${analysis.days}d`
-        : `No files older than ${analysis.days}d`
+        ? `${analysis.oldFileCount} old files (${widgetThresholds})`
+        : `No old files (${widgetThresholds})`
     );
     detail.font = Font.systemFont(FONT_SIZES.widget.small);
     detail.textColor = new Color(BRAND.textMuted);
@@ -1101,14 +1154,14 @@ class PageCacheMaintenance {
 (async () => {
   try {
     const maintenance = new PageCacheMaintenance();
-    const days = maintenance.getSelectedDays();
-    const actionResult = maintenance.runtime.runsInWidget ? null : await maintenance.maybeRunAction(days);
+    const daysByScope = maintenance.getSelectedDays();
+    const actionResult = maintenance.runtime.runsInWidget ? null : await maintenance.maybeRunAction(daysByScope);
 
     if (maintenance.runtime.runsInWidget) {
-      const widget = await maintenance.renderWidget(days);
+      const widget = await maintenance.renderWidget(daysByScope);
       Script.setWidget(widget);
     } else {
-      const analysis = await maintenance.analyzePageCache(days);
+      const analysis = await maintenance.analyzePageCache(daysByScope);
       await maintenance.renderApp(analysis, actionResult);
     }
   } catch (error) {

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -25,6 +25,13 @@ const ImportedEventSchema = (() => {
     return null;
 })();
 
+// Persistent cache entries (OCR, classification) are retained by LAST USE, not
+// write date: cache hits refresh a `lastUsedAt` payload field so recurring
+// flyers survive the adapter's end-of-run pruning. Refreshes are rate-limited
+// to once per this many days so steady-state runs do zero extra writes (and no
+// iCloud sync churn).
+const CACHE_TOUCH_INTERVAL_DAYS = 7;
+
 // ============================================================================
 // NORMALIZATION HELPERS
 // ============================================================================
@@ -2259,6 +2266,32 @@ class AiWebParser {
         return null;
     }
 
+    // "Touch" a cache entry on a hit so pruning can work from last USE instead
+    // of write date. Scriptable's FileManager has no utimes, so the mechanism is
+    // a `lastUsedAt` payload field (ISO day precision) plus an occasional full
+    // rewrite — Node deliberately uses the same payload field (not fs.utimes) so
+    // both platforms share one code path. Rate-limited: the file is only
+    // rewritten when the stored marker is absent or older than
+    // CACHE_TOUCH_INTERVAL_DAYS, so entries hit on every run cost nothing.
+    // Because a touch rewrites the file, mtime tracks last use to within the
+    // interval — the adapter's auto-prune reads mtime alone, no payloads.
+    async touchCacheEntryOnHit(runtime, cachePath, cached) {
+        if (!runtime || !cachePath || !cached || typeof cached !== 'object') return;
+        const lastUsedMs = Date.parse(String(cached.lastUsedAt || ''));
+        const staleMs = CACHE_TOUCH_INTERVAL_DAYS * 24 * 60 * 60 * 1000;
+        if (Number.isFinite(lastUsedMs) && (Date.now() - lastUsedMs) <= staleMs) return;
+        cached.lastUsedAt = new Date().toISOString().slice(0, 10);
+        try {
+            if (runtime.type === 'scriptable') {
+                runtime.fm.writeString(cachePath, JSON.stringify(cached, null, 2));
+            } else {
+                await runtime.fs.promises.writeFile(cachePath, JSON.stringify(cached, null, 2), 'utf8');
+            }
+        } catch (_) {
+            // A failed touch is harmless — the entry just keeps aging by mtime
+        }
+    }
+
     getOcrCachePathParts(imageUrl, ocrConfig = {}) {
         const rawUrl = String(imageUrl || '').trim();
         const normalizedSource = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(rawUrl) || rawUrl);
@@ -2368,20 +2401,23 @@ class AiWebParser {
         if (!runtime) return null;
         const { hostDir, fileName } = this.getAiClassificationCachePathParts(url, signature);
         try {
+            let cachePath;
             let rawPayload = null;
             if (runtime.type === 'scriptable') {
-                const cachePath = runtime.fm.joinPath(runtime.fm.joinPath(runtime.baseDir, hostDir), fileName);
+                cachePath = runtime.fm.joinPath(runtime.fm.joinPath(runtime.baseDir, hostDir), fileName);
                 if (!runtime.fm.fileExists(cachePath)) return null;
                 try {
                     await runtime.fm.downloadFileFromiCloud(cachePath);
                 } catch (_) {}
                 rawPayload = runtime.fm.readString(cachePath);
             } else {
-                const cachePath = runtime.path.join(runtime.baseDir, hostDir, fileName);
+                cachePath = runtime.path.join(runtime.baseDir, hostDir, fileName);
                 rawPayload = await runtime.fs.promises.readFile(cachePath, 'utf8');
             }
             const cached = JSON.parse(rawPayload);
-            return cached && cached.outcome && typeof cached.outcome === 'object' ? cached.outcome : null;
+            const outcome = cached && cached.outcome && typeof cached.outcome === 'object' ? cached.outcome : null;
+            if (outcome) await this.touchCacheEntryOnHit(runtime, cachePath, cached);
+            return outcome;
         } catch (error) {
             const missingFile = error && (error.code === 'ENOENT' || /does not exist/i.test(String(error.message || '')));
             if (!missingFile) {
@@ -2450,6 +2486,9 @@ class AiWebParser {
             if (responseText === undefined || responseText === null) return null;
 
             const parsed = JSON.parse(responseText);
+            // A parseable payload is a hit either way — negative-cached failures
+            // included — so refresh its last-use marker before branching
+            await this.touchCacheEntryOnHit(runtime, cachePath, cached);
             if (parsed && typeof parsed === 'object' && parsed.failureKind) {
                 return {
                     imageUrl: cached.url || normalizedUrl,

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -2493,3 +2493,86 @@ test('the fast path logs a JSON-LD coverage line and a gap-fill outcome line', a
   assert.match(gapFillLine, /requested=\[cover\]/);
   assert.match(gapFillLine, /filled=\[cover\]/);
 });
+
+// ---------------------------------------------------------------------------
+// Cache retention: hits refresh a lastUsedAt marker, rate-limited to 7 days,
+// so the adapter's end-of-run prune can work from file mtime alone
+// ---------------------------------------------------------------------------
+
+test('OCR cache hits stamp lastUsedAt at most once per 7 days', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-touch-test-'));
+
+  const parser = new AiWebParser({ normalizeUrl, ocrCacheDir: cacheDir });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+
+  const ocrConfig = { cacheEnabled: true, model: 'test-model', prompt: 'ocr prompt' };
+  const imageUrl = 'https://cdn.example/recurring-flyer.jpg';
+  const resultText = JSON.stringify({ text: 'BEAR NIGHT 10PM', imageClassification: 'event-flyer' });
+  const cachePath = await parser.writeCachedOcrResult(imageUrl, ocrConfig, resultText);
+  assert.ok(cachePath, 'cache write should return the entry path');
+  assert.equal(JSON.parse(fs.readFileSync(cachePath, 'utf8')).lastUsedAt, undefined);
+
+  // First hit on a legacy entry (no lastUsedAt): rewritten with a day-precision stamp
+  const today = new Date().toISOString().slice(0, 10);
+  const first = await parser.readCachedOcrResult(imageUrl, ocrConfig);
+  assert.equal(first.cached, true);
+  const afterFirst = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  assert.equal(afterFirst.lastUsedAt, today);
+  assert.equal(afterFirst.response.text, resultText, 'touching must preserve the cached payload');
+
+  // Second hit the same day: rate-limited, NO rewrite (sentinel survives)
+  afterFirst._sentinel = 'untouched';
+  fs.writeFileSync(cachePath, JSON.stringify(afterFirst, null, 2), 'utf8');
+  const second = await parser.readCachedOcrResult(imageUrl, ocrConfig);
+  assert.equal(second.cached, true);
+  assert.equal(
+    JSON.parse(fs.readFileSync(cachePath, 'utf8'))._sentinel,
+    'untouched',
+    'a same-day hit must not rewrite the entry'
+  );
+
+  // A marker older than the 7-day rate limit is refreshed
+  const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  afterFirst.lastUsedAt = eightDaysAgo;
+  fs.writeFileSync(cachePath, JSON.stringify(afterFirst, null, 2), 'utf8');
+  await parser.readCachedOcrResult(imageUrl, ocrConfig);
+  assert.equal(JSON.parse(fs.readFileSync(cachePath, 'utf8')).lastUsedAt, today);
+
+  // Negative-cached failures are valid hits too — touched the same way
+  const failureUrl = 'https://cdn.example/huge-banner.webp';
+  const failurePath = await parser.writeCachedOcrResult(
+    failureUrl,
+    ocrConfig,
+    JSON.stringify({ failureKind: 'context-overflow' })
+  );
+  const failureHit = await parser.readCachedOcrResult(failureUrl, ocrConfig);
+  assert.equal(failureHit.failureKind, 'context-overflow');
+  assert.equal(JSON.parse(fs.readFileSync(failurePath, 'utf8')).lastUsedAt, today);
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+test('classification cache hits refresh lastUsedAt through the same touch helper', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cls-touch-test-'));
+
+  const parser = new AiWebParser({ normalizeUrl, classificationCacheDir: cacheDir });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+
+  const url = 'https://bearracuda.example/events';
+  const signature = { model: 'test-model', summaryHash: 'abc' };
+  const written = await parser.writeCachedAiClassification(url, signature, { classification: 'multi-event-page' });
+  assert.ok(written);
+
+  const outcome = await parser.readCachedAiClassification(url, signature);
+  assert.equal(outcome.classification, 'multi-event-page');
+  const payload = JSON.parse(fs.readFileSync(written, 'utf8'));
+  assert.equal(payload.lastUsedAt, new Date().toISOString().slice(0, 10));
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -91,6 +91,10 @@ const scraperConfig = {
       concurrency: 1, // Concurrent OCR requests; keep 1 for a single local GPU
       maxTextChars: 4000,
       cache: true, // OCR result cache (key is `cache`, not `cacheEnabled`)
+      // End-of-run auto-prune: cached OCR results unused for this many days
+      // are deleted (cache hits refresh an entry's last-use marker, so
+      // recurring flyers are kept indefinitely). Default: 90.
+      cacheRetentionDays: 90,
       requireMissingFields: true,
     },
     // Discovery URL blocklist inherited by every parser — UNIONED with each


### PR DESCRIPTION
## What

Fixes the weekly re-OCR churn: cached OCR results were being deleted by the broom script's 7-day default, forcing expensive vision-model re-runs of the same flyers. Cache entries are now retained by **last use**, not write date.

### Touch-on-use (`ai-web-parser.js`)
- Every OCR cache hit (including negative-cached failures) and AI-classification cache hit stamps a day-precision `lastUsedAt` field into the payload and rewrites the file.
- Rate-limited to once per 7 days per entry — steady-state runs do zero extra writes (no iCloud sync churn). Legacy entries get the field on first hit.
- Because a touch rewrites the file, **mtime tracks last use** to within the 7-day window — pruning needs no payload reads.

### End-of-run auto-prune (`scriptable-adapter.js`)
- `storage/pages`: pruned past page-cache TTL + 1d grace (expired entries are dead weight — `readCachedPage` already ignores them).
- `storage/ocr` + `storage/classification`: pruned when unused for `cacheRetentionDays` (default 90) + 7d touch-interval grace, by mtime alone.
- One summary log line per scope, whole block in its own try/catch, skipped when displaying a saved run.
- `cleanupOldFiles` gained `recurse` for nested `storage/<scope>/<host>/` layouts (flat runs/logs behavior unchanged) and returns the pruned count.
- No web-adapter prune: CI checkouts are ephemeral.

### Broom script per-scope defaults (`page-cache-maintenance.js`)
- Pages: 7d default, quick options 3/7/14/30/60 (unchanged).
- OCR: **90d** default, quick options 30/60/90/180/365 — the default tap can no longer mass-delete OCR results.
- Per-scope query params (`days` / `ocrDays`); self-links carry both thresholds so changing one never resets the other. Widget parameter keeps its original pages-only meaning.

### Config
- One knob: `config.ocr.cacheRetentionDays` (default 90), documented in `scraper-input.js`, threaded through the orchestrator like `pageCache`. Not part of the OCR request signature (allow-listed keys only), so existing cache entries stay valid.

## Tests

328 pass / 0 fail (4 new): touch-on-first-hit, same-day no-rewrite, stale-marker refresh, failureKind touch, classification touch (real tmpdir fs); cleanupOldFiles recursion/cutoff/count via injected in-memory FileManager; retention-config getter. `node --check` clean on all touched files including the Scriptable-only broom script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP