### PR TITLE
feat(scraper): bear-check cascade — keyword+AI verdicts with provenance, report-only default

### DIFF
--- a/data/calendars/atlanta.json
+++ b/data/calendars/atlanta.json
@@ -36,6 +36,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Heretic%20Atlanta%2C%202069%20Cheshire%20Bridge%20Road%20Northeast%2C%20Atlanta%2C%20GA%2C%2030324",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-17/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -94,6 +95,7 @@
       "gmaps": "https://maps.google.com/?q=33.81158,-84.3554",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-atlanta-bulges-jocks-tickets-1751306507909",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -156,6 +158,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Heretic%2C%202069%20Cheshire%20Bridge%20Rd%20NE%2C%20Atlanta%2C%20GA%2030324",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-atlanta-bear-pride-2026-tickets-1978849934423",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -216,6 +219,7 @@
       "instagram": "https://www.instagram.com/bearracuda",
       "gmaps": "https://www.google.com/maps/search/?api=1&query=33.81158%2C-84.3554&query_place_id=ChIJHfQbk9cF9YgRffpBbinNqZk",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -268,6 +272,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Heretic%2C%202069%20Cheshire%20Bridge%20Rd%20NE%2C%20Atlanta%2C%20GA%2030324",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-atlantawinter-beef-ball-jock-underwear-party-tickets-1967115296806?aff=oddtdtcreator",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/chicago.json
+++ b/data/calendars/chicago.json
@@ -52,6 +52,7 @@
       "website": "https://jackhammerchicago.com/belly-up",
       "facebook": "https://www.facebook.com/chijackhammer/events",
       "gmaps": "https://maps.app.goo.gl/Groc2oBnZyjMU2cJA",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -102,6 +103,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Cell%20Block%2C%203702%20N%20HALSTED%20ST",
       "ticketUrl": "https://www.chunk-party.com",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -159,6 +161,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626",
       "ticketUrl": "https://www.eventbrite.com/e/coach-after-dark-market-days-tickets-1991246880021",
       "shortName": "COACH",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -212,6 +215,7 @@
       "address": null,
       "website": "https://northalsted.com/main-events/northalsted-market-days/",
       "instagram": "https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -256,6 +260,7 @@
       "gmaps": "https://maps.app.goo.gl/Gwxy5yMhZhZFEfsBA?g_st=ipc",
       "shortName": "Furball",
       "shorterName": "FUR",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -302,6 +307,7 @@
       "instagram": "https://www.instagram.com/coachafterdark",
       "gmaps": "https://www.google.com/maps/search/?api=1&query=41.998402%2C-87.6709808&query_place_id=ChIJ44RAWrzRD4gRDGoLchD_2SI",
       "ticketUrl": "https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1980995304282",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -352,6 +358,7 @@
       "instagram": "https://www.instagram.com/coachafterdark",
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626",
       "ticketUrl": "https://www.eventbrite.com/e/coach-after-dark-chicago-tickets-1987165553664",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -409,6 +416,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Cell%20Block%20Chicago%2C%203702%20N%20Halsted%20St%2C%20Chicago%2C%20IL%2060613%2C%20USA",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-chicago-presents-spring-thaw",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -466,6 +474,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Jackhammer%2C%206406%20North%20Clark%20Street%2C%20Chicago%2C%20IL%2060626",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-chicago-july-bearwatch-tickets-1987363318183",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -523,6 +532,7 @@
       "gmaps": "https://maps.google.com/?q=41.9493756,-87.64979",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-chicago-presents-sausage-party",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -579,6 +589,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Metro%2C%203730%20N%20CLARK%20ST",
       "ticketUrl": "https://www.etix.com/ticket/p/54403374/?partner_id=100&_gl=1*1bmryzt*_ga*MTI5NjI5MTA1OS4xNzgzNzA5NzI5*_ga_Z3MV4KFJMN*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGgxNzA5NTE2OTA5*_ga_DSG080VB8M*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGg3NjY5MDM0NTA.*_ga_68TT1Q537T*czE3ODM3MDk3MjkkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGg5NTk4NTE2Njg.*_ga_MCR6RT8ZB7*czE3ODM3MDk3MzAkbzEkZzEkdDE3ODM3MDk5NDMkajQ3JGwwJGgw&_ga=2.96391708.1430242853.1783709730-1296291059.1783709729",
       "shortName": "FUR-BALL",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -632,6 +643,7 @@
       "address": null,
       "website": "https://northalsted.com/main-events/northalsted-market-days/",
       "instagram": "https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -676,6 +688,7 @@
       "gmaps": "https://maps.google.com/?q=41.99842,-87.67112",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-chicago-labor-day-jockstrap-party-tickets-1412963053529?aff=oddtdtcreator",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -734,6 +747,7 @@
       "address": null,
       "website": "https://northalsted.com/main-events/northalsted-market-days/",
       "instagram": "https://www.instagram.com/marketdayschicago?igsh=eXZkc3kxMjV0Y3U1",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -774,6 +788,7 @@
       "website": "https://linktr.ee/bearhappyhour",
       "instagram": "https://www.instagram.com/bearhappyhourchi",
       "shorterName": "BHH",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -819,6 +834,7 @@
       "instagram": "https://www.instagram.com/bearracuda",
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Cell%20Block%2C%203702%20N.%20Halsted%2C%20Chicago%2C%20IL%2C%2060613",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/dallas.json
+++ b/data/calendars/dallas.json
@@ -34,6 +34,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=STATION%204%2C%20391%20Cedar%20Springs%20Rd",
       "ticketUrl": "https://events.ticketleap.com/tickets/furballnyc/furball-dallas-freedom-tea-2026",
       "shortName": "FUR-BALL",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/dc.json
+++ b/data/calendars/dc.json
@@ -37,6 +37,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=38.9162081%2C-77.0213011&query_place_id=ChIJvfMkyPq3t4kRztqpgf-qNEc",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-svalentine-weekend-tickets-1981048053055",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/denver.json
+++ b/data/calendars/denver.json
@@ -33,6 +33,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Ophelia's%2C%201215%2020th%20Street%2C%20Denver%2C%20CO",
       "ticketUrl": "https://www.ticketmaster.com/bearracuda-denver-colorado-03-14-2026/event/1E0064260CAC881B",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -91,6 +92,7 @@
       "gmaps": "https://maps.google.com/?q=1902%20Blake%20St%2C%20Denver%2C%20CO%2080202",
       "ticketUrl": "https://www.ticketmaster.com/event/1E0062E79CD214B2",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -154,6 +156,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=39.7402498%2C-104.9790098&query_place_id=ChIJw4sroyx5bIcR5jU8EDoneGU",
       "ticketUrl": "https://www.eventbrite.com/e/twisted-bear-denver-feat-djproducer-matt-consola-tickets-1985473771498",
       "shortName": "TWIST-ED BEAR",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -207,6 +210,7 @@
       "gmaps": "https://maps.google.com/?q=1215%2020th%20Street%2C%20Denver%2C%20CO%2080202",
       "ticketUrl": "https://www.ticketmaster.com/event/1E00632CA5D027C6",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -265,6 +269,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=SUMMIT%2C%201302%20Blake%20St%2C%20Denver%2C%20CO",
       "ticketUrl": "https://www.ticketmaster.com/event/1E00642CF2CCADDC",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -326,6 +331,7 @@
       "instagram": "https://www.instagram.com/megawoof_america",
       "gmaps": "https://www.google.com/maps/search/?api=1&query=39.7239346%2C-104.9987819&query_place_id=ChIJly0oIDt_bIcRWYKaXvlNsQY",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/la.json
+++ b/data/calendars/la.json
@@ -54,6 +54,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Globe%2C%20740%20South%20Broadway%2C%20Los%20Angeles%2C%20CA%2090014",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-pride-free-june-6th-free-tkts-the-globe-tickets-1987743346859",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -107,6 +108,7 @@
       "website": null,
       "instagram": "https://www.instagram.com/clubchubparty?igsh=MWxjZHprZnl6NWc0NQ==",
       "gmaps": "https://maps.app.goo.gl/pfwrr6oMcbTvdFtx7?g_st=ipc",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -153,6 +155,7 @@
       "instagram": "https://www.instagram.com/megawoof_america",
       "gmaps": "https://www.google.com/maps/search/?api=1&query=33.9139036%2C-118.2805709&query_place_id=ChIJg2cOgOq2woAR8bONfuIJg_k",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -198,6 +201,7 @@
       "website": "https://linktr.ee/bearhappyhour",
       "instagram": "https://www.instagram.com/bearhappyhourla",
       "shorterName": "BHH",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -245,6 +249,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Falcon%20North%2C%202020%20East%20Artesia%20Boulevard%2C%20Long%20Beach%2C%20CA%2090805",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-long-beach-pride-tickets-1986926425425",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -297,6 +302,7 @@
       "instagram": "https://www.instagram.com/megawoof_america",
       "ticketUrl": "https://www.eventbrite.com/e/duro-is-back-new-outdoor-location-night-foam-party-and-special-guest-tickets-1991255145744",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -349,6 +355,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=33.87445400000001%2C-118.1680614&query_place_id=ChIJ91NzVy4z3YARBNuS8BZHBGg",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-bear-watchers-long-beach-tickets-1520432868639",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -400,6 +407,7 @@
       "instagram": "https://www.instagram.com/megawoof_america",
       "ticketUrl": "https://www.eventbrite.com/e/duro-megawoof-america-10-year-anniversary-edition-tickets-1688815666119",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/nola.json
+++ b/data/calendars/nola.json
@@ -36,6 +36,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Joy%20Theater%2C%201200%20Canal%20Street%2C%20New%20Orleans%2C%20LA",
       "ticketUrl": "https://www.ticketmaster.com/event/1B006454A32CE162",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -89,6 +90,7 @@
       "gmaps": "https://maps.google.com/?q=1200%20Canal%20St%2C%20New%20Orleans%2C%20LA%2070112",
       "ticketUrl": "https://www.ticketmaster.com/bearracuda-new-orleans-louisiana-08-29-2025/event/1B006275D3607BD4",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/nyc.json
+++ b/data/calendars/nyc.json
@@ -54,6 +54,7 @@
       "gmaps": "https://maps.app.goo.gl/3WsBUpQjekPZUW4u7",
       "shortName": "Rock-strap",
       "shorterName": "RBR",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -103,6 +104,7 @@
       "ticketUrl": "https://redeyetickets.com/events/goldiloxx-mdw",
       "shortName": "GOLDI-LOXX",
       "shorterName": "GLX",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -154,6 +156,7 @@
       "gmaps": "https://maps.app.goo.gl/XvrwkXqQApYfaj6h9",
       "shortName": "Animal",
       "shorterName": "BAA",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -206,6 +209,7 @@
       "facebook": "https://www.facebook.com/fuzzy.nyc",
       "gmaps": "https://www.google.com/maps/place/?q=place_id:ChIJZ1fMFZ5ZwokRkYrV85CZorY",
       "shortName": "FUZZY",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -256,6 +260,7 @@
       "website": "https://linktr.ee/bearhappyhour",
       "instagram": "https://www.instagram.com/bearhappyhournyc",
       "shorterName": "BHH",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -303,6 +308,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=HOLO%2C%2010-90%20Wyckoff%20Avenue%2C%20Queens%2C%20NY%2011385",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-bearmilk-present-megamilk-tickets-1991421809239",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -382,6 +388,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-brooklyn-the-return",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -437,6 +444,7 @@
       "instagram": "https://instagram.com/furballnyc/",
       "gmaps": "https://www.google.com/maps/search/?api=1&query=ROCKBAR%2C%20125%20CHRISTOPHER%20ST%20NYC",
       "shortName": "FUR-BALL",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -489,6 +497,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=C'mon%20Everybody%2C%20325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-brooklyn-7-4",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -546,6 +555,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=C'mon%20Everybody%2C%20325%20Franklin%20Ave%2C%20Brooklyn%2C%20NY%2011238%2C%20USA",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-brooklyn-5-9",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -597,6 +607,7 @@
       "instagram": "https://www.instagram.com/urbanbearnyc",
       "gmaps": "https://maps.app.goo.gl/3WsBUpQjekPZUW4u7",
       "shorterName": "BNO",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -669,6 +680,7 @@
       "gmaps": "https://maps.app.goo.gl/8N8zpGGAYwXJjgsGA",
       "shortName": "Eagle",
       "shorterName": "EGL",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/palm-springs.json
+++ b/data/calendars/palm-springs.json
@@ -37,6 +37,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=33.8189101%2C-116.5470896&query_place_id=ChIJs-Xb_9Qa24ARfHntwodp5aE",
       "ticketUrl": "https://www.eventbrite.com/e/shiny-disco-balls-ibc-weekend-mlk-special-early-bird-15-tickets-1976070697651",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/philly.json
+++ b/data/calendars/philly.json
@@ -36,6 +36,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=254%20South%2012th%20Street%2C%20Philadelphia%2C%20PA%2019107",
       "ticketUrl": "https://www.eventbrite.com/e/cubhouse-philly-valentines-dance-party-tickets-1936787556719",
       "shortName": "CUB-HOUSE",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -92,6 +93,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=254%20South%2012th%20Street%2C%20Philadelphia%2C%20PA%2019107",
       "ticketUrl": "https://www.eventbrite.com/e/cubhouse-philly-pride-2026-kickoff-dance-party-tickets-1987102314514",
       "shortName": "CUB-HOUSE",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -144,6 +146,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=39.9470542%2C-75.161054&query_place_id=101718083",
       "ticketUrl": "https://www.eventbrite.com/e/cubhouse-philly-halloween-dance-party-tickets-1633106779339",
       "shortName": "CUB-HOUSE",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/phoenix.json
+++ b/data/calendars/phoenix.json
@@ -36,6 +36,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Kobalt%2C%203110%20N%20Central%20Ave",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-phoenix-relaunch-party/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -93,6 +94,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=33.4833086%2C-112.0754149&query_place_id=ChIJkRBEr18SK4cR8jynbFt5fPM",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-10-year-anniversary-phoenix-kick-off-tickets-1675720327609",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -150,6 +152,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Kobalt%2C%203110%20North%20Central%20Avenue%2C%20%23175%2C%20Phoenix%2C%20AZ%2085012",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-phoenix-summer-woofers-tickets-1992064021112",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/portland.json
+++ b/data/calendars/portland.json
@@ -37,6 +37,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=722%20E%20Burnside%20St%2C%20Portland%2C%20OR%2097214%2C%20USA",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-portland-the-return-saturday-march-14th",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -95,6 +96,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-portland-16-year-anniversary-tickets-1546221061819",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -158,6 +160,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-portland-saturday-november-15th-tickets-1557485975479",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -219,6 +222,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20E%20Burnside%20St%2C%20Portland%2C%20OR%2097214%2C%20USA",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-portland-summer-blow-out",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -276,6 +280,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20E%20Burnside%20St%2C%20Portland%2C%20OR%2097214%2C%20USA",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-portland-5-23",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -331,6 +336,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Sanctuary%20Club%2C%2033%20Northwest%209th%20Avenue%2C%20Portland%2C%20OR%2C%2097209",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-treasure-trail-portland-pride/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -388,6 +394,7 @@
       "gmaps": "https://maps.google.com/?q=45.5235017,-122.6802365",
       "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-portland-saturday-jan-24th-tickets-1976421422679",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -450,6 +457,7 @@
       "gmaps": "https://maps.google.com/?q=45.52281000000001,-122.6581342",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-portland-friday-november-7th",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -507,6 +515,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Sanctuary%20Club%2C%2033%20Northwest%209th%20Avenue",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-treasure-trail-portland-back/tickets",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -565,6 +574,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=45.5227415%2C-122.6580938&query_place_id=101715829",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-portland-the-great-blumpkin-tickets-1681430587149",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -628,6 +638,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=45.5235017%2C-122.6802365&query_place_id=101715829",
       "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-portland-tickets-1559975281059",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -689,6 +700,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20East%20Burnside%20Street%2C%20Portland%2C%20OR%2C%2097214",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-portland-pridefriday/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -744,6 +756,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=NOVA%20PDX%2C%20722%20East%20Burnside%20Street%2C%20Portland%2C%20OR%2C%2097214",
       "ticketUrl": "https://www.sickening.events/e/nini/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -801,6 +814,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20East%20Burnside%20Street",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-portland-pridesaturday/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -858,6 +872,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Bossanova%20Ballroom%2C%20722%20E%20Burnside%2C%20Portland%2C%20OR%2097213",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-portland-crotch-carnival-tickets-1979122152635",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -916,6 +931,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=NOVA%20PDX%2C%20722%20E%20Burnside%2C%20Portland%2C%20OR",
       "ticketUrl": "https://sickening.events/e/hot-take",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -974,6 +990,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Nova%20PDX%2C%20722%20East%20Burnside%20Street",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-portland-gearnight/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/ptown.json
+++ b/data/calendars/ptown.json
@@ -37,6 +37,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=REDROOM%2C%20258%20COMMERCIAL%20ST%2C%20PROVINCETOWN%2C%20MA",
       "ticketUrl": "https://events.ticketleap.com/tickets/furballnyc/UnderbearNYC-bear-week-2026",
       "shortName": "FUR-BALL",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -94,6 +95,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Boatslip%2C%20161%20Commercial%20St",
       "ticketUrl": "https://events.ticketleap.com/tickets/furballnyc/furball-official-bear-week-underwear-opening-party-2026",
       "shortName": "FUR-BALL",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/san-diego.json
+++ b/data/calendars/san-diego.json
@@ -37,6 +37,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=32.7468303%2C-117.1607394&query_place_id=ChIJwdJrt9pU2YARYuac9G61qQE",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-10-year-san-diego-debut-international-hallowoof-tickets-1692702351299",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -94,6 +95,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Brass%20Rail%2C%203796%20Fifth%20Avenue%2C%20San%20Diego%2C%20CA%2092103",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-san-diego-tickets-1986666861061",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -151,6 +153,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=32.7468303%2C-117.1607394&query_place_id=ChIJwdJrt9pU2YARYuac9G61qQE",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-san-diego-feb-6th-tickets-1979742608435",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/data/calendars/seattle.json
+++ b/data/calendars/seattle.json
@@ -54,6 +54,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
       "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-seattletrail-head-tickets-1980435540012",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -113,6 +114,7 @@
       "instagram": "https://www.instagram.com/southseattlebearsocial/",
       "gmaps": "https://maps.app.goo.gl/SDUbV4qsRpivNiX39",
       "shortName": "South Seattle Social",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -156,6 +158,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
       "ticketUrl": "https://sickening.events/e/bearracuda-treasure-trail-seattle-4/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -214,6 +217,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-seattle-serious-wood-tickets-1565073299369?aff=oddtdtcreator",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -273,6 +277,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-seattle-glow/tickets",
       "shortName": "South Seattle Social",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -327,6 +332,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
       "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-seattle-tickets-1497840042889",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -389,6 +395,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E%20Pine%2C%20Seattle%2C%20WA%2098122",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-seattle-winter-beef-ball-2026-tickets-1977102214947",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -450,6 +457,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Massive%2C%20619%20East%20Pine%20Street%2C%20Seattle%2C%20WA%2C%2098122",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-treasure-trail-summer/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -508,6 +516,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=47.6150572%2C-122.3236574&query_place_id=101730401",
       "ticketUrl": "https://www.eventbrite.com/e/treasure-trail-seattle-wish-boned-tickets-1754983576119",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -567,6 +576,7 @@
       "instagram": "https://www.instagram.com/dieselseattle",
       "facebook": "https://www.facebook.com/DieselSeattle",
       "gmaps": "https://maps.app.goo.gl/yDDhdkV7M7p2mYEP7",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -620,6 +630,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=MASSIVE%2C%20619%20E.%20Pine%20St%2C%20Seattle%2C%20WA",
       "ticketUrl": "https://sickening.events/e/bearracuda-seattle-glow",
       "shortName": "South Seattle Social",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",

--- a/data/calendars/sf.json
+++ b/data/calendars/sf.json
@@ -54,6 +54,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=37.7761825%2C-122.4083567&query_place_id=ChIJBWia_yh-j4ARczXTRg2RGCs",
       "ticketUrl": "https://www.eventbrite.com/e/beefwitch-tickets-1728182092159",
       "shortName": "Coach After Dark",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -106,6 +107,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Public%20Works%2C%20161%20Erie%20Street%2C%20San%20Francisco%2C%20CA%2C%2094103",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-san-francisco-hmd/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -163,6 +165,7 @@
       "gmaps": "https://maps.google.com/?q=37.77526599999999,-122.4100374",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-presents-folsom-25",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -216,6 +219,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Public%20Works%2C%20161%20Erie%20Street",
       "ticketUrl": "https://www.sickening.events/e/bearracuda-sf-pride-2026-beefcakes/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -269,6 +273,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street",
       "ticketUrl": "https://www.sickening.events/e/treasuresf/tickets",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -325,6 +330,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=F8%20Nightclub%20%26%20Bar%2C%201192%20Folsom%20St%2C%20San%20Francisco%2C%20CA%2094103%2C%20USA",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-dore-alley-saturday-july-25th",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -375,6 +381,7 @@
       "website": "https://linktr.ee/bearhappyhour",
       "instagram": "https://www.instagram.com/bearhappyhoursf",
       "shorterName": "BHH",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -422,6 +429,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-san-francisco-tickets-1988522943654",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -479,6 +487,7 @@
       "gmaps": "https://maps.google.com/?q=37.77526599999999,-122.4100374",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-san-francisco-saturday-january-17th",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -536,6 +545,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=The%20Stud%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103",
       "ticketUrl": "https://www.eventbrite.com/e/beefwitch-tickets-1988340517011",
       "shortName": "BEEFWITCH",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",
@@ -588,6 +598,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=THE%20STUD%2C%201123%20Folsom%20Street%2C%20San%20Francisco%2C%20CA%2094103",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-sf-20-year-anniversary-tickets-1976399528192",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -651,6 +662,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=37.7689137%2C-122.4192514&query_place_id=85922583",
       "ticketUrl": "https://www.eventbrite.com/e/bearracuda-sf-flsm-friday-tickets-1370410668199",
       "shortName": "Bear-rac-uda",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -713,6 +725,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=F8%20Nightclub%20%26%20Bar%2C%201192%20Folsom%20St%2C%20San%20Francisco%2C%20CA%2094103%2C%20USA",
       "ticketUrl": "https://www.chunk-party.com/event-details/chunk-sf-presents-father-figure",
       "shortName": "CHUNK",
+      "bearReview": null,
       "links": [
         {
           "type": "instagram",

--- a/data/calendars/vegas.json
+++ b/data/calendars/vegas.json
@@ -37,6 +37,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=36.1214368%2C-115.144945&query_place_id=ChIJxfTt6N_FyIARvHYdOaAV7t8",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-america-las-vegas-labor-day-weekend-bears-at-work-tickets-1531257726079",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -94,6 +95,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=36.1214368%2C-115.144945&query_place_id=ChIJxfTt6N_FyIARvHYdOaAV7t8",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-10-year-us-anniversary-international-hallowoof-las-vegas-tickets-1636556246789",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",
@@ -151,6 +153,7 @@
       "gmaps": "https://www.google.com/maps/search/?api=1&query=Dust%20Las%20Vegas%2C%20855%20East%20Twain%20Avenue%2C%20%23UNIT%20114%2C%20Las%20Vegas%2C%20NV%2089169",
       "ticketUrl": "https://www.eventbrite.com/e/megawoof-las-vegas-memorial-day-weekend--tickets-1987462465736",
       "shortName": "MEGA-WOOF",
+      "bearReview": null,
       "links": [
         {
           "type": "website",

--- a/img/favicons/favicon-bigfunco.myshopify.com-256px.ico.meta
+++ b/img/favicons/favicon-bigfunco.myshopify.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-bigfunco.myshopify.com-256px.ico",
   "size": "256",
-  "failureCount": 11
+  "failureCount": 12
 }

--- a/img/favicons/favicon-bigfunco.myshopify.com-64px.ico.meta
+++ b/img/favicons/favicon-bigfunco.myshopify.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-bigfunco.myshopify.com-64px.ico",
   "size": "64",
-  "failureCount": 11
+  "failureCount": 12
 }

--- a/img/favicons/favicon-noxsatvrn.carrd.co-256px.ico.meta
+++ b/img/favicons/favicon-noxsatvrn.carrd.co-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-noxsatvrn.carrd.co-256px.ico",
   "size": "256",
-  "failureCount": 11
+  "failureCount": 12
 }

--- a/img/favicons/favicon-noxsatvrn.carrd.co-64px.ico.meta
+++ b/img/favicons/favicon-noxsatvrn.carrd.co-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-noxsatvrn.carrd.co-64px.ico",
   "size": "64",
-  "failureCount": 11
+  "failureCount": 12
 }

--- a/img/favicons/favicon-seattleeagle.com-256px.ico.meta
+++ b/img/favicons/favicon-seattleeagle.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-seattleeagle.com-256px.ico",
   "size": "256",
-  "failureCount": 11
+  "failureCount": 12
 }

--- a/img/favicons/favicon-seattleeagle.com-64px.ico.meta
+++ b/img/favicons/favicon-seattleeagle.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-seattleeagle.com-64px.ico",
   "size": "64",
-  "failureCount": 11
+  "failureCount": 12
 }

--- a/img/favicons/favicon-theoldbaby.com-256px.ico.meta
+++ b/img/favicons/favicon-theoldbaby.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-theoldbaby.com-256px.ico",
   "size": "256",
-  "failureCount": 11
+  "failureCount": 12
 }

--- a/img/favicons/favicon-theoldbaby.com-64px.ico.meta
+++ b/img/favicons/favicon-theoldbaby.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-theoldbaby.com-64px.ico",
   "size": "64",
-  "failureCount": 11
+  "failureCount": 12
 }

--- a/img/favicons/favicon-yeahbuzzy.com-256px.ico.meta
+++ b/img/favicons/favicon-yeahbuzzy.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-yeahbuzzy.com-256px.ico",
   "size": "256",
-  "failureCount": 11
+  "failureCount": 12
 }

--- a/img/favicons/favicon-yeahbuzzy.com-64px.ico.meta
+++ b/img/favicons/favicon-yeahbuzzy.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-yeahbuzzy.com-64px.ico",
   "size": "64",
-  "failureCount": 11
+  "failureCount": 12
 }

--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -103,8 +103,12 @@ class CalendarCore {
                     });
                     
                     const eventData = this.parseEventData(currentEvent);
-                    
-                    if (eventData) {
+
+                    if (eventData && this.isHiddenForBearReview(eventData.bearReview)) {
+                        logger.info('CALENDAR', `Hiding event flagged for bear review: ${eventData.name}`, {
+                            bearReview: eventData.bearReview
+                        });
+                    } else if (eventData) {
                         events.push(eventData);
                         logger.debug('CALENDAR', `✅ Successfully parsed event: ${eventData.name}`, {
                             eventType: eventData.eventType,
@@ -342,6 +346,14 @@ class CalendarCore {
     }
 
     // Parse individual event data
+    // Events the scraper's bear-check cascade flagged for review (bearReview
+    // starting "unlikely"/"unsure") stay off the website until a human edits
+    // the flag (e.g. to "confirmed") or removes it.
+    isHiddenForBearReview(bearReview) {
+        if (typeof bearReview !== 'string') return false;
+        return /^(unlikely|unsure)/i.test(bearReview.trim());
+    }
+
     parseEventData(calendarEvent) {
         try {
             const eventData = {
@@ -402,6 +414,7 @@ class CalendarCore {
                     eventData.ticketUrl = additionalData.ticketUrl;
                     eventData.shortName = additionalData.shortName;
                     eventData.shorterName = additionalData.shorterName;
+                    eventData.bearReview = additionalData.bearReview || null;
                     eventData.links = this.parseLinks(additionalData);
                     
                     if (additionalData.type || additionalData.eventType) {

--- a/js/event-schema.js
+++ b/js/event-schema.js
@@ -89,6 +89,7 @@ const EVENT_KEY_ALIASES = {
     img: 'image',
     photo: 'image',
     cover: 'cover',
+    bearreview: 'bearReview',
 
     shortname: 'shortName',
     short: 'shortName',

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2515,6 +2515,17 @@ class ScriptableAdapter {
       // Show event actions summary if available
       const allEvents = this.getAllEventsFromResults(results);
       if (allEvents && allEvents.length > 0) {
+        const bearReviewCount = allEvents.filter(
+          (event) =>
+            typeof event?.bearReview === "string" &&
+            /^(unlikely|unsure)/i.test(event.bearReview.trim()),
+        ).length;
+        if (bearReviewCount > 0) {
+          console.log(
+            `🐻 ${bearReviewCount} event(s) flagged for bear review`,
+          );
+        }
+
         const intentCounts = this.countMetricsActions(allEvents);
         const writeCounts = this.countMetricsCalendarActions(allEvents);
         const hasIntentCounts = Object.values(intentCounts).some(

--- a/scripts/event-schema.js
+++ b/scripts/event-schema.js
@@ -89,6 +89,7 @@ const EVENT_KEY_ALIASES = {
     img: 'image',
     photo: 'image',
     cover: 'cover',
+    bearreview: 'bearReview',
 
     shortname: 'shortName',
     short: 'shortName',

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -58,6 +58,7 @@ const scraperConfig = {
       // (scraped clobbers). This global block also serves events from non-AI
       // parsers; per-parser ai.arbitrateMerges overrides. Set false to disable.
       arbitrateMerges: true,
+      bearCheck: { mode: "report" }, // Bear-check cascade: keywords → AI verdict with promoter context. "report" logs decisions without changing behavior; "enforce" flags/rescues/drops; "off" = legacy alwaysBear/keyword behavior.
       // extraContext (override-only): free-form text appended VERBATIM to the
       // context of every AI extraction prompt. Organizer/brand context is
       // normally derived automatically from each page's own metadata (JSON-LD
@@ -218,7 +219,7 @@ const scraperConfig = {
       automationEnabled: true,
       parser: "auto", // chunk-party.com auto-detects the chunk parser (absent = pinned ai-web)
       urls: ["https://www.chunk-party.com"],
-      alwaysBear: true, // Chunk parties are always bear events
+      alwaysBear: true, // Trusted bear-scene promoter: prompt context + fallback for the bear-check cascade (still a full bypass while bearCheck mode is report/off)
       urlDiscoveryDepth: 1, // Depth 1 to find detail pages from main page // No limit on additional URLs discovered           // Override global dryRun if needed
       discoveryBlockedPatterns: [
         "chunk-party.com/chunkbearandcubsocial",

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -47,10 +47,19 @@ class SharedCore {
         }
 
         this.visitedUrls = new Set();
-        this.bearKeywords = [
-            'bear', 'bears', 'woof', 'grr', 'furry', 'hairy', 'daddy', 'cub', 
-            'otter', 'leather', 'muscle bear', 'bearracuda', 'furball', 'megawoof',
-            'leather bears', 'bear night', 'bear party', 'polar bear', 'grizzly'
+        // Two-tier bear keyword lists (see matchBearKeywords): substring terms
+        // are distinctive enough to hit smooshed brand names (CHUNKA GO,
+        // CUBHOUSE, BEEFWITCH, Bearracuda); common words that misfire as
+        // substrings ("fatal", "furniture", "update", "puppet") require word
+        // boundaries.
+        this.bearSubstringKeywords = [
+            'bear', 'woof', 'grr', 'furry', 'hairy', 'daddy', 'cub', 'otter',
+            'leather', 'bearracuda', 'furball', 'megawoof', 'grizzly', 'chunk',
+            'chub', 'beef', 'scruff', 'jock'
+        ];
+        this.bearWordBoundaryKeywords = [
+            'dad', 'dads', 'fat', 'fur', 'pup', 'pig', 'wolf', 'wolves',
+            'thick', 'burly', 'stocky', 'husky', 'beard', 'bearded', 'harness'
         ];
         
         // Store cities config for timezone assignment
@@ -986,7 +995,7 @@ class SharedCore {
 
         // Filter and process events
         const futureEvents = this.filterFutureEvents(allEvents, effectiveParserConfig.daysToLookAhead, effectiveParserConfig.allowPastEvents);
-        const bearEvents = this.filterBearEvents(futureEvents, effectiveParserConfig);
+        const bearEvents = await this.filterBearEvents(futureEvents, effectiveParserConfig, httpAdapter);
         const deduplicatedEvents = await this.deduplicateEvents(bearEvents, httpAdapter, mainConfig?.config || mainConfig || null);
         
         // Calculate deduplication stats
@@ -1714,25 +1723,112 @@ class SharedCore {
         });
     }
 
-    filterBearEvents(events, parserConfig) {
-        // If alwaysBear is true, return all events
-        if (parserConfig.alwaysBear) {
-            return events.map(event => ({...event, isBearEvent: true}));
+    // Bear-check cascade: keyword match → AI verdict with promoter context →
+    // alwaysBear as trusted-promoter fallback. Mode knob
+    // (parserConfig.ai.bearCheck.mode): 'report' (default) logs each event's
+    // would-be decision while returning exactly today's behavior; 'enforce'
+    // keeps/flags/rescues/drops on the cascade's decisions; 'off' is exact
+    // legacy behavior (alwaysBear bypass, keyword filter) with no new logs.
+    async filterBearEvents(events, parserConfig, httpAdapter = null) {
+        const legacyFilter = () => parserConfig.alwaysBear
+            ? events.map(event => ({...event, isBearEvent: true}))
+            : events.filter(event => this.isBearEvent(event, parserConfig));
+
+        const mode = this.getBearCheckMode(parserConfig);
+        if (mode === 'off') return legacyFilter();
+
+        const trusted = parserConfig.alwaysBear === true;
+        const tag = mode === 'report' ? ' [report]' : '';
+        const counts = { bear: 0, keyword: 0, ai: 0, flagged: 0, dropped: 0 };
+        const kept = [];
+        for (const event of events) {
+            const decision = await this.computeBearCheckDecision(event, parserConfig, httpAdapter);
+            const title = event.title || 'Unknown';
+            if (decision.result === 'bear') {
+                counts.bear++;
+                if (decision.provenance.startsWith('keyword:')) counts.keyword++;
+                if (decision.provenance.startsWith('ai:')) counts.ai++;
+                // In report mode an AI-bear verdict on an untrusted source is a
+                // rescue the legacy keyword filter still drops — say so, or the
+                // calibration logs claim the event was kept when it wasn't.
+                const rescueNote = tag && !trusted && decision.provenance.startsWith('ai:')
+                    ? ' (would-rescue — legacy keyword filter still drops it)'
+                    : '';
+                console.log(`🐻 BEAR CHECK${tag}: "${title}" → bear (${decision.provenance})${rescueNote}`);
+                kept.push({...event, isBearEvent: true});
+            } else if (decision.result === 'not_bear' && !trusted) {
+                counts.dropped++;
+                console.log(`🐻 BEAR CHECK${tag}: "${title}" → DROP (${decision.provenance})`);
+            } else {
+                // alwaysBear sources never lose events: not_bear/unsure is kept
+                // with a review flag; untrusted unsure is likewise kept+flagged.
+                counts.flagged++;
+                console.log(`🐻 BEAR CHECK${tag}: "${title}" → FLAG (${decision.provenance})`);
+                const label = decision.result === 'not_bear' ? 'unlikely' : 'unsure';
+                kept.push({...event, bearReview: `${label} — ${decision.provenance}`});
+            }
+        }
+        const flagLabel = mode === 'report' ? 'would-flag' : 'flagged';
+        const dropLabel = mode === 'report' ? 'would-drop' : 'dropped';
+        console.log(`🐻 BEAR CHECK${tag}: ${counts.bear} bear (${counts.keyword} keyword, ${counts.ai} ai), ${counts.flagged} ${flagLabel}, ${counts.dropped} ${dropLabel}`);
+
+        return mode === 'report' ? legacyFilter() : kept;
+    }
+
+    getBearCheckMode(parserConfig) {
+        const bearCheck = parserConfig && parserConfig.ai && parserConfig.ai.bearCheck && typeof parserConfig.ai.bearCheck === 'object'
+            ? parserConfig.ai.bearCheck
+            : null;
+        const mode = bearCheck ? String(bearCheck.mode || '').trim().toLowerCase() : '';
+        return mode === 'enforce' || mode === 'off' ? mode : 'report';
+    }
+
+    // One cascade decision per event: { result: 'bear'|'not_bear'|'unsure',
+    // provenance: 'keyword: ...' | 'allowlist: ...' | 'ai: ...' | 'config/fallback: ...' }.
+    async computeBearCheckDecision(event, parserConfig, httpAdapter) {
+        const searchText = `${event.title || ''} ${event.description || ''} ${event.bar || ''}`;
+
+        // Existing allowlist gate keeps its exact legacy semantics: for
+        // non-alwaysBear sources with requireKeywords, an allowlist miss
+        // rejects the event before any other tier.
+        if (!parserConfig.alwaysBear
+            && parserConfig.allowlist && parserConfig.allowlist.length > 0
+            && parserConfig.requireKeywords) {
+            const lowered = searchText.toLowerCase();
+            const hasAllowlistKeyword = parserConfig.allowlist.some(keyword =>
+                lowered.includes(String(keyword).toLowerCase())
+            );
+            if (!hasAllowlistKeyword) {
+                return { result: 'not_bear', provenance: 'allowlist: required keyword missing' };
+            }
         }
 
-        // Filter based on keywords and allowlist
-        return events.filter(event => this.isBearEvent(event, parserConfig));
+        const matched = this.matchBearKeywords(searchText);
+        if (matched.length > 0) {
+            return { result: 'bear', provenance: `keyword: ${matched.join(', ')}` };
+        }
+
+        const aiVerdict = await this.getAiBearVerdict(event, parserConfig, httpAdapter);
+        if (aiVerdict) {
+            return { result: aiVerdict.verdict, provenance: `ai: ${aiVerdict.reason || 'no reason given'}` };
+        }
+
+        if (parserConfig.alwaysBear === true) {
+            return { result: 'bear', provenance: 'config: alwaysBear (ai unavailable)' };
+        }
+        return { result: 'unsure', provenance: 'fallback: ai unavailable' };
     }
 
     isBearEvent(event, parserConfig) {
         if (parserConfig.alwaysBear) return true;
 
-        const searchText = `${event.title || ''} ${event.description || ''} ${event.bar || ''}`.toLowerCase();
-        
+        const searchText = `${event.title || ''} ${event.description || ''} ${event.bar || ''}`;
+
         // Check allowlist first (if provided)
         if (parserConfig.allowlist && parserConfig.allowlist.length > 0) {
-            const hasAllowlistKeyword = parserConfig.allowlist.some(keyword => 
-                searchText.includes(keyword.toLowerCase())
+            const lowered = searchText.toLowerCase();
+            const hasAllowlistKeyword = parserConfig.allowlist.some(keyword =>
+                lowered.includes(keyword.toLowerCase())
             );
             if (parserConfig.requireKeywords && !hasAllowlistKeyword) {
                 return false;
@@ -1740,7 +1836,103 @@ class SharedCore {
         }
 
         // Check bear keywords
-        return this.bearKeywords.some(keyword => searchText.includes(keyword));
+        return this.matchBearKeywords(searchText).length > 0;
+    }
+
+    // Returns the list of bear keywords the text hits (empty array = no match).
+    matchBearKeywords(text) {
+        const source = String(text || '').toLowerCase();
+        if (!source) return [];
+        const matched = [];
+        for (const keyword of this.bearSubstringKeywords) {
+            if (source.includes(keyword)) matched.push(keyword);
+        }
+        for (const keyword of this.bearWordBoundaryKeywords) {
+            const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            if (new RegExp(`\\b${escaped}\\b`, 'i').test(source)) matched.push(keyword);
+        }
+        return matched;
+    }
+
+    // Provenance context for the bear-check prompt: where the event was scraped
+    // from, plus the owner's trusted-promoter marking when alwaysBear is set —
+    // that promoter context is what lets the model keep promoter events with
+    // zero bear vocabulary (validated against real calendar data).
+    buildBearCheckProvenance(event, parserConfig) {
+        const sourceUrl = String(event.url || event.website || (parserConfig.urls && parserConfig.urls[0]) || '');
+        const hostMatch = sourceUrl.match(/^https?:\/\/([^/?#]+)/i);
+        const origin = hostMatch ? hostMatch[1] : (sourceUrl || 'unknown source');
+        let provenance = `Scraped from ${origin}, source entry "${parserConfig.name || 'unknown'}".`;
+        if (parserConfig.alwaysBear === true) {
+            provenance += ' The calendar owner has marked this promoter as a trusted bear-scene promoter.';
+        }
+        return provenance;
+    }
+
+    // AI verdict tier of the bear-check cascade. Returns
+    // { verdict: 'bear'|'not_bear'|'unsure', reason, provenance } or null when
+    // AI is unavailable or the response is unusable (caller falls back).
+    // Memoized per run by title+description+bar so duplicate records and
+    // repeat titles cost one request.
+    async getAiBearVerdict(event, parserConfig, httpAdapter) {
+        if (!httpAdapter || typeof httpAdapter.postJson !== 'function') return null;
+        const rawAi = parserConfig && parserConfig.ai && typeof parserConfig.ai === 'object' ? parserConfig.ai : {};
+        if (rawAi.enabled === false) return null;
+        const resolved = this.resolveAiConfig(rawAi);
+        if (!resolved.enabled || !resolved.endpoint) return null;
+
+        const title = String(event.title || '').trim();
+        const description = String(event.description || '').trim();
+        const bar = String(event.bar || '').trim();
+        const memoKey = `${title}|${description}|${bar}`;
+        if (!this._bearVerdictMemo) {
+            this._bearVerdictMemo = new Map();
+        }
+        if (this._bearVerdictMemo.has(memoKey)) {
+            return this._bearVerdictMemo.get(memoKey);
+        }
+
+        const provenance = this.buildBearCheckProvenance(event, parserConfig);
+        const prompt = [
+            'You are curating a calendar for the gay bear community. Decide whether the event below belongs on a BEAR calendar.',
+            '',
+            "Bear events include: bear/cub/chub/otter parties, bear happy hours, bear-run dance parties, leather/kink nights with bear crowds, and cruise/underwear/jockstrap parties thrown by bear promoters. Events thrown by a bear-scene promoter are almost always bear events even when the event text has no bear words — the promoter's crowd follows the promoter.",
+            '',
+            'NOT bear events: shows or parties aimed at a clearly different audience (e.g. a drag-headliner show, a lesbian night, a general-audience concert) even when a bear promoter produces them, and generic events with no connection to the bear scene.',
+            '',
+            'Event:',
+            `- Title: ${title}`,
+            `- Venue: ${bar || 'unknown'}`,
+            `- City: ${event.city || 'unknown'}`,
+            `- Description: ${description ? description.slice(0, 500) : '(none)'}`,
+            `- Provenance: ${provenance}`,
+            '',
+            'Respond with ONLY a JSON object, no other text:',
+            '{"verdict": "bear" | "not_bear" | "unsure", "reason": "<one short sentence>"}',
+            '',
+            'Rules: answer "bear" when the promoter is bear-scene and nothing signals a different target audience. When the calendar owner has marked the promoter as trusted, default to "bear" — but still answer "not_bear" when the event itself clearly targets a different audience (e.g. a drag-headliner show). Answer "not_bear" only when you are confident. Answer "unsure" only when you genuinely cannot tell.'
+        ].join('\n');
+
+        const verdictConfig = { ...resolved, temperature: 0, numPredict: Math.min(Number(resolved.numPredict) || 200, 200) };
+        const pending = (async () => {
+            const rawResponse = await this.callAiGenerate(verdictConfig, prompt, 'bear-check', httpAdapter);
+            if (!rawResponse) return null;
+            let parsed = null;
+            try {
+                parsed = JSON.parse(this.extractFirstJsonObject(rawResponse) || rawResponse);
+            } catch (_) {
+                return null;
+            }
+            const verdict = parsed && typeof parsed.verdict === 'string' ? parsed.verdict.trim().toLowerCase() : '';
+            if (verdict !== 'bear' && verdict !== 'not_bear' && verdict !== 'unsure') return null;
+            return {
+                verdict,
+                reason: typeof parsed.reason === 'string' ? parsed.reason.trim() : '',
+                provenance
+            };
+        })().catch(() => null);
+        this._bearVerdictMemo.set(memoKey, pending);
+        return pending;
     }
 
     async deduplicateEvents(events, httpAdapter, globalConfig = null) {
@@ -2493,6 +2685,18 @@ class SharedCore {
                     console.log(`📍 MERGE: "${mergeTitle}" location kept from calendar (scrape found none)`);
                     continue;
                 }
+            }
+
+            // bearReview is a human-owned review flag: the bear-check cascade
+            // writes it, the calendar owner edits it (e.g. to "confirmed") —
+            // the calendar's value ALWAYS wins over a fresh scrape's flag, and
+            // the field never enters clobber/arbitration tracking (a fresh flag
+            // differing from the human's edit would otherwise churn every run).
+            if (fieldName === 'bearReview') {
+                mergedObject[fieldName] = !this.isEmptyArbitrationValue(calendarValue)
+                    ? calendarValue
+                    : scraperValue;
+                continue;
             }
 
             // An empty scraped bar is an extraction gap, not data (e.g. the venue

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -2143,18 +2143,18 @@ test('filterFutureEvents drops events with missing or invalid startDate', () => 
 // filterBearEvents
 // ---------------------------------------------------------------------------
 
-test('filterBearEvents: alwaysBear keeps everything and stamps isBearEvent', () => {
+test('filterBearEvents: alwaysBear keeps everything and stamps isBearEvent', async () => {
   const core = createCore();
   const events = [
     { title: 'Techno Tuesday' },
     { title: 'Wine Tasting' }
   ];
-  const result = core.filterBearEvents(events, { alwaysBear: true });
+  const result = await core.filterBearEvents(events, { alwaysBear: true });
   assert.equal(result.length, 2);
   assert.ok(result.every(e => e.isBearEvent === true));
 });
 
-test('filterBearEvents matches bear keywords in title, description, or bar', () => {
+test('filterBearEvents matches bear keywords in title, description, or bar', async () => {
   const core = createCore();
   const events = [
     { title: 'Bear Night' },
@@ -2162,19 +2162,201 @@ test('filterBearEvents matches bear keywords in title, description, or bar', () 
     { title: 'Happy Hour', bar: 'Woof Lounge' },
     { title: 'Techno Tuesday', description: 'four to the floor' }
   ];
-  const result = core.filterBearEvents(events, {});
+  const result = await core.filterBearEvents(events, {});
   assert.deepEqual(result.map(e => e.title), ['Bear Night', 'Saturday Social', 'Happy Hour']);
 });
 
-test('filterBearEvents: requireKeywords + allowlist gates keyword matching', () => {
+test('filterBearEvents: requireKeywords + allowlist gates keyword matching', async () => {
   const core = createCore();
   const events = [
     { title: 'Bear Night at the Eagle' },
     { title: 'FURBALL Bear Bash' }
   ];
-  // Both match bear keywords, but only the allowlisted one passes the gate
-  const result = core.filterBearEvents(events, { allowlist: ['furball'], requireKeywords: true });
-  assert.deepEqual(result.map(e => e.title), ['FURBALL Bear Bash']);
+  // Both match bear keywords, but only the allowlisted one passes the gate —
+  // in every mode, and without ever consulting the AI tier
+  for (const mode of ['report', 'enforce', 'off']) {
+    const adapter = buildBearVerdictAdapter({ verdict: 'bear', reason: 'should not be asked' });
+    const result = await core.filterBearEvents(
+      events,
+      { allowlist: ['furball'], requireKeywords: true, ai: { provider: 'ollama', endpoint: 'http://ai.example/api/generate', model: 'm', bearCheck: { mode } } },
+      adapter
+    );
+    assert.deepEqual(result.map(e => e.title), ['FURBALL Bear Bash'], `mode ${mode}`);
+    assert.equal(adapter.calls.length, 0, `mode ${mode} must not call the AI`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Bear-check cascade: matchBearKeywords → AI verdict → alwaysBear fallback
+// ---------------------------------------------------------------------------
+
+function buildBearVerdictAdapter(verdict, options = {}) {
+  const calls = [];
+  return {
+    calls,
+    postJson: async (endpoint, payload) => {
+      calls.push(payload);
+      if (options.fail) throw new Error('AI endpoint down');
+      const body = options.raw !== undefined ? options.raw : JSON.stringify(verdict);
+      return { ok: true, status: 200, text: JSON.stringify({ response: body }) };
+    }
+  };
+}
+
+function bearCheckConfig(mode, overrides = {}) {
+  return {
+    name: 'Test Promoter',
+    urls: ['https://promoter.example/events'],
+    ai: { provider: 'ollama', endpoint: 'http://ai.example/api/generate', model: 'test-model', bearCheck: { mode } },
+    ...overrides
+  };
+}
+
+test('matchBearKeywords: substring tier hits smooshed brand names', () => {
+  const core = createCore();
+  assert.ok(core.matchBearKeywords('CHUNKA GO').includes('chunk'));
+  assert.ok(core.matchBearKeywords('CUBHOUSE presents').includes('cub'));
+  assert.ok(core.matchBearKeywords('BEEFWITCH').includes('beef'));
+  assert.ok(core.matchBearKeywords('Bearracuda Portland').includes('bearracuda'));
+});
+
+test('matchBearKeywords: boundary tier hits whole words, never substrings', () => {
+  const core = createCore();
+  const hits = core.matchBearKeywords('Fat dad happy hour');
+  assert.ok(hits.includes('fat'));
+  assert.ok(hits.includes('dad'));
+  // "fatal" (fat), "furniture" (fur), "update" (dad), "puppet" (pup) must not fire
+  assert.deepEqual(core.matchBearKeywords('fatal furniture update puppet'), []);
+});
+
+test('bear check report mode returns exactly what legacy returns', async () => {
+  const events = [
+    { title: 'Bear Night' },
+    { title: 'HOT TAKE' },
+    { title: 'Treasure Trail Seattle' }
+  ];
+  const notBearAdapter = () => buildBearVerdictAdapter({ verdict: 'not_bear', reason: 'drag show' });
+
+  for (const alwaysBear of [true, false]) {
+    const legacy = await createCore().filterBearEvents(events, bearCheckConfig('off', { alwaysBear }));
+    const withAdapter = await createCore().filterBearEvents(events, bearCheckConfig('report', { alwaysBear }), notBearAdapter());
+    const withoutAdapter = await createCore().filterBearEvents(events, bearCheckConfig('report', { alwaysBear }), null);
+    assert.deepEqual(withAdapter, legacy, `alwaysBear:${alwaysBear} with adapter`);
+    assert.deepEqual(withoutAdapter, legacy, `alwaysBear:${alwaysBear} without adapter`);
+  }
+});
+
+test('bear check enforce: trusted promoter keeps AI-not_bear events with an unlikely flag', async () => {
+  const core = createCore();
+  const adapter = buildBearVerdictAdapter({ verdict: 'not_bear', reason: 'drag-headliner show' });
+  const result = await core.filterBearEvents(
+    [{ title: 'HOT TAKE' }],
+    bearCheckConfig('enforce', { alwaysBear: true }),
+    adapter
+  );
+  assert.equal(result.length, 1, 'alwaysBear sources never lose events');
+  assert.equal(result[0].bearReview, 'unlikely — ai: drag-headliner show');
+  // The trusted-promoter sentence is what makes prompt accuracy work
+  assert.match(adapter.calls[0].prompt, /trusted bear-scene promoter/);
+  assert.match(adapter.calls[0].prompt, /source entry "Test Promoter"/);
+});
+
+test('bear check enforce: untrusted sources rescue on bear, flag on unsure, drop on not_bear', async () => {
+  const cases = [
+    { verdict: { verdict: 'bear', reason: 'bear promoter event' }, kept: true, bearReview: undefined, isBearEvent: true },
+    { verdict: { verdict: 'unsure', reason: 'cannot tell' }, kept: true, bearReview: 'unsure — ai: cannot tell', isBearEvent: undefined },
+    { verdict: { verdict: 'not_bear', reason: 'lesbian night' }, kept: false }
+  ];
+  for (const testCase of cases) {
+    const core = createCore();
+    const adapter = buildBearVerdictAdapter(testCase.verdict);
+    const result = await core.filterBearEvents(
+      [{ title: 'Treasure Trail Seattle' }],
+      bearCheckConfig('enforce'),
+      adapter
+    );
+    if (!testCase.kept) {
+      assert.equal(result.length, 0, `${testCase.verdict.verdict} must drop`);
+      continue;
+    }
+    assert.equal(result.length, 1, `${testCase.verdict.verdict} must keep`);
+    assert.equal(result[0].bearReview, testCase.bearReview);
+    assert.equal(result[0].isBearEvent, testCase.isBearEvent);
+  }
+});
+
+test('bear check enforce: AI failure falls back to alwaysBear or an unsure flag', async () => {
+  // Trusted source + dead AI → kept as bear via config provenance, no flag
+  const trustedCore = createCore();
+  const trusted = await trustedCore.filterBearEvents(
+    [{ title: 'DENVER @ Ophelia\'s' }],
+    bearCheckConfig('enforce', { alwaysBear: true }),
+    buildBearVerdictAdapter(null, { fail: true })
+  );
+  assert.equal(trusted.length, 1);
+  assert.equal(trusted[0].isBearEvent, true);
+  assert.equal(trusted[0].bearReview, undefined);
+
+  // Untrusted source + unparseable AI response → kept with an unsure fallback flag
+  const untrustedCore = createCore();
+  const untrusted = await untrustedCore.filterBearEvents(
+    [{ title: 'DENVER @ Ophelia\'s' }],
+    bearCheckConfig('enforce'),
+    buildBearVerdictAdapter(null, { raw: 'no json here' })
+  );
+  assert.equal(untrusted.length, 1);
+  assert.equal(untrusted[0].bearReview, 'unsure — fallback: ai unavailable');
+});
+
+test('bear check: keyword hit short-circuits without any AI call', async () => {
+  const core = createCore();
+  const adapter = buildBearVerdictAdapter({ verdict: 'not_bear', reason: 'should never be asked' });
+  const result = await core.filterBearEvents(
+    [{ title: 'Bear Night' }, { title: 'CHUNKA GO' }],
+    bearCheckConfig('enforce'),
+    adapter
+  );
+  assert.equal(result.length, 2);
+  assert.equal(adapter.calls.length, 0);
+});
+
+test('bear check: identical events share one memoized AI call per run', async () => {
+  const core = createCore();
+  const adapter = buildBearVerdictAdapter({ verdict: 'bear', reason: 'bear promoter' });
+  const event = { title: 'Treasure Trail Seattle', description: 'promoter party', bar: 'Neighbours' };
+  const result = await core.filterBearEvents(
+    [{ ...event }, { ...event }],
+    bearCheckConfig('enforce'),
+    adapter
+  );
+  assert.equal(result.length, 2);
+  assert.equal(adapter.calls.length, 1, 'second identical event must reuse the memoized verdict');
+});
+
+test('bearReview round-trips notes and an existing calendar value survives merges', async () => {
+  const core = createCore();
+
+  // Notes codec round-trip (value contains a colon — must escape/unescape)
+  const notes = core.formatEventNotes({ bar: 'Eagle', bearReview: 'unlikely — ai: drag show' });
+  assert.equal(core.parseNotesIntoFields(notes).bearReview, 'unlikely — ai: drag show');
+
+  // Existing calendar bearReview (human-edited "confirmed") beats an incoming flag
+  const scraped = buildScrapedEvent({ bearReview: 'unlikely — ai: drag show' });
+  const existing = buildCalendarEvent({}, [
+    'bar: STATION 4',
+    'bearReview: confirmed'
+  ].join('\n'));
+  const finalEvent = await core.createFinalEventObject(existing, scraped, {});
+  assert.equal(finalEvent.bearReview, 'confirmed');
+  assert.equal(core.parseNotesIntoFields(finalEvent.notes).bearReview, 'confirmed');
+
+  // With no calendar value, the incoming flag lands in the merged notes
+  const freshFlag = await core.createFinalEventObject(
+    buildCalendarEvent(),
+    buildScrapedEvent({ bearReview: 'unsure — fallback: ai unavailable' }),
+    {}
+  );
+  assert.equal(core.parseNotesIntoFields(freshFlag.notes).bearReview, 'unsure — fallback: ai unavailable');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Replaces the all-or-nothing `alwaysBear` bypass with a provenance-carrying cascade, shipped in **report-only mode** (zero behavior change; logs what it would decide). Fixes both verified failure modes: `alwaysBear: true` admitted HOT TAKE (a drag show Bearracuda's promoter runs) onto the Portland calendar, while the keyword filter alone would wrongly drop ~30% of real saved events (Treasure Trail, Bearracuda city nights, D>U>R>O…).

### The cascade (per scraped event)
1. **Keywords, two-mode**: substring for distinctive terms that must hit smooshed brand names (chunk→CHUNKA GO, cub→CUBHOUSE, beef→BEEFWITCH) + word-boundary for common bear words that misfire as substrings (fat, dad, fur, pup — no more matching "fatal"/"furniture"). Free; covers ~74% of real events.
2. **AI verdict** with promoter context: prompt validated offline against all 109 saved calendar events on the production local model — 21/22 scraper events correct, HOT TAKE correctly flagged, all Treasure Trail kept. `alwaysBear: true` now means *trusted bear-scene promoter*: injected into the prompt (this is what fixed Megawoof/Coach verdicts) and used as the AI-down fallback — no longer a blind bypass. Verdicts memoized per run; temp 0, ≤200 tokens.
3. **Decisions**: `bear` → kept; trusted sources NEVER lose events — `not_bear`/`unsure` → kept with a `bearReview: unlikely/unsure — <provenance>` notes flag; untrusted sources: AI-bear rescues events keywords missed, confident `not_bear` drops (today's curation intent), `unsure` flags.

### Modes (`ai.bearCheck.mode`, inherited globally via config inheritance)
- **`report` (default)**: behavior byte-identical to today; every decision logged as `🐻 BEAR CHECK [report]: "<title>" → bear (keyword: woof)` / `→ FLAG (ai: drag-headliner show)`, would-rescues on untrusted sources labeled explicitly, plus a per-parser summary line. Calibrate on real runs, then flip.
- **`enforce`**: acts on the decisions; flagged events save to the calendar but are hidden from the website.
- **`off`**: exact legacy behavior.

### bearReview lifecycle (flag, don't drop)
- Round-trips notes via the schema alias (both event-schema copies).
- **The calendar's value always wins the merge** — editing a flag to `bearReview: confirmed` is permanent; a fresh scrape can never clobber it, and the field is excluded from clobber/arbitration tracking so it can't churn.
- `js/calendar-core.js` hides events whose flag starts with unlikely/unsure from chunky.dad (inert until enforce mode writes flags); Scriptable run summary shows `🐻 <n> event(s) flagged for bear review`.

## Tests

337 pass / 0 fail (+9 new): two-mode keyword matching incl. false-positive guards, report-mode ≡ legacy for trusted+untrusted parsers, enforce flag/rescue/drop semantics, AI-failure fallbacks, keyword short-circuit (zero AI calls), per-run memoization, bearReview notes round-trip + merge preservation, allowlist semantics unchanged. No `new URL`, no load-bearing log shapes touched, `node --check` clean incl. the js/ files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP