### PR TITLE
chore(bars): add Massive (Seattle) to curated bars data

### DIFF
--- a/data/bars/seattle.json
+++ b/data/bars/seattle.json
@@ -71,5 +71,14 @@
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJRUOyfc5qkFQRDZLLFj1Q264",
     "gayCities": "https://seattle.gaycities.com/bars/2442-pony",
     "gayCitiesLastScrapedAt": "2026-06-13T15:19:22.288Z"
+  },
+  {
+    "name": "Massive",
+    "city": "seattle",
+    "address": "619 E Pine St, Seattle, WA 98122",
+    "coordinates": "47.6150824, -122.3237201",
+    "website": "https://www.massive.club",
+    "instagram": "https://www.instagram.com/massive_club",
+    "gayCities": "https://seattle.gaycities.com/bars/511-massive-nightclub"
   }
 ]

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -642,6 +642,15 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJRUOyfc5qkFQRDZLLFj1Q264",
       "gayCities": "https://seattle.gaycities.com/bars/2442-pony",
       "gayCitiesLastScrapedAt": "2026-06-13T15:19:22.288Z"
+    },
+    {
+      "name": "Massive",
+      "city": "seattle",
+      "address": "619 E Pine St, Seattle, WA 98122",
+      "coordinates": "47.6150824, -122.3237201",
+      "website": "https://www.massive.club",
+      "instagram": "https://www.instagram.com/massive_club",
+      "gayCities": "https://seattle.gaycities.com/bars/511-massive-nightclub"
     }
   ],
   "sf": [

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -651,6 +651,15 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJRUOyfc5qkFQRDZLLFj1Q264",
       "gayCities": "https://seattle.gaycities.com/bars/2442-pony",
       "gayCitiesLastScrapedAt": "2026-06-13T15:19:22.288Z"
+    },
+    {
+      "name": "Massive",
+      "city": "seattle",
+      "address": "619 E Pine St, Seattle, WA 98122",
+      "coordinates": "47.6150824, -122.3237201",
+      "website": "https://www.massive.club",
+      "instagram": "https://www.instagram.com/massive_club",
+      "gayCities": "https://seattle.gaycities.com/bars/511-massive-nightclub"
     }
   ],
   "sf": [


### PR DESCRIPTION
Adds **Massive** (619 E Pine St, Seattle) to `data/bars/seattle.json` and regenerates the derived `data/scraper-bars.json` + `scripts/scraper-bars.js`.

This closes the data gap behind today's Shore Thing incident: the curated-bar merge rule (#1499) was deployed and running on-device but failed open to AI arbitration because Massive wasn't in the Seattle data. With this entry, `bar` conflicts involving Massive resolve deterministically (🔒) and never reach the AI — and the geocode pipeline gains the curated pin as authority.

Verification:
- OSM's POI at 619 E Pine St is literally named "Massive"; coordinates `47.6150824, -122.3237201` match Nominatim and every run log
- GayCities reference (owner-provided): https://seattle.gaycities.com/bars/511-massive-nightclub
- Website massive.club + instagram massive_club both observed in crawl logs
- `faviconBg`/`faviconFg` intentionally omitted — the site's favicon-color automation fills those

Suite: 507 pass / 0 fail (bars data feeds tests via fixtures only; no code changed).

📲 No phone download needed — the scraper fetches bars data live from chunky.dad, so this takes effect once the site deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP