### PR TITLE
fix(scraper): iOS-safe image-size parsing + scheme-less flyer URL normalization

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -3758,12 +3758,13 @@ class AiWebParser {
         const search = String(parsed.search || '').toLowerCase();
         const path = String(parsed.pathname || '').toLowerCase();
 
-        // Check query parameters for size indicators
-        const searchParams = new URLSearchParams(search);
+        // Check query parameters for size indicators (extractSearchParamValue,
+        // not URLSearchParams — the latter doesn't exist in iOS JavaScriptCore)
+        const getParam = (key) => this.extractSearchParamValue(search, key);
 
         // Width/height parameters (e.g., ?w=1920, ?width=1080, ?h=1080, ?height=1920)
-        const width = searchParams.get('w') || searchParams.get('width') || searchParams.get('wpx');
-        const height = searchParams.get('h') || searchParams.get('height') || searchParams.get('hpx');
+        const width = getParam('w') || getParam('width') || getParam('wpx');
+        const height = getParam('h') || getParam('height') || getParam('hpx');
 
         if (width) {
             const w = parseInt(width, 10);
@@ -3775,7 +3776,7 @@ class AiWebParser {
         }
 
         // Size scale parameters (e.g., ?scale=2, ?size=large)
-        const scale = searchParams.get('scale') || searchParams.get('size');
+        const scale = getParam('scale') || getParam('size');
         if (scale) {
             const s = scale.toLowerCase();
             if (s === 'large' || s === 'big' || s === 'max' || s === 'original' || s === 'full') {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -2962,3 +2962,26 @@ test('extractAdditionalUrls tags uniqueValidCount (pre-budget) non-enumerably fo
   assert.equal(links.uniqueValidCount, 3, 'but the pre-budget valid count is preserved');
   assert.ok(!Object.keys(links).includes('uniqueValidCount'), 'tag is non-enumerable');
 });
+
+test('getImageSizeFromUrl and OCR consolidation work without URLSearchParams (iOS JavaScriptCore)', () => {
+  const parser = createParser();
+  // Scriptable's JavaScriptCore has no URLSearchParams — this exact gap crashed the
+  // Decadence page ("Failed to parse AI event: ReferenceError: Can't find variable:
+  // URLSearchParams" from consolidateDuplicateOcrResults → getImageSizeFromUrl).
+  const original = global.URLSearchParams;
+  delete global.URLSearchParams;
+  try {
+    const large = parser.getImageSizeFromUrl('https://cdn.example.com/img.jpg?w=1920&h=1080');
+    const small = parser.getImageSizeFromUrl('https://cdn.example.com/img.jpg?w=100&h=100');
+    assert.ok(large > small, 'width/height params still rank images');
+    assert.ok(parser.getImageSizeFromUrl('https://cdn.example.com/img.jpg?size=large') >= 5000, 'named size params still score');
+
+    const consolidated = parser.consolidateDuplicateOcrResults([
+      { url: 'https://bearracuda.com/wp-content/uploads/2026/03/igdecad-2.jpg', text: 'DECADENCE NEW ORLEANS SAT AUG 29' },
+      { url: 'https://bearracuda.com/wp-content/uploads/2026/03/igdecad-2-768x1187.jpg', text: 'DECADENCE NEW ORLEANS SAT AUG 29' }
+    ]);
+    assert.equal(consolidated.length, 1, 'duplicate size variants consolidate without throwing');
+  } finally {
+    global.URLSearchParams = original;
+  }
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -4000,6 +4000,15 @@ class SharedCore {
             return `https:${normalized}`;
         }
 
+        // Flyer OCR and AI-extracted fields carry scheme-less URLs ("WWW.MASSIVE.CLUB",
+        // "BEARRACUDA.COM") that would otherwise be resolved as relative paths (or, on
+        // iOS, returned verbatim and fail to fetch as "unsupported URL"). Must run
+        // BEFORE relative resolution, which would silently misresolve them.
+        const schemelessHost = this.normalizeSchemelessHostUrl(normalized);
+        if (schemelessHost) {
+            return schemelessHost;
+        }
+
         try {
             const resolved = new URL(normalized, baseUrl).toString();
             return resolved;
@@ -4013,6 +4022,35 @@ class SharedCore {
         }
 
         return normalized;
+    }
+
+    // A candidate is treated as a scheme-less host only when unambiguous:
+    // it starts with "www." (path allowed), or it is a bare dotted domain with
+    // NO path whose final label is a plausible TLD — never a path-bearing
+    // relative href like "events/foo" or a filename like "index.html".
+    normalizeSchemelessHostUrl(candidate) {
+        const text = String(candidate || '').trim();
+        if (!text || /\s/.test(text)) return null;
+        if (/^[a-z][a-z0-9+.-]*:/i.test(text)) return null; // already has a scheme
+
+        const hostEnd = text.search(/[/?#]/);
+        const host = hostEnd === -1 ? text : text.slice(0, hostEnd);
+        const rest = hostEnd === -1 ? '' : text.slice(hostEnd);
+        const hostPattern = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/i;
+        if (!hostPattern.test(host)) return null;
+
+        if (!/^www\./i.test(host)) {
+            if (rest !== '') return null; // path-bearing non-www stays relative
+            const tld = host.slice(host.lastIndexOf('.') + 1).toLowerCase();
+            if (!/^[a-z]{2,24}$/.test(tld)) return null;
+            // Dotted filenames are relative paths, not hosts ("index.html")
+            const fileExtensions = ['html', 'htm', 'shtml', 'php', 'asp', 'aspx', 'jsp',
+                'xml', 'json', 'txt', 'pdf', 'md', 'css', 'js',
+                'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'ico'];
+            if (fileExtensions.includes(tld)) return null;
+        }
+
+        return `https://${host.toLowerCase()}${rest}`;
     }
 
     decodeUrlEscapes(url) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4597,3 +4597,28 @@ test('review: on a platform that CAN cross-check, an Apple outage rejects candid
   }
   assert.equal(byId.get('moved').current.location, '32.8285, -96.8110709', 'the stored pin is untouched');
 });
+
+test('normalizeUrl: scheme-less flyer hosts become https URLs; relative paths keep resolving', () => {
+  const core = createCore();
+  // OCR ticket URLs ("ADVANCED TIX AT WWW.MASSIVE.CLUB") previously failed the
+  // crawl fetch as "unsupported URL" and were stored verbatim as ticketUrl.
+  assert.equal(core.normalizeUrl('WWW.MASSIVE.CLUB', 'https://bearracuda.com/events/treasure-trail-seattle/'), 'https://www.massive.club');
+  assert.equal(core.normalizeUrl('BEARRACUDA.COM', ''), 'https://bearracuda.com');
+  assert.equal(core.normalizeUrl('www.example.com/tickets?ref=1', ''), 'https://www.example.com/tickets?ref=1');
+  // Ambiguous candidates keep today's behavior: relative resolution against the page.
+  assert.equal(core.normalizeUrl('events/foo', 'https://bearracuda.com/'), 'https://bearracuda.com/events/foo');
+  assert.equal(core.normalizeUrl('index.html', 'https://bearracuda.com/'), 'https://bearracuda.com/index.html');
+  // Real absolute URLs pass through untouched.
+  assert.equal(core.normalizeUrl('https://massive.club/x', ''), 'https://massive.club/x');
+});
+
+test('adaptive crawl follows a scheme-less OCR ticketUrl as a fetchable https URL', () => {
+  const core = createCore();
+  const links = core.selectAdaptiveFollowLinks(
+    'event-page',
+    [],
+    { events: [{ ticketUrl: 'WWW.MASSIVE.CLUB' }] },
+    'https://bearracuda.com/events/treasure-trail-seattle/'
+  );
+  assert.deepEqual(links, ['https://www.massive.club']);
+});


### PR DESCRIPTION
## Problem (from 2026-07-21 Bearracuda phone runs)

**1. New Orleans (Decadence) event lost on every run.** `getImageSizeFromUrl` uses `URLSearchParams`, which doesn't exist in Scriptable's JavaScriptCore. When a page's OCR results contain duplicate size variants of the same flyer (Decadence has `igdecad-2.jpg` + `igdecad-2-768x1187.jpg`), `consolidateDuplicateOcrResults` sorts by image size and crashes:

```
🤖 AI Web: Failed to parse AI event: ReferenceError: Can't find variable: URLSearchParams
getImageSizeFromUrl@ ... consolidateDuplicateOcrResults@ extractOcrFromAllImages@
SYSTEM: Parsed https://bearracuda.com/events/decadence/ → 0 events, 1 link
```

**2. Scheme-less flyer URLs fail to crawl and pollute ticketUrl.** The Seattle flyer's "ADVANCED TIX AT WWW.MASSIVE.CLUB" was followed verbatim (`HTTP request failed for WWW.MASSIVE.CLUB: unsupported URL`) and stored as `ticketUrl: "WWW.MASSIVE.CLUB"` (merge arbitration had to rescue it with the calendar value).

## Fix

- `getImageSizeFromUrl` now reads query params via the parser's existing JavaScriptCore-safe `extractSearchParamValue` helper — no behavior change on any platform, no crash on iOS.
- `SharedCore.normalizeUrl` gains a conservative scheme-less-host step (before relative resolution): `www.`-prefixed candidates and bare dotted domains with no path and a plausible TLD become `https://<lowercased-host>...`. Path-bearing relative hrefs (`events/foo`) and dotted filenames (`index.html`) keep exactly today's behavior. This fixes both the crawl fetch and the stored `ticketUrl` field (which flows through `normalizeHttpUrlValue` → `normalizeUrl`).

## Tests

- New regression test runs `getImageSizeFromUrl` + `consolidateDuplicateOcrResults` with `global.URLSearchParams` deleted (simulating JavaScriptCore) using the exact Decadence duplicate pair.
- New `normalizeUrl` cases: `WWW.MASSIVE.CLUB` → `https://www.massive.club`, bare `BEARRACUDA.COM`, `www.` host with path/query, and negative cases (`events/foo`, `index.html`, absolute URLs unchanged).
- New adaptive-crawl case: a scheme-less OCR `ticketUrl` is followed as a fetchable https URL.

Suite: 469 pass / 0 fail.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/parsers/ai-web-parser.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP