### PR TITLE
feat(scraper): near-zero-config parser onboarding — adaptive depth, learned dead ends, suggested config

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1088,31 +1088,6 @@ class ScriptableAdapter {
     }
   }
 
-  // Paste-ready suggested parser entry from a discoveryOnly run — written as a
-  // file so it can be copied cleanly from the Files app instead of out of a
-  // timestamped log. One file per parser, overwritten on each discovery run.
-  async saveSuggestedConfig(parserName, text) {
-    if (!text || typeof text !== "string") {
-      return null;
-    }
-    try {
-      const dir = this.fm.joinPath(this.baseDir, "suggested-configs");
-      this.ensureDirectoryExists(dir);
-      const path = this.fm.joinPath(
-        dir,
-        `${this.sanitizePageCacheSegment(parserName)}.js`,
-      );
-      this.fm.writeString(path, text);
-      console.log(`📱 Scriptable: ✓ Saved suggested config to ${path}`);
-      return path;
-    } catch (error) {
-      console.log(
-        `📱 Scriptable: Suggested config write failed: ${error.message}`,
-      );
-      return null;
-    }
-  }
-
   extractHttpStatusCodeFromError(error) {
     const message =
       error && typeof error.message === "string" ? error.message : "";
@@ -5861,6 +5836,18 @@ class ScriptableAdapter {
             : 0;
         const mermaidEncoded = encodeURIComponent(r.mermaidGraph || "");
         const asciiEncoded = encodeURIComponent(r.asciiTree || "");
+        // Paste-ready parser entry (the log header line is dropped — the copied
+        // text starts at "{" so it pastes straight into parsers[]).
+        const suggestedConfigText =
+          typeof r.suggestedConfig === "string"
+            ? r.suggestedConfig
+                .split("\n")
+                .filter((line) => !line.startsWith("📋"))
+                .join("\n")
+                .trim()
+            : "";
+        const suggestedEncoded = encodeURIComponent(suggestedConfigText);
+        const hasSuggestedConfig = suggestedConfigText.length > 0;
         const urlListItems =
           r.discoveryTree && Array.isArray(r.discoveryTree.allNodes)
             ? r.discoveryTree.allNodes
@@ -5883,12 +5870,24 @@ class ScriptableAdapter {
         <div class="discovery-parser" style="margin-bottom:16px;">
             <div style="font-weight:600; margin-bottom:8px;">${this.escapeHtml(r.name || "Parser")} <span style="font-weight:400; opacity:0.7;">— ${nodeCount} URL(s) found${hasSegments ? `, ${totalSegments} segment(s)` : ""}</span></div>
             <div style="display:flex; gap:6px; margin-bottom:8px; flex-wrap:wrap;">
-                <button onclick="switchDiscoveryTab(this,'mermaid_${safeId}')" class="disc-tab-btn disc-tab-active" data-tab="mermaid_${safeId}">Mermaid Graph</button>
+                ${hasSuggestedConfig ? `<button onclick="switchDiscoveryTab(this,'suggested_${safeId}')" class="disc-tab-btn disc-tab-active" data-tab="suggested_${safeId}">📋 Suggested Config</button>` : ""}
+                <button onclick="switchDiscoveryTab(this,'mermaid_${safeId}')" class="disc-tab-btn${hasSuggestedConfig ? "" : " disc-tab-active"}" data-tab="mermaid_${safeId}">Mermaid Graph</button>
                 <button onclick="switchDiscoveryTab(this,'ascii_${safeId}')" class="disc-tab-btn" data-tab="ascii_${safeId}">ASCII Tree</button>
                 <button onclick="switchDiscoveryTab(this,'urls_${safeId}')" class="disc-tab-btn" data-tab="urls_${safeId}">URL List</button>
                 ${segmentsTabButton}
             </div>
-            <div id="mermaid_${safeId}" class="disc-tab-panel">
+            ${
+              hasSuggestedConfig
+                ? `<div id="suggested_${safeId}" class="disc-tab-panel">
+                <div style="display:flex; gap:6px; margin-bottom:6px; flex-wrap:wrap; align-items:center;">
+                    <button onclick="copyDiscoveryText(this)" class="log-copy-btn" data-encoded="${this.escapeHtml(suggestedEncoded)}">📋 Copy Config</button>
+                    <span style="font-size:12px; color:var(--text-secondary);">Paste into parsers[] in scraper-input.js</span>
+                </div>
+                <pre class="discovery-output">${this.escapeHtml(suggestedConfigText)}</pre>
+            </div>`
+                : ""
+            }
+            <div id="mermaid_${safeId}" class="disc-tab-panel"${hasSuggestedConfig ? ' style="display:none"' : ""}>
                 <div style="display:flex; gap:6px; margin-bottom:6px; flex-wrap:wrap;">
                     <button onclick="copyDiscoveryText(this)" class="log-copy-btn" data-encoded="${this.escapeHtml(mermaidEncoded)}">📋 Copy Mermaid</button>
                     <a href="https://mermaid.live" target="_blank" style="padding:4px 10px; background:var(--background-light); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--primary-color); text-decoration:none;">Open mermaid.live ↗</a>

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1088,6 +1088,31 @@ class ScriptableAdapter {
     }
   }
 
+  // Paste-ready suggested parser entry from a discoveryOnly run — written as a
+  // file so it can be copied cleanly from the Files app instead of out of a
+  // timestamped log. One file per parser, overwritten on each discovery run.
+  async saveSuggestedConfig(parserName, text) {
+    if (!text || typeof text !== "string") {
+      return null;
+    }
+    try {
+      const dir = this.fm.joinPath(this.baseDir, "suggested-configs");
+      this.ensureDirectoryExists(dir);
+      const path = this.fm.joinPath(
+        dir,
+        `${this.sanitizePageCacheSegment(parserName)}.js`,
+      );
+      this.fm.writeString(path, text);
+      console.log(`📱 Scriptable: ✓ Saved suggested config to ${path}`);
+      return path;
+    } catch (error) {
+      console.log(
+        `📱 Scriptable: Suggested config write failed: ${error.message}`,
+      );
+      return null;
+    }
+  }
+
   extractHttpStatusCodeFromError(error) {
     const message =
       error && typeof error.message === "string" ? error.message : "";

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1033,6 +1033,61 @@ class ScriptableAdapter {
     }
   }
 
+  // ---------------------------------------------------------------------
+  // Learned dead-end store persistence: dead-ends.json alongside the other
+  // scraper storage. Shape: { "<url>": { firstSeen, lastSeen, misses } }.
+  // The semantics (skip/retry/prune) live in shared-core; the orchestrator
+  // loads the store before the run and saves the updated store after it.
+  // ---------------------------------------------------------------------
+  getDeadEndsFilePath() {
+    return this.fm.joinPath(this.baseDir, "dead-ends.json");
+  }
+
+  async loadDeadEnds() {
+    const path = this.getDeadEndsFilePath();
+    try {
+      if (!this.fm.fileExists(path)) {
+        return {};
+      }
+      try {
+        await this.fm.downloadFileFromiCloud(path);
+      } catch (_) {}
+      const parsed = JSON.parse(this.fm.readString(path));
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        console.log(
+          "📱 Scriptable: Dead-end store has unexpected shape — starting with empty store",
+        );
+        return {};
+      }
+      return parsed;
+    } catch (error) {
+      // Corrupt or unreadable file must never break a run — the store is a
+      // pure optimization and rebuilds itself over subsequent runs.
+      console.log(
+        `📱 Scriptable: Dead-end store read failed (${error.message}) — starting with empty store`,
+      );
+      return {};
+    }
+  }
+
+  async saveDeadEnds(store) {
+    if (!store || typeof store !== "object" || Array.isArray(store)) {
+      return;
+    }
+    const path = this.getDeadEndsFilePath();
+    try {
+      this.ensureDirectoryExists(this.baseDir);
+      this.fm.writeString(path, JSON.stringify(store, null, 2));
+      console.log(
+        `📱 Scriptable: ✓ Saved dead-end store (${Object.keys(store).length} entries) to ${path}`,
+      );
+    } catch (error) {
+      console.log(
+        `📱 Scriptable: Dead-end store write failed: ${error.message}`,
+      );
+    }
+  }
+
   extractHttpStatusCodeFromError(error) {
     const message =
       error && typeof error.message === "string" ? error.message : "";

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -435,15 +435,57 @@ test('loadDeadEnds tolerates corrupt or wrong-shaped files with an empty store',
   assert.ok(!adapter.fm.files.has(path));
 });
 
-test('saveSuggestedConfig writes a sanitized per-parser file and tolerates bad input', async () => {
+// ---------------------------------------------------------------------------
+// Suggested-config tab in the URL Discovery UI section
+// ---------------------------------------------------------------------------
+
+test('generateDiscoverySection renders a default-active Suggested Config tab with a copy button', () => {
   const adapter = buildAdapter();
-  adapter.fm = createDeadEndFmStub();
+  const suggested = '📋 SUGGESTED CONFIG for "New Site" — paste into parsers[] in scraper-input.js:\n{\n  name: "New Site",\n  urls: ["https://x.example"],\n},';
+  const results = {
+    parserResults: [{
+      name: 'New Site',
+      discoveryOnly: true,
+      mermaidGraph: 'graph TD;A-->B;',
+      asciiTree: 'A\n└─ B',
+      discoveryTree: { rootUrls: ['https://x.example'], edges: [], allNodes: ['https://x.example'], segmentsByUrl: {} },
+      suggestedConfig: suggested
+    }]
+  };
 
-  const text = '// Suggested parser entry for "Twisted Bear!"\n{\n  name: "Twisted Bear!",\n},\n';
-  const path = await adapter.saveSuggestedConfig('Twisted Bear!', text);
-  assert.ok(path.endsWith('suggested-configs/twisted-bear.js'), `sanitized filename, got ${path}`);
-  assert.equal(adapter.fm.files.get(path), text);
+  const html = adapter.generateDiscoverySection(results);
+  assert.ok(html.includes('📋 Suggested Config'), 'suggested-config tab button rendered');
+  assert.ok(html.includes(`class="disc-tab-btn disc-tab-active" data-tab="suggested_New_Site_0"`),
+    'suggested tab is the default-active tab');
+  assert.ok(html.includes(`class="disc-tab-btn" data-tab="mermaid_New_Site_0"`),
+    'mermaid tab is no longer default-active');
+  assert.ok(html.includes('📋 Copy Config'), 'copy button rendered');
 
-  assert.equal(await adapter.saveSuggestedConfig('X', ''), null, 'empty text → no write');
-  assert.equal(await adapter.saveSuggestedConfig('X', null), null, 'null text → no write');
+  // The copy payload starts at "{" — the log header line is stripped so the
+  // copied text pastes straight into parsers[].
+  const payloadMatch = html.match(/data-encoded="([^"]*)"[^>]*>📋 Copy Config/);
+  assert.ok(payloadMatch, 'copy button carries an encoded payload');
+  const decoded = decodeURIComponent(payloadMatch[1].replace(/&quot;/g, '"').replace(/&amp;/g, '&'));
+  assert.ok(decoded.startsWith('{'), `payload starts at the config object, got: ${decoded.slice(0, 30)}`);
+  assert.ok(!decoded.includes('📋'), 'log header line stripped from the payload');
+
+  // Mermaid panel is hidden by default when the suggested tab is present
+  assert.ok(html.includes(`<div id="mermaid_New_Site_0" class="disc-tab-panel" style="display:none">`));
+});
+
+test('generateDiscoverySection keeps Mermaid default-active when no suggested config exists', () => {
+  const adapter = buildAdapter();
+  const results = {
+    parserResults: [{
+      name: 'Old Run',
+      discoveryOnly: true,
+      mermaidGraph: 'graph TD;A-->B;',
+      asciiTree: 'A',
+      discoveryTree: { rootUrls: [], edges: [], allNodes: [], segmentsByUrl: {} }
+    }]
+  };
+  const html = adapter.generateDiscoverySection(results);
+  assert.ok(!html.includes('📋 Suggested Config'), 'no suggested tab without data');
+  assert.ok(html.includes(`class="disc-tab-btn disc-tab-active" data-tab="mermaid_Old_Run_0"`), 'mermaid stays the default tab');
+  assert.ok(html.includes(`<div id="mermaid_Old_Run_0" class="disc-tab-panel">`), 'mermaid panel visible');
 });

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -375,3 +375,62 @@ test('getOcrCacheRetentionDays reads config.ocr.cacheRetentionDays with a 90d de
     90
   );
 });
+
+// ---------------------------------------------------------------------------
+// Learned dead-end store persistence (dead-ends.json)
+// ---------------------------------------------------------------------------
+
+function createDeadEndFmStub() {
+  const files = new Map();
+  return {
+    files,
+    documentsDirectory: () => '/tmp/chunky-dad-adapter-test',
+    joinPath: (a, b) => `${a}/${b}`,
+    fileExists: (p) => files.has(p),
+    isDirectory: () => false,
+    createDirectory: () => {},
+    readString: (p) => (files.has(p) ? files.get(p) : null),
+    writeString: (p, s) => { files.set(p, s); },
+    downloadFileFromiCloud: async () => {}
+  };
+}
+
+test('loadDeadEnds/saveDeadEnds round-trip through dead-ends.json', async () => {
+  const adapter = buildAdapter();
+  adapter.fm = createDeadEndFmStub();
+
+  // Missing file → empty store, never throws
+  assert.deepEqual(await adapter.loadDeadEnds(), {});
+
+  const store = {
+    'https://site.example/dead': {
+      firstSeen: '2026-06-01T00:00:00.000Z',
+      lastSeen: '2026-07-01T00:00:00.000Z',
+      misses: 3
+    }
+  };
+  await adapter.saveDeadEnds(store);
+  assert.ok(adapter.fm.files.has(adapter.getDeadEndsFilePath()), 'store written to dead-ends.json in the scraper dir');
+  assert.deepEqual(await adapter.loadDeadEnds(), store);
+});
+
+test('loadDeadEnds tolerates corrupt or wrong-shaped files with an empty store', async () => {
+  const adapter = buildAdapter();
+  adapter.fm = createDeadEndFmStub();
+  const path = adapter.getDeadEndsFilePath();
+
+  adapter.fm.files.set(path, '{"https://x.example": {broken json');
+  assert.deepEqual(await adapter.loadDeadEnds(), {}, 'parse failure → empty store');
+
+  adapter.fm.files.set(path, '["not", "an", "object"]');
+  assert.deepEqual(await adapter.loadDeadEnds(), {}, 'array payload → empty store');
+
+  adapter.fm.files.set(path, 'null');
+  assert.deepEqual(await adapter.loadDeadEnds(), {}, 'null payload → empty store');
+
+  // saveDeadEnds refuses non-object stores instead of clobbering the file
+  adapter.fm.files.delete(path);
+  await adapter.saveDeadEnds(null);
+  await adapter.saveDeadEnds(['nope']);
+  assert.ok(!adapter.fm.files.has(path));
+});

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -434,3 +434,16 @@ test('loadDeadEnds tolerates corrupt or wrong-shaped files with an empty store',
   await adapter.saveDeadEnds(['nope']);
   assert.ok(!adapter.fm.files.has(path));
 });
+
+test('saveSuggestedConfig writes a sanitized per-parser file and tolerates bad input', async () => {
+  const adapter = buildAdapter();
+  adapter.fm = createDeadEndFmStub();
+
+  const text = '// Suggested parser entry for "Twisted Bear!"\n{\n  name: "Twisted Bear!",\n},\n';
+  const path = await adapter.saveSuggestedConfig('Twisted Bear!', text);
+  assert.ok(path.endsWith('suggested-configs/twisted-bear.js'), `sanitized filename, got ${path}`);
+  assert.equal(adapter.fm.files.get(path), text);
+
+  assert.equal(await adapter.saveSuggestedConfig('X', ''), null, 'empty text → no write');
+  assert.equal(await adapter.saveSuggestedConfig('X', null), null, 'null text → no write');
+});

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -251,17 +251,6 @@ class WebAdapter {
         }
     }
 
-    // Web/Node equivalent of the Scriptable adapter's suggested-config file:
-    // kept in memory for programmatic access (tests, web UI).
-    async saveSuggestedConfig(parserName, text) {
-        if (!text || typeof text !== 'string') {
-            return null;
-        }
-        this.suggestedConfigs = this.suggestedConfigs || {};
-        this.suggestedConfigs[String(parserName || 'unnamed')] = text;
-        return null;
-    }
-
     getRunContext() {
         const isNode = typeof window === 'undefined';
         const environment = isNode ? 'node' : 'web';

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -29,6 +29,9 @@ class WebAdapter {
         
         // Store cities configuration for calendar mapping
         this.cities = config.cities || {};
+        // In-memory learned dead-end store (web/Node runs don't persist it;
+        // the Scriptable adapter is the durable home for dead-ends.json)
+        this.deadEndStore = {};
         this.isNode = typeof process !== 'undefined' && !!(process.versions && process.versions.node);
         this.fs = null;
         this.path = null;
@@ -233,6 +236,21 @@ class WebAdapter {
         }
     }
     
+    // In-memory equivalents of the Scriptable adapter's dead-end persistence:
+    // same interface, survives only for the adapter instance's lifetime.
+    async loadDeadEnds() {
+        if (!this.deadEndStore || typeof this.deadEndStore !== 'object' || Array.isArray(this.deadEndStore)) {
+            this.deadEndStore = {};
+        }
+        return this.deadEndStore;
+    }
+
+    async saveDeadEnds(store) {
+        if (store && typeof store === 'object' && !Array.isArray(store)) {
+            this.deadEndStore = store;
+        }
+    }
+
     getRunContext() {
         const isNode = typeof window === 'undefined';
         const environment = isNode ? 'node' : 'web';

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -251,6 +251,17 @@ class WebAdapter {
         }
     }
 
+    // Web/Node equivalent of the Scriptable adapter's suggested-config file:
+    // kept in memory for programmatic access (tests, web UI).
+    async saveSuggestedConfig(parserName, text) {
+        if (!text || typeof text !== 'string') {
+            return null;
+        }
+        this.suggestedConfigs = this.suggestedConfigs || {};
+        this.suggestedConfigs[String(parserName || 'unnamed')] = text;
+        return null;
+    }
+
     getRunContext() {
         const isNode = typeof window === 'undefined';
         const environment = isNode ? 'node' : 'web';

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -300,24 +300,6 @@ class BearEventScraperOrchestrator {
                 console.log(`🐻 Orchestrator: Dead-end store save failed: ${error.message}`);
             }
 
-            // Suggested configs from discoveryOnly runs: also save each as a
-            // clean paste-ready file (the log copy carries timestamps).
-            try {
-                if (typeof finalAdapter.saveSuggestedConfig === 'function' && Array.isArray(results.parserResults)) {
-                    for (const parserResult of results.parserResults) {
-                        if (!parserResult || typeof parserResult.suggestedConfig !== 'string') continue;
-                        const body = parserResult.suggestedConfig
-                            .split('\n')
-                            .filter(line => !line.startsWith('📋'))
-                            .join('\n');
-                        const fileText = `// Suggested parser entry for "${parserResult.name}" — paste into parsers[] in scraper-input.js\n${body}\n`;
-                        await finalAdapter.saveSuggestedConfig(parserResult.name, fileText);
-                    }
-                }
-            } catch (error) {
-                console.log(`🐻 Orchestrator: Suggested config save failed: ${error.message}`);
-            }
-
             results.config = config;
             results.calendarEvents = 0;
             if (!Array.isArray(results.analyzedEvents)) {

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -278,8 +278,28 @@ class BearEventScraperOrchestrator {
                 }
             }
 
+            // Learned dead-end store: adapter owns persistence, shared-core owns
+            // the (pure) skip/retry semantics — load before the run, save after.
+            try {
+                if (typeof finalAdapter.loadDeadEnds === 'function') {
+                    config.deadEndStore = await finalAdapter.loadDeadEnds();
+                }
+            } catch (error) {
+                console.log(`🐻 Orchestrator: Dead-end store load failed (${error.message}) — continuing with empty store`);
+                config.deadEndStore = {};
+            }
+
             // Process events using shared core
             const results = await sharedCore.processEvents(config, finalAdapter, finalAdapter, parsers);
+
+            try {
+                if (results.deadEndStoreChanged && results.deadEndStore && typeof finalAdapter.saveDeadEnds === 'function') {
+                    await finalAdapter.saveDeadEnds(results.deadEndStore);
+                }
+            } catch (error) {
+                console.log(`🐻 Orchestrator: Dead-end store save failed: ${error.message}`);
+            }
+
             results.config = config;
             results.calendarEvents = 0;
             if (!Array.isArray(results.analyzedEvents)) {

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -300,6 +300,24 @@ class BearEventScraperOrchestrator {
                 console.log(`🐻 Orchestrator: Dead-end store save failed: ${error.message}`);
             }
 
+            // Suggested configs from discoveryOnly runs: also save each as a
+            // clean paste-ready file (the log copy carries timestamps).
+            try {
+                if (typeof finalAdapter.saveSuggestedConfig === 'function' && Array.isArray(results.parserResults)) {
+                    for (const parserResult of results.parserResults) {
+                        if (!parserResult || typeof parserResult.suggestedConfig !== 'string') continue;
+                        const body = parserResult.suggestedConfig
+                            .split('\n')
+                            .filter(line => !line.startsWith('📋'))
+                            .join('\n');
+                        const fileText = `// Suggested parser entry for "${parserResult.name}" — paste into parsers[] in scraper-input.js\n${body}\n`;
+                        await finalAdapter.saveSuggestedConfig(parserResult.name, fileText);
+                    }
+                }
+            } catch (error) {
+                console.log(`🐻 Orchestrator: Suggested config save failed: ${error.message}`);
+            }
+
             results.config = config;
             results.calendarEvents = 0;
             if (!Array.isArray(results.analyzedEvents)) {

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -433,10 +433,28 @@ class AiWebParser {
                     console.log(`🤖 AI Web: JSON-LD provided ${discoveredSegments.length} event segment(s) for discovery`);
                 }
                 console.log(`🤖 AI Web: Link-finding mode (${parserConfig.discoveryOnly ? 'discoveryOnly' : 'link-aggregator'}) found ${additionalLinks.length} additional links`);
+                // Onboarding harvest — discoveryOnly mode ONLY (inert everywhere
+                // else): social profile links + JSON-LD organizer feed the
+                // suggested-config block printed after discovery.
+                let discoveredSocialLinks = null;
+                let discoveredOrganizer = null;
+                if (parserConfig.discoveryOnly === true) {
+                    const socialLinks = this.collectDiscoverySocialLinks(html, sourceUrl);
+                    if (Object.keys(socialLinks).length > 0) {
+                        discoveredSocialLinks = socialLinks;
+                        console.log(`🤖 AI Web: Discovery harvested social link(s): ${Object.values(socialLinks).join(', ')}`);
+                    }
+                    discoveredOrganizer = this.extractJsonLdOrganizer(html);
+                    if (discoveredOrganizer) {
+                        console.log(`🤖 AI Web: Discovery harvested JSON-LD organizer: ${discoveredOrganizer.name || '(no name)'}${discoveredOrganizer.url ? ` (${discoveredOrganizer.url})` : ''}`);
+                    }
+                }
                 return {
                     events: [],
                     additionalLinks: additionalLinks,
                     discoveredSegments,
+                    discoveredSocialLinks,
+                    discoveredOrganizer,
                     ocrResults: ocrResults,
                     source: this.config.source,
                     url: sourceUrl
@@ -1870,6 +1888,14 @@ class AiWebParser {
         const limitedUrls = hasFiniteLimit
             ? dedupedRankedUrls.slice(0, maxAdditionalUrls)
             : dedupedRankedUrls;
+        // Non-enumerable tag: valid unique links BEFORE the maxAdditionalUrls
+        // budget. The dead-end detector reads this so a budget of 0 (e.g.
+        // Furball) can never make a link-rich page look like a dead end.
+        Object.defineProperty(limitedUrls, 'uniqueValidCount', {
+            value: dedupedRankedUrls.length,
+            enumerable: false,
+            configurable: true
+        });
         const limitText = hasFiniteLimit ? `${maxAdditionalUrls}` : 'none';
         const rejectedTopReasons = this.formatTopRejectedReasons(discoveryStats.rejectedReasons);
         const extraSources = discoveryStats.serverDataCandidates > 0 || discoveryStats.nextDataCandidates > 0
@@ -1944,6 +1970,63 @@ class AiWebParser {
             candidates.push({ url: match[1], context: match[0] });
         }
         return candidates;
+    }
+
+    // Onboarding harvest (discoveryOnly runs only): instagram/facebook links are
+    // scanned during URL discovery but rejected as blocked hosts — here the FIRST
+    // profile-like link per host is collected instead, for the suggested-config
+    // block. Profile-like = non-empty path whose first segment is not a
+    // share/login/interstitial endpoint.
+    collectDiscoverySocialLinks(html, sourceUrl) {
+        const results = {};
+        if (!html) return results;
+        const hostKeys = [
+            { key: 'instagram', host: 'instagram.com' },
+            { key: 'facebook', host: 'facebook.com' }
+        ];
+        const excludedFirstSegments = /^(?:sharer(?:\.php)?|share|login|intent|plugins)$/i;
+        for (const candidate of this.extractHrefCandidates(html)) {
+            const url = this.stripTrackingParams(this.normalizeUrl(candidate.url, sourceUrl));
+            const parsedUrl = this.parseUrlComponents(url);
+            if (!parsedUrl || !/^https?:$/.test(parsedUrl.protocol)) continue;
+            const hostname = String(parsedUrl.hostname || '').toLowerCase();
+            const hostEntry = hostKeys.find(entry => hostname === entry.host || hostname.endsWith(`.${entry.host}`));
+            if (!hostEntry || results[hostEntry.key]) continue;
+            const pathSegments = String(parsedUrl.pathname || '').split('/').filter(Boolean);
+            if (pathSegments.length === 0) continue;
+            if (excludedFirstSegments.test(pathSegments[0])) continue;
+            results[hostEntry.key] = url;
+            if (Object.keys(results).length === hostKeys.length) break;
+        }
+        return results;
+    }
+
+    // Onboarding harvest (discoveryOnly runs only): the organizer name/url from
+    // the page's schema.org Event JSON-LD, seeding shortName and website in the
+    // suggested-config block. First Event node with an organizer wins.
+    extractJsonLdOrganizer(html) {
+        if (!this.core || typeof this.core.extractJsonLdEventNodes !== 'function') return null;
+        let nodes = [];
+        try {
+            nodes = this.core.extractJsonLdEventNodes(html);
+        } catch (error) {
+            console.warn(`🤖 AI Web: JSON-LD organizer extraction failed: ${error.message}`);
+            return null;
+        }
+        for (const node of nodes) {
+            const organizers = Array.isArray(node.organizer) ? node.organizer : [node.organizer];
+            for (const organizer of organizers) {
+                if (!organizer || typeof organizer !== 'object') continue;
+                const name = typeof organizer.name === 'string'
+                    ? this.normalizeWhitespace(this.decodeBasicEntities(organizer.name))
+                    : '';
+                const url = this.normalizeHttpUrlValue(organizer.url) || '';
+                if (name || url) {
+                    return { name, url };
+                }
+            }
+        }
+        return null;
     }
 
     addAdditionalUrlCandidate(urls, rawUrl, sourceUrl, context = '', discoveryStats = null, parserConfig = {}) {
@@ -3934,6 +4017,14 @@ class AiWebParser {
             /\/[^/?#\s]+@[^/?#\s]+\.[a-z]{2,}(?:[/?#]|$)/i,
             // Block Wix auto-frontend module paths including malformed static./services variant.
             /\/static\.?\/services\/auto-frontend-modules\//i,
+            // Generic non-event site sections, anchored to WHOLE path segments so
+            // event slugs containing these words survive (e.g. /events/all-about-bears).
+            // /login is already covered by the substring list above.
+            /\/(?:shop|store|merch|cart|checkout|contact|about|faq|account|signin|signup)(?:\/|[?#]|$)/i,
+            // Wix internal API endpoints (e.g. chunk-party.com/_api/...)
+            '/_api/',
+            // WordPress ?p=<digits> shortlinks (e.g. bearracuda.com/?p=8724)
+            /[?&]p=\d+(?:[&#]|$)/,
             'googletagmanager.com', 'google-analytics.com', 'doubleclick.net',
             'analytics.google.com'
         ];

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -582,28 +582,35 @@ test('validateEventUrl applies global + parser discoveryBlockedPatterns unioned 
   const parser = createParser();
   const mainConfig = {
     config: {
-      discoveryBlockedPatterns: [/\/(shop|cart|contact(?:-us)?)(?:\/|[?#]|$)/, '/_api/']
+      // /shop etc. are blocked built-in now — the config union mechanism is
+      // exercised with patterns the built-ins do NOT cover
+      discoveryBlockedPatterns: [/\/(members|vip-lounge)(?:\/|[?#]|$)/, '/private-hire/']
     }
   };
   const effective = parser.core.resolveEffectiveParserConfig(
-    { name: 'Union', discoveryBlockedPatterns: ['x.example/?p='] },
+    { name: 'Union', discoveryBlockedPatterns: ['x.example/hidden'] },
     mainConfig
   );
   const sourceUrl = 'https://x.example/events';
 
   // Global RegExp entries block whole path segments...
-  const shop = parser.validateEventUrl('https://x.example/shop', sourceUrl, effective);
-  assert.equal(shop.valid, false);
-  assert.match(shop.reason, /^config-blocked-pattern:/);
-  assert.equal(parser.validateEventUrl('https://x.example/_api/v1/foo', sourceUrl, effective).valid, false);
+  const members = parser.validateEventUrl('https://x.example/members', sourceUrl, effective);
+  assert.equal(members.valid, false);
+  assert.match(members.reason, /^config-blocked-pattern:/);
+  assert.equal(parser.validateEventUrl('https://x.example/private-hire/rooms', sourceUrl, effective).valid, false);
 
   // ...without swallowing legitimate event slugs that merely start the same way
-  assert.equal(parser.validateEventUrl('https://x.example/shop-party', sourceUrl, effective).valid, true);
+  assert.equal(parser.validateEventUrl('https://x.example/members-party', sourceUrl, effective).valid, true);
 
   // The parser's own substring patterns still apply alongside the global list
-  const own = parser.validateEventUrl('https://x.example/?p=123', sourceUrl, effective);
+  const own = parser.validateEventUrl('https://x.example/hidden', sourceUrl, effective);
   assert.equal(own.valid, false);
-  assert.equal(own.reason, 'config-blocked-pattern:x.example/?p=');
+  assert.equal(own.reason, 'config-blocked-pattern:x.example/hidden');
+
+  // The formerly-config-only generic junk is now built-in (no config needed)
+  const shop = parser.validateEventUrl('https://x.example/shop', sourceUrl, {});
+  assert.equal(shop.valid, false);
+  assert.match(shop.reason, /^blocked-pattern:/);
 });
 
 test('parseOcrResponseWithClassification salvages OCR text from truncated/degenerate JSON', () => {
@@ -2734,4 +2741,129 @@ test('classification cache hits refresh lastUsedAt through the same touch helper
   assert.equal(payload.lastUsedAt, new Date().toISOString().slice(0, 10));
 
   fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Built-in generic blocked patterns (segment-anchored, accuracy first)
+// ---------------------------------------------------------------------------
+
+test('validateEventUrl blocks generic non-event paths built-in, anchored to whole path segments', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://x.example/events';
+  const blocked = [
+    'https://x.example/shop',
+    'https://x.example/shop/tees',
+    'https://x.example/store',
+    'https://x.example/merch',
+    'https://x.example/cart',
+    'https://x.example/checkout',
+    'https://x.example/contact',
+    'https://x.example/about',
+    'https://x.example/faq',
+    'https://x.example/account',
+    'https://x.example/signin',
+    'https://x.example/signup',
+    'https://x.example/_api/v1/site',
+    'https://bearracuda.example/?p=8724'   // WordPress shortlink
+  ];
+  for (const url of blocked) {
+    const result = parser.validateEventUrl(url, sourceUrl, {});
+    assert.equal(result.valid, false, `${url} should be blocked`);
+    assert.match(result.reason, /^blocked-pattern:/, `${url} → ${result.reason}`);
+  }
+
+  // Event slugs containing overlapping WORDS survive — anchoring is per path segment
+  const allowed = [
+    'https://x.example/events/all-about-bears',
+    'https://x.example/shop-party',
+    'https://x.example/events/checkout-these-bears',
+    'https://x.example/contact-high-dance-party',
+    'https://x.example/events/party?page=2'
+  ];
+  for (const url of allowed) {
+    const result = parser.validateEventUrl(url, sourceUrl, {});
+    assert.equal(result.valid, true, `${url} should pass but was rejected: ${result.reason}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// discoveryOnly onboarding harvest (social links + JSON-LD organizer)
+// ---------------------------------------------------------------------------
+
+const HARVEST_HTML = `
+  <html>
+    <head>
+      <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "Event",
+          "name": "Twisted Bear: Dallas",
+          "startDate": "2026-08-15T21:00:00-05:00",
+          "organizer": {
+            "@type": "Organization",
+            "name": "Twisted Bear Events",
+            "url": "https://twistedbear.example"
+          }
+        }
+      </script>
+    </head>
+    <body>
+      <a href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fx.example">Share</a>
+      <a href="https://www.instagram.com/">Instagram home</a>
+      <a href="https://www.instagram.com/twistedbearparty">Follow us</a>
+      <a href="https://www.instagram.com/other.account">Second profile (first wins)</a>
+      <a href="https://www.facebook.com/login/?next=x">Log in</a>
+      <a href="https://www.facebook.com/twistedglobal/">Facebook page</a>
+      <a href="https://x.example/e/party-tickets">Tickets</a>
+    </body>
+  </html>
+`;
+
+test('discoveryOnly harvests the first profile-like social link per host and the JSON-LD organizer', async () => {
+  const parser = createParser();
+  const result = await parser.parseEvents(
+    { html: HARVEST_HTML, url: 'https://x.example/events' },
+    { discoveryOnly: true },
+    null,
+    'event-page',
+    null
+  );
+
+  assert.deepEqual(result.discoveredSocialLinks, {
+    instagram: 'https://www.instagram.com/twistedbearparty',
+    facebook: 'https://www.facebook.com/twistedglobal/'
+  }, 'sharer/login/root links are excluded; first profile-like link per host wins');
+  assert.deepEqual(result.discoveredOrganizer, {
+    name: 'Twisted Bear Events',
+    url: 'https://twistedbear.example/'
+  });
+  assert.deepEqual(result.events, [], 'discoveryOnly extracts no events');
+});
+
+test('social/organizer harvest is inert outside discoveryOnly mode', async () => {
+  const parser = createParser();
+  // link-aggregator classification takes the same no-AI return path as discovery,
+  // so this exercises a normal (non-discovery) run without any network use.
+  const result = await parser.parseEvents(
+    { html: HARVEST_HTML, url: 'https://x.example/events' },
+    {},
+    null,
+    'link-aggregator',
+    null
+  );
+  assert.equal(result.discoveredSocialLinks, null);
+  assert.equal(result.discoveredOrganizer, null);
+});
+
+test('extractAdditionalUrls tags uniqueValidCount (pre-budget) non-enumerably for the dead-end detector', () => {
+  const parser = createParser();
+  const html = `
+    <a href="https://x.example/e/party-one">One</a>
+    <a href="https://x.example/e/party-two">Two</a>
+    <a href="https://x.example/e/party-three">Three</a>
+  `;
+  const links = parser.extractAdditionalUrls(html, 'https://x.example/events', { maxAdditionalUrls: 0 });
+  assert.equal(links.length, 0, 'budget of 0 returns no links');
+  assert.equal(links.uniqueValidCount, 3, 'but the pre-budget valid count is preserved');
+  assert.ok(!Object.keys(links).includes('uniqueValidCount'), 'tag is non-enumerable');
 });

--- a/scripts/parsers/redeyetickets-parser.js
+++ b/scripts/parsers/redeyetickets-parser.js
@@ -46,7 +46,12 @@ class RedEyeTicketsParser {
             }
             
             const jsonEvents = discoveryOnly ? [] : (jsonParseResult.events || []);
-            const additionalLinks = parserConfig.urlDiscoveryDepth > 0 ? (jsonParseResult.additionalLinks || []) : [];
+            // Absent urlDiscoveryDepth = adaptive crawling (shared-core decides
+            // what gets followed), so discovery stays on; explicit numeric depth
+            // keeps the legacy rule (0 disables link discovery).
+            const configuredDepth = parserConfig.urlDiscoveryDepth;
+            const urlDiscoveryEnabled = configuredDepth === undefined || configuredDepth === null || configuredDepth > 0;
+            const additionalLinks = urlDiscoveryEnabled ? (jsonParseResult.additionalLinks || []) : [];
             console.log(`🎫 RedEyeTickets: Parsed API payload -> ${jsonEvents.length} events, ${additionalLinks.length} additional links`);
             
             return {

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -365,17 +365,79 @@ const scraperConfig = {
         shortName: { value: "NEW-SITE" }, // add a hyphen where it should line-break
         instagram: { value: "https://www.instagram.com/example" },
       },
-      // ── Optional fields (shown with their defaults) ───────────────────
-      // discoveryOnly: true, // First-run mapping: crawl + print the 📋 SUGGESTED CONFIG block, extract no events (default: false)
+      // ── Optional fields — exhaustive reference (defaults noted) ────────
+      //
+      // Crawl & discovery:
+      // discoveryOnly: true, // First-run mapping: crawl + print/save the 📋 SUGGESTED CONFIG block, extract no events (default: false)
       // urlDiscoveryDepth: 2, // Omit → adaptive crawling (each page's type decides what gets followed); set a number to pin exact depth, 0 = never crawl (default: adaptive)
-      // discoveryBlockedPatterns: ["example.com/members-only"], // Rarely needed: generic junk is blocked built-in and dead ends are learned + auto-retried; set only for deliberate exclusions (default: none)
+      // maxAdditionalUrls: 15, // Budget of discovered URLs followed per page (default: 15)
+      // discoveryBlockedPatterns: ["example.com/members-only"], // Deliberate exclusions only — generic junk is blocked built-in and dead ends are learned + auto-retried (default: none)
+      // discoveryBlockedHosts: ["example.com"], // Suppress ALL discovered links to these hostnames (default: none)
+      //
+      // Run behavior:
       // dryRun: true, // Preview this parser's events without writing to the calendar (default: false — global config.dryRun also applies)
       // automationEnabled: false, // Skip this parser in scheduled automation runs (default: true)
-      // ai: { endpoint: "...", model: "..." }, // Per-parser AI override, merged over the global `ai` block (default: global block — normally omit)
-      // ai: { provider: "openai", endpoint: "https://api.openai.com/v1/chat/completions", model: "gpt-4o", openai: { responseFormat: "json_object" } }, // Hosted OpenAI instead of the local default (ai.ocr accepts the same shape with a vision model)
-      // fieldPriorities: { title: { priority: ["ai-web", "static"], merge: "clobber" } }, // Per-field merge override (default: all fields ai-web + AI arbitration; metadata keys auto-static)
-      // conditionalValues example for sub-brands sharing one parser:
-      // metadata: { shortName: { value: "MAIN", conditionalValues: [{ keywords: ["subbrand"], value: "SUB-BRAND" }] } },
+      // daysToLookAhead: 90, // Only keep events starting within N days (default: global config.daysToLookAhead, null = no limit)
+      // allowPastEvents: true, // Keep events whose start date already passed (default: false)
+      // calendarSearchRangeDays: 40, // ± days searched for wildcard matchKey calendar matches (default: unset)
+      //
+      // AI extraction override — merged key-wise over the global `ai` block.
+      // Normally omit entirely: the built-in default is the local rybook text
+      // server. Shown exhaustively for reference:
+      // ai: {
+      //   enabled: true,
+      //   provider: "openai", // "openai" (OpenAI-compatible, e.g. rapid-mlx/LM Studio/hosted) or "ollama"
+      //   endpoint: "http://rybook.taila7523c.ts.net:8000/v1/chat/completions",
+      //   model: "lmstudio-community/Qwen3-Coder-Next-MLX-6bit",
+      //   // Hosted OpenAI variant:
+      //   // provider: "openai", endpoint: "https://api.openai.com/v1/chat/completions", model: "gpt-4o", openai: { responseFormat: "json_object" },
+      //   // Ollama variant:
+      //   // provider: "ollama", endpoint: "http://desktop.taila7523c.ts.net:11434/api/generate", model: "qwen3.5:4b",
+      //   payloadMode: "best", // "best" | "html" | "text" — what gets sent to the model
+      //   maxHtmlChars: 6000,
+      //   numCtx: 2048,
+      //   numPredict: 2000,
+      //   temperature: 0,
+      //   think: false,
+      //   timeoutSeconds: 120,
+      //   keepAlive: "5m",
+      //   classifyPages: true, // AI second opinion when URL rules/JSON-LD can't classify a page (default: true)
+      //   // OCR override lives INSIDE `ai` (canonical spot: ai.ocr). Default is
+      //   // the rybook VISION server on :8001 — text models reject images.
+      //   ocr: {
+      //     enabled: true,
+      //     provider: "openai",
+      //     endpoint: "http://rybook.taila7523c.ts.net:8001/v1/chat/completions",
+      //     model: "mlx-community/Qwen3-VL-4B-Instruct-4bit", // OCR requires a VISION model
+      //     // Ollama vision variant:
+      //     // provider: "ollama", endpoint: "http://desktop.taila7523c.ts.net:11434/api/generate", model: "qwen3-vl:4b-instruct",
+      //     timeoutSeconds: 120,
+      //     numCtx: 8192,
+      //     numPredict: 2000,
+      //     temperature: 0,
+      //     think: false,
+      //     keepAlive: "5m",
+      //     maxImages: 2, // Per-page OCR budget on single-event pages (multi-event pages use 10 + segment top-up)
+      //     concurrency: 1, // Concurrent OCR requests; keep 1 for a single local GPU
+      //     maxTextChars: 4000,
+      //     cache: true, // OCR result cache (key is `cache`, not `cacheEnabled`)
+      //     cacheRetentionDays: 90,
+      //     requireMissingFields: true, // Only OCR when fields are still missing
+      //   },
+      // },
+      //
+      // Merging & identity:
+      // fieldPriorities: { title: { priority: ["ai-web", "static"], merge: "clobber" }, shortName: { priority: ["static"], merge: "upsert" } }, // Per-field override (default: every field ai-web + AI arbitration; metadata keys auto-static)
+      //
+      // Metadata extras (all static-upserted into events automatically):
+      // metadata: {
+      //   shortName: { value: "MAIN", conditionalValues: [{ keywords: ["subbrand"], value: "SUB-BRAND" }] }, // sub-brands sharing one parser
+      //   shorterName: { value: "MN" }, // ultra-compact display name
+      //   website: { value: "https://example.com" }, // `url` is an alias — website and url are ONE field
+      //   facebook: { value: "https://www.facebook.com/example" },
+      //   favicon: { value: "https://linktr.ee/example" }, // icon-source override, resolved dynamically by the website
+      //   matchKey: { value: "example*|${year}-${month}-*|*" }, // wildcard calendar-dedup key (pair with calendarSearchRangeDays)
+      // },
     },
   ],
 };

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -372,43 +372,10 @@ const scraperConfig = {
       // dryRun: true, // Preview this parser's events without writing to the calendar (default: false — global config.dryRun also applies)
       // automationEnabled: false, // Skip this parser in scheduled automation runs (default: true)
       // ai: { endpoint: "...", model: "..." }, // Per-parser AI override, merged over the global `ai` block (default: global block — normally omit)
+      // ai: { provider: "openai", endpoint: "https://api.openai.com/v1/chat/completions", model: "gpt-4o", openai: { responseFormat: "json_object" } }, // Hosted OpenAI instead of the local default (ai.ocr accepts the same shape with a vision model)
       // fieldPriorities: { title: { priority: ["ai-web", "static"], merge: "clobber" } }, // Per-field merge override (default: all fields ai-web + AI arbitration; metadata keys auto-static)
       // conditionalValues example for sub-brands sharing one parser:
       // metadata: { shortName: { value: "MAIN", conditionalValues: [{ keywords: ["subbrand"], value: "SUB-BRAND" }] } },
-    },
-    {
-      name: "AI Web Parser (OpenAI Sample)",
-      enabled: false,
-      automationEnabled: false,
-      parser: "ai-web",
-      urls: ["https://example.com/openai-events"],
-      alwaysBear: false,
-      urlDiscoveryDepth: 1,
-      maxAdditionalUrls: 15,
-      dryRun: true,
-      ai: {
-        enabled: true,
-        provider: "openai",
-        endpoint: "https://api.openai.com/v1/chat/completions",
-        model: "gpt-4o",
-        numPredict: 2000,
-        temperature: 0,
-        openai: {
-          responseFormat: "json_object",
-        },
-      },
-      ocr: {
-        enabled: true,
-        provider: "openai",
-        endpoint: "https://api.openai.com/v1/chat/completions",
-        model: "gpt-4o-mini",
-        numPredict: 2000,
-        temperature: 0,
-        openai: {
-          responseFormat: "json_object",
-        },
-      },
-      metadata: {},
     },
   ],
 };

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -10,27 +10,15 @@
 const scraperConfig = {
   config: {
     daysToLookAhead: null,
+    // dryRun: true, // Preview mode: analyze + display without writing to the calendar (default: false)
     pageCache: {
       enabled: true,
       ttlDays: 3,
     },
-    aiConfidenceDefaults: {
-      confidence: {
-        expectations: {
-          urlPatterns: [
-            {
-              pattern: "^https?://(?:www\\.)?eventbrite\\.com/e/",
-              fields: {
-                cover: { expected: ["jsonld"], strong: ["jsonld"] },
-                image: { expected: ["jsonld"], strong: ["jsonld"] },
-                ticketUrl: { expected: ["jsonld"], strong: ["jsonld"] },
-                location: { expected: ["meta"], strong: ["meta"] },
-              },
-            },
-          ],
-        },
-      },
-    },
+    // deadEndRetryDays: 30, // Learned dead-end URLs (fetched fine but yielded nothing) are skipped for this many days, then retried once; 0 disables the store (default: 30)
+    // NOTE: Eventbrite /e/ confidence defaults (JSON-LD cover/image/ticketUrl,
+    // meta location) are built into shared-core now — an aiConfidenceDefaults
+    // block here is only needed to extend or override them.
     // Global AI extraction defaults — inherited by EVERY parser (extraction +
     // merge arbitration). The effective per-parser block is a deep merge of this
     // block with the parser's own `ai`, so per-parser keys override key-wise.
@@ -98,35 +86,25 @@ const scraperConfig = {
       cacheRetentionDays: 90,
       requireMissingFields: true,
     },
-    // Discovery URL blocklist inherited by every parser — UNIONED with each
-    // parser's own discoveryBlockedPatterns (global entries first). String
-    // entries are case-insensitive URL substrings (same semantics as per-parser
-    // lists); RegExp entries test against the lowercased URL, which allows
-    // anchoring — a plain "/shop" substring would also swallow legitimate event
-    // slugs like "/shop-party", so store/contact paths use an anchored RegExp
-    // that requires the whole path segment.
-    discoveryBlockedPatterns: [
-      // Store/checkout/contact pages, matched as a complete path segment
-      /\/(shop|cart|contact(?:-us)?)(?:\/|[?#]|$)/,
-      // Policy pages — safe as plain substrings ("/privacy-policy" and
-      // "/terms-of-service" are junk too)
-      "/privacy",
-      "/terms",
-      // Wix internal API endpoints (e.g. chunk-party.com/_api/...)
-      "/_api/",
-    ],
+    // NOTE: Generic junk URLs (/shop, /cart, /contact, /_api/, ?p=<digits>
+    // shortlinks, /privacy, /terms, ...) are blocked built-in now, and pages
+    // that fetch fine but yield nothing are learned as dead ends and skipped
+    // automatically. A discoveryBlockedPatterns list (global here, or
+    // per-parser) is only for deliberate exclusions — "never fetch, not even
+    // once". String entries are case-insensitive URL substrings; RegExp
+    // entries test against the lowercased URL, which allows anchoring.
     // URL pattern rules for page classification. Checked in order — first match wins.
     // More specific patterns (e.g. /events/:slug) must come before broader ones (e.g. domain root).
+    // Built-in platform rules apply automatically BENEATH these (config wins):
+    // eventbrite.com/e/ → event-page, eventbrite.com/o/ → multi-event-page,
+    // linktr.ee → link-aggregator. Only site-specific rules belong here.
     pageClassificationRules: [
-      { pattern: /eventbrite\.com\/e\//i, classification: "event-page" },
-      { pattern: /eventbrite\.com\/o\//i, classification: "multi-event-page" },
       { pattern: /furball\.nyc/i, classification: "multi-event-page" },
       {
         pattern: /bearracuda\.com\/events\/[^/?&#\s]+/i,
         classification: "event-page",
       },
       { pattern: /bearracuda\.com/i, classification: "link-aggregator" },
-      { pattern: /linktr\.ee/i, classification: "link-aggregator" },
     ],
   },
   parsers: [
@@ -373,91 +351,30 @@ const scraperConfig = {
       },
     },
     {
-      name: "AI Web Parser (Sample)",
-      enabled: false,
-      automationEnabled: false,
-      parser: "ai-web",
+      // ── New Site Template ─────────────────────────────────────────────
+      // Copy this entry, fill in the live fields, and you're done — depth,
+      // URL blocking, AI/OCR settings, and field merging are all automatic.
+      // Tip: run once with discoveryOnly: true and the scraper prints a
+      // 📋 SUGGESTED CONFIG block (with harvested instagram/facebook/website)
+      // you can paste right back here.
+      name: "New Site Template",
+      enabled: false, // flip on after a dry-run preview looks right
       urls: ["https://example.com/events"],
-      alwaysBear: false,
-      urlDiscoveryDepth: 1,
-      maxAdditionalUrls: 15,
-      discoveryOnly: false, // Set true to run normal crawl/discovery flow while skipping event extraction
-      discoveryBlockedHosts: [], // Hostnames to suppress during URL discovery (e.g. ["example.com"] blocks links back to the source site)
-      discoveryBlockedPatterns: [], // Case-insensitive URL substrings to suppress during discovery (e.g. ["example.com/?p="])
-      dryRun: true,
-      ai: {
-        enabled: true,
-        // --- Option A (default): rapid-mlx text server on rybook ---
-        provider: "openai",
-        endpoint: "http://rybook.taila7523c.ts.net:8000/v1/chat/completions",
-        model: "lmstudio-community/Qwen3-Coder-Next-MLX-6bit", // Main AI model for parsing
-        // --- Option B: Ollama on desktop ---
-        // provider: "ollama",
-        // endpoint: "http://desktop.taila7523c.ts.net:11434/api/generate",
-        // model: "qwen3.5:4b",
-        payloadMode: "best",
-        maxHtmlChars: 6000,
-        numCtx: 2048,
-        numPredict: 2000,
-        temperature: 0,
-        think: false,
-        timeoutSeconds: 120,
-        keepAlive: "5m",
-        // AI page classification second opinion (default: true). When the deterministic
-        // classifiers (URL rules, JSON-LD Event markup) have no answer, the text model
-        // classifies the page instead of the crude month-count heuristic (one small
-        // request per weak-signal page). URL rules and JSON-LD always take precedence.
-        // Set to false to fall back to the month-count heuristic only.
-        classifyPages: true,
-        // OCR settings live inside `ai` (getOcrConfig reads parserConfig.ai.ocr; a
-        // top-level `ocr` block is accepted as fallback, but this is the canonical spot).
-        ocr: {
-          enabled: true,
-          // --- Option A (default): rapid-mlx (OpenAI-compatible, Apple Silicon) on rybook ---
-          // rapid-mlx must be serving a VISION (VLM) model — text models reject image
-          // input with "Model ... does not support image, video, or audio inputs."
-          // A rapid-mlx instance serves ONE model, so the vision server runs on its
-          // own port (8001) alongside the text/extraction server on 8000.
-          // Check what's served: http://rybook.taila7523c.ts.net:8001/v1/models
-          provider: "openai",
-          endpoint: "http://rybook.taila7523c.ts.net:8001/v1/chat/completions",
-          model: "mlx-community/Qwen3-VL-4B-Instruct-4bit", // OCR requires a VISION model
-          // --- Option B: Ollama vision model on desktop ---
-          // provider: "ollama",
-          // endpoint: "http://desktop.taila7523c.ts.net:11434/api/generate",
-          // model: "qwen3-vl:4b-instruct",
-          timeoutSeconds: 120,
-          numCtx: 8192,
-          numPredict: 2000,
-          temperature: 0,
-          think: false,
-          keepAlive: "5m",
-          maxImages: 2, // Per-page OCR budget on single-event pages (multi-event pages use 10 + segment top-up)
-          concurrency: 1, // Concurrent OCR requests; keep 1 for a single local GPU
-          maxTextChars: 4000,
-          cache: true, // OCR result cache (key is `cache`, not `cacheEnabled`)
-          requireMissingFields: true,
-        },
+      alwaysBear: false, // set true for trusted bear promoters (AI trust context)
+      metadata: {
+        shortName: { value: "NEW-SITE" }, // add a hyphen where it should line-break
+        instagram: { value: "https://www.instagram.com/example" },
       },
-      // Comprehensive example of fieldPriorities for merging data from different sources
-      fieldPriorities: {
-        title: { priority: ["ai-web", "static"], merge: "clobber" },
-        shortName: { priority: ["static"], merge: "upsert" },
-        description: { priority: ["ai-web"], merge: "clobber" },
-        bar: { priority: ["ai-web"], merge: "clobber" },
-        address: { priority: ["ai-web"], merge: "clobber" },
-        startDate: { priority: ["ai-web"], merge: "clobber" },
-        endDate: { priority: ["ai-web"], merge: "clobber" },
-        url: { priority: ["ai-web"], merge: "clobber" },
-        location: { priority: ["ai-web"], merge: "clobber" },
-        gmaps: { priority: ["ai-web"], merge: "clobber" },
-        image: { priority: ["ai-web"], merge: "clobber" },
-        cover: { priority: ["ai-web"], merge: "clobber" },
-        facebook: { priority: ["ai-web"], merge: "clobber" },
-        ticketUrl: { priority: ["ai-web"], merge: "clobber" },
-        key: { priority: ["ai-web"], merge: "clobber" },
-      },
-      metadata: {},
+      // ── Optional fields (shown with their defaults) ───────────────────
+      // discoveryOnly: true, // First-run mapping: crawl + print the 📋 SUGGESTED CONFIG block, extract no events (default: false)
+      // urlDiscoveryDepth: 2, // Omit → adaptive crawling (each page's type decides what gets followed); set a number to pin exact depth, 0 = never crawl (default: adaptive)
+      // discoveryBlockedPatterns: ["example.com/members-only"], // Rarely needed: generic junk is blocked built-in and dead ends are learned + auto-retried; set only for deliberate exclusions (default: none)
+      // dryRun: true, // Preview this parser's events without writing to the calendar (default: false — global config.dryRun also applies)
+      // automationEnabled: false, // Skip this parser in scheduled automation runs (default: true)
+      // ai: { endpoint: "...", model: "..." }, // Per-parser AI override, merged over the global `ai` block (default: global block — normally omit)
+      // fieldPriorities: { title: { priority: ["ai-web", "static"], merge: "clobber" } }, // Per-field merge override (default: all fields ai-web + AI arbitration; metadata keys auto-static)
+      // conditionalValues example for sub-brands sharing one parser:
+      // metadata: { shortName: { value: "MAIN", conditionalValues: [{ keywords: ["subbrand"], value: "SUB-BRAND" }] } },
     },
     {
       name: "AI Web Parser (OpenAI Sample)",

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -19,6 +19,14 @@
 // 📖 READ scripts/README.md BEFORE EDITING - Contains full architecture rules
 // ============================================================================
 
+// Sentinel maxDepth for adaptive crawling (urlDiscoveryDepth absent): each
+// page's classification decides whether its links are followed, bounded by a
+// hard chain cap instead of a fixed numeric depth.
+const ADAPTIVE_CRAWL_DEPTH = 'adaptive';
+// Hard cap on adaptive crawl chains: pages this many hops from a root never
+// have their links followed, no matter how they classify.
+const ADAPTIVE_CRAWL_MAX_HOPS = 4;
+
 class SharedCore {
     constructor(cities, options = {}) {
         if (!cities || typeof cities !== 'object') {
@@ -75,6 +83,9 @@ class SharedCore {
         // Initialize city mappings from centralized cities config
         this.cityMappings = this.convertCitiesConfigToCityMappings(this.cities);
         this.loggedWarnings = new Set();
+        // Per-run learned dead-end context (created by processEvents from the
+        // store the orchestrator loaded; null outside a run = feature inert)
+        this.deadEndRunContext = null;
         this.trackingParamPattern = /^(aff|affix|affiliate|utm_source|utm_medium|utm_campaign|utm_content|utm_term|ref|referral|fbclid|gclid|msclkid|dclid|source|mc_cid|mc_eid)$/i;
         
         // URL-to-parser mapping for automatic parser detection
@@ -106,8 +117,12 @@ class SharedCore {
             // Generic parser will be used as fallback if no pattern matches
         ];
 
-        // URL pattern rules for page classification (checked in order, first match wins)
-        this.pageClassificationRules = this.normalizePageClassificationRules(options.pageClassificationRules || []);
+        // URL pattern rules for page classification (checked in order, first match wins).
+        // Built-in platform rules are appended AFTER config rules so config always overrides.
+        this.pageClassificationRules = [
+            ...this.normalizePageClassificationRules(options.pageClassificationRules || []),
+            ...this.normalizePageClassificationRules(this.getBuiltInPageClassificationRules())
+        ];
 
         // Compiled regex and thresholds for HTML heuristics in classifyPage
         this.pageClassificationMonthPattern = /\b(?:january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\b/gi;
@@ -185,13 +200,9 @@ class SharedCore {
     // optionally re-check them with AI.
     classifyPageWithSignal(url, html) {
         // 1. URL pattern rules (deterministic, no HTML needed)
-        if (url) {
-            for (const rule of this.pageClassificationRules) {
-                if (this.pageClassificationRuleMatchesUrl(rule, url)) {
-                    return { classification: rule.classification, signal: 'url-rule' };
-                }
-            }
-
+        const ruleClassification = this.classifyUrlByRules(url);
+        if (ruleClassification) {
+            return { classification: ruleClassification, signal: 'url-rule' };
         }
 
         // 2. Schema.org Event JSON-LD (deterministic). Ticketing pages (sickening.events,
@@ -724,6 +735,29 @@ class SharedCore {
         }
     }
 
+    // Baked-in platform knowledge: URL shapes that are the same on every site.
+    // These sit BENEATH config rules (config is checked first), so a config rule
+    // matching the same URL always wins.
+    getBuiltInPageClassificationRules() {
+        return [
+            { pattern: /eventbrite\.com\/e\//i, classification: 'event-page' },
+            { pattern: /eventbrite\.com\/o\//i, classification: 'multi-event-page' },
+            { pattern: /linktr\.ee/i, classification: 'link-aggregator' }
+        ];
+    }
+
+    // Classify a URL using ONLY the URL pattern rules (config + built-ins, first
+    // match wins) — no HTML heuristics. Returns null when no rule matches.
+    classifyUrlByRules(url) {
+        if (!url) return null;
+        for (const rule of this.pageClassificationRules) {
+            if (this.pageClassificationRuleMatchesUrl(rule, url)) {
+                return rule.classification;
+            }
+        }
+        return null;
+    }
+
     normalizePageClassificationRules(rules) {
         if (!Array.isArray(rules)) {
             return [];
@@ -825,8 +859,16 @@ class SharedCore {
         const automationContext = this.resolveAutomationContext(config);
         const automationSkipped = [];
 
+        // Learned dead-end store: orchestrator loads it into config.deadEndStore
+        // and saves results.deadEndStore back when results.deadEndStoreChanged.
+        this.deadEndRunContext = this.createDeadEndRunContext(config);
+        if (this.deadEndRunContext.disabledExplicitly) {
+            await displayAdapter.logInfo('SYSTEM: Dead-end store disabled (deadEndRetryDays ≤ 0) — no URLs skipped or learned');
+        }
+
         if (!config.parsers || config.parsers.length === 0) {
             await displayAdapter.logWarn('SYSTEM: No parser configurations found in config');
+            await this.finalizeDeadEndRun(displayAdapter, results);
             return results;
         }
 
@@ -904,6 +946,8 @@ class SharedCore {
             results.automationSkippedParsers = automationSkipped;
         }
 
+        await this.finalizeDeadEndRun(displayAdapter, results);
+
         const duplicateSummary = results.duplicatesRemoved > 0
             ? ` (removed ${results.duplicatesRemoved} dupes)`
             : ' (no duplicates)';
@@ -957,9 +1001,16 @@ class SharedCore {
         // Use global processedUrls to prevent duplicate processing across all parsers
 
         const discoveryOnly = effectiveParserConfig.discoveryOnly === true;
-        const maxDepth = effectiveParserConfig.urlDiscoveryDepth ?? 1;
+        // Absent urlDiscoveryDepth → adaptive crawling: each page's classification
+        // decides whether its links are followed. An explicit numeric depth
+        // (including 0) keeps the exact legacy fixed-depth behavior.
+        const configuredDepth = effectiveParserConfig.urlDiscoveryDepth;
+        const adaptiveDepth = configuredDepth === undefined || configuredDepth === null;
+        const maxDepth = adaptiveDepth ? ADAPTIVE_CRAWL_DEPTH : configuredDepth;
         if (discoveryOnly) {
-            await displayAdapter.logInfo(`SYSTEM: ${effectiveParserConfig.name} → Discovery only mode (depth ${maxDepth})`);
+            await displayAdapter.logInfo(`SYSTEM: ${effectiveParserConfig.name} → Discovery only mode (depth ${adaptiveDepth ? 'adaptive' : maxDepth})`);
+        } else if (adaptiveDepth) {
+            await displayAdapter.logInfo(`SYSTEM: ${effectiveParserConfig.name} → adaptive crawl depth`);
         }
 
         const discoveryTreeCollector = discoveryOnly
@@ -968,7 +1019,9 @@ class SharedCore {
                 rootUrlSet: new Set(),
                 allNodes: new Set(),
                 edges: [],
-                segmentsByUrl: {}
+                segmentsByUrl: {},
+                socialLinks: {},
+                organizer: null
             }
             : null;
 
@@ -1032,9 +1085,120 @@ class SharedCore {
             const totalSegmentCount = Object.values(discoveryTree.segmentsByUrl).reduce((sum, segs) => sum + segs.length, 0);
             const segmentSuffix = segmentUrlCount > 0 ? `, ${totalSegmentCount} segment(s) on ${segmentUrlCount} multi-event page(s)` : '';
             await displayAdapter.logInfo(`SYSTEM: Discovery complete: ${discoveryTree.allNodes.length} URL(s) found across ${discoveryTree.edges.length} link(s)${segmentSuffix}`);
+            await displayAdapter.logInfo(this.buildSuggestedParserConfig(effectiveParserConfig, discoveryTreeCollector));
         }
 
         return result;
+    }
+
+    // Paste-ready parser entry printed after discoveryOnly runs. Only
+    // high-confidence lines are included: configured root URLs always; social
+    // links and organizer website only when harvested from the crawled pages.
+    buildSuggestedParserConfig(parserConfig, collector = null) {
+        const name = parserConfig && typeof parserConfig.name === 'string' && parserConfig.name.trim()
+            ? parserConfig.name.trim()
+            : 'New Site';
+        const rootUrls = Array.isArray(parserConfig && parserConfig.urls) ? parserConfig.urls : [];
+        const organizer = collector && collector.organizer && typeof collector.organizer === 'object'
+            ? collector.organizer
+            : null;
+        const socialLinks = collector && collector.socialLinks && typeof collector.socialLinks === 'object'
+            ? collector.socialLinks
+            : {};
+        const organizerName = organizer && typeof organizer.name === 'string' ? organizer.name.trim() : '';
+        const organizerUrl = organizer && typeof organizer.url === 'string' ? organizer.url.trim() : '';
+        const shortName = (organizerName || name).toUpperCase();
+
+        const lines = [];
+        lines.push(`📋 SUGGESTED CONFIG for "${name}" — paste into parsers[] in scraper-input.js:`);
+        lines.push('{');
+        lines.push(`  name: ${JSON.stringify(name)},`);
+        lines.push('  enabled: false, // flip on after a dry-run preview looks right');
+        lines.push(`  urls: [${rootUrls.map(url => JSON.stringify(url)).join(', ')}],`);
+        lines.push('  alwaysBear: false, // set true for trusted bear promoters (AI trust context)');
+        lines.push('  metadata: {');
+        lines.push(`    shortName: { value: ${JSON.stringify(shortName)} }, // add a hyphen where it should line-break`);
+        if (socialLinks.instagram) {
+            lines.push(`    instagram: { value: ${JSON.stringify(socialLinks.instagram)} }, // found on page`);
+        }
+        if (socialLinks.facebook) {
+            lines.push(`    facebook: { value: ${JSON.stringify(socialLinks.facebook)} }, // found on page`);
+        }
+        if (organizerUrl) {
+            lines.push(`    website: { value: ${JSON.stringify(organizerUrl)} }, // found on page`);
+        }
+        lines.push('  },');
+        lines.push('},');
+        return lines.join('\n');
+    }
+
+    // Baked-in platform confidence expectations: Eventbrite /e/ event pages ship
+    // complete JSON-LD (offers → cover, image, ticketUrl) and reliable location
+    // meta tags. Merged BENEATH config-provided aiConfidenceDefaults, which are in
+    // turn beneath per-parser blocks — later urlPatterns entries win in
+    // getAiConfidenceExpectations, so config extends/overrides the built-ins.
+    getBuiltInAiConfidenceDefaults() {
+        return {
+            confidence: {
+                expectations: {
+                    urlPatterns: [
+                        {
+                            pattern: '^https?://(?:www\\.)?eventbrite\\.com/e/',
+                            fields: {
+                                cover: { expected: ['jsonld'], strong: ['jsonld'] },
+                                image: { expected: ['jsonld'], strong: ['jsonld'] },
+                                ticketUrl: { expected: ['jsonld'], strong: ['jsonld'] },
+                                location: { expected: ['meta'], strong: ['meta'] }
+                            }
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    // Merge one confidence block beneath another: override keys win key-wise for
+    // confidence/expectations/fields; urlPatterns concatenate base-first (later
+    // entries win at consumption time, so override extends/overrides base).
+    mergeAiConfidenceLayers(baseConfidence, overrideConfidence) {
+        const base = baseConfidence && typeof baseConfidence === 'object' ? baseConfidence : {};
+        const override = overrideConfidence && typeof overrideConfidence === 'object' ? overrideConfidence : {};
+
+        const baseExpectations = base.expectations && typeof base.expectations === 'object'
+            ? base.expectations
+            : {};
+        const overrideExpectations = override.expectations && typeof override.expectations === 'object'
+            ? override.expectations
+            : {};
+        const baseFields = baseExpectations.fields && typeof baseExpectations.fields === 'object'
+            ? baseExpectations.fields
+            : {};
+        const overrideFields = overrideExpectations.fields && typeof overrideExpectations.fields === 'object'
+            ? overrideExpectations.fields
+            : {};
+
+        const baseUrlPatterns = Array.isArray(baseExpectations.urlPatterns) ? baseExpectations.urlPatterns : [];
+        const overrideUrlPatterns = Array.isArray(overrideExpectations.urlPatterns) ? overrideExpectations.urlPatterns : [];
+
+        const mergedExpectations = {
+            ...baseExpectations,
+            ...overrideExpectations
+        };
+        if (Object.keys(baseFields).length > 0 || Object.keys(overrideFields).length > 0) {
+            mergedExpectations.fields = {
+                ...baseFields,
+                ...overrideFields
+            };
+        }
+        if (baseUrlPatterns.length > 0 || overrideUrlPatterns.length > 0) {
+            mergedExpectations.urlPatterns = [...baseUrlPatterns, ...overrideUrlPatterns];
+        }
+
+        return {
+            ...base,
+            ...override,
+            expectations: mergedExpectations
+        };
     }
 
     applyGlobalAiConfidenceDefaults(parserConfig, mainConfig) {
@@ -1045,53 +1209,25 @@ class SharedCore {
             && typeof mainConfig.config.aiConfidenceDefaults === 'object'
             ? mainConfig.config.aiConfidenceDefaults
             : null;
-        if (!globalDefaults) return parser;
 
-        const globalConfidence = globalDefaults.confidence && typeof globalDefaults.confidence === 'object'
+        const builtInConfidence = this.getBuiltInAiConfidenceDefaults().confidence;
+        const globalConfidence = globalDefaults
+            && globalDefaults.confidence
+            && typeof globalDefaults.confidence === 'object'
             ? globalDefaults.confidence
             : null;
-        if (!globalConfidence) return parser;
+
+        // Layering (lowest first): built-in platform defaults < global config < parser
+        const effectiveGlobalConfidence = globalConfidence
+            ? this.mergeAiConfidenceLayers(builtInConfidence, globalConfidence)
+            : builtInConfidence;
 
         const parserAi = parser.ai && typeof parser.ai === 'object' ? parser.ai : {};
         const parserConfidence = parserAi.confidence && typeof parserAi.confidence === 'object'
             ? parserAi.confidence
             : {};
 
-        const globalExpectations = globalConfidence.expectations && typeof globalConfidence.expectations === 'object'
-            ? globalConfidence.expectations
-            : {};
-        const parserExpectations = parserConfidence.expectations && typeof parserConfidence.expectations === 'object'
-            ? parserConfidence.expectations
-            : {};
-        const globalFields = globalExpectations.fields && typeof globalExpectations.fields === 'object'
-            ? globalExpectations.fields
-            : {};
-        const parserFields = parserExpectations.fields && typeof parserExpectations.fields === 'object'
-            ? parserExpectations.fields
-            : {};
-
-        const globalUrlPatterns = Array.isArray(globalExpectations.urlPatterns) ? globalExpectations.urlPatterns : [];
-        const parserUrlPatterns = Array.isArray(parserExpectations.urlPatterns) ? parserExpectations.urlPatterns : [];
-
-        const mergedExpectations = {
-            ...globalExpectations,
-            ...parserExpectations
-        };
-        if (Object.keys(globalFields).length > 0 || Object.keys(parserFields).length > 0) {
-            mergedExpectations.fields = {
-                ...globalFields,
-                ...parserFields
-            };
-        }
-        if (globalUrlPatterns.length > 0 || parserUrlPatterns.length > 0) {
-            mergedExpectations.urlPatterns = [...globalUrlPatterns, ...parserUrlPatterns];
-        }
-
-        const mergedConfidence = {
-            ...globalConfidence,
-            ...parserConfidence,
-            expectations: mergedExpectations
-        };
+        const mergedConfidence = this.mergeAiConfidenceLayers(effectiveGlobalConfidence, parserConfidence);
 
         return {
             ...parser,
@@ -1263,12 +1399,15 @@ class SharedCore {
         discoveryOnly = false,
         discoveryTreeCollector = null
     }) {
+        const adaptiveCrawl = maxDepth === ADAPTIVE_CRAWL_DEPTH;
         const urlsToProcess = currentDepth > 0
             ? this.limitAdditionalUrls(urls, parserConfig)
             : (Array.isArray(urls) ? urls : []);
 
         if (currentDepth > 0) {
-            await displayAdapter.logInfo(`SYSTEM: Crawling ${urlsToProcess.length} discovered URLs (depth ${currentDepth}/${maxDepth})`);
+            await displayAdapter.logInfo(adaptiveCrawl
+                ? `SYSTEM: Crawling ${urlsToProcess.length} discovered URLs (depth ${currentDepth}, adaptive)`
+                : `SYSTEM: Crawling ${urlsToProcess.length} discovered URLs (depth ${currentDepth}/${maxDepth})`);
         }
 
         for (let i = 0; i < urlsToProcess.length; i++) {
@@ -1311,7 +1450,10 @@ class SharedCore {
                     ? { html: '', url, statusCode: 200, headers: {}, input: parserConfig.input }
                     : await httpAdapter.fetchData(url);
 
-                const perPageParserConfig = currentDepth === 0
+                // Adaptive mode keeps urlDiscoveryDepth ABSENT on per-page configs
+                // (absence is what signals adaptive to parsers); numeric mode passes
+                // the remaining depth budget down exactly as before.
+                const perPageParserConfig = currentDepth === 0 || adaptiveCrawl
                     ? parserConfig
                     : {
                         ...parserConfig,
@@ -1345,6 +1487,27 @@ class SharedCore {
                     discoveryTreeCollector.segmentsByUrl[url] = parseResult.discoveredSegments;
                 }
 
+                // Harvested onboarding hints (discoveryOnly runs): first-seen wins
+                // for each social host and for the JSON-LD organizer.
+                if (discoveryTreeCollector) {
+                    const harvestedSocial = parseResult?.discoveredSocialLinks;
+                    if (harvestedSocial && typeof harvestedSocial === 'object') {
+                        for (const [host, link] of Object.entries(harvestedSocial)) {
+                            if (link && !discoveryTreeCollector.socialLinks[host]) {
+                                discoveryTreeCollector.socialLinks[host] = link;
+                            }
+                        }
+                    }
+                    const harvestedOrganizer = parseResult?.discoveredOrganizer;
+                    if (harvestedOrganizer && typeof harvestedOrganizer === 'object' && !discoveryTreeCollector.organizer) {
+                        discoveryTreeCollector.organizer = harvestedOrganizer;
+                    }
+                }
+
+                // Learned dead-end store: the page fetched successfully, so record
+                // whether it was productive (raw pre-filter counts) or a dead end.
+                this.recordDeadEndObservation({ url, currentDepth, parseResult, pageClassification, discoveryOnly });
+
                 if (!discoveryOnly) {
                     const parsedEvents = await this.prepareParsedEvents(parseResult?.events, parserConfig, mainConfig, pageClassification, this.normalizerPipeline, httpAdapter);
                     if (parsedEvents.length > 0) {
@@ -1353,12 +1516,26 @@ class SharedCore {
                 }
 
                 const additionalLinks = parseResult?.additionalLinks || [];
-                if (additionalLinks.length === 0) {
+                let linksToConsider = additionalLinks;
+                if (adaptiveCrawl) {
+                    // The page's own classification decides which links (if any)
+                    // are followed; a hard hop cap bounds runaway chains.
+                    linksToConsider = this.selectAdaptiveFollowLinks(pageClassification, additionalLinks, parseResult, url);
+                    if (linksToConsider.length > 0 && currentDepth >= ADAPTIVE_CRAWL_MAX_HOPS) {
+                        await displayAdapter.logInfo(`SYSTEM: Adaptive crawl: chain cap (${ADAPTIVE_CRAWL_MAX_HOPS} hops) reached at ${url} — not following ${linksToConsider.length} link(s)`);
+                        linksToConsider = [];
+                    } else if (linksToConsider.length > 0) {
+                        await displayAdapter.logInfo(`SYSTEM: Adaptive crawl: following ${linksToConsider.length} links from ${url} (${pageClassification})`);
+                    } else if (additionalLinks.length > 0) {
+                        await displayAdapter.logInfo(`SYSTEM: Adaptive crawl: stopping at ${url} (${pageClassification})`);
+                    }
+                }
+                if (linksToConsider.length === 0) {
                     continue;
                 }
 
-                const deduplicatedUrls = this.deduplicateUrls(additionalLinks, processedUrls);
-                const shouldFollowLinks = currentDepth < maxDepth;
+                const deduplicatedUrls = this.deduplicateUrls(linksToConsider, processedUrls);
+                const shouldFollowLinks = adaptiveCrawl || currentDepth < maxDepth;
 
                 if (shouldFollowLinks) {
                     if (discoveryTreeCollector) {
@@ -1369,12 +1546,15 @@ class SharedCore {
                     }
                     await displayAdapter.logInfo(
                         currentDepth === 0
-                            ? `SYSTEM: Following ${additionalLinks.length} discovered URLs → ${deduplicatedUrls.length} unique for crawl depth ${currentDepth + 1}`
-                            : `SYSTEM: Crawl page ${url} found ${additionalLinks.length} URLs → ${deduplicatedUrls.length} unique for depth ${currentDepth + 1}`
+                            ? `SYSTEM: Following ${linksToConsider.length} discovered URLs → ${deduplicatedUrls.length} unique for crawl depth ${currentDepth + 1}`
+                            : `SYSTEM: Crawl page ${url} found ${linksToConsider.length} URLs → ${deduplicatedUrls.length} unique for depth ${currentDepth + 1}`
                     );
-                    if (deduplicatedUrls.length > 0) {
+                    // Known dead ends younger than the retry window are skipped
+                    // before enqueueing (discoveryOnly always fetches everything).
+                    const enqueueUrls = this.filterKnownDeadEndUrls(deduplicatedUrls, discoveryOnly);
+                    if (enqueueUrls.length > 0) {
                         await this.crawlUrlsForEvents({
-                            urls: deduplicatedUrls,
+                            urls: enqueueUrls,
                             allEvents,
                             parsers,
                             parserConfig,
@@ -1438,6 +1618,207 @@ class SharedCore {
         return Number.isFinite(maxUrls)
             ? additionalLinks.slice(0, maxUrls)
             : additionalLinks;
+    }
+
+    // Adaptive crawl follow rules — the parent page's classification decides:
+    //   link-aggregator   → follow every valid link (links ARE the payload)
+    //   multi-event-page  → follow every valid link (detail pages carry the data)
+    //   event-page        → follow ONLY links pre-classifiable as event-page via
+    //                       URL rules, plus the page's own extracted ticketUrl(s)
+    //   ad / unknown      → follow nothing
+    selectAdaptiveFollowLinks(pageClassification, additionalLinks, parseResult, pageUrl) {
+        const links = Array.isArray(additionalLinks) ? additionalLinks : [];
+        if (pageClassification === 'link-aggregator' || pageClassification === 'multi-event-page') {
+            return links;
+        }
+        if (pageClassification !== 'event-page') {
+            return [];
+        }
+        const selected = [];
+        const seen = new Set();
+        const push = (candidate) => {
+            const normalized = this.normalizeUrl(candidate, pageUrl || candidate);
+            if (!normalized || seen.has(normalized)) return;
+            seen.add(normalized);
+            selected.push(normalized);
+        };
+        for (const link of links) {
+            if (this.classifyUrlByRules(link) === 'event-page') {
+                push(link);
+            }
+        }
+        const events = Array.isArray(parseResult?.events) ? parseResult.events : [];
+        for (const event of events) {
+            const ticketUrl = event && typeof event.ticketUrl === 'string' ? event.ticketUrl.trim() : '';
+            if (ticketUrl) {
+                push(ticketUrl);
+            }
+        }
+        return selected;
+    }
+
+    // ------------------------------------------------------------------
+    // Learned dead-end store (pure logic — persistence lives in adapters).
+    // A URL is a dead end only if it FETCHED successfully AND produced 0 raw
+    // events (pre future/bear filtering), 0 segments, AND 0 valid discovered
+    // links. Fetch failures and configured root URLs are never dead-ended.
+    // ------------------------------------------------------------------
+
+    createDeadEndRunContext(config) {
+        const globalConfig = config && config.config && typeof config.config === 'object' ? config.config : {};
+        const raw = globalConfig.deadEndRetryDays;
+        let retryDays = 30;
+        let disabledExplicitly = false;
+        if (raw !== undefined && raw !== null) {
+            const parsed = Number(raw);
+            if (Number.isFinite(parsed)) {
+                if (parsed <= 0) {
+                    // Kill switch: non-positive disables the store entirely
+                    disabledExplicitly = true;
+                } else {
+                    retryDays = parsed;
+                }
+            }
+        }
+        const store = config && config.deadEndStore && typeof config.deadEndStore === 'object' && !Array.isArray(config.deadEndStore)
+            ? config.deadEndStore
+            : {};
+        return {
+            enabled: !disabledExplicitly,
+            disabledExplicitly,
+            retryDays,
+            store,
+            dirty: false,
+            skippedCount: 0,
+            skippedSamples: [],
+            learned: [],
+            recovered: [],
+            prunedCount: 0
+        };
+    }
+
+    // Drop discovered URLs whose dead-end entry is younger than the retry
+    // window. Older entries pass through and get retried once. discoveryOnly
+    // runs never skip — discovery is the mapping/debugging mode and must fetch
+    // everything (productive pages then self-heal out of the store).
+    filterKnownDeadEndUrls(urls, discoveryOnly = false, nowMs = Date.now()) {
+        const context = this.deadEndRunContext;
+        const list = Array.isArray(urls) ? urls : [];
+        if (!context || !context.enabled || discoveryOnly) {
+            return list;
+        }
+        const retryMs = context.retryDays * 24 * 60 * 60 * 1000;
+        const allowed = [];
+        for (const url of list) {
+            const entry = context.store[url];
+            const lastSeenMs = entry && entry.lastSeen ? Date.parse(entry.lastSeen) : NaN;
+            if (entry && Number.isFinite(lastSeenMs) && (nowMs - lastSeenMs) < retryMs) {
+                context.skippedCount += 1;
+                if (context.skippedSamples.length < 3 && !context.skippedSamples.includes(url)) {
+                    context.skippedSamples.push(url);
+                }
+                continue;
+            }
+            allowed.push(url);
+        }
+        return allowed;
+    }
+
+    // Record the outcome of a successfully-fetched page. Productive pages are
+    // removed from the store (self-heal); dead pages refresh an existing entry
+    // (retry miss) or are learned as new dead ends — never for root URLs.
+    // Pages classified 'ad' are ALWAYS dead ends (ads never get extraction or
+    // link-following, so re-fetching them is pure waste); 'unknown' pages stay
+    // under the strict output rule — that classification is too weak a signal.
+    recordDeadEndObservation({ url, currentDepth, parseResult, pageClassification = null, discoveryOnly = false, nowMs = Date.now() }) {
+        const context = this.deadEndRunContext;
+        if (!context || !context.enabled || !url) {
+            return;
+        }
+        // RAW pre-filter counts: a page whose events are all in the past still
+        // produced events — it is NOT a dead end.
+        const rawEventCount = Array.isArray(parseResult?.events) ? parseResult.events.length : 0;
+        const segmentCount = Array.isArray(parseResult?.discoveredSegments) ? parseResult.discoveredSegments.length : 0;
+        const links = parseResult?.additionalLinks;
+        // uniqueValidCount (when the parser tags it) counts valid links BEFORE
+        // the maxAdditionalUrls budget, so a budget of 0 can't fake a dead end.
+        const taggedUniqueValid = Array.isArray(links) ? Number(links.uniqueValidCount) : NaN;
+        const uniqueValidLinkCount = Number.isFinite(taggedUniqueValid)
+            ? taggedUniqueValid
+            : (Array.isArray(links) ? links.length : 0);
+        const productive = pageClassification !== 'ad'
+            && (rawEventCount > 0 || segmentCount > 0 || uniqueValidLinkCount > 0);
+
+        const store = context.store;
+        const entry = store[url];
+        if (productive) {
+            if (entry) {
+                delete store[url];
+                context.dirty = true;
+                context.recovered.push(url);
+            }
+            return;
+        }
+        if (currentDepth === 0) {
+            // Configured root URLs are never dead-ended
+            return;
+        }
+        const nowIso = new Date(nowMs).toISOString();
+        if (entry) {
+            entry.lastSeen = nowIso;
+            entry.misses = (Number(entry.misses) || 0) + 1;
+            context.dirty = true;
+        } else {
+            store[url] = { firstSeen: nowIso, lastSeen: nowIso, misses: 1 };
+            context.dirty = true;
+            context.learned.push(url);
+        }
+    }
+
+    // End-of-run retention pass: entries unseen for 2× the retry window are
+    // stale (their page has been retried and confirmed dead at least once
+    // without ever recovering) and get dropped.
+    pruneDeadEndStore(context, nowMs = Date.now()) {
+        if (!context || !context.enabled) {
+            return;
+        }
+        const horizonMs = 2 * context.retryDays * 24 * 60 * 60 * 1000;
+        for (const [url, entry] of Object.entries(context.store)) {
+            const lastSeenMs = entry && entry.lastSeen ? Date.parse(entry.lastSeen) : NaN;
+            if (!Number.isFinite(lastSeenMs) || (nowMs - lastSeenMs) > horizonMs) {
+                delete context.store[url];
+                context.prunedCount += 1;
+                context.dirty = true;
+            }
+        }
+    }
+
+    async finalizeDeadEndRun(displayAdapter, results, nowMs = Date.now()) {
+        const context = this.deadEndRunContext;
+        this.deadEndRunContext = null;
+        if (!context) {
+            return;
+        }
+        if (context.enabled) {
+            this.pruneDeadEndStore(context, nowMs);
+            if (context.skippedCount > 0) {
+                const samples = context.skippedSamples.length > 0 ? `: ${context.skippedSamples.join(', ')}` : '';
+                await displayAdapter.logInfo(`SYSTEM: Skipped ${context.skippedCount} known dead-end URL(s) (retry after ${context.retryDays}d; delete dead-ends.json or set deadEndRetryDays: 0 to reset)${samples}`);
+            }
+            if (context.learned.length > 0) {
+                await displayAdapter.logInfo(`SYSTEM: Learned ${context.learned.length} new dead-end URL(s): ${context.learned.join(', ')}`);
+            }
+            if (context.recovered.length > 0) {
+                await displayAdapter.logInfo(`SYSTEM: Removed ${context.recovered.length} recovered URL(s) from dead-end store: ${context.recovered.join(', ')}`);
+            }
+            if (context.prunedCount > 0) {
+                await displayAdapter.logInfo(`SYSTEM: Pruned ${context.prunedCount} stale dead-end URL(s) (last seen more than ${2 * context.retryDays}d ago)`);
+            }
+        }
+        if (results && typeof results === 'object') {
+            results.deadEndStore = context.store;
+            results.deadEndStoreChanged = context.dirty;
+        }
     }
 
     async prepareParsedEvents(events, parserConfig, mainConfig, pageClassification, normalizerPipeline, httpAdapter) {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1085,7 +1085,9 @@ class SharedCore {
             const totalSegmentCount = Object.values(discoveryTree.segmentsByUrl).reduce((sum, segs) => sum + segs.length, 0);
             const segmentSuffix = segmentUrlCount > 0 ? `, ${totalSegmentCount} segment(s) on ${segmentUrlCount} multi-event page(s)` : '';
             await displayAdapter.logInfo(`SYSTEM: Discovery complete: ${discoveryTree.allNodes.length} URL(s) found across ${discoveryTree.edges.length} link(s)${segmentSuffix}`);
-            await displayAdapter.logInfo(this.buildSuggestedParserConfig(effectiveParserConfig, discoveryTreeCollector));
+            const suggestedConfig = this.buildSuggestedParserConfig(effectiveParserConfig, discoveryTreeCollector);
+            result.suggestedConfig = suggestedConfig;
+            await displayAdapter.logInfo(suggestedConfig);
         }
 
         return result;

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -2947,3 +2947,567 @@ test('PARSER MERGE summary lists only fields the merge actually changed on the o
   assert.match(summary, /1 field updated \(bar\)/, 'only the genuinely changed field is counted');
   assert.ok(!summary.includes('cover'), 'a preserved-from-base field must not be listed as updated');
 });
+
+// ---------------------------------------------------------------------------
+// Built-in page classification rules (platform defaults beneath config rules)
+// ---------------------------------------------------------------------------
+
+test('built-in classification rules are active with an empty config', () => {
+  const core = createCore();
+  assert.equal(core.classifyPage('https://www.eventbrite.com/e/party-123', null), 'event-page');
+  assert.equal(core.classifyPage('https://www.eventbrite.com/o/org-456', null), 'multi-event-page');
+  assert.equal(core.classifyPage('https://linktr.ee/somepromoter', null), 'link-aggregator');
+  // They resolve at the deterministic url-rule tier (no HTML needed)
+  assert.deepEqual(
+    core.classifyPageWithSignal('https://linktr.ee/somepromoter', null),
+    { classification: 'link-aggregator', signal: 'url-rule' }
+  );
+});
+
+test('config classification rules are checked BEFORE built-ins (config overrides)', () => {
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    pageClassificationRules: [
+      { pattern: /eventbrite\.com\/e\//i, classification: 'multi-event-page' }
+    ]
+  });
+  assert.equal(core.classifyPage('https://www.eventbrite.com/e/party-123', null), 'multi-event-page',
+    'first match wins, and config rules come first');
+  // Untouched built-ins still apply beneath the config rule
+  assert.equal(core.classifyPage('https://www.eventbrite.com/o/org-456', null), 'multi-event-page');
+  assert.equal(core.classifyPage('https://linktr.ee/x', null), 'link-aggregator');
+});
+
+// ---------------------------------------------------------------------------
+// Built-in Eventbrite /e/ confidence defaults (merge-under config)
+// ---------------------------------------------------------------------------
+
+test('built-in Eventbrite confidence defaults apply without any config and sit beneath config defaults', () => {
+  const core = createCore();
+
+  // No global config at all → built-in urlPattern present
+  const bare = core.applyGlobalAiConfidenceDefaults({ name: 'X' }, null);
+  const barePatterns = bare.ai.confidence.expectations.urlPatterns;
+  assert.equal(barePatterns.length, 1);
+  assert.match(barePatterns[0].pattern, /eventbrite\\\.com\/e\//);
+  assert.deepEqual(barePatterns[0].fields.cover, { expected: ['jsonld'], strong: ['jsonld'] });
+  assert.deepEqual(barePatterns[0].fields.location, { expected: ['meta'], strong: ['meta'] });
+
+  // Config-provided defaults come AFTER the built-in (later urlPatterns entries
+  // win at consumption time, so config extends/overrides)
+  const mainConfig = {
+    config: {
+      aiConfidenceDefaults: {
+        confidence: {
+          expectations: {
+            urlPatterns: [{ pattern: 'custom-site', fields: { image: { expected: ['meta'] } } }]
+          }
+        }
+      }
+    }
+  };
+  const merged = core.applyGlobalAiConfidenceDefaults({ name: 'X' }, mainConfig);
+  const mergedPatterns = merged.ai.confidence.expectations.urlPatterns;
+  assert.equal(mergedPatterns.length, 2);
+  assert.match(mergedPatterns[0].pattern, /eventbrite/);
+  assert.equal(mergedPatterns[1].pattern, 'custom-site');
+
+  // A parser's own confidence keys still win key-wise over both layers
+  const parserEntry = {
+    name: 'Y',
+    ai: { confidence: { minScore: 42, expectations: { urlPatterns: [{ pattern: 'parser-own', fields: {} }] } } }
+  };
+  const parserMerged = core.applyGlobalAiConfidenceDefaults(parserEntry, mainConfig);
+  assert.equal(parserMerged.ai.confidence.minScore, 42);
+  const parserPatterns = parserMerged.ai.confidence.expectations.urlPatterns;
+  assert.deepEqual(parserPatterns.map(p => p.pattern), [
+    barePatterns[0].pattern, 'custom-site', 'parser-own'
+  ], 'layering is built-in < global config < parser');
+});
+
+// ---------------------------------------------------------------------------
+// Adaptive crawl depth (urlDiscoveryDepth absent)
+// ---------------------------------------------------------------------------
+
+// Harness: canned pages keyed by URL. `fail` throws on fetch; everything else
+// returns 200 with empty HTML — classification is driven purely by URL rules.
+function createCrawlHarness(pages) {
+  const fetched = [];
+  const parsedConfigs = {};
+  const httpAdapter = {
+    fetchData: async (url) => {
+      const page = pages[url];
+      if (page && page.fail) {
+        throw new Error(page.fail);
+      }
+      fetched.push(url);
+      return { html: (page && page.html) || '<html><body></body></html>', url, statusCode: 200, headers: {} };
+    }
+  };
+  const parsers = {
+    'ai-web': {
+      parseEvents: (htmlData, parserConfig) => {
+        const page = pages[htmlData.url] || {};
+        parsedConfigs[htmlData.url] = parserConfig;
+        const result = {
+          events: page.events || [],
+          additionalLinks: page.additionalLinks || []
+        };
+        if (page.discoveredSegments) result.discoveredSegments = page.discoveredSegments;
+        if (page.discoveredSocialLinks) result.discoveredSocialLinks = page.discoveredSocialLinks;
+        if (page.discoveredOrganizer) result.discoveredOrganizer = page.discoveredOrganizer;
+        return result;
+      }
+    }
+  };
+  return { fetched, parsedConfigs, httpAdapter, parsers };
+}
+
+// Deterministic crawl entries: no AI classification second opinion, no bear-check chatter
+const CRAWL_AI = { classifyPages: false, bearCheck: { mode: 'off' } };
+
+test('adaptive crawl: aggregator and multi-event pages follow links; event pages follow only rule-classified event links + extracted ticketUrl', async () => {
+  const core = createCore();
+  const display = createDisplayAdapterStub();
+  const pages = {
+    'https://linktr.ee/newsite': { additionalLinks: ['https://www.eventbrite.com/o/newsite-123'] },
+    'https://www.eventbrite.com/o/newsite-123': { additionalLinks: ['https://www.eventbrite.com/e/party-1'] },
+    'https://www.eventbrite.com/e/party-1': {
+      events: [{ title: 'Party One', startDate: new Date(Date.now() + 7 * 86400000), ticketUrl: 'https://tickets.example/party-1' }],
+      additionalLinks: [
+        'https://www.eventbrite.com/e/party-2',      // rule-classifiable event page → followed
+        'https://newsite.example/press-and-media'     // valid but not an event page by URL rules → NOT followed
+      ]
+    },
+    'https://www.eventbrite.com/e/party-2': {},
+    'https://tickets.example/party-1': {}
+  };
+  const { fetched, parsedConfigs, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  await core.processParser(
+    { name: 'Adaptive Chain', urls: ['https://linktr.ee/newsite'], ai: CRAWL_AI },
+    {}, httpAdapter, display, parsers
+  );
+
+  assert.ok(display.logs.includes('SYSTEM: Adaptive Chain → adaptive crawl depth'), 'adaptive mode announced once per parser');
+  assert.ok(fetched.includes('https://www.eventbrite.com/o/newsite-123'), 'link-aggregator links are followed');
+  assert.ok(fetched.includes('https://www.eventbrite.com/e/party-1'), 'multi-event-page links are followed');
+  assert.ok(fetched.includes('https://www.eventbrite.com/e/party-2'), 'event page follows sibling links pre-classifiable as event-page');
+  assert.ok(fetched.includes('https://tickets.example/party-1'), 'event page follows its extracted ticketUrl');
+  assert.ok(!fetched.includes('https://newsite.example/press-and-media'), 'nav/related links stay unfollowed on event pages');
+
+  // Adaptive mode never stamps a numeric depth onto per-page configs
+  assert.equal(parsedConfigs['https://www.eventbrite.com/e/party-1'].urlDiscoveryDepth, undefined);
+});
+
+test('adaptive crawl: ad and unknown pages follow nothing', async () => {
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    pageClassificationRules: [{ pattern: /ads\.example/i, classification: 'ad' }]
+  });
+  const display = createDisplayAdapterStub();
+  const pages = {
+    // No URL rule + empty HTML → 'unknown'
+    'https://mystery.example/': { additionalLinks: ['https://mystery.example/next'] },
+    'https://mystery.example/next': {},
+    'https://ads.example/': { additionalLinks: ['https://ads.example/promo'] },
+    'https://ads.example/promo': {}
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  await core.processParser(
+    { name: 'Unknown Root', urls: ['https://mystery.example/'], ai: CRAWL_AI },
+    {}, httpAdapter, display, parsers
+  );
+  assert.deepEqual(fetched, ['https://mystery.example/'], 'unknown pages follow nothing');
+  assert.ok(display.logs.includes('SYSTEM: Adaptive crawl: stopping at https://mystery.example/ (unknown)'));
+
+  fetched.length = 0;
+  await core.processParser(
+    { name: 'Ad Root', urls: ['https://ads.example/'], ai: CRAWL_AI },
+    {}, httpAdapter, display, parsers
+  );
+  assert.deepEqual(fetched, ['https://ads.example/'], 'ad pages skip the parser and follow nothing');
+});
+
+test('adaptive crawl: hard chain cap at 4 hops (logged when hit)', async () => {
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    pageClassificationRules: [{ pattern: /chain\.example/i, classification: 'link-aggregator' }]
+  });
+  const display = createDisplayAdapterStub();
+  const pages = {};
+  for (let i = 1; i <= 6; i++) {
+    pages[`https://chain.example/p${i}`] = i < 6
+      ? { additionalLinks: [`https://chain.example/p${i + 1}`] }
+      : {};
+  }
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  await core.processParser(
+    { name: 'Chain', urls: ['https://chain.example/p1'], ai: CRAWL_AI },
+    {}, httpAdapter, display, parsers
+  );
+
+  assert.deepEqual(fetched, [1, 2, 3, 4, 5].map(i => `https://chain.example/p${i}`),
+    'pages 4 hops from the root never have their links followed');
+  assert.ok(
+    display.logs.some(line => line.includes('Adaptive crawl: chain cap (4 hops) reached at https://chain.example/p5')),
+    `expected chain-cap log, got: ${JSON.stringify(display.logs.filter(l => l.includes('Adaptive')))}`
+  );
+});
+
+test('explicit numeric urlDiscoveryDepth keeps legacy behavior byte-for-byte (including 0 = never crawl)', async () => {
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    pageClassificationRules: [{ pattern: /fixed\.example/i, classification: 'link-aggregator' }]
+  });
+  const pages = {
+    'https://fixed.example/root': { additionalLinks: ['https://fixed.example/a'] },
+    'https://fixed.example/a': { additionalLinks: ['https://fixed.example/b'] },
+    'https://fixed.example/b': {}
+  };
+
+  // depth 1: root + depth-1 pages, deeper links hit the legacy depth-limit log
+  {
+    const display = createDisplayAdapterStub();
+    const { fetched, parsedConfigs, httpAdapter, parsers } = createCrawlHarness(pages);
+    await core.processParser(
+      { name: 'Depth One', urls: ['https://fixed.example/root'], urlDiscoveryDepth: 1, ai: CRAWL_AI },
+      {}, httpAdapter, display, parsers
+    );
+    assert.deepEqual(fetched, ['https://fixed.example/root', 'https://fixed.example/a']);
+    assert.ok(display.logs.includes('SYSTEM: Crawling 1 discovered URLs (depth 1/1)'), 'numeric crawl log keeps its exact shape');
+    assert.ok(display.logs.includes(
+      'SYSTEM: Crawl page https://fixed.example/a found 1 unique additional URLs, but depth limit (1) reached or URL discovery disabled - ignoring'
+    ), 'legacy depth-limit log unchanged');
+    assert.ok(!display.logs.some(line => line.includes('adaptive')), 'no adaptive logs in numeric mode');
+    // Legacy remaining-depth math still stamped onto per-page configs
+    assert.equal(parsedConfigs['https://fixed.example/a'].urlDiscoveryDepth, 0);
+  }
+
+  // depth 0: never crawl
+  {
+    const display = createDisplayAdapterStub();
+    const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+    await core.processParser(
+      { name: 'Depth Zero', urls: ['https://fixed.example/root'], urlDiscoveryDepth: 0, ai: CRAWL_AI },
+      {}, httpAdapter, display, parsers
+    );
+    assert.deepEqual(fetched, ['https://fixed.example/root']);
+    assert.ok(display.logs.some(line => line.includes('depth limit (0) reached')));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Suggested-config block (discoveryOnly onboarding output)
+// ---------------------------------------------------------------------------
+
+test('buildSuggestedParserConfig renders harvested fields and omits lines without data', () => {
+  const core = createCore();
+
+  const full = core.buildSuggestedParserConfig(
+    { name: 'Twisted Bear', urls: ['https://www.eventbrite.com/o/nab-events-llc-51471535173'] },
+    {
+      socialLinks: { instagram: 'https://www.instagram.com/twistedbearparty' },
+      organizer: { name: 'Twisted Bear Events', url: 'https://twistedbear.example' }
+    }
+  );
+  assert.equal(full, [
+    '📋 SUGGESTED CONFIG for "Twisted Bear" — paste into parsers[] in scraper-input.js:',
+    '{',
+    '  name: "Twisted Bear",',
+    '  enabled: false, // flip on after a dry-run preview looks right',
+    '  urls: ["https://www.eventbrite.com/o/nab-events-llc-51471535173"],',
+    '  alwaysBear: false, // set true for trusted bear promoters (AI trust context)',
+    '  metadata: {',
+    '    shortName: { value: "TWISTED BEAR EVENTS" }, // add a hyphen where it should line-break',
+    '    instagram: { value: "https://www.instagram.com/twistedbearparty" }, // found on page',
+    '    website: { value: "https://twistedbear.example" }, // found on page',
+    '  },',
+    '},'
+  ].join('\n'));
+
+  // Nothing harvested → shortName falls back to the parser name; no social/website lines
+  const minimal = core.buildSuggestedParserConfig(
+    { name: 'Plain Site', urls: ['https://plain.example/events'] },
+    { socialLinks: {}, organizer: null }
+  );
+  assert.ok(minimal.includes('    shortName: { value: "PLAIN SITE" }, // add a hyphen where it should line-break'));
+  assert.ok(!minimal.includes('instagram:'));
+  assert.ok(!minimal.includes('facebook:'));
+  assert.ok(!minimal.includes('website:'));
+});
+
+test('discoveryOnly runs emit the suggested-config block with harvested social links', async () => {
+  const core = createCore();
+  const display = createDisplayAdapterStub();
+  const pages = {
+    'https://www.eventbrite.com/o/newsite-123': {
+      additionalLinks: ['https://www.eventbrite.com/e/party-1'],
+      discoveredSocialLinks: { instagram: 'https://www.instagram.com/newsite' }
+    },
+    'https://www.eventbrite.com/e/party-1': {
+      discoveredOrganizer: { name: 'New Site Events', url: 'https://newsite.example' },
+      discoveredSegments: [{ index: 1, lineCount: 2, preview: 'PARTY', imageUrls: [], resourceLines: [] }]
+    }
+  };
+  const { httpAdapter, parsers } = createCrawlHarness(pages);
+
+  await core.processParser(
+    { name: 'New Site', urls: ['https://www.eventbrite.com/o/newsite-123'], discoveryOnly: true, ai: CRAWL_AI },
+    {}, httpAdapter, display, parsers
+  );
+
+  assert.ok(display.logs.some(line => line.startsWith('SYSTEM: New Site → Discovery only mode (depth adaptive)')),
+    'discoveryOnly startup line carries the adaptive marker when depth is absent');
+  const block = display.logs.find(line => line.startsWith('📋 SUGGESTED CONFIG for "New Site"'));
+  assert.ok(block, 'suggested config emitted after discovery');
+  assert.ok(block.includes('    shortName: { value: "NEW SITE EVENTS" }, // add a hyphen where it should line-break'));
+  assert.ok(block.includes('    instagram: { value: "https://www.instagram.com/newsite" }, // found on page'));
+  assert.ok(block.includes('    website: { value: "https://newsite.example" }, // found on page'));
+});
+
+// ---------------------------------------------------------------------------
+// Learned dead-end store (pure semantics — persistence lives in adapters)
+// ---------------------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function deadEndCore() {
+  // hub.example → multi-event-page so its links are always followed in adaptive mode
+  return new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    pageClassificationRules: [
+      { pattern: /hub\.example/i, classification: 'multi-event-page' },
+      { pattern: /ads\.example/i, classification: 'ad' }
+    ]
+  });
+}
+
+function deadEndConfig({ store = {}, retryDays, discoveryOnly = false, links, name = 'Dead End Run' } = {}) {
+  return {
+    config: retryDays === undefined ? {} : { deadEndRetryDays: retryDays },
+    deadEndStore: store,
+    parsers: [{
+      name,
+      urls: ['https://hub.example/'],
+      discoveryOnly,
+      ai: CRAWL_AI,
+      _links: links
+    }]
+  };
+}
+
+test('dead-end store: barren discovered pages are learned; productive, failed-fetch, and root pages never are', async () => {
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  const pages = {
+    'https://hub.example/': {
+      additionalLinks: [
+        'https://site.example/dead',
+        'https://site.example/past-events',
+        'https://site.example/broken'
+      ]
+    },
+    'https://site.example/dead': {},                        // fetched fine, 0 events/segments/links → dead end
+    'https://site.example/past-events': {
+      // RAW parse output counts: all-past events are still events → NOT a dead end
+      events: [{ title: 'Old Party', startDate: new Date('2020-01-01T00:00:00.000Z') }]
+    },
+    'https://site.example/broken': { fail: 'HTTP 503: unavailable' } // fetch failure → never dead-ended
+  };
+  const { httpAdapter, parsers } = createCrawlHarness(pages);
+  const config = deadEndConfig({});
+
+  const results = await core.processEvents(config, httpAdapter, display, parsers);
+
+  assert.deepEqual(Object.keys(results.deadEndStore), ['https://site.example/dead']);
+  const entry = results.deadEndStore['https://site.example/dead'];
+  assert.equal(entry.misses, 1);
+  assert.ok(Date.parse(entry.firstSeen) > 0 && entry.firstSeen === entry.lastSeen);
+  assert.equal(results.deadEndStoreChanged, true);
+  assert.ok(display.logs.includes('SYSTEM: Learned 1 new dead-end URL(s): https://site.example/dead'));
+  // The barren ROOT of a barren site is still never stored
+  assert.ok(!('https://hub.example/' in results.deadEndStore));
+});
+
+test('dead-end store: young entries are skipped before enqueueing, with the reset hint in the log', async () => {
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  const youngLastSeen = new Date(Date.now() - 1 * DAY_MS).toISOString();
+  const store = {
+    'https://site.example/dead': { firstSeen: youngLastSeen, lastSeen: youngLastSeen, misses: 1 }
+  };
+  const pages = {
+    'https://hub.example/': { additionalLinks: ['https://site.example/dead'] },
+    'https://site.example/dead': {}
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  const results = await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
+
+  assert.ok(!fetched.includes('https://site.example/dead'), 'young dead end is not fetched');
+  assert.equal(results.deadEndStoreChanged, false, 'skipping does not touch the store');
+  const skipLine = display.logs.find(line => line.startsWith('SYSTEM: Skipped 1 known dead-end URL(s)'));
+  assert.ok(skipLine, `expected skip log, got: ${JSON.stringify(display.logs)}`);
+  assert.ok(skipLine.includes('retry after 30d'), 'retry horizon in the log');
+  assert.ok(skipLine.includes('delete dead-ends.json or set deadEndRetryDays: 0 to reset'), 'recovery hint in the log');
+  assert.ok(skipLine.includes('https://site.example/dead'), 'sample URL in the log');
+});
+
+test('dead-end store: expired entries retry once — removed when productive, refreshed when still dead', async () => {
+  const core = deadEndCore();
+  const expiredLastSeen = new Date(Date.now() - 40 * DAY_MS).toISOString();
+
+  // Now productive → removed from the store
+  {
+    const display = createDisplayAdapterStub();
+    const store = {
+      'https://site.example/revived': { firstSeen: expiredLastSeen, lastSeen: expiredLastSeen, misses: 2 }
+    };
+    const pages = {
+      'https://hub.example/': { additionalLinks: ['https://site.example/revived'] },
+      'https://site.example/revived': {
+        events: [{ title: 'Comeback Party', startDate: new Date(Date.now() + 7 * DAY_MS) }]
+      }
+    };
+    const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+    const results = await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
+
+    assert.ok(fetched.includes('https://site.example/revived'), 'expired entry is retried');
+    assert.deepEqual(results.deadEndStore, {}, 'productive page self-heals out of the store');
+    assert.equal(results.deadEndStoreChanged, true);
+  }
+
+  // Still dead → lastSeen refreshed + misses incremented (not re-learned)
+  {
+    const display = createDisplayAdapterStub();
+    const store = {
+      'https://site.example/still-dead': { firstSeen: expiredLastSeen, lastSeen: expiredLastSeen, misses: 2 }
+    };
+    const pages = {
+      'https://hub.example/': { additionalLinks: ['https://site.example/still-dead'] },
+      'https://site.example/still-dead': {}
+    };
+    const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+    const results = await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
+
+    assert.ok(fetched.includes('https://site.example/still-dead'));
+    const entry = results.deadEndStore['https://site.example/still-dead'];
+    assert.equal(entry.misses, 3);
+    assert.ok(Date.parse(entry.lastSeen) > Date.now() - DAY_MS, 'lastSeen refreshed to now');
+    assert.equal(entry.firstSeen, expiredLastSeen, 'firstSeen preserved');
+    assert.ok(!display.logs.some(line => line.includes('Learned 1 new dead-end')), 'a refreshed miss is not re-learned');
+  }
+});
+
+test('dead-end store: entries unseen for 2× the retry window are pruned at end of run', async () => {
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  const staleLastSeen = new Date(Date.now() - 90 * DAY_MS).toISOString();  // > 2×30d
+  const freshLastSeen = new Date(Date.now() - 10 * DAY_MS).toISOString();
+  const store = {
+    'https://gone.example/forgotten': { firstSeen: staleLastSeen, lastSeen: staleLastSeen, misses: 4 },
+    'https://site.example/recent': { firstSeen: freshLastSeen, lastSeen: freshLastSeen, misses: 1 }
+  };
+  const pages = { 'https://hub.example/': {} };
+  const { httpAdapter, parsers } = createCrawlHarness(pages);
+
+  const results = await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
+
+  assert.deepEqual(Object.keys(results.deadEndStore), ['https://site.example/recent']);
+  assert.equal(results.deadEndStoreChanged, true);
+  assert.ok(display.logs.some(line => line.includes('Pruned 1 stale dead-end URL(s)')));
+});
+
+test('dead-end store: deadEndRetryDays 0 is a kill switch — nothing skipped, nothing learned', async () => {
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  const youngLastSeen = new Date(Date.now() - 1 * DAY_MS).toISOString();
+  const store = {
+    'https://site.example/dead': { firstSeen: youngLastSeen, lastSeen: youngLastSeen, misses: 1 }
+  };
+  const pages = {
+    'https://hub.example/': { additionalLinks: ['https://site.example/dead', 'https://site.example/newly-dead'] },
+    'https://site.example/dead': {},
+    'https://site.example/newly-dead': {}
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  const results = await core.processEvents(deadEndConfig({ store, retryDays: 0 }), httpAdapter, display, parsers);
+
+  assert.ok(fetched.includes('https://site.example/dead'), 'young entry fetched anyway — no skipping when disabled');
+  assert.ok(!('https://site.example/newly-dead' in results.deadEndStore), 'nothing new learned when disabled');
+  assert.equal(results.deadEndStoreChanged, false);
+  assert.ok(display.logs.some(line => line.includes('Dead-end store disabled')), 'one-liner announces the store is off');
+});
+
+test('dead-end store: discoveryOnly never skips, and a productive fetch removes the entry', async () => {
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  const youngLastSeen = new Date(Date.now() - 1 * DAY_MS).toISOString();
+  const store = {
+    'https://site.example/revived': { firstSeen: youngLastSeen, lastSeen: youngLastSeen, misses: 1 }
+  };
+  const pages = {
+    'https://hub.example/': { additionalLinks: ['https://site.example/revived'] },
+    'https://site.example/revived': { additionalLinks: ['https://site.example/deeper'] },
+    'https://site.example/deeper': {}
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  const results = await core.processEvents(deadEndConfig({ store, discoveryOnly: true }), httpAdapter, display, parsers);
+
+  assert.ok(fetched.includes('https://site.example/revived'), 'discovery mode always fetches, even young dead ends');
+  assert.ok(!('https://site.example/revived' in results.deadEndStore), 'productive page removed from the store');
+  assert.equal(results.deadEndStoreChanged, true);
+});
+
+test('dead-end store: ad-classified pages are stored regardless of links; unknown pages follow the strict output rule', async () => {
+  const core = deadEndCore();
+
+  // Unit-level force rule: 'ad' with plenty of valid links is still a dead end
+  core.deadEndRunContext = core.createDeadEndRunContext({ deadEndStore: {} });
+  core.recordDeadEndObservation({
+    url: 'https://ads.example/promo',
+    currentDepth: 1,
+    parseResult: { events: [], additionalLinks: ['https://x.example/e/party'] },
+    pageClassification: 'ad'
+  });
+  core.recordDeadEndObservation({
+    url: 'https://mystery.example/links',
+    currentDepth: 1,
+    parseResult: { events: [], additionalLinks: ['https://x.example/e/party'] },
+    pageClassification: 'unknown'
+  });
+  const store = core.deadEndRunContext.store;
+  assert.ok('https://ads.example/promo' in store, 'ad page with valid links is a dead end');
+  assert.ok(!('https://mystery.example/links' in store), 'unknown page with valid links is NOT force-stored');
+  core.deadEndRunContext = null;
+
+  // End-to-end: a discovered ad page lands in the store after the run
+  const display = createDisplayAdapterStub();
+  const pages = {
+    'https://hub.example/': { additionalLinks: ['https://ads.example/promo'] },
+    'https://ads.example/promo': {}
+  };
+  const { httpAdapter, parsers } = createCrawlHarness(pages);
+  const results = await core.processEvents(deadEndConfig({}), httpAdapter, display, parsers);
+  assert.ok('https://ads.example/promo' in results.deadEndStore);
+});
+
+test('dead-end store: maxAdditionalUrls 0 cannot fake a dead end when the parser tags uniqueValidCount', () => {
+  const core = deadEndCore();
+  core.deadEndRunContext = core.createDeadEndRunContext({ deadEndStore: {} });
+  const budgetedLinks = [];
+  Object.defineProperty(budgetedLinks, 'uniqueValidCount', { value: 7, enumerable: false });
+  core.recordDeadEndObservation({
+    url: 'https://site.example/budgeted',
+    currentDepth: 1,
+    parseResult: { events: [], additionalLinks: budgetedLinks },
+    pageClassification: 'multi-event-page'
+  });
+  assert.deepEqual(core.deadEndRunContext.store, {}, 'valid-but-budget-capped links keep the page productive');
+  core.deadEndRunContext = null;
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -3254,7 +3254,7 @@ test('discoveryOnly runs emit the suggested-config block with harvested social l
   };
   const { httpAdapter, parsers } = createCrawlHarness(pages);
 
-  await core.processParser(
+  const parserResult = await core.processParser(
     { name: 'New Site', urls: ['https://www.eventbrite.com/o/newsite-123'], discoveryOnly: true, ai: CRAWL_AI },
     {}, httpAdapter, display, parsers
   );
@@ -3263,6 +3263,8 @@ test('discoveryOnly runs emit the suggested-config block with harvested social l
     'discoveryOnly startup line carries the adaptive marker when depth is absent');
   const block = display.logs.find(line => line.startsWith('📋 SUGGESTED CONFIG for "New Site"'));
   assert.ok(block, 'suggested config emitted after discovery');
+  assert.equal(parserResult.suggestedConfig, block,
+    'suggested config also carried on the parser result so the orchestrator can save it as a file');
   assert.ok(block.includes('    shortName: { value: "NEW SITE EVENTS" }, // add a hyphen where it should line-break'));
   assert.ok(block.includes('    instagram: { value: "https://www.instagram.com/newsite" }, // found on page'));
   assert.ok(block.includes('    website: { value: "https://newsite.example" }, // found on page'));

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -3264,7 +3264,7 @@ test('discoveryOnly runs emit the suggested-config block with harvested social l
   const block = display.logs.find(line => line.startsWith('📋 SUGGESTED CONFIG for "New Site"'));
   assert.ok(block, 'suggested config emitted after discovery');
   assert.equal(parserResult.suggestedConfig, block,
-    'suggested config also carried on the parser result so the orchestrator can save it as a file');
+    'suggested config also carried on the parser result so the results UI can render it with a copy button');
   assert.ok(block.includes('    shortName: { value: "NEW SITE EVENTS" }, // add a hyphen where it should line-break'));
   assert.ok(block.includes('    instagram: { value: "https://www.instagram.com/newsite" }, // found on page'));
   assert.ok(block.includes('    website: { value: "https://newsite.example" }, // found on page'));


### PR DESCRIPTION
## What

Adding a new website now needs only: name, urls, alwaysBear, shortName/instagram. Depth, URL blocking, platform classification, and confidence expectations are automatic — config keys remain as overrides.

### 1. Adaptive crawl depth (`urlDiscoveryDepth` absent)
- Explicit numeric depth (including `0`) behaves **byte-for-byte as before** — every existing entry is unaffected.
- Absent depth → each fetched page's classification decides what gets followed:
  - `link-aggregator` / `multi-event-page` → follow links
  - `event-page` → follow ONLY links URL-rule-classified as event pages + its extracted `ticketUrl` (ticket/detail pages carry JSON-LD offers → cover, exact times); nav sprawl unfollowed
  - `ad` / `unknown` → follow nothing
- Safety: 4-hop chain cap, existing dedup + `maxAdditionalUrls` budget.

### 2. Built-in generic URL blocking
`/shop /store /merch /cart /checkout /contact /about /faq /account /signin /signup` (whole-path-segment anchored so `/events/all-about-bears` survives), `/_api/` (Wix), `?p=<digits>` (WordPress shortlinks). Per-site `discoveryBlockedPatterns` stays for deliberate exclusions.

### 3. Learned dead-end store (`dead-ends.json`)
- Dead end = fetched OK but 0 raw events (pre future/bear filtering), 0 segments, 0 valid links; pages classified `ad` always qualify; `unknown` stays under the strict output rule.
- Never stored: root urls, fetch failures, pages with only past events.
- Skipped for `deadEndRetryDays` (default 30), then retried once — still dead → snoozed; productive → removed (self-heals). Stale entries pruned at 2× window.
- Recovery levers: `deadEndRetryDays: 0` kill switch, `discoveryOnly` never skips, file is deletable; skip log names the reset path.

### 4. Baked-in platform defaults
Eventbrite `/e/`→event-page, `/o/`→multi-event-page, `linktr.ee`→link-aggregator classification rules and Eventbrite JSON-LD confidence expectations now built-in; config rules/patterns still win (config-first, 3-layer merge built-in < global < parser).

### 5. Discovery onboarding output
`discoveryOnly: true` runs harvest instagram/facebook profile links + JSON-LD organizer and print a paste-ready `📋 SUGGESTED CONFIG` block.

### 6. One clean sample
Both stale samples (desktop-ollama block, 15-field clobber `fieldPriorities`, separate OpenAI sample) replaced by a single **New Site Template** entry: minimal live fields + one commented line per optional knob with its default. Template globals drop the now-built-in Eventbrite/linktr.ee rules, confidence block, and generic blocklist.

## Known tradeoffs
- `?p=<digits>` blocking would also skip a site that paginates with `?p=N` (none configured today; a config `pageClassificationRules`/parser can be added if one appears).
- Old template blocked `/contact-us`; the anchored built-in doesn't — such pages now cost one fetch, then get learned as dead ends.

## Tests
371 pass / 0 fail (23 new): adaptive follow matrix + hop cap + legacy-depth byte-compat, dead-end lifecycle (learn/skip/retry/recover/prune/kill switch/ad-vs-unknown/past-events-only), built-in rules + confidence merge layering, social/organizer harvest, blocked-pattern accuracy. Also verified end-to-end against a live local fixture site through the real orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP