### PR TITLE
fix(reviewer): only verified exact-grade pins may back proposals + US Census rescue rung

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2814,6 +2814,7 @@ class ScriptableAdapter {
       "pin-moved": { icon: "📍", label: "Pin moved" },
       "missing-pin": { icon: "➕", label: "Missing pin" },
       "missing-address": { icon: "🏠", label: "Missing address" },
+      unverified: { icon: "⚠️", label: "Unverified" },
       unpinnable: { icon: "🚫", label: "Won't geocode" },
       "no-data": { icon: "❓", label: "No location data" },
     };
@@ -2821,6 +2822,7 @@ class ScriptableAdapter {
       "pin-moved",
       "missing-pin",
       "missing-address",
+      "unverified",
       "unpinnable",
       "no-data",
       "ok",
@@ -3025,6 +3027,7 @@ class ScriptableAdapter {
         .status-chip.status-pin-moved { background: var(--warn-color); }
         .status-chip.status-missing-pin { background: var(--gradient-primary); }
         .status-chip.status-missing-address { background: var(--accent-color); }
+        .status-chip.status-unverified { background: var(--warn-color); }
         .status-chip.status-unpinnable { background: var(--secondary-color); }
         .status-chip.status-no-data { background: var(--text-secondary); }
 

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -593,6 +593,12 @@ function buildReviewFindingsFixture() {
       startDate: '2026-08-04T02:00:00.000Z', check: 'geocode', status: 'unpinnable',
       current: { location: '', address: 'Somewhere Nowhere 123' }, proposed: {},
       detail: 'no usable geocoordinate for this address (grade gate/ladder found nothing)'
+    },
+    {
+      id: 'uv-1', calendarTitle: 'chunky-dad-seattle', eventTitle: 'Street Grade Only',
+      startDate: '2026-08-05T02:00:00.000Z', check: 'geocode', status: 'unverified',
+      current: { location: '47.61, -122.33', address: '3796 Fifth Avenue, Seattle' }, proposed: {},
+      detail: 'address only resolves to a street-grade pin — stored pin kept, verify manually'
     }
   ];
 }
@@ -603,9 +609,9 @@ test('generateReviewHTML renders per-calendar sections, chips, buttons, and esca
 
   // Summary header: events reviewed / ok / needing attention
   assert.ok(html.includes('Calendar Reviewer'));
-  assert.ok(html.includes('<span class="stat-value">4</span>'));
+  assert.ok(html.includes('<span class="stat-value">5</span>'));
   assert.ok(html.includes('<span class="stat-value">1</span>'));
-  assert.ok(html.includes('<span class="stat-value">3</span>'));
+  assert.ok(html.includes('<span class="stat-value">4</span>'));
 
   // One section per calendar
   assert.ok(html.includes('chunky-dad-nyc'));
@@ -621,6 +627,14 @@ test('generateReviewHTML renders per-calendar sections, chips, buttons, and esca
   assert.ok(html.includes('status-chip status-pin-moved'));
   assert.ok(html.includes('status-chip status-missing-address'));
   assert.ok(html.includes('status-chip status-unpinnable'));
+  assert.ok(html.includes('status-chip status-unverified'));
+  assert.ok(html.includes('.status-chip.status-unverified'), 'the unverified chip must have its own style');
+  assert.ok(html.includes('⚠️ Unverified'));
+
+  // An unverified finding renders its keep-the-pin detail but NO Apply button
+  const unverifiedCard = html.match(/<div class="event-card review-card" data-finding-id="uv-1"[\s\S]*?<\/div>\s*<\/div>/);
+  assert.ok(unverifiedCard, 'the unverified finding renders a card');
+  assert.ok(html.includes('stored pin kept, verify manually'));
 
   // Distance badge for pin-moved
   assert.ok(html.includes('1.3 km'));

--- a/scripts/calendar-reviewer.js
+++ b/scripts/calendar-reviewer.js
@@ -35,8 +35,10 @@ const REVIEWER_CONFIG = {
     lookaheadDays: 365,
     // Stored pin vs fresh verified geocode divergence that flags "pin-moved"
     pinMovedThresholdKm: 0.4,
-    // Same knob as the scraper (scraper-input.js): report | enforce | off
-    geocodeVerification: { mode: 'report' },
+    // NOTE: there is deliberately no geocodeVerification knob here — reviewer
+    // probes always run in enforce mode (see SharedCore.runGeocodeReviewCheck):
+    // the reviewer proposes destructive pin replacements, so the scraper's
+    // accept-and-flag report semantics are never good enough for it.
     // Same shape as the scraper's pageCache so geocode results share the
     // scraper's persistent cache
     pageCache: { enabled: true, ttlDays: 3 }
@@ -111,8 +113,7 @@ class CalendarReviewerOrchestrator {
             const findings = await core.reviewCalendarEvents(events, {
                 httpAdapter: adapter,
                 geocodeNormalizer,
-                pinMovedThresholdKm: config.pinMovedThresholdKm,
-                geocodeVerification: config.geocodeVerification
+                pinMovedThresholdKm: config.pinMovedThresholdKm
             });
 
             const summary = this.modules.SharedCore.summarizeReviewFindings(findings);

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -718,9 +718,10 @@ const CITY_CENTER_RADIUS_KM = 50;
 // ladder. 5 covers the full ladder (canonical address, unit/suite strip,
 // postal/country strip, directional strip, venue-name rescue); every request
 // stays 1.1s-throttled and later rungs only fire after earlier ones return
-// nothing usable. A single Photon rescue request may follow when every
-// Nominatim rung fails; it shares the same rate limiter. Never raise this
-// without revisiting the rate-limit budget.
+// nothing usable. A single US Census rescue request (US-looking addresses
+// only) and a single Photon rescue request may follow when every Nominatim
+// rung fails; both share the same rate limiter. Never raise this without
+// revisiting the rate-limit budget.
 const MAX_GEOCODE_QUERIES_PER_EVENT = 5;
 
 // Street-type words a trailing directional can follow ("Cheshire Bridge Rd NE").
@@ -768,11 +769,25 @@ const GEOCODE_GENERIC_STREET_TOKENS = [
     'place', 'court', 'east', 'west', 'north', 'south', 'way', 'the'
 ];
 
-// Unit/suite decoration ("Suite 200", "#4", "Apt 5B", "Fl 2") that chokes
-// Nominatim's free-text parser; stripped as its own retry rung. The word
-// tokens are boundary-guarded so street names like "Halsted" or "Steiner"
-// pass through untouched.
-const GEOCODE_UNIT_TOKEN_RE = /,?\s*(?:#|(?:ste|suite|apt|unit|fl|floor|rm|room)\b\.?)\s*[^\s,]+/gi;
+// Unit/suite decoration ("Suite 200", "#4", "#UNIT 114", "Apt 5B", "Fl. 2")
+// that chokes Nominatim's free-text parser; stripped as its own retry rung.
+// Three alternatives (2026-07-15 run findings shaped each one):
+//   1. "#" markers, optionally naming the unit kind — "#UNIT 114" must go
+//      entirely (stripping only "#UNIT" left a dangling "114").
+//   2. Bare unit words with their following token, or trailing with NO token
+//      before a comma/end ("333 S Palm Canyon Dr Unit, Palm Springs").
+//   3. Dotted "fl."/"rm." abbreviations — the dot is REQUIRED so a state+ZIP
+//      tail like ", FL 33101" never matches ("floor"/"room" stay bare words).
+// Word tokens are boundary-guarded so street names like "Halsted", "Steiner"
+// or "Sainte-Catherine" pass through untouched.
+const GEOCODE_UNIT_TOKEN_RE = new RegExp(
+    ',?\\s*(?:' +
+        '#\\s*(?:(?:ste|suite|apt|unit|floor|room)\\b\\.?\\s*)?[^\\s,]*' +
+        '|(?:ste|suite|apt|unit|floor|room)\\b\\.?(?:\\s+[^\\s,]+|(?=\\s*(?:,|$)))' +
+        '|(?:fl|rm)\\.\\s*[^\\s,]+' +
+    ')',
+    'gi'
+);
 
 // Leading street number ("1192 Folsom St"). Used only to decide whether a
 // street-grade pin is tolerable for this input — a house-numbered address
@@ -1103,11 +1118,13 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     // Final acceptance for a grade-gate-passing candidate: reverse cross-check
     // against the input address (Apple placemark via the adapter, when that
     // capability exists) plus suspect flagging per verification mode. Returns
-    // the "lat, lon" string to write, or null when enforce mode sends the
-    // ladder on to its next rung.
+    // { location, crossCheck } — the "lat, lon" string to write plus the
+    // cross-check verdict ('pass' | 'fail' | 'skipped'; 'fail' only survives
+    // in report mode) — or null when enforce mode sends the ladder on to its
+    // next rung.
     async confirmGeocodeCandidate(candidate, context, httpAdapter) {
         const { title, address, inputHasHouseNumber, verifyMode, source, rung } = context;
-        let crossCheckRan = false;
+        let crossCheck = 'skipped';
         if (verifyMode !== 'off' && typeof httpAdapter.reverseGeocodePlacemark === 'function') {
             let placemark = null;
             try {
@@ -1118,7 +1135,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             if (placemark) {
                 const comparison = this.comparePinToAddress(placemark, address);
                 if (comparison) {
-                    crossCheckRan = true;
+                    crossCheck = comparison.matched ? 'pass' : 'fail';
                     if (!comparison.matched) {
                         console.warn(`🗺️ GEOCODE VERIFY: "${title}" pin failed reverse cross-check ("${comparison.got}" vs "${address}") — verify pin`);
                         if (verifyMode === 'enforce') return null;
@@ -1129,10 +1146,10 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         if (candidate.grade === 'street' && inputHasHouseNumber && verifyMode === 'report') {
             console.warn(`🗺️ GEOCODE VERIFY: "${title}" street-grade pin for house-numbered address "${address}" — verify pin`);
         }
-        if (rung > 1 || crossCheckRan) {
+        if (rung > 1 || crossCheck !== 'skipped') {
             console.log(`🗺️ GEOCODE VERIFY: "${title}" accepted ${candidate.grade} pin from ${source} (rung ${rung})`);
         }
-        return `${candidate.lat}, ${candidate.lon}`;
+        return { location: `${candidate.lat}, ${candidate.lon}`, crossCheck };
     }
 
     // Canonical addresses ("1192 Folsom St, San Francisco, CA 94103, USA") return
@@ -1159,6 +1176,17 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         return parts.join(', ');
     }
 
+    // US-ish gate for the Census rescue rung: a 5-digit ZIP anywhere in the
+    // address, or a two-letter state token after a comma at the tail
+    // (optionally followed by a USA/US/United States segment). The gate only
+    // needs to be roughly right — a false positive just sends one query the
+    // Census geocoder answers with no match.
+    looksLikeUsAddress(address) {
+        const text = String(address || '').trim();
+        if (/\b\d{5}(?:-\d{4})?\b/.test(text)) return true;
+        return /,\s*[A-Za-z]{2}\.?\s*(?:,\s*(?:USA|US|United States)\s*)?$/i.test(text);
+    }
+
     // Strip directionals that FOLLOW a street-type word — at the end of the
     // address or before a comma. "2069 Cheshire Bridge Rd NE" → "2069 Cheshire
     // Bridge Rd"; "…Road Northeast, Atlanta, GA" → "…Road, Atlanta, GA".
@@ -1171,10 +1199,26 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             .trim();
     }
 
+    // Display-name anchor for outbound geocode queries. Internal city keys are
+    // meaningless to geocoders ("1123 Folsom Street, sf", "Palm Springs,
+    // palm-springs", "1200 Canal St, nola" all confuse Nominatim's free-text
+    // parser), so anchor with the city's first configured pattern (e.g. nyc →
+    // "new york"), falling back to the key itself when the config carries
+    // none. Only QUERY strings use this — city-center radius lookups and
+    // geocodeResultMatchesCity keep using the raw key.
+    geocodeCityAnchorName(cityKey) {
+        const key = String(cityKey || '').trim();
+        if (!key || !this.core || !this.core.cities) return key;
+        const cityConfig = this.core.cities[key];
+        const patterns = cityConfig && Array.isArray(cityConfig.patterns) ? cityConfig.patterns : [];
+        const displayName = typeof patterns[0] === 'string' ? patterns[0].trim() : '';
+        return displayName || key;
+    }
+
     // Forward-geocode retry ladder: deduped, ordered query strings, hard-capped
     // at MAX_GEOCODE_QUERIES_PER_EVENT. Order:
-    //   1. The query exactly as built today (city-anchored when the address
-    //      doesn't already contain the city).
+    //   1. The query exactly as built today (anchored to the city display name
+    //      when the address doesn't already contain it).
     //   2. The address with unit/suite tokens stripped (same anchoring) —
     //      "Suite 200" / "#4" decoration returns 0 results.
     //   3. The address with postal-code/country decoration stripped (same
@@ -1183,7 +1227,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     //      Nominatim's free-text parser chokes on "Rd NE" / "Road Northeast".
     //   5. "<bar>, <city>" — venue-name lookup rescues venues OSM knows by name.
     buildGeocodeQueryVariants(address, eventCity, bar) {
-        const city = typeof eventCity === 'string' ? eventCity.trim() : '';
+        const city = this.geocodeCityAnchorName(typeof eventCity === 'string' ? eventCity.trim() : '');
         const anchorToCity = (text) => {
             const includesCity = city && text.toLowerCase().includes(city.toLowerCase());
             return city && !includesCity ? `${text}, ${city}` : text;
@@ -1264,6 +1308,15 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             const queryVariants = this.buildGeocodeQueryVariants(address, eventCity, event.bar);
             let attempts = 0;
             let resolvedLocation = null;
+            // Verdict of the accepted pin ({grade, crossCheck, source, rung}),
+            // committed to the event's _geocode* metadata fields below. When the
+            // ladder ends UNPINNED, rejectedVerdict remembers the first candidate
+            // enforce mode turned away (street-grade for a house-numbered input,
+            // or a cross-check failure) so the calendar reviewer can tell "this
+            // address only resolves to an unverifiable pin" apart from "nothing
+            // resolves at all". Coarse refusals never leave a breadcrumb.
+            let resolvedVerdict = null;
+            let rejectedVerdict = null;
             for (let i = 0; i < queryVariants.length && !resolvedLocation; i++) {
                 const queryText = queryVariants[i];
                 const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(queryText)}&limit=${resultLimit}&addressdetails=1`;
@@ -1295,6 +1348,9 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                             continue;
                         }
                         if (grade === 'street' && inputHasHouseNumber && verifyMode === 'enforce') {
+                            if (!rejectedVerdict) {
+                                rejectedVerdict = { grade: 'street', crossCheck: 'skipped', source: 'nominatim', rung: i + 1 };
+                            }
                             continue;
                         }
                         graded.push({ result, grade });
@@ -1318,11 +1374,18 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                             }
                         }
                         if (pickedCandidate) {
-                            resolvedLocation = await this.confirmGeocodeCandidate(
+                            const confirmed = await this.confirmGeocodeCandidate(
                                 pickedCandidate,
                                 { ...verifyContext, source: 'nominatim', rung: i + 1 },
                                 httpAdapter
                             );
+                            if (confirmed) {
+                                resolvedLocation = confirmed.location;
+                                resolvedVerdict = { grade: pickedCandidate.grade, crossCheck: confirmed.crossCheck, source: 'nominatim', rung: i + 1 };
+                            } else if (!rejectedVerdict) {
+                                // null only means an enforce-mode cross-check failure
+                                rejectedVerdict = { grade: pickedCandidate.grade, crossCheck: 'fail', source: 'nominatim', rung: i + 1 };
+                            }
                         }
                     } else if ((!Array.isArray(data) || data.length === 0) && i < queryVariants.length - 1) {
                         console.log(`🗺️ OpenStreetMapNormalizer: 0 geocode results for "${queryText}" — trying next variant`);
@@ -1339,10 +1402,61 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                     }
                 }
             }
+            if (!resolvedLocation && this.looksLikeUsAddress(address)) {
+                // US Census rescue rung: free, no key, house-number-accurate for
+                // US addresses (TIGER interpolation), tried BEFORE Photon when
+                // every Nominatim rung failed or was rejected. Gated on the
+                // address looking US-ish — a miss just returns no match. Same
+                // rate limiter, same caches. Coordinates come back {x: lon, y: lat}.
+                const censusUrl = `https://geocoding.geo.census.gov/geocoder/locations/onelineaddress?address=${encodeURIComponent(address)}&benchmark=Public_AR_Current&format=json`;
+                attempts += 1;
+                try {
+                    const data = await this.fetchDataWithCacheAndRateLimit(censusUrl, options, httpAdapter);
+                    const matches = data && data.result && Array.isArray(data.result.addressMatches)
+                        ? data.result.addressMatches
+                        : [];
+                    const match = matches.length > 0 ? matches[0] : null;
+                    const coords = match && match.coordinates && typeof match.coordinates === 'object' ? match.coordinates : null;
+                    const lon = coords ? Number(coords.x) : NaN;
+                    const lat = coords ? Number(coords.y) : NaN;
+                    if (Number.isFinite(lat) && Number.isFinite(lon)) {
+                        const withinRadius = !cityCenter ||
+                            this.haversineDistanceKm(lat, lon, cityCenter.lat, cityCenter.lng) <= CITY_CENTER_RADIUS_KM;
+                        if (withinRadius) {
+                            // A Census match is a house-number interpolation → grade
+                            // 'exact'; it still has to survive the reverse cross-check
+                            // like any other pin.
+                            const confirmed = await this.confirmGeocodeCandidate(
+                                { lat, lon, grade: 'exact' },
+                                { ...verifyContext, source: 'census', rung: attempts },
+                                httpAdapter
+                            );
+                            if (confirmed) {
+                                resolvedLocation = confirmed.location;
+                                resolvedVerdict = { grade: 'exact', crossCheck: confirmed.crossCheck, source: 'census', rung: attempts };
+                            } else if (!rejectedVerdict) {
+                                rejectedVerdict = { grade: 'exact', crossCheck: 'fail', source: 'census', rung: attempts };
+                            }
+                        } else {
+                            console.warn(`🗺️ OpenStreetMapNormalizer: Census match for "${address}" falls outside ${CITY_CENTER_RADIUS_KM} km of ${eventCity} center — ignoring coordinates`);
+                        }
+                    } else {
+                        console.log(`🗺️ OpenStreetMapNormalizer: Census geocoder had no match for "${address}"`);
+                    }
+                } catch (err) {
+                    console.log(`🗺️ OpenStreetMapNormalizer: Failed to geocode address "${event.address}": ${err.message}`);
+                }
+                if (resolvedLocation) {
+                    event.location = resolvedLocation;
+                    modified = true;
+                    console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
+                }
+            }
             if (!resolvedLocation) {
                 // Photon rescue rung: a second geocoder with a friendlier free-text
-                // parser, tried once after every Nominatim rung failed. Same
-                // rate limiter, same caches. GeoJSON coordinates are [lon, lat].
+                // parser, tried once after every Nominatim rung (and the Census
+                // rescue, when eligible) failed. Same rate limiter, same caches.
+                // GeoJSON coordinates are [lon, lat].
                 const photonUrl = `https://photon.komoot.io/api/?q=${encodeURIComponent(address)}&limit=1`;
                 attempts += 1;
                 try {
@@ -1362,12 +1476,21 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                             console.warn(`🗺️ GEOCODE VERIFY: "${title}" refused generic pin (${props.osm_value || 'unknown'}) for address "${address}"`);
                         } else if (grade === 'street' && inputHasHouseNumber && verifyMode === 'enforce') {
                             // enforce demands house-number quality; stay unpinned
+                            if (!rejectedVerdict) {
+                                rejectedVerdict = { grade: 'street', crossCheck: 'skipped', source: 'photon', rung: attempts };
+                            }
                         } else if (withinRadius) {
-                            resolvedLocation = await this.confirmGeocodeCandidate(
+                            const confirmed = await this.confirmGeocodeCandidate(
                                 { lat: coords[1], lon: coords[0], grade },
-                                { ...verifyContext, source: 'photon', rung: queryVariants.length + 1 },
+                                { ...verifyContext, source: 'photon', rung: attempts },
                                 httpAdapter
                             );
+                            if (confirmed) {
+                                resolvedLocation = confirmed.location;
+                                resolvedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
+                            } else if (!rejectedVerdict) {
+                                rejectedVerdict = { grade, crossCheck: 'fail', source: 'photon', rung: attempts };
+                            }
                         }
                     }
                 } catch (err) {
@@ -1378,6 +1501,17 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                     modified = true;
                     console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
                 }
+            }
+            // Geocode verdict metadata for downstream consumers (the calendar
+            // reviewer's proposal gate). Underscore-prefixed fields are
+            // systematically excluded from notes/merge output. An unpinned event
+            // carries the breadcrumb of the best rejected candidate, when any.
+            const verdict = resolvedLocation ? resolvedVerdict : rejectedVerdict;
+            if (verdict) {
+                event._geocodeGrade = verdict.grade;
+                event._geocodeCrossCheck = verdict.crossCheck;
+                event._geocodeSource = verdict.source;
+                event._geocodeRung = verdict.rung;
             }
             if (!resolvedLocation) {
                 // Exact shape counted by run-log-summary's geocodeNoResults guard.

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -491,12 +491,14 @@ test('stripPostalCodeAndCountry keeps street + city and drops postal/country dec
 
 test('buildGeocodeQueryVariants tries the postal/country-stripped core after the full address', () => {
   const normalizer = createOsmNormalizerWithNyc();
+  // Anchors carry the city DISPLAY name ("new york"), never the internal key
+  // ("nyc") — geocoders can't parse internal keys (see geocodeCityAnchorName).
   assert.deepEqual(
     normalizer.buildGeocodeQueryVariants('325 Franklin Ave, Brooklyn, NY 11238, USA', 'nyc', "C'mon Everybody"),
     [
-      '325 Franklin Ave, Brooklyn, NY 11238, USA, nyc',
-      '325 Franklin Ave, Brooklyn, nyc',
-      "C'mon Everybody, nyc"
+      '325 Franklin Ave, Brooklyn, NY 11238, USA, new york',
+      '325 Franklin Ave, Brooklyn, new york',
+      "C'mon Everybody, new york"
     ]
   );
   // With a strippable directional too, the full 4-rung ladder fits the cap and
@@ -533,8 +535,9 @@ test('a simplified-query admin-area match is rejected instead of poisoning coord
     warns.some(w => w.includes('Rejected admin-area result') && w.includes('type=borough')),
     `the rejection must be logged: ${warns.join(' | ')}`
   );
-  assert.equal(httpAdapter.requests.length, 4, 'the ladder continues past the rejected result through the Photon rescue');
-  assert.ok(httpAdapter.requests[3].includes('photon.komoot.io'), 'the final request is the Photon rescue');
+  assert.equal(httpAdapter.requests.length, 5, 'the ladder continues past the rejected result through the Census and Photon rescues');
+  assert.ok(httpAdapter.requests[3].includes('geocoding.geo.census.gov'), 'the US-looking address gets a Census rescue before Photon');
+  assert.ok(httpAdapter.requests[4].includes('photon.komoot.io'), 'the final request is the Photon rescue');
 });
 
 test('a venue-name simplified query still resolves through an amenity result', async () => {
@@ -553,7 +556,7 @@ test('a venue-name simplified query still resolves through an amenity result', a
 
   assert.equal(event.location, '40.6791213, -73.9556999', 'the amenity match must keep working');
   assert.ok(
-    logs.some(l => l.includes('Geocoded via simplified query "C\'mon Everybody, nyc"')),
+    logs.some(l => l.includes('Geocoded via simplified query "C\'mon Everybody, new york"')),
     `the simplified-query success log must be preserved: ${logs.join(' | ')}`
   );
 });
@@ -1009,6 +1012,243 @@ test('geocode verification: the coords→address reverse path is untouched by ve
   assert.equal(event.address, '1192 Folsom St, San Francisco, CA');
   assert.ok(requests[0].includes('nominatim.openstreetmap.org/reverse'), 'the reverse endpoint stays Nominatim');
   assert.ok(!lines.some(l => l.includes('GEOCODE VERIFY')), `the reverse path never emits verification flags: ${lines.join(' | ')}`);
+});
+
+// ---------------------------------------------------------------------------
+// 2026-07-15 run findings: reviewer proposed replacing correct pins with
+// street centroids ("3796 Fifth Avenue, San Diego" → Fifth Avenue downtown,
+// 4.7 km away). Fixes under test here: geocode verdict fields (_geocodeGrade
+// etc.), city display-name query anchoring, the US Census rescue rung, and
+// the tightened unit-strip rung.
+// ---------------------------------------------------------------------------
+
+const CITIES_SAN_DIEGO = {
+  'san-diego': {
+    timezone: 'America/Los_Angeles',
+    patterns: ['san diego'],
+    coordinates: { lat: 32.7157, lng: -117.1611 }
+  }
+};
+
+function createOsmNormalizerWithSanDiego() {
+  const core = new SharedCore(CITIES_SAN_DIEGO, { eventSchema: EventSchema });
+  return new OpenStreetMapNormalizer(core);
+}
+
+// The street "Fifth Avenue" itself — a highway-class match whose centroid sits
+// downtown, kilometers from house 3796 (inside the 50 km radius, so only the
+// grade gate can stop it).
+const FIFTH_AVENUE_STREET_RESULT = {
+  lat: '32.7150000',
+  lon: '-117.1590000',
+  class: 'highway',
+  type: 'residential',
+  addresstype: 'road',
+  display_name: 'Fifth Avenue, San Diego, California, United States',
+  address: { road: 'Fifth Avenue', city: 'San Diego' }
+};
+
+// US Census house-number interpolation for the same address. NOTE the
+// coordinates shape: {x: lon, y: lat}.
+const CENSUS_FIFTH_AVENUE_MATCH = {
+  result: {
+    addressMatches: [{
+      matchedAddress: '3796 FIFTH AVE, SAN DIEGO, CA, 92103',
+      coordinates: { x: -117.1609, y: 32.7481 }
+    }]
+  }
+};
+
+const FIFTH_AVENUE_PLACEMARK = {
+  subThoroughfare: '3796',
+  thoroughfare: 'Fifth Avenue',
+  locality: 'San Diego',
+  postalCode: '92103'
+};
+
+test('geocode verdict fields record grade, cross-check, source, and rung on accepted pins — and never leak into notes', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter(
+    [['nominatim', [POWERHOUSE_POI_RESULT]]],
+    { reverseGeocodePlacemark: async () => FOLSOM_PLACEMARK }
+  );
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+
+  assert.equal(event.location, '37.7756941, -122.4103049');
+  assert.equal(event._geocodeGrade, 'exact');
+  assert.equal(event._geocodeCrossCheck, 'pass');
+  assert.equal(event._geocodeSource, 'nominatim');
+  assert.equal(event._geocodeRung, 1);
+  assert.ok(typeof event.notes === 'string' && event.notes.length > 0, 'a successful geocode refreshes notes');
+  assert.ok(!event.notes.includes('_geocode'), `underscore verdict fields must never leak into notes: ${event.notes}`);
+});
+
+test('geocode verdict: report-mode cross-check failure and street-grade accepts are recorded truthfully', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const failAdapter = createRoutedStubAdapter(
+    [['nominatim', [WRONG_STREET_POI_RESULT]]],
+    { reverseGeocodePlacemark: async () => MISSION_PLACEMARK }
+  );
+  const failEvent = { title: 'CHUNK', address: '1192 Folsom St' };
+  await withCapturedConsole(() =>
+    normalizer.normalizeAsync(failEvent, failAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+  assert.equal(failEvent.location, '37.7752000, -122.4180000', 'report mode still keeps the suspect pin');
+  assert.equal(failEvent._geocodeCrossCheck, 'fail');
+  assert.equal(failEvent._geocodeGrade, 'exact');
+
+  const streetNormalizer = createOsmNormalizer();
+  streetNormalizer.delayForRateLimit = async () => {};
+  const streetAdapter = createRoutedStubAdapter([['nominatim', [FOLSOM_STREET_ONLY_RESULT]]]);
+  const streetEvent = { title: 'CHUNK', address: '1192 Folsom St' };
+  await withCapturedConsole(() =>
+    streetNormalizer.normalizeAsync(streetEvent, streetAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+  assert.equal(streetEvent._geocodeGrade, 'street');
+  assert.equal(streetEvent._geocodeCrossCheck, 'skipped', 'no placemark hook → the cross-check is skipped');
+});
+
+test('geocode verdict: enforce leaves a street-grade breadcrumb when the ladder ends unpinned', async () => {
+  const normalizer = createOsmNormalizerWithSanDiego();
+  normalizer.delayForRateLimit = async () => {};
+  // Nominatim only knows the street; Census has no match; Photon has nothing.
+  const httpAdapter = createRoutedStubAdapter([
+    ['nominatim', [FIFTH_AVENUE_STREET_RESULT]],
+    ['geocoding.geo.census.gov', { result: { addressMatches: [] } }]
+  ]);
+  const event = { title: 'SD BEAR', address: '3796 Fifth Avenue, San Diego, CA 92103', city: 'san-diego' };
+
+  await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+
+  assert.equal(event.location, undefined, 'enforce refuses a street-grade pin for a house-numbered address');
+  assert.equal(event._geocodeGrade, 'street', 'the rejected street-grade candidate leaves a breadcrumb');
+  assert.equal(event._geocodeCrossCheck, 'skipped');
+  assert.equal(event._geocodeSource, 'nominatim');
+});
+
+test('geocode queries anchor with the city display name, never the internal key', () => {
+  const normalizer = createOsmNormalizer(); // CITIES: nyc → patterns ['new york', 'nyc']
+  assert.deepEqual(
+    normalizer.buildGeocodeQueryVariants('10-90 Wyckoff Avenue, Queens', 'nyc', ''),
+    ['10-90 Wyckoff Avenue, Queens, new york']
+  );
+  assert.deepEqual(
+    normalizer.buildGeocodeQueryVariants('Some Bar', 'nyc', 'Some Bar'),
+    ['Some Bar, new york'],
+    'the venue-name rescue rung is display-name-anchored too'
+  );
+  // A key with no cities config entry falls back to the key itself
+  assert.deepEqual(
+    normalizer.buildGeocodeQueryVariants('922 E. BURNSIDE', 'portland', ''),
+    ['922 E. BURNSIDE, portland']
+  );
+});
+
+test('census rescue: a house-numbered address that only street-grades on Nominatim gets a house-level Census pin', async () => {
+  const normalizer = createOsmNormalizerWithSanDiego();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter(
+    [
+      ['nominatim', [FIFTH_AVENUE_STREET_RESULT]],
+      ['geocoding.geo.census.gov', CENSUS_FIFTH_AVENUE_MATCH]
+    ],
+    { reverseGeocodePlacemark: async () => FIFTH_AVENUE_PLACEMARK }
+  );
+  const event = { title: 'SD BEAR', address: '3796 Fifth Avenue, San Diego, CA 92103', city: 'san-diego' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+
+  assert.equal(event.location, '32.7481, -117.1609', 'Census {x: lon, y: lat} must come out as "lat, lon"');
+  assert.equal(event._geocodeGrade, 'exact');
+  assert.equal(event._geocodeCrossCheck, 'pass');
+  assert.equal(event._geocodeSource, 'census');
+  const censusRequest = httpAdapter.requests.find(url => url.includes('geocoding.geo.census.gov'));
+  assert.ok(
+    censusRequest.includes('/geocoder/locations/onelineaddress?address=') &&
+    censusRequest.includes('benchmark=Public_AR_Current') &&
+    censusRequest.includes('format=json'),
+    `the Census request must use the onelineaddress endpoint: ${censusRequest}`
+  );
+  assert.ok(!httpAdapter.requests.some(url => url.includes('photon.komoot.io')), 'Census rescued the pin before Photon was needed');
+  assert.ok(
+    lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "SD BEAR" accepted exact pin from census (rung 2)')),
+    `the Census accept must be logged: ${lines.join(' | ')}`
+  );
+});
+
+test('census rescue is skipped for non-US-looking addresses', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([['nominatim', []]]);
+  const event = { title: 'TORREMOLINOS BEARS', address: 'LA NOGALERA, Torremolinos' };
+
+  await withCapturedConsole(() => normalizer.normalizeAsync(event, httpAdapter));
+
+  assert.ok(!httpAdapter.requests.some(url => url.includes('geocoding.geo.census.gov')), 'no Census request for a non-US address');
+  assert.ok(httpAdapter.requests.some(url => url.includes('photon.komoot.io')), 'the Photon rescue still runs');
+});
+
+test('census rescue: still subject to the reverse cross-check and the city-center radius', async () => {
+  // Cross-check mismatch in enforce mode → rejected, event stays unpinned
+  const normalizer = createOsmNormalizerWithSanDiego();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter(
+    [['geocoding.geo.census.gov', CENSUS_FIFTH_AVENUE_MATCH]],
+    { reverseGeocodePlacemark: async () => MISSION_PLACEMARK }
+  );
+  const event = { title: 'SD BEAR', address: '3796 Fifth Avenue, San Diego, CA 92103', city: 'san-diego' };
+  await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+  assert.equal(event.location, undefined, 'a cross-check-failed Census pin must not be written in enforce mode');
+  assert.equal(event._geocodeCrossCheck, 'fail', 'the rejection breadcrumb records the failed cross-check');
+
+  // A Census match outside the 50 km radius is ignored like any other candidate
+  const farNormalizer = createOsmNormalizerWithSanDiego();
+  farNormalizer.delayForRateLimit = async () => {};
+  const farAdapter = createRoutedStubAdapter([
+    ['geocoding.geo.census.gov', { result: { addressMatches: [{ matchedAddress: 'X', coordinates: { x: -74.006, y: 40.7128 } }] } }]
+  ]);
+  const farEvent = { title: 'SD BEAR', address: '3796 Fifth Avenue, San Diego, CA 92103', city: 'san-diego' };
+  await withCapturedConsole(() => farNormalizer.normalizeAsync(farEvent, farAdapter));
+  assert.equal(farEvent.location, undefined, 'a Census match outside the city radius must be ignored');
+});
+
+test('stripUnitTokens: hash-unit markers, trailing bare units, and state/ZIP tails', () => {
+  const normalizer = createOsmNormalizer();
+  // Simple hash markers keep stripping
+  assert.equal(normalizer.stripUnitTokens('1123 Folsom St #4, San Francisco'), '1123 Folsom St, San Francisco');
+  // "#UNIT 114" must go entirely, not leave a dangling "114"
+  assert.equal(
+    normalizer.stripUnitTokens('3796 Fifth Avenue #UNIT 114, San Diego'),
+    '3796 Fifth Avenue, San Diego'
+  );
+  // A trailing bare "Unit"/"Suite" with no token before a comma/end is stripped
+  assert.equal(
+    normalizer.stripUnitTokens('333 S Palm Canyon Dr Unit, Palm Springs'),
+    '333 S Palm Canyon Dr, Palm Springs'
+  );
+  assert.equal(normalizer.stripUnitTokens('333 S Palm Canyon Dr Suite'), '333 S Palm Canyon Dr');
+  // The classic forms keep working
+  assert.equal(normalizer.stripUnitTokens('1192 Folsom St Suite 200, San Francisco'), '1192 Folsom St, San Francisco');
+  assert.equal(normalizer.stripUnitTokens('123 Main St Fl. 2, Boston'), '123 Main St, Boston');
+  assert.equal(normalizer.stripUnitTokens('123 Main St Floor 2, Boston'), '123 Main St, Boston');
+  // Street names never match the boundary-guarded unit words
+  assert.equal(normalizer.stripUnitTokens('3702 N Halsted, Chicago'), '3702 N Halsted, Chicago');
+  assert.equal(normalizer.stripUnitTokens('2199 Steiner St, San Francisco'), '2199 Steiner St, San Francisco');
+  assert.equal(normalizer.stripUnitTokens('1500 Rue Sainte-Catherine, Montreal'), '1500 Rue Sainte-Catherine, Montreal');
+  // A Florida state+ZIP tail must never match the old bare "fl" token
+  assert.equal(normalizer.stripUnitTokens('101 Ocean Dr, Miami, FL 33101'), '101 Ocean Dr, Miami, FL 33101');
 });
 
 test('resolveWallClockDates ignores events without the wall-clock flag', () => {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -6143,11 +6143,17 @@ class SharedCore {
         }
         const thresholdRaw = Number(context.pinMovedThresholdKm);
         const thresholdKm = Number.isFinite(thresholdRaw) && thresholdRaw > 0 ? thresholdRaw : PIN_MOVED_THRESHOLD_KM;
-        const geocodeOptions = {
-            geocodeVerification: context.geocodeVerification && typeof context.geocodeVerification === 'object'
-                ? context.geocodeVerification
-                : { mode: 'report' }
-        };
+        // Probes ALWAYS run in enforce mode — any caller-supplied
+        // context.geocodeVerification is deliberately ignored. The scraper's
+        // report mode accepts-and-flags suspect pins (right for scraping: a
+        // flagged pin beats no pin on a brand-new event), but the reviewer
+        // proposes DESTRUCTIVE replacements of stored pins, so a pin that
+        // failed the reverse cross-check or is only street-grade for a
+        // house-numbered address must reject and continue the ladder instead
+        // of coming back as a "fresh verified geocode" (2026-07 run:
+        // report-mode probes proposed moving correct pins 4.7 km onto a
+        // street centroid).
+        const geocodeOptions = { geocodeVerification: { mode: 'enforce' } };
         const normalizeAddressKey = (address) => String(address || '').replace(/\s+/g, ' ').trim().toLowerCase();
         const forwardKeyFor = (city, address) => `${city}|${normalizeAddressKey(address)}`;
         const reverseKeyFor = (pin) => `${pin.lat.toFixed(5)},${pin.lng.toFixed(5)}`;
@@ -6204,7 +6210,16 @@ class SharedCore {
             } catch (error) {
                 console.warn(`🔎 REVIEW: Geocode failed for "${job.address}": ${error.message}`);
             }
-            freshPinByKey.set(key, this.isCoordinatePair(probe.location) ? probe.location.trim() : null);
+            // Keep the normalizer's verdict alongside the pin: only exact-grade,
+            // non-cross-check-failed pins may back a proposal. The grade/crossCheck
+            // breadcrumb also survives when NO pin resolved (enforce rejected a
+            // street-grade or cross-check-failed candidate) so findings can say
+            // "unverifiable" instead of "won't geocode".
+            freshPinByKey.set(key, {
+                location: this.isCoordinatePair(probe.location) ? probe.location.trim() : null,
+                grade: typeof probe._geocodeGrade === 'string' ? probe._geocodeGrade : null,
+                crossCheck: typeof probe._geocodeCrossCheck === 'string' ? probe._geocodeCrossCheck : null
+            });
         }
         // Reverse path (pin → address) is nearly free: the normalizer prefers
         // the adapter's native reverse geocoder over Nominatim.
@@ -6242,23 +6257,41 @@ class SharedCore {
             };
             if (address) {
                 const fresh = freshPinByKey.get(forwardKeyFor(city, address)) || null;
-                if (!fresh) {
+                const freshLocation = fresh && fresh.location ? fresh.location : null;
+                // Belt-and-suspenders proposal gate: only an exact-grade pin whose
+                // reverse cross-check did not fail may be proposed. Enforce-mode
+                // probes should already have rejected failures; street-grade pins
+                // still reach here for addresses without a parseable house number
+                // (e.g. hyphenated Queens numbers like "10-90 Wyckoff Avenue").
+                const proposalGrade = !!(freshLocation && fresh.grade === 'exact' && fresh.crossCheck !== 'fail');
+                if (!freshLocation && !(fresh && fresh.grade)) {
                     finding.status = 'unpinnable';
                     finding.detail = hasPin
                         ? 'address no longer geocodes to a usable pin — stored pin kept but unverified'
                         : 'no usable geocoordinate for this address (grade gate/ladder found nothing)';
+                } else if (!proposalGrade) {
+                    // A pin resolved (or a candidate was rejected by enforce) but
+                    // it is not proposal-grade — never propose it, never touch the
+                    // stored pin.
+                    finding.status = 'unverified';
+                    const reason = fresh.crossCheck === 'fail'
+                        ? 'address geocode failed the reverse cross-check'
+                        : 'address only resolves to a street-grade pin';
+                    finding.detail = hasPin
+                        ? `${reason} — stored pin kept, verify manually`
+                        : `${reason} — not proposing it`;
                 } else if (!hasPin) {
                     finding.status = 'missing-pin';
-                    finding.proposed.location = fresh;
+                    finding.proposed.location = freshLocation;
                     finding.detail = location
                         ? `location "${location}" is not a coordinate pair — fresh geocode proposed`
                         : 'address geocodes but no pin is stored — fresh geocode proposed';
                 } else {
-                    const distanceKm = this.coordinatePairDistanceKm(location, fresh);
+                    const distanceKm = this.coordinatePairDistanceKm(location, freshLocation);
                     finding.distanceKm = distanceKm;
                     if (distanceKm !== null && distanceKm > thresholdKm) {
                         finding.status = 'pin-moved';
-                        finding.proposed.location = fresh;
+                        finding.proposed.location = freshLocation;
                         finding.detail = `stored pin is ${distanceKm.toFixed(1)}km from the fresh verified geocode of this address`;
                     } else {
                         finding.detail = 'stored pin matches a fresh geocode of the address';

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4000,13 +4000,183 @@ test('review: summarizeReviewFindings counts statuses and proposals', () => {
     { status: 'pin-moved', proposed: { location: '1, 2' } },
     { status: 'missing-pin', proposed: { location: '1, 2' } },
     { status: 'missing-address', proposed: { address: 'x' } },
+    { status: 'unverified', proposed: {} },
     { status: 'unpinnable', proposed: {} }
   ]);
-  assert.equal(summary.findings, 6);
+  assert.equal(summary.findings, 7);
   assert.equal(summary.ok, 2);
-  assert.equal(summary.proposals, 3);
+  assert.equal(summary.proposals, 3, 'unverified findings never carry a proposal');
   assert.equal(summary.missingProposals, 2);
   assert.deepEqual(summary.byStatus, {
-    ok: 2, 'pin-moved': 1, 'missing-pin': 1, 'missing-address': 1, unpinnable: 1
+    ok: 2, 'pin-moved': 1, 'missing-pin': 1, 'missing-address': 1, unverified: 1, unpinnable: 1
   });
+});
+
+// ---------------------------------------------------------------------------
+// Reviewer proposal verification (2026-07-15 phone run findings: report-mode
+// probes returned accept-and-flag pins as "fresh verified geocodes" and the
+// reviewer proposed replacing CORRECT stored pins with them — e.g. "3796
+// Fifth Avenue, San Diego" onto the Fifth Avenue street centroid 4.7 km away
+// downtown). Probes now always run in enforce mode and only exact-grade,
+// non-cross-check-failed pins may back a proposal.
+// ---------------------------------------------------------------------------
+
+const SAN_DIEGO_REVIEW_CITIES = {
+  'san-diego': {
+    timezone: 'America/Los_Angeles',
+    calendar: 'chunky-dad-san-diego',
+    patterns: ['san diego'],
+    coordinates: { lat: 32.7157, lng: -117.1611 }
+  }
+};
+
+const SD_ADDRESS = '3796 Fifth Avenue, San Diego, CA 92103';
+const SD_STORED_PIN = '32.7481, -117.1609'; // correct hand-verified pin at house 3796
+
+// Nominatim's only answer: the STREET "Fifth Avenue" itself (highway class),
+// centroid kilometers from house 3796 but inside the 50 km city radius.
+const SD_FIFTH_AVENUE_STREET_RESULT = {
+  lat: '32.7150000',
+  lon: '-117.1590000',
+  class: 'highway',
+  type: 'residential',
+  addresstype: 'road',
+  display_name: 'Fifth Avenue, San Diego, California, United States',
+  address: { road: 'Fifth Avenue', city: 'San Diego' }
+};
+
+// What Apple's reverse geocoder said about that street centroid on the real
+// run: a different street entirely.
+const SD_MISMATCH_PLACEMARK = {
+  subThoroughfare: '204',
+  thoroughfare: 'Marina Park Way',
+  locality: 'San Diego'
+};
+
+const SD_HOUSE_PLACEMARK = {
+  subThoroughfare: '3796',
+  thoroughfare: 'Fifth Avenue',
+  locality: 'San Diego',
+  postalCode: '92103'
+};
+
+// US Census house-number interpolation for the same address ({x: lon, y: lat}).
+const SD_CENSUS_MATCH = {
+  result: {
+    addressMatches: [{
+      matchedAddress: '3796 FIFTH AVE, SAN DIEGO, CA, 92103',
+      coordinates: { x: -117.1609, y: 32.7481 }
+    }]
+  }
+};
+
+function buildSanDiegoReviewEvent(overrides = {}) {
+  return {
+    id: 'sd-1',
+    calendarTitle: 'chunky-dad-san-diego',
+    title: 'SD BEAR NIGHT',
+    startDate: new Date('2026-08-01T04:00:00.000Z'),
+    location: SD_STORED_PIN,
+    address: SD_ADDRESS,
+    bar: '',
+    ...overrides
+  };
+}
+
+test('review: San Diego regression — a street-grade-only probe never proposes; the stored pin is kept as unverified', async () => {
+  const core = new SharedCore(SAN_DIEGO_REVIEW_CITIES, { eventSchema: EventSchema });
+  // Nominatim only knows the street; Census/Photon URLs get the same array
+  // body, which their parsers read as "no match"; the reverse placemark for
+  // the street centroid mismatches the input address.
+  const adapter = buildReviewGeocodeAdapter([SD_FIFTH_AVENUE_STREET_RESULT], {
+    reverseGeocodePlacemark: async () => SD_MISMATCH_PLACEMARK
+  });
+  const events = [buildSanDiegoReviewEvent()];
+
+  const { findings } = await captureReview(core, events, createReviewContext(core, adapter));
+
+  assert.equal(findings.length, 1);
+  const finding = findings[0];
+  assert.equal(finding.status, 'unverified');
+  assert.deepEqual(finding.proposed, {}, 'a street-grade probe must NEVER back a pin-replacement proposal');
+  assert.equal(finding.current.location, SD_STORED_PIN, 'the stored pin is untouched');
+  assert.ok(finding.detail.includes('stored pin kept'), `detail must say the pin was kept: ${finding.detail}`);
+
+  // Probes ignore any caller-supplied verification mode: report mode from the
+  // caller must not resurrect the accept-and-flag pin as a proposal.
+  const reportAdapter = buildReviewGeocodeAdapter([SD_FIFTH_AVENUE_STREET_RESULT], {
+    reverseGeocodePlacemark: async () => SD_MISMATCH_PLACEMARK
+  });
+  const { findings: reportFindings } = await captureReview(core, [buildSanDiegoReviewEvent()],
+    createReviewContext(core, reportAdapter, { geocodeVerification: { mode: 'report' } }));
+  assert.equal(reportFindings[0].status, 'unverified');
+  assert.deepEqual(reportFindings[0].proposed, {}, 'the reviewer always probes in enforce mode');
+});
+
+test('review: San Diego regression — a Census house-level match restores verified exact-grade proposals', async () => {
+  const core = new SharedCore(SAN_DIEGO_REVIEW_CITIES, { eventSchema: EventSchema });
+  const calls = [];
+  const adapter = {
+    calls,
+    async fetchData(url) {
+      calls.push(url);
+      if (url.includes('geocoding.geo.census.gov')) return JSON.stringify(SD_CENSUS_MATCH);
+      if (url.includes('nominatim')) return JSON.stringify([SD_FIFTH_AVENUE_STREET_RESULT]);
+      return JSON.stringify([]);
+    },
+    reverseGeocodePlacemark: async () => SD_HOUSE_PLACEMARK
+  };
+  const events = [
+    buildSanDiegoReviewEvent({ id: 'no-pin', location: '' }),
+    // The garbage street-centroid pin the old reviewer would have written
+    buildSanDiegoReviewEvent({ id: 'moved', location: '32.7150, -117.1590' })
+  ];
+
+  const { findings } = await captureReview(core, events, createReviewContext(core, adapter));
+  const byId = new Map(findings.map(finding => [finding.id, finding]));
+
+  assert.equal(byId.get('no-pin').status, 'missing-pin');
+  assert.equal(byId.get('no-pin').proposed.location, '32.7481, -117.1609', 'the verified Census pin is proposed');
+  assert.equal(byId.get('moved').status, 'pin-moved');
+  assert.equal(byId.get('moved').proposed.location, '32.7481, -117.1609');
+  assert.ok(calls.some(url => url.includes('geocoding.geo.census.gov')), 'the Census rescue rung must have run');
+});
+
+test('review: a hyphenated house number that only street-grades stays unverified — hand-verified pins survive', async () => {
+  // "10-90 Wyckoff Avenue, Queens": the house-number regex cannot parse the
+  // hyphenated Queens number, so enforce mode accepts the street-grade pin —
+  // but the reviewer must still refuse to propose it over the stored pin.
+  const core = new SharedCore({
+    nyc: {
+      timezone: 'America/New_York',
+      calendar: 'chunky-dad-nyc',
+      patterns: ['new york', 'nyc'],
+      coordinates: { lat: 40.7128, lng: -74.006 }
+    }
+  }, { eventSchema: EventSchema });
+  const adapter = buildReviewGeocodeAdapter([{
+    lat: '40.7069000',
+    lon: '-73.9216000',
+    class: 'highway',
+    type: 'residential',
+    addresstype: 'road',
+    display_name: 'Wyckoff Avenue, Queens, City of New York, New York, United States',
+    address: { road: 'Wyckoff Avenue', city: 'City of New York' }
+  }]);
+  const events = [{
+    id: 'wyckoff',
+    calendarTitle: 'chunky-dad-nyc',
+    title: 'QUEENS BEAR BASH',
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    location: '40.7002, -73.9070', // hand-verified pin at the venue itself
+    address: '10-90 Wyckoff Avenue, Queens',
+    bar: ''
+  }];
+
+  const { findings } = await captureReview(core, events, createReviewContext(core, adapter));
+
+  assert.equal(findings[0].status, 'unverified');
+  assert.deepEqual(findings[0].proposed, {}, 'the street-grade pin must not replace the hand-verified pin');
+  assert.equal(findings[0].current.location, '40.7002, -73.9070');
+  assert.ok(findings[0].detail.includes('street-grade'), findings[0].detail);
 });


### PR DESCRIPTION
## The bug (real phone run, 2026-07-16)

The Calendar Reviewer proposed replacing CORRECT stored pins with garbage — e.g. "3796 Fifth Avenue, San Diego" where Nominatim had no house match and returned the STREET "Fifth Avenue" (centroid 4.7km away, downtown). The pipeline's own verification flagged it twice (`pin failed reverse cross-check`, `street-grade pin for house-numbered address`) but in report mode a suspect pin is accepted-and-flagged — right for scraping, where a flagged pin beats no pin — and the reviewer then used that flagged pin as a "fresh verified geocode" and proposed a destructive pin-moved fix. Same class: "10-90 Wyckoff Avenue, Queens" (hyphenated house number → street-grade only, would have moved a hand-verified pin), "325 Franklin Ave, Brooklyn" (matched house 303, cross-check said so), "Poconos, PA", "LA NOGALERA, Torremolinos", and "333 S Palm Canyon Dr Unit, Palm Springs" where the ladder degraded to the query "Palm Springs".

## The fix

1. **Reviewer probes always run in enforce mode** — caller-supplied mode is deliberately ignored (documented): cross-check failures and street-grade-for-house-numbered candidates reject and continue the ladder instead of coming back flagged.
2. **Normalizer exposes its verdict** — `_geocodeGrade`/`_geocodeCrossCheck`/`_geocodeSource`/`_geocodeRung` on the geocoded object (underscore fields are already excluded from notes/merge everywhere). When the ladder ends UNPINNED, a breadcrumb records the first enforce-rejected candidate so the reviewer can distinguish "resolves only to an unverifiable pin" from "nothing resolves"; coarse refusals leave no breadcrumb.
3. **Proposal gate** — pin-moved / missing-pin proposals require `grade === 'exact' && crossCheck !== 'fail'`. Anything less is a new **`unverified`** status: visible card (⚠️ chip), stored pin kept, NO Apply button. Kills all six bad proposals from the run.
4. **Real city names in geocode queries** — anchor with `cities[key].patterns[0]` (nyc → "new york") instead of internal keys; "1123 Folsom Street, sf" / "Palm Springs, palm-springs" no longer go to Nominatim. Radius checks and city matching keep the raw key.
5. **US Census rescue rung** (user-requested backup geocoder) — free, keyless, house-number-accurate TIGER interpolation; runs before Photon when all Nominatim rungs fail, gated on US-looking addresses (ZIP or trailing state), `{x: lon, y: lat}` order handled, still subject to the Apple cross-check + city-radius, same rate limiter + caches. Rescues the San Diego case with a real house-level pin.
6. **Unit-strip regex reworked** — "#UNIT 114" strips fully (no dangling "114"), trailing bare "Unit,"/"Suite," strips, `fl`/`rm` require a literal dot so ", FL 33101" is never eaten, "Halsted"/"Steiner"/"Ste-Catherine" untouched.

## Regression test

End-to-end San Diego pair driving the real `reviewCalendarEvents` → `OpenStreetMapNormalizer` stack: street-only Nominatim + mismatching reverse placemark → status `unverified`, empty proposal, stored pin untouched (and identical outcome when a caller tries `{mode:'report'}`); then Census returning the house match → verified `exact` proposals (missing-pin + pin-moved) produced.

## Tests
403 → 414, quiet runner, all green. `node --check` clean; zero `new URL(` additions; existing 🗺️/📍/🔎 log shapes untouched (new lines only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP