### PR TITLE
chore(bars): promote first venue-queue cycle — The Heretic, Joy Theater, Public Works

### DIFF
--- a/data/bars/atlanta.json
+++ b/data/bars/atlanta.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "The Heretic",
+    "city": "atlanta",
+    "address": "2069 Cheshire Bridge Rd NE, Atlanta, GA 30324",
+    "coordinates": "33.8115012, -84.3552779",
+    "website": "https://hereticatlanta.com"
+  }
+]

--- a/data/bars/nola.json
+++ b/data/bars/nola.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "Joy Theater",
+    "city": "nola",
+    "address": "1200 Canal St, New Orleans, LA 70112",
+    "coordinates": "29.9559524, -90.0738975",
+    "website": "https://thejoytheater.com"
+  }
+]

--- a/data/bars/sf.json
+++ b/data/bars/sf.json
@@ -50,5 +50,12 @@
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJlYxnqhx-j4ARE6-6BQBetEI",
     "gayCities": "https://sanfrancisco.gaycities.com/bars/3-castro",
     "gayCitiesLastScrapedAt": "2026-06-14T05:42:29.719Z"
+  },
+  {
+    "name": "Public Works",
+    "city": "sf",
+    "address": "161 Erie St, San Francisco, CA 94103",
+    "coordinates": "37.7688931, -122.4192651",
+    "website": "https://publicsf.com"
   }
 ]

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -1,4 +1,13 @@
 {
+  "atlanta": [
+    {
+      "name": "The Heretic",
+      "city": "atlanta",
+      "address": "2069 Cheshire Bridge Rd NE, Atlanta, GA 30324",
+      "coordinates": "33.8115012, -84.3552779",
+      "website": "https://hereticatlanta.com"
+    }
+  ],
   "bangkok": [
     {
       "name": "BEEF.BKK",
@@ -309,6 +318,15 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJEc7NGK4byUwR1QVPh5qsYCY",
       "gayCities": "https://montreal.gaycities.com/bars/710-aigle-noir",
       "gayCitiesLastScrapedAt": "2026-06-14T01:14:34.423Z"
+    }
+  ],
+  "nola": [
+    {
+      "name": "Joy Theater",
+      "city": "nola",
+      "address": "1200 Canal St, New Orleans, LA 70112",
+      "coordinates": "29.9559524, -90.0738975",
+      "website": "https://thejoytheater.com"
     }
   ],
   "nyc": [
@@ -650,7 +668,11 @@
       "coordinates": "47.6150824, -122.3237201",
       "website": "https://www.massive.club",
       "instagram": "https://www.instagram.com/massive_club",
-      "gayCities": "https://seattle.gaycities.com/bars/511-massive-nightclub"
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJsabypgNrkFQRWpvZ09NjiBQ",
+      "gayCities": "https://seattle.gaycities.com/bars/511-massive-nightclub",
+      "faviconBg": "#010102",
+      "faviconFg": "#535557",
+      "gayCitiesLastScrapedAt": "2026-07-22T18:31:06.867Z"
     }
   ],
   "sf": [
@@ -705,6 +727,13 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJlYxnqhx-j4ARE6-6BQBetEI",
       "gayCities": "https://sanfrancisco.gaycities.com/bars/3-castro",
       "gayCitiesLastScrapedAt": "2026-06-14T05:42:29.719Z"
+    },
+    {
+      "name": "Public Works",
+      "city": "sf",
+      "address": "161 Erie St, San Francisco, CA 94103",
+      "coordinates": "37.7688931, -122.4192651",
+      "website": "https://publicsf.com"
     }
   ],
   "tokyo": [

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -8,6 +8,15 @@
 // - Can be imported in both Scriptable and web environments
 // - Keep this file environment-agnostic (no Scriptable or DOM APIs)
 const scraperBars = {
+  "atlanta": [
+    {
+      "name": "The Heretic",
+      "city": "atlanta",
+      "address": "2069 Cheshire Bridge Rd NE, Atlanta, GA 30324",
+      "coordinates": "33.8115012, -84.3552779",
+      "website": "https://hereticatlanta.com"
+    }
+  ],
   "bangkok": [
     {
       "name": "BEEF.BKK",
@@ -318,6 +327,15 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJEc7NGK4byUwR1QVPh5qsYCY",
       "gayCities": "https://montreal.gaycities.com/bars/710-aigle-noir",
       "gayCitiesLastScrapedAt": "2026-06-14T01:14:34.423Z"
+    }
+  ],
+  "nola": [
+    {
+      "name": "Joy Theater",
+      "city": "nola",
+      "address": "1200 Canal St, New Orleans, LA 70112",
+      "coordinates": "29.9559524, -90.0738975",
+      "website": "https://thejoytheater.com"
     }
   ],
   "nyc": [
@@ -659,7 +677,11 @@ const scraperBars = {
       "coordinates": "47.6150824, -122.3237201",
       "website": "https://www.massive.club",
       "instagram": "https://www.instagram.com/massive_club",
-      "gayCities": "https://seattle.gaycities.com/bars/511-massive-nightclub"
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJsabypgNrkFQRWpvZ09NjiBQ",
+      "gayCities": "https://seattle.gaycities.com/bars/511-massive-nightclub",
+      "faviconBg": "#010102",
+      "faviconFg": "#535557",
+      "gayCitiesLastScrapedAt": "2026-07-22T18:31:06.867Z"
     }
   ],
   "sf": [
@@ -714,6 +736,13 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJlYxnqhx-j4ARE6-6BQBetEI",
       "gayCities": "https://sanfrancisco.gaycities.com/bars/3-castro",
       "gayCitiesLastScrapedAt": "2026-06-14T05:42:29.719Z"
+    },
+    {
+      "name": "Public Works",
+      "city": "sf",
+      "address": "161 Erie St, San Francisco, CA 94103",
+      "coordinates": "37.7688931, -122.4192651",
+      "website": "https://publicsf.com"
     }
   ],
   "tokyo": [


### PR DESCRIPTION
The first real cycle of the Phase-4 growth loop: three venues you tap-queued in today's run, verified, promoted.

## Evidence per venue (queue dossier + out-of-band verification)

| Venue | City | Queue signal | OSM POI verification | Website |
|---|---|---|---|---|
| The Heretic | atlanta | page-adjacent, exact pin | POI "The Heretic" @ 33.8115012, -84.3552779 — exact match | hereticatlanta.com (200) |
| Joy Theater | nola | page-adjacent, exact pin | POI "Joy Theater" @ 1200 Canal, 70112 — ~10 m from queued pin (same building) | thejoytheater.com (403 to bots; canonical site) |
| Public Works | sf | page-adjacent, exact pin | POI "Public Works" @ 37.7688931, -122.4192651 — exact match | publicsf.com (200) |

## Notes
- **atlanta.json and nola.json are new** — first curated bars for those cities.
- The queue dossiers' website/instagram fields (Bearracuda's links — organizer metadata leaked from promoter-scraped events) were **deliberately not copied**; that dossier bug is being fixed in the map-verify-links PR. Websites here are the venues' own, checked.
- Names stored in canonical case ("Joy Theater", not the flyer's "JOY THEATER") — the matcher is case-insensitive with the-stripping, so "The Heretic"/"Heretic"/"JOY THEATER" extractions all match.
- Effect once deployed: these three venues become deterministic authorities for bar/address/pin merges (🔒, zero AI) and exit the candidate list automatically.

Validated: regeneration via tools/generate-scraper-bars.js; all three present in derived data; suite 607 pass / 0 fail.

📲 No phone download — bars data is fetched live from chunky.dad after the site deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP