### PR TITLE
feat(scraper): geocode verification — grade gate, retry rungs, Apple reverse cross-check

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1263,54 +1263,76 @@ class ScriptableAdapter {
   }
 
   // Native reverse geocode via Scriptable's Location API (Apple's geocoding
-  // service — no network quota, no Nominatim rate-limit budget). Returns a
-  // "street, city, state zip" string or null when nothing usable comes back.
-  // normalizers.js calls this hook only when it exists; all Scriptable API
-  // usage stays in this adapter (pure-module rule).
-  async reverseGeocode(lat, lon) {
+  // service — no network quota, no Nominatim rate-limit budget). Returns the
+  // raw first placemark object (subThoroughfare/thoroughfare/locality/
+  // postalCode/postalAddress keys) or null. normalizers.js uses this for the
+  // geocode-verification cross-check; all Scriptable API usage stays in this
+  // adapter (pure-module rule). Results are memoized per run, keyed by the
+  // coordinates rounded to 5 decimals (~1 m).
+  async reverseGeocodePlacemark(lat, lon) {
     if (
       typeof Location === "undefined" ||
       typeof Location.reverseGeocode !== "function"
     ) {
       return null;
     }
+    if (!this.reverseGeocodeCache) {
+      this.reverseGeocodeCache = {};
+    }
+    const cacheKey = `${Number(lat).toFixed(5)},${Number(lon).toFixed(5)}`;
+    if (
+      Object.prototype.hasOwnProperty.call(this.reverseGeocodeCache, cacheKey)
+    ) {
+      return this.reverseGeocodeCache[cacheKey];
+    }
+    let mark = null;
     try {
       const placemarks = await Location.reverseGeocode(lat, lon);
-      const mark =
+      const first =
         Array.isArray(placemarks) && placemarks.length > 0
           ? placemarks[0]
           : null;
-      if (!mark || typeof mark !== "object") {
-        return null;
-      }
-      const postal =
-        mark.postalAddress && typeof mark.postalAddress === "object"
-          ? mark.postalAddress
-          : {};
-      const clean = (value) =>
-        typeof value === "string" || typeof value === "number"
-          ? String(value).trim()
-          : "";
-      let street = clean(postal.street);
-      if (!street) {
-        street = [clean(mark.subThoroughfare), clean(mark.thoroughfare)]
-          .filter((part) => part.length > 0)
-          .join(" ");
-      }
-      const city = clean(postal.city) || clean(mark.locality);
-      const state = clean(postal.state) || clean(mark.administrativeArea);
-      const zip = clean(postal.postalCode) || clean(mark.postalCode);
-      const stateZip = [state, zip].filter((part) => part.length > 0).join(" ");
-      const parts = [street, city, stateZip].filter(
-        (part) => part.length > 0,
-      );
-      return parts.length > 0 ? parts.join(", ") : null;
+      mark = first && typeof first === "object" ? first : null;
     } catch (error) {
       console.log(
         `📱 Scriptable: Native reverse geocode failed for ${lat},${lon}: ${error.message}`,
       );
+      mark = null;
+    }
+    this.reverseGeocodeCache[cacheKey] = mark;
+    return mark;
+  }
+
+  // Formatted "street, city, state zip" string built from the placemark hook
+  // above, or null when nothing usable comes back. normalizers.js calls this
+  // hook only when it exists (coords→address enrichment).
+  async reverseGeocode(lat, lon) {
+    const mark = await this.reverseGeocodePlacemark(lat, lon);
+    if (!mark) {
       return null;
     }
+    const postal =
+      mark.postalAddress && typeof mark.postalAddress === "object"
+        ? mark.postalAddress
+        : {};
+    const clean = (value) =>
+      typeof value === "string" || typeof value === "number"
+        ? String(value).trim()
+        : "";
+    let street = clean(postal.street);
+    if (!street) {
+      street = [clean(mark.subThoroughfare), clean(mark.thoroughfare)]
+        .filter((part) => part.length > 0)
+        .join(" ");
+    }
+    const city = clean(postal.city) || clean(mark.locality);
+    const state = clean(postal.state) || clean(mark.administrativeArea);
+    const zip = clean(postal.postalCode) || clean(mark.postalCode);
+    const stateZip = [state, zip].filter((part) => part.length > 0).join(" ");
+    const parts = [street, city, stateZip].filter(
+      (part) => part.length > 0,
+    );
+    return parts.length > 0 ? parts.join(", ") : null;
   }
 
   hasNonEmptyValue(value) {

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -49,6 +49,13 @@ class WebAdapter {
         }
     }
 
+    // Apple's native reverse geocoder is a Scriptable-only capability; Node has
+    // no equivalent, so this honestly reports absence and the normalizer skips
+    // its geocode-verification cross-check.
+    async reverseGeocodePlacemark() {
+        return null;
+    }
+
     getPageCacheConfig() {
         const pageCache = this.config.pageCache || {};
         const ttlDays = Number(pageCache.ttlDays);

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -52,23 +52,23 @@ class NormalizerPipeline {
         return events.map(event => this.normalizeEvent(event));
     }
 
-    async normalizeEventAsync(event, httpAdapter) {
+    async normalizeEventAsync(event, httpAdapter, options = {}) {
         if (!event) return event;
         let normalized = { ...event };
         for (const normalizer of this.normalizers) {
             normalized = normalizer.normalize(normalized);
             if (typeof normalizer.normalizeAsync === 'function') {
-                normalized = await normalizer.normalizeAsync(normalized, httpAdapter);
+                normalized = await normalizer.normalizeAsync(normalized, httpAdapter, options);
             }
         }
         return normalized;
     }
 
-    async normalizeEventsAsync(events, httpAdapter) {
+    async normalizeEventsAsync(events, httpAdapter, options = {}) {
         if (!Array.isArray(events)) return [];
         const normalizedEvents = [];
         for (const event of events) {
-            normalizedEvents.push(await this.normalizeEventAsync(event, httpAdapter));
+            normalizedEvents.push(await this.normalizeEventAsync(event, httpAdapter, options));
         }
         return normalizedEvents;
     }
@@ -715,11 +715,13 @@ class LocationNormalizer extends BaseNormalizer {
 const CITY_CENTER_RADIUS_KM = 50;
 
 // Hard cap on Nominatim requests per event for the forward-geocode retry
-// ladder. 4 covers the full ladder (canonical address, postal/country strip,
-// directional strip, venue-name rescue); every request stays 1.1s-throttled
-// and later rungs only fire after earlier ones return nothing usable. Never
-// raise this without revisiting the rate-limit budget.
-const MAX_GEOCODE_QUERIES_PER_EVENT = 4;
+// ladder. 5 covers the full ladder (canonical address, unit/suite strip,
+// postal/country strip, directional strip, venue-name rescue); every request
+// stays 1.1s-throttled and later rungs only fire after earlier ones return
+// nothing usable. A single Photon rescue request may follow when every
+// Nominatim rung fails; it shares the same rate limiter. Never raise this
+// without revisiting the rate-limit budget.
+const MAX_GEOCODE_QUERIES_PER_EVENT = 5;
 
 // Street-type words a trailing directional can follow ("Cheshire Bridge Rd NE").
 const GEOCODE_STREET_TYPE_WORDS = 'Street|St|Road|Rd|Avenue|Ave|Boulevard|Blvd|Drive|Dr|Lane|Ln|Way|Place|Pl|Court|Ct|Parkway|Pkwy|Highway|Hwy';
@@ -735,6 +737,47 @@ const GEOCODE_ADMIN_AREA_TYPES = [
     'city', 'borough', 'suburb', 'neighbourhood', 'quarter', 'town', 'village',
     'state', 'county', 'municipality', 'district', 'city_district', 'postcode'
 ];
+
+// Forward-geocode grade tiers, shared between Nominatim (class/type/addresstype
+// plus address.house_number) and Photon (osm_key/osm_value plus housenumber):
+//   exact  — a concrete venue/building or a house-numbered address match.
+//   street — a road-level match; tolerable only when the input address carries
+//            no house number (or the verification mode allows flagged accepts).
+//   coarse — a city/borough/suburb/state centroid. A coarse pin is always
+//            worse than no pin and is refused in EVERY verification mode.
+const GEOCODE_EXACT_GRADE_CLASSES = [
+    'building', 'amenity', 'shop', 'leisure', 'tourism', 'office', 'club', 'craft', 'nightclub'
+];
+const GEOCODE_STREET_GRADE_TYPES = ['road', 'street', 'pedestrian'];
+const GEOCODE_COARSE_GRADE_TYPES = [
+    'city', 'town', 'village', 'suburb', 'neighbourhood', 'quarter', 'borough',
+    'state', 'county', 'postcode', 'country'
+];
+
+// Street abbreviations expanded on BOTH sides of the reverse cross-check so
+// "Folsom St" / "Folsom Street" and "E" / "East" compare equal.
+const GEOCODE_ABBREVIATION_EXPANSIONS = {
+    st: 'street', ave: 'avenue', blvd: 'boulevard', rd: 'road', dr: 'drive',
+    ln: 'lane', hwy: 'highway', pl: 'place', ct: 'court',
+    e: 'east', w: 'west', n: 'north', s: 'south'
+};
+// Overlap on generic street-type/directional words alone never proves two
+// street names match ("Mission Street" vs "Folsom Street" share "street").
+const GEOCODE_GENERIC_STREET_TOKENS = [
+    'street', 'avenue', 'boulevard', 'road', 'drive', 'lane', 'highway',
+    'place', 'court', 'east', 'west', 'north', 'south', 'way', 'the'
+];
+
+// Unit/suite decoration ("Suite 200", "#4", "Apt 5B", "Fl 2") that chokes
+// Nominatim's free-text parser; stripped as its own retry rung. The word
+// tokens are boundary-guarded so street names like "Halsted" or "Steiner"
+// pass through untouched.
+const GEOCODE_UNIT_TOKEN_RE = /,?\s*(?:#|(?:ste|suite|apt|unit|fl|floor|rm|room)\b\.?)\s*[^\s,]+/gi;
+
+// Leading street number ("1192 Folsom St"). Used only to decide whether a
+// street-grade pin is tolerable for this input — a house-numbered address
+// deserves better than a road centroid.
+const GEOCODE_HOUSE_NUMBER_RE = /(^|\s)\d+[a-z]?\s+\S/i;
 
 // A directional that FOLLOWS a street-type word and ends the address or a
 // comma-separated segment ("...Cheshire Bridge Rd NE", "...Road Northeast,
@@ -970,6 +1013,128 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         return GEOCODE_ADMIN_AREA_TYPES.includes(String(result.addresstype || '').toLowerCase());
     }
 
+    // Grade a forward-geocode candidate into the exact/street/coarse tiers (see
+    // the tier constants above). Kinds that fit no tier grade as 'street': never
+    // silently refused, but suspect enough to flag/replace for a house-numbered
+    // input.
+    classifyGeocodeGrade(resultClass, resultType, addressType, hasHouseNumber) {
+        const cls = String(resultClass || '').toLowerCase();
+        const type = String(resultType || '').toLowerCase();
+        const addr = String(addressType || '').toLowerCase();
+        if (hasHouseNumber || GEOCODE_EXACT_GRADE_CLASSES.includes(cls)) return 'exact';
+        if (cls === 'highway' || GEOCODE_STREET_GRADE_TYPES.includes(addr)) return 'street';
+        if (GEOCODE_COARSE_GRADE_TYPES.includes(addr) || GEOCODE_COARSE_GRADE_TYPES.includes(type) ||
+            cls === 'place' || cls === 'boundary') return 'coarse';
+        return 'street';
+    }
+
+    gradeNominatimResult(result) {
+        if (!result || typeof result !== 'object') return 'coarse';
+        const details = result.address && typeof result.address === 'object' ? result.address : {};
+        return this.classifyGeocodeGrade(result.class, result.type, result.addresstype, !!details.house_number);
+    }
+
+    // "1192 Folsom St Suite 200, San Francisco" → "1192 Folsom St, San
+    // Francisco": unit/suite/floor decoration chokes Nominatim's free-text
+    // parser. Returns the address unchanged when no unit token is present.
+    stripUnitTokens(address) {
+        return String(address || '')
+            .replace(GEOCODE_UNIT_TOKEN_RE, '')
+            .replace(/\s{2,}/g, ' ')
+            .replace(/\s+,/g, ',')
+            .replace(/^[,\s]+|[,\s]+$/g, '');
+    }
+
+    // Lowercased, punctuation-free tokens with street abbreviations expanded —
+    // the comparable form used on both sides of the reverse cross-check.
+    expandAddressTokens(text) {
+        return String(text || '')
+            .toLowerCase()
+            .replace(/[^a-z0-9\s]/g, ' ')
+            .split(/\s+/)
+            .filter(Boolean)
+            .map(token => Object.prototype.hasOwnProperty.call(GEOCODE_ABBREVIATION_EXPANSIONS, token)
+                ? GEOCODE_ABBREVIATION_EXPANSIONS[token]
+                : token);
+    }
+
+    extractHouseNumber(text) {
+        const match = /(^|\s)(\d+[a-z]?)\s+\S/i.exec(String(text || ''));
+        return match ? match[2].toLowerCase() : '';
+    }
+
+    // Lenient reverse cross-check: compare an Apple placemark (subThoroughfare/
+    // thoroughfare/locality/postalCode) against the input address. Returns
+    // { matched, got } or null when the two sides share nothing comparable —
+    // this is a tripwire, not a parser.
+    comparePinToAddress(placemark, address) {
+        if (!placemark || typeof placemark !== 'object') return null;
+        const clean = value => (typeof value === 'string' || typeof value === 'number') ? String(value).trim() : '';
+        const pinHouse = clean(placemark.subThoroughfare).toLowerCase();
+        const pinStreet = clean(placemark.thoroughfare);
+        const pinLocality = clean(placemark.locality);
+        const pinPostal = clean(placemark.postalCode);
+        const got = [pinHouse, pinStreet, pinLocality].filter(part => part.length > 0).join(' ') || pinPostal || 'unknown place';
+        const inputTokens = this.expandAddressTokens(address);
+        const inputHouse = this.extractHouseNumber(address);
+
+        // Street-name comparison: at least one distinctive (non-generic,
+        // non-numeric) token of the pin's street must appear in the input.
+        const streetTokens = this.expandAddressTokens(pinStreet)
+            .filter(token => !GEOCODE_GENERIC_STREET_TOKENS.includes(token) && !/^\d/.test(token));
+        if (streetTokens.length > 0 && inputTokens.length > 0) {
+            const streetMatch = streetTokens.some(token => inputTokens.includes(token));
+            const houseMatch = inputHouse && pinHouse ? inputHouse === pinHouse : true;
+            return { matched: streetMatch && houseMatch, got };
+        }
+
+        // No street to compare — fall back to postal code, then locality.
+        const zipMatch = /\b(\d{5})(?:-\d{4})?\b/.exec(String(address || ''));
+        if (zipMatch && pinPostal) {
+            return { matched: zipMatch[1] === pinPostal.slice(0, 5), got };
+        }
+        if (pinLocality && inputTokens.length > 0) {
+            const localityTokens = this.expandAddressTokens(pinLocality);
+            return { matched: localityTokens.some(token => inputTokens.includes(token)), got };
+        }
+        return null;
+    }
+
+    // Final acceptance for a grade-gate-passing candidate: reverse cross-check
+    // against the input address (Apple placemark via the adapter, when that
+    // capability exists) plus suspect flagging per verification mode. Returns
+    // the "lat, lon" string to write, or null when enforce mode sends the
+    // ladder on to its next rung.
+    async confirmGeocodeCandidate(candidate, context, httpAdapter) {
+        const { title, address, inputHasHouseNumber, verifyMode, source, rung } = context;
+        let crossCheckRan = false;
+        if (verifyMode !== 'off' && typeof httpAdapter.reverseGeocodePlacemark === 'function') {
+            let placemark = null;
+            try {
+                placemark = await httpAdapter.reverseGeocodePlacemark(Number(candidate.lat), Number(candidate.lon));
+            } catch (err) {
+                placemark = null;
+            }
+            if (placemark) {
+                const comparison = this.comparePinToAddress(placemark, address);
+                if (comparison) {
+                    crossCheckRan = true;
+                    if (!comparison.matched) {
+                        console.warn(`🗺️ GEOCODE VERIFY: "${title}" pin failed reverse cross-check ("${comparison.got}" vs "${address}") — verify pin`);
+                        if (verifyMode === 'enforce') return null;
+                    }
+                }
+            }
+        }
+        if (candidate.grade === 'street' && inputHasHouseNumber && verifyMode === 'report') {
+            console.warn(`🗺️ GEOCODE VERIFY: "${title}" street-grade pin for house-numbered address "${address}" — verify pin`);
+        }
+        if (rung > 1 || crossCheckRan) {
+            console.log(`🗺️ GEOCODE VERIFY: "${title}" accepted ${candidate.grade} pin from ${source} (rung ${rung})`);
+        }
+        return `${candidate.lat}, ${candidate.lon}`;
+    }
+
     // Canonical addresses ("1192 Folsom St, San Francisco, CA 94103, USA") return
     // 0 Nominatim results while "1192 Folsom St, San Francisco" resolves — the
     // postal-code/country decoration chokes the free-text parser (verified live
@@ -1010,11 +1175,13 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     // at MAX_GEOCODE_QUERIES_PER_EVENT. Order:
     //   1. The query exactly as built today (city-anchored when the address
     //      doesn't already contain the city).
-    //   2. The address with postal-code/country decoration stripped (same
+    //   2. The address with unit/suite tokens stripped (same anchoring) —
+    //      "Suite 200" / "#4" decoration returns 0 results.
+    //   3. The address with postal-code/country decoration stripped (same
     //      anchoring) — Nominatim chokes on "…, CA 94103, USA" endings.
-    //   3. The address with trailing directionals stripped (same anchoring) —
+    //   4. The address with trailing directionals stripped (same anchoring) —
     //      Nominatim's free-text parser chokes on "Rd NE" / "Road Northeast".
-    //   4. "<bar>, <city>" — venue-name lookup rescues venues OSM knows by name.
+    //   5. "<bar>, <city>" — venue-name lookup rescues venues OSM knows by name.
     buildGeocodeQueryVariants(address, eventCity, bar) {
         const city = typeof eventCity === 'string' ? eventCity.trim() : '';
         const anchorToCity = (text) => {
@@ -1034,6 +1201,8 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
 
         const baseAddress = String(address || '').trim();
         push(anchorToCity(baseAddress));
+        const unitStripped = this.stripUnitTokens(baseAddress);
+        if (unitStripped && unitStripped !== baseAddress) push(anchorToCity(unitStripped));
         const postalStripped = this.stripPostalCodeAndCountry(baseAddress);
         if (postalStripped) push(anchorToCity(postalStripped));
         push(anchorToCity(this.stripTrailingDirectionals(baseAddress)));
@@ -1045,11 +1214,19 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         return variants.slice(0, MAX_GEOCODE_QUERIES_PER_EVENT);
     }
 
-    async normalizeAsync(event, httpAdapter) {
+    async normalizeAsync(event, httpAdapter, pipelineOptions = {}) {
         if (!event || !httpAdapter || typeof httpAdapter.fetchData !== 'function') return event;
 
         const hasAddress = typeof event.address === 'string' && event.address.trim().length > 0;
         const hasLocation = typeof event.location === 'string' && event.location.trim().length > 0 && event.location.includes(',');
+
+        // Pin verification knob (config.geocodeVerification.mode). The coarse
+        // grade gate is data correctness and stays active in every mode — the
+        // knob only governs the reverse cross-check and suspect handling.
+        const verification = pipelineOptions && pipelineOptions.geocodeVerification && typeof pipelineOptions.geocodeVerification === 'object'
+            ? pipelineOptions.geocodeVerification
+            : {};
+        const verifyMode = verification.mode === 'off' || verification.mode === 'enforce' ? verification.mode : 'report';
 
         let modified = false;
 
@@ -1074,12 +1251,14 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             // fall back to rejecting results whose address details don't mention the city.
             const eventCity = typeof event.city === 'string' ? event.city.trim() : '';
             const cityCenter = this.getCityCenterCoordinates(eventCity);
-            const cityValidationParam = eventCity ? '&addressdetails=1' : '';
             const resultLimit = cityCenter ? 5 : 1;
+            const title = event.title || 'unknown';
+            const inputHasHouseNumber = GEOCODE_HOUSE_NUMBER_RE.test(address);
+            const verifyContext = { title, address, inputHasHouseNumber, verifyMode };
 
             // Retry ladder: when a query returns 0 candidates (or every candidate
-            // is rejected by the distance/city checks), retry with progressively
-            // simplified queries. Every attempt goes through
+            // is rejected by the grade gate / distance / city checks), retry with
+            // progressively simplified queries. Every attempt goes through
             // fetchDataWithCacheAndRateLimit (rate-limited AND cached) and the
             // ladder is hard-capped at MAX_GEOCODE_QUERIES_PER_EVENT requests.
             const queryVariants = this.buildGeocodeQueryVariants(address, eventCity, event.bar);
@@ -1087,14 +1266,14 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             let resolvedLocation = null;
             for (let i = 0; i < queryVariants.length && !resolvedLocation; i++) {
                 const queryText = queryVariants[i];
-                const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(queryText)}&limit=${resultLimit}${cityValidationParam}`;
+                const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(queryText)}&limit=${resultLimit}&addressdetails=1`;
                 attempts += 1;
                 try {
                     const data = await this.fetchDataWithCacheAndRateLimit(url, options, httpAdapter);
                     // Simplified/fallback queries can degrade to a bare place name and
                     // match the admin area itself — reject those centroids. The first
-                    // (full-address) query keeps today's behavior: a full address that
-                    // resolves to an admin boundary is a different failure mode.
+                    // (full-address) query relies on the grade gate below: a full
+                    // address that resolves to an admin boundary is a coarse pin.
                     let candidates = Array.isArray(data) ? data : [];
                     if (i > 0 && candidates.length > 0) {
                         candidates = candidates.filter(result => {
@@ -1104,22 +1283,46 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                             return false;
                         });
                     }
-                    if (candidates.length > 0) {
+                    // Grade gate (all rungs, every mode): a coarse candidate never
+                    // becomes a pin; street-grade candidates are dropped up front
+                    // only when enforce mode demands house-number quality.
+                    const graded = [];
+                    for (const result of candidates) {
+                        const grade = this.gradeNominatimResult(result);
+                        if (grade === 'coarse') {
+                            const kind = result.addresstype || result.type || 'unknown';
+                            console.warn(`🗺️ GEOCODE VERIFY: "${title}" refused generic pin (${kind}) for address "${address}"`);
+                            continue;
+                        }
+                        if (grade === 'street' && inputHasHouseNumber && verifyMode === 'enforce') {
+                            continue;
+                        }
+                        graded.push({ result, grade });
+                    }
+                    if (graded.length > 0) {
+                        let pickedCandidate = null;
                         if (cityCenter) {
                             // Distance-ranked selection: nearest candidate within the radius wins
-                            const picked = this.pickNearestGeocodeCandidate(candidates, cityCenter, eventCity, queryText);
+                            const picked = this.pickNearestGeocodeCandidate(graded.map(entry => entry.result), cityCenter, eventCity, queryText);
                             if (picked) {
-                                resolvedLocation = `${picked.lat}, ${picked.lon}`;
+                                pickedCandidate = { lat: picked.lat, lon: picked.lon, grade: graded[picked.index].grade };
                             }
                         } else {
-                            const firstResult = candidates[0];
+                            const firstResult = graded[0].result;
                             if (firstResult.lat && firstResult.lon) {
                                 if (eventCity && !this.geocodeResultMatchesCity(firstResult, eventCity)) {
                                     console.warn(`🗺️ OpenStreetMapNormalizer: Geocode for "${queryText}" resolved outside event city "${eventCity}" ("${firstResult.display_name || 'no display name'}") — ignoring coordinates`);
                                 } else {
-                                    resolvedLocation = `${firstResult.lat}, ${firstResult.lon}`;
+                                    pickedCandidate = { lat: firstResult.lat, lon: firstResult.lon, grade: graded[0].grade };
                                 }
                             }
+                        }
+                        if (pickedCandidate) {
+                            resolvedLocation = await this.confirmGeocodeCandidate(
+                                pickedCandidate,
+                                { ...verifyContext, source: 'nominatim', rung: i + 1 },
+                                httpAdapter
+                            );
                         }
                     } else if ((!Array.isArray(data) || data.length === 0) && i < queryVariants.length - 1) {
                         console.log(`🗺️ OpenStreetMapNormalizer: 0 geocode results for "${queryText}" — trying next variant`);
@@ -1137,8 +1340,51 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 }
             }
             if (!resolvedLocation) {
+                // Photon rescue rung: a second geocoder with a friendlier free-text
+                // parser, tried once after every Nominatim rung failed. Same
+                // rate limiter, same caches. GeoJSON coordinates are [lon, lat].
+                const photonUrl = `https://photon.komoot.io/api/?q=${encodeURIComponent(address)}&limit=1`;
+                attempts += 1;
+                try {
+                    const data = await this.fetchDataWithCacheAndRateLimit(photonUrl, options, httpAdapter);
+                    const feature = data && Array.isArray(data.features) && data.features.length > 0 ? data.features[0] : null;
+                    const coords = feature && feature.geometry && Array.isArray(feature.geometry.coordinates)
+                        ? feature.geometry.coordinates
+                        : null;
+                    const lon = coords ? Number(coords[0]) : NaN;
+                    const lat = coords ? Number(coords[1]) : NaN;
+                    if (Number.isFinite(lat) && Number.isFinite(lon)) {
+                        const props = feature.properties && typeof feature.properties === 'object' ? feature.properties : {};
+                        const grade = this.classifyGeocodeGrade(props.osm_key, props.osm_value, props.osm_value, !!props.housenumber);
+                        const withinRadius = !cityCenter ||
+                            this.haversineDistanceKm(lat, lon, cityCenter.lat, cityCenter.lng) <= CITY_CENTER_RADIUS_KM;
+                        if (grade === 'coarse') {
+                            console.warn(`🗺️ GEOCODE VERIFY: "${title}" refused generic pin (${props.osm_value || 'unknown'}) for address "${address}"`);
+                        } else if (grade === 'street' && inputHasHouseNumber && verifyMode === 'enforce') {
+                            // enforce demands house-number quality; stay unpinned
+                        } else if (withinRadius) {
+                            resolvedLocation = await this.confirmGeocodeCandidate(
+                                { lat: coords[1], lon: coords[0], grade },
+                                { ...verifyContext, source: 'photon', rung: queryVariants.length + 1 },
+                                httpAdapter
+                            );
+                        }
+                    }
+                } catch (err) {
+                    console.log(`🗺️ OpenStreetMapNormalizer: Failed to geocode address "${event.address}": ${err.message}`);
+                }
+                if (resolvedLocation) {
+                    event.location = resolvedLocation;
+                    modified = true;
+                    console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
+                }
+            }
+            if (!resolvedLocation) {
                 // Exact shape counted by run-log-summary's geocodeNoResults guard.
                 console.warn(`🗺️ OpenStreetMapNormalizer: No geocode results for "${address}" (${eventCity || 'no city'}) after ${attempts} ${attempts === 1 ? 'query' : 'queries'} — leaving location empty`);
+                if (inputHasHouseNumber) {
+                    console.warn(`🗺️ GEOCODE VERIFY: "${title}" full address but no usable geocoordinate — left unpinned`);
+                }
             }
         } else if (hasLocation && !hasAddress) {
             const parts = event.location.split(',').map(p => p.trim());

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -183,8 +183,8 @@ test('forward geocode without an event city keeps the legacy query and accepts t
   assert.equal(event.location, '43.2105820, -83.0771632', 'no city context means no validation (old behavior)');
   assert.equal(
     httpAdapter.requests[0],
-    `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent('922 E. BURNSIDE')}&limit=1`,
-    'the request URL must be byte-identical to the pre-validation behavior'
+    `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent('922 E. BURNSIDE')}&limit=1&addressdetails=1`,
+    'the request keeps the legacy query but always carries address details for the grade gate'
   );
 });
 
@@ -399,7 +399,11 @@ test('retry ladder: distance validation still applies to fallback variants', asy
   await normalizer.normalizeAsync(event, httpAdapter);
 
   assert.equal(event.location, undefined, 'a far-away candidate from a simplified query must not win');
-  assert.equal(httpAdapter.requests.length, 3, 'rejection counts as failure and the ladder continues to the cap');
+  assert.equal(httpAdapter.requests.length, 4, 'rejection counts as failure and the ladder continues through the Photon rescue');
+  assert.ok(
+    httpAdapter.requests[3].includes('photon.komoot.io/api/?q='),
+    `the final rung must be the Photon rescue: ${httpAdapter.requests[3]}`
+  );
 });
 
 test('retry ladder: identical variants are deduped so no duplicate request is sent', async () => {
@@ -411,7 +415,9 @@ test('retry ladder: identical variants are deduped so no duplicate request is se
 
   await normalizer.normalizeAsync(event, httpAdapter);
 
-  assert.equal(httpAdapter.requests.length, 1, 'the stripped variant equals the original and must be skipped');
+  assert.equal(httpAdapter.requests.length, 2, 'the stripped variant equals the original and must be skipped (only the Photon rescue follows)');
+  assert.ok(httpAdapter.requests[0].includes('nominatim'), 'exactly one Nominatim query for the deduped ladder');
+  assert.ok(httpAdapter.requests[1].includes('photon.komoot.io'), 'the extra request is the Photon rescue, not a duplicate');
   assert.equal(event.location, undefined);
 });
 
@@ -527,7 +533,8 @@ test('a simplified-query admin-area match is rejected instead of poisoning coord
     warns.some(w => w.includes('Rejected admin-area result') && w.includes('type=borough')),
     `the rejection must be logged: ${warns.join(' | ')}`
   );
-  assert.equal(httpAdapter.requests.length, 3, 'the ladder continues past the rejected result');
+  assert.equal(httpAdapter.requests.length, 4, 'the ladder continues past the rejected result through the Photon rescue');
+  assert.ok(httpAdapter.requests[3].includes('photon.komoot.io'), 'the final request is the Photon rescue');
 });
 
 test('a venue-name simplified query still resolves through an amenity result', async () => {
@@ -667,6 +674,341 @@ test('reverse geocode falls back to Nominatim when the native hook returns nothi
 
   assert.equal(event.address, '722 E Burnside St, Portland, OR');
   assert.equal(requests.length, 1, 'Nominatim stays the fallback');
+});
+
+// ---------------------------------------------------------------------------
+// Geocode verification: grade gate (coarse pins are never written, in any
+// mode), suspect handling per geocodeVerification.mode, the unit/suite and
+// Photon retry rungs, and the Apple reverse cross-check tripwire.
+// ---------------------------------------------------------------------------
+
+// Stub adapter that answers by URL substring (Nominatim query text or the
+// Photon host); unmatched URLs get an empty result set.
+function createRoutedStubAdapter(routes, extras = {}) {
+  const requests = [];
+  return {
+    requests,
+    fetchData: async (url) => {
+      requests.push(url);
+      for (const [substring, response] of routes) {
+        if (url.includes(substring)) return JSON.stringify(response);
+      }
+      return JSON.stringify([]);
+    },
+    ...extras
+  };
+}
+
+async function withCapturedConsole(fn) {
+  const lines = [];
+  const realLog = console.log;
+  const realWarn = console.warn;
+  console.log = (message) => { lines.push(String(message)); };
+  console.warn = (message) => { lines.push(String(message)); };
+  try {
+    await fn();
+  } finally {
+    console.log = realLog;
+    console.warn = realWarn;
+  }
+  return lines;
+}
+
+const POWERHOUSE_POI_RESULT = {
+  lat: '37.7756941',
+  lon: '-122.4103049',
+  class: 'amenity',
+  type: 'nightclub',
+  addresstype: 'amenity',
+  display_name: 'Powerhouse, 1192, Folsom Street, San Francisco, California, 94103, United States',
+  address: { house_number: '1192', road: 'Folsom Street', city: 'San Francisco' }
+};
+
+const FOLSOM_STREET_ONLY_RESULT = {
+  lat: '37.7740000',
+  lon: '-122.4120000',
+  class: 'highway',
+  type: 'secondary',
+  addresstype: 'road',
+  display_name: 'Folsom Street, San Francisco, California, United States',
+  address: { road: 'Folsom Street', city: 'San Francisco' }
+};
+
+const BROOKLYN_SUBURB_RESULT = {
+  lat: '40.6526006',
+  lon: '-73.9497211',
+  class: 'place',
+  type: 'suburb',
+  addresstype: 'suburb',
+  display_name: 'Brooklyn, Kings County, City of New York, New York, United States',
+  address: { suburb: 'Brooklyn', city: 'City of New York' }
+};
+
+const WRONG_STREET_POI_RESULT = {
+  lat: '37.7752000',
+  lon: '-122.4180000',
+  class: 'amenity',
+  type: 'bar',
+  addresstype: 'amenity',
+  display_name: 'Some Other Bar, 999, Mission Street, San Francisco, California, 94103, United States',
+  address: { house_number: '999', road: 'Mission Street', city: 'San Francisco' }
+};
+
+const FOLSOM_PLACEMARK = {
+  subThoroughfare: '1192',
+  thoroughfare: 'Folsom Street',
+  locality: 'San Francisco',
+  postalCode: '94103'
+};
+
+const MISSION_PLACEMARK = {
+  subThoroughfare: '999',
+  thoroughfare: 'Mission Street',
+  locality: 'San Francisco',
+  postalCode: '94103'
+};
+
+test('geocode verification: a POI-grade result pins exactly as before, with no flags', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([['nominatim', [POWERHOUSE_POI_RESULT]]]);
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  const lines = await withCapturedConsole(() => normalizer.normalizeAsync(event, httpAdapter));
+
+  assert.equal(event.location, '37.7756941, -122.4103049');
+  assert.ok(
+    lines.some(l => l.includes('OpenStreetMapNormalizer: Found coordinates for address "1192 Folsom St"')),
+    `the load-bearing success line must still emit: ${lines.join(' | ')}`
+  );
+  assert.ok(!lines.some(l => l.includes('GEOCODE VERIFY')), `a clean first-rung accept stays silent: ${lines.join(' | ')}`);
+});
+
+test('geocode verification: a coarse result is refused in every mode, including off', async () => {
+  for (const mode of ['off', 'report', 'enforce']) {
+    const normalizer = createOsmNormalizer();
+    normalizer.delayForRateLimit = async () => {};
+    const httpAdapter = createRoutedStubAdapter([['nominatim', [BROOKLYN_SUBURB_RESULT]]]);
+    const event = { title: 'BK BEAR', address: 'Brooklyn' };
+
+    const lines = await withCapturedConsole(() =>
+      normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode } })
+    );
+
+    assert.equal(event.location, undefined, `mode "${mode}" must never write a borough/suburb centroid`);
+    assert.ok(
+      lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "BK BEAR" refused generic pin (suburb) for address "Brooklyn"')),
+      `mode "${mode}" must log the refusal flag: ${lines.join(' | ')}`
+    );
+  }
+});
+
+test('geocode verification: street-grade pin for a house-numbered input is kept but flagged in report mode', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([['nominatim', [FOLSOM_STREET_ONLY_RESULT]]]);
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+
+  assert.equal(event.location, '37.7740000, -122.4120000', 'report mode still writes the pin');
+  assert.ok(
+    lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "CHUNK" street-grade pin for house-numbered address "1192 Folsom St" — verify pin')),
+    `the suspect flag must be logged: ${lines.join(' | ')}`
+  );
+});
+
+test('geocode verification: enforce mode exhausts the ladder on street-grade results and leaves the event unpinned', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([
+    ['nominatim', [FOLSOM_STREET_ONLY_RESULT]],
+    ['photon.komoot.io', {
+      type: 'FeatureCollection',
+      features: [{
+        geometry: { type: 'Point', coordinates: [-122.412, 37.774] },
+        properties: { street: 'Folsom Street', city: 'San Francisco', osm_key: 'highway', osm_value: 'secondary' }
+      }]
+    }]
+  ]);
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+
+  assert.equal(event.location, undefined, 'enforce mode demands house-number quality for a house-numbered input');
+  assert.ok(httpAdapter.requests.some(url => url.includes('photon.komoot.io')), 'the Photon rung must still be tried');
+  assert.ok(
+    lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "CHUNK" full address but no usable geocoordinate — left unpinned')),
+    `the give-up flag must be logged: ${lines.join(' | ')}`
+  );
+});
+
+test('geocode verification: cross-check mismatch keeps the pin but flags it in report mode', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter(
+    [['nominatim', [WRONG_STREET_POI_RESULT]]],
+    { reverseGeocodePlacemark: async () => MISSION_PLACEMARK }
+  );
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+
+  assert.equal(event.location, '37.7752000, -122.4180000', 'report mode keeps the suspect pin');
+  assert.ok(
+    lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "CHUNK" pin failed reverse cross-check') && l.includes('— verify pin')),
+    `the mismatch flag must be logged: ${lines.join(' | ')}`
+  );
+});
+
+test('geocode verification: cross-check mismatch rejects the pin in enforce mode and the ladder recovers on the next rung', async () => {
+  const core = new SharedCore(CITIES_SF_WITH_COORDS, { eventSchema: EventSchema });
+  const normalizer = new OpenStreetMapNormalizer(core);
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter(
+    [
+      [encodeURIComponent('1192 Folsom St, sf'), [WRONG_STREET_POI_RESULT]],
+      [encodeURIComponent('Powerhouse, sf'), [POWERHOUSE_POI_RESULT]]
+    ],
+    {
+      reverseGeocodePlacemark: async (lat, lon) =>
+        Math.abs(lon - (-122.418)) < 0.0001 ? MISSION_PLACEMARK : FOLSOM_PLACEMARK
+    }
+  );
+  const event = { title: 'CHUNK', address: '1192 Folsom St', bar: 'Powerhouse', city: 'sf' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+
+  assert.equal(event.location, '37.7756941, -122.4103049', 'the venue-name rung must recover a verified pin');
+  assert.ok(
+    lines.some(l => l.includes('pin failed reverse cross-check')),
+    `the rejected first pin must be flagged: ${lines.join(' | ')}`
+  );
+  assert.ok(
+    lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "CHUNK" accepted exact pin from nominatim (rung 2)')),
+    `the verified accept must be logged: ${lines.join(' | ')}`
+  );
+});
+
+test('geocode verification: cross-check pass writes the pin with no mismatch flag', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter(
+    [['nominatim', [POWERHOUSE_POI_RESULT]]],
+    { reverseGeocodePlacemark: async () => FOLSOM_PLACEMARK }
+  );
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+
+  assert.equal(event.location, '37.7756941, -122.4103049');
+  assert.ok(!lines.some(l => l.includes('verify pin')), `no suspect flag on a clean cross-check: ${lines.join(' | ')}`);
+  assert.ok(
+    lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "CHUNK" accepted exact pin from nominatim (rung 1)')),
+    `a cross-checked accept is worth one log line: ${lines.join(' | ')}`
+  );
+});
+
+test('geocode verification: the unit/suite-stripping rung recovers a pin the raw address could not get', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([
+    [encodeURIComponent('1192 Folsom St Suite 200, San Francisco'), []],
+    [encodeURIComponent('1192 Folsom St, San Francisco'), [POWERHOUSE_POI_RESULT]]
+  ]);
+  const event = { title: 'CHUNK', address: '1192 Folsom St Suite 200, San Francisco' };
+
+  await withCapturedConsole(() => normalizer.normalizeAsync(event, httpAdapter));
+
+  assert.equal(event.location, '37.7756941, -122.4103049');
+  assert.equal(httpAdapter.requests.length, 2);
+  assert.equal(
+    decodeQueryParam(httpAdapter.requests[1]),
+    '1192 Folsom St, San Francisco',
+    'the second rung must be the unit/suite-stripped address'
+  );
+});
+
+test('geocode verification: the Photon rung recovers when Nominatim returns nothing, with [lon, lat] order handled', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([
+    ['nominatim', []],
+    ['photon.komoot.io', {
+      type: 'FeatureCollection',
+      features: [{
+        geometry: { type: 'Point', coordinates: [-122.4103049, 37.7756941] },
+        properties: { housenumber: '1192', street: 'Folsom Street', city: 'San Francisco', osm_key: 'building', osm_value: 'yes' }
+      }]
+    }]
+  ]);
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  const lines = await withCapturedConsole(() => normalizer.normalizeAsync(event, httpAdapter));
+
+  assert.equal(event.location, '37.7756941, -122.4103049', 'the pin must come out "lat, lon" despite GeoJSON [lon, lat]');
+  assert.ok(httpAdapter.requests[httpAdapter.requests.length - 1].includes('photon.komoot.io/api/?q='));
+  assert.ok(
+    lines.some(l => l.includes('accepted exact pin from photon (rung 2)')),
+    `the Photon accept must be logged: ${lines.join(' | ')}`
+  );
+});
+
+test('geocode verification: an adapter without the placemark hook skips the cross-check and still pins', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  // web-adapter case: the hook exists but honestly returns null
+  const httpAdapter = createRoutedStubAdapter(
+    [['nominatim', [POWERHOUSE_POI_RESULT]]],
+    { reverseGeocodePlacemark: async () => null }
+  );
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+
+  assert.equal(event.location, '37.7756941, -122.4103049');
+  assert.ok(!lines.some(l => l.includes('verify pin')), 'a skipped cross-check never flags');
+
+  // and an adapter with no hook at all (plain fetch stub) must not crash
+  const bareAdapter = createRoutedStubAdapter([['nominatim', [POWERHOUSE_POI_RESULT]]]);
+  const bareEvent = { title: 'CHUNK', address: '1192 Folsom St' };
+  await withCapturedConsole(() =>
+    normalizer.normalizeAsync(bareEvent, bareAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+  assert.equal(bareEvent.location, '37.7756941, -122.4103049');
+});
+
+test('geocode verification: the coords→address reverse path is untouched by verification modes', async () => {
+  const normalizer = createOsmNormalizer();
+  const requests = [];
+  const httpAdapter = {
+    fetchData: async (url) => {
+      requests.push(url);
+      return JSON.stringify({ display_name: '1192 Folsom St, San Francisco, CA' });
+    },
+    reverseGeocode: async () => null
+  };
+  const event = { title: 'CHUNK', location: '37.7756941, -122.4103049' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+
+  assert.equal(event.address, '1192 Folsom St, San Francisco, CA');
+  assert.ok(requests[0].includes('nominatim.openstreetmap.org/reverse'), 'the reverse endpoint stays Nominatim');
+  assert.ok(!lines.some(l => l.includes('GEOCODE VERIFY')), `the reverse path never emits verification flags: ${lines.join(' | ')}`);
 });
 
 test('resolveWallClockDates ignores events without the wall-clock flag', () => {

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -16,6 +16,7 @@ const scraperConfig = {
       ttlDays: 3,
     },
     // deadEndRetryDays: 30, // Learned dead-end URLs (fetched fine but yielded nothing) are skipped for this many days, then retried once; 0 disables the store (default: 30)
+    // geocodeVerification: { mode: "report" }, // verify geocoded pins: grade-gate + Apple reverse cross-check. "report" (default) flags suspects in logs, "enforce" refuses suspect pins, "off" skips extra checks. Generic city-level pins are always refused.
     // NOTE: Eventbrite /e/ confidence defaults (JSON-LD cover/image/ticketUrl,
     // meta location) are built into shared-core now — an aiConfidenceDefaults
     // block here is only needed to extend or override them.

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1839,8 +1839,9 @@ class SharedCore {
         // Use the passed pipeline or the instance property
         const pipelineToUse = normalizerPipeline || this.normalizerPipeline;
 
+        const globalConfig = mainConfig && mainConfig.config && typeof mainConfig.config === 'object' ? mainConfig.config : {};
         const enrichedEvents = pipelineToUse
-            ? await pipelineToUse.normalizeEventsAsync(filteredEvents, httpAdapter)
+            ? await pipelineToUse.normalizeEventsAsync(filteredEvents, httpAdapter, { geocodeVerification: globalConfig.geocodeVerification })
             : filteredEvents.map(event => this.normalizeEventTextFields(event));
 
         enrichedEvents.forEach((event, index) => {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -3513,3 +3513,23 @@ test('dead-end store: maxAdditionalUrls 0 cannot fake a dead end when the parser
   assert.deepEqual(core.deadEndRunContext.store, {}, 'valid-but-budget-capped links keep the page productive');
   core.deadEndRunContext = null;
 });
+
+test('prepareParsedEvents threads the geocodeVerification knob into the normalizer pipeline', async () => {
+  const core = createCore();
+  let capturedOptions = null;
+  const pipeline = {
+    normalizeEventsAsync: async (events, httpAdapter, options) => {
+      capturedOptions = options;
+      return events;
+    }
+  };
+  const mainConfig = { config: { geocodeVerification: { mode: 'enforce' } } };
+
+  await core.prepareParsedEvents([{ title: 'CHUNK' }], {}, mainConfig, null, pipeline, {});
+
+  assert.deepEqual(capturedOptions, { geocodeVerification: { mode: 'enforce' } });
+
+  // No knob configured → the option is passed through as undefined (normalizers default to "report")
+  await core.prepareParsedEvents([{ title: 'CHUNK' }], {}, {}, null, pipeline, {});
+  assert.deepEqual(capturedOptions, { geocodeVerification: undefined });
+});


### PR DESCRIPTION
## What

Stops bad pins at the source. Three verification layers on forward geocoding (address → coordinates), integrated into the existing retry ladder:

### 1. Grade gate — always on, every mode
Every Nominatim query now requests `addressdetails=1` (URL change auto-invalidates stale cache entries) and every candidate is graded **exact** (POI/building or house-numbered) / **street** (road-level) / **coarse** (city/borough/suburb/state centroid). **Coarse pins are refused in every mode, no knob** — a generic "Brooklyn centroid" pin is always worse than no pin. Photon results are graded through the same tiers via `osm_key`/`osm_value`.

### 2. Expanded retry ladder + Photon rescue
- New unit/suite-strip rung ("1192 Folsom St **Suite 200**" chokes Nominatim's free-text parser) — boundary-guarded regex so street names like "Halsted"/"Steiner" survive. Nominatim cap 4 → 5 so the venue-name rescue rung is never evicted.
- New final rescue rung: **Photon** (Komoot's free geocoder, no key, friendlier fuzzy parser) tried once when every Nominatim rung fails. Same shared 1.1s rate limiter, same in-memory + page caches. GeoJSON `[lon, lat]` order handled.

### 3. Apple reverse cross-check — behind the knob
New adapter capability `reverseGeocodePlacemark(lat, lon)` (Scriptable: `Location.reverseGeocode`, memoized at 5-decimal precision; web adapter honestly returns null → check skipped). After a candidate passes the grade gate, the pin is reverse-geocoded and compared to the input address — house number + distinctive street tokens with abbreviation expansion both ways (St↔Street, E↔East, …), falling back to postal code, then locality.

### Knob
```js
geocodeVerification: { mode: "report" } // "report" (default) | "enforce" | "off"
```
- **report** (default): suspect pins (street-grade for a house-numbered address, cross-check mismatch) are written but flagged in the log.
- **enforce**: suspect pins are rejected — ladder continues; if nothing survives, the event is left unpinned with a loud flag.
- **off**: no cross-check calls; the coarse grade gate still applies.

New log lines use a `🗺️ GEOCODE VERIFY:` prefix (additions only — all existing `🗺️` line shapes untouched; the reverse coords→address path is byte-identical).

## Cost profile
Verification only runs on fresh geocodes (cache misses). Apple reverse geocoding is on-device (no Nominatim budget). Photon fires only after all Nominatim rungs fail and shares the rate limiter.

## Tests
373 → 385 (11 new in normalizers.test.js incl. coarse-refusal in every mode, enforce-mode ladder walk, Photon [lon,lat] handling, adapter-without-capability; 1 threading test in shared-core.test.js), quiet runner, all green. `node --check` clean on all touched files; zero `new URL(` additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP