### PR TITLE
feat(scraper): manual bear/not-bear overrides — verdict lives on the calendar event

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -4550,6 +4550,9 @@ class ScriptableAdapter {
       // webview→native pattern, see presentReviewResults). Currently used by
       // the discovered-venue "Copy parser entry" buttons (chunkyscrape://).
       const venueEntrySnippets = this.collectVenueEntrySnippets(results);
+      // Manual bear/not-bear override taps recorded during the WebView session,
+      // applied after dismissal. Keyed by row id so repeat taps stay idempotent.
+      const bearOverridePending = { markedBear: {}, markedNotBear: {} };
       const webView = new WebView();
       await webView.loadHTML(html);
       webView.shouldAllowRequest = (request) => {
@@ -4564,10 +4567,28 @@ class ScriptableAdapter {
             // Fire-and-forget: the handler must return a bool synchronously
             this.copyVenueEntryAndReport(snippet, params.id, webView);
           }
+        } else if (params.a === "mark-bear" || params.a === "mark-not-bear") {
+          // Fire-and-forget: records the override natively; the page gets
+          // best-effort "Marked ✓" feedback via evaluateJavaScript.
+          this.recordBearOverrideAndReport(
+            params.a,
+            params.id,
+            results,
+            bearOverridePending,
+            webView,
+          );
         }
         return false; // cancel the fake navigation; the page stays put
       };
       await webView.present(true);
+
+      // Apply recorded overrides: marked-bear drops get the same calendar prep
+      // as normally kept events and join the write plan; marked-not-bear events
+      // are adjusted in the plan into hidden tombstones.
+      const bearOverrideCounts = await this.applyPendingBearOverrides(
+        results,
+        bearOverridePending,
+      );
 
       // After displaying results, prompt for calendar execution if we have analyzed events
       // Don't prompt when displaying saved runs (they should use isDryRun override instead)
@@ -4592,6 +4613,7 @@ class ScriptableAdapter {
           const executedCount = await this.promptForCalendarExecution(
             eventsFromActiveParsers,
             results.config,
+            bearOverrideCounts,
           );
           results.calendarEvents = executedCount;
         } else {
@@ -6045,6 +6067,10 @@ class ScriptableAdapter {
         : ""
     }
 
+    ${this.generateBearDroppedSection(results)}
+
+    ${this.generateBearKeptOverrideSection(results)}
+
     ${this.generateDiscoveredVenueSection(results)}
 
     ${this.generateDiscoverySection(results)}
@@ -6071,6 +6097,27 @@ class ScriptableAdapter {
                 if (btn) {
                     btn.textContent = '✅ Copied!';
                     setTimeout(function () { btn.textContent = '📋 Copy parser entry'; }, 2000);
+                }
+            } catch (ignore) {}
+        }
+
+        // Manual bear/not-bear override buttons use the same chunkyscrape://
+        // navigation bridge (shouldAllowRequest, set before present()); the
+        // per-tap nonce keeps repeat taps firing as distinct navigations.
+        window.__bearOverrideNonce = 0;
+        function markBearOverride(btn) {
+            var idx = btn ? (btn.getAttribute('data-bear-idx') || '') : '';
+            var act = btn ? (btn.getAttribute('data-bear-act') || '') : '';
+            if (act !== 'mark-bear' && act !== 'mark-not-bear') return;
+            window.location.href = 'chunkyscrape://act?a=' + encodeURIComponent(act) +
+                '&id=' + encodeURIComponent(idx) + '&n=' + (window.__bearOverrideNonce++);
+        }
+        function markBearOverrideDone(idx, act) {
+            try {
+                var btn = document.querySelector('.bear-override-btn[data-bear-idx="' + idx + '"][data-bear-act="' + act + '"]');
+                if (btn) {
+                    btn.textContent = act === 'mark-bear' ? 'Marked bear ✓' : 'Marked not-bear ✓';
+                    btn.disabled = true;
                 }
             } catch (ignore) {}
         }
@@ -7150,6 +7197,246 @@ class ScriptableAdapter {
     } catch (error) {
       /* button feedback is optional polish; the copy already happened */
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Manual bear/not-bear overrides (results-UI ↔ chunkyscrape:// bridge).
+  // The owner's verdict is stamped as `bearSource: manual-*` in the event's
+  // notes, so it persists on the calendar record and wins over the AI on
+  // future scrapes (see SharedCore.prepareEventsForCalendar).
+  // ---------------------------------------------------------------------------
+
+  // Compact date label for override rows ("" when absent/unparseable).
+  formatBearOverrideDate(value) {
+    if (!value) return "";
+    const date = value instanceof Date ? value : new Date(value);
+    if (isNaN(date.getTime())) return "";
+    return date.toDateString();
+  }
+
+  // "Dropped as non-bear (N)" section: enforce-mode bear-check drops with the
+  // AI's one-line reason and a "Mark bear & save" button per row. Buttons are
+  // omitted for saved-run display (no post-dismissal execution there) and for
+  // rows already rescued by a calendar manual-bear record.
+  generateBearDroppedSection(results) {
+    const entries = Array.isArray(results && results.bearDroppedEvents)
+      ? results.bearDroppedEvents
+      : [];
+    if (entries.length === 0) return "";
+    const interactive =
+      !results || results._isDisplayingSavedRun !== true;
+
+    const rows = entries
+      .map((entry, index) => {
+        if (!entry) return "";
+        const metaBits = [
+          this.formatBearOverrideDate(entry.startDate),
+          entry.venue || "",
+          entry.host ? `from ${entry.host}` : "",
+        ]
+          .filter(Boolean)
+          .join(" · ");
+        const control = entry.rescued
+          ? `<span style="font-size:12px; color:var(--text-secondary);">🐻 Rescued (manual override on calendar record)</span>`
+          : interactive
+            ? `<button onclick="markBearOverride(this)" class="log-copy-btn bear-override-btn" data-bear-idx="${index}" data-bear-act="mark-bear">🐻 Mark bear &amp; save</button>`
+            : "";
+        return `
+        <div class="bear-dropped-item" style="margin-bottom:12px; padding:10px; background:var(--background-light); border-radius:8px;">
+            <div style="font-weight:600;">${this.escapeHtml(entry.title || "Unknown")}</div>
+            ${metaBits ? `<div style="font-size:12px; color:var(--text-secondary);">${this.escapeHtml(metaBits)}</div>` : ""}
+            ${entry.reason ? `<div style="font-size:12px; margin:4px 0; color:var(--text-secondary);">${this.escapeHtml(entry.reason)}</div>` : ""}
+            ${control}
+        </div>`;
+      })
+      .join("");
+
+    return `
+    <div class="section">
+        <div class="section-header">
+            <span class="section-icon">🚫</span>
+            <span class="section-title">Dropped as non-bear</span>
+            <span class="section-count">${entries.length}</span>
+        </div>
+        ${rows}
+    </div>
+    `;
+  }
+
+  // Compact symmetric section for kept/analyzed events: each row gets a
+  // "Mark not-bear" button (per-card buttons would tangle the event-card HTML;
+  // a dedicated list keeps the bridge indexes 1:1 with results.analyzedEvents).
+  // Live runs only — saved-run display has no post-dismissal execution.
+  generateBearKeptOverrideSection(results) {
+    if (results && results._isDisplayingSavedRun === true) return "";
+    const events = Array.isArray(results && results.analyzedEvents)
+      ? results.analyzedEvents
+      : [];
+    if (events.length === 0) return "";
+
+    const rows = events
+      .map((event, index) => {
+        if (!event) return "";
+        const meta = [
+          this.formatBearOverrideDate(event.startDate),
+          event.bar || event.venue || "",
+        ]
+          .filter(Boolean)
+          .join(" · ");
+        return `
+        <div class="bear-kept-item" style="display:flex; align-items:center; gap:8px; justify-content:space-between; margin-bottom:6px; padding:6px 10px; background:var(--background-light); border-radius:8px;">
+            <div style="min-width:0;">
+                <span style="font-weight:600;">${this.escapeHtml(event.title || "Unknown")}</span>
+                ${meta ? `<span style="font-size:12px; color:var(--text-secondary);"> — ${this.escapeHtml(meta)}</span>` : ""}
+            </div>
+            <button onclick="markBearOverride(this)" class="log-copy-btn bear-override-btn" data-bear-idx="${index}" data-bear-act="mark-not-bear">🚫 Mark not-bear</button>
+        </div>`;
+      })
+      .join("");
+
+    return `
+    <div class="section">
+        <div class="section-header">
+            <span class="section-icon">🐻</span>
+            <span class="section-title">Kept as bear — mark mistakes not-bear</span>
+            <span class="section-count">${events.length}</span>
+        </div>
+        <div style="font-size:12px; color:var(--text-secondary); margin-bottom:8px;">Marked events are still saved to the calendar but hidden on the website, and the override sticks on future scrapes.</div>
+        ${rows}
+    </div>
+    `;
+  }
+
+  // Record one override tap natively and (best-effort) flash the row's button.
+  // Called fire-and-forget from shouldAllowRequest, which must synchronously
+  // return a bool — so the await lives here, not in the handler. Repeat taps
+  // (per-tap nonce keeps them firing) overwrite the same pending slot.
+  async recordBearOverrideAndReport(action, id, results, pending, webView) {
+    try {
+      const key = String(id || "");
+      const index = Number(key);
+      if (!Number.isInteger(index) || index < 0) return;
+      let title = "";
+      if (action === "mark-bear") {
+        const entries = Array.isArray(results && results.bearDroppedEvents)
+          ? results.bearDroppedEvents
+          : [];
+        const entry = entries[index];
+        if (!entry || !entry.event || entry.rescued) return;
+        pending.markedBear[key] = entry;
+        title = entry.title || "";
+      } else {
+        const events = Array.isArray(results && results.analyzedEvents)
+          ? results.analyzedEvents
+          : [];
+        const event = events[index];
+        if (!event) return;
+        pending.markedNotBear[key] = event;
+        title = event.title || "";
+      }
+      console.log(
+        `📱 Scriptable: Bear override tapped — ${action} #${key} "${title}"`,
+      );
+      const feedbackJs = `markBearOverrideDone(${JSON.stringify(key)}, ${JSON.stringify(String(action))})`;
+      try {
+        await webView.evaluateJavaScript(feedbackJs, false);
+      } catch (error) {
+        /* in-page feedback is optional polish; the override is recorded */
+      }
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Failed to record bear override: ${error.message}`,
+      );
+    }
+  }
+
+  // Apply the overrides recorded during the WebView session. Returns
+  // { markedBear, markedNotBear } counts for the execution-confirmation Alert.
+  async applyPendingBearOverrides(results, pending) {
+    const counts = { markedBear: 0, markedNotBear: 0 };
+    const markedBearIds = Object.keys(
+      pending && pending.markedBear ? pending.markedBear : {},
+    );
+    const markedNotBearIds = Object.keys(
+      pending && pending.markedNotBear ? pending.markedNotBear : {},
+    );
+    if (markedBearIds.length === 0 && markedNotBearIds.length === 0) {
+      return counts;
+    }
+    const core = this.getIdentityCore();
+    if (!core) {
+      console.warn(
+        "📱 Scriptable: Bear overrides skipped (identity core failed to initialize)",
+      );
+      return counts;
+    }
+
+    // Marked not-bear: the analyzed event stays in the write plan but is
+    // adjusted in place — its one write stamps the hidden tombstone (the
+    // bearReview flag the website already hides, plus bearSource manual-*).
+    for (const id of markedNotBearIds) {
+      const event = pending.markedNotBear[id];
+      if (!event) continue;
+      const overriddenReason =
+        typeof event.bearReview === "string" && event.bearReview
+          ? event.bearReview
+          : typeof event.bearSource === "string" && event.bearSource
+            ? `${event.bearSource} verdict`
+            : "";
+      event.bearSource = SharedCore.buildManualBearSource(
+        "not-bear",
+        overriddenReason,
+      );
+      if (!/^(unlikely|unsure)/i.test(String(event.bearReview || "").trim())) {
+        event.bearReview = "unlikely — manual: marked not-bear by calendar owner";
+      }
+      event.notes = core.formatEventNotes(event);
+      counts.markedNotBear += 1;
+      console.log(
+        `📱 Scriptable: Manual override — "${event.title || "Unknown"}" marked not-bear (hidden tombstone will be written)`,
+      );
+    }
+
+    // Marked bear: stamp the manual verdict, then run the SAME calendar prep
+    // (calendar assignment + merge analysis) the normal flow uses so these
+    // late-added events join the write plan as fully analyzed events.
+    const toPrep = [];
+    for (const id of markedBearIds) {
+      const entry = pending.markedBear[id];
+      if (!entry || !entry.event) continue;
+      toPrep.push({
+        ...entry.event,
+        isBearEvent: true,
+        bearSource: SharedCore.buildManualBearSource("bear", entry.reason),
+      });
+      entry.manuallyMarkedBear = true;
+    }
+    if (toPrep.length > 0) {
+      try {
+        const globalConfig =
+          (results && results.config && results.config.config) || {};
+        const prepped = await core.prepareEventsForCalendar(
+          toPrep,
+          this,
+          globalConfig,
+        );
+        if (!Array.isArray(results.analyzedEvents)) {
+          results.analyzedEvents = [];
+        }
+        results.analyzedEvents.push(...prepped);
+        counts.markedBear = prepped.length;
+        prepped.forEach((event) =>
+          console.log(
+            `📱 Scriptable: Manual override — "${event.title || "Unknown"}" marked bear and prepped for calendar (${event._action || "new"})`,
+          ),
+        );
+      } catch (error) {
+        console.warn(
+          `📱 Scriptable: Manual bear override prep failed: ${error.message}`,
+        );
+      }
+    }
+    return counts;
   }
 
   // Generate HTML for URL discovery section (discoveryOnly mode results)
@@ -8734,7 +9021,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
   }
 
   // Prompt user for calendar execution after displaying results
-  async promptForCalendarExecution(analyzedEvents, config) {
+  async promptForCalendarExecution(analyzedEvents, config, overrideCounts = null) {
     if (!analyzedEvents || analyzedEvents.length === 0) {
       return false;
     }
@@ -8742,7 +9029,9 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     const alert = new Alert();
     alert.title = "Execute Calendar Actions?";
 
-    // Count actions by type (intent and write)
+    // Count actions by type (intent and write) — analyzedEvents already
+    // includes manually marked-bear rescues and adjusted not-bear tombstones,
+    // so these counts reflect the adjusted plan.
     const intentCounts = this.countMetricsActions(analyzedEvents);
     const writeCounts = this.countMetricsCalendarActions(analyzedEvents);
 
@@ -8762,6 +9051,12 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     if (writeCounts.skip) message += `⚠️ Skip ${writeCounts.skip} events\n`;
     if (writeCounts.other)
       message += `❓ Other write actions: ${writeCounts.other}\n`;
+    if (
+      overrideCounts &&
+      (overrideCounts.markedBear || overrideCounts.markedNotBear)
+    ) {
+      message += `\n🐻 Manual overrides: ${overrideCounts.markedBear || 0} marked bear, ${overrideCounts.markedNotBear || 0} marked not-bear (hidden)\n`;
+    }
 
     alert.message = message;
     alert.addAction("Execute");

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1328,3 +1328,161 @@ test('presentRichResults copies a venue parser entry natively via shouldAllowReq
     delete global.Pasteboard;
   }
 });
+
+// ---------------------------------------------------------------------------
+// Manual bear/not-bear overrides: results-UI sections + chunkyscrape:// bridge
+// ---------------------------------------------------------------------------
+
+const { EventSchema: TestEventSchema } = require(path.join(__dirname, '..', 'event-schema'));
+
+function buildBearDroppedFixture() {
+  return {
+    title: 'Twink Bash',
+    startDate: '2026-08-02T21:00:00.000Z',
+    venue: 'Neon Room',
+    reason: 'ai: drag show, no bear context',
+    host: 'promoter.example',
+    event: {
+      title: 'Twink Bash',
+      startDate: '2026-08-02T21:00:00.000Z',
+      bar: 'Neon Room',
+      city: 'dallas'
+    }
+  };
+}
+
+test('parseReviewActionUrl decodes mark-bear/mark-not-bear actions with their nonce', () => {
+  const adapter = buildAdapter();
+  const markBear = adapter.parseReviewActionUrl('chunkyscrape://act?a=mark-bear&id=3&n=7');
+  assert.equal(markBear.a, 'mark-bear');
+  assert.equal(markBear.id, '3');
+  assert.equal(markBear.n, '7');
+  const markNotBear = adapter.parseReviewActionUrl('chunkyscrape://act?a=mark-not-bear&id=0&n=12');
+  assert.equal(markNotBear.a, 'mark-not-bear');
+  assert.equal(markNotBear.id, '0');
+  assert.equal(markNotBear.n, '12');
+});
+
+test('generateBearDroppedSection renders drops with reason and button only when drops exist', () => {
+  const adapter = buildAdapter();
+
+  assert.equal(adapter.generateBearDroppedSection({}), '', 'no section without drops');
+  assert.equal(adapter.generateBearDroppedSection({ bearDroppedEvents: [] }), '', 'no section for an empty list');
+
+  const html = adapter.generateBearDroppedSection({ bearDroppedEvents: [buildBearDroppedFixture()] });
+  assert.ok(html.includes('Dropped as non-bear'), 'section title present');
+  assert.ok(html.includes('Twink Bash'), 'title shown');
+  assert.ok(html.includes('Neon Room'), 'venue shown');
+  assert.ok(html.includes('ai: drag show, no bear context'), 'AI reason shown');
+  assert.ok(html.includes('from promoter.example'), 'source host shown');
+  assert.ok(html.includes('data-bear-idx="0"'), 'row index carried on the button');
+  assert.ok(html.includes('data-bear-act="mark-bear"'), 'mark-bear action wired');
+  assert.ok(html.includes('markBearOverride(this)'), 'button signals via the bridge');
+
+  // A rescued row shows its badge instead of a button
+  const rescuedHtml = adapter.generateBearDroppedSection({
+    bearDroppedEvents: [{ ...buildBearDroppedFixture(), rescued: true }]
+  });
+  assert.ok(rescuedHtml.includes('Rescued (manual override on calendar record)'));
+  assert.ok(!rescuedHtml.includes('data-bear-act="mark-bear"'), 'no button on rescued rows');
+
+  // Saved-run display lists the drops but offers no buttons
+  const savedHtml = adapter.generateBearDroppedSection({
+    _isDisplayingSavedRun: true,
+    bearDroppedEvents: [buildBearDroppedFixture()]
+  });
+  assert.ok(savedHtml.includes('Twink Bash'));
+  assert.ok(!savedHtml.includes('data-bear-act="mark-bear"'));
+});
+
+test('generateBearKeptOverrideSection lists kept events with mark-not-bear buttons on live runs only', () => {
+  const adapter = buildAdapter();
+  const results = buildResultsStub();
+
+  const html = adapter.generateBearKeptOverrideSection(results);
+  assert.ok(html.includes('mark mistakes not-bear'), 'section title present');
+  assert.ok(html.includes('data-bear-idx="0"'));
+  assert.ok(html.includes('data-bear-idx="1"'));
+  assert.ok(html.includes('data-bear-act="mark-not-bear"'));
+
+  assert.equal(
+    adapter.generateBearKeptOverrideSection({ ...results, _isDisplayingSavedRun: true }),
+    '',
+    'saved-run display has no post-dismissal execution, so no buttons'
+  );
+  assert.equal(adapter.generateBearKeptOverrideSection({ analyzedEvents: [] }), '');
+});
+
+test('generateRichHTML embeds the dropped section only when bearDroppedEvents is non-empty', async () => {
+  const adapter = buildAdapter();
+  const withDrops = await adapter.generateRichHTML({
+    ...buildResultsStub(),
+    bearDroppedEvents: [buildBearDroppedFixture()]
+  });
+  assert.ok(withDrops.includes('Dropped as non-bear'), 'dropped section present');
+  assert.ok(withDrops.includes('chunkyscrape://act?a='), 'override buttons signal via the custom scheme');
+  assert.ok(withDrops.includes('__bearOverrideNonce'), 'per-tap nonce keeps repeat taps distinct navigations');
+  assert.ok(withDrops.includes('markBearOverrideDone'), 'best-effort feedback handler defined');
+
+  const withoutDrops = await adapter.generateRichHTML(buildResultsStub());
+  assert.ok(!withoutDrops.includes('Dropped as non-bear'), 'no dropped section without drops');
+});
+
+test('presentRichResults records override taps and applies them after dismissal', async () => {
+  const adapter = buildAdapter();
+  const droppedEntry = buildBearDroppedFixture();
+  // calendarEvents already set → the execution prompt path is skipped
+  const results = {
+    ...buildResultsStub(),
+    calendarEvents: 1,
+    config: { config: {} },
+    bearDroppedEvents: [droppedEntry]
+  };
+  const keptEvent = results.analyzedEvents[0];
+
+  const wv = installFakeWebView();
+  try {
+    const done = adapter.presentRichResults(results);
+    for (let i = 0; i < 200 && !wv.getHandler(); i++) {
+      await new Promise((r) => setImmediate(r));
+    }
+    assert.ok(wv.getHandler(), 'shouldAllowRequest assigned before present()');
+
+    // Taps: rescue the dropped event, bury a kept one. Navigation cancelled.
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-bear&id=0&n=1'), false);
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-not-bear&id=0&n=2'), false);
+    await new Promise((r) => setImmediate(r));
+    assert.ok(
+      wv.evals.some((js) => js.includes('markBearOverrideDone("0", "mark-bear")')),
+      'in-page "Marked" feedback pushed (best-effort)'
+    );
+
+    // Out-of-range ids are ignored without crashing.
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-bear&id=99&n=3'), false);
+
+    wv.dismiss();
+    await done;
+  } finally {
+    delete global.WebView;
+  }
+
+  // Marked not-bear: adjusted in the plan as a hidden tombstone — the
+  // bearReview flag matches the exact regex the website hides on
+  // (js/calendar-core.js isHiddenForBearReview) plus bearSource manual-*.
+  assert.ok(/^(unlikely|unsure)/i.test(keptEvent.bearReview), 'tombstone carries the site-hidden bearReview flag');
+  assert.ok(String(keptEvent.bearSource).startsWith('manual-not-bear'), 'manual verdict stamped');
+  const tombstoneFields = TestEventSchema.parseNotesIntoFields(keptEvent.notes);
+  assert.equal(tombstoneFields.bearSource, keptEvent.bearSource, 'bearSource persisted in notes');
+  assert.equal(tombstoneFields.bearReview, keptEvent.bearReview, 'hide flag persisted in notes');
+
+  // Marked bear: prepped through the normal calendar flow and appended to the
+  // plan (the stubbed environment yields action "new").
+  assert.equal(results.analyzedEvents.length, 3, 'rescued event joined the plan');
+  const rescued = results.analyzedEvents[2];
+  assert.equal(rescued.title, 'Twink Bash');
+  assert.equal(rescued._action, 'new');
+  assert.equal(rescued.isBearEvent, true);
+  assert.ok(String(rescued.bearSource).startsWith('manual-bear (overrode ai: drag show'), 'manual verdict records what it overrode');
+  assert.equal(TestEventSchema.parseNotesIntoFields(rescued.notes).bearSource, rescued.bearSource);
+  assert.equal(droppedEntry.manuallyMarkedBear, true);
+});

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -327,22 +327,44 @@ class BearEventScraperOrchestrator {
                 results.analyzedEvents = [];
             }
 
-            // Add to calendar if not dry run and we have events
-            if (results.allProcessedEvents && results.allProcessedEvents.length > 0) {
+            // Add to calendar if not dry run and we have events. Enforce-mode
+            // bear-check drops still get their prep-time manual-override check
+            // (a calendar record stamped `bearSource: manual-bear…` rescues
+            // them) even when every scraped event was dropped.
+            const hasBearDrops = Array.isArray(results.bearDroppedEvents) && results.bearDroppedEvents.length > 0;
+            if ((results.allProcessedEvents && results.allProcessedEvents.length > 0) || hasBearDrops) {
                 console.log(`🐻 Orchestrator: Preparing ${results.allProcessedEvents.length} events for calendar...`);
 
                 let calendarEvents = 0;
 
                 // Check if we should add to calendar
                 const isDryRun = Boolean(config.config?.dryRun);
-                
+
                 // Always prepare events for analysis (even in dry run mode) to show action types
                 // Perform cross-parser deduplication to merge events from different parsers
                 const deduplicatedEvents = await sharedCore.deduplicateEvents(results.allProcessedEvents, finalAdapter, config.config);
-                
-                const analyzedEvents = await sharedCore.prepareEventsForCalendar(deduplicatedEvents, finalAdapter, config.config);
+
+                // Manual bear/not-bear overrides stored on calendar records win
+                // over this run's automatic verdicts, in both directions.
+                const bearOverrideContext = {
+                    droppedEvents: hasBearDrops ? results.bearDroppedEvents : [],
+                    demoted: [],
+                    rescued: []
+                };
+
+                const analyzedEvents = await sharedCore.prepareEventsForCalendar(deduplicatedEvents, finalAdapter, config.config, bearOverrideContext);
                 console.log(`🐻 Orchestrator: Calendar analysis complete (${deduplicatedEvents.length} unique)`);
-                
+
+                // Demoted events (kept by the cascade, overridden by a calendar
+                // manual-not-bear record) surface alongside the cascade's drops;
+                // rescued drops are already flagged `rescued` on their entries.
+                if (bearOverrideContext.demoted.length > 0) {
+                    if (!Array.isArray(results.bearDroppedEvents)) {
+                        results.bearDroppedEvents = [];
+                    }
+                    results.bearDroppedEvents.push(...bearOverrideContext.demoted);
+                }
+
                 // Store analyzed events back into results for display
                 results.analyzedEvents = analyzedEvents;
                 

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -377,9 +377,45 @@ class SharedCore {
         // finalized location/address deterministically (see setProvenanceSource
         // in createFinalEventObject) — never sent to the AI, so a hand-fixed
         // pin/address is never relabeled with a source the scrape didn't produce.
+        // bearSource is bear-verdict provenance (keyword/ai/config or a
+        // manual-* owner override) — like pinSource it is metadata about how a
+        // value was decided, never content the AI may arbitrate; its merge is
+        // resolved deterministically in createFinalEventObject so a manual
+        // override can never be relabeled by a scraped verdict.
         return name !== 'key' && name !== 'notes' && name !== 'source'
             && name !== 'location' && name !== 'gmaps'
-            && name !== 'pinSource' && name !== 'addressSource';
+            && name !== 'pinSource' && name !== 'addressSource'
+            && name !== 'bearSource';
+    }
+
+    // True when a bearSource value records the calendar owner's manual verdict
+    // ("manual-bear ..." / "manual-not-bear ..." as stamped by the results UI).
+    isManualBearSource(value) {
+        return typeof value === 'string' && value.trim().toLowerCase().startsWith('manual-');
+    }
+
+    // The owner's manual verdict stored on a calendar record's notes, or null.
+    // Accepts any object carrying `notes` (Scriptable CalendarEvent or plain).
+    getManualBearVerdictFromRecord(record) {
+        if (!record || typeof record !== 'object') return null;
+        const fields = this.parseNotesIntoFields(record.notes || '');
+        const value = typeof fields.bearSource === 'string' ? fields.bearSource.trim().toLowerCase() : '';
+        if (value.startsWith('manual-not-bear')) return 'manual-not-bear';
+        if (value.startsWith('manual-bear')) return 'manual-bear';
+        return null;
+    }
+
+    // One-line manual bearSource value: `manual-bear (overrode ai: <reason>)` /
+    // `manual-not-bear (overrode ai: <reason>)`, reason truncated to ~80 chars.
+    static buildManualBearSource(direction, overriddenReason) {
+        const label = direction === 'bear' ? 'manual-bear' : 'manual-not-bear';
+        let reason = String(overriddenReason || '').replace(/\s+/g, ' ').trim();
+        // The stored verdict reasons are prefixed with their cascade tier
+        // ("ai: drag show") — the label already says "overrode ai", so strip it.
+        reason = reason.replace(/^ai:\s*/i, '');
+        if (!reason) return label;
+        if (reason.length > 80) reason = `${reason.slice(0, 77)}...`;
+        return `${label} (overrode ai: ${reason})`;
     }
 
     // Provenance (pinSource/addressSource) follows the finalized value: whichever
@@ -995,7 +1031,11 @@ class SharedCore {
             duplicatesRemoved: 0,
             errors: [],
             parserResults: [],
-            allProcessedEvents: [] // All events ready for calendar
+            allProcessedEvents: [], // All events ready for calendar
+            // Enforce-mode bear-check drops, surfaced for the results UI and the
+            // prep-time manual-override check. Never enter the write plan,
+            // dedup, or calendar analysis by default.
+            bearDroppedEvents: []
         };
         const disabledParsers = [];
         const automationContext = this.resolveAutomationContext(config);
@@ -1058,7 +1098,21 @@ class SharedCore {
                     });
                     results.allProcessedEvents.push(...parserResult.events);
                 }
-                
+
+                // Aggregate enforce-mode bear-check drops. Their event objects
+                // carry the effective parser config too — a prep-time manual
+                // rescue needs calendar assignment and dry-run filtering to
+                // behave exactly like a normally kept event.
+                if (Array.isArray(parserResult.bearDroppedEvents) && parserResult.bearDroppedEvents.length > 0) {
+                    const stampedConfig = parserResult.config || parserConfig;
+                    for (const dropped of parserResult.bearDroppedEvents) {
+                        if (dropped && dropped.event && Object.isExtensible(dropped.event)) {
+                            dropped.event._parserConfig = stampedConfig;
+                        }
+                    }
+                    results.bearDroppedEvents.push(...parserResult.bearDroppedEvents);
+                }
+
                 await displayAdapter.logSuccess(`SYSTEM: ${parserConfig.name}: ${parserResult.bearEvents} bear events`);
                 
             } catch (error) {
@@ -1204,9 +1258,11 @@ class SharedCore {
 
         // Metadata is applied dynamically by parsers using the {value, merge} format
 
-        // Filter and process events
+        // Filter and process events. Enforce-mode bear-check drops are carried
+        // through to results (flag, don't drop) — never into the write plan.
+        const bearDropCollector = [];
         const futureEvents = this.filterFutureEvents(allEvents, effectiveParserConfig.daysToLookAhead, effectiveParserConfig.allowPastEvents);
-        const bearEvents = await this.filterBearEvents(futureEvents, effectiveParserConfig, httpAdapter);
+        const bearEvents = await this.filterBearEvents(futureEvents, effectiveParserConfig, httpAdapter, bearDropCollector);
         const deduplicatedEvents = await this.deduplicateEvents(bearEvents, httpAdapter, mainConfig?.config || mainConfig || null);
         
         // Calculate deduplication stats
@@ -1230,6 +1286,10 @@ class SharedCore {
 
         if (enrichDropCollector.length > 0) {
             result.enrichOnlyDrops = enrichDropCollector;
+        }
+
+        if (bearDropCollector.length > 0) {
+            result.bearDroppedEvents = bearDropCollector;
         }
 
         if (discoveryOnly && discoveryTreeCollector) {
@@ -2457,7 +2517,7 @@ class SharedCore {
     // would-be decision while returning exactly today's behavior; 'enforce'
     // keeps/flags/rescues/drops on the cascade's decisions; 'off' is exact
     // legacy behavior (alwaysBear bypass, keyword filter) with no new logs.
-    async filterBearEvents(events, parserConfig, httpAdapter = null) {
+    async filterBearEvents(events, parserConfig, httpAdapter = null, dropCollector = null) {
         const legacyFilter = () => parserConfig.alwaysBear
             ? events.map(event => ({...event, isBearEvent: true}))
             : events.filter(event => this.isBearEvent(event, parserConfig));
@@ -2483,10 +2543,32 @@ class SharedCore {
                     ? ' (would-rescue — legacy keyword filter still drops it)'
                     : '';
                 console.log(`🐻 BEAR CHECK${tag}: "${title}" → bear (${decision.provenance})${rescueNote}`);
-                kept.push({...event, isBearEvent: true});
+                // bearSource provenance stamp (notes-serialized like pinSource):
+                // records which cascade tier produced the bear verdict so a
+                // later manual override can say what it overrode.
+                const bearSource = decision.provenance.startsWith('keyword:') ? 'keyword'
+                    : decision.provenance.startsWith('ai:') ? 'ai'
+                        : decision.provenance.startsWith('config:') ? 'config'
+                            : '';
+                kept.push(bearSource
+                    ? {...event, isBearEvent: true, bearSource}
+                    : {...event, isBearEvent: true});
             } else if (decision.result === 'not_bear' && !trusted) {
                 counts.dropped++;
                 console.log(`🐻 BEAR CHECK${tag}: "${title}" → DROP (${decision.provenance})`);
+                // Flag, don't drop silently: enforce-mode drops are surfaced to
+                // the results UI (and prep-time manual-override rescue) via the
+                // caller's collector. Report mode changes nothing.
+                if (dropCollector && mode === 'enforce') {
+                    dropCollector.push({
+                        title,
+                        startDate: event.startDate || event.date || null,
+                        venue: event.bar || event.venue || '',
+                        reason: decision.provenance,
+                        host: this.getHostFromUrl(event._sourcePageUrl || event.url || event.website || '') || '',
+                        event: { ...event }
+                    });
+                }
             } else {
                 // alwaysBear sources never lose events: not_bear/unsure is kept
                 // with a review flag; untrusted unsure is likewise kept+flagged.
@@ -3502,9 +3584,39 @@ class SharedCore {
             // the field never enters clobber/arbitration tracking (a fresh flag
             // differing from the human's edit would otherwise churn every run).
             if (fieldName === 'bearReview') {
+                // Exception to calendar-wins: a fresh manual-bear override from
+                // the results UI is the owner's newest verdict — it must clear a
+                // stored hide/review flag (e.g. a manual-not-bear tombstone's
+                // "unlikely — …" flag), or the rescued event stays hidden.
+                const scraperBearSource = typeof scraperObject.bearSource === 'string'
+                    ? scraperObject.bearSource.trim().toLowerCase()
+                    : '';
+                if (scraperBearSource.startsWith('manual-bear')) {
+                    if (!this.isEmptyArbitrationValue(scraperValue)) {
+                        mergedObject[fieldName] = scraperValue;
+                    }
+                    continue;
+                }
                 mergedObject[fieldName] = !this.isEmptyArbitrationValue(calendarValue)
                     ? calendarValue
                     : scraperValue;
+                continue;
+            }
+
+            // bearSource is bear-verdict provenance, resolved deterministically
+            // (never arbitrated, see isArbitrationEligibleField): a freshly
+            // tapped manual-* override (scraped side) is the owner's newest
+            // word and wins; otherwise a stored manual-* value is never
+            // clobbered by an automatic keyword/ai/config stamp; otherwise the
+            // fresh automatic verdict follows this run's cascade decision.
+            if (fieldName === 'bearSource') {
+                if (this.isManualBearSource(scraperValue)) {
+                    mergedObject[fieldName] = scraperValue;
+                } else if (this.isManualBearSource(calendarValue) || this.isEmptyArbitrationValue(scraperValue)) {
+                    mergedObject[fieldName] = calendarValue;
+                } else {
+                    mergedObject[fieldName] = scraperValue;
+                }
                 continue;
             }
 
@@ -4932,22 +5044,84 @@ class SharedCore {
     }
 
     // Prepare events for calendar integration with conflict analysis
-    async prepareEventsForCalendar(events, calendarAdapter, config = {}) {
+    async prepareEventsForCalendar(events, calendarAdapter, config = {}, bearOverrideContext = null) {
         // Events are already properly formatted - no need for additional formatting
-        
+
+        // Use default merge mode since parser-level mergeMode is handled by field priorities
+        const mergeMode = config.mergeMode || 'upsert';
+
         // Analyze each event against existing calendar events
         const analyzedEvents = [];
-        
+
         for (const event of events) {
-            // Use default merge mode since parser-level mergeMode is handled by field priorities
-            const mergeMode = config.mergeMode || 'upsert';
-            
             // Get existing events from the adapter
             const existingEvents = await calendarAdapter.getExistingEvents(event);
-            
+
             // Analyze what action to take
             const analysis = this.analyzeEventAction(event, existingEvents, mergeMode);
-            
+
+            // Manual override, demote direction: a kept event whose identity-
+            // matched calendar record carries `bearSource: manual-not-bear…` is
+            // NOT merged/written — the calendar record stays as-is (the hidden
+            // tombstone) and the event surfaces as an overridden drop instead.
+            // A scraped manual-* verdict (a fresh owner tap from the results
+            // UI) is newer than the stored one and is never demoted by it.
+            // Reuses the existing-event search prep just performed — no extra
+            // calendar scans.
+            if (bearOverrideContext && !this.isManualBearSource(event.bearSource)) {
+                const matchedRecord = analysis.existingEvent || analysis.sourceEvent || null;
+                if (matchedRecord && this.getManualBearVerdictFromRecord(matchedRecord) === 'manual-not-bear') {
+                    console.log(`🐻 BEAR CHECK: "${event.title || 'Unknown'}" → not_bear (manual override on calendar record)`);
+                    if (Array.isArray(bearOverrideContext.demoted)) {
+                        bearOverrideContext.demoted.push({
+                            title: event.title || 'Unknown',
+                            startDate: event.startDate || null,
+                            venue: event.bar || event.venue || '',
+                            reason: 'manual-not-bear (manual override on calendar record)',
+                            host: this.getHostFromUrl(event._sourcePageUrl || event.url || event.website || '') || '',
+                            event: { ...event },
+                            demoted: true
+                        });
+                    }
+                    continue;
+                }
+            }
+
+            analyzedEvents.push(await this.buildAnalyzedCalendarEvent(event, analysis, calendarAdapter, config));
+        }
+
+        // Manual override, rescue direction: an enforce-mode dropped event whose
+        // identity-matched calendar record carries `bearSource: manual-bear…`
+        // is treated as kept and proceeds through the normal merge/write path.
+        // Only ambiguous (dropped) events get this one extra existing-event
+        // search — absence of a match simply means the drop stands.
+        if (bearOverrideContext && Array.isArray(bearOverrideContext.droppedEvents)) {
+            for (const dropped of bearOverrideContext.droppedEvents) {
+                const droppedEvent = dropped && dropped.event;
+                if (!droppedEvent || dropped.rescued) continue;
+                const existingEvents = await calendarAdapter.getExistingEvents(droppedEvent);
+                const analysis = this.analyzeEventAction(droppedEvent, existingEvents, mergeMode);
+                const matchedRecord = analysis.existingEvent || analysis.sourceEvent || null;
+                if (!matchedRecord || this.getManualBearVerdictFromRecord(matchedRecord) !== 'manual-bear') continue;
+                console.log(`🐻 BEAR CHECK: "${droppedEvent.title || 'Unknown'}" → bear (manual override on calendar record)`);
+                const rescuedEvent = { ...droppedEvent, isBearEvent: true };
+                analyzedEvents.push(await this.buildAnalyzedCalendarEvent(rescuedEvent, analysis, calendarAdapter, config));
+                dropped.rescued = true;
+                if (Array.isArray(bearOverrideContext.rescued)) {
+                    bearOverrideContext.rescued.push(dropped);
+                }
+            }
+        }
+
+        return analyzedEvents;
+    }
+
+    // One event's calendar-prep analysis (extracted from prepareEventsForCalendar
+    // so manually rescued events run the exact same merge/diff pipeline).
+    async buildAnalyzedCalendarEvent(event, analysis, calendarAdapter, config = {}) {
+        // (Block wrapper keeps the extracted loop body byte-identical to its
+        // original prepareEventsForCalendar form — minimal, reviewable diff.)
+        {
             // Create a new object with all properties to avoid readonly errors
             let analyzedEvent = { ...event };
             
@@ -5071,13 +5245,11 @@ class SharedCore {
             if (!analyzedEvent.notes) {
                 analyzedEvent.notes = this.formatEventNotes(analyzedEvent);
             }
-            
-            analyzedEvents.push(analyzedEvent);
+
+            return analyzedEvent;
         }
-        
-        return analyzedEvents;
     }
-    
+
     // Analyze events against existing calendar events and determine actions
     // This is pure business logic - adapters provide the existing events data
     analyzeEventActions(newEvents, existingEventsData) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -2734,6 +2734,271 @@ test('bearReview round-trips notes and an existing calendar value survives merge
 });
 
 // ---------------------------------------------------------------------------
+// Manual bear/not-bear overrides: dropped events carried to results,
+// bearSource provenance, and prep-time calendar-record overrides
+// ---------------------------------------------------------------------------
+
+test('filterBearEvents enforce: drops land in the collector with verdict info, kept behavior unchanged', async () => {
+  const core = createCore();
+  const adapter = buildBearVerdictAdapter({ verdict: 'not_bear', reason: 'drag show, no bear context' });
+  const dropCollector = [];
+  const result = await core.filterBearEvents(
+    [
+      { title: 'Bear Night', bar: 'The Eagle', startDate: new Date('2026-08-01T21:00:00.000Z') },
+      { title: 'Twink Bash', bar: 'Neon Room', startDate: new Date('2026-08-02T21:00:00.000Z'), url: 'https://promoter.example/twink-bash' }
+    ],
+    bearCheckConfig('enforce'),
+    adapter,
+    dropCollector
+  );
+
+  // Kept behavior unchanged: the keyword event survives with its stamps
+  assert.deepEqual(result.map(e => e.title), ['Bear Night']);
+  assert.equal(result[0].isBearEvent, true);
+
+  // The drop is carried through with its verdict info, not silently gone
+  assert.equal(dropCollector.length, 1);
+  const dropped = dropCollector[0];
+  assert.equal(dropped.title, 'Twink Bash');
+  assert.equal(dropped.venue, 'Neon Room');
+  assert.equal(dropped.reason, 'ai: drag show, no bear context');
+  assert.equal(dropped.host, 'promoter.example');
+  assert.equal(dropped.event.title, 'Twink Bash');
+  assert.ok(dropped.startDate instanceof Date);
+});
+
+test('filterBearEvents report/off modes never fill the drop collector', async () => {
+  for (const mode of ['report', 'off']) {
+    const core = createCore();
+    const adapter = buildBearVerdictAdapter({ verdict: 'not_bear', reason: 'drag show' });
+    const dropCollector = [];
+    await core.filterBearEvents(
+      [{ title: 'Twink Bash' }],
+      bearCheckConfig(mode),
+      adapter,
+      dropCollector
+    );
+    assert.equal(dropCollector.length, 0, `mode ${mode} must not collect drops`);
+  }
+});
+
+test('bearSource: stamped keyword/ai on enforce keeps and round-trips through notes', async () => {
+  // keyword tier
+  const keywordCore = createCore();
+  const keywordKept = await keywordCore.filterBearEvents(
+    [{ title: 'Bear Night' }],
+    bearCheckConfig('enforce'),
+    buildBearVerdictAdapter({ verdict: 'bear', reason: 'unused' })
+  );
+  assert.equal(keywordKept[0].bearSource, 'keyword');
+
+  // ai tier
+  const aiCore = createCore();
+  const aiKept = await aiCore.filterBearEvents(
+    [{ title: 'Treasure Trail Seattle' }],
+    bearCheckConfig('enforce'),
+    buildBearVerdictAdapter({ verdict: 'bear', reason: 'bear promoter event' })
+  );
+  assert.equal(aiKept[0].bearSource, 'ai');
+
+  // config tier (trusted promoter, AI unavailable)
+  const configCore = createCore();
+  const configKept = await configCore.filterBearEvents(
+    [{ title: 'DENVER @ Ophelia\'s' }],
+    bearCheckConfig('enforce', { alwaysBear: true }),
+    buildBearVerdictAdapter(null, { fail: true })
+  );
+  assert.equal(configKept[0].bearSource, 'config');
+
+  // Notes codec round-trip (values contain colons — must escape/unescape)
+  const core = createCore();
+  for (const value of ['ai', 'manual-not-bear (overrode ai: drag show)', 'manual-bear (overrode ai: lesbian night)']) {
+    const notes = core.formatEventNotes({ bar: 'Eagle', bearSource: value });
+    assert.equal(core.parseNotesIntoFields(notes).bearSource, value);
+  }
+});
+
+test('bearSource: excluded from arbitration and a scraped value never clobbers manual-*', async () => {
+  const core = createCore();
+  assert.equal(core.isArbitrationEligibleField('bearSource'), false);
+  assert.equal(core.isArbitrationEligibleField('bearReview'), true, 'bearReview keeps its own dedicated rule');
+
+  // A stored manual-* verdict survives a fresh automatic stamp
+  const manualKept = await core.createFinalEventObject(
+    buildCalendarEvent({}, 'bar: STATION 4\nbearSource: manual-bear (overrode ai: drag show)'),
+    buildScrapedEvent({ bearSource: 'ai' }),
+    {}
+  );
+  assert.equal(manualKept.bearSource, 'manual-bear (overrode ai: drag show)');
+  assert.equal(core.parseNotesIntoFields(manualKept.notes).bearSource, 'manual-bear (overrode ai: drag show)');
+
+  // A fresh automatic verdict follows this run over a stale automatic one
+  const freshAuto = await core.createFinalEventObject(
+    buildCalendarEvent({}, 'bar: STATION 4\nbearSource: ai'),
+    buildScrapedEvent({ bearSource: 'keyword' }),
+    {}
+  );
+  assert.equal(freshAuto.bearSource, 'keyword');
+
+  // A freshly tapped manual override (scraped side) is the owner's newest word
+  const freshManual = await core.createFinalEventObject(
+    buildCalendarEvent({}, 'bar: STATION 4\nbearSource: manual-not-bear (overrode ai: x)\nbearReview: unlikely — manual\\: marked not-bear by calendar owner'),
+    buildScrapedEvent({ bearSource: 'manual-bear (overrode ai: x)' }),
+    {}
+  );
+  assert.equal(freshManual.bearSource, 'manual-bear (overrode ai: x)');
+  // ...and it clears the tombstone's hide flag so the rescue is visible again
+  assert.equal(core.parseNotesIntoFields(freshManual.notes).bearReview, undefined);
+});
+
+test('buildManualBearSource: one line, ai-prefix stripped, reason truncated ~80 chars', () => {
+  assert.equal(
+    SharedCore.buildManualBearSource('bear', 'ai: drag show'),
+    'manual-bear (overrode ai: drag show)'
+  );
+  assert.equal(SharedCore.buildManualBearSource('not-bear', ''), 'manual-not-bear');
+  const long = SharedCore.buildManualBearSource('not-bear', 'x'.repeat(200));
+  assert.ok(long.startsWith('manual-not-bear (overrode ai: '));
+  assert.ok(long.length <= 'manual-not-bear (overrode ai: )'.length + 80);
+  assert.ok(!long.includes('\n'));
+});
+
+// Calendar adapter stub for prep-time override tests: every event search
+// returns the same canned records, and calls are counted.
+function buildPrepCalendarAdapter(records) {
+  const calls = [];
+  return {
+    calls,
+    getExistingEvents: async (event) => {
+      calls.push(event.title);
+      return records;
+    }
+  };
+}
+
+function buildOverrideContext(droppedEvents = []) {
+  return { droppedEvents, demoted: [], rescued: [] };
+}
+
+test('prep-time override: dropped event with a manual-bear calendar match is rescued into the plan', async () => {
+  const core = createCore();
+  const calendarRecord = {
+    title: 'OUTDRAG',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    endDate: new Date('2026-08-02T01:00:00.000Z'),
+    location: '',
+    notes: 'bar: The Eagle\nbearSource: manual-bear (overrode ai: drag show)'
+  };
+  const adapter = buildPrepCalendarAdapter([calendarRecord]);
+  const droppedEntry = {
+    title: 'OUTDRAG',
+    reason: 'ai: drag show',
+    event: { title: 'OUTDRAG', startDate: new Date('2026-08-01T21:00:00.000Z'), bar: 'The Eagle' }
+  };
+  const context = buildOverrideContext([droppedEntry]);
+
+  const analyzed = await core.prepareEventsForCalendar([], adapter, {}, context);
+
+  assert.equal(analyzed.length, 1, 'the dropped event is rescued into the plan');
+  assert.equal(analyzed[0]._action, 'merge', 'rescue proceeds through the normal merge path');
+  assert.equal(analyzed[0].isBearEvent, true);
+  assert.equal(
+    core.parseNotesIntoFields(analyzed[0].notes).bearSource,
+    'manual-bear (overrode ai: drag show)',
+    'the calendar record\'s manual verdict follows the merged event'
+  );
+  assert.equal(droppedEntry.rescued, true);
+  assert.deepEqual(context.rescued, [droppedEntry]);
+});
+
+test('prep-time override: kept event with a manual-not-bear calendar match is demoted, record untouched', async () => {
+  const core = createCore();
+  const tombstoneNotes = 'bar: Neon Room\nbearSource: manual-not-bear (overrode ai: kept wrongly)\nbearReview: unlikely — manual\\: marked not-bear by calendar owner';
+  const calendarRecord = {
+    title: 'Bronze Babez',
+    startDate: new Date('2026-08-05T21:00:00.000Z'),
+    endDate: new Date('2026-08-06T01:00:00.000Z'),
+    location: '',
+    notes: tombstoneNotes
+  };
+  const adapter = buildPrepCalendarAdapter([calendarRecord]);
+  const keptEvent = { title: 'Bronze Babez', startDate: new Date('2026-08-05T21:00:00.000Z'), bar: 'Neon Room', bearSource: 'ai' };
+  const context = buildOverrideContext();
+
+  const analyzed = await core.prepareEventsForCalendar([keptEvent], adapter, {}, context);
+
+  assert.equal(analyzed.length, 0, 'demoted events never enter the write plan');
+  assert.equal(context.demoted.length, 1);
+  assert.equal(context.demoted[0].title, 'Bronze Babez');
+  assert.equal(context.demoted[0].reason, 'manual-not-bear (manual override on calendar record)');
+  assert.equal(calendarRecord.notes, tombstoneNotes, 'the calendar tombstone stays exactly as-is');
+  assert.equal(adapter.calls.length, 1, 'the demote check reuses prep\'s one existing-event search');
+});
+
+test('prep-time override: no calendar match (or no manual verdict) leaves behavior unchanged', async () => {
+  // Kept event, empty calendar → analyzed as new, nothing demoted
+  const core = createCore();
+  const emptyAdapter = buildPrepCalendarAdapter([]);
+  const context = buildOverrideContext([
+    { title: 'Twink Bash', reason: 'ai: drag show', event: { title: 'Twink Bash', startDate: new Date('2026-08-02T21:00:00.000Z') } }
+  ]);
+  const analyzed = await core.prepareEventsForCalendar(
+    [{ title: 'Bear Night', startDate: new Date('2026-08-01T21:00:00.000Z'), bearSource: 'keyword' }],
+    emptyAdapter,
+    {},
+    context
+  );
+  assert.equal(analyzed.length, 1);
+  assert.equal(analyzed[0]._action, 'new');
+  assert.equal(context.demoted.length, 0);
+  assert.equal(context.rescued.length, 0, 'an unmatched drop stays dropped');
+
+  // A matching record WITHOUT a manual verdict never rescues or demotes
+  const autoCore = createCore();
+  const autoRecord = {
+    title: 'Twink Bash',
+    startDate: new Date('2026-08-02T21:00:00.000Z'),
+    endDate: new Date('2026-08-03T01:00:00.000Z'),
+    location: '',
+    notes: 'bar: Neon Room\nbearSource: ai'
+  };
+  const autoContext = buildOverrideContext([
+    { title: 'Twink Bash', reason: 'ai: drag show', event: { title: 'Twink Bash', startDate: new Date('2026-08-02T21:00:00.000Z') } }
+  ]);
+  const autoAnalyzed = await autoCore.prepareEventsForCalendar([], buildPrepCalendarAdapter([autoRecord]), {}, autoContext);
+  assert.equal(autoAnalyzed.length, 0);
+  assert.equal(autoContext.rescued.length, 0);
+});
+
+test('prep-time override: a freshly tapped manual-bear event is never demoted by the old tombstone', async () => {
+  const core = createCore();
+  const calendarRecord = {
+    title: 'Bronze Babez',
+    startDate: new Date('2026-08-05T21:00:00.000Z'),
+    endDate: new Date('2026-08-06T01:00:00.000Z'),
+    location: '',
+    notes: 'bar: Neon Room\nbearSource: manual-not-bear (overrode ai: kept wrongly)'
+  };
+  const adapter = buildPrepCalendarAdapter([calendarRecord]);
+  const flippedEvent = {
+    title: 'Bronze Babez',
+    startDate: new Date('2026-08-05T21:00:00.000Z'),
+    bar: 'Neon Room',
+    bearSource: 'manual-bear (overrode ai: kept wrongly)'
+  };
+  const context = buildOverrideContext();
+
+  const analyzed = await core.prepareEventsForCalendar([flippedEvent], adapter, {}, context);
+
+  assert.equal(analyzed.length, 1, 'the owner\'s fresh verdict wins over the stored one');
+  assert.equal(context.demoted.length, 0);
+  assert.equal(
+    core.parseNotesIntoFields(analyzed[0].notes).bearSource,
+    'manual-bear (overrode ai: kept wrongly)'
+  );
+});
+
+// ---------------------------------------------------------------------------
 // logDebug / logAiPayloadDebug (two-tier logging)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What this adds

The calendar owner gets final say over the bear-check, both directions, with the verdict persisted ON the calendar event (no side files — the calendar is the database).

1. **Drops are shown, not swallowed** — enforce-mode drops now flow into the results UI as a "Dropped as non-bear" section with the AI's one-line reason per event.
2. **Mark bear & save** — each dropped event gets a button (chunkyscrape:// shouldAllowRequest bridge from #1506). Marked events run the REAL calendar prep (the per-event analysis was extracted verbatim into `buildAnalyzedCalendarEvent` and reused) and join the normal execution prompt with correct counts.
3. **Mark not-bear** — symmetric buttons on kept events. Marked events are written exactly once as a hidden tombstone: `bearReview: unlikely — manual: …` (matches `js/calendar-core.js isHiddenForBearReview`'s `/^(unlikely|unsure)/i` — js/ untouched, asserted by test) so the site hides it but the record persists.
4. **`bearSource` provenance in notes** — `keyword` / `ai` / `config` stamped automatically; `manual-bear (overrode ai: …)` / `manual-not-bear (…)` on taps. Follows the pinSource pattern: notes round-trip, excluded from AI arbitration, deterministic merge where manual always outranks automatic.
5. **Manual verdicts win on identity match, both directions** — at prep time, a dropped scrape whose matched calendar record says manual-bear is rescued (`🐻 BEAR CHECK: … → bear (manual override on calendar record)`); a kept scrape matching a manual-not-bear tombstone is demoted and the tombstone left untouched. A fresh manual-bear tap un-buries a tombstone (clears bearReview in the merge), and deleting the calendar record resets everything. Future editions (new date, no record) reappear for one tap — the agreed option 1; series-level lookback intentionally deferred.

## Tests
+14 (shared-core 9, scriptable-adapter 5): drop collection, bearSource stamping/round-trip/arbitration-exclusion/merge precedence, rescue + demote + no-match paths, tombstone regex match, action-URL parsing with nonce, conditional UI sections. Suite: **494 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/adapters/scriptable-adapter.js`, `scripts/bear-event-scraper-unified.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP