### PR TITLE
fix(reviewer): curated bar data authority + live sync from chunky.dad + Apple quota hygiene

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2087,6 +2087,68 @@ class ScriptableAdapter {
     }
   }
 
+  // Bar data merged on the website is the source of truth; the phone's local
+  // scraper-bars.js copy goes stale the moment a bar edit lands. Fetch the
+  // per-city JSON the site already serves (data/bars/<city>.json) for the
+  // requested cities, replacing that city's local entry wholesale. Bars URLs
+  // carry their own 1-day cache TTL so runs stay fast without re-downloading
+  // every time; any failure (404 for cities without a file, offline, bad
+  // JSON) quietly keeps the local entry. Returns { bars, counts } — counts
+  // feed the review UI's freshness line.
+  async refreshRemoteBars(cityKeys, localBars) {
+    const merged = {
+      ...(localBars && typeof localBars === "object" ? localBars : {}),
+    };
+    const counts = { remote: 0, local: 0, unavailable: 0 };
+    const keys = Array.isArray(cityKeys) ? cityKeys.filter(Boolean) : [];
+    const barsCacheConfig = {
+      enabled: this.getPageCacheConfig().enabled,
+      ttlDays: 1,
+    };
+    for (const cityKey of keys) {
+      const url = `https://chunky.dad/data/bars/${encodeURIComponent(cityKey)}.json`;
+      let remoteList = null;
+      try {
+        let body = null;
+        const cached = await this.readCachedPage(url, barsCacheConfig);
+        if (cached && typeof cached.html === "string") {
+          body = cached.html;
+        } else {
+          const responseData = await this.fetchData(url, {
+            headers: { Accept: "application/json" },
+            // Bars URLs use barsCacheConfig's 1-day TTL, so keep fetchData's
+            // global-TTL cache out of the way and write back explicitly.
+            isCacheableResponse: () => false,
+          });
+          if (responseData && typeof responseData.html === "string") {
+            body = responseData.html;
+            await this.writeCachedPage(url, responseData, barsCacheConfig);
+          }
+        }
+        if (body) {
+          const parsed = JSON.parse(body);
+          if (Array.isArray(parsed)) {
+            remoteList = parsed;
+          }
+        }
+      } catch (error) {
+        remoteList = null;
+      }
+      if (remoteList) {
+        merged[cityKey] = remoteList;
+        counts.remote += 1;
+      } else if (merged[cityKey]) {
+        counts.local += 1;
+      } else {
+        counts.unavailable += 1;
+      }
+    }
+    console.log(
+      `📱 Scriptable: Bars data — ${counts.remote} cities from chunky.dad, ${counts.local} from local file, ${counts.unavailable} unavailable`,
+    );
+    return { bars: merged, counts };
+  }
+
   // Get existing events for a specific event (called by shared-core)
   async getExistingEvents(event) {
     try {
@@ -3012,6 +3074,28 @@ class ScriptableAdapter {
       )
       .join("\n");
 
+    // Bars freshness line: where the curated bar data came from this run
+    // (counts from refreshRemoteBars). Absent when the caller didn't refresh.
+    const barsFreshness =
+      options.barsFreshness && typeof options.barsFreshness === "object"
+        ? options.barsFreshness
+        : null;
+    const barsFreshnessLine = barsFreshness
+      ? [
+          barsFreshness.remote > 0
+            ? `${barsFreshness.remote} ${barsFreshness.remote === 1 ? "city" : "cities"} live from chunky.dad`
+            : "",
+          barsFreshness.local > 0
+            ? `${barsFreshness.local} local fallback`
+            : "",
+          barsFreshness.unavailable > 0
+            ? `${barsFreshness.unavailable} without bar data`
+            : "",
+        ]
+          .filter(Boolean)
+          .join(" · ")
+      : "";
+
     const sections = [];
     for (const [calendarTitle, calendarFindings] of byCalendar) {
       const okFindings = calendarFindings.filter((f) => f.status === "ok");
@@ -3124,6 +3208,7 @@ class ScriptableAdapter {
         .stat-label { font-size: 13px; opacity: 0.9; }
 
         .summary-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+        .bars-freshness { font-size: 12px; opacity: 0.85; margin-top: 10px; }
         .summary-chip {
             font-size: 12px;
             font-weight: 600;
@@ -3309,6 +3394,7 @@ class ScriptableAdapter {
             </div>
         </div>
         ${summaryChips ? `<div class="summary-chips">${summaryChips}</div>` : ""}
+        ${barsFreshnessLine ? `<div class="bars-freshness">🍺 Bars: ${this.escapeHtml(barsFreshnessLine)}</div>` : ""}
     </div>
 
     ${sections.join("\n") || '<div class="section">No events found in the review window.</div>'}

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1262,13 +1262,114 @@ class ScriptableAdapter {
     }
   }
 
+  // ---------------------------------------------------------------------
   // Native reverse geocode via Scriptable's Location API (Apple's geocoding
-  // service — no network quota, no Nominatim rate-limit budget). Returns the
-  // raw first placemark object (subThoroughfare/thoroughfare/locality/
-  // postalCode/postalAddress keys) or null. normalizers.js uses this for the
-  // geocode-verification cross-check; all Scriptable API usage stays in this
-  // adapter (pure-module rule). Results are memoized per run, keyed by the
-  // coordinates rounded to 5 decimals (~1 m).
+  // service). Apple rate-limits reverse geocoding GLOBALLY across all
+  // Scriptable users, so this path practices strict quota hygiene
+  // (2026-07-16 run: ~50 calls in 6 seconds tripped the global limit and
+  // every cross-check for the rest of the run silently degraded to
+  // 'skipped'):
+  //   1. In-memory memoization per run (successes AND failures), keyed by
+  //      the coordinates rounded to 5 decimals (~1 m).
+  //   2. Persistent placemark cache (reverse-geocode-cache.json alongside
+  //      dead-ends.json), successes only, ~30-day TTL, pruned on save;
+  //      corrupt file → empty cache, never throws.
+  //   3. ≥500 ms pacing between actual Location.reverseGeocode calls
+  //      (cache hits never wait).
+  //   4. Circuit breaker: 3 consecutive failures stop native attempts for
+  //      the rest of the run.
+  // Returns the raw first placemark object (subThoroughfare/thoroughfare/
+  // locality/postalCode/postalAddress keys) or null. normalizers.js uses
+  // this for the geocode-verification cross-check; all Scriptable API usage
+  // stays in this adapter (pure-module rule).
+  // ---------------------------------------------------------------------
+
+  getReverseGeocodeCacheFilePath() {
+    return this.fm.joinPath(this.baseDir, "reverse-geocode-cache.json");
+  }
+
+  // Lazy load-on-first-use; shape { "<lat5>,<lon5>": { placemark, ts } }.
+  loadReverseGeocodeDiskCache() {
+    if (this.reverseGeocodeDiskCache) {
+      return this.reverseGeocodeDiskCache;
+    }
+    let cache = {};
+    const path = this.getReverseGeocodeCacheFilePath();
+    try {
+      if (this.fm.fileExists(path)) {
+        const parsed = JSON.parse(this.fm.readString(path));
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          cache = parsed;
+        }
+      }
+    } catch (error) {
+      // Corrupt/unreadable cache must never break a run — it is a pure
+      // optimization and rebuilds itself over subsequent runs.
+      console.log(
+        `📱 Scriptable: Reverse geocode cache read failed (${error.message}) — starting with empty cache`,
+      );
+      cache = {};
+    }
+    this.reverseGeocodeDiskCache = cache;
+    return cache;
+  }
+
+  // Save after every write (paced native calls make this cheap) so a crash
+  // never loses earned placemarks; stale entries are pruned on the way out.
+  saveReverseGeocodeDiskCache() {
+    const cache = this.reverseGeocodeDiskCache;
+    if (!cache || typeof cache !== "object") {
+      return;
+    }
+    const ttlMs = 30 * 24 * 60 * 60 * 1000;
+    const cutoff = Date.now() - ttlMs;
+    for (const key of Object.keys(cache)) {
+      const entry = cache[key];
+      const ts = entry && Number(entry.ts);
+      if (!Number.isFinite(ts) || ts < cutoff) {
+        delete cache[key];
+      }
+    }
+    try {
+      this.ensureDirectoryExists(this.baseDir);
+      this.fm.writeString(
+        this.getReverseGeocodeCacheFilePath(),
+        JSON.stringify(cache),
+      );
+    } catch (error) {
+      console.log(
+        `📱 Scriptable: Reverse geocode cache write failed: ${error.message}`,
+      );
+    }
+  }
+
+  // Minimum spacing between actual Location.reverseGeocode calls — same
+  // pattern as normalizers.js delayForRateLimit, kept inside the adapter
+  // because the quota being protected is Apple's, not Nominatim's.
+  async delayForReverseGeocodeRateLimit() {
+    const minimumDelay = 500;
+    const now = Date.now();
+    const elapsed = now - (this.lastReverseGeocodeTime || 0);
+    if (this.lastReverseGeocodeTime && elapsed < minimumDelay) {
+      await this.sleepForReverseGeocode(minimumDelay - elapsed);
+    }
+    this.lastReverseGeocodeTime = Date.now();
+  }
+
+  sleepForReverseGeocode(delayMs) {
+    return new Promise((resolve) => {
+      if (typeof setTimeout !== "undefined") {
+        setTimeout(resolve, delayMs);
+      } else if (typeof Timer !== "undefined") {
+        const timer = new Timer();
+        timer.timeInterval = delayMs;
+        timer.schedule(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+
   async reverseGeocodePlacemark(lat, lon) {
     if (
       typeof Location === "undefined" ||
@@ -1285,6 +1386,25 @@ class ScriptableAdapter {
     ) {
       return this.reverseGeocodeCache[cacheKey];
     }
+    // Durable second layer: placemarks earned on earlier runs never spend
+    // Apple quota again.
+    const diskCache = this.loadReverseGeocodeDiskCache();
+    const diskEntry = diskCache[cacheKey];
+    if (
+      diskEntry &&
+      typeof diskEntry === "object" &&
+      diskEntry.placemark &&
+      typeof diskEntry.placemark === "object"
+    ) {
+      this.reverseGeocodeCache[cacheKey] = diskEntry.placemark;
+      return diskEntry.placemark;
+    }
+    // Circuit breaker: once Apple's service proves unavailable this run,
+    // stop burning the global quota on attempts that cannot succeed.
+    if (this.reverseGeocodeCircuitOpen) {
+      return null;
+    }
+    await this.delayForReverseGeocodeRateLimit();
     let mark = null;
     try {
       const placemarks = await Location.reverseGeocode(lat, lon);
@@ -1293,13 +1413,30 @@ class ScriptableAdapter {
           ? placemarks[0]
           : null;
       mark = first && typeof first === "object" ? first : null;
+      // The service answered (even with no placemark) — failures are only
+      // consecutive when nothing succeeds in between.
+      this.reverseGeocodeConsecutiveFailures = 0;
     } catch (error) {
       console.log(
         `📱 Scriptable: Native reverse geocode failed for ${lat},${lon}: ${error.message}`,
       );
       mark = null;
+      this.reverseGeocodeConsecutiveFailures =
+        (this.reverseGeocodeConsecutiveFailures || 0) + 1;
+      if (this.reverseGeocodeConsecutiveFailures >= 3) {
+        this.reverseGeocodeCircuitOpen = true;
+        console.log(
+          "📱 Scriptable: Apple reverse geocoding unavailable after 3 consecutive failures — skipping remaining lookups this run",
+        );
+      }
     }
     this.reverseGeocodeCache[cacheKey] = mark;
+    if (mark) {
+      // Failures/nulls are NEVER persisted — only real placemarks earn a
+      // durable entry.
+      diskCache[cacheKey] = { placemark: mark, ts: Date.now() };
+      this.saveReverseGeocodeDiskCache();
+    }
     return mark;
   }
 
@@ -1919,6 +2056,34 @@ class ScriptableAdapter {
         `📱 Scriptable: ✗ Failed to load configuration: ${error.message}`,
       );
       throw new Error(`Configuration loading failed: ${error.message}`);
+    }
+  }
+
+  // Standalone bars-config loader for the calendar reviewer: same file, same
+  // module name, and the same optional semantics as loadConfiguration's
+  // scraper-bars.js load above (the scraper reads it into config.bars). The
+  // reviewer has no scraper-input.js run, so it loads bars directly; a
+  // missing/empty/broken file degrades to {} — bar matching simply finds
+  // nothing.
+  async loadBarsConfiguration() {
+    try {
+      const fm = FileManager.iCloud();
+      const scriptableDir = fm.documentsDirectory();
+      const configPath = fm.joinPath(scriptableDir, "scraper-bars.js");
+      if (!fm.fileExists(configPath)) {
+        return {};
+      }
+      const configText = fm.readString(configPath);
+      if (!configText || configText.trim().length === 0) {
+        return {};
+      }
+      const configModule = importModule("scraper-bars");
+      return configModule || eval(configText) || {};
+    } catch (error) {
+      console.log(
+        `📱 Scriptable: Bars configuration load failed (${error.message}) — continuing without curated bar data`,
+      );
+      return {};
     }
   }
 
@@ -2584,6 +2749,8 @@ class ScriptableAdapter {
           location: typeof item.location === "string" ? item.location : "",
           address: typeof fields.address === "string" ? fields.address : "",
           bar: typeof fields.bar === "string" ? fields.bar : "",
+          description:
+            typeof fields.description === "string" ? fields.description : "",
         });
         mapped += 1;
       }

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -855,3 +855,99 @@ test('selectReviewFindingsForAction resolves single, bulk, and missing-only payl
   assert.deepEqual(adapter.selectReviewFindingsForAction({ action: 'apply', id: 'pm-"1"' }, findings), []);
   assert.deepEqual(adapter.selectReviewFindingsForAction({ action: 'apply', id: 'up-1' }, findings), []);
 });
+
+// ---------------------------------------------------------------------------
+// refreshRemoteBars — website bar data wins per city, local file is fallback
+// ---------------------------------------------------------------------------
+
+function buildRemoteBarsAdapter(remoteByCity) {
+  const adapter = buildAdapter();
+  adapter.getPageCacheConfig = () => ({ enabled: true, ttlDays: 3 });
+  adapter.cacheReads = [];
+  adapter.cacheWrites = [];
+  adapter.fetches = [];
+  adapter.readCachedPage = async (url, config) => {
+    adapter.cacheReads.push({ url, config });
+    return null;
+  };
+  adapter.writeCachedPage = async (url, responseData, config) => {
+    adapter.cacheWrites.push({ url, config });
+  };
+  adapter.fetchData = async (url, options) => {
+    adapter.fetches.push({ url, options });
+    const cityKey = url.split('/').pop().replace('.json', '');
+    if (!(cityKey in remoteByCity)) {
+      throw new Error(`HTTP 404 error from ${url}`);
+    }
+    const body = remoteByCity[cityKey];
+    return { html: typeof body === 'string' ? body : JSON.stringify(body), url, statusCode: 200, headers: {} };
+  };
+  return adapter;
+}
+
+test('refreshRemoteBars replaces a city wholesale from chunky.dad and keeps local on failure', async () => {
+  const localBars = {
+    poconos: [{ name: 'Stale Camp Out', coordinates: '40.0, -75.0' }],
+    nyc: [{ name: 'Eagle NYC', coordinates: '40.7517, -74.0043' }],
+    seattle: [{ name: 'The Cuff', coordinates: '47.6138, -122.3142' }]
+  };
+  const adapter = buildRemoteBarsAdapter({
+    poconos: [{ name: 'Camp Out', city: 'poconos', address: '446 MT NEBO RD, EAST STROUDSBURG, PA, 18301', coordinates: '41.0219799, -75.1167816' }]
+    // nyc: 404 (no remote file) → local entry kept
+  });
+
+  const result = await adapter.refreshRemoteBars(['poconos', 'nyc', 'bogota'], localBars);
+
+  assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Camp Out'],
+    'remote city replaces the local entry wholesale');
+  assert.deepEqual(result.bars.nyc.map((b) => b.name), ['Eagle NYC'],
+    'fetch failure keeps the local entry');
+  assert.deepEqual(result.bars.seattle.map((b) => b.name), ['The Cuff'],
+    'cities not under review pass through untouched');
+  assert.equal(result.bars.bogota, undefined, 'no remote and no local stays absent');
+  assert.deepEqual(result.counts, { remote: 1, local: 1, unavailable: 1 });
+});
+
+test('refreshRemoteBars caches bars URLs with a 1-day TTL, separate from the global pageCache TTL', async () => {
+  const adapter = buildRemoteBarsAdapter({ poconos: [] });
+  await adapter.refreshRemoteBars(['poconos'], {});
+
+  assert.equal(adapter.cacheReads.length, 1);
+  assert.equal(adapter.cacheReads[0].config.ttlDays, 1, 'bars cache reads use the 1-day TTL');
+  assert.equal(adapter.cacheWrites.length, 1);
+  assert.equal(adapter.cacheWrites[0].config.ttlDays, 1, 'bars cache writes use the 1-day TTL');
+  assert.equal(adapter.fetches.length, 1);
+  assert.equal(adapter.fetches[0].options.isCacheableResponse(), false,
+    'fetchData is told to keep its global-TTL cache out of the way');
+
+  // A fresh 1-day cache hit spends no fetch at all
+  adapter.readCachedPage = async () => ({ html: JSON.stringify([{ name: 'Cached Bar' }]) });
+  const cachedRun = await adapter.refreshRemoteBars(['poconos'], {});
+  assert.equal(adapter.fetches.length, 1, 'cache hit performs no network fetch');
+  assert.deepEqual(cachedRun.bars.poconos.map((b) => b.name), ['Cached Bar']);
+});
+
+test('refreshRemoteBars survives invalid JSON and non-array payloads by keeping local data', async () => {
+  const adapter = buildRemoteBarsAdapter({
+    poconos: 'not json at all',
+    nyc: { object: 'not an array' }
+  });
+  const localBars = { poconos: [{ name: 'Local Camp Out' }] };
+  const result = await adapter.refreshRemoteBars(['poconos', 'nyc'], localBars);
+  assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Local Camp Out'], 'invalid JSON keeps local');
+  assert.equal(result.bars.nyc, undefined, 'non-array payload never becomes bar data');
+  assert.deepEqual(result.counts, { remote: 0, local: 1, unavailable: 1 });
+});
+
+test('generateReviewHTML renders the bars freshness line when counts are supplied', () => {
+  const adapter = buildAdapter();
+  const withCounts = adapter.generateReviewHTML([], {
+    barsFreshness: { remote: 18, local: 2, unavailable: 3 }
+  });
+  assert.ok(withCounts.includes('18 cities live from chunky.dad'), 'remote count rendered');
+  assert.ok(withCounts.includes('2 local fallback'), 'local fallback count rendered');
+  assert.ok(withCounts.includes('3 without bar data'), 'unavailable count rendered');
+
+  const without = adapter.generateReviewHTML([], {});
+  assert.ok(!without.includes('🍺 Bars:'), 'no freshness line without counts');
+});

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -436,6 +436,175 @@ test('loadDeadEnds tolerates corrupt or wrong-shaped files with an empty store',
 });
 
 // ---------------------------------------------------------------------------
+// Apple reverse-geocode quota hygiene: persistent placemark cache, pacing,
+// circuit breaker (2026-07-16 run: ~50 uncached calls in 6 s tripped Apple's
+// GLOBAL rate limit and every cross-check silently degraded to 'skipped')
+// ---------------------------------------------------------------------------
+
+const CAMP_OUT_PLACEMARK = {
+  subThoroughfare: '446',
+  thoroughfare: 'Mt Nebo Rd',
+  locality: 'East Stroudsburg',
+  postalCode: '18301'
+};
+
+function buildReverseGeocodeAdapter() {
+  const adapter = buildAdapter();
+  adapter.fm = createDeadEndFmStub();
+  adapter.sleepForReverseGeocode = async () => {};
+  return adapter;
+}
+
+test('reverseGeocodePlacemark round-trips placemarks through reverse-geocode-cache.json', async () => {
+  const adapter = buildReverseGeocodeAdapter();
+  let calls = 0;
+  global.Location = {
+    reverseGeocode: async () => { calls += 1; return [CAMP_OUT_PLACEMARK]; }
+  };
+  try {
+    const first = await adapter.reverseGeocodePlacemark(41.0219799, -75.1167816);
+    assert.deepEqual(first, CAMP_OUT_PLACEMARK);
+    assert.equal(calls, 1);
+
+    const cachePath = adapter.getReverseGeocodeCacheFilePath();
+    assert.ok(adapter.fm.files.has(cachePath), 'placemark persisted to reverse-geocode-cache.json');
+    const stored = JSON.parse(adapter.fm.files.get(cachePath));
+    assert.deepEqual(stored['41.02198,-75.11678'].placemark, CAMP_OUT_PLACEMARK);
+    assert.ok(Number.isFinite(stored['41.02198,-75.11678'].ts), 'entries carry a timestamp for TTL pruning');
+
+    // A fresh adapter (a later run) reads the disk cache instead of Apple
+    const laterRun = buildReverseGeocodeAdapter();
+    laterRun.fm = adapter.fm;
+    const second = await laterRun.reverseGeocodePlacemark(41.0219799, -75.1167816);
+    assert.deepEqual(second, CAMP_OUT_PLACEMARK);
+    assert.equal(calls, 1, 'a disk-cache hit spends no Apple quota');
+  } finally {
+    delete global.Location;
+  }
+});
+
+test('reverse geocode disk cache tolerates corrupt files, prunes stale entries, and never persists nulls', async () => {
+  const adapter = buildReverseGeocodeAdapter();
+  const cachePath = adapter.getReverseGeocodeCacheFilePath();
+  // Corrupt file → empty cache, never throws; a stale entry rides along to
+  // prove the TTL prune on the next save.
+  adapter.fm.files.set(cachePath, '{"41.00000,-75.00000": {broken json');
+  let calls = 0;
+  global.Location = {
+    reverseGeocode: async (lat) => {
+      calls += 1;
+      return lat < 41 ? [] : [CAMP_OUT_PLACEMARK]; // 40.x → no placemark
+    }
+  };
+  try {
+    assert.equal(await adapter.reverseGeocodePlacemark(40.7, -73.9), null, 'corrupt cache degrades to a live lookup');
+    assert.equal(calls, 1);
+    assert.equal(adapter.fm.files.get(cachePath), '{"41.00000,-75.00000": {broken json',
+      'a null result never writes the cache file');
+    assert.equal(await adapter.reverseGeocodePlacemark(40.7, -73.9), null);
+    assert.equal(calls, 1, 'null results stay memoized in memory for the run');
+
+    // Seed a stale entry in the loaded cache, then earn a success: the save
+    // prunes anything past the ~30-day TTL.
+    adapter.reverseGeocodeDiskCache['40.00000,-74.00000'] = {
+      placemark: { locality: 'Stale Town' },
+      ts: Date.now() - 31 * 24 * 60 * 60 * 1000
+    };
+    await adapter.reverseGeocodePlacemark(41.0219799, -75.1167816);
+    const stored = JSON.parse(adapter.fm.files.get(cachePath));
+    assert.deepEqual(Object.keys(stored), ['41.02198,-75.11678'],
+      'stale entries pruned on save; nulls absent');
+  } finally {
+    delete global.Location;
+  }
+});
+
+test('circuit breaker stops native reverse geocoding after 3 consecutive failures and logs once', async () => {
+  const adapter = buildReverseGeocodeAdapter();
+  let attempts = 0;
+  global.Location = {
+    reverseGeocode: async () => {
+      attempts += 1;
+      throw new Error('limited on how many reverse-geocoding requests');
+    }
+  };
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  try {
+    for (let i = 0; i < 5; i += 1) {
+      assert.equal(await adapter.reverseGeocodePlacemark(40 + i, -73), null);
+    }
+  } finally {
+    console.log = originalLog;
+    delete global.Location;
+  }
+  assert.equal(attempts, 3, 'the breaker opens after the third failure — later lookups never call Apple');
+  assert.equal(
+    logLines.filter((line) => line.includes(
+      'Apple reverse geocoding unavailable after 3 consecutive failures — skipping remaining lookups this run'
+    )).length,
+    1,
+    'the breaker line is logged exactly once'
+  );
+  assert.equal(
+    logLines.filter((line) => line.includes('Native reverse geocode failed for')).length,
+    3,
+    'the per-attempt failure line keeps its shape for attempts that do happen'
+  );
+});
+
+test('a success between failures resets the consecutive-failure count', async () => {
+  const adapter = buildReverseGeocodeAdapter();
+  let attempts = 0;
+  global.Location = {
+    reverseGeocode: async () => {
+      attempts += 1;
+      if (attempts === 3) return [CAMP_OUT_PLACEMARK];
+      throw new Error('rate limited');
+    }
+  };
+  try {
+    await adapter.reverseGeocodePlacemark(40.1, -73); // fail 1
+    await adapter.reverseGeocodePlacemark(40.2, -73); // fail 2
+    await adapter.reverseGeocodePlacemark(40.3, -73); // success → reset
+    await adapter.reverseGeocodePlacemark(40.4, -73); // fail 1 again
+    assert.equal(await adapter.reverseGeocodePlacemark(40.5, -73), null);
+    assert.equal(attempts, 5, 'the breaker never opened');
+    assert.notEqual(adapter.reverseGeocodeCircuitOpen, true);
+  } finally {
+    delete global.Location;
+  }
+});
+
+test('reverse geocode pacing waits ~500ms between actual Apple calls but never for cache hits', async () => {
+  const adapter = buildAdapter();
+  adapter.fm = createDeadEndFmStub();
+  const sleeps = [];
+  adapter.sleepForReverseGeocode = async (delayMs) => { sleeps.push(delayMs); };
+  let calls = 0;
+  global.Location = {
+    reverseGeocode: async () => { calls += 1; return [CAMP_OUT_PLACEMARK]; }
+  };
+  const realNow = Date.now;
+  Date.now = () => 1752600000000; // frozen clock: back-to-back calls are 0ms apart
+  try {
+    await adapter.reverseGeocodePlacemark(40.7, -73.9);
+    assert.deepEqual(sleeps, [], 'the first call never waits');
+
+    await adapter.reverseGeocodePlacemark(40.8, -73.8);
+    assert.deepEqual(sleeps, [500], 'an immediate second call waits the full spacing');
+
+    await adapter.reverseGeocodePlacemark(40.7, -73.9); // in-memory hit
+    assert.equal(calls, 2);
+    assert.deepEqual(sleeps, [500], 'cache hits never wait');
+  } finally {
+    Date.now = realNow;
+    delete global.Location;
+  }
+});
+
+// ---------------------------------------------------------------------------
 // Suggested-config tab in the URL Discovery UI section
 // ---------------------------------------------------------------------------
 

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -56,6 +56,17 @@ class WebAdapter {
         return null;
     }
 
+    // On Scriptable the reviewer refreshes bar data from the live site; on
+    // Node the repo checkout IS the source the site deploys from, so the
+    // local bars are already current — pass them through honestly.
+    async refreshRemoteBars(cityKeys, localBars) {
+        const bars = localBars && typeof localBars === 'object' ? localBars : {};
+        return {
+            bars,
+            counts: { remote: 0, local: Object.keys(bars).length, unavailable: 0 }
+        };
+    }
+
     getPageCacheConfig() {
         const pageCache = this.config.pageCache || {};
         const ttlDays = Number(pageCache.ttlDays);

--- a/scripts/calendar-reviewer.js
+++ b/scripts/calendar-reviewer.js
@@ -63,6 +63,7 @@ class CalendarReviewerOrchestrator {
                 SharedCore: sharedCoreModule.SharedCore,
                 EventSchema: eventSchemaModule.EventSchema,
                 OpenStreetMapNormalizer: normalizersModule.OpenStreetMapNormalizer,
+                BarDataNormalizer: normalizersModule.BarDataNormalizer,
                 Adapter: scriptableAdapterModule.ScriptableAdapter,
                 cities: importModule('scraper-cities')
             };
@@ -71,10 +72,12 @@ class CalendarReviewerOrchestrator {
             // the pure modules load (CI syntax checking). The adapter is NOT
             // required here — it needs Scriptable globals at load time.
             console.log('🔎 Calendar Reviewer: Loading Node.js modules...');
+            const normalizersModule = require('./normalizers');
             this.modules = {
                 SharedCore: require('./shared-core').SharedCore,
                 EventSchema: require('./event-schema').EventSchema,
-                OpenStreetMapNormalizer: require('./normalizers').OpenStreetMapNormalizer,
+                OpenStreetMapNormalizer: normalizersModule.OpenStreetMapNormalizer,
+                BarDataNormalizer: normalizersModule.BarDataNormalizer,
                 Adapter: null,
                 cities: null
             };
@@ -94,13 +97,21 @@ class CalendarReviewerOrchestrator {
             cities: this.modules.cities,
             pageCache: config.pageCache || null
         });
+        // Curated bars config, loaded exactly the way the scraper's
+        // loadConfiguration loads scraper-bars.js (optional file → {}): the
+        // reviewer must consult BarDataNormalizer before geocoding, same as
+        // the scraper pipeline does.
+        const bars = await adapter.loadBarsConfiguration();
         const core = new this.modules.SharedCore(this.modules.cities, {
             eventSchema: this.modules.EventSchema,
-            additionalExcludedFields: this.modules.Adapter.NOTES_EXCLUDED_FIELDS
+            additionalExcludedFields: this.modules.Adapter.NOTES_EXCLUDED_FIELDS,
+            bars
         });
-        // The geocode check reuses the scraper's normalizer (grade gate, retry
-        // ladder, verification) rather than reimplementing any of it
+        // The geocode check reuses the scraper's normalizers (bar-data match,
+        // grade gate, retry ladder, verification) rather than reimplementing
+        // any of them
         const geocodeNormalizer = new this.modules.OpenStreetMapNormalizer(core);
+        const barDataNormalizer = new this.modules.BarDataNormalizer(core);
 
         try {
             const calendars = await adapter.getReviewCalendars(config.calendars);
@@ -113,6 +124,7 @@ class CalendarReviewerOrchestrator {
             const findings = await core.reviewCalendarEvents(events, {
                 httpAdapter: adapter,
                 geocodeNormalizer,
+                barDataNormalizer,
                 pinMovedThresholdKm: config.pinMovedThresholdKm
             });
 

--- a/scripts/calendar-reviewer.js
+++ b/scripts/calendar-reviewer.js
@@ -121,6 +121,17 @@ class CalendarReviewerOrchestrator {
             }
 
             const events = await adapter.getReviewCalendarEvents(calendars, config);
+
+            // Bar data merged on the website is fresher than the phone's
+            // local scraper-bars.js copy: refresh the cities under review
+            // from chunky.dad (1-day cache TTL), keeping the local entry per
+            // city when the site is unreachable.
+            const cityKeys = [...new Set(events
+                .map(event => core.cityForCalendarTitle(event.calendarTitle))
+                .filter(Boolean))];
+            const refreshedBars = await adapter.refreshRemoteBars(cityKeys, bars);
+            core.bars = refreshedBars.bars;
+
             const findings = await core.reviewCalendarEvents(events, {
                 httpAdapter: adapter,
                 geocodeNormalizer,
@@ -131,7 +142,7 @@ class CalendarReviewerOrchestrator {
             const summary = this.modules.SharedCore.summarizeReviewFindings(findings);
             console.log(`🔎 REVIEW: ${summary.findings} event(s) reviewed — ${summary.ok} ok, ${summary.proposals} with proposed fixes`);
 
-            const appliedCounts = await adapter.presentReviewResults(findings, { config });
+            const appliedCounts = await adapter.presentReviewResults(findings, { config, barsFreshness: refreshedBars.counts });
             return { findings, summary, appliedCounts };
         } catch (error) {
             console.error(`🔎 Calendar Reviewer: ✗ Review failed: ${error}`);

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -794,6 +794,11 @@ const GEOCODE_UNIT_TOKEN_RE = new RegExp(
 // deserves better than a road centroid.
 const GEOCODE_HOUSE_NUMBER_RE = /(^|\s)\d+[a-z]?\s+\S/i;
 
+// Any street-type word on its own word boundary ("Folsom St", "Mt Nebo Rd").
+// Together with GEOCODE_HOUSE_NUMBER_RE this decides whether an INPUT address
+// carries street-level detail at all — see isStreetSpecificAddress.
+const GEOCODE_STREET_TYPE_WORD_RE = new RegExp(`\\b(?:${GEOCODE_STREET_TYPE_WORDS})\\b`, 'i');
+
 // A directional that FOLLOWS a street-type word and ends the address or a
 // comma-separated segment ("...Cheshire Bridge Rd NE", "...Road Northeast,
 // Atlanta"). Nominatim's free-text parser returns 0 results for these
@@ -854,6 +859,16 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             // Ignore cache read errors
         }
         return null;
+    }
+
+    // Input-specificity gate for geocode-backed reviewer proposals: an address
+    // without street-level detail ("Poconos, PA", "LA NOGALERA, Torremolinos")
+    // asks a question no geocoder can answer precisely — whatever it returns
+    // (even an exact-grade POI) is an arbitrary same-named candidate, never
+    // proposal material. Street-specific = a house number OR a street-type word.
+    isStreetSpecificAddress(address) {
+        const text = String(address || '');
+        return GEOCODE_HOUSE_NUMBER_RE.test(text) || GEOCODE_STREET_TYPE_WORD_RE.test(text);
     }
 
     // Usable geocode payload: a non-empty array (forward search) or an object

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -6066,7 +6066,8 @@ class SharedCore {
     // function (events, context) → findings; register future checks
     // (missing fields, duplicates, ...) in getCalendarReviewChecks.
     // Events are plain objects mapped by the adapter:
-    //   { id, calendarTitle, title, startDate, location, address, bar }
+    //   { id, calendarTitle, title, startDate, location, address, bar,
+    //     description }
     // Findings (one per event; 'ok' ones are countable for the summary):
     //   { id, calendarTitle, eventTitle, startDate, check, status,
     //     current: {location, address}, proposed: {location?, address?},
@@ -6133,8 +6134,11 @@ class SharedCore {
     // missing one side, and surface addresses that refuse to geocode.
     // context.geocodeNormalizer must be an OpenStreetMapNormalizer instance —
     // the scraper's forward ladder / grade gate / verification is reused, not
-    // reimplemented. Unique addresses are geocoded once: venues repeat across
-    // events and every Nominatim call costs 1.1s of throttle.
+    // reimplemented. context.barDataNormalizer (optional, a BarDataNormalizer
+    // instance whose core carries the bars config) makes curated bar data the
+    // authoritative source before any geocoding happens. Unique addresses are
+    // geocoded once: venues repeat across events and every Nominatim call
+    // costs 1.1s of throttle.
     async runGeocodeReviewCheck(events, context = {}) {
         const httpAdapter = context.httpAdapter || null;
         const geocoder = context.geocodeNormalizer;
@@ -6158,8 +6162,53 @@ class SharedCore {
         const forwardKeyFor = (city, address) => `${city}|${normalizeAddressKey(address)}`;
         const reverseKeyFor = (pin) => `${pin.lat.toFixed(5)},${pin.lng.toFixed(5)}`;
 
+        // Pass 0: curated bar data is the AUTHORITATIVE location source — a
+        // vague address like "Poconos, PA" can never geocode to the venue, but
+        // the bars config knows it exactly (2026-07-16 run: "FURBALL CAMP" at
+        // Camp Out got a pin-moved proposal 33 km off from a Nominatim POI).
+        // Each event's probe (location stripped so the bar's own coordinates
+        // must fill it) runs through the REAL BarDataNormalizer — the same
+        // name/title/address/coordinates/description matching the scraper
+        // pipeline applies. A match only counts when it yielded coordinates;
+        // matched events skip the geocode pool entirely.
+        const barNormalizer = context.barDataNormalizer && typeof context.barDataNormalizer.normalize === 'function'
+            ? context.barDataNormalizer
+            : null;
+        const barMatchByEvent = new Map();
+        if (barNormalizer) {
+            for (const event of events) {
+                if (!event) continue;
+                const city = this.cityForCalendarTitle(String(event.calendarTitle || ''));
+                const eventAddress = typeof event.address === 'string' ? event.address.trim() : '';
+                const probe = {
+                    title: event.title,
+                    address: eventAddress,
+                    city,
+                    bar: typeof event.bar === 'string' ? event.bar.trim() : '',
+                    description: typeof event.description === 'string' ? event.description : ''
+                };
+                barNormalizer.normalize(probe);
+                if (this.isCoordinatePair(probe.location)) {
+                    const curatedAddress = typeof probe.address === 'string' ? probe.address.trim() : '';
+                    barMatchByEvent.set(event, {
+                        barName: typeof probe.bar === 'string' && probe.bar.trim() ? probe.bar.trim() : 'curated bar',
+                        location: probe.location.trim(),
+                        // The normalizer already applied its own address heuristic
+                        // (missing or shorter event address loses to the curated
+                        // one), so any difference here IS a material upgrade.
+                        address: curatedAddress && curatedAddress !== eventAddress ? curatedAddress : ''
+                    });
+                }
+            }
+            if (barMatchByEvent.size > 0) {
+                console.log(`🔎 REVIEW: ${barMatchByEvent.size} event(s) matched curated bar data — skipping geocode for them`);
+            }
+        }
+
         // Pass 1: unique forward jobs (per city + address) and unique reverse
         // jobs (per stored pin), plus per-calendar counts for the progress log.
+        // Bar-matched events never enter the pools — curated data needs no
+        // external verification.
         const forwardJobs = new Map();
         const reverseJobs = new Map();
         const calendarCounts = new Map();
@@ -6169,6 +6218,7 @@ class SharedCore {
             const counts = calendarCounts.get(calendarTitle) || { events: 0, addresses: new Set() };
             counts.events += 1;
             calendarCounts.set(calendarTitle, counts);
+            if (barMatchByEvent.has(event)) continue;
             const city = this.cityForCalendarTitle(calendarTitle);
             const address = typeof event.address === 'string' ? event.address.trim() : '';
             const title = event.title || address || event.location || 'unknown';
@@ -6255,6 +6305,32 @@ class SharedCore {
                 proposed: {},
                 detail: ''
             };
+            const barMatch = barMatchByEvent.get(event) || null;
+            if (barMatch) {
+                // Curated bar data: grade 'exact' + crossCheck 'pass' by fiat —
+                // hand-maintained coordinates need no external verification, so
+                // the specificity gate and cross-check policy below never apply.
+                const withAddress = barMatch.address ? ' + address' : '';
+                if (!hasPin) {
+                    finding.status = 'missing-pin';
+                    finding.proposed.location = barMatch.location;
+                    if (barMatch.address) finding.proposed.address = barMatch.address;
+                    finding.detail = `pin${withAddress} from curated bar data (${barMatch.barName})`;
+                } else {
+                    const distanceKm = this.coordinatePairDistanceKm(location, barMatch.location);
+                    finding.distanceKm = distanceKm;
+                    if (distanceKm !== null && distanceKm > thresholdKm) {
+                        finding.status = 'pin-moved';
+                        finding.proposed.location = barMatch.location;
+                        if (barMatch.address) finding.proposed.address = barMatch.address;
+                        finding.detail = `stored pin is ${distanceKm.toFixed(1)}km off — pin${withAddress} from curated bar data (${barMatch.barName})`;
+                    } else {
+                        finding.detail = `matches curated bar data (${barMatch.barName})`;
+                    }
+                }
+                findings.push(finding);
+                continue;
+            }
             if (address) {
                 const fresh = freshPinByKey.get(forwardKeyFor(city, address)) || null;
                 const freshLocation = fresh && fresh.location ? fresh.location : null;
@@ -6264,11 +6340,22 @@ class SharedCore {
                 // still reach here for addresses without a parseable house number
                 // (e.g. hyphenated Queens numbers like "10-90 Wyckoff Avenue").
                 const proposalGrade = !!(freshLocation && fresh.grade === 'exact' && fresh.crossCheck !== 'fail');
+                // Input-specificity gate: geocoder answers for a vague input
+                // ("Poconos, PA") are arbitrary no matter their grade or
+                // cross-check — never proposal material (2026-07-16 run:
+                // Nominatim's POI candidate for "Poconos, PA" graded 'exact'
+                // and was proposed 33 km from the venue).
+                const streetSpecific = typeof geocoder.isStreetSpecificAddress === 'function'
+                    ? geocoder.isStreetSpecificAddress(address)
+                    : true;
                 if (!freshLocation && !(fresh && fresh.grade)) {
                     finding.status = 'unpinnable';
                     finding.detail = hasPin
                         ? 'address no longer geocodes to a usable pin — stored pin kept but unverified'
                         : 'no usable geocoordinate for this address (grade gate/ladder found nothing)';
+                } else if (!streetSpecific) {
+                    finding.status = 'unverified';
+                    finding.detail = 'address too vague to geocode reliably — fix the address or add a bar field first';
                 } else if (!proposalGrade) {
                     // A pin resolved (or a candidate was rejected by enforce) but
                     // it is not proposal-grade — never propose it, never touch the
@@ -6290,9 +6377,20 @@ class SharedCore {
                     const distanceKm = this.coordinatePairDistanceKm(location, freshLocation);
                     finding.distanceKm = distanceKm;
                     if (distanceKm !== null && distanceKm > thresholdKm) {
-                        finding.status = 'pin-moved';
-                        finding.proposed.location = freshLocation;
-                        finding.detail = `stored pin is ${distanceKm.toFixed(1)}km from the fresh verified geocode of this address`;
+                        // Destructively replacing a stored pin demands a PASSED
+                        // reverse cross-check. A 'skipped' cross-check (Apple
+                        // reverse geocoding rate-limited/unavailable) silently
+                        // removed the whole safety layer on the 2026-07-16 run —
+                        // additive missing-pin proposals stay allowed on
+                        // 'skipped', destructive pin-moved ones do not.
+                        if (fresh.crossCheck === 'pass') {
+                            finding.status = 'pin-moved';
+                            finding.proposed.location = freshLocation;
+                            finding.detail = `stored pin is ${distanceKm.toFixed(1)}km from the fresh verified geocode of this address`;
+                        } else {
+                            finding.status = 'unverified';
+                            finding.detail = 'reverse cross-check unavailable — re-run when Apple geocoding recovers';
+                        }
                     } else {
                         finding.detail = 'stored pin matches a fresh geocode of the address';
                     }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 
 const { SharedCore } = require('./shared-core');
 const { EventSchema } = require('./event-schema');
-const { OpenStreetMapNormalizer } = require('./normalizers');
+const { OpenStreetMapNormalizer, BarDataNormalizer } = require('./normalizers');
 
 const CITIES = {
   dallas: { timezone: 'America/Chicago', patterns: ['dallas'] }
@@ -3918,9 +3918,20 @@ test('review: unique addresses are geocoded once, no matter how many events shar
   assert.equal(byId.get('c').proposed.location, '32.810535, -96.8110709');
 });
 
+// Apple placemark that agrees with PIN_TEST_ADDRESS — the reverse cross-check
+// passes, so destructive pin-moved proposals stay allowed.
+const STATION_4_PLACEMARK = {
+  subThoroughfare: '3911',
+  thoroughfare: 'Cedar Springs Road',
+  locality: 'Dallas',
+  postalCode: '75219'
+};
+
 test('review: pin-moved beyond the threshold proposes the fresh verified pin; below stays ok', async () => {
   const core = createCore();
-  const adapter = buildReviewGeocodeAdapter();
+  const adapter = buildReviewGeocodeAdapter(REVIEW_GEOCODE_RESULTS, {
+    reverseGeocodePlacemark: async () => STATION_4_PLACEMARK
+  });
   const events = [
     buildReviewEvent({ id: 'moved', location: '32.8285, -96.8110709' }), // ~2km off
     buildReviewEvent({ id: 'jitter', location: '32.8106, -96.8110709' }) // ~7m off
@@ -4179,4 +4190,154 @@ test('review: a hyphenated house number that only street-grades stays unverified
   assert.deepEqual(findings[0].proposed, {}, 'the street-grade pin must not replace the hand-verified pin');
   assert.equal(findings[0].current.location, '40.7002, -73.9070');
   assert.ok(findings[0].detail.includes('street-grade'), findings[0].detail);
+});
+
+// ---------------------------------------------------------------------------
+// Bar-data authority + input-specificity + cross-check tightening (2026-07-16
+// phone run: Apple's reverse geocoder was rate-limited for the WHOLE run, so
+// every cross-check silently became 'skipped' — and "FURBALL CAMP" with the
+// vague address "Poconos, PA" got a pin-moved proposal 33 km off from a
+// Nominatim POI that graded 'exact'. The correct answer only exists in the
+// curated bars config.)
+// ---------------------------------------------------------------------------
+
+const CAMP_OUT_BAR = {
+  name: 'Camp Out',
+  address: '446 MT NEBO RD, EAST STROUDSBURG, PA, 18301',
+  coordinates: '41.0219799, -75.1167816'
+};
+
+function createPoconosCore(withBars = true) {
+  return new SharedCore({
+    poconos: { timezone: 'America/New_York', calendar: 'chunky-dad-poconos', patterns: ['poconos'] }
+  }, {
+    eventSchema: EventSchema,
+    bars: withBars ? { poconos: [CAMP_OUT_BAR] } : {}
+  });
+}
+
+function buildPoconosEvent(overrides = {}) {
+  return {
+    id: 'furball-camp',
+    calendarTitle: 'chunky-dad-poconos',
+    title: 'FURBALL CAMP',
+    startDate: new Date('2026-08-15T00:00:00.000Z'),
+    location: '41.0, -75.5', // ~32 km west of the real Camp Out pin
+    address: 'Poconos, PA',
+    bar: 'Camp Out',
+    ...overrides
+  };
+}
+
+function createPoconosContext(core, adapter, overrides = {}) {
+  return createReviewContext(core, adapter, {
+    barDataNormalizer: new BarDataNormalizer(core),
+    ...overrides
+  });
+}
+
+test('review: Poconos regression — curated bar data backs the proposal and no geocode fetch is spent', async () => {
+  const core = createPoconosCore();
+  const adapter = buildReviewGeocodeAdapter([]); // must never be consulted
+  const events = [buildPoconosEvent()];
+
+  const { findings, logLines } = await captureReview(core, events, createPoconosContext(core, adapter));
+
+  assert.equal(findings.length, 1);
+  const finding = findings[0];
+  assert.equal(finding.status, 'pin-moved');
+  assert.equal(finding.proposed.location, '41.0219799, -75.1167816', 'the curated Camp Out pin is proposed');
+  assert.equal(finding.proposed.address, CAMP_OUT_BAR.address, 'one Apply fixes the pin AND the vague address');
+  assert.ok(finding.detail.includes('Camp Out'), `detail must name the bar: ${finding.detail}`);
+  assert.ok(finding.distanceKm > 30 && finding.distanceKm < 35, `distance carried, got ${finding.distanceKm}`);
+  assert.equal(adapter.calls.length, 0, 'bar-matched events never reach the geocoders');
+  assert.ok(logLines.includes('🔎 REVIEW: 1 event(s) matched curated bar data — skipping geocode for them'),
+    `skip log missing, got: ${JSON.stringify(logLines)}`);
+});
+
+test('review: bar-data missing pin proposes the curated pin and address together', async () => {
+  const core = createPoconosCore();
+  const adapter = buildReviewGeocodeAdapter([]);
+  const events = [buildPoconosEvent({ location: '' })];
+
+  const { findings } = await captureReview(core, events, createPoconosContext(core, adapter));
+
+  assert.equal(findings[0].status, 'missing-pin');
+  assert.equal(findings[0].proposed.location, '41.0219799, -75.1167816');
+  assert.equal(findings[0].proposed.address, CAMP_OUT_BAR.address);
+  assert.equal(findings[0].detail, 'pin + address from curated bar data (Camp Out)');
+  assert.equal(adapter.calls.length, 0);
+});
+
+test('review: bar-data within the threshold is ok with a bar-named detail', async () => {
+  const core = createPoconosCore();
+  const adapter = buildReviewGeocodeAdapter([]);
+  const events = [buildPoconosEvent({ location: '41.0220, -75.1168' })]; // a few meters off
+
+  const { findings } = await captureReview(core, events, createPoconosContext(core, adapter));
+
+  assert.equal(findings[0].status, 'ok');
+  assert.equal(findings[0].detail, 'matches curated bar data (Camp Out)');
+  assert.deepEqual(findings[0].proposed, {}, 'ok findings carry no proposal');
+  assert.equal(adapter.calls.length, 0);
+});
+
+// Without the bars config, "Poconos, PA" reaches Nominatim, which happily
+// returns an exact-grading POI for it — the real 2026-07-16 failure mode.
+const POCONOS_POI_RESULT = [{
+  lat: '41.3000000',
+  lon: '-75.3000000',
+  class: 'tourism',
+  type: 'attraction',
+  addresstype: 'tourism',
+  display_name: 'Some Attraction, Poconos, Pennsylvania, United States',
+  address: { county: 'Poconos' }
+}];
+
+test('review: input-specificity gate — a vague address is unverified no matter what the geocoder returns', async () => {
+  const core = createPoconosCore(false); // no bar match available
+  const adapter = buildReviewGeocodeAdapter(POCONOS_POI_RESULT);
+  const events = [
+    buildPoconosEvent(),                  // stored pin present → would have been pin-moved
+    buildPoconosEvent({ id: 'no-pin', location: '' }) // absent → would have been missing-pin
+  ];
+
+  const { findings } = await captureReview(core, events, createPoconosContext(core, adapter));
+  const byId = new Map(findings.map(finding => [finding.id, finding]));
+
+  for (const id of ['furball-camp', 'no-pin']) {
+    assert.equal(byId.get(id).status, 'unverified', `${id} must be unverified`);
+    assert.ok(byId.get(id).detail.includes('too vague'), byId.get(id).detail);
+    assert.ok(byId.get(id).detail.includes('add a bar field'), byId.get(id).detail);
+    assert.deepEqual(byId.get(id).proposed, {}, 'a vague input never backs a proposal');
+  }
+  assert.ok(adapter.calls.length > 0, 'the geocode path ran — the input gate refused its answer');
+});
+
+test('review: cross-check policy — replacing a stored pin needs a PASSED cross-check; additive pins tolerate skipped', async () => {
+  const core = createCore();
+  // No reverseGeocodePlacemark hook → every cross-check is 'skipped'
+  // (exactly what an Apple rate-limit outage looks like).
+  const skippedAdapter = buildReviewGeocodeAdapter();
+  const { findings } = await captureReview(core, [
+    buildReviewEvent({ id: 'moved', location: '32.8285, -96.8110709' }), // ~2 km off
+    buildReviewEvent({ id: 'missing', location: '' })
+  ], createReviewContext(core, skippedAdapter));
+  const byId = new Map(findings.map(finding => [finding.id, finding]));
+
+  assert.equal(byId.get('moved').status, 'unverified');
+  assert.equal(byId.get('moved').detail, 'reverse cross-check unavailable — re-run when Apple geocoding recovers');
+  assert.deepEqual(byId.get('moved').proposed, {}, 'a skipped cross-check never backs a destructive replacement');
+  assert.equal(byId.get('missing').status, 'missing-pin', 'additive proposals stay allowed on skipped');
+  assert.equal(byId.get('missing').proposed.location, '32.810535, -96.8110709');
+
+  // A passing cross-check restores the destructive proposal.
+  const passAdapter = buildReviewGeocodeAdapter(REVIEW_GEOCODE_RESULTS, {
+    reverseGeocodePlacemark: async () => STATION_4_PLACEMARK
+  });
+  const { findings: passFindings } = await captureReview(core,
+    [buildReviewEvent({ id: 'moved', location: '32.8285, -96.8110709' })],
+    createReviewContext(core, passAdapter));
+  assert.equal(passFindings[0].status, 'pin-moved');
+  assert.equal(passFindings[0].proposed.location, '32.810535, -96.8110709');
 });


### PR DESCRIPTION
## The bugs (real phone run, 2026-07-16 14:52)

1. **Apple's reverse geocoder hit Scriptable's global rate limit for the entire run** (~50 lookups in 6 seconds — Nominatim was fully page-cached so nothing paced it). Every cross-check silently became 'skipped', which the proposal gate allowed, so the verification layer evaporated without any signal.
2. With the safety off, "FURBALL CAMP" (address **"Poconos, PA"**) got a 33km pin-moved proposal from an incidental exact-graded POI. But no geocoder can ever fix "Poconos, PA" — the correct answer is curated in the repo's bars data (Camp Out, 446 Mt Nebo Rd, `41.0219799, -75.1167816`), which the scraper consults via `BarDataNormalizer` but the reviewer never did. Worse, the phone's `scraper-bars.js` copy goes stale the moment a bar edit is merged on the website.

## The fix (two commits)

### Commit 1 — bar-data authority, vague-input gate, cross-check policy, quota hygiene
- **Bar data is the authoritative location source.** The reviewer runs each event through the real `BarDataNormalizer` (bar name / title / address / coordinates / description matching) BEFORE any geocoding. Matches yield exact/pass findings by fiat: pin-moved/missing-pin proposing the curated pin, `proposed.address` riding along when the curated address wins (one Apply fixes both), details naming the bar. Matched events skip the geocode pool entirely (logged).
- **Vague addresses can never back a geocode proposal.** No house number and no street word ("Poconos, PA", "LA NOGALERA") → 'unverified' card, "address too vague to geocode reliably — fix the address or add a bar field first". Applies to pin-moved AND missing-pin.
- **pin-moved now requires a cross-check *pass*** — 'skipped' (Apple down) → 'unverified' with "re-run when Apple geocoding recovers". Additive missing-pin still allowed on pass/skipped for street-specific inputs.
- **Apple quota hygiene**: persistent `reverse-geocode-cache.json` (30-day TTL, successes only, corrupt-tolerant) so re-runs spend no quota; ≥500ms pacing between real `Location.reverseGeocode` calls; circuit breaker stops attempts after 3 consecutive failures (logged once).

### Commit 2 — bar data live from the website
`refreshRemoteBars(cityKeys, localBars)`: fetches `https://chunky.dad/data/bars/<city>.json` for each calendar under review through the existing page-cache plumbing with a **1-day TTL**, replacing that city's local entry wholesale (the website is the source of truth); 404/offline/bad JSON quietly keeps the local entry. Review UI header shows the split ("🍺 Bars: 18 cities live from chunky.dad · 2 local fallback"), log line reports counts. Cities with zero events are never fetched. Node web-adapter passes local bars through honestly (the repo checkout IS what the site deploys).

## Regression tests
Poconos end-to-end: Camp Out bar match → pin-moved proposing `41.0219799, -75.1167816` + curated address, ZERO geocoder calls; same event without bar data → 'unverified', no proposal even with an exact-grade POI and skipped cross-check. Cross-check policy matrix (pass/skipped × pin-moved/missing-pin). Adapter: placemark disk cache round-trip, TTL prune, nulls never persisted, circuit breaker, pacing; refreshRemoteBars wholesale-replace/fallback/counts, 1-day TTL isolation from the global cache, freshness line rendering.

## Tests
414 → 428, quiet runner, all green. `node --check` clean; `node scripts/calendar-reviewer.js` exits gracefully on Node; zero `new URL(` additions; existing log shapes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP