### PR TITLE
feat(pipeline): live bar data via combined scraper-bars.json + fail-closed enforce geocoding

### DIFF
--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -1,0 +1,735 @@
+{
+  "bangkok": [
+    {
+      "name": "BEEF.BKK",
+      "city": "bangkok",
+      "address": "9th Fl. SilomEdge Si Lom Rd, Suriya Wong, Bang Rak, Bangkok 10500, Thailand",
+      "coordinates": "13.729305880910303, 100.53569913387547",
+      "instagram": "https://www.instagram.com/beef.bkk",
+      "facebook": "https://www.facebook.com/beef.bkkbar/",
+      "googleMaps": "https://maps.app.goo.gl/zEYjJa9v8AJJGUNB6"
+    },
+    {
+      "name": "CAKE",
+      "city": "bangkok",
+      "address": "ตั้งอยู่ที่ 942/27 Rama IV Rd, Suriya Wong, Bang Rak, Bangkok 10500, Thailand",
+      "coordinates": "13.730338066694463, 100.53405491726055",
+      "instagram": "https://www.instagram.com/cake.bangkok",
+      "facebook": "https://www.facebook.com/CakeBangkokTH/",
+      "googleMaps": "https://maps.app.goo.gl/GrhBKQzDEFfvcUFn8"
+    },
+    {
+      "name": "BARBER.BAR",
+      "city": "bangkok",
+      "address": "ชั้น 2 109/111 Si Lom Rd, Khwaeng Suriya Wong, Khet Bang Rak, Bangkok 10500, Thailand",
+      "coordinates": "13.727938343038128, 100.53224466713601",
+      "instagram": "https://www.instagram.com/bar.ber.bar/",
+      "googleMaps": "https://maps.app.goo.gl/V96bZYM6qBm8tqQs5"
+    }
+  ],
+  "boston": [
+    {
+      "name": "The Alley Bar",
+      "city": "boston",
+      "address": "14 Pi Alley, Boston, MA 02108",
+      "coordinates": "42.358084, -71.0587317",
+      "facebook": "https://www.facebook.com/thealleybarboston",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJDzxFQ4Rw44kRAxo45UBkJKM",
+      "gayCities": "https://boston.gaycities.com/bars/127-the-alley-bar",
+      "gayCitiesLastScrapedAt": "2026-06-13T20:34:56.886Z"
+    }
+  ],
+  "chicago": [
+    {
+      "name": "Meeting House Tavern",
+      "city": "chicago",
+      "address": "5025 N Clark St, Chicago, IL 60640",
+      "coordinates": "41.9732343, -87.6678243",
+      "instagram": "https://www.instagram.com/meetinghousetavernchi",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJndazcVjTD4gRimEFGWVA_AU",
+      "gayCities": "https://chicago.gaycities.com/bars/311263-meeting-house-tavern",
+      "gayCitiesLastScrapedAt": "2026-06-13T18:37:35.740Z"
+    },
+    {
+      "name": "The SoFo Tap",
+      "city": "chicago",
+      "address": "4923 N Clark St 1st floor, Chicago, IL 60640",
+      "coordinates": "41.9724308, -87.6676099",
+      "instagram": "https://www.instagram.com/thesofotap",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJUztUhCjSD4gRnZEajxMfo7Q",
+      "gayCities": "https://chicago.gaycities.com/bars/2076-the-sofo-tap",
+      "gayCitiesLastScrapedAt": "2026-06-13T18:37:37.979Z"
+    },
+    {
+      "name": "Jackhammer",
+      "city": "chicago",
+      "address": "6406 N Clark St, Chicago, IL 60626",
+      "coordinates": "41.9984139, -87.6710111",
+      "instagram": "https://www.instagram.com/?hl=en",
+      "facebook": "https://www.facebook.com/chijackhammer/",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ44RAWrzRD4gRDGoLchD_2SI",
+      "gayCities": "https://chicago.gaycities.com/bars/176-jackhammer",
+      "gayCitiesLastScrapedAt": "2026-06-13T18:37:40.195Z"
+    },
+    {
+      "name": "Touché",
+      "city": "chicago",
+      "address": "6412 N Clark St, Chicago, IL 60626",
+      "coordinates": "41.9985708, -87.670974",
+      "instagram": "https://www.instagram.com/?hl=en",
+      "facebook": "https://www.facebook.com/ToucheChicago",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJnwLkWrzRD4gREreJ-KlTEoU",
+      "gayCities": "https://chicago.gaycities.com/bars/184-touch%C3%A9",
+      "gayCitiesLastScrapedAt": "2026-06-13T20:34:54.431Z"
+    },
+    {
+      "name": "Cell Block",
+      "city": "chicago",
+      "address": "3702 N Halsted St, Chicago, IL 60613",
+      "coordinates": "41.9493268, -87.6498756",
+      "instagram": "https://www.instagram.com/cellblockchi?fbclid=IwAR3LhbkA3SomCj4qvipwYyqsRpeFs6ANoAc4-LU8KvFOUKpRt_n2AyTHsqY",
+      "facebook": "https://www.facebook.com/cellblockchi",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJP1xBx7DTD4gR1jLvMA_vZss",
+      "gayCities": "https://chicago.gaycities.com/bars/145-cell-block",
+      "gayCitiesLastScrapedAt": "2026-06-14T01:14:36.735Z"
+    }
+  ],
+  "dallas": [
+    {
+      "name": "Station 4",
+      "city": "dallas",
+      "address": "3911 Cedar Springs Rd, Dallas, TX 75219",
+      "coordinates": "32.810535, -96.8110709",
+      "instagram": "https://www.instagram.com/s4dallas",
+      "facebook": "https://www.facebook.com/S4Dallas",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJd6m0dcmeToYR3R7XzdFC07U",
+      "gayCities": "https://dallas.gaycities.com/bars/213-station",
+      "gayCitiesLastScrapedAt": "2026-06-26T15:16:43.357Z"
+    }
+  ],
+  "fort-lauderdale": [
+    {
+      "name": "Eagle",
+      "city": "fort-lauderdale",
+      "address": "2209 Wilton Dr, Wilton Manors, FL 33305",
+      "coordinates": "26.156486, -80.138547",
+      "instagram": "https://www.instagram.com/eaglebarwm",
+      "facebook": "https://www.facebook.com/EagleBarWM/",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJu6n6wQ0B2YgRuXxB9KC59OA",
+      "gayCities": "https://fortlauderdale.gaycities.com/bars/309115-eagle-wilton-manors",
+      "gayCitiesLastScrapedAt": "2026-06-13T22:28:52.503Z"
+    },
+    {
+      "name": "Gym Sports Bar",
+      "city": "fort-lauderdale",
+      "address": "2287 Wilton Dr, Wilton Manors, FL 33305",
+      "coordinates": "26.1572257, -80.1373084",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJPUAeAZwB2YgRL0hklcfzn6A",
+      "gayCities": "https://fortlauderdale.gaycities.com/bars/309259-gym-sportsbar-wilton-manors",
+      "gayCitiesLastScrapedAt": "2026-06-13T22:28:54.785Z"
+    },
+    {
+      "name": "The Pub",
+      "city": "fort-lauderdale",
+      "address": "2283 Wilton Dr, Wilton Manors, FL 33305",
+      "coordinates": "26.1571585, -80.1374938",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJj6QjAJwB2YgRf7XQXta65mY",
+      "gayCities": "https://fortlauderdale.gaycities.com/bars/304345-the-pub-wilton-manors",
+      "gayCitiesLastScrapedAt": "2026-06-14T03:19:23.849Z"
+    },
+    {
+      "name": "Hunters",
+      "city": "fort-lauderdale",
+      "address": "2232-2238 Wilton Dr, Wilton Manors, FL 33305",
+      "coordinates": "26.1557905, -80.1381831",
+      "facebook": "https://www.facebook.com/huntersfl",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJde9xlp4B2YgRVl9hn3TriiI",
+      "gayCities": "https://fortlauderdale.gaycities.com/bars/247-hunters-nightclub-wilton-manors",
+      "gayCitiesLastScrapedAt": "2026-06-14T03:19:26.131Z"
+    },
+    {
+      "name": "Scandals Saloon",
+      "city": "fort-lauderdale",
+      "address": "3073 NE 6th Ave, Wilton Manors, FL 33334",
+      "coordinates": "26.1661037, -80.138715",
+      "facebook": "https://www.facebook.com/scandalsfla",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJK4HWoYMB2YgRf442vxEUrM8",
+      "gayCities": "https://fortlauderdale.gaycities.com/bars/256-scandals-saloon",
+      "gayCitiesLastScrapedAt": "2026-06-14T03:19:30.718Z"
+    }
+  ],
+  "hong-kong": [
+    {
+      "name": "Boo Bar",
+      "city": "hong-kong",
+      "address": "Hong Kong, Yau Ma Tei, Nathan Rd, 225號五樓 Pearl Oriental Tower",
+      "coordinates": "22.304447393688015, 114.17136209855921",
+      "instagram": "https://www.instagram.com/boobarhk",
+      "facebook": "https://www.facebook.com/boobar.hk/",
+      "googleMaps": "https://maps.app.goo.gl/jPTA9KhoNaEzNhCJA"
+    }
+  ],
+  "honolulu": [
+    {
+      "name": "Hula's Bar and Lei Stand",
+      "city": "honolulu",
+      "address": "134 Kapahulu Ave, Honolulu, HI 96815",
+      "coordinates": "21.2718488, -157.8216485",
+      "instagram": "https://www.instagram.com/hulaswaikiki",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ58CUmHByAHwRx45RwUAMUzo",
+      "gayCities": "https://hawaii.gaycities.com/bars/276-hulas-bar-lei-stand",
+      "gayCitiesLastScrapedAt": "2026-06-14T07:46:30.629Z"
+    },
+    {
+      "name": "In Between",
+      "city": "honolulu",
+      "address": "2155 Lauula St, Honolulu, HI 96815",
+      "coordinates": "21.2807141, -157.8297099",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJK93OZIptAHwRwR-r34F8Zj4",
+      "gayCities": "https://hawaii.gaycities.com/bars/277-in-between",
+      "gayCitiesLastScrapedAt": "2026-06-14T07:46:32.659Z"
+    }
+  ],
+  "la": [
+    {
+      "name": "Eagle LA",
+      "city": "la",
+      "address": "4219 Santa Monica Blvd, Los Angeles, CA 90029",
+      "coordinates": "34.0912127, -118.2840632",
+      "instagram": "dirtybird_la",
+      "facebook": "https://www.facebook.com/eagle.bar.la/",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJLwuhHU_HwoARdQQ1PfOn6B4",
+      "gayCities": "https://losangeles.gaycities.com/bars/357-eagle-la",
+      "gayCitiesLastScrapedAt": "2026-06-13T15:14:53.360Z"
+    },
+    {
+      "name": "Precinct LA",
+      "city": "la",
+      "address": "357 S Broadway, Los Angeles, CA 90013",
+      "coordinates": "34.0498149, -118.2493321",
+      "instagram": "https://www.instagram.com/precinctdtla",
+      "facebook": "https://www.facebook.com/precinctdtla",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ16rgokvGwoARgLmCBWa28wI",
+      "gayCities": "https://losangeles.gaycities.com/bars/306866-precinct",
+      "gayCitiesLastScrapedAt": "2026-06-13T15:14:55.610Z"
+    },
+    {
+      "name": "Akbar",
+      "city": "la",
+      "address": "4356 Sunset Blvd, Los Angeles, CA 90029",
+      "coordinates": "34.0956924, -118.2842979",
+      "facebook": "https://www.facebook.com/Akbarsilverlake",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJOwpNUEzHwoARAPHUIkcyjdM",
+      "gayCities": "https://losangeles.gaycities.com/bars/359-akbar",
+      "gayCitiesLastScrapedAt": "2026-06-13T18:37:31.295Z"
+    },
+    {
+      "name": "The Falcon",
+      "city": "la",
+      "address": "1435 E Broadway, Long Beach, CA 90802",
+      "coordinates": "33.768209, -118.173899",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJqVioYxAx3YARhUlzgOXT0Zs",
+      "gayCities": "https://longbeach.gaycities.com/bars/1215-falcon",
+      "gayCitiesLastScrapedAt": "2026-06-13T18:37:33.538Z"
+    },
+    {
+      "name": "GYM Bar",
+      "city": "la",
+      "address": "8919 Santa Monica Blvd, West Hollywood, CA 90069",
+      "coordinates": "34.0847604, -118.3846815",
+      "instagram": "https://www.instagram.com/wehogymbar",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJXxXPUMi_woARE46Y7WO-Ww0",
+      "gayCities": "https://losangeles.gaycities.com/bars/309258-gym-bar-weho",
+      "gayCitiesLastScrapedAt": "2026-06-14T03:19:33.089Z"
+    }
+  ],
+  "london": [
+    {
+      "name": "Royal Vauxhall Tavern",
+      "city": "london",
+      "address": "372 Kennington Ln, London, United Kingdom SE11 5HY",
+      "coordinates": "51.4863391, -0.1217784",
+      "instagram": "https://www.instagram.com/rvtofficial",
+      "facebook": "https://www.facebook.com/TheRVT",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJuYgA--wEdkgRD-0ylWTyMkw",
+      "gayCities": "https://london.gaycities.com/bars/1710-royal-vauxhall-tavern",
+      "gayCitiesLastScrapedAt": "2026-06-13T15:19:24.741Z"
+    },
+    {
+      "name": "Duke of Wellington",
+      "city": "london",
+      "address": "77 Wardour St, London, England W1D 6QA",
+      "coordinates": "51.512343, -0.1331208",
+      "instagram": "https://www.instagram.com/dukeofwellington_soho",
+      "facebook": "https://www.facebook.com/Duke.Of.Welly",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJkUcf6v4PdkgR8zHSLztcmdw",
+      "gayCities": "https://london.gaycities.com/bars/1704-the-duke-of-wellington",
+      "gayCitiesLastScrapedAt": "2026-06-13T16:37:27.264Z"
+    },
+    {
+      "name": "Kings Arms",
+      "city": "london",
+      "address": "23 Poland St, London, England W1F 8QL",
+      "coordinates": "51.5151643, -0.1371827",
+      "instagram": "https://www.instagram.com/KingsArms.soho",
+      "facebook": "https://www.facebook.com/kingsarms.soho",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJBUDtIZcEdkgR0k-Xw7rA8wM",
+      "gayCities": "https://london.gaycities.com/bars/2046-the-kings-arms",
+      "gayCitiesLastScrapedAt": "2026-06-13T16:37:29.296Z"
+    },
+    {
+      "name": "Eagle London",
+      "city": "london",
+      "address": "349 Kennington Lane, London, England SE11 5QY",
+      "coordinates": "51.4862598, -0.1193404",
+      "instagram": "https://www.instagram.com/eagleldn",
+      "facebook": "https://www.facebook.com/EagleLDN",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ-crt4uwEdkgRt13r0ih1Lgk",
+      "gayCities": "https://london.gaycities.com/bars/1685-eagle-london",
+      "gayCitiesLastScrapedAt": "2026-06-13T16:37:31.585Z"
+    }
+  ],
+  "montreal": [
+    {
+      "name": "Le Stud",
+      "city": "montreal",
+      "address": "1812 Rue Sainte-Catherine E, Montreal, QC H2K 2H3",
+      "coordinates": "45.522756, -73.5519804",
+      "facebook": "https://www.facebook.com/groups/42513323876/",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ6615i68byUwRS5KOpOHOFB8",
+      "gayCities": "https://montreal.gaycities.com/bars/724-le-stud",
+      "gayCitiesLastScrapedAt": "2026-06-14T01:14:32.066Z"
+    },
+    {
+      "name": "Aigle Noir",
+      "city": "montreal",
+      "address": "1315 St Catherine St E, Montreal, QC H2L 2H4",
+      "coordinates": "45.519641, -73.555339",
+      "facebook": "https://www.facebook.com/Bar.Aigle.Noir/",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJEc7NGK4byUwR1QVPh5qsYCY",
+      "gayCities": "https://montreal.gaycities.com/bars/710-aigle-noir",
+      "gayCitiesLastScrapedAt": "2026-06-14T01:14:34.423Z"
+    }
+  ],
+  "nyc": [
+    {
+      "name": "Animal",
+      "city": "nyc",
+      "address": "307 Meeker Ave, NY 11211",
+      "coordinates": "40.7173904, -73.9493112",
+      "instagram": "https://www.instagram.com/animal.nyc",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJdaGX6E9ZwokRrcrhq8cMM-8",
+      "gayCities": "https://newyork.gaycities.com/bars/312406-animal",
+      "gayCitiesLastScrapedAt": "2026-06-14T16:38:14.085Z"
+    },
+    {
+      "name": "Rockbar",
+      "city": "nyc",
+      "address": "185 Christopher St, New York, NY 10014",
+      "coordinates": "40.7326534, -74.0096996",
+      "instagram": "https://www.instagram.com/rockbarnyc",
+      "facebook": "https://www.facebook.com/Rockbar-NYC",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJlwfqXuxZwokRTlizRW_4cwc",
+      "gayCities": "https://newyork.gaycities.com/bars/3486-rockbar-nyc",
+      "gayCitiesLastScrapedAt": "2026-06-14T16:38:16.402Z"
+    },
+    {
+      "name": "Eagle NYC",
+      "city": "nyc",
+      "address": "554 W 28th St, New York, NY 10001",
+      "coordinates": "40.751694, -74.004306",
+      "website": "http://eagle-ny.com",
+      "instagram": "https://www.instagram.com/eaglenyc",
+      "facebook": "https://www.facebook.com/eaglenyc",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJmaM5RbZZwokRwpJUp-ClLKw",
+      "wikipedia": "https://en.wikipedia.org/wiki/Eagle_NYC",
+      "gayCities": "https://newyork.gaycities.com/bars/400-eagle-nyc",
+      "faviconBg": "#f0f0f0",
+      "faviconFg": "#565656",
+      "gayCitiesLastScrapedAt": "2026-06-26T17:08:38.515Z",
+      "wikipediaLastScrapedAt": "2026-06-26T15:16:42.784Z"
+    },
+    {
+      "name": "3 Dollar Bill",
+      "city": "nyc",
+      "address": "260 Meserole St, Brooklyn, NY 11206",
+      "coordinates": "40.7084144, -73.9380583",
+      "instagram": "https://www.instagram.com/3dollarbillbk",
+      "facebook": "https://www.facebook.com/3dollarbillbk",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ7zm6H3JbwokR3ui1wTNr6Xc",
+      "gayCities": "https://newyork.gaycities.com/bars/309059-dollar-bill",
+      "gayCitiesLastScrapedAt": "2026-06-14T16:38:18.601Z"
+    },
+    {
+      "name": "Ty's",
+      "city": "nyc",
+      "address": "114 Christopher St, New York, NY 10014",
+      "coordinates": "40.7330387, -74.0052985",
+      "instagram": "https://www.instagram.com/tysbar",
+      "facebook": "https://www.facebook.com/TysNYC",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJaVvpXJNZwokRT3p02KL_TrY",
+      "gayCities": "https://newyork.gaycities.com/bars/388-tys-bar-nyc",
+      "gayCitiesLastScrapedAt": "2026-06-14T16:38:20.711Z"
+    },
+    {
+      "name": "Nowhere Bar",
+      "city": "nyc",
+      "address": "322 E 14th St, New York, NY 10003",
+      "coordinates": "40.7316977, -73.9841737",
+      "instagram": "https://www.instagram.com/nowherenyc",
+      "facebook": "https://www.facebook.com/nowherebar",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJZ1fMFZ5ZwokRkYrV85CZorY",
+      "gayCities": "https://newyork.gaycities.com/bars/415-nowhere-bar",
+      "gayCitiesLastScrapedAt": "2026-06-14T16:38:22.742Z"
+    },
+    {
+      "name": "Albatross",
+      "city": "nyc",
+      "address": "3619 24th Ave, Queens, NY 11103",
+      "coordinates": "40.7701915, -73.9121803",
+      "facebook": "https://www.facebook.com/albatrossastoria",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ8RSx_WlfwokRa_PTy_InEnM",
+      "gayCities": "https://newyork.gaycities.com/bars/449-albatross-bar",
+      "gayCitiesLastScrapedAt": "2026-06-13T15:19:27.078Z"
+    },
+    {
+      "name": "Gym Sports Bar",
+      "city": "nyc",
+      "address": "167 8th Ave, New York, NY 10011",
+      "coordinates": "40.7426478, -74.0007982",
+      "instagram": "https://www.instagram.com/gymsportsbarny",
+      "facebook": "https://www.facebook.com/GYMSPORTSBARNY",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJX-P_qr5ZwokR7pssvk2V9b0",
+      "gayCities": "https://newyork.gaycities.com/bars/394-gym-sportsbar",
+      "gayCitiesLastScrapedAt": "2026-06-13T22:28:57.028Z"
+    },
+    {
+      "name": "FLEX",
+      "city": "nyc",
+      "address": "405 W 51st St, New York, NY 10019",
+      "coordinates": "40.7644457, -73.9888453",
+      "instagram": "https://www.instagram.com/flexnyc",
+      "facebook": "https://www.facebook.com/flexbarnyc",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJBWXY9oZZwokRA9xrSOqTNjc",
+      "gayCities": "https://newyork.gaycities.com/bars/311127-flex",
+      "gayCitiesLastScrapedAt": "2026-06-14T07:46:24.312Z"
+    },
+    {
+      "name": "Atlas Social Club",
+      "city": "nyc",
+      "address": "753 9th Ave, New York, NY 10019",
+      "coordinates": "40.7640829, -73.9889102",
+      "facebook": "https://www.facebook.com/atlassocialclub",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJSYrBMldYwokRuer87cJcwiw",
+      "gayCities": "https://newyork.gaycities.com/bars/305118-atlas-social-club",
+      "gayCitiesLastScrapedAt": "2026-06-14T07:46:26.352Z"
+    },
+    {
+      "name": "9th Avenue Saloon",
+      "city": "nyc",
+      "address": "656 9th Ave, New York, NY 10036",
+      "coordinates": "40.7607576, -73.9906454",
+      "instagram": "https://www.instagram.com/9thavesaloon",
+      "facebook": "https://www.facebook.com/9thAveSaloon",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJte-0gz9ZwokR5wz0wDUVOpQ",
+      "gayCities": "https://newyork.gaycities.com/bars/426-th-avenue-saloon",
+      "gayCitiesLastScrapedAt": "2026-06-14T07:46:28.587Z"
+    }
+  ],
+  "palm-springs": [
+    {
+      "name": "Hunters",
+      "city": "palm-springs",
+      "address": "302 E Arenas Rd, Palm Springs, CA 92262",
+      "coordinates": "33.8214288, -116.544092",
+      "instagram": "https://www.instagram.com/hunterspalmsprings",
+      "facebook": "https://www.facebook.com/HuntersPS",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJbXdJHxEb24ARI5sarz94EAI",
+      "gayCities": "https://palmsprings.gaycities.com/bars/588-hunters-palm-springs",
+      "gayCitiesLastScrapedAt": "2026-06-14T03:19:28.458Z"
+    }
+  ],
+  "paris": [
+    {
+      "name": "Bear's Den",
+      "city": "paris",
+      "address": "6 Rue des Lombards, Paris, IDF 75004",
+      "coordinates": "48.8591657, 2.3500783",
+      "facebook": "https://www.facebook.com/Bearsden-Paris-306571042732756/",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ3wmsgx5u5kcRX4l_NuRC3z0",
+      "gayCities": "https://paris.gaycities.com/bars/1625-bears-den",
+      "gayCitiesLastScrapedAt": "2026-06-13T16:37:22.662Z"
+    },
+    {
+      "name": "El Hombre",
+      "city": "paris",
+      "address": "15 rue de la Reynie, Paris, France 75004",
+      "coordinates": "48.859861, 2.349458",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJsYcLoB5u5kcRvlZDfSyg7w4",
+      "gayCities": "https://paris.gaycities.com/bars/307921-el-hombre",
+      "gayCitiesLastScrapedAt": "2026-06-13T16:37:24.689Z"
+    }
+  ],
+  "poconos": [
+    {
+      "name": "Camp Out",
+      "city": "poconos",
+      "address": "446 MT NEBO RD, EAST STROUDSBURG, PA, 18301",
+      "coordinates": "41.0219799, -75.1167816",
+      "website": "https://campoutpoconos.com",
+      "instagram": "https://www.instagram.com/campoutpoconos",
+      "facebook": "https://www.facebook.com/campout.poconos",
+      "googleMaps": "https://maps.app.goo.gl/LYwCKGeMJAJTy8hx9?g_st=ic",
+      "faviconBg": "#f4f3ef",
+      "faviconFg": "#60514d"
+    }
+  ],
+  "portland": [
+    {
+      "name": "CC Slaughters",
+      "city": "portland",
+      "address": "219 NW Davis St, Portland, OR 97209",
+      "coordinates": "45.5246478, -122.6729183",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJnfNLuwAKlVQRXZrfhfLp_i4",
+      "gayCities": "https://portland.gaycities.com/bars/893-cc-slaughters-nightclub-and-lounge",
+      "gayCitiesLastScrapedAt": "2026-06-13T22:29:01.943Z"
+    }
+  ],
+  "ptown": [
+    {
+      "name": "A-House",
+      "city": "ptown",
+      "address": "6 Masonic Pl #4, Provincetown, MA 02657",
+      "coordinates": "42.0500638, -70.1888875",
+      "facebook": "https://www.facebook.com/ahouseprovincetown",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJyQ3ZXX6n_IkR0_ZfyWwD6Zg",
+      "gayCities": "https://ptown.gaycities.com/bars/535-a-house",
+      "gayCitiesLastScrapedAt": "2026-06-13T20:34:59.308Z"
+    },
+    {
+      "name": "Boatslip",
+      "city": "ptown",
+      "address": "161 Commercial St, Provincetown, MA 02657",
+      "coordinates": "42.0470329, -70.1901852",
+      "instagram": "https://www.instagram.com/boatslipresort",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ-fvjNIBY-4kRHNO3kg_G5Cc",
+      "gayCities": "https://ptown.gaycities.com/hotels/10272-boatslip-resort-beach-club",
+      "gayCitiesLastScrapedAt": "2026-06-13T20:35:01.413Z"
+    },
+    {
+      "name": "Crown & Anchor",
+      "city": "ptown",
+      "address": "247 Commercial St, Provincetown, MA 02657",
+      "coordinates": "42.0502291, -70.1876737",
+      "facebook": "https://www.facebook.com/CrownAnchorProvincetown",
+      "googleMaps": "https://www.google.com/maps/place/?q=247+Commercial+St,+Provincetown,+MA+02657",
+      "gayCities": "https://ptown.gaycities.com/bars/541-crown-anchor",
+      "gayCitiesLastScrapedAt": "2026-06-13T20:35:03.709Z"
+    },
+    {
+      "name": "Purgatory Gifford House",
+      "city": "ptown",
+      "address": "11 Carver St, Provincetown, MA 02657",
+      "coordinates": "42.0496268, -70.1900224",
+      "instagram": "https://www.instagram.com/gifford_house",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJE9zxSn6n_IkRbOMJFiVbw_k",
+      "gayCities": "https://ptown.gaycities.com/bars/543-purgatory-gifford-house",
+      "gayCitiesLastScrapedAt": "2026-06-14T01:14:29.670Z"
+    },
+    {
+      "name": "Red Room",
+      "city": "ptown",
+      "address": "258 Commercial St, Provincetown, MA 02657",
+      "coordinates": "42.0510476, -70.1876737",
+      "instagram": "https://www.instagram.com/redroomptown",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJqbgqyVOn_IkRIAI-jRz2eak",
+      "gayCities": "https://ptown.gaycities.com/bars/309562-red-room",
+      "gayCitiesLastScrapedAt": "2026-06-26T15:16:45.767Z"
+    }
+  ],
+  "pv": [
+    {
+      "name": "STUDS",
+      "city": "pv",
+      "address": "283 Basilio Badillo, Puerto Vallarta, Jal. 48380",
+      "coordinates": "20.6025646, -105.2351825",
+      "facebook": "https://www.facebook.com/studsbarpv/",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJYT0eSbpFIYQRxx74YO-xYsY",
+      "gayCities": "https://vallarta.gaycities.com/bars/309956-studs-bear-bar",
+      "gayCitiesLastScrapedAt": "2026-06-13T15:19:29.495Z"
+    },
+    {
+      "name": "CC Slaughters",
+      "city": "pv",
+      "address": "Lazaro Cardenas 254, Puerto Vallarta, JAL 48290",
+      "coordinates": "20.6483408, -105.1980403",
+      "facebook": "https://www.facebook.com/CCSlaughtersPV/",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJZa2WW0xFIYQRrzpGYnmf8Og",
+      "gayCities": "https://vallarta.gaycities.com/bars/302724-cc-slaughters",
+      "gayCitiesLastScrapedAt": "2026-06-13T22:28:59.439Z"
+    }
+  ],
+  "seattle": [
+    {
+      "name": "Diesel",
+      "city": "seattle",
+      "address": "1413 14th Ave, Seattle, WA 98122",
+      "coordinates": "47.6133, -122.3143",
+      "website": "http://dieselseattle.com/DIESEL.html",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJCfyfcs5qkFQR84fyFrPsC58",
+      "wikipedia": "https://en.wikipedia.org/wiki/Diesel_(gay_bar)",
+      "gayCities": "https://seattle.gaycities.com/bars/302690-diesel",
+      "faviconBg": "#335a91",
+      "faviconFg": "#c3cbd4",
+      "gayCitiesLastScrapedAt": "2026-06-26T17:08:40.863Z",
+      "wikipediaLastScrapedAt": "2026-06-26T15:16:42.812Z"
+    },
+    {
+      "name": "The Lumber Yard Bar",
+      "city": "seattle",
+      "address": "9630 16th Ave SW, Seattle, WA 98106",
+      "coordinates": "47.5165235, -122.3548059",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ-8uYrt9DkFQRXv1WZmNZ8F0",
+      "gayCities": "https://seattle.gaycities.com/bars/309627-the-lumber-yard-bar",
+      "gayCitiesLastScrapedAt": "2026-06-13T15:14:46.563Z"
+    },
+    {
+      "name": "The Cuff Complex",
+      "city": "seattle",
+      "address": "1533 13th Ave, Seattle, WA 98122",
+      "coordinates": "47.6150778, -122.3157208",
+      "facebook": "https://www.facebook.com/thecuffcomplex",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJuQVbk81qkFQRkm6N_RnwHQY",
+      "gayCities": "https://seattle.gaycities.com/bars/514-the-cuff-complex",
+      "gayCitiesLastScrapedAt": "2026-06-13T15:14:48.626Z"
+    },
+    {
+      "name": "Seattle Eagle",
+      "city": "seattle",
+      "address": "314 E Pike St, Seattle, WA 98122",
+      "coordinates": "47.61427, -122.32708",
+      "website": "http://seattleeagle.com",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJOcPt38pqkFQRWmTOs3bUrgk",
+      "wikipedia": "https://en.wikipedia.org/wiki/Seattle_Eagle",
+      "gayCities": "https://seattle.gaycities.com/bars/506-seattle-eagle",
+      "gayCitiesLastScrapedAt": "2026-06-26T17:08:43.316Z",
+      "wikipediaLastScrapedAt": "2026-06-26T15:16:42.842Z"
+    },
+    {
+      "name": "CC’s Seattle",
+      "city": "seattle",
+      "address": "1701 E Olive Wy, Seattle, WA 98102",
+      "coordinates": "47.6196626, -122.3233158",
+      "facebook": "https://www.facebook.com/ccsseattle",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJk-Ws_tFqkFQRc2h8MPRvv5I",
+      "gayCities": "https://seattle.gaycities.com/bars/505-ccs-seattle",
+      "gayCitiesLastScrapedAt": "2026-06-13T15:14:51.206Z"
+    },
+    {
+      "name": "Madison Pub",
+      "city": "seattle",
+      "address": "1315 E Madison St, Seattle, WA 98122",
+      "coordinates": "47.6133619, -122.3149054",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJB_-ecc5qkFQRS1xH4lgadrg",
+      "gayCities": "https://seattle.gaycities.com/bars/508-madison-pub",
+      "gayCitiesLastScrapedAt": "2026-06-13T15:19:20.182Z"
+    },
+    {
+      "name": "Pony",
+      "city": "seattle",
+      "address": "1221 E Madison St, Seattle, WA 98122",
+      "coordinates": "47.6130663, -122.3157243",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJRUOyfc5qkFQRDZLLFj1Q264",
+      "gayCities": "https://seattle.gaycities.com/bars/2442-pony",
+      "gayCitiesLastScrapedAt": "2026-06-13T15:19:22.288Z"
+    }
+  ],
+  "sf": [
+    {
+      "name": "SF Eagle",
+      "city": "sf",
+      "address": "398 12th St, San Francisco, CA 94103",
+      "coordinates": "37.7699927, -122.4134077",
+      "instagram": "https://www.instagram.com/sfeaglebar",
+      "facebook": "https://www.facebook.com/SFEagleBar",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJeQ6_GyZ-j4ARj3aV_MeMyf8",
+      "gayCities": "https://sanfrancisco.gaycities.com/bars/304619-sf-eagle",
+      "gayCitiesLastScrapedAt": "2026-06-14T05:42:19.861Z"
+    },
+    {
+      "name": "Powerhouse",
+      "city": "sf",
+      "address": "1347 Folsom St, San Francisco, CA 94103",
+      "coordinates": "37.773088, -122.412193",
+      "instagram": "https://www.instagram.com/sfpowerhouse",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJY_ioDSh-j4ARCCFmqIVhgZo",
+      "gayCities": "https://sanfrancisco.gaycities.com/bars/43-powerhouse",
+      "gayCitiesLastScrapedAt": "2026-06-14T05:42:22.526Z"
+    },
+    {
+      "name": "Hole in the Wall Saloon",
+      "city": "sf",
+      "address": "1369 Folsom St, San Francisco, CA 94103",
+      "coordinates": "37.7729155, -122.4123163",
+      "instagram": "https://www.instagram.com/the-hole-in-the-wall-saloon",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJExXNdCh-j4AR6JuGm4ElqcQ",
+      "gayCities": "https://sanfrancisco.gaycities.com/bars/40-hole-in-the-wall-saloon",
+      "gayCitiesLastScrapedAt": "2026-06-14T05:42:24.790Z"
+    },
+    {
+      "name": "Lone Star Saloon",
+      "city": "sf",
+      "address": "1354 Harrison St, San Francisco, CA 94103",
+      "coordinates": "37.7721717, -122.410901",
+      "facebook": "https://www.facebook.com/lonestarsf",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ4yvd8Ch-j4ARGZFAn1jfTl8",
+      "gayCities": "https://sanfrancisco.gaycities.com/bars/42-lone-star-saloon",
+      "gayCitiesLastScrapedAt": "2026-06-14T05:42:27.073Z"
+    },
+    {
+      "name": "440 Castro",
+      "city": "sf",
+      "address": "440 Castro St, San Francisco, CA 94114",
+      "coordinates": "37.7618335, -122.4352736",
+      "instagram": "https://www.instagram.com/440castro",
+      "facebook": "https://www.facebook.com/440Castro",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJlYxnqhx-j4ARE6-6BQBetEI",
+      "gayCities": "https://sanfrancisco.gaycities.com/bars/3-castro",
+      "gayCitiesLastScrapedAt": "2026-06-14T05:42:29.719Z"
+    }
+  ],
+  "tokyo": [
+    {
+      "name": "EAGLE TOKYO",
+      "city": "tokyo",
+      "address": "2 Chome-12-3 Shinjuku, Tokyo, Tōkyō-to 160-0022",
+      "coordinates": "35.6904391, 139.7076017",
+      "facebook": "https://www.facebook.com/eagletokyojp",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJAQCrt9yMGGARObx5wDPQtAA",
+      "gayCities": "https://tokyo.gaycities.com/bars/307927-eagle-tokyo",
+      "gayCitiesLastScrapedAt": "2026-06-14T09:13:52.895Z"
+    },
+    {
+      "name": "EAGLE TOKYO BLUE",
+      "city": "tokyo",
+      "address": "2 Chome−11−2 Casa Verde, 1階、地下1階, Shinjuku City, Tokyo 160-0022",
+      "coordinates": "35.690086, 139.7077713",
+      "instagram": "https://www.instagram.com/eagletokyojp",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJVVvvklSNGGAR4pCosef9zpQ",
+      "gayCities": "https://tokyo.gaycities.com/bars/312380-eagle-tokyo-blue",
+      "gayCitiesLastScrapedAt": "2026-06-14T09:13:55.162Z"
+    }
+  ],
+  "vegas": [
+    {
+      "name": "Fun Hog Ranch",
+      "city": "vegas",
+      "address": "495 E Twain Ave, Las Vegas, NV 89169",
+      "coordinates": "36.1208359, -115.1522707",
+      "instagram": "https://www.instagram.com/funhogranchlv",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJKfM4OVvEyIARKXe7Mp57Uv0",
+      "gayCities": "https://lasvegas.gaycities.com/bars/1346-fun-hog-ranch",
+      "gayCitiesLastScrapedAt": "2026-06-14T01:14:27.328Z"
+    }
+  ]
+}

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1370,6 +1370,18 @@ class ScriptableAdapter {
     });
   }
 
+  // Adapter self-description for normalizers' enforce mode: does this
+  // platform structurally have Apple's reverse geocoding? True whenever the
+  // Location API is present (the same typeof checks reverseGeocodePlacemark
+  // gates on) — a rate-limited/down service still "supports" the capability,
+  // which is exactly the case enforce mode must fail closed on.
+  supportsReverseGeocode() {
+    return (
+      typeof Location !== "undefined" &&
+      typeof Location.reverseGeocode === "function"
+    );
+  }
+
   async reverseGeocodePlacemark(lat, lon) {
     if (
       typeof Location === "undefined" ||
@@ -2087,60 +2099,101 @@ class ScriptableAdapter {
     }
   }
 
+  // One bars URL → parsed JSON, or null on any failure (404, offline,
+  // unparseable body). Bars URLs carry their own 1-day cache TTL — read that
+  // cache first, keep fetchData's global-TTL cache out of the way, and write
+  // back explicitly.
+  async fetchRemoteBarsJson(url, barsCacheConfig) {
+    try {
+      let body = null;
+      const cached = await this.readCachedPage(url, barsCacheConfig);
+      if (cached && typeof cached.html === "string") {
+        body = cached.html;
+      } else {
+        const responseData = await this.fetchData(url, {
+          headers: { Accept: "application/json" },
+          isCacheableResponse: () => false,
+        });
+        if (responseData && typeof responseData.html === "string") {
+          body = responseData.html;
+          await this.writeCachedPage(url, responseData, barsCacheConfig);
+        }
+      }
+      return body ? JSON.parse(body) : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
   // Bar data merged on the website is the source of truth; the phone's local
-  // scraper-bars.js copy goes stale the moment a bar edit lands. Fetch the
-  // per-city JSON the site already serves (data/bars/<city>.json) for the
-  // requested cities, replacing that city's local entry wholesale. Bars URLs
-  // carry their own 1-day cache TTL so runs stay fast without re-downloading
-  // every time; any failure (404 for cities without a file, offline, bad
-  // JSON) quietly keeps the local entry. Returns { bars, counts } — counts
-  // feed the review UI's freshness line.
+  // scraper-bars.js copy goes stale the moment a bar edit lands. Try the
+  // combined file FIRST — one fetch of data/scraper-bars.json covers every
+  // city (the scraper can't know its cities before parsing assigns them, and
+  // per-city fetching would mean ~45 requests with many 404s on a fresh
+  // day) — and fall back to the per-city files (data/bars/<city>.json) when
+  // the combined fetch fails. cityKeys is the array of cities to refresh, or
+  // null for "all cities": the whole combined object replaces local
+  // wholesale, with local-only cities kept as fallback entries (per-city
+  // fetching is impossible without a city list, so a combined failure
+  // returns the local bars unchanged). Any per-city failure quietly keeps
+  // the local entry. Returns { bars, counts } — counts feed the review UI's
+  // freshness line (remote = cities served from website data, combined or
+  // per-city; local = kept from the local file; unavailable = neither).
   async refreshRemoteBars(cityKeys, localBars) {
     const merged = {
       ...(localBars && typeof localBars === "object" ? localBars : {}),
     };
     const counts = { remote: 0, local: 0, unavailable: 0 };
-    const keys = Array.isArray(cityKeys) ? cityKeys.filter(Boolean) : [];
     const barsCacheConfig = {
       enabled: this.getPageCacheConfig().enabled,
       ttlDays: 1,
     };
-    for (const cityKey of keys) {
-      const url = `https://chunky.dad/data/bars/${encodeURIComponent(cityKey)}.json`;
-      let remoteList = null;
-      try {
-        let body = null;
-        const cached = await this.readCachedPage(url, barsCacheConfig);
-        if (cached && typeof cached.html === "string") {
-          body = cached.html;
+    const combinedRaw = await this.fetchRemoteBarsJson(
+      "https://chunky.dad/data/scraper-bars.json",
+      barsCacheConfig,
+    );
+    // The combined file is an object keyed by city — an array (or any other
+    // shape) is not usable and falls back to the per-city path.
+    const combinedBars =
+      combinedRaw &&
+      typeof combinedRaw === "object" &&
+      !Array.isArray(combinedRaw)
+        ? combinedRaw
+        : null;
+    if (combinedBars) {
+      const keys =
+        cityKeys === null
+          ? Object.keys({ ...merged, ...combinedBars })
+          : Array.isArray(cityKeys)
+            ? cityKeys.filter(Boolean)
+            : [];
+      for (const cityKey of keys) {
+        if (Array.isArray(combinedBars[cityKey])) {
+          merged[cityKey] = combinedBars[cityKey];
+          counts.remote += 1;
+        } else if (merged[cityKey]) {
+          counts.local += 1;
         } else {
-          const responseData = await this.fetchData(url, {
-            headers: { Accept: "application/json" },
-            // Bars URLs use barsCacheConfig's 1-day TTL, so keep fetchData's
-            // global-TTL cache out of the way and write back explicitly.
-            isCacheableResponse: () => false,
-          });
-          if (responseData && typeof responseData.html === "string") {
-            body = responseData.html;
-            await this.writeCachedPage(url, responseData, barsCacheConfig);
-          }
+          counts.unavailable += 1;
         }
-        if (body) {
-          const parsed = JSON.parse(body);
-          if (Array.isArray(parsed)) {
-            remoteList = parsed;
-          }
-        }
-      } catch (error) {
-        remoteList = null;
       }
-      if (remoteList) {
-        merged[cityKey] = remoteList;
-        counts.remote += 1;
-      } else if (merged[cityKey]) {
-        counts.local += 1;
-      } else {
-        counts.unavailable += 1;
+    } else if (cityKeys === null) {
+      // No combined file and no city list to fetch per city — keep the local
+      // bars and let the counts say so.
+      counts.local = Object.keys(merged).length;
+    } else {
+      const keys = Array.isArray(cityKeys) ? cityKeys.filter(Boolean) : [];
+      for (const cityKey of keys) {
+        const url = `https://chunky.dad/data/bars/${encodeURIComponent(cityKey)}.json`;
+        const parsed = await this.fetchRemoteBarsJson(url, barsCacheConfig);
+        if (Array.isArray(parsed)) {
+          merged[cityKey] = parsed;
+          counts.remote += 1;
+        } else if (merged[cityKey]) {
+          counts.local += 1;
+        } else {
+          counts.unavailable += 1;
+        }
       }
     }
     console.log(

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -857,10 +857,16 @@ test('selectReviewFindingsForAction resolves single, bulk, and missing-only payl
 });
 
 // ---------------------------------------------------------------------------
-// refreshRemoteBars — website bar data wins per city, local file is fallback
+// refreshRemoteBars — the combined data/scraper-bars.json is tried FIRST (one
+// fetch for every city); the per-city files are the fallback when it fails,
+// and the local file backstops both. `combined` is the payload for the
+// combined URL — omit it to 404 the combined fetch and exercise the per-city
+// fallback path.
 // ---------------------------------------------------------------------------
 
-function buildRemoteBarsAdapter(remoteByCity) {
+const COMBINED_BARS_URL = 'https://chunky.dad/data/scraper-bars.json';
+
+function buildRemoteBarsAdapter(remoteByCity, combined) {
   const adapter = buildAdapter();
   adapter.getPageCacheConfig = () => ({ enabled: true, ttlDays: 3 });
   adapter.cacheReads = [];
@@ -875,6 +881,12 @@ function buildRemoteBarsAdapter(remoteByCity) {
   };
   adapter.fetchData = async (url, options) => {
     adapter.fetches.push({ url, options });
+    if (url === COMBINED_BARS_URL) {
+      if (combined === undefined) {
+        throw new Error(`HTTP 404 error from ${url}`);
+      }
+      return { html: typeof combined === 'string' ? combined : JSON.stringify(combined), url, statusCode: 200, headers: {} };
+    }
     const cityKey = url.split('/').pop().replace('.json', '');
     if (!(cityKey in remoteByCity)) {
       throw new Error(`HTTP 404 error from ${url}`);
@@ -885,7 +897,7 @@ function buildRemoteBarsAdapter(remoteByCity) {
   return adapter;
 }
 
-test('refreshRemoteBars replaces a city wholesale from chunky.dad and keeps local on failure', async () => {
+test('refreshRemoteBars falls back per city when the combined file 404s, keeping local on failure', async () => {
   const localBars = {
     poconos: [{ name: 'Stale Camp Out', coordinates: '40.0, -75.0' }],
     nyc: [{ name: 'Eagle NYC', coordinates: '40.7517, -74.0043' }],
@@ -893,11 +905,12 @@ test('refreshRemoteBars replaces a city wholesale from chunky.dad and keeps loca
   };
   const adapter = buildRemoteBarsAdapter({
     poconos: [{ name: 'Camp Out', city: 'poconos', address: '446 MT NEBO RD, EAST STROUDSBURG, PA, 18301', coordinates: '41.0219799, -75.1167816' }]
-    // nyc: 404 (no remote file) → local entry kept
+    // combined: 404 → per-city fallback; nyc: 404 (no remote file) → local entry kept
   });
 
   const result = await adapter.refreshRemoteBars(['poconos', 'nyc', 'bogota'], localBars);
 
+  assert.equal(adapter.fetches[0].url, COMBINED_BARS_URL, 'the combined file is tried first');
   assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Camp Out'],
     'remote city replaces the local entry wholesale');
   assert.deepEqual(result.bars.nyc.map((b) => b.name), ['Eagle NYC'],
@@ -909,21 +922,22 @@ test('refreshRemoteBars replaces a city wholesale from chunky.dad and keeps loca
 });
 
 test('refreshRemoteBars caches bars URLs with a 1-day TTL, separate from the global pageCache TTL', async () => {
-  const adapter = buildRemoteBarsAdapter({ poconos: [] });
+  const adapter = buildRemoteBarsAdapter({ poconos: [] }); // combined 404s → per-city fallback
   await adapter.refreshRemoteBars(['poconos'], {});
 
-  assert.equal(adapter.cacheReads.length, 1);
-  assert.equal(adapter.cacheReads[0].config.ttlDays, 1, 'bars cache reads use the 1-day TTL');
-  assert.equal(adapter.cacheWrites.length, 1);
+  assert.equal(adapter.cacheReads.length, 2, 'combined attempt + per-city fallback');
+  assert.ok(adapter.cacheReads.every((read) => read.config.ttlDays === 1), 'bars cache reads use the 1-day TTL');
+  assert.equal(adapter.cacheWrites.length, 1, 'only the successful per-city fetch writes back');
   assert.equal(adapter.cacheWrites[0].config.ttlDays, 1, 'bars cache writes use the 1-day TTL');
-  assert.equal(adapter.fetches.length, 1);
-  assert.equal(adapter.fetches[0].options.isCacheableResponse(), false,
+  assert.equal(adapter.fetches.length, 2);
+  assert.ok(adapter.fetches.every((fetch) => fetch.options.isCacheableResponse() === false),
     'fetchData is told to keep its global-TTL cache out of the way');
 
-  // A fresh 1-day cache hit spends no fetch at all
-  adapter.readCachedPage = async () => ({ html: JSON.stringify([{ name: 'Cached Bar' }]) });
+  // A fresh 1-day cache hit spends no fetch at all — the combined file served
+  // from cache covers the city on its own.
+  adapter.readCachedPage = async () => ({ html: JSON.stringify({ poconos: [{ name: 'Cached Bar' }] }) });
   const cachedRun = await adapter.refreshRemoteBars(['poconos'], {});
-  assert.equal(adapter.fetches.length, 1, 'cache hit performs no network fetch');
+  assert.equal(adapter.fetches.length, 2, 'cache hit performs no network fetch');
   assert.deepEqual(cachedRun.bars.poconos.map((b) => b.name), ['Cached Bar']);
 });
 
@@ -937,6 +951,73 @@ test('refreshRemoteBars survives invalid JSON and non-array payloads by keeping 
   assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Local Camp Out'], 'invalid JSON keeps local');
   assert.equal(result.bars.nyc, undefined, 'non-array payload never becomes bar data');
   assert.deepEqual(result.counts, { remote: 0, local: 1, unavailable: 1 });
+});
+
+test('refreshRemoteBars serves requested cities from the combined file with a single fetch', async () => {
+  const localBars = {
+    nyc: [{ name: 'Stale Eagle' }],
+    seattle: [{ name: 'The Cuff' }],
+    denver: [{ name: 'Trade' }]
+  };
+  const adapter = buildRemoteBarsAdapter({}, {
+    poconos: [{ name: 'Camp Out' }],
+    nyc: [{ name: 'Eagle NYC' }]
+  });
+
+  const result = await adapter.refreshRemoteBars(['poconos', 'nyc', 'seattle', 'bogota'], localBars);
+
+  assert.equal(adapter.fetches.length, 1, 'one combined fetch, no per-city fetches');
+  assert.equal(adapter.fetches[0].url, COMBINED_BARS_URL);
+  assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Camp Out'], 'a combined city replaces local wholesale');
+  assert.deepEqual(result.bars.nyc.map((b) => b.name), ['Eagle NYC'], 'the combined file wins over a stale local entry');
+  assert.deepEqual(result.bars.seattle.map((b) => b.name), ['The Cuff'],
+    'a city absent from the combined file falls back to local');
+  assert.equal(result.bars.bogota, undefined, 'neither combined nor local stays absent');
+  assert.deepEqual(result.bars.denver.map((b) => b.name), ['Trade'], 'cities not requested pass through untouched');
+  assert.deepEqual(result.counts, { remote: 2, local: 1, unavailable: 1 });
+});
+
+test('refreshRemoteBars with null cityKeys refreshes ALL cities from the combined file, keeping local-only ones', async () => {
+  const localBars = {
+    nyc: [{ name: 'Stale Eagle' }],
+    'local-only': [{ name: 'Local Hold Out' }]
+  };
+  const adapter = buildRemoteBarsAdapter({}, {
+    nyc: [{ name: 'Eagle NYC' }],
+    poconos: [{ name: 'Camp Out' }]
+  });
+
+  const result = await adapter.refreshRemoteBars(null, localBars);
+
+  assert.equal(adapter.fetches.length, 1, 'null cityKeys never triggers per-city fetches');
+  assert.deepEqual(result.bars.nyc.map((b) => b.name), ['Eagle NYC'], 'the combined object replaces local wholesale');
+  assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Camp Out'], 'combined-only cities appear');
+  assert.deepEqual(result.bars['local-only'].map((b) => b.name), ['Local Hold Out'],
+    'local-only cities are kept as fallback entries');
+  assert.deepEqual(result.counts, { remote: 2, local: 1, unavailable: 0 });
+});
+
+test('refreshRemoteBars with null cityKeys and no combined file returns local bars unchanged', async () => {
+  const localBars = { nyc: [{ name: 'Eagle NYC' }], seattle: [{ name: 'The Cuff' }] };
+  // combined 404s and there is no city list → the per-city path is impossible
+  const adapter = buildRemoteBarsAdapter({});
+
+  const result = await adapter.refreshRemoteBars(null, localBars);
+
+  assert.equal(adapter.fetches.length, 1, 'only the combined fetch is attempted');
+  assert.deepEqual(result.bars, localBars);
+  assert.deepEqual(result.counts, { remote: 0, local: 2, unavailable: 0 });
+});
+
+test('supportsReverseGeocode reflects Location API availability', () => {
+  const adapter = buildAdapter();
+  assert.equal(adapter.supportsReverseGeocode(), false, 'no Location global under Node');
+  global.Location = { reverseGeocode: async () => [] };
+  try {
+    assert.equal(adapter.supportsReverseGeocode(), true, 'Location.reverseGeocode present → capability declared');
+  } finally {
+    delete global.Location;
+  }
 });
 
 test('generateReviewHTML renders the bars freshness line when counts are supplied', () => {

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -56,6 +56,14 @@ class WebAdapter {
         return null;
     }
 
+    // Adapter self-description for normalizers' enforce mode: Node has no
+    // Apple geocoding service, so the reverse cross-check capability is
+    // structurally absent — a skipped cross-check here is not a failure and
+    // enforce mode accepts it as before.
+    supportsReverseGeocode() {
+        return false;
+    }
+
     // On Scriptable the reviewer refreshes bar data from the live site; on
     // Node the repo checkout IS the source the site deploys from, so the
     // local bars are already current — pass them through honestly.

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -224,7 +224,25 @@ class BearEventScraperOrchestrator {
             
             // Load configuration early so we can pass cities config to SharedCore
             const config = await adapter.loadConfiguration();
-            
+
+            // Curated bar data: the website's merged copy is fresher than any
+            // local scraper-bars.js the moment a bar edit lands. Refresh ALL
+            // cities up front (null cityKeys — the scraper can't know its
+            // cities before normalization assigns them). Fail-soft: any error
+            // keeps the local bars, and adapters without the method (web) are
+            // tolerated — scraping must never depend on chunky.dad being up.
+            let bars = config.bars || {};
+            if (typeof adapter.refreshRemoteBars === 'function') {
+                try {
+                    const refreshed = await adapter.refreshRemoteBars(null, bars);
+                    if (refreshed && refreshed.bars && typeof refreshed.bars === 'object') {
+                        bars = refreshed.bars;
+                    }
+                } catch (error) {
+                    console.log(`🐻 Orchestrator: Bar data refresh failed (${error.message}) — continuing with local bars`);
+                }
+            }
+
             // Create the normalizer pipeline first
             const normalizerPipeline = new this.modules.NormalizerPipeline();
 
@@ -234,7 +252,7 @@ class BearEventScraperOrchestrator {
                 normalizerPipeline: normalizerPipeline,
                 additionalExcludedFields: this.modules.adapter.NOTES_EXCLUDED_FIELDS,
                 pageClassificationRules: config.config?.pageClassificationRules || [],
-                bars: config.bars || {}
+                bars
             });
             
             // Wire the core back into the pipeline

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -225,23 +225,7 @@ class BearEventScraperOrchestrator {
             // Load configuration early so we can pass cities config to SharedCore
             const config = await adapter.loadConfiguration();
 
-            // Curated bar data: the website's merged copy is fresher than any
-            // local scraper-bars.js the moment a bar edit lands. Refresh ALL
-            // cities up front (null cityKeys — the scraper can't know its
-            // cities before normalization assigns them). Fail-soft: any error
-            // keeps the local bars, and adapters without the method (web) are
-            // tolerated — scraping must never depend on chunky.dad being up.
-            let bars = config.bars || {};
-            if (typeof adapter.refreshRemoteBars === 'function') {
-                try {
-                    const refreshed = await adapter.refreshRemoteBars(null, bars);
-                    if (refreshed && refreshed.bars && typeof refreshed.bars === 'object') {
-                        bars = refreshed.bars;
-                    }
-                } catch (error) {
-                    console.log(`🐻 Orchestrator: Bar data refresh failed (${error.message}) — continuing with local bars`);
-                }
-            }
+            const bars = config.bars || {};
 
             // Create the normalizer pipeline first
             const normalizerPipeline = new this.modules.NormalizerPipeline();
@@ -271,6 +255,25 @@ class BearEventScraperOrchestrator {
                     runtime: config.runtime || null,
                     ...this.config
                 });
+            }
+
+            // Curated bar data: the website's merged copy is fresher than any
+            // local scraper-bars.js the moment a bar edit lands. Refresh ALL
+            // cities up front (null cityKeys — the scraper can't know its
+            // cities before normalization assigns them) on finalAdapter, whose
+            // pageCache config gives the combined file its 1-day TTL. Fail-soft:
+            // any error keeps the local bars, and adapters without the method
+            // (web) are tolerated — scraping must never depend on chunky.dad
+            // being up.
+            if (typeof finalAdapter.refreshRemoteBars === 'function') {
+                try {
+                    const refreshed = await finalAdapter.refreshRemoteBars(null, bars);
+                    if (refreshed && refreshed.bars && typeof refreshed.bars === 'object') {
+                        sharedCore.bars = refreshed.bars;
+                    }
+                } catch (error) {
+                    console.log(`🐻 Orchestrator: Bar data refresh failed (${error.message}) — continuing with local bars`);
+                }
             }
 
             // Create parser instances

--- a/scripts/bear-event-scraper-unified.test.js
+++ b/scripts/bear-event-scraper-unified.test.js
@@ -67,8 +67,11 @@ function createStubAdapter({ config, executeError = null, omitExecute = false, r
 
 // Subclass (never prototype mutation) so each test gets an isolated SharedCore
 // whose event-production stages are canned while run()'s real branching
-// executes. coreOptionsLog (optional array) records the constructor options so
-// tests can observe what run() wired into the core (e.g. the bars config).
+// executes. coreOptionsLog (optional array) records the constructor options
+// plus the core's bars AT processEvents TIME (`barsAtProcessEvents`) so tests
+// can observe what run() wired into the core — the bar-data refresh happens
+// after construction (it needs finalAdapter's pageCache config), so the
+// processEvents-time value is the one BarDataNormalizer actually sees.
 function createSharedCoreStub(events, coreOptionsLog = null) {
   return class StubSharedCore extends SharedCore {
     constructor(cities, options) {
@@ -76,6 +79,9 @@ function createSharedCoreStub(events, coreOptionsLog = null) {
       if (coreOptionsLog) coreOptionsLog.push(options);
     }
     async processEvents() {
+      if (coreOptionsLog && coreOptionsLog.length > 0) {
+        coreOptionsLog[coreOptionsLog.length - 1].barsAtProcessEvents = this.bars;
+      }
       return {
         totalEvents: events.length,
         rawBearEvents: events.length,
@@ -220,7 +226,8 @@ test('run() refreshes bar data with null cityKeys and wires the merged result in
   assert.equal(calls.refreshRemoteBars.length, 1, 'exactly one refresh per run');
   assert.equal(calls.refreshRemoteBars[0].cityKeys, null, 'the scraper cannot know its cities yet — all of them');
   assert.deepEqual(calls.refreshRemoteBars[0].localBars, localBars, 'local bars are offered as the fallback');
-  assert.deepEqual(coreOptionsLog[0].bars, remoteBars, 'SharedCore receives the merged (refreshed) bars');
+  assert.deepEqual(coreOptionsLog[0].barsAtProcessEvents, remoteBars,
+    'the core carries the merged (refreshed) bars by the time events are processed');
 });
 
 test('run() tolerates an adapter without refreshRemoteBars and keeps the local bars', async () => {
@@ -231,7 +238,7 @@ test('run() tolerates an adapter without refreshRemoteBars and keeps the local b
 
   const results = await orch.run();
 
-  assert.deepEqual(coreOptionsLog[0].bars, localBars, 'local bars flow through unchanged');
+  assert.deepEqual(coreOptionsLog[0].barsAtProcessEvents, localBars, 'local bars flow through unchanged');
   assert.equal(results.analyzedEvents.length, 2, 'the run completes normally');
   assert.equal(calls.displayResults.length, 1);
 });
@@ -252,7 +259,7 @@ test('run() keeps local bars and continues when the refresh throws', async () =>
   const results = await orch.run();
 
   assert.equal(calls.refreshRemoteBars.length, 1, 'the refresh was attempted');
-  assert.deepEqual(coreOptionsLog[0].bars, localBars, 'a refresh failure keeps the local bars');
+  assert.deepEqual(coreOptionsLog[0].barsAtProcessEvents, localBars, 'a refresh failure keeps the local bars');
   assert.equal(results.analyzedEvents.length, 2, 'the run continues');
   assert.equal(calls.showError.length, 0, 'a bars refresh failure is never fatal');
 });

--- a/scripts/bear-event-scraper-unified.test.js
+++ b/scripts/bear-event-scraper-unified.test.js
@@ -26,9 +26,11 @@ function buildConfig(overrides = {}) {
 }
 
 // Adapter class factory: run() instantiates the class twice (bootstrap + final),
-// so recorded calls live in a closure shared by all instances.
-function createStubAdapter({ config, executeError = null, omitExecute = false } = {}) {
-  const calls = { executeCalendarActions: [], displayResults: [], showError: [] };
+// so recorded calls live in a closure shared by all instances. refreshBars
+// (optional) becomes the adapter's refreshRemoteBars implementation — omit it
+// to model an adapter without the method (web-adapter-shaped tolerance).
+function createStubAdapter({ config, executeError = null, omitExecute = false, refreshBars = null } = {}) {
+  const calls = { executeCalendarActions: [], displayResults: [], showError: [], refreshRemoteBars: [] };
 
   class StubAdapter {
     constructor(options = {}) {
@@ -53,13 +55,26 @@ function createStubAdapter({ config, executeError = null, omitExecute = false } 
     };
   }
 
+  if (refreshBars) {
+    StubAdapter.prototype.refreshRemoteBars = async function refreshRemoteBars(cityKeys, localBars) {
+      calls.refreshRemoteBars.push({ cityKeys, localBars });
+      return refreshBars(cityKeys, localBars);
+    };
+  }
+
   return { StubAdapter, calls };
 }
 
 // Subclass (never prototype mutation) so each test gets an isolated SharedCore
-// whose event-production stages are canned while run()'s real branching executes.
-function createSharedCoreStub(events) {
+// whose event-production stages are canned while run()'s real branching
+// executes. coreOptionsLog (optional array) records the constructor options so
+// tests can observe what run() wired into the core (e.g. the bars config).
+function createSharedCoreStub(events, coreOptionsLog = null) {
   return class StubSharedCore extends SharedCore {
+    constructor(cities, options) {
+      super(cities, options);
+      if (coreOptionsLog) coreOptionsLog.push(options);
+    }
     async processEvents() {
       return {
         totalEvents: events.length,
@@ -80,14 +95,14 @@ function createSharedCoreStub(events) {
   };
 }
 
-function createOrchestrator({ config, events = [], adapterOptions = {}, isScriptable = true } = {}) {
+function createOrchestrator({ config, events = [], adapterOptions = {}, isScriptable = true, coreOptionsLog = null } = {}) {
   const { StubAdapter, calls } = createStubAdapter({ config, ...adapterOptions });
   const orch = new BearEventScraperOrchestrator();
   orch.isInitialized = true;
   orch.isScriptable = isScriptable;
   orch.isWeb = false;
   orch.modules = {
-    SharedCore: createSharedCoreStub(events),
+    SharedCore: createSharedCoreStub(events, coreOptionsLog),
     EventSchema,
     NormalizerPipeline: StubNormalizerPipeline,
     adapter: StubAdapter,
@@ -184,6 +199,62 @@ test('zero events found short-circuits the calendar stage', async () => {
   assert.deepEqual(results.analyzedEvents, []);
   assert.equal(calls.executeCalendarActions.length, 0);
   assert.equal(calls.displayResults.length, 1);
+});
+
+test('run() refreshes bar data with null cityKeys and wires the merged result into SharedCore', async () => {
+  const localBars = { dallas: [{ name: 'Stale Station 4' }] };
+  const remoteBars = { dallas: [{ name: 'Station 4' }], poconos: [{ name: 'Camp Out' }] };
+  const config = buildConfig({ bars: localBars });
+  const coreOptionsLog = [];
+  const { orch, calls } = createOrchestrator({
+    config,
+    events: buildEvents(),
+    coreOptionsLog,
+    adapterOptions: {
+      refreshBars: async () => ({ bars: remoteBars, counts: { remote: 2, local: 0, unavailable: 0 } })
+    }
+  });
+
+  await orch.run();
+
+  assert.equal(calls.refreshRemoteBars.length, 1, 'exactly one refresh per run');
+  assert.equal(calls.refreshRemoteBars[0].cityKeys, null, 'the scraper cannot know its cities yet — all of them');
+  assert.deepEqual(calls.refreshRemoteBars[0].localBars, localBars, 'local bars are offered as the fallback');
+  assert.deepEqual(coreOptionsLog[0].bars, remoteBars, 'SharedCore receives the merged (refreshed) bars');
+});
+
+test('run() tolerates an adapter without refreshRemoteBars and keeps the local bars', async () => {
+  const localBars = { dallas: [{ name: 'Station 4' }] };
+  const config = buildConfig({ bars: localBars });
+  const coreOptionsLog = [];
+  const { orch, calls } = createOrchestrator({ config, events: buildEvents(), coreOptionsLog });
+
+  const results = await orch.run();
+
+  assert.deepEqual(coreOptionsLog[0].bars, localBars, 'local bars flow through unchanged');
+  assert.equal(results.analyzedEvents.length, 2, 'the run completes normally');
+  assert.equal(calls.displayResults.length, 1);
+});
+
+test('run() keeps local bars and continues when the refresh throws', async () => {
+  const localBars = { dallas: [{ name: 'Station 4' }] };
+  const config = buildConfig({ bars: localBars });
+  const coreOptionsLog = [];
+  const { orch, calls } = createOrchestrator({
+    config,
+    events: buildEvents(),
+    coreOptionsLog,
+    adapterOptions: {
+      refreshBars: async () => { throw new Error('chunky.dad unreachable'); }
+    }
+  });
+
+  const results = await orch.run();
+
+  assert.equal(calls.refreshRemoteBars.length, 1, 'the refresh was attempted');
+  assert.deepEqual(coreOptionsLog[0].bars, localBars, 'a refresh failure keeps the local bars');
+  assert.equal(results.analyzedEvents.length, 2, 'the run continues');
+  assert.equal(calls.showError.length, 0, 'a bars refresh failure is never fatal');
 });
 
 test('require() exports the orchestrator without auto-executing', () => {

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -1135,10 +1135,25 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     // capability exists) plus suspect flagging per verification mode. Returns
     // { location, crossCheck } — the "lat, lon" string to write plus the
     // cross-check verdict ('pass' | 'fail' | 'skipped'; 'fail' only survives
-    // in report mode) — or null when enforce mode sends the ladder on to its
-    // next rung.
+    // in report mode) — or, when enforce mode sends the ladder on to its next
+    // rung, { location: null, crossCheck } carrying the rejection breadcrumb
+    // ('fail' for a failed cross-check, 'skipped' for a vague input or an
+    // unavailable cross-check).
     async confirmGeocodeCandidate(candidate, context, httpAdapter) {
-        const { title, address, inputHasHouseNumber, verifyMode, source, rung } = context;
+        const { title, address, inputHasHouseNumber, verifyMode, streetSpecific, flags, source, rung } = context;
+        // Vague-input rule (enforce only): an address without street-level
+        // detail ("Poconos, PA") asks a question no geocoder can answer
+        // precisely — whatever came back is an arbitrary same-named candidate.
+        // Refuse it before spending cross-check budget; the flag fires once
+        // per event, not per rung. Curated venues never get here — the
+        // BarDataNormalizer runs before geocoding in the pipeline.
+        if (verifyMode === 'enforce' && streetSpecific === false) {
+            if (flags && !flags.vagueInputFlagged) {
+                flags.vagueInputFlagged = true;
+                console.warn(`🗺️ GEOCODE VERIFY: "${title}" address too vague for a trustworthy pin — left unpinned (enforce)`);
+            }
+            return { location: null, crossCheck: 'skipped' };
+        }
         let crossCheck = 'skipped';
         if (verifyMode !== 'off' && typeof httpAdapter.reverseGeocodePlacemark === 'function') {
             let placemark = null;
@@ -1153,13 +1168,35 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                     crossCheck = comparison.matched ? 'pass' : 'fail';
                     if (!comparison.matched) {
                         console.warn(`🗺️ GEOCODE VERIFY: "${title}" pin failed reverse cross-check ("${comparison.got}" vs "${address}") — verify pin`);
-                        if (verifyMode === 'enforce') return null;
+                        if (verifyMode === 'enforce') return { location: null, crossCheck: 'fail' };
                     }
                 }
             }
         }
+        // Skipped ≠ pass rule (enforce only): when the platform CAN reverse
+        // geocode (adapter self-description via supportsReverseGeocode) but
+        // the cross-check produced no comparison (Apple rate-limited/down, no
+        // placemark, nothing comparable), the candidate is rejected — the
+        // 2026-07-16 run showed 'skipped' silently removing the whole safety
+        // layer. Structural absence of the capability (Node/web) is not a
+        // failure and accepts exactly as before. Flag once per event.
+        if (crossCheck === 'skipped' && verifyMode === 'enforce' &&
+            typeof httpAdapter.supportsReverseGeocode === 'function' &&
+            httpAdapter.supportsReverseGeocode() === true) {
+            if (flags && !flags.crossCheckUnavailableFlagged) {
+                flags.crossCheckUnavailableFlagged = true;
+                console.warn(`🗺️ GEOCODE VERIFY: "${title}" pin rejected — cross-check unavailable (enforce)`);
+            }
+            return { location: null, crossCheck: 'skipped' };
+        }
         if (candidate.grade === 'street' && inputHasHouseNumber && verifyMode === 'report') {
             console.warn(`🗺️ GEOCODE VERIFY: "${title}" street-grade pin for house-numbered address "${address}" — verify pin`);
+        }
+        if (streetSpecific === false && verifyMode === 'report') {
+            // Report mode accepts the pin (flag-don't-drop: a flagged pin
+            // beats no pin on a brand-new event) but makes the vagueness
+            // visible.
+            console.warn(`🗺️ GEOCODE VERIFY: "${title}" pin from vague address "${address}" — verify pin`);
         }
         if (rung > 1 || crossCheck !== 'skipped') {
             console.log(`🗺️ GEOCODE VERIFY: "${title}" accepted ${candidate.grade} pin from ${source} (rung ${rung})`);
@@ -1313,7 +1350,10 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             const resultLimit = cityCenter ? 5 : 1;
             const title = event.title || 'unknown';
             const inputHasHouseNumber = GEOCODE_HOUSE_NUMBER_RE.test(address);
-            const verifyContext = { title, address, inputHasHouseNumber, verifyMode };
+            const streetSpecific = this.isStreetSpecificAddress(address);
+            // flags carries the once-per-event verification flag lines across
+            // ladder rungs (the per-rung spreads copy this same object reference).
+            const verifyContext = { title, address, inputHasHouseNumber, verifyMode, streetSpecific, flags: {} };
 
             // Retry ladder: when a query returns 0 candidates (or every candidate
             // is rejected by the grade gate / distance / city checks), retry with
@@ -1327,7 +1367,8 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             // committed to the event's _geocode* metadata fields below. When the
             // ladder ends UNPINNED, rejectedVerdict remembers the first candidate
             // enforce mode turned away (street-grade for a house-numbered input,
-            // or a cross-check failure) so the calendar reviewer can tell "this
+            // a cross-check failure, a vague input, or an unavailable
+            // cross-check) so the calendar reviewer can tell "this
             // address only resolves to an unverifiable pin" apart from "nothing
             // resolves at all". Coarse refusals never leave a breadcrumb.
             let resolvedVerdict = null;
@@ -1394,12 +1435,14 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                                 { ...verifyContext, source: 'nominatim', rung: i + 1 },
                                 httpAdapter
                             );
-                            if (confirmed) {
+                            if (confirmed.location) {
                                 resolvedLocation = confirmed.location;
                                 resolvedVerdict = { grade: pickedCandidate.grade, crossCheck: confirmed.crossCheck, source: 'nominatim', rung: i + 1 };
                             } else if (!rejectedVerdict) {
-                                // null only means an enforce-mode cross-check failure
-                                rejectedVerdict = { grade: pickedCandidate.grade, crossCheck: 'fail', source: 'nominatim', rung: i + 1 };
+                                // enforce-mode rejection: 'fail' for a failed
+                                // cross-check, 'skipped' for a vague input or
+                                // an unavailable cross-check
+                                rejectedVerdict = { grade: pickedCandidate.grade, crossCheck: confirmed.crossCheck, source: 'nominatim', rung: i + 1 };
                             }
                         }
                     } else if ((!Array.isArray(data) || data.length === 0) && i < queryVariants.length - 1) {
@@ -1446,11 +1489,11 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                                 { ...verifyContext, source: 'census', rung: attempts },
                                 httpAdapter
                             );
-                            if (confirmed) {
+                            if (confirmed.location) {
                                 resolvedLocation = confirmed.location;
                                 resolvedVerdict = { grade: 'exact', crossCheck: confirmed.crossCheck, source: 'census', rung: attempts };
                             } else if (!rejectedVerdict) {
-                                rejectedVerdict = { grade: 'exact', crossCheck: 'fail', source: 'census', rung: attempts };
+                                rejectedVerdict = { grade: 'exact', crossCheck: confirmed.crossCheck, source: 'census', rung: attempts };
                             }
                         } else {
                             console.warn(`🗺️ OpenStreetMapNormalizer: Census match for "${address}" falls outside ${CITY_CENTER_RADIUS_KM} km of ${eventCity} center — ignoring coordinates`);
@@ -1500,11 +1543,11 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                                 { ...verifyContext, source: 'photon', rung: attempts },
                                 httpAdapter
                             );
-                            if (confirmed) {
+                            if (confirmed.location) {
                                 resolvedLocation = confirmed.location;
                                 resolvedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
                             } else if (!rejectedVerdict) {
-                                rejectedVerdict = { grade, crossCheck: 'fail', source: 'photon', rung: attempts };
+                                rejectedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
                             }
                         }
                     }

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -1224,6 +1224,126 @@ test('census rescue: still subject to the reverse cross-check and the city-cente
   assert.equal(farEvent.location, undefined, 'a Census match outside the city radius must be ignored');
 });
 
+// ---------------------------------------------------------------------------
+// Fail-closed enforce semantics (2026-07-16 run findings, pipeline side):
+// a vague input refuses every geocoder candidate, and a cross-check the
+// platform COULD run but didn't rejects the candidate. Report mode stays
+// accept-and-flag for scraping.
+// ---------------------------------------------------------------------------
+
+// An exact-grading POI Nominatim happily returns for the vague query
+// "Poconos, PA" — an arbitrary same-named candidate, kilometers from the venue.
+const POCONOS_ATTRACTION_RESULT = {
+  lat: '41.3000000',
+  lon: '-75.3000000',
+  class: 'tourism',
+  type: 'attraction',
+  addresstype: 'tourism',
+  display_name: 'Some Attraction, Poconos, Pennsylvania, United States',
+  address: { county: 'Poconos' }
+};
+
+test('geocode verification: enforce refuses every candidate for a vague address and flags once', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([['nominatim', [POCONOS_ATTRACTION_RESULT]]]);
+  const event = { title: 'FURBALL CAMP', address: 'Poconos, PA' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+
+  assert.equal(event.location, undefined, 'enforce must never pin a vague input, whatever the grade');
+  assert.ok(httpAdapter.requests.length > 0, 'the ladder still ran — the gate refused its answers');
+  const flagCount = lines.filter(l =>
+    l.includes('🗺️ GEOCODE VERIFY: "FURBALL CAMP" address too vague for a trustworthy pin — left unpinned (enforce)')).length;
+  assert.equal(flagCount, 1, `the vague flag fires once per event: ${lines.join(' | ')}`);
+  assert.equal(event._geocodeGrade, 'exact', 'the refused candidate leaves a breadcrumb');
+  assert.equal(event._geocodeCrossCheck, 'skipped', 'a vague refusal is not a cross-check failure');
+});
+
+test('geocode verification: report mode keeps the pin from a vague address but flags it', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([['nominatim', [POCONOS_ATTRACTION_RESULT]]]);
+  const event = { title: 'FURBALL CAMP', address: 'Poconos, PA' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+
+  assert.equal(event.location, '41.3000000, -75.3000000', 'report mode accepts as today (flag, don\'t drop)');
+  assert.ok(
+    lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "FURBALL CAMP" pin from vague address "Poconos, PA" — verify pin')),
+    `the vague-pin flag must be logged: ${lines.join(' | ')}`
+  );
+});
+
+test('geocode verification: enforce rejects a candidate when the platform can cross-check but none ran', async () => {
+  const core = new SharedCore(CITIES_SF_WITH_COORDS, { eventSchema: EventSchema });
+  const normalizer = new OpenStreetMapNormalizer(core);
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter(
+    [
+      [encodeURIComponent('1192 Folsom St, sf'), [POWERHOUSE_POI_RESULT]],
+      [encodeURIComponent('Powerhouse, sf'), [POWERHOUSE_POI_RESULT]]
+    ],
+    {
+      // Apple rate-limited/down: the capability exists but yields nothing
+      reverseGeocodePlacemark: async () => null,
+      supportsReverseGeocode: () => true
+    }
+  );
+  const event = { title: 'CHUNK', address: '1192 Folsom St', bar: 'Powerhouse', city: 'sf' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+
+  assert.equal(event.location, undefined, 'skipped is not pass — the candidate must be rejected in enforce mode');
+  assert.ok(httpAdapter.requests.some(url => url.includes('photon.komoot.io')), 'the ladder continues past the rejection');
+  const flagCount = lines.filter(l =>
+    l.includes('🗺️ GEOCODE VERIFY: "CHUNK" pin rejected — cross-check unavailable (enforce)')).length;
+  assert.equal(flagCount, 1, `the unavailable flag fires once per event, not per rung: ${lines.join(' | ')}`);
+  assert.equal(event._geocodeGrade, 'exact', 'the rejected candidate leaves a breadcrumb');
+  assert.equal(event._geocodeCrossCheck, 'skipped',
+    'skipped (not fail) — the reviewer renders its "re-run when Apple geocoding recovers" hint from this');
+});
+
+test('geocode verification: structural absence of the cross-check (Node/web) still accepts in enforce mode', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter(
+    [['nominatim', [POWERHOUSE_POI_RESULT]]],
+    { reverseGeocodePlacemark: async () => null, supportsReverseGeocode: () => false }
+  );
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+
+  assert.equal(event.location, '37.7756941, -122.4103049', 'structural absence is not a failure');
+  assert.ok(!lines.some(l => l.includes('cross-check unavailable')), `no rejection flag: ${lines.join(' | ')}`);
+});
+
+test('geocode verification: report mode is unchanged for street-specific inputs even with the capability present', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter(
+    [['nominatim', [POWERHOUSE_POI_RESULT]]],
+    { reverseGeocodePlacemark: async () => null, supportsReverseGeocode: () => true }
+  );
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+
+  assert.equal(event.location, '37.7756941, -122.4103049', 'report mode accepts exactly as before');
+  assert.ok(!lines.some(l => l.includes('GEOCODE VERIFY')), `a clean rung-1 accept stays silent: ${lines.join(' | ')}`);
+});
+
 test('stripUnitTokens: hash-unit markers, trailing bare units, and state/ZIP tails', () => {
   const normalizer = createOsmNormalizer();
   // Simple hash markers keep stripping

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -6359,11 +6359,16 @@ class SharedCore {
                 } else if (!proposalGrade) {
                     // A pin resolved (or a candidate was rejected by enforce) but
                     // it is not proposal-grade — never propose it, never touch the
-                    // stored pin.
+                    // stored pin. An exact-grade candidate that ended UNPINNED
+                    // with a 'skipped' breadcrumb was rejected because the
+                    // reverse cross-check could not run (Apple rate-limited/
+                    // down) — surface the recover hint, not a grade complaint.
                     finding.status = 'unverified';
                     const reason = fresh.crossCheck === 'fail'
                         ? 'address geocode failed the reverse cross-check'
-                        : 'address only resolves to a street-grade pin';
+                        : (!freshLocation && fresh.grade === 'exact')
+                            ? 'reverse cross-check unavailable — re-run when Apple geocoding recovers'
+                            : 'address only resolves to a street-grade pin';
                     finding.detail = hasPin
                         ? `${reason} — stored pin kept, verify manually`
                         : `${reason} — not proposing it`;

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4341,3 +4341,27 @@ test('review: cross-check policy — replacing a stored pin needs a PASSED cross
   assert.equal(passFindings[0].status, 'pin-moved');
   assert.equal(passFindings[0].proposed.location, '32.810535, -96.8110709');
 });
+
+test('review: on a platform that CAN cross-check, an Apple outage rejects candidates with the recover hint', async () => {
+  const core = createCore();
+  // supportsReverseGeocode() true + no placemark = Apple rate-limited/down on
+  // the phone: enforce probes now reject the exact-grade candidate outright
+  // (skipped ≠ pass), leaving a { grade: 'exact', crossCheck: 'skipped' }
+  // breadcrumb the finding renders as "re-run when Apple geocoding recovers".
+  const adapter = buildReviewGeocodeAdapter(REVIEW_GEOCODE_RESULTS, {
+    reverseGeocodePlacemark: async () => null,
+    supportsReverseGeocode: () => true
+  });
+  const { findings } = await captureReview(core, [
+    buildReviewEvent({ id: 'moved', location: '32.8285, -96.8110709' }), // ~2 km off
+    buildReviewEvent({ id: 'missing', location: '' })
+  ], createReviewContext(core, adapter));
+  const byId = new Map(findings.map(finding => [finding.id, finding]));
+
+  for (const id of ['moved', 'missing']) {
+    assert.equal(byId.get(id).status, 'unverified', `${id} must be unverified`);
+    assert.ok(byId.get(id).detail.includes('re-run when Apple geocoding recovers'), byId.get(id).detail);
+    assert.deepEqual(byId.get(id).proposed, {}, 'no proposal may ride on an unavailable cross-check');
+  }
+  assert.equal(byId.get('moved').current.location, '32.8285, -96.8110709', 'the stored pin is untouched');
+});

--- a/tools/generate-scraper-bars.js
+++ b/tools/generate-scraper-bars.js
@@ -90,3 +90,16 @@ if (changed) {
 } else {
   console.log(`⏭️  No change for ${path.relative(ROOT, outputPath)}`);
 }
+
+// Combined pure-JSON twin of scraper-bars.js: the same object keyed by city,
+// served by the deployed site at https://chunky.dad/data/scraper-bars.json so
+// the scraper/reviewer can refresh every city's bar data with ONE fetch
+// (per-city fetching would mean ~45 requests with many 404s).
+const jsonOutputPath = path.join(ROOT, 'data', 'scraper-bars.json');
+const jsonChanged = writeIfChanged(jsonOutputPath, `${JSON.stringify(scraperBars, null, 2)}\n`);
+
+if (jsonChanged) {
+  console.log(`✓ Wrote ${path.relative(ROOT, jsonOutputPath)}`);
+} else {
+  console.log(`⏭️  No change for ${path.relative(ROOT, jsonOutputPath)}`);
+}


### PR DESCRIPTION
Re-opened replacement for #1497, which GitHub auto-closed when its stacked base (#1496) was squash-merged. Same two commits, cleanly rebased onto main — the diff is identical to what #1497 carried.

## What

Brings both reviewer protections into the SCRAPER pipeline.

### 1. Live bar data for every run (scraper + reviewer)
- `tools/generate-scraper-bars.js` now also emits **`data/scraper-bars.json`** (combined, pure JSON, deep-equals the module export; generated + committed, so merging publishes it at chunky.dad/data/scraper-bars.json).
- `refreshRemoteBars` tries the combined file FIRST (one fetch, 1-day cache TTL) — per-city files are the fallback, local file last. New `cityKeys === null` semantics = "all cities", which is what the scraper needs since city assignment happens during normalization.
- The scraper orchestrator refreshes bars on `finalAdapter` (the instance carrying the real pageCache config, so the 1-day TTL actually applies) and hands the merged result to the core before `processEvents`. Fail-soft: any error keeps local bars; adapters without the method are tolerated; scraping never depends on chunky.dad being up.

### 2. Fail-closed geocoding in ENFORCE mode (report mode byte-identical for street-specific inputs)
- **Vague-input rule**: an address without street-level detail ("Poconos, PA") refuses ALL geocoder candidates in enforce — left unpinned, flagged once per event. Report mode accepts as today but now flags `pin from vague address — verify pin`. Curated venues unaffected (BarDataNormalizer runs before geocoding).
- **Skipped ≠ pass rule**: new adapter self-description `supportsReverseGeocode()` (scriptable: Location availability; web: false). In enforce, when the platform CAN cross-check but no comparison ran (Apple rate-limited/down — exactly what disarmed the 2026-07-16 run), the candidate is rejected and flagged once. Structural absence (Node) accepts as before.
- `confirmGeocodeCandidate` rejections return truthful breadcrumbs (`{location: null, crossCheck: 'fail'|'skipped'}`), and the reviewer renders unavailable-cross-check rejections as "re-run when Apple geocoding recovers".

## Tests
428 → 441, quiet runner, all green post-rebase. `node --check` clean; zero `new URL(` additions; existing log shapes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP