### PR TITLE
fix(scraper): deterministic address merging — same-address variants and curated-bar addresses never reach AI

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -32,6 +32,29 @@ const ADAPTIVE_CRAWL_MAX_HOPS = 4;
 // and the calendar reviewer's pin-moved check.
 const PIN_MOVED_THRESHOLD_KM = 0.4;
 
+// Merge-time address comparison: street-type abbreviations and directionals
+// expanded on BOTH sides so "619 E. Pine St" and "619 East Pine Street"
+// tokenize identically. Modeled on normalizers.js
+// GEOCODE_ABBREVIATION_EXPANSIONS (the geocode reverse cross-check) and the
+// ai-web-parser street-line matcher — both of those maps are deliberately
+// narrower (each tuned to its own run-verified check), and both modules sit
+// DOWNSTREAM of shared-core (they receive a core instance; shared-core can
+// import from neither), so the merge ladder carries its own superset map.
+const ADDRESS_ABBREVIATION_EXPANSIONS = {
+    st: 'street', ave: 'avenue', rd: 'road', blvd: 'boulevard', dr: 'drive',
+    ln: 'lane', pl: 'place', ct: 'court', hwy: 'highway', pkwy: 'parkway',
+    n: 'north', s: 'south', e: 'east', w: 'west',
+    ne: 'northeast', nw: 'northwest', se: 'southeast', sw: 'southwest'
+};
+// Generic street-type designators: a street line that only ADDS one of these
+// ("619 E. Pine" vs "619 E. Pine Street") is the same street line; any other
+// surplus token ("Pine Street" vs "Pine Avenue", or a different street name)
+// is a real difference and must still arbitrate.
+const ADDRESS_STREET_TYPE_TOKENS = [
+    'street', 'avenue', 'road', 'boulevard', 'drive', 'lane', 'place',
+    'court', 'highway', 'parkway', 'way'
+];
+
 class SharedCore {
     constructor(cities, options = {}) {
         if (!cities || typeof cities !== 'object') {
@@ -641,12 +664,126 @@ class SharedCore {
         return /(?:^|[\s,])(?:St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Ln|Lane|Way|Pl|Place|Ct|Court|Pkwy|Hwy)\.?(?:$|[\s,])/i.test(afterNumber);
     }
 
+    // Lowercased, punctuation-free address tokens with street abbreviations
+    // and directionals expanded (see ADDRESS_ABBREVIATION_EXPANSIONS), so
+    // every spelling of the same address compares equal token-for-token.
+    normalizeAddressTokens(text) {
+        const expanded = String(text || '')
+            .toLowerCase()
+            .replace(/[^a-z0-9\s]/g, ' ')
+            .split(/\s+/)
+            .filter(Boolean)
+            .map(token => Object.prototype.hasOwnProperty.call(ADDRESS_ABBREVIATION_EXPANSIONS, token)
+                ? ADDRESS_ABBREVIATION_EXPANSIONS[token]
+                : token);
+        // Compound directionals: "N. E." / "North East" → "northeast", so
+        // every compound spelling matches the fused "NE"/"Northeast" forms.
+        const fused = [];
+        for (const token of expanded) {
+            const previous = fused[fused.length - 1];
+            if ((previous === 'north' || previous === 'south') && (token === 'east' || token === 'west')) {
+                fused[fused.length - 1] = previous + token;
+            } else {
+                fused.push(token);
+            }
+        }
+        return fused;
+    }
+
+    // Parse an address candidate for the same-address merge rung. Returns
+    // null unless the value leads with a house number (incl. hyphenated
+    // Queens style) — a candidate without one is never comparable here.
+    parseAddressForComparison(value) {
+        if (typeof value !== 'string') return null;
+        const text = value.trim();
+        const numberMatch = text.match(/^(\d{1,6}(?:-\d{1,6})?)\s+\S/);
+        if (!numberMatch) return null;
+        const rest = text.slice(numberMatch[1].length);
+        const tokens = this.normalizeAddressTokens(rest);
+        if (tokens.length === 0) return null;
+        return {
+            streetNumber: numberMatch[1].toLowerCase(),
+            tokens,
+            // First comma-separated segment: the street line proper (comma-less
+            // formats fold the city in here; the full-token prefix rule covers
+            // those).
+            streetLineTokens: this.normalizeAddressTokens(rest.split(',')[0]),
+            zips: tokens.filter(token => /^\d{5}$/.test(token))
+        };
+    }
+
+    // Same-address detection for two parseAddressForComparison results.
+    // Conservative on purpose: equal street numbers AND (one full token
+    // sequence a prefix of the other — the longer just adds city/state/zip —
+    // OR equal street lines, tolerating only a trailing generic street-type
+    // designator). Anything else — differing numbers, differing streets,
+    // differing explicit ZIPs — is NOT the same address (no fuzzy scoring),
+    // and the conflict falls through to AI arbitration.
+    isSameStreetAddress(parsedA, parsedB) {
+        if (!parsedA || !parsedB) return false;
+        if (parsedA.streetNumber !== parsedB.streetNumber) return false;
+        // A candidate with repeated tokens is malformed, not more complete —
+        // the Eventbrite doubled-address bug ("3911 Cedar Springs Rd, Dallas,
+        // TX 75219, Dallas, TX") would otherwise OUTSCORE the clean form on
+        // components. Repetition is malformation, not information: those
+        // conflicts keep arbitrating (the AI reliably picks the clean form).
+        const hasDuplicateTokens = parsed => new Set(parsed.tokens).size !== parsed.tokens.length;
+        if (hasDuplicateTokens(parsedA) || hasDuplicateTokens(parsedB)) return false;
+        if (parsedA.zips.length > 0 && parsedB.zips.length > 0
+            && !parsedA.zips.some(zip => parsedB.zips.includes(zip))) return false;
+        const isPrefix = (shorter, longer) => shorter.length <= longer.length
+            && shorter.every((token, index) => token === longer[index]);
+        if (isPrefix(parsedA.tokens, parsedB.tokens) || isPrefix(parsedB.tokens, parsedA.tokens)) return true;
+        const lineA = parsedA.streetLineTokens;
+        const lineB = parsedB.streetLineTokens;
+        if (lineA.length === 0 || lineB.length === 0) return false;
+        const [shorterLine, longerLine] = lineA.length <= lineB.length ? [lineA, lineB] : [lineB, lineA];
+        if (!isPrefix(shorterLine, longerLine)) return false;
+        return longerLine.slice(shorterLine.length).every(token => ADDRESS_STREET_TYPE_TOKENS.includes(token));
+    }
+
+    // Completeness score for the same-address winner: comma-separated
+    // components beyond the street line (city, state, zip each usually get
+    // their own segment) plus an explicit ZIP bonus. Comma-formatted
+    // candidates deliberately outscore comma-less twins carrying the same
+    // components — the calendar's canonical address format is comma-separated.
+    scoreAddressCompleteness(value, parsed) {
+        const segments = String(value).split(',').map(segment => segment.trim()).filter(Boolean);
+        return Math.max(0, segments.length - 1) + (parsed.zips.length > 0 ? 1 : 0);
+    }
+
+    // Curated bars for a merge-context city — shared by the curated-bar-name
+    // rule and the curated-address rung in resolveConflictDeterministically.
+    // Returns a non-empty array or null (missing city/bars data fails open).
+    getCuratedCityBars(cityKey) {
+        const key = cityKey ? String(cityKey) : '';
+        if (!key || !this.bars) return null;
+        const cityBars = this.bars[key] || this.bars[key.trim().toLowerCase()];
+        return Array.isArray(cityBars) && cityBars.length > 0 ? cityBars : null;
+    }
+
+    // Same normalization BarDataNormalizer matches with (lowercase, strip
+    // non-alphanumerics) so curated matching agrees everywhere, plus a leading
+    // "the " is dropped on BOTH sides ("The Eagle" is the curated "Eagle" and
+    // vice versa). Full-name equality only — never substring — so "Eagle"
+    // can't claim "Eagle Bar" vs "Dallas Eagle" ambiguously within a city.
+    findCuratedBarByName(cityBars, value) {
+        const normalizeBarName = name => String(name || '')
+            .toLowerCase()
+            .replace(/^\s*the\s+/, '')
+            .replace(/[^a-z0-9]/g, '');
+        const normalized = normalizeBarName(value);
+        if (!normalized) return null;
+        return cityBars.find(bar => bar && typeof bar.name === 'string'
+            && normalizeBarName(bar.name) === normalized) || null;
+    }
+
     // Deterministic conflict resolution consulted by BOTH merge paths
     // (createFinalEventObject and mergeParsedEvents) before a field is queued
     // for AI arbitration. Returns { winner: 'a'|'b', reason } or null (→
     // arbitrate as usual). Callers map a/b onto their own labels and thread
-    // event context (currently { cityKey }) for the city-aware title and
-    // curated-bar rules.
+    // event context (currently { cityKey, barNames }) for the city-aware
+    // title, curated-bar, and curated-address rules.
     resolveConflictDeterministically(fieldName, valueA, valueB, context = null) {
         const urlA = this.getUrlRuleParts(valueA);
         const urlB = this.getUrlRuleParts(valueB);
@@ -726,29 +863,10 @@ class SharedCore {
         // backstop) — this path FAILS OPEN to today's behavior, as do a
         // missing city and missing bars data.
         if (fieldName === 'bar') {
-            const barCityKey = context && context.cityKey ? String(context.cityKey) : '';
-            const cityBars = barCityKey && this.bars
-                ? (this.bars[barCityKey] || this.bars[barCityKey.trim().toLowerCase()])
-                : null;
-            if (Array.isArray(cityBars) && cityBars.length > 0) {
-                // Same normalization BarDataNormalizer matches with (lowercase,
-                // strip non-alphanumerics) so curated matching agrees everywhere,
-                // plus a leading "the " is dropped on BOTH sides ("The Eagle" is
-                // the curated "Eagle" and vice versa). Full-name equality only —
-                // never substring — so "Eagle" can't claim "Eagle Bar" vs
-                // "Dallas Eagle" ambiguously within a city.
-                const normalizeBarName = value => String(value || '')
-                    .toLowerCase()
-                    .replace(/^\s*the\s+/, '')
-                    .replace(/[^a-z0-9]/g, '');
-                const findCuratedBar = value => {
-                    const normalized = normalizeBarName(value);
-                    if (!normalized) return null;
-                    return cityBars.find(bar => bar && typeof bar.name === 'string'
-                        && normalizeBarName(bar.name) === normalized) || null;
-                };
-                const curatedA = findCuratedBar(valueA);
-                const curatedB = findCuratedBar(valueB);
+            const cityBars = this.getCuratedCityBars(context && context.cityKey);
+            if (cityBars) {
+                const curatedA = this.findCuratedBarByName(cityBars, valueA);
+                const curatedB = this.findCuratedBarByName(cityBars, valueB);
                 if (Boolean(curatedA) !== Boolean(curatedB)) {
                     const matched = curatedA || curatedB;
                     return {
@@ -764,6 +882,67 @@ class SharedCore {
                     winner: addressShapedA ? 'b' : 'a',
                     reason: 'a street address is not a venue name'
                 };
+            }
+        }
+        // Deterministic address ladder: EVERY address conflict in run
+        // 20260722-124758 (all six) was the SAME address in two formats
+        // ("619 East Pine Street, Seattle, WA, 98122" vs "619 E. Pine St,
+        // Seattle, WA"), each burning an AI arbitration with coin-flip risk.
+        // Rung 1: same-address detection — equal street numbers plus a
+        // normalized-token prefix/street-line match (isSameStreetAddress) means
+        // the two candidates denote one address, and the MORE COMPLETE form
+        // wins (component count, then normalized length; a full tie falls
+        // through so the case-only rule below can still settle pure case
+        // twins). Rung 2: when either record's bar matches a curated bar for
+        // the event's city and exactly one candidate is that bar's curated
+        // address (in any format), the curated one wins — but ONLY when the
+        // other candidate is not itself a parseable street address: a
+        // parseable candidate that failed the same-address check is a genuine
+        // CONTRADICTION of curated data and is never silently resolved.
+        // Rung 3 (future): geocode-equality — two candidates geocoding to the
+        // same pin are the same address — needs adapter/network threading in
+        // the merge path, deliberately out of scope here. Everything not
+        // decided above FAILS OPEN to AI arbitration exactly as today.
+        if (fieldName === 'address' && typeof valueA === 'string' && typeof valueB === 'string') {
+            const parsedA = this.parseAddressForComparison(valueA);
+            const parsedB = this.parseAddressForComparison(valueB);
+            if (parsedA && parsedB && this.isSameStreetAddress(parsedA, parsedB)) {
+                const scoreA = this.scoreAddressCompleteness(valueA, parsedA);
+                const scoreB = this.scoreAddressCompleteness(valueB, parsedB);
+                const lengthA = parsedA.tokens.join(' ').length;
+                const lengthB = parsedB.tokens.join(' ').length;
+                if (scoreA !== scoreB || lengthA !== lengthB) {
+                    return {
+                        winner: scoreA !== scoreB
+                            ? (scoreA > scoreB ? 'a' : 'b')
+                            : (lengthA > lengthB ? 'a' : 'b'),
+                        reason: 'same address, kept the more complete form'
+                    };
+                }
+                // Full tie → fall through (case-only rule below, else AI).
+            } else {
+                const cityBars = this.getCuratedCityBars(context && context.cityKey);
+                const barNames = context && Array.isArray(context.barNames) ? context.barNames : [];
+                let curatedBar = null;
+                if (cityBars) {
+                    for (const barName of barNames) {
+                        curatedBar = this.findCuratedBarByName(cityBars, barName);
+                        if (curatedBar) break;
+                    }
+                }
+                const curatedAddress = curatedBar && typeof curatedBar.address === 'string'
+                    ? curatedBar.address.trim() : '';
+                const parsedCurated = curatedAddress ? this.parseAddressForComparison(curatedAddress) : null;
+                if (parsedCurated) {
+                    const matchesCuratedA = this.isSameStreetAddress(parsedA, parsedCurated);
+                    const matchesCuratedB = this.isSameStreetAddress(parsedB, parsedCurated);
+                    if (matchesCuratedA !== matchesCuratedB && !(matchesCuratedA ? parsedB : parsedA)) {
+                        return {
+                            winner: matchesCuratedA ? 'a' : 'b',
+                            reason: `matches curated bar address (${curatedBar.name})`
+                        };
+                    }
+                }
             }
         }
         // Case-only variants are not a real conflict: production runs burned
@@ -3066,8 +3245,12 @@ class SharedCore {
         const mergeEventTitle = newEvent.title || existingEvent.title || 'event';
         // City context for the city-aware title rule (a bare city title loses
         // to a named title) — both records describe the same event, so either
-        // side's resolved city works.
-        const mergeContext = { cityKey: newEvent.city || existingEvent.city || '' };
+        // side's resolved city works. barNames feeds the curated-address rung:
+        // either record's bar matching a curated bar anchors the address.
+        const mergeContext = {
+            cityKey: newEvent.city || existingEvent.city || '',
+            barNames: [existingEvent.bar, newEvent.bar]
+        };
         const queueArbitrationConflict = (fieldName, existingValue, newValue, fallbackPick, fallbackReason) => {
             const resolved = this.resolveConflictDeterministically(fieldName, existingValue, newValue, mergeContext);
             if (!resolved) {
@@ -3481,8 +3664,13 @@ class SharedCore {
         // resolveConflictDeterministically so behavior is identical.
         // City context for the city-aware title rule (a bare city title loses
         // to a named title) — the scraper object carries the resolved city; the
-        // calendar object may carry one parsed from its notes.
-        const mergeContext = { cityKey: scraperObject.city || calendarObject.city || '' };
+        // calendar object may carry one parsed from its notes. barNames feeds
+        // the curated-address rung: either record's bar matching a curated bar
+        // anchors the address.
+        const mergeContext = {
+            cityKey: scraperObject.city || calendarObject.city || '',
+            barNames: [calendarObject.bar, scraperObject.bar]
+        };
         const queueArbitrationConflict = (fieldName, calendarValue, scraperValue) => {
             const resolved = this.resolveConflictDeterministically(fieldName, calendarValue, scraperValue, mergeContext);
             if (!resolved) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1446,7 +1446,10 @@ test('guardrail: case-only variants keep the less-uppercased form without AI', (
     { winner: 'a', reason: 'case-only variants — kept less-uppercased form' });
   // Genuinely different values must still go to AI
   assert.equal(core.resolveConflictDeterministically('bar', 'The Heretic', 'The Heretic Atlanta'), null);
-  assert.equal(core.resolveConflictDeterministically('address', '722 E Burnside', '722 East Burnside Street'), null);
+  // ("722 E Burnside" vs "722 East Burnside Street" used to be the example
+  // here — the address ladder now resolves same-address variants like that
+  // deterministically; see the deterministic address ladder tests below.)
+  assert.equal(core.resolveConflictDeterministically('address', '722 E Burnside', '1200 Canal Street'), null);
 });
 
 test('guardrail: earlier deterministic rules keep priority over the case-only rule', () => {
@@ -1470,6 +1473,243 @@ test('guardrail: earlier deterministic rules keep priority over the case-only ru
   assert.deepEqual(
     cityCore.resolveConflictDeterministically('title', 'BEARRACUDA: New Orleans⚜️', 'New Orleans⚜️', { cityKey: 'nola' }),
     { winner: 'a', reason: 'named title beats bare city title' });
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic address ladder (run 20260722-124758: ALL SIX address merge
+// conflicts were the SAME address in different formats, each burning an AI
+// arbitration call with coin-flip risk)
+// ---------------------------------------------------------------------------
+
+const SAME_ADDRESS_REASON = 'same address, kept the more complete form';
+
+// Five of the six real pairs from the run, as [more complete, less complete].
+// The first five replay through the scraped-vs-calendar flow below; the sixth
+// pair (observed in the enrich flow) replays through mergeParsedEvents.
+const RUN_20260722_ADDRESS_PAIRS = [
+  { complete: '619 East Pine Street, Seattle, WA, 98122', partial: '619 E. Pine St, Seattle, WA' },
+  { complete: '2069 Cheshire Bridge Road Northeast, Atlanta, GA, 30324', partial: '2069 CHESHIRE BRIDGE RD NE' },
+  { complete: '1200 Canal Street, New Orleans, LA', partial: '1200 Canal Street' },
+  { complete: '619 E. Pine, Seattle, WA, 98122', partial: '619 E. Pine Street' },
+  { complete: '161 Erie Street, San Francisco, CA, 94103', partial: '161 Erie St' }
+];
+
+test('address rung 1: every run-20260722 pair resolves to the more complete form, in both directions', () => {
+  const core = createCore();
+  for (const { complete, partial } of RUN_20260722_ADDRESS_PAIRS) {
+    assert.deepEqual(
+      core.resolveConflictDeterministically('address', complete, partial),
+      { winner: 'a', reason: SAME_ADDRESS_REASON }, `${complete} vs ${partial}`);
+    assert.deepEqual(
+      core.resolveConflictDeterministically('address', partial, complete),
+      { winner: 'b', reason: SAME_ADDRESS_REASON }, `${partial} vs ${complete}`);
+  }
+  // The enrich-flow pair carries the same components on both sides — the
+  // comma-separated (calendar-canonical) format counts as the more complete
+  // form over the run-on one.
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', '619 E. PINE ST. SEATTLE, WA', '619 E. Pine St, Seattle, WA'),
+    { winner: 'b', reason: SAME_ADDRESS_REASON });
+});
+
+test('run 20260722 (scraped-vs-calendar flow): same-address conflicts resolve with ZERO AI calls', async () => {
+  for (const { complete, partial } of RUN_20260722_ADDRESS_PAIRS) {
+    const core = createCore();
+    const { scraped, existing } = buildAlignedArbitrationPair();
+    scraped.address = partial;
+    existing.notes = existing.notes.replace(
+      'address: 3911 Cedar Springs Rd, Dallas, TX 75219', `address: ${complete}`);
+    const adapter = buildArbitrationAdapter({});
+
+    const logLines = [];
+    const originalLog = console.log;
+    console.log = (message) => { logLines.push(String(message)); };
+    let finalEvent;
+    try {
+      finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+    } finally {
+      console.log = originalLog;
+    }
+
+    assert.equal(adapter.calls.length, 0, `no AI request for "${partial}" vs "${complete}"`);
+    assert.equal(finalEvent.address, complete, 'the more complete form wins');
+    assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['address']);
+    assert.ok(logLines.includes(
+      `🔒 MERGE: "FURBALL DALLAS" field=address resolved deterministically — ${SAME_ADDRESS_REASON}`
+    ), `stable 🔒 log line expected, got: ${JSON.stringify(logLines)}`);
+  }
+});
+
+test('run 20260722 (enrich flow): "619 E. PINE ST. SEATTLE, WA" vs "619 E. Pine St, Seattle, WA" — AI never called', async () => {
+  const core = createSeattleCore();
+  const priorities = { address: { priority: ['ai-web'], merge: 'ai' } };
+  const aiParserConfig = { ai: { provider: 'ollama', endpoint: 'http://ai.example', model: 'm' } };
+  const existing = { title: 'BEARRACUDA SEATTLE', address: '619 E. PINE ST. SEATTLE, WA', city: 'seattle', source: 'ai-web', _fieldPriorities: priorities };
+  const incoming = { title: 'BEARRACUDA SEATTLE', address: '619 E. Pine St, Seattle, WA', city: 'seattle', source: 'ai-web', _parserConfig: aiParserConfig, _fieldPriorities: priorities };
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let merged;
+  try {
+    merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'same-address conflict resolves deterministically in the enrich flow');
+  assert.equal(merged.address, '619 E. Pine St, Seattle, WA', 'the comma-separated form is the more complete one');
+  assert.ok(logLines.includes(
+    `🔒 MERGE: "BEARRACUDA SEATTLE" field=address resolved deterministically — ${SAME_ADDRESS_REASON}`
+  ), `stable 🔒 log line expected, got: ${JSON.stringify(logLines)}`);
+});
+
+test('address rung 1: abbreviation/directional symmetry, case-insensitivity, punctuation', () => {
+  const core = createCore();
+  // RD NE ↔ Road Northeast (directionals fuse: "N.E." == "NE" == "Northeast")
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', '2069 Cheshire Bridge Road Northeast, Atlanta, GA, 30324', '2069 CHESHIRE BRIDGE RD N.E.'),
+    { winner: 'a', reason: SAME_ADDRESS_REASON });
+  // Symmetric in both abbreviation directions
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', '161 Erie St', '161 Erie Street, San Francisco, CA, 94103'),
+    { winner: 'b', reason: SAME_ADDRESS_REASON });
+  // Case and punctuation never block the match
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', '619 e pine st seattle wa', '619 E. Pine St., Seattle, WA, 98122'),
+    { winner: 'b', reason: SAME_ADDRESS_REASON });
+});
+
+test('address rung 1 is conservative: genuinely different addresses still reach the AI', () => {
+  const core = createCore();
+  // Different street numbers, same street
+  assert.equal(core.resolveConflictDeterministically('address', '617 E Pine St, Seattle, WA', '619 E Pine St, Seattle, WA'), null);
+  // Same number, different streets
+  assert.equal(core.resolveConflictDeterministically('address', '314 E Pike St, Seattle, WA', '314 E Pine St, Seattle, WA'), null);
+  // Entirely different addresses (the fail-open cases from the task)
+  assert.equal(core.resolveConflictDeterministically('address', '619 E Pine St', '1200 Canal Street'), null);
+  assert.equal(core.resolveConflictDeterministically('address', '314 E Pike St', '619 E Pine St'), null);
+  // A candidate without a leading street number never matches
+  assert.equal(core.resolveConflictDeterministically('address', 'Massive Nightclub, Seattle', '619 E Pine St, Seattle, WA'), null);
+  // Different explicit ZIPs are different places even with equal street lines
+  assert.equal(core.resolveConflictDeterministically('address', '619 E Pine St, Seattle, WA 98122', '619 E Pine St, Tacoma, WA 98402'), null);
+  // The Eventbrite doubled-address shape must keep arbitrating — repetition is
+  // malformation, not completeness (the AI reliably picks the clean form)
+  assert.equal(core.resolveConflictDeterministically('address',
+    '3911 Cedar Springs Rd, Dallas, TX 75219', '3911 Cedar Springs Rd, Dallas, TX 75219, Dallas, TX'), null);
+  // The ladder is scoped to the address field
+  assert.equal(core.resolveConflictDeterministically('shortName', '619 E Pine St', '619 East Pine Street, Seattle'), null);
+  // Empty candidates never resolve here (existing empty-field handling owns them)
+  assert.equal(core.resolveConflictDeterministically('address', '', '619 E Pine St, Seattle, WA'), null);
+});
+
+test('address flow: an empty scraped address keeps the calendar value without AI (existing handling untouched)', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.address = '';
+  const adapter = buildArbitrationAdapter({});
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 0, 'one-sided address is not a conflict');
+  assert.equal(finalEvent.address, '3911 Cedar Springs Rd, Dallas, TX 75219', 'calendar address kept');
+  const arbitration = finalEvent._original && finalEvent._original.aiArbitration;
+  assert.ok(!arbitration || arbitration.deterministic.length === 0,
+    'the empty-scrape rule, not the ladder, decided');
+});
+
+test('address rung 2: the curated bar address anchors the conflict when the event bar matches curated data', () => {
+  const core = createSeattleCore({ seattle: [{ name: 'Massive', address: '619 E Pine St, Seattle, WA 98122' }] });
+  const context = { cityKey: 'seattle', barNames: ['MASSIVE'] };
+  // A curated-address variant beats a non-address candidate, in both directions
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', 'somewhere else entirely', '619 East Pine Street, Seattle, WA', context),
+    { winner: 'b', reason: 'matches curated bar address (Massive)' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', '619 East Pine Street, Seattle, WA', 'somewhere else entirely', context),
+    { winner: 'a', reason: 'matches curated bar address (Massive)' });
+  // Contradiction: the other candidate is a DIFFERENT parseable address —
+  // never silently resolved, the AI sees it
+  assert.equal(
+    core.resolveConflictDeterministically('address', '1200 Canal Street, New Orleans, LA', '619 East Pine Street, Seattle, WA', context),
+    null, 'a parseable address contradicting curated data still arbitrates');
+  // Both candidates differ from the curated address → AI
+  assert.equal(
+    core.resolveConflictDeterministically('address', 'somewhere else entirely', '2069 Cheshire Bridge Rd NE', context),
+    null, 'both differing from curated → arbitrate');
+  // No curated match for the event's bar, no bar context, or no curated
+  // address on file → rung inert, AI path unchanged
+  assert.equal(
+    core.resolveConflictDeterministically('address', 'somewhere else entirely', '619 East Pine Street, Seattle, WA',
+      { cityKey: 'seattle', barNames: ['Neighbours'] }),
+    null);
+  assert.equal(
+    core.resolveConflictDeterministically('address', 'somewhere else entirely', '619 East Pine Street, Seattle, WA',
+      { cityKey: 'seattle' }),
+    null);
+  const noAddressCore = createSeattleCore(); // curated Massive has no address field
+  assert.equal(
+    noAddressCore.resolveConflictDeterministically('address', 'somewhere else entirely', '619 East Pine Street, Seattle, WA', context),
+    null);
+});
+
+test('address rung 2 (calendar flow): bar=Massive anchors the calendar address without AI', async () => {
+  const core = createSeattleCore({ seattle: [{ name: 'Massive', address: '619 E Pine St, Seattle, WA 98122' }] });
+  const scraped = {
+    title: 'BEARRACUDA SEATTLE',
+    bar: 'Massive',
+    address: 'somewhere else entirely',
+    city: 'seattle',
+    startDate: new Date('2026-08-01T05:00:00.000Z'),
+    endDate: new Date('2026-08-01T09:00:00.000Z'),
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: { ai: { provider: 'ollama', endpoint: 'http://ai.example/api/generate', model: 'test-model' } }
+  };
+  const existing = {
+    title: 'BEARRACUDA SEATTLE',
+    startDate: new Date(scraped.startDate.getTime()),
+    endDate: new Date(scraped.endDate.getTime()),
+    notes: ['bar: Massive', 'address: 619 East Pine Street, Seattle, WA'].join('\n')
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'curated bar address settles the only conflict — no AI request');
+  assert.equal(finalEvent.address, '619 East Pine Street, Seattle, WA', 'the curated-matching candidate wins');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['address']);
+  assert.ok(logLines.includes(
+    '🔒 MERGE: "BEARRACUDA SEATTLE" field=address resolved deterministically — matches curated bar address (Massive)'
+  ), `stable 🔒 log line expected, got: ${JSON.stringify(logLines)}`);
+});
+
+test('address completeness: component count wins, normalized length breaks ties, full ties fall through', () => {
+  const core = createCore();
+  // zip+state+city beats the bare street line (component count)
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', '161 Erie Street, San Francisco, CA, 94103', '161 Erie St'),
+    { winner: 'a', reason: SAME_ADDRESS_REASON });
+  // Equal component count → the longer normalized form wins
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', '619 E Pine St, Seattle, WA', '619 East Pine Street, Seattle, Washington'),
+    { winner: 'b', reason: SAME_ADDRESS_REASON });
+  // Pure case twins tie completely and fall through to the case-only rule
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', '619 E PINE ST, SEATTLE, WA', '619 E Pine St, Seattle, WA'),
+    { winner: 'b', reason: 'case-only variants — kept less-uppercased form' });
+  // Abbreviation-only twins with identical components and normalized length
+  // are a genuine toss-up — stably deferred to the AI, exactly as today
+  assert.equal(
+    core.resolveConflictDeterministically('address', '619 E Pine St, Seattle, WA', '619 East Pine St, Seattle, WA'),
+    null);
 });
 
 test('resolveAiConfig defaults and the arbitrateMerges flag', () => {


### PR DESCRIPTION
## Problem (run 20260722-124758)

All **six** address merge conflicts in the run were the same address in different formats ("619 East Pine Street, Seattle, WA, 98122" vs "619 E. Pine St, Seattle, WA", "…Cheshire Bridge Road Northeast…" vs "…CHESHIRE BRIDGE RD NE", etc.) — each burned an AI arbitration call with coin-flip risk to conclude 'the complete one is better'.

## Fix: explicit ladder in `resolveConflictDeterministically` (both merge flows), AI only as fallback

1. **Same-address detection** — house number required + symmetric street-abbreviation/directional normalization (St↔Street, RD NE↔Road Northeast, compound-directional fusing so N.E./North East/NE compare equal). Same street → winner by completeness (comma segments beyond the street line + ZIP bonus, then normalized length); `🔒 … same address, kept the more complete form`.
2. **Curated-bar-address authority** — when either record's bar matches a curated city bar (reusing the #1499/#1511 matching helpers, now extracted), the candidate that IS the curated address in any format wins; contradictions still arbitrate.
3. Geocode-equality documented as a future rung (needs network threading; out of scope).

**Conservative guards:** different street numbers/streets → AI; missing house number → AI; duplicated-token (Eventbrite doubled-address) candidates disqualified → AI, which reliably picks the clean form; equal streets with two different explicit ZIPs never match.

## Tests
+9: all six real-world pairs resolve deterministically with zero AI calls and the correct winner (five via calendar flow, one via enrich flow); abbreviation/directional/case symmetry; the conservative negatives above; curated-Massive rung both directions incl. contradiction→AI; completeness scoring + tie-breaks. One pre-existing assertion updated: '722 E Burnside' vs '722 East Burnside Street' was the old "goes to AI" example — it's exactly the shape this fix targets; replaced with a genuinely-different pair. Suite: **523 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP