### PR TITLE
fix(merge): a street address is never a venue name — deterministic bar rules

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -2736,8 +2736,18 @@ class AiWebParser {
         const end = this.parseJsonLdDateValue(node.endDate);
 
         const place = this.pickJsonLdPlace(node.location);
-        const bar = place ? clean(place.name) : '';
         const address = place ? this.formatJsonLdAddress(place.address, clean) : '';
+        let bar = place ? clean(place.name) : '';
+        // Ticketing JSON-LD sometimes fills the venue NAME with the street
+        // address (observed 2026-07-17: Eventbrite location.name was "10-90
+        // Wyckoff Ave" for an event at HOLO) — an address-shaped bar then
+        // fights the calendar's curated venue name in merge. Drop it: an
+        // absent bar is a gap that bar-data normalization or the calendar
+        // fills, never a conflict. The address field is unaffected.
+        if (bar && this.venueNameLooksLikeStreetAddress(bar, address)) {
+            console.log(`🤖 AI Web: JSON-LD venue name "${bar}" looks like a street address — not using it as bar`);
+            bar = '';
+        }
 
         const offer = Array.isArray(node.offers) ? node.offers[0] : node.offers;
         const offerUrl = offer && typeof offer === 'object' ? this.normalizeHttpUrlValue(offer.url) : '';
@@ -2862,6 +2872,35 @@ class AiWebParser {
         const needle = tokenize(part);
         if (!needle) return false;
         return ` ${tokenize(builtSoFar)} `.includes(` ${needle} `);
+    }
+
+    // True when a JSON-LD venue NAME is really a street address: either shaped
+    // like one (shared-core's looksLikeStreetAddress heuristic), or a
+    // normalized duplicate of the address's street line — lowercase,
+    // punctuation collapsed to token boundaries, common street-type
+    // abbreviations expanded so "10-90 Wyckoff Ave" duplicates the street line
+    // of "10-90 Wyckoff Avenue, Queens, NY 11385".
+    venueNameLooksLikeStreetAddress(name, address) {
+        if (this.core && typeof this.core.looksLikeStreetAddress === 'function'
+            && this.core.looksLikeStreetAddress(name)) {
+            return true;
+        }
+        const streetLine = String(address || '').split(',')[0];
+        const expandAbbreviation = {
+            st: 'street', ave: 'avenue', blvd: 'boulevard', rd: 'road',
+            dr: 'drive', ln: 'lane', pl: 'place', ct: 'court',
+            pkwy: 'parkway', hwy: 'highway', mt: 'mount'
+        };
+        const normalizeStreetText = (value) => String(value || '')
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, ' ')
+            .trim()
+            .split(' ')
+            .filter(Boolean)
+            .map(token => expandAbbreviation[token] || token)
+            .join(' ');
+        const normalizedName = normalizeStreetText(name);
+        return normalizedName.length > 0 && normalizedName === normalizeStreetText(streetLine);
     }
 
     pickJsonLdImage(image) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -934,6 +934,49 @@ test('buildEventFromJsonLdNode resolves city and timezone from the address', () 
   assert.equal(bare[0].city, undefined);
 });
 
+test('buildEventFromJsonLdNode never uses an address-shaped venue name as the bar', () => {
+  const parser = createParser();
+  const buildNode = (venueName, streetAddress = '10-90 Wyckoff Avenue, Queens, NY 11385') => ({
+    '@type': 'MusicEvent',
+    name: 'MEGAWOOF & BEARMILK present MEGAMILK',
+    startDate: '2026-07-18T22:00:00-04:00',
+    location: {
+      '@type': 'Place',
+      name: venueName,
+      address: { '@type': 'PostalAddress', streetAddress }
+    }
+  });
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let addressShaped;
+  let streetLineTwin;
+  let realVenue;
+  try {
+    // Observed 2026-07-17: Eventbrite filled location.name with the street address
+    addressShaped = parser.buildEventFromJsonLdNode(buildNode('10-90 Wyckoff Ave'), 'https://tickets.example/e/megamilk');
+    // Not address-shaped (no street-type word), but a normalized duplicate of
+    // the address's street line — still never a venue name
+    streetLineTwin = parser.buildEventFromJsonLdNode(buildNode('10-90 Wyckoff', '10-90 Wyckoff, Queens, NY'), 'https://tickets.example/e/megamilk');
+    // A real venue name is emitted exactly as today
+    realVenue = parser.buildEventFromJsonLdNode(buildNode('HOLO'), 'https://tickets.example/e/megamilk');
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(addressShaped.bar, '', 'the address-shaped venue name must not become the bar');
+  assert.equal(addressShaped.address, '10-90 Wyckoff Avenue, Queens, NY 11385', 'the address field is unaffected');
+  assert.ok(logLines.includes(
+    '🤖 AI Web: JSON-LD venue name "10-90 Wyckoff Ave" looks like a street address — not using it as bar'
+  ), `drop log line expected, got: ${JSON.stringify(logLines)}`);
+
+  assert.equal(streetLineTwin.bar, '', 'a street-line duplicate must not become the bar');
+
+  assert.equal(realVenue.bar, 'HOLO');
+  assert.ok(!logLines.some(line => line.includes('"HOLO"')), 'a real venue name is never logged as dropped');
+});
+
 test('getAiConfig delegates to SharedCore.resolveAiConfig', () => {
   const parser = createParser();
   const viaParser = parser.getAiConfig({ ai: { provider: 'ollama', numPredict: 1234 } });

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -557,11 +557,33 @@ class SharedCore {
         return candidates.has(normalizedTitle);
     }
 
+    // A value shaped like a street address is NEVER a venue name. Anchored on
+    // a leading house number (incl. hyphenated Queens style "10-90") with a
+    // street-type word appearing somewhere after it. The leading-number anchor
+    // is what keeps real venue names out: "9th Avenue Saloon" (ordinal, not a
+    // house number), "3 Dollar Bill" (number but no street word), "Rockbar" /
+    // "Eagle NYC" / "The Rail" (no leading number) all classify as NOT
+    // address-shaped.
+    looksLikeStreetAddress(value) {
+        if (typeof value !== 'string') return false;
+        const text = value.trim();
+        // Leading house number: digits (optionally hyphenated) followed by
+        // whitespace — "9th" never anchors because the digits run straight
+        // into the ordinal suffix instead of a space.
+        const houseNumber = text.match(/^\d{1,6}(?:-\d{1,6})?\s+/);
+        if (!houseNumber) return false;
+        // A street-type word after the house number ("Wyckoff Ave", "MT NEBO
+        // RD"): whole word, optional trailing period, case-insensitive.
+        const afterNumber = text.slice(houseNumber[0].length);
+        return /(?:^|[\s,])(?:St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Ln|Lane|Way|Pl|Place|Ct|Court|Pkwy|Hwy)\.?(?:$|[\s,])/i.test(afterNumber);
+    }
+
     // Deterministic conflict resolution consulted by BOTH merge paths
     // (createFinalEventObject and mergeParsedEvents) before a field is queued
     // for AI arbitration. Returns { winner: 'a'|'b', reason } or null (→
     // arbitrate as usual). Callers map a/b onto their own labels and thread
-    // event context (currently { cityKey }) for the city-aware title rule.
+    // event context (currently { cityKey }) for the city-aware title and
+    // curated-bar rules.
     resolveConflictDeterministically(fieldName, valueA, valueB, context = null) {
         const urlA = this.getUrlRuleParts(valueA);
         const urlB = this.getUrlRuleParts(valueB);
@@ -625,6 +647,48 @@ class SharedCore {
                 }
             }
         }
+        // A street address is never a venue name: Eventbrite JSON-LD shipped
+        // location.name as the street line ("10-90 Wyckoff Ave") and AI
+        // arbitration picked it over the calendar's real venue ("HOLO") with
+        // exactly backwards reasoning (observed 2026-07-17). Decidable
+        // deterministically, in order: 1) exactly one side matching a curated
+        // bar name for the event's city wins; 2) exactly one address-shaped
+        // side LOSES. Both sides curated, both address-shaped, or neither rule
+        // applying still arbitrate (with a prompt rule as backstop).
+        if (fieldName === 'bar') {
+            const barCityKey = context && context.cityKey ? String(context.cityKey) : '';
+            const cityBars = barCityKey && this.bars
+                ? (this.bars[barCityKey] || this.bars[barCityKey.trim().toLowerCase()])
+                : null;
+            if (Array.isArray(cityBars) && cityBars.length > 0) {
+                // Same normalization BarDataNormalizer matches with (lowercase,
+                // strip non-alphanumerics) so curated matching agrees everywhere.
+                const normalizeBarName = value => String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+                const findCuratedBar = value => {
+                    const normalized = normalizeBarName(value);
+                    if (!normalized) return null;
+                    return cityBars.find(bar => bar && typeof bar.name === 'string'
+                        && normalizeBarName(bar.name) === normalized) || null;
+                };
+                const curatedA = findCuratedBar(valueA);
+                const curatedB = findCuratedBar(valueB);
+                if (Boolean(curatedA) !== Boolean(curatedB)) {
+                    const matched = curatedA || curatedB;
+                    return {
+                        winner: curatedA ? 'a' : 'b',
+                        reason: `matches curated bar data (${matched.name})`
+                    };
+                }
+            }
+            const addressShapedA = this.looksLikeStreetAddress(valueA);
+            const addressShapedB = this.looksLikeStreetAddress(valueB);
+            if (addressShapedA !== addressShapedB) {
+                return {
+                    winner: addressShapedA ? 'b' : 'a',
+                    reason: 'a street address is not a venue name'
+                };
+            }
+        }
         // Case-only variants are not a real conflict: production runs burned
         // 1.5–7s AI arbitrations on bar="NOVA PDX" vs "Nova PDX" and
         // title="TREASURE TRAIL Portland PRIDE" vs "Treasure Trail Portland
@@ -684,6 +748,7 @@ class SharedCore {
             'Rules:',
             '- You MUST copy one of the two provided values EXACTLY. Never invent, edit, merge, or reformat a value.',
             '- "bar" must be the physical venue where the event takes place — never the promoter, organizer, or brand whose name appears in page titles.',
+            '- A street address (e.g. "10-90 Wyckoff Ave") is never a venue name — for "bar", prefer a named venue over an address.',
             organizer ? `- KNOWN ORGANIZER: ${JSON.stringify(String(organizer))} — never pick a bar value equal to the organizer.` : '',
             '- For "title", prefer the actual event name — do not prefer a variant just because it appends status text (e.g. sold-out notices) or site branding.',
             '- For "title", a bare city name is not an event name — prefer the variant that names the event or its organizer.',

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1078,6 +1078,125 @@ test('guardrail: logo-path image loses to event artwork in both directions; both
   assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['image']);
 });
 
+test('looksLikeStreetAddress: leading house number + street-type word; real venue names never match', () => {
+  const core = createCore();
+  for (const positive of ['10-90 Wyckoff Ave', '1090 Wyckoff Avenue', '446 MT NEBO RD']) {
+    assert.equal(core.looksLikeStreetAddress(positive), true, `"${positive}" is address-shaped`);
+  }
+  // Pinned venue names: a number without a street word, an ordinal street word
+  // without a house number, and no-number names must all stay venue names.
+  for (const negative of ['3 Dollar Bill', '9th Avenue Saloon', 'Rockbar', 'Eagle NYC', 'The Rail', '', null]) {
+    assert.equal(core.looksLikeStreetAddress(negative), false, `"${negative}" is NOT address-shaped`);
+  }
+});
+
+test('guardrail: an address-shaped bar never beats a named venue — the MEGAMILK regression, zero AI calls', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  // Observed production shape (2026-07-17): Eventbrite JSON-LD carried the
+  // street address in the venue-name slot, and the model picked it over the
+  // calendar's real venue with exactly backwards reasoning.
+  scraped.title = 'MEGAWOOF & BEARMILK present MEGAMILK';
+  existing.title = scraped.title;
+  scraped.bar = '10-90 Wyckoff Ave';
+  existing.notes = existing.notes.replace('bar: S4', 'bar: HOLO');
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'the only conflict resolved deterministically — no AI request at all');
+  assert.equal(finalEvent.bar, 'HOLO', 'the named venue wins over the street address');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['bar']);
+  assert.deepEqual(finalEvent._original.aiArbitration.fallbacks, [], 'resolved, not a fallback');
+  const record = finalEvent._mergeDecisions.find(decision => decision.field === 'bar');
+  assert.equal(record.source, 'deterministic');
+  assert.equal(record.reason, 'a street address is not a venue name');
+  assert.ok(logLines.includes(
+    '🔒 MERGE: "MEGAWOOF & BEARMILK present MEGAMILK" field=bar resolved deterministically — a street address is not a venue name'
+  ), `stable 🔒 log line expected, got: ${JSON.stringify(logLines)}`);
+});
+
+test('guardrail: exactly one address-shaped bar loses in both directions; bar-only rule', () => {
+  const core = createCore();
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'HOLO', '10-90 Wyckoff Ave'),
+    { winner: 'a', reason: 'a street address is not a venue name' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', '10-90 Wyckoff Ave', 'HOLO'),
+    { winner: 'b', reason: 'a street address is not a venue name' });
+  assert.equal(core.resolveConflictDeterministically('bar', 'HOLO', 'The Rail'), null,
+    'two named venues still arbitrate');
+  assert.equal(core.resolveConflictDeterministically('shortName', 'HOLO', '10-90 Wyckoff Ave'), null,
+    'the address-shape rule applies to bar only');
+});
+
+test('guardrail: both bars address-shaped still reaches the AI, with the prompt backstop rule', async () => {
+  const core = createCore();
+  assert.equal(
+    core.resolveConflictDeterministically('bar', '10-90 Wyckoff Ave', '446 Mt Nebo Rd'), null,
+    'both sides address-shaped → arbitrate');
+
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.bar = '10-90 Wyckoff Ave';
+  existing.notes = existing.notes.replace('bar: S4', 'bar: 446 Mt Nebo Rd');
+  const adapter = buildArbitrationAdapter({
+    bar: { pick: 'scraped', value: '10-90 Wyckoff Ave', reason: 'matches the ticket page' }
+  });
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 1, 'both-address conflict still batches to the AI');
+  assert.equal(finalEvent.bar, '10-90 Wyckoff Ave');
+  assert.match(adapter.calls[0].prompt, /A street address \(e\.g\. "10-90 Wyckoff Ave"\) is never a venue name/,
+    'the prompt carries the defense-in-depth rule');
+});
+
+test('guardrail: a bar matching curated city bar data beats a non-matching side', async () => {
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    bars: { dallas: [{ name: 'Eagle NYC', address: '554 W 28th St' }] }
+  });
+  const context = { cityKey: 'dallas' };
+  // Normalized matching (lowercase, non-alphanumerics stripped — same as
+  // BarDataNormalizer) in both directions
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'eagle-nyc', 'Dallas Woody\'s', context),
+    { winner: 'a', reason: 'matches curated bar data (Eagle NYC)' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'Dallas Woody\'s', 'Eagle NYC', context),
+    { winner: 'b', reason: 'matches curated bar data (Eagle NYC)' });
+  // Curated match outranks the address-shape rule: the curated side wins even
+  // against a side the address heuristic would also have picked
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', '554 W 28th St', 'Eagle NYC', context),
+    { winner: 'b', reason: 'matches curated bar data (Eagle NYC)' });
+  // Both sides matching curated is no tiebreak — still arbitrates
+  assert.equal(
+    core.resolveConflictDeterministically('bar', 'Eagle NYC', 'Eagle N.Y.C.', context), null,
+    'both sides curated → arbitrate');
+  // No city context or unknown city → curated rule inert (address rule may still apply)
+  assert.equal(
+    core.resolveConflictDeterministically('bar', 'Eagle NYC', 'Dallas Woody\'s'), null);
+  assert.equal(
+    core.resolveConflictDeterministically('bar', 'Eagle NYC', 'Dallas Woody\'s', { cityKey: 'denver' }), null);
+
+  // End-to-end: the curated calendar venue survives without an AI request
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.bar = 'Woody\'s Rooftop';
+  existing.notes = existing.notes.replace('bar: S4', 'bar: Eagle NYC');
+  const adapter = buildArbitrationAdapter({});
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 0, 'curated-name rule decides the only conflict — no AI request');
+  assert.equal(finalEvent.bar, 'Eagle NYC');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['bar']);
+});
+
 test('mergeParsedEvents: same-host root-vs-deep website resolves deterministically too', async () => {
   const core = createCore();
   const priorities = { website: { priority: ['ai-web'], merge: 'ai' } };


### PR DESCRIPTION
## The bug (real phone run, 2026-07-17 13:43)

Eventbrite JSON-LD for MEGAMILK shipped the venue NAME as the street address, so the scraper emitted `bar: "10-90 Wyckoff Ave"`; merge arbitration sent "HOLO vs 10-90 Wyckoff Ave" to the AI, which picked the address with exactly backwards reasoning. The same conflict was arbitrated correctly a day earlier — the AI is a coin flip on a question that has an objectively correct answer.

## The fix — three layers

1. **Extraction** (ai-web-parser): a JSON-LD venue name that is address-shaped or a normalized duplicate of the address's street line is dropped (`🤖 AI Web: JSON-LD venue name "…" looks like a street address — not using it as bar`). Absent bar = no conflict = the calendar's curated value survives untouched.
2. **Deterministic pre-arbitration rules** in `resolveConflictDeterministically` (both merge paths, exact #1492 cover-rule pattern incl. `source:'deterministic'` records): (a) a side matching a curated bar name for the event's city wins (`🔒 … matches curated bar data (<name>)`); (b) exactly one address-shaped side loses (`🔒 … a street address is not a venue name`). Both-curated/both-address/neither → AI as before.
3. **Prompt backstop**: one added rule line — a street address is never a venue name.

`looksLikeStreetAddress`: leading bare house number (hyphenated Queens style included) + a street-type word after it. Pinned negatives: "3 Dollar Bill", "9th Avenue Saloon", "Rockbar", "Eagle NYC", "The Rail".

## Tests
441 → 447: the exact MEGAMILK regression (HOLO wins, zero AI calls), rule matrices both directions, both-address falls through to AI with the prompt line, curated-beats-address precedence, JSON-LD drop + venue-name-passthrough. Existing 🔒/🤝/🔄 log shapes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP