### PR TITLE
feat(scraper): deterministic merge sweep — time-evidence hardening, image/ticketUrl/description rungs + NYE fix

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -3765,89 +3765,17 @@ class AiWebParser {
     /**
      * Extract a size score from a URL to determine which image is larger.
      * Returns a numeric score - higher means larger image.
+     * The scoring itself lives in SharedCore.getImageSizeScoreFromUrl so the
+     * merge's deterministic image rung ranks candidates on the SAME scale as
+     * the OCR dedup here. Core is always wired in production; the URL-length
+     * fallback only covers stubbed cores in isolated tests.
      */
     getImageSizeFromUrl(url) {
         if (!url || typeof url !== 'string') return -1;
-
-        const lowerUrl = url.toLowerCase();
-        const parsed = this.parseUrlComponents(url);
-
-        if (!parsed) {
-            // Fallback: longer URL often means higher quality
-            return url.length;
+        if (this.core && typeof this.core.getImageSizeScoreFromUrl === 'function') {
+            return this.core.getImageSizeScoreFromUrl(url);
         }
-
-        let score = 0;
-        const search = String(parsed.search || '').toLowerCase();
-        const path = String(parsed.pathname || '').toLowerCase();
-
-        // Check query parameters for size indicators (extractSearchParamValue,
-        // not URLSearchParams — the latter doesn't exist in iOS JavaScriptCore)
-        const getParam = (key) => this.extractSearchParamValue(search, key);
-
-        // Width/height parameters (e.g., ?w=1920, ?width=1080, ?h=1080, ?height=1920)
-        const width = getParam('w') || getParam('width') || getParam('wpx');
-        const height = getParam('h') || getParam('height') || getParam('hpx');
-
-        if (width) {
-            const w = parseInt(width, 10);
-            if (!isNaN(w)) score += w;
-        }
-        if (height) {
-            const h = parseInt(height, 10);
-            if (!isNaN(h)) score += h;
-        }
-
-        // Size scale parameters (e.g., ?scale=2, ?size=large)
-        const scale = getParam('scale') || getParam('size');
-        if (scale) {
-            const s = scale.toLowerCase();
-            if (s === 'large' || s === 'big' || s === 'max' || s === 'original' || s === 'full') {
-                score += 5000;
-            } else if (s === 'medium' || s === 'mid') {
-                score += 2500;
-            } else if (s === 'small' || s === 'tiny') {
-                score += 500;
-            } else {
-                const num = parseInt(s, 10);
-                if (!isNaN(num)) score += num;
-            }
-        }
-
-        // Check path for resolution indicators (e.g., /1920x1080/, /large/, /original/)
-        const pathSegments = path.split('/').filter(Boolean);
-        for (const segment of pathSegments) {
-            // Match resolution patterns like 1920x1080, 1080p, 4k
-            const resolutionMatch = segment.match(/(\d+)x(\d+)/);
-            if (resolutionMatch) {
-                const w = parseInt(resolutionMatch[1], 10);
-                const h = parseInt(resolutionMatch[2], 10);
-                score += w * h;
-            }
-
-            // Match pixel patterns like 1920px, 1080px
-            const pxMatch = segment.match(/(\d+)px/);
-            if (pxMatch) {
-                const px = parseInt(pxMatch[1], 10);
-                score += px;
-            }
-
-            // Check for size keywords
-            if (segment === 'large' || segment === 'big' || segment === 'max' || segment === 'original' || segment === 'full' || segment === 'high') {
-                score += 5000;
-            } else if (segment === 'medium' || segment === 'mid') {
-                score += 2500;
-            } else if (segment === 'small' || segment === 'tiny') {
-                score += 500;
-            }
-        }
-
-        // Fallback: longer URL often means higher quality (more parameters, paths, etc.)
-        if (score === 0) {
-            score = url.length;
-        }
-
-        return score;
+        return url.length;
     }
 
     /**
@@ -5426,6 +5354,17 @@ class AiWebParser {
                 };
                 return;
             }
+            // Per-field model evidence strings (see parseAndFilterConfidence): union
+            // across passes like the pin flags — each pass's evidence covers the
+            // fields that pass extracted. Consumed by the evidence gate at pass time;
+            // harmless (and internal-only) afterwards.
+            if (key === '__fieldEvidence' && value && typeof value === 'object') {
+                merged.__fieldEvidence = {
+                    ...(merged.__fieldEvidence && typeof merged.__fieldEvidence === 'object' ? merged.__fieldEvidence : {}),
+                    ...value
+                };
+                return;
+            }
             if (!this.isUsableAiFieldValue(value)) return;
             const normalizedName = this.normalizePromptFieldName(key);
             if (this.hasResolvedFieldValue(merged, normalizedName)) return;
@@ -6427,6 +6366,17 @@ TEXT:
                         continue; // Drop it
                     }
                     let value = fieldData.value;
+                    // Carry the model's per-field evidence string forward as internal
+                    // metadata: the evidence gate (validateAiEventEvidence) uses it to
+                    // reject time values whose evidence admits inference ("interpreted
+                    // as ~3am (common club close time)") instead of quoting the source.
+                    // Internal __ keys never reach calendar notes or merge field loops.
+                    if (typeof fieldData.evidence === 'string' && fieldData.evidence.trim()) {
+                        if (!filteredEvent.__fieldEvidence || typeof filteredEvent.__fieldEvidence !== 'object') {
+                            filteredEvent.__fieldEvidence = {};
+                        }
+                        filteredEvent.__fieldEvidence[key] = fieldData.evidence.trim();
+                    }
                     // Weekday-pinned year inference: the evidence string is only
                     // available here (it is discarded when field objects flatten to
                     // scalars), so this is the seam where "Sat, Aug 22" can pin the
@@ -7023,11 +6973,19 @@ TEXT:
             .some(variant => normalizedEvidence.includes(variant));
         if (!hasDateMatch) return false;
         if (!dateParts.hasTime) return true;
-        const evidenceHasTimeSignal = /\b\d{1,2}(?::\d{2})?\s*(?:am|pm)\b|\b\d{1,2}:\d{2}\b|\b(?:noon|midnight)\b/i.test(normalizedEvidence);
-        if (!evidenceHasTimeSignal) return true;
+        // T00:00 is the pipeline's "no time stated" placeholder (see
+        // isInventedMidnight in normalizeAiEvent) — not a time claim.
+        if (Number(dateParts.hour) === 0 && Number(dateParts.minute) === 0) return true;
         const timeVariants = this.buildTimeEvidenceVariants(dateParts);
         if (timeVariants.length === 0) return true;
-        return timeVariants.some(variant => normalizedEvidence.includes(variant));
+        if (timeVariants.some(variant => normalizedEvidence.includes(variant))) return true;
+        // The claimed time component must appear somewhere in the source in a
+        // recognized format — hasTimeEvidence also understands OCR forms ("01H",
+        // "@10", "noon"/"midnight"). Times are never merge-arbitrated downstream
+        // (scraped clobbers), so an invented time here would flow straight into
+        // calendars; if the source never states it, drop the field.
+        const timeComponent = `${String(Number(dateParts.hour)).padStart(2, '0')}:${String(Math.max(0, Number(dateParts.minute) || 0)).padStart(2, '0')}`;
+        return this.hasTimeEvidence(evidenceContext, timeComponent);
     }
 
     hasTimeEvidence(evidenceContext, value) {
@@ -7050,6 +7008,10 @@ TEXT:
             return true;
         }
 
+        // Midnight and noon are written as words, not digits
+        if (normalizedTime === '00:00' && /\bmidnight\b/.test(lowerEvidence)) return true;
+        if (normalizedTime === '12:00' && /\bnoon\b/.test(lowerEvidence)) return true;
+
         // Also check for OCR-specific formats in raw evidence
         const rawEvidence = String(evidenceContext && evidenceContext.raw ? evidenceContext.raw : '');
         const lowerRaw = rawEvidence.toLowerCase();
@@ -7058,14 +7020,20 @@ TEXT:
         const hour24 = parseInt(normalizedTime.split(':')[0], 10);
         const hour12 = hour24 % 12 || 12;
 
-        // Pattern 1: @HH, @HHmm, @HHH, @HH H, @HH H mm (OCR time indicators)
-        // Matches: @10PM, @10PM30, 01H, 10H, @10, @10 H, etc.
-        const ocrTimePattern = /(?:^|[\s,@"'`(]|at\s)(\d{1,2})(?::?(\d{2}))?\s*(H|[ap]m)?/gi;
+        // Pattern 1: @HH, @HHmm, @HH H, 01H, 10PM (OCR time indicators).
+        // A BARE number is NOT time evidence — "MAY 3", "$3" or a street number
+        // must never corroborate an invented "03:00" (observed on-device: endTime
+        // 03:00 whose evidence said "interpreted as ~3am" passed on a stray
+        // digit). Require an explicit time marker: an @/"at" prefix or an
+        // H/am/pm suffix. Colon forms ("22:00", "10:30pm") are covered by the
+        // variant path above and the standalone path below.
+        const ocrTimePattern = /(?:(@|\bat\s+)|^|[\s,"'`(])(\d{1,2})(?::?(\d{2}))?\s*(h\b|[ap]m)?/gi;
         let ocrMatch;
         while ((ocrMatch = ocrTimePattern.exec(lowerRaw)) !== null) {
-            const ocrHour = parseInt(ocrMatch[1], 10);
-            const ocrMinute = ocrMatch[2] ? parseInt(ocrMatch[2], 10) : 0;
-            const ocrSuffix = ocrMatch[3] ? ocrMatch[3].toLowerCase() : null;
+            const hasTimeMarkerPrefix = Boolean(ocrMatch[1]);
+            const ocrHour = parseInt(ocrMatch[2], 10);
+            const ocrSuffix = ocrMatch[4] ? ocrMatch[4].trim().toLowerCase() : null;
+            if (!hasTimeMarkerPrefix && !ocrSuffix) continue; // bare number — not a time
 
             // Convert OCR hour to 24-hour format
             let ocrHour24 = ocrHour;
@@ -7316,11 +7284,47 @@ TEXT:
     }
 
     /**
+     * True when the value claims a specific time of day: time-mode fields
+     * (startTime/endTime) always do; date-mode fields (start/end/startDate/
+     * endDate) only when they carry a non-midnight time component — T00:00 is
+     * the pipeline's "no time stated" placeholder (see isInventedMidnight in
+     * normalizeAiEvent) and must never be treated as a time claim.
+     */
+    valueClaimsTimeOfDay(mode, value) {
+        if (mode === 'time') return true;
+        if (mode !== 'date') return false;
+        const parts = this.extractDateEvidenceParts(String(value === null || value === undefined ? '' : value));
+        if (!parts || !parts.hasTime) return false;
+        return !(Number(parts.hour) === 0 && Number(parts.minute) === 0);
+    }
+
+    /**
+     * Tell-tale inference language in a model evidence string: the model is
+     * admitting it derived the value ("interpreted as ~3am (common club close
+     * time)", "no explicit end time") instead of quoting the source. Used to
+     * fail time-value corroboration even when some time-like token matches.
+     */
+    evidenceAdmitsInference(evidence) {
+        const text = String(evidence || '').toLowerCase();
+        if (!text) return false;
+        return /\b(?:interpret(?:ed|s|ing)?|assum(?:e|ed|es|ing|ption)|typical(?:ly)?|common(?:ly)?|inferr?(?:ed|ing)?|infers?|guess(?:ed|ing)?|estimat(?:e|ed|es|ing)|presum(?:e|ed|es|ing|ably)|probabl[ey]|likely|usually|implie[ds]|implicit(?:ly)?)\b|no explicit|not (?:stated|shown|specified|listed|visible|explicit)/.test(text);
+    }
+
+    /**
      * Validate a single field value against evidence.
      * Returns true if valid, false if should be dropped.
      */
-    validateFieldValueAgainstEvidence(key, value, rule, evidenceContext, validationContext, report) {
-        const hasEvidence = this.hasFieldEvidence(evidenceContext, value, rule.mode, validationContext);
+    validateFieldValueAgainstEvidence(key, value, rule, evidenceContext, validationContext, report, modelEvidence = '') {
+        // Times are never merge-arbitrated downstream (scraped clobbers), so an
+        // invented time here flows straight into calendars. A time value whose
+        // own evidence string admits inference fails corroboration outright —
+        // even if some time-like token in the source happens to match (observed
+        // on-device: endTime "03:00" with evidence "LATE in OCR_IMAGE_TEXT —
+        // interpreted as ~3am (common club close time)" passed the gate).
+        const inventedTime = this.valueClaimsTimeOfDay(rule.mode, value)
+            && this.evidenceAdmitsInference(modelEvidence);
+        const hasEvidence = !inventedTime
+            && this.hasFieldEvidence(evidenceContext, value, rule.mode, validationContext);
         if (!hasEvidence) {
             report.dropped.push({
                 field: rule.field,
@@ -7384,6 +7388,12 @@ TEXT:
             : null;
 
         // === STEP 3: Validate Each Field ===
+        // Model-provided per-field evidence strings (captured at confidence-
+        // filter time; see parseAndFilterConfidence) — consulted for time
+        // fields so inference-language evidence fails corroboration.
+        const modelFieldEvidence = aiEvent.__fieldEvidence && typeof aiEvent.__fieldEvidence === 'object'
+            ? aiEvent.__fieldEvidence
+            : {};
         Object.keys(aiEvent).forEach(key => {
             const rule = this.getFieldValidationRule(key, validationConfig);
 
@@ -7400,7 +7410,7 @@ TEXT:
 
             // Validate field value against evidence
             const value = aiEvent[key];
-            const isValid = this.validateFieldValueAgainstEvidence(key, value, rule, evidenceContext, validationContext, report);
+            const isValid = this.validateFieldValueAgainstEvidence(key, value, rule, evidenceContext, validationContext, report, modelFieldEvidence[key]);
             if (!isValid) {
                 delete validated[key];
             }
@@ -8307,7 +8317,26 @@ TEXT:
         }
         let normalizedEnd = adjustedEnd || new Date(adjustedStart);
         if (normalizedEnd < adjustedStart) {
-            normalizedEnd = new Date(adjustedStart);
+            // NYE year-jump: a Dec 31 event ending "2am Jan 1" can arrive with
+            // the end on the SAME year's Jan 1 — eleven months BEFORE the start
+            // — when the model reuses the start's year and the window repair
+            // leaves it (e.g. it falls inside the past window). Bump the end
+            // one year forward, but ONLY when that lands it within a week
+            // AFTER the start (a genuine overnight/multi-day tail across the
+            // year boundary); anything else keeps today's collapse-to-start.
+            // Weekday-pinned ends are deterministic and never bumped.
+            if (!pinned.end) {
+                const bumpedEnd = new Date(normalizedEnd);
+                bumpedEnd.setFullYear(bumpedEnd.getFullYear() + 1);
+                const tailMs = bumpedEnd.getTime() - adjustedStart.getTime();
+                if (tailMs >= 0 && tailMs <= 7 * this.extractionLimits.millisPerDay) {
+                    console.log(`🤖 AI Web: End predates start by ~a year — rolled end across the year boundary: ${bumpedEnd.toISOString()}`);
+                    normalizedEnd = bumpedEnd;
+                }
+            }
+            if (normalizedEnd < adjustedStart) {
+                normalizedEnd = new Date(adjustedStart);
+            }
         }
         return { startDate: adjustedStart, endDate: normalizedEnd };
     }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -3069,3 +3069,164 @@ test('every log-producing importModule module exports the __wireConsoleTee shim'
   }
   // event-schema is intentionally absent: it never logs, so it needs no shim.
 });
+
+// ---------------------------------------------------------------------------
+// Time-evidence hardening: extraction-invented times must never survive the
+// evidence gate. Times/dates are never merge-arbitrated downstream (scraped
+// clobbers), so an invented time flows straight into calendars. Observed
+// on-device: endTime "03:00" with evidence "LATE in OCR_IMAGE_TEXT —
+// interpreted as ~3am (common club close time)" at confidence 60 passed the
+// gate on a stray digit.
+// ---------------------------------------------------------------------------
+
+test('evidence gate drops an invented endTime the source never states (the ~3am case)', () => {
+  const parser = createParser();
+  // OCR text says "LATE", never 3am. "DECEMBER 3" plants the stray bare digit
+  // that used to corroborate 03:00; "@10"/"10PM" are the real (start) times.
+  const source = 'MEGAWOOF DECEMBER 3 DOORS @10 10PM TIL LATE';
+  const evidenceContext = parser.buildAiEvidenceContextFromText(source);
+  const validationContext = { imageEvidenceUrls: new Set() };
+
+  const result = parser.validateAiEventEvidence(
+    {
+      endTime: '03:00',
+      __fieldEvidence: { endTime: 'LATE in OCR_IMAGE_TEXT — interpreted as ~3am (common club close time)' }
+    },
+    { html: source }, {}, null,
+    { evidenceContext, validationContext }
+  );
+  assert.equal(result.event.endTime, undefined, 'invented 03:00 must be dropped');
+  assert.ok(result.report.dropped.some(entry => entry.key === 'endTime'), 'drop must be reported in the existing shape');
+
+  // Same value with NO model evidence string: the bare "3" in "DECEMBER 3"
+  // still must not corroborate a time.
+  const bareDigit = parser.validateAiEventEvidence(
+    { endTime: '03:00' }, { html: source }, {}, null,
+    { evidenceContext, validationContext }
+  );
+  assert.equal(bareDigit.event.endTime, undefined, 'a bare digit in the source is not time evidence');
+});
+
+test('evidence gate keeps legitimate time conversions (9PM -> 21:00, 01H, midnight)', () => {
+  const parser = createParser();
+  const validationContext = { imageEvidenceUrls: new Set() };
+  const check = (source, field, value) => parser.validateAiEventEvidence(
+    { [field]: value }, { html: source }, {}, null,
+    { evidenceContext: parser.buildAiEvidenceContextFromText(source), validationContext }
+  ).event[field];
+
+  assert.equal(check('DOORS 9PM SATURDAY', 'startTime', '21:00'), '21:00', '9PM in source corroborates 21:00');
+  assert.equal(check('BEARRACUDA JUSQU\'A 01H', 'endTime', '01:00'), '01:00', '01H military format still corroborates');
+  assert.equal(check('PARTY TIL MIDNIGHT', 'endTime', '00:00'), '00:00', 'the word midnight corroborates 00:00');
+  assert.equal(check('SHOW AT 10:30PM', 'startTime', '22:30'), '22:30', '10:30PM corroborates 22:30');
+});
+
+test('inference language in the model evidence fails corroboration even when a time token matches', () => {
+  const parser = createParser();
+  const source = 'SAT DEC 12 9PM - 3AM';
+  const evidenceContext = parser.buildAiEvidenceContextFromText(source);
+  const validationContext = { imageEvidenceUrls: new Set() };
+
+  // The source DOES contain 3AM — but the model admits it inferred the value,
+  // so the corroboration is not trusted.
+  const inferred = parser.validateAiEventEvidence(
+    {
+      endTime: '03:00',
+      __fieldEvidence: { endTime: 'no explicit end time; typically 3am at this venue' }
+    },
+    { html: source }, {}, null, { evidenceContext, validationContext }
+  );
+  assert.equal(inferred.event.endTime, undefined, 'inference language must fail corroboration');
+
+  // The same value with verbatim evidence is kept.
+  const verbatim = parser.validateAiEventEvidence(
+    { endTime: '03:00', __fieldEvidence: { endTime: '9PM - 3AM' } },
+    { html: source }, {}, null, { evidenceContext, validationContext }
+  );
+  assert.equal(verbatim.event.endTime, '03:00', 'verbatim-backed 3AM stays');
+});
+
+test('extraction captures per-field evidence so the gate can reject the exact on-device case', async () => {
+  global.EventSchema = EventSchema; // earlier tests leak a mocked schema — pin the real one
+  const parser = createParser();
+  const response = JSON.stringify({
+    title: { value: 'MEGAWOOF', evidence: 'MEGAWOOF', confidence: 95 },
+    endTime: { value: '03:00', evidence: 'LATE in OCR_IMAGE_TEXT — interpreted as ~3am (common club close time)', confidence: 60 }
+  });
+  parser.core.callAiGenerate = async () => response;
+
+  const source = 'MEGAWOOF 10PM TIL LATE';
+  const event = await parser.extractEventWithTwoPassAi(
+    { html: `<p>${source}</p>`, url: 'https://x.example/events' },
+    {}, null, {}, ['title', 'endTime'], source, 'test',
+    { dataFlags: { jsonLd: true } }
+  );
+  assert.equal(event.endTime, '03:00', 'confidence 60 passes the confidence filter');
+  assert.equal(
+    event.__fieldEvidence.endTime,
+    'LATE in OCR_IMAGE_TEXT — interpreted as ~3am (common club close time)',
+    'the evidence string must be carried for the gate'
+  );
+
+  const validated = parser.validateAiEventEvidence(event, { html: source }, {}, null, {
+    evidenceContext: parser.buildAiEvidenceContextFromText(source),
+    validationContext: { imageEvidenceUrls: new Set() }
+  });
+  assert.equal(validated.event.title, 'MEGAWOOF', 'verbatim title survives');
+  assert.equal(validated.event.endTime, undefined, 'the invented end time is dropped by the gate');
+});
+
+test('date-mode values with a time component need that time in the source (T00:00 placeholder exempt)', () => {
+  const parser = createParser();
+  const validationContext = { imageEvidenceUrls: new Set() };
+  const check = (source, value) => parser.validateAiEventEvidence(
+    { startDate: value }, { html: source }, {}, null,
+    { evidenceContext: parser.buildAiEvidenceContextFromText(source), validationContext }
+  ).event.startDate;
+
+  assert.equal(check('DEC 12 BEAR NIGHT 3AM', '2026-12-12T03:00'), '2026-12-12T03:00', 'stated 3AM corroborates the component');
+  assert.equal(check('DEC 12 BEAR NIGHT', '2026-12-12T03:00'), undefined, 'an invented time component drops the field');
+  assert.equal(check('DEC 12 BEAR NIGHT', '2026-12-12T00:00'), '2026-12-12T00:00', 'T00:00 is the no-time placeholder, not a claim');
+  assert.equal(check('DEC 12 BEAR NIGHT', '2026-12-12'), '2026-12-12', 'date-only values are unaffected');
+});
+
+// ---------------------------------------------------------------------------
+// NYE year-jump: a Dec 31 event ending 2am must land on Jan 1 of the NEXT
+// year — never the same year's Jan 1 eleven months in the past (which used to
+// collapse the end onto the start).
+// ---------------------------------------------------------------------------
+
+test('normalizeEventDates rolls a same-year Jan 1 end across the year boundary', () => {
+  const parser = createParser();
+  parser.now = () => new Date(Date.UTC(2026, 0, 15)); // mid-January: Jan 1 of the CURRENT year sits inside the past window
+  const start = new Date(Date.UTC(2026, 11, 31, 22, 0, 0)); // Dec 31 2026 22:00 (weekday-pinned)
+  const wrongEnd = new Date(Date.UTC(2026, 0, 1, 2, 0, 0)); // Jan 1 2026 02:00 — in-window, so year repair leaves it
+
+  const result = parser.normalizeEventDates(new Date(start), new Date(wrongEnd), { start: true });
+  assert.equal(result.startDate.toISOString(), '2026-12-31T22:00:00.000Z');
+  assert.equal(result.endDate.toISOString(), '2027-01-01T02:00:00.000Z', 'the end must land on Jan 1 of the NEXT year');
+
+  // A weekday-pinned end is deterministic — never bumped; existing collapse applies.
+  const pinnedEnd = parser.normalizeEventDates(new Date(start), new Date(wrongEnd), { start: true, end: true });
+  assert.equal(pinnedEnd.endDate.toISOString(), '2026-12-31T22:00:00.000Z', 'pinned ends keep the collapse-to-start behavior');
+
+  // An end genuinely months before the start (not a year-boundary tail) still collapses.
+  const farEnd = parser.normalizeEventDates(
+    new Date(start), new Date(Date.UTC(2026, 5, 1, 2, 0, 0)), { start: true });
+  assert.equal(farEnd.endDate.toISOString(), '2026-12-31T22:00:00.000Z', 'non-NYE past ends keep today\'s behavior');
+});
+
+test('normalizeAiEvent keeps Dec 31 22:00 -> Jan 1 02:00 in the next year (endTime rollover path)', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = FROZEN_NOW; // 2026-07-13: Dec 31 2026 is inside the future window
+  const normalized = parser.normalizeAiEvent({
+    title: 'NYE BEAR BASH',
+    startDate: '2026-12-31',
+    startTime: '22:00',
+    endTime: '02:00'
+  }, {}, null, null, null);
+  assert.ok(normalized);
+  assert.equal(normalized.startDate.toISOString(), '2026-12-31T22:00:00.000Z');
+  assert.equal(normalized.endDate.toISOString(), '2027-01-01T02:00:00.000Z', 'the 2am end lands on next year\'s Jan 1');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -55,6 +55,16 @@ const ADDRESS_STREET_TYPE_TOKENS = [
     'court', 'highway', 'parkway', 'way'
 ];
 
+// Known ticketing platforms for the cross-host ticketUrl merge rung. This is a
+// PREFERENCE HEURISTIC, not a gate: a ticketing-platform URL only beats a BARE
+// domain root on a non-ticketing host; hosts missing from this list (or any
+// non-ticketing candidate with a real path) simply fall through to AI
+// arbitration — nothing is ever dropped or blocked for not being listed here.
+const TICKETING_PLATFORM_HOSTS = [
+    'sickening.events', 'eventbrite.com', 'tixr.com', 'ticketmaster.com',
+    'ticketleap.com', 'dice.fm', 'eventeny.com', 'showclix.com'
+];
+
 class SharedCore {
     constructor(cities, options = {}) {
         if (!cities || typeof cities !== 'object') {
@@ -604,6 +614,142 @@ class SharedCore {
         return { host, segments, hasQuery };
     }
 
+    // Exact host or subdomain of a known ticketing platform (host must already
+    // be lowercased/www-stripped, as getUrlRuleParts returns it). Subdomain
+    // matching covers e.g. events.ticketleap.com.
+    isKnownTicketingPlatformHost(host) {
+        const normalized = String(host || '').toLowerCase();
+        if (!normalized) return false;
+        return TICKETING_PLATFORM_HOSTS.some(platform =>
+            normalized === platform || normalized.endsWith(`.${platform}`));
+    }
+
+    // Query-string parameter lookup built on plain string splitting —
+    // URLSearchParams does not exist in iOS JavaScriptCore (Scriptable).
+    extractSearchParamValue(search, key) {
+        if (!search || !key) return '';
+        const normalizedKey = String(key).trim().toLowerCase();
+        const searchText = String(search).replace(/^\?/, '');
+        if (!normalizedKey || !searchText) return '';
+        for (const pair of searchText.split('&')) {
+            if (!pair) continue;
+            const separatorIndex = pair.indexOf('=');
+            const rawKey = separatorIndex >= 0 ? pair.slice(0, separatorIndex) : pair;
+            const rawValue = separatorIndex >= 0 ? pair.slice(separatorIndex + 1) : '';
+            let decodedKey = rawKey;
+            try {
+                decodedKey = decodeURIComponent(rawKey.replace(/\+/g, ' '));
+            } catch (_) {}
+            if (String(decodedKey || '').trim().toLowerCase() !== normalizedKey) continue;
+            try {
+                return decodeURIComponent(rawValue.replace(/\+/g, ' '));
+            } catch (_) {
+                return rawValue;
+            }
+        }
+        return '';
+    }
+
+    // Pure size score for an image URL — higher means larger. Canonical home of
+    // the scoring the ai-web-parser previously owned (its getImageSizeFromUrl
+    // now delegates here) so the deterministic image merge rung below and OCR
+    // dedup in the parser rank candidates on the SAME scale. No network calls:
+    // the score reads width/height/scale query params and resolution-ish path
+    // segments; when a URL advertises nothing, the URL length is a weak
+    // fallback signal (kept for parser parity — the merge rung's margin guard
+    // deliberately ignores that noise floor).
+    getImageSizeScoreFromUrl(url) {
+        if (!url || typeof url !== 'string') return -1;
+
+        const parsed = this.parseUrl(url);
+        if (!parsed) {
+            // Fallback: longer URL often means higher quality
+            return url.length;
+        }
+
+        let score = 0;
+        const search = String(parsed.search || '').toLowerCase();
+        const path = String(parsed.pathname || '').toLowerCase();
+        const getParam = (key) => this.extractSearchParamValue(search, key);
+
+        // Width/height parameters (e.g., ?w=1920, ?width=1080, ?h=1080)
+        const width = getParam('w') || getParam('width') || getParam('wpx');
+        const height = getParam('h') || getParam('height') || getParam('hpx');
+        if (width) {
+            const w = parseInt(width, 10);
+            if (!isNaN(w)) score += w;
+        }
+        if (height) {
+            const h = parseInt(height, 10);
+            if (!isNaN(h)) score += h;
+        }
+
+        // Size scale parameters (e.g., ?scale=2, ?size=large)
+        const scale = getParam('scale') || getParam('size');
+        if (scale) {
+            const s = scale.toLowerCase();
+            if (s === 'large' || s === 'big' || s === 'max' || s === 'original' || s === 'full') {
+                score += 5000;
+            } else if (s === 'medium' || s === 'mid') {
+                score += 2500;
+            } else if (s === 'small' || s === 'tiny') {
+                score += 500;
+            } else {
+                const num = parseInt(s, 10);
+                if (!isNaN(num)) score += num;
+            }
+        }
+
+        // Path resolution indicators (e.g., /1920x1080/, /large/, /original/)
+        for (const segment of path.split('/').filter(Boolean)) {
+            const resolutionMatch = segment.match(/(\d+)x(\d+)/);
+            if (resolutionMatch) {
+                score += parseInt(resolutionMatch[1], 10) * parseInt(resolutionMatch[2], 10);
+            }
+            const pxMatch = segment.match(/(\d+)px/);
+            if (pxMatch) {
+                score += parseInt(pxMatch[1], 10);
+            }
+            if (segment === 'large' || segment === 'big' || segment === 'max' || segment === 'original' || segment === 'full' || segment === 'high') {
+                score += 5000;
+            } else if (segment === 'medium' || segment === 'mid') {
+                score += 2500;
+            } else if (segment === 'small' || segment === 'tiny') {
+                score += 500;
+            }
+        }
+
+        // Fallback: longer URL often means higher quality
+        if (score === 0) {
+            score = url.length;
+        }
+        return score;
+    }
+
+    // Normalized view of a description for the strict-superset merge rule:
+    // lowercased, basic HTML entities decoded, whitespace collapsed. BOTH
+    // candidates pass through this, so entity/whitespace differences never
+    // block a genuine containment.
+    normalizeDescriptionForContainment(value) {
+        return String(value || '')
+            .replace(/&amp;/gi, '&')
+            .replace(/&(?:rsquo|lsquo|apos|#8217|#8216|#39);/gi, "'")
+            .replace(/&(?:rdquo|ldquo|quot|#8221|#8220|#34);/gi, '"')
+            .replace(/&(?:nbsp|#160);/gi, ' ')
+            .replace(/&(?:ndash|mdash|#8211|#8212);/gi, '-')
+            .replace(/&(?:hellip|#8230);/gi, '...')
+            // Fold the literal unicode twins of those entities too, so an
+            // entity-encoded copy contains its decoded (curly-quote) twin.
+            .replace(/[\u2018\u2019]/g, "'")
+            .replace(/[\u201C\u201D]/g, '"')
+            .replace(/\u00A0/g, ' ')
+            .replace(/[\u2013\u2014]/g, '-')
+            .replace(/\u2026/g, '...')
+            .toLowerCase()
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
     // Emoji/pictograph-stripped view of a title: pictograph blocks, variation
     // selectors, the keycap combiner and ZWJ removed, whitespace collapsed.
     // Conservative on purpose: ASCII and real punctuation are never stripped.
@@ -931,6 +1077,26 @@ class SharedCore {
                     return { winner: 'a', reason: 'same-host deeper URL beats domain root' };
                 }
             }
+            // Cross-host ticketUrl: a candidate on a known ticketing platform
+            // (TICKETING_PLATFORM_HOSTS — a preference heuristic, not a gate)
+            // beats a BARE domain root on a non-ticketing host: the root of an
+            // organizer/venue site is never the ticket page. Conservative on
+            // purpose: a non-ticketing candidate WITH a real path could itself
+            // be the event page, and two ticketing candidates are a genuine
+            // question — both still arbitrate (fail open).
+            if (fieldName === 'ticketUrl' && urlA.host !== urlB.host) {
+                const ticketingA = this.isKnownTicketingPlatformHost(urlA.host);
+                const ticketingB = this.isKnownTicketingPlatformHost(urlB.host);
+                if (ticketingA !== ticketingB) {
+                    const isBareRoot = (parts) => parts.segments.length === 0 && !parts.hasQuery;
+                    if (ticketingA && isBareRoot(urlB)) {
+                        return { winner: 'a', reason: 'ticketing-platform URL beats bare non-ticketing domain root' };
+                    }
+                    if (ticketingB && isBareRoot(urlA)) {
+                        return { winner: 'b', reason: 'ticketing-platform URL beats bare non-ticketing domain root' };
+                    }
+                }
+            }
             // A logo-path image never beats a non-logo image: ticketing
             // services attach their own ".../saas/logos/..." asset, which the
             // model picked over the actual event poster. Matches path
@@ -942,6 +1108,23 @@ class SharedCore {
                 const logoB = hasLogoSegment(urlB);
                 if (logoA !== logoB) {
                     return { winner: logoA ? 'b' : 'a', reason: 'event artwork beats logo-path image' };
+                }
+                // Resolution rung: when one URL advertises a clearly larger
+                // image (same scoring the parser uses for OCR dedup —
+                // getImageSizeScoreFromUrl), prefer it deterministically; the
+                // arbitration model contradicted itself between runs on exactly
+                // this shape (called a real og:image flyer "a generic
+                // placeholder", then reversed). Requires a meaningful margin
+                // (winner >= 2x loser or +500) so near-ties still arbitrate,
+                // and the winner must score above the URL-length noise floor —
+                // a score that could just be a long URL decides nothing.
+                const scoreA = this.getImageSizeScoreFromUrl(String(valueA).trim());
+                const scoreB = this.getImageSizeScoreFromUrl(String(valueB).trim());
+                const winnerScore = Math.max(scoreA, scoreB);
+                const loserScore = Math.min(scoreA, scoreB);
+                if (winnerScore >= 500 && loserScore >= 0 && winnerScore > loserScore
+                    && (winnerScore >= 2 * loserScore || winnerScore - loserScore >= 500)) {
+                    return { winner: scoreA > scoreB ? 'a' : 'b', reason: 'clearly higher-resolution image URL' };
                 }
             }
         }
@@ -1091,6 +1274,25 @@ class SharedCore {
                     // street mismatch always leaves a manual-review trail.
                     const mismatchEventTitle = context && context.eventTitle ? context.eventTitle : 'event';
                     console.warn(`⚠️ MERGE: "${mismatchEventTitle}" field=address street mismatch arbitrated by AI ("${valueA}" vs "${valueB}") — verify manually`);
+                }
+            }
+        }
+        // Description strict superset: when one candidate's normalized text
+        // (lowercased, entities decoded, whitespace collapsed — see
+        // normalizeDescriptionForContainment) CONTAINS the other's ENTIRE
+        // normalized text and is longer, the superset carries strictly more
+        // information — keep it without burning an AI arbitration. Partial
+        // overlap is a genuine conflict and still arbitrates; equal-after-
+        // normalization pairs fall through to the case-only rule below.
+        if (fieldName === 'description' && typeof valueA === 'string' && typeof valueB === 'string') {
+            const containA = this.normalizeDescriptionForContainment(valueA);
+            const containB = this.normalizeDescriptionForContainment(valueB);
+            if (containA && containB && containA !== containB) {
+                if (containA.includes(containB)) {
+                    return { winner: 'a', reason: 'description contains the other candidate\'s full text' };
+                }
+                if (containB.includes(containA)) {
+                    return { winner: 'b', reason: 'description contains the other candidate\'s full text' };
                 }
             }
         }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1155,6 +1155,162 @@ test('guardrail: logo-path image loses to event artwork in both directions; both
   assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['image']);
 });
 
+// ---------------------------------------------------------------------------
+// Deterministic image resolution rung: a URL advertising a clearly larger
+// image wins without AI (the arbitration model contradicted itself between
+// runs on exactly this shape). Near-ties and size-less URLs still arbitrate.
+// ---------------------------------------------------------------------------
+
+test('guardrail: clearly higher-resolution image URL wins in both directions without AI', async () => {
+  const core = createCore();
+  const hiRes = 'https://cdn.example.com/uploads/1920x1080/poster.jpg';
+  const plain = 'https://bearracuda.com/wp-content/uploads/poster.jpg';
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image', hiRes, plain),
+    { winner: 'a', reason: 'clearly higher-resolution image URL' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image', plain, hiRes),
+    { winner: 'b', reason: 'clearly higher-resolution image URL' });
+  // Query-param sizes rank on the same scale as the parser's OCR dedup
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image',
+      'https://cdn.example.com/img.jpg?w=1920&h=1080', 'https://cdn.example.com/thumbs/img.jpg?w=150&h=150'),
+    { winner: 'a', reason: 'clearly higher-resolution image URL' });
+
+  // End-to-end: zero AI calls on a deterministic resolution win
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.image = hiRes;
+  existing.notes += `\nimage: ${plain}`;
+  const adapter = buildArbitrationAdapter({});
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 0, 'a clear resolution margin never reaches the AI');
+  assert.equal(finalEvent.image, hiRes);
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['image']);
+});
+
+test('guardrail: image URLs without a clear resolution margin still go to the AI', () => {
+  const core = createCore();
+  // Below the meaningful margin (no 2x, no +500) → arbitrate
+  assert.equal(
+    core.resolveConflictDeterministically('image',
+      'https://cdn.example.com/img.jpg?w=800', 'https://cdn.example.com/img.jpg?w=700'),
+    null, 'an 800-vs-700 width is a near-tie');
+  // Neither URL advertises a size: the URL-length fallback is noise, never a 🔒 win
+  assert.equal(
+    core.resolveConflictDeterministically('image',
+      'https://a.example/p.jpg',
+      'https://cdn.other-host.example/wp-content/uploads/2026/05/some-quite-long-poster-file-name.jpg'),
+    null, 'length-only scores decide nothing');
+  // Equal scores → arbitrate (logo rule and case-only rule aside)
+  assert.equal(
+    core.resolveConflictDeterministically('image',
+      'https://a.example/x/poster.jpg?w=900', 'https://b.example/y/poster.jpg?w=900'),
+    null, 'equal advertised sizes still arbitrate');
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic cross-host ticketUrl rung: a known ticketing-platform URL
+// beats a bare non-ticketing domain root. Preference heuristic, not a gate —
+// everything else falls through to AI exactly as before.
+// ---------------------------------------------------------------------------
+
+test('guardrail: ticketing-platform URL beats a bare non-ticketing domain root in both directions', async () => {
+  const core = createCore();
+  const ticketing = 'https://www.eventbrite.com/e/megawoof-dallas-tickets-1234';
+  const bareRoot = 'https://megawoof.com/';
+  assert.deepEqual(
+    core.resolveConflictDeterministically('ticketUrl', ticketing, bareRoot),
+    { winner: 'a', reason: 'ticketing-platform URL beats bare non-ticketing domain root' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('ticketUrl', bareRoot, ticketing),
+    { winner: 'b', reason: 'ticketing-platform URL beats bare non-ticketing domain root' });
+  // Subdomains of listed platforms count (events.ticketleap.com)
+  assert.deepEqual(
+    core.resolveConflictDeterministically('ticketUrl', 'https://events.ticketleap.com/venue/show', 'https://somebar.example'),
+    { winner: 'a', reason: 'ticketing-platform URL beats bare non-ticketing domain root' });
+
+  // End-to-end: zero AI calls on the deterministic win
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.ticketUrl = ticketing;
+  existing.notes = existing.notes.replace(
+    'ticketUrl: https://tickets.example/furball',
+    `ticketUrl: ${bareRoot}`);
+  const adapter = buildArbitrationAdapter({});
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 0, 'ticketing-vs-bare-root never reaches the AI');
+  assert.equal(finalEvent.ticketUrl, ticketing);
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['ticketUrl']);
+});
+
+test('guardrail: conservative ticketUrl fall-throughs still go to the AI', () => {
+  const core = createCore();
+  // Non-ticketing candidate with a REAL path could itself be the event page
+  assert.equal(
+    core.resolveConflictDeterministically('ticketUrl',
+      'https://www.eventbrite.com/e/megawoof-tickets-1234', 'https://megawoof.com/events/dec-31'),
+    null, 'a non-ticketing event page is a genuine question');
+  // A root with a query string is not a bare root
+  assert.equal(
+    core.resolveConflictDeterministically('ticketUrl',
+      'https://www.eventbrite.com/e/megawoof-tickets-1234', 'https://megawoof.com/?event=123'),
+    null, 'query-bearing roots are not bare');
+  // Two ticketing platforms are a genuine question
+  assert.equal(
+    core.resolveConflictDeterministically('ticketUrl',
+      'https://www.eventbrite.com/e/tickets-1234', 'https://dice.fm/event/abcdef'),
+    null, 'both-ticketing still arbitrates');
+  // The rung is ticketUrl-only: website keeps today's cross-host AI behavior
+  assert.equal(
+    core.resolveConflictDeterministically('website',
+      'https://www.eventbrite.com/e/tickets-1234', 'https://megawoof.com/'),
+    null, 'website is not a ticket field');
+});
+
+// ---------------------------------------------------------------------------
+// Description strict-superset rule: the candidate containing the other's
+// ENTIRE normalized text carries strictly more information — no AI needed.
+// Partial overlap still arbitrates; equal pairs keep existing behavior.
+// ---------------------------------------------------------------------------
+
+test('guardrail: description strict superset wins in both directions (entities and whitespace normalized)', async () => {
+  const core = createCore();
+  const subset = 'It&rsquo;s the biggest bear party in Dallas &amp; beyond.';
+  const superset = 'MEGAWOOF PRESENTS!  It’s the biggest   bear party in Dallas & beyond. Doors at 9PM.';
+  assert.deepEqual(
+    core.resolveConflictDeterministically('description', superset, subset),
+    { winner: 'a', reason: 'description contains the other candidate\'s full text' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('description', subset, superset),
+    { winner: 'b', reason: 'description contains the other candidate\'s full text' });
+
+  // End-to-end: zero AI calls on the deterministic win
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.description = superset;
+  existing.notes += `\ndescription: ${subset}`;
+  const adapter = buildArbitrationAdapter({});
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 0, 'a strict superset never reaches the AI');
+  assert.equal(finalEvent.description, superset);
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['description']);
+});
+
+test('guardrail: partial-overlap descriptions still arbitrate; equal pairs keep existing behavior', () => {
+  const core = createCore();
+  // Shared prefix but neither contains the other's FULL text → AI
+  assert.equal(
+    core.resolveConflictDeterministically('description',
+      'Bear party with go-go dancers all night', 'Bear party with DJ sets till 4am'),
+    null, 'partial overlap is a genuine conflict');
+  // Equal after normalization → the existing case-only rule decides (not the superset rule)
+  assert.deepEqual(
+    core.resolveConflictDeterministically('description', 'BEAR PARTY  TONIGHT', 'Bear Party Tonight'),
+    { winner: 'b', reason: 'case-only variants — kept less-uppercased form' });
+  // The rule is description-only: other text fields keep today's behavior
+  assert.equal(
+    core.resolveConflictDeterministically('title', 'MEGAWOOF: DECADENCE EDITION', 'DECADENCE'),
+    null, 'titles never use the superset rule');
+});
+
 test('looksLikeStreetAddress: leading house number + street-type word; real venue names never match', () => {
   const core = createCore();
   for (const positive of ['10-90 Wyckoff Ave', '1090 Wyckoff Avenue', '446 MT NEBO RD']) {


### PR DESCRIPTION
The queued sweep completing the explicit-rules-first trust ladder across remaining merge fields, plus two extraction correctness fixes.

## 1. Time-evidence hardening (the data-correctness fix)
The gate that dropped fields "lacking source evidence" had a hole for times: any bare 1-2 digit number in the source corroborated an invented time ("DECEMBER 3" corroborated "03:00"). Observed on-device: `endTime 03:00` justified as `"LATE — interpreted as ~3am (common club close time)"` at confidence 60, passing straight into the (never-arbitrated) date path. Now:
- Bare numbers need an explicit time marker (@/at prefix, H/am/pm suffix); legit conversions ("9PM"→21:00, "01H"→01:00, "10:30PM"→22:30) all still pass, midnight/noon now corroborate.
- The model's own evidence string is checked for inference language ("interpreted as", "assume", "typically", "common", "no explicit", …) — a confessed guess fails even when a time token happens to match.
- The exact real case is a regression test and is rejected by both layers independently.

## 2. NYE year-jump fix (long-flagged, finally contained)
End-before-start across a year boundary now bumps forward one year only when that lands 0-7 days after the start (a genuine Dec 31 → Jan 1-style tail); weekday-pinned and genuinely-past ends keep today's behavior. Tested under UTC/New_York/Auckland.

## 3-5. Deterministic merge rungs (shared-core, all fail-open to AI)
- **image**: resolution scoring (extracted to platform-pure `getImageSizeScoreFromUrl`; parser delegates) with a real margin (≥2× or +500, winner ≥500 so URL-length fallback noise can't win) — kills the observed same-run self-contradiction. Provenance rung deliberately skipped: nothing marks an image as the page's own og:image today, and inventing provenance was out of bounds.
- **ticketUrl**: known ticketing platform host (sickening.events/eventbrite/tixr/ticketmaster/ticketleap/dice/showclix/eventeny) beats a bare domain root on a non-ticketing host; real paths and both-ticketing cases still reach AI.
- **description**: strict full-text superset after normalization (entities + unicode twins + whitespace) wins without AI; partial overlap still arbitrates.

## Tests
+13 (parser 7, shared-core 6), incl. end-to-end zero-postJson assertions on all deterministic wins and the NYE cases under three timezones. Suite: **547 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/parsers/ai-web-parser.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP