### PR TITLE
fix(merge): address dedup, pin protection, cover freshness, derived gmaps

### DIFF
--- a/scripts/calendar-contract.test.js
+++ b/scripts/calendar-contract.test.js
@@ -113,10 +113,13 @@ test('contract: createFinalEventObject keeps location as coordinates against the
 
   const table = [
     {
-      name: 'scraped coordinates replace calendar coordinates',
+      // Both sides are coordinates and the address did not change → the stored
+      // pin (possibly human-corrected) is KEPT; the divergent fresh geocode is
+      // flagged in the logs instead of silently applied.
+      name: 'calendar pin kept over scraped coordinates when the address is unchanged',
       existing: calendarWithCoords,
       scraped: buildScrapedEvent({ location: NOLA_COORDS }),
-      expected: NOLA_COORDS
+      expected: PORTLAND_COORDS_LEADING_SPACE
     },
     {
       name: 'scraped address text must NOT wipe calendar coordinates',

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -2826,12 +2826,42 @@ class AiWebParser {
         if (typeof address === 'string') return clean(address);
         if (Array.isArray(address)) return this.formatJsonLdAddress(address[0], clean);
         if (typeof address === 'object') {
-            return [address.streetAddress, address.addressLocality, address.addressRegion, address.postalCode]
+            // Eventbrite (and other ticketing) JSON-LD often packs the FULL
+            // address into streetAddress ("10-90 Wyckoff Avenue, Queens, NY
+            // 11385") while still supplying addressLocality/addressRegion —
+            // naive joining doubled the city/state ("..., Queens, NY, Queens,
+            // NY"), which churned merge arbitration every run and degraded
+            // geocoding. Skip a part that already appears in the address
+            // accumulated so far. Bear-site pages with a bare streetAddress
+            // ("123 Main St") still get locality/region/postal appended,
+            // because those parts are genuinely absent from the street text.
+            const parts = [address.streetAddress, address.addressLocality, address.addressRegion, address.postalCode]
                 .map(part => clean(part))
-                .filter(Boolean)
-                .join(', ');
+                .filter(Boolean);
+            const accumulated = [];
+            for (const part of parts) {
+                if (!this.addressAlreadyContainsPart(accumulated.join(', '), part)) {
+                    accumulated.push(part);
+                }
+            }
+            return accumulated.join(', ');
         }
         return '';
+    }
+
+    // True when `part` already appears in the address text built so far,
+    // compared case-insensitively on whitespace/punctuation-normalized word
+    // sequences. Whole word-boundary matching only — the region "NY" must not
+    // be considered "present" just because the street contains "SUNNYSIDE".
+    addressAlreadyContainsPart(builtSoFar, part) {
+        if (!builtSoFar || !part) return false;
+        const tokenize = (value) => String(value)
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, ' ')
+            .trim();
+        const needle = tokenize(part);
+        if (!needle) return false;
+        return ` ${tokenize(builtSoFar)} `.includes(` ${needle} `);
     }
 
     pickJsonLdImage(image) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -768,6 +768,58 @@ test('extractEventsFromJsonLd builds a complete event from ticketing-page struct
   assert.equal(event.url, 'https://sickening.events/e/bearracuda-portland-pridefriday');
 });
 
+test('formatJsonLdAddress never duplicates locality/region already inside the street address', () => {
+  const parser = createParser();
+  const clean = (value) => String(value || '').replace(/\s+/g, ' ').trim();
+
+  // Eventbrite shape (2026-07-15 Megawoof run): streetAddress already carries
+  // the FULL address — appending locality/region again produced
+  // "..., Queens, NY 11385, Queens, NY", which churned AI merge arbitration on
+  // address/gmaps every run and degraded geocoding.
+  assert.equal(
+    parser.formatJsonLdAddress({
+      streetAddress: '10-90 Wyckoff Avenue, Queens, NY 11385',
+      addressLocality: 'Queens',
+      addressRegion: 'NY',
+      postalCode: '11385'
+    }, clean),
+    '10-90 Wyckoff Avenue, Queens, NY 11385'
+  );
+
+  // Bare street (typical bear-site JSON-LD): locality/region/postal MUST still
+  // be appended — they are genuinely absent from the street text.
+  assert.equal(
+    parser.formatJsonLdAddress({
+      streetAddress: '123 Main St',
+      addressLocality: 'Phoenix',
+      addressRegion: 'AZ',
+      postalCode: '85004'
+    }, clean),
+    '123 Main St, Phoenix, AZ, 85004'
+  );
+
+  // Token guard: the region "NY" is NOT "present" just because the street
+  // contains "SUNNYSIDE" — containment is whole-token, not bare substring.
+  assert.equal(
+    parser.formatJsonLdAddress({
+      streetAddress: '4501 SUNNYSIDE AVE',
+      addressLocality: 'Brooklyn',
+      addressRegion: 'NY'
+    }, clean),
+    '4501 SUNNYSIDE AVE, Brooklyn, NY'
+  );
+
+  // String and array address shapes pass through unchanged.
+  assert.equal(
+    parser.formatJsonLdAddress('10-90 Wyckoff Avenue, Queens, NY 11385', clean),
+    '10-90 Wyckoff Avenue, Queens, NY 11385'
+  );
+  assert.equal(
+    parser.formatJsonLdAddress([{ streetAddress: '123 Main St', addressLocality: 'Phoenix' }], clean),
+    '123 Main St, Phoenix'
+  );
+});
+
 test('parseJsonLdDateValue anchors offset-less dates as wall-clock UTC and flags them', () => {
   const parser = createParser();
 

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -364,7 +364,12 @@ class SharedCore {
         // location is never arbitrated: it is ALWAYS coordinates (the calendar is
         // used as a database), so merges resolve it deterministically via
         // isCoordinatePair — human-readable text belongs in address/bar.
-        return name !== 'key' && name !== 'notes' && name !== 'source' && name !== 'location';
+        // gmaps is never arbitrated either: it is DERIVED (a pure function of
+        // bar + address), so arbitrating it independently let it disagree with
+        // the merged bar/address — createFinalEventObject regenerates it from
+        // the final merged values instead.
+        return name !== 'key' && name !== 'notes' && name !== 'source'
+            && name !== 'location' && name !== 'gmaps';
     }
 
     // "lat, lng" / "lat,lng": two finite floats with lat in [-90, 90] and lng in
@@ -379,6 +384,28 @@ class SharedCore {
         const lng = Number(match[2]);
         return Number.isFinite(lat) && Number.isFinite(lng)
             && Math.abs(lat) <= 90 && Math.abs(lng) <= 180;
+    }
+
+    // "lat, lng" string → { lat, lng } numbers, or null when not a pair.
+    parseCoordinatePair(value) {
+        if (!this.isCoordinatePair(value)) return null;
+        const [lat, lng] = String(value).split(',').map(part => Number(part.trim()));
+        return { lat, lng };
+    }
+
+    // Great-circle distance in km between two "lat, lng" strings (haversine —
+    // pure math, no platform APIs). Null when either side isn't a pair.
+    coordinatePairDistanceKm(valueA, valueB) {
+        const a = this.parseCoordinatePair(valueA);
+        const b = this.parseCoordinatePair(valueB);
+        if (!a || !b) return null;
+        const toRadians = (degrees) => degrees * Math.PI / 180;
+        const sinHalfLat = Math.sin(toRadians(b.lat - a.lat) / 2);
+        const sinHalfLng = Math.sin(toRadians(b.lng - a.lng) / 2);
+        const h = sinHalfLat * sinHalfLat
+            + Math.cos(toRadians(a.lat)) * Math.cos(toRadians(b.lat)) * sinHalfLng * sinHalfLng;
+        const earthRadiusKm = 6371;
+        return 2 * earthRadiusKm * Math.asin(Math.min(1, Math.sqrt(h)));
     }
 
     // Date-or-ISO-string → epoch milliseconds, or null when absent/unparseable.
@@ -427,13 +454,27 @@ class SharedCore {
         return String(value === null || value === undefined ? '' : value).trim();
     }
 
+    // Cover values that differ only in whitespace are the SAME price: the old
+    // formatter spaced the range dash ("$22.10 - $39.98"), the sticker-price
+    // formatter doesn't ("$22.10-$39.98"), and that formatting twin burned an
+    // AI arbitration on every run.
+    coverValuesEquivalent(valueA, valueB) {
+        const stripWhitespace = (value) => String(value === null || value === undefined ? '' : value).replace(/\s+/g, '');
+        const strippedA = stripWhitespace(valueA);
+        return strippedA !== '' && strippedA === stripWhitespace(valueB);
+    }
+
     // A genuine conflict: both sides non-empty primitives whose serialized forms
-    // differ. Same-instant Date vs ISO string is NOT a conflict.
+    // differ. Same-instant Date vs ISO string is NOT a conflict, and neither are
+    // whitespace-only cover formatting twins.
     isGenuineFieldConflict(fieldName, valueA, valueB) {
         if (this.isEmptyArbitrationValue(valueA) || this.isEmptyArbitrationValue(valueB)) return false;
         const isPrimitive = (v) => v instanceof Date || typeof v !== 'object';
         if (!isPrimitive(valueA) || !isPrimitive(valueB)) return false;
-        return this.serializeArbitrationValue(fieldName, valueA) !== this.serializeArbitrationValue(fieldName, valueB);
+        const serializedA = this.serializeArbitrationValue(fieldName, valueA);
+        const serializedB = this.serializeArbitrationValue(fieldName, valueB);
+        if (fieldName === 'cover' && this.coverValuesEquivalent(serializedA, serializedB)) return false;
+        return serializedA !== serializedB;
     }
 
     arbitrationValuesEqual(fieldName, answerText, candidateText) {
@@ -443,6 +484,9 @@ class SharedCore {
             const candidateDate = new Date(candidateText);
             return !Number.isNaN(answerDate.getTime()) && !Number.isNaN(candidateDate.getTime())
                 && answerDate.getTime() === candidateDate.getTime();
+        }
+        if (fieldName === 'cover') {
+            return this.coverValuesEquivalent(answerText, candidateText);
         }
         return false;
     }
@@ -3006,6 +3050,9 @@ class SharedCore {
         const pendingAiConflicts = [];
         // Arbitration outcomes (deterministic, ai, fallback) for display/metrics
         const aiDecisionRecords = [];
+        // Both-coordinates location conflict, resolved AFTER arbitration when
+        // the final merged address is known (see the location block below).
+        let deferredCoordinateDecision = null;
 
         const mergeTitle = scraperObject.title || calendarObject.title || 'event';
 
@@ -3059,6 +3106,11 @@ class SharedCore {
             // as a separate field; website is the only field that merges.
             if (fieldName.startsWith('_') || fieldName === 'notes' || fieldName === 'url') continue;
 
+            // gmaps is DERIVED (a pure function of the merged bar + address) —
+            // it never merges or arbitrates; STEP 4 below regenerates it from
+            // the final merged bar/address so it can never disagree with them.
+            if (fieldName === 'gmaps') continue;
+
             const priorityConfig = fieldPriorities[fieldName];
             const mergeStrategy = priorityConfig?.merge || 'upsert';
             const scraperValue = scraperObject[fieldName];
@@ -3072,11 +3124,22 @@ class SharedCore {
             if (fieldName === 'location') {
                 // location is ALWAYS coordinates (the calendar is the database; the
                 // normalization layer fills this field with coordinates). Resolve it
-                // deterministically — never via AI: scraped coordinates win; else
-                // calendar coordinates are KEPT (an empty or text scrape must not
-                // wipe them); when neither side is coordinates, fall through to the
-                // configured merge strategy (clobber semantics today).
+                // deterministically — never via AI: scraped coordinates win over a
+                // non-coordinate calendar value; else calendar coordinates are KEPT
+                // (an empty or text scrape must not wipe them); when neither side is
+                // coordinates, fall through to the configured merge strategy
+                // (clobber semantics today).
                 if (this.isCoordinatePair(scraperValue)) {
+                    if (this.isCoordinatePair(calendarValue)) {
+                        // Both sides are coordinates: whether the fresh geocode may
+                        // replace the stored pin depends on whether this event's
+                        // ADDRESS actually changed this run — and the address may
+                        // still be pending AI arbitration at this point in the
+                        // loop, so the decision is deferred until after
+                        // arbitration, when the final merged address is known.
+                        deferredCoordinateDecision = { scraperValue, calendarValue };
+                        continue;
+                    }
                     mergedObject[fieldName] = scraperValue;
                     if (!this.mergeValuesEqualForTracking(scraperValue, calendarValue)) {
                         clobberedFields.push(fieldName);
@@ -3135,6 +3198,43 @@ class SharedCore {
                     calendarKeptFields.push(fieldName);
                 }
                 continue;
+            }
+
+            // Cover is priced by the LIVE ticket page: the calendar copy is just
+            // last run's snapshot, so AI arbitration (which has no freshness
+            // signal) is the wrong tool. Under the default "ai" strategy
+            // (explicit parser-config strategies still win):
+            // - formatting twins (whitespace-only difference, e.g.
+            //   "$22.10 - $39.98" vs "$22.10-$39.98") are the SAME price — the
+            //   calendar value is kept: no conflict, no AI call, no clobber entry;
+            // - genuinely different prices take the scraped (fresh) value
+            //   deterministically. An empty scraped cover never reaches here —
+            //   the empty-scrape rule above already kept the calendar value.
+            if (fieldName === 'cover' && mergeStrategy === 'ai'
+                && !this.isEmptyArbitrationValue(scraperValue)
+                && !this.isEmptyArbitrationValue(calendarValue)) {
+                const serializedScraped = this.serializeArbitrationValue(fieldName, scraperValue);
+                const serializedCalendar = this.serializeArbitrationValue(fieldName, calendarValue);
+                if (this.coverValuesEquivalent(serializedScraped, serializedCalendar)) {
+                    mergedObject[fieldName] = calendarValue;
+                    continue;
+                }
+                if (serializedScraped !== serializedCalendar) {
+                    const freshnessReason = 'cover reflects the live ticket page — freshness wins';
+                    mergedObject[fieldName] = scraperValue;
+                    clobberedFields.push(fieldName);
+                    console.log(`🔒 MERGE: "${mergeTitle}" field=${fieldName} resolved deterministically — ${freshnessReason}`);
+                    aiDecisionRecords.push({
+                        field: fieldName,
+                        existingValue: calendarValue,
+                        newValue: scraperValue,
+                        chosenValue: scraperValue,
+                        reason: freshnessReason,
+                        source: 'deterministic'
+                    });
+                    continue;
+                }
+                // Identical values fall through to the configured strategy (no-op).
             }
 
             // Dates are calendar-critical: a genuinely different startDate/endDate is
@@ -3242,6 +3342,79 @@ class SharedCore {
             }
         }
 
+        // STEP 3c: deferred both-coordinates location decision — resolved only
+        // now because the final address may have been decided by arbitration
+        // above. The stored pin may be human-corrected, so it is only replaced
+        // when the venue actually MOVED (the final merged address differs from
+        // the calendar's stored address). When the address is unchanged the
+        // calendar pin is kept, and a large divergence from the fresh geocode
+        // is FLAGGED for review — never silently applied or dropped.
+        if (deferredCoordinateDecision) {
+            const { scraperValue, calendarValue } = deferredCoordinateDecision;
+            const normalizeAddressForComparison = (value) =>
+                String(value === null || value === undefined ? '' : value).replace(/\s+/g, ' ').trim().toLowerCase();
+            const calendarAddress = normalizeAddressForComparison(calendarObject.address);
+            const finalAddress = normalizeAddressForComparison(
+                Object.prototype.hasOwnProperty.call(mergedObject, 'address') ? mergedObject.address : calendarObject.address
+            );
+            // "Unchanged" requires a stored calendar address to compare against:
+            // with no address on record there is no venue-stability signal, and
+            // the scraped (fresher) coordinates win as they always have.
+            const addressUnchanged = calendarAddress !== '' && finalAddress === calendarAddress;
+            if (addressUnchanged) {
+                mergedObject.location = calendarValue;
+                if (scraperValue !== calendarValue) {
+                    console.log(`📍 MERGE: "${mergeTitle}" location kept calendar pin (address unchanged)`);
+                    const distanceKm = this.coordinatePairDistanceKm(calendarValue, scraperValue);
+                    if (distanceKm !== null && distanceKm > 1) {
+                        console.log(`📍 MERGE: "${mergeTitle}" calendar pin is ${distanceKm.toFixed(1)}km from fresh geocode of the same address — verify pin`);
+                    }
+                }
+            } else {
+                mergedObject.location = scraperValue;
+                if (!this.mergeValuesEqualForTracking(scraperValue, calendarValue)) {
+                    clobberedFields.push('location');
+                }
+            }
+        }
+
+        // STEP 4: regenerate gmaps from the FINAL merged bar + address. gmaps
+        // is a derived field — a pure function of bar + address — so merging or
+        // arbitrating it independently let it disagree with the merged
+        // bar/address (and churn arbitration every run). Regeneration happens
+        // only when the field is actually in play (either side carries a
+        // non-empty gmaps — the normalizer builds one for every scraped event)
+        // AND there is a bar or address to derive from; otherwise whatever
+        // existed is kept (calendar first), and an absent field stays absent.
+        {
+            const finalBar = typeof mergedObject.bar === 'string' ? mergedObject.bar.trim() : '';
+            const finalAddressForGmaps = typeof mergedObject.address === 'string' ? mergedObject.address.trim() : '';
+            const calendarHasGmaps = !this.isEmptyArbitrationValue(calendarObject.gmaps);
+            const scraperHasGmaps = !this.isEmptyArbitrationValue(scraperObject.gmaps);
+            let finalGmaps = calendarHasGmaps
+                ? calendarObject.gmaps
+                : (scraperHasGmaps ? scraperObject.gmaps : '');
+            if ((calendarHasGmaps || scraperHasGmaps) && (finalBar || finalAddressForGmaps)) {
+                const regenerated = SharedCore.generateGoogleMapsUrl({
+                    coordinates: null,
+                    placeId: null,
+                    address: finalAddressForGmaps || null,
+                    venueName: finalBar || null,
+                    cityName: null
+                });
+                if (regenerated) finalGmaps = regenerated;
+            }
+            if (finalGmaps !== '' || allFields.has('gmaps')) {
+                mergedObject.gmaps = finalGmaps;
+            }
+            // Clobber tracking stays honest: gmaps counts as changed only when
+            // the final value actually differs from the calendar's.
+            const calendarGmaps = calendarHasGmaps ? String(calendarObject.gmaps).trim() : '';
+            if (String(finalGmaps || '').trim() !== calendarGmaps) {
+                clobberedFields.push('gmaps');
+            }
+        }
+
         if (calendarKeptFields.length > 0) {
             console.log(`📍 MERGE: "${mergeTitle}" kept calendar values for empty-scraped field(s): ${calendarKeptFields.join(', ')}`);
         }
@@ -3255,9 +3428,6 @@ class SharedCore {
                 : previewFields.join(', ');
             console.log(`🔄 MERGE: "${mergedObject.title || 'event'}" clobbered ${clobberedFields.length} field${clobberedFields.length === 1 ? '' : 's'} (${previewText})`);
         }
-        
-        // STEP 4: Gmaps URLs are already built by parsers and enrichEventLocation()
-        // The merge strategy above has already chosen the correct gmaps URL
         
         // STEP 5: Build new notes from merged object
         const newNotes = this.formatEventNotes(mergedObject);

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1383,6 +1383,136 @@ test('location preserve-on-empty: an empty scrape never clears a calendar locati
   assert.equal(adapter.calls.length, 0, 'location is never AI-arbitrated');
 });
 
+// ---------------------------------------------------------------------------
+// Location follows the address decision (2026-07-15 run: "scraped coordinates
+// win" rewrote stored pins with whatever the geocoder produced that day and
+// would overwrite human-corrected pins)
+// ---------------------------------------------------------------------------
+
+const PIN_TEST_ADDRESS = '3911 Cedar Springs Rd, Dallas, TX 75219';
+
+function buildPinScraped(overrides = {}) {
+  const core = createCore();
+  return {
+    title: 'FURBALL',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    address: PIN_TEST_ADDRESS,
+    location: '32.810535, -96.8110709',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG,
+    ...overrides
+  };
+}
+
+function buildPinExisting(overrides = {}, address = PIN_TEST_ADDRESS) {
+  return {
+    title: 'FURBALL',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    endDate: new Date('2026-07-06T02:00:00.000Z'),
+    location: '32.810535, -96.8110709',
+    notes: address ? `address: ${address}` : '',
+    ...overrides
+  };
+}
+
+async function capturePinMerge(core, existing, scraped, options) {
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, options);
+  } finally {
+    console.log = originalLog;
+  }
+  return { finalEvent, logLines };
+}
+
+test('unchanged address keeps the calendar pin; a divergent fresh geocode is flagged, not applied', async () => {
+  const core = createCore();
+  const adapter = buildArbitrationAdapter({});
+
+  // Geocode jitter (well under 1km): pin kept, logged, but not flagged
+  const near = await capturePinMerge(core,
+    buildPinExisting(),
+    buildPinScraped({ location: '32.8106, -96.8110709' }),
+    { httpAdapter: adapter });
+  assert.equal(near.finalEvent.location, '32.810535, -96.8110709', 'the calendar pin must survive geocode jitter');
+  assert.ok(near.logLines.includes('📍 MERGE: "FURBALL" location kept calendar pin (address unchanged)'),
+    `the kept pin is logged, got: ${JSON.stringify(near.logLines)}`);
+  assert.ok(!near.logLines.some(line => line.includes('verify pin')), 'sub-km jitter is not flagged');
+  assert.ok(!near.logLines.some(line => line.startsWith('🔄 MERGE:')),
+    `a kept pin must not count as clobbered, got: ${JSON.stringify(near.logLines)}`);
+
+  // Fresh geocode ~2km away: pin STILL kept (flag, don't drop), divergence flagged
+  const far = await capturePinMerge(core,
+    buildPinExisting(),
+    buildPinScraped({ location: '32.8285, -96.8110709' }),
+    { httpAdapter: adapter });
+  assert.equal(far.finalEvent.location, '32.810535, -96.8110709', 'a divergent geocode must not silently move the pin');
+  assert.ok(far.logLines.some(line =>
+    /^📍 MERGE: "FURBALL" calendar pin is 2\.0km from fresh geocode of the same address — verify pin$/.test(line)),
+    `the divergence is flagged with its distance, got: ${JSON.stringify(far.logLines)}`);
+
+  // Identical pins stay quiet: no kept-pin line, no flag
+  const same = await capturePinMerge(core, buildPinExisting(), buildPinScraped(), { httpAdapter: adapter });
+  assert.equal(same.finalEvent.location, '32.810535, -96.8110709');
+  assert.ok(!same.logLines.some(line => line.includes('kept calendar pin')), 'identical pins log nothing');
+
+  assert.equal(adapter.calls.length, 0, 'location never consults the AI');
+});
+
+test('a changed address means the venue moved — scraped coordinates are adopted', async () => {
+  const core = createCore();
+  const movedAddress = '5025 Bowser Ave, Dallas, TX 75209';
+  const adapter = buildArbitrationAdapter({
+    address: { pick: 'scraped', value: movedAddress, reason: 'venue moved' }
+  });
+
+  const { finalEvent, logLines } = await capturePinMerge(core,
+    buildPinExisting(),
+    buildPinScraped({ address: movedAddress, location: '32.8285, -96.8300' }),
+    { httpAdapter: adapter });
+
+  assert.equal(finalEvent.address, movedAddress);
+  assert.equal(finalEvent.location, '32.8285, -96.8300', 'a changed address adopts the fresh geocode');
+  assert.ok(logLines.some(line => line.startsWith('🔄 MERGE:') && line.includes('location')),
+    `the adopted pin is tracked as clobbered, got: ${JSON.stringify(logLines)}`);
+
+  // A calendar event without coordinates is always filled by scraped ones
+  const filled = await core.createFinalEventObject(
+    buildPinExisting({ location: '' }),
+    buildPinScraped(),
+    { httpAdapter: buildArbitrationAdapter({}) });
+  assert.equal(filled.location, '32.810535, -96.8110709', 'an empty calendar location is filled by the scrape');
+});
+
+test('when arbitration keeps the calendar address, the calendar pin is kept too', async () => {
+  // The Eventbrite doubled-address bug: the scraped address is malformed, the
+  // AI keeps picking the clean calendar value — the venue did NOT move, so the
+  // pin must not follow the (rejected) scraped geocode. This only works if the
+  // location decision is deferred until the final merged address is known.
+  const core = createCore();
+  const doubledAddress = `${PIN_TEST_ADDRESS}, Dallas, TX`;
+  const adapter = buildArbitrationAdapter({
+    address: { pick: 'calendar', value: PIN_TEST_ADDRESS, reason: 'clean address' }
+  });
+
+  const { finalEvent, logLines } = await capturePinMerge(core,
+    buildPinExisting(),
+    buildPinScraped({ address: doubledAddress, location: '32.8285, -96.8110709' }),
+    { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1, 'the address conflict itself still arbitrates');
+  assert.equal(finalEvent.address, PIN_TEST_ADDRESS);
+  assert.equal(finalEvent.location, '32.810535, -96.8110709',
+    'the AI keeping the calendar address means the venue did not move — keep the calendar pin');
+  assert.ok(logLines.includes('📍 MERGE: "FURBALL" location kept calendar pin (address unchanged)'),
+    `the kept pin is logged, got: ${JSON.stringify(logLines)}`);
+});
+
 test('mergeParsedEvents: an empty location loses to the non-empty side (text and coordinates)', async () => {
   const core = createCore();
   const priorities = core.getResolvedFieldPriorities({});
@@ -2881,7 +3011,46 @@ test('an empty scraped cover keeps the calendar cover and never appears clobbere
     `expected the kept-calendar summary to list cover, got: ${JSON.stringify(logLines)}`);
 });
 
-test('a genuinely differing scraped cover still reaches arbitration and the winner is applied', async () => {
+test('cover formatting twins are not a conflict: calendar value kept, no AI, no clobber', async () => {
+  // 2026-07-15 run: the old formatter spaced the range dash, the sticker-price
+  // formatter doesn't — the SAME price burned an AI arbitration every run.
+  const core = createCore();
+  const scraped = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    cover: '$22.10-$39.98',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const existing = {
+    title: 'CHUNK DORE ALLEY',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    notes: 'cover: $22.10 - $39.98'
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'a whitespace-only cover twin must never reach the AI');
+  assert.equal(finalEvent.cover, '$22.10 - $39.98', 'the calendar formatting is kept — nothing churns');
+  assert.equal(core.parseNotesIntoFields(finalEvent.notes).cover, '$22.10 - $39.98');
+  assert.ok(!logLines.some(line => line.startsWith('🔄 MERGE:')),
+    `a formatting twin must not be tracked as clobbered, got: ${JSON.stringify(logLines)}`);
+});
+
+test('a genuinely differing scraped cover wins deterministically — freshness, not arbitration', async () => {
+  // Prices only ever come from the live ticket page; the calendar copy is last
+  // scrape's snapshot, so arbitration (which has no freshness signal) is the
+  // wrong tool for genuine cover differences.
   const core = createCore();
   const scraped = {
     title: 'CHUNK DORE ALLEY',
@@ -2897,15 +3066,28 @@ test('a genuinely differing scraped cover still reaches arbitration and the winn
     notes: 'cover: $25.63 - $61.50'
   };
   const adapter = buildArbitrationAdapter({
-    cover: { pick: 'scraped', value: '$46.13-$61.50', reason: 'current listed price' }
+    cover: { pick: 'calendar', value: '$25.63 - $61.50', reason: 'should never be asked' }
   });
 
-  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
 
-  assert.equal(adapter.calls.length, 1, 'a genuine cover conflict must reach arbitration');
-  assert.match(adapter.calls[0].prompt, /field: cover/);
-  assert.equal(finalEvent.cover, '$46.13-$61.50');
+  assert.equal(adapter.calls.length, 0, 'genuine cover differences must never reach the AI');
+  assert.equal(finalEvent.cover, '$46.13-$61.50', 'the live-page price wins');
   assert.equal(core.parseNotesIntoFields(finalEvent.notes).cover, '$46.13-$61.50');
+  assert.ok(logLines.some(line => line.startsWith('🔒 MERGE:')
+    && line.includes('field=cover')
+    && line.includes('cover reflects the live ticket page — freshness wins')),
+    `the deterministic decision must be logged, got: ${JSON.stringify(logLines)}`);
+  assert.ok(finalEvent._original.aiArbitration.deterministic.includes('cover'),
+    'the decision is recorded as deterministic for display/metrics');
 });
 
 test('PARSER MERGE summary lists only fields the merge actually changed on the outgoing record', async () => {
@@ -2946,6 +3128,104 @@ test('PARSER MERGE summary lists only fields the merge actually changed on the o
   assert.ok(summary, `expected a PARSER MERGE summary, got: ${JSON.stringify(logLines)}`);
   assert.match(summary, /1 field updated \(bar\)/, 'only the genuinely changed field is counted');
   assert.ok(!summary.includes('cover'), 'a preserved-from-base field must not be listed as updated');
+});
+
+// ---------------------------------------------------------------------------
+// gmaps is DERIVED (a pure function of bar + address) — never arbitrated,
+// always regenerated from the final merged values (2026-07-15 run: arbitrating
+// gmaps independently let it disagree with the merged bar/address)
+// ---------------------------------------------------------------------------
+
+const GMAPS_TEST_ADDRESS = '10-90 Wyckoff Avenue, Queens, NY 11385';
+
+function buildGmapsUrl(barName) {
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${barName}, ${GMAPS_TEST_ADDRESS}`)}`;
+}
+
+function buildGmapsScraped(overrides = {}) {
+  const core = createCore();
+  return {
+    title: 'MEGAWOOF',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    bar: 'Basement',
+    address: GMAPS_TEST_ADDRESS,
+    gmaps: buildGmapsUrl('Basement'),
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG,
+    ...overrides
+  };
+}
+
+function buildGmapsExisting(barName, gmapsValue) {
+  return {
+    title: 'MEGAWOOF',
+    startDate: new Date('2026-07-25T21:00:00.000Z'),
+    notes: [
+      `bar: ${barName}`,
+      `address: ${GMAPS_TEST_ADDRESS}`,
+      `gmaps: ${gmapsValue}`
+    ].join('\n')
+  };
+}
+
+test('gmaps is regenerated from the merged bar + address and never enters arbitration', async () => {
+  const core = createCore();
+
+  // AI picks the CALENDAR bar → gmaps is rebuilt around it
+  const calendarWins = buildArbitrationAdapter({
+    bar: { pick: 'calendar', value: 'HOLO', reason: 'official venue name' }
+  });
+  const holoEvent = await core.createFinalEventObject(
+    buildGmapsExisting('HOLO', 'https://www.google.com/maps/search/?api=1&query=stale'),
+    buildGmapsScraped(),
+    { httpAdapter: calendarWins });
+  assert.equal(calendarWins.calls.length, 1, 'only the bar conflict arbitrates');
+  assert.ok(!/field: gmaps/.test(calendarWins.calls[0].prompt), 'gmaps must never be in the AI batch');
+  assert.equal(holoEvent.bar, 'HOLO');
+  assert.equal(holoEvent.gmaps, buildGmapsUrl('HOLO'), 'gmaps follows the merged bar + address');
+  assert.equal(core.parseNotesIntoFields(holoEvent.notes).gmaps, buildGmapsUrl('HOLO'), 'the derived gmaps round-trips');
+
+  // AI picks the SCRAPED bar → gmaps is rebuilt around that instead
+  const scrapedWins = buildArbitrationAdapter({
+    bar: { pick: 'scraped', value: 'Basement', reason: 'venue changed' }
+  });
+  const basementEvent = await core.createFinalEventObject(
+    buildGmapsExisting('HOLO', buildGmapsUrl('HOLO')),
+    buildGmapsScraped(),
+    { httpAdapter: scrapedWins });
+  assert.equal(basementEvent.bar, 'Basement');
+  assert.equal(basementEvent.gmaps, buildGmapsUrl('Basement'), 'gmaps is rebuilt when the scraped bar wins');
+});
+
+test('gmaps clobber tracking: an unchanged regenerated URL is quiet, a changed one is reported', async () => {
+  const core = createCore();
+  const capture = async (existing, scraped) => {
+    const logLines = [];
+    const originalLog = console.log;
+    console.log = (message) => { logLines.push(String(message)); };
+    try {
+      await core.createFinalEventObject(existing, scraped, { httpAdapter: buildArbitrationAdapter({}) });
+    } finally {
+      console.log = originalLog;
+    }
+    return logLines;
+  };
+
+  // Stored gmaps already equals the regenerated value → nothing reported, even
+  // though the scraped side carried a different (e.g. coordinate-form) URL
+  const quietLines = await capture(
+    buildGmapsExisting('Basement', buildGmapsUrl('Basement')),
+    buildGmapsScraped({ gmaps: 'https://www.google.com/maps/search/?api=1&query=40.7089%2C-73.9188' }));
+  assert.ok(!quietLines.some(line => line.startsWith('🔄 MERGE:')),
+    `an unchanged derived gmaps must not be reported clobbered, got: ${JSON.stringify(quietLines)}`);
+
+  // Stale stored gmaps → the regenerated value replaces it and IS reported
+  const changedLines = await capture(
+    buildGmapsExisting('Basement', 'https://www.google.com/maps/search/?api=1&query=stale'),
+    buildGmapsScraped());
+  assert.ok(changedLines.some(line => line.startsWith('🔄 MERGE:') && line.includes('gmaps')),
+    `a genuinely changed gmaps is tracked, got: ${JSON.stringify(changedLines)}`);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Four merge-hygiene fixes driven by today's Megawoof run log, where one malformed address caused a chain reaction: eternal AI arbitration churn on address/gmaps, degraded geocoding ("0 geocode results" → simplified-query fallback), and freshly-wobbly coordinates clobbering stored calendar pins every run.

### 1. Address composition dedup (`formatJsonLdAddress`)
Eventbrite JSON-LD packs the full address into `streetAddress` while still supplying `addressLocality`/`addressRegion`; naive joining produced `"10-90 Wyckoff Avenue, Queens, NY 11385, Queens, NY"`. Parts already contained in the accumulated address are now skipped — compared as whole word-boundary token sequences (region `"NY"` is not "present" just because the street contains `"SUNNYSIDE"`). **Bear-site pages with a bare `streetAddress` still get locality/region/postal appended** — only genuinely duplicated parts are dropped.

### 2. Location follows the address decision
"Scraped coordinates always win" is gone. Both-sides-coordinates conflicts now defer until after arbitration, when the final merged address is known:
- final address ≠ stored calendar address (venue actually moved) → scraped coordinates adopted
- address unchanged → **calendar pin kept** (protects human-corrected pins) — and when the kept pin sits >1 km from the fresh geocode, the run logs `📍 MERGE: "…" calendar pin is N.Nkm from fresh geocode of the same address — verify pin` (flag, don't drop)
- calendar has no coordinates / no stored address to compare → scraped coordinates fill, as before

### 3. Cover out of AI arbitration
Prices come from the live ticket page; the calendar copy is last run's snapshot, and the arbitration model has no freshness signal (today it chose between `"$22.10 - $39.98"` and `"$22.10-$39.98"` — a formatting twin from the old vs new formatter). Now: whitespace-insensitive equality means formatting twins are not conflicts at all (no AI call), and genuinely different prices take the scraped value deterministically (`🔒 MERGE: … cover reflects the live ticket page — freshness wins`). Empty-scrape and explicit parser-config strategies keep their existing behavior.

### 4. gmaps derived, never arbitrated
gmaps is a pure function of bar + address, but was arbitrated independently — it could disagree with the merged bar/address. It's now removed from arbitration eligibility and regenerated post-merge from the final merged bar + address via the existing `generateGoogleMapsUrl` (only when the field is in play; clobber-tracked only on real change).

## Tests
380 pass / 0 fail (7 new, 2 legacy expectations updated because they encoded the removed behaviors). New coverage: both address shapes + token guard, kept-pin/changed-address/deferred-arbitration/empty-calendar location matrix, verify-pin distance flag, cover twin + freshness + empty-scrape regression, gmaps regeneration in both arbitration directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP