### PR TITLE
feat(scraper): geo-POI corroboration — map placemark names vouch for bar names, zero new API calls

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1288,7 +1288,11 @@ class ScriptableAdapter {
   //   4. Circuit breaker: 3 consecutive failures stop native attempts for
   //      the rest of the run.
   // Returns the raw first placemark object (subThoroughfare/thoroughfare/
-  // locality/postalCode/postalAddress keys) or null. normalizers.js uses
+  // locality/postalCode/postalAddress keys — plus name/areasOfInterest when
+  // Apple knows a POI at the point, which the geo-POI bar corroboration in
+  // normalizers.js harvests; the raw object is persisted verbatim, so cached
+  // entries carry those fields forward and pre-harvest entries without them
+  // simply yield no POI names — fail open) or null. normalizers.js uses
   // this for the geocode-verification cross-check; all Scriptable API usage
   // stays in this adapter (pure-module rule).
   // ---------------------------------------------------------------------

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1592,3 +1592,51 @@ test('wired-then-restored console does not double-append into a capturing logger
     delete console.__consoleTeeRestore;
   }
 });
+
+// ---------------------------------------------------------------------------
+// Geo-POI bar corroboration (phase 3): the raw placemark is persisted
+// verbatim, so newly cached entries carry Apple's POI fields (name/
+// areasOfInterest) forward for the normalizers' geo-POI harvest, while
+// pre-harvest entries without them are still served unchanged (fail open —
+// the old cache is never invalidated).
+// ---------------------------------------------------------------------------
+
+test('reverse-geocode cache carries POI fields forward on new entries; old nameless entries stay served', async () => {
+  const POI_PLACEMARK = {
+    subThoroughfare: '1192',
+    thoroughfare: 'Folsom Street',
+    locality: 'San Francisco',
+    postalCode: '94103',
+    name: 'Powerhouse',
+    areasOfInterest: ['SoMa']
+  };
+  const adapter = buildReverseGeocodeAdapter();
+  let calls = 0;
+  global.Location = {
+    reverseGeocode: async () => { calls += 1; return [POI_PLACEMARK]; }
+  };
+  try {
+    await adapter.reverseGeocodePlacemark(37.7756941, -122.4103049);
+    const stored = JSON.parse(adapter.fm.files.get(adapter.getReverseGeocodeCacheFilePath()));
+    const entry = stored['37.77569,-122.41030'];
+    assert.equal(entry.placemark.name, 'Powerhouse', 'newly written entries carry the POI name');
+    assert.deepEqual(entry.placemark.areasOfInterest, ['SoMa'], 'areasOfInterest rides along too');
+
+    // A later run serves the POI fields from disk without spending quota
+    const laterRun = buildReverseGeocodeAdapter();
+    laterRun.fm = adapter.fm;
+    const served = await laterRun.reverseGeocodePlacemark(37.7756941, -122.4103049);
+    assert.equal(served.name, 'Powerhouse');
+    assert.equal(calls, 1, 'disk hit — no Apple call');
+
+    // Pre-harvest entry (no name/areasOfInterest) is served as-is: the
+    // normalizers' harvest finds no POI and fails open; never refetched.
+    const oldEntry = { subThoroughfare: '446', thoroughfare: 'Mt Nebo Rd', locality: 'East Stroudsburg' };
+    laterRun.reverseGeocodeDiskCache['41.02198,-75.11678'] = { placemark: oldEntry, ts: Date.now() };
+    const legacy = await laterRun.reverseGeocodePlacemark(41.0219799, -75.1167816);
+    assert.deepEqual(legacy, oldEntry, 'old cache entries are honored, not invalidated');
+    assert.equal(calls, 1, 'no refetch for nameless legacy entries');
+  } finally {
+    delete global.Location;
+  }
+});

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -805,6 +805,15 @@ const GEOCODE_GENERIC_STREET_TOKENS = [
     'place', 'court', 'east', 'west', 'north', 'south', 'way', 'the'
 ];
 
+// Generic venue-type words stripped SYMMETRICALLY from the tail of both sides
+// of the geo-POI ↔ bar comparison ("Massive" matches the map POI "Massive
+// Nightclub"), only ever when a non-empty remainder is left. The remainder
+// must equal the other side token-for-token — never a substring — so "Eagle"
+// can't claim "Eagle Creek Cafe".
+const GEOCODE_GENERIC_VENUE_SUFFIXES = [
+    'nightclub', 'club', 'bar', 'lounge', 'theater', 'theatre', 'tavern', 'pub', 'hall'
+];
+
 // Unit/suite decoration ("Suite 200", "#4", "#UNIT 114", "Apt 5B", "Fl. 2")
 // that chokes Nominatim's free-text parser; stripped as its own retry rung.
 // Three alternatives (2026-07-15 run findings shaped each one):
@@ -1166,15 +1175,156 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         return null;
     }
 
+    // -----------------------------------------------------------------------
+    // Geo-POI harvest + bar corroboration (bar corroboration phase 3): the
+    // geocoder responses the pipeline ALREADY fetches name the place at the
+    // pinned coordinates; when that map-grade name matches the event's bar,
+    // the bar is corroborated by an authority independent of the source page.
+    // ZERO new network calls — every name below rides on a response an
+    // existing rung fetched anyway.
+    // -----------------------------------------------------------------------
+
+    // POI name from a forward-geocode result the ladder picked. Prefer the
+    // explicit name field(s); fall back to the leading display_name component,
+    // which is the POI for venue hits ("Massive, 619, East Pine Street, …")
+    // but the house number for bare-address hits ("619, East Pine Street, …")
+    // — leading-digit components are never harvested. Photon results reuse
+    // this via { name: properties.name } (no display_name → same guards).
+    extractNominatimPoiName(result) {
+        if (!result || typeof result !== 'object') return '';
+        const clean = value => typeof value === 'string' ? value.trim() : '';
+        const explicit = clean(result.name)
+            || (result.namedetails && typeof result.namedetails === 'object'
+                ? clean(result.namedetails.name)
+                : '');
+        if (explicit && !/^\d/.test(explicit)) return explicit;
+        const first = clean(String(result.display_name || '').split(',')[0]);
+        if (first && !/^\d/.test(first)) return first;
+        return '';
+    }
+
+    // POI names from an Apple reverse placemark the cross-check already
+    // fetched: `name` plus any `areasOfInterest` entries. Apple sets `name`
+    // to the street address line when it knows no POI at the point — leading-
+    // digit names and names equal to the thoroughfare are skipped. Cached
+    // placemarks from before these fields were harvested simply lack them →
+    // empty harvest (fail open).
+    extractPlacemarkPoiNames(placemark) {
+        if (!placemark || typeof placemark !== 'object') return [];
+        const clean = value => typeof value === 'string' ? value.trim() : '';
+        const names = [];
+        const thoroughfare = clean(placemark.thoroughfare).toLowerCase();
+        const name = clean(placemark.name);
+        if (name && !/^\d/.test(name) && name.toLowerCase() !== thoroughfare) {
+            names.push(name);
+        }
+        if (Array.isArray(placemark.areasOfInterest)) {
+            for (const area of placemark.areasOfInterest) {
+                const areaName = clean(area);
+                if (areaName && !/^\d/.test(areaName)) names.push(areaName);
+            }
+        }
+        return names;
+    }
+
+    // Names attached to an accepted pin: the forward result's POI (exact-grade
+    // hits only — a street hit's "name" is the street, not a venue) plus
+    // whatever the reverse cross-check placemark exposed.
+    collectAcceptedPoiNames(forwardPoiName, confirmed) {
+        const names = [];
+        if (forwardPoiName) names.push(forwardPoiName);
+        if (confirmed && Array.isArray(confirmed.poiNames)) {
+            for (const name of confirmed.poiNames) {
+                if (name) names.push(name);
+            }
+        }
+        return names;
+    }
+
+    // Comparable token list for the POI ↔ bar comparison: lowercase,
+    // punctuation → token breaks, leading "the" dropped — the same
+    // normalization spirit as shared-core's findCuratedBarByName, kept
+    // token-shaped so the generic-suffix rule can demand full-token alignment.
+    tokenizePoiBarName(name) {
+        const tokens = String(name || '')
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, ' ')
+            .split(/\s+/)
+            .filter(Boolean);
+        if (tokens.length > 1 && tokens[0] === 'the') tokens.shift();
+        return tokens;
+    }
+
+    // Trailing generic-venue word(s) dropped for matching, only when a
+    // non-empty remainder is left ("night club" is the one two-token form).
+    stripGenericVenueSuffix(tokens) {
+        if (tokens.length >= 3 && tokens[tokens.length - 2] === 'night' && tokens[tokens.length - 1] === 'club') {
+            return tokens.slice(0, -2);
+        }
+        if (tokens.length >= 2 && GEOCODE_GENERIC_VENUE_SUFFIXES.includes(tokens[tokens.length - 1])) {
+            return tokens.slice(0, -1);
+        }
+        return tokens;
+    }
+
+    // Full-name equality after normalization, with the generic venue suffix
+    // stripped symmetrically: "Massive" ↔ "Massive Nightclub" match because
+    // the stripped remainder equals the other side exactly; "Eagle" ↔ "Eagle
+    // Creek Cafe" never match (no substring/prefix matching).
+    poiNameMatchesBar(poiName, barName) {
+        const poiTokens = this.tokenizePoiBarName(poiName);
+        const barTokens = this.tokenizePoiBarName(barName);
+        if (poiTokens.length === 0 || barTokens.length === 0) return false;
+        const poiFull = poiTokens.join('');
+        const barFull = barTokens.join('');
+        if (poiFull === barFull) return true;
+        const poiStripped = this.stripGenericVenueSuffix(poiTokens).join('');
+        const barStripped = this.stripGenericVenueSuffix(barTokens).join('');
+        return poiStripped === barFull || poiFull === barStripped || poiStripped === barStripped;
+    }
+
+    // After a pin is accepted, map POI names vouch for the event's bar:
+    //   match → an unstamped or `uncorroborated` bar upgrades to
+    //           barSource 'geo-poi'; the equal-or-higher-trust stamps
+    //           (curated/venue-site/page-adjacent) are NEVER overwritten;
+    //   POI present but ≠ an `uncorroborated` bar → log-only mismatch flag
+    //           (flag-don't-drop);
+    //   no POI / no bar → nothing (fail open).
+    corroborateBarWithGeoPoi(event, poiNames) {
+        if (!event || typeof event !== 'object') return;
+        const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+        const names = [];
+        for (const name of Array.isArray(poiNames) ? poiNames : []) {
+            const cleanName = typeof name === 'string' ? name.trim() : '';
+            if (cleanName && !names.includes(cleanName)) names.push(cleanName);
+        }
+        if (!bar || names.length === 0) return;
+        const title = event.title || 'unknown';
+        const stamp = typeof event.barSource === 'string' ? event.barSource.trim() : '';
+        const matched = names.find(name => this.poiNameMatchesBar(name, bar));
+        if (matched) {
+            if (!stamp || stamp === 'uncorroborated') {
+                event.barSource = 'geo-poi';
+            }
+            console.log(`🗺️ GEOCODE VERIFY: "${title}" bar "${bar}" corroborated by map POI "${matched}"`);
+            return;
+        }
+        if (stamp === 'uncorroborated') {
+            console.warn(`🗺️ GEOCODE VERIFY: "${title}" address POI is "${names[0]}" but bar is "${bar}" — possible venue-name mismatch`);
+        }
+    }
+
     // Final acceptance for a grade-gate-passing candidate: reverse cross-check
     // against the input address (Apple placemark via the adapter, when that
     // capability exists) plus suspect flagging per verification mode. Returns
-    // { location, crossCheck } — the "lat, lon" string to write plus the
+    // { location, crossCheck, poiNames } — the "lat, lon" string to write, the
     // cross-check verdict ('pass' | 'fail' | 'skipped'; 'fail' only survives
-    // in report mode) — or, when enforce mode sends the ladder on to its next
-    // rung, { location: null, crossCheck } carrying the rejection breadcrumb
-    // ('fail' for a failed cross-check, 'skipped' for a vague input or an
-    // unavailable cross-check).
+    // in report mode), and any POI names harvested from the reverse placemark
+    // the cross-check already fetched (geo-POI bar corroboration; empty when
+    // no placemark or no name) — or, when enforce mode sends the ladder on to
+    // its next rung, { location: null, crossCheck } carrying the rejection
+    // breadcrumb ('fail' for a failed cross-check, 'skipped' for a vague
+    // input or an unavailable cross-check).
     async confirmGeocodeCandidate(candidate, context, httpAdapter) {
         const { title, address, inputHasHouseNumber, verifyMode, streetSpecific, flags, source, rung } = context;
         // Vague-input rule (enforce only): an address without street-level
@@ -1191,6 +1341,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             return { location: null, crossCheck: 'skipped' };
         }
         let crossCheck = 'skipped';
+        let poiNames = [];
         if (verifyMode !== 'off' && typeof httpAdapter.reverseGeocodePlacemark === 'function') {
             let placemark = null;
             try {
@@ -1199,6 +1350,9 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 placemark = null;
             }
             if (placemark) {
+                // Geo-POI harvest from the SAME placemark the cross-check
+                // fetched — no additional reverse-geocode call.
+                poiNames = this.extractPlacemarkPoiNames(placemark);
                 const comparison = this.comparePinToAddress(placemark, address);
                 if (comparison) {
                     crossCheck = comparison.matched ? 'pass' : 'fail';
@@ -1237,7 +1391,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         if (rung > 1 || crossCheck !== 'skipped') {
             console.log(`🗺️ GEOCODE VERIFY: "${title}" accepted ${candidate.grade} pin from ${source} (rung ${rung})`);
         }
-        return { location: `${candidate.lat}, ${candidate.lon}`, crossCheck };
+        return { location: `${candidate.lat}, ${candidate.lon}`, crossCheck, poiNames };
     }
 
     // Canonical addresses ("1192 Folsom St, San Francisco, CA 94103, USA") return
@@ -1409,6 +1563,9 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             // resolves at all". Coarse refusals never leave a breadcrumb.
             let resolvedVerdict = null;
             let rejectedVerdict = null;
+            // POI names harvested from the responses that produced/verified the
+            // accepted pin (geo-POI bar corroboration; empty when unpinned).
+            let resolvedPoiNames = [];
             for (let i = 0; i < queryVariants.length && !resolvedLocation; i++) {
                 const queryText = queryVariants[i];
                 const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(queryText)}&limit=${resultLimit}&addressdetails=1`;
@@ -1449,11 +1606,13 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                     }
                     if (graded.length > 0) {
                         let pickedCandidate = null;
+                        let pickedResult = null;
                         if (cityCenter) {
                             // Distance-ranked selection: nearest candidate within the radius wins
                             const picked = this.pickNearestGeocodeCandidate(graded.map(entry => entry.result), cityCenter, eventCity, queryText);
                             if (picked) {
                                 pickedCandidate = { lat: picked.lat, lon: picked.lon, grade: graded[picked.index].grade };
+                                pickedResult = graded[picked.index].result;
                             }
                         } else {
                             const firstResult = graded[0].result;
@@ -1462,6 +1621,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                                     console.warn(`🗺️ OpenStreetMapNormalizer: Geocode for "${queryText}" resolved outside event city "${eventCity}" ("${firstResult.display_name || 'no display name'}") — ignoring coordinates`);
                                 } else {
                                     pickedCandidate = { lat: firstResult.lat, lon: firstResult.lon, grade: graded[0].grade };
+                                    pickedResult = firstResult;
                                 }
                             }
                         }
@@ -1474,6 +1634,10 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                             if (confirmed.location) {
                                 resolvedLocation = confirmed.location;
                                 resolvedVerdict = { grade: pickedCandidate.grade, crossCheck: confirmed.crossCheck, source: 'nominatim', rung: i + 1 };
+                                resolvedPoiNames = this.collectAcceptedPoiNames(
+                                    pickedCandidate.grade === 'exact' ? this.extractNominatimPoiName(pickedResult) : '',
+                                    confirmed
+                                );
                             } else if (!rejectedVerdict) {
                                 // enforce-mode rejection: 'fail' for a failed
                                 // cross-check, 'skipped' for a vague input or
@@ -1528,6 +1692,9 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                             if (confirmed.location) {
                                 resolvedLocation = confirmed.location;
                                 resolvedVerdict = { grade: 'exact', crossCheck: confirmed.crossCheck, source: 'census', rung: attempts };
+                                // Census names no POIs (address interpolation
+                                // only) — harvest just the cross-check side.
+                                resolvedPoiNames = this.collectAcceptedPoiNames('', confirmed);
                             } else if (!rejectedVerdict) {
                                 rejectedVerdict = { grade: 'exact', crossCheck: confirmed.crossCheck, source: 'census', rung: attempts };
                             }
@@ -1582,6 +1749,10 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                             if (confirmed.location) {
                                 resolvedLocation = confirmed.location;
                                 resolvedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
+                                resolvedPoiNames = this.collectAcceptedPoiNames(
+                                    grade === 'exact' ? this.extractNominatimPoiName({ name: props.name }) : '',
+                                    confirmed
+                                );
                             } else if (!rejectedVerdict) {
                                 rejectedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
                             }
@@ -1615,6 +1786,9 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 event.pinSource = (resolvedVerdict && resolvedVerdict.grade === 'exact' && resolvedVerdict.crossCheck !== 'fail')
                     ? 'geocoded-exact'
                     : 'geocoded-approx';
+                // Geo-POI bar corroboration: the map names harvested from the
+                // accepted pin's own responses vouch for (or question) the bar.
+                this.corroborateBarWithGeoPoi(event, resolvedPoiNames);
             }
             if (!resolvedLocation) {
                 // Exact shape counted by run-log-summary's geocodeNoResults guard.

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -1525,3 +1525,265 @@ test('OpenStreetMapNormalizer reverse geocode of a pin without an address → ad
   assert.equal(event.address, '350 5th Ave, New York, NY 10118, USA');
   assert.equal(event.addressSource, 'inferred', 'reverse-geocoded address → addressSource inferred');
 });
+
+// ---------------------------------------------------------------------------
+// Geo-POI bar corroboration (bar corroboration phase 3): POI names harvested
+// from geocoder responses the pipeline ALREADY fetches (Nominatim forward
+// results, Apple reverse placemarks) vouch for the event's bar. Zero new
+// network calls — every test below asserts the request counts stay exactly
+// what the geocode ladder spent before this feature existed.
+// ---------------------------------------------------------------------------
+
+// Venue hit with the explicit name field (modern Nominatim json output).
+const MASSIVE_POI_RESULT = {
+  lat: '47.6152000',
+  lon: '-122.3204000',
+  class: 'amenity',
+  type: 'nightclub',
+  addresstype: 'amenity',
+  name: 'Massive',
+  display_name: 'Massive, 619, East Pine Street, Seattle, King County, Washington, 98122, United States',
+  address: { house_number: '619', road: 'East Pine Street', city: 'Seattle' }
+};
+
+// The same address as a bare-address hit: exact grade (house number) but the
+// leading display_name component is the house number — never a POI name.
+const PINE_STREET_ADDRESS_RESULT = {
+  lat: '47.6152000',
+  lon: '-122.3204000',
+  class: 'place',
+  type: 'house',
+  addresstype: 'place',
+  display_name: '619, East Pine Street, Seattle, King County, Washington, 98122, United States',
+  address: { house_number: '619', road: 'East Pine Street', city: 'Seattle' }
+};
+
+test('geo-POI harvest: extractNominatimPoiName prefers name, falls back to a non-numeric display_name lead', () => {
+  const normalizer = createOsmNormalizer();
+  // Explicit name field wins
+  assert.equal(normalizer.extractNominatimPoiName(MASSIVE_POI_RESULT), 'Massive');
+  // namedetails.name serves when the top-level name is absent
+  assert.equal(
+    normalizer.extractNominatimPoiName({ namedetails: { name: 'Massive' }, display_name: '619, East Pine Street' }),
+    'Massive'
+  );
+  // Venue-led display_name (no name field — cached/older responses)
+  assert.equal(normalizer.extractNominatimPoiName(POWERHOUSE_POI_RESULT), 'Powerhouse');
+  // Bare-address display_name: numeric first component is a house number, not a POI
+  assert.equal(normalizer.extractNominatimPoiName(PINE_STREET_ADDRESS_RESULT), '');
+  // Garbage shapes fail open
+  assert.equal(normalizer.extractNominatimPoiName(null), '');
+  assert.equal(normalizer.extractNominatimPoiName({}), '');
+});
+
+test('geo-POI harvest: extractPlacemarkPoiNames takes name + areasOfInterest, skips address-shaped names', () => {
+  const normalizer = createOsmNormalizer();
+  assert.deepEqual(
+    normalizer.extractPlacemarkPoiNames({ ...FOLSOM_PLACEMARK, name: 'Powerhouse', areasOfInterest: ['SoMa'] }),
+    ['Powerhouse', 'SoMa']
+  );
+  // Apple sets name to the address line when it knows no POI at the point
+  assert.deepEqual(
+    normalizer.extractPlacemarkPoiNames({ ...FOLSOM_PLACEMARK, name: '1192 Folsom St' }),
+    []
+  );
+  // …or to the bare street name for street-level hits
+  assert.deepEqual(
+    normalizer.extractPlacemarkPoiNames({ ...FOLSOM_PLACEMARK, name: 'Folsom Street' }),
+    []
+  );
+  // Cached placemarks from before harvesting simply lack the fields → fail open
+  assert.deepEqual(normalizer.extractPlacemarkPoiNames(FOLSOM_PLACEMARK), []);
+  assert.deepEqual(normalizer.extractPlacemarkPoiNames(null), []);
+});
+
+test('geo-POI matching: full-name equality with symmetric generic-suffix stripping, never substrings', () => {
+  const normalizer = createOsmNormalizer();
+  assert.equal(normalizer.poiNameMatchesBar('Massive', 'MASSIVE'), true, 'case-insensitive');
+  assert.equal(normalizer.poiNameMatchesBar('Massive Nightclub', 'Massive'), true, 'generic suffix strips');
+  assert.equal(normalizer.poiNameMatchesBar('Massive', 'Massive Nightclub'), true, 'suffix strips symmetrically');
+  assert.equal(normalizer.poiNameMatchesBar('Massive Night Club', 'Massive'), true, 'two-token "night club" form');
+  assert.equal(normalizer.poiNameMatchesBar('Heretic', 'The Heretic'), true, 'leading "the" drops on either side');
+  assert.equal(normalizer.poiNameMatchesBar('The Eagle', 'Eagle'), true);
+  assert.equal(normalizer.poiNameMatchesBar('Eagle Creek Cafe', 'Eagle'), false, 'no prefix/substring matching');
+  assert.equal(normalizer.poiNameMatchesBar('Massive Nightclub', 'Mass'), false, 'stripped remainder must match exactly');
+  assert.equal(normalizer.poiNameMatchesBar('Nightclub', 'Massive'), false, 'suffix never strips to empty');
+  assert.equal(normalizer.poiNameMatchesBar('', 'Massive'), false);
+  assert.equal(normalizer.poiNameMatchesBar('Massive', ''), false);
+});
+
+test('geo-POI corroboration: an uncorroborated bar upgrades to geo-poi with the corroboration log, one request only', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([['nominatim', [MASSIVE_POI_RESULT]]]);
+  const event = { title: 'BEARRACUDA', address: '619 E Pine St', bar: 'MASSIVE', barSource: 'uncorroborated' };
+
+  const lines = await withCapturedConsole(() => normalizer.normalizeAsync(event, httpAdapter));
+
+  assert.equal(event.location, '47.6152000, -122.3204000');
+  assert.equal(event.barSource, 'geo-poi', 'uncorroborated upgrades to geo-poi');
+  assert.ok(
+    lines.includes('🗺️ GEOCODE VERIFY: "BEARRACUDA" bar "MASSIVE" corroborated by map POI "Massive"'),
+    `the corroboration log must emit verbatim: ${lines.join(' | ')}`
+  );
+  assert.equal(httpAdapter.requests.length, 1, 'harvesting spends ZERO requests beyond the geocode itself');
+});
+
+test('geo-POI corroboration: an unstamped bar upgrades via the venue-led display_name (no name field)', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([['nominatim', [POWERHOUSE_POI_RESULT]]]);
+  const event = { title: 'CHUNK', address: '1192 Folsom St', bar: 'The Powerhouse' };
+
+  const lines = await withCapturedConsole(() => normalizer.normalizeAsync(event, httpAdapter));
+
+  assert.equal(event.barSource, 'geo-poi', 'unstamped bars are upgradeable too');
+  assert.ok(
+    lines.includes('🗺️ GEOCODE VERIFY: "CHUNK" bar "The Powerhouse" corroborated by map POI "Powerhouse"'),
+    `display_name-harvested POI corroborates: ${lines.join(' | ')}`
+  );
+  assert.equal(httpAdapter.requests.length, 1);
+});
+
+test('geo-POI corroboration: curated/venue-site/page-adjacent stamps are never overwritten', async () => {
+  for (const stamp of ['curated', 'venue-site', 'page-adjacent']) {
+    const normalizer = createOsmNormalizer();
+    normalizer.delayForRateLimit = async () => {};
+    const httpAdapter = createRoutedStubAdapter([['nominatim', [MASSIVE_POI_RESULT]]]);
+    const event = { title: 'BEARRACUDA', address: '619 E Pine St', bar: 'Massive', barSource: stamp };
+
+    const lines = await withCapturedConsole(() => normalizer.normalizeAsync(event, httpAdapter));
+
+    assert.equal(event.barSource, stamp, `${stamp} is equal-or-higher trust and must survive`);
+    assert.ok(
+      lines.some(l => l.includes('corroborated by map POI "Massive"')),
+      `the corroboration is still logged additively for ${stamp}: ${lines.join(' | ')}`
+    );
+  }
+});
+
+test('geo-POI corroboration: POI ≠ uncorroborated bar flags a possible venue-name mismatch, value untouched', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([['nominatim', [MASSIVE_POI_RESULT]]]);
+  const event = { title: 'BEARRACUDA', address: '619 E Pine St', bar: 'Neighbours', barSource: 'uncorroborated' };
+
+  const lines = await withCapturedConsole(() => normalizer.normalizeAsync(event, httpAdapter));
+
+  assert.equal(event.bar, 'Neighbours', 'flag-don\'t-drop: the value never changes');
+  assert.equal(event.barSource, 'uncorroborated', 'a mismatch never restamps');
+  assert.ok(
+    lines.includes('🗺️ GEOCODE VERIFY: "BEARRACUDA" address POI is "Massive" but bar is "Neighbours" — possible venue-name mismatch'),
+    `the mismatch flag must emit verbatim: ${lines.join(' | ')}`
+  );
+
+  // The same mismatch against a corroborated (or unstamped) bar stays silent
+  for (const stamp of ['page-adjacent', undefined]) {
+    const quietNormalizer = createOsmNormalizer();
+    quietNormalizer.delayForRateLimit = async () => {};
+    const quietAdapter = createRoutedStubAdapter([['nominatim', [MASSIVE_POI_RESULT]]]);
+    const quietEvent = { title: 'BEARRACUDA', address: '619 E Pine St', bar: 'Neighbours' };
+    if (stamp) quietEvent.barSource = stamp;
+    const quietLines = await withCapturedConsole(() => quietNormalizer.normalizeAsync(quietEvent, quietAdapter));
+    assert.ok(
+      !quietLines.some(l => l.includes('possible venue-name mismatch')),
+      `the flag fires ONLY for uncorroborated bars (stamp=${stamp}): ${quietLines.join(' | ')}`
+    );
+    assert.equal(quietEvent.barSource, stamp, 'no restamping either way');
+  }
+});
+
+test('geo-POI corroboration: bare-address hits and street-grade pins harvest nothing — fully inert', async () => {
+  // Exact-grade bare-address hit: house-number lead is never a POI name
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([['nominatim', [PINE_STREET_ADDRESS_RESULT]]]);
+  const event = { title: 'BEARRACUDA', address: '619 E Pine St', bar: 'Massive', barSource: 'uncorroborated' };
+  const lines = await withCapturedConsole(() => normalizer.normalizeAsync(event, httpAdapter));
+  assert.equal(event.location, '47.6152000, -122.3204000', 'the pin itself is unaffected');
+  assert.equal(event.barSource, 'uncorroborated', 'no POI → no upgrade (fail open)');
+  assert.ok(
+    !lines.some(l => l.includes('map POI') || l.includes('venue-name mismatch')),
+    `no corroboration lines without a POI: ${lines.join(' | ')}`
+  );
+
+  // Street-grade pin: the result's "name" is the street, never harvested
+  const streetNormalizer = createOsmNormalizer();
+  streetNormalizer.delayForRateLimit = async () => {};
+  const streetAdapter = createRoutedStubAdapter([['nominatim', [FOLSOM_STREET_ONLY_RESULT]]]);
+  const streetEvent = { title: 'CHUNK', address: 'Folsom St', bar: 'Folsom', barSource: 'uncorroborated' };
+  const streetLines = await withCapturedConsole(() => streetNormalizer.normalizeAsync(streetEvent, streetAdapter));
+  assert.equal(streetEvent.location, '37.7740000, -122.4120000');
+  assert.equal(streetEvent.barSource, 'uncorroborated', 'a street name must never corroborate a bar');
+  assert.ok(
+    !streetLines.some(l => l.includes('map POI') || l.includes('venue-name mismatch')),
+    `street-grade pins are inert: ${streetLines.join(' | ')}`
+  );
+
+  // No pin at all → nothing runs
+  const unpinnedNormalizer = createOsmNormalizer();
+  unpinnedNormalizer.delayForRateLimit = async () => {};
+  const unpinnedAdapter = createRoutedStubAdapter([['nominatim', []]]);
+  const unpinnedEvent = { title: 'CHUNK', address: '1192 Folsom St', bar: 'Powerhouse', barSource: 'uncorroborated' };
+  const unpinnedLines = await withCapturedConsole(() => unpinnedNormalizer.normalizeAsync(unpinnedEvent, unpinnedAdapter));
+  assert.equal(unpinnedEvent.location, undefined);
+  assert.equal(unpinnedEvent.barSource, 'uncorroborated');
+  assert.ok(!unpinnedLines.some(l => l.includes('map POI') || l.includes('venue-name mismatch')));
+});
+
+test('geo-POI corroboration: the Apple reverse placemark corroborates when the forward hit is address-only', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  let reverseCalls = 0;
+  // Bare-address forward hit (no POI) + the cross-check placemark Apple
+  // already returns naming the venue at the point.
+  const httpAdapter = createRoutedStubAdapter(
+    [['nominatim', [{
+      ...PINE_STREET_ADDRESS_RESULT,
+      lat: '37.7756941',
+      lon: '-122.4103049',
+      display_name: '1192, Folsom Street, San Francisco, California, 94103, United States',
+      address: { house_number: '1192', road: 'Folsom Street', city: 'San Francisco' }
+    }]]],
+    {
+      reverseGeocodePlacemark: async () => {
+        reverseCalls += 1;
+        return { ...FOLSOM_PLACEMARK, name: 'Powerhouse', areasOfInterest: ['SoMa'] };
+      }
+    }
+  );
+  const event = { title: 'CHUNK', address: '1192 Folsom St', bar: 'Powerhouse', barSource: 'uncorroborated' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+
+  assert.equal(event.location, '37.7756941, -122.4103049');
+  assert.equal(event.barSource, 'geo-poi', 'the placemark name corroborates the bar');
+  assert.ok(
+    lines.includes('🗺️ GEOCODE VERIFY: "CHUNK" bar "Powerhouse" corroborated by map POI "Powerhouse"'),
+    `Apple-harvested POI corroborates: ${lines.join(' | ')}`
+  );
+  assert.equal(httpAdapter.requests.length, 1, 'one forward geocode fetch, exactly as before');
+  assert.equal(reverseCalls, 1, 'the SAME single cross-check reverse call — harvesting adds none');
+
+  // A pre-harvest cached placemark (no name field) fails open: pin accepted,
+  // no corroboration, no mismatch flag.
+  const staleNormalizer = createOsmNormalizer();
+  staleNormalizer.delayForRateLimit = async () => {};
+  const staleAdapter = createRoutedStubAdapter(
+    [['nominatim', [POWERHOUSE_POI_RESULT]]],
+    { reverseGeocodePlacemark: async () => FOLSOM_PLACEMARK }
+  );
+  const staleEvent = { title: 'CHUNK', address: '1192 Folsom St', bar: 'Some Other Bar', barSource: 'uncorroborated' };
+  const staleLines = await withCapturedConsole(() =>
+    staleNormalizer.normalizeAsync(staleEvent, staleAdapter, { geocodeVerification: { mode: 'report' } })
+  );
+  assert.equal(staleEvent.location, '37.7756941, -122.4103049');
+  // POWERHOUSE_POI_RESULT still names the venue, so the mismatch flag comes
+  // from the forward harvest — but the nameless placemark contributed nothing.
+  assert.ok(
+    staleLines.includes('🗺️ GEOCODE VERIFY: "CHUNK" address POI is "Powerhouse" but bar is "Some Other Bar" — possible venue-name mismatch'),
+    `forward POI still flags; the stale placemark stays silent: ${staleLines.join(' | ')}`
+  );
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -420,8 +420,9 @@ class SharedCore {
         // the finalized image deterministically (setProvenanceSource), never
         // be arbitrated as content.
         // barSource is bar provenance (page-adjacent/venue-site/curated/
-        // uncorroborated — whether the extracted venue was corroborated by the
-        // source page); like imageSource it must FOLLOW the finalized bar
+        // geo-poi/uncorroborated — whether the extracted venue was
+        // corroborated by the source page or a map POI); like imageSource it
+        // must FOLLOW the finalized bar
         // deterministically (setProvenanceSource), never be arbitrated as
         // content.
         return name !== 'key' && name !== 'notes' && name !== 'source'
@@ -1241,8 +1242,10 @@ class SharedCore {
             // Corroboration demotion rung: barSource provenance stamped at
             // extraction (page-adjacent = bar found next to the address in the
             // source; venue-site = the venue's own site; curated = curated
-            // bars data; uncorroborated = the address was in the source but
-            // the bar was NOT near it — the flyer-subtitle failure shape).
+            // bars data; geo-poi = a reverse/forward-geocode POI name matched
+            // the bar (OpenStreetMapNormalizer, phase 3); uncorroborated =
+            // the address was in the source but the bar was NOT near it — the
+            // flyer-subtitle failure shape).
             // Exactly one candidate stamped uncorroborated while the other is
             // corroborated → the corroborated one wins without AI. Attribution
             // is strict like the image provenance rung: a record's barSource
@@ -1260,7 +1263,8 @@ class SharedCore {
                     return typeof record.barSource === 'string' ? record.barSource.trim() : '';
                 };
                 const isCorroboratedStamp = stamp =>
-                    stamp === 'page-adjacent' || stamp === 'venue-site' || stamp === 'curated';
+                    stamp === 'page-adjacent' || stamp === 'venue-site' || stamp === 'curated'
+                    || stamp === 'geo-poi';
                 const matchesCuratedBar = value =>
                     Boolean(cityBars && this.findCuratedBarByName(cityBars, value));
                 const provenanceA = getBarProvenance(barContextRecords.a, valueA);

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -6464,3 +6464,85 @@ test('incident phase 2 (calendar flow): uncorroborated scraped bar never clobber
   assert.equal(adapterD.calls.length, 1, 'both-uncorroborated still reaches the AI');
   assert.equal(finalD.bar, 'MASSIVE');
 });
+
+// ---------------------------------------------------------------------------
+// Bar corroboration phase 3: `geo-poi` (a reverse/forward-geocode POI name
+// matched the bar) counts as corroborated in the demotion rung — same tier
+// as page-adjacent/venue-site/curated, both merge flows, zero AI calls.
+// ---------------------------------------------------------------------------
+
+test('phase 3: geo-poi counts as corroborated in the demotion rung', () => {
+  const core = createCore();
+  const context = (recordA, recordB, sideLabels = { a: 'existing', b: 'incoming' }) => ({
+    sideLabels,
+    records: { a: recordA, b: recordB }
+  });
+
+  // geo-poi beats uncorroborated in both directions
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'MASSIVE', barSource: 'geo-poi' }, { bar: 'Shore Thing', barSource: 'uncorroborated' })),
+    { winner: 'a', reason: 'corroborated bar beats uncorroborated' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'Shore Thing', 'MASSIVE',
+      context({ bar: 'Shore Thing', barSource: 'uncorroborated' }, { bar: 'MASSIVE', barSource: 'geo-poi' })),
+    { winner: 'b', reason: 'corroborated bar beats uncorroborated' });
+
+  // geo-poi vs a corroborated stamp is NOT a demotion case — falls through
+  assert.equal(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'MASSIVE', barSource: 'geo-poi' }, { bar: 'Shore Thing', barSource: 'page-adjacent' })),
+    null, 'two corroborated bars stay a genuine question');
+});
+
+test('phase 3 (enrich flow): a geo-poi bar beats an uncorroborated bar with zero AI calls; stamp follows the winner', async () => {
+  const core = createCore();
+  const priorities = { bar: { priority: ['ai-web'], merge: 'ai' } };
+  const aiParserConfig = { ai: { provider: 'ollama', endpoint: 'http://ai.example', model: 'm' } };
+  const base = { title: 'BEARRACUDA SEATTLE', city: 'seattle', source: 'ai-web', _fieldPriorities: priorities };
+
+  const adapter = buildArbitrationAdapter({});
+  const merged = await core.mergeParsedEvents(
+    { ...base, bar: 'MASSIVE', barSource: 'geo-poi' },
+    { ...base, bar: 'Shore Thing', barSource: 'uncorroborated', _parserConfig: aiParserConfig },
+    { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 0, 'geo-poi corroboration settles the bar without AI (zero postJson)');
+  assert.equal(merged.bar, 'MASSIVE');
+  assert.equal(merged.barSource, 'geo-poi', 'the geo-poi stamp follows the winning bar');
+
+  const adapterReversed = buildArbitrationAdapter({});
+  const mergedReversed = await core.mergeParsedEvents(
+    { ...base, bar: 'Shore Thing', barSource: 'uncorroborated' },
+    { ...base, bar: 'MASSIVE', barSource: 'geo-poi', _parserConfig: aiParserConfig },
+    { httpAdapter: adapterReversed });
+  assert.equal(adapterReversed.calls.length, 0);
+  assert.equal(mergedReversed.bar, 'MASSIVE');
+  assert.equal(mergedReversed.barSource, 'geo-poi');
+});
+
+test('phase 3 (calendar flow): a geo-poi scraped bar beats an uncorroborated calendar bar with zero AI calls', async () => {
+  const core = createCore();
+  const pair = buildAlignedArbitrationPair();
+  pair.scraped.bar = 'MASSIVE';
+  pair.scraped.barSource = 'geo-poi';
+  pair.existing.notes = pair.existing.notes.replace('bar: S4', 'bar: Shore Thing\nbarSource: uncorroborated');
+  const adapter = buildArbitrationAdapter({});
+  const final = await core.createFinalEventObject(pair.existing, pair.scraped, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 0, 'zero postJson');
+  assert.equal(final.bar, 'MASSIVE', 'the map-corroborated scraped bar wins');
+  assert.equal(final.barSource, 'geo-poi');
+  assert.deepEqual(final._original.aiArbitration.deterministic, ['bar']);
+  const parsedNotes = core.parseNotesIntoFields(final.notes);
+  assert.equal(parsedNotes.barSource, 'geo-poi', 'the stamp persists to notes for the next run');
+
+  // And an uncorroborated scraped bar still loses to a geo-poi calendar bar
+  const reversed = buildAlignedArbitrationPair();
+  reversed.scraped.bar = 'Shore Thing';
+  reversed.scraped.barSource = 'uncorroborated';
+  reversed.existing.notes = reversed.existing.notes.replace('bar: S4', 'bar: MASSIVE\nbarSource: geo-poi');
+  const adapterB = buildArbitrationAdapter({});
+  const finalB = await core.createFinalEventObject(reversed.existing, reversed.scraped, { httpAdapter: adapterB });
+  assert.equal(adapterB.calls.length, 0);
+  assert.equal(finalB.bar, 'MASSIVE');
+  assert.equal(finalB.barSource, 'geo-poi', 'the notes-parsed geo-poi stamp participates and survives');
+});


### PR DESCRIPTION
Phase 3 of the bar-corroboration roadmap: the map itself becomes a corroboration signal, harvested entirely from responses the pipeline already fetches — **request counts are test-asserted unchanged**.

## Harvest points (no new calls anywhere)
- **Nominatim forward**: `result.name` → `namedetails.name` → leading `display_name` component (leading-digit candidates rejected — a bare house number is not a POI). Harvested only for **exact-grade** hits, so a street-grade result's name (which is the street) can never corroborate or false-flag. `namedetails=1` deliberately NOT added to the request URL — it would have invalidated every cached geocode entry (cache keys are the URL).
- **Photon rescue rung**: `properties.name` from the same already-fetched response, same guards — corroboration exactly where it's scarcest.
- **Apple reverse cross-check**: the placemark the cross-check already fetches carries `name`/`areasOfInterest`; names equal to the thoroughfare are skipped (Apple sets name to the address line when it knows no POI). Web adapter has no Apple geocoding — documented skip.
- **Reverse cache**: persists raw placemarks, so new entries carry names automatically; old nameless entries fail open, never invalidated.

## Corroboration + merge
After a pin is accepted: POI ≈ bar (token equality with leading-"the" and symmetric generic-venue-suffix stripping — "Massive"↔"Massive Nightclub" ✓, "Eagle"↔"Eagle Creek Cafe" ✗) upgrades unstamped/`uncorroborated` → `barSource: geo-poi` with `🗺️ GEOCODE VERIFY: … corroborated by map POI`; higher-trust stamps (curated/venue-site/page-adjacent) are never overwritten. POI ≠ an uncorroborated bar → `possible venue-name mismatch` flag, log-only. `geo-poi` joins the corroborated tier in the merge demotion rung (one-line change).

+13 tests. Suite: **579 pass / 0 fail**.

📲 After merge, download to phone: `scripts/normalizers.js`, `scripts/shared-core.js`, `scripts/adapters/scriptable-adapter.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP