### PR TITLE
feat(reviewer): standalone Calendar Reviewer — verify + fix existing events via interactive UI

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2510,6 +2510,812 @@ class ScriptableAdapter {
     }
   }
 
+  // ==========================================================================
+  // CALENDAR REVIEWER - calendar enumeration, plain-event mapping, fix
+  // application, and the interactive findings UI. Nothing here writes to a
+  // calendar except applyReviewFinding, and that only runs from the UI's
+  // Apply buttons (see presentReviewResults).
+  // ==========================================================================
+
+  // Candidate calendars for review: explicit titles when configured,
+  // otherwise every writable calendar whose title starts with "chunky-dad".
+  async getReviewCalendars(configuredTitles = []) {
+    const wanted = (Array.isArray(configuredTitles) ? configuredTitles : [])
+      .map((title) => String(title || "").trim())
+      .filter((title) => title.length > 0);
+    const calendars = await Calendar.forEvents();
+    const selected = (Array.isArray(calendars) ? calendars : []).filter(
+      (calendar) => {
+        const title = String(calendar?.title || "");
+        if (wanted.length > 0) return wanted.includes(title);
+        return (
+          title.startsWith("chunky-dad") &&
+          calendar.allowsContentModifications !== false
+        );
+      },
+    );
+    console.log(
+      `🔎 REVIEW: Reviewing ${selected.length} calendar(s): ${selected.map((calendar) => calendar.title).join(", ") || "(none)"}`,
+    );
+    return selected;
+  }
+
+  // Fetch events over the review window and map them to the plain objects the
+  // review core consumes. The live CalendarEvent objects are kept in
+  // reviewEventIndex (by finding id) so applyReviewFinding can save them.
+  async getReviewCalendarEvents(calendars, windowConfig = {}) {
+    const coerceDays = (value, fallback) => {
+      const days = Number(value);
+      return Number.isFinite(days) && days >= 0 ? days : fallback;
+    };
+    const lookbackDays = coerceDays(windowConfig.lookbackDays, 365);
+    const lookaheadDays = coerceDays(windowConfig.lookaheadDays, 365);
+    const start = new Date();
+    start.setHours(0, 0, 0, 0);
+    start.setDate(start.getDate() - lookbackDays);
+    const end = new Date();
+    end.setHours(23, 59, 59, 999);
+    end.setDate(end.getDate() + lookaheadDays);
+
+    this.reviewEventIndex = {};
+    const events = [];
+    for (const calendar of Array.isArray(calendars) ? calendars : []) {
+      const slice = await CalendarEvent.between(start, end, [calendar]);
+      let mapped = 0;
+      for (const item of Array.isArray(slice) ? slice : []) {
+        if (!item) continue;
+        const startIso =
+          item.startDate instanceof Date && !isNaN(item.startDate.getTime())
+            ? item.startDate.toISOString()
+            : String(item.startDate || "");
+        const id = String(
+          item.identifier || `${calendar.title}|${item.title || ""}|${startIso}`,
+        );
+        // Recurring series surface one occurrence per identifier — reviewing
+        // the same series once is enough (the fix saves through that object).
+        if (this.reviewEventIndex[id]) continue;
+        this.reviewEventIndex[id] = item;
+        const fields = this.parseNotesIntoFields(item.notes || "");
+        events.push({
+          id,
+          calendarTitle: calendar.title,
+          title: item.title || "",
+          startDate: item.startDate || null,
+          location: typeof item.location === "string" ? item.location : "",
+          address: typeof fields.address === "string" ? fields.address : "",
+          bar: typeof fields.bar === "string" ? fields.bar : "",
+        });
+        mapped += 1;
+      }
+      console.log(
+        `🔎 REVIEW: ${calendar.title} — fetched ${mapped} event(s) (${start.toISOString().slice(0, 10)} → ${end.toISOString().slice(0, 10)})`,
+      );
+    }
+    return events;
+  }
+
+  // Replace or append a single `key: value` line in a notes blob without
+  // reformatting the rest — manually created events can carry free text that
+  // a full parse → format round-trip would drop.
+  upsertNotesField(notes, fieldName, value) {
+    const canonicalTarget = SharedEventSchema.canonicalizeEventKey(fieldName, {
+      context: "notes",
+    });
+    const valueString = String(value);
+    const formattedLine = `${fieldName}: ${
+      SharedEventSchema.isUrlLikeField(fieldName, valueString)
+        ? valueString
+        : SharedEventSchema.escapeText(valueString)
+    }`;
+    const keyForLine = (line) => {
+      const colonIndex = SharedEventSchema.findUnescaped(line, ":");
+      if (colonIndex <= 0) return null;
+      const key = SharedEventSchema.unescapeText(
+        line.substring(0, colonIndex).trim(),
+      );
+      if (!key || !SharedEventSchema.isValidMetadataKey(key)) return null;
+      return SharedEventSchema.canonicalizeEventKey(key, { context: "notes" });
+    };
+    const lines = String(notes || "").split("\n");
+    const result = [];
+    let replaced = false;
+    for (let i = 0; i < lines.length; i += 1) {
+      if (!replaced && keyForLine(lines[i]) === canonicalTarget) {
+        result.push(formattedLine);
+        replaced = true;
+        // Swallow continuation lines that belonged to the replaced value
+        while (
+          i + 1 < lines.length &&
+          lines[i + 1].trim() &&
+          keyForLine(lines[i + 1]) === null
+        ) {
+          i += 1;
+        }
+        continue;
+      }
+      result.push(lines[i]);
+    }
+    if (!replaced) {
+      if (result.length === 1 && result[0].trim() === "") result.pop();
+      result.push(formattedLine);
+    }
+    return result.join("\n");
+  }
+
+  // Apply one finding: mutate ONLY the fields in `proposed` on the matching
+  // CalendarEvent (location string, or the address line inside notes), then
+  // save. Returns { success, appliedFields?, message? }.
+  async applyReviewFinding(finding) {
+    try {
+      const id = finding && finding.id ? String(finding.id) : "";
+      const target =
+        id && this.reviewEventIndex ? this.reviewEventIndex[id] : null;
+      if (!target) {
+        return { success: false, message: "calendar event not found" };
+      }
+      const proposed =
+        finding.proposed && typeof finding.proposed === "object"
+          ? finding.proposed
+          : {};
+      const appliedFields = [];
+      if (
+        typeof proposed.location === "string" &&
+        proposed.location.trim().length > 0
+      ) {
+        target.location = proposed.location.trim();
+        appliedFields.push("location");
+      }
+      if (
+        typeof proposed.address === "string" &&
+        proposed.address.trim().length > 0
+      ) {
+        target.notes = this.upsertNotesField(
+          target.notes || "",
+          "address",
+          proposed.address.trim(),
+        );
+        appliedFields.push("address");
+      }
+      if (appliedFields.length === 0) {
+        return { success: false, message: "no proposed changes" };
+      }
+      await target.save();
+      console.log(
+        `🔎 REVIEW: Applied ${appliedFields.join(" + ")} to "${finding.eventTitle}" in ${finding.calendarTitle}`,
+      );
+      return { success: true, appliedFields };
+    } catch (error) {
+      console.log(
+        `🔎 REVIEW: ✗ Failed to apply finding for "${finding?.eventTitle}": ${error.message}`,
+      );
+      return { success: false, message: error.message };
+    }
+  }
+
+  // Resolve a UI action payload to the findings it targets. Only findings
+  // with an unapplied proposal are actionable.
+  selectReviewFindingsForAction(payload, findings) {
+    const all = Array.isArray(findings) ? findings : [];
+    const actionable = (finding) =>
+      finding &&
+      finding.proposed &&
+      Object.keys(finding.proposed).length > 0 &&
+      !finding._applied &&
+      !finding._applyFailed;
+    if (payload && payload.action === "apply") {
+      const finding = all.find(
+        (candidate) => candidate && String(candidate.id) === String(payload.id),
+      );
+      return finding && actionable(finding) ? [finding] : [];
+    }
+    if (payload && payload.action === "apply-bulk") {
+      if (payload.mode === "missing-only") {
+        return all.filter(
+          (finding) =>
+            actionable(finding) &&
+            (finding.status === "missing-pin" ||
+              finding.status === "missing-address"),
+        );
+      }
+      return all.filter(actionable);
+    }
+    return [];
+  }
+
+  formatReviewDate(value) {
+    const date = value instanceof Date ? value : new Date(value || NaN);
+    return isNaN(date.getTime()) ? "" : date.toDateString();
+  }
+
+  // Coordinate pin block: coords + Apple Maps link + a collapsed OpenStreetMap
+  // embed whose iframe src is only assigned on first expand (keeps the page
+  // light; the OSM iframe is the page's only remote resource).
+  buildReviewPinHtml(pinString, eventTitle) {
+    const parts = String(pinString || "")
+      .split(",")
+      .map((part) => part.trim());
+    const lat = Number(parts[0]);
+    const lon = Number(parts[1]);
+    if (parts.length !== 2 || !Number.isFinite(lat) || !Number.isFinite(lon)) {
+      return "";
+    }
+    const appleUrl = `https://maps.apple.com/?ll=${lat},${lon}&q=${encodeURIComponent(String(eventTitle || "Event"))}`;
+    const boxDegrees = 0.004; // ~400m viewport around the pin
+    const embedUrl = `https://www.openstreetmap.org/export/embed.html?bbox=${lon - boxDegrees},${lat - boxDegrees},${lon + boxDegrees},${lat + boxDegrees}&layer=mapnik&marker=${lat},${lon}`;
+    return `
+                <div class="pin-block">
+                    <span class="pin-coords">📍 ${this.escapeHtml(`${lat}, ${lon}`)}</span>
+                    <a class="pin-link" href="${this.escapeHtml(appleUrl)}"> Apple Maps</a>
+                    <details class="map-details" ontoggle="loadMapFrame(this)">
+                        <summary>🗺️ Map preview</summary>
+                        <iframe class="osm-frame" data-src="${this.escapeHtml(embedUrl)}"></iframe>
+                    </details>
+                </div>`;
+  }
+
+  buildReviewFindingCard(finding, statusMeta) {
+    const meta = statusMeta[finding.status] || { icon: "❓", label: finding.status };
+    const current = finding.current || {};
+    const proposed = finding.proposed || {};
+    const hasProposal = Object.keys(proposed).length > 0;
+    const dateLabel = this.formatReviewDate(finding.startDate);
+    const distanceBadge =
+      typeof finding.distanceKm === "number" && finding.status === "pin-moved"
+        ? `<span class="distance-badge">↔️ ${finding.distanceKm.toFixed(1)} km</span>`
+        : "";
+
+    const sideHtml = (label, values, extraClass) => {
+      const rows = [];
+      if (values.address) {
+        rows.push(
+          `<div class="review-field">🏠 ${this.escapeHtml(values.address)}</div>`,
+        );
+      }
+      if (values.location) {
+        rows.push(this.buildReviewPinHtml(values.location, finding.eventTitle));
+      }
+      if (rows.length === 0) return "";
+      return `
+                <div class="review-side ${extraClass}">
+                    <div class="review-side-label">${label}</div>
+                    ${rows.join("\n")}
+                </div>`;
+    };
+    const currentSide = sideHtml("Current", current, "current");
+    const proposedSide = hasProposal
+      ? sideHtml("Proposed", proposed, "proposed")
+      : "";
+
+    return `
+            <div class="event-card review-card" data-finding-id="${this.escapeHtml(String(finding.id))}" data-status="${this.escapeHtml(finding.status)}">
+                <div class="review-chip-row">
+                    <span class="status-chip status-${this.escapeHtml(finding.status)}">${meta.icon} ${this.escapeHtml(meta.label)}</span>
+                    ${distanceBadge}
+                </div>
+                <div class="event-title">${this.escapeHtml(finding.eventTitle)}</div>
+                ${dateLabel ? `<div class="review-meta">📅 ${this.escapeHtml(dateLabel)}</div>` : ""}
+                ${finding.detail ? `<div class="review-detail">${this.escapeHtml(finding.detail)}</div>` : ""}
+                ${currentSide || proposedSide ? `<div class="review-compare">${currentSide}${proposedSide}</div>` : ""}
+                ${hasProposal ? `<div class="review-actions"><button class="apply-btn" onclick="applyFinding(this)">✅ Apply</button></div>` : ""}
+            </div>`;
+  }
+
+  // Rich HTML for the reviewer findings UI. Same visual language as
+  // generateRichHTML (colors, cards, chips, dark mode) but fully
+  // self-contained: no external fonts/scripts — the OSM embed iframes are
+  // the only remote resources, and they load on first expand.
+  generateReviewHTML(findings, options = {}) {
+    const list = Array.isArray(findings) ? findings : [];
+    const isDarkMode =
+      typeof Device !== "undefined" && Device.isUsingDarkAppearance();
+    const summary = SharedCore.summarizeReviewFindings(list);
+    const statusMeta = {
+      ok: { icon: "✅", label: "Looks right" },
+      "pin-moved": { icon: "📍", label: "Pin moved" },
+      "missing-pin": { icon: "➕", label: "Missing pin" },
+      "missing-address": { icon: "🏠", label: "Missing address" },
+      unpinnable: { icon: "🚫", label: "Won't geocode" },
+      "no-data": { icon: "❓", label: "No location data" },
+    };
+    const statusOrder = [
+      "pin-moved",
+      "missing-pin",
+      "missing-address",
+      "unpinnable",
+      "no-data",
+      "ok",
+    ];
+
+    // Group findings per calendar, preserving input order
+    const byCalendar = new Map();
+    list.forEach((finding) => {
+      if (!finding) return;
+      const key = finding.calendarTitle || "(unknown calendar)";
+      if (!byCalendar.has(key)) byCalendar.set(key, []);
+      byCalendar.get(key).push(finding);
+    });
+
+    const summaryChips = statusOrder
+      .filter((status) => summary.byStatus[status])
+      .map(
+        (status) =>
+          `<span class="summary-chip status-${status}">${statusMeta[status].icon} ${this.escapeHtml(statusMeta[status].label)}: ${summary.byStatus[status]}</span>`,
+      )
+      .join("\n");
+
+    const sections = [];
+    for (const [calendarTitle, calendarFindings] of byCalendar) {
+      const okFindings = calendarFindings.filter((f) => f.status === "ok");
+      const attention = calendarFindings.filter((f) => f.status !== "ok");
+      const okBlock =
+        okFindings.length > 0
+          ? `
+                <details class="ok-details">
+                    <summary>✅ ${okFindings.length} event${okFindings.length === 1 ? " looks" : "s look"} right</summary>
+                    <ul class="ok-list">
+                        ${okFindings
+                          .map(
+                            (f) =>
+                              `<li>${this.escapeHtml(f.eventTitle)}${this.formatReviewDate(f.startDate) ? ` — ${this.escapeHtml(this.formatReviewDate(f.startDate))}` : ""}</li>`,
+                          )
+                          .join("\n")}
+                    </ul>
+                </details>`
+          : "";
+      sections.push(`
+            <div class="section">
+                <div class="section-header">
+                    <span class="section-icon">📅</span>
+                    <span class="section-title">${this.escapeHtml(calendarTitle)}</span>
+                    <span class="section-count">${attention.length} finding${attention.length === 1 ? "" : "s"}</span>
+                </div>
+                ${okBlock}
+                ${attention.map((finding) => this.buildReviewFindingCard(finding, statusMeta)).join("\n")}
+            </div>`);
+    }
+
+    return `
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Calendar Reviewer</title>
+    <style>
+        :root {
+            /* chunky.dad brand colors - light mode (matches the scraper UI) */
+            --primary-color: #667eea;
+            --secondary-color: #ff6b6b;
+            --accent-color: #764ba2;
+            --ok-color: #2ecc71;
+            --warn-color: #f39c12;
+            --text-primary: #333;
+            --text-secondary: #666;
+            --text-inverse: #ffffff;
+            --background-primary: #ffffff;
+            --background-light: #f8f9ff;
+            --gradient-primary: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
+            --border-color: rgba(102, 126, 234, 0.1);
+            --card-shadow: 0 4px 15px rgba(0,0,0,0.08);
+            --card-hover-shadow: 0 8px 25px rgba(102, 126, 234, 0.15);
+        }
+
+        ${
+          isDarkMode
+            ? `
+        :root {
+            /* Dark mode overrides for better bar/low-light readability */
+            --primary-color: #8b9cf7;
+            --secondary-color: #ff8a8a;
+            --accent-color: #9575cd;
+            --ok-color: #4cd98a;
+            --warn-color: #ffb74d;
+            --text-primary: #e0e0e0;
+            --text-secondary: #b0b0b0;
+            --text-inverse: #1a1a1a;
+            --background-primary: #2d2d2d;
+            --background-light: #1a1a1a;
+            --gradient-primary: linear-gradient(135deg, var(--primary-color) 0%, var(--accent-color) 100%);
+            --border-color: rgba(139, 156, 247, 0.2);
+            --card-shadow: 0 4px 15px rgba(0,0,0,0.3);
+            --card-hover-shadow: 0 8px 25px rgba(139, 156, 247, 0.25);
+        }
+        `
+            : ""
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            margin: 0;
+            padding: 20px;
+            padding-bottom: calc(90px + env(safe-area-inset-bottom));
+            background-color: var(--background-light);
+            color: var(--text-primary);
+            line-height: 1.6;
+        }
+
+        a { color: var(--primary-color); text-decoration: none; }
+        a:hover { color: var(--accent-color); text-decoration: underline; }
+
+        .header {
+            background: var(--gradient-primary);
+            color: var(--text-inverse);
+            padding: 25px;
+            border-radius: 15px;
+            margin-bottom: 25px;
+            box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+        }
+
+        .header h1 { margin: 0; font-size: 26px; font-weight: 700; }
+        .header-subtitle { font-size: 14px; opacity: 0.9; margin-top: 4px; }
+
+        .header .stats { display: flex; gap: 30px; margin-top: 18px; }
+        .stat { display: flex; flex-direction: column; text-align: center; }
+        .stat-value { font-size: 30px; font-weight: 700; text-shadow: 0 2px 10px rgba(0,0,0,0.2); }
+        .stat-label { font-size: 13px; opacity: 0.9; }
+
+        .summary-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+        .summary-chip {
+            font-size: 12px;
+            font-weight: 600;
+            padding: 4px 12px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.18);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+        }
+
+        .section {
+            background: var(--background-primary);
+            border-radius: 15px;
+            padding: 20px;
+            margin-bottom: 20px;
+            box-shadow: var(--card-shadow);
+            border: 1px solid var(--border-color);
+        }
+
+        .section-header {
+            display: flex;
+            align-items: center;
+            margin-bottom: 15px;
+            padding-bottom: 12px;
+            border-bottom: 2px solid var(--border-color);
+        }
+        .section-icon { font-size: 22px; margin-right: 10px; }
+        .section-title { font-size: 18px; font-weight: 600; flex: 1; }
+        .section-count {
+            background: var(--gradient-primary);
+            color: var(--text-inverse);
+            padding: 4px 12px;
+            border-radius: 20px;
+            font-size: 13px;
+            font-weight: 600;
+        }
+
+        .ok-details {
+            margin-bottom: 14px;
+            font-size: 14px;
+            color: var(--ok-color);
+        }
+        .ok-details summary { cursor: pointer; font-weight: 600; }
+        .ok-list { color: var(--text-secondary); font-size: 13px; margin: 8px 0 0; }
+
+        .event-card {
+            background: var(--background-primary);
+            border: 1px solid var(--border-color);
+            border-radius: 12px;
+            padding: 16px;
+            margin-bottom: 14px;
+            box-shadow: var(--card-shadow);
+        }
+
+        .event-title { font-size: 17px; font-weight: 600; margin: 8px 0 2px; }
+        .review-meta { font-size: 13px; color: var(--text-secondary); }
+        .review-detail { font-size: 13px; color: var(--text-secondary); margin-top: 6px; font-style: italic; }
+
+        .review-chip-row { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+        .status-chip {
+            display: inline-block;
+            padding: 4px 10px;
+            border-radius: 15px;
+            font-size: 12px;
+            font-weight: 600;
+            color: var(--text-inverse);
+        }
+        .status-chip.status-ok { background: var(--ok-color); }
+        .status-chip.status-pin-moved { background: var(--warn-color); }
+        .status-chip.status-missing-pin { background: var(--gradient-primary); }
+        .status-chip.status-missing-address { background: var(--accent-color); }
+        .status-chip.status-unpinnable { background: var(--secondary-color); }
+        .status-chip.status-no-data { background: var(--text-secondary); }
+
+        .distance-badge {
+            font-size: 12px;
+            font-weight: 600;
+            padding: 3px 10px;
+            border-radius: 999px;
+            border: 1px solid var(--warn-color);
+            color: var(--warn-color);
+        }
+
+        .apply-state { font-size: 12px; font-weight: 600; }
+        .apply-state.applied { color: var(--ok-color); }
+        .apply-state.failed { color: var(--secondary-color); }
+
+        .review-compare { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+        .review-side {
+            flex: 1 1 220px;
+            border: 1px solid var(--border-color);
+            border-radius: 10px;
+            padding: 10px 12px;
+            font-size: 13px;
+        }
+        .review-side.proposed { border-color: var(--ok-color); }
+        .review-side-label {
+            font-size: 11px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: var(--text-secondary);
+            margin-bottom: 6px;
+        }
+        .review-side.proposed .review-side-label { color: var(--ok-color); }
+        .review-field { margin-bottom: 6px; overflow-wrap: anywhere; }
+
+        .pin-block { margin-bottom: 6px; }
+        .pin-coords { font-family: ui-monospace, Menlo, monospace; font-size: 12px; margin-right: 8px; }
+        .pin-link { font-size: 12px; font-weight: 600; }
+        .map-details { margin-top: 6px; font-size: 12px; }
+        .map-details summary { cursor: pointer; color: var(--primary-color); font-weight: 600; }
+        .osm-frame {
+            width: 100%;
+            height: 220px;
+            border: 1px solid var(--border-color);
+            border-radius: 10px;
+            margin-top: 6px;
+        }
+
+        .review-actions { margin-top: 12px; }
+        .apply-btn {
+            padding: 8px 16px;
+            font-size: 14px;
+            font-weight: 600;
+            background: var(--gradient-primary);
+            color: var(--text-inverse);
+            border: none;
+            border-radius: 10px;
+            cursor: pointer;
+            box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
+        }
+        .apply-btn:disabled { opacity: 0.55; cursor: default; }
+
+        .review-footer {
+            position: fixed;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+            background: var(--background-primary);
+            border-top: 1px solid var(--border-color);
+            box-shadow: 0 -4px 15px rgba(0,0,0,0.1);
+        }
+        .footer-btn {
+            flex: 1;
+            padding: 12px 10px;
+            font-size: 14px;
+            font-weight: 600;
+            border: 1px solid var(--primary-color);
+            border-radius: 12px;
+            background: var(--background-primary);
+            color: var(--primary-color);
+            cursor: pointer;
+        }
+        .footer-btn.primary {
+            background: var(--gradient-primary);
+            color: var(--text-inverse);
+            border: none;
+        }
+        .footer-btn:disabled { opacity: 0.5; cursor: default; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>🔎 Calendar Reviewer</h1>
+        <div class="header-subtitle">Geocode check — nothing changes without an Apply tap</div>
+        <div class="stats">
+            <div class="stat">
+                <span class="stat-value">${summary.findings}</span>
+                <span class="stat-label">Events Reviewed</span>
+            </div>
+            <div class="stat">
+                <span class="stat-value">${summary.ok}</span>
+                <span class="stat-label">Look Right</span>
+            </div>
+            <div class="stat">
+                <span class="stat-value">${summary.findings - summary.ok}</span>
+                <span class="stat-label">Need Attention</span>
+            </div>
+        </div>
+        ${summaryChips ? `<div class="summary-chips">${summaryChips}</div>` : ""}
+    </div>
+
+    ${sections.join("\n") || '<div class="section">No events found in the review window.</div>'}
+
+    <div class="review-footer">
+        <button class="footer-btn" id="missingOnlyBtn" onclick="applyBulk('missing-only')">➕ Add missing only (<span id="missingOnlyCount">0</span>)</button>
+        <button class="footer-btn primary" id="applyAllBtn" onclick="applyBulk('all')">✅ Apply all (<span id="applyAllCount">0</span>)</button>
+    </div>
+
+    <script>
+        // Native bridge: every action is queued and drained by the Scriptable
+        // side's evaluateJavaScript polling loop (see presentReviewResults).
+        window.__reviewQueue = [];
+        window.__reviewWaiter = null;
+        function postReviewAction(payload) {
+            var message = JSON.stringify(payload);
+            if (window.__reviewWaiter) {
+                var waiter = window.__reviewWaiter;
+                window.__reviewWaiter = null;
+                waiter(message);
+            } else {
+                window.__reviewQueue.push(message);
+            }
+        }
+
+        function pendingCards(missingOnly) {
+            var cards = document.querySelectorAll('.review-card');
+            var out = [];
+            for (var i = 0; i < cards.length; i++) {
+                var card = cards[i];
+                if (card.getAttribute('data-applied')) continue;
+                if (!card.querySelector('.apply-btn')) continue;
+                var status = card.getAttribute('data-status');
+                if (missingOnly && status !== 'missing-pin' && status !== 'missing-address') continue;
+                out.push(card);
+            }
+            return out;
+        }
+
+        function updateFooterCounts() {
+            var all = pendingCards(false).length;
+            var missing = pendingCards(true).length;
+            document.getElementById('applyAllCount').textContent = all;
+            document.getElementById('missingOnlyCount').textContent = missing;
+            document.getElementById('applyAllBtn').disabled = all === 0;
+            document.getElementById('missingOnlyBtn').disabled = missing === 0;
+        }
+
+        function applyFinding(btn) {
+            var card = btn.closest('.review-card');
+            if (!card) return;
+            btn.disabled = true;
+            btn.textContent = '⏳ Applying…';
+            postReviewAction({ action: 'apply', id: card.getAttribute('data-finding-id') });
+        }
+
+        function applyBulk(mode) {
+            var cards = pendingCards(mode === 'missing-only');
+            for (var i = 0; i < cards.length; i++) {
+                var btn = cards[i].querySelector('.apply-btn');
+                if (btn) { btn.disabled = true; btn.textContent = '⏳ Queued…'; }
+            }
+            postReviewAction({ action: 'apply-bulk', mode: mode });
+        }
+
+        // Called from native after each applyReviewFinding completes.
+        function markFindingApplied(id, ok, message) {
+            var cards = document.querySelectorAll('.review-card');
+            var card = null;
+            for (var i = 0; i < cards.length; i++) {
+                if (cards[i].getAttribute('data-finding-id') === id) { card = cards[i]; break; }
+            }
+            if (!card) return;
+            card.setAttribute('data-applied', ok ? 'ok' : 'failed');
+            var chip = card.querySelector('.apply-state');
+            if (!chip) {
+                chip = document.createElement('span');
+                var row = card.querySelector('.review-chip-row');
+                if (row) row.appendChild(chip);
+            }
+            chip.className = 'apply-state ' + (ok ? 'applied' : 'failed');
+            chip.textContent = ok ? '✅ Applied' : ('❌ Failed' + (message ? ': ' + message : ''));
+            var btn = card.querySelector('.apply-btn');
+            if (btn) { btn.disabled = true; btn.textContent = ok ? '✅ Applied' : '❌ Failed'; }
+            updateFooterCounts();
+        }
+
+        // Assign the OSM iframe src on first expand only — collapsed maps
+        // cost nothing.
+        function loadMapFrame(details) {
+            if (!details.open) return;
+            var frame = details.querySelector('iframe[data-src]');
+            if (frame) {
+                frame.src = frame.getAttribute('data-src');
+                frame.removeAttribute('data-src');
+            }
+        }
+
+        updateFooterCounts();
+    </script>
+</body>
+</html>`;
+  }
+
+  // Drained by the polling loop: hands the completion callback to the page
+  // when no action is queued, so the next button tap resolves it.
+  buildReviewBridgeJs() {
+    return `
+      if (window.__reviewQueue && window.__reviewQueue.length > 0) {
+        completion(window.__reviewQueue.shift());
+      } else {
+        window.__reviewWaiter = completion;
+      }
+    `;
+  }
+
+  // Interactive findings UI. Unlike the scraper's static WebView.loadHTML,
+  // this uses an instance WebView so page buttons can call back into
+  // Scriptable: the loop awaits evaluateJavaScript(bridge, true) — the page
+  // resolves it with a JSON action payload — applies the fix natively, then
+  // pushes the result back into the page and re-arms. The bridge await is
+  // raced against present() so dismissing the sheet exits the loop cleanly.
+  async presentReviewResults(findings, options = {}) {
+    const list = Array.isArray(findings) ? findings : [];
+    const html = this.generateReviewHTML(list, options);
+    const webView = new WebView();
+    await webView.loadHTML(html);
+
+    const DISMISSED = "__review_dismissed__";
+    let dismissed = false;
+    const presented = webView.present(true).then(
+      () => {
+        dismissed = true;
+        return DISMISSED;
+      },
+      () => {
+        dismissed = true;
+        return DISMISSED;
+      },
+    );
+
+    const appliedCounts = { applied: 0, failed: 0 };
+    while (!dismissed) {
+      const bridge = webView
+        .evaluateJavaScript(this.buildReviewBridgeJs(), true)
+        .catch(() => DISMISSED);
+      const message = await Promise.race([bridge, presented]);
+      if (dismissed || message === DISMISSED || typeof message !== "string") {
+        break;
+      }
+      let payload = null;
+      try {
+        payload = JSON.parse(message);
+      } catch (error) {
+        continue;
+      }
+      const targets = this.selectReviewFindingsForAction(payload, list);
+      for (const finding of targets) {
+        const result = await this.applyReviewFinding(finding);
+        finding._applied = result.success === true;
+        finding._applyFailed = result.success !== true;
+        if (result.success) {
+          appliedCounts.applied += 1;
+        } else {
+          appliedCounts.failed += 1;
+        }
+        const updateJs = `markFindingApplied(${JSON.stringify(String(finding.id))}, ${result.success === true}, ${JSON.stringify(result.message || "")})`;
+        await webView.evaluateJavaScript(updateJs, false).catch(() => {});
+      }
+    }
+    await presented;
+    console.log(
+      `🔎 REVIEW: UI closed — ${appliedCounts.applied} fix(es) applied, ${appliedCounts.failed} failed`,
+    );
+    return appliedCounts;
+  }
+
   // Display/Logging Adapter Implementation
   async logInfo(message) {
     console.log(message);

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -489,3 +489,186 @@ test('generateDiscoverySection keeps Mermaid default-active when no suggested co
   assert.ok(html.includes(`class="disc-tab-btn disc-tab-active" data-tab="mermaid_Old_Run_0"`), 'mermaid stays the default tab');
   assert.ok(html.includes(`<div id="mermaid_Old_Run_0" class="disc-tab-panel">`), 'mermaid panel visible');
 });
+
+// ---------------------------------------------------------------------------
+// Calendar reviewer: calendar filtering, apply-finding writes, findings UI
+// ---------------------------------------------------------------------------
+
+test('getReviewCalendars keeps writable chunky-dad calendars by default and honors explicit titles', async () => {
+  const adapter = buildAdapter();
+  const calendars = [
+    { title: 'chunky-dad-nyc', allowsContentModifications: true },
+    { title: 'chunky-dad-seattle', allowsContentModifications: false },
+    { title: 'Personal', allowsContentModifications: true }
+  ];
+  const originalForEvents = global.Calendar.forEvents;
+  global.Calendar.forEvents = async () => calendars;
+  try {
+    const auto = await adapter.getReviewCalendars([]);
+    assert.deepEqual(auto.map((calendar) => calendar.title), ['chunky-dad-nyc'],
+      'read-only and non-chunky-dad calendars are excluded by default');
+
+    const explicit = await adapter.getReviewCalendars(['Personal', 'chunky-dad-seattle']);
+    assert.deepEqual(explicit.map((calendar) => calendar.title), ['chunky-dad-seattle', 'Personal'],
+      'explicit titles override the default filter');
+  } finally {
+    global.Calendar.forEvents = originalForEvents;
+  }
+});
+
+test('applyReviewFinding mutates only the proposed fields on the stubbed CalendarEvent', async () => {
+  const adapter = buildAdapter();
+  const originalNotes = 'bar: STATION 4\naddress: 100 Old Rd, Dallas\nwebsite: https://x.example';
+  let saves = 0;
+  const stubEvent = {
+    title: 'FURBALL',
+    location: '1, 2',
+    notes: originalNotes,
+    save: async () => { saves += 1; }
+  };
+  adapter.reviewEventIndex = { 'evt-1': stubEvent };
+
+  // Location proposal: only the location field changes
+  const pinResult = await adapter.applyReviewFinding({
+    id: 'evt-1', eventTitle: 'FURBALL', calendarTitle: 'chunky-dad-dallas',
+    proposed: { location: '32.810535, -96.8110709' }
+  });
+  assert.equal(pinResult.success, true);
+  assert.deepEqual(pinResult.appliedFields, ['location']);
+  assert.equal(stubEvent.location, '32.810535, -96.8110709');
+  assert.equal(stubEvent.notes, originalNotes, 'notes untouched by a location-only fix');
+  assert.equal(stubEvent.title, 'FURBALL');
+  assert.equal(saves, 1);
+
+  // Address proposal: only the address line inside notes is rewritten
+  await adapter.applyReviewFinding({
+    id: 'evt-1', eventTitle: 'FURBALL', calendarTitle: 'chunky-dad-dallas',
+    proposed: { address: '3911 Cedar Springs Rd, Dallas, TX 75219' }
+  });
+  assert.equal(stubEvent.notes,
+    'bar: STATION 4\naddress: 3911 Cedar Springs Rd, Dallas, TX 75219\nwebsite: https://x.example');
+  assert.equal(stubEvent.location, '32.810535, -96.8110709', 'location untouched by an address-only fix');
+  assert.equal(saves, 2);
+
+  // Missing address line is appended; free text in notes survives
+  stubEvent.notes = 'Doors at 9pm, no cover\nbar: STATION 4';
+  await adapter.applyReviewFinding({
+    id: 'evt-1', eventTitle: 'FURBALL', calendarTitle: 'chunky-dad-dallas',
+    proposed: { address: '5025 Bowser Ave, Dallas' }
+  });
+  assert.equal(stubEvent.notes, 'Doors at 9pm, no cover\nbar: STATION 4\naddress: 5025 Bowser Ave, Dallas');
+
+  // Unknown finding id or an empty proposal never saves
+  const missing = await adapter.applyReviewFinding({ id: 'nope', proposed: { location: '1, 2' } });
+  assert.equal(missing.success, false);
+  const empty = await adapter.applyReviewFinding({ id: 'evt-1', proposed: {} });
+  assert.equal(empty.success, false);
+  assert.equal(saves, 3);
+});
+
+function buildReviewFindingsFixture() {
+  return [
+    {
+      id: 'ok-1', calendarTitle: 'chunky-dad-nyc', eventTitle: 'OK Event',
+      startDate: '2026-08-01T02:00:00.000Z', check: 'geocode', status: 'ok',
+      current: { location: '40.7, -73.9', address: '123 W 4th St' }, proposed: {},
+      detail: 'stored pin matches a fresh geocode of the address'
+    },
+    {
+      id: 'pm-"1"', calendarTitle: 'chunky-dad-nyc', eventTitle: 'Bear <b>Night</b>',
+      startDate: '2026-08-02T02:00:00.000Z', check: 'geocode', status: 'pin-moved',
+      current: { location: '40.7, -73.9', address: '123 W 4th St' },
+      proposed: { location: '40.71, -73.99' }, distanceKm: 1.25,
+      detail: 'stored pin is 1.3km from the fresh verified geocode of this address'
+    },
+    {
+      id: 'ma-1', calendarTitle: 'chunky-dad-seattle', eventTitle: 'Pin Only',
+      startDate: '2026-08-03T02:00:00.000Z', check: 'geocode', status: 'missing-address',
+      current: { location: '47.6, -122.3', address: '' },
+      proposed: { address: '1600 Broadway, Seattle' },
+      detail: 'pin has no address — reverse-geocoded address proposed'
+    },
+    {
+      id: 'up-1', calendarTitle: 'chunky-dad-seattle', eventTitle: 'Mystery Venue',
+      startDate: '2026-08-04T02:00:00.000Z', check: 'geocode', status: 'unpinnable',
+      current: { location: '', address: 'Somewhere Nowhere 123' }, proposed: {},
+      detail: 'no usable geocoordinate for this address (grade gate/ladder found nothing)'
+    }
+  ];
+}
+
+test('generateReviewHTML renders per-calendar sections, chips, buttons, and escaped payloads', () => {
+  const adapter = buildAdapter();
+  const html = adapter.generateReviewHTML(buildReviewFindingsFixture());
+
+  // Summary header: events reviewed / ok / needing attention
+  assert.ok(html.includes('Calendar Reviewer'));
+  assert.ok(html.includes('<span class="stat-value">4</span>'));
+  assert.ok(html.includes('<span class="stat-value">1</span>'));
+  assert.ok(html.includes('<span class="stat-value">3</span>'));
+
+  // One section per calendar
+  assert.ok(html.includes('chunky-dad-nyc'));
+  assert.ok(html.includes('chunky-dad-seattle'));
+
+  // OK events collapse into a single expandable line, with no buttons inside
+  assert.ok(html.includes('1 event looks right'));
+  const okDetails = html.match(/<details class="ok-details">[\s\S]*?<\/details>/);
+  assert.ok(okDetails && okDetails[0].includes('OK Event'));
+  assert.ok(!okDetails[0].includes('<button'));
+
+  // Status chips are color-coded per status
+  assert.ok(html.includes('status-chip status-pin-moved'));
+  assert.ok(html.includes('status-chip status-missing-address'));
+  assert.ok(html.includes('status-chip status-unpinnable'));
+
+  // Distance badge for pin-moved
+  assert.ok(html.includes('1.3 km'));
+
+  // Titles and ids are escaped — raw markup and quotes never leak into the DOM
+  assert.ok(!html.includes('<b>Night</b>'));
+  assert.ok(html.includes('Bear &lt;b&gt;Night&lt;/b&gt;'));
+  assert.ok(html.includes('data-finding-id="pm-&quot;1&quot;"'));
+
+  // Apply buttons only where a proposal exists (pin-moved + missing-address)
+  assert.equal((html.match(/class="apply-btn"/g) || []).length, 2);
+
+  // Map links: Apple Maps anchor plus a collapsed OSM iframe that only
+  // carries data-src (the frame src is assigned on first expand)
+  assert.ok(html.includes('https://maps.apple.com/?ll=40.71,-73.99&amp;q=Bear%20%3Cb%3ENight%3C%2Fb%3E'));
+  assert.ok(html.includes('data-src="https://www.openstreetmap.org/export/embed.html?bbox='));
+  assert.ok(!/<iframe[^>]* src=/.test(html), 'iframes must stay unloaded until expanded');
+
+  // Sticky footer bulk actions + the native bridge plumbing
+  assert.ok(html.includes('Add missing only'));
+  assert.ok(html.includes('Apply all'));
+  assert.ok(html.includes("applyBulk('missing-only')"));
+  assert.ok(html.includes("applyBulk('all')"));
+  assert.ok(html.includes('function postReviewAction'));
+  assert.ok(html.includes('function markFindingApplied'));
+
+  // Self-contained page: no external scripts or stylesheets
+  assert.ok(!html.includes('<link '));
+  assert.ok(!/<script[^>]+src=/.test(html));
+});
+
+test('selectReviewFindingsForAction resolves single, bulk, and missing-only payloads', () => {
+  const adapter = buildAdapter();
+  const findings = buildReviewFindingsFixture();
+
+  const single = adapter.selectReviewFindingsForAction({ action: 'apply', id: 'pm-"1"' }, findings);
+  assert.deepEqual(single.map((finding) => finding.id), ['pm-"1"']);
+
+  const missingOnly = adapter.selectReviewFindingsForAction({ action: 'apply-bulk', mode: 'missing-only' }, findings);
+  assert.deepEqual(missingOnly.map((finding) => finding.id), ['ma-1'],
+    'missing-only excludes pin-moved corrections');
+
+  const all = adapter.selectReviewFindingsForAction({ action: 'apply-bulk', mode: 'all' }, findings);
+  assert.deepEqual(all.map((finding) => finding.id), ['pm-"1"', 'ma-1'],
+    'bulk apply targets every finding with a proposal');
+
+  // Applied findings are never re-applied; proposal-less findings never match
+  findings[1]._applied = true;
+  assert.deepEqual(adapter.selectReviewFindingsForAction({ action: 'apply', id: 'pm-"1"' }, findings), []);
+  assert.deepEqual(adapter.selectReviewFindingsForAction({ action: 'apply', id: 'up-1' }, findings), []);
+});

--- a/scripts/calendar-reviewer.js
+++ b/scripts/calendar-reviewer.js
@@ -1,0 +1,175 @@
+// Variables used by Scriptable.
+// These must be at the very top of the file. Do not edit.
+// icon-color: deep-brown; icon-glyph: map-marked-alt;
+//
+// ============================================================================
+// CALENDAR REVIEWER - LIGHTWEIGHT ORCHESTRATOR
+// ============================================================================
+// ⚠️  AI ASSISTANT WARNING: This file is a LIGHTWEIGHT ORCHESTRATOR only
+//
+// Reviews EXISTING chunky-dad calendar events against pluggable data-quality
+// checks (v1: geocode — see SharedCore.getCalendarReviewChecks) and presents
+// the findings in an interactive WebView UI. Nothing is written to a
+// calendar except through the UI's Apply buttons.
+//
+// ✅ THIS FILE SHOULD CONTAIN:
+// ✅ Environment detection and module loading
+// ✅ Configuration management
+// ✅ Error handling and user feedback
+//
+// ❌ NEVER ADD THESE TO THIS FILE:
+// ❌ Business logic (that belongs in shared-core.js)
+// ❌ Calendar/UI operations (that belongs in adapters/)
+//
+// 📖 READ scripts/README.md BEFORE EDITING - Contains full architecture rules
+// ============================================================================
+
+console.log('🔎 Calendar Reviewer: Starting...');
+
+// User-tunable configuration
+const REVIEWER_CONFIG = {
+    // Explicit calendar titles to review; empty = every writable calendar
+    // whose title starts with "chunky-dad"
+    calendars: [],
+    lookbackDays: 365,
+    lookaheadDays: 365,
+    // Stored pin vs fresh verified geocode divergence that flags "pin-moved"
+    pinMovedThresholdKm: 0.4,
+    // Same knob as the scraper (scraper-input.js): report | enforce | off
+    geocodeVerification: { mode: 'report' },
+    // Same shape as the scraper's pageCache so geocode results share the
+    // scraper's persistent cache
+    pageCache: { enabled: true, ttlDays: 3 }
+};
+
+class CalendarReviewerOrchestrator {
+    constructor(config = {}) {
+        this.isScriptable = typeof importModule !== 'undefined';
+        this.isNode = typeof module !== 'undefined' && module.exports && typeof window === 'undefined';
+        this.config = { ...REVIEWER_CONFIG, ...config };
+        this.modules = {};
+    }
+
+    loadModules() {
+        if (this.isScriptable) {
+            console.log('🔎 Calendar Reviewer: Loading Scriptable modules...');
+            const sharedCoreModule = importModule('shared-core');
+            const eventSchemaModule = importModule('event-schema');
+            const normalizersModule = importModule('normalizers');
+            const scriptableAdapterModule = importModule('adapters/scriptable-adapter');
+            this.modules = {
+                SharedCore: sharedCoreModule.SharedCore,
+                EventSchema: eventSchemaModule.EventSchema,
+                OpenStreetMapNormalizer: normalizersModule.OpenStreetMapNormalizer,
+                Adapter: scriptableAdapterModule.ScriptableAdapter,
+                cities: importModule('scraper-cities')
+            };
+        } else {
+            // Node: no Scriptable calendars exist, so a Node run only proves
+            // the pure modules load (CI syntax checking). The adapter is NOT
+            // required here — it needs Scriptable globals at load time.
+            console.log('🔎 Calendar Reviewer: Loading Node.js modules...');
+            this.modules = {
+                SharedCore: require('./shared-core').SharedCore,
+                EventSchema: require('./event-schema').EventSchema,
+                OpenStreetMapNormalizer: require('./normalizers').OpenStreetMapNormalizer,
+                Adapter: null,
+                cities: null
+            };
+        }
+    }
+
+    async run() {
+        this.loadModules();
+
+        if (!this.isScriptable) {
+            console.log('🔎 Calendar Reviewer: This tool reviews iOS calendars — run it in Scriptable. (Modules loaded OK; exiting.)');
+            return null;
+        }
+
+        const config = this.config;
+        const adapter = new this.modules.Adapter({
+            cities: this.modules.cities,
+            pageCache: config.pageCache || null
+        });
+        const core = new this.modules.SharedCore(this.modules.cities, {
+            eventSchema: this.modules.EventSchema,
+            additionalExcludedFields: this.modules.Adapter.NOTES_EXCLUDED_FIELDS
+        });
+        // The geocode check reuses the scraper's normalizer (grade gate, retry
+        // ladder, verification) rather than reimplementing any of it
+        const geocodeNormalizer = new this.modules.OpenStreetMapNormalizer(core);
+
+        try {
+            const calendars = await adapter.getReviewCalendars(config.calendars);
+            if (calendars.length === 0) {
+                await adapter.showError('Calendar Reviewer', 'No matching calendars found. Create chunky-dad-<city> calendars or list titles in REVIEWER_CONFIG.calendars.');
+                return null;
+            }
+
+            const events = await adapter.getReviewCalendarEvents(calendars, config);
+            const findings = await core.reviewCalendarEvents(events, {
+                httpAdapter: adapter,
+                geocodeNormalizer,
+                pinMovedThresholdKm: config.pinMovedThresholdKm,
+                geocodeVerification: config.geocodeVerification
+            });
+
+            const summary = this.modules.SharedCore.summarizeReviewFindings(findings);
+            console.log(`🔎 REVIEW: ${summary.findings} event(s) reviewed — ${summary.ok} ok, ${summary.proposals} with proposed fixes`);
+
+            const appliedCounts = await adapter.presentReviewResults(findings, { config });
+            return { findings, summary, appliedCounts };
+        } catch (error) {
+            console.error(`🔎 Calendar Reviewer: ✗ Review failed: ${error}`);
+            if (error.stack && error.stack.trim()) {
+                console.error(`🔎 Calendar Reviewer: ✗ Error stack trace: ${error.stack}`);
+            }
+            try {
+                await adapter.showError('Calendar Reviewer Error', `${error.name || 'Error'}: ${error.message || 'An unexpected error occurred'}\n\nCheck console for full details.`);
+            } catch (displayError) {
+                console.error(`🔎 Calendar Reviewer: ✗ Failed to show error dialog: ${displayError}`);
+            }
+            throw error;
+        }
+    }
+
+    // Static method for easy execution
+    static async execute() {
+        const orchestrator = new CalendarReviewerOrchestrator();
+        return await orchestrator.run();
+    }
+}
+
+// Auto-execute when loaded — but never on require(): in Node, only run when
+// invoked directly, so tests/tools can import the orchestrator without
+// touching calendars. Scriptable also defines a module global, so check
+// importModule first.
+const isScriptableEnvironment = typeof importModule !== 'undefined';
+const isNodeEnvironment = !isScriptableEnvironment && typeof module !== 'undefined' && module.exports && typeof window === 'undefined';
+const isDirectNodeRun = isNodeEnvironment && typeof require !== 'undefined' && require.main === module;
+if (!isNodeEnvironment || isDirectNodeRun) {
+    (async () => {
+        try {
+            await CalendarReviewerOrchestrator.execute();
+            console.log('🔎 Calendar Reviewer: Execution completed successfully');
+        } catch (error) {
+            console.error(`🔎 Calendar Reviewer: Execution failed: ${error}`);
+            if (typeof process !== 'undefined') {
+                process.exitCode = 1;
+            }
+        } finally {
+            if (typeof Script !== 'undefined' && typeof Script.complete === 'function') {
+                Script.complete();
+            }
+        }
+    })();
+}
+
+// Export for manual execution if needed
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { CalendarReviewerOrchestrator };
+} else {
+    // Scriptable environment
+    this.CalendarReviewerOrchestrator = CalendarReviewerOrchestrator;
+}

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -26,6 +26,11 @@ const ADAPTIVE_CRAWL_DEPTH = 'adaptive';
 // Hard cap on adaptive crawl chains: pages this many hops from a root never
 // have their links followed, no matter how they classify.
 const ADAPTIVE_CRAWL_MAX_HOPS = 4;
+// Stored-pin vs fresh-geocode divergence (km) that warrants human review.
+// Fresh geocodes are grade-gated and cross-checked (normalizers.js), so
+// sub-km disagreement is meaningful. Shared by the merge-time STEP 3c flag
+// and the calendar reviewer's pin-moved check.
+const PIN_MOVED_THRESHOLD_KM = 0.4;
 
 class SharedCore {
     constructor(cities, options = {}) {
@@ -3367,7 +3372,7 @@ class SharedCore {
                 if (scraperValue !== calendarValue) {
                     console.log(`📍 MERGE: "${mergeTitle}" location kept calendar pin (address unchanged)`);
                     const distanceKm = this.coordinatePairDistanceKm(calendarValue, scraperValue);
-                    if (distanceKm !== null && distanceKm > 1) {
+                    if (distanceKm !== null && distanceKm > PIN_MOVED_THRESHOLD_KM) {
                         console.log(`📍 MERGE: "${mergeTitle}" calendar pin is ${distanceKm.toFixed(1)}km from fresh geocode of the same address — verify pin`);
                     }
                 }
@@ -6054,6 +6059,227 @@ class SharedCore {
             console.warn(`🤖 AI Web: AI request${label} to ${aiConfig.endpoint} with model ${aiConfig.model} failed after ${elapsed}ms (${errorType}): ${error.message}`);
             return null;
         }
+    }
+
+    // ------------------------------------------------------------------
+    // CALENDAR REVIEWER — pure review core. Each check is a named async
+    // function (events, context) → findings; register future checks
+    // (missing fields, duplicates, ...) in getCalendarReviewChecks.
+    // Events are plain objects mapped by the adapter:
+    //   { id, calendarTitle, title, startDate, location, address, bar }
+    // Findings (one per event; 'ok' ones are countable for the summary):
+    //   { id, calendarTitle, eventTitle, startDate, check, status,
+    //     current: {location, address}, proposed: {location?, address?},
+    //     distanceKm?, detail }
+    // Network only via context.httpAdapter and the injected geocode
+    // normalizer — no Scriptable APIs, no env detection.
+    // ------------------------------------------------------------------
+
+    getCalendarReviewChecks() {
+        return {
+            geocode: (events, context) => this.runGeocodeReviewCheck(events, context)
+        };
+    }
+
+    async reviewCalendarEvents(events, context = {}) {
+        const list = Array.isArray(events) ? events : [];
+        const checks = context.checks && typeof context.checks === 'object'
+            ? context.checks
+            : this.getCalendarReviewChecks();
+        const findings = [];
+        for (const [checkName, runCheck] of Object.entries(checks)) {
+            const checkFindings = await runCheck(list, context);
+            if (Array.isArray(checkFindings)) {
+                findings.push(...checkFindings);
+            } else {
+                console.warn(`🔎 REVIEW: Check "${checkName}" returned no findings array — skipped`);
+            }
+        }
+        return findings;
+    }
+
+    // Reverse of the adapter's getCalendarName: calendar title → city key,
+    // via the cities config first, then the `chunky-dad-<city>` convention.
+    cityForCalendarTitle(calendarTitle) {
+        const title = String(calendarTitle || '').trim();
+        if (!title) return '';
+        for (const [cityKey, cityConfig] of Object.entries(this.cities)) {
+            if (cityConfig && cityConfig.calendar === title) return cityKey;
+        }
+        const match = /^chunky-dad-(.+)$/.exec(title);
+        return match ? match[1] : '';
+    }
+
+    static summarizeReviewFindings(findings) {
+        const summary = { findings: 0, ok: 0, byStatus: {}, proposals: 0, missingProposals: 0 };
+        (Array.isArray(findings) ? findings : []).forEach(finding => {
+            if (!finding) return;
+            summary.findings += 1;
+            const status = String(finding.status || 'unknown');
+            summary.byStatus[status] = (summary.byStatus[status] || 0) + 1;
+            if (status === 'ok') summary.ok += 1;
+            if (finding.proposed && Object.keys(finding.proposed).length > 0) {
+                summary.proposals += 1;
+                if (status === 'missing-pin' || status === 'missing-address') {
+                    summary.missingProposals += 1;
+                }
+            }
+        });
+        return summary;
+    }
+
+    // v1 geocode check: verify stored pins against a fresh grade-gated
+    // geocode of each event's address, propose pins/addresses for events
+    // missing one side, and surface addresses that refuse to geocode.
+    // context.geocodeNormalizer must be an OpenStreetMapNormalizer instance —
+    // the scraper's forward ladder / grade gate / verification is reused, not
+    // reimplemented. Unique addresses are geocoded once: venues repeat across
+    // events and every Nominatim call costs 1.1s of throttle.
+    async runGeocodeReviewCheck(events, context = {}) {
+        const httpAdapter = context.httpAdapter || null;
+        const geocoder = context.geocodeNormalizer;
+        if (!geocoder || typeof geocoder.normalizeAsync !== 'function') {
+            throw new Error('Geocode review check requires context.geocodeNormalizer (OpenStreetMapNormalizer instance)');
+        }
+        const thresholdRaw = Number(context.pinMovedThresholdKm);
+        const thresholdKm = Number.isFinite(thresholdRaw) && thresholdRaw > 0 ? thresholdRaw : PIN_MOVED_THRESHOLD_KM;
+        const geocodeOptions = {
+            geocodeVerification: context.geocodeVerification && typeof context.geocodeVerification === 'object'
+                ? context.geocodeVerification
+                : { mode: 'report' }
+        };
+        const normalizeAddressKey = (address) => String(address || '').replace(/\s+/g, ' ').trim().toLowerCase();
+        const forwardKeyFor = (city, address) => `${city}|${normalizeAddressKey(address)}`;
+        const reverseKeyFor = (pin) => `${pin.lat.toFixed(5)},${pin.lng.toFixed(5)}`;
+
+        // Pass 1: unique forward jobs (per city + address) and unique reverse
+        // jobs (per stored pin), plus per-calendar counts for the progress log.
+        const forwardJobs = new Map();
+        const reverseJobs = new Map();
+        const calendarCounts = new Map();
+        for (const event of events) {
+            if (!event) continue;
+            const calendarTitle = String(event.calendarTitle || '');
+            const counts = calendarCounts.get(calendarTitle) || { events: 0, addresses: new Set() };
+            counts.events += 1;
+            calendarCounts.set(calendarTitle, counts);
+            const city = this.cityForCalendarTitle(calendarTitle);
+            const address = typeof event.address === 'string' ? event.address.trim() : '';
+            const title = event.title || address || event.location || 'unknown';
+            if (address) {
+                const key = forwardKeyFor(city, address);
+                counts.addresses.add(key);
+                if (!forwardJobs.has(key)) {
+                    forwardJobs.set(key, {
+                        address,
+                        city,
+                        bar: typeof event.bar === 'string' ? event.bar.trim() : '',
+                        title
+                    });
+                }
+            } else if (this.isCoordinatePair(event.location)) {
+                const pin = this.parseCoordinatePair(event.location);
+                const key = reverseKeyFor(pin);
+                if (!reverseJobs.has(key)) {
+                    reverseJobs.set(key, { location: event.location.trim(), title });
+                }
+            }
+        }
+        for (const [calendarTitle, counts] of calendarCounts) {
+            console.log(`🔎 REVIEW: ${calendarTitle || '(unknown calendar)'} — ${counts.events} events, ${counts.addresses.size} unique addresses to geocode`);
+        }
+
+        // Pass 2: geocode. Probes carry only {title, address, city, bar} with
+        // location stripped so the normalizer's forward path runs exactly as
+        // it does for scraped events (the normalizer's own 🗺️ lines show the
+        // ladder detail).
+        const freshPinByKey = new Map();
+        let jobIndex = 0;
+        for (const [key, job] of forwardJobs) {
+            jobIndex += 1;
+            console.log(`🔎 REVIEW: Geocoding "${job.address}"${job.city ? ` (${job.city})` : ''} — ${jobIndex}/${forwardJobs.size}`);
+            const probe = { title: job.title, address: job.address, city: job.city, bar: job.bar };
+            try {
+                await geocoder.normalizeAsync(probe, httpAdapter, geocodeOptions);
+            } catch (error) {
+                console.warn(`🔎 REVIEW: Geocode failed for "${job.address}": ${error.message}`);
+            }
+            freshPinByKey.set(key, this.isCoordinatePair(probe.location) ? probe.location.trim() : null);
+        }
+        // Reverse path (pin → address) is nearly free: the normalizer prefers
+        // the adapter's native reverse geocoder over Nominatim.
+        const addressByPinKey = new Map();
+        for (const [key, job] of reverseJobs) {
+            const probe = { title: job.title, location: job.location };
+            try {
+                await geocoder.normalizeAsync(probe, httpAdapter, geocodeOptions);
+            } catch (error) {
+                console.warn(`🔎 REVIEW: Reverse geocode failed for "${job.location}": ${error.message}`);
+            }
+            const address = typeof probe.address === 'string' ? probe.address.trim() : '';
+            addressByPinKey.set(key, address || null);
+        }
+
+        // Pass 3: one finding per event.
+        const findings = [];
+        for (const event of events) {
+            if (!event) continue;
+            const calendarTitle = String(event.calendarTitle || '');
+            const city = this.cityForCalendarTitle(calendarTitle);
+            const address = typeof event.address === 'string' ? event.address.trim() : '';
+            const location = typeof event.location === 'string' ? event.location.trim() : '';
+            const hasPin = this.isCoordinatePair(location);
+            const finding = {
+                id: event.id,
+                calendarTitle,
+                eventTitle: event.title || '(untitled)',
+                startDate: event.startDate || null,
+                check: 'geocode',
+                status: 'ok',
+                current: { location, address },
+                proposed: {},
+                detail: ''
+            };
+            if (address) {
+                const fresh = freshPinByKey.get(forwardKeyFor(city, address)) || null;
+                if (!fresh) {
+                    finding.status = 'unpinnable';
+                    finding.detail = hasPin
+                        ? 'address no longer geocodes to a usable pin — stored pin kept but unverified'
+                        : 'no usable geocoordinate for this address (grade gate/ladder found nothing)';
+                } else if (!hasPin) {
+                    finding.status = 'missing-pin';
+                    finding.proposed.location = fresh;
+                    finding.detail = location
+                        ? `location "${location}" is not a coordinate pair — fresh geocode proposed`
+                        : 'address geocodes but no pin is stored — fresh geocode proposed';
+                } else {
+                    const distanceKm = this.coordinatePairDistanceKm(location, fresh);
+                    finding.distanceKm = distanceKm;
+                    if (distanceKm !== null && distanceKm > thresholdKm) {
+                        finding.status = 'pin-moved';
+                        finding.proposed.location = fresh;
+                        finding.detail = `stored pin is ${distanceKm.toFixed(1)}km from the fresh verified geocode of this address`;
+                    } else {
+                        finding.detail = 'stored pin matches a fresh geocode of the address';
+                    }
+                }
+            } else if (hasPin) {
+                const reverse = addressByPinKey.get(reverseKeyFor(this.parseCoordinatePair(location))) || null;
+                finding.status = 'missing-address';
+                if (reverse) {
+                    finding.proposed.address = reverse;
+                    finding.detail = 'pin has no address — reverse-geocoded address proposed';
+                } else {
+                    finding.detail = 'pin has no address and reverse geocoding returned nothing';
+                }
+            } else {
+                finding.status = 'no-data';
+                finding.detail = 'no coordinates and no address on this event';
+            }
+            findings.push(finding);
+        }
+        return findings;
     }
 
 }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 
 const { SharedCore } = require('./shared-core');
 const { EventSchema } = require('./event-schema');
+const { OpenStreetMapNormalizer } = require('./normalizers');
 
 const CITIES = {
   dallas: { timezone: 'America/Chicago', patterns: ['dallas'] }
@@ -1434,7 +1435,7 @@ test('unchanged address keeps the calendar pin; a divergent fresh geocode is fla
   const core = createCore();
   const adapter = buildArbitrationAdapter({});
 
-  // Geocode jitter (well under 1km): pin kept, logged, but not flagged
+  // Geocode jitter (well under the 0.4km threshold): pin kept, logged, but not flagged
   const near = await capturePinMerge(core,
     buildPinExisting(),
     buildPinScraped({ location: '32.8106, -96.8110709' }),
@@ -1442,9 +1443,20 @@ test('unchanged address keeps the calendar pin; a divergent fresh geocode is fla
   assert.equal(near.finalEvent.location, '32.810535, -96.8110709', 'the calendar pin must survive geocode jitter');
   assert.ok(near.logLines.includes('📍 MERGE: "FURBALL" location kept calendar pin (address unchanged)'),
     `the kept pin is logged, got: ${JSON.stringify(near.logLines)}`);
-  assert.ok(!near.logLines.some(line => line.includes('verify pin')), 'sub-km jitter is not flagged');
+  assert.ok(!near.logLines.some(line => line.includes('verify pin')), 'sub-threshold jitter is not flagged');
   assert.ok(!near.logLines.some(line => line.startsWith('🔄 MERGE:')),
     `a kept pin must not count as clobbered, got: ${JSON.stringify(near.logLines)}`);
+
+  // Fresh geocode ~0.6km away: beyond the 0.4km threshold — flagged. Fresh
+  // geocodes are grade-gated + cross-checked, so sub-km disagreement matters.
+  const mid = await capturePinMerge(core,
+    buildPinExisting(),
+    buildPinScraped({ location: '32.816, -96.8110709' }),
+    { httpAdapter: adapter });
+  assert.equal(mid.finalEvent.location, '32.810535, -96.8110709', 'a sub-km divergence still keeps the pin');
+  assert.ok(mid.logLines.some(line =>
+    /^📍 MERGE: "FURBALL" calendar pin is 0\.6km from fresh geocode of the same address — verify pin$/.test(line)),
+    `a 0.6km divergence is flagged, got: ${JSON.stringify(mid.logLines)}`);
 
   // Fresh geocode ~2km away: pin STILL kept (flag, don't drop), divergence flagged
   const far = await capturePinMerge(core,
@@ -3812,4 +3824,189 @@ test('prepareParsedEvents threads the geocodeVerification knob into the normaliz
   // No knob configured → the option is passed through as undefined (normalizers default to "report")
   await core.prepareParsedEvents([{ title: 'CHUNK' }], {}, {}, null, pipeline, {});
   assert.deepEqual(capturedOptions, { geocodeVerification: undefined });
+});
+
+// ---------------------------------------------------------------------------
+// Calendar reviewer core: geocode check statuses, unique-address dedup,
+// configurable pin-moved threshold, calendar-title → city mapping
+// ---------------------------------------------------------------------------
+
+// One exact-grade Nominatim candidate for the STATION 4 address.
+const REVIEW_GEOCODE_RESULTS = [{
+  lat: '32.810535',
+  lon: '-96.8110709',
+  class: 'amenity',
+  type: 'nightclub',
+  addresstype: 'amenity',
+  display_name: 'Station 4, Cedar Springs Road, Dallas, TX 75219',
+  address: { city: 'Dallas', house_number: '3911' }
+}];
+
+function buildReviewGeocodeAdapter(results = REVIEW_GEOCODE_RESULTS, extras = {}) {
+  const calls = [];
+  return {
+    calls,
+    async fetchData(url) {
+      calls.push(url);
+      return JSON.stringify(results);
+    },
+    ...extras
+  };
+}
+
+function createReviewContext(core, adapter, overrides = {}) {
+  const geocodeNormalizer = new OpenStreetMapNormalizer(core);
+  geocodeNormalizer.delayForRateLimit = async () => {}; // keep the suite fast
+  return { httpAdapter: adapter, geocodeNormalizer, ...overrides };
+}
+
+function buildReviewEvent(overrides = {}) {
+  return {
+    id: 'evt-1',
+    calendarTitle: 'chunky-dad-dallas',
+    title: 'FURBALL',
+    startDate: new Date('2026-07-05T22:00:00.000Z'),
+    location: '32.810535, -96.8110709',
+    address: PIN_TEST_ADDRESS,
+    bar: 'STATION 4',
+    ...overrides
+  };
+}
+
+async function captureReview(core, events, context) {
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let findings;
+  try {
+    findings = await core.reviewCalendarEvents(events, context);
+  } finally {
+    console.log = originalLog;
+  }
+  return { findings, logLines };
+}
+
+test('review: calendar title maps to city via the cities config, then the chunky-dad prefix', () => {
+  const core = new SharedCore({
+    nyc: { timezone: 'America/New_York', calendar: 'NYC Bears', patterns: ['nyc'] },
+    dallas: { timezone: 'America/Chicago', patterns: ['dallas'] }
+  }, { eventSchema: EventSchema });
+  assert.equal(core.cityForCalendarTitle('NYC Bears'), 'nyc');
+  assert.equal(core.cityForCalendarTitle('chunky-dad-dallas'), 'dallas');
+  assert.equal(core.cityForCalendarTitle('Personal'), '');
+});
+
+test('review: unique addresses are geocoded once, no matter how many events share them', async () => {
+  const core = createCore();
+  const adapter = buildReviewGeocodeAdapter();
+  const events = [
+    buildReviewEvent({ id: 'a' }),
+    buildReviewEvent({ id: 'b', title: 'FURBALL: ROUND 2' }),
+    buildReviewEvent({ id: 'c', title: 'FURBALL: NO PIN', location: '' })
+  ];
+
+  const { findings, logLines } = await captureReview(core, events, createReviewContext(core, adapter));
+
+  assert.equal(adapter.calls.length, 1, `one shared address → one geocode fetch, got: ${JSON.stringify(adapter.calls)}`);
+  assert.ok(logLines.includes('🔎 REVIEW: chunky-dad-dallas — 3 events, 1 unique addresses to geocode'),
+    `per-calendar progress line logged, got: ${JSON.stringify(logLines)}`);
+
+  const byId = new Map(findings.map(finding => [finding.id, finding]));
+  assert.equal(byId.get('a').status, 'ok');
+  assert.equal(byId.get('b').status, 'ok');
+  assert.equal(byId.get('c').status, 'missing-pin');
+  assert.equal(byId.get('c').proposed.location, '32.810535, -96.8110709');
+});
+
+test('review: pin-moved beyond the threshold proposes the fresh verified pin; below stays ok', async () => {
+  const core = createCore();
+  const adapter = buildReviewGeocodeAdapter();
+  const events = [
+    buildReviewEvent({ id: 'moved', location: '32.8285, -96.8110709' }), // ~2km off
+    buildReviewEvent({ id: 'jitter', location: '32.8106, -96.8110709' }) // ~7m off
+  ];
+
+  const { findings } = await captureReview(core, events, createReviewContext(core, adapter));
+  const byId = new Map(findings.map(finding => [finding.id, finding]));
+
+  const moved = byId.get('moved');
+  assert.equal(moved.status, 'pin-moved');
+  assert.equal(moved.proposed.location, '32.810535, -96.8110709');
+  assert.ok(moved.distanceKm > 1.9 && moved.distanceKm < 2.1, `distance carried on the finding, got ${moved.distanceKm}`);
+  assert.equal(moved.check, 'geocode');
+  assert.equal(moved.calendarTitle, 'chunky-dad-dallas');
+
+  const jitter = byId.get('jitter');
+  assert.equal(jitter.status, 'ok');
+  assert.deepEqual(jitter.proposed, {}, 'ok findings carry no proposal');
+});
+
+test('review: pinMovedThresholdKm is configurable', async () => {
+  const core = createCore();
+  const adapter = buildReviewGeocodeAdapter();
+  const events = [buildReviewEvent({ id: 'moved', location: '32.8285, -96.8110709' })];
+
+  const { findings } = await captureReview(core, events,
+    createReviewContext(core, adapter, { pinMovedThresholdKm: 5 }));
+
+  assert.equal(findings[0].status, 'ok', 'a 2km divergence is ok under a 5km threshold');
+});
+
+test('review: an address the ladder cannot pin is surfaced as unpinnable', async () => {
+  const core = createCore();
+  const adapter = buildReviewGeocodeAdapter([]); // every rung (and Photon) returns nothing
+  const events = [
+    buildReviewEvent({ id: 'no-pin', location: '' }),
+    buildReviewEvent({ id: 'has-pin' })
+  ];
+
+  const { findings } = await captureReview(core, events, createReviewContext(core, adapter));
+  const byId = new Map(findings.map(finding => [finding.id, finding]));
+
+  assert.equal(byId.get('no-pin').status, 'unpinnable');
+  assert.deepEqual(byId.get('no-pin').proposed, {});
+  assert.ok(byId.get('no-pin').detail.includes('no usable geocoordinate'));
+  // A stored pin whose address no longer geocodes is also surfaced — kept, unverified
+  assert.equal(byId.get('has-pin').status, 'unpinnable');
+  assert.ok(byId.get('has-pin').detail.includes('stored pin kept'));
+});
+
+test('review: a pin without an address proposes the reverse-geocoded address', async () => {
+  const core = createCore();
+  const adapter = buildReviewGeocodeAdapter([], {
+    reverseGeocode: async () => '3911 Cedar Springs Rd, Dallas, TX 75219'
+  });
+  const events = [
+    buildReviewEvent({ id: 'pin-only', address: '', bar: '' }),
+    buildReviewEvent({ id: 'nothing', address: '', bar: '', location: '' })
+  ];
+
+  const { findings } = await captureReview(core, events, createReviewContext(core, adapter));
+  const byId = new Map(findings.map(finding => [finding.id, finding]));
+
+  const pinOnly = byId.get('pin-only');
+  assert.equal(pinOnly.status, 'missing-address');
+  assert.equal(pinOnly.proposed.address, '3911 Cedar Springs Rd, Dallas, TX 75219');
+  assert.equal(adapter.calls.length, 0, 'the native reverse path never spends Nominatim budget');
+
+  assert.equal(byId.get('nothing').status, 'no-data');
+  assert.deepEqual(byId.get('nothing').proposed, {});
+});
+
+test('review: summarizeReviewFindings counts statuses and proposals', () => {
+  const summary = SharedCore.summarizeReviewFindings([
+    { status: 'ok', proposed: {} },
+    { status: 'ok', proposed: {} },
+    { status: 'pin-moved', proposed: { location: '1, 2' } },
+    { status: 'missing-pin', proposed: { location: '1, 2' } },
+    { status: 'missing-address', proposed: { address: 'x' } },
+    { status: 'unpinnable', proposed: {} }
+  ]);
+  assert.equal(summary.findings, 6);
+  assert.equal(summary.ok, 2);
+  assert.equal(summary.proposals, 3);
+  assert.equal(summary.missingProposals, 2);
+  assert.deepEqual(summary.byStatus, {
+    ok: 2, 'pin-moved': 1, 'missing-pin': 1, 'missing-address': 1, unpinnable: 1
+  });
 });


### PR DESCRIPTION
## What

New standalone Scriptable script `scripts/calendar-reviewer.js`: reviews EXISTING calendar events (manual or scraped, past year + next year by default) against pluggable data-quality checks and presents findings in an interactive WebView UI. **Nothing writes to a calendar except through a button tap.**

### v1 check: geocode — reuses #1493, never reimplements
Unique addresses are deduped per city (venues repeat; Nominatim is throttled at 1.1s) and each is geocoded ONCE through the real `OpenStreetMapNormalizer` — grade gate, retry ladder, Photon rescue, Apple reverse cross-check — then compared to every stored pin via `coordinatePairDistanceKm`. Statuses:

- **pin-moved** — stored pin > 0.4km from the fresh verified geocode (proposed fix: new pin)
- **missing-pin** — address geocodes but no coordinates stored (proposed)
- **unpinnable** — "hey, we aren't getting a geocoordinate for a full address" (also covers stored-pin events whose address no longer verifies)
- **missing-address** — pin but no address; reverse-geocoded address proposed (native Apple reverse preferred)
- **no-data** / **ok**

### Interactive UI
Same visual language as the scraper results page (cards, chips, dark mode). Summary header → per-calendar sections → finding cards with status chips, distance badges, current vs proposed, Apple Maps links, and tap-to-expand OSM map embeds (lazy `data-src` iframes — the page's only remote resource). Buttons: per-card **Apply**, sticky-footer **Add missing only** / **Apply all**. OK events collapse to one "✅ N events look right" line per calendar.

The static `WebView.loadHTML` used by the scraper can't do callbacks, so the reviewer uses an interactive bridge: the page queues button payloads, native loops `evaluateJavaScript(bridge, true)` raced against `present()` with a dismissal sentinel (pending evals carry their own catch — no unhandled rejections on close). Applies update the card chip in place (✅ Applied / ❌ Failed).

### Architecture
- **Pure review core in shared-core.js** (`reviewCalendarEvents` + check registry `getCalendarReviewChecks` — future checks like missing website/instagram or duplicate detection slot in as named functions).
- **Adapter layer** — calendar enumeration (writable `chunky-dad*` by default), event window fetch, `applyReviewFinding` mutating only proposed fields with one `save()`, line-surgical `upsertNotesField` (preserves free text; continuation-line handling matches `parseNotesIntoFields` semantics exactly).
- **Ride-along**: merge-time STEP 3c verify-pin threshold 1km → shared `PIN_MOVED_THRESHOLD_KM = 0.4` (safe now that fresh geocodes are verified; a 0.6km-off pin like the MEGAMILK case now flags).

## Tests
392 → 403 (review-core statuses + address dedup + threshold in shared-core.test.js; calendar filtering, apply write-scope, UI HTML in scriptable-adapter.test.js — existing enumerated files only), quiet runner, all green. `node --check` clean incl. the new entry script; `node scripts/calendar-reviewer.js` exits gracefully on Node; zero `new URL(` additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP