### PR TITLE
fix(scraper): empty side never displaces data — same-priority dedup wipe + calendar clear-on-empty-scrape

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2373,6 +2373,29 @@ class SharedCore {
                 }
             }
 
+            // Universal empty-loses rule: when exactly one side has a value it
+            // wins, regardless of source priority — an empty side is an
+            // extraction gap, never data. Without this, the same-priority
+            // branch below (every dedup pair now that ai-web is the universal
+            // parser) "preserved existing" even when existing was EMPTY,
+            // wiping one-sided values the { ...newEvent } base already carried
+            // (observed 2026-07-14: cover/ticketUrl from a detail page erased
+            // by the coverless homepage-segment record).
+            const existingSideEmpty = isEmpty(existingValue);
+            const newSideEmpty = isEmpty(newValue);
+            if (existingSideEmpty !== newSideEmpty) {
+                const chosenValue = existingSideEmpty ? newValue : existingValue;
+                mergedEvent[fieldName] = chosenValue;
+                mergeDecisions.push({
+                    field: fieldName,
+                    existingValue: existingValue,
+                    newValue: newValue,
+                    chosenValue: chosenValue,
+                    reason: 'kept the non-empty side — an empty side never displaces data'
+                });
+                return;
+            }
+
             const canArbitrate = this.isArbitrationEligibleField(fieldName)
                 && this.isGenuineFieldConflict(fieldName, existingValue, newValue);
 
@@ -2521,15 +2544,24 @@ class SharedCore {
         }
 
         if (mergeDecisions.length > 0) {
-            const changedFields = Array.from(new Set(mergeDecisions.map(decision => decision.field)));
-            const previewFields = changedFields.slice(0, 6);
-            const extraCount = changedFields.length - previewFields.length;
-            const previewText = extraCount > 0
-                ? `${previewFields.join(', ')}, +${extraCount} more`
-                : previewFields.join(', ');
-            const existingTitle = existingEvent.title || 'event';
-            const newTitle = newEvent.title || 'event';
-            console.log(`🔄 PARSER MERGE: "${existingTitle}" (${existingEvent.source}) + "${newTitle}" (${newEvent.source}) → ${changedFields.length} field${changedFields.length === 1 ? '' : 's'} updated (${previewText})`);
+            // "updated" means the merge changed the outgoing record: only count
+            // fields whose final value differs from what the { ...newEvent }
+            // base spread put there. Decisions that PRESERVED the base value
+            // stay in mergeDecisions (display/metrics) but not in this line —
+            // listing them here as "updated" is how the empty-side wipe hid.
+            const changedFields = Array.from(new Set(mergeDecisions
+                .filter(decision => !this.mergeValuesEqualForTracking(mergedEvent[decision.field], newEvent[decision.field]))
+                .map(decision => decision.field)));
+            if (changedFields.length > 0) {
+                const previewFields = changedFields.slice(0, 6);
+                const extraCount = changedFields.length - previewFields.length;
+                const previewText = extraCount > 0
+                    ? `${previewFields.join(', ')}, +${extraCount} more`
+                    : previewFields.join(', ');
+                const existingTitle = existingEvent.title || 'event';
+                const newTitle = newEvent.title || 'event';
+                console.log(`🔄 PARSER MERGE: "${existingTitle}" (${existingEvent.source}) + "${newTitle}" (${newEvent.source}) → ${changedFields.length} field${changedFields.length === 1 ? '' : 's'} updated (${previewText})`);
+            }
         }
         
         return mergedEvent;
@@ -2585,6 +2617,8 @@ class SharedCore {
 
         // Track clobbered fields for summary logging
         const clobberedFields = [];
+        // Fields where an empty scrape kept the calendar value (summary log)
+        const calendarKeptFields = [];
         // Genuine conflicts deferred to AI arbitration (strategy "ai")
         const pendingAiConflicts = [];
         // Arbitration outcomes (deterministic, ai, fallback) for display/metrics
@@ -2699,16 +2733,24 @@ class SharedCore {
                 continue;
             }
 
-            // An empty scraped bar is an extraction gap, not data (e.g. the venue
-            // was rejected by the organizer-brand guard and never recovered) — it
-            // must never clear the calendar's venue, even under clobber/ai
-            // clear-on-empty-scrape semantics. A non-empty scraped bar keeps
-            // today's behavior exactly (strategy/arbitration below).
-            if (fieldName === 'bar'
+            // An empty scraped value is an extraction gap, never a deletion
+            // instruction — deleting data is the calendar owner's job. Any
+            // field the scrape came back empty on keeps the calendar's value,
+            // ending clear-on-empty-scrape semantics for clobber/ai strategies
+            // (upsert/preserve already kept the calendar value). startDate/
+            // endDate are excluded: their own rules above/below own them
+            // (degenerate-end, routeDateConflictToAi); key is scraper-owned.
+            // location and bearReview never reach here empty-vs-non-empty —
+            // their special cases above already continue.
+            if (fieldName !== 'startDate' && fieldName !== 'endDate' && fieldName !== 'key'
                 && this.isEmptyArbitrationValue(scraperValue)
                 && !this.isEmptyArbitrationValue(calendarValue)) {
                 mergedObject[fieldName] = calendarValue;
-                console.log(`📍 MERGE: "${mergeTitle}" bar kept from calendar (scrape found no venue)`);
+                if (fieldName === 'bar') {
+                    console.log(`📍 MERGE: "${mergeTitle}" bar kept from calendar (scrape found no venue)`);
+                } else {
+                    calendarKeptFields.push(fieldName);
+                }
                 continue;
             }
 
@@ -2815,6 +2857,10 @@ class SharedCore {
                     });
                 }
             }
+        }
+
+        if (calendarKeptFields.length > 0) {
+            console.log(`📍 MERGE: "${mergeTitle}" kept calendar values for empty-scraped field(s): ${calendarKeptFields.join(', ')}`);
         }
 
         // Log summary of clobbered fields

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -2752,3 +2752,198 @@ test('deduplicateEvents merges same-URL records whose titles are prefixed varian
   const result = await core.deduplicateEvents([segment, detail], null);
   assert.equal(result.length, 1, 'variant titles at the same event URL must merge');
 });
+
+// ---------------------------------------------------------------------------
+// Empty side never displaces data (2026-07-14 run findings: with ai-web as the
+// universal parser every dedup pair hits the same-priority branch, which
+// "preserved existing" even when existing was EMPTY — wiping the detail page's
+// cover/ticketUrl; the emptied cover then reached the calendar merge, whose
+// clear-on-empty-scrape clobber semantics deleted the stored cover: notes line)
+// ---------------------------------------------------------------------------
+
+test('mergeParsedEvents: one-sided cover/ticketUrl survive a same-source dedup merge', async () => {
+  const core = createCore();
+  // Homepage segment record: flyers don't print prices — no cover, no ticketUrl
+  const existing = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    bar: 'SF Eagle',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  // Detail-page record: JSON-LD carries the price and ticket link
+  const incoming = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    bar: 'SF Eagle',
+    cover: '$46.13-$61.50',
+    ticketUrl: 'https://tickets.example/chunk-dore-alley',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'one-sided fields are not conflicts — no arbitration request');
+  assert.equal(merged.cover, '$46.13-$61.50', 'the empty existing side must not wipe the incoming cover');
+  assert.equal(merged.ticketUrl, 'https://tickets.example/chunk-dore-alley');
+});
+
+test('mergeParsedEvents: an existing cover survives an incoming record without one', async () => {
+  const core = createCore();
+  const existing = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    cover: '$25.63 - $61.50',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const incoming = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    cover: '',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0);
+  assert.equal(merged.cover, '$25.63 - $61.50', 'the empty incoming side must not wipe the existing cover');
+});
+
+test('mergeParsedEvents: both-non-empty differing covers at the same priority still arbitrate', async () => {
+  const core = createCore();
+  const existing = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    cover: '$25.63 - $61.50',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const incoming = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    cover: '$46.13-$61.50',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const adapter = buildArbitrationAdapter({
+    cover: { pick: 'incoming', value: '$46.13-$61.50', reason: 'detail page price' }
+  });
+
+  const merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1, 'a genuine same-priority cover conflict must reach arbitration');
+  assert.match(adapter.calls[0].prompt, /field: cover/);
+  assert.equal(merged.cover, '$46.13-$61.50', 'the arbitration winner is applied');
+});
+
+test('an empty scraped cover keeps the calendar cover and never appears clobbered', async () => {
+  const core = createCore();
+  const scraped = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    bar: 'SF Eagle',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const existing = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    notes: 'bar: SF Eagle\ncover: $25.63 - $61.50'
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'empty vs non-empty cover is not a conflict — no arbitration request');
+  assert.equal(finalEvent.cover, '$25.63 - $61.50', 'the calendar cover must survive an empty scrape');
+  assert.equal(core.parseNotesIntoFields(finalEvent.notes).cover, '$25.63 - $61.50',
+    'the cover: notes line round-trips');
+  assert.ok(!logLines.some(line => line.includes('clobbered') && line.includes('cover')),
+    `cover must never be logged as clobbered, got: ${JSON.stringify(logLines)}`);
+  assert.ok(logLines.some(line => line.includes('kept calendar values for empty-scraped field(s):') && line.includes('cover')),
+    `expected the kept-calendar summary to list cover, got: ${JSON.stringify(logLines)}`);
+});
+
+test('a genuinely differing scraped cover still reaches arbitration and the winner is applied', async () => {
+  const core = createCore();
+  const scraped = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    cover: '$46.13-$61.50',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const existing = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    notes: 'cover: $25.63 - $61.50'
+  };
+  const adapter = buildArbitrationAdapter({
+    cover: { pick: 'scraped', value: '$46.13-$61.50', reason: 'current listed price' }
+  });
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1, 'a genuine cover conflict must reach arbitration');
+  assert.match(adapter.calls[0].prompt, /field: cover/);
+  assert.equal(finalEvent.cover, '$46.13-$61.50');
+  assert.equal(core.parseNotesIntoFields(finalEvent.notes).cover, '$46.13-$61.50');
+});
+
+test('PARSER MERGE summary lists only fields the merge actually changed on the outgoing record', async () => {
+  const core = createCore();
+  // bar: existing wins over the empty incoming side → the outgoing record changed.
+  // cover: incoming wins (existing empty) → the base { ...newEvent } spread already
+  // carried it, so nothing changed — it must NOT be listed as updated.
+  const existing = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    bar: 'SF Eagle',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const incoming = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    bar: '',
+    cover: '$46.13-$61.50',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let merged;
+  try {
+    merged = await core.mergeParsedEvents(existing, incoming, {});
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(merged.bar, 'SF Eagle');
+  assert.equal(merged.cover, '$46.13-$61.50');
+  const summary = logLines.find(line => line.includes('🔄 PARSER MERGE:'));
+  assert.ok(summary, `expected a PARSER MERGE summary, got: ${JSON.stringify(logLines)}`);
+  assert.match(summary, /1 field updated \(bar\)/, 'only the genuinely changed field is counted');
+  assert.ok(!summary.includes('cover'), 'a preserved-from-base field must not be listed as updated');
+});


### PR DESCRIPTION
## What

Fixes the vanishing `cover` field — extracted values were being destroyed twice after extraction. Root-caused with replays against the exact 2026-07-14 19:31 CHUNK run data.

### Bug 1 — dedup merge wiped one-sided values
`mergeParsedEvents`' same-priority branch (and the only-one-source-in-list branches) preserved the *existing* side with **no empty check** — and since ai-web is now the universal parser with `["ai-web"]` default priorities, every dedup pair lands there. Homepage segment event (parsed first → "existing", no cover: flyers don't print prices) + detail-page event (cover `$46.13-$61.50` from JSON-LD) → cover overwritten with `undefined`. The `🔄 PARSER MERGE` log even reported the wiped field as "updated", which is how this hid. `bar`/`location` survived only via bespoke guards.

**Fix:** universal empty-loses rule before priority resolution — when exactly one side has a value, it wins, for every field. Both-empty and both-non-empty flow through exactly as before (arbitration, priorities, deterministic rules).

### Bug 2 — calendar merge then erased the stored value
The emptied scraped cover reached `createFinalEventObject`; empty-vs-non-empty is no genuine conflict, so clobber/'ai' semantics assigned the empty scraped value — **deleting the calendar's `cover:` notes line on every write**. This is why covers saved weeks ago are gone from the phone calendar.

**Fix:** the bar-only keep-calendar guard is now general: an empty scraped value never clears a non-empty calendar value (all fields except startDate/endDate/key, which have their own rules). This deliberately **ends clear-on-empty-scrape semantics** — an empty scrape is an extraction gap, never a deletion instruction; deleting data is the calendar owner's job. Bar keeps its byte-identical log line; other kept fields get one summary line: `📍 MERGE: "..." kept calendar values for empty-scraped field(s): cover, ticketUrl`.

### Also: honest `🔄 PARSER MERGE` summary
The summary now lists only fields whose final value actually differs from the incoming base record (same-instant Date re-picks excluded via `mergeValuesEqualForTracking`). Preserved-existing decisions stay in `mergeDecisions` for display/metrics but no longer masquerade as updates. Line shape unchanged.

### Recovery
Previously erased covers self-heal: on the next scrape of each source the surviving cover is a plain fill (calendar side now empty) or a genuine conflict that arbitrates.

## Tests

343 pass / 0 fail (+6): one-sided cover/ticketUrl survive same-source dedup in both directions; both-non-empty same-priority conflicts still batch to AI arbitration; calendar cover survives an empty scrape (notes round-trip, no clobber log); genuine cover conflict still arbitrates with winner applied; PARSER MERGE summary omits preserved fields. Replayed the exact production Dore Alley scenario end-to-end: cover survives dedup and the calendar merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP