### PR TITLE
feat(scraper): image provenance — the event page's own artwork wins merges deterministically

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -366,6 +366,10 @@ class AiWebParser {
                 // never skips or replaces an extraction step.
                 this.applyWixServerDataEnrichment(completeJsonLdEvents, htmlData, cityConfig);
                 await this.applyJsonLdGapFill(completeJsonLdEvents, htmlData, parserConfig, cityConfig, httpAdapter);
+                // Images the JSON-LD nodes carried are already stamped 'jsonld';
+                // an image the gap-fill pulled from page content gets its own
+                // og-image/page provenance here (no image → no stamp).
+                completeJsonLdEvents.forEach(event => this.stampImageProvenance(event, htmlData));
                 return {
                     events: completeJsonLdEvents,
                     additionalLinks: additionalLinks,
@@ -2789,6 +2793,13 @@ class AiWebParser {
             image: this.pickJsonLdImage(node.image),
             source: this.config.source
         };
+        // imageSource provenance (notes-serialized like pinSource): structured
+        // data the page itself published — its own value, distinct from
+        // 'og-image'/'page', but og-grade in shared-core's image provenance
+        // merge rung. Absent image → no stamp (fail open).
+        if (event.image) {
+            event.imageSource = 'jsonld';
+        }
         if (cover) {
             event.cover = cover;
             // Wix JSON-LD offers only publish fee-inclusive totals ("46.13" =
@@ -7776,6 +7787,11 @@ TEXT:
             });
         }
 
+        // Provenance stamp for the FINAL image value (after any parser-config
+        // metadata override): 'og-image' when it is the page's own artwork,
+        // 'page' otherwise; no image → no stamp.
+        this.stampImageProvenance(event, htmlData);
+
         return event;
     }
 
@@ -8674,6 +8690,65 @@ TEXT:
             htmlData.pageOgSiteName = siteName;
         }
         return siteName;
+    }
+
+    // Canonical identity form for comparing an extracted image value against the
+    // page's own og:image/twitter:image meta URLs: the existing URL
+    // normalization (normalizeHttpUrlValue) first, then trailing-slash and case
+    // differences collapsed. Identity comparison ONLY — never stored on events.
+    canonicalizeImageUrlForComparison(url) {
+        const normalized = this.normalizeHttpUrlValue(url);
+        if (!normalized) return '';
+        return normalized.replace(/\/+$/, '').toLowerCase();
+    }
+
+    // The page's own social-artwork meta URLs (og:image / twitter:image and
+    // their variants) in canonical comparison form. Each raw meta value is also
+    // added in its CDN-upgraded form because the final extracted image went
+    // through upgradeCdnThumbnailUrl. Cached per page like getPageOgTitle
+    // (segment/OCR copies spread htmlData and inherit the cache).
+    getPageMetaImageUrls(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object') return [];
+        if (Array.isArray(htmlData.pageMetaImageUrls)) return htmlData.pageMetaImageUrls;
+        const html = typeof htmlData.html === 'string' ? htmlData.html : '';
+        const metaKeys = ['og:image', 'og:image:url', 'og:image:secure_url', 'twitter:image', 'twitter:image:src'];
+        const urls = new Set();
+        for (const metaKey of metaKeys) {
+            // extractOgMetaContent entity-decodes except &amp; — same explicit
+            // second decode as buildEventFromJsonLdNode's clean().
+            const content = this.extractOgMetaContent(html, metaKey).replace(/&amp;/gi, '&');
+            if (!content) continue;
+            const canonical = this.canonicalizeImageUrlForComparison(content);
+            if (canonical) urls.add(canonical);
+            const upgraded = this.canonicalizeImageUrlForComparison(this.upgradeCdnThumbnailUrl(content));
+            if (upgraded) urls.add(upgraded);
+        }
+        const list = Array.from(urls);
+        if (Object.isExtensible(htmlData)) {
+            htmlData.pageMetaImageUrls = list;
+        }
+        return list;
+    }
+
+    // imageSource provenance stamp (notes-serialized like pinSource, excluded
+    // from AI arbitration — see shared-core's image provenance rung):
+    //   - 'og-image' when the extracted image IS the source page's own
+    //     og:image/twitter:image artwork (compared by canonical URL, robust to
+    //     which extraction pass produced the value);
+    //   - 'page' for everything else the AI-web pipeline extracted from page
+    //     content/OCR/segments (the default for AI-web extracted images).
+    // An already-stamped or absent image is left untouched (fail open), so the
+    // JSON-LD path's 'jsonld' stamp and other parsers' unstamped images are
+    // never relabeled.
+    stampImageProvenance(event, htmlData) {
+        if (!event || typeof event !== 'object') return event;
+        if (event.imageSource) return event;
+        const image = typeof event.image === 'string' ? event.image.trim() : '';
+        if (!image) return event;
+        const canonical = this.canonicalizeImageUrlForComparison(image);
+        const metaImageUrls = this.getPageMetaImageUrls(htmlData);
+        event.imageSource = canonical && metaImageUrls.includes(canonical) ? 'og-image' : 'page';
+        return event;
     }
 
     // A bare city name is not an event name. True when the title — after

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -308,6 +308,57 @@ test('normalizeAiEvent flags wall-clock dates when no timezone can be resolved',
   assert.equal(event._timezoneUnresolved, true);
 });
 
+test('normalizeAiEvent stamps imageSource og-image for the page\'s own meta artwork, page otherwise', () => {
+  const parser = createParser();
+  const htmlData = {
+    url: 'https://bearracuda.com/events/sausage-party/',
+    html: `<html><head>
+      <meta property="og:image" content="https://Bearracuda.com/wp-content/Uploads/SausageWeb.jpg/" />
+      <meta name="twitter:image" content="https://bearracuda.com/img.jpg?a=1&amp;b=2" />
+    </head><body></body></html>`
+  };
+  const base = { title: 'SAUSAGE PARTY', startDate: '2026-08-01', startTime: '21:00' };
+
+  // og:image match is robust to case and trailing-slash differences
+  const ogEvent = parser.normalizeAiEvent(
+    { ...base, image: 'https://bearracuda.com/wp-content/uploads/sausageweb.jpg' }, {}, htmlData, null, null);
+  assert.equal(ogEvent.imageSource, 'og-image');
+
+  // twitter:image counts too; the meta value is entity-decoded before comparing
+  const twitterEvent = parser.normalizeAiEvent(
+    { ...base, image: 'https://bearracuda.com/img.jpg?a=1&b=2' }, {}, htmlData, null, null);
+  assert.equal(twitterEvent.imageSource, 'og-image');
+
+  // A content/OCR/segment image that is NOT the page's meta artwork → page
+  const pageEvent = parser.normalizeAiEvent(
+    { ...base, image: 'https://static.wixstatic.com/media/8ff085_massiveparty~mv2.webp' }, {}, htmlData, null, null);
+  assert.equal(pageEvent.imageSource, 'page');
+
+  // No image → no stamp at all (fail open)
+  const bareEvent = parser.normalizeAiEvent({ ...base }, {}, htmlData, null, null);
+  assert.equal('imageSource' in bareEvent, false);
+
+  // No htmlData (no meta to compare against) → the AI-web default, page
+  const noHtmlEvent = parser.normalizeAiEvent(
+    { ...base, image: 'https://x.example/poster.jpg' }, {}, null, null, null);
+  assert.equal(noHtmlEvent.imageSource, 'page');
+});
+
+test('JSON-LD structured-data images are stamped imageSource jsonld', () => {
+  const parser = createParser();
+  const events = parser.extractEventsFromJsonLd(SICKENING_JSONLD_HTML, 'https://sickening.events/e/x');
+  assert.equal(events.length, 1);
+  assert.equal(events[0].image, 'https://res.cloudinary.example/cover.webp');
+  assert.equal(events[0].imageSource, 'jsonld');
+
+  // A node without an image gets no stamp (fail open)
+  const bare = parser.buildEventFromJsonLdNode({
+    '@type': 'Event', name: 'BEAR NIGHT', startDate: '2026-08-01T21:00:00-05:00'
+  }, 'https://tickets.example/e/bear-night', null);
+  assert.ok(bare, 'event should build');
+  assert.equal('imageSource' in bare, false);
+});
+
 test('mergeAiEventFields canonicalizes lowercase response keys to schema keys', () => {
   const parser = createParser();
   const merged = parser.mergeAiEventFields({}, {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -415,10 +415,14 @@ class SharedCore {
         // value was decided, never content the AI may arbitrate; its merge is
         // resolved deterministically in createFinalEventObject so a manual
         // override can never be relabeled by a scraped verdict.
+        // imageSource is image provenance (og-image/jsonld/page — where the
+        // image value came from at extraction); like pinSource it must FOLLOW
+        // the finalized image deterministically (setProvenanceSource), never
+        // be arbitrated as content.
         return name !== 'key' && name !== 'notes' && name !== 'source'
             && name !== 'location' && name !== 'gmaps'
             && name !== 'pinSource' && name !== 'addressSource'
-            && name !== 'bearSource';
+            && name !== 'bearSource' && name !== 'imageSource';
     }
 
     // True when a bearSource value records the calendar owner's manual verdict
@@ -1108,6 +1112,39 @@ class SharedCore {
                 const logoB = hasLogoSegment(urlB);
                 if (logoA !== logoB) {
                     return { winner: logoA ? 'b' : 'a', reason: 'event artwork beats logo-path image' };
+                }
+                // Provenance rung: an image that IS the event page's own
+                // artwork — its og:image/twitter:image meta ('og-image') or
+                // its published structured data ('jsonld'), as stamped at
+                // extraction — beats a merely page-derived candidate (content/
+                // OCR/segment images, 'page' or unstamped). The arbitration
+                // model flip-flopped between runs on exactly this shape.
+                // Attribution is strict like the address evidence rung: a
+                // record's imageSource only vouches for the candidate when the
+                // record's own image field IS that candidate value. Both
+                // og-grade, neither, or unattributable → fall through to the
+                // resolution-margin rung / AI (fail open).
+                const contextRecords = context && context.records && typeof context.records === 'object'
+                    ? context.records : null;
+                if (contextRecords) {
+                    const getOgGradeImageProvenance = (record, value) => {
+                        if (!record || typeof record !== 'object') return '';
+                        const recordImage = typeof record.image === 'string' ? record.image.trim() : '';
+                        const candidate = typeof value === 'string' ? value.trim() : '';
+                        if (!recordImage || !candidate || recordImage !== candidate) return '';
+                        const imageSource = typeof record.imageSource === 'string' ? record.imageSource.trim() : '';
+                        return (imageSource === 'og-image' || imageSource === 'jsonld') ? imageSource : '';
+                    };
+                    const provenanceA = getOgGradeImageProvenance(contextRecords.a, valueA);
+                    const provenanceB = getOgGradeImageProvenance(contextRecords.b, valueB);
+                    if (Boolean(provenanceA) !== Boolean(provenanceB)) {
+                        const provenanceLabels = context.sideLabels && typeof context.sideLabels === 'object'
+                            ? context.sideLabels : { a: 'a', b: 'b' };
+                        return {
+                            winner: provenanceA ? 'a' : 'b',
+                            reason: `"${provenanceA ? provenanceLabels.a : provenanceLabels.b}" image is the event page's own artwork (${provenanceA || provenanceB})`
+                        };
+                    }
                 }
                 // Resolution rung: when one URL advertises a clearly larger
                 // image (same scoring the parser uses for OCR dedup —
@@ -3635,6 +3672,12 @@ class SharedCore {
         allFields.forEach(fieldName => {
             if (fieldName.startsWith('_')) return; // Skip metadata fields
 
+            // imageSource is image provenance that must FOLLOW the finalized
+            // image (recomputed after the loop + arbitration via
+            // setProvenanceSource) — merging it as its own field could pair the
+            // winning image with the LOSING side's provenance stamp.
+            if (fieldName === 'imageSource') return;
+
             const priorityConfig = fieldPriorities[fieldName];
             const existingValue = existingEvent[fieldName];
             const newValue = newEvent[fieldName];
@@ -3900,6 +3943,14 @@ class SharedCore {
             }
         }
 
+        // imageSource follows the finalized image (deterministic, never AI-
+        // arbitrated): the `{ ...newEvent }` base spread copied newEvent's
+        // stamp regardless of which side's image won, so recompute it from
+        // whichever record supplied the final value. A final image neither
+        // side stamped (or no image at all) carries no imageSource (fail open).
+        delete mergedEvent.imageSource;
+        this.setProvenanceSource(mergedEvent, 'image', 'imageSource', newEvent, existingEvent);
+
         // _timezoneUnresolved must describe the merged event's DATES, not the base
         // record: the `{ ...newEvent }` spread above copies newEvent's flag even
         // when existing's anchored dates won, and drops existing's flag even when
@@ -4083,11 +4134,12 @@ class SharedCore {
             // the final merged bar/address so it can never disagree with them.
             if (fieldName === 'gmaps') continue;
 
-            // pinSource/addressSource are provenance metadata that must FOLLOW
-            // the finalized location/address (set by setProvenanceSource after
-            // STEP 3c) — they never merge or arbitrate on their own, or the
-            // generic loop could clobber a kept-pin's source with a stale one.
-            if (fieldName === 'pinSource' || fieldName === 'addressSource') continue;
+            // pinSource/addressSource/imageSource are provenance metadata that
+            // must FOLLOW the finalized location/address/image (set by
+            // setProvenanceSource after STEP 3c) — they never merge or arbitrate
+            // on their own, or the generic loop could clobber a kept value's
+            // source with a stale one.
+            if (fieldName === 'pinSource' || fieldName === 'addressSource' || fieldName === 'imageSource') continue;
 
             const priorityConfig = fieldPriorities[fieldName];
             const mergeStrategy = priorityConfig?.merge || 'upsert';
@@ -4394,6 +4446,7 @@ class SharedCore {
         // address is never mislabeled with a source the scrape didn't produce.
         this.setProvenanceSource(mergedObject, 'location', 'pinSource', scraperObject, calendarObject);
         this.setProvenanceSource(mergedObject, 'address', 'addressSource', scraperObject, calendarObject);
+        this.setProvenanceSource(mergedObject, 'image', 'imageSource', scraperObject, calendarObject);
 
         // STEP 4: regenerate gmaps from the FINAL merged bar + address. gmaps
         // is a derived field — a pure function of bar + address — so merging or

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1209,6 +1209,157 @@ test('guardrail: image URLs without a clear resolution margin still go to the AI
 });
 
 // ---------------------------------------------------------------------------
+// Image provenance rung: an image stamped as the event page's OWN artwork
+// (imageSource og-image / jsonld at extraction) beats a merely page-derived
+// candidate deterministically. Attribution is strict (the record's image must
+// BE the candidate), both-og-grade / neither falls through to the resolution
+// margin rung, and imageSource follows the winning value like pinSource.
+// ---------------------------------------------------------------------------
+
+test('guardrail: own-page artwork (og-image/jsonld) beats a page-sourced image; ambiguity falls through', () => {
+  const core = createCore();
+  const og = 'https://bearracuda.com/wp-content/uploads/2026/06/sausageweb.jpg';
+  const page = 'https://static.wixstatic.com/media/8ff085_massiveparty~mv2.webp';
+  const context = (recordA, recordB) => ({
+    sideLabels: { a: 'existing', b: 'incoming' },
+    records: { a: recordA, b: recordB }
+  });
+
+  // og-image beats page-sourced in both directions
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image', og, page,
+      context({ image: og, imageSource: 'og-image' }, { image: page, imageSource: 'page' })),
+    { winner: 'a', reason: '"existing" image is the event page\'s own artwork (og-image)' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image', page, og,
+      context({ image: page, imageSource: 'page' }, { image: og, imageSource: 'og-image' })),
+    { winner: 'b', reason: '"incoming" image is the event page\'s own artwork (og-image)' });
+
+  // jsonld is og-grade too, and an entirely unstamped other side also loses
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image', og, page,
+      context({ image: og, imageSource: 'jsonld' }, { image: page })),
+    { winner: 'a', reason: '"existing" image is the event page\'s own artwork (jsonld)' });
+
+  // Both og-grade → no provenance edge; these URLs advertise no size → AI
+  assert.equal(
+    core.resolveConflictDeterministically('image', og, page,
+      context({ image: og, imageSource: 'og-image' }, { image: page, imageSource: 'jsonld' })),
+    null, 'both own-artwork candidates are a genuine question');
+
+  // Neither og-grade → the existing resolution-margin rung still decides
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image',
+      'https://cdn.example.com/img.jpg?w=1920&h=1080', 'https://cdn.example.com/thumbs/img.jpg?w=150&h=150',
+      context(
+        { image: 'https://cdn.example.com/img.jpg?w=1920&h=1080', imageSource: 'page' },
+        { image: 'https://cdn.example.com/thumbs/img.jpg?w=150&h=150', imageSource: 'page' })),
+    { winner: 'a', reason: 'clearly higher-resolution image URL' });
+
+  // Attribution caution: a record whose OWN image is not the candidate never
+  // vouches for it — the stray og-image stamp decides nothing.
+  assert.equal(
+    core.resolveConflictDeterministically('image', og, page,
+      context({ image: 'https://bearracuda.com/other.jpg', imageSource: 'og-image' },
+        { image: page, imageSource: 'page' })),
+    null, 'provenance only counts when the record\'s image field IS the candidate');
+
+  // The logo rung stays ABOVE provenance: an og-stamped logo-path asset still loses
+  const logo = 'https://res.cloudinary.com/eventservice/image/upload/saas/logos/image_abc.webp';
+  assert.deepEqual(
+    core.resolveConflictDeterministically('image', logo, page,
+      context({ image: logo, imageSource: 'og-image' }, { image: page, imageSource: 'page' })),
+    { winner: 'b', reason: 'event artwork beats logo-path image' });
+
+  // No records context at all → fail open exactly as before
+  assert.equal(core.resolveConflictDeterministically('image', og, page), null);
+});
+
+test('imageSource is never arbitration-eligible and round-trips through notes like pinSource', () => {
+  const core = createCore();
+  assert.equal(core.isArbitrationEligibleField('imageSource'), false);
+  assert.equal(core.isArbitrationEligibleField('image'), true, 'the image VALUE itself still arbitrates');
+
+  const notes = core.formatEventNotes({
+    image: 'https://bearracuda.com/wp-content/uploads/2026/06/sausageweb.jpg',
+    imageSource: 'og-image'
+  });
+  assert.match(notes, /imageSource: og-image/);
+  const parsed = core.parseNotesIntoFields(notes);
+  assert.equal(parsed.image, 'https://bearracuda.com/wp-content/uploads/2026/06/sausageweb.jpg');
+  assert.equal(parsed.imageSource, 'og-image');
+});
+
+test('regression: bearracuda og-image artwork beats the massive.club page-sourced webp in BOTH merge flows', async () => {
+  const core = createCore();
+  const sausage = 'https://bearracuda.com/wp-content/uploads/2026/06/sausageweb.jpg';
+  const webp = 'https://static.wixstatic.com/media/8ff085_massiveparty~mv2.webp';
+
+  // Enrich direction (mergeParsedEvents), both orders — zero AI calls.
+  const priorities = { image: { priority: ['ai-web'], merge: 'ai' } };
+  const aiParserConfig = { ai: { provider: 'ollama', endpoint: 'http://ai.example', model: 'm' } };
+  const base = {
+    title: 'SAUSAGE PARTY', city: 'dallas', source: 'ai-web',
+    startDate: new Date('2026-08-01T02:00:00.000Z'), _fieldPriorities: priorities
+  };
+
+  const adapterA = buildArbitrationAdapter({});
+  const mergedA = await core.mergeParsedEvents(
+    { ...base, image: webp, imageSource: 'page' },
+    { ...base, image: sausage, imageSource: 'og-image', _parserConfig: aiParserConfig },
+    { httpAdapter: adapterA });
+  assert.equal(adapterA.calls.length, 0, 'own-page artwork resolves without AI');
+  assert.equal(mergedA.image, sausage);
+  assert.equal(mergedA.imageSource, 'og-image', 'imageSource follows the winning image');
+
+  const adapterB = buildArbitrationAdapter({});
+  const mergedB = await core.mergeParsedEvents(
+    { ...base, image: sausage, imageSource: 'og-image' },
+    { ...base, image: webp, imageSource: 'page', _parserConfig: aiParserConfig },
+    { httpAdapter: adapterB });
+  assert.equal(adapterB.calls.length, 0);
+  assert.equal(mergedB.image, sausage);
+  assert.equal(mergedB.imageSource, 'og-image',
+    'the incoming base-spread stamp (page) is replaced by the winning side\'s');
+
+  // A winning image with NO stamp leaves imageSource absent — the losing
+  // side's stamp is never inherited (fail open, no mislabeling).
+  const adapterE = buildArbitrationAdapter({});
+  const mergedE = await core.mergeParsedEvents(
+    { ...base, image: 'https://cdn.example.com/img.jpg?w=1920&h=1080' },
+    { ...base, image: 'https://cdn.example.com/thumbs/img.jpg?w=150&h=150', imageSource: 'page', _parserConfig: aiParserConfig },
+    { httpAdapter: adapterE });
+  assert.equal(adapterE.calls.length, 0);
+  assert.equal(mergedE.image, 'https://cdn.example.com/img.jpg?w=1920&h=1080');
+  assert.equal(mergedE.imageSource, undefined, 'a winner with no stamp never inherits the loser\'s');
+
+  // Calendar direction (createFinalEventObject), both sides — zero AI calls.
+  const fresh = buildAlignedArbitrationPair();
+  fresh.scraped.image = sausage;
+  fresh.scraped.imageSource = 'og-image';
+  fresh.existing.notes += `\nimage: ${webp}\nimageSource: page`;
+  const adapterC = buildArbitrationAdapter({});
+  const finalC = await core.createFinalEventObject(fresh.existing, fresh.scraped, { httpAdapter: adapterC });
+  assert.equal(adapterC.calls.length, 0);
+  assert.equal(finalC.image, sausage, 'the scraped own-artwork image wins');
+  assert.equal(finalC.imageSource, 'og-image');
+  assert.deepEqual(finalC._original.aiArbitration.deterministic, ['image']);
+  const parsedNotes = core.parseNotesIntoFields(finalC.notes);
+  assert.equal(parsedNotes.image, sausage);
+  assert.equal(parsedNotes.imageSource, 'og-image', 'the stamp persists to notes for the next run');
+
+  const stored = buildAlignedArbitrationPair();
+  stored.scraped.image = webp;
+  stored.scraped.imageSource = 'page';
+  stored.existing.notes += `\nimage: ${sausage}\nimageSource: og-image`;
+  const adapterD = buildArbitrationAdapter({});
+  const finalD = await core.createFinalEventObject(stored.existing, stored.scraped, { httpAdapter: adapterD });
+  assert.equal(adapterD.calls.length, 0);
+  assert.equal(finalD.image, sausage, 'the calendar-stored own-artwork image is kept');
+  assert.equal(finalD.imageSource, 'og-image', 'the notes-parsed calendar stamp participates and survives');
+});
+
+// ---------------------------------------------------------------------------
 // Deterministic cross-host ticketUrl rung: a known ticketing-platform URL
 // beats a bare non-ticketing domain root. Preference heuristic, not a gate —
 // everything else falls through to AI exactly as before.


### PR DESCRIPTION
Completes the rung deliberately deferred from #1515 (nothing marked image provenance until now).

## Part 1 — `imageSource` provenance stamped at extraction
Follows the pinSource/bearSource pattern exactly (notes round-trip, no schema change, js/ untouched, arbitration-excluded, follows the winning value via setProvenanceSource):
- `og-image` — final image equals the page's own og:image/twitter:image meta (compared against the actual meta URLs, canonicalized + CDN-thumbnail-upgraded, so it's robust to which extraction pass produced the value)
- `jsonld` — JSON-LD fast path images
- `page` — AI-web content/OCR/segment images
- other parsers/unknown → unstamped (fail open)

## Part 2 — merge rung
In the image block, between the existing logo rule (still wins — an og-stamped logo asset still loses) and the resolution-margin rung: exactly one candidate carrying og-grade provenance for its exact value → deterministic win, `🔒 … image is the event page's own artwork (og-image)`. Strict value attribution as in the address evidence rung. Both/neither og-grade → resolution margin → AI.

## Regression locked
The observed same-run flip-flop (AI called the event page's real flyer 'a generic placeholder', then reversed): bearracuda sausageweb.jpg (og-image) vs massive.club webp (page-sourced) now resolves deterministically to the event page's artwork in **both flows, both directions, zero AI calls**.

+5 tests. Suite: **552 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/parsers/ai-web-parser.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP