### PR TITLE
fix(scraper): OCR defaults to the rybook vision server, not desktop ollama

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4584,11 +4584,15 @@ class AiWebParser {
             temperature: this.defaultOcrRequestConfig.temperature,
             think: this.defaultOcrRequestConfig.think
         };
-        const provider = String(rawOcr.provider || 'ollama');
+        // Default provider is the rybook rapid-mlx vision server — desktop
+        // ollama is explicit opt-in only (provider: "ollama").
+        const provider = String(rawOcr.provider || 'openai');
 
         let defaultEndpoint;
         if (provider === 'openai') {
-            defaultEndpoint = 'http://rybook.taila7523c.ts.net:8000/v1/chat/completions';
+            // Port 8001 is the VISION (VLM) server; 8000 serves the text/coder
+            // model and rejects image input.
+            defaultEndpoint = 'http://rybook.taila7523c.ts.net:8001/v1/chat/completions';
         } else {
             // If the base AI config is also ollama, inherit its endpoint so custom endpoints aren't lost
             defaultEndpoint = baseAiConfig.provider === 'ollama' && baseAiConfig.endpoint

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -485,11 +485,20 @@ test('extractOcrFromAllImages respects maxImages without letting uninteresting i
 test('getOcrConfig defaults the openai provider to a vision model and accepts top-level ocr blocks', () => {
   const parser = createParser();
 
-  // openai provider must never default to the text/coder extraction model
+  // openai provider must never default to the text/coder extraction model,
+  // and the default endpoint must be the VISION server (8001) — the text
+  // server on 8000 rejects image input
   const openaiOcr = parser.getOcrConfig({ ai: { ocr: { provider: 'openai' } } });
   assert.equal(openaiOcr.provider, 'openai');
   assert.match(openaiOcr.model, /VL/i, 'openai OCR default must be a vision model');
-  assert.equal(openaiOcr.endpoint, 'http://rybook.taila7523c.ts.net:8000/v1/chat/completions');
+  assert.equal(openaiOcr.endpoint, 'http://rybook.taila7523c.ts.net:8001/v1/chat/completions');
+
+  // With NO provider configured at all, OCR defaults to the rybook vision
+  // server — desktop ollama is explicit opt-in only
+  const bare = parser.getOcrConfig({});
+  assert.equal(bare.provider, 'openai');
+  assert.equal(bare.endpoint, 'http://rybook.taila7523c.ts.net:8001/v1/chat/completions');
+  assert.match(bare.model, /VL/i);
 
   // A mis-nested top-level ocr block should still configure OCR (fallback)...
   const topLevel = parser.getOcrConfig({ ocr: { maxImages: 3, concurrency: 2 } });

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -387,8 +387,14 @@ const scraperConfig = {
       dryRun: true,
       ai: {
         enabled: true,
-        endpoint: "http://desktop.taila7523c.ts.net:11434/api/generate",
-        model: "qwen3.5:4b", // Main AI model for parsing
+        // --- Option A (default): rapid-mlx text server on rybook ---
+        provider: "openai",
+        endpoint: "http://rybook.taila7523c.ts.net:8000/v1/chat/completions",
+        model: "lmstudio-community/Qwen3-Coder-Next-MLX-6bit", // Main AI model for parsing
+        // --- Option B: Ollama on desktop ---
+        // provider: "ollama",
+        // endpoint: "http://desktop.taila7523c.ts.net:11434/api/generate",
+        // model: "qwen3.5:4b",
         payloadMode: "best",
         maxHtmlChars: 6000,
         numCtx: 2048,
@@ -407,19 +413,19 @@ const scraperConfig = {
         // top-level `ocr` block is accepted as fallback, but this is the canonical spot).
         ocr: {
           enabled: true,
-          // --- Option A (default): Ollama vision model on desktop ---
-          provider: "ollama",
-          endpoint: "http://desktop.taila7523c.ts.net:11434/api/generate",
-          model: "qwen3-vl:4b-instruct", // OCR requires a VISION model
-          // --- Option B: rapid-mlx (OpenAI-compatible, Apple Silicon) on rybook ---
+          // --- Option A (default): rapid-mlx (OpenAI-compatible, Apple Silicon) on rybook ---
           // rapid-mlx must be serving a VISION (VLM) model — text models reject image
           // input with "Model ... does not support image, video, or audio inputs."
           // A rapid-mlx instance serves ONE model, so the vision server runs on its
-          // own port (e.g. 8001) alongside the text/extraction server on 8000.
+          // own port (8001) alongside the text/extraction server on 8000.
           // Check what's served: http://rybook.taila7523c.ts.net:8001/v1/models
-          // provider: "openai",
-          // endpoint: "http://rybook.taila7523c.ts.net:8001/v1/chat/completions",
-          // model: "mlx-community/Qwen3-VL-4B-Instruct-4bit",
+          provider: "openai",
+          endpoint: "http://rybook.taila7523c.ts.net:8001/v1/chat/completions",
+          model: "mlx-community/Qwen3-VL-4B-Instruct-4bit", // OCR requires a VISION model
+          // --- Option B: Ollama vision model on desktop ---
+          // provider: "ollama",
+          // endpoint: "http://desktop.taila7523c.ts.net:11434/api/generate",
+          // model: "qwen3-vl:4b-instruct",
           timeoutSeconds: 120,
           numCtx: 8192,
           numPredict: 2000,


### PR DESCRIPTION
## What

- `getOcrConfig`'s default provider was `"ollama"` → desktop:11434 whenever no OCR config reached it; now defaults to `"openai"` → **rybook:8001** with `Qwen3-VL-4B-Instruct-4bit`.
- Fixed a latent bug alongside: the `openai` provider's default endpoint was rybook **:8000** — the text/coder server, which rejects image input ("Model ... does not support image, video, or audio inputs"). Vision lives on :8001.
- Explicit `provider: "ollama"` keeps the desktop fallback (opt-in only).
- Sample parser entry's `ai`/`ocr` blocks flipped: rybook rapid-mlx is Option A (default), desktop ollama the commented Option B — docs now match code defaults.

## Impact

No cache churn when the global `ocr` block is configured (inherited per parser since #1484) — request signatures unchanged. This changes what happens when config is missing, which previously meant silent requests to the retired desktop stack.

## Tests

348 pass / 0 fail. Updated the existing default-endpoint assertion to :8001 and added a bare-config case (no provider at all → rybook vision server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP