### PR TITLE
feat(scraper): venue discovery queue — gather confirmed new venues as evidence, promote out-of-band

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1097,6 +1097,146 @@ class ScriptableAdapter {
     }
   }
 
+  // ---------------------------------------------------------------------
+  // Venue discovery queue persistence: bar-additions.json alongside the
+  // other scraper storage, mirroring the dead-end store I/O (adapter owns
+  // the file; corrupt/missing file → start fresh, never throw).
+  //
+  // GATHERING-ONLY BY DESIGN: this queue is written by results-UI taps and
+  // read back ONLY to render the "Queued ✓" badge in the results UI.
+  // NOTHING in the scraping pipeline reads it — no bars-data merging, no
+  // provisional-curated entries, zero effect on any run behavior.
+  // Promotion to data/bars/<city>.json happens out-of-band after
+  // verification against independent references; this queue is
+  // evidence-gathering only.
+  //
+  // Shape: { "<cityKey>|<normalized name>": { name, city, address,
+  //   coordinates, signals: [...], website?, instagram?, sourceEvents: [...],
+  //   firstSeen, lastSeen, timesSeen, runIds: [...] } }
+  // ---------------------------------------------------------------------
+  getBarAdditionsFilePath() {
+    return this.fm.joinPath(this.baseDir, "bar-additions.json");
+  }
+
+  async loadBarAdditions() {
+    const path = this.getBarAdditionsFilePath();
+    try {
+      if (!this.fm.fileExists(path)) {
+        return {};
+      }
+      try {
+        await this.fm.downloadFileFromiCloud(path);
+      } catch (_) {}
+      const parsed = JSON.parse(this.fm.readString(path));
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        console.log(
+          "📱 Scriptable: Venue queue has unexpected shape — starting with empty queue",
+        );
+        return {};
+      }
+      return parsed;
+    } catch (error) {
+      // Corrupt or unreadable file must never break the UI — the queue is
+      // pure evidence and rebuilds itself over subsequent runs/taps.
+      console.log(
+        `📱 Scriptable: Venue queue read failed (${error.message}) — starting with empty queue`,
+      );
+      return {};
+    }
+  }
+
+  async saveBarAdditions(queue) {
+    if (!queue || typeof queue !== "object" || Array.isArray(queue)) {
+      return;
+    }
+    const path = this.getBarAdditionsFilePath();
+    try {
+      this.ensureDirectoryExists(this.baseDir);
+      this.fm.writeString(path, JSON.stringify(queue, null, 2));
+      console.log(
+        `📱 Scriptable: ✓ Saved venue queue (${Object.keys(queue).length} entries) to ${path}`,
+      );
+    } catch (error) {
+      console.log(`📱 Scriptable: Venue queue write failed: ${error.message}`);
+    }
+  }
+
+  // Fold one tapped candidate into the queue object (caller persists).
+  // Existing key → merge: bump lastSeen/timesSeen, union signals/runIds/
+  // sourceEvents (runIds keep the 10 most recent, sourceEvents cap at 5),
+  // keep the most complete address, fill website/instagram blanks only.
+  // Returns the entry, or null when the candidate has no key.
+  mergeBarAdditionEntry(queue, candidate, runId, nowIso) {
+    const key =
+      candidate && typeof candidate.key === "string" ? candidate.key : "";
+    if (!key || !queue || typeof queue !== "object") return null;
+    const signals = Array.isArray(candidate.signals) ? candidate.signals : [];
+    const sourceEvents = Array.isArray(candidate.sourceEvents)
+      ? candidate.sourceEvents
+      : [];
+    const runIdText = runId ? String(runId) : "";
+
+    const existing = queue[key];
+    if (!existing || typeof existing !== "object") {
+      const entry = {
+        name: candidate.name || "",
+        city: candidate.city || "",
+        address: candidate.address || "",
+        coordinates: candidate.coordinates || "",
+        signals: [...signals],
+        sourceEvents: sourceEvents.slice(0, 5),
+        firstSeen: nowIso,
+        lastSeen: nowIso,
+        timesSeen: 1,
+        runIds: runIdText ? [runIdText] : [],
+      };
+      if (candidate.website) entry.website = candidate.website;
+      if (candidate.instagram) entry.instagram = candidate.instagram;
+      queue[key] = entry;
+      return entry;
+    }
+
+    existing.lastSeen = nowIso;
+    existing.timesSeen = (Number(existing.timesSeen) || 0) + 1;
+    if (!Array.isArray(existing.signals)) existing.signals = [];
+    for (const signal of signals) {
+      if (!existing.signals.includes(signal)) existing.signals.push(signal);
+    }
+    if (!Array.isArray(existing.runIds)) existing.runIds = [];
+    if (runIdText && !existing.runIds.includes(runIdText)) {
+      existing.runIds.push(runIdText);
+    }
+    existing.runIds = existing.runIds.slice(-10);
+    if (!Array.isArray(existing.sourceEvents)) existing.sourceEvents = [];
+    const seenEventKeys = new Set(
+      existing.sourceEvents.map(
+        (event) => `${event && event.title}|${event && event.date}|${event && event.sourcePageUrl}`,
+      ),
+    );
+    for (const event of sourceEvents) {
+      if (existing.sourceEvents.length >= 5) break;
+      const eventKey = `${event && event.title}|${event && event.date}|${event && event.sourcePageUrl}`;
+      if (seenEventKeys.has(eventKey)) continue;
+      seenEventKeys.add(eventKey);
+      existing.sourceEvents.push(event);
+    }
+    if (
+      SharedCore.isMoreCompleteVenueAddressStatic(
+        candidate.address,
+        existing.address,
+      )
+    ) {
+      existing.address = candidate.address;
+    }
+    if (!existing.website && candidate.website) {
+      existing.website = candidate.website;
+    }
+    if (!existing.instagram && candidate.instagram) {
+      existing.instagram = candidate.instagram;
+    }
+    return existing;
+  }
+
   extractHttpStatusCodeFromError(error) {
     const message =
       error && typeof error.message === "string" ? error.message : "";
@@ -4566,6 +4706,9 @@ class ScriptableAdapter {
       // Manual bear/not-bear override taps recorded during the WebView session,
       // applied after dismissal. Keyed by row id so repeat taps stay idempotent.
       const bearOverridePending = { markedBear: {}, markedNotBear: {} };
+      // Venue-queue taps this session: candidate index → timesSeen after the
+      // write. Repeat taps re-flash feedback without re-writing the queue.
+      const venueQueueTaps = {};
       const webView = new WebView();
       await webView.loadHTML(html);
       webView.shouldAllowRequest = (request) => {
@@ -4588,6 +4731,16 @@ class ScriptableAdapter {
             params.id,
             results,
             bearOverridePending,
+            webView,
+          );
+        } else if (params.a === "queue-venue") {
+          // Fire-and-forget: appends the candidate to the gathering-only
+          // bar-additions queue; the page gets best-effort "Queued ✓"
+          // feedback via evaluateJavaScript.
+          this.queueVenueCandidateAndReport(
+            params.id,
+            results,
+            venueQueueTaps,
             webView,
           );
         }
@@ -4682,6 +4835,10 @@ class ScriptableAdapter {
     );
     const headerLogoData = await this.loadHeaderLogoData();
     const headerLogoSrc = headerLogoData || HEADER_LOGO_URL;
+    // Async section (reads the gathering-only venue queue for badge state),
+    // pre-rendered here because the template below is synchronous.
+    const newVenueSectionHtml =
+      await this.generateNewVenueCandidateSection(results);
 
     // Group events by intent actions (intent can differ from write action for overrides)
     const newEvents = [];
@@ -6086,6 +6243,8 @@ class ScriptableAdapter {
 
     ${this.generateDiscoveredVenueSection(results)}
 
+    ${newVenueSectionHtml}
+
     ${this.generateDiscoverySection(results)}
 
     ${insightSectionsHtml}
@@ -6130,6 +6289,25 @@ class ScriptableAdapter {
                 var btn = document.querySelector('.bear-override-btn[data-bear-idx="' + idx + '"][data-bear-act="' + act + '"]');
                 if (btn) {
                     btn.textContent = act === 'mark-bear' ? 'Marked bear ✓' : 'Marked not-bear ✓';
+                    btn.disabled = true;
+                }
+            } catch (ignore) {}
+        }
+
+        // "Queue for bars data" buttons use the same chunkyscrape://
+        // navigation bridge (shouldAllowRequest, set before present()); the
+        // per-tap nonce keeps repeat taps firing as distinct navigations.
+        window.__venueQueueNonce = 0;
+        function queueVenueCandidate(btn) {
+            var idx = btn ? (btn.getAttribute('data-nvq-index') || '') : '';
+            window.location.href = 'chunkyscrape://act?a=queue-venue&id=' +
+                encodeURIComponent(idx) + '&n=' + (window.__venueQueueNonce++);
+        }
+        function markVenueCandidateQueued(idx, timesSeen) {
+            try {
+                var btn = document.querySelector('.venue-queue-btn[data-nvq-index="' + idx + '"]');
+                if (btn) {
+                    btn.textContent = 'Queued ✓ (seen ' + timesSeen + ' times)';
                     btn.disabled = true;
                 }
             } catch (ignore) {}
@@ -7209,6 +7387,119 @@ class ScriptableAdapter {
       await webView.evaluateJavaScript(feedbackJs, false);
     } catch (error) {
       /* button feedback is optional polish; the copy already happened */
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // New venue candidates (results-UI ↔ chunkyscrape:// bridge, GATHERING-ONLY).
+  // Confirmed-new venues detected by SharedCore.buildNewVenueCandidates get a
+  // "Queue for bars data" button; a tap appends evidence to bar-additions.json.
+  // The queue is loaded here ONLY for the "Queued ✓" badge — the scraping
+  // pipeline never reads it, and promotion to data/bars/<city>.json happens
+  // out-of-band after verification against independent references.
+  // ---------------------------------------------------------------------------
+
+  // "New venue candidates (N)" section: live runs only (no queue writes on
+  // saved-run display), rendered only when the run produced candidates.
+  // Already-queued candidates show a "Queued ✓ (seen N times)" badge instead
+  // of the button.
+  async generateNewVenueCandidateSection(results) {
+    if (results && results._isDisplayingSavedRun === true) return "";
+    const candidates = Array.isArray(results && results.newVenueCandidates)
+      ? results.newVenueCandidates
+      : [];
+    if (candidates.length === 0) return "";
+    const queue = await this.loadBarAdditions();
+
+    const rows = candidates
+      .map((candidate, index) => {
+        if (!candidate) return "";
+        const signalsText = Array.isArray(candidate.signals)
+          ? candidate.signals.join(", ")
+          : "";
+        const sourceEvents = Array.isArray(candidate.sourceEvents)
+          ? candidate.sourceEvents
+          : [];
+        const eventsText = sourceEvents
+          .map((event) => {
+            const dateLabel = this.formatBearOverrideDate(event && event.date);
+            const title = (event && event.title) || "Unknown";
+            return dateLabel ? `${title} (${dateLabel})` : title;
+          })
+          .join(", ");
+        const queuedEntry =
+          candidate.key && queue[candidate.key] ? queue[candidate.key] : null;
+        const control = queuedEntry
+          ? `<span style="font-size:12px; color:var(--text-secondary);">Queued ✓ (seen ${Number(queuedEntry.timesSeen) || 1} times)</span>`
+          : `<button onclick="queueVenueCandidate(this)" class="log-copy-btn venue-queue-btn" data-nvq-index="${index}">➕ Queue for bars data</button>`;
+        return `
+        <div class="new-venue-candidate" style="margin-bottom:14px; padding:10px; background:var(--background-light); border-radius:8px;">
+            <div style="font-weight:600; margin-bottom:4px;">${this.escapeHtml(candidate.name || "Unknown")} <span style="font-weight:400; opacity:0.7;">(${this.escapeHtml(candidate.city || "unknown city")})</span></div>
+            ${candidate.address ? `<div style="font-size:12px; margin-bottom:2px; color:var(--text-secondary);">${this.escapeHtml(candidate.address)}</div>` : ""}
+            <div style="font-size:12px; margin-bottom:2px; color:var(--text-secondary);">Signals: ${this.escapeHtml(signalsText)}</div>
+            ${eventsText ? `<div style="font-size:12px; margin-bottom:6px; color:var(--text-secondary);">Hosting: ${this.escapeHtml(eventsText)}</div>` : ""}
+            ${control}
+        </div>`;
+      })
+      .join("");
+
+    return `
+    <div class="section">
+        <div class="section-header">
+            <span class="section-icon">🆕</span>
+            <span class="section-title">New venue candidates</span>
+            <span class="section-count">${candidates.length}</span>
+        </div>
+        <div style="font-size:12px; color:var(--text-secondary); margin-bottom:8px;">Corroborated venues not in curated bars data. Queueing gathers evidence only — it never changes scraping behavior; promotion to data/bars happens out-of-band after verification.</div>
+        ${rows}
+    </div>
+    `;
+  }
+
+  // Queue one tapped candidate natively and (best-effort) flash its button.
+  // Called fire-and-forget from shouldAllowRequest, which must synchronously
+  // return a bool — so the await lives here, not in the handler. Repeat taps
+  // (per-tap nonce keeps them firing) skip the write and just re-flash.
+  async queueVenueCandidateAndReport(id, results, tapped, webView) {
+    try {
+      const key = String(id || "");
+      const index = Number(key);
+      const candidates = Array.isArray(results && results.newVenueCandidates)
+        ? results.newVenueCandidates
+        : [];
+      if (!Number.isInteger(index) || index < 0 || index >= candidates.length) {
+        return;
+      }
+      const candidate = candidates[index];
+      if (!candidate) return;
+      let timesSeen = tapped[key];
+      if (timesSeen === undefined) {
+        const queue = await this.loadBarAdditions();
+        const runId = results.savedRunId || results.sourceRunId || null;
+        const entry = this.mergeBarAdditionEntry(
+          queue,
+          candidate,
+          runId,
+          new Date().toISOString(),
+        );
+        if (!entry) return;
+        await this.saveBarAdditions(queue);
+        timesSeen = Number(entry.timesSeen) || 1;
+        tapped[key] = timesSeen;
+        console.log(
+          `📱 Scriptable: Queued venue candidate "${candidate.name}" (${candidate.city}) — seen ${timesSeen} time(s)`,
+        );
+      }
+      const feedbackJs = `markVenueCandidateQueued(${JSON.stringify(key)}, ${JSON.stringify(String(timesSeen))})`;
+      try {
+        await webView.evaluateJavaScript(feedbackJs, false);
+      } catch (error) {
+        /* in-page feedback is optional polish; the queue write already happened */
+      }
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Failed to queue venue candidate: ${error.message}`,
+      );
     }
   }
 

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1718,3 +1718,230 @@ test('an equal-tier provenance change (venue-site → geo-poi, same corroborated
   assert.ok(!rows.includes('PRESERVE FAILED'));
   assert.ok(!rows.includes('⚠️'));
 });
+
+// ---------------------------------------------------------------------------
+// Venue discovery queue (bar-additions.json) — gathering-only evidence store
+// ---------------------------------------------------------------------------
+
+function buildVenueCandidate(overrides = {}) {
+  return {
+    key: 'seattle|massive',
+    name: 'Massive',
+    city: 'seattle',
+    address: '1400 12th Ave, Seattle, WA 98122',
+    coordinates: '47.6135, -122.3163',
+    signals: ['venue-site'],
+    website: 'https://massiveseattle.com',
+    sourceEvents: [
+      {
+        title: 'Bear Night',
+        date: '2026-08-01T02:00:00.000Z',
+        sourcePageUrl: 'https://massiveseattle.com/events/bear-night'
+      }
+    ],
+    runId: null,
+    ...overrides
+  };
+}
+
+test('venue queue round-trip: a tapped candidate becomes a bar-additions.json entry', async () => {
+  const adapter = buildAdapter();
+  adapter.fm = createDeadEndFmStub();
+
+  // Missing file → empty queue, never throws
+  assert.deepEqual(await adapter.loadBarAdditions(), {});
+
+  const queue = await adapter.loadBarAdditions();
+  const entry = adapter.mergeBarAdditionEntry(
+    queue, buildVenueCandidate(), '20260722-120000', '2026-07-22T12:00:00.000Z');
+  await adapter.saveBarAdditions(queue);
+
+  assert.ok(adapter.fm.files.has(adapter.getBarAdditionsFilePath()),
+    'queue written to bar-additions.json in the scraper dir');
+  assert.deepEqual(await adapter.loadBarAdditions(), {
+    'seattle|massive': {
+      name: 'Massive',
+      city: 'seattle',
+      address: '1400 12th Ave, Seattle, WA 98122',
+      coordinates: '47.6135, -122.3163',
+      signals: ['venue-site'],
+      sourceEvents: [
+        {
+          title: 'Bear Night',
+          date: '2026-08-01T02:00:00.000Z',
+          sourcePageUrl: 'https://massiveseattle.com/events/bear-night'
+        }
+      ],
+      firstSeen: '2026-07-22T12:00:00.000Z',
+      lastSeen: '2026-07-22T12:00:00.000Z',
+      timesSeen: 1,
+      runIds: ['20260722-120000'],
+      website: 'https://massiveseattle.com'
+    }
+  });
+  assert.equal(entry.timesSeen, 1);
+});
+
+test('venue queue merge on repeat: timesSeen/lastSeen bump, unions, caps, best address', async () => {
+  const adapter = buildAdapter();
+  adapter.fm = createDeadEndFmStub();
+
+  const queue = await adapter.loadBarAdditions();
+  adapter.mergeBarAdditionEntry(
+    queue, buildVenueCandidate({ address: 'Seattle, WA', website: '' }),
+    'run-1', '2026-07-01T00:00:00.000Z');
+  const merged = adapter.mergeBarAdditionEntry(
+    queue,
+    buildVenueCandidate({
+      signals: ['venue-site', 'geo-poi'],
+      sourceEvents: [
+        // duplicate of the first tap's event → deduped
+        { title: 'Bear Night', date: '2026-08-01T02:00:00.000Z', sourcePageUrl: 'https://massiveseattle.com/events/bear-night' },
+        { title: 'Underwear Party', date: '2026-08-08T02:00:00.000Z', sourcePageUrl: 'https://massiveseattle.com/events/underwear' }
+      ]
+    }),
+    'run-2', '2026-07-22T12:00:00.000Z');
+
+  assert.equal(merged.timesSeen, 2);
+  assert.equal(merged.firstSeen, '2026-07-01T00:00:00.000Z', 'firstSeen unchanged');
+  assert.equal(merged.lastSeen, '2026-07-22T12:00:00.000Z');
+  assert.deepEqual(merged.signals, ['venue-site', 'geo-poi'], 'signals unioned');
+  assert.deepEqual(merged.runIds, ['run-1', 'run-2'], 'runIds unioned');
+  assert.equal(merged.address, '1400 12th Ave, Seattle, WA 98122',
+    'more complete address replaces the sparse one');
+  assert.equal(merged.website, 'https://massiveseattle.com', 'website blank filled');
+  assert.deepEqual(merged.sourceEvents.map(e => e.title), ['Bear Night', 'Underwear Party'],
+    'sourceEvents unioned without duplicates');
+
+  // Caps: runIds keep the 10 most recent, sourceEvents never exceed 5
+  for (let i = 3; i <= 14; i++) {
+    adapter.mergeBarAdditionEntry(
+      queue,
+      buildVenueCandidate({
+        sourceEvents: [{ title: `Event ${i}`, date: '', sourcePageUrl: '' }]
+      }),
+      `run-${i}`, '2026-07-23T00:00:00.000Z');
+  }
+  assert.equal(merged.runIds.length, 10, 'runIds capped at 10');
+  assert.equal(merged.runIds[9], 'run-14', 'most recent runId kept');
+  assert.ok(!merged.runIds.includes('run-1'), 'oldest runId dropped by the cap');
+  assert.equal(merged.sourceEvents.length, 5, 'sourceEvents capped at 5');
+
+  // A LESS complete address never replaces a more complete one
+  adapter.mergeBarAdditionEntry(
+    queue, buildVenueCandidate({ address: 'Seattle' }),
+    'run-x', '2026-07-24T00:00:00.000Z');
+  assert.equal(merged.address, '1400 12th Ave, Seattle, WA 98122');
+});
+
+test('venue queue tolerates corrupt or wrong-shaped files with an empty queue', async () => {
+  const adapter = buildAdapter();
+  adapter.fm = createDeadEndFmStub();
+  const path = adapter.getBarAdditionsFilePath();
+
+  adapter.fm.files.set(path, '{"seattle|massive": {broken json');
+  assert.deepEqual(await adapter.loadBarAdditions(), {}, 'parse failure → empty queue');
+
+  adapter.fm.files.set(path, '["not", "an", "object"]');
+  assert.deepEqual(await adapter.loadBarAdditions(), {}, 'array payload → empty queue');
+
+  adapter.fm.files.set(path, 'null');
+  assert.deepEqual(await adapter.loadBarAdditions(), {}, 'null payload → empty queue');
+
+  // saveBarAdditions refuses non-object queues instead of clobbering the file
+  adapter.fm.files.delete(path);
+  await adapter.saveBarAdditions(null);
+  await adapter.saveBarAdditions(['nope']);
+  assert.ok(!adapter.fm.files.has(path));
+
+  // mergeBarAdditionEntry fails open on keyless candidates
+  assert.equal(adapter.mergeBarAdditionEntry({}, { name: 'No Key' }, null, 'now'), null);
+});
+
+test('queue-venue action URLs parse like the other chunkyscrape actions', () => {
+  const adapter = buildAdapter();
+  const params = adapter.parseReviewActionUrl('chunkyscrape://act?a=queue-venue&id=2&n=7');
+  assert.equal(params.a, 'queue-venue');
+  assert.equal(params.id, '2');
+  assert.equal(params.n, '7');
+});
+
+test('new-venue section renders only when candidates exist, never on saved runs', async () => {
+  const adapter = buildAdapter();
+  adapter.fm = createDeadEndFmStub();
+
+  assert.equal(await adapter.generateNewVenueCandidateSection({}), '');
+  assert.equal(await adapter.generateNewVenueCandidateSection({ newVenueCandidates: [] }), '');
+  assert.equal(
+    await adapter.generateNewVenueCandidateSection({
+      _isDisplayingSavedRun: true,
+      newVenueCandidates: [buildVenueCandidate()]
+    }),
+    '', 'saved-run display never renders the queue section');
+
+  const html = await adapter.generateNewVenueCandidateSection({
+    newVenueCandidates: [buildVenueCandidate()]
+  });
+  assert.ok(html.includes('New venue candidates'));
+  assert.ok(html.includes('Massive'));
+  assert.ok(html.includes('(seattle)'));
+  assert.ok(html.includes('1400 12th Ave, Seattle, WA 98122'));
+  assert.ok(html.includes('Signals: venue-site'));
+  assert.ok(html.includes('Bear Night'));
+  assert.ok(html.includes('data-nvq-index="0"'));
+  assert.ok(html.includes('Queue for bars data'));
+  assert.ok(!html.includes('Queued ✓'));
+});
+
+test('already-queued candidates render the Queued badge instead of the button', async () => {
+  const adapter = buildAdapter();
+  adapter.fm = createDeadEndFmStub();
+  adapter.fm.files.set(
+    adapter.getBarAdditionsFilePath(),
+    JSON.stringify({ 'seattle|massive': { name: 'Massive', timesSeen: 3 } }));
+
+  const html = await adapter.generateNewVenueCandidateSection({
+    newVenueCandidates: [
+      buildVenueCandidate(),
+      buildVenueCandidate({ key: 'seattle|neighbours', name: 'Neighbours' })
+    ]
+  });
+  assert.ok(html.includes('Queued ✓ (seen 3 times)'), 'queued candidate shows badge');
+  assert.ok(!html.includes('data-nvq-index="0"'), 'queued candidate has no button');
+  assert.ok(html.includes('data-nvq-index="1"'), 'unqueued candidate keeps its button');
+});
+
+test('NOTHING in the scraping pipeline reads bar-additions.json (gathering-only)', () => {
+  const fs = require('node:fs');
+  // The scraping pipeline — shared-core, orchestrator, parsers, normalizers,
+  // and the web adapter — must never reference the queue file or its
+  // accessors at all: the queue is write-and-display evidence only.
+  const pipelineFiles = [
+    '../shared-core.js',
+    '../bear-event-scraper-unified.js',
+    '../normalizers.js',
+    '../parsers/ai-web-parser.js',
+    './web-adapter.js'
+  ];
+  for (const rel of pipelineFiles) {
+    const source = fs.readFileSync(path.join(__dirname, rel), 'utf8');
+    assert.ok(!source.includes('bar-additions'), `${rel} must not reference bar-additions.json`);
+    assert.ok(!source.includes('BarAdditions'), `${rel} must not call the queue accessors`);
+  }
+  // In the Scriptable adapter the queue is read in exactly two places, both
+  // results-UI-side: the "Queued ✓" badge and the queue-tap handler. The
+  // bars-data load path (loadBarsConfiguration/fetchRemoteBarsJson) and the
+  // run pipeline never touch it.
+  const adapterSource = fs.readFileSync(path.join(__dirname, 'scriptable-adapter.js'), 'utf8');
+  const readCallSites = adapterSource
+    .split('\n')
+    .filter(line => line.includes('this.loadBarAdditions('));
+  assert.equal(readCallSites.length, 2,
+    `queue reads allowed only in the badge renderer and the tap handler, found: ${readCallSites.join(' | ')}`);
+  const barsLoaderSource = adapterSource.slice(
+    adapterSource.indexOf('async loadBarsConfiguration'),
+    adapterSource.indexOf('async fetchRemoteBarsJson'));
+  assert.ok(barsLoaderSource.length > 0, 'bars loader located');
+  assert.ok(!barsLoaderSource.includes('BarAdditions') && !barsLoaderSource.includes('bar-additions'),
+    'the bars-data load path never reads the queue');
+});

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -767,6 +767,18 @@ async saveFailureNote(url, error, metadata = {}) {
                 console.log('\n' + results.discoveredVenueSummary);
             }
 
+            // New venue candidates: read-only display on web. Queueing lives
+            // in the Scriptable adapter only, and that queue is gathering-only
+            // evidence — it never affects scraping behavior.
+            if (Array.isArray(results.newVenueCandidates) && results.newVenueCandidates.length > 0) {
+                console.log(`\n🆕 New venue candidates (${results.newVenueCandidates.length}) — read-only here (queueing is Scriptable-only):`);
+                results.newVenueCandidates.forEach(candidate => {
+                    const signals = Array.isArray(candidate.signals) ? candidate.signals.join(', ') : '';
+                    const addressSuffix = candidate.address ? ` — ${candidate.address}` : '';
+                    console.log(`   • "${candidate.name}" (${candidate.city}) — signals: ${signals}${addressSuffix}`);
+                });
+            }
+
             // Show summary and recommended actions
             await this.displaySummaryAndActions(results);
             

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -32,6 +32,12 @@ const ADAPTIVE_CRAWL_MAX_HOPS = 4;
 // and the calendar reviewer's pin-moved check.
 const PIN_MOVED_THRESHOLD_KM = 0.4;
 
+// New-venue-candidate detection (gathering-only growth loop): barSource
+// stamps that positively corroborate an extracted bar name without meaning
+// "already curated". Candidate evidence caps sourceEvents per venue.
+const NEW_VENUE_CANDIDATE_BAR_SOURCES = Object.freeze(['page-adjacent', 'venue-site', 'geo-poi']);
+const NEW_VENUE_CANDIDATE_SOURCE_EVENT_CAP = 5;
+
 // Merge-time address comparison: street-type abbreviations and directionals
 // expanded on BOTH sides so "619 E. Pine St" and "619 East Pine Street"
 // tokenize identically. Modeled on normalizers.js
@@ -962,14 +968,20 @@ class SharedCore {
     // vice versa). Full-name equality only — never substring — so "Eagle"
     // can't claim "Eagle Bar" vs "Dallas Eagle" ambiguously within a city.
     findCuratedBarByName(cityBars, value) {
-        const normalizeBarName = name => String(name || '')
+        const normalized = this.normalizeBarNameKey(value);
+        if (!normalized) return null;
+        return cityBars.find(bar => bar && typeof bar.name === 'string'
+            && this.normalizeBarNameKey(bar.name) === normalized) || null;
+    }
+
+    // The bar-name identity key shared by curated matching (above) and the
+    // new-venue-candidate dedup key: lowercase, drop a leading "the ", strip
+    // non-alphanumerics — so "The Eagle" / "EAGLE!" collapse to one venue.
+    normalizeBarNameKey(name) {
+        return String(name || '')
             .toLowerCase()
             .replace(/^\s*the\s+/, '')
             .replace(/[^a-z0-9]/g, '');
-        const normalized = normalizeBarName(value);
-        if (!normalized) return null;
-        return cityBars.find(bar => bar && typeof bar.name === 'string'
-            && normalizeBarName(bar.name) === normalized) || null;
     }
 
     // City-center coordinates from the cities config as a "lat, lng" pair
@@ -1832,6 +1844,18 @@ class SharedCore {
             await displayAdapter.logInfo(results.discoveredVenueSummary);
         }
 
+        // New venue candidates (GATHERING-ONLY): corroborated + exactly-pinned
+        // venues absent from curated bars data, aggregated once per run per
+        // venue. Evidence for out-of-band curation; the pipeline NEVER reads
+        // this list (or the adapter's venue queue file) back.
+        const newVenueCandidates = this.buildNewVenueCandidates(results.allProcessedEvents);
+        if (newVenueCandidates.length > 0) {
+            results.newVenueCandidates = newVenueCandidates;
+            for (const candidate of newVenueCandidates) {
+                await displayAdapter.logInfo(this.formatNewVenueCandidateLogLine(candidate));
+            }
+        }
+
         await this.finalizeDeadEndRun(displayAdapter, results);
 
         const duplicateSummary = results.duplicatesRemoved > 0
@@ -2105,6 +2129,137 @@ class SharedCore {
             ].join('\n');
         });
         return blocks.join('\n\n');
+    }
+
+    // ------------------------------------------------------------------
+    // New venue candidates (growth loop, GATHERING-ONLY): venues this run's
+    // own evidence corroborates (vouched-for bar name + exact geocoded pin)
+    // that curated bars data does not know yet. This is information
+    // collection, NOT authority: the candidate list is displayed and
+    // optionally queued by the adapter as evidence for out-of-band curation,
+    // and NOTHING in the scraping pipeline ever reads it back.
+    // ------------------------------------------------------------------
+
+    // An event vouches for a NEW venue only when every signal is positive
+    // (fail open — any missing field means "not a candidate"):
+    //   - bar present with corroborated non-curated provenance: page-adjacent
+    //     / venue-site (extraction-time corroboration) or geo-poi (map
+    //     placemark corroboration). curated = already known; uncorroborated
+    //     or unstamped = nothing vouched for the name.
+    //   - pin present with pinSource geocoded-exact (a curated pin also means
+    //     already-known; approx/page pins are not location proof).
+    //   - resolved city, and the bar name does NOT match that city's curated
+    //     bars (findCuratedBarByName's normalization).
+    isNewVenueCandidateEvent(event) {
+        if (!event || typeof event !== 'object') return false;
+        const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+        if (!bar) return false;
+        const barSource = typeof event.barSource === 'string' ? event.barSource.trim() : '';
+        if (!NEW_VENUE_CANDIDATE_BAR_SOURCES.includes(barSource)) return false;
+        const pinSource = typeof event.pinSource === 'string' ? event.pinSource.trim() : '';
+        if (pinSource !== 'geocoded-exact') return false;
+        const location = typeof event.location === 'string' ? event.location.trim() : '';
+        if (!this.isCoordinatePair(location)) return false;
+        const cityKey = typeof event.city === 'string' ? event.city.trim() : '';
+        if (!cityKey) return false;
+        const cityBars = this.getCuratedCityBars(cityKey);
+        if (cityBars && this.findCuratedBarByName(cityBars, bar)) return false;
+        return true;
+    }
+
+    // Aggregate qualifying events into one candidate per unique
+    // (cityKey, normalized bar name). Pure: reads only data already on the
+    // events; timestamps/file I/O belong to the adapter.
+    buildNewVenueCandidates(events, options = {}) {
+        const runId = options && options.runId ? String(options.runId) : null;
+        const byKey = new Map();
+        for (const event of Array.isArray(events) ? events : []) {
+            if (!this.isNewVenueCandidateEvent(event)) continue;
+            const bar = event.bar.trim();
+            const cityKey = event.city.trim().toLowerCase();
+            const key = `${cityKey}|${this.normalizeBarNameKey(bar)}`;
+            const barSource = event.barSource.trim();
+            const address = typeof event.address === 'string' ? event.address.trim() : '';
+            const website = typeof event.website === 'string' && event.website.trim()
+                ? event.website.trim()
+                : (typeof event.url === 'string' ? event.url.trim() : '');
+            const instagram = typeof event.instagram === 'string' ? event.instagram.trim() : '';
+
+            let candidate = byKey.get(key);
+            if (!candidate) {
+                candidate = {
+                    key,
+                    name: bar,
+                    city: cityKey,
+                    address: '',
+                    coordinates: event.location.trim(),
+                    signals: [],
+                    sourceEvents: [],
+                    runId
+                };
+                byKey.set(key, candidate);
+            }
+            candidate.name = this.pickBetterCasedVenueName(candidate.name, bar);
+            if (this.isMoreCompleteVenueAddress(address, candidate.address)) {
+                candidate.address = address;
+            }
+            if (!candidate.signals.includes(barSource)) candidate.signals.push(barSource);
+            if (website && !candidate.website) candidate.website = website;
+            if (instagram && !candidate.instagram) candidate.instagram = instagram;
+            if (candidate.sourceEvents.length < NEW_VENUE_CANDIDATE_SOURCE_EVENT_CAP) {
+                candidate.sourceEvents.push({
+                    title: typeof event.title === 'string' ? event.title : '',
+                    date: this.formatNewVenueCandidateDate(event.startDate),
+                    sourcePageUrl: typeof event._sourcePageUrl === 'string' && event._sourcePageUrl
+                        ? event._sourcePageUrl
+                        : (typeof event.url === 'string' ? event.url : '')
+                });
+            }
+        }
+        return Array.from(byKey.values());
+    }
+
+    // Prefer a mixed-case observation of the venue name over an ALL-CAPS or
+    // all-lowercase one ("Massive" beats "MASSIVE"); otherwise first wins.
+    pickBetterCasedVenueName(current, next) {
+        const isMixedCase = value => /[a-z]/.test(value) && /[A-Z]/.test(value);
+        return isMixedCase(next) && !isMixedCase(current) ? next : current;
+    }
+
+    // Candidate ISO date string ('' when absent/unparseable) — durable
+    // conversion of data already on the event, not a clock read.
+    formatNewVenueCandidateDate(startDate) {
+        const date = startDate instanceof Date ? startDate : this.parseDate(startDate);
+        if (!date || Number.isNaN(date.getTime())) return '';
+        return date.toISOString();
+    }
+
+    // "Most complete observed address" order: more comma segments + a ZIP
+    // outrank fewer; ties go to the longer string; first observation wins
+    // exact ties. Static so the adapter's queue merge reuses the same rule.
+    static scoreVenueCandidateAddress(value) {
+        const text = typeof value === 'string' ? value.trim() : '';
+        if (!text) return -1;
+        const segments = text.split(',').map(segment => segment.trim()).filter(Boolean);
+        return segments.length + (/\b\d{5}\b/.test(text) ? 1 : 0);
+    }
+
+    static isMoreCompleteVenueAddressStatic(next, current) {
+        const nextScore = SharedCore.scoreVenueCandidateAddress(next);
+        const currentScore = SharedCore.scoreVenueCandidateAddress(current);
+        if (nextScore !== currentScore) return nextScore > currentScore;
+        return String(next || '').trim().length > String(current || '').trim().length;
+    }
+
+    isMoreCompleteVenueAddress(next, current) {
+        return SharedCore.isMoreCompleteVenueAddressStatic(next, current);
+    }
+
+    // One additive log line per run per candidate venue.
+    formatNewVenueCandidateLogLine(candidate) {
+        const signals = Array.isArray(candidate.signals) ? candidate.signals.join(', ') : '';
+        const address = candidate.address || 'no address observed';
+        return `📋 NEW VENUE CANDIDATE: "${candidate.name}" (${candidate.city}) — signals: ${signals} — ${address}`;
     }
 
     // Baked-in platform confidence expectations: Eventbrite /e/ event pages ship

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -6647,3 +6647,162 @@ test('unknown provenance values and unknown fields rank null so callers fail ope
     'non-provenance fields have no tiers');
   assert.equal(SharedCore.getProvenanceTrustTier('', 'curated'), null);
 });
+
+// ---------------------------------------------------------------------------
+// New venue candidates (gathering-only growth loop): detection builder
+// ---------------------------------------------------------------------------
+
+const SEATTLE_CUFF_BAR = {
+  name: 'The Cuff Complex',
+  city: 'seattle',
+  address: '1533 13th Ave, Seattle, WA 98122',
+  coordinates: '47.6142041, -122.3168539'
+};
+
+function createVenueDiscoveryCore(withBars = true) {
+  return new SharedCore({
+    seattle: { timezone: 'America/Los_Angeles', calendar: 'chunky-dad-seattle', patterns: ['seattle'] }
+  }, {
+    eventSchema: EventSchema,
+    bars: withBars ? { seattle: [SEATTLE_CUFF_BAR] } : {}
+  });
+}
+
+function buildVenueCandidateEvent(overrides = {}) {
+  return {
+    title: 'Bear Night',
+    startDate: new Date('2026-08-01T02:00:00.000Z'),
+    city: 'seattle',
+    bar: 'Massive',
+    barSource: 'venue-site',
+    address: '1400 12th Ave, Seattle, WA 98122',
+    location: '47.6135, -122.3163',
+    pinSource: 'geocoded-exact',
+    website: 'https://massiveseattle.com/events/bear-night',
+    _sourcePageUrl: 'https://massiveseattle.com/events/bear-night',
+    ...overrides
+  };
+}
+
+test('corroborated bar + exact pin + uncurated name yields a new venue candidate', () => {
+  const core = createVenueDiscoveryCore();
+  const candidates = core.buildNewVenueCandidates([buildVenueCandidateEvent()]);
+
+  assert.equal(candidates.length, 1);
+  const candidate = candidates[0];
+  assert.equal(candidate.key, 'seattle|massive');
+  assert.equal(candidate.name, 'Massive');
+  assert.equal(candidate.city, 'seattle');
+  assert.equal(candidate.address, '1400 12th Ave, Seattle, WA 98122');
+  assert.equal(candidate.coordinates, '47.6135, -122.3163');
+  assert.deepEqual(candidate.signals, ['venue-site']);
+  assert.equal(candidate.website, 'https://massiveseattle.com/events/bear-night');
+  assert.equal(candidate.sourceEvents.length, 1);
+  assert.equal(candidate.sourceEvents[0].title, 'Bear Night');
+  assert.equal(candidate.sourceEvents[0].date, '2026-08-01T02:00:00.000Z');
+  assert.equal(candidate.sourceEvents[0].sourcePageUrl, 'https://massiveseattle.com/events/bear-night');
+});
+
+test('curated, uncorroborated, and unstamped barSource are all excluded', () => {
+  const core = createVenueDiscoveryCore();
+  assert.deepEqual(core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({ barSource: 'curated' }),
+    buildVenueCandidateEvent({ barSource: 'uncorroborated' }),
+    buildVenueCandidateEvent({ barSource: undefined }),
+    buildVenueCandidateEvent({ barSource: '' })
+  ]), []);
+});
+
+test('non-exact pins and missing pins are excluded', () => {
+  const core = createVenueDiscoveryCore();
+  assert.deepEqual(core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({ pinSource: 'geocoded-approx' }),
+    buildVenueCandidateEvent({ pinSource: 'curated' }),
+    buildVenueCandidateEvent({ pinSource: 'page' }),
+    buildVenueCandidateEvent({ pinSource: undefined }),
+    buildVenueCandidateEvent({ location: undefined }),
+    buildVenueCandidateEvent({ location: 'The Cuff, Seattle' })
+  ]), []);
+});
+
+test('missing bar or missing resolved city fails open to no candidate', () => {
+  const core = createVenueDiscoveryCore();
+  assert.deepEqual(core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({ bar: undefined }),
+    buildVenueCandidateEvent({ bar: '   ' }),
+    buildVenueCandidateEvent({ city: undefined }),
+    buildVenueCandidateEvent({ city: '' })
+  ]), []);
+  assert.deepEqual(core.buildNewVenueCandidates(null), []);
+});
+
+test('a bar matching the city\'s curated bars is excluded (already known)', () => {
+  const core = createVenueDiscoveryCore();
+  // Same normalization as findCuratedBarByName: leading "the" and
+  // punctuation/case differences still match the curated entry.
+  assert.deepEqual(core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({ bar: 'The Cuff Complex' }),
+    buildVenueCandidateEvent({ bar: 'CUFF COMPLEX!' })
+  ]), []);
+  // Without curated bars data for the city, the same name IS a candidate
+  // (nothing curated to match against).
+  const bareCore = createVenueDiscoveryCore(false);
+  assert.equal(bareCore.buildNewVenueCandidates([
+    buildVenueCandidateEvent({ bar: 'The Cuff Complex' })
+  ]).length, 1);
+});
+
+test('events of the same venue dedup into one candidate with unioned evidence', () => {
+  const core = createVenueDiscoveryCore();
+  const candidates = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      bar: 'MASSIVE',
+      barSource: 'page-adjacent',
+      address: 'Seattle, WA',
+      title: 'Underwear Party'
+    }),
+    buildVenueCandidateEvent({
+      bar: 'Massive',
+      barSource: 'geo-poi',
+      address: '1400 12th Ave, Seattle, WA 98122',
+      title: 'Bear Night'
+    }),
+    buildVenueCandidateEvent({
+      bar: 'The Massive', // normalizes to the same venue key
+      barSource: 'geo-poi',
+      title: 'Furry Friday'
+    })
+  ]);
+
+  assert.equal(candidates.length, 1);
+  const candidate = candidates[0];
+  assert.equal(candidate.key, 'seattle|massive');
+  assert.equal(candidate.name, 'Massive', 'mixed-case observation beats ALL-CAPS');
+  assert.deepEqual(candidate.signals, ['page-adjacent', 'geo-poi'], 'signals unioned and deduped');
+  assert.equal(candidate.address, '1400 12th Ave, Seattle, WA 98122', 'most complete observed address kept');
+  assert.equal(candidate.sourceEvents.length, 3);
+});
+
+test('sourceEvents cap at 5 per candidate', () => {
+  const core = createVenueDiscoveryCore();
+  const events = Array.from({ length: 8 }, (_, i) =>
+    buildVenueCandidateEvent({ title: `Bear Night ${i + 1}` }));
+  const candidates = core.buildNewVenueCandidates(events);
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].sourceEvents.length, 5);
+});
+
+test('new venue candidate log line has the documented shape', () => {
+  const core = createVenueDiscoveryCore();
+  const [candidate] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({ barSource: 'geo-poi' })
+  ]);
+  assert.equal(
+    core.formatNewVenueCandidateLogLine(candidate),
+    '📋 NEW VENUE CANDIDATE: "Massive" (seattle) — signals: geo-poi — 1400 12th Ave, Seattle, WA 98122'
+  );
+  assert.equal(
+    core.formatNewVenueCandidateLogLine({ name: 'Massive', city: 'seattle', signals: ['venue-site'], address: '' }),
+    '📋 NEW VENUE CANDIDATE: "Massive" (seattle) — signals: venue-site — no address observed'
+  );
+});


### PR DESCRIPTION
Phase 4 of the bar-corroboration roadmap, in its deliberately cautious form: the queue is **evidence collection, never authority**.

## Detection (pure, fail-open)
After processing, an event yields a NEW VENUE CANDIDATE only when its bar is corroborated (`page-adjacent`/`venue-site`/`geo-poi`), its pin is `geocoded-exact` with valid coordinates, its city resolved, and the bar is NOT already curated (same normalization as curated matching — one helper). Candidates dedup per city+venue; `📋 NEW VENUE CANDIDATE` logged once per venue per run.

## One-tap queueing (results UI)
"New venue candidates (N)" section with a **Queue for bars data** button (chunkyscrape:// bridge, per-tap nonce, session-idempotent). Taps append an evidence dossier to `bar-additions.json` in the scraper storage dir (dead-ends.json patterns: adapter-owned I/O, corrupt-file tolerant): name, city, most-complete address, coordinates, signals, hosting events (capped), firstSeen/lastSeen/timesSeen, runIds, website/instagram when observed. Repeat sightings across runs MERGE into the same dossier — a venue builds a track record. Already-queued candidates show "Queued ✓ (seen N times)".

## The queue has ZERO effect on runs — enforced by test
A structural test asserts shared-core, the orchestrator, normalizers, ai-web-parser, and web-adapter contain no reference to the queue, and that the bars-data load path never touches it. No provisional-curated, no auto-PRs, no external lookups. **Promotion is out-of-band**: candidates get verified against independent references (per-venue GayCities lookup, OSM POI, venue site) and only verified entries become `data/bars/<city>.json` PRs with the evidence attached — the Massive flow, systematized. An apply/verification tool can formalize this after a few manual cycles.

+15 tests. Suite: **607 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/adapters/scriptable-adapter.js`, `scripts/adapters/web-adapter.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP