### PR TITLE
fix(reviewer): shouldAllowRequest UI bridge — replaces the unreliable evaluateJavaScript approach

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -3464,34 +3464,25 @@ class ScriptableAdapter {
     </div>
 
     <script>
-        // Native bridge: every action is queued and drained by the Scriptable
-        // side's evaluateJavaScript polling loop (see presentReviewResults).
-        window.__reviewQueue = [];
-        window.__reviewWaiter = null;
-        // A dead page script means dead buttons with no trace — surface any
-        // page error as a banner AND ship it to the native log via the queue.
+        // Buttons signal native via a custom-scheme navigation that the
+        // Scriptable side intercepts with shouldAllowRequest (set before
+        // present()) — the battle-tested webview→native pattern. The nonce
+        // makes each tap a distinct navigation so repeat/identical taps still
+        // fire. No evaluateJavaScript is in the critical path.
+        window.__reviewNonce = 0;
         window.onerror = function (message, source, line) {
             try {
                 var banner = document.getElementById('reviewErrorBanner');
                 if (banner) {
                     banner.style.display = 'block';
-                    banner.textContent = '⚠️ UI error: ' + message;
-                }
-                if (window.__reviewQueue) {
-                    window.__reviewQueue.push(JSON.stringify({ action: 'page-error', message: String(message) + ' (line ' + line + ')' }));
+                    banner.textContent = '⚠️ UI error: ' + message + ' (line ' + line + ')';
                 }
             } catch (ignore) {}
             return false;
         };
-        function postReviewAction(payload) {
-            var message = JSON.stringify(payload);
-            if (window.__reviewWaiter) {
-                var waiter = window.__reviewWaiter;
-                window.__reviewWaiter = null;
-                waiter(message);
-            } else {
-                window.__reviewQueue.push(message);
-            }
+        function reviewSignal(action, id) {
+            window.location.href = 'chunkyreview://act?a=' + encodeURIComponent(action) +
+                '&id=' + encodeURIComponent(id || '') + '&n=' + (window.__reviewNonce++);
         }
 
         function pendingCards(missingOnly) {
@@ -3522,7 +3513,7 @@ class ScriptableAdapter {
             if (!card) return;
             btn.disabled = true;
             btn.textContent = '⏳ Applying…';
-            postReviewAction({ action: 'apply', id: card.getAttribute('data-finding-id') });
+            reviewSignal('apply', card.getAttribute('data-finding-id'));
         }
 
         function applyBulk(mode) {
@@ -3531,7 +3522,7 @@ class ScriptableAdapter {
                 var btn = cards[i].querySelector('.apply-btn');
                 if (btn) { btn.disabled = true; btn.textContent = '⏳ Queued…'; }
             }
-            postReviewAction({ action: 'apply-bulk', mode: mode });
+            reviewSignal('apply-bulk', mode);
         }
 
         // Called from native after each applyReviewFinding completes.
@@ -3573,111 +3564,110 @@ class ScriptableAdapter {
 </html>`;
   }
 
-  // Drained by the polling loop: hands the completion callback to the page
-  // when no action is queued, so the next button tap resolves it.
-  // Synchronous drain of the page's action queue. No useCallback, no stored
-  // completion: a 2026-07-17 device run proved the callback-style bridge can
-  // die silently (taps queued in-page, loop already gone, zero applied), so
-  // the native side now POLLS with plain synchronous evals — the dumbest
-  // primitive Scriptable offers, and the only one with nothing to reject.
-  buildReviewDrainJs() {
-    return `
-      JSON.stringify(
-        window.__reviewQueue && window.__reviewQueue.length > 0
-          ? window.__reviewQueue.splice(0, window.__reviewQueue.length)
-          : []
-      );
-    `;
+  // Parse a chunkyreview:// action URL into { a, id } without `new URL` (the
+  // page sends "chunkyreview://act?a=apply&id=<finding>&n=<nonce>").
+  parseReviewActionUrl(url) {
+    const out = { a: "", id: "" };
+    const text = String(url || "");
+    const q = text.indexOf("?") >= 0 ? text.slice(text.indexOf("?") + 1) : "";
+    q.split("&").forEach((pair) => {
+      if (!pair) return;
+      const eq = pair.indexOf("=");
+      const rawKey = eq >= 0 ? pair.slice(0, eq) : pair;
+      const rawVal = eq >= 0 ? pair.slice(eq + 1) : "";
+      let key = rawKey;
+      let val = rawVal;
+      try {
+        key = decodeURIComponent(rawKey);
+        val = decodeURIComponent(rawVal);
+      } catch (error) {
+        /* keep raw */
+      }
+      out[key] = val;
+    });
+    return out;
   }
 
-  sleepForReviewPoll(delayMs) {
-    return this.sleepForReverseGeocode(delayMs);
+  async showReviewSummaryAlert(counts) {
+    try {
+      const alert = new Alert();
+      alert.title = "Calendar Reviewer";
+      const applied = `Applied ${counts.applied} fix${counts.applied === 1 ? "" : "es"}`;
+      alert.message = counts.failed
+        ? `${applied}, ${counts.failed} failed.`
+        : `${applied}.`;
+      alert.addAction("OK");
+      await alert.present();
+    } catch (error) {
+      /* summary alert is best-effort */
+    }
   }
 
-  // Interactive findings UI. Unlike the scraper's static WebView.loadHTML,
-  // this uses an instance WebView so page buttons can call back into
-  // Scriptable: page buttons push JSON action payloads onto
-  // window.__reviewQueue, and the native loop drains that queue with a
-  // synchronous evaluateJavaScript every ~400ms while the sheet is up,
-  // applies fixes natively, and pushes each result back into the page.
-  // present() resolving flips the dismissed flag and ends the loop.
+  // Interactive findings UI. Unlike the scraper's static WebView.loadHTML, this
+  // needs page buttons to trigger native calendar writes. The reliable
+  // Scriptable pattern for that is shouldAllowRequest (NOT evaluateJavaScript,
+  // which is unreliable on a presented web view — a 2026-07-17 device run
+  // proved a callback/poll bridge dies silently): the handler is assigned
+  // BEFORE present(), fires synchronously each time a button navigates to
+  // chunkyreview://…, kicks off the native apply, and returns false to cancel
+  // the navigation so the page stays put. Chip feedback via evaluateJavaScript
+  // is fire-and-forget polish; the authoritative confirmation is the summary
+  // Alert after dismissal.
   async presentReviewResults(findings, options = {}) {
     const list = Array.isArray(findings) ? findings : [];
     const html = this.generateReviewHTML(list, options);
     const webView = new WebView();
     await webView.loadHTML(html);
 
-    let dismissed = false;
-    const presented = webView.present(true).then(
-      () => {
-        dismissed = true;
-      },
-      () => {
-        dismissed = true;
-      },
-    );
-
     const appliedCounts = { applied: 0, failed: 0 };
-    let pollFailures = 0;
-    while (!dismissed) {
-      await this.sleepForReviewPoll(400);
-      if (dismissed) break;
-      let messages = [];
-      try {
-        const drained = await webView.evaluateJavaScript(
-          this.buildReviewDrainJs(),
-          false,
-        );
-        messages = typeof drained === "string" ? JSON.parse(drained) : [];
-        pollFailures = 0;
-      } catch (error) {
-        // A dismissal races the in-flight eval — that rejection is expected.
-        // Anything else must be VISIBLE: a silently dead bridge is exactly
-        // the failure mode this poll design replaces.
-        if (dismissed) break;
-        pollFailures += 1;
-        if (pollFailures === 1 || pollFailures === 10) {
-          console.warn(
-            `🔎 REVIEW: UI bridge poll failed (${error.message})${pollFailures >= 10 ? " — giving up on Apply buttons this run" : ""}`,
-          );
-        }
-        if (pollFailures >= 10) break;
-        continue;
+    const inFlight = [];
+
+    webView.shouldAllowRequest = (request) => {
+      const url = request && request.url ? String(request.url) : "";
+      if (url.indexOf("chunkyreview://") !== 0) {
+        return true; // normal navigation (OSM map iframes, about:blank, …)
       }
-      if (!Array.isArray(messages)) continue;
-      for (const message of messages) {
-        let payload = null;
-        try {
-          payload = JSON.parse(message);
-        } catch (error) {
-          continue;
-        }
-        if (payload && payload.action === "page-error") {
-          console.warn(
-            `🔎 REVIEW: UI page error: ${payload.message || "unknown"}`,
-          );
-          continue;
-        }
-        const targets = this.selectReviewFindingsForAction(payload, list);
-        for (const finding of targets) {
-          const result = await this.applyReviewFinding(finding);
-          finding._applied = result.success === true;
-          finding._applyFailed = result.success !== true;
-          if (result.success) {
-            appliedCounts.applied += 1;
-          } else {
-            appliedCounts.failed += 1;
-          }
-          const updateJs = `markFindingApplied(${JSON.stringify(String(finding.id))}, ${result.success === true}, ${JSON.stringify(result.message || "")})`;
-          await webView.evaluateJavaScript(updateJs, false).catch(() => {});
-        }
+      const params = this.parseReviewActionUrl(url);
+      const payload =
+        params.a === "apply-bulk"
+          ? { action: "apply-bulk", mode: params.id }
+          : { action: "apply", id: params.id };
+      const targets = this.selectReviewFindingsForAction(payload, list);
+      for (const finding of targets) {
+        inFlight.push(this.applyReviewFindingAndReport(finding, webView, appliedCounts));
       }
-    }
-    await presented;
+      return false; // cancel the fake navigation; the page stays put
+    };
+
+    await webView.present(true); // blocks until the user dismisses the sheet
+    await Promise.allSettled(inFlight);
     console.log(
       `🔎 REVIEW: UI closed — ${appliedCounts.applied} fix(es) applied, ${appliedCounts.failed} failed`,
     );
+    if (appliedCounts.applied > 0 || appliedCounts.failed > 0) {
+      await this.showReviewSummaryAlert(appliedCounts);
+    }
     return appliedCounts;
+  }
+
+  // Apply one finding natively and (best-effort) reflect the result in the page.
+  // Called fire-and-forget from shouldAllowRequest, which must return a bool
+  // synchronously — so the await lives here, not in the handler.
+  async applyReviewFindingAndReport(finding, webView, appliedCounts) {
+    const result = await this.applyReviewFinding(finding);
+    finding._applied = result.success === true;
+    finding._applyFailed = result.success !== true;
+    if (result.success) {
+      appliedCounts.applied += 1;
+    } else {
+      appliedCounts.failed += 1;
+    }
+    const updateJs = `markFindingApplied(${JSON.stringify(String(finding.id))}, ${result.success === true}, ${JSON.stringify(result.message || "")})`;
+    try {
+      await webView.evaluateJavaScript(updateJs, false);
+    } catch (error) {
+      /* chip feedback is optional; the summary Alert is authoritative */
+    }
   }
 
   // Display/Logging Adapter Implementation

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -827,7 +827,8 @@ test('generateReviewHTML renders per-calendar sections, chips, buttons, and esca
   assert.ok(html.includes('Apply all'));
   assert.ok(html.includes("applyBulk('missing-only')"));
   assert.ok(html.includes("applyBulk('all')"));
-  assert.ok(html.includes('function postReviewAction'));
+  assert.ok(html.includes('function reviewSignal'));
+  assert.ok(html.includes('chunkyreview://act'));
   assert.ok(html.includes('function markFindingApplied'));
 
   // Self-contained page: no external scripts or stylesheets
@@ -1034,11 +1035,12 @@ test('generateReviewHTML renders the bars freshness line when counts are supplie
 });
 
 // ---------------------------------------------------------------------------
-// presentReviewResults — synchronous poll-drain bridge (the callback-style
-// bridge died silently on-device 2026-07-17: taps queued in-page, zero applied)
+// presentReviewResults — shouldAllowRequest bridge (the reliable Scriptable
+// webview→native pattern; the callback/poll bridge died silently on-device
+// 2026-07-17 because evaluateJavaScript on a presented web view is unreliable)
 // ---------------------------------------------------------------------------
 
-function buildPollFinding() {
+function buildBridgeFinding() {
   return {
     id: 'f1', calendarTitle: 'chunky-dad-nyc', eventTitle: 'MEGAMILK',
     startDate: null, check: 'geocode', status: 'missing-pin',
@@ -1047,95 +1049,132 @@ function buildPollFinding() {
   };
 }
 
-test('presentReviewResults drains page actions with synchronous evals only and applies fixes', async () => {
+// A fake WebView that lets a test drive shouldAllowRequest like the device
+// does: tap → navigate to a URL → handler fires synchronously → present()
+// resolves on dismissal.
+function installFakeWebView() {
+  let handler = null;
+  let resolvePresent = null;
+  const evals = [];
+  global.WebView = class {
+    async loadHTML() {}
+    set shouldAllowRequest(fn) { handler = fn; }
+    get shouldAllowRequest() { return handler; }
+    present() { return new Promise((resolve) => { resolvePresent = resolve; }); }
+    async evaluateJavaScript(js) { evals.push(js); return undefined; }
+  };
+  return {
+    tap: (url) => handler({ url }),
+    dismiss: () => resolvePresent(),
+    evals,
+    getHandler: () => handler
+  };
+}
+
+test('parseReviewActionUrl decodes action and id without new URL', () => {
   const adapter = buildAdapter();
-  adapter.sleepForReviewPoll = () => new Promise((resolve) => setImmediate(resolve));
+  const single = adapter.parseReviewActionUrl('chunkyreview://act?a=apply&id=f%2F1&n=3');
+  assert.equal(single.a, 'apply');
+  assert.equal(single.id, 'f/1', 'percent-encoded id is decoded');
+  const bulk = adapter.parseReviewActionUrl('chunkyreview://act?a=apply-bulk&id=missing-only&n=9');
+  assert.equal(bulk.a, 'apply-bulk');
+  assert.equal(bulk.id, 'missing-only');
+});
+
+test('presentReviewResults applies via shouldAllowRequest and cancels the navigation', async () => {
+  const adapter = buildAdapter();
   let saved = 0;
   adapter.reviewEventIndex = { f1: { location: '', notes: '', save: async () => { saved += 1; } } };
+  let summaryShown = null;
+  adapter.showReviewSummaryAlert = async (counts) => { summaryShown = counts; };
 
-  const pageQueue = ['{"action":"apply","id":"f1"}'];
-  const evals = [];
-  let resolvePresent = null;
-  global.WebView = class {
-    async loadHTML() {}
-    present() { return new Promise((resolve) => { resolvePresent = resolve; }); }
-    async evaluateJavaScript(js, useCallback) {
-      evals.push({ js, useCallback });
-      if (js.includes('__reviewQueue')) {
-        return JSON.stringify(pageQueue.splice(0, pageQueue.length));
-      }
-      if (js.includes('markFindingApplied')) {
-        resolvePresent();
-      }
-      return undefined;
-    }
-  };
+  const wv = installFakeWebView();
   try {
-    const counts = await adapter.presentReviewResults([buildPollFinding()], {});
+    const done = adapter.presentReviewResults([buildBridgeFinding()], {});
+    await new Promise((r) => setImmediate(r)); // let present() wire up
+
+    // A normal navigation (OSM map iframe) is allowed through.
+    assert.equal(wv.getHandler()({ url: 'https://www.openstreetmap.org/x' }), true,
+      'non-scheme navigation is allowed');
+
+    // A button tap: handler returns false (cancels nav) and kicks off the apply.
+    assert.equal(wv.tap('chunkyreview://act?a=apply&id=f1&n=1'), false,
+      'the fake navigation is cancelled');
+    await new Promise((r) => setImmediate(r)); // let the fire-and-forget apply settle
+
+    wv.dismiss();
+    const counts = await done;
     assert.deepEqual(counts, { applied: 1, failed: 0 });
     assert.equal(saved, 1, 'the calendar event was saved');
-    assert.ok(evals.length >= 2, 'drain + markFindingApplied evals ran');
-    assert.ok(evals.every((e) => e.useCallback === false),
-      'every eval is synchronous — no stored-completion callbacks anywhere');
-    assert.ok(evals.some((e) => e.js.includes('markFindingApplied("f1", true')),
-      'the applied state was pushed back into the page');
+    assert.ok(wv.evals.some((js) => js.includes('markFindingApplied("f1", true')),
+      'chip feedback pushed to the page (best-effort)');
+    assert.deepEqual(summaryShown, { applied: 1, failed: 0 },
+      'the authoritative summary Alert is shown after dismissal');
   } finally {
     delete global.WebView;
   }
 });
 
-test('presentReviewResults surfaces page errors and gives up loudly after repeated poll failures', async () => {
+test('presentReviewResults survives evaluateJavaScript rejection — the apply still lands', async () => {
   const adapter = buildAdapter();
-  adapter.sleepForReviewPoll = () => new Promise((resolve) => setImmediate(resolve));
-  adapter.reviewEventIndex = {};
-  const warns = [];
-  const originalWarn = console.warn;
-  console.warn = (msg) => { warns.push(String(msg)); };
+  let saved = 0;
+  adapter.reviewEventIndex = { f1: { location: '', notes: '', save: async () => { saved += 1; } } };
+  adapter.showReviewSummaryAlert = async () => {};
 
-  // Page-error payloads reach the native log
+  let handler = null;
   let resolvePresent = null;
-  const pageQueue = ['{"action":"page-error","message":"boom (line 3)"}'];
   global.WebView = class {
     async loadHTML() {}
+    set shouldAllowRequest(fn) { handler = fn; }
     present() { return new Promise((resolve) => { resolvePresent = resolve; }); }
-    async evaluateJavaScript(js) {
-      if (js.includes('__reviewQueue')) {
-        const out = JSON.stringify(pageQueue.splice(0, pageQueue.length));
-        if (out === '[]') resolvePresent();
-        return out;
-      }
-      return undefined;
-    }
+    // Mirrors the device failure: evaluateJavaScript on a presented web view throws.
+    async evaluateJavaScript() { throw new Error('evaluateJavaScript unavailable'); }
   };
   try {
-    await adapter.presentReviewResults([buildPollFinding()], {});
-    assert.ok(warns.some((w) => w.includes('UI page error: boom (line 3)')),
-      'page-side errors are logged natively');
-
-    // Persistent poll failures: warned at 1 and 10, then the loop gives up
-    warns.length = 0;
-    global.WebView = class {
-      async loadHTML() {}
-      present() { return new Promise((resolve) => { resolvePresent = resolve; }); }
-      async evaluateJavaScript() { throw new Error('bridge down'); }
-    };
-    const done = adapter.presentReviewResults([buildPollFinding()], {});
-    // the loop breaks after 10 failures; the UI stays up until dismissal
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    const done = adapter.presentReviewResults([buildBridgeFinding()], {});
+    await new Promise((r) => setImmediate(r));
+    handler({ url: 'chunkyreview://act?a=apply&id=f1&n=1' });
+    await new Promise((r) => setImmediate(r));
     resolvePresent();
     const counts = await done;
-    assert.deepEqual(counts, { applied: 0, failed: 0 });
-    assert.equal(warns.filter((w) => w.includes('UI bridge poll failed')).length, 2,
-      'warned on the first and the giving-up failure, not all ten');
-    assert.ok(warns.some((w) => w.includes('giving up on Apply buttons')),
-      'the give-up is loud, not silent');
+    assert.deepEqual(counts, { applied: 1, failed: 0 },
+      'a dead chip-feedback channel never blocks the native apply');
+    assert.equal(saved, 1, 'the calendar write happened regardless');
   } finally {
-    console.warn = originalWarn;
     delete global.WebView;
   }
 });
 
-test('review page carries the error banner, onerror trap, and bar-data visibility', () => {
+test('presentReviewResults bulk apply resolves every eligible finding', async () => {
+  const adapter = buildAdapter();
+  const saves = [];
+  adapter.reviewEventIndex = {
+    m1: { location: '', notes: '', save: async () => { saves.push('m1'); } },
+    p1: { location: '1,2', notes: '', save: async () => { saves.push('p1'); } }
+  };
+  adapter.showReviewSummaryAlert = async () => {};
+  const findings = [
+    { id: 'm1', calendarTitle: 'c', eventTitle: 'M', startDate: null, check: 'geocode', status: 'missing-pin', current: { location: '', address: 'x' }, proposed: { location: '3,4' }, detail: 'd' },
+    { id: 'p1', calendarTitle: 'c', eventTitle: 'P', startDate: null, check: 'geocode', status: 'pin-moved', current: { location: '1,2', address: 'y' }, proposed: { location: '5,6' }, detail: 'd' }
+  ];
+
+  const wv = installFakeWebView();
+  try {
+    const done = adapter.presentReviewResults(findings, {});
+    await new Promise((r) => setImmediate(r));
+    // "missing only" applies just the missing-pin finding.
+    wv.tap('chunkyreview://act?a=apply-bulk&id=missing-only&n=1');
+    await new Promise((r) => setImmediate(r));
+    wv.dismiss();
+    const counts = await done;
+    assert.deepEqual(saves, ['m1'], 'only the missing-pin finding was applied');
+    assert.deepEqual(counts, { applied: 1, failed: 0 });
+  } finally {
+    delete global.WebView;
+  }
+});
+
+test('review page uses the chunkyreview scheme, error banner, and bar-data visibility', () => {
   const adapter = buildAdapter();
   const barFinding = {
     id: 'b1', calendarTitle: 'chunky-dad-poconos', eventTitle: 'FURBALL CAMP',
@@ -1144,6 +1183,9 @@ test('review page carries the error banner, onerror trap, and bar-data visibilit
     proposed: {}, detail: 'matches curated bar data (Camp Out)'
   };
   const html = adapter.generateReviewHTML([barFinding], { barsFreshness: { remote: 12, local: 0, unavailable: 10 } });
+  assert.ok(html.includes('chunkyreview://act'), 'buttons signal via the custom scheme');
+  assert.ok(!html.includes('__reviewQueue') && !html.includes('postReviewAction'),
+    'no leftover poll/callback bridge plumbing in the page');
   assert.ok(html.includes('reviewErrorBanner'), 'error banner div present');
   assert.ok(html.includes('window.onerror'), 'page error trap installed');
   assert.ok(html.includes('1 event verified against curated bar data'), 'bar-data count in header');


### PR DESCRIPTION
Follow-up that **replaces the just-merged #1500 poll bridge**. #1500's poll loop still called `evaluateJavaScript` on a presented WebView — the same unreliable API that caused the original dead buttons. This swaps it for the correct pattern.

## Root cause (researched)

`await webView.present()` blocks until dismissal, and `evaluateJavaScript` against a *presented* WebView is unreliable on-device (can reject outright). Every reliable interaction elsewhere in this app displays in a static WebView, then acts via native Alert/UITable — the reviewer was the lone exception.

## The fix: `shouldAllowRequest`

- Assigned **before** `present()`; fires **synchronously** when a button navigates to `chunkyreview://act?a=…&id=…&n=<nonce>`; performs the native calendar write; returns **false** to cancel the navigation. No polling, no callback lifecycle, nothing to reject.
- `evaluateJavaScript` gone from the critical path (optional fire-and-forget chip feedback only — a test proves the apply still lands when it throws).
- Optimistic in-page ⏳ feedback on tap; authoritative native summary Alert after dismissal.
- OSM map iframes / about:blank pass through.

## Also
Bar-data visibility (`source:'bar-data'` → header count + ✅ notes) and a page-error red banner.

## Verification
jsdom end-to-end (tap → optimistic ⏳ → `chunkyreview://` with incrementing nonce → native confirm → ✅ → footer recount); native fake-WebView tests driving `shouldAllowRequest` (apply/cancel/save/summary-Alert, **survives evaluateJavaScript rejection**, bulk missing-only, URL parsing without `new URL`). 452 tests green; `node --check` clean; zero `new URL(`; existing log shapes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP