### PR TITLE
feat(scraper): enrich-only ticket crawl + honest bear-check provenance + segment listing-title hint

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -3832,6 +3832,10 @@ class ScriptableAdapter {
         console.log(`   • ${result.name}: ${result.bearEvents} bear events`);
       });
 
+      if (results.discoveredVenueSummary) {
+        console.log("\n" + results.discoveredVenueSummary);
+      }
+
       console.log("\n" + "=".repeat(60));
 
       const shouldSkipUi = this.shouldSkipResultsUi(results);
@@ -4541,8 +4545,29 @@ class ScriptableAdapter {
       // Generate HTML for rich display
       const html = await this.generateRichHTML(results);
 
-      // Present using WebView
-      await WebView.loadHTML(html, null, null, true);
+      // Present using an instance WebView so page buttons can signal native
+      // via shouldAllowRequest (assigned BEFORE present() — the reliable
+      // webview→native pattern, see presentReviewResults). Currently used by
+      // the discovered-venue "Copy parser entry" buttons (chunkyscrape://).
+      const venueEntrySnippets = this.collectVenueEntrySnippets(results);
+      const webView = new WebView();
+      await webView.loadHTML(html);
+      webView.shouldAllowRequest = (request) => {
+        const url = request && request.url ? String(request.url) : "";
+        if (url.indexOf("chunkyscrape://") !== 0) {
+          return true; // normal navigation (links, about:blank, …)
+        }
+        const params = this.parseReviewActionUrl(url);
+        if (params.a === "copy-venue") {
+          const snippet = venueEntrySnippets[params.id];
+          if (typeof snippet === "string" && snippet.length > 0) {
+            // Fire-and-forget: the handler must return a bool synchronously
+            this.copyVenueEntryAndReport(snippet, params.id, webView);
+          }
+        }
+        return false; // cancel the fake navigation; the page stays put
+      };
+      await webView.present(true);
 
       // After displaying results, prompt for calendar execution if we have analyzed events
       // Don't prompt when displaying saved runs (they should use isDryRun override instead)
@@ -6020,6 +6045,8 @@ class ScriptableAdapter {
         : ""
     }
 
+    ${this.generateDiscoveredVenueSection(results)}
+
     ${this.generateDiscoverySection(results)}
 
     ${insightSectionsHtml}
@@ -6027,6 +6054,27 @@ class ScriptableAdapter {
     ${logSectionHtml}
     
     <script>
+        // Discovered-venue copy buttons signal native via a custom-scheme
+        // navigation intercepted by shouldAllowRequest (set before present()) —
+        // the same battle-tested webview→native pattern as the review UI. The
+        // nonce makes each tap a distinct navigation so repeat taps still fire.
+        // The snippet text itself stays native-side, keyed by venue index.
+        window.__venueCopyNonce = 0;
+        function copyVenueEntry(btn) {
+            var venueIndex = btn ? (btn.getAttribute('data-venue-index') || '') : '';
+            window.location.href = 'chunkyscrape://act?a=copy-venue&id=' +
+                encodeURIComponent(venueIndex) + '&n=' + (window.__venueCopyNonce++);
+        }
+        function markVenueEntryCopied(venueIndex) {
+            try {
+                var btn = document.querySelector('.venue-copy-btn[data-venue-index="' + venueIndex + '"]');
+                if (btn) {
+                    btn.textContent = '✅ Copied!';
+                    setTimeout(function () { btn.textContent = '📋 Copy parser entry'; }, 2000);
+                }
+            } catch (ignore) {}
+        }
+
         function copyDiscoveryText(btn) {
             const encoded = btn.getAttribute('data-encoded') || '';
             let text = '';
@@ -7019,6 +7067,91 @@ class ScriptableAdapter {
     return { button, panel, totalSegments };
   }
 
+  // Discovered venue calendars (enrich-only ticket crawl): hosts whose sibling
+  // events were dropped, with a paste-ready parser entry and a copy button.
+  // The button signals native via the chunkyscrape:// scheme handled in
+  // presentRichResults (shouldAllowRequest → Pasteboard.copy).
+  generateDiscoveredVenueSection(results) {
+    const venues = Array.isArray(results && results.discoveredVenueCalendars)
+      ? results.discoveredVenueCalendars
+      : [];
+    if (venues.length === 0) return "";
+
+    const venueBlocks = venues
+      .map((venue, index) => {
+        const sampleTitles = Array.isArray(venue.sampleTitles)
+          ? venue.sampleTitles
+          : [];
+        const extraCount = venue.droppedCount - sampleTitles.length;
+        const titlesText =
+          sampleTitles.join(", ") +
+          (extraCount > 0 ? `, … (+${extraCount} more)` : "");
+        const viaText = venue.parentTitle
+          ? ` — reached via ticket link from "${venue.parentTitle}"`
+          : "";
+        return `
+        <div class="discovered-venue" style="margin-bottom:14px; padding:10px; background:var(--background-light); border-radius:8px;">
+            <div style="font-weight:600; margin-bottom:4px;">${this.escapeHtml(venue.host)} <span style="font-weight:400; opacity:0.7;">— ${venue.droppedCount} event(s) found but not ingested (enrich-only ticket crawl)${this.escapeHtml(viaText)}</span></div>
+            ${titlesText ? `<div style="font-size:12px; margin-bottom:6px; color:var(--text-secondary);">Titles: ${this.escapeHtml(titlesText)}</div>` : ""}
+            <div style="display:flex; gap:6px; margin-bottom:6px; flex-wrap:wrap; align-items:center;">
+                <button onclick="copyVenueEntry(this)" class="log-copy-btn venue-copy-btn" data-venue-index="${index}">📋 Copy parser entry</button>
+                <span style="font-size:12px; color:var(--text-secondary);">To scrape this venue, paste into parsers[] in scraper-input.js</span>
+            </div>
+            <pre class="discovery-output">${this.escapeHtml(venue.parserEntrySnippet || "")}</pre>
+        </div>`;
+      })
+      .join("");
+
+    return `
+    <div class="section">
+        <div class="section-header">
+            <span class="section-icon">📋</span>
+            <span class="section-title">Discovered Venue Calendars</span>
+            <span class="section-count">${venues.length}</span>
+        </div>
+        ${venueBlocks}
+    </div>
+    `;
+  }
+
+  // Native-side snippet map for the chunkyscrape://copy-venue bridge: venue
+  // index → paste-ready parser entry. Snippets never travel through the URL.
+  collectVenueEntrySnippets(results) {
+    const venues = Array.isArray(results && results.discoveredVenueCalendars)
+      ? results.discoveredVenueCalendars
+      : [];
+    const snippets = {};
+    venues.forEach((venue, index) => {
+      if (venue && typeof venue.parserEntrySnippet === "string") {
+        snippets[String(index)] = venue.parserEntrySnippet;
+      }
+    });
+    return snippets;
+  }
+
+  // Copy one venue's parser entry natively and (best-effort) flash the button.
+  // Called fire-and-forget from shouldAllowRequest, which must synchronously
+  // return a bool — so the await lives here, not in the handler.
+  async copyVenueEntryAndReport(snippet, venueIndex, webView) {
+    try {
+      Pasteboard.copy(snippet);
+      console.log(
+        `📱 Scriptable: Copied discovered-venue parser entry #${venueIndex} to clipboard`,
+      );
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Failed to copy venue parser entry: ${error.message}`,
+      );
+      return;
+    }
+    const feedbackJs = `markVenueEntryCopied(${JSON.stringify(String(venueIndex))})`;
+    try {
+      await webView.evaluateJavaScript(feedbackJs, false);
+    } catch (error) {
+      /* button feedback is optional polish; the copy already happened */
+    }
+  }
+
   // Generate HTML for URL discovery section (discoveryOnly mode results)
   generateDiscoverySection(results) {
     const parserResults = Array.isArray(results && results.parserResults)
@@ -7880,6 +8013,11 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       results.parserResults.forEach((result) => {
         lines.push(`  • ${result.name}: ${result.bearEvents} bear events`);
       });
+    }
+
+    if (results.discoveredVenueSummary) {
+      lines.push("");
+      lines.push(results.discoveredVenueSummary);
     }
 
     const allEvents = this.getAllEventsFromResults(results);

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1234,3 +1234,97 @@ test('review page uses the chunkyreview scheme, error banner, and bar-data visib
   assert.ok(html.includes('1 event verified against curated bar data'), 'bar-data count in header');
   assert.ok(html.includes('matches curated bar data (Camp Out)'), 'ok entry shows the bar note');
 });
+
+// ---------------------------------------------------------------------------
+// Discovered venue calendars (enrich-only ticket crawl): results-UI section
+// with a native copy-parser-entry bridge (chunkyscrape:// + shouldAllowRequest)
+// ---------------------------------------------------------------------------
+
+function buildDiscoveredVenueFixture() {
+  return {
+    host: 'www.massive.club',
+    origin: 'https://www.massive.club',
+    suggestedName: 'massive.club',
+    parentTitle: 'BEARRACUDA: LA',
+    sourceEntryName: 'Bearracuda Events',
+    droppedCount: 9,
+    sampleTitles: ['Butt Blast (Jul 23)', 'Twink Bash: Birthday Suit (Aug 1)'],
+    parserEntrySnippet: '{ name: "massive.club", enabled: false, urls: ["https://www.massive.club"], alwaysBear: false },'
+  };
+}
+
+test('generateDiscoveredVenueSection renders host, counts, titles, snippet, and copy button only when venue data exists', () => {
+  const adapter = buildAdapter();
+
+  assert.equal(adapter.generateDiscoveredVenueSection({}), '', 'no section without venue data');
+  assert.equal(adapter.generateDiscoveredVenueSection({ discoveredVenueCalendars: [] }), '', 'no section for an empty list');
+
+  const html = adapter.generateDiscoveredVenueSection({ discoveredVenueCalendars: [buildDiscoveredVenueFixture()] });
+  assert.ok(html.includes('Discovered Venue Calendars'), 'section title present');
+  assert.ok(html.includes('www.massive.club'), 'host shown');
+  assert.ok(html.includes('9 event(s) found but not ingested (enrich-only ticket crawl)'), 'count line present');
+  assert.ok(html.includes('Butt Blast (Jul 23)'), 'sample titles shown');
+  assert.ok(html.includes('reached via ticket link from &quot;BEARRACUDA: LA&quot;'), 'parent event named (escaped)');
+  assert.ok(html.includes('data-venue-index="0"'), 'copy button carries the venue index, not the snippet');
+  assert.ok(html.includes('copyVenueEntry(this)'), 'copy button wired to the custom-scheme signal');
+  assert.ok(html.includes('&quot;https://www.massive.club&quot;'), 'paste-ready snippet rendered (escaped)');
+  assert.ok(!html.includes('chunkyscrape://act?a=copy-venue&id={'), 'snippet text never travels through the URL');
+});
+
+test('generateRichHTML embeds the discovered-venue section and the chunkyscrape page bridge', async () => {
+  const adapter = buildAdapter();
+  const results = { ...buildResultsStub(), discoveredVenueCalendars: [buildDiscoveredVenueFixture()] };
+  const html = await adapter.generateRichHTML(results);
+  assert.ok(html.includes('Discovered Venue Calendars'), 'section present when venue data exists');
+  assert.ok(html.includes("chunkyscrape://act?a=copy-venue"), 'buttons signal via the custom scheme');
+  assert.ok(html.includes('markVenueEntryCopied'), 'best-effort feedback handler defined');
+  assert.ok(html.includes('__venueCopyNonce'), 'per-tap nonce keeps repeat taps distinct navigations');
+
+  const withoutVenues = await adapter.generateRichHTML(buildResultsStub());
+  assert.ok(!withoutVenues.includes('Discovered Venue Calendars'), 'no section without venue data');
+});
+
+test('presentRichResults copies a venue parser entry natively via shouldAllowRequest', async () => {
+  const adapter = buildAdapter();
+  const venue = buildDiscoveredVenueFixture();
+  // calendarEvents already set → the execution prompt path is skipped
+  const results = { ...buildResultsStub(), calendarEvents: 1, discoveredVenueCalendars: [venue] };
+
+  const copies = [];
+  global.Pasteboard = { copy: (text) => { copies.push(text); } };
+  const wv = installFakeWebView();
+  try {
+    const done = adapter.presentRichResults(results);
+    // generateRichHTML awaits several stubs before the handler is assigned
+    for (let i = 0; i < 200 && !wv.getHandler(); i++) {
+      await new Promise((r) => setImmediate(r));
+    }
+    assert.ok(wv.getHandler(), 'shouldAllowRequest assigned before present()');
+
+    // Normal navigation passes through untouched.
+    assert.equal(wv.getHandler()({ url: 'https://mermaid.live/' }), true, 'non-scheme navigation allowed');
+
+    // A copy tap: navigation cancelled, snippet copied natively from the
+    // native-side map (never decoded out of the URL).
+    assert.equal(wv.tap('chunkyscrape://act?a=copy-venue&id=0&n=1'), false, 'fake navigation cancelled');
+    await new Promise((r) => setImmediate(r));
+    assert.deepEqual(copies, [venue.parserEntrySnippet], 'the paste-ready parser entry reached the pasteboard');
+    assert.ok(wv.evals.some((js) => js.includes('markVenueEntryCopied("0")')), 'button feedback pushed (best-effort)');
+
+    // A repeat tap (new nonce) copies again.
+    wv.tap('chunkyscrape://act?a=copy-venue&id=0&n=2');
+    await new Promise((r) => setImmediate(r));
+    assert.equal(copies.length, 2, 'repeat taps register (nonce makes each tap distinct)');
+
+    // An unknown venue id is ignored without crashing.
+    assert.equal(wv.tap('chunkyscrape://act?a=copy-venue&id=99&n=3'), false);
+    await new Promise((r) => setImmediate(r));
+    assert.equal(copies.length, 2);
+
+    wv.dismiss();
+    await done;
+  } finally {
+    delete global.WebView;
+    delete global.Pasteboard;
+  }
+});

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -762,7 +762,11 @@ async saveFailureNote(url, error, metadata = {}) {
             results.parserResults.forEach(result => {
                 console.log(`   • ${result.name}: ${result.bearEvents} bear events`);
             });
-            
+
+            if (results.discoveredVenueSummary) {
+                console.log('\n' + results.discoveredVenueSummary);
+            }
+
             // Show summary and recommended actions
             await this.displaySummaryAndActions(results);
             

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -656,6 +656,28 @@ class AiWebParser {
         return `🤖 AI Web: Extracted ${sourceUrl} → ${parts.join(', ')}`;
     }
 
+    // The page's own listing title for a segment: the first non-empty page-text
+    // line that is not a date/time line, not a SEGMENT_*/OCR marker line, and
+    // not a URL. Multi-event listings put the event name first (segment
+    // discovery splits on exactly that title/date structure), so this recovers
+    // the site's title even when flyer OCR is stylized taglines/DJ names.
+    // Returns '' when no plausible listing title exists.
+    deriveSegmentListingTitle(segment) {
+        const lines = segment && Array.isArray(segment.lines) ? segment.lines : [];
+        for (const rawLine of lines) {
+            const line = this.normalizeWhitespace(rawLine);
+            if (!line) continue;
+            if (/^(SEGMENT_[A-Z_]+|OCR_IMAGE_TEXT)/i.test(line)) continue;
+            if (this.hasMultiEventDateSignal(line)) continue;
+            if (/^\d{1,2}(:\d{2})?\s*(am|pm)?(\s*[-–]\s*\d{1,2}(:\d{2})?\s*(am|pm)?)?$/i.test(line)) continue;
+            if (/^https?:\/\//i.test(line)) continue;
+            // First candidate decides: a plausible title is short; a long first
+            // line is prose/description, so no hint is derived at all.
+            return line.length <= this.extractionLimits.multiEventTitleMaxChars ? line : '';
+        }
+        return '';
+    }
+
     buildMultiEventSegmentHtmlData(htmlData, segment, index, totalSegments, ocrResults = []) {
         const sourceUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
         const segmentHtml = segment && typeof segment.html === 'string' ? segment.html : '';
@@ -682,6 +704,7 @@ class AiWebParser {
             aiEvent: null,
             aiExtraction: null,
             ocrResults: segmentOcrResults,
+            segmentListingTitle: this.deriveSegmentListingTitle(segment),
             dataFlags: { ocr: true, segment: true }  // Segments are unstructured data
         };
     }
@@ -6252,6 +6275,19 @@ ${String(snippet || '')}`;
             steeringContext += `\n`;
         }
 
+        // Multi-event segment listing title: the site's own name for this event,
+        // taken from the listing text. Anchors "title" so stylized flyer OCR
+        // (taglines, DJ names) can't displace the page's own title.
+        const segmentListingTitle = htmlData && typeof htmlData.segmentListingTitle === 'string'
+            ? htmlData.segmentListingTitle.trim()
+            : '';
+        const segmentListingContext = segmentListingTitle
+            ? `SEGMENT_LISTING_TITLE (the page's own listing title for this event): ${JSON.stringify(segmentListingTitle)}\n\n`
+            : '';
+        const segmentListingTitleRule = segmentListingTitle
+            ? `\n- For "title", prefer SEGMENT_LISTING_TITLE or a fuller variant of the same name from the flyer; flyer text that does not contain it (taglines, DJ names, stylized graphics text) is NOT the title.`
+            : '';
+
         const exampleOutput = `EXAMPLE OUTPUT FORMAT (structure only, not real data):\n{"city": {"value": "miami", "evidence": "Miami, FL", "confidence": 90}, "bar": {"value": "Eagle Bar", "evidence": "@ Eagle Bar", "confidence": 95}}`;
 
         const templates = {
@@ -6259,12 +6295,12 @@ ${String(snippet || '')}`;
 
 Format the output as a single JSON object where each requested key maps to an object containing "value", "evidence", and "confidence".
 
-${dataProvided}${sourceData}${additionalContext}${steeringContext}Preferred keys:
+${dataProvided}${sourceData}${additionalContext}${steeringContext}${segmentListingContext}Preferred keys:
 ${fieldContext}
 Rules:
 - Return a single JSON object only
 - Return only keys from the Preferred keys list, formatted as objects with value, evidence, and confidence (0-100)
-- Omit unknown fields; do not invent details and do not estimate. ONLY use data from the source material.
+- Omit unknown fields; do not invent details and do not estimate. ONLY use data from the source material.${segmentListingTitleRule}
 
 ${exampleOutput}
 
@@ -6273,13 +6309,13 @@ ${exampleOutput}
 
 Format the output as a single JSON object where each requested key maps to an object containing "value", "evidence", and "confidence".
 
-${dataProvided}${sourceData}${additionalContext}${steeringContext}Fields to find:
+${dataProvided}${sourceData}${additionalContext}${steeringContext}${segmentListingContext}Fields to find:
 ${fieldContext}
 Rules:
 - Return a single JSON object only
 - Include only fields whose values are found verbatim in the text below, formatted as objects with value, evidence, and confidence (0-100)
 - Do not guess, invent, or infer missing values
-- Omit any field not explicitly present in the source
+- Omit any field not explicitly present in the source${segmentListingTitleRule}
 
 ${exampleOutput}
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -2985,3 +2985,61 @@ test('getImageSizeFromUrl and OCR consolidation work without URLSearchParams (iO
     global.URLSearchParams = original;
   }
 });
+
+// ---------------------------------------------------------------------------
+// Segment listing-title hint: the page's own listing title anchors "title" so
+// stylized flyer OCR (taglines, DJ names) can't displace it.
+// ---------------------------------------------------------------------------
+
+test('segment extraction prompt carries SEGMENT_LISTING_TITLE and the title rule when derivable', () => {
+  const parser = createParser();
+  const segment = {
+    lines: ['PERVERT', 'Aug 7, 2026 10:00 PM', 'DJs Villa Senor and Dee Jay Energy'],
+    html: ''
+  };
+  const htmlData = parser.buildMultiEventSegmentHtmlData(
+    { html: '', url: 'https://venue.example/calendar' }, segment, 0, 3, []
+  );
+  assert.equal(htmlData.segmentListingTitle, 'PERVERT', 'first non-date page-text line is the listing title');
+
+  // Both the extraction prompt and the confidence-retry prompt (the alternate
+  // variant) must carry the hint and the rule.
+  for (const variant of ['default', 'alternate']) {
+    const prompt = parser.buildExtractionPrompt(htmlData, {}, null, {}, ['title'], 'SNIPPET', variant, { ocr: true, segment: true });
+    assert.ok(
+      prompt.includes('SEGMENT_LISTING_TITLE (the page\'s own listing title for this event): "PERVERT"'),
+      `${variant} prompt carries the listing title`
+    );
+    assert.ok(
+      prompt.includes('- For "title", prefer SEGMENT_LISTING_TITLE or a fuller variant of the same name from the flyer; flyer text that does not contain it (taglines, DJ names, stylized graphics text) is NOT the title.'),
+      `${variant} prompt carries the title rule`
+    );
+  }
+});
+
+test('segment extraction prompt is unchanged when no listing title can be derived', () => {
+  const parser = createParser();
+  const segment = {
+    lines: ['Aug 7, 2026 10:00 PM', 'https://venue.example/tickets'],
+    html: ''
+  };
+  const htmlData = parser.buildMultiEventSegmentHtmlData(
+    { html: '', url: 'https://venue.example/calendar' }, segment, 0, 3, []
+  );
+  assert.equal(htmlData.segmentListingTitle, '', 'date/URL-only segments derive no listing title');
+
+  const prompt = parser.buildExtractionPrompt(htmlData, {}, null, {}, ['title'], 'SNIPPET', 'default', { ocr: true, segment: true });
+  assert.ok(!prompt.includes('SEGMENT_LISTING_TITLE'), 'no hint line without a derived title');
+  assert.ok(!prompt.includes('is NOT the title'), 'no rule line without a derived title');
+});
+
+test('deriveSegmentListingTitle skips marker, time-only, and date lines; long prose derives nothing', () => {
+  const parser = createParser();
+  assert.equal(parser.deriveSegmentListingTitle({
+    lines: ['SEGMENT_IMAGE_URL: https://cdn.example/flyer.jpg', '10:00 PM', 'July 25, 2026', 'BEAR NIGHT']
+  }), 'BEAR NIGHT');
+  assert.equal(parser.deriveSegmentListingTitle({ lines: [] }), '');
+  assert.equal(parser.deriveSegmentListingTitle(null), '');
+  // A long prose first line is a description, not a title — derive nothing
+  assert.equal(parser.deriveSegmentListingTitle({ lines: ['x'.repeat(200), 'BEAR NIGHT'] }), '');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1088,6 +1088,16 @@ class SharedCore {
             results.automationSkippedParsers = automationSkipped;
         }
 
+        // Discovered venue calendars (enrich-only ticket crawl drops): logged
+        // here and attached to results so the UI summaries can render the same
+        // block with a paste-ready parser entry.
+        const discoveredVenueCalendars = this.buildDiscoveredVenueCalendars(results.parserResults);
+        if (discoveredVenueCalendars.length > 0) {
+            results.discoveredVenueCalendars = discoveredVenueCalendars;
+            results.discoveredVenueSummary = this.buildDiscoveredVenueSummaryText(discoveredVenueCalendars);
+            await displayAdapter.logInfo(results.discoveredVenueSummary);
+        }
+
         await this.finalizeDeadEndRun(displayAdapter, results);
 
         const duplicateSummary = results.duplicatesRemoved > 0
@@ -1167,6 +1177,10 @@ class SharedCore {
             }
             : null;
 
+        // Sibling events dropped by the enrich-only ticket crawl (flag, don't
+        // drop silently): surfaced as a discovered-venue suggestion block.
+        const enrichDropCollector = [];
+
         await this.crawlUrlsForEvents({
             urls: effectiveParserConfig.urls || [],
             allEvents,
@@ -1183,7 +1197,9 @@ class SharedCore {
             urlClassifications,
             includeInlineInput: hasInlineInput,
             discoveryOnly,
-            discoveryTreeCollector
+            discoveryTreeCollector,
+            enrichOnlyByUrl: null,
+            enrichDropCollector
         });
 
         // Metadata is applied dynamically by parsers using the {value, merge} format
@@ -1211,6 +1227,10 @@ class SharedCore {
             urlClassifications,
             config: effectiveParserConfig // Include config for orchestrator to use
         };
+
+        if (enrichDropCollector.length > 0) {
+            result.enrichOnlyDrops = enrichDropCollector;
+        }
 
         if (discoveryOnly && discoveryTreeCollector) {
             const discoveryTree = {
@@ -1274,6 +1294,77 @@ class SharedCore {
         lines.push('  },');
         lines.push('},');
         return lines.join('\n');
+    }
+
+    // ------------------------------------------------------------------
+    // Discovered venue calendars (flag, don't drop): siblings dropped by the
+    // enrich-only ticket crawl are surfaced as a paste-ready parser entry
+    // suggestion instead of being silently discarded.
+    // ------------------------------------------------------------------
+
+    // Aggregate per-parser enrichOnlyDrops into one entry per host.
+    buildDiscoveredVenueCalendars(parserResults) {
+        const byHost = new Map();
+        for (const parserResult of Array.isArray(parserResults) ? parserResults : []) {
+            const drops = parserResult && Array.isArray(parserResult.enrichOnlyDrops) ? parserResult.enrichOnlyDrops : [];
+            for (const drop of drops) {
+                if (!drop || !drop.host) continue;
+                const hostKey = String(drop.host).toLowerCase();
+                if (!byHost.has(hostKey)) {
+                    byHost.set(hostKey, {
+                        host: drop.host,
+                        origin: `https://${drop.host}`,
+                        suggestedName: String(drop.host).replace(/^www\./i, ''),
+                        parentTitle: drop.parentTitle || '',
+                        sourceEntryName: parserResult && parserResult.name ? parserResult.name : '',
+                        droppedCount: 0,
+                        droppedEvents: []
+                    });
+                }
+                const entry = byHost.get(hostKey);
+                const dropped = Array.isArray(drop.droppedEvents) ? drop.droppedEvents : [];
+                entry.droppedCount += dropped.length;
+                entry.droppedEvents.push(...dropped);
+            }
+        }
+        const venues = [];
+        for (const entry of byHost.values()) {
+            if (entry.droppedCount === 0) continue;
+            entry.sampleTitles = entry.droppedEvents.slice(0, 8).map(event => {
+                const dateLabel = this.formatDiscoveredVenueDateLabel(event.startDate);
+                return dateLabel ? `${event.title} (${dateLabel})` : event.title;
+            });
+            entry.parserEntrySnippet = `{ name: ${JSON.stringify(entry.suggestedName)}, enabled: false, urls: [${JSON.stringify(entry.origin)}], alwaysBear: false },`;
+            delete entry.droppedEvents;
+            venues.push(entry);
+        }
+        return venues;
+    }
+
+    // Short "Jul 23" label for a dropped sibling's start date ('' when unknown).
+    formatDiscoveredVenueDateLabel(startDate) {
+        const date = startDate instanceof Date ? startDate : this.parseDate(startDate);
+        if (!date || Number.isNaN(date.getTime())) return '';
+        const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        return `${months[date.getMonth()]} ${date.getDate()}`;
+    }
+
+    // Text block for the results summary ('' when nothing was dropped).
+    buildDiscoveredVenueSummaryText(venues) {
+        const list = Array.isArray(venues) ? venues : [];
+        if (list.length === 0) return '';
+        const blocks = list.map(venue => {
+            const extraCount = venue.droppedCount - venue.sampleTitles.length;
+            const titlesLine = venue.sampleTitles.join(', ') + (extraCount > 0 ? `, … (+${extraCount} more)` : '');
+            return [
+                `📋 DISCOVERED VENUE CALENDAR: ${venue.host}`,
+                `   ${venue.droppedCount} event(s) found but not ingested (enrich-only ticket crawl)`,
+                `   Titles: ${titlesLine}`,
+                '   To scrape this venue, add a parser entry to scraper-input.js:',
+                `   ${venue.parserEntrySnippet}`
+            ].join('\n');
+        });
+        return blocks.join('\n\n');
     }
 
     // Baked-in platform confidence expectations: Eventbrite /e/ event pages ship
@@ -1557,7 +1648,13 @@ class SharedCore {
         urlClassifications = null,
         includeInlineInput = false,
         discoveryOnly = false,
-        discoveryTreeCollector = null
+        discoveryTreeCollector = null,
+        // Enrich-only ticket crawl: pages reached via an event-page's follow
+        // links (rule-classified event links + extracted ticketUrls) may only
+        // ENRICH the originating event, never spawn new events. Keyed by URL
+        // dedupe key → { parentEvents, parentTitle, parentUrl }.
+        enrichOnlyByUrl = null,
+        enrichDropCollector = null
     }) {
         const adaptiveCrawl = maxDepth === ADAPTIVE_CRAWL_DEPTH;
         const urlsToProcess = currentDepth > 0
@@ -1668,11 +1765,56 @@ class SharedCore {
                 // whether it was productive (raw pre-filter counts) or a dead end.
                 this.recordDeadEndObservation({ url, currentDepth, parseResult, pageClassification, discoveryOnly });
 
+                const enrichContext = !discoveryOnly && enrichOnlyByUrl
+                    ? (enrichOnlyByUrl[this.getUrlDedupeKey(url)] || null)
+                    : null;
+
+                let pageEventsForEnrich = [];
                 if (!discoveryOnly) {
-                    const parsedEvents = await this.prepareParsedEvents(parseResult?.events, parserConfig, mainConfig, pageClassification, this.normalizerPipeline, httpAdapter);
+                    let parsedEvents = await this.prepareParsedEvents(parseResult?.events, parserConfig, mainConfig, pageClassification, this.normalizerPipeline, httpAdapter);
+                    // Each event remembers the page it was actually extracted from
+                    // (underscore field: never serialized into notes/schema). The
+                    // bear-check provenance uses it for honest cross-host wording.
+                    parsedEvents.forEach(event => {
+                        if (!event._sourcePageUrl) {
+                            event._sourcePageUrl = url;
+                        }
+                    });
+                    if (enrichContext && parsedEvents.length > 0) {
+                        // Enrich-only page: keep ONLY events that are the same event
+                        // as the originating (parent) event — same identity predicate
+                        // the parser-level dedup uses — and drop the venue's sibling
+                        // events (they belong to the venue calendar, not this source).
+                        const keptEvents = [];
+                        const droppedEvents = [];
+                        for (const childEvent of parsedEvents) {
+                            const matchesParent = enrichContext.parentEvents.some(parentEvent =>
+                                this.getSameEventIdentitySignal(childEvent, parentEvent, { requireCloseStartTimes: false }));
+                            (matchesParent ? keptEvents : droppedEvents).push(childEvent);
+                        }
+                        if (droppedEvents.length > 0) {
+                            const childHost = this.getHostFromUrl(url) || url;
+                            await displayAdapter.logInfo(`SYSTEM: Enrich-only crawl: kept ${keptEvents.length} matching event(s), dropped ${droppedEvents.length} sibling event(s) from ${childHost} (reached via ticket link from "${enrichContext.parentTitle}")`);
+                            if (enrichDropCollector) {
+                                enrichDropCollector.push({
+                                    host: childHost,
+                                    url,
+                                    parentTitle: enrichContext.parentTitle,
+                                    parentUrl: enrichContext.parentUrl,
+                                    keptCount: keptEvents.length,
+                                    droppedEvents: droppedEvents.map(event => ({
+                                        title: event.title || 'Untitled event',
+                                        startDate: event.startDate
+                                    }))
+                                });
+                            }
+                        }
+                        parsedEvents = keptEvents;
+                    }
                     if (parsedEvents.length > 0) {
                         allEvents.push(...parsedEvents);
                     }
+                    pageEventsForEnrich = parsedEvents;
                 }
 
                 const additionalLinks = parseResult?.additionalLinks || [];
@@ -1681,7 +1823,14 @@ class SharedCore {
                     // The page's own classification decides which links (if any)
                     // are followed; a hard hop cap bounds runaway chains.
                     linksToConsider = this.selectAdaptiveFollowLinks(pageClassification, additionalLinks, parseResult, url);
-                    if (linksToConsider.length > 0 && currentDepth >= ADAPTIVE_CRAWL_MAX_HOPS) {
+                    if (enrichContext) {
+                        // No fan-out from enrich-only pages: a venue calendar reached
+                        // through a ticket link must never seed further crawling.
+                        if (linksToConsider.length > 0) {
+                            await displayAdapter.logInfo(`SYSTEM: Enrich-only crawl: not following ${linksToConsider.length} link(s) from ${url}`);
+                        }
+                        linksToConsider = [];
+                    } else if (linksToConsider.length > 0 && currentDepth >= ADAPTIVE_CRAWL_MAX_HOPS) {
                         await displayAdapter.logInfo(`SYSTEM: Adaptive crawl: chain cap (${ADAPTIVE_CRAWL_MAX_HOPS} hops) reached at ${url} — not following ${linksToConsider.length} link(s)`);
                         linksToConsider = [];
                     } else if (linksToConsider.length > 0) {
@@ -1713,6 +1862,25 @@ class SharedCore {
                     // before enqueueing (discoveryOnly always fetches everything).
                     const enqueueUrls = this.filterKnownDeadEndUrls(deduplicatedUrls, discoveryOnly);
                     if (enqueueUrls.length > 0) {
+                        // Links followed FROM an event-page (rule-classified event
+                        // links + extracted ticketUrls) are enrich-only for the
+                        // page's own event(s): child pages may confirm/enrich that
+                        // event but never contribute unrelated sibling events.
+                        let childEnrichOnlyByUrl = null;
+                        if (adaptiveCrawl && !discoveryOnly && pageClassification === 'event-page' && pageEventsForEnrich.length > 0) {
+                            childEnrichOnlyByUrl = {};
+                            const parentTitle = pageEventsForEnrich[0].title || 'event';
+                            for (const enqueueUrl of enqueueUrls) {
+                                const enqueueKey = this.getUrlDedupeKey(enqueueUrl);
+                                if (enqueueKey) {
+                                    childEnrichOnlyByUrl[enqueueKey] = {
+                                        parentEvents: pageEventsForEnrich,
+                                        parentTitle,
+                                        parentUrl: url
+                                    };
+                                }
+                            }
+                        }
                         await this.crawlUrlsForEvents({
                             urls: enqueueUrls,
                             allEvents,
@@ -1729,7 +1897,9 @@ class SharedCore {
                             urlClassifications: null,
                             includeInlineInput: false,
                             discoveryOnly,
-                            discoveryTreeCollector
+                            discoveryTreeCollector,
+                            enrichOnlyByUrl: childEnrichOnlyByUrl,
+                            enrichDropCollector
                         });
                     }
                 } else {
@@ -2085,6 +2255,22 @@ class SharedCore {
         return String(url || '').replace(/^https?:\/\//, '');
     }
 
+    // Host portion of an http(s) URL ('' when absent). Regex, not `new URL`
+    // (iOS JavaScriptCore has no URL global).
+    getHostFromUrl(url) {
+        const match = String(url || '').match(/^https?:\/\/([^/?#]+)/i);
+        return match ? match[1] : '';
+    }
+
+    // Hosts compared case-insensitively with a leading "www." ignored, so
+    // www.bearracuda.com and bearracuda.com count as the same site.
+    areUrlHostsSameSite(hostA, hostB) {
+        const normalize = (host) => String(host || '').toLowerCase().replace(/^www\./, '');
+        const a = normalize(hostA);
+        const b = normalize(hostB);
+        return Boolean(a) && a === b;
+    }
+
     // Build a Mermaid graph LR string from a URL tree.
     buildMermaidGraph(treeData) {
         const { allNodes, edges } = treeData;
@@ -2401,6 +2587,25 @@ class SharedCore {
     // that promoter context is what lets the model keep promoter events with
     // zero bear vocabulary (validated against real calendar data).
     buildBearCheckProvenance(event, parserConfig) {
+        // Honest cross-host provenance: when the event was actually extracted
+        // from a page on a DIFFERENT site than the parser's configured host(s)
+        // (e.g. a venue calendar reached via a ticket link), say so — otherwise
+        // the model wrongly trusts the source entry's promoter framing for
+        // events that promoter never produced.
+        const actualPageUrl = typeof event._sourcePageUrl === 'string' ? event._sourcePageUrl : '';
+        const actualHost = this.getHostFromUrl(actualPageUrl);
+        const configuredUrls = Array.isArray(parserConfig.urls) ? parserConfig.urls : [];
+        const configuredHosts = configuredUrls.map(configuredUrl => this.getHostFromUrl(configuredUrl)).filter(Boolean);
+        const isCrossHost = Boolean(actualHost) && configuredHosts.length > 0 &&
+            !configuredHosts.some(configuredHost => this.areUrlHostsSameSite(actualHost, configuredHost));
+        if (isCrossHost) {
+            let crossProvenance = `extracted from ${actualHost}, a page discovered while crawling source entry "${parserConfig.name || 'unknown'}" (${configuredHosts[0]}). The source entry's promoter did NOT necessarily produce this event — judge by the event content and the hosting site.`;
+            if (parserConfig.alwaysBear === true) {
+                crossProvenance += " The calendar owner has marked the source entry's promoter as a trusted bear-scene promoter, but that trust only covers that promoter's own events.";
+            }
+            return crossProvenance;
+        }
+
         const sourceUrl = String(event.url || event.website || (parserConfig.urls && parserConfig.urls[0]) || '');
         const hostMatch = sourceUrl.match(/^https?:\/\/([^/?#]+)/i);
         const origin = hostMatch ? hostMatch[1] : (sourceUrl || 'unknown source');
@@ -2426,7 +2631,10 @@ class SharedCore {
         const title = String(event.title || '').trim();
         const description = String(event.description || '').trim();
         const bar = String(event.bar || '').trim();
-        const memoKey = `${title}|${description}|${bar}`;
+        // The actual source host is part of the key: provenance wording differs
+        // for cross-host events, so verdicts must not be shared across hosts.
+        const memoHost = this.getHostFromUrl(typeof event._sourcePageUrl === 'string' ? event._sourcePageUrl : '');
+        const memoKey = `${title}|${description}|${bar}|${memoHost}`;
         if (!this._bearVerdictMemo) {
             this._bearVerdictMemo = new Map();
         }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4653,3 +4653,180 @@ test('merge arbitration prompt: descriptive subtitles/editions win for title; st
   assert.match(capturedPrompt, /bare city name is not an event name/);
   assert.deepEqual(result, { title: { pick: 'calendar', reason: 'richer name' } });
 });
+
+// ---------------------------------------------------------------------------
+// Enrich-only ticket crawl: pages reached via an event-page's follow links may
+// only enrich the originating event, never spawn new (sibling) events.
+// ---------------------------------------------------------------------------
+
+const ENRICH_RULES = [
+  { pattern: /promoter\.example\/e\//i, classification: 'event-page' },
+  { pattern: /venue\.example/i, classification: 'multi-event-page' }
+];
+
+test('enrich-only crawl: ticket link to a venue calendar keeps the matching event and drops siblings', async () => {
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    pageClassificationRules: ENRICH_RULES
+  });
+  const display = createDisplayAdapterStub();
+  const partyDate = new Date(Date.now() + 7 * 86400000);
+  const pages = {
+    'https://promoter.example/e/bear-party': {
+      events: [{ title: 'Bear Party', bar: 'Venue Club', startDate: partyDate, ticketUrl: 'https://venue.example/calendar' }]
+    },
+    'https://venue.example/calendar': {
+      events: [
+        { title: 'Bear Party', bar: 'Venue Club', startDate: partyDate },
+        { title: 'HOSTILE NOISE', bar: 'Venue Club', startDate: new Date(partyDate.getTime() + 86400000) },
+        { title: 'Twink Bash', bar: 'Venue Club', startDate: new Date(partyDate.getTime() + 2 * 86400000) }
+      ],
+      additionalLinks: ['https://venue.example/other-page']
+    },
+    'https://venue.example/other-page': {}
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  const result = await core.processParser(
+    { name: 'Bear Promoter', urls: ['https://promoter.example/e/bear-party'], alwaysBear: true, ai: CRAWL_AI },
+    {}, httpAdapter, display, parsers
+  );
+
+  // The ticket link is followed and the venue calendar parsed...
+  assert.ok(fetched.includes('https://venue.example/calendar'), 'ticket link is still followed');
+  // ...but only the identity-matching event survives; siblings are dropped.
+  assert.equal(result.totalEvents, 2, 'parent event + matching child event; siblings never ingested');
+  assert.equal(result.events.length, 1, 'matching child merges into the parent through the existing dedup');
+  assert.equal(result.events[0].title, 'Bear Party');
+  assert.ok(
+    display.logs.includes('SYSTEM: Enrich-only crawl: kept 1 matching event(s), dropped 2 sibling event(s) from venue.example (reached via ticket link from "Bear Party")'),
+    `expected enrich-only drop log, got: ${JSON.stringify(display.logs.filter(l => l.includes('Enrich-only')))}`
+  );
+
+  // Dropped siblings are collected for the discovered-venue suggestion block.
+  assert.equal(result.enrichOnlyDrops.length, 1);
+  assert.equal(result.enrichOnlyDrops[0].host, 'venue.example');
+  assert.equal(result.enrichOnlyDrops[0].parentTitle, 'Bear Party');
+  assert.deepEqual(result.enrichOnlyDrops[0].droppedEvents.map(e => e.title), ['HOSTILE NOISE', 'Twink Bash']);
+
+  // No fan-out from enrich-only pages: the venue calendar's own links stay unfollowed.
+  assert.ok(!fetched.includes('https://venue.example/other-page'), 'no links are followed from an enrich-only page');
+  assert.ok(
+    display.logs.includes('SYSTEM: Enrich-only crawl: not following 1 link(s) from https://venue.example/calendar'),
+    `expected enrich-only no-follow log, got: ${JSON.stringify(display.logs.filter(l => l.includes('Enrich-only')))}`
+  );
+});
+
+test('enrich-only crawl: aggregator and multi-event-page crawls still ingest every event', async () => {
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    pageClassificationRules: [
+      { pattern: /venuehub\.example\/$/i, classification: 'multi-event-page' },
+      { pattern: /venuehub\.example\/events\//i, classification: 'event-page' }
+    ]
+  });
+  const display = createDisplayAdapterStub();
+  const day = new Date(Date.now() + 7 * 86400000);
+  const pages = {
+    'https://venuehub.example/': {
+      events: [
+        { title: 'Bear Tea Dance', bar: 'Hub Hall', startDate: day },
+        { title: 'Drag Brunch', bar: 'Hub Hall', startDate: new Date(day.getTime() + 86400000) }
+      ],
+      additionalLinks: ['https://venuehub.example/events/underwear-night', 'https://venuehub.example/events/leather-social']
+    },
+    'https://venuehub.example/events/underwear-night': {
+      events: [{ title: 'Underwear Night', bar: 'Hub Hall', startDate: new Date(day.getTime() + 2 * 86400000) }]
+    },
+    'https://venuehub.example/events/leather-social': {
+      events: [{ title: 'Leather Social', bar: 'Hub Hall', startDate: new Date(day.getTime() + 3 * 86400000) }]
+    }
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  const result = await core.processParser(
+    { name: 'Venue Hub', urls: ['https://venuehub.example/'], alwaysBear: true, ai: CRAWL_AI },
+    {}, httpAdapter, display, parsers
+  );
+
+  assert.equal(fetched.length, 3, 'multi-event-page links are all followed');
+  assert.equal(result.totalEvents, 4, 'every event from the multi-event page AND its detail pages is ingested');
+  assert.equal(result.enrichOnlyDrops, undefined, 'nothing was dropped');
+  assert.ok(!display.logs.some(l => l.includes('Enrich-only')), 'no enrich-only logs on aggregator/multi-event crawls');
+});
+
+test('bear-check provenance: same-host keeps legacy wording exactly; cross-host gets honest wording', async () => {
+  // Same host (configured promoter.example, page on www.promoter.example)
+  const sameHostAdapter = buildBearVerdictAdapter({ verdict: 'bear', reason: 'promoter party' });
+  await createCore().filterBearEvents(
+    [{ title: 'HOT TAKE', url: 'https://promoter.example/events/hot-take', _sourcePageUrl: 'https://www.promoter.example/events/hot-take' }],
+    bearCheckConfig('enforce'),
+    sameHostAdapter
+  );
+  assert.match(
+    sameHostAdapter.calls[0].prompt,
+    /- Provenance: Scraped from promoter\.example, source entry "Test Promoter"\./,
+    'same-host events keep the legacy provenance wording byte-for-byte'
+  );
+
+  // No _sourcePageUrl at all → legacy wording (existing behavior untouched)
+  const legacyAdapter = buildBearVerdictAdapter({ verdict: 'bear', reason: 'promoter party' });
+  await createCore().filterBearEvents([{ title: 'HOT TAKE' }], bearCheckConfig('enforce'), legacyAdapter);
+  assert.match(legacyAdapter.calls[0].prompt, /- Provenance: Scraped from promoter\.example, source entry "Test Promoter"\./);
+
+  // Cross host (page on www.massive.club, configured promoter.example)
+  const crossAdapter = buildBearVerdictAdapter({ verdict: 'not_bear', reason: 'punk show' });
+  await createCore().filterBearEvents(
+    [{ title: 'HOSTILE NOISE', _sourcePageUrl: 'https://www.massive.club/calendar' }],
+    bearCheckConfig('enforce'),
+    crossAdapter
+  );
+  const crossPrompt = crossAdapter.calls[0].prompt;
+  assert.match(crossPrompt, /- Provenance: extracted from www\.massive\.club, a page discovered while crawling source entry "Test Promoter" \(promoter\.example\)\./);
+  assert.match(crossPrompt, /The source entry's promoter did NOT necessarily produce this event — judge by the event content and the hosting site\./);
+  assert.ok(!crossPrompt.includes('Scraped from'), 'cross-host events never claim to be scraped from the source entry');
+
+  // Cross host + alwaysBear: trust is scoped to the promoter's own events
+  const trustedCrossAdapter = buildBearVerdictAdapter({ verdict: 'not_bear', reason: 'punk show' });
+  await createCore().filterBearEvents(
+    [{ title: 'HOSTILE NOISE', _sourcePageUrl: 'https://www.massive.club/calendar' }],
+    bearCheckConfig('enforce', { alwaysBear: true }),
+    trustedCrossAdapter
+  );
+  assert.match(trustedCrossAdapter.calls[0].prompt, /trust only covers that promoter's own events/);
+  assert.ok(!trustedCrossAdapter.calls[0].prompt.includes('has marked this promoter as a trusted bear-scene promoter'),
+    'the unscoped trusted-promoter sentence never appears for cross-host events');
+});
+
+test('discovered-venue summary block renders only when siblings were dropped', () => {
+  const core = createCore();
+
+  // No drops → no block
+  assert.equal(core.buildDiscoveredVenueSummaryText(core.buildDiscoveredVenueCalendars([])), '');
+  assert.equal(core.buildDiscoveredVenueSummaryText(core.buildDiscoveredVenueCalendars([{ name: 'X' }])), '');
+
+  const parserResults = [{
+    name: 'Bearracuda Events',
+    enrichOnlyDrops: [{
+      host: 'www.massive.club',
+      url: 'https://www.massive.club/calendar',
+      parentTitle: 'BEARRACUDA: LA',
+      parentUrl: 'https://bearracuda.com/events/la',
+      keptCount: 1,
+      droppedEvents: [
+        { title: 'Butt Blast', startDate: new Date('2026-07-23T15:00:00.000Z') },
+        { title: 'Twink Bash: Birthday Suit', startDate: new Date('2026-08-01T15:00:00.000Z') }
+      ]
+    }]
+  }];
+  const venues = core.buildDiscoveredVenueCalendars(parserResults);
+  assert.equal(venues.length, 1);
+  assert.equal(venues[0].droppedCount, 2);
+
+  const text = core.buildDiscoveredVenueSummaryText(venues);
+  assert.ok(text.includes('📋 DISCOVERED VENUE CALENDAR: www.massive.club'));
+  assert.ok(text.includes('2 event(s) found but not ingested (enrich-only ticket crawl)'));
+  assert.ok(text.includes('Titles: Butt Blast (Jul 23), Twink Bash: Birthday Suit (Aug 1)'));
+  assert.ok(text.includes('To scrape this venue, add a parser entry to scraper-input.js:'));
+  assert.ok(text.includes('{ name: "massive.club", enabled: false, urls: ["https://www.massive.club"], alwaysBear: false },'));
+});


### PR DESCRIPTION
## Problem (2026-07-22 Bearracuda run)

A Bearracuda event page's flyer ticket URL resolved to https://www.massive.club — the venue's whole-site calendar. The crawl ingested all 9 house events (drag shows, twink parties, punk shows) as Bearracuda events, fanned out into the venue's nav (tixr 403s to the chain cap), and told the bear-check these events were "Scraped from bearracuda.com" — false provenance that kept junk like "HOSTILE NOISE". One segment was also mangled: the page listed the event as **PERVERT** but extraction took stylized flyer text "DEE JAY ENERGY" as the title and DJ names as the venue.

## Changes (4 parts)

1. **Enrich-only ticket crawl** — pages reached via an event-page's ticket link can only enrich the originating event: child events are filtered with the existing same-event identity predicate (kept ones merge in as before — better image, corrected ticketUrl), siblings are dropped with a `SYSTEM: Enrich-only crawl:` log, and no further links are followed from those pages. Aggregator/multi-event-page crawls are unchanged; discovery-only runs keep full fan-out.
2. **Honest bear-check provenance** — events carry their actual source page (`_sourcePageUrl`, underscore-metadata, never serialized). Same-host events keep today's provenance wording byte-for-byte; cross-host events get "extracted from <host>… the source entry's promoter did NOT necessarily produce this event", with alwaysBear trust scoped to the promoter's own events. Verdict memoization is now provenance-aware.
3. **Discovered-venue calendars (flag, don't drop)** — dropped siblings surface as a `📋 DISCOVERED VENUE CALENDAR` block in the run summary AND as a results-UI section with a per-venue **Copy parser entry** button (shouldAllowRequest → native `Pasteboard.copy`, per-tap nonce, snippets held native-side — the proven presentReviewResults bridge; `presentRichResults` now uses the instance-WebView pattern throughout). One paste onboards the venue as a first-class parser.
4. **Segment listing-title hint** — multi-event segment extraction prompts now carry `SEGMENT_LISTING_TITLE` (the page's own listing title) plus a rule that flyer text not containing it is not the title. Fixes the PERVERT/DEE JAY ENERGY class of mangling for every multi-event parser.

## Tests

+10 tests across shared-core / ai-web-parser / scriptable-adapter: enrich-only keep/drop + no fan-out, aggregator crawls unchanged, same-host provenance byte-identical + cross-host wording, venue summary only when drops exist, copy-action URL parsing + nonce, listing-title derivation and prompt injection (absent → byte-identical prompts). Suite: **480 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/parsers/ai-web-parser.js`, `scripts/adapters/scriptable-adapter.js`, `scripts/adapters/web-adapter.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP