### PR TITLE
feat(scraper): persist pin/address provenance (pinSource/addressSource)

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2940,12 +2940,27 @@ class ScriptableAdapter {
           ? finding.proposed
           : {};
       const appliedFields = [];
+      // Provenance for applied fixes: the reviewer knows each finding's origin
+      // (finding.source === 'bar-data' → curated; otherwise the geocode verdict
+      // for a pin, or a reverse-geocoded address). Stamp the source ONLY for a
+      // field this finding actually wrote.
+      const isBarData = finding && finding.source === "bar-data";
       if (
         typeof proposed.location === "string" &&
         proposed.location.trim().length > 0
       ) {
         target.location = proposed.location.trim();
         appliedFields.push("location");
+        const pinSource = isBarData
+          ? "curated"
+          : finding && finding.grade === "exact" && finding.crossCheck !== "fail"
+            ? "geocoded-exact"
+            : "geocoded-approx";
+        target.notes = this.upsertNotesField(
+          target.notes || "",
+          "pinSource",
+          pinSource,
+        );
       }
       if (
         typeof proposed.address === "string" &&
@@ -2955,6 +2970,12 @@ class ScriptableAdapter {
           target.notes || "",
           "address",
           proposed.address.trim(),
+        );
+        // Curated bar address vs a reverse-geocoded (inferred) one.
+        target.notes = this.upsertNotesField(
+          target.notes || "",
+          "addressSource",
+          isBarData ? "curated" : "inferred",
         );
         appliedFields.push("address");
       }

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -705,17 +705,23 @@ test('applyReviewFinding mutates only the proposed fields on the stubbed Calenda
   assert.equal(pinResult.success, true);
   assert.deepEqual(pinResult.appliedFields, ['location']);
   assert.equal(stubEvent.location, '32.810535, -96.8110709');
-  assert.equal(stubEvent.notes, originalNotes, 'notes untouched by a location-only fix');
+  // A location fix now also stamps pin provenance in notes. This finding carries
+  // no source/grade, so it defaults to geocoded-approx; only the pinSource line
+  // is added — the rest of the notes are untouched.
+  assert.equal(stubEvent.notes,
+    originalNotes + '\npinSource: geocoded-approx',
+    'location fix stamps pinSource but leaves other notes untouched');
   assert.equal(stubEvent.title, 'FURBALL');
   assert.equal(saves, 1);
 
-  // Address proposal: only the address line inside notes is rewritten
+  // Address proposal: the address line inside notes is rewritten and the
+  // reverse-geocoded address is labeled inferred (non-bar-data finding).
   await adapter.applyReviewFinding({
     id: 'evt-1', eventTitle: 'FURBALL', calendarTitle: 'chunky-dad-dallas',
     proposed: { address: '3911 Cedar Springs Rd, Dallas, TX 75219' }
   });
   assert.equal(stubEvent.notes,
-    'bar: STATION 4\naddress: 3911 Cedar Springs Rd, Dallas, TX 75219\nwebsite: https://x.example');
+    'bar: STATION 4\naddress: 3911 Cedar Springs Rd, Dallas, TX 75219\nwebsite: https://x.example\npinSource: geocoded-approx\naddressSource: inferred');
   assert.equal(stubEvent.location, '32.810535, -96.8110709', 'location untouched by an address-only fix');
   assert.equal(saves, 2);
 
@@ -725,7 +731,7 @@ test('applyReviewFinding mutates only the proposed fields on the stubbed Calenda
     id: 'evt-1', eventTitle: 'FURBALL', calendarTitle: 'chunky-dad-dallas',
     proposed: { address: '5025 Bowser Ave, Dallas' }
   });
-  assert.equal(stubEvent.notes, 'Doors at 9pm, no cover\nbar: STATION 4\naddress: 5025 Bowser Ave, Dallas');
+  assert.equal(stubEvent.notes, 'Doors at 9pm, no cover\nbar: STATION 4\naddress: 5025 Bowser Ave, Dallas\naddressSource: inferred');
 
   // Unknown finding id or an empty proposal never saves
   const missing = await adapter.applyReviewFinding({ id: 'nope', proposed: { location: '1, 2' } });
@@ -733,6 +739,43 @@ test('applyReviewFinding mutates only the proposed fields on the stubbed Calenda
   const empty = await adapter.applyReviewFinding({ id: 'evt-1', proposed: {} });
   assert.equal(empty.success, false);
   assert.equal(saves, 3);
+});
+
+test('applyReviewFinding stamps provenance by finding origin (bar-data curated, geocode graded, reverse inferred)', async () => {
+  const adapter = buildAdapter();
+
+  // Bar-data finding applying pin + address → both are curated.
+  const barEvent = {
+    title: 'MEGAWOOF', location: '', notes: 'bar: EAGLE',
+    save: async () => {}
+  };
+  adapter.reviewEventIndex = { 'bar-1': barEvent };
+  await adapter.applyReviewFinding({
+    id: 'bar-1', eventTitle: 'MEGAWOOF', calendarTitle: 'chunky-dad-la',
+    source: 'bar-data',
+    proposed: { location: '34.05, -118.24', address: '4219 Santa Monica Blvd, Los Angeles' }
+  });
+  assert.ok(barEvent.notes.includes('pinSource: curated'), 'bar-data pin is curated');
+  assert.ok(barEvent.notes.includes('addressSource: curated'), 'bar-data address is curated');
+
+  // Geocode finding carrying an exact + passing verdict → geocoded-exact.
+  const exactEvent = { title: 'FUR', location: '', notes: 'bar: X', save: async () => {} };
+  adapter.reviewEventIndex = { 'geo-1': exactEvent };
+  await adapter.applyReviewFinding({
+    id: 'geo-1', eventTitle: 'FUR', calendarTitle: 'chunky-dad-nyc',
+    grade: 'exact', crossCheck: 'pass',
+    proposed: { location: '40.71, -73.99' }
+  });
+  assert.ok(exactEvent.notes.includes('pinSource: geocoded-exact'), 'exact+pass verdict → geocoded-exact');
+
+  // Reverse-geocoded address (no bar-data source) → addressSource inferred.
+  const reverseEvent = { title: 'PIN', location: '47.6, -122.3', notes: '', save: async () => {} };
+  adapter.reviewEventIndex = { 'rev-1': reverseEvent };
+  await adapter.applyReviewFinding({
+    id: 'rev-1', eventTitle: 'PIN', calendarTitle: 'chunky-dad-seattle',
+    proposed: { address: '1600 Broadway, Seattle' }
+  });
+  assert.ok(reverseEvent.notes.includes('addressSource: inferred'), 'reverse-geocoded address is inferred');
 });
 
 function buildReviewFindingsFixture() {

--- a/scripts/event-schema.test.js
+++ b/scripts/event-schema.test.js
@@ -26,6 +26,28 @@ test('notes round-trip: colons, backslashes, and newlines in values survive exac
   assert.equal(parsed.title, undefined, 'excluded fields never enter the notes');
 });
 
+test('notes round-trip: pinSource/addressSource persist while underscore _geocode* fields are excluded', () => {
+  const event = {
+    bar: 'The Eagle',
+    address: '554 W 28th St, New York, NY 10001',
+    pinSource: 'geocoded-exact',
+    addressSource: 'page',
+    // Underscore-prefixed geocode verdict fields must never enter the notes.
+    _geocodeGrade: 'exact',
+    _geocodeCrossCheck: 'pass',
+    _geocodeSource: 'nominatim'
+  };
+
+  const notes = EventSchema.formatEventNotes(event);
+  const parsed = EventSchema.parseNotesIntoFields(notes);
+
+  assert.equal(parsed.pinSource, 'geocoded-exact', 'pinSource round-trips through notes');
+  assert.equal(parsed.addressSource, 'page', 'addressSource round-trips through notes');
+  assert.ok(!/_geocode/.test(notes), 'underscore geocode fields are excluded from notes');
+  assert.equal(parsed._geocodeGrade, undefined);
+  assert.equal(parsed._geocodeCrossCheck, undefined);
+});
+
 test('notes round-trip: URL-like values keep their unescaped colons', () => {
   const event = {
     ticketUrl: 'https://tickets.example/e/furball?time=21:00',

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -86,12 +86,46 @@ class BaseNormalizer {
 
 class BasicDataNormalizer extends BaseNormalizer {
     normalize(event) {
+        // Stamp page-provenance defaults BEFORE any bar match or geocoding runs
+        // (BasicDataNormalizer is first in the pipeline, ahead of BarData and
+        // OSM in both the sync and async paths). Coordinates/address that
+        // arrived on the event from the parser (JSON-LD/page text) are
+        // provenance 'page'; the later writers OVERWRITE the source only when
+        // THEY set/replace the value (bar→curated, geocode→geocoded-*,
+        // reverse→inferred). Pure and idempotent — only stamps an unset source
+        // when the corresponding value is present.
+        event = this.stampPageProvenanceDefaults(event);
+
         if (!this.core) return event;
         // Sync URL and website fields
         event = this.syncUrlAndWebsiteFields(event);
 
         // Normalize basic text fields
         return this.core.normalizeEventTextFields(event);
+    }
+
+    // Coordinate-pair check kept local so this normalizer stays platform-pure
+    // (mirrors SharedCore.isCoordinatePair: two finite floats, lat within ±90,
+    // lng within ±180).
+    isCoordinatePairString(value) {
+        if (typeof value !== 'string') return false;
+        const match = value.trim().match(/^(-?\d{1,3}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)$/);
+        if (!match) return false;
+        const lat = Number(match[1]);
+        const lng = Number(match[2]);
+        return Number.isFinite(lat) && Number.isFinite(lng)
+            && Math.abs(lat) <= 90 && Math.abs(lng) <= 180;
+    }
+
+    stampPageProvenanceDefaults(event) {
+        if (!event || typeof event !== 'object') return event;
+        if (!event.pinSource && this.isCoordinatePairString(event.location)) {
+            event.pinSource = 'page';
+        }
+        if (!event.addressSource && typeof event.address === 'string' && event.address.trim().length > 0) {
+            event.addressSource = 'page';
+        }
+        return event;
     }
 
     syncUrlAndWebsiteFields(event) {
@@ -251,6 +285,7 @@ class BarDataNormalizer extends BaseNormalizer {
             if (matchedBar.address) {
                 if (!event.address || event.address.length < matchedBar.address.length) {
                     event.address = matchedBar.address;
+                    event.addressSource = 'curated';
                     modified = true;
                 }
             }
@@ -258,6 +293,7 @@ class BarDataNormalizer extends BaseNormalizer {
             // Prefer the bar's coordinates if missing in event
             if (matchedBar.coordinates && !event.location) {
                 event.location = matchedBar.coordinates;
+                event.pinSource = 'curated';
                 modified = true;
             }
 
@@ -1571,6 +1607,15 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 event._geocodeSource = verdict.source;
                 event._geocodeRung = verdict.rung;
             }
+            if (resolvedLocation) {
+                // Provenance for the forward-geocoded pin: an exact grade whose
+                // reverse cross-check did not fail is our best pin
+                // (geocoded-exact). Everything else — street/photon/census-grade
+                // or a failed cross-check — is only approximate (geocoded-approx).
+                event.pinSource = (resolvedVerdict && resolvedVerdict.grade === 'exact' && resolvedVerdict.crossCheck !== 'fail')
+                    ? 'geocoded-exact'
+                    : 'geocoded-approx';
+            }
             if (!resolvedLocation) {
                 // Exact shape counted by run-log-summary's geocodeNoResults guard.
                 console.warn(`🗺️ OpenStreetMapNormalizer: No geocode results for "${address}" (${eventCity || 'no city'}) after ${attempts} ${attempts === 1 ? 'query' : 'queries'} — leaving location empty`);
@@ -1598,6 +1643,8 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                     }
                     if (typeof nativeAddress === 'string' && nativeAddress.trim().length > 0) {
                         event.address = nativeAddress.trim();
+                        // Reverse-geocoded from the pin — the address is inferred.
+                        event.addressSource = 'inferred';
                         modified = true;
                         console.log(`🗺️ OpenStreetMapNormalizer: Found address for coordinates "${event.location}" -> ${event.address} (native reverse geocode)`);
                     } else {
@@ -1606,6 +1653,8 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                             const data = await this.fetchDataWithCacheAndRateLimit(url, options, httpAdapter);
                             if (data && data.display_name) {
                                 event.address = data.display_name;
+                                // Reverse-geocoded from the pin — the address is inferred.
+                                event.addressSource = 'inferred';
                                 modified = true;
                                 console.log(`🗺️ OpenStreetMapNormalizer: Found address for coordinates "${event.location}" -> ${event.address}`);
                             }

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { LocationNormalizer, OpenStreetMapNormalizer } = require('./normalizers');
+const { LocationNormalizer, OpenStreetMapNormalizer, BasicDataNormalizer, BarDataNormalizer } = require('./normalizers');
 const { SharedCore } = require('./shared-core');
 const { EventSchema } = require('./event-schema');
 
@@ -1383,4 +1383,145 @@ test('resolveWallClockDates ignores events without the wall-clock flag', () => {
 
   assert.equal(event.startDate.toISOString(), '2026-07-18T02:00:00.000Z');
   assert.equal(event.timezone, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Geo-provenance: pinSource / addressSource stamping across the normalizers
+// (page → curated → geocoded-* → inferred).
+// ---------------------------------------------------------------------------
+
+function createBasicNormalizer() {
+  const core = new SharedCore(CITIES, { eventSchema: EventSchema });
+  return new BasicDataNormalizer(core);
+}
+
+test('BasicDataNormalizer stamps page provenance for coordinates and address that arrived from the parser', () => {
+  const normalizer = createBasicNormalizer();
+  const event = { title: 'PAGE PIN', city: 'nyc', location: '40.7128, -74.006', address: '123 W 4th St' };
+
+  normalizer.normalize(event);
+
+  assert.equal(event.pinSource, 'page', 'a coordinate pair on the event → pinSource page');
+  assert.equal(event.addressSource, 'page', 'a non-empty address on the event → addressSource page');
+});
+
+test('BasicDataNormalizer leaves sources absent when the corresponding value is absent', () => {
+  const normalizer = createBasicNormalizer();
+  const noPin = { title: 'NO PIN', city: 'nyc', address: '123 W 4th St' };
+  normalizer.normalize(noPin);
+  assert.equal(noPin.pinSource, undefined, 'no coordinates → no pinSource');
+  assert.equal(noPin.addressSource, 'page');
+
+  const noAddress = { title: 'NO ADDR', city: 'nyc', location: '40.7128, -74.006' };
+  normalizer.normalize(noAddress);
+  assert.equal(noAddress.pinSource, 'page');
+  assert.equal(noAddress.addressSource, undefined, 'no address → no addressSource');
+
+  const textLocation = { title: 'TEXT LOC', city: 'nyc', location: 'somewhere downtown' };
+  normalizer.normalize(textLocation);
+  assert.equal(textLocation.pinSource, undefined, 'a non-coordinate location is not a page pin');
+});
+
+test('BasicDataNormalizer never overwrites a source that is already set', () => {
+  const normalizer = createBasicNormalizer();
+  const event = {
+    title: 'ALREADY SOURCED', city: 'nyc', location: '40.7128, -74.006', address: '123 W 4th St',
+    pinSource: 'curated', addressSource: 'curated'
+  };
+  normalizer.normalize(event);
+  assert.equal(event.pinSource, 'curated');
+  assert.equal(event.addressSource, 'curated');
+});
+
+function createBarNormalizerWithBar() {
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    bars: {
+      nyc: [
+        {
+          name: 'The Eagle NYC',
+          address: '554 W 28th St, New York, NY 10001',
+          coordinates: '40.7506, -74.0035',
+          googleMaps: 'https://maps.example/eagle'
+        }
+      ]
+    }
+  });
+  return new BarDataNormalizer(core);
+}
+
+test('BarDataNormalizer stamps curated provenance when a bar match fills location and address', () => {
+  const normalizer = createBarNormalizerWithBar();
+  const event = { title: 'Bear Night', city: 'nyc', bar: 'The Eagle NYC' };
+
+  normalizer.normalize(event);
+
+  assert.equal(event.location, '40.7506, -74.0035');
+  assert.equal(event.pinSource, 'curated', 'bar coordinates → pinSource curated');
+  assert.equal(event.address, '554 W 28th St, New York, NY 10001');
+  assert.equal(event.addressSource, 'curated', 'bar address → addressSource curated');
+});
+
+test('BarDataNormalizer does not stamp curated for a value it did not write', () => {
+  const normalizer = createBarNormalizerWithBar();
+  // Event already has coordinates → bar coordinates are not applied, so pinSource stays as-is.
+  const event = { title: 'Bear Night', city: 'nyc', bar: 'The Eagle NYC', location: '41.0, -73.0', pinSource: 'page' };
+
+  normalizer.normalize(event);
+
+  assert.equal(event.location, '41.0, -73.0', 'existing pin is kept');
+  assert.equal(event.pinSource, 'page', 'pinSource is untouched when bar coordinates are not applied');
+  // Bar address is longer than none → address (and its source) do get written.
+  assert.equal(event.addressSource, 'curated');
+});
+
+// Nominatim result with a house number → grade 'exact'. Coordinates sit within
+// the Portland acceptance radius so distance ranking keeps it.
+const PORTLAND_EXACT_RESULT = {
+  lat: '45.5230622',
+  lon: '-122.6564816',
+  display_name: '722, East Burnside Street, Portland, Multnomah County, Oregon, 97214, United States',
+  class: 'place',
+  type: 'house',
+  address: { house_number: '722', road: 'East Burnside Street', city: 'Portland', county: 'Multnomah County', state: 'Oregon' }
+};
+
+test('OpenStreetMapNormalizer forward geocode of an exact-grade result → pinSource geocoded-exact', async () => {
+  const normalizer = createOsmNormalizerWithCoords();
+  const httpAdapter = createStubHttpAdapter([PORTLAND_EXACT_RESULT]);
+  const event = { title: 'EXACT PIN', address: '722 E Burnside', city: 'portland' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.location, '45.5230622, -122.6564816');
+  assert.equal(event.pinSource, 'geocoded-exact', 'exact grade + non-failed cross-check → geocoded-exact');
+});
+
+test('OpenStreetMapNormalizer forward geocode of a street-grade result → pinSource geocoded-approx', async () => {
+  const normalizer = createOsmNormalizerWithCoords();
+  // PORTLAND_RESULT carries no house number → street grade.
+  const httpAdapter = createStubHttpAdapter([PORTLAND_RESULT]);
+  const event = { title: 'STREET PIN', address: '722 E Burnside', city: 'portland' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.location, '45.5230622, -122.6564816');
+  assert.equal(event.pinSource, 'geocoded-approx', 'street/photon/census-grade → geocoded-approx');
+});
+
+test('OpenStreetMapNormalizer reverse geocode of a pin without an address → addressSource inferred', async () => {
+  const normalizer = createOsmNormalizer();
+  const httpAdapter = {
+    requests: [],
+    fetchData: async (url) => {
+      httpAdapter.requests.push(url);
+      return JSON.stringify({ display_name: '350 5th Ave, New York, NY 10118, USA' });
+    }
+  };
+  const event = { title: 'REVERSE ADDR', location: '40.748817, -73.985428' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(event.address, '350 5th Ave, New York, NY 10118, USA');
+  assert.equal(event.addressSource, 'inferred', 'reverse-geocoded address → addressSource inferred');
 });

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -373,8 +373,35 @@ class SharedCore {
         // bar + address), so arbitrating it independently let it disagree with
         // the merged bar/address — createFinalEventObject regenerates it from
         // the final merged values instead.
+        // pinSource/addressSource are provenance metadata that must FOLLOW the
+        // finalized location/address deterministically (see setProvenanceSource
+        // in createFinalEventObject) — never sent to the AI, so a hand-fixed
+        // pin/address is never relabeled with a source the scrape didn't produce.
         return name !== 'key' && name !== 'notes' && name !== 'source'
-            && name !== 'location' && name !== 'gmaps';
+            && name !== 'location' && name !== 'gmaps'
+            && name !== 'pinSource' && name !== 'addressSource';
+    }
+
+    // Provenance (pinSource/addressSource) follows the finalized value: whichever
+    // side's value the merge kept for `valueField`, copy that side's `sourceField`
+    // onto the merged object. A value the merge produced fresh from the scrape
+    // carries the scrape's source; a value KEPT from the calendar carries the
+    // calendar's stored source (absent → left absent, so a hand-fixed pin/address
+    // is never relabeled with a source the scrape didn't produce for it). Purely
+    // deterministic value comparison — never AI-arbitrated.
+    setProvenanceSource(mergedObject, valueField, sourceField, scraperObject, calendarObject) {
+        const finalValue = mergedObject[valueField];
+        if (finalValue === undefined || finalValue === null || finalValue === '') return;
+        const scraperMatches = this.mergeValuesEqualForTracking(finalValue, scraperObject[valueField]);
+        const calendarMatches = this.mergeValuesEqualForTracking(finalValue, calendarObject[valueField]);
+        const isUsableSource = (value) => typeof value === 'string' && value.trim().length > 0;
+        let source;
+        if (scraperMatches && isUsableSource(scraperObject[sourceField])) {
+            source = scraperObject[sourceField].trim();
+        } else if (calendarMatches && isUsableSource(calendarObject[sourceField])) {
+            source = calendarObject[sourceField].trim();
+        }
+        if (source) mergedObject[sourceField] = source;
     }
 
     // "lat, lng" / "lat,lng": two finite floats with lat in [-90, 90] and lng in
@@ -3182,6 +3209,12 @@ class SharedCore {
             // the final merged bar/address so it can never disagree with them.
             if (fieldName === 'gmaps') continue;
 
+            // pinSource/addressSource are provenance metadata that must FOLLOW
+            // the finalized location/address (set by setProvenanceSource after
+            // STEP 3c) — they never merge or arbitrate on their own, or the
+            // generic loop could clobber a kept-pin's source with a stale one.
+            if (fieldName === 'pinSource' || fieldName === 'addressSource') continue;
+
             const priorityConfig = fieldPriorities[fieldName];
             const mergeStrategy = priorityConfig?.merge || 'upsert';
             const scraperValue = scraperObject[fieldName];
@@ -3448,6 +3481,15 @@ class SharedCore {
                 }
             }
         }
+
+        // Provenance follows the finalized value (deterministic, never AI-
+        // arbitrated): now that location and address are final, stamp
+        // pinSource/addressSource to match whichever side's value won. A fresh
+        // scraped value carries the scrape's source; a kept calendar value keeps
+        // the calendar's stored source (absent → absent) so a hand-fixed pin or
+        // address is never mislabeled with a source the scrape didn't produce.
+        this.setProvenanceSource(mergedObject, 'location', 'pinSource', scraperObject, calendarObject);
+        this.setProvenanceSource(mergedObject, 'address', 'addressSource', scraperObject, calendarObject);
 
         // STEP 4: regenerate gmaps from the FINAL merged bar + address. gmaps
         // is a derived field — a pure function of bar + address — so merging or
@@ -6443,6 +6485,10 @@ class SharedCore {
                 } else if (!hasPin) {
                     finding.status = 'missing-pin';
                     finding.proposed.location = freshLocation;
+                    // Carry the geocode verdict so applyReviewFinding can stamp
+                    // the pin's provenance (geocoded-exact vs geocoded-approx).
+                    finding.grade = fresh.grade;
+                    finding.crossCheck = fresh.crossCheck;
                     finding.detail = location
                         ? `location "${location}" is not a coordinate pair — fresh geocode proposed`
                         : 'address geocodes but no pin is stored — fresh geocode proposed';
@@ -6459,6 +6505,10 @@ class SharedCore {
                         if (fresh.crossCheck === 'pass') {
                             finding.status = 'pin-moved';
                             finding.proposed.location = freshLocation;
+                            // Carry the geocode verdict so applyReviewFinding can
+                            // stamp the pin's provenance (geocoded-exact/approx).
+                            finding.grade = fresh.grade;
+                            finding.crossCheck = fresh.crossCheck;
                             finding.detail = `stored pin is ${distanceKm.toFixed(1)}km from the fresh verified geocode of this address`;
                         } else {
                             finding.status = 'unverified';

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -610,6 +610,83 @@ test('non-conflicts never reach the AI and keep clobber semantics', async () => 
   assert.equal(finalEvent.cover, '$10', 'one-sided fields are added via clobber semantics');
 });
 
+// ---------------------------------------------------------------------------
+// Geo-provenance merge: pinSource/addressSource follow the finalized value,
+// deterministically and never via AI (calendar-is-database, no mislabeling).
+// ---------------------------------------------------------------------------
+
+// address uses clobber so the merge stays fully deterministic (no AI) — the
+// provenance logic must never depend on arbitration.
+const PROVENANCE_PRIORITIES = { address: { merge: 'clobber' } };
+
+test('merge: a fresh scraped pin that wins carries the scrape pinSource/addressSource', async () => {
+  const core = createCore();
+  const adapter = buildArbitrationAdapter({});
+  const scraped = {
+    title: 'FURBALL', city: 'dallas', source: 'ai-web', _fieldPriorities: PROVENANCE_PRIORITIES,
+    location: '32.8105, -96.8110', address: '3911 Cedar Springs Rd, Dallas',
+    pinSource: 'geocoded-exact', addressSource: 'page'
+  };
+  const existing = {
+    title: 'FURBALL', location: '32.7000, -96.7000', url: '',
+    notes: ['address: 100 Old Rd, Dallas', 'pinSource: page', 'addressSource: page'].join('\n')
+  };
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'provenance never triggers an AI request');
+  assert.equal(finalEvent.location, '32.8105, -96.8110', 'the fresh pin wins (address changed)');
+  assert.equal(finalEvent.pinSource, 'geocoded-exact', 'pinSource follows the fresh scraped pin');
+  assert.equal(finalEvent.addressSource, 'page', 'addressSource follows the fresh scraped address');
+  const parsed = core.parseNotesIntoFields(finalEvent.notes);
+  assert.equal(parsed.pinSource, 'geocoded-exact');
+  assert.equal(parsed.addressSource, 'page');
+});
+
+test('merge: a kept calendar pin (address unchanged) keeps the calendar stored sources, never relabeled', async () => {
+  const core = createCore();
+  const adapter = buildArbitrationAdapter({});
+  // Fresh geocode DIFFERS from the stored (curated) pin; the scrape brought no
+  // address, so the calendar address is kept → address unchanged → pin kept.
+  const scraped = {
+    title: 'FURBALL', city: 'dallas', source: 'ai-web', _fieldPriorities: PROVENANCE_PRIORITIES,
+    location: '32.9999, -96.9999', pinSource: 'geocoded-approx'
+  };
+  const existing = {
+    title: 'FURBALL', location: '32.7000, -96.7000', url: '',
+    notes: ['address: 100 Old Rd, Dallas', 'pinSource: curated', 'addressSource: curated'].join('\n')
+  };
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'provenance never triggers an AI request');
+  assert.equal(finalEvent.location, '32.7000, -96.7000', 'the calendar pin is kept');
+  assert.equal(finalEvent.pinSource, 'curated', 'kept calendar pin keeps its stored pinSource, not the fresh geocode label');
+  assert.equal(finalEvent.addressSource, 'curated', 'kept calendar address keeps its stored addressSource');
+});
+
+test('merge: a kept calendar pin with NO stored source leaves the merged source absent (hand-fix not mislabeled)', async () => {
+  const core = createCore();
+  const adapter = buildArbitrationAdapter({});
+  // Hand-fixed calendar pin (no pinSource on record); the fresh geocode differs
+  // and the address is unchanged → the calendar pin is kept.
+  const scraped = {
+    title: 'FURBALL', city: 'dallas', source: 'ai-web', _fieldPriorities: PROVENANCE_PRIORITIES,
+    location: '32.9999, -96.9999', pinSource: 'geocoded-approx'
+  };
+  const existing = {
+    title: 'FURBALL', location: '32.7000, -96.7000', url: '',
+    notes: 'address: 100 Old Rd, Dallas'
+  };
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'provenance never triggers an AI request');
+  assert.equal(finalEvent.location, '32.7000, -96.7000', 'the hand-fixed calendar pin is kept');
+  assert.equal(finalEvent.pinSource, undefined, 'no fresh geocode label is stamped onto a pin we kept but did not produce');
+  assert.ok(!/pinSource/.test(finalEvent.notes), 'no pinSource line is written to the notes');
+});
+
 test('same-instant Date vs ISO string is not a conflict; differing instants are', () => {
   const core = createCore();
   assert.equal(


### PR DESCRIPTION
## What

Saves WHERE each event's coordinates and address came from, as two notes-metadata fields (calendar-is-the-database), so the website can later show an inferred/approximate marker. **Persistence only — no UI/web rendering in this PR.**

- **`pinSource`** — coordinates origin: `curated` (bar data) · `page` (coords the source published) · `geocoded-exact` (exact grade, cross-check not failed) · `geocoded-approx` (street/photon/census grade or unconfirmed cross-check)
- **`addressSource`** — address origin: `curated` · `page` · `inferred` (reverse-geocoded from coordinates)

Both optional; absent = unknown (all existing events). Cheap because the verification pipeline already computed this (the `_geocode*` verdict) and was discarding it at write time.

## How

- **Stamp at the write points** (`scripts/normalizers.js`): `BasicDataNormalizer` (pipeline index 0) stamps `page` defaults for any parser-provided coords/address before bar-match or geocoding; then `BarDataNormalizer` sets `curated` where it fills from a bar, the forward-geocode path sets `geocoded-exact`/`geocoded-approx` from the verdict, and the reverse-geocode path sets `inferred`.
- **Persist for free**: any non-underscore event field auto-serializes into notes via the existing `formatEventNotes` and reads back via `parseNotesIntoFields` — verified round-trip; underscore `_geocode*` stays excluded.
- **Merge is deterministic and safe** (`scripts/shared-core.js`): both fields are excluded from AI arbitration and skipped in the generic per-field loop; instead **provenance follows the finalized value** — whichever side's `location`/`address` the merge kept, its source is copied over. A pin/address kept from the calendar (including a hand-fixed pin) keeps the calendar's stored source (absent → absent), so a manual correction is **never relabeled** as geocoded.
- **Reviewer apply** (`scripts/adapters/scriptable-adapter.js`): stamps the correct source when it writes a proposed fix (curated / geocoded-* / inferred), only for the field it wrote.

## Tests
452 → 465 (+13): normalizer stamping for every source value + absent-when-value-absent; notes round-trip + `_geocode*` still excluded; merge cases (fresh pin wins → follows scrape; kept calendar pin → keeps calendar source; hand-fix with no stored source → stays absent; zero AI calls asserted); reviewer apply stamps curated/inferred. `node --check` clean; zero `new URL(`; existing log shapes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP