### PR TITLE
fix(scraper): tee module consoles into the run-log file (Scriptable per-module console)

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -194,6 +194,15 @@ class FileLogger {
     }
   }
 
+  // Scriptable gives every imported module its own console binding, so
+  // captureConsole() above only sees THIS module's output. getConsoleTee()
+  // hands out a sink the orchestrator can wire into the other modules'
+  // consoles (via their __wireConsoleTee helpers) so their lines land in the
+  // same run-log file with identical formatting and captureMode gating.
+  getConsoleTee() {
+    return (level, args) => this.append(level, this.formatArgs(args));
+  }
+
   append(level, message) {
     const normalized = this.normalizeLevel(level);
     if (this.captureMode === "none") {
@@ -10170,5 +10179,12 @@ ScriptableAdapter.NOTES_EXCLUDED_FIELDS = new Set([
   "searchEndDate",
 ]);
 
-// Export for Scriptable environment
-module.exports = { ScriptableAdapter };
+// The run-log console tee: appends (level, args) into this module's singleton
+// FileLogger — the same buffer captureConsole() fills — so the orchestrator can
+// route other modules' per-module consoles into the saved run log.
+function getConsoleTee() {
+  return logger.getConsoleTee();
+}
+
+// Export for Scriptable environment (FileLogger exported for tests)
+module.exports = { ScriptableAdapter, FileLogger, getConsoleTee };

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -29,7 +29,7 @@ global.FileManager = {
   local: () => fileManagerStub
 };
 
-const { ScriptableAdapter } = require('./scriptable-adapter');
+const { ScriptableAdapter, FileLogger, getConsoleTee } = require('./scriptable-adapter');
 
 const LOG_FIXTURE = [
   '2026-07-12T03:00:00.000Z [INFO] SYSTEM: Bearracuda → bearracuda (1 URL): https://bearracuda.com/',
@@ -1485,4 +1485,110 @@ test('presentRichResults records override taps and applies them after dismissal'
   assert.ok(String(rescued.bearSource).startsWith('manual-bear (overrode ai: drag show'), 'manual verdict records what it overrode');
   assert.equal(TestEventSchema.parseNotesIntoFields(rescued.notes).bearSource, rescued.bearSource);
   assert.equal(droppedEntry.manuallyMarkedBear, true);
+});
+
+// ---------------------------------------------------------------------------
+// getConsoleTee: the sink the orchestrator wires into other modules' consoles
+// (Scriptable gives each imported module its own console binding, so
+// captureConsole alone only ever saw this adapter module's output).
+// ---------------------------------------------------------------------------
+
+test('getConsoleTee routes (level, args) into the logger with captureConsole formatting', () => {
+  const fileLogger = new FileLogger();
+  const tee = fileLogger.getConsoleTee();
+  const err = new Error('tee boom');
+  const obj = { a: 1, nested: ['x'] };
+
+  tee('info', ['🐻 message', err, obj]);
+  tee('warn', ['warned']);
+  tee('error', [err]);
+  tee('debug', ['payload', obj]);
+
+  assert.equal(fileLogger.entries.length, 4);
+  assert.deepEqual(
+    fileLogger.entries.map((entry) => entry.level),
+    ['info', 'warn', 'error', 'debug']
+  );
+
+  // Identical formatting to captureConsole: both feed formatArgs(args) into
+  // append, so Error args keep their stack and objects JSON-stringify.
+  const expectedInfo = fileLogger.formatArgs(['🐻 message', err, obj]);
+  assert.ok(fileLogger.entries[0].line.endsWith(`[INFO] ${expectedInfo}`));
+  assert.ok(expectedInfo.includes('"a":1'), 'object arg is JSON-stringified');
+
+  const expectedError = fileLogger.formatArgs([err]);
+  assert.ok(fileLogger.entries[2].line.endsWith(`[ERROR] ${expectedError}`));
+  assert.ok(expectedError.includes('tee boom'), 'Error arg keeps its message/stack');
+
+  const expectedDebug = fileLogger.formatArgs(['payload', obj]);
+  assert.ok(fileLogger.entries[3].line.endsWith(`[DEBUG] ${expectedDebug}`));
+});
+
+test('getConsoleTee respects captureMode none/errors identically to append', () => {
+  const fileLogger = new FileLogger({ captureMode: 'none' });
+  const tee = fileLogger.getConsoleTee();
+
+  tee('error', ['dropped even at error level']);
+  tee('info', ['dropped']);
+  assert.equal(fileLogger.entries.length, 0, 'captureMode none drops everything');
+
+  fileLogger.configure({ captureMode: 'errors' });
+  tee('info', ['dropped info']);
+  tee('debug', ['dropped debug']);
+  tee('warn', ['kept warn']);
+  tee('error', ['kept error']);
+  assert.deepEqual(
+    fileLogger.entries.map((entry) => entry.level),
+    ['warn', 'error'],
+    'captureMode errors keeps only warn/error, like append'
+  );
+});
+
+test('module-level getConsoleTee export hands the orchestrator a tee function', () => {
+  assert.equal(typeof getConsoleTee, 'function');
+  assert.equal(typeof getConsoleTee(), 'function');
+});
+
+test('wired-then-restored console does not double-append into a capturing logger', () => {
+  // Node-only hazard check: here the module console IS the shared global
+  // console, so wiring a tee for the same logger that also captureConsole'd
+  // would double-append. On Scriptable module consoles are separate objects,
+  // so the tee and captureConsole never see the same call. This test proves
+  // the restore path leaves exactly one capture in place.
+  const savedConsole = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+    debug: console.debug
+  };
+  const { __wireConsoleTee } = require('../shared-core');
+  const fileLogger = new FileLogger();
+  try {
+    fileLogger.captureConsole();
+
+    // Wired on top of captureConsole (shared console): tee appends AND the
+    // echo reaches the captureConsole wrapper — the double-append Scriptable
+    // never hits because each module gets its own console object.
+    const restore = __wireConsoleTee(fileLogger.getConsoleTee());
+    assert.equal(typeof restore, 'function');
+    console.log('tee-marker-wired');
+    assert.equal(
+      fileLogger.entries.filter((entry) => entry.line.includes('tee-marker-wired')).length,
+      2
+    );
+
+    // Restored: only captureConsole remains — exactly one append per line.
+    restore();
+    console.log('tee-marker-restored');
+    assert.equal(
+      fileLogger.entries.filter((entry) => entry.line.includes('tee-marker-restored')).length,
+      1
+    );
+  } finally {
+    console.log = savedConsole.log;
+    console.warn = savedConsole.warn;
+    console.error = savedConsole.error;
+    console.debug = savedConsole.debug;
+    delete console.__consoleTeeRestore;
+  }
 });

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -81,7 +81,27 @@ class BearEventScraperOrchestrator {
             const redeyeticketsParserModule = importModule('parsers/redeyetickets-parser');
             const scriptableUrlParserModule = importModule('parsers/scriptable-url-parser');
             const aiWebParserModule = importModule('parsers/ai-web-parser');
-            
+
+            // Scriptable gives every imported module (and this main script) its
+            // own console binding, so the adapter's console capture only ever
+            // saw the adapter's own lines. Route each module's console — and
+            // this script's own — into the adapter's run-log file logger.
+            const consoleTee = typeof scriptableAdapterModule.getConsoleTee === 'function'
+                ? scriptableAdapterModule.getConsoleTee()
+                : null;
+            wireConsoleTees(consoleTee, [
+                sharedCoreModule,
+                eventSchemaModule,
+                normalizersModule,
+                bearracudaParserModule,
+                chunkParserModule,
+                linktreeParserModule,
+                redeyeticketsParserModule,
+                scriptableUrlParserModule,
+                aiWebParserModule,
+                { __wireConsoleTee } // this orchestrator script's own console
+            ]);
+
             // Store modules
             this.modules = {
                 SharedCore: sharedCoreModule.SharedCore,
@@ -450,6 +470,31 @@ class BearEventScraperOrchestrator {
     }
 }
 
+// Wire the adapter's run-log tee into each loaded module's console. Modules
+// without a __wireConsoleTee helper are skipped (event-schema never logs); a
+// missing tee is a no-op — the Node/web adapters never expose one, so nothing
+// changes off-device. Returns the collected restore functions (used by tests).
+function wireConsoleTees(tee, modules) {
+    const restores = [];
+    if (typeof tee !== 'function' || !Array.isArray(modules)) {
+        return restores;
+    }
+    for (const moduleExports of modules) {
+        if (!moduleExports || typeof moduleExports.__wireConsoleTee !== 'function') {
+            continue;
+        }
+        try {
+            const restore = moduleExports.__wireConsoleTee(tee);
+            if (typeof restore === 'function') {
+                restores.push(restore);
+            }
+        } catch (wireError) {
+            // Log wiring must never block startup.
+        }
+    }
+    return restores;
+}
+
 // Auto-execute when loaded — but never on require(): in Node, only run when
 // invoked directly, so tests/tools can import the orchestrator without scraping.
 // Scriptable also defines a module global, so check importModule first.
@@ -476,10 +521,58 @@ if (!isNodeEnvironment || isDirectNodeRun) {
 
 // Export for manual execution if needed
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { BearEventScraperOrchestrator };
+    module.exports = { BearEventScraperOrchestrator, wireConsoleTees };
 } else if (typeof window !== 'undefined') {
     window.BearEventScraperOrchestrator = BearEventScraperOrchestrator;
 } else {
     // Scriptable environment
     this.BearEventScraperOrchestrator = BearEventScraperOrchestrator;
+}
+
+// Scriptable gives every imported module its own console binding, so the
+// adapter's console capture (run-log file) can't see this module's output.
+// The orchestrator wires the adapter's file logger in here at startup.
+// Returns a restore function; no-ops (returns null) if tee is not a function.
+// log/warn/error keep echoing to the visible console; debug becomes file-only
+// (full AI payload dumps belong in the run log, not on screen). Idempotent per
+// console object: re-wiring returns the existing restore instead of stacking.
+function __wireConsoleTee(tee) {
+    if (typeof tee !== 'function' || typeof console === 'undefined' || !console) {
+        return null;
+    }
+    if (typeof console.__consoleTeeRestore === 'function') {
+        return console.__consoleTeeRestore;
+    }
+    const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug
+    };
+    const wrap = (level, method, echo) => function (...args) {
+        try {
+            tee(level, args);
+        } catch (teeError) {
+            // Log capture must never break the caller.
+        }
+        if (echo && typeof method === 'function') {
+            method.apply(console, args);
+        }
+    };
+    console.log = wrap('info', original.log, true);
+    console.warn = wrap('warn', original.warn, true);
+    console.error = wrap('error', original.error, true);
+    console.debug = wrap('debug', original.debug, false);
+    const restore = function () {
+        console.log = original.log;
+        console.warn = original.warn;
+        console.error = original.error;
+        console.debug = original.debug;
+        delete console.__consoleTeeRestore;
+    };
+    console.__consoleTeeRestore = restore;
+    return restore;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.__wireConsoleTee = __wireConsoleTee;
 }

--- a/scripts/bear-event-scraper-unified.test.js
+++ b/scripts/bear-event-scraper-unified.test.js
@@ -273,3 +273,47 @@ test('require() exports the orchestrator without auto-executing', () => {
   assert.equal(fresh.isInitialized, false);
   assert.equal(fresh.isNode, true);
 });
+
+// ---------------------------------------------------------------------------
+// wireConsoleTees: the Scriptable-startup routine that routes each imported
+// module's per-module console into the adapter's run-log tee. Pure stubs only
+// — the real global console is never touched here.
+// ---------------------------------------------------------------------------
+const { wireConsoleTees } = require('./bear-event-scraper-unified');
+
+test('wireConsoleTees wires every module exposing __wireConsoleTee and skips the rest', () => {
+  const wired = [];
+  const tee = () => {};
+  const restoreA = () => {};
+  const modA = { __wireConsoleTee: (t) => { wired.push(['a', t]); return restoreA; } };
+  const modNoHelper = { SharedCore: class {} }; // e.g. event-schema (never logs)
+  const modNull = null;
+  const modDeclined = { __wireConsoleTee: (t) => { wired.push(['d', t]); return null; } };
+
+  const restores = wireConsoleTees(tee, [modA, modNoHelper, modNull, modDeclined]);
+
+  assert.deepEqual(wired.map((call) => call[0]), ['a', 'd']);
+  assert.ok(wired.every((call) => call[1] === tee), 'each helper receives the tee');
+  assert.deepEqual(restores, [restoreA], 'only real restore functions are collected');
+});
+
+test('wireConsoleTees is a no-op when no tee function is supplied', () => {
+  let helperCalls = 0;
+  const mod = { __wireConsoleTee: () => { helperCalls += 1; } };
+  assert.deepEqual(wireConsoleTees(null, [mod]), []);
+  assert.deepEqual(wireConsoleTees(undefined, [mod]), []);
+  assert.deepEqual(wireConsoleTees('not a function', [mod]), []);
+  assert.deepEqual(wireConsoleTees(() => {}, 'not an array'), []);
+  assert.equal(helperCalls, 0, 'module helpers never invoked without a tee');
+});
+
+test('wireConsoleTees survives a module whose helper throws', () => {
+  const wired = [];
+  const throwing = { __wireConsoleTee: () => { throw new Error('boom'); } };
+  const healthy = { __wireConsoleTee: () => { wired.push('ok'); return () => {}; } };
+
+  const restores = wireConsoleTees(() => {}, [throwing, healthy]);
+
+  assert.deepEqual(wired, ['ok'], 'later modules still get wired');
+  assert.equal(restores.length, 1);
+});

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -1691,3 +1691,51 @@ if (typeof module !== 'undefined' && module.exports) {
     this.BarDataNormalizer = BarDataNormalizer;
     this.OpenStreetMapNormalizer = OpenStreetMapNormalizer;
 }
+
+// Scriptable gives every imported module its own console binding, so the
+// adapter's console capture (run-log file) can't see this module's output.
+// The orchestrator wires the adapter's file logger in here at startup.
+// Returns a restore function; no-ops (returns null) if tee is not a function.
+// log/warn/error keep echoing to the visible console; debug becomes file-only
+// (full AI payload dumps belong in the run log, not on screen). Idempotent per
+// console object: re-wiring returns the existing restore instead of stacking.
+function __wireConsoleTee(tee) {
+    if (typeof tee !== 'function' || typeof console === 'undefined' || !console) {
+        return null;
+    }
+    if (typeof console.__consoleTeeRestore === 'function') {
+        return console.__consoleTeeRestore;
+    }
+    const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug
+    };
+    const wrap = (level, method, echo) => function (...args) {
+        try {
+            tee(level, args);
+        } catch (teeError) {
+            // Log capture must never break the caller.
+        }
+        if (echo && typeof method === 'function') {
+            method.apply(console, args);
+        }
+    };
+    console.log = wrap('info', original.log, true);
+    console.warn = wrap('warn', original.warn, true);
+    console.error = wrap('error', original.error, true);
+    console.debug = wrap('debug', original.debug, false);
+    const restore = function () {
+        console.log = original.log;
+        console.warn = original.warn;
+        console.error = original.error;
+        console.debug = original.debug;
+        delete console.__consoleTeeRestore;
+    };
+    console.__consoleTeeRestore = restore;
+    return restore;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.__wireConsoleTee = __wireConsoleTee;
+}

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -9092,3 +9092,51 @@ if (typeof module !== 'undefined' && module.exports) {
     this.normalizeStartTimeValue = normalizeStartTimeValue;
     this.combineDateAndTime = combineDateAndTime;
 }
+
+// Scriptable gives every imported module its own console binding, so the
+// adapter's console capture (run-log file) can't see this module's output.
+// The orchestrator wires the adapter's file logger in here at startup.
+// Returns a restore function; no-ops (returns null) if tee is not a function.
+// log/warn/error keep echoing to the visible console; debug becomes file-only
+// (full AI payload dumps belong in the run log, not on screen). Idempotent per
+// console object: re-wiring returns the existing restore instead of stacking.
+function __wireConsoleTee(tee) {
+    if (typeof tee !== 'function' || typeof console === 'undefined' || !console) {
+        return null;
+    }
+    if (typeof console.__consoleTeeRestore === 'function') {
+        return console.__consoleTeeRestore;
+    }
+    const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug
+    };
+    const wrap = (level, method, echo) => function (...args) {
+        try {
+            tee(level, args);
+        } catch (teeError) {
+            // Log capture must never break the caller.
+        }
+        if (echo && typeof method === 'function') {
+            method.apply(console, args);
+        }
+    };
+    console.log = wrap('info', original.log, true);
+    console.warn = wrap('warn', original.warn, true);
+    console.error = wrap('error', original.error, true);
+    console.debug = wrap('debug', original.debug, false);
+    const restore = function () {
+        console.log = original.log;
+        console.warn = original.warn;
+        console.error = original.error;
+        console.debug = original.debug;
+        delete console.__consoleTeeRestore;
+    };
+    console.__consoleTeeRestore = restore;
+    return restore;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.__wireConsoleTee = __wireConsoleTee;
+}

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -3043,3 +3043,29 @@ test('deriveSegmentListingTitle skips marker, time-only, and date lines; long pr
   // A long prose first line is a description, not a title — derive nothing
   assert.equal(parser.deriveSegmentListingTitle({ lines: ['x'.repeat(200), 'BEAR NIGHT'] }), '');
 });
+
+// ---------------------------------------------------------------------------
+// Console-tee coverage: every log-producing module imported via importModule
+// must carry the __wireConsoleTee shim, or its output silently vanishes from
+// the saved Scriptable run log (each imported module has its own console).
+// ---------------------------------------------------------------------------
+test('every log-producing importModule module exports the __wireConsoleTee shim', () => {
+  const wiredModules = {
+    'shared-core': require('../shared-core'),
+    normalizers: require('../normalizers'),
+    'parsers/ai-web-parser': require('./ai-web-parser'),
+    'parsers/bearracuda-parser': require('./bearracuda-parser'),
+    'parsers/chunk-parser': require('./chunk-parser'),
+    'parsers/linktree-parser': require('./linktree-parser'),
+    'parsers/redeyetickets-parser': require('./redeyetickets-parser'),
+    'parsers/scriptable-url-parser': require('./scriptable-url-parser')
+  };
+  for (const [name, moduleExports] of Object.entries(wiredModules)) {
+    assert.equal(
+      typeof moduleExports.__wireConsoleTee,
+      'function',
+      `${name} must export __wireConsoleTee so its logs reach the run-log file`
+    );
+  }
+  // event-schema is intentionally absent: it never logs, so it needs no shim.
+});

--- a/scripts/parsers/bearracuda-parser.js
+++ b/scripts/parsers/bearracuda-parser.js
@@ -1147,3 +1147,51 @@ if (typeof module !== 'undefined' && module.exports) {
     // Scriptable environment
     this.BearraccudaParser = BearraccudaParser;
 }
+
+// Scriptable gives every imported module its own console binding, so the
+// adapter's console capture (run-log file) can't see this module's output.
+// The orchestrator wires the adapter's file logger in here at startup.
+// Returns a restore function; no-ops (returns null) if tee is not a function.
+// log/warn/error keep echoing to the visible console; debug becomes file-only
+// (full AI payload dumps belong in the run log, not on screen). Idempotent per
+// console object: re-wiring returns the existing restore instead of stacking.
+function __wireConsoleTee(tee) {
+    if (typeof tee !== 'function' || typeof console === 'undefined' || !console) {
+        return null;
+    }
+    if (typeof console.__consoleTeeRestore === 'function') {
+        return console.__consoleTeeRestore;
+    }
+    const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug
+    };
+    const wrap = (level, method, echo) => function (...args) {
+        try {
+            tee(level, args);
+        } catch (teeError) {
+            // Log capture must never break the caller.
+        }
+        if (echo && typeof method === 'function') {
+            method.apply(console, args);
+        }
+    };
+    console.log = wrap('info', original.log, true);
+    console.warn = wrap('warn', original.warn, true);
+    console.error = wrap('error', original.error, true);
+    console.debug = wrap('debug', original.debug, false);
+    const restore = function () {
+        console.log = original.log;
+        console.warn = original.warn;
+        console.error = original.error;
+        console.debug = original.debug;
+        delete console.__consoleTeeRestore;
+    };
+    console.__consoleTeeRestore = restore;
+    return restore;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.__wireConsoleTee = __wireConsoleTee;
+}

--- a/scripts/parsers/chunk-parser.js
+++ b/scripts/parsers/chunk-parser.js
@@ -412,3 +412,51 @@ if (typeof module !== 'undefined' && module.exports) {
     // Scriptable environment
     this.ChunkParser = ChunkParser;
 }
+
+// Scriptable gives every imported module its own console binding, so the
+// adapter's console capture (run-log file) can't see this module's output.
+// The orchestrator wires the adapter's file logger in here at startup.
+// Returns a restore function; no-ops (returns null) if tee is not a function.
+// log/warn/error keep echoing to the visible console; debug becomes file-only
+// (full AI payload dumps belong in the run log, not on screen). Idempotent per
+// console object: re-wiring returns the existing restore instead of stacking.
+function __wireConsoleTee(tee) {
+    if (typeof tee !== 'function' || typeof console === 'undefined' || !console) {
+        return null;
+    }
+    if (typeof console.__consoleTeeRestore === 'function') {
+        return console.__consoleTeeRestore;
+    }
+    const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug
+    };
+    const wrap = (level, method, echo) => function (...args) {
+        try {
+            tee(level, args);
+        } catch (teeError) {
+            // Log capture must never break the caller.
+        }
+        if (echo && typeof method === 'function') {
+            method.apply(console, args);
+        }
+    };
+    console.log = wrap('info', original.log, true);
+    console.warn = wrap('warn', original.warn, true);
+    console.error = wrap('error', original.error, true);
+    console.debug = wrap('debug', original.debug, false);
+    const restore = function () {
+        console.log = original.log;
+        console.warn = original.warn;
+        console.error = original.error;
+        console.debug = original.debug;
+        delete console.__consoleTeeRestore;
+    };
+    console.__consoleTeeRestore = restore;
+    return restore;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.__wireConsoleTee = __wireConsoleTee;
+}

--- a/scripts/parsers/linktree-parser.js
+++ b/scripts/parsers/linktree-parser.js
@@ -402,3 +402,51 @@ if (typeof module !== 'undefined' && module.exports) {
     // Scriptable environment
     this.LinktreeParser = LinktreeParser;
 }
+
+// Scriptable gives every imported module its own console binding, so the
+// adapter's console capture (run-log file) can't see this module's output.
+// The orchestrator wires the adapter's file logger in here at startup.
+// Returns a restore function; no-ops (returns null) if tee is not a function.
+// log/warn/error keep echoing to the visible console; debug becomes file-only
+// (full AI payload dumps belong in the run log, not on screen). Idempotent per
+// console object: re-wiring returns the existing restore instead of stacking.
+function __wireConsoleTee(tee) {
+    if (typeof tee !== 'function' || typeof console === 'undefined' || !console) {
+        return null;
+    }
+    if (typeof console.__consoleTeeRestore === 'function') {
+        return console.__consoleTeeRestore;
+    }
+    const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug
+    };
+    const wrap = (level, method, echo) => function (...args) {
+        try {
+            tee(level, args);
+        } catch (teeError) {
+            // Log capture must never break the caller.
+        }
+        if (echo && typeof method === 'function') {
+            method.apply(console, args);
+        }
+    };
+    console.log = wrap('info', original.log, true);
+    console.warn = wrap('warn', original.warn, true);
+    console.error = wrap('error', original.error, true);
+    console.debug = wrap('debug', original.debug, false);
+    const restore = function () {
+        console.log = original.log;
+        console.warn = original.warn;
+        console.error = original.error;
+        console.debug = original.debug;
+        delete console.__consoleTeeRestore;
+    };
+    console.__consoleTeeRestore = restore;
+    return restore;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.__wireConsoleTee = __wireConsoleTee;
+}

--- a/scripts/parsers/redeyetickets-parser.js
+++ b/scripts/parsers/redeyetickets-parser.js
@@ -526,3 +526,51 @@ if (typeof module !== 'undefined' && module.exports) {
     // Scriptable environment
     this.RedEyeTicketsParser = RedEyeTicketsParser;
 }
+
+// Scriptable gives every imported module its own console binding, so the
+// adapter's console capture (run-log file) can't see this module's output.
+// The orchestrator wires the adapter's file logger in here at startup.
+// Returns a restore function; no-ops (returns null) if tee is not a function.
+// log/warn/error keep echoing to the visible console; debug becomes file-only
+// (full AI payload dumps belong in the run log, not on screen). Idempotent per
+// console object: re-wiring returns the existing restore instead of stacking.
+function __wireConsoleTee(tee) {
+    if (typeof tee !== 'function' || typeof console === 'undefined' || !console) {
+        return null;
+    }
+    if (typeof console.__consoleTeeRestore === 'function') {
+        return console.__consoleTeeRestore;
+    }
+    const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug
+    };
+    const wrap = (level, method, echo) => function (...args) {
+        try {
+            tee(level, args);
+        } catch (teeError) {
+            // Log capture must never break the caller.
+        }
+        if (echo && typeof method === 'function') {
+            method.apply(console, args);
+        }
+    };
+    console.log = wrap('info', original.log, true);
+    console.warn = wrap('warn', original.warn, true);
+    console.error = wrap('error', original.error, true);
+    console.debug = wrap('debug', original.debug, false);
+    const restore = function () {
+        console.log = original.log;
+        console.warn = original.warn;
+        console.error = original.error;
+        console.debug = original.debug;
+        delete console.__consoleTeeRestore;
+    };
+    console.__consoleTeeRestore = restore;
+    return restore;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.__wireConsoleTee = __wireConsoleTee;
+}

--- a/scripts/parsers/scriptable-url-parser.js
+++ b/scripts/parsers/scriptable-url-parser.js
@@ -554,3 +554,51 @@ if (typeof module !== 'undefined' && module.exports) {
     // Scriptable environment
     this.ScriptableUrlParser = ScriptableUrlParser;
 }
+
+// Scriptable gives every imported module its own console binding, so the
+// adapter's console capture (run-log file) can't see this module's output.
+// The orchestrator wires the adapter's file logger in here at startup.
+// Returns a restore function; no-ops (returns null) if tee is not a function.
+// log/warn/error keep echoing to the visible console; debug becomes file-only
+// (full AI payload dumps belong in the run log, not on screen). Idempotent per
+// console object: re-wiring returns the existing restore instead of stacking.
+function __wireConsoleTee(tee) {
+    if (typeof tee !== 'function' || typeof console === 'undefined' || !console) {
+        return null;
+    }
+    if (typeof console.__consoleTeeRestore === 'function') {
+        return console.__consoleTeeRestore;
+    }
+    const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug
+    };
+    const wrap = (level, method, echo) => function (...args) {
+        try {
+            tee(level, args);
+        } catch (teeError) {
+            // Log capture must never break the caller.
+        }
+        if (echo && typeof method === 'function') {
+            method.apply(console, args);
+        }
+    };
+    console.log = wrap('info', original.log, true);
+    console.warn = wrap('warn', original.warn, true);
+    console.error = wrap('error', original.error, true);
+    console.debug = wrap('debug', original.debug, false);
+    const restore = function () {
+        console.log = original.log;
+        console.warn = original.warn;
+        console.error = original.error;
+        console.debug = original.debug;
+        delete console.__consoleTeeRestore;
+    };
+    console.__consoleTeeRestore = restore;
+    return restore;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.__wireConsoleTee = __wireConsoleTee;
+}

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -6984,3 +6984,51 @@ if (typeof module !== 'undefined' && module.exports) {
 
 
 }
+
+// Scriptable gives every imported module its own console binding, so the
+// adapter's console capture (run-log file) can't see this module's output.
+// The orchestrator wires the adapter's file logger in here at startup.
+// Returns a restore function; no-ops (returns null) if tee is not a function.
+// log/warn/error keep echoing to the visible console; debug becomes file-only
+// (full AI payload dumps belong in the run log, not on screen). Idempotent per
+// console object: re-wiring returns the existing restore instead of stacking.
+function __wireConsoleTee(tee) {
+    if (typeof tee !== 'function' || typeof console === 'undefined' || !console) {
+        return null;
+    }
+    if (typeof console.__consoleTeeRestore === 'function') {
+        return console.__consoleTeeRestore;
+    }
+    const original = {
+        log: console.log,
+        warn: console.warn,
+        error: console.error,
+        debug: console.debug
+    };
+    const wrap = (level, method, echo) => function (...args) {
+        try {
+            tee(level, args);
+        } catch (teeError) {
+            // Log capture must never break the caller.
+        }
+        if (echo && typeof method === 'function') {
+            method.apply(console, args);
+        }
+    };
+    console.log = wrap('info', original.log, true);
+    console.warn = wrap('warn', original.warn, true);
+    console.error = wrap('error', original.error, true);
+    console.debug = wrap('debug', original.debug, false);
+    const restore = function () {
+        console.log = original.log;
+        console.warn = original.warn;
+        console.error = original.error;
+        console.debug = original.debug;
+        delete console.__consoleTeeRestore;
+    };
+    console.__consoleTeeRestore = restore;
+    return restore;
+}
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.__wireConsoleTee = __wireConsoleTee;
+}

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -5095,3 +5095,145 @@ test('discovered-venue summary block renders only when siblings were dropped', (
   assert.ok(text.includes('To scrape this venue, add a parser entry to scraper-input.js:'));
   assert.ok(text.includes('{ name: "massive.club", enabled: false, urls: ["https://www.massive.club"], alwaysBear: false },'));
 });
+
+// ---------------------------------------------------------------------------
+// __wireConsoleTee: on Scriptable every imported module has its own console
+// binding, so the orchestrator wires the adapter's run-log tee into each
+// module through this helper. In Node the module console IS the shared global
+// console (which test-quiet-console also wraps), so every test here restores
+// in a finally block.
+// ---------------------------------------------------------------------------
+const sharedCoreModule = require('./shared-core');
+const normalizersModule = require('./normalizers');
+
+function snapshotConsole() {
+  return {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+    debug: console.debug
+  };
+}
+
+function restoreConsole(saved) {
+  console.log = saved.log;
+  console.warn = saved.warn;
+  console.error = saved.error;
+  console.debug = saved.debug;
+  delete console.__consoleTeeRestore;
+}
+
+test('__wireConsoleTee tees info/warn/error with echo preserved and debug without echo', () => {
+  const saved = snapshotConsole();
+  const teed = [];
+  const echoed = [];
+  console.log = (...args) => echoed.push(['log', args]);
+  console.warn = (...args) => echoed.push(['warn', args]);
+  console.error = (...args) => echoed.push(['error', args]);
+  console.debug = (...args) => echoed.push(['debug', args]);
+  try {
+    const restore = sharedCoreModule.__wireConsoleTee((level, args) => teed.push([level, args]));
+    assert.equal(typeof restore, 'function');
+
+    console.log('🐻 line', 1);
+    console.warn('careful');
+    console.error('broken');
+    console.debug('full AI payload');
+
+    assert.deepEqual(teed, [
+      ['info', ['🐻 line', 1]],
+      ['warn', ['careful']],
+      ['error', ['broken']],
+      ['debug', ['full AI payload']]
+    ]);
+    // log/warn/error still reach the original console; debug is file-only
+    // (the documented debug channel: payloads go to the run log, not screen).
+    assert.deepEqual(echoed, [
+      ['log', ['🐻 line', 1]],
+      ['warn', ['careful']],
+      ['error', ['broken']]
+    ]);
+  } finally {
+    restoreConsole(saved);
+  }
+});
+
+test('__wireConsoleTee is idempotent: double-wire (even cross-module) does not double-tee', () => {
+  const saved = snapshotConsole();
+  const teed = [];
+  console.log = () => {};
+  try {
+    const tee = (level, args) => teed.push([level, args]);
+    const restore1 = sharedCoreModule.__wireConsoleTee(tee);
+    const restore2 = sharedCoreModule.__wireConsoleTee(tee);
+    // In Node all modules share the global console, so a second module's shim
+    // must also detect the existing wiring instead of stacking another tee.
+    const restore3 = normalizersModule.__wireConsoleTee(tee);
+    assert.equal(restore1, restore2);
+    assert.equal(restore1, restore3);
+
+    console.log('once');
+    assert.equal(teed.length, 1);
+  } finally {
+    restoreConsole(saved);
+  }
+});
+
+test('__wireConsoleTee restore() returns console to the exact original functions', () => {
+  const saved = snapshotConsole();
+  const spyLog = () => {};
+  const spyWarn = () => {};
+  const spyError = () => {};
+  const spyDebug = () => {};
+  console.log = spyLog;
+  console.warn = spyWarn;
+  console.error = spyError;
+  console.debug = spyDebug;
+  try {
+    const restore = sharedCoreModule.__wireConsoleTee(() => {});
+    assert.notEqual(console.log, spyLog, 'wiring replaced console.log');
+    assert.notEqual(console.debug, spyDebug, 'wiring replaced console.debug');
+
+    restore();
+    assert.equal(console.log, spyLog);
+    assert.equal(console.warn, spyWarn);
+    assert.equal(console.error, spyError);
+    assert.equal(console.debug, spyDebug);
+
+    // After restore the console is re-wireable (marker cleared).
+    const restoreAgain = sharedCoreModule.__wireConsoleTee(() => {});
+    assert.equal(typeof restoreAgain, 'function');
+    restoreAgain();
+    assert.equal(console.log, spyLog);
+  } finally {
+    restoreConsole(saved);
+  }
+});
+
+test('__wireConsoleTee no-ops (returns null) when tee is not a function', () => {
+  const saved = snapshotConsole();
+  try {
+    assert.equal(sharedCoreModule.__wireConsoleTee(null), null);
+    assert.equal(sharedCoreModule.__wireConsoleTee(undefined), null);
+    assert.equal(sharedCoreModule.__wireConsoleTee('not a tee'), null);
+    assert.equal(console.log, saved.log, 'console left untouched');
+    assert.equal(console.debug, saved.debug, 'console left untouched');
+  } finally {
+    restoreConsole(saved);
+  }
+});
+
+test('__wireConsoleTee keeps working when a tee throws (logging never breaks the app)', () => {
+  const saved = snapshotConsole();
+  const echoed = [];
+  console.log = (...args) => echoed.push(args);
+  try {
+    sharedCoreModule.__wireConsoleTee(() => {
+      throw new Error('sink failure');
+    });
+    assert.doesNotThrow(() => console.log('still logs'));
+    assert.deepEqual(echoed, [['still logs']], 'echo survives a throwing tee');
+  } finally {
+    restoreConsole(saved);
+  }
+});


### PR DESCRIPTION
## Problem

On-device, saved `logs/<runId>.log` files were missing virtually all diagnostic lines — zero 🤖 AI Web, 🗺️ geocode, 🐻 BEAR CHECK, 🤝 merge lines in every log back to July 18. Root cause: the FileLogger captures by wrapping `console.log`, but **Scriptable's importModule gives each module its own console binding**, so only the adapter module's own lines (📱 + adapter-routed SYSTEM) ever reached the buffer. The debug channel was also inverted: full AI payloads (console.debug, designed to be file-only) printed to the visible console and never hit the file.

## Fix: deterministic tee wiring

- `FileLogger.getConsoleTee()` exposes the capture sink (same append/formatArgs path as captureConsole — identical formatting, trimming, and captureMode gating).
- Every log-producing module (shared-core, normalizers, all six parsers) exports a **byte-identical** `__wireConsoleTee(tee)` shim (md5-verified across files): log/warn/error tee-then-echo, debug tees **file-only**, idempotent via a marker on the console object (safe on Node's shared console), returns a restore function, a throwing tee can never break logging.
- The orchestrator wires everything once right after importModule (including its own console via the same shim), obtaining the tee from the adapter module. Node/web paths untouched — web-adapter exposes no tee, so off-device behavior is byte-identical.
- `event-schema.js` skipped (zero console calls — verified); the wiring routine null-safely skips modules without the helper.

## Effects on-device
1. Run-log files become complete — every diagnostic line lands on disk.
2. Full AI prompt payloads move to the file only; the visible console gets dramatically shorter.

## Tests
+13 across shared-core / ai-web-parser / scriptable-adapter / unified: tee semantics incl. debug no-echo, cross-module idempotency on a shared console, exact-original restore, formatting parity vs formatArgs (Error + object args), captureMode parity, shim presence on all 8 modules, orchestrator wiring/skip/absent/throwing paths. Suite: **507 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/normalizers.js`, `scripts/bear-event-scraper-unified.js`, `scripts/adapters/scriptable-adapter.js`, and all six `scripts/parsers/*.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP