### PR TITLE
fix(scraper): provenance-aware merge verification — upgrades are good news, only downgrades warn

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -8817,9 +8817,36 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
               '<span style="color: #007aff;">PRESERVED UNDEFINED (ignored scraped)</span>';
           }
         } else {
-          // Preserve didn't work as expected - should always keep existing
-          flowIcon = "⚠️";
-          resultText = `<span style="color: #ff3b30;">PRESERVE FAILED (expected: ${existingValue === undefined ? "undefined" : existingValue}, got: ${finalValue === undefined ? "undefined" : finalValue})</span>`;
+          // Provenance companion fields (pinSource/addressSource/imageSource/
+          // barSource/bearSource) legitimately CHANGE under preserve: the
+          // stamp follows the finalized value (setProvenanceSource), so when a
+          // higher authority vouches for the SAME kept value the attribution
+          // upgrades (e.g. pinSource geocoded-exact → curated once the bar
+          // joins the curated data). Equal-or-higher tier → informational;
+          // lower tier → a genuine downgrade warning. Unknown values (null
+          // tier) fail open to the PRESERVE FAILED line, byte-identical to
+          // before — as do all non-provenance fields.
+          const existingTier = SharedCore.isProvenanceCompanionField(field)
+            ? SharedCore.getProvenanceTrustTier(field, existingValue)
+            : null;
+          const finalTier = SharedCore.isProvenanceCompanionField(field)
+            ? SharedCore.getProvenanceTrustTier(field, finalValue)
+            : null;
+          const describeStamp = (val) =>
+            val === undefined || val === null || String(val).trim() === ""
+              ? "unstamped"
+              : this.escapeHtml(String(val));
+          if (existingTier !== null && finalTier !== null && finalTier >= existingTier) {
+            flowIcon = "→";
+            resultText = `<span style="color: #34c759;">PROVENANCE UPGRADED (${describeStamp(existingValue)} → ${describeStamp(finalValue)})</span>`;
+          } else if (existingTier !== null && finalTier !== null) {
+            flowIcon = "⚠️";
+            resultText = `<span style="color: #ff3b30;">PROVENANCE DOWNGRADED (${describeStamp(existingValue)} → ${describeStamp(finalValue)})</span>`;
+          } else {
+            // Preserve didn't work as expected - should always keep existing
+            flowIcon = "⚠️";
+            resultText = `<span style="color: #ff3b30;">PRESERVE FAILED (expected: ${existingValue === undefined ? "undefined" : existingValue}, got: ${finalValue === undefined ? "undefined" : finalValue})</span>`;
+          }
         }
       } else if (wasUsed === "existing") {
         // Merge strategy explicitly chose existing value

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1640,3 +1640,81 @@ test('reverse-geocode cache carries POI fields forward on new entries; old namel
     delete global.Location;
   }
 });
+
+// ---------------------------------------------------------------------------
+// Provenance-aware preserve verification in the merge-detail comparison rows:
+// companion stamps legitimately CHANGE under preserve when a higher authority
+// vouches for the kept value — upgrades are good news, only downgrades warn.
+// ---------------------------------------------------------------------------
+
+function buildPreserveComparisonEvent(field, { existing, scraped, final: finalValue }) {
+  // title/startDate agree on every side so their rows render as SAME VALUE —
+  // the row under test is the only one that can warn.
+  return {
+    title: 'MEGAWOOF: MASSIVE',
+    startDate: '2026-08-01T02:00:00.000Z',
+    _action: 'merge',
+    [field]: finalValue,
+    _fieldPriorities: { [field]: { merge: 'preserve' } },
+    _original: {
+      scraper: { title: 'MEGAWOOF: MASSIVE', startDate: '2026-08-01T02:00:00.000Z', [field]: scraped },
+      calendar: { title: 'MEGAWOOF: MASSIVE', startDate: '2026-08-01T02:00:00.000Z', [field]: existing },
+      merged: {}
+    }
+  };
+}
+
+test('run 20260722-150336 case: pinSource preserve geocoded-exact → curated renders PROVENANCE UPGRADED, not a failure', () => {
+  const adapter = buildAdapter();
+  const rows = adapter.generateComparisonRows(buildPreserveComparisonEvent('pinSource', {
+    existing: 'geocoded-exact', scraped: 'curated', final: 'curated'
+  }));
+
+  assert.ok(rows.includes('PROVENANCE UPGRADED (geocoded-exact → curated)'), rows);
+  assert.ok(rows.includes('#34c759'), 'renders in the informational green style');
+  assert.ok(!rows.includes('PRESERVE FAILED'), 'must NOT be reported as a failure');
+  assert.ok(!rows.includes('⚠️'), 'no warning icon for an upgrade');
+});
+
+test('a provenance downgrade (curated → geocoded-approx) keeps the red warning, reworded as PROVENANCE DOWNGRADED', () => {
+  const adapter = buildAdapter();
+  const rows = adapter.generateComparisonRows(buildPreserveComparisonEvent('pinSource', {
+    existing: 'curated', scraped: 'geocoded-approx', final: 'geocoded-approx'
+  }));
+
+  assert.ok(rows.includes('PROVENANCE DOWNGRADED (curated → geocoded-approx)'), rows);
+  assert.ok(rows.includes('<span style="color: #ff3b30;">PROVENANCE DOWNGRADED'), 'existing red style');
+  assert.ok(rows.includes('⚠️'), 'downgrades keep the warning icon');
+  assert.ok(!rows.includes('PRESERVE FAILED'));
+});
+
+test('non-provenance preserve mismatch still renders PRESERVE FAILED byte-identically', () => {
+  const adapter = buildAdapter();
+  const rows = adapter.generateComparisonRows(buildPreserveComparisonEvent('shortName', {
+    existing: 'FURBALL', scraped: 'MEGAWOOF', final: 'MEGAWOOF'
+  }));
+
+  assert.ok(rows.includes('<span style="color: #ff3b30;">PRESERVE FAILED (expected: FURBALL, got: MEGAWOOF)</span>'), rows);
+  assert.ok(!rows.includes('PROVENANCE'));
+});
+
+test('an unknown provenance value fails open to the existing PRESERVE FAILED behavior', () => {
+  const adapter = buildAdapter();
+  const rows = adapter.generateComparisonRows(buildPreserveComparisonEvent('pinSource', {
+    existing: 'weird-stamp', scraped: 'curated', final: 'curated'
+  }));
+
+  assert.ok(rows.includes('<span style="color: #ff3b30;">PRESERVE FAILED (expected: weird-stamp, got: curated)</span>'), rows);
+  assert.ok(!rows.includes('PROVENANCE'));
+});
+
+test('an equal-tier provenance change (venue-site → geo-poi, same corroborated class) is informational, not a warning', () => {
+  const adapter = buildAdapter();
+  const rows = adapter.generateComparisonRows(buildPreserveComparisonEvent('barSource', {
+    existing: 'venue-site', scraped: 'geo-poi', final: 'geo-poi'
+  }));
+
+  assert.ok(rows.includes('PROVENANCE UPGRADED (venue-site → geo-poi)'), rows);
+  assert.ok(!rows.includes('PRESERVE FAILED'));
+  assert.ok(!rows.includes('⚠️'));
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -425,11 +425,48 @@ class SharedCore {
         // must FOLLOW the finalized bar
         // deterministically (setProvenanceSource), never be arbitrated as
         // content.
+        if (SharedCore.isProvenanceCompanionField(name)) return false;
         return name !== 'key' && name !== 'notes' && name !== 'source'
-            && name !== 'location' && name !== 'gmaps'
-            && name !== 'pinSource' && name !== 'addressSource'
-            && name !== 'bearSource' && name !== 'imageSource'
-            && name !== 'barSource';
+            && name !== 'location' && name !== 'gmaps';
+    }
+
+    // True for the provenance companion fields (the canonical list lives on
+    // SharedCore.PROVENANCE_COMPANION_FIELDS) — metadata that FOLLOWS its value
+    // field deterministically (setProvenanceSource / the bearSource merge rule)
+    // and is never arbitrated as content.
+    static isProvenanceCompanionField(fieldName) {
+        return SharedCore.PROVENANCE_COMPANION_FIELDS.indexOf(String(fieldName || '')) !== -1;
+    }
+
+    // Trust tier for a provenance companion field's value — higher number =
+    // higher authority (per-family vocabularies live on
+    // SharedCore.PROVENANCE_TRUST_TIERS). Used by merge verification to tell a
+    // legitimate provenance UPGRADE (a higher authority now vouches for the
+    // same value, e.g. pinSource geocoded-exact → curated once the bar joins
+    // the curated data) apart from a genuine DOWNGRADE.
+    //   - unstamped (null/undefined/blank) → 0, the floor of every family
+    //     (a fresh stamp where the calendar had none is an upgrade)
+    //   - recorded suffixes rank by their prefix at a word boundary, so
+    //     `manual-bear (overrode ai: ...)` ranks as `manual-bear`
+    //   - unknown/unparseable values (and unknown field names) → null, so
+    //     callers FAIL OPEN to today's behavior
+    static getProvenanceTrustTier(fieldName, value) {
+        const tiers = SharedCore.PROVENANCE_TRUST_TIERS[String(fieldName || '')];
+        if (!tiers) return null;
+        const normalized = (value === null || value === undefined) ? '' : String(value).trim().toLowerCase();
+        if (!normalized) return 0;
+        if (Object.prototype.hasOwnProperty.call(tiers, normalized)) return tiers[normalized];
+        // Longest prefix wins so 'manual-not-bear ...' can never rank as
+        // 'manual-bear'; the prefix must end at a word boundary (space or an
+        // opening paren, the shapes buildManualBearSource records).
+        const keys = Object.keys(tiers).sort((a, b) => b.length - a.length);
+        for (const key of keys) {
+            if (normalized.length > key.length && normalized.startsWith(key)) {
+                const boundary = normalized.charAt(key.length);
+                if (boundary === ' ' || boundary === '(' || boundary === '\t') return tiers[key];
+            }
+        }
+        return null;
     }
 
     // True when a bearSource value records the calendar owner's manual verdict
@@ -7666,9 +7703,47 @@ class SharedCore {
 
 }
 
+// Canonical list of provenance companion fields — metadata stamps that record
+// WHERE a value field's content came from (pinSource↔location,
+// addressSource↔address, imageSource↔image, barSource↔bar,
+// bearSource↔bear verdict). They follow their value field deterministically
+// (setProvenanceSource / the bearSource merge rule), are excluded from AI
+// arbitration (isArbitrationEligibleField), and legitimately CHANGE under a
+// preserve merge when a higher authority vouches for the kept value. This is
+// the ONE list — do not scatter per-file copies.
+SharedCore.PROVENANCE_COMPANION_FIELDS = Object.freeze([
+    'pinSource', 'addressSource', 'imageSource', 'barSource', 'bearSource'
+]);
+
+// Trust tiers per provenance family (higher = more authoritative). Values are
+// the REAL vocabularies stamped by the pipeline:
+//   - pinSource:     normalizers.js (page/geocoded-exact/geocoded-approx,
+//                    curated via bar-data), scriptable-adapter review-apply
+//   - addressSource: normalizers.js (page/curated/inferred),
+//                    scriptable-adapter review-apply (curated/inferred)
+//   - barSource:     ai-web-parser.js (curated/venue-site/page-adjacent/
+//                    uncorroborated), normalizers.js (geo-poi); the three
+//                    corroborated stamps share a tier, matching
+//                    isCorroboratedStamp's one-class treatment in the bar
+//                    demotion rung
+//   - imageSource:   ai-web-parser.js (og-image/jsonld/page); og-image and
+//                    jsonld share a tier, matching the meta-artwork class in
+//                    the image provenance rung
+//   - bearSource:    shared-core bear cascade (keyword/ai/config) and the
+//                    results-UI manual override (manual-bear/manual-not-bear
+//                    — manual always outranks automatic)
+// Values absent from a family rank null (fail open); blank ranks 0 (unstamped).
+SharedCore.PROVENANCE_TRUST_TIERS = Object.freeze({
+    pinSource: Object.freeze({ 'curated': 4, 'geocoded-exact': 3, 'geocoded-approx': 2, 'page': 1 }),
+    addressSource: Object.freeze({ 'curated': 3, 'page': 2, 'inferred': 1 }),
+    barSource: Object.freeze({ 'curated': 3, 'venue-site': 2, 'page-adjacent': 2, 'geo-poi': 2, 'uncorroborated': 1 }),
+    imageSource: Object.freeze({ 'og-image': 2, 'jsonld': 2, 'page': 1 }),
+    bearSource: Object.freeze({ 'manual-bear': 2, 'manual-not-bear': 2, 'keyword': 1, 'ai': 1, 'config': 1 })
+});
+
 // Export for both environments
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { SharedCore };
+    module.exports = { SharedCore, PROVENANCE_COMPANION_FIELDS: SharedCore.PROVENANCE_COMPANION_FIELDS };
 } else if (typeof window !== 'undefined') {
     window.SharedCore = SharedCore;
 } else {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -6546,3 +6546,104 @@ test('phase 3 (calendar flow): a geo-poi scraped bar beats an uncorroborated cal
   assert.equal(finalB.bar, 'MASSIVE');
   assert.equal(finalB.barSource, 'geo-poi', 'the notes-parsed geo-poi stamp participates and survives');
 });
+
+// ---------------------------------------------------------------------------
+// Provenance companion fields: canonical list + trust-tier ranking
+// (provenance-aware merge verification — upgrades are good news)
+// ---------------------------------------------------------------------------
+
+test('PROVENANCE_COMPANION_FIELDS is exported and matches the arbitration-exclusion set', () => {
+  const { PROVENANCE_COMPANION_FIELDS } = require('./shared-core');
+  assert.deepEqual(
+    [...PROVENANCE_COMPANION_FIELDS].sort(),
+    ['addressSource', 'barSource', 'bearSource', 'imageSource', 'pinSource']
+  );
+  assert.equal(PROVENANCE_COMPANION_FIELDS, SharedCore.PROVENANCE_COMPANION_FIELDS,
+    'named export and the SharedCore static are the SAME canonical list');
+  assert.ok(Object.isFrozen(PROVENANCE_COMPANION_FIELDS));
+
+  const core = createCore();
+  for (const field of PROVENANCE_COMPANION_FIELDS) {
+    assert.equal(SharedCore.isProvenanceCompanionField(field), true);
+    assert.equal(core.isArbitrationEligibleField(field), false,
+      `${field} must stay excluded from AI arbitration`);
+  }
+  // The list is exactly the companion stamps — value fields and the other
+  // non-arbitrable fields are NOT provenance companions.
+  for (const field of ['location', 'image', 'bar', 'address', 'key', 'notes', 'source', 'gmaps']) {
+    assert.equal(SharedCore.isProvenanceCompanionField(field), false);
+  }
+  // The rewrite kept the non-provenance exclusions byte-for-byte.
+  for (const field of ['key', 'notes', 'source', 'location', 'gmaps']) {
+    assert.equal(core.isArbitrationEligibleField(field), false);
+  }
+  assert.equal(core.isArbitrationEligibleField('bar'), true);
+});
+
+test('pinSource trust tiers: curated > geocoded-exact > geocoded-approx > page > unstamped', () => {
+  const tier = (value) => SharedCore.getProvenanceTrustTier('pinSource', value);
+  assert.ok(tier('curated') > tier('geocoded-exact'));
+  assert.ok(tier('geocoded-exact') > tier('geocoded-approx'));
+  assert.ok(tier('geocoded-approx') > tier('page'));
+  assert.ok(tier('page') > tier(undefined), 'unstamped is the floor');
+  assert.equal(tier(''), 0);
+  assert.equal(tier(null), 0);
+});
+
+test('addressSource trust tiers: curated > page > inferred', () => {
+  const tier = (value) => SharedCore.getProvenanceTrustTier('addressSource', value);
+  assert.ok(tier('curated') > tier('page'));
+  assert.ok(tier('page') > tier('inferred'));
+  assert.ok(tier('inferred') > tier(undefined));
+});
+
+test('barSource trust tiers: curated > corroborated class (venue-site/page-adjacent/geo-poi) > uncorroborated > unstamped', () => {
+  const tier = (value) => SharedCore.getProvenanceTrustTier('barSource', value);
+  assert.ok(tier('curated') > tier('venue-site'));
+  // The three corroborated stamps share a tier, matching isCorroboratedStamp's
+  // one-class treatment — moves among them are never downgrades.
+  assert.equal(tier('venue-site'), tier('page-adjacent'));
+  assert.equal(tier('page-adjacent'), tier('geo-poi'));
+  assert.ok(tier('geo-poi') > tier('uncorroborated'));
+  assert.ok(tier('uncorroborated') > tier(undefined));
+});
+
+test('imageSource trust tiers: og-image and jsonld share the meta-artwork tier above page', () => {
+  const tier = (value) => SharedCore.getProvenanceTrustTier('imageSource', value);
+  assert.equal(tier('og-image'), tier('jsonld'));
+  assert.ok(tier('og-image') > tier('page'));
+  assert.ok(tier('page') > tier(undefined));
+});
+
+test('bearSource trust tiers: manual-* always outranks automatic (keyword/ai/config)', () => {
+  const tier = (value) => SharedCore.getProvenanceTrustTier('bearSource', value);
+  for (const automatic of ['keyword', 'ai', 'config']) {
+    assert.ok(tier('manual-bear') > tier(automatic), `manual-bear > ${automatic}`);
+    assert.ok(tier('manual-not-bear') > tier(automatic), `manual-not-bear > ${automatic}`);
+  }
+  assert.equal(tier('keyword'), tier('ai'));
+  assert.equal(tier('ai'), tier('config'));
+});
+
+test('suffixed provenance values rank by their prefix at a word boundary', () => {
+  const tier = (value) => SharedCore.getProvenanceTrustTier('bearSource', value);
+  // The exact shape buildManualBearSource records.
+  assert.equal(tier('manual-bear (overrode ai: drag show)'), tier('manual-bear'));
+  assert.ok(tier('manual-bear (overrode ai: drag show)') > tier('ai'));
+  // Longest prefix wins — a manual-not-bear record never ranks as manual-bear.
+  assert.equal(tier('manual-not-bear (overrode ai: club night)'), tier('manual-not-bear'));
+  // Case/whitespace-insensitive like the rest of the stamp handling.
+  assert.equal(tier('  Manual-Bear (overrode ai: x)  '), tier('manual-bear'));
+  // A prefix WITHOUT a word boundary is not a match — fail open.
+  assert.equal(tier('aime'), null);
+  assert.equal(SharedCore.getProvenanceTrustTier('pinSource', 'curatedish'), null);
+});
+
+test('unknown provenance values and unknown fields rank null so callers fail open', () => {
+  assert.equal(SharedCore.getProvenanceTrustTier('pinSource', 'weird-stamp'), null);
+  assert.equal(SharedCore.getProvenanceTrustTier('bearSource', 'manual'), null,
+    'bare manual- prefix without a known verdict is unknown');
+  assert.equal(SharedCore.getProvenanceTrustTier('title', 'curated'), null,
+    'non-provenance fields have no tiers');
+  assert.equal(SharedCore.getProvenanceTrustTier('', 'curated'), null);
+});


### PR DESCRIPTION
## Bug (observed in the results UI, run 20260722-150336)

`pinSource | preserve | geocoded-exact | ⚠️ curated | PRESERVE FAILED` — a false alarm. With Massive now in curated bars data (#1512), the pin's attribution legitimately upgraded from `geocoded-exact` to `curated` (identical coordinates, higher authority). Provenance companion fields are DESIGNED to follow their value; 'preserve' was never the right expectation for them, but the verifier treated them like ordinary fields.

## Fix
- `SharedCore.PROVENANCE_COMPANION_FIELDS` — one canonical frozen list (pinSource/addressSource/imageSource/barSource/bearSource) that now also backs the arbitration-exclusion check (behavior identical, single source of truth).
- `getProvenanceTrustTier(field, value)` — platform-pure ranking using the REAL value vocabularies found at every stamp site (e.g. pinSource: curated > geocoded-exact > geocoded-approx > page; bearSource: manual-* > keyword/ai/config with word-boundary prefix matching so `manual-not-bear (…)` never ranks as `manual-bear`; corroborated barSource stamps share one tier, matching the merge rung's one-class treatment). Unknown values → null → fail open.
- The preserve-mismatch renderer (the single call site): equal-or-higher tier → green `PROVENANCE UPGRADED (geocoded-exact → curated)`; lower tier → red `PROVENANCE DOWNGRADED (…)` — which makes this check genuinely protective (a future bug replacing a curated pin with a derived one now screams). Unknown/non-provenance → byte-identical `PRESERVE FAILED`. A dropped stamp renders as `curated → unstamped` DOWNGRADED instead of `got: undefined`.
- Write plan/merge executor untouched — the merge was always correct; the display layer was the bug. New strings HTML-escape values from calendar notes.

+13 tests incl. the exact observed row rendering as UPGRADED, downgrade/unknown/non-provenance paths byte-identical, and tier-table coverage per field family. Suite: **592 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/adapters/scriptable-adapter.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP