### PR TITLE
feat(scraper): cover shows sticker prices — availability-aware Wix ticket data upgrades JSON-LD fee totals

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -2673,7 +2673,15 @@ class AiWebParser {
             image: this.pickJsonLdImage(node.image),
             source: this.config.source
         };
-        if (cover) event.cover = cover;
+        if (cover) {
+            event.cover = cover;
+            // Wix JSON-LD offers only publish fee-inclusive totals ("46.13" =
+            // $45.00 + service fee). Flag the cover so Wix warmup enrichment —
+            // the same system's data at base-sticker-price fidelity — may
+            // upgrade it. Underscore fields are internal metadata (excluded
+            // from calendar notes and merge field loops).
+            event._coverFromJsonLdOffers = true;
+        }
         // The JSON-LD address carries the locality (e.g. "Portland, OR") — resolve city
         // and timezone from it directly so nothing downstream has to guess. Address only:
         // bar names produce false city matches ("Brooklyn Bowl" in Vegas).
@@ -2869,8 +2877,8 @@ class AiWebParser {
             if (!startMatch) return null;
             const jsonString = this.extractJsonObject(html, startMatch.index + startMatch[0].length);
             if (!jsonString) return null;
-            const eventNode = this.findWixWarmupEventNode(JSON.parse(jsonString));
-            return eventNode ? this.buildWixServerEventRecord(eventNode) : null;
+            const found = this.findWixWarmupEventNode(JSON.parse(jsonString));
+            return found ? this.buildWixServerEventRecord(found.event, found.tickets) : null;
         } catch (error) {
             return null;
         }
@@ -2878,6 +2886,8 @@ class AiWebParser {
 
     // The events-app GUID key inside appsWarmupData is deployment-specific —
     // iterate every app's state and take the first EventsPageInitialState event.
+    // Returns { event, tickets }: the per-ticket array (state.tickets, a sibling
+    // of state.event) is the only Wix surface carrying BASE sticker prices.
     findWixWarmupEventNode(warmup) {
         if (!warmup || typeof warmup !== 'object') return null;
         const apps = warmup.appsWarmupData && typeof warmup.appsWarmupData === 'object'
@@ -2889,15 +2899,16 @@ class AiWebParser {
             if (!state || typeof state !== 'object') continue;
             const wrapper = state.event;
             if (!wrapper || typeof wrapper !== 'object') continue;
+            const tickets = Array.isArray(state.tickets) ? state.tickets : [];
             // Observed shape nests the event once more (state.event.event); accept
             // the flat shape too in case other app versions skip the wrapper.
-            if (wrapper.event && typeof wrapper.event === 'object') return wrapper.event;
-            if (wrapper.title || wrapper.scheduling) return wrapper;
+            if (wrapper.event && typeof wrapper.event === 'object') return { event: wrapper.event, tickets };
+            if (wrapper.title || wrapper.scheduling) return { event: wrapper, tickets };
         }
         return null;
     }
 
-    buildWixServerEventRecord(node) {
+    buildWixServerEventRecord(node, tickets) {
         const clean = (value) => typeof value === 'string' ? this.normalizeWhitespace(value) : '';
         const location = node.location && typeof node.location === 'object' ? node.location : {};
         const fullAddress = location.fullAddress && typeof location.fullAddress === 'object' ? location.fullAddress : {};
@@ -2916,9 +2927,6 @@ class AiWebParser {
             ? node.scheduling.config
             : {};
         const timeZoneId = clean(scheduling.timeZoneId);
-        const ticketing = node.registration && node.registration.ticketing && typeof node.registration.ticketing === 'object'
-            ? node.registration.ticketing
-            : {};
 
         const record = {
             title: clean(node.title) || null,
@@ -2931,7 +2939,7 @@ class AiWebParser {
             endDateUtc: this.parseWixExactInstant(scheduling.endDate),
             address: clean(location.address) || clean(fullAddress.formattedAddress) || null,
             city: clean(fullAddress.city).toLowerCase() || null,
-            cover: this.formatWixTicketPriceRange(ticketing)
+            cover: this.formatWixTicketPriceRange(tickets)
         };
         return Object.values(record).some(value => value !== null) ? record : null;
     }
@@ -2945,22 +2953,62 @@ class AiWebParser {
         return Number.isNaN(date.getTime()) ? null : date;
     }
 
-    // "$20.50-$30.75" from the Wix ticketing block, collapsing equal bounds to a
-    // single value. Sold-out events keep their price — sold-out handling is a
-    // separate concern.
-    formatWixTicketPriceRange(ticketing) {
-        const formatAmount = (price) => {
-            if (!price || typeof price !== 'object') return '';
-            const amount = String(price.amount || '').trim();
-            if (!amount || !Number.isFinite(Number(amount))) return '';
-            const currency = String(price.currency || '').trim().toUpperCase();
-            return currency === 'USD' ? `$${amount}` : (currency ? `${amount} ${currency}` : amount);
+    // "$45-$60" from the warmup tickets[] array — the only Wix surface with BASE
+    // sticker prices. Both JSON-LD offers and the registration.ticketing summary
+    // publish fee-inclusive totals only ("46.13" = $45.00 + $1.13 service fee).
+    // Tiers still purchasable define the walk-up range; when EVERY tier is sold
+    // out, the full range across all tiers backs the cover instead (mirroring
+    // formatJsonLdOffersCover). Sold-out signal, verified empirically against
+    // the live chunk-party.com Dore Alley page (2026-07-14) by cross-checking
+    // each warmup ticket with the JSON-LD offer of the same name: every SoldOut
+    // offer had `limitPerCheckout: 0` and every InStock offer had
+    // `limitPerCheckout > 0` (1 and 50), while `saleStatus` was 1 on ALL
+    // tickets regardless of availability — so `limitPerCheckout === 0` is the
+    // reliable signal and saleStatus is useless. Only an explicit 0 counts as
+    // sold out; an absent limit never hides a purchasable tier.
+    formatWixTicketPriceRange(tickets) {
+        const list = Array.isArray(tickets) ? tickets : [];
+        // Prices of 0, negative, or unparseable never make a cover (free
+        // tickets are RSVPs, not a "$0" cover) — same rule as JSON-LD offers.
+        const parsePrice = (price) => {
+            if (!price || typeof price !== 'object') return null;
+            const amount = Number(String(price.amount || '').trim());
+            return Number.isFinite(amount) && amount > 0 ? amount : null;
         };
-        const formattedText = (value) => typeof value === 'string' ? value.trim() : '';
-        const low = formattedText(ticketing.lowestTicketPriceFormatted) || formatAmount(ticketing.lowestTicketPrice);
-        const high = formattedText(ticketing.highestTicketPriceFormatted) || formatAmount(ticketing.highestTicketPrice);
-        if (low && high) return low === high ? low : `${low}-${high}`;
-        return low || high || null;
+        const priced = [];
+        for (const ticket of list) {
+            if (!ticket || typeof ticket !== 'object') continue;
+            const base = ticket.price && typeof ticket.price === 'object' ? ticket.price : null;
+            const fixed = ticket.pricing && ticket.pricing.fixedPrice && typeof ticket.pricing.fixedPrice === 'object'
+                ? ticket.pricing.fixedPrice
+                : null;
+            const source = parsePrice(base) !== null ? base : fixed;
+            const amount = parsePrice(source);
+            if (amount === null) continue;
+            priced.push({
+                amount,
+                currency: String(source.currency || '').trim().toUpperCase(),
+                soldOut: ticket.limitPerCheckout === 0
+            });
+        }
+        let selected = priced.filter(entry => !entry.soldOut);
+        if (selected.length === 0) selected = priced;
+        if (selected.length === 0) return null;
+
+        const amounts = selected.map(entry => entry.amount);
+        const min = Math.min(...amounts);
+        const max = Math.max(...amounts);
+        // Same conventions as formatJsonLdOffersCover: whole dollars drop the
+        // trailing ".00", real cents keep two decimals ("45.5" → "$45.50").
+        const formatAmount = (amount) => Number.isInteger(amount) ? String(amount) : amount.toFixed(2);
+        const firstCurrency = selected.find(entry => entry.currency);
+        const currency = firstCurrency ? firstCurrency.currency : '';
+        if (!currency || currency === 'USD' || currency === '$') {
+            return min === max ? `$${formatAmount(min)}` : `$${formatAmount(min)}-$${formatAmount(max)}`;
+        }
+        return min === max
+            ? `${formatAmount(min)} ${currency}`
+            : `${formatAmount(min)}-${formatAmount(max)} ${currency}`;
     }
 
     // ENRICHMENT ONLY — runs on the parser's finished events just before they
@@ -2978,18 +3026,23 @@ class AiWebParser {
             if (!record) return events;
 
             const filledFields = new Set();
+            const upgradedFields = new Set();
             let enrichedCount = 0;
             for (const event of events) {
                 if (!event || typeof event !== 'object') continue;
                 if (!this.wixServerRecordMatchesEvent(record, event, sourceUrl, events.length)) continue;
-                const filled = this.fillEventFromWixServerRecord(event, record, cityConfig);
-                if (filled.length > 0) {
+                const { filled, upgraded } = this.fillEventFromWixServerRecord(event, record, cityConfig);
+                if (filled.length > 0 || upgraded.length > 0) {
                     enrichedCount += 1;
                     filled.forEach(field => filledFields.add(field));
+                    upgraded.forEach(field => upgradedFields.add(field));
                 }
             }
-            if (filledFields.size > 0) {
-                console.log(`🤖 AI Web: Wix server data enriched ${enrichedCount} event(s) for ${sourceUrl}: filled=[${Array.from(filledFields).join(', ')}]`);
+            if (filledFields.size > 0 || upgradedFields.size > 0) {
+                const upgradedSuffix = upgradedFields.size > 0
+                    ? ` upgraded=[${Array.from(upgradedFields).join(', ')}]`
+                    : '';
+                console.log(`🤖 AI Web: Wix server data enriched ${enrichedCount} event(s) for ${sourceUrl}: filled=[${Array.from(filledFields).join(', ')}]${upgradedSuffix}`);
             } else {
                 console.log(`🤖 AI Web: Wix server data present for ${sourceUrl} but no empty fields to fill`);
             }
@@ -3016,6 +3069,7 @@ class AiWebParser {
 
     fillEventFromWixServerRecord(event, record, cityConfig) {
         const filled = [];
+        const upgraded = [];
         const isEmpty = (value) => value === null || value === undefined || String(value).trim() === '';
         const fill = (field, value) => {
             if (value && isEmpty(event[field])) {
@@ -3025,7 +3079,18 @@ class AiWebParser {
         };
         fill('location', record.coordinates);
         fill('timezone', record.timezone);
-        fill('cover', record.cover);
+        // Cover exception to fill-only-empty: a cover flagged _coverFromJsonLdOffers
+        // came from the SAME Wix system as the warmup blob, just at lower fidelity —
+        // JSON-LD offers only publish fee-inclusive totals while the warmup tickets
+        // carry base sticker prices. Upgrading it follows the same precedent as
+        // exact UTC instants replacing _timezoneUnresolved wall-clock dates below.
+        // A cover extracted by OCR/AI (no flag) is independent evidence and is
+        // NEVER overridden.
+        if (record.cover && (isEmpty(event.cover) || event._coverFromJsonLdOffers)) {
+            (isEmpty(event.cover) ? filled : upgraded).push('cover');
+            event.cover = record.cover;
+            delete event._coverFromJsonLdOffers;
+        }
         fill('address', record.address);
         if (record.city && isEmpty(event.city)) {
             // Only configured city keys, resolved through the same alias matching
@@ -3050,7 +3115,7 @@ class AiWebParser {
             }
             delete event._timezoneUnresolved;
         }
-        return filled;
+        return { filled, upgraded };
     }
 
     // Event property that carries a prompt field on JSON-LD-built events: split

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -2015,7 +2015,10 @@ test('extraction flattens field objects through weekday pinning and normalizeAiE
 // ---------------------------------------------------------------------------
 
 // Trimmed real structure from chunk-party.com (the app GUID is deliberately
-// NOT the production events-app GUID — the extractor must iterate keys).
+// NOT the production events-app GUID — the extractor must iterate keys). The
+// registration.ticketing summary carries fee-INCLUSIVE totals ($21.03/$31.52)
+// while the tickets[] array (a sibling of "event") carries the base sticker
+// prices — the cover must come from tickets[], never the summary.
 const WIX_WARMUP_HTML = `
 <html><head>
 <script type="application/json" id="wix-warmup-data">{"appsWarmupData":{"deadbeef-0000-4000-8000-000000000000":{"EventsPageInitialState":{"event":{"event":{
@@ -2023,8 +2026,11 @@ const WIX_WARMUP_HTML = `
   "location":{"name":"Nova PDX","coordinates":{"lat":45.52281000000001,"lng":-122.6581342},"address":"722 E Burnside St, Portland, OR 97214, USA","fullAddress":{"country":"US","subdivision":"OR","city":"Portland","postalCode":"97214-1219","formattedAddress":"722 E Burnside St, Portland, OR 97214, USA","geocode":{"latitude":45.52281000000001,"longitude":-122.6581342}}},
   "scheduling":{"config":{"startDate":"2026-08-23T04:00:00.000Z","endDate":"2026-08-23T09:00:00.000Z","timeZoneId":"America/Los_Angeles"}},
   "title":"CHUNK Portland - SUMMER BLOW OUT!","slug":"chunk-portland-summer-blow-out",
-  "registration":{"ticketing":{"lowestTicketPrice":{"amount":"20.50","currency":"USD"},"highestTicketPrice":{"amount":"30.75","currency":"USD"},"lowestTicketPriceFormatted":"$20.50","highestTicketPriceFormatted":"$30.75","soldOut":false}}
-}}}}}}</script>
+  "registration":{"ticketing":{"lowestTicketPrice":{"amount":"21.03","currency":"USD"},"highestTicketPrice":{"amount":"31.52","currency":"USD"},"lowestTicketPriceFormatted":"$21.03","highestTicketPriceFormatted":"$31.52","soldOut":false}}
+}},"tickets":[
+  {"id":"t1","price":{"amount":"20.50","currency":"USD","value":"20.50"},"free":false,"name":"Early Bird GA","limitPerCheckout":20,"orderIndex":0,"wixFeeConfig":{"type":2},"saleStatus":1,"pricing":{"fixedPrice":{"amount":"20.50","currency":"USD","value":"20.50"},"pricingType":0}},
+  {"id":"t2","price":{"amount":"30.75","currency":"USD","value":"30.75"},"free":false,"name":"Tier 1 GA","limitPerCheckout":50,"orderIndex":1,"wixFeeConfig":{"type":2},"saleStatus":1,"pricing":{"fixedPrice":{"amount":"30.75","currency":"USD","value":"30.75"},"pricingType":0}}
+]}}}}</script>
 </head><body>CHUNK Portland - SUMMER BLOW OUT!</body></html>`;
 
 const CHUNK_PAGE_URL = 'https://www.chunk-party.com/event-details/chunk-portland-summer-blow-out';
@@ -2182,6 +2188,150 @@ test('applyWixServerDataEnrichment applies nothing when the slug and title both 
 
   assert.equal(events[0].location, '', 'an event-details URL naming a different slug must not be enriched');
   assert.equal(events[0].cover, '');
+});
+
+// ---------------------------------------------------------------------------
+// Sticker-price covers: the warmup tickets[] array carries BASE prices
+// ("45.00") while JSON-LD offers and the registration.ticketing summary are
+// fee-inclusive totals ("46.13" = $45.00 + service fee). Verified live on the
+// chunk-party.com Dore Alley page: sold-out tickets keep saleStatus 1 but get
+// limitPerCheckout 0; purchasable ones have limitPerCheckout > 0.
+// ---------------------------------------------------------------------------
+
+const doreTicket = (name, amount, limitPerCheckout) => ({
+  id: name, price: { amount, currency: 'USD', value: amount }, free: false,
+  name, limitPerCheckout, orderIndex: 0, wixFeeConfig: { type: 2 }, saleStatus: 1,
+  pricing: { fixedPrice: { amount, currency: 'USD', value: amount }, pricingType: 0 }
+});
+
+// Real Dore Alley shape: 25/30 tiers sold out, 45/60 tiers still purchasable
+const DORE_TICKETS = [
+  doreTicket("CHUNK DORE '26 Early Bird GA 1", '25.00', 0),
+  doreTicket("CHUNK DORE '26 Tier 1 GA 1", '30.00', 0),
+  doreTicket("CHUNK DORE '26 Tier 2 GA 1", '45.00', 1),
+  doreTicket("CHUNK DORE '26 Tier 3 GA 1", '60.00', 50)
+];
+
+const DORE_PAGE_URL = 'https://www.chunk-party.com/event-details/chunk-dore-alley-saturday-july-25th';
+
+const DORE_WARMUP_HTML = `
+<html><head>
+<script type="application/json" id="wix-warmup-data">${JSON.stringify({
+  appsWarmupData: {
+    'deadbeef-0000-4000-8000-000000000000': {
+      EventsPageInitialState: {
+        event: {
+          event: {
+            title: 'CHUNK DORE ALLEY - Saturday July 25th',
+            slug: 'chunk-dore-alley-saturday-july-25th',
+            scheduling: { config: { startDate: '2026-07-26T05:00:00.000Z', endDate: '2026-07-26T11:00:00.000Z', timeZoneId: 'America/Los_Angeles' } },
+            registration: { ticketing: { lowestTicketPriceFormatted: '$25.63', highestTicketPriceFormatted: '$61.50', soldOut: false } }
+          }
+        },
+        tickets: DORE_TICKETS
+      }
+    }
+  }
+})}</script>
+</head><body>CHUNK DORE ALLEY - Saturday July 25th</body></html>`;
+
+// The fee-inclusive offers the same page publishes in JSON-LD (real values)
+const DORE_OFFERS = {
+  '@type': 'AggregateOffer', highPrice: '61.50', lowPrice: '25.63',
+  offerCount: '4', priceCurrency: 'USD',
+  availability: 'https://schema.org/InStock',
+  offers: [
+    { '@type': 'offer', name: "CHUNK DORE '26 Early Bird GA 1", price: '25.63', priceCurrency: 'USD', availability: 'https://schema.org/SoldOut' },
+    { '@type': 'offer', name: "CHUNK DORE '26 Tier 1 GA 1", price: '30.75', priceCurrency: 'USD', availability: 'https://schema.org/SoldOut' },
+    { '@type': 'offer', name: "CHUNK DORE '26 Tier 2 GA 1", price: '46.13', priceCurrency: 'USD', availability: 'https://schema.org/InStock' },
+    { '@type': 'offer', name: "CHUNK DORE '26 Tier 3 GA 1", price: '61.5', priceCurrency: 'USD', availability: 'https://schema.org/InStock' }
+  ]
+};
+
+test('formatWixTicketPriceRange ranges over base prices of purchasable tiers only', () => {
+  const parser = createParser();
+  // 25/30 sold out (limitPerCheckout 0), 45/60 purchasable → walk-up range
+  assert.equal(parser.formatWixTicketPriceRange(DORE_TICKETS), '$45-$60');
+  // ALL tiers sold out → the full range across all tiers keeps a price
+  const allSoldOut = DORE_TICKETS.map(ticket => ({ ...ticket, limitPerCheckout: 0 }));
+  assert.equal(parser.formatWixTicketPriceRange(allSoldOut), '$25-$60');
+  // A single purchasable tier collapses to one value
+  assert.equal(parser.formatWixTicketPriceRange([DORE_TICKETS[0], DORE_TICKETS[2]]), '$45');
+  // Real cents keep two decimals; whole dollars drop the ".00"
+  assert.equal(parser.formatWixTicketPriceRange([doreTicket('GA', '45.50', 10)]), '$45.50');
+  // An absent limitPerCheckout never marks a tier sold out
+  const noLimit = doreTicket('GA', '45.00', 10);
+  delete noLimit.limitPerCheckout;
+  assert.equal(parser.formatWixTicketPriceRange([noLimit]), '$45');
+  // price absent → pricing.fixedPrice fallback
+  const fixedOnly = doreTicket('GA', '45.00', 10);
+  delete fixedOnly.price;
+  assert.equal(parser.formatWixTicketPriceRange([fixedOnly]), '$45');
+  // Non-USD renders as amount + space + code
+  const eur = doreTicket('GA', '45.00', 10);
+  eur.price.currency = 'EUR';
+  assert.equal(parser.formatWixTicketPriceRange([eur]), '45 EUR');
+  // No priced tickets → null: never "$0", never a throw
+  assert.equal(parser.formatWixTicketPriceRange([]), null);
+  assert.equal(parser.formatWixTicketPriceRange(null), null);
+  assert.equal(parser.formatWixTicketPriceRange(undefined), null);
+  assert.equal(parser.formatWixTicketPriceRange([{ free: true, name: 'RSVP', limitPerCheckout: 10 }]), null);
+  assert.equal(parser.formatWixTicketPriceRange([doreTicket('GA', '0.00', 10)]), null);
+  assert.equal(parser.formatWixTicketPriceRange(['garbage', null, 42]), null);
+});
+
+test('a JSON-LD-offers cover is upgraded to warmup base sticker prices and the flag is consumed', () => {
+  const parser = createParser();
+  const event = parser.buildEventFromJsonLdNode({
+    name: 'CHUNK DORE ALLEY - Saturday July 25th',
+    startDate: '2026-07-25T22:00:00-07:00',
+    offers: DORE_OFFERS
+  }, DORE_PAGE_URL);
+  assert.equal(event.cover, '$46.13-$61.50', 'JSON-LD can only see fee-inclusive totals');
+  assert.equal(event._coverFromJsonLdOffers, true, 'the offers-sourced cover is flagged upgradeable');
+
+  const logs = [];
+  const realLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  try {
+    parser.applyWixServerDataEnrichment([event], { url: DORE_PAGE_URL, html: DORE_WARMUP_HTML }, {});
+  } finally {
+    console.log = realLog;
+  }
+  assert.equal(event.cover, '$45-$60', 'base prices of purchasable tiers replace fee totals');
+  assert.equal(event._coverFromJsonLdOffers, undefined, 'the scratch flag is consumed by the upgrade');
+  assert.ok(
+    logs.some(line => line.includes('filled=[') && line.includes('upgraded=[cover]')),
+    'the enrichment summary reports the upgrade alongside filled fields'
+  );
+});
+
+test('an OCR/AI-extracted cover (no flag) is never overridden by warmup ticket prices', () => {
+  const parser = createParser();
+  const events = [{
+    title: 'CHUNK DORE ALLEY - Saturday July 25th',
+    startDate: new Date('2026-07-26T05:00:00.000Z'),
+    cover: '$40 at the door'
+  }];
+  parser.applyWixServerDataEnrichment(events, { url: DORE_PAGE_URL, html: DORE_WARMUP_HTML }, {});
+  assert.equal(events[0].cover, '$40 at the door', 'independent OCR/AI evidence always wins');
+});
+
+test('an empty cover is still filled from warmup tickets (fill-only-empty path)', () => {
+  const parser = createParser();
+  const events = [{
+    title: 'CHUNK DORE ALLEY - Saturday July 25th',
+    startDate: new Date('2026-07-26T05:00:00.000Z'),
+    cover: ''
+  }];
+  parser.applyWixServerDataEnrichment(events, { url: DORE_PAGE_URL, html: DORE_WARMUP_HTML }, {});
+  assert.equal(events[0].cover, '$45-$60');
+});
+
+test('formatJsonLdOffersCover keeps the honest fee-inclusive range for non-Wix pages', () => {
+  const parser = createParser();
+  // Dore-shaped offers: unchanged fallback when no warmup data exists
+  assert.equal(parser.formatJsonLdOffersCover(DORE_OFFERS), '$46.13-$61.50');
 });
 
 test('parseEvents enriches the JSON-LD fast-path result from Wix server data without running OCR or AI', async () => {


### PR DESCRIPTION
## What

Cover now reads **`$45-$60`** (base sticker prices of purchasable tiers) instead of `$46.13-$61.50` (fee-inclusive totals) on Wix event pages. Verified against the live Dore Alley page.

### Why the old value was wrong-ish
Wix JSON-LD offers only publish **fee-inclusive totals** ("46.13" = $45.00 + $1.13 service fee) — the advertised prices don't exist in that data. The warmup blob's `EventsPageInitialState.tickets[]` carries base `price.amount` plus per-ticket availability, but `formatWixTicketPriceRange` read the fee-inclusive `registration.ticketing` summary and never applied anyway (JSON-LD filled cover first; enrichment is fill-only-empty).

### Changes
- **`formatWixTicketPriceRange`** now works from the warmup `tickets[]` array: base sticker prices, purchasable tiers define the range, all-sold-out falls back to the full range, free/zero-price tickets never produce a cover. **Sold-out signal verified empirically** against the live page by cross-checking warmup tickets with same-name JSON-LD offers: `limitPerCheckout === 0` ⇔ SoldOut on every tier, while `saleStatus` was identical for sold-out and available tiers (useless). Only an explicit 0 counts — an absent field never hides a tier.
- **Cover upgrade exception to fill-only-empty**: covers sourced from JSON-LD offers are stamped `_coverFromJsonLdOffers`; Wix warmup enrichment replaces exactly those (same Wix system, higher fidelity — the same precedent as exact UTC instants replacing `_timezoneUnresolved` wall-clock dates). Covers extracted by OCR/AI carry no flag and are **never overridden**. The flag is an underscore field — already excluded from notes, merges, and arbitration.
- Enrichment log gains ` upgraded=[cover]` alongside the unchanged `filled=[...]`.
- `formatJsonLdOffersCover` untouched — non-Wix sites keep the honest fee-inclusive fallback (regression-tested).

### End-to-end proof (real downloaded page HTML)
JSON-LD cover `$46.13-$61.50` → final cover `$45-$60`, flag consumed, log: `filled=[location, timezone] upgraded=[cover]`.

## Tests

342 pass / 0 fail (+5): availability-aware range, all-sold-out fallback, single tier, cents preservation, null on no priced tickets, flagged-cover upgrade with flag consumption, OCR/AI cover untouched, fill-when-empty path, JSON-LD formatter regression. Test fixture's ticketing summary deliberately uses fee-inclusive values so any regression back to reading it fails.

Note: independent of #1488 (different files); covers restored by that fix get their format upgraded by this one on the following scrape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP