### PR TITLE
feat(scraper): map verify links + inline OSM maps in results UI; fix venue-queue runIds and organizer-link pollution

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1237,6 +1237,46 @@ class ScriptableAdapter {
     return existing;
   }
 
+  // Stamp the just-saved run id into venue-queue entries tapped this session.
+  // Queue taps happen while the results sheet is up, BEFORE the run is saved,
+  // so results.savedRunId is null at queue-write time and entries were landing
+  // with runIds: []. The run id is generated from the save timestamp
+  // (saveRun → getRunId), so assigning it earlier would change what a run id
+  // means; instead queueVenueCandidateAndReport records which candidate keys
+  // it wrote and this backfill — called right after saveRun assigns
+  // results.savedRunId — stamps the now-known id into exactly those entries.
+  // Fail open: any failure leaves entries as the tap wrote them.
+  async backfillQueuedVenueRunIds(results) {
+    try {
+      const runId =
+        results && results.savedRunId ? String(results.savedRunId) : "";
+      const keys = Array.isArray(results && results._queuedVenueCandidateKeys)
+        ? results._queuedVenueCandidateKeys
+        : [];
+      if (!runId || keys.length === 0) return;
+      const queue = await this.loadBarAdditions();
+      let stamped = 0;
+      for (const key of keys) {
+        const entry = queue[key];
+        if (!entry || typeof entry !== "object") continue;
+        if (!Array.isArray(entry.runIds)) entry.runIds = [];
+        if (entry.runIds.includes(runId)) continue;
+        entry.runIds.push(runId);
+        entry.runIds = entry.runIds.slice(-10); // same cap as the tap merge
+        stamped += 1;
+      }
+      if (stamped === 0) return;
+      await this.saveBarAdditions(queue);
+      console.log(
+        `📱 Scriptable: Backfilled run id ${runId} into ${stamped} queued venue entr${stamped === 1 ? "y" : "ies"}`,
+      );
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Venue-queue run id backfill failed: ${error.message}`,
+      );
+    }
+  }
+
   extractHttpStatusCodeFromError(error) {
     const message =
       error && typeof error.message === "string" ? error.message : "";
@@ -4032,6 +4072,9 @@ class ScriptableAdapter {
         if (runId) {
           results.savedRunId = runId;
           results.savedRunPath = this.getRunFilePath(runId);
+          // Venue-queue taps happened before this id existed — stamp it into
+          // the entries queued during this session's results sheet.
+          await this.backfillQueuedVenueRunIds(results);
         }
         // Cleanup old JSON runs
         await this.cleanupOldFiles("chunky-dad-scraper/runs", {
@@ -4743,6 +4786,10 @@ class ScriptableAdapter {
             venueQueueTaps,
             webView,
           );
+        } else if (params.a === "open-url") {
+          // Fire-and-forget: opens the registered map verify link in Safari
+          // ON TOP of the results sheet (the WebView never navigates).
+          this.openMapVerifyUrl(params.id);
         }
         return false; // cancel the fake navigation; the page stays put
       };
@@ -4800,6 +4847,10 @@ class ScriptableAdapter {
 
   // Generate rich HTML for WebView display
   async generateRichHTML(results) {
+    // Fresh per-render registry for the open-url bridge: every map verify
+    // link rendered below registers its real URL natively and embeds only
+    // the returned id, so ids in this HTML always match the handler's map.
+    this.resetMapVerifyUrls();
     const allEvents = this.getAllEventsFromResults(results);
     const availableCalendars = await Calendar.forEvents();
 
@@ -6313,6 +6364,43 @@ class ScriptableAdapter {
             } catch (ignore) {}
         }
 
+        // Map verify links: a plain https href would navigate this WebView
+        // away (shouldAllowRequest returns true for normal URLs), so the
+        // links route through the same chunkyscrape:// bridge — native looks
+        // the real URL up by id and opens Safari ON TOP of the results
+        // sheet. Per-tap nonce keeps repeat taps firing as distinct
+        // navigations; returning false cancels the default '#' navigation.
+        window.__mapVerifyNonce = 0;
+        function openMapVerify(el) {
+            var id = el ? (el.getAttribute('data-map-url-id') || '') : '';
+            window.location.href = 'chunkyscrape://act?a=open-url&id=' +
+                encodeURIComponent(id) + '&n=' + (window.__mapVerifyNonce++);
+            return false;
+        }
+
+        // Inline OSM map toggle — pure page JS, no bridge. Lazy by design:
+        // the iframe src is only assigned on the FIRST tap (no map tiles
+        // load until asked), later taps just show/hide the already-loaded
+        // frame. OpenStreetMap embed because it is keyless and matches the
+        // Nominatim geocoding stack the scraper already uses; Google Maps
+        // embeds require an API key.
+        function toggleCandidateMap(btn) {
+            try {
+                var frame = document.getElementById(btn.getAttribute('data-map-target') || '');
+                if (!frame) return;
+                if (frame.style.display === 'none') {
+                    if (!frame.getAttribute('src')) {
+                        frame.setAttribute('src', btn.getAttribute('data-map-embed') || '');
+                    }
+                    frame.style.display = 'block';
+                    btn.textContent = '🗺️ Hide map';
+                } else {
+                    frame.style.display = 'none';
+                    btn.textContent = '🗺️ Show map';
+                }
+            } catch (ignore) {}
+        }
+
         function copyDiscoveryText(btn) {
             const encoded = btn.getAttribute('data-encoded') || '';
             let text = '';
@@ -7391,6 +7479,154 @@ class ScriptableAdapter {
   }
 
   // ---------------------------------------------------------------------------
+  // Map verify links (results-UI ↔ chunkyscrape:// bridge, read-only).
+  // The owner verifies a venue by comparing three independent Google Maps
+  // lookups: what the bar name+city resolves to, what the address resolves
+  // to, and where the stored pin actually is. Each row gets up to three
+  // compact links (only for data that exists). A plain https href would
+  // navigate the results WebView away (shouldAllowRequest returns true for
+  // normal URLs), so links route through the chunkyscrape:// bridge: the
+  // page navigates to chunkyscrape://act?a=open-url&id=<n>, native looks the
+  // real URL up in a per-render registry and calls Safari.open — Safari
+  // opens ON TOP and the results sheet stays put. URLs are built with
+  // encodeURIComponent only (no `new URL`/URLSearchParams in this runtime).
+  // ---------------------------------------------------------------------------
+
+  // "lat, lng" text → { lat, lng } numbers, or null (shared by the pin link
+  // and the OSM embed; candidates/events store coordinates as one string).
+  parseCoordinatePairText(value) {
+    const parts = String(value || "").split(",");
+    if (parts.length !== 2) return null;
+    const lat = Number(parts[0].trim());
+    const lng = Number(parts[1].trim());
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+    return { lat, lng };
+  }
+
+  // Human-searchable city name for Maps queries. The generated
+  // scraper-cities.js carries no display name, but each city's FIRST alias
+  // pattern is its full lowercase name ("nyc" → "new york", "la" →
+  // "los angeles"); unknown keys fall back to the de-hyphenated key
+  // ("fort-lauderdale" → "fort lauderdale"). Maps search is case-insensitive.
+  getCityDisplayNameForMaps(cityKey) {
+    const key = typeof cityKey === "string" ? cityKey.trim() : "";
+    if (!key) return "";
+    const cityConfig = this.cities ? this.cities[key] : null;
+    const firstPattern =
+      cityConfig && Array.isArray(cityConfig.patterns)
+        ? cityConfig.patterns[0]
+        : "";
+    if (typeof firstPattern === "string" && firstPattern.trim()) {
+      return firstPattern.trim();
+    }
+    return key.replace(/-/g, " ");
+  }
+
+  buildMapsSearchUrl(query) {
+    const text = typeof query === "string" ? query.trim() : "";
+    if (!text) return "";
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(text)}`;
+  }
+
+  // Bar link: what "<bar name>, <city>" resolves to on Google Maps.
+  buildBarMapsSearchUrl(barName, cityKey) {
+    const name = typeof barName === "string" ? barName.trim() : "";
+    if (!name) return "";
+    const city = this.getCityDisplayNameForMaps(cityKey);
+    return this.buildMapsSearchUrl(city ? `${name}, ${city}` : name);
+  }
+
+  // Address link: what the stored address resolves to. The city is appended
+  // ONLY when the address doesn't already contain the city name
+  // (case-insensitive) — bare street addresses are ambiguous across cities.
+  buildAddressMapsSearchUrl(address, cityKey) {
+    const text = typeof address === "string" ? address.trim() : "";
+    if (!text) return "";
+    const city = this.getCityDisplayNameForMaps(cityKey);
+    const alreadyHasCity =
+      city && text.toLowerCase().includes(city.toLowerCase());
+    return this.buildMapsSearchUrl(
+      city && !alreadyHasCity ? `${text}, ${city}` : text,
+    );
+  }
+
+  // Pin link: where the stored coordinates actually land.
+  buildPinMapsSearchUrl(coordinates) {
+    const pair = this.parseCoordinatePairText(coordinates);
+    if (!pair) return "";
+    return this.buildMapsSearchUrl(`${pair.lat},${pair.lng}`);
+  }
+
+  // Keyless OpenStreetMap embed centered on the pin (~400m box, marker on
+  // the pin). OSM because it needs no API key and matches the Nominatim
+  // stack the scraper already geocodes with; Google Maps embeds require an
+  // API key. Same viewport as the review UI's buildReviewPinHtml.
+  buildOsmEmbedUrl(coordinates) {
+    const pair = this.parseCoordinatePairText(coordinates);
+    if (!pair) return "";
+    const boxDegrees = 0.004;
+    const bbox = `${pair.lng - boxDegrees},${pair.lat - boxDegrees},${pair.lng + boxDegrees},${pair.lat + boxDegrees}`;
+    const marker = `${pair.lat},${pair.lng}`;
+    return `https://www.openstreetmap.org/export/embed.html?bbox=${encodeURIComponent(bbox)}&layer=mapnik&marker=${encodeURIComponent(marker)}`;
+  }
+
+  // Per-render native-side URL registry for the open-url bridge (same
+  // pattern as collectVenueEntrySnippets: URLs never travel through the
+  // chunkyscrape:// URL, only their ids do). generateRichHTML resets it so
+  // ids embedded in the HTML always match what the handler reads.
+  resetMapVerifyUrls() {
+    this._mapVerifyUrls = {};
+    this._mapVerifyUrlNextId = 0;
+  }
+
+  registerMapVerifyUrl(url) {
+    if (!this._mapVerifyUrls || typeof this._mapVerifyUrlNextId !== "number") {
+      this.resetMapVerifyUrls();
+    }
+    const id = String(this._mapVerifyUrlNextId++);
+    this._mapVerifyUrls[id] = url;
+    return id;
+  }
+
+  // Compact "Verify:" row with up to three bridge links; "" when no data.
+  buildMapVerifyLinksHtml({ bar, city, address, coordinates } = {}) {
+    const links = [];
+    const barUrl = this.buildBarMapsSearchUrl(bar, city);
+    if (barUrl) links.push({ label: "Bar", url: barUrl });
+    const addressUrl = this.buildAddressMapsSearchUrl(address, city);
+    if (addressUrl) links.push({ label: "Address", url: addressUrl });
+    const pinUrl = this.buildPinMapsSearchUrl(coordinates);
+    if (pinUrl) links.push({ label: "Pin", url: pinUrl });
+    if (links.length === 0) return "";
+    const anchors = links
+      .map(({ label, url }) => {
+        const id = this.registerMapVerifyUrl(url);
+        return `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="map-verify-link" style="color:var(--primary-color); text-decoration:none;">${label} ↗</a>`;
+      })
+      .join("");
+    return `<div class="map-verify-row" style="display:flex; gap:10px; align-items:center; font-size:12px; margin:4px 0;"><span style="color:var(--text-secondary);">Verify:</span>${anchors}</div>`;
+  }
+
+  // Open one registered verify link in Safari, on top of the results sheet.
+  // Called fire-and-forget from shouldAllowRequest (which must synchronously
+  // return false to cancel the fake navigation) — Safari opens over the
+  // sheet and the results WebView never navigates.
+  openMapVerifyUrl(id) {
+    try {
+      const url = this._mapVerifyUrls
+        ? this._mapVerifyUrls[String(id)]
+        : undefined;
+      if (typeof url !== "string" || url.indexOf("https://") !== 0) return;
+      Safari.open(url);
+      console.log(`📱 Scriptable: Opened map verify link #${id} in Safari`);
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Failed to open map verify link: ${error.message}`,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // New venue candidates (results-UI ↔ chunkyscrape:// bridge, GATHERING-ONLY).
   // Confirmed-new venues detected by SharedCore.buildNewVenueCandidates get a
   // "Queue for bars data" button; a tap appends evidence to bar-additions.json.
@@ -7432,13 +7668,34 @@ class ScriptableAdapter {
         const control = queuedEntry
           ? `<span style="font-size:12px; color:var(--text-secondary);">Queued ✓ (seen ${Number(queuedEntry.timesSeen) || 1} times)</span>`
           : `<button onclick="queueVenueCandidate(this)" class="log-copy-btn venue-queue-btn" data-nvq-index="${index}">➕ Queue for bars data</button>`;
+        // Primary verification surface: Bar/Address/Pin Google Maps links
+        // (bridge-routed so Safari opens over the sheet) plus a lazy inline
+        // OSM map — no iframe loads anything until its toggle is tapped.
+        const verifyRow = this.buildMapVerifyLinksHtml({
+          bar: candidate.name,
+          city: candidate.city,
+          address: candidate.address,
+          coordinates: candidate.coordinates,
+        });
+        const osmEmbedUrl = this.buildOsmEmbedUrl(candidate.coordinates);
+        const mapToggle = osmEmbedUrl
+          ? `<button onclick="toggleCandidateMap(this)" class="log-copy-btn nvq-map-btn" data-map-embed="${this.escapeHtml(osmEmbedUrl)}" data-map-target="nvq_map_${index}">🗺️ Show map</button>`
+          : "";
+        const mapFrame = osmEmbedUrl
+          ? `<iframe id="nvq_map_${index}" class="nvq-map-frame" style="display:none; width:100%; height:220px; border:0; border-radius:8px; margin-top:6px;"></iframe>`
+          : "";
         return `
         <div class="new-venue-candidate" style="margin-bottom:14px; padding:10px; background:var(--background-light); border-radius:8px;">
             <div style="font-weight:600; margin-bottom:4px;">${this.escapeHtml(candidate.name || "Unknown")} <span style="font-weight:400; opacity:0.7;">(${this.escapeHtml(candidate.city || "unknown city")})</span></div>
             ${candidate.address ? `<div style="font-size:12px; margin-bottom:2px; color:var(--text-secondary);">${this.escapeHtml(candidate.address)}</div>` : ""}
             <div style="font-size:12px; margin-bottom:2px; color:var(--text-secondary);">Signals: ${this.escapeHtml(signalsText)}</div>
             ${eventsText ? `<div style="font-size:12px; margin-bottom:6px; color:var(--text-secondary);">Hosting: ${this.escapeHtml(eventsText)}</div>` : ""}
-            ${control}
+            ${verifyRow}
+            <div style="display:flex; gap:6px; align-items:center; flex-wrap:wrap;">
+                ${control}
+                ${mapToggle}
+            </div>
+            ${mapFrame}
         </div>`;
       })
       .join("");
@@ -7486,6 +7743,15 @@ class ScriptableAdapter {
         await this.saveBarAdditions(queue);
         timesSeen = Number(entry.timesSeen) || 1;
         tapped[key] = timesSeen;
+        // Remember which entries this session wrote: the run id does not
+        // exist yet (the run is saved after the sheet is dismissed), so
+        // backfillQueuedVenueRunIds stamps it into these keys post-save.
+        if (!Array.isArray(results._queuedVenueCandidateKeys)) {
+          results._queuedVenueCandidateKeys = [];
+        }
+        if (!results._queuedVenueCandidateKeys.includes(candidate.key)) {
+          results._queuedVenueCandidateKeys.push(candidate.key);
+        }
         console.log(
           `📱 Scriptable: Queued venue candidate "${candidate.name}" (${candidate.city}) — seen ${timesSeen} time(s)`,
         );
@@ -7909,6 +8175,16 @@ class ScriptableAdapter {
     const notes = event.notes || "";
     const calendarName = this.getCalendarNameForDisplay(event);
 
+    // Secondary verification surface (kept small): the same Bar/Address/Pin
+    // Google Maps links as the new-venue-candidates section, rendered only
+    // when the card has data for them (empty string otherwise).
+    const mapVerifyRow = this.buildMapVerifyLinksHtml({
+      bar: event.bar || event.venue,
+      city: event.city,
+      address: event.address,
+      coordinates: event.location,
+    });
+
     let html = `
         <div class="event-card">
             ${actionBadge}
@@ -7947,6 +8223,7 @@ class ScriptableAdapter {
                 `
                     : ""
                 }
+                ${mapVerifyRow}
                 <div class="event-detail">
                     <span>📅</span>
                     <span>${dateStr} ${timeStr}${endTimeStr ? ` - ${endTimeStr}` : ""}</span>

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1928,20 +1928,291 @@ test('NOTHING in the scraping pipeline reads bar-additions.json (gathering-only)
     assert.ok(!source.includes('bar-additions'), `${rel} must not reference bar-additions.json`);
     assert.ok(!source.includes('BarAdditions'), `${rel} must not call the queue accessors`);
   }
-  // In the Scriptable adapter the queue is read in exactly two places, both
-  // results-UI-side: the "Queued ✓" badge and the queue-tap handler. The
-  // bars-data load path (loadBarsConfiguration/fetchRemoteBarsJson) and the
-  // run pipeline never touch it.
+  // In the Scriptable adapter the queue is read in exactly three places, all
+  // results-UI-side: the "Queued ✓" badge, the queue-tap handler, and the
+  // post-save run-id backfill for this session's taps. The bars-data load
+  // path (loadBarsConfiguration/fetchRemoteBarsJson) and the run pipeline
+  // never touch it.
   const adapterSource = fs.readFileSync(path.join(__dirname, 'scriptable-adapter.js'), 'utf8');
   const readCallSites = adapterSource
     .split('\n')
     .filter(line => line.includes('this.loadBarAdditions('));
-  assert.equal(readCallSites.length, 2,
-    `queue reads allowed only in the badge renderer and the tap handler, found: ${readCallSites.join(' | ')}`);
+  assert.equal(readCallSites.length, 3,
+    `queue reads allowed only in the badge renderer, the tap handler, and the run-id backfill, found: ${readCallSites.join(' | ')}`);
   const barsLoaderSource = adapterSource.slice(
     adapterSource.indexOf('async loadBarsConfiguration'),
     adapterSource.indexOf('async fetchRemoteBarsJson'));
   assert.ok(barsLoaderSource.length > 0, 'bars loader located');
   assert.ok(!barsLoaderSource.includes('BarAdditions') && !barsLoaderSource.includes('bar-additions'),
     'the bars-data load path never reads the queue');
+});
+
+// ---------------------------------------------------------------------------
+// Map verify links (Bar/Address/Pin Google Maps lookups) + inline OSM maps
+// ---------------------------------------------------------------------------
+
+const MAPS_SEARCH_PREFIX = 'https://www.google.com/maps/search/?api=1&query=';
+
+function buildMapsAdapter() {
+  return new ScriptableAdapter({
+    cities: {
+      nyc: { patterns: ['new york', 'nyc', 'manhattan'] },
+      seattle: { patterns: ['seattle'] }
+    }
+  });
+}
+
+test('open-url action URLs parse like the other chunkyscrape actions', () => {
+  const adapter = buildMapsAdapter();
+  const params = adapter.parseReviewActionUrl('chunkyscrape://act?a=open-url&id=4&n=9');
+  assert.equal(params.a, 'open-url');
+  assert.equal(params.id, '4');
+  assert.equal(params.n, '9');
+});
+
+test('bar verify link searches "<bar>, <city display name>" with full encoding', () => {
+  const adapter = buildMapsAdapter();
+  assert.equal(
+    adapter.buildBarMapsSearchUrl('Massive', 'seattle'),
+    `${MAPS_SEARCH_PREFIX}Massive%2C%20seattle`);
+  // The city display name is the first alias pattern ("nyc" → "new york"),
+  // and ampersands are percent-encoded (no new URL/URLSearchParams).
+  assert.equal(
+    adapter.buildBarMapsSearchUrl('Bear & Bull', 'nyc'),
+    `${MAPS_SEARCH_PREFIX}Bear%20%26%20Bull%2C%20new%20york`);
+  // Unicode venue names survive encodeURIComponent.
+  assert.equal(
+    adapter.buildBarMapsSearchUrl('Café Lambda', 'seattle'),
+    `${MAPS_SEARCH_PREFIX}Caf%C3%A9%20Lambda%2C%20seattle`);
+  // Unknown city keys fall back to the de-hyphenated key.
+  assert.equal(
+    adapter.buildBarMapsSearchUrl('Ramrod', 'fort-lauderdale'),
+    `${MAPS_SEARCH_PREFIX}Ramrod%2C%20fort%20lauderdale`);
+  // No city → bar alone; no bar → no link at all.
+  assert.equal(adapter.buildBarMapsSearchUrl('Massive', ''), `${MAPS_SEARCH_PREFIX}Massive`);
+  assert.equal(adapter.buildBarMapsSearchUrl('', 'seattle'), '');
+  assert.equal(adapter.buildBarMapsSearchUrl('   ', 'seattle'), '');
+});
+
+test('address verify link appends the city only when the address lacks it', () => {
+  const adapter = buildMapsAdapter();
+  // Address already contains the city name (case-insensitive) → no append.
+  assert.equal(
+    adapter.buildAddressMapsSearchUrl('1400 12th Ave, Seattle, WA 98122', 'seattle'),
+    `${MAPS_SEARCH_PREFIX}1400%2012th%20Ave%2C%20Seattle%2C%20WA%2098122`);
+  // Bare street address → city appended for disambiguation.
+  assert.equal(
+    adapter.buildAddressMapsSearchUrl('1400 12th Ave', 'seattle'),
+    `${MAPS_SEARCH_PREFIX}1400%2012th%20Ave%2C%20seattle`);
+  // City display name (not the key) is what gets matched and appended.
+  assert.equal(
+    adapter.buildAddressMapsSearchUrl('225 E Houston St, New York, NY', 'nyc'),
+    `${MAPS_SEARCH_PREFIX}225%20E%20Houston%20St%2C%20New%20York%2C%20NY`);
+  // No address → no link.
+  assert.equal(adapter.buildAddressMapsSearchUrl('', 'seattle'), '');
+});
+
+test('pin verify link searches the raw coordinates; non-coordinates yield no link', () => {
+  const adapter = buildMapsAdapter();
+  assert.equal(
+    adapter.buildPinMapsSearchUrl('47.6135, -122.3163'),
+    `${MAPS_SEARCH_PREFIX}47.6135%2C-122.3163`);
+  assert.equal(adapter.buildPinMapsSearchUrl('The Cuff, Seattle'), '');
+  assert.equal(adapter.buildPinMapsSearchUrl(''), '');
+  assert.equal(adapter.buildPinMapsSearchUrl(undefined), '');
+});
+
+test('verify row renders only links whose data exists, always via the bridge', () => {
+  const adapter = buildMapsAdapter();
+  assert.equal(adapter.buildMapVerifyLinksHtml({}), '', 'no data → no row');
+  assert.equal(adapter.buildMapVerifyLinksHtml(), '', 'no argument → no row');
+
+  const pinOnly = adapter.buildMapVerifyLinksHtml({ coordinates: '47.61, -122.33' });
+  assert.ok(pinOnly.includes('Pin ↗'));
+  assert.ok(!pinOnly.includes('Bar ↗') && !pinOnly.includes('Address ↗'),
+    'absent fields render no links');
+
+  const full = adapter.buildMapVerifyLinksHtml({
+    bar: 'Massive', city: 'seattle',
+    address: '1400 12th Ave', coordinates: '47.6135, -122.3163'
+  });
+  for (const label of ['Bar ↗', 'Address ↗', 'Pin ↗']) {
+    assert.ok(full.includes(label), `${label} link present`);
+  }
+  assert.ok(full.includes('openMapVerify(this)'), 'links signal via the bridge');
+  assert.ok(!full.includes('href="https'),
+    'no plain https hrefs — those would navigate the results WebView away');
+  // Each embedded id resolves to a registered Google Maps URL natively.
+  const ids = [...full.matchAll(/data-map-url-id="(\d+)"/g)].map((m) => m[1]);
+  assert.equal(ids.length, 3);
+  for (const id of ids) {
+    assert.ok(adapter._mapVerifyUrls[id].startsWith(MAPS_SEARCH_PREFIX),
+      'URL retrievable from the native-side registry');
+  }
+});
+
+test('OSM embed URL has the keyless bbox/marker shape with encoded commas', () => {
+  const adapter = buildMapsAdapter();
+  const lat = 47.6135;
+  const lng = -122.3163;
+  const d = 0.004;
+  const url = adapter.buildOsmEmbedUrl(`${lat}, ${lng}`);
+  assert.equal(
+    url,
+    'https://www.openstreetmap.org/export/embed.html'
+      + `?bbox=${encodeURIComponent(`${lng - d},${lat - d},${lng + d},${lat + d}`)}`
+      + `&layer=mapnik&marker=${encodeURIComponent(`${lat},${lng}`)}`);
+  assert.ok(url.includes('marker=47.6135%2C-122.3163'), 'marker is lat%2Clng');
+  assert.ok(!url.includes('key='), 'keyless embed (why OSM, not Google)');
+  assert.equal(adapter.buildOsmEmbedUrl('not coordinates'), '');
+});
+
+test('candidate rows carry the verify row and a lazy inline map toggle', async () => {
+  const adapter = buildMapsAdapter();
+  adapter.fm = createDeadEndFmStub();
+
+  const html = await adapter.generateNewVenueCandidateSection({
+    newVenueCandidates: [buildVenueCandidate()]
+  });
+  assert.ok(html.includes('Verify:'), 'verify row present');
+  assert.ok(html.includes('Bar ↗') && html.includes('Address ↗') && html.includes('Pin ↗'));
+  assert.ok(html.includes('toggleCandidateMap(this)'), 'map toggle wired');
+  assert.ok(html.includes('data-map-embed='), 'embed URL carried on the toggle');
+  assert.ok(html.includes('id="nvq_map_0"'), 'iframe target present');
+  assert.ok(!/<iframe[^>]*\ssrc=/.test(html),
+    'lazy: no iframe src until the toggle is tapped');
+
+  // Without coordinates there is no pin link and no map toggle at all.
+  const noCoords = await adapter.generateNewVenueCandidateSection({
+    newVenueCandidates: [buildVenueCandidate({ coordinates: '' })]
+  });
+  assert.ok(!noCoords.includes('toggleCandidateMap'), 'no toggle without coordinates');
+  assert.ok(!noCoords.includes('<iframe'), 'no iframe without coordinates');
+  assert.ok(!noCoords.includes('Pin ↗'), 'no pin link without coordinates');
+  assert.ok(noCoords.includes('Bar ↗'), 'other links unaffected');
+});
+
+test('event cards carry the compact verify row only when venue-ish data exists', () => {
+  const adapter = buildMapsAdapter();
+  const html = adapter.generateEventCard({
+    title: 'Bear Night',
+    startDate: '2026-08-01T02:00:00.000Z',
+    city: 'seattle',
+    bar: 'Massive',
+    address: '1400 12th Ave',
+    location: '47.6135, -122.3163',
+    _action: 'new'
+  });
+  assert.ok(html.includes('map-verify-row'), 'compact row on the card');
+  assert.ok(html.includes('Bar ↗') && html.includes('Address ↗') && html.includes('Pin ↗'));
+
+  const bare = adapter.generateEventCard({
+    title: 'No venue data',
+    startDate: '2026-08-01T02:00:00.000Z',
+    _action: 'new'
+  });
+  assert.ok(!bare.includes('map-verify-row'), 'no row without bar/address/location');
+});
+
+test('presentRichResults opens verify links in Safari via the open-url bridge', async () => {
+  const adapter = buildMapsAdapter();
+  adapter.fm = createDeadEndFmStub();
+  // calendarEvents already set → the execution prompt path is skipped
+  const results = {
+    ...buildResultsStub(),
+    calendarEvents: 1,
+    newVenueCandidates: [buildVenueCandidate()]
+  };
+
+  const opened = [];
+  global.Safari = { open: (url) => { opened.push(url); } };
+  const wv = installFakeWebView();
+  try {
+    const done = adapter.presentRichResults(results);
+    for (let i = 0; i < 200 && !wv.getHandler(); i++) {
+      await new Promise((r) => setImmediate(r));
+    }
+    assert.ok(wv.getHandler(), 'shouldAllowRequest assigned before present()');
+    const ids = Object.keys(adapter._mapVerifyUrls);
+    assert.ok(ids.length >= 3, 'candidate verify URLs registered natively during render');
+
+    // A verify tap: navigation cancelled, Safari opens the registered URL
+    // on top — the results WebView itself never navigates.
+    assert.equal(wv.tap(`chunkyscrape://act?a=open-url&id=${ids[0]}&n=1`), false,
+      'fake navigation cancelled');
+    await new Promise((r) => setImmediate(r));
+    assert.deepEqual(opened, [adapter._mapVerifyUrls[ids[0]]],
+      'Safari.open received the native-side URL');
+
+    // An unknown id is ignored without crashing.
+    assert.equal(wv.tap('chunkyscrape://act?a=open-url&id=999&n=2'), false);
+    await new Promise((r) => setImmediate(r));
+    assert.equal(opened.length, 1);
+
+    wv.dismiss();
+    await done;
+  } finally {
+    delete global.WebView;
+    delete global.Safari;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Venue-queue run id backfill (taps precede the save that mints the run id)
+// ---------------------------------------------------------------------------
+
+test('venue-queue entries queued before the run id exists get it backfilled after save', async () => {
+  const adapter = buildMapsAdapter();
+  adapter.fm = createDeadEndFmStub();
+  const results = { newVenueCandidates: [buildVenueCandidate()] };
+  const wvStub = { evaluateJavaScript: async () => {} };
+
+  // Tap while the results sheet is up: the run has not been saved yet, so
+  // no run id exists and the entry lands with runIds: [] — the bug shape.
+  await adapter.queueVenueCandidateAndReport('0', results, {}, wvStub);
+  let queue = await adapter.loadBarAdditions();
+  assert.deepEqual(queue['seattle|massive'].runIds, [],
+    'tap-time write has no run id (display precedes save)');
+  assert.deepEqual(results._queuedVenueCandidateKeys, ['seattle|massive'],
+    'the session remembers which keys it queued');
+
+  // The save path mints the id afterwards; the backfill stamps it in.
+  results.savedRunId = '20260723-101010';
+  await adapter.backfillQueuedVenueRunIds(results);
+  queue = await adapter.loadBarAdditions();
+  assert.deepEqual(queue['seattle|massive'].runIds, ['20260723-101010'],
+    'queued entry ends up with the real run id');
+
+  // Idempotent — a repeat backfill never duplicates the id.
+  await adapter.backfillQueuedVenueRunIds(results);
+  queue = await adapter.loadBarAdditions();
+  assert.deepEqual(queue['seattle|massive'].runIds, ['20260723-101010']);
+});
+
+test('run id backfill preserves history, skips foreign entries, and fails open', async () => {
+  const adapter = buildMapsAdapter();
+  adapter.fm = createDeadEndFmStub();
+  adapter.fm.files.set(adapter.getBarAdditionsFilePath(), JSON.stringify({
+    'seattle|massive': { name: 'Massive', timesSeen: 2, runIds: ['20260701-090000'] },
+    'seattle|neighbours': { name: 'Neighbours', timesSeen: 1, runIds: [] }
+  }));
+
+  // Only this session's keys are stamped; prior run ids are kept.
+  const results = {
+    savedRunId: '20260723-101010',
+    _queuedVenueCandidateKeys: ['seattle|massive', 'seattle|gone-missing']
+  };
+  await adapter.backfillQueuedVenueRunIds(results);
+  const queue = await adapter.loadBarAdditions();
+  assert.deepEqual(queue['seattle|massive'].runIds,
+    ['20260701-090000', '20260723-101010'], 'new id appended after history');
+  assert.deepEqual(queue['seattle|neighbours'].runIds, [],
+    'entries not queued this session are untouched');
+
+  // No session keys or no run id → no write at all (fail open).
+  const before = adapter.fm.files.get(adapter.getBarAdditionsFilePath());
+  await adapter.backfillQueuedVenueRunIds({ savedRunId: '20260724-000000' });
+  await adapter.backfillQueuedVenueRunIds({ _queuedVenueCandidateKeys: ['seattle|massive'] });
+  assert.equal(adapter.fm.files.get(adapter.getBarAdditionsFilePath()), before,
+    'nothing rewritten without both a run id and session keys');
 });

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2180,10 +2180,27 @@ class SharedCore {
             const key = `${cityKey}|${this.normalizeBarNameKey(bar)}`;
             const barSource = event.barSource.trim();
             const address = typeof event.address === 'string' ? event.address.trim() : '';
-            const website = typeof event.website === 'string' && event.website.trim()
-                ? event.website.trim()
-                : (typeof event.url === 'string' ? event.url.trim() : '');
-            const instagram = typeof event.instagram === 'string' ? event.instagram.trim() : '';
+            // Organizer-link pollution guard: an event's website/instagram
+            // describe whatever entity the SOURCE PAGE is about — on
+            // promoter-scraped events that's the ORGANIZER (e.g.
+            // bearracuda.com / @bearracuda), not the venue hosting the party.
+            // The only stamp proving the page IS the venue's own site is
+            // barSource === 'venue-site' (siteRole=venue + page-name match at
+            // extraction time — see ai-web-parser's stampBarSourceProvenance),
+            // so the dossier carries website/instagram only from those events.
+            // Otherwise both fields are omitted entirely: in a curation
+            // dossier, missing data beats wrong data (and the adapter's
+            // fill-blanks-only queue merge means an omission here never
+            // re-adds organizer links to entries that lack them).
+            const linksAreVenueAttributable = barSource === 'venue-site';
+            const website = linksAreVenueAttributable
+                ? (typeof event.website === 'string' && event.website.trim()
+                    ? event.website.trim()
+                    : (typeof event.url === 'string' ? event.url.trim() : ''))
+                : '';
+            const instagram = linksAreVenueAttributable && typeof event.instagram === 'string'
+                ? event.instagram.trim()
+                : '';
 
             let candidate = byKey.get(key);
             if (!candidate) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -6806,3 +6806,77 @@ test('new venue candidate log line has the documented shape', () => {
     '📋 NEW VENUE CANDIDATE: "Massive" (seattle) — signals: venue-site — no address observed'
   );
 });
+
+test('candidate dossier omits website/instagram unless the source page is the venue\'s own site', () => {
+  const core = createVenueDiscoveryCore();
+
+  // Organizer-page events (e.g. a promoter site like bearracuda.com): the
+  // event's website/instagram are the ORGANIZER's metadata, not the venue's —
+  // both fields must be omitted from the dossier entirely.
+  const [organizer] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      barSource: 'page-adjacent',
+      website: 'https://bearracuda.com/',
+      instagram: 'https://instagram.com/bearracuda',
+      url: 'https://bearracuda.com/events/seattle'
+    })
+  ]);
+  assert.ok(!('website' in organizer), 'organizer website omitted from the dossier');
+  assert.ok(!('instagram' in organizer), 'organizer instagram omitted from the dossier');
+
+  // geo-poi corroborates the bar name via map placemarks — still not the
+  // venue's own site, so links stay out.
+  const [geoPoi] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      barSource: 'geo-poi',
+      instagram: 'https://instagram.com/bearracuda'
+    })
+  ]);
+  assert.ok(!('website' in geoPoi) && !('instagram' in geoPoi),
+    'geo-poi events contribute no links');
+
+  // venue-site events keep both: barSource 'venue-site' is only stamped when
+  // the source page IS the venue's own site (siteRole venue + name match).
+  const [venueSite] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      barSource: 'venue-site',
+      website: 'https://massiveseattle.com',
+      instagram: 'https://instagram.com/massiveseattle'
+    })
+  ]);
+  assert.equal(venueSite.website, 'https://massiveseattle.com');
+  assert.equal(venueSite.instagram, 'https://instagram.com/massiveseattle');
+
+  // The event-page-url fallback for website also only applies to venue-site
+  // events (a page on the venue's own site is venue-attributable).
+  const [urlFallback] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      barSource: 'venue-site',
+      website: undefined,
+      url: 'https://massiveseattle.com/events/bear-night'
+    })
+  ]);
+  assert.equal(urlFallback.website, 'https://massiveseattle.com/events/bear-night');
+});
+
+test('mixed-provenance dedup takes links only from the venue-site observation', () => {
+  const core = createVenueDiscoveryCore();
+  const [candidate] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      barSource: 'page-adjacent',
+      website: 'https://bearracuda.com/',
+      instagram: 'https://instagram.com/bearracuda',
+      title: 'Bearracuda Seattle'
+    }),
+    buildVenueCandidateEvent({
+      barSource: 'venue-site',
+      website: 'https://massiveseattle.com',
+      instagram: undefined,
+      title: 'Bear Night'
+    })
+  ]);
+  assert.equal(candidate.website, 'https://massiveseattle.com',
+    'venue-site link lands; the organizer link never does');
+  assert.ok(!('instagram' in candidate),
+    'no venue-attributable instagram observed → field omitted');
+});


### PR DESCRIPTION
The verification workflow from the first queue cycle, built into the UI — plus the two Phase-4 bugs that cycle exposed.

## Map verify links
Every new-venue candidate (primary) and event card (compact secondary) gets a `Verify: Bar ↗ Address ↗ Pin ↗` row:
- **Bar** → Google Maps search for `<bar>, <city>`
- **Address** → Google Maps search, city appended only when the address doesn't already contain it
- **Pin** → Google Maps at the exact stored coordinates
Three quick taps tell you whether name, address, and pin all agree — the exact manual check from today, one tap each. Links route through the chunkyscrape:// bridge → `Safari.open()` (native-side URL registry, per-tap nonce), so Safari opens on top and the results sheet never navigates away.

## Inline map
Per-candidate **Show map** toggle: lazy keyless OpenStreetMap embed (marker at the pin, loads only on first tap). OSM chosen over Google embeds (no API key; matches the Nominatim stack).

## Phase-4 fixes from today's real queue file
- **`runIds: []` bug**: run ids are assigned at save time, after the taps — queued keys are now recorded per session and **backfilled** with the real run id right after the run saves. (Chosen over early assignment, which would have decoupled the id from the save timestamp and stamped never-saved runs.)
- **Organizer-link pollution**: dossiers were inheriting Bearracuda's website/instagram from promoter-scraped events. Now website/instagram enter a dossier only from `venue-site`-stamped events — the one stamp that proves the source page belongs to the venue. Existing wrong entries left for the verification cycle (which already caught them in #1521).

+13 tests (URL construction incl. encoding + city-dedup, open-url bridge action, OSM embed shape, section placement, runId backfill, venue-attribution both ways, gathering-only purity test updated). Suite: **620 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/adapters/scriptable-adapter.js`, `scripts/parsers/ai-web-parser.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP