### PR TITLE
feat(scraper): map verification suite — verify/route links, dual inline maps, computed evidence panel + venue-queue fixes

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -6386,17 +6386,25 @@ class ScriptableAdapter {
         // embeds require an API key.
         function toggleCandidateMap(btn) {
             try {
-                var frame = document.getElementById(btn.getAttribute('data-map-target') || '');
-                if (!frame) return;
-                if (frame.style.display === 'none') {
-                    if (!frame.getAttribute('src')) {
-                        frame.setAttribute('src', btn.getAttribute('data-map-embed') || '');
+                var target = document.getElementById(btn.getAttribute('data-map-target') || '');
+                if (!target) return;
+                if (target.style.display === 'none') {
+                    // Lazy: every iframe in the container (OSM + the legacy
+                    // Google embed) gets its src from its own data-map-embed
+                    // only on the first reveal — nothing loads until then.
+                    var frames = target.tagName === 'IFRAME'
+                        ? [target]
+                        : target.querySelectorAll('iframe');
+                    for (var i = 0; i < frames.length; i++) {
+                        if (!frames[i].getAttribute('src')) {
+                            frames[i].setAttribute('src', frames[i].getAttribute('data-map-embed') || '');
+                        }
                     }
-                    frame.style.display = 'block';
-                    btn.textContent = '🗺️ Hide map';
+                    target.style.display = 'block';
+                    btn.textContent = '🗺️ Hide maps';
                 } else {
-                    frame.style.display = 'none';
-                    btn.textContent = '🗺️ Show map';
+                    target.style.display = 'none';
+                    btn.textContent = '🗺️ Show maps';
                 }
             } catch (ignore) {}
         }
@@ -7528,33 +7536,74 @@ class ScriptableAdapter {
     return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(text)}`;
   }
 
-  // Bar link: what "<bar name>, <city>" resolves to on Google Maps.
-  buildBarMapsSearchUrl(barName, cityKey) {
+  // Bar query: "<bar name>, <city>" ("" without a bar). The single Bar link
+  // and the Route link both build from this exact string.
+  buildBarMapsQuery(barName, cityKey) {
     const name = typeof barName === "string" ? barName.trim() : "";
     if (!name) return "";
     const city = this.getCityDisplayNameForMaps(cityKey);
-    return this.buildMapsSearchUrl(city ? `${name}, ${city}` : name);
+    return city ? `${name}, ${city}` : name;
   }
 
-  // Address link: what the stored address resolves to. The city is appended
-  // ONLY when the address doesn't already contain the city name
-  // (case-insensitive) — bare street addresses are ambiguous across cities.
-  buildAddressMapsSearchUrl(address, cityKey) {
+  // Bar link: what "<bar name>, <city>" resolves to on Google Maps.
+  buildBarMapsSearchUrl(barName, cityKey) {
+    return this.buildMapsSearchUrl(this.buildBarMapsQuery(barName, cityKey));
+  }
+
+  // Address query: the stored address, with the city appended ONLY when the
+  // address doesn't already contain the city name (case-insensitive) — bare
+  // street addresses are ambiguous across cities. Shared by the single
+  // Address link and the Route link.
+  buildAddressMapsQuery(address, cityKey) {
     const text = typeof address === "string" ? address.trim() : "";
     if (!text) return "";
     const city = this.getCityDisplayNameForMaps(cityKey);
     const alreadyHasCity =
       city && text.toLowerCase().includes(city.toLowerCase());
-    return this.buildMapsSearchUrl(
-      city && !alreadyHasCity ? `${text}, ${city}` : text,
-    );
+    return city && !alreadyHasCity ? `${text}, ${city}` : text;
+  }
+
+  // Address link: what the stored address resolves to.
+  buildAddressMapsSearchUrl(address, cityKey) {
+    return this.buildMapsSearchUrl(this.buildAddressMapsQuery(address, cityKey));
+  }
+
+  // Pin query: "lat,lng" ("" without a coordinate pair). Shared by the
+  // single Pin link and the Route link.
+  buildPinMapsQuery(coordinates) {
+    const pair = this.parseCoordinatePairText(coordinates);
+    if (!pair) return "";
+    return `${pair.lat},${pair.lng}`;
   }
 
   // Pin link: where the stored coordinates actually land.
   buildPinMapsSearchUrl(coordinates) {
-    const pair = this.parseCoordinatePairText(coordinates);
-    if (!pair) return "";
-    return this.buildMapsSearchUrl(`${pair.lat},${pair.lng}`);
+    return this.buildMapsSearchUrl(this.buildPinMapsQuery(coordinates));
+  }
+
+  // Route link: one Google Maps Directions URL threading every stored
+  // location signal (bar+city query → address query → pin), using the SAME
+  // query strings as the single links above. Purpose: if all points resolve
+  // to the same venue, the rendered route is ~0 m — a one-glance identity
+  // check; a pin or address belonging to a different place shows up as a
+  // real route. Requires at least two of {bar+city, address, coordinates};
+  // with all three the address rides as a waypoint, with two the pair maps
+  // to origin → destination. "" when fewer than two points exist.
+  buildRouteMapsDirectionsUrl({ bar, city, address, coordinates } = {}) {
+    const barQuery = this.buildBarMapsQuery(bar, city);
+    const addressQuery = this.buildAddressMapsQuery(address, city);
+    const pinQuery = this.buildPinMapsQuery(coordinates);
+    const points = [barQuery, addressQuery, pinQuery].filter(Boolean);
+    if (points.length < 2) return "";
+    const origin = points[0];
+    const destination = points[points.length - 1];
+    const waypoints = points.length === 3 ? points[1] : "";
+    let url =
+      "https://www.google.com/maps/dir/?api=1" +
+      `&origin=${encodeURIComponent(origin)}` +
+      `&destination=${encodeURIComponent(destination)}`;
+    if (waypoints) url += `&waypoints=${encodeURIComponent(waypoints)}`;
+    return url;
   }
 
   // Keyless OpenStreetMap embed centered on the pin (~400m box, marker on
@@ -7568,6 +7617,18 @@ class ScriptableAdapter {
     const bbox = `${pair.lng - boxDegrees},${pair.lat - boxDegrees},${pair.lng + boxDegrees},${pair.lat + boxDegrees}`;
     const marker = `${pair.lat},${pair.lng}`;
     return `https://www.openstreetmap.org/export/embed.html?bbox=${encodeURIComponent(bbox)}&layer=mapnik&marker=${encodeURIComponent(marker)}`;
+  }
+
+  // Keyless LEGACY Google Maps embed centered on the pin, shown alongside
+  // the OSM embed so the reviewer sees Google's venue-aware basemap (POI
+  // labels at the pin) next to OSM's. NOTE: maps.google.com/maps?...&output=
+  // embed is an unofficial keyless endpoint — the official Maps Embed API
+  // requires an API key — and it may break without notice; the OSM embed
+  // above remains the dependable inline map.
+  buildGoogleEmbedUrl(coordinates) {
+    const pair = this.parseCoordinatePairText(coordinates);
+    if (!pair) return "";
+    return `https://maps.google.com/maps?q=${encodeURIComponent(`${pair.lat},${pair.lng}`)}&z=16&output=embed`;
   }
 
   // Per-render native-side URL registry for the open-url bridge (same
@@ -7588,7 +7649,7 @@ class ScriptableAdapter {
     return id;
   }
 
-  // Compact "Verify:" row with up to three bridge links; "" when no data.
+  // Compact "Verify:" row with up to four bridge links; "" when no data.
   buildMapVerifyLinksHtml({ bar, city, address, coordinates } = {}) {
     const links = [];
     const barUrl = this.buildBarMapsSearchUrl(bar, city);
@@ -7597,6 +7658,14 @@ class ScriptableAdapter {
     if (addressUrl) links.push({ label: "Address", url: addressUrl });
     const pinUrl = this.buildPinMapsSearchUrl(coordinates);
     if (pinUrl) links.push({ label: "Pin", url: pinUrl });
+    // Route: only when ≥2 points exist (the builder returns "" otherwise).
+    const routeUrl = this.buildRouteMapsDirectionsUrl({
+      bar,
+      city,
+      address,
+      coordinates,
+    });
+    if (routeUrl) links.push({ label: "Route", url: routeUrl });
     if (links.length === 0) return "";
     const anchors = links
       .map(({ label, url }) => {
@@ -7605,6 +7674,21 @@ class ScriptableAdapter {
       })
       .join("");
     return `<div class="map-verify-row" style="display:flex; gap:10px; align-items:center; font-size:12px; margin:4px 0;"><span style="color:var(--text-secondary);">Verify:</span>${anchors}</div>`;
+  }
+
+  // Muted "Evidence" block from SharedCore.buildEventEvidenceLines output
+  // (computed consistency checks — distances, POI match, provenance). One
+  // line per string; "" when there are no lines (fail open — the panel is
+  // additive and its absence never blocks a card or candidate row).
+  buildEvidenceLinesHtml(lines) {
+    const list = Array.isArray(lines)
+      ? lines.filter((line) => typeof line === "string" && line.trim())
+      : [];
+    if (list.length === 0) return "";
+    const rows = list
+      .map((line) => `<div>${this.escapeHtml(line)}</div>`)
+      .join("");
+    return `<div class="evidence-block" style="font-size:11px; color:var(--text-secondary); margin:4px 0; line-height:1.6;"><div style="font-weight:600;">Evidence</div>${rows}</div>`;
   }
 
   // Open one registered verify link in Safari, on top of the results sheet.
@@ -7677,12 +7761,23 @@ class ScriptableAdapter {
           address: candidate.address,
           coordinates: candidate.coordinates,
         });
+        // Computed evidence panel (SharedCore.buildNewVenueCandidates attaches
+        // candidate.evidence); "" when nothing was computable.
+        const evidenceBlock = this.buildEvidenceLinesHtml(candidate.evidence);
         const osmEmbedUrl = this.buildOsmEmbedUrl(candidate.coordinates);
+        // Second, side-by-side inline map: the keyless legacy Google embed
+        // (see buildGoogleEmbedUrl — unofficial endpoint, may break without
+        // notice; OSM stays the dependable one). Both iframes stay lazy:
+        // each carries its URL in data-map-embed and gets a src only on the
+        // first "Show maps" tap (pure page JS, no bridge involvement).
+        const googleEmbedUrl = this.buildGoogleEmbedUrl(candidate.coordinates);
         const mapToggle = osmEmbedUrl
-          ? `<button onclick="toggleCandidateMap(this)" class="log-copy-btn nvq-map-btn" data-map-embed="${this.escapeHtml(osmEmbedUrl)}" data-map-target="nvq_map_${index}">🗺️ Show map</button>`
+          ? `<button onclick="toggleCandidateMap(this)" class="log-copy-btn nvq-map-btn" data-map-target="nvq_map_${index}">🗺️ Show maps</button>`
           : "";
+        const embedFrameStyle =
+          "width:100%; height:220px; border:0; border-radius:8px;";
         const mapFrame = osmEmbedUrl
-          ? `<iframe id="nvq_map_${index}" class="nvq-map-frame" style="display:none; width:100%; height:220px; border:0; border-radius:8px; margin-top:6px;"></iframe>`
+          ? `<div id="nvq_map_${index}" class="nvq-map-frames" style="display:none; margin-top:6px;"><iframe class="nvq-map-frame" data-map-embed="${this.escapeHtml(osmEmbedUrl)}" style="${embedFrameStyle}"></iframe>${googleEmbedUrl ? `<iframe class="nvq-map-frame" data-map-embed="${this.escapeHtml(googleEmbedUrl)}" style="${embedFrameStyle} margin-top:6px;"></iframe>` : ""}</div>`
           : "";
         return `
         <div class="new-venue-candidate" style="margin-bottom:14px; padding:10px; background:var(--background-light); border-radius:8px;">
@@ -7691,6 +7786,7 @@ class ScriptableAdapter {
             <div style="font-size:12px; margin-bottom:2px; color:var(--text-secondary);">Signals: ${this.escapeHtml(signalsText)}</div>
             ${eventsText ? `<div style="font-size:12px; margin-bottom:6px; color:var(--text-secondary);">Hosting: ${this.escapeHtml(eventsText)}</div>` : ""}
             ${verifyRow}
+            ${evidenceBlock}
             <div style="display:flex; gap:6px; align-items:center; flex-wrap:wrap;">
                 ${control}
                 ${mapToggle}
@@ -8184,6 +8280,9 @@ class ScriptableAdapter {
       address: event.address,
       coordinates: event.location,
     });
+    // Computed evidence panel (SharedCore attaches _evidenceLines during
+    // calendar prep); "" when absent — e.g. saved-run display (fail open).
+    const evidenceBlock = this.buildEvidenceLinesHtml(event._evidenceLines);
 
     let html = `
         <div class="event-card">
@@ -8224,6 +8323,7 @@ class ScriptableAdapter {
                     : ""
                 }
                 ${mapVerifyRow}
+                ${evidenceBlock}
                 <div class="event-detail">
                     <span>📅</span>
                     <span>${dateStr} ${timeStr}${endTimeStr ? ` - ${endTimeStr}` : ""}</span>

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1237,6 +1237,46 @@ class ScriptableAdapter {
     return existing;
   }
 
+  // Stamp the just-saved run id into venue-queue entries tapped this session.
+  // Queue taps happen while the results sheet is up, BEFORE the run is saved,
+  // so results.savedRunId is null at queue-write time and entries were landing
+  // with runIds: []. The run id is generated from the save timestamp
+  // (saveRun → getRunId), so assigning it earlier would change what a run id
+  // means; instead queueVenueCandidateAndReport records which candidate keys
+  // it wrote and this backfill — called right after saveRun assigns
+  // results.savedRunId — stamps the now-known id into exactly those entries.
+  // Fail open: any failure leaves entries as the tap wrote them.
+  async backfillQueuedVenueRunIds(results) {
+    try {
+      const runId =
+        results && results.savedRunId ? String(results.savedRunId) : "";
+      const keys = Array.isArray(results && results._queuedVenueCandidateKeys)
+        ? results._queuedVenueCandidateKeys
+        : [];
+      if (!runId || keys.length === 0) return;
+      const queue = await this.loadBarAdditions();
+      let stamped = 0;
+      for (const key of keys) {
+        const entry = queue[key];
+        if (!entry || typeof entry !== "object") continue;
+        if (!Array.isArray(entry.runIds)) entry.runIds = [];
+        if (entry.runIds.includes(runId)) continue;
+        entry.runIds.push(runId);
+        entry.runIds = entry.runIds.slice(-10); // same cap as the tap merge
+        stamped += 1;
+      }
+      if (stamped === 0) return;
+      await this.saveBarAdditions(queue);
+      console.log(
+        `📱 Scriptable: Backfilled run id ${runId} into ${stamped} queued venue entr${stamped === 1 ? "y" : "ies"}`,
+      );
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Venue-queue run id backfill failed: ${error.message}`,
+      );
+    }
+  }
+
   extractHttpStatusCodeFromError(error) {
     const message =
       error && typeof error.message === "string" ? error.message : "";
@@ -4032,6 +4072,9 @@ class ScriptableAdapter {
         if (runId) {
           results.savedRunId = runId;
           results.savedRunPath = this.getRunFilePath(runId);
+          // Venue-queue taps happened before this id existed — stamp it into
+          // the entries queued during this session's results sheet.
+          await this.backfillQueuedVenueRunIds(results);
         }
         // Cleanup old JSON runs
         await this.cleanupOldFiles("chunky-dad-scraper/runs", {
@@ -4743,6 +4786,10 @@ class ScriptableAdapter {
             venueQueueTaps,
             webView,
           );
+        } else if (params.a === "open-url") {
+          // Fire-and-forget: opens the registered map verify link in Safari
+          // ON TOP of the results sheet (the WebView never navigates).
+          this.openMapVerifyUrl(params.id);
         }
         return false; // cancel the fake navigation; the page stays put
       };
@@ -4800,6 +4847,10 @@ class ScriptableAdapter {
 
   // Generate rich HTML for WebView display
   async generateRichHTML(results) {
+    // Fresh per-render registry for the open-url bridge: every map verify
+    // link rendered below registers its real URL natively and embeds only
+    // the returned id, so ids in this HTML always match the handler's map.
+    this.resetMapVerifyUrls();
     const allEvents = this.getAllEventsFromResults(results);
     const availableCalendars = await Calendar.forEvents();
 
@@ -6313,6 +6364,43 @@ class ScriptableAdapter {
             } catch (ignore) {}
         }
 
+        // Map verify links: a plain https href would navigate this WebView
+        // away (shouldAllowRequest returns true for normal URLs), so the
+        // links route through the same chunkyscrape:// bridge — native looks
+        // the real URL up by id and opens Safari ON TOP of the results
+        // sheet. Per-tap nonce keeps repeat taps firing as distinct
+        // navigations; returning false cancels the default '#' navigation.
+        window.__mapVerifyNonce = 0;
+        function openMapVerify(el) {
+            var id = el ? (el.getAttribute('data-map-url-id') || '') : '';
+            window.location.href = 'chunkyscrape://act?a=open-url&id=' +
+                encodeURIComponent(id) + '&n=' + (window.__mapVerifyNonce++);
+            return false;
+        }
+
+        // Inline OSM map toggle — pure page JS, no bridge. Lazy by design:
+        // the iframe src is only assigned on the FIRST tap (no map tiles
+        // load until asked), later taps just show/hide the already-loaded
+        // frame. OpenStreetMap embed because it is keyless and matches the
+        // Nominatim geocoding stack the scraper already uses; Google Maps
+        // embeds require an API key.
+        function toggleCandidateMap(btn) {
+            try {
+                var frame = document.getElementById(btn.getAttribute('data-map-target') || '');
+                if (!frame) return;
+                if (frame.style.display === 'none') {
+                    if (!frame.getAttribute('src')) {
+                        frame.setAttribute('src', btn.getAttribute('data-map-embed') || '');
+                    }
+                    frame.style.display = 'block';
+                    btn.textContent = '🗺️ Hide map';
+                } else {
+                    frame.style.display = 'none';
+                    btn.textContent = '🗺️ Show map';
+                }
+            } catch (ignore) {}
+        }
+
         function copyDiscoveryText(btn) {
             const encoded = btn.getAttribute('data-encoded') || '';
             let text = '';
@@ -7391,6 +7479,154 @@ class ScriptableAdapter {
   }
 
   // ---------------------------------------------------------------------------
+  // Map verify links (results-UI ↔ chunkyscrape:// bridge, read-only).
+  // The owner verifies a venue by comparing three independent Google Maps
+  // lookups: what the bar name+city resolves to, what the address resolves
+  // to, and where the stored pin actually is. Each row gets up to three
+  // compact links (only for data that exists). A plain https href would
+  // navigate the results WebView away (shouldAllowRequest returns true for
+  // normal URLs), so links route through the chunkyscrape:// bridge: the
+  // page navigates to chunkyscrape://act?a=open-url&id=<n>, native looks the
+  // real URL up in a per-render registry and calls Safari.open — Safari
+  // opens ON TOP and the results sheet stays put. URLs are built with
+  // encodeURIComponent only (no `new URL`/URLSearchParams in this runtime).
+  // ---------------------------------------------------------------------------
+
+  // "lat, lng" text → { lat, lng } numbers, or null (shared by the pin link
+  // and the OSM embed; candidates/events store coordinates as one string).
+  parseCoordinatePairText(value) {
+    const parts = String(value || "").split(",");
+    if (parts.length !== 2) return null;
+    const lat = Number(parts[0].trim());
+    const lng = Number(parts[1].trim());
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+    return { lat, lng };
+  }
+
+  // Human-searchable city name for Maps queries. The generated
+  // scraper-cities.js carries no display name, but each city's FIRST alias
+  // pattern is its full lowercase name ("nyc" → "new york", "la" →
+  // "los angeles"); unknown keys fall back to the de-hyphenated key
+  // ("fort-lauderdale" → "fort lauderdale"). Maps search is case-insensitive.
+  getCityDisplayNameForMaps(cityKey) {
+    const key = typeof cityKey === "string" ? cityKey.trim() : "";
+    if (!key) return "";
+    const cityConfig = this.cities ? this.cities[key] : null;
+    const firstPattern =
+      cityConfig && Array.isArray(cityConfig.patterns)
+        ? cityConfig.patterns[0]
+        : "";
+    if (typeof firstPattern === "string" && firstPattern.trim()) {
+      return firstPattern.trim();
+    }
+    return key.replace(/-/g, " ");
+  }
+
+  buildMapsSearchUrl(query) {
+    const text = typeof query === "string" ? query.trim() : "";
+    if (!text) return "";
+    return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(text)}`;
+  }
+
+  // Bar link: what "<bar name>, <city>" resolves to on Google Maps.
+  buildBarMapsSearchUrl(barName, cityKey) {
+    const name = typeof barName === "string" ? barName.trim() : "";
+    if (!name) return "";
+    const city = this.getCityDisplayNameForMaps(cityKey);
+    return this.buildMapsSearchUrl(city ? `${name}, ${city}` : name);
+  }
+
+  // Address link: what the stored address resolves to. The city is appended
+  // ONLY when the address doesn't already contain the city name
+  // (case-insensitive) — bare street addresses are ambiguous across cities.
+  buildAddressMapsSearchUrl(address, cityKey) {
+    const text = typeof address === "string" ? address.trim() : "";
+    if (!text) return "";
+    const city = this.getCityDisplayNameForMaps(cityKey);
+    const alreadyHasCity =
+      city && text.toLowerCase().includes(city.toLowerCase());
+    return this.buildMapsSearchUrl(
+      city && !alreadyHasCity ? `${text}, ${city}` : text,
+    );
+  }
+
+  // Pin link: where the stored coordinates actually land.
+  buildPinMapsSearchUrl(coordinates) {
+    const pair = this.parseCoordinatePairText(coordinates);
+    if (!pair) return "";
+    return this.buildMapsSearchUrl(`${pair.lat},${pair.lng}`);
+  }
+
+  // Keyless OpenStreetMap embed centered on the pin (~400m box, marker on
+  // the pin). OSM because it needs no API key and matches the Nominatim
+  // stack the scraper already geocodes with; Google Maps embeds require an
+  // API key. Same viewport as the review UI's buildReviewPinHtml.
+  buildOsmEmbedUrl(coordinates) {
+    const pair = this.parseCoordinatePairText(coordinates);
+    if (!pair) return "";
+    const boxDegrees = 0.004;
+    const bbox = `${pair.lng - boxDegrees},${pair.lat - boxDegrees},${pair.lng + boxDegrees},${pair.lat + boxDegrees}`;
+    const marker = `${pair.lat},${pair.lng}`;
+    return `https://www.openstreetmap.org/export/embed.html?bbox=${encodeURIComponent(bbox)}&layer=mapnik&marker=${encodeURIComponent(marker)}`;
+  }
+
+  // Per-render native-side URL registry for the open-url bridge (same
+  // pattern as collectVenueEntrySnippets: URLs never travel through the
+  // chunkyscrape:// URL, only their ids do). generateRichHTML resets it so
+  // ids embedded in the HTML always match what the handler reads.
+  resetMapVerifyUrls() {
+    this._mapVerifyUrls = {};
+    this._mapVerifyUrlNextId = 0;
+  }
+
+  registerMapVerifyUrl(url) {
+    if (!this._mapVerifyUrls || typeof this._mapVerifyUrlNextId !== "number") {
+      this.resetMapVerifyUrls();
+    }
+    const id = String(this._mapVerifyUrlNextId++);
+    this._mapVerifyUrls[id] = url;
+    return id;
+  }
+
+  // Compact "Verify:" row with up to three bridge links; "" when no data.
+  buildMapVerifyLinksHtml({ bar, city, address, coordinates } = {}) {
+    const links = [];
+    const barUrl = this.buildBarMapsSearchUrl(bar, city);
+    if (barUrl) links.push({ label: "Bar", url: barUrl });
+    const addressUrl = this.buildAddressMapsSearchUrl(address, city);
+    if (addressUrl) links.push({ label: "Address", url: addressUrl });
+    const pinUrl = this.buildPinMapsSearchUrl(coordinates);
+    if (pinUrl) links.push({ label: "Pin", url: pinUrl });
+    if (links.length === 0) return "";
+    const anchors = links
+      .map(({ label, url }) => {
+        const id = this.registerMapVerifyUrl(url);
+        return `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="map-verify-link" style="color:var(--primary-color); text-decoration:none;">${label} ↗</a>`;
+      })
+      .join("");
+    return `<div class="map-verify-row" style="display:flex; gap:10px; align-items:center; font-size:12px; margin:4px 0;"><span style="color:var(--text-secondary);">Verify:</span>${anchors}</div>`;
+  }
+
+  // Open one registered verify link in Safari, on top of the results sheet.
+  // Called fire-and-forget from shouldAllowRequest (which must synchronously
+  // return false to cancel the fake navigation) — Safari opens over the
+  // sheet and the results WebView never navigates.
+  openMapVerifyUrl(id) {
+    try {
+      const url = this._mapVerifyUrls
+        ? this._mapVerifyUrls[String(id)]
+        : undefined;
+      if (typeof url !== "string" || url.indexOf("https://") !== 0) return;
+      Safari.open(url);
+      console.log(`📱 Scriptable: Opened map verify link #${id} in Safari`);
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Failed to open map verify link: ${error.message}`,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // New venue candidates (results-UI ↔ chunkyscrape:// bridge, GATHERING-ONLY).
   // Confirmed-new venues detected by SharedCore.buildNewVenueCandidates get a
   // "Queue for bars data" button; a tap appends evidence to bar-additions.json.
@@ -7432,13 +7668,34 @@ class ScriptableAdapter {
         const control = queuedEntry
           ? `<span style="font-size:12px; color:var(--text-secondary);">Queued ✓ (seen ${Number(queuedEntry.timesSeen) || 1} times)</span>`
           : `<button onclick="queueVenueCandidate(this)" class="log-copy-btn venue-queue-btn" data-nvq-index="${index}">➕ Queue for bars data</button>`;
+        // Primary verification surface: Bar/Address/Pin Google Maps links
+        // (bridge-routed so Safari opens over the sheet) plus a lazy inline
+        // OSM map — no iframe loads anything until its toggle is tapped.
+        const verifyRow = this.buildMapVerifyLinksHtml({
+          bar: candidate.name,
+          city: candidate.city,
+          address: candidate.address,
+          coordinates: candidate.coordinates,
+        });
+        const osmEmbedUrl = this.buildOsmEmbedUrl(candidate.coordinates);
+        const mapToggle = osmEmbedUrl
+          ? `<button onclick="toggleCandidateMap(this)" class="log-copy-btn nvq-map-btn" data-map-embed="${this.escapeHtml(osmEmbedUrl)}" data-map-target="nvq_map_${index}">🗺️ Show map</button>`
+          : "";
+        const mapFrame = osmEmbedUrl
+          ? `<iframe id="nvq_map_${index}" class="nvq-map-frame" style="display:none; width:100%; height:220px; border:0; border-radius:8px; margin-top:6px;"></iframe>`
+          : "";
         return `
         <div class="new-venue-candidate" style="margin-bottom:14px; padding:10px; background:var(--background-light); border-radius:8px;">
             <div style="font-weight:600; margin-bottom:4px;">${this.escapeHtml(candidate.name || "Unknown")} <span style="font-weight:400; opacity:0.7;">(${this.escapeHtml(candidate.city || "unknown city")})</span></div>
             ${candidate.address ? `<div style="font-size:12px; margin-bottom:2px; color:var(--text-secondary);">${this.escapeHtml(candidate.address)}</div>` : ""}
             <div style="font-size:12px; margin-bottom:2px; color:var(--text-secondary);">Signals: ${this.escapeHtml(signalsText)}</div>
             ${eventsText ? `<div style="font-size:12px; margin-bottom:6px; color:var(--text-secondary);">Hosting: ${this.escapeHtml(eventsText)}</div>` : ""}
-            ${control}
+            ${verifyRow}
+            <div style="display:flex; gap:6px; align-items:center; flex-wrap:wrap;">
+                ${control}
+                ${mapToggle}
+            </div>
+            ${mapFrame}
         </div>`;
       })
       .join("");
@@ -7486,6 +7743,15 @@ class ScriptableAdapter {
         await this.saveBarAdditions(queue);
         timesSeen = Number(entry.timesSeen) || 1;
         tapped[key] = timesSeen;
+        // Remember which entries this session wrote: the run id does not
+        // exist yet (the run is saved after the sheet is dismissed), so
+        // backfillQueuedVenueRunIds stamps it into these keys post-save.
+        if (!Array.isArray(results._queuedVenueCandidateKeys)) {
+          results._queuedVenueCandidateKeys = [];
+        }
+        if (!results._queuedVenueCandidateKeys.includes(candidate.key)) {
+          results._queuedVenueCandidateKeys.push(candidate.key);
+        }
         console.log(
           `📱 Scriptable: Queued venue candidate "${candidate.name}" (${candidate.city}) — seen ${timesSeen} time(s)`,
         );
@@ -7909,6 +8175,16 @@ class ScriptableAdapter {
     const notes = event.notes || "";
     const calendarName = this.getCalendarNameForDisplay(event);
 
+    // Secondary verification surface (kept small): the same Bar/Address/Pin
+    // Google Maps links as the new-venue-candidates section, rendered only
+    // when the card has data for them (empty string otherwise).
+    const mapVerifyRow = this.buildMapVerifyLinksHtml({
+      bar: event.bar || event.venue,
+      city: event.city,
+      address: event.address,
+      coordinates: event.location,
+    });
+
     let html = `
         <div class="event-card">
             ${actionBadge}
@@ -7947,6 +8223,7 @@ class ScriptableAdapter {
                 `
                     : ""
                 }
+                ${mapVerifyRow}
                 <div class="event-detail">
                     <span>📅</span>
                     <span>${dateStr} ${timeStr}${endTimeStr ? ` - ${endTimeStr}` : ""}</span>

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1952,6 +1952,7 @@ test('NOTHING in the scraping pipeline reads bar-additions.json (gathering-only)
 // ---------------------------------------------------------------------------
 
 const MAPS_SEARCH_PREFIX = 'https://www.google.com/maps/search/?api=1&query=';
+const MAPS_DIR_PREFIX = 'https://www.google.com/maps/dir/?api=1&';
 
 function buildMapsAdapter() {
   return new ScriptableAdapter({
@@ -2031,24 +2032,147 @@ test('verify row renders only links whose data exists, always via the bridge', (
   assert.ok(pinOnly.includes('Pin ↗'));
   assert.ok(!pinOnly.includes('Bar ↗') && !pinOnly.includes('Address ↗'),
     'absent fields render no links');
+  assert.ok(!pinOnly.includes('Route ↗'), 'a single point never gets a route');
 
   const full = adapter.buildMapVerifyLinksHtml({
     bar: 'Massive', city: 'seattle',
     address: '1400 12th Ave', coordinates: '47.6135, -122.3163'
   });
-  for (const label of ['Bar ↗', 'Address ↗', 'Pin ↗']) {
+  for (const label of ['Bar ↗', 'Address ↗', 'Pin ↗', 'Route ↗']) {
     assert.ok(full.includes(label), `${label} link present`);
   }
   assert.ok(full.includes('openMapVerify(this)'), 'links signal via the bridge');
   assert.ok(!full.includes('href="https'),
     'no plain https hrefs — those would navigate the results WebView away');
-  // Each embedded id resolves to a registered Google Maps URL natively.
+  // Each embedded id resolves to a registered Google Maps URL natively —
+  // three search links plus the directions Route link.
   const ids = [...full.matchAll(/data-map-url-id="(\d+)"/g)].map((m) => m[1]);
-  assert.equal(ids.length, 3);
-  for (const id of ids) {
+  assert.equal(ids.length, 4);
+  for (const id of ids.slice(0, 3)) {
     assert.ok(adapter._mapVerifyUrls[id].startsWith(MAPS_SEARCH_PREFIX),
       'URL retrievable from the native-side registry');
   }
+  assert.ok(adapter._mapVerifyUrls[ids[3]].startsWith(MAPS_DIR_PREFIX),
+    'the Route link registers the directions URL');
+});
+
+test('route link chains origin bar → waypoint address → destination pin, fully encoded', () => {
+  const adapter = buildMapsAdapter();
+  const all = adapter.buildRouteMapsDirectionsUrl({
+    bar: 'Bear & Bull', city: 'nyc',
+    address: '225 E Houston St', coordinates: '40.7223, -73.9874'
+  });
+  assert.equal(all,
+    'https://www.google.com/maps/dir/?api=1'
+    + '&origin=Bear%20%26%20Bull%2C%20new%20york'
+    + '&destination=40.7223%2C-73.9874'
+    + '&waypoints=225%20E%20Houston%20St%2C%20new%20york');
+  // The route legs are the EXACT query strings the single links search for,
+  // so a ~0 m rendered route proves all three resolve to one venue.
+  assert.ok(adapter.buildBarMapsSearchUrl('Bear & Bull', 'nyc')
+    .endsWith('Bear%20%26%20Bull%2C%20new%20york'));
+  assert.ok(adapter.buildAddressMapsSearchUrl('225 E Houston St', 'nyc')
+    .endsWith('225%20E%20Houston%20St%2C%20new%20york'));
+  assert.ok(adapter.buildPinMapsSearchUrl('40.7223, -73.9874')
+    .endsWith('40.7223%2C-73.9874'));
+});
+
+test('route link with two points maps them to origin → destination, no waypoints', () => {
+  const adapter = buildMapsAdapter();
+  // bar + pin
+  assert.equal(
+    adapter.buildRouteMapsDirectionsUrl({
+      bar: 'Massive', city: 'seattle', coordinates: '47.6135, -122.3163'
+    }),
+    'https://www.google.com/maps/dir/?api=1'
+    + '&origin=Massive%2C%20seattle&destination=47.6135%2C-122.3163');
+  // bar + address
+  assert.equal(
+    adapter.buildRouteMapsDirectionsUrl({
+      bar: 'Massive', city: 'seattle', address: '1400 12th Ave'
+    }),
+    'https://www.google.com/maps/dir/?api=1'
+    + '&origin=Massive%2C%20seattle&destination=1400%2012th%20Ave%2C%20seattle');
+  // address + pin
+  assert.equal(
+    adapter.buildRouteMapsDirectionsUrl({
+      city: 'seattle', address: '1400 12th Ave', coordinates: '47.6135, -122.3163'
+    }),
+    'https://www.google.com/maps/dir/?api=1'
+    + '&origin=1400%2012th%20Ave%2C%20seattle&destination=47.6135%2C-122.3163');
+});
+
+test('route link needs at least two resolvable points', () => {
+  const adapter = buildMapsAdapter();
+  assert.equal(adapter.buildRouteMapsDirectionsUrl({}), '');
+  assert.equal(adapter.buildRouteMapsDirectionsUrl(), '');
+  assert.equal(adapter.buildRouteMapsDirectionsUrl({ bar: 'Massive', city: 'seattle' }), '');
+  assert.equal(adapter.buildRouteMapsDirectionsUrl({ coordinates: '47.61, -122.33' }), '');
+  // A non-coordinate "pin" contributes nothing, leaving only one real point.
+  assert.equal(
+    adapter.buildRouteMapsDirectionsUrl({ bar: 'Massive', city: 'seattle', coordinates: 'The Cuff' }),
+    '');
+});
+
+test('evidence block renders one muted line per string and fails open when empty', () => {
+  const adapter = buildMapsAdapter();
+  assert.equal(adapter.buildEvidenceLinesHtml([]), '');
+  assert.equal(adapter.buildEvidenceLinesHtml(undefined), '');
+  assert.equal(adapter.buildEvidenceLinesHtml('not an array'), '');
+  assert.equal(adapter.buildEvidenceLinesHtml(['   ', null]), '', 'blank/non-string lines are dropped');
+
+  const html = adapter.buildEvidenceLinesHtml([
+    'pin is 42 m from curated "Massive" pin',
+    'provenance: bar=venue-site, pin=geocoded-exact'
+  ]);
+  assert.ok(html.includes('evidence-block'));
+  assert.ok(html.includes('Evidence'));
+  assert.ok(html.includes('pin is 42 m from curated &quot;Massive&quot; pin'), 'lines are HTML-escaped');
+  assert.ok(html.includes('provenance: bar=venue-site, pin=geocoded-exact'));
+});
+
+test('candidate rows render the evidence block only when the candidate carries lines', async () => {
+  const adapter = buildMapsAdapter();
+  adapter.fm = createDeadEndFmStub();
+
+  const withEvidence = await adapter.generateNewVenueCandidateSection({
+    newVenueCandidates: [buildVenueCandidate({
+      evidence: ['bar corroborated: venue-site', 'provenance: bar=venue-site, pin=geocoded-exact']
+    })]
+  });
+  assert.ok(withEvidence.includes('evidence-block'), 'evidence block present');
+  assert.ok(withEvidence.includes('bar corroborated: venue-site'));
+  assert.ok(withEvidence.includes('Route ↗'), 'route link present on candidate rows');
+
+  const withoutEvidence = await adapter.generateNewVenueCandidateSection({
+    newVenueCandidates: [buildVenueCandidate()]
+  });
+  assert.ok(!withoutEvidence.includes('evidence-block'), 'no block without lines');
+});
+
+test('event cards render the evidence block only when _evidenceLines exist', () => {
+  const adapter = buildMapsAdapter();
+  const baseEvent = {
+    title: 'Bear Night',
+    startDate: '2026-08-01T02:00:00.000Z',
+    city: 'seattle',
+    bar: 'Massive',
+    address: '1400 12th Ave',
+    location: '47.6135, -122.3163',
+    _action: 'new'
+  };
+  const html = adapter.generateEventCard({
+    ...baseEvent,
+    _evidenceLines: ['pin is 0.7 km from seattle center', 'bar corroborated: geo-poi']
+  });
+  assert.ok(html.includes('evidence-block'), 'evidence block on the card');
+  assert.ok(html.includes('pin is 0.7 km from seattle center'));
+  assert.ok(html.includes('Route ↗'), 'route link present on event cards');
+
+  const bare = adapter.generateEventCard(baseEvent);
+  assert.ok(!bare.includes('evidence-block'), 'no block without lines');
+  const empty = adapter.generateEventCard({ ...baseEvent, _evidenceLines: [] });
+  assert.ok(!empty.includes('evidence-block'), 'empty array → no block (fail open)');
 });
 
 test('OSM embed URL has the keyless bbox/marker shape with encoded commas', () => {
@@ -2067,7 +2191,18 @@ test('OSM embed URL has the keyless bbox/marker shape with encoded commas', () =
   assert.equal(adapter.buildOsmEmbedUrl('not coordinates'), '');
 });
 
-test('candidate rows carry the verify row and a lazy inline map toggle', async () => {
+test('legacy Google embed URL is keyless output=embed with encoded coordinates', () => {
+  const adapter = buildMapsAdapter();
+  assert.equal(
+    adapter.buildGoogleEmbedUrl('47.6135, -122.3163'),
+    'https://maps.google.com/maps?q=47.6135%2C-122.3163&z=16&output=embed');
+  assert.ok(!adapter.buildGoogleEmbedUrl('47.6135, -122.3163').includes('key='),
+    'unofficial keyless endpoint — no API key anywhere');
+  assert.equal(adapter.buildGoogleEmbedUrl('not coordinates'), '');
+  assert.equal(adapter.buildGoogleEmbedUrl(''), '');
+});
+
+test('candidate rows carry the verify row and a lazy inline dual-map toggle', async () => {
   const adapter = buildMapsAdapter();
   adapter.fm = createDeadEndFmStub();
 
@@ -2077,10 +2212,20 @@ test('candidate rows carry the verify row and a lazy inline map toggle', async (
   assert.ok(html.includes('Verify:'), 'verify row present');
   assert.ok(html.includes('Bar ↗') && html.includes('Address ↗') && html.includes('Pin ↗'));
   assert.ok(html.includes('toggleCandidateMap(this)'), 'map toggle wired');
-  assert.ok(html.includes('data-map-embed='), 'embed URL carried on the toggle');
-  assert.ok(html.includes('id="nvq_map_0"'), 'iframe target present');
+  assert.ok(html.includes('id="nvq_map_0"'), 'toggle target container present');
+  // Both inline maps ride the toggle: OSM (dependable) + legacy Google
+  // (keyless, unofficial), each with its URL parked in data-map-embed.
+  const embedUrls = [...html.matchAll(/data-map-embed="([^"]+)"/g)].map((m) => m[1]);
+  assert.equal(embedUrls.length, 2, 'exactly two lazy embeds per candidate');
+  assert.ok(embedUrls[0].startsWith('https://www.openstreetmap.org/export/embed.html?'),
+    'OSM embed first');
+  assert.ok(embedUrls[0].includes('marker=47.6135%2C-122.3163'),
+    'OSM marker carries the encoded coordinates');
+  assert.equal(embedUrls[1],
+    'https://maps.google.com/maps?q=47.6135%2C-122.3163&amp;z=16&amp;output=embed',
+    'legacy Google embed second (HTML-escaped in the attribute)');
   assert.ok(!/<iframe[^>]*\ssrc=/.test(html),
-    'lazy: no iframe src until the toggle is tapped');
+    'lazy: neither iframe has a src until the toggle is tapped');
 
   // Without coordinates there is no pin link and no map toggle at all.
   const noCoords = await adapter.generateNewVenueCandidateSection({

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1928,20 +1928,291 @@ test('NOTHING in the scraping pipeline reads bar-additions.json (gathering-only)
     assert.ok(!source.includes('bar-additions'), `${rel} must not reference bar-additions.json`);
     assert.ok(!source.includes('BarAdditions'), `${rel} must not call the queue accessors`);
   }
-  // In the Scriptable adapter the queue is read in exactly two places, both
-  // results-UI-side: the "Queued ✓" badge and the queue-tap handler. The
-  // bars-data load path (loadBarsConfiguration/fetchRemoteBarsJson) and the
-  // run pipeline never touch it.
+  // In the Scriptable adapter the queue is read in exactly three places, all
+  // results-UI-side: the "Queued ✓" badge, the queue-tap handler, and the
+  // post-save run-id backfill for this session's taps. The bars-data load
+  // path (loadBarsConfiguration/fetchRemoteBarsJson) and the run pipeline
+  // never touch it.
   const adapterSource = fs.readFileSync(path.join(__dirname, 'scriptable-adapter.js'), 'utf8');
   const readCallSites = adapterSource
     .split('\n')
     .filter(line => line.includes('this.loadBarAdditions('));
-  assert.equal(readCallSites.length, 2,
-    `queue reads allowed only in the badge renderer and the tap handler, found: ${readCallSites.join(' | ')}`);
+  assert.equal(readCallSites.length, 3,
+    `queue reads allowed only in the badge renderer, the tap handler, and the run-id backfill, found: ${readCallSites.join(' | ')}`);
   const barsLoaderSource = adapterSource.slice(
     adapterSource.indexOf('async loadBarsConfiguration'),
     adapterSource.indexOf('async fetchRemoteBarsJson'));
   assert.ok(barsLoaderSource.length > 0, 'bars loader located');
   assert.ok(!barsLoaderSource.includes('BarAdditions') && !barsLoaderSource.includes('bar-additions'),
     'the bars-data load path never reads the queue');
+});
+
+// ---------------------------------------------------------------------------
+// Map verify links (Bar/Address/Pin Google Maps lookups) + inline OSM maps
+// ---------------------------------------------------------------------------
+
+const MAPS_SEARCH_PREFIX = 'https://www.google.com/maps/search/?api=1&query=';
+
+function buildMapsAdapter() {
+  return new ScriptableAdapter({
+    cities: {
+      nyc: { patterns: ['new york', 'nyc', 'manhattan'] },
+      seattle: { patterns: ['seattle'] }
+    }
+  });
+}
+
+test('open-url action URLs parse like the other chunkyscrape actions', () => {
+  const adapter = buildMapsAdapter();
+  const params = adapter.parseReviewActionUrl('chunkyscrape://act?a=open-url&id=4&n=9');
+  assert.equal(params.a, 'open-url');
+  assert.equal(params.id, '4');
+  assert.equal(params.n, '9');
+});
+
+test('bar verify link searches "<bar>, <city display name>" with full encoding', () => {
+  const adapter = buildMapsAdapter();
+  assert.equal(
+    adapter.buildBarMapsSearchUrl('Massive', 'seattle'),
+    `${MAPS_SEARCH_PREFIX}Massive%2C%20seattle`);
+  // The city display name is the first alias pattern ("nyc" → "new york"),
+  // and ampersands are percent-encoded (no new URL/URLSearchParams).
+  assert.equal(
+    adapter.buildBarMapsSearchUrl('Bear & Bull', 'nyc'),
+    `${MAPS_SEARCH_PREFIX}Bear%20%26%20Bull%2C%20new%20york`);
+  // Unicode venue names survive encodeURIComponent.
+  assert.equal(
+    adapter.buildBarMapsSearchUrl('Café Lambda', 'seattle'),
+    `${MAPS_SEARCH_PREFIX}Caf%C3%A9%20Lambda%2C%20seattle`);
+  // Unknown city keys fall back to the de-hyphenated key.
+  assert.equal(
+    adapter.buildBarMapsSearchUrl('Ramrod', 'fort-lauderdale'),
+    `${MAPS_SEARCH_PREFIX}Ramrod%2C%20fort%20lauderdale`);
+  // No city → bar alone; no bar → no link at all.
+  assert.equal(adapter.buildBarMapsSearchUrl('Massive', ''), `${MAPS_SEARCH_PREFIX}Massive`);
+  assert.equal(adapter.buildBarMapsSearchUrl('', 'seattle'), '');
+  assert.equal(adapter.buildBarMapsSearchUrl('   ', 'seattle'), '');
+});
+
+test('address verify link appends the city only when the address lacks it', () => {
+  const adapter = buildMapsAdapter();
+  // Address already contains the city name (case-insensitive) → no append.
+  assert.equal(
+    adapter.buildAddressMapsSearchUrl('1400 12th Ave, Seattle, WA 98122', 'seattle'),
+    `${MAPS_SEARCH_PREFIX}1400%2012th%20Ave%2C%20Seattle%2C%20WA%2098122`);
+  // Bare street address → city appended for disambiguation.
+  assert.equal(
+    adapter.buildAddressMapsSearchUrl('1400 12th Ave', 'seattle'),
+    `${MAPS_SEARCH_PREFIX}1400%2012th%20Ave%2C%20seattle`);
+  // City display name (not the key) is what gets matched and appended.
+  assert.equal(
+    adapter.buildAddressMapsSearchUrl('225 E Houston St, New York, NY', 'nyc'),
+    `${MAPS_SEARCH_PREFIX}225%20E%20Houston%20St%2C%20New%20York%2C%20NY`);
+  // No address → no link.
+  assert.equal(adapter.buildAddressMapsSearchUrl('', 'seattle'), '');
+});
+
+test('pin verify link searches the raw coordinates; non-coordinates yield no link', () => {
+  const adapter = buildMapsAdapter();
+  assert.equal(
+    adapter.buildPinMapsSearchUrl('47.6135, -122.3163'),
+    `${MAPS_SEARCH_PREFIX}47.6135%2C-122.3163`);
+  assert.equal(adapter.buildPinMapsSearchUrl('The Cuff, Seattle'), '');
+  assert.equal(adapter.buildPinMapsSearchUrl(''), '');
+  assert.equal(adapter.buildPinMapsSearchUrl(undefined), '');
+});
+
+test('verify row renders only links whose data exists, always via the bridge', () => {
+  const adapter = buildMapsAdapter();
+  assert.equal(adapter.buildMapVerifyLinksHtml({}), '', 'no data → no row');
+  assert.equal(adapter.buildMapVerifyLinksHtml(), '', 'no argument → no row');
+
+  const pinOnly = adapter.buildMapVerifyLinksHtml({ coordinates: '47.61, -122.33' });
+  assert.ok(pinOnly.includes('Pin ↗'));
+  assert.ok(!pinOnly.includes('Bar ↗') && !pinOnly.includes('Address ↗'),
+    'absent fields render no links');
+
+  const full = adapter.buildMapVerifyLinksHtml({
+    bar: 'Massive', city: 'seattle',
+    address: '1400 12th Ave', coordinates: '47.6135, -122.3163'
+  });
+  for (const label of ['Bar ↗', 'Address ↗', 'Pin ↗']) {
+    assert.ok(full.includes(label), `${label} link present`);
+  }
+  assert.ok(full.includes('openMapVerify(this)'), 'links signal via the bridge');
+  assert.ok(!full.includes('href="https'),
+    'no plain https hrefs — those would navigate the results WebView away');
+  // Each embedded id resolves to a registered Google Maps URL natively.
+  const ids = [...full.matchAll(/data-map-url-id="(\d+)"/g)].map((m) => m[1]);
+  assert.equal(ids.length, 3);
+  for (const id of ids) {
+    assert.ok(adapter._mapVerifyUrls[id].startsWith(MAPS_SEARCH_PREFIX),
+      'URL retrievable from the native-side registry');
+  }
+});
+
+test('OSM embed URL has the keyless bbox/marker shape with encoded commas', () => {
+  const adapter = buildMapsAdapter();
+  const lat = 47.6135;
+  const lng = -122.3163;
+  const d = 0.004;
+  const url = adapter.buildOsmEmbedUrl(`${lat}, ${lng}`);
+  assert.equal(
+    url,
+    'https://www.openstreetmap.org/export/embed.html'
+      + `?bbox=${encodeURIComponent(`${lng - d},${lat - d},${lng + d},${lat + d}`)}`
+      + `&layer=mapnik&marker=${encodeURIComponent(`${lat},${lng}`)}`);
+  assert.ok(url.includes('marker=47.6135%2C-122.3163'), 'marker is lat%2Clng');
+  assert.ok(!url.includes('key='), 'keyless embed (why OSM, not Google)');
+  assert.equal(adapter.buildOsmEmbedUrl('not coordinates'), '');
+});
+
+test('candidate rows carry the verify row and a lazy inline map toggle', async () => {
+  const adapter = buildMapsAdapter();
+  adapter.fm = createDeadEndFmStub();
+
+  const html = await adapter.generateNewVenueCandidateSection({
+    newVenueCandidates: [buildVenueCandidate()]
+  });
+  assert.ok(html.includes('Verify:'), 'verify row present');
+  assert.ok(html.includes('Bar ↗') && html.includes('Address ↗') && html.includes('Pin ↗'));
+  assert.ok(html.includes('toggleCandidateMap(this)'), 'map toggle wired');
+  assert.ok(html.includes('data-map-embed='), 'embed URL carried on the toggle');
+  assert.ok(html.includes('id="nvq_map_0"'), 'iframe target present');
+  assert.ok(!/<iframe[^>]*\ssrc=/.test(html),
+    'lazy: no iframe src until the toggle is tapped');
+
+  // Without coordinates there is no pin link and no map toggle at all.
+  const noCoords = await adapter.generateNewVenueCandidateSection({
+    newVenueCandidates: [buildVenueCandidate({ coordinates: '' })]
+  });
+  assert.ok(!noCoords.includes('toggleCandidateMap'), 'no toggle without coordinates');
+  assert.ok(!noCoords.includes('<iframe'), 'no iframe without coordinates');
+  assert.ok(!noCoords.includes('Pin ↗'), 'no pin link without coordinates');
+  assert.ok(noCoords.includes('Bar ↗'), 'other links unaffected');
+});
+
+test('event cards carry the compact verify row only when venue-ish data exists', () => {
+  const adapter = buildMapsAdapter();
+  const html = adapter.generateEventCard({
+    title: 'Bear Night',
+    startDate: '2026-08-01T02:00:00.000Z',
+    city: 'seattle',
+    bar: 'Massive',
+    address: '1400 12th Ave',
+    location: '47.6135, -122.3163',
+    _action: 'new'
+  });
+  assert.ok(html.includes('map-verify-row'), 'compact row on the card');
+  assert.ok(html.includes('Bar ↗') && html.includes('Address ↗') && html.includes('Pin ↗'));
+
+  const bare = adapter.generateEventCard({
+    title: 'No venue data',
+    startDate: '2026-08-01T02:00:00.000Z',
+    _action: 'new'
+  });
+  assert.ok(!bare.includes('map-verify-row'), 'no row without bar/address/location');
+});
+
+test('presentRichResults opens verify links in Safari via the open-url bridge', async () => {
+  const adapter = buildMapsAdapter();
+  adapter.fm = createDeadEndFmStub();
+  // calendarEvents already set → the execution prompt path is skipped
+  const results = {
+    ...buildResultsStub(),
+    calendarEvents: 1,
+    newVenueCandidates: [buildVenueCandidate()]
+  };
+
+  const opened = [];
+  global.Safari = { open: (url) => { opened.push(url); } };
+  const wv = installFakeWebView();
+  try {
+    const done = adapter.presentRichResults(results);
+    for (let i = 0; i < 200 && !wv.getHandler(); i++) {
+      await new Promise((r) => setImmediate(r));
+    }
+    assert.ok(wv.getHandler(), 'shouldAllowRequest assigned before present()');
+    const ids = Object.keys(adapter._mapVerifyUrls);
+    assert.ok(ids.length >= 3, 'candidate verify URLs registered natively during render');
+
+    // A verify tap: navigation cancelled, Safari opens the registered URL
+    // on top — the results WebView itself never navigates.
+    assert.equal(wv.tap(`chunkyscrape://act?a=open-url&id=${ids[0]}&n=1`), false,
+      'fake navigation cancelled');
+    await new Promise((r) => setImmediate(r));
+    assert.deepEqual(opened, [adapter._mapVerifyUrls[ids[0]]],
+      'Safari.open received the native-side URL');
+
+    // An unknown id is ignored without crashing.
+    assert.equal(wv.tap('chunkyscrape://act?a=open-url&id=999&n=2'), false);
+    await new Promise((r) => setImmediate(r));
+    assert.equal(opened.length, 1);
+
+    wv.dismiss();
+    await done;
+  } finally {
+    delete global.WebView;
+    delete global.Safari;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Venue-queue run id backfill (taps precede the save that mints the run id)
+// ---------------------------------------------------------------------------
+
+test('venue-queue entries queued before the run id exists get it backfilled after save', async () => {
+  const adapter = buildMapsAdapter();
+  adapter.fm = createDeadEndFmStub();
+  const results = { newVenueCandidates: [buildVenueCandidate()] };
+  const wvStub = { evaluateJavaScript: async () => {} };
+
+  // Tap while the results sheet is up: the run has not been saved yet, so
+  // no run id exists and the entry lands with runIds: [] — the bug shape.
+  await adapter.queueVenueCandidateAndReport('0', results, {}, wvStub);
+  let queue = await adapter.loadBarAdditions();
+  assert.deepEqual(queue['seattle|massive'].runIds, [],
+    'tap-time write has no run id (display precedes save)');
+  assert.deepEqual(results._queuedVenueCandidateKeys, ['seattle|massive'],
+    'the session remembers which keys it queued');
+
+  // The save path mints the id afterwards; the backfill stamps it in.
+  results.savedRunId = '20260723-101010';
+  await adapter.backfillQueuedVenueRunIds(results);
+  queue = await adapter.loadBarAdditions();
+  assert.deepEqual(queue['seattle|massive'].runIds, ['20260723-101010'],
+    'queued entry ends up with the real run id');
+
+  // Idempotent — a repeat backfill never duplicates the id.
+  await adapter.backfillQueuedVenueRunIds(results);
+  queue = await adapter.loadBarAdditions();
+  assert.deepEqual(queue['seattle|massive'].runIds, ['20260723-101010']);
+});
+
+test('run id backfill preserves history, skips foreign entries, and fails open', async () => {
+  const adapter = buildMapsAdapter();
+  adapter.fm = createDeadEndFmStub();
+  adapter.fm.files.set(adapter.getBarAdditionsFilePath(), JSON.stringify({
+    'seattle|massive': { name: 'Massive', timesSeen: 2, runIds: ['20260701-090000'] },
+    'seattle|neighbours': { name: 'Neighbours', timesSeen: 1, runIds: [] }
+  }));
+
+  // Only this session's keys are stamped; prior run ids are kept.
+  const results = {
+    savedRunId: '20260723-101010',
+    _queuedVenueCandidateKeys: ['seattle|massive', 'seattle|gone-missing']
+  };
+  await adapter.backfillQueuedVenueRunIds(results);
+  const queue = await adapter.loadBarAdditions();
+  assert.deepEqual(queue['seattle|massive'].runIds,
+    ['20260701-090000', '20260723-101010'], 'new id appended after history');
+  assert.deepEqual(queue['seattle|neighbours'].runIds, [],
+    'entries not queued this session are untouched');
+
+  // No session keys or no run id → no write at all (fail open).
+  const before = adapter.fm.files.get(adapter.getBarAdditionsFilePath());
+  await adapter.backfillQueuedVenueRunIds({ savedRunId: '20260724-000000' });
+  await adapter.backfillQueuedVenueRunIds({ _queuedVenueCandidateKeys: ['seattle|massive'] });
+  assert.equal(adapter.fm.files.get(adapter.getBarAdditionsFilePath()), before,
+    'nothing rewritten without both a run id and session keys');
 });

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -776,6 +776,11 @@ async saveFailureNote(url, error, metadata = {}) {
                     const signals = Array.isArray(candidate.signals) ? candidate.signals.join(', ') : '';
                     const addressSuffix = candidate.address ? ` — ${candidate.address}` : '';
                     console.log(`   • "${candidate.name}" (${candidate.city}) — signals: ${signals}${addressSuffix}`);
+                    // Computed evidence lines (SharedCore.buildNewVenueCandidates
+                    // attaches candidate.evidence); absent → nothing printed.
+                    if (Array.isArray(candidate.evidence)) {
+                        candidate.evidence.forEach(line => console.log(`     evidence: ${line}`));
+                    }
                 });
             }
 

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -1786,6 +1786,21 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 event.pinSource = (resolvedVerdict && resolvedVerdict.grade === 'exact' && resolvedVerdict.crossCheck !== 'fail')
                     ? 'geocoded-exact'
                     : 'geocoded-approx';
+                // Retain the harvested map POI name for the results-UI evidence
+                // panel (underscore fields — display-only, systematically
+                // excluded from notes/merge serialization; only set when THIS
+                // run harvested a POI, so cached/skipped geocodes add nothing).
+                // The bar-match verdict is computed here, where the existing
+                // poiNameMatchesBar lives, preferring a bar-matching name over
+                // the first harvested one.
+                if (resolvedPoiNames.length > 0) {
+                    const poiBar = typeof event.bar === 'string' ? event.bar.trim() : '';
+                    const matchedPoiName = poiBar
+                        ? resolvedPoiNames.find(name => this.poiNameMatchesBar(name, poiBar))
+                        : undefined;
+                    event._geoPoiName = matchedPoiName || resolvedPoiNames[0];
+                    if (poiBar) event._geoPoiBarMatch = Boolean(matchedPoiName);
+                }
                 // Geo-POI bar corroboration: the map names harvested from the
                 // accepted pin's own responses vouch for (or question) the bar.
                 this.corroborateBarWithGeoPoi(event, resolvedPoiNames);

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -1787,3 +1787,43 @@ test('geo-POI corroboration: the Apple reverse placemark corroborates when the f
     `forward POI still flags; the stale placemark stays silent: ${staleLines.join(' | ')}`
   );
 });
+
+test('geo-POI harvest stashes _geoPoiName/_geoPoiBarMatch on the event for the evidence panel', async () => {
+  // Matching POI: the stashed name is the one that matched the bar and the
+  // verdict comes from the existing poiNameMatchesBar at harvest time.
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createRoutedStubAdapter([['nominatim', [MASSIVE_POI_RESULT]]]);
+  const event = { title: 'BEARRACUDA', address: '619 E Pine St', bar: 'MASSIVE', barSource: 'uncorroborated' };
+  await withCapturedConsole(() => normalizer.normalizeAsync(event, httpAdapter));
+  assert.equal(event._geoPoiName, 'Massive', 'harvested POI name stashed (underscore — never serialized)');
+  assert.equal(event._geoPoiBarMatch, true, 'match verdict stashed alongside');
+
+  // Differing POI: first harvested name stashed with a false verdict.
+  const mismatchNormalizer = createOsmNormalizer();
+  mismatchNormalizer.delayForRateLimit = async () => {};
+  const mismatchAdapter = createRoutedStubAdapter([['nominatim', [MASSIVE_POI_RESULT]]]);
+  const mismatchEvent = { title: 'BEARRACUDA', address: '619 E Pine St', bar: 'Neighbours', barSource: 'uncorroborated' };
+  await withCapturedConsole(() => mismatchNormalizer.normalizeAsync(mismatchEvent, mismatchAdapter));
+  assert.equal(mismatchEvent._geoPoiName, 'Massive');
+  assert.equal(mismatchEvent._geoPoiBarMatch, false);
+
+  // No bar on the event: the POI name still lands, but no verdict either way.
+  const noBarNormalizer = createOsmNormalizer();
+  noBarNormalizer.delayForRateLimit = async () => {};
+  const noBarAdapter = createRoutedStubAdapter([['nominatim', [MASSIVE_POI_RESULT]]]);
+  const noBarEvent = { title: 'BEARRACUDA', address: '619 E Pine St' };
+  await withCapturedConsole(() => noBarNormalizer.normalizeAsync(noBarEvent, noBarAdapter));
+  assert.equal(noBarEvent._geoPoiName, 'Massive');
+  assert.ok(!('_geoPoiBarMatch' in noBarEvent), 'no bar → no verdict field');
+
+  // No POI harvested (bare-address hit): neither field appears (fail open —
+  // cached/skipped geocodes without a POI render no evidence line).
+  const inertNormalizer = createOsmNormalizer();
+  inertNormalizer.delayForRateLimit = async () => {};
+  const inertAdapter = createRoutedStubAdapter([['nominatim', [PINE_STREET_ADDRESS_RESULT]]]);
+  const inertEvent = { title: 'BEARRACUDA', address: '619 E Pine St', bar: 'Massive', barSource: 'uncorroborated' };
+  await withCapturedConsole(() => inertNormalizer.normalizeAsync(inertEvent, inertAdapter));
+  assert.ok(!('_geoPoiName' in inertEvent), 'no harvest → no stash');
+  assert.ok(!('_geoPoiBarMatch' in inertEvent));
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2173,6 +2173,7 @@ class SharedCore {
     buildNewVenueCandidates(events, options = {}) {
         const runId = options && options.runId ? String(options.runId) : null;
         const byKey = new Map();
+        const poiByKey = new Map();
         for (const event of Array.isArray(events) ? events : []) {
             if (!this.isNewVenueCandidateEvent(event)) continue;
             const bar = event.bar.trim();
@@ -2215,6 +2216,15 @@ class SharedCore {
                     runId
                 };
                 byKey.set(key, candidate);
+                // Geo-POI evidence rides with the coordinate-donor event (the
+                // candidate's coordinates come from this first event, so its
+                // harvested POI name is the one naming THAT pin). Kept in a
+                // side map — never on the candidate itself, which is written
+                // verbatim into results/venue-queue files.
+                poiByKey.set(key, {
+                    _geoPoiName: typeof event._geoPoiName === 'string' ? event._geoPoiName : '',
+                    _geoPoiBarMatch: event._geoPoiBarMatch
+                });
             }
             candidate.name = this.pickBetterCasedVenueName(candidate.name, bar);
             if (this.isMoreCompleteVenueAddress(address, candidate.address)) {
@@ -2232,6 +2242,24 @@ class SharedCore {
                         : (typeof event.url === 'string' ? event.url : '')
                 });
             }
+        }
+        // Computed evidence panel per candidate (results-UI display only):
+        // the candidate re-shaped as an event drives the same pure builder
+        // the event cards use. pinSource is 'geocoded-exact' by construction
+        // (isNewVenueCandidateEvent requires it) and the barSource shown is
+        // the first observed signal.
+        for (const candidate of byKey.values()) {
+            const poi = poiByKey.get(candidate.key) || {};
+            candidate.evidence = this.buildEventEvidenceLines({
+                bar: candidate.name,
+                city: candidate.city,
+                address: candidate.address,
+                location: candidate.coordinates,
+                barSource: candidate.signals[0] || '',
+                pinSource: 'geocoded-exact',
+                _geoPoiName: poi._geoPoiName,
+                _geoPoiBarMatch: poi._geoPoiBarMatch
+            }, { cityKey: candidate.city });
         }
         return Array.from(byKey.values());
     }
@@ -2277,6 +2305,109 @@ class SharedCore {
         const signals = Array.isArray(candidate.signals) ? candidate.signals.join(', ') : '';
         const address = candidate.address || 'no address observed';
         return `📋 NEW VENUE CANDIDATE: "${candidate.name}" (${candidate.city}) — signals: ${signals} — ${address}`;
+    }
+
+    // ------------------------------------------------------------------
+    // Computed evidence panel (results-UI only). Short human-readable
+    // consistency checks derived ONLY from data already on the event plus
+    // the threaded config context (cities / curated bars) — no lookups, no
+    // network. Every line is independent and every guard fails open: when
+    // an input is absent its line is simply omitted, and an event with
+    // nothing computable yields []. Rendered by the adapters as a muted
+    // "Evidence" block; never serialized into notes (the builder writes
+    // nothing onto the event).
+    // ------------------------------------------------------------------
+
+    // Distance label for evidence lines: <1 km → whole meters, else 1-decimal
+    // km ("42 m", "1.3 km").
+    formatEvidenceDistance(km) {
+        return km < 1 ? `${Math.round(km * 1000)} m` : `${km.toFixed(1)} km`;
+    }
+
+    // Evidence lines for one event (or an event-shaped venue candidate).
+    // context.cityKey overrides event.city for the config lookups (candidates
+    // carry their own city key). Returns an array of short strings; [] when
+    // nothing is computable.
+    buildEventEvidenceLines(event, context = {}) {
+        const lines = [];
+        if (!event || typeof event !== 'object') return lines;
+        const cityKey = typeof context.cityKey === 'string' && context.cityKey.trim()
+            ? context.cityKey.trim()
+            : (typeof event.city === 'string' ? event.city.trim() : '');
+        const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+        const pin = this.isCoordinatePair(event.location) ? String(event.location).trim() : '';
+
+        // Pin ↔ curated bar: the pinned coordinates against the curated city
+        // bar the event's bar name matches. Same venue → tens of meters; >150 m
+        // means the pin and the curated record disagree about where this bar is.
+        if (pin && bar) {
+            const cityBars = this.getCuratedCityBars(cityKey);
+            const curated = cityBars ? this.findCuratedBarByName(cityBars, bar) : null;
+            if (curated && this.isCoordinatePair(curated.coordinates)) {
+                const km = this.coordinatePairDistanceKm(pin, curated.coordinates);
+                if (km !== null) {
+                    const warn = km > 0.15 ? '⚠️ ' : '';
+                    lines.push(`${warn}pin is ${this.formatEvidenceDistance(km)} from curated "${curated.name}" pin`);
+                }
+            }
+        }
+
+        // Pin ↔ city center: a sanity radius, not an identity check — venues
+        // sit within a metro, so >50 km says the pin landed in the wrong place
+        // (same-named venue in another city, geocoder mishap).
+        if (pin) {
+            const center = this.getCityCenterCoordinatePair(cityKey);
+            const km = center ? this.coordinatePairDistanceKm(pin, center) : null;
+            if (km !== null) {
+                const warn = km > 50 ? '⚠️ ' : '';
+                lines.push(`${warn}pin is ${km.toFixed(1)} km from ${cityKey} center`);
+            }
+        }
+
+        // Map POI at the pin: the place name the geocoder reported AT the
+        // accepted coordinates, harvested this run by OpenStreetMapNormalizer
+        // (_geoPoiName / _geoPoiBarMatch — underscore fields, never serialized;
+        // the match verdict comes from the normalizer's poiNameMatchesBar at
+        // harvest time). Cached/skipped geocodes carry no POI → no line.
+        const poiName = typeof event._geoPoiName === 'string' ? event._geoPoiName.trim() : '';
+        if (poiName) {
+            if (bar && event._geoPoiBarMatch === true) {
+                lines.push(`map POI at pin: "${poiName}" — ✓ matches bar`);
+            } else if (bar && event._geoPoiBarMatch === false) {
+                lines.push(`map POI at pin: "${poiName}" — ⚠️ differs from bar "${bar}"`);
+            } else {
+                lines.push(`map POI at pin: "${poiName}"`);
+            }
+        }
+
+        // Bar corroboration verdict from barSource provenance.
+        const barSource = typeof event.barSource === 'string' ? event.barSource.trim() : '';
+        if (bar && barSource) {
+            if (['page-adjacent', 'venue-site', 'geo-poi', 'curated'].includes(barSource)) {
+                lines.push(`bar corroborated: ${barSource}`);
+            } else if (barSource === 'uncorroborated') {
+                lines.push('⚠️ bar uncorroborated (not found near address in source)');
+            }
+        }
+
+        // Compact provenance summary of whichever companion stamps exist.
+        const provenance = [
+            ['bar', 'barSource'],
+            ['pin', 'pinSource'],
+            ['address', 'addressSource'],
+            ['image', 'imageSource'],
+            ['bear', 'bearSource']
+        ]
+            .map(([label, field]) => {
+                const value = typeof event[field] === 'string' ? event[field].trim() : '';
+                return value ? `${label}=${value}` : '';
+            })
+            .filter(Boolean);
+        if (provenance.length > 0) {
+            lines.push(`provenance: ${provenance.join(', ')}`);
+        }
+
+        return lines;
     }
 
     // Baked-in platform confidence expectations: Eventbrite /e/ event pages ship
@@ -6147,6 +6278,12 @@ class SharedCore {
             if (!analyzedEvent.notes) {
                 analyzedEvent.notes = this.formatEventNotes(analyzedEvent);
             }
+
+            // Computed evidence panel for the results-UI event card (underscore
+            // field: display-only, systematically excluded from notes/merge
+            // serialization). Computed AFTER the final merged object exists so
+            // the lines describe exactly what will be written.
+            analyzedEvent._evidenceLines = this.buildEventEvidenceLines(analyzedEvent, { cityKey: analyzedEvent.city });
 
             return analyzedEvent;
         }

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2180,10 +2180,27 @@ class SharedCore {
             const key = `${cityKey}|${this.normalizeBarNameKey(bar)}`;
             const barSource = event.barSource.trim();
             const address = typeof event.address === 'string' ? event.address.trim() : '';
-            const website = typeof event.website === 'string' && event.website.trim()
-                ? event.website.trim()
-                : (typeof event.url === 'string' ? event.url.trim() : '');
-            const instagram = typeof event.instagram === 'string' ? event.instagram.trim() : '';
+            // Organizer-link pollution guard: an event's website/instagram
+            // describe whatever entity the SOURCE PAGE is about — on
+            // promoter-scraped events that's the ORGANIZER (e.g.
+            // bearracuda.com / @bearracuda), not the venue hosting the party.
+            // The only stamp proving the page IS the venue's own site is
+            // barSource === 'venue-site' (siteRole=venue + page-name match at
+            // extraction time — see ai-web-parser's stampBarSourceProvenance),
+            // so the dossier carries website/instagram only from those events.
+            // Otherwise both fields are omitted entirely: in a curation
+            // dossier, missing data beats wrong data (and the adapter's
+            // fill-blanks-only queue merge means an omission here never
+            // re-adds organizer links to entries that lack them).
+            const linksAreVenueAttributable = barSource === 'venue-site';
+            const website = linksAreVenueAttributable
+                ? (typeof event.website === 'string' && event.website.trim()
+                    ? event.website.trim()
+                    : (typeof event.url === 'string' ? event.url.trim() : ''))
+                : '';
+            const instagram = linksAreVenueAttributable && typeof event.instagram === 'string'
+                ? event.instagram.trim()
+                : '';
 
             let candidate = byKey.get(key);
             if (!candidate) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -6806,3 +6806,77 @@ test('new venue candidate log line has the documented shape', () => {
     '📋 NEW VENUE CANDIDATE: "Massive" (seattle) — signals: venue-site — no address observed'
   );
 });
+
+test('candidate dossier omits website/instagram unless the source page is the venue\'s own site', () => {
+  const core = createVenueDiscoveryCore();
+
+  // Organizer-page events (e.g. a promoter site like bearracuda.com): the
+  // event's website/instagram are the ORGANIZER's metadata, not the venue's —
+  // both fields must be omitted from the dossier entirely.
+  const [organizer] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      barSource: 'page-adjacent',
+      website: 'https://bearracuda.com/',
+      instagram: 'https://instagram.com/bearracuda',
+      url: 'https://bearracuda.com/events/seattle'
+    })
+  ]);
+  assert.ok(!('website' in organizer), 'organizer website omitted from the dossier');
+  assert.ok(!('instagram' in organizer), 'organizer instagram omitted from the dossier');
+
+  // geo-poi corroborates the bar name via map placemarks — still not the
+  // venue's own site, so links stay out.
+  const [geoPoi] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      barSource: 'geo-poi',
+      instagram: 'https://instagram.com/bearracuda'
+    })
+  ]);
+  assert.ok(!('website' in geoPoi) && !('instagram' in geoPoi),
+    'geo-poi events contribute no links');
+
+  // venue-site events keep both: barSource 'venue-site' is only stamped when
+  // the source page IS the venue's own site (siteRole venue + name match).
+  const [venueSite] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      barSource: 'venue-site',
+      website: 'https://massiveseattle.com',
+      instagram: 'https://instagram.com/massiveseattle'
+    })
+  ]);
+  assert.equal(venueSite.website, 'https://massiveseattle.com');
+  assert.equal(venueSite.instagram, 'https://instagram.com/massiveseattle');
+
+  // The event-page-url fallback for website also only applies to venue-site
+  // events (a page on the venue's own site is venue-attributable).
+  const [urlFallback] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      barSource: 'venue-site',
+      website: undefined,
+      url: 'https://massiveseattle.com/events/bear-night'
+    })
+  ]);
+  assert.equal(urlFallback.website, 'https://massiveseattle.com/events/bear-night');
+});
+
+test('mixed-provenance dedup takes links only from the venue-site observation', () => {
+  const core = createVenueDiscoveryCore();
+  const [candidate] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      barSource: 'page-adjacent',
+      website: 'https://bearracuda.com/',
+      instagram: 'https://instagram.com/bearracuda',
+      title: 'Bearracuda Seattle'
+    }),
+    buildVenueCandidateEvent({
+      barSource: 'venue-site',
+      website: 'https://massiveseattle.com',
+      instagram: undefined,
+      title: 'Bear Night'
+    })
+  ]);
+  assert.equal(candidate.website, 'https://massiveseattle.com',
+    'venue-site link lands; the organizer link never does');
+  assert.ok(!('instagram' in candidate),
+    'no venue-attributable instagram observed → field omitted');
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -6880,3 +6880,193 @@ test('mixed-provenance dedup takes links only from the venue-site observation', 
   assert.ok(!('instagram' in candidate),
     'no venue-attributable instagram observed → field omitted');
 });
+
+// ---------------------------------------------------------------------------
+// Computed evidence panel (results-UI): buildEventEvidenceLines
+// ---------------------------------------------------------------------------
+
+// Seattle with center coordinates plus one curated bar with a pin — the two
+// config sources the evidence distances are computed against.
+function createEvidencePanelCore() {
+  return new SharedCore({
+    seattle: {
+      timezone: 'America/Los_Angeles',
+      calendar: 'chunky-dad-seattle',
+      patterns: ['seattle'],
+      coordinates: { lat: 47.6062, lng: -122.3321 }
+    }
+  }, {
+    eventSchema: EventSchema,
+    bars: { seattle: [SEATTLE_CUFF_BAR] }
+  });
+}
+
+test('evidence: pin ↔ curated bar distance in meters, ⚠️ beyond 150 m', () => {
+  const core = createEvidencePanelCore();
+  // ~3.5 m from the curated Cuff pin → meters, no warning.
+  const near = core.buildEventEvidenceLines({
+    bar: 'The Cuff Complex',
+    city: 'seattle',
+    location: '47.6142, -122.3169'
+  });
+  assert.ok(near.includes('pin is 3 m from curated "The Cuff Complex" pin'),
+    `expected curated-distance line, got: ${JSON.stringify(near)}`);
+  // ~1.76 km away → 1-decimal km with the warning prefix.
+  const far = core.buildEventEvidenceLines({
+    bar: 'The Cuff Complex',
+    city: 'seattle',
+    location: '47.63, -122.3168539'
+  });
+  assert.ok(far.includes('⚠️ pin is 1.8 km from curated "The Cuff Complex" pin'),
+    `expected warned curated-distance line, got: ${JSON.stringify(far)}`);
+  // Between 150 m and 1 km: warned, still meters.
+  const mid = core.buildEventEvidenceLines({
+    bar: 'The Cuff Complex',
+    city: 'seattle',
+    location: '47.6142041, -122.32'
+  });
+  assert.ok(mid.includes('⚠️ pin is 236 m from curated "The Cuff Complex" pin'),
+    `expected warned meter line, got: ${JSON.stringify(mid)}`);
+  // A non-curated bar has no curated pin to compare against → no line.
+  const uncurated = core.buildEventEvidenceLines({
+    bar: 'Massive',
+    city: 'seattle',
+    location: '47.6142, -122.3169'
+  });
+  assert.ok(!uncurated.some(line => line.includes('curated')),
+    'no curated line for a bar absent from curated data');
+});
+
+test('evidence: pin ↔ city center distance in km, ⚠️ beyond 50 km', () => {
+  const core = createEvidencePanelCore();
+  const near = core.buildEventEvidenceLines({
+    bar: 'Massive',
+    city: 'seattle',
+    location: '47.6142, -122.3169'
+  });
+  assert.ok(near.includes('pin is 1.4 km from seattle center'),
+    `expected center-distance line, got: ${JSON.stringify(near)}`);
+  const far = core.buildEventEvidenceLines({
+    city: 'seattle',
+    location: '48.5, -122.33'
+  });
+  assert.ok(far.includes('⚠️ pin is 99.4 km from seattle center'),
+    `expected warned center-distance line, got: ${JSON.stringify(far)}`);
+  // City without center coordinates (the discovery fixture) → no line.
+  const noCenter = createVenueDiscoveryCore().buildEventEvidenceLines({
+    city: 'seattle',
+    location: '47.6142, -122.3169'
+  });
+  assert.ok(!noCenter.some(line => line.includes('center')),
+    'no center line without city coordinates');
+});
+
+test('evidence: map POI line renders match, mismatch, and bar-less variants', () => {
+  const core = createEvidencePanelCore();
+  const match = core.buildEventEvidenceLines({
+    bar: 'Massive',
+    city: 'seattle',
+    _geoPoiName: 'Massive Nightclub',
+    _geoPoiBarMatch: true
+  });
+  assert.ok(match.includes('map POI at pin: "Massive Nightclub" — ✓ matches bar'),
+    `expected POI match line, got: ${JSON.stringify(match)}`);
+  const differ = core.buildEventEvidenceLines({
+    bar: 'Massive',
+    city: 'seattle',
+    _geoPoiName: 'Corner Deli',
+    _geoPoiBarMatch: false
+  });
+  assert.ok(differ.includes('map POI at pin: "Corner Deli" — ⚠️ differs from bar "Massive"'),
+    `expected POI mismatch line, got: ${JSON.stringify(differ)}`);
+  const noBar = core.buildEventEvidenceLines({
+    city: 'seattle',
+    _geoPoiName: 'Corner Deli'
+  });
+  assert.ok(noBar.includes('map POI at pin: "Corner Deli"'),
+    `expected bare POI line, got: ${JSON.stringify(noBar)}`);
+  // No harvested POI this run (cached/skipped geocode) → no POI line at all.
+  const noPoi = core.buildEventEvidenceLines({ bar: 'Massive', city: 'seattle' });
+  assert.ok(!noPoi.some(line => line.includes('map POI')), 'no POI line without a harvest');
+});
+
+test('evidence: barSource renders a corroboration verdict and a provenance summary', () => {
+  const core = createEvidencePanelCore();
+  for (const source of ['page-adjacent', 'venue-site', 'geo-poi', 'curated']) {
+    const lines = core.buildEventEvidenceLines({ bar: 'Massive', city: 'seattle', barSource: source });
+    assert.ok(lines.includes(`bar corroborated: ${source}`),
+      `expected corroboration line for ${source}, got: ${JSON.stringify(lines)}`);
+  }
+  const flagged = core.buildEventEvidenceLines({
+    bar: 'Massive',
+    city: 'seattle',
+    barSource: 'uncorroborated'
+  });
+  assert.ok(flagged.includes('⚠️ bar uncorroborated (not found near address in source)'),
+    `expected uncorroborated warning, got: ${JSON.stringify(flagged)}`);
+
+  const provenance = core.buildEventEvidenceLines({
+    bar: 'Massive',
+    city: 'seattle',
+    barSource: 'page-adjacent',
+    pinSource: 'geocoded-exact',
+    addressSource: 'page',
+    imageSource: 'jsonld',
+    bearSource: 'ai'
+  });
+  assert.ok(provenance.includes(
+    'provenance: bar=page-adjacent, pin=geocoded-exact, address=page, image=jsonld, bear=ai'),
+    `expected full provenance line, got: ${JSON.stringify(provenance)}`);
+  // Only the stamps that exist appear.
+  const partial = core.buildEventEvidenceLines({ city: 'seattle', pinSource: 'geocoded-exact' });
+  assert.ok(partial.includes('provenance: pin=geocoded-exact'),
+    `expected partial provenance line, got: ${JSON.stringify(partial)}`);
+});
+
+test('evidence: nothing computable fails open to an empty array', () => {
+  const core = createEvidencePanelCore();
+  assert.deepEqual(core.buildEventEvidenceLines({}), []);
+  assert.deepEqual(core.buildEventEvidenceLines(null), []);
+  assert.deepEqual(core.buildEventEvidenceLines(undefined), []);
+  assert.deepEqual(core.buildEventEvidenceLines({ title: 'Bear Night', city: 'nowhere' }), []);
+  // A non-coordinate location contributes no distance lines.
+  assert.deepEqual(core.buildEventEvidenceLines({ city: 'seattle', location: 'The Cuff, Seattle' }), []);
+});
+
+test('evidence: _geoPoiName and _geoPoiBarMatch never serialize into notes', () => {
+  const core = createEvidencePanelCore();
+  const notes = core.formatEventNotes({
+    bar: 'Massive',
+    barSource: 'geo-poi',
+    _geoPoiName: 'Massive Nightclub',
+    _geoPoiBarMatch: true,
+    _evidenceLines: ['bar corroborated: geo-poi']
+  });
+  assert.ok(notes.includes('bar: Massive'), 'real fields serialize');
+  assert.ok(!notes.includes('_geoPoiName'), 'underscore key excluded');
+  assert.ok(!notes.includes('Massive Nightclub'), 'underscore value excluded');
+  assert.ok(!notes.includes('_geoPoiBarMatch') && !notes.includes('_evidenceLines'),
+    'companion underscore fields excluded too');
+});
+
+test('new venue candidates carry a computed evidence panel from the same builder', () => {
+  const core = createEvidencePanelCore();
+  const [candidate] = core.buildNewVenueCandidates([
+    buildVenueCandidateEvent({
+      location: '47.6142, -122.3169',
+      _geoPoiName: 'Massive Nightclub',
+      _geoPoiBarMatch: true
+    })
+  ]);
+  assert.ok(Array.isArray(candidate.evidence), 'evidence array attached');
+  assert.ok(candidate.evidence.includes('pin is 1.4 km from seattle center'),
+    `center line from candidate coordinates, got: ${JSON.stringify(candidate.evidence)}`);
+  assert.ok(candidate.evidence.includes('map POI at pin: "Massive Nightclub" — ✓ matches bar'),
+    'geo-POI evidence rides over from the coordinate-donor event');
+  assert.ok(candidate.evidence.includes('bar corroborated: venue-site'),
+    'first observed signal is the corroboration verdict');
+  assert.ok(candidate.evidence.includes('provenance: bar=venue-site, pin=geocoded-exact'),
+    'candidate provenance is signal + the exact pin its detection required');
+  assert.ok(!('_geoPoiName' in candidate),
+    'raw POI underscore fields never land on the candidate itself');
+});


### PR DESCRIPTION
Supersedes #1522 (includes its commit; #1522 will be closed). The complete location-verification toolkit for the results UI.

## Verify links (candidates + event cards)
`Verify: Bar ↗ Address ↗ Pin ↗ Route ↗` — the first three open Google Maps searches (bar+city, address with city-dedup, exact pin); **Route** chains all three as directions (origin bar → waypoint address → destination pin): identical points render a ~0 m route, so same-place verification is one glance. All via the chunkyscrape:// bridge → `Safari.open()` — the results sheet never navigates away.

## Dual inline maps
Per-candidate **Show map** reveals BOTH: the OSM embed (keyless by design, dependable) and the legacy Google `output=embed` iframe (keyless but unofficial — commented as may-break-without-notice). Both fully lazy: no src until first tap.

## Computed evidence panel ('just show me what you computed')
Pure shared-core builder surfacing already-computed facts as compact lines on candidates and event cards, ⚠️-prefixed past sanity thresholds:
- `pin is 3 m from curated "The Cuff Complex" pin` (⚠️ past 150 m)
- `pin is 1.4 km from seattle center` (⚠️ past 50 km)
- `map POI at pin: "The Cuff" — ✓ matches bar` / `⚠️ differs from bar "…"` (Phase-3 POI harvest now retained on the event as underscore metadata — it was previously computed and discarded)
- `bar corroborated: page-adjacent` / `⚠️ bar uncorroborated (…)`
- `provenance: bar=curated, pin=geocoded-exact, address=page`
Zero new lookups; evidence never leaks into `bar-additions.json` (explicit-field queue writes, tested).

## Venue-queue fixes (from the first real cycle)
- `runIds: []` — queued keys now backfilled with the real run id right after the run saves.
- Organizer-link pollution — website/instagram enter dossiers only from `venue-site`-stamped events.

+28 tests over the #1520 baseline. Suite: **635 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/normalizers.js`, `scripts/adapters/scriptable-adapter.js`, `scripts/parsers/ai-web-parser.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP