### PR TITLE
feat(scraper): accept top-level config.bearCheck as an alias for config.ai.bearCheck

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -47,7 +47,7 @@ const scraperConfig = {
       // (scraped clobbers). This global block also serves events from non-AI
       // parsers; per-parser ai.arbitrateMerges overrides. Set false to disable.
       arbitrateMerges: true,
-      bearCheck: { mode: "report" }, // Bear-check cascade: keywords → AI verdict with promoter context. "report" logs decisions without changing behavior; "enforce" flags/rescues/drops; "off" = legacy alwaysBear/keyword behavior.
+      bearCheck: { mode: "report" }, // Bear-check cascade: keywords → AI verdict with promoter context. "report" logs decisions without changing behavior; "enforce" flags/rescues/drops; "off" = legacy alwaysBear/keyword behavior. (Also accepted as a top-level config.bearCheck, like geocodeVerification; canonical location is here under ai.)
       // extraContext (override-only): free-form text appended VERBATIM to the
       // context of every AI extraction prompt. Organizer/brand context is
       // normally derived automatically from each page's own metadata (JSON-LD

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1409,11 +1409,27 @@ class SharedCore {
         const globalConfig = mainConfig && mainConfig.config && typeof mainConfig.config === 'object'
             ? mainConfig.config
             : {};
-        const globalAi = globalConfig.ai && typeof globalConfig.ai === 'object' ? globalConfig.ai : null;
         const globalOcr = globalConfig.ocr && typeof globalConfig.ocr === 'object' ? globalConfig.ocr : null;
         const globalBlockedPatterns = Array.isArray(globalConfig.discoveryBlockedPatterns) && globalConfig.discoveryBlockedPatterns.length > 0
             ? globalConfig.discoveryBlockedPatterns
             : null;
+
+        // bearCheck is read from `<parser>.ai.bearCheck`, but geocodeVerification
+        // (a sibling {mode} knob) is read from the top-level `config`, so a
+        // top-level `config.bearCheck` is an easy and reasonable mistake. Accept
+        // it as an alias for `config.ai.bearCheck`: fold it into the global ai
+        // block when the canonical nested location didn't set one. Canonical
+        // `config.ai.bearCheck` wins over the top-level alias; a per-parser
+        // `ai.bearCheck` still wins over both via the deepMergeConfig below.
+        const rawGlobalAi = globalConfig.ai && typeof globalConfig.ai === 'object' ? globalConfig.ai : null;
+        const topLevelBearCheck = globalConfig.bearCheck && typeof globalConfig.bearCheck === 'object'
+            ? globalConfig.bearCheck
+            : null;
+        let globalAi = rawGlobalAi;
+        if (topLevelBearCheck && !(rawGlobalAi && rawGlobalAi.bearCheck)) {
+            globalAi = { ...(rawGlobalAi || {}), bearCheck: topLevelBearCheck };
+        }
+
         if (!globalAi && !globalOcr && !globalBlockedPatterns) return parser;
 
         const parserAi = parser.ai && typeof parser.ai === 'object' ? parser.ai : null;

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -2161,6 +2161,42 @@ test('resolveEffectiveParserConfig without global blocks returns the parser entr
   assert.equal(core.resolveEffectiveParserConfig(parserEntry, null), parserEntry);
 });
 
+test('top-level config.bearCheck is an alias for config.ai.bearCheck and reaches getBearCheckMode', () => {
+  const core = createCore();
+
+  // Top-level alias with NO global ai block at all (the real-world case):
+  // it must still fold into the parser's ai.bearCheck and drive enforce mode.
+  const aliasOnly = core.resolveEffectiveParserConfig(
+    { name: 'Bearracuda', alwaysBear: false },
+    { config: { bearCheck: { mode: 'enforce' } } }
+  );
+  assert.deepEqual(aliasOnly.ai.bearCheck, { mode: 'enforce' });
+  assert.equal(core.getBearCheckMode(aliasOnly), 'enforce');
+
+  // Canonical config.ai.bearCheck wins when BOTH are set.
+  const both = core.resolveEffectiveParserConfig(
+    { name: 'B' },
+    { config: { bearCheck: { mode: 'enforce' }, ai: { bearCheck: { mode: 'off' }, model: 'm' } } }
+  );
+  assert.equal(core.getBearCheckMode(both), 'off');
+  assert.equal(both.ai.model, 'm', 'the rest of the global ai block still inherits');
+
+  // A per-parser ai.bearCheck still wins over the top-level alias.
+  const perParser = core.resolveEffectiveParserConfig(
+    { name: 'B', ai: { bearCheck: { mode: 'report' } } },
+    { config: { bearCheck: { mode: 'enforce' } } }
+  );
+  assert.equal(core.getBearCheckMode(perParser), 'report');
+
+  // The alias folds into an existing global ai block that lacks bearCheck.
+  const intoExistingAi = core.resolveEffectiveParserConfig(
+    { name: 'B' },
+    { config: { bearCheck: { mode: 'enforce' }, ai: { model: 'global-m' } } }
+  );
+  assert.equal(core.getBearCheckMode(intoExistingAi), 'enforce');
+  assert.equal(intoExistingAi.ai.model, 'global-m');
+});
+
 test('resolveEffectiveParserConfig unions global discoveryBlockedPatterns with the parser list', () => {
   const core = createCore();
   const globalPattern = /\/(shop|cart)(?:\/|[?#]|$)/;


### PR DESCRIPTION
## Why

The bear-check mode is read from `<parser>.ai.bearCheck` (inherited from the global `config.ai` block). But `geocodeVerification` — a sibling `{ mode }` knob — is read from the **top-level** `config`. So setting `config.bearCheck: { mode: "enforce" }` at the top level (the natural thing to do after `geocodeVerification`) silently does nothing, and the run stays on the default `report` — exactly the trap a real config hit this week (Bearracuda events kept getting dropped by the legacy keyword filter because enforce never took effect).

## What

`resolveEffectiveParserConfig` now folds a top-level `config.bearCheck` into the global `ai` block as an alias:
- Works even when there is **no** global `ai` block at all (synthesizes one carrying just `bearCheck`).
- Canonical `config.ai.bearCheck` **wins** when both are set.
- A per-parser `ai.bearCheck` still **wins over both** (unchanged precedence via the existing `deepMergeConfig`).
- Everything else about ai/ocr/blocked-pattern inheritance is untouched.

Template comment updated to note both placements work (canonical stays under `ai`).

## Tests
452 → 453: alias-only (no global ai block) reaches `getBearCheckMode` as enforce; canonical-wins-when-both; per-parser-wins-over-alias; alias folds into an existing global ai block without clobbering it. `node --check` clean; existing inheritance tests unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP