### PR TITLE
fix(scraper): evidence-based address mismatch resolution — pins, city distance, curated proximity before AI

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -778,12 +778,141 @@ class SharedCore {
             && normalizeBarName(bar.name) === normalized) || null;
     }
 
+    // City-center coordinates from the cities config as a "lat, lng" pair
+    // string (same source OpenStreetMapNormalizer.getCityCenterCoordinates
+    // reads — cityConfig.coordinates from js/city-config.js via
+    // tools/generate-scraper-cities.js). Null when the city is unknown or has
+    // no coordinates — pure config lookup, never a network call.
+    getCityCenterCoordinatePair(cityKey) {
+        const key = cityKey ? String(cityKey).trim() : '';
+        if (!key || !this.cities || typeof this.cities !== 'object') return null;
+        const cityConfig = this.cities[key] || this.cities[key.toLowerCase()];
+        const coords = cityConfig && cityConfig.coordinates;
+        if (!coords) return null;
+        const lat = Number(coords.lat);
+        const lng = Number(coords.lng);
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+        return `${lat}, ${lng}`;
+    }
+
+    // The pin evidence one merge side contributes to the address evidence rung:
+    // { location: "lat, lng", verified } or null when the record carries no pin
+    // ATTRIBUTABLE to that address candidate. Attribution is strict — the pin
+    // must have been produced FROM this address by the pipeline:
+    //   - pinSource geocoded-exact / geocoded-approx: OpenStreetMapNormalizer
+    //     forward-geocoded record.address (BarDataNormalizer runs BEFORE
+    //     geocoding, so the geocoded address IS the record's final address);
+    //     exact = accepted exact-grade pin (verified), approx = street/census
+    //     grade or failed cross-check (usable for distance checks only).
+    //   - pinSource curated WITH addressSource curated: pin and address both
+    //     came from the same curated bar entry (verified). A curated pin next
+    //     to a non-curated address was not derived from that address.
+    // Everything else — page pins, absent provenance, or a record whose own
+    // address is not this candidate value — is uncertain attribution and
+    // counts as NO PIN (fail open). Calendar records satisfy the same shape:
+    // their stored pin/address/pinSource were finalized together by a previous
+    // run's merge (setProvenanceSource keeps them coherent).
+    getAddressPinEvidence(record, addressValue) {
+        if (!record || typeof record !== 'object') return null;
+        const location = typeof record.location === 'string' ? record.location.trim() : '';
+        if (!this.isCoordinatePair(location)) return null;
+        const recordAddress = typeof record.address === 'string' ? record.address.trim() : '';
+        const candidate = typeof addressValue === 'string' ? addressValue.trim() : '';
+        if (!recordAddress || !candidate || recordAddress !== candidate) return null;
+        const pinSource = typeof record.pinSource === 'string' ? record.pinSource.trim() : '';
+        if (pinSource === 'geocoded-exact') return { location, verified: true };
+        if (pinSource === 'geocoded-approx') return { location, verified: false };
+        if (pinSource === 'curated') {
+            const addressSource = typeof record.addressSource === 'string' ? record.addressSource.trim() : '';
+            return addressSource === 'curated' ? { location, verified: true } : null;
+        }
+        return null;
+    }
+
+    // Evidence rung for GENUINELY DIFFERENT address candidates (the cases the
+    // same-address and curated-address rungs could not settle). Uses ONLY
+    // evidence the pipeline already computed — verified pins on the two merge
+    // records, the city center from the cities config, curated bar
+    // coordinates — never a network call. Steps, in order:
+    //   1. exactly one candidate has a VERIFIED pin derived from its address
+    //      (the other side is unpinned: geocode refused / found nothing) → it
+    //      wins;
+    //   2. both pinned and the city center is known: exactly one pin within a
+    //      sane radius (≤ 30 km) while the other is absurd (> 50 km) → the
+    //      sane one wins (the 30–50 km band is ambiguous on purpose);
+    //   3. the event's bar matches a curated bar with coordinates and exactly
+    //      one candidate's pin is within 150 m of the curated pin → it wins.
+    // Any ambiguity — no attributable pins, no city center, both distances
+    // sane/absurd, both pins near the curated bar — FAILS OPEN (null → AI
+    // arbitration exactly as before).
+    resolveAddressMismatchByEvidence(valueA, valueB, context) {
+        if (!context || !context.records || typeof context.records !== 'object') return null;
+        const labels = context.sideLabels && typeof context.sideLabels === 'object'
+            ? context.sideLabels
+            : { a: 'a', b: 'b' };
+        const evidenceA = this.getAddressPinEvidence(context.records.a, valueA);
+        const evidenceB = this.getAddressPinEvidence(context.records.b, valueB);
+
+        // Step 1: exactly one side carries a pin at all, and it is verified.
+        if (evidenceA && !evidenceB && evidenceA.verified) {
+            return { winner: 'a', reason: `only "${labels.a}" has a verified pin` };
+        }
+        if (evidenceB && !evidenceA && evidenceB.verified) {
+            return { winner: 'b', reason: `only "${labels.b}" has a verified pin` };
+        }
+
+        // Step 2: both pinned + known city center — sane beats absurd.
+        if (evidenceA && evidenceB) {
+            const center = this.getCityCenterCoordinatePair(context.cityKey);
+            if (center) {
+                const distanceA = this.coordinatePairDistanceKm(evidenceA.location, center);
+                const distanceB = this.coordinatePairDistanceKm(evidenceB.location, center);
+                if (distanceA !== null && distanceB !== null) {
+                    const saneBeatsAbsurd = (sane, absurd) => sane <= 30 && absurd > 50;
+                    if (saneBeatsAbsurd(distanceA, distanceB)) {
+                        return { winner: 'a', reason: `only "${labels.a}" pin is near the city center (${Math.round(distanceA)} km vs ${Math.round(distanceB)} km)` };
+                    }
+                    if (saneBeatsAbsurd(distanceB, distanceA)) {
+                        return { winner: 'b', reason: `only "${labels.b}" pin is near the city center (${Math.round(distanceB)} km vs ${Math.round(distanceA)} km)` };
+                    }
+                }
+            }
+        }
+
+        // Step 3: curated bar proximity. Same bar selection as the
+        // curated-address rung (first barNames match wins), then the curated
+        // coordinates must exist and exactly one pin must sit within 150 m.
+        const cityBars = this.getCuratedCityBars(context.cityKey);
+        const barNames = Array.isArray(context.barNames) ? context.barNames : [];
+        let curatedBar = null;
+        if (cityBars) {
+            for (const barName of barNames) {
+                curatedBar = this.findCuratedBarByName(cityBars, barName);
+                if (curatedBar) break;
+            }
+        }
+        if (curatedBar && this.isCoordinatePair(curatedBar.coordinates)) {
+            const isNearCuratedPin = evidence => {
+                if (!evidence) return false;
+                const km = this.coordinatePairDistanceKm(evidence.location, curatedBar.coordinates);
+                return km !== null && km <= 0.15;
+            };
+            const nearA = isNearCuratedPin(evidenceA);
+            const nearB = isNearCuratedPin(evidenceB);
+            if (nearA !== nearB) {
+                return { winner: nearA ? 'a' : 'b', reason: `pin matches curated bar "${curatedBar.name}"` };
+            }
+        }
+        return null;
+    }
+
     // Deterministic conflict resolution consulted by BOTH merge paths
     // (createFinalEventObject and mergeParsedEvents) before a field is queued
     // for AI arbitration. Returns { winner: 'a'|'b', reason } or null (→
     // arbitrate as usual). Callers map a/b onto their own labels and thread
-    // event context (currently { cityKey, barNames }) for the city-aware
-    // title, curated-bar, and curated-address rules.
+    // event context (currently { cityKey, barNames, eventTitle, sideLabels,
+    // records }) for the city-aware title, curated-bar, curated-address, and
+    // address-evidence rules.
     resolveConflictDeterministically(fieldName, valueA, valueB, context = null) {
         const urlA = this.getUrlRuleParts(valueA);
         const urlB = this.getUrlRuleParts(valueB);
@@ -899,10 +1028,14 @@ class SharedCore {
         // other candidate is not itself a parseable street address: a
         // parseable candidate that failed the same-address check is a genuine
         // CONTRADICTION of curated data and is never silently resolved.
-        // Rung 3 (future): geocode-equality — two candidates geocoding to the
-        // same pin are the same address — needs adapter/network threading in
-        // the merge path, deliberately out of scope here. Everything not
-        // decided above FAILS OPEN to AI arbitration exactly as today.
+        // Rung 3: evidence — for candidates rungs 1–2 found genuinely
+        // different (or unparseable but both present), pins the pipeline
+        // ALREADY produced decide when they can (see
+        // resolveAddressMismatchByEvidence: one verified pin, city-center
+        // sanity, curated-bar proximity — no network calls). Everything not
+        // decided above FAILS OPEN to AI arbitration exactly as today, but a
+        // true street mismatch reaching the AI is warned about first so it is
+        // never silent.
         if (fieldName === 'address' && typeof valueA === 'string' && typeof valueB === 'string') {
             const parsedA = this.parseAddressForComparison(valueA);
             const parsedB = this.parseAddressForComparison(valueB);
@@ -942,6 +1075,22 @@ class SharedCore {
                             reason: `matches curated bar address (${curatedBar.name})`
                         };
                     }
+                }
+                // Rung 3 (evidence). Case-only twins are NOT a street
+                // mismatch — they fall through untouched so the case-only
+                // rule below keeps deciding them; empty candidates belong to
+                // the existing empty-field handling.
+                const collapseForTwinCheck = value => String(value).replace(/\s+/g, ' ').trim().toLowerCase();
+                const collapsedMismatchA = collapseForTwinCheck(valueA);
+                const collapsedMismatchB = collapseForTwinCheck(valueB);
+                if (collapsedMismatchA && collapsedMismatchB && collapsedMismatchA !== collapsedMismatchB) {
+                    const evidenceResolution = this.resolveAddressMismatchByEvidence(valueA, valueB, context);
+                    if (evidenceResolution) return evidenceResolution;
+                    // Nothing decidable from evidence: the AI arbitrates
+                    // exactly as before, but never silently — a genuine
+                    // street mismatch always leaves a manual-review trail.
+                    const mismatchEventTitle = context && context.eventTitle ? context.eventTitle : 'event';
+                    console.warn(`⚠️ MERGE: "${mismatchEventTitle}" field=address street mismatch arbitrated by AI ("${valueA}" vs "${valueB}") — verify manually`);
                 }
             }
         }
@@ -3247,9 +3396,15 @@ class SharedCore {
         // to a named title) — both records describe the same event, so either
         // side's resolved city works. barNames feeds the curated-address rung:
         // either record's bar matching a curated bar anchors the address.
+        // records/sideLabels feed the address evidence rung: each side's
+        // already-computed pin (+ pinSource provenance) is attributed to its
+        // own address candidate; eventTitle is for the mismatch warning only.
         const mergeContext = {
             cityKey: newEvent.city || existingEvent.city || '',
-            barNames: [existingEvent.bar, newEvent.bar]
+            barNames: [existingEvent.bar, newEvent.bar],
+            eventTitle: mergeEventTitle,
+            sideLabels: { a: 'existing', b: 'incoming' },
+            records: { a: existingEvent, b: newEvent }
         };
         const queueArbitrationConflict = (fieldName, existingValue, newValue, fallbackPick, fallbackReason) => {
             const resolved = this.resolveConflictDeterministically(fieldName, existingValue, newValue, mergeContext);
@@ -3666,10 +3821,17 @@ class SharedCore {
         // to a named title) — the scraper object carries the resolved city; the
         // calendar object may carry one parsed from its notes. barNames feeds
         // the curated-address rung: either record's bar matching a curated bar
-        // anchors the address.
+        // anchors the address. records/sideLabels feed the address evidence
+        // rung: the scraper object carries this run's geocode-verified pin
+        // (location + pinSource from the normalizers), the calendar object its
+        // stored pin (native location + notes-parsed pinSource); eventTitle is
+        // for the mismatch warning only.
         const mergeContext = {
             cityKey: scraperObject.city || calendarObject.city || '',
-            barNames: [calendarObject.bar, scraperObject.bar]
+            barNames: [calendarObject.bar, scraperObject.bar],
+            eventTitle: mergeTitle,
+            sideLabels: { a: 'calendar', b: 'scraped' },
+            records: { a: calendarObject, b: scraperObject }
         };
         const queueArbitrationConflict = (fieldName, calendarValue, scraperValue) => {
             const resolved = this.resolveConflictDeterministically(fieldName, calendarValue, scraperValue, mergeContext);

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1712,6 +1712,336 @@ test('address completeness: component count wins, normalized length breaks ties,
     null);
 });
 
+// ---------------------------------------------------------------------------
+// Address evidence rung (rung 3): genuinely-different addresses decided by
+// pins the pipeline already produced — one verified pin, city-center sanity,
+// curated-bar proximity — before any AI arbitration. No network calls.
+// ---------------------------------------------------------------------------
+
+const EVIDENCE_CITIES = {
+  seattle: { timezone: 'America/Los_Angeles', patterns: ['seattle'], coordinates: { lat: 47.6062, lng: -122.3321 } }
+};
+function createEvidenceCore(bars = null) {
+  return new SharedCore(EVIDENCE_CITIES, { eventSchema: EventSchema, ...(bars ? { bars } : {}) });
+}
+// Two genuinely different addresses (different street AND number — rung 1
+// can never match them, rung 2 never silently overrides a parseable pair).
+const CANAL_ADDRESS = '1200 Canal Street, New Orleans, LA';
+const PINE_ADDRESS = '619 E Pine St, Seattle, WA';
+// Distances from the Seattle center above (haversine, precomputed):
+const NEAR_CENTER_PIN = '47.6062, -122.3241';   // ~0.6 km from center
+const ABSURD_PIN = '48.3249, -122.3321';        // ~79.9 km from center
+const MASSIVE_PIN = '47.6152, -122.3225';       // curated Massive (~1.2 km from center)
+const NEAR_MASSIVE_PIN = '47.6157, -122.3225';  // ~56 m from Massive (~1.3 km from center)
+const FAR_MASSIVE_PIN = '47.6252, -122.3225';   // ~1.1 km from Massive (~2.2 km from center)
+
+function evidenceContext(recordA, recordB, extra = {}) {
+  return {
+    cityKey: 'seattle',
+    eventTitle: 'BEARRACUDA SEATTLE',
+    sideLabels: { a: 'calendar', b: 'scraped' },
+    records: { a: recordA, b: recordB },
+    ...extra
+  };
+}
+
+test('address evidence step 1: exactly one verified pin wins, in both directions', () => {
+  const core = createEvidenceCore();
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: NEAR_CENTER_PIN, pinSource: 'geocoded-exact' },
+      { address: PINE_ADDRESS })),
+    { winner: 'a', reason: 'only "calendar" has a verified pin' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS },
+      { address: PINE_ADDRESS, location: NEAR_CENTER_PIN, pinSource: 'geocoded-exact' })),
+    { winner: 'b', reason: 'only "scraped" has a verified pin' });
+  // A curated pin stamped alongside a curated address is verified too
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS },
+      { address: PINE_ADDRESS, location: MASSIVE_PIN, pinSource: 'curated', addressSource: 'curated' })),
+    { winner: 'b', reason: 'only "scraped" has a verified pin' });
+});
+
+test('address evidence step 1 is conservative: unverified or unattributable pins never decide alone', () => {
+  const core = createEvidenceCore();
+  // The only pin is geocoded-approx (street grade / failed cross-check) → AI
+  assert.equal(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS },
+      { address: PINE_ADDRESS, location: NEAR_CENTER_PIN, pinSource: 'geocoded-approx' })),
+    null);
+  // A page pin was never derived from the address → no attribution → AI
+  assert.equal(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS },
+      { address: PINE_ADDRESS, location: NEAR_CENTER_PIN, pinSource: 'page' })),
+    null);
+  // A pin with no provenance at all (hand-fixed) → uncertain → AI
+  assert.equal(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS },
+      { address: PINE_ADDRESS, location: NEAR_CENTER_PIN })),
+    null);
+  // A curated pin WITHOUT a curated address was not derived from this address
+  assert.equal(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS },
+      { address: PINE_ADDRESS, location: MASSIVE_PIN, pinSource: 'curated', addressSource: 'page' })),
+    null);
+  // No records threaded (direct/legacy callers) → rung inert
+  assert.equal(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS,
+      { cityKey: 'seattle' }),
+    null);
+});
+
+test('address evidence attribution: a pin not derived from the candidate address is treated as no-pin', () => {
+  const core = createEvidenceCore();
+  // The record carries a verified pin, but its own address is NOT the
+  // candidate value being merged — attribution is uncertain, so the pin must
+  // not count and the conflict falls through to the AI.
+  assert.equal(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS },
+      { address: '500 Somewhere Else Ave, Seattle, WA', location: NEAR_CENTER_PIN, pinSource: 'geocoded-exact' })),
+    null);
+});
+
+test('address evidence step 2: a sane city-center distance beats an absurd one, in both directions', () => {
+  const core = createEvidenceCore();
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: ABSURD_PIN, pinSource: 'geocoded-approx' },
+      { address: PINE_ADDRESS, location: NEAR_CENTER_PIN, pinSource: 'geocoded-exact' })),
+    { winner: 'b', reason: 'only "scraped" pin is near the city center (1 km vs 80 km)' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: NEAR_CENTER_PIN, pinSource: 'geocoded-exact' },
+      { address: PINE_ADDRESS, location: ABSURD_PIN, pinSource: 'geocoded-exact' })),
+    { winner: 'a', reason: 'only "calendar" pin is near the city center (1 km vs 80 km)' });
+});
+
+test('address evidence step 2 fails open: both sane, gray zone, or no city center → AI as today', () => {
+  const core = createEvidenceCore();
+  // Both pins within 30 km → ambiguous (no curated bar → nothing decides)
+  assert.equal(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: MASSIVE_PIN, pinSource: 'geocoded-exact' },
+      { address: PINE_ADDRESS, location: FAR_MASSIVE_PIN, pinSource: 'geocoded-exact' })),
+    null);
+  // The 30–50 km band is ambiguous on purpose: ~40 km is neither sane nor absurd
+  assert.equal(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: '47.9659, -122.3321', pinSource: 'geocoded-exact' },
+      { address: PINE_ADDRESS, location: NEAR_CENTER_PIN, pinSource: 'geocoded-exact' })),
+    null);
+  // No city-center coordinates in the cities config → step 2 inert
+  const noCenterCore = new SharedCore(
+    { seattle: { timezone: 'America/Los_Angeles', patterns: ['seattle'] } },
+    { eventSchema: EventSchema });
+  assert.equal(
+    noCenterCore.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: ABSURD_PIN, pinSource: 'geocoded-exact' },
+      { address: PINE_ADDRESS, location: NEAR_CENTER_PIN, pinSource: 'geocoded-exact' })),
+    null);
+});
+
+test('address evidence step 3: exactly one pin within 150 m of the curated bar pin wins', () => {
+  const core = createEvidenceCore({ seattle: [{ name: 'Massive', coordinates: MASSIVE_PIN }] });
+  const barContext = { barNames: ['MASSIVE'] };
+  // Both pins are sane city distances (step 2 stays silent) — proximity decides
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: FAR_MASSIVE_PIN, pinSource: 'geocoded-approx' },
+      { address: PINE_ADDRESS, location: NEAR_MASSIVE_PIN, pinSource: 'geocoded-approx' }, barContext)),
+    { winner: 'b', reason: 'pin matches curated bar "Massive"' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: NEAR_MASSIVE_PIN, pinSource: 'geocoded-approx' },
+      { address: PINE_ADDRESS, location: FAR_MASSIVE_PIN, pinSource: 'geocoded-approx' }, barContext)),
+    { winner: 'a', reason: 'pin matches curated bar "Massive"' });
+  // A lone geocoded-approx pin (too weak for step 1) matching the curated pin
+  // still wins here — the curated coordinates ARE the verification
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS },
+      { address: PINE_ADDRESS, location: NEAR_MASSIVE_PIN, pinSource: 'geocoded-approx' }, barContext)),
+    { winner: 'b', reason: 'pin matches curated bar "Massive"' });
+});
+
+test('address evidence step 3 fails open: both pins near, both far, or no curated coordinates → AI', () => {
+  const core = createEvidenceCore({ seattle: [{ name: 'Massive', coordinates: MASSIVE_PIN }] });
+  const barContext = { barNames: ['MASSIVE'] };
+  // Both within 150 m → ambiguous
+  assert.equal(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: MASSIVE_PIN, pinSource: 'geocoded-approx' },
+      { address: PINE_ADDRESS, location: NEAR_MASSIVE_PIN, pinSource: 'geocoded-approx' }, barContext)),
+    null);
+  // Both outside 150 m → ambiguous
+  assert.equal(
+    core.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: FAR_MASSIVE_PIN, pinSource: 'geocoded-approx' },
+      { address: PINE_ADDRESS, location: NEAR_CENTER_PIN, pinSource: 'geocoded-approx' }, barContext)),
+    null);
+  // Curated bar with no coordinates on file → step 3 inert
+  const noCoordsCore = createEvidenceCore({ seattle: [{ name: 'Massive' }] });
+  assert.equal(
+    noCoordsCore.resolveConflictDeterministically('address', CANAL_ADDRESS, PINE_ADDRESS, evidenceContext(
+      { address: CANAL_ADDRESS, location: FAR_MASSIVE_PIN, pinSource: 'geocoded-approx' },
+      { address: PINE_ADDRESS, location: NEAR_MASSIVE_PIN, pinSource: 'geocoded-approx' },
+      { barNames: ['MASSIVE'] })),
+    null);
+});
+
+function captureMergeLogs() {
+  const lines = [];
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  console.log = (message) => { lines.push(String(message)); };
+  console.warn = (message) => { lines.push(String(message)); };
+  return { lines, restore: () => { console.log = originalLog; console.warn = originalWarn; } };
+}
+
+function buildEvidenceFlowScrape(core, overrides = {}) {
+  return {
+    title: 'BEARRACUDA SEATTLE',
+    city: 'seattle',
+    startDate: new Date('2026-08-01T05:00:00.000Z'),
+    endDate: new Date('2026-08-01T09:00:00.000Z'),
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: { ai: { provider: 'ollama', endpoint: 'http://ai.example/api/generate', model: 'test-model' } },
+    ...overrides
+  };
+}
+
+test('address evidence (calendar flow): the scraped side\'s verified pin wins with ZERO AI calls', async () => {
+  const core = createEvidenceCore();
+  const scraped = buildEvidenceFlowScrape(core, {
+    address: PINE_ADDRESS, location: MASSIVE_PIN, pinSource: 'geocoded-exact'
+  });
+  const existing = {
+    title: 'BEARRACUDA SEATTLE',
+    startDate: new Date(scraped.startDate.getTime()),
+    endDate: new Date(scraped.endDate.getTime()),
+    notes: `address: ${CANAL_ADDRESS}`
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const capture = captureMergeLogs();
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    capture.restore();
+  }
+
+  assert.equal(adapter.calls.length, 0, 'the verified pin settles the only conflict — no AI request');
+  assert.equal(finalEvent.address, PINE_ADDRESS, 'the pinned scraped address wins');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['address']);
+  assert.ok(capture.lines.includes(
+    '🔒 MERGE: "BEARRACUDA SEATTLE" field=address resolved deterministically — only "scraped" has a verified pin'
+  ), `stable 🔒 log line expected, got: ${JSON.stringify(capture.lines)}`);
+  assert.ok(!capture.lines.some(line => line.includes('street mismatch arbitrated by AI')),
+    'a deterministically resolved mismatch never emits the manual-review warning');
+});
+
+test('address evidence (calendar flow): the calendar side\'s stored verified pin wins with ZERO AI calls', async () => {
+  const core = createEvidenceCore();
+  const scraped = buildEvidenceFlowScrape(core, { address: CANAL_ADDRESS });
+  const existing = {
+    title: 'BEARRACUDA SEATTLE',
+    startDate: new Date(scraped.startDate.getTime()),
+    endDate: new Date(scraped.endDate.getTime()),
+    location: MASSIVE_PIN,
+    notes: [`address: ${PINE_ADDRESS}`, 'pinSource: geocoded-exact'].join('\n')
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const capture = captureMergeLogs();
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    capture.restore();
+  }
+
+  assert.equal(adapter.calls.length, 0, 'the stored calendar pin settles the only conflict — no AI request');
+  assert.equal(finalEvent.address, PINE_ADDRESS, 'the pinned calendar address wins');
+  assert.equal(finalEvent.location, MASSIVE_PIN, 'the calendar pin is kept');
+  assert.ok(capture.lines.includes(
+    '🔒 MERGE: "BEARRACUDA SEATTLE" field=address resolved deterministically — only "calendar" has a verified pin'
+  ), `stable 🔒 log line expected, got: ${JSON.stringify(capture.lines)}`);
+});
+
+test('address evidence (enrich flow): one verified pin decides in both directions with ZERO AI calls', async () => {
+  const priorities = { address: { priority: ['ai-web'], merge: 'ai' } };
+  const aiParserConfig = { ai: { provider: 'ollama', endpoint: 'http://ai.example', model: 'm' } };
+  const buildPinned = () => ({
+    title: 'BEARRACUDA SEATTLE', city: 'seattle', source: 'ai-web', _fieldPriorities: priorities,
+    _parserConfig: aiParserConfig,
+    address: PINE_ADDRESS, location: MASSIVE_PIN, pinSource: 'geocoded-exact'
+  });
+  const buildUnpinned = () => ({
+    title: 'BEARRACUDA SEATTLE', city: 'seattle', source: 'ai-web', _fieldPriorities: priorities,
+    _parserConfig: aiParserConfig,
+    address: CANAL_ADDRESS
+  });
+
+  for (const [existing, incoming, winnerLabel] of [
+    [buildPinned(), buildUnpinned(), 'existing'],
+    [buildUnpinned(), buildPinned(), 'incoming']
+  ]) {
+    const core = createEvidenceCore();
+    const adapter = buildArbitrationAdapter({});
+    const capture = captureMergeLogs();
+    let merged;
+    try {
+      merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+    } finally {
+      capture.restore();
+    }
+    assert.equal(adapter.calls.length, 0, `no AI request when "${winnerLabel}" carries the verified pin`);
+    assert.equal(merged.address, PINE_ADDRESS, 'the pinned address wins');
+    assert.ok(capture.lines.includes(
+      `🔒 MERGE: "BEARRACUDA SEATTLE" field=address resolved deterministically — only "${winnerLabel}" has a verified pin`
+    ), `stable 🔒 log line expected, got: ${JSON.stringify(capture.lines)}`);
+  }
+});
+
+test('address evidence step 4: an undecidable street mismatch reaches the AI exactly as today, plus the ⚠️ warning', async () => {
+  const core = createEvidenceCore();
+  const scraped = buildEvidenceFlowScrape(core, { address: PINE_ADDRESS });
+  const existing = {
+    title: 'BEARRACUDA SEATTLE',
+    startDate: new Date(scraped.startDate.getTime()),
+    endDate: new Date(scraped.endDate.getTime()),
+    notes: `address: ${CANAL_ADDRESS}`
+  };
+  const adapter = buildArbitrationAdapter({
+    address: { pick: 'scraped', value: PINE_ADDRESS, reason: 'matches the event city' }
+  });
+
+  const capture = captureMergeLogs();
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    capture.restore();
+  }
+
+  assert.equal(adapter.calls.length, 1, 'no evidence on either side → the AI arbitrates exactly as before');
+  assert.match(adapter.calls[0].prompt, /field: address/, 'the address conflict reaches the prompt');
+  assert.equal(finalEvent.address, PINE_ADDRESS, 'the AI pick still lands');
+  assert.ok(capture.lines.includes(
+    `⚠️ MERGE: "BEARRACUDA SEATTLE" field=address street mismatch arbitrated by AI ("${CANAL_ADDRESS}" vs "${PINE_ADDRESS}") — verify manually`
+  ), `additive ⚠️ warning expected, got: ${JSON.stringify(capture.lines)}`);
+});
+
 test('resolveAiConfig defaults and the arbitrateMerges flag', () => {
   const core = createCore();
   const defaults = core.resolveAiConfig({});


### PR DESCRIPTION
## What this adds

Extends #1513's address ladder with an EVIDENCE rung for genuinely-different addresses — using signals the pipeline already computed, **zero new network calls** in the merge path:

1. **Only one candidate has a verified pin** (geocoded-exact with clean reverse cross-check, or curated bar pin with curated address) → it wins. A pin only counts when provenance proves it was derived from that exact address (`pinSource`/`addressSource` from the provenance PR); `page` pins, missing provenance, or address mismatch → treated as no-pin.
2. **Both pinned → city-center sanity**: one ≤30 km from the city center and the other >50 km → the sane one wins, distances logged in km. Uses the same city-center coordinates the geocoder already reads; approximate-grade pins participate here (distance itself is the verification).
3. **Curated-bar pin proximity**: the candidate whose pin sits within 150 m of the matched curated bar's coordinates wins — same bar matching as the curated rules.
4. **Genuinely ambiguous → AI as today, but never silently**: `⚠️ MERGE: … street mismatch arbitrated by AI (… vs …) — verify manually`.

Fail-open at every step; unparseable case-fold twins skip the rung entirely (existing case-only rule keeps them, no spurious warnings).

## Tests
+11: lone-verified-pin both directions in both flows (zero AI calls, stable 🔒 lines), city-distance 0.6 km vs 80 km both directions + both-sane + 40 km gray zone + no-center fail-opens, curated proximity both directions incl. an approx pin verified by curated coordinates + both-near/both-far fail-opens, step-4 AI-called-once with the ⚠️ asserted, and the pin-attribution mismatch case. All #1513 rung tests untouched. Suite: **534 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP