### PR TITLE
feat(scraper): bar corroboration phase 2 — address adjacency, KNOWN VENUE context, siteRole

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -335,6 +335,13 @@ class AiWebParser {
                 console.log(`🤖 AI Web: Page organizer/brand derived from metadata: ${pageBrandNames.map(name => `"${name}"`).join(', ')}`);
             }
 
+            // Classify who this SITE is (venue vs organizer) from hard facts
+            // only — parser config override, then the page's own JSON-LD types
+            // (segment-derived facts are layered in on multi-event pages).
+            // 'venue' switches extraction steering from KNOWN ORGANIZER to
+            // KNOWN VENUE; undetermined changes nothing (fail open).
+            this.resolvePageSiteRole(htmlData, parserConfig);
+
             // Deterministic extraction from schema.org Event JSON-LD. Ticketing pages
             // (sickening.events, tryst.events, Eventbrite) hand us complete structured
             // data — when it covers title + start + venue, OCR and AI extraction add
@@ -370,6 +377,10 @@ class AiWebParser {
                 // an image the gap-fill pulled from page content gets its own
                 // og-image/page provenance here (no image → no stamp).
                 completeJsonLdEvents.forEach(event => this.stampImageProvenance(event, htmlData));
+                // Bar provenance for the structured-data path: curated/
+                // venue-site stamps only — there is no extraction evidence
+                // corpus here, so the adjacency check never runs (fail open).
+                completeJsonLdEvents.forEach(event => this.stampBarSourceProvenance(event, null, htmlData));
                 return {
                     events: completeJsonLdEvents,
                     additionalLinks: additionalLinks,
@@ -504,6 +515,10 @@ class AiWebParser {
     }
 
     async extractEventsFromSinglePage(htmlData, parserConfig, cityConfig, promptFields, ocrResults = [], httpAdapter = null) {
+        // Site role (venue/organizer/undetermined) was resolved page-level in
+        // parseEvents; announce it once before extraction prompts are built.
+        this.resolvePageSiteRole(htmlData, parserConfig);
+        this.logPageSiteRoleOnce(htmlData);
         const segmentHtmlData = {
             ...htmlData,
             ocrResults: ocrResults
@@ -535,6 +550,14 @@ class AiWebParser {
 
         // OCR any segment images the capped page-level pass missed
         await this.ensureSegmentOcrCoverage(segments, ocrResults, parserConfig, sourceUrl, httpAdapter);
+
+        // Segment-derived site-role facts (multiple distinct addresses →
+        // organizer; one recurring address that also appears outside the
+        // listings → venue) can settle what the JSON-LD types alone could not.
+        // Must run BEFORE the per-segment htmlData copies are spread below so
+        // every segment inherits the page-level determination.
+        this.resolvePageSiteRole(htmlData, parserConfig, segments);
+        this.logPageSiteRoleOnce(htmlData);
 
         // Segments are unstructured data (page content + OCR), so always use split fields
         const segmentDataFlags = { ocr: true, segment: true };
@@ -612,6 +635,10 @@ class AiWebParser {
             console.warn('🤖 AI Web: AI output missing required title/startDate after normalization');
             return null;
         }
+        // Bar corroboration stamp (barSource): checks the final bar+address
+        // pair against the same corpora the evidence gate uses (page text,
+        // OCR text, segment text). Flag-don't-drop: values are never changed.
+        this.stampBarSourceProvenance(event, evidenceContext, promptHtmlData);
         console.log(this.formatExtractionSummary(event, htmlData && htmlData.url ? htmlData.url : 'unknown URL'));
         const confidenceDiagnostics = aiEvent && aiEvent.__confidenceDiagnostics && typeof aiEvent.__confidenceDiagnostics === 'object'
             ? aiEvent.__confidenceDiagnostics
@@ -5419,7 +5446,11 @@ class AiWebParser {
             const value = guarded[key];
             if (typeof value !== 'string' || !value.trim()) return;
             const normalizedField = this.normalizePromptFieldName(key);
-            if (normalizedField === 'bar' && brandNames.length > 0 && this.matchesPageBrandName(value, brandNames)) {
+            // On a venue's own site the brand IS the venue — a bar equal to
+            // the site name is the correct answer there, never a leak.
+            if (normalizedField === 'bar' && brandNames.length > 0
+                && this.getPageSiteRole(htmlData) !== 'venue'
+                && this.matchesPageBrandName(value, brandNames)) {
                 console.log(`🤖 AI Web: Rejecting bar "${value}" from ${passName} pass — matches page organizer/brand; keeping field open for later passes`);
                 delete guarded[key];
                 return;
@@ -6211,7 +6242,16 @@ ${String(snippet || '')}`;
         // which is appended verbatim.
         let steeringContext = '';
         const pageBrandNames = this.getPageBrandNames(htmlData);
-        if (pageBrandNames.length > 0) {
+        // A page classified as the VENUE's own site gets the KNOWN VENUE
+        // steering line instead of KNOWN ORGANIZER: on a venue site the brand
+        // IS the venue, and telling the model "never return it as bar" is
+        // exactly backwards there. Organizer/undetermined pages keep today's
+        // organizer line verbatim.
+        const siteRole = this.getPageSiteRole(htmlData);
+        const knownVenueName = siteRole === 'venue' ? this.getPageVenueName(htmlData) : '';
+        if (knownVenueName) {
+            steeringContext += `KNOWN VENUE (this is the venue's own site): "${knownVenueName}" — events on this page take place AT this venue unless the page states another location; DJ names, taglines, and edition subtitles are NOT the venue.\n`;
+        } else if (pageBrandNames.length > 0 && siteRole !== 'venue') {
             const aliasSuffix = pageBrandNames.length > 1
                 ? ` (also appears as ${pageBrandNames.slice(1).map(name => `"${name}"`).join(', ')})`
                 : '';
@@ -6299,10 +6339,15 @@ TEXT:
 
     buildJsonRepairPrompt(rawResponse, aiConfig, cityConfig, parserConfig, fields, dataFlags = {}, htmlData = null) {
         // The repair pass sees only the broken JSON text, but still needs the
-        // page-level steering context (organizer brand, ai.extraContext). Pass the
-        // cached brand names through WITHOUT the page html so the repair prompt
+        // page-level steering context (organizer brand or known venue,
+        // ai.extraContext). Pass the cached brand names + site-role
+        // determination through WITHOUT the page html so the repair prompt
         // stays free of page/OCR payload.
-        const contextHtmlData = htmlData ? { pageBrandNames: this.getPageBrandNames(htmlData) } : null;
+        const contextHtmlData = htmlData ? {
+            pageBrandNames: this.getPageBrandNames(htmlData),
+            pageSiteRole: this.getPageSiteRole(htmlData),
+            pageVenueName: this.getPageSiteRole(htmlData) === 'venue' ? this.getPageVenueName(htmlData) : ''
+        } : null;
         return this.buildExtractionPrompt(contextHtmlData, aiConfig, cityConfig, parserConfig, fields, rawResponse, 'repair', dataFlags);
     }
 
@@ -7484,11 +7529,16 @@ TEXT:
         // see extractPageBrandNames — never from a hardcoded organizer list.
         // (Cached per page; parseEvents primes the cache on the original html.)
         const pageBrandNames = this.getPageBrandNames(htmlData);
+        // A page classified as the venue's own site (siteRole 'venue') is the
+        // one case where the site brand IS the venue: the organizer bar-drop
+        // guard must not fire there, and the merge-side organizer stamp would
+        // wrongly veto the venue as bar.
+        const pageIsVenueSite = this.getPageSiteRole(htmlData) === 'venue';
         if (pageBrandNames.length > 0) {
             // Only AI-extracted values are guarded: an explicitly configured bar is a
             // deliberate override and must survive even when it matches the site brand
             // (venue sites ARE their own brand, e.g. a bar scraping its own homepage).
-            if (bar && bar === aiBar && this.matchesPageBrandName(bar, pageBrandNames)) {
+            if (!pageIsVenueSite && bar && bar === aiBar && this.matchesPageBrandName(bar, pageBrandNames)) {
                 console.log(`🤖 AI Web: Dropping bar "${bar}" — matches the page's organizer/site name, not a venue`);
                 bar = configBar;
             }
@@ -7769,7 +7819,9 @@ TEXT:
         // Stamp the derived organizer as internal metadata (underscore fields are
         // excluded from calendar notes and merge field loops) so downstream merge
         // arbitration can warn the model off picking the organizer as the venue.
-        if (pageBrandNames.length > 0) {
+        // Never on a venue's own site: there the brand IS the venue, and the
+        // organizer stamp would make arbitration veto the correct bar.
+        if (pageBrandNames.length > 0 && !pageIsVenueSite) {
             event._organizer = pageBrandNames[0];
         }
 
@@ -8748,6 +8800,417 @@ TEXT:
         const canonical = this.canonicalizeImageUrlForComparison(image);
         const metaImageUrls = this.getPageMetaImageUrls(htmlData);
         event.imageSource = canonical && metaImageUrls.includes(canonical) ? 'og-image' : 'page';
+        return event;
+    }
+
+    // ========================================================================
+    // SITE ROLE (venue vs organizer) + BAR CORROBORATION (barSource)
+    // ========================================================================
+    // Page-derived trust signals for the extracted bar, protecting venues the
+    // curated bars data has never seen. All determinations are hard facts
+    // (config override, the page's own JSON-LD types, observed addresses) —
+    // no AI tiebreak. Everything fails open: undetermined role injects no
+    // context, an unverifiable bar gets no stamp.
+
+    // 'venue' | 'organizer' | '' — normalized siteRole value.
+    normalizeSiteRoleValue(value) {
+        const text = String(value || '').trim().toLowerCase();
+        return text === 'venue' || text === 'organizer' ? text : '';
+    }
+
+    // Cache-only reader for the page's resolved site role. Segment/OCR
+    // htmlData copies spread the original object, so the page-level
+    // determination (resolvePageSiteRole) is inherited everywhere.
+    getPageSiteRole(htmlData) {
+        return htmlData && typeof htmlData === 'object' && typeof htmlData.pageSiteRole === 'string'
+            ? this.normalizeSiteRoleValue(htmlData.pageSiteRole)
+            : '';
+    }
+
+    // Resolve who this SITE is, hard facts in precedence order:
+    //   1) parser config override `siteRole: "venue" | "organizer"`;
+    //   2) the page's own JSON-LD @type being venue-ish (NightClub/BarOrPub/
+    //      EventVenue/MusicVenue) → venue;
+    //   3) segment-derived facts when segments are provided (multi-event
+    //      pages): a JSON-LD Organization/PerformingGroup whose listings sit
+    //      at MULTIPLE distinct street addresses → organizer; a single
+    //      recurring street address that ALSO appears outside the listings
+    //      (footer/contact) → venue.
+    // Anything else stays '' (undetermined — no steering context injected).
+    // The result is cached on htmlData so every downstream copy inherits it.
+    resolvePageSiteRole(htmlData, parserConfig = {}, segments = null) {
+        const configRole = this.normalizeSiteRoleValue(parserConfig && parserConfig.siteRole);
+        if (configRole) {
+            if (htmlData && typeof htmlData === 'object' && Object.isExtensible(htmlData)) {
+                htmlData.pageSiteRole = configRole;
+                htmlData.pageSiteRoleReason = 'parser config siteRole';
+                if (configRole === 'venue') this.getPageVenueName(htmlData);
+            }
+            return configRole;
+        }
+        if (!htmlData || typeof htmlData !== 'object') return '';
+        if (typeof htmlData.pageSiteRole !== 'string') {
+            const signals = this.getJsonLdSiteSignals(htmlData);
+            const role = signals.venueType ? 'venue' : '';
+            if (Object.isExtensible(htmlData)) {
+                htmlData.pageSiteRole = role;
+                htmlData.pageSiteRoleReason = role ? `json-ld @type ${signals.venueType}` : '';
+            }
+        }
+        if (htmlData.pageSiteRole === '' && Array.isArray(segments) && segments.length > 0
+            && !htmlData.pageSiteRoleSegmentsChecked && Object.isExtensible(htmlData)) {
+            htmlData.pageSiteRoleSegmentsChecked = true;
+            const derived = this.deriveSiteRoleFromSegments(htmlData, segments);
+            if (derived.role) {
+                htmlData.pageSiteRole = derived.role;
+                htmlData.pageSiteRoleReason = derived.reason;
+            }
+        }
+        // Prime the venue-name cache on the ORIGINAL htmlData while its full
+        // html (meta tags, JSON-LD) is still present — segment copies replace
+        // html with segment text and could no longer derive it.
+        if (htmlData.pageSiteRole === 'venue') this.getPageVenueName(htmlData);
+        return this.getPageSiteRole(htmlData);
+    }
+
+    // One line per page describing the site-role outcome (determined or not).
+    logPageSiteRoleOnce(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object' || htmlData.pageSiteRoleLogged) return;
+        if (Object.isExtensible(htmlData)) htmlData.pageSiteRoleLogged = true;
+        const components = this.parseUrlComponents(typeof htmlData.url === 'string' ? htmlData.url : '');
+        const host = components && components.hostname ? components.hostname : 'unknown-host';
+        const role = this.getPageSiteRole(htmlData);
+        if (!role) {
+            console.log(`🤖 AI Web: siteRole for ${host} undetermined`);
+            return;
+        }
+        const reason = typeof htmlData.pageSiteRoleReason === 'string' && htmlData.pageSiteRoleReason
+            ? ` (${htmlData.pageSiteRoleReason})`
+            : '';
+        console.log(`🤖 AI Web: siteRole for ${host}: ${role}${reason}`);
+    }
+
+    // JSON-LD facts about the page's own identity. Same traversal rule as
+    // extractPageBrandNames: top-level nodes and @graph containers only — a
+    // venue-typed Place nested inside an Event is that EVENT's location, not
+    // the page's identity. Cached per page.
+    getJsonLdSiteSignals(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object') {
+            return { venueType: '', venueName: '', organizationTypeFound: false };
+        }
+        if (htmlData.pageJsonLdSiteSignals && typeof htmlData.pageJsonLdSiteSignals === 'object') {
+            return htmlData.pageJsonLdSiteSignals;
+        }
+        const signals = this.extractJsonLdSiteSignals(typeof htmlData.html === 'string' ? htmlData.html : '');
+        if (Object.isExtensible(htmlData)) {
+            htmlData.pageJsonLdSiteSignals = signals;
+        }
+        return signals;
+    }
+
+    extractJsonLdSiteSignals(html) {
+        const source = String(html || '').slice(0, 500000);
+        const signals = { venueType: '', venueName: '', organizationTypeFound: false };
+        const venueTypePattern = /^(NightClub|BarOrPub|EventVenue|MusicVenue)$/i;
+        const organizerTypePattern = /^(Organization|PerformingGroup)$/i;
+        const collect = (node, depth) => {
+            if (!node || depth > 6) return;
+            if (Array.isArray(node)) {
+                node.forEach(child => collect(child, depth + 1));
+                return;
+            }
+            if (typeof node !== 'object') return;
+            const types = (Array.isArray(node['@type']) ? node['@type'] : [node['@type']])
+                .map(type => String(type || '').replace(/^https?:\/\/schema\.org\//i, '').trim());
+            const venueType = types.find(type => venueTypePattern.test(type));
+            if (venueType) {
+                if (!signals.venueType) signals.venueType = venueType;
+                if (!signals.venueName && typeof node.name === 'string') {
+                    signals.venueName = this.normalizeWhitespace(this.decodeBasicEntities(node.name));
+                }
+            }
+            if (types.some(type => organizerTypePattern.test(type))) {
+                signals.organizationTypeFound = true;
+            }
+            if (node['@graph']) collect(node['@graph'], depth + 1);
+        };
+        const scriptRegex = /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+        let match;
+        while ((match = scriptRegex.exec(source)) !== null) {
+            const text = this.normalizeWhitespace(this.decodeBasicEntities(match[1] || ''));
+            if (!text) continue;
+            let parsed = null;
+            try {
+                parsed = JSON.parse(text);
+            } catch (_) {
+                continue;
+            }
+            collect(parsed, 0);
+        }
+        return signals;
+    }
+
+    // Segment-derived site-role facts for multi-event pages (hard facts only).
+    deriveSiteRoleFromSegments(htmlData, segments) {
+        const streetCounts = new Map();
+        for (const segment of Array.isArray(segments) ? segments : []) {
+            const text = segment && Array.isArray(segment.lines) ? segment.lines.join('\n') : '';
+            for (const street of this.extractStreetLineCandidates(text)) {
+                const normalized = this.normalizeAdjacencyText(street);
+                if (!normalized) continue;
+                streetCounts.set(normalized, (streetCounts.get(normalized) || 0) + 1);
+            }
+        }
+        if (streetCounts.size >= 2 && this.getJsonLdSiteSignals(htmlData).organizationTypeFound) {
+            return { role: 'organizer', reason: `json-ld organization with events at ${streetCounts.size} distinct addresses` };
+        }
+        if (streetCounts.size === 1) {
+            const [streetNormalized, segmentCount] = streetCounts.entries().next().value;
+            const pageText = this.normalizeAdjacencyText(
+                this.getPageTextForSiteRole(htmlData && typeof htmlData.html === 'string' ? htmlData.html : ''));
+            if (this.countOccurrences(pageText, streetNormalized) > segmentCount) {
+                return { role: 'venue', reason: 'single recurring address also appears outside the event listings' };
+            }
+        }
+        return { role: '', reason: '' };
+    }
+
+    // Full-page text INCLUDING footer/contact regions (extractBodyParts strips
+    // them, but "the venue's address in the site footer" is exactly the
+    // signal the single-recurring-address fact needs).
+    getPageTextForSiteRole(html) {
+        let text = String(html || '').slice(0, 500000);
+        text = text.replace(/<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi, ' ');
+        text = text.replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi, ' ');
+        text = text.replace(/<!--[\s\S]*?-->/g, ' ');
+        text = text.replace(/<[^>]+>/g, ' ');
+        return this.decodeBasicEntities(text);
+    }
+
+    // Street-line shapes in free text: house number + 1-4 name words + a
+    // street-type word ("619 E. PINE ST"). Suffix-less styles ("3702 N
+    // Halsted") are deliberately not matched here — this feeds the site-role
+    // facts, which fail open when nothing matches.
+    extractStreetLineCandidates(text) {
+        const results = [];
+        // [ \t] only — a street line never spans corpus lines here, and \s+
+        // would glue a date line's trailing number onto the next line's street.
+        const pattern = /\b\d{1,6}(?:-\d{1,4})?(?:[ \t]+[\w][\w.'’-]*){1,4}[ \t]+(?:St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Ln|Lane|Way|Hwy|Highway|Pl|Place|Ct|Court|Pkwy|Parkway|Sq|Square|Ter|Terrace)\b\.?/gi;
+        let match;
+        while ((match = pattern.exec(String(text || ''))) !== null) {
+            results.push(match[0]);
+        }
+        return results;
+    }
+
+    countOccurrences(text, needle) {
+        if (!text || !needle) return 0;
+        let count = 0;
+        let from = 0;
+        let position;
+        while ((position = text.indexOf(needle, from)) !== -1) {
+            count += 1;
+            from = position + needle.length;
+        }
+        return count;
+    }
+
+    // The venue's display name for a venue-role page, best declared source
+    // first: og:site_name → the JSON-LD venue node's name → the page brand
+    // name → the host's base label ("massive" from massive.club). Cached per
+    // page (resolvePageSiteRole primes it before segment copies are made).
+    getPageVenueName(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object') return '';
+        if (typeof htmlData.pageVenueName === 'string') return htmlData.pageVenueName;
+        let name = this.getPageOgSiteName(htmlData)
+            || this.getJsonLdSiteSignals(htmlData).venueName
+            || (this.getPageBrandNames(htmlData)[0] || '');
+        if (!name) {
+            const components = this.parseUrlComponents(typeof htmlData.url === 'string' ? htmlData.url : '');
+            const host = components && components.hostname
+                ? components.hostname.split(':')[0].replace(/^www\./, '')
+                : '';
+            name = host ? host.split('.')[0] : '';
+        }
+        if (Object.isExtensible(htmlData)) {
+            htmlData.pageVenueName = name;
+        }
+        return name;
+    }
+
+    // Comparison view for bar/address adjacency: lowercased, emoji and
+    // punctuation noise stripped (the 🪩 marker etc.), whitespace collapsed.
+    normalizeAdjacencyText(value) {
+        return String(value || '')
+            .replace(/[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0E}\u{FE0F}\u{20E3}\u{200D}]/gu, ' ')
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, ' ')
+            .trim();
+    }
+
+    // The address's street line: the first comma/newline segment that starts
+    // with a house number and contains letters ("619 E. Pine St" from
+    // "619 E. Pine St, Seattle, WA 98122"). '' when none (fail open).
+    getAddressStreetLine(address) {
+        const segments = String(address || '').split(/[,\n]/);
+        for (const segment of segments) {
+            const text = segment.trim();
+            if (!text) continue;
+            if (/^\d{1,6}(?:-\d{1,6})?\s+/.test(text) && /[a-z]/i.test(text)) return text;
+        }
+        return '';
+    }
+
+    // Deterministic adjacency test: does the bar name appear within ±2 lines
+    // (or ~150 characters) of ANY occurrence of the address street line in
+    // the source corpus? Case/whitespace-insensitive containment on the
+    // normalized (emoji/punctuation-stripped) view.
+    checkBarAddressAdjacency(bar, streetLine, corpusText) {
+        const barNormalized = this.normalizeAdjacencyText(bar);
+        const streetNormalized = this.normalizeAdjacencyText(streetLine);
+        if (!barNormalized || !streetNormalized) {
+            return { addressFound: false, adjacent: false, rawLines: [], occurrenceLines: [] };
+        }
+        const rawLines = String(corpusText || '').split('\n');
+        const normalizedLines = rawLines.map(line => this.normalizeAdjacencyText(line));
+        const occurrenceLines = [];
+        normalizedLines.forEach((line, index) => {
+            if (line && line.includes(streetNormalized)) occurrenceLines.push(index);
+        });
+        let adjacent = false;
+        for (const index of occurrenceLines) {
+            const windowText = normalizedLines.slice(Math.max(0, index - 2), index + 3).join(' ');
+            if (windowText.includes(barNormalized)) {
+                adjacent = true;
+                break;
+            }
+        }
+        // ~150-character fallback on the flattened text: catches street lines
+        // broken across corpus lines, which per-line containment cannot see.
+        let addressFound = occurrenceLines.length > 0;
+        if (!adjacent) {
+            const flatText = normalizedLines.filter(Boolean).join(' ');
+            let from = 0;
+            let position;
+            while ((position = flatText.indexOf(streetNormalized, from)) !== -1) {
+                addressFound = true;
+                const windowText = flatText.slice(Math.max(0, position - 150), position + streetNormalized.length + 150);
+                if (windowText.includes(barNormalized)) {
+                    adjacent = true;
+                    break;
+                }
+                from = position + 1;
+            }
+        }
+        return { addressFound, adjacent, rawLines, occurrenceLines };
+    }
+
+    // Deterministic rescue signal (log only, never auto-applied): when the
+    // extracted bar was NOT adjacent to the address, look for exactly one
+    // OTHER capitalized token-run directly adjacent (±1 line) to the address
+    // — the shape of "MASSIVE: 619 E. PINE ST". Runs that are the organizer,
+    // part of the address, address-shaped, or boilerplate words are excluded;
+    // anything other than exactly one surviving candidate returns '' (a noisy
+    // window proves nothing).
+    findAdjacentVenueCandidate(event, adjacency, htmlData) {
+        const occurrenceLines = adjacency && Array.isArray(adjacency.occurrenceLines)
+            ? adjacency.occurrenceLines : [];
+        const rawLines = adjacency && Array.isArray(adjacency.rawLines) ? adjacency.rawLines : [];
+        if (occurrenceLines.length === 0 || rawLines.length === 0) return '';
+        const barNormalized = this.normalizeAdjacencyText(event && event.bar);
+        const addressNormalized = this.normalizeAdjacencyText(event && event.address);
+        const brandNames = this.getPageBrandNames(htmlData);
+        const organizer = event && typeof event._organizer === 'string' ? event._organizer : '';
+        const stopwords = new Set([
+            'doors', 'tickets', 'presents', 'free', 'rsvp', 'vip', 'info', 'ages',
+            'admission', 'cover', 'at', 'the', 'and', 'door', 'pm', 'am',
+            'ocr', 'image', 'text', 'url', 'segment', 'index'
+        ]);
+        const runPattern = /[A-Z][A-Za-z0-9&'’.-]*(?:[ \t]+[A-Z][A-Za-z0-9&'’.-]*)*/g;
+        const windowLineIndexes = new Set();
+        occurrenceLines.forEach(lineIndex => {
+            for (let delta = -1; delta <= 1; delta += 1) {
+                const index = lineIndex + delta;
+                if (index >= 0 && index < rawLines.length) windowLineIndexes.add(index);
+            }
+        });
+        const candidates = new Map();
+        for (const index of windowLineIndexes) {
+            const line = String(rawLines[index] || '');
+            let match;
+            runPattern.lastIndex = 0;
+            while ((match = runPattern.exec(line)) !== null) {
+                const run = match[0].replace(/[.,:;|]+$/, '').trim();
+                if (run.length < 2 || run.length > 30) continue;
+                const runNormalized = this.normalizeAdjacencyText(run);
+                if (!runNormalized) continue;
+                if (barNormalized && (runNormalized.includes(barNormalized) || barNormalized.includes(runNormalized))) continue;
+                if (addressNormalized && addressNormalized.includes(runNormalized)) continue;
+                const tokens = runNormalized.split(' ');
+                if (tokens.every(token => stopwords.has(token) || /^\d+$/.test(token))) continue;
+                if (organizer && this.matchesPageBrandName(run, [organizer])) continue;
+                if (brandNames.length > 0 && this.matchesPageBrandName(run, brandNames)) continue;
+                if (this.core && typeof this.core.looksLikeStreetAddress === 'function'
+                    && this.core.looksLikeStreetAddress(run)) continue;
+                if (/\d/.test(run)
+                    && /(?:^|\s)(?:St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Ln|Lane|Way|Hwy|Pl|Place|Ct|Court)\.?(?:\s|$)/i.test(run)) continue;
+                if (!candidates.has(runNormalized)) candidates.set(runNormalized, run);
+                if (candidates.size > 1) return '';
+            }
+        }
+        return candidates.size === 1 ? candidates.values().next().value : '';
+    }
+
+    // barSource provenance stamp (notes-serialized like imageSource, excluded
+    // from AI arbitration — see shared-core's corroboration demotion rung):
+    //   - 'curated'       the bar matches curated bars data for its city
+    //                     (only when bars data is reachable via this.core);
+    //   - 'venue-site'    the bar IS the venue whose own site this page is;
+    //   - 'page-adjacent' the bar sits next to the address in the source;
+    //   - 'uncorroborated' the address is in the source but the bar is NOT
+    //                     near it (flag-don't-drop: the value is kept).
+    // No bar, no address, address not locatable in the corpus, or an already
+    // stamped event → left untouched (fail open).
+    stampBarSourceProvenance(event, evidenceContext, htmlData) {
+        if (!event || typeof event !== 'object' || event.barSource) return event;
+        const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+        if (!bar) return event;
+        if (this.core && typeof this.core.getCuratedCityBars === 'function'
+            && typeof this.core.findCuratedBarByName === 'function') {
+            try {
+                const cityBars = this.core.getCuratedCityBars(event.city);
+                if (cityBars && this.core.findCuratedBarByName(cityBars, bar)) {
+                    event.barSource = 'curated';
+                    return event;
+                }
+            } catch (_) {
+                // curated matching is best-effort — fail open to the checks below
+            }
+        }
+        if (this.getPageSiteRole(htmlData) === 'venue') {
+            const venueName = this.getPageVenueName(htmlData);
+            if (venueName && this.matchesPageBrandName(bar, [venueName])) {
+                event.barSource = 'venue-site';
+                return event;
+            }
+        }
+        const address = typeof event.address === 'string' ? event.address.trim() : '';
+        const corpus = evidenceContext && typeof evidenceContext.raw === 'string' ? evidenceContext.raw : '';
+        if (!address || !corpus) return event;
+        const streetLine = this.getAddressStreetLine(address);
+        if (!streetLine) return event;
+        const adjacency = this.checkBarAddressAdjacency(bar, streetLine, corpus);
+        if (!adjacency.addressFound) return event;
+        if (adjacency.adjacent) {
+            event.barSource = 'page-adjacent';
+            return event;
+        }
+        event.barSource = 'uncorroborated';
+        console.log(`🤖 AI Web: Bar "${bar}" not found near address "${streetLine}" in source — flagging as uncorroborated`);
+        const candidate = this.findAdjacentVenueCandidate(event, adjacency, htmlData);
+        if (candidate) {
+            console.log(`🤖 AI Web: Adjacent venue candidate: "${candidate}"`);
+        }
         return event;
     }
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -3281,3 +3281,259 @@ test('normalizeAiEvent keeps Dec 31 22:00 -> Jan 1 02:00 in the next year (endTi
   assert.equal(normalized.startDate.toISOString(), '2026-12-31T22:00:00.000Z');
   assert.equal(normalized.endDate.toISOString(), '2027-01-01T02:00:00.000Z', 'the 2am end lands on next year\'s Jan 1');
 });
+
+// ---------------------------------------------------------------------------
+// Bar corroboration (barSource): address-adjacency on the extraction corpus,
+// venue-site stamping, curated stamping, and the siteRole facts. All checks
+// fail open — no bar, no address, or an unlocatable address stamps nothing.
+// ---------------------------------------------------------------------------
+
+// The real incident shape: flyer OCR where the edition subtitle ("SHORE
+// THING") sits far above the address while the actual venue is adjacent to it
+// ("MASSIVE: 619 E. PINE ST"). Padding lines keep SHORE THING outside both
+// the ±2-line and ~150-character windows.
+const SHORE_THING_CORPUS = [
+  'OCR_IMAGE_TEXT (https://massive.club/media/shore-thing-flyer.jpg):',
+  'BEARRACUDA SEATTLE PRESENTS',
+  'SHORE THING',
+  'THE ANNUAL SUMMER KICKOFF FOR BEARS AND CUBS OF THE PACIFIC NORTHWEST',
+  'FEATURING DJ BEARZERKER SPINNING DISCO AND HOUSE ALL NIGHT LONG',
+  'WITH SPECIAL GUEST DJ TOPHER JOINING US FROM SAN FRANCISCO',
+  'GOGO BEARS SURPRISE PERFORMANCES GIVEAWAYS AND MORE',
+  'SATURDAY AUGUST 1ST 2026 FROM TEN UNTIL LATE',
+  'TICKETS TWENTY DOLLARS AT THE DOOR OR ONLINE WHILE THEY LAST',
+  '10PM - 2AM • 21+',
+  'MASSIVE: 619 E. PINE ST',
+  'SEATTLE WA 98122'
+].join('\n');
+
+function captureLogs(fn) {
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (message) => { lines.push(String(message)); };
+  try {
+    fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return lines;
+}
+
+test('Shore Thing incident: subtitle bar far from the address is stamped uncorroborated with flag + adjacent candidate logs', () => {
+  const parser = createParser();
+  const evidenceContext = parser.buildAiEvidenceContextFromText(SHORE_THING_CORPUS);
+  const event = {
+    title: 'BEARRACUDA SEATTLE',
+    bar: 'Shore Thing',
+    address: '619 E. Pine St, Seattle, WA 98122'
+  };
+  const logs = captureLogs(() => {
+    parser.stampBarSourceProvenance(event, evidenceContext, { url: 'https://bearracuda.com/seattle', html: '' });
+  });
+  assert.equal(event.bar, 'Shore Thing', 'flag-don\'t-drop: the value is never changed');
+  assert.equal(event.barSource, 'uncorroborated');
+  assert.ok(logs.includes(
+    '🤖 AI Web: Bar "Shore Thing" not found near address "619 E. Pine St" in source — flagging as uncorroborated'
+  ), `flag log expected, got: ${JSON.stringify(logs)}`);
+  assert.ok(logs.includes('🤖 AI Web: Adjacent venue candidate: "MASSIVE"'),
+    `candidate log expected, got: ${JSON.stringify(logs)}`);
+});
+
+test('bar adjacent to the address stamps page-adjacent: same-line, multi-line, and emoji/punctuation tolerance', () => {
+  const parser = createParser();
+
+  // Same line as the address ("MASSIVE: 619 E. PINE ST")
+  const sameLine = { title: 'X', bar: 'MASSIVE', address: '619 E. Pine St, Seattle, WA 98122' };
+  parser.stampBarSourceProvenance(sameLine, parser.buildAiEvidenceContextFromText(SHORE_THING_CORPUS), null);
+  assert.equal(sameLine.barSource, 'page-adjacent');
+
+  // Within ±2 lines
+  const multiLineCorpus = [
+    'UPCOMING EVENTS',
+    'MASSIVE',
+    'NIGHTCLUB AND EVENT SPACE',
+    '619 E. PINE ST, SEATTLE, WA',
+    'DOORS AT TEN'
+  ].join('\n');
+  const multiLine = { title: 'X', bar: 'Massive', address: '619 E Pine St, Seattle' };
+  parser.stampBarSourceProvenance(multiLine, parser.buildAiEvidenceContextFromText(multiLineCorpus), null);
+  assert.equal(multiLine.barSource, 'page-adjacent', 'case/punctuation-insensitive containment across the line window');
+
+  // Emoji + punctuation noise, suffix-less street line
+  const emojiCorpus = 'Weekly parties\n🪩 Cell Block / 3702 N Halsted\nChicago bears night';
+  const emoji = { title: 'X', bar: 'Cell Block', address: '3702 N Halsted, Chicago, IL 60613' };
+  parser.stampBarSourceProvenance(emoji, parser.buildAiEvidenceContextFromText(emojiCorpus), null);
+  assert.equal(emoji.barSource, 'page-adjacent');
+});
+
+test('no stamp when the address is absent from the corpus, missing, or the bar/corpus is empty (fail open)', () => {
+  const parser = createParser();
+
+  const addressAbsent = { title: 'X', bar: 'Shore Thing', address: '4067 W Pico Blvd, Los Angeles, CA' };
+  parser.stampBarSourceProvenance(addressAbsent, parser.buildAiEvidenceContextFromText(SHORE_THING_CORPUS), null);
+  assert.equal('barSource' in addressAbsent, false, 'address not locatable in source → no stamp');
+
+  const noAddress = { title: 'X', bar: 'Shore Thing' };
+  parser.stampBarSourceProvenance(noAddress, parser.buildAiEvidenceContextFromText(SHORE_THING_CORPUS), null);
+  assert.equal('barSource' in noAddress, false);
+
+  const noBar = { title: 'X', address: '619 E. Pine St, Seattle, WA 98122' };
+  parser.stampBarSourceProvenance(noBar, parser.buildAiEvidenceContextFromText(SHORE_THING_CORPUS), null);
+  assert.equal('barSource' in noBar, false);
+
+  const noCorpus = { title: 'X', bar: 'Shore Thing', address: '619 E. Pine St, Seattle' };
+  parser.stampBarSourceProvenance(noCorpus, null, null);
+  assert.equal('barSource' in noCorpus, false);
+
+  // A street line without a leading house number is never searched for
+  const unparseable = { title: 'X', bar: 'Shore Thing', address: 'Pier Sixty, New York' };
+  parser.stampBarSourceProvenance(unparseable, parser.buildAiEvidenceContextFromText(SHORE_THING_CORPUS), null);
+  assert.equal('barSource' in unparseable, false);
+});
+
+test('curated bars data (when reachable through core) outranks adjacency: curated stamp even when not adjacent', () => {
+  const parser = createParser();
+  parser.core = new SharedCore({}, {
+    eventSchema: EventSchema,
+    bars: { seattle: [{ name: 'Massive' }] }
+  });
+  const event = { title: 'X', bar: 'MASSIVE', city: 'seattle', address: '4067 W Pico Blvd, Los Angeles' };
+  parser.stampBarSourceProvenance(event, parser.buildAiEvidenceContextFromText('no addresses here'), null);
+  assert.equal(event.barSource, 'curated');
+
+  // No bars data for the city → the adjacency path still runs (fail open)
+  const unknownCity = { title: 'X', bar: 'MASSIVE', city: 'portland', address: '619 E. Pine St, Seattle' };
+  parser.stampBarSourceProvenance(unknownCity, parser.buildAiEvidenceContextFromText(SHORE_THING_CORPUS), null);
+  assert.equal(unknownCity.barSource, 'page-adjacent');
+});
+
+// ---------------------------------------------------------------------------
+// siteRole classification: hard facts only, config override on top.
+// ---------------------------------------------------------------------------
+
+const VENUE_SITE_HTML = `<html><head>
+  <meta property="og:site_name" content="MASSIVE" />
+  <script type="application/ld+json">{"@type":"NightClub","name":"Massive","url":"https://massive.club"}</script>
+</head><body>MASSIVE NIGHTCLUB SEATTLE</body></html>`;
+
+test('siteRole: JSON-LD venue-ish @type classifies the page as venue; config override wins over it', () => {
+  const parser = createParser();
+  const htmlData = { url: 'https://massive.club/events', html: VENUE_SITE_HTML };
+  assert.equal(parser.resolvePageSiteRole(htmlData, {}), 'venue');
+  assert.equal(parser.getPageSiteRole(htmlData), 'venue', 'cached for downstream copies');
+
+  // Config override has top precedence — even against a venue-typed page
+  const overridden = { url: 'https://massive.club/events', html: VENUE_SITE_HTML };
+  assert.equal(parser.resolvePageSiteRole(overridden, { siteRole: 'organizer' }), 'organizer');
+  const venueOverride = { url: 'https://promoter.example/events', html: '<html><body>hi</body></html>' };
+  assert.equal(parser.resolvePageSiteRole(venueOverride, { siteRole: 'venue' }), 'venue');
+
+  // A venue-typed Place nested inside an Event is the EVENT's location, not the page's identity
+  const eventNested = {
+    url: 'https://promoter.example/e/1',
+    html: `<script type="application/ld+json">{"@type":"Event","name":"Bear Night","location":{"@type":"NightClub","name":"Massive"}}</script>`
+  };
+  assert.equal(parser.resolvePageSiteRole(eventNested, {}), '');
+});
+
+test('siteRole: segment facts — multiple distinct addresses under an Organization → organizer; single recurring address + footer → venue', () => {
+  const parser = createParser();
+
+  const organizerHtml = `<html><head>
+    <script type="application/ld+json">{"@type":"Organization","name":"Bearracuda"}</script>
+  </head><body>tour dates</body></html>`;
+  const organizerData = { url: 'https://bearracuda.example/events', html: organizerHtml };
+  const multiCitySegments = [
+    { lines: ['FURBALL BLACKOUT', 'JULY 10', '619 E. PINE ST, SEATTLE'] },
+    { lines: ['FURBALL LA', 'JULY 24', '4067 W PICO BLVD, LOS ANGELES'] }
+  ];
+  assert.equal(parser.resolvePageSiteRole(organizerData, {}, multiCitySegments), 'organizer');
+
+  const venueHtml = `<html><body>
+    <div>AUG 1 BEAR NIGHT at 619 E. PINE ST</div>
+    <div>AUG 8 UNDERWEAR PARTY</div>
+    <footer>MASSIVE • 619 E. PINE ST • SEATTLE, WA 98122</footer>
+  </body></html>`;
+  const venueData = { url: 'https://massive.club/calendar', html: venueHtml };
+  const singleAddressSegments = [
+    { lines: ['BEAR NIGHT', 'AUG 1', '619 E. PINE ST'] },
+    { lines: ['UNDERWEAR PARTY', 'AUG 8'] }
+  ];
+  assert.equal(parser.resolvePageSiteRole(venueData, {}, singleAddressSegments), 'venue');
+
+  // Multiple addresses WITHOUT an Organization/PerformingGroup type stays undetermined
+  const bareData = { url: 'https://somewhere.example/events', html: '<html><body>list</body></html>' };
+  assert.equal(parser.resolvePageSiteRole(bareData, {}, multiCitySegments), '');
+});
+
+test('siteRole: undetermined pages log once and inject no venue context', () => {
+  const parser = createParser();
+  const htmlData = { url: 'https://promoter.example/events', html: '<html><body>events</body></html>' };
+  assert.equal(parser.resolvePageSiteRole(htmlData, {}), '');
+  const logs = captureLogs(() => {
+    parser.logPageSiteRoleOnce(htmlData);
+    parser.logPageSiteRoleOnce(htmlData);
+  });
+  assert.deepEqual(logs, ['🤖 AI Web: siteRole for promoter.example undetermined'], 'exactly once per page');
+});
+
+test('KNOWN VENUE line appears in extraction prompts only for venue pages, replacing KNOWN ORGANIZER there', () => {
+  const parser = createParser();
+  const venueData = { url: 'https://massive.club/events', html: VENUE_SITE_HTML };
+  parser.resolvePageSiteRole(venueData, {});
+  const venuePrompt = parser.buildExtractionPrompt(venueData, {}, null, {}, ['title', 'bar'], 'SNIPPET', 'default', {});
+  assert.match(venuePrompt,
+    /KNOWN VENUE \(this is the venue's own site\): "MASSIVE" — events on this page take place AT this venue unless the page states another location; DJ names, taglines, and edition subtitles are NOT the venue\./);
+  assert.ok(!/KNOWN ORGANIZER/.test(venuePrompt),
+    'the organizer line would contradict KNOWN VENUE on the venue\'s own site');
+
+  // Undetermined page with a brand keeps today's organizer line, no venue line
+  const organizerData = {
+    url: 'https://bearracuda.example/events',
+    html: '<html><head><meta property="og:site_name" content="Bearracuda" /></head><body></body></html>'
+  };
+  parser.resolvePageSiteRole(organizerData, {});
+  const organizerPrompt = parser.buildExtractionPrompt(organizerData, {}, null, {}, ['title', 'bar'], 'SNIPPET', 'default', {});
+  assert.match(organizerPrompt, /KNOWN ORGANIZER \(derived from page metadata\): "Bearracuda"/);
+  assert.ok(!/KNOWN VENUE/.test(organizerPrompt));
+});
+
+test('venue-site: a bar equal to the known venue is stamped venue-site and survives the brand guards', () => {
+  const parser = createParser();
+  const htmlData = { url: 'https://massive.club/events', html: VENUE_SITE_HTML };
+  parser.resolvePageSiteRole(htmlData, {});
+
+  // The pass-level brand guard must NOT reject the venue's own name as bar
+  const guarded = parser.rejectBrandLikePassFields({ bar: 'MASSIVE' }, htmlData, 'test');
+  assert.equal(guarded.bar, 'MASSIVE', 'venue site: the site name IS the venue');
+
+  // normalizeAiEvent keeps the bar, stamps no _organizer on a venue site
+  const event = parser.normalizeAiEvent(
+    { title: 'BEAR NIGHT', startDate: '2026-08-01', startTime: '21:00', bar: 'MASSIVE' },
+    {}, htmlData, null, null);
+  assert.equal(event.bar, 'MASSIVE', 'the organizer bar-drop guard is off on venue sites');
+  assert.equal(event._organizer, undefined, 'no organizer stamp — arbitration must not veto the venue as bar');
+
+  // And the corroboration stamp marks it venue-site
+  parser.stampBarSourceProvenance(event, parser.buildAiEvidenceContextFromText('no addresses in this corpus'), htmlData);
+  assert.equal(event.barSource, 'venue-site');
+
+  // A different bar on the same venue page is NOT stamped venue-site
+  const other = { title: 'OFFSITE', bar: 'The Cuff', address: '1533 13th Ave, Seattle' };
+  parser.stampBarSourceProvenance(other, parser.buildAiEvidenceContextFromText('somewhere else entirely'), htmlData);
+  assert.equal('barSource' in other, false);
+});
+
+test('venue name derivation prefers declared names and falls back to the host base', () => {
+  const parser = createParser();
+  // og:site_name wins
+  assert.equal(parser.getPageVenueName({ url: 'https://massive.club/e', html: VENUE_SITE_HTML }), 'MASSIVE');
+  // JSON-LD venue node name when no og:site_name
+  const jsonLdOnly = {
+    url: 'https://massive.club/e',
+    html: '<script type="application/ld+json">{"@type":"NightClub","name":"Massive"}</script>'
+  };
+  assert.equal(parser.getPageVenueName(jsonLdOnly), 'Massive');
+  // Host base as last resort ("massive" from www.massive.club)
+  assert.equal(parser.getPageVenueName({ url: 'https://www.massive.club/events', html: '<html></html>' }), 'massive');
+});

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -266,6 +266,9 @@ const scraperConfig = {
       // discoveryBlockedPatterns: ["example.com/members-only"], // Deliberate exclusions only — generic junk is blocked built-in and dead ends are learned + auto-retried (default: none)
       // discoveryBlockedHosts: ["example.com"], // Suppress ALL discovered links to these hostnames (default: none)
       //
+      // Extraction steering:
+      // siteRole: "venue", // "venue" | "organizer" — who this SITE is (top precedence over page-derived detection). "venue": events on the page happen AT this venue — its own name may be returned as bar, and the KNOWN VENUE extraction context is injected. "organizer": promoter/brand site — the site name is never the bar. Omit → derived from page facts (JSON-LD types, observed addresses); undetermined changes nothing.
+      //
       // Run behavior:
       // dryRun: true, // Preview this parser's events without writing to the calendar (default: false — global config.dryRun also applies)
       // automationEnabled: false, // Skip this parser in scheduled automation runs (default: true)

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -419,10 +419,16 @@ class SharedCore {
         // image value came from at extraction); like pinSource it must FOLLOW
         // the finalized image deterministically (setProvenanceSource), never
         // be arbitrated as content.
+        // barSource is bar provenance (page-adjacent/venue-site/curated/
+        // uncorroborated — whether the extracted venue was corroborated by the
+        // source page); like imageSource it must FOLLOW the finalized bar
+        // deterministically (setProvenanceSource), never be arbitrated as
+        // content.
         return name !== 'key' && name !== 'notes' && name !== 'source'
             && name !== 'location' && name !== 'gmaps'
             && name !== 'pinSource' && name !== 'addressSource'
-            && name !== 'bearSource' && name !== 'imageSource';
+            && name !== 'bearSource' && name !== 'imageSource'
+            && name !== 'barSource';
     }
 
     // True when a bearSource value records the calendar owner's manual verdict
@@ -1231,6 +1237,57 @@ class SharedCore {
                     winner: addressShapedA ? 'b' : 'a',
                     reason: 'a street address is not a venue name'
                 };
+            }
+            // Corroboration demotion rung: barSource provenance stamped at
+            // extraction (page-adjacent = bar found next to the address in the
+            // source; venue-site = the venue's own site; curated = curated
+            // bars data; uncorroborated = the address was in the source but
+            // the bar was NOT near it — the flyer-subtitle failure shape).
+            // Exactly one candidate stamped uncorroborated while the other is
+            // corroborated → the corroborated one wins without AI. Attribution
+            // is strict like the image provenance rung: a record's barSource
+            // only speaks for the candidate when the record's own bar field IS
+            // that candidate value. Both uncorroborated, both corroborated, or
+            // stamps missing → fall through to today's behavior (fail open).
+            const barContextRecords = context && context.records && typeof context.records === 'object'
+                ? context.records : null;
+            if (barContextRecords) {
+                const getBarProvenance = (record, value) => {
+                    if (!record || typeof record !== 'object') return '';
+                    const recordBar = typeof record.bar === 'string' ? record.bar.trim() : '';
+                    const candidate = typeof value === 'string' ? value.trim() : '';
+                    if (!recordBar || !candidate || recordBar !== candidate) return '';
+                    return typeof record.barSource === 'string' ? record.barSource.trim() : '';
+                };
+                const isCorroboratedStamp = stamp =>
+                    stamp === 'page-adjacent' || stamp === 'venue-site' || stamp === 'curated';
+                const matchesCuratedBar = value =>
+                    Boolean(cityBars && this.findCuratedBarByName(cityBars, value));
+                const provenanceA = getBarProvenance(barContextRecords.a, valueA);
+                const provenanceB = getBarProvenance(barContextRecords.b, valueB);
+                const uncorroboratedA = provenanceA === 'uncorroborated';
+                const uncorroboratedB = provenanceB === 'uncorroborated';
+                if (uncorroboratedA !== uncorroboratedB) {
+                    const corroboratedA = isCorroboratedStamp(provenanceA) || matchesCuratedBar(valueA);
+                    const corroboratedB = isCorroboratedStamp(provenanceB) || matchesCuratedBar(valueB);
+                    if (uncorroboratedA && corroboratedB) {
+                        return { winner: 'b', reason: 'corroborated bar beats uncorroborated' };
+                    }
+                    if (uncorroboratedB && corroboratedA) {
+                        return { winner: 'a', reason: 'corroborated bar beats uncorroborated' };
+                    }
+                    // Demotion doctrine: an uncorroborated SCRAPED bar never
+                    // clobbers ANY calendar bar deterministically — calendar
+                    // records are curated-by-usage, so an unstamped (legacy)
+                    // calendar bar still outranks a flagged scrape. Calendar
+                    // flow only (side "a" is the calendar record there); the
+                    // enrich flow's two scraped records keep today's behavior.
+                    const sideLabels = context.sideLabels && typeof context.sideLabels === 'object'
+                        ? context.sideLabels : null;
+                    if (sideLabels && sideLabels.a === 'calendar' && uncorroboratedB && !provenanceA) {
+                        return { winner: 'a', reason: 'corroborated bar beats uncorroborated' };
+                    }
+                }
             }
         }
         // Deterministic address ladder: EVERY address conflict in run
@@ -3678,6 +3735,10 @@ class SharedCore {
             // winning image with the LOSING side's provenance stamp.
             if (fieldName === 'imageSource') return;
 
+            // barSource is bar provenance and must FOLLOW the finalized bar
+            // the same way (recomputed after the loop + arbitration).
+            if (fieldName === 'barSource') return;
+
             const priorityConfig = fieldPriorities[fieldName];
             const existingValue = existingEvent[fieldName];
             const newValue = newEvent[fieldName];
@@ -3951,6 +4012,12 @@ class SharedCore {
         delete mergedEvent.imageSource;
         this.setProvenanceSource(mergedEvent, 'image', 'imageSource', newEvent, existingEvent);
 
+        // barSource follows the finalized bar exactly like imageSource above:
+        // the corroboration stamp must always describe the WINNING bar value —
+        // a final bar neither side stamped carries no barSource (fail open).
+        delete mergedEvent.barSource;
+        this.setProvenanceSource(mergedEvent, 'bar', 'barSource', newEvent, existingEvent);
+
         // _timezoneUnresolved must describe the merged event's DATES, not the base
         // record: the `{ ...newEvent }` spread above copies newEvent's flag even
         // when existing's anchored dates won, and drops existing's flag even when
@@ -4134,12 +4201,13 @@ class SharedCore {
             // the final merged bar/address so it can never disagree with them.
             if (fieldName === 'gmaps') continue;
 
-            // pinSource/addressSource/imageSource are provenance metadata that
-            // must FOLLOW the finalized location/address/image (set by
-            // setProvenanceSource after STEP 3c) — they never merge or arbitrate
-            // on their own, or the generic loop could clobber a kept value's
-            // source with a stale one.
-            if (fieldName === 'pinSource' || fieldName === 'addressSource' || fieldName === 'imageSource') continue;
+            // pinSource/addressSource/imageSource/barSource are provenance
+            // metadata that must FOLLOW the finalized location/address/image/
+            // bar (set by setProvenanceSource after STEP 3c) — they never merge
+            // or arbitrate on their own, or the generic loop could clobber a
+            // kept value's source with a stale one.
+            if (fieldName === 'pinSource' || fieldName === 'addressSource'
+                || fieldName === 'imageSource' || fieldName === 'barSource') continue;
 
             const priorityConfig = fieldPriorities[fieldName];
             const mergeStrategy = priorityConfig?.merge || 'upsert';
@@ -4447,6 +4515,7 @@ class SharedCore {
         this.setProvenanceSource(mergedObject, 'location', 'pinSource', scraperObject, calendarObject);
         this.setProvenanceSource(mergedObject, 'address', 'addressSource', scraperObject, calendarObject);
         this.setProvenanceSource(mergedObject, 'image', 'imageSource', scraperObject, calendarObject);
+        this.setProvenanceSource(mergedObject, 'bar', 'barSource', scraperObject, calendarObject);
 
         // STEP 4: regenerate gmaps from the FINAL merged bar + address. gmaps
         // is a derived field — a pure function of bar + address — so merging or

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -6273,3 +6273,194 @@ test('__wireConsoleTee keeps working when a tee throws (logging never breaks the
     restoreConsole(saved);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Bar corroboration demotion rung (phase 2): a bar stamped `uncorroborated`
+// at extraction (address in source, bar NOT near it) loses deterministically
+// to a corroborated bar (page-adjacent/venue-site/curated stamp, or a curated
+// bars match) — and an uncorroborated SCRAPED bar never clobbers ANY calendar
+// bar, stamped or not. Attribution is strict like the image provenance rung;
+// stamps missing keeps today's behavior byte-identical.
+// ---------------------------------------------------------------------------
+
+test('guardrail: corroborated bar beats uncorroborated in both directions; ambiguity falls through', () => {
+  const core = createCore();
+  const context = (recordA, recordB, sideLabels = { a: 'existing', b: 'incoming' }) => ({
+    sideLabels,
+    records: { a: recordA, b: recordB }
+  });
+
+  // page-adjacent beats uncorroborated in both directions
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'MASSIVE', barSource: 'page-adjacent' }, { bar: 'Shore Thing', barSource: 'uncorroborated' })),
+    { winner: 'a', reason: 'corroborated bar beats uncorroborated' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'Shore Thing', 'MASSIVE',
+      context({ bar: 'Shore Thing', barSource: 'uncorroborated' }, { bar: 'MASSIVE', barSource: 'page-adjacent' })),
+    { winner: 'b', reason: 'corroborated bar beats uncorroborated' });
+
+  // venue-site and curated stamps are corroborated too
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'MASSIVE', barSource: 'venue-site' }, { bar: 'Shore Thing', barSource: 'uncorroborated' })),
+    { winner: 'a', reason: 'corroborated bar beats uncorroborated' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'MASSIVE', barSource: 'curated' }, { bar: 'Shore Thing', barSource: 'uncorroborated' })),
+    { winner: 'a', reason: 'corroborated bar beats uncorroborated' });
+
+  // Both uncorroborated → genuine question, arbitrate as today
+  assert.equal(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'MASSIVE', barSource: 'uncorroborated' }, { bar: 'Shore Thing', barSource: 'uncorroborated' })),
+    null);
+
+  // Enrich flow (two scraped records): uncorroborated vs UNSTAMPED falls
+  // through — the calendar doctrine applies to the calendar flow only
+  assert.equal(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'MASSIVE' }, { bar: 'Shore Thing', barSource: 'uncorroborated' })),
+    null);
+
+  // Calendar flow: an unstamped (legacy) calendar bar still beats an
+  // uncorroborated scraped bar — calendar records are curated-by-usage
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'MASSIVE' }, { bar: 'Shore Thing', barSource: 'uncorroborated' },
+        { a: 'calendar', b: 'scraped' })),
+    { winner: 'a', reason: 'corroborated bar beats uncorroborated' });
+  // ...but an uncorroborated CALENDAR bar vs unstamped scraped is not decided here
+  assert.equal(
+    core.resolveConflictDeterministically('bar', 'Shore Thing', 'MASSIVE',
+      context({ bar: 'Shore Thing', barSource: 'uncorroborated' }, { bar: 'MASSIVE' },
+        { a: 'calendar', b: 'scraped' })),
+    null);
+
+  // Attribution caution: a stamp only speaks for the record's OWN bar value
+  assert.equal(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'Neighbours', barSource: 'page-adjacent' }, { bar: 'Shore Thing', barSource: 'uncorroborated' })),
+    null, 'a stray stamp on a different bar value decides nothing');
+
+  // Stamps missing entirely (or no records context) → byte-identical today
+  assert.equal(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'MASSIVE' }, { bar: 'Shore Thing' })),
+    null);
+  assert.equal(core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing'), null);
+});
+
+test('barSource is never arbitration-eligible and round-trips through notes like imageSource', () => {
+  const core = createCore();
+  assert.equal(core.isArbitrationEligibleField('barSource'), false);
+  assert.equal(core.isArbitrationEligibleField('bar'), true, 'the bar VALUE itself still arbitrates');
+
+  const notes = core.formatEventNotes({ bar: 'MASSIVE', barSource: 'page-adjacent' });
+  assert.match(notes, /barSource: page-adjacent/);
+  const parsed = core.parseNotesIntoFields(notes);
+  assert.equal(parsed.bar, 'MASSIVE');
+  assert.equal(parsed.barSource, 'page-adjacent');
+});
+
+test('incident phase 2 (enrich flow): corroborated bar beats uncorroborated in both directions — zero AI calls, stamp follows the winner', async () => {
+  const core = createCore();
+  const priorities = { bar: { priority: ['ai-web'], merge: 'ai' } };
+  const aiParserConfig = { ai: { provider: 'ollama', endpoint: 'http://ai.example', model: 'm' } };
+  const base = { title: 'BEARRACUDA SEATTLE', city: 'seattle', source: 'ai-web', _fieldPriorities: priorities };
+
+  const adapterA = buildArbitrationAdapter({});
+  const logLinesA = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLinesA.push(String(message)); };
+  let mergedA;
+  try {
+    mergedA = await core.mergeParsedEvents(
+      { ...base, bar: 'MASSIVE', barSource: 'page-adjacent' },
+      { ...base, bar: 'Shore Thing', barSource: 'uncorroborated', _parserConfig: aiParserConfig },
+      { httpAdapter: adapterA });
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(adapterA.calls.length, 0, 'corroboration settles the bar without AI');
+  assert.equal(mergedA.bar, 'MASSIVE');
+  assert.equal(mergedA.barSource, 'page-adjacent', 'barSource follows the winning bar');
+  assert.ok(logLinesA.includes(
+    '🔒 MERGE: "BEARRACUDA SEATTLE" field=bar resolved deterministically — corroborated bar beats uncorroborated'
+  ), `stable 🔒 log line expected, got: ${JSON.stringify(logLinesA)}`);
+
+  const adapterB = buildArbitrationAdapter({});
+  const mergedB = await core.mergeParsedEvents(
+    { ...base, bar: 'Shore Thing', barSource: 'uncorroborated' },
+    { ...base, bar: 'MASSIVE', barSource: 'page-adjacent', _parserConfig: aiParserConfig },
+    { httpAdapter: adapterB });
+  assert.equal(adapterB.calls.length, 0);
+  assert.equal(mergedB.bar, 'MASSIVE');
+  assert.equal(mergedB.barSource, 'page-adjacent',
+    'the incoming base-spread stamp is replaced by the winning side\'s');
+
+  // Both uncorroborated → the AI is consulted exactly as today
+  const adapterC = buildArbitrationAdapter({
+    bar: { pick: 'existing', value: 'MASSIVE', reason: 'venue' }
+  });
+  const mergedC = await core.mergeParsedEvents(
+    { ...base, bar: 'MASSIVE', barSource: 'uncorroborated' },
+    { ...base, bar: 'Shore Thing', barSource: 'uncorroborated', _parserConfig: aiParserConfig },
+    { httpAdapter: adapterC });
+  assert.equal(adapterC.calls.length, 1, 'both-uncorroborated is a genuine question');
+  assert.equal(mergedC.bar, 'MASSIVE');
+});
+
+test('incident phase 2 (calendar flow): uncorroborated scraped bar never clobbers the calendar bar — stamped or legacy-unstamped', async () => {
+  const core = createCore();
+
+  // Calendar stamped page-adjacent (from a previous run's notes round-trip)
+  const stamped = buildAlignedArbitrationPair();
+  stamped.scraped.bar = 'Shore Thing';
+  stamped.scraped.barSource = 'uncorroborated';
+  stamped.existing.notes = stamped.existing.notes.replace('bar: S4', 'bar: MASSIVE\nbarSource: page-adjacent');
+  const adapterA = buildArbitrationAdapter({});
+  const finalA = await core.createFinalEventObject(stamped.existing, stamped.scraped, { httpAdapter: adapterA });
+  assert.equal(adapterA.calls.length, 0, 'no AI request at all');
+  assert.equal(finalA.bar, 'MASSIVE');
+  assert.equal(finalA.barSource, 'page-adjacent', 'the notes-parsed calendar stamp participates and survives');
+  assert.deepEqual(finalA._original.aiArbitration.deterministic, ['bar']);
+  const parsedNotesA = core.parseNotesIntoFields(finalA.notes);
+  assert.equal(parsedNotesA.bar, 'MASSIVE');
+  assert.equal(parsedNotesA.barSource, 'page-adjacent', 'the stamp persists to notes for the next run');
+
+  // Legacy calendar record with NO stamp still wins (curated-by-usage)
+  const legacy = buildAlignedArbitrationPair();
+  legacy.scraped.bar = 'Shore Thing';
+  legacy.scraped.barSource = 'uncorroborated';
+  legacy.existing.notes = legacy.existing.notes.replace('bar: S4', 'bar: MASSIVE');
+  const adapterB = buildArbitrationAdapter({});
+  const finalB = await core.createFinalEventObject(legacy.existing, legacy.scraped, { httpAdapter: adapterB });
+  assert.equal(adapterB.calls.length, 0, 'the demotion doctrine needs no AI');
+  assert.equal(finalB.bar, 'MASSIVE');
+  assert.equal(finalB.barSource, undefined, 'an unstamped winner never inherits the loser\'s stamp');
+  assert.deepEqual(finalB._original.aiArbitration.deterministic, ['bar']);
+
+  // Reverse: a corroborated SCRAPED bar beats an uncorroborated calendar bar
+  const reversed = buildAlignedArbitrationPair();
+  reversed.scraped.bar = 'MASSIVE';
+  reversed.scraped.barSource = 'page-adjacent';
+  reversed.existing.notes = reversed.existing.notes.replace('bar: S4', 'bar: Shore Thing\nbarSource: uncorroborated');
+  const adapterC = buildArbitrationAdapter({});
+  const finalC = await core.createFinalEventObject(reversed.existing, reversed.scraped, { httpAdapter: adapterC });
+  assert.equal(adapterC.calls.length, 0);
+  assert.equal(finalC.bar, 'MASSIVE', 'the corroborated scraped bar wins');
+  assert.equal(finalC.barSource, 'page-adjacent');
+
+  // Both uncorroborated → AI arbitration exactly as today
+  const contested = buildAlignedArbitrationPair();
+  contested.scraped.bar = 'Shore Thing';
+  contested.scraped.barSource = 'uncorroborated';
+  contested.existing.notes = contested.existing.notes.replace('bar: S4', 'bar: MASSIVE\nbarSource: uncorroborated');
+  const adapterD = buildArbitrationAdapter({
+    bar: { pick: 'calendar', value: 'MASSIVE', reason: 'venue' }
+  });
+  const finalD = await core.createFinalEventObject(contested.existing, contested.scraped, { httpAdapter: adapterD });
+  assert.equal(adapterD.calls.length, 1, 'both-uncorroborated still reaches the AI');
+  assert.equal(finalD.bar, 'MASSIVE');
+});


### PR DESCRIPTION
The brand-new-venue defense: curated data only protects venues we already know; these signals protect venues we've never seen, using page-derived facts.

## 1. Address-adjacency corroboration (extraction)
Venue names sit next to addresses on flyers and pages (`MASSIVE: 619 E. PINE ST`, `🪩 Cell Block / 3702 N Halsted`). Post-extraction, the final bar is checked against every occurrence of the address street line in the same corpus the evidence gate reads (page + OCR + segments), ±2 lines with a ~150-char flattened-window fallback, emoji/punctuation-tolerant:
- adjacent → `barSource: page-adjacent`
- present-address but non-adjacent bar → `barSource: uncorroborated` + flag log, value untouched (flag-don't-drop) — and if exactly one other capitalized candidate sits adjacent to the address, it's logged as `Adjacent venue candidate` (log-only, no auto-replacement)
- curated/venue-site matches stamp `curated`/`venue-site`; no address in source → no stamp (fail open)
The real Shore Thing corpus is the regression: "Shore Thing" → uncorroborated with "MASSIVE" logged as the adjacent candidate.

## 2. Merge demotion (shared-core)
After the curated rule: a corroborated candidate beats an uncorroborated one deterministically (🔒, zero AI); an **uncorroborated scraped bar can never deterministically beat any calendar bar** — unstamped legacy calendar records win too (calendar is curated-by-usage). Both-uncorroborated/stamps-missing → byte-identical existing behavior. Explicit `merge: 'clobber'` configs still clobber — deliberate config stays deliberate.

## 3. KNOWN VENUE + siteRole
Per-page role: `siteRole` config override (documented in the New Site Template) → hard facts (JSON-LD NightClub/BarOrPub/EventVenue/MusicVenue page identity; Organization + multi-address segments → organizer; single recurring segment address that also appears in the page's footer/contact → venue) → undetermined = no injection (logged once; no AI tiebreak in this PR, deliberately). Venue pages get `KNOWN VENUE` extraction context (name from og:site_name → JSON-LD → brand → host base) and — the one substantive behavior change — the KNOWN ORGANIZER line and organizer bar-drop guards are suppressed there, since on a venue's own site those guards would veto the correct bar. Organizer/undetermined pages byte-identical.

+14 tests. Suite: **566 pass / 0 fail**. No schema/js changes; provenance persists like imageSource/bearSource.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/parsers/ai-web-parser.js`, `scripts/scraper-input.js` (comment-only template addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP