### PR TITLE
fix(scraper): strip redundant dates from titles when they match the event date — and never let them win merges

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -25,6 +25,31 @@ const ImportedEventSchema = (() => {
     return null;
 })();
 
+// SharedCore's title date-segment detector (ONE implementation, shared with
+// the deterministic merge rung — defined upstream in shared-core.js and
+// exported from there). The wired this.core reference is preferred at the
+// call site; this import is the fallback for isolated construction (tests).
+// Missing both → the title date-strip fails open (title kept).
+const ImportedDetectTitleDateSegment = (() => {
+    try {
+        if (typeof importModule === 'function') {
+            const sharedCoreModule = importModule('shared-core');
+            if (sharedCoreModule && typeof sharedCoreModule.detectTitleDateSegment === 'function') {
+                return sharedCoreModule.detectTitleDateSegment;
+            }
+        }
+    } catch (_) {}
+    try {
+        if (typeof require === 'function') {
+            const sharedCoreModule = require('../shared-core');
+            if (sharedCoreModule && typeof sharedCoreModule.detectTitleDateSegment === 'function') {
+                return sharedCoreModule.detectTitleDateSegment;
+            }
+        }
+    } catch (_) {}
+    return null;
+})();
+
 // Persistent cache entries (OCR, classification) are retained by LAST USE, not
 // write date: cache hits refresh a `lastUsedAt` payload field so recurring
 // flyers survive the adapter's end-of-run pruning. Refreshes are rate-limited
@@ -6136,6 +6161,14 @@ class AiWebParser {
         const normalized = this.normalizePromptFieldName(field);
         const schemaDescription = this.getEventSchemaPromptFieldDescription(normalized);
         let description = schemaDescription || 'Event field';
+        // Prompt-only steering (run 20260723 findings): source sites lead the
+        // description with the event's own date line ("CHUNK returns to PDX…
+        // Saturday AUGUST 22nd!"), which is redundant next to startDate/
+        // startTime. Appended to the schema line so the schema text itself
+        // stays byte-identical.
+        if (normalized === 'description') {
+            description += ` Do not lead with the event's date/time (those are captured separately) — start from the actual description text.`;
+        }
         return description;
     }
 
@@ -7788,6 +7821,50 @@ TEXT:
         if (!title || !startDate) {
             console.warn(`🤖 AI Web: Normalization failed — title=${title}, startDate=${startDate}`);
             return null;
+        }
+
+        // Deterministic title date-strip: source sites bake the date into the
+        // title ("CHUNK DORE ALLEY - Saturday July 25th") — on a calendar that
+        // date is pure redundancy (startDate carries it), and a dated variant
+        // could beat the clean one in title merges under the more-descriptive
+        // rule. Strip ONLY when the printed date provably matches the event's
+        // own startDate, compared against the ORIGINAL extracted date string
+        // (aiEvent.startDate / aiEvent.start — pre-normalization): the
+        // combined startDate above may have rolled past midnight in UTC (late
+        // local start times) or been year-adjusted, so its ISO date can
+        // legitimately differ from the printed local date. startDateRaw's ISO
+        // date part is the same local-date view the combination logic itself
+        // uses, so it is a safe fallback. The detector lives in SharedCore
+        // (detectTitleDateSegment — one implementation, shared with the merge
+        // rung); a mismatching printed date keeps the title and leaves a
+        // manual-review trail. Any parse uncertainty fails open (title kept).
+        const detectTitleDateSegment = this.core && typeof this.core.detectTitleDateSegment === 'function'
+            ? (value) => this.core.detectTitleDateSegment(value)
+            : ImportedDetectTitleDateSegment;
+        const titleDateSegment = typeof detectTitleDateSegment === 'function' ? detectTitleDateSegment(title) : null;
+        if (titleDateSegment) {
+            const extractLocalDateParts = (value) => {
+                if (typeof value !== 'string') return null;
+                const match = value.trim().match(/^(\d{4})-(\d{2})-(\d{2})(?:[T\s]|$)/);
+                if (!match) return null;
+                return { year: parseInt(match[1], 10), month: parseInt(match[2], 10), day: parseInt(match[3], 10) };
+            };
+            const expectedDate = extractLocalDateParts(aiEvent.startDate)
+                || extractLocalDateParts(aiEvent.start)
+                || (startDateRaw instanceof Date && !Number.isNaN(startDateRaw.getTime())
+                    ? extractLocalDateParts(startDateRaw.toISOString())
+                    : null);
+            if (expectedDate) {
+                const monthDayMatches = titleDateSegment.month === expectedDate.month && titleDateSegment.day === expectedDate.day;
+                const yearMatches = titleDateSegment.year === null || titleDateSegment.year === expectedDate.year;
+                if (monthDayMatches && yearMatches) {
+                    console.log(`🤖 AI Web: Stripped redundant date from title ("${title}" → "${titleDateSegment.base}")`);
+                    title = titleDateSegment.base;
+                } else {
+                    const expectedIso = `${expectedDate.year}-${String(expectedDate.month).padStart(2, '0')}-${String(expectedDate.day).padStart(2, '0')}`;
+                    console.log(`🤖 AI Web: Title contains a date that does not match startDate ("${title}" vs ${expectedIso}) — kept, verify manually`);
+                }
+            }
         }
 
         const event = {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1446,6 +1446,106 @@ test('normalizeAiEvent keeps a bare-city title when no organizer or no city is k
   assert.equal(unknownCity.title, 'Denver');
 });
 
+test('normalizeAiEvent strips a redundant title date matching startDate (real run 20260723 cases)', () => {
+  const parser = createParser();
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let doreAlley;
+  let chicago;
+  try {
+    doreAlley = parser.normalizeAiEvent(
+      { title: 'CHUNK DORE ALLEY - Saturday July 25th', startDate: '2026-07-25', startTime: '15:00', timezone: 'America/Los_Angeles' },
+      {}, null, null, null);
+    chicago = parser.normalizeAiEvent(
+      { title: 'CHUNK Chicago - September 19th', startDate: '2026-09-19', timezone: 'America/Chicago' },
+      {}, null, null, null);
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(doreAlley.title, 'CHUNK DORE ALLEY');
+  assert.equal(chicago.title, 'CHUNK Chicago');
+  assert.ok(logs.includes(
+    '🤖 AI Web: Stripped redundant date from title ("CHUNK DORE ALLEY - Saturday July 25th" → "CHUNK DORE ALLEY")'
+  ), `additive strip log line expected, got: ${JSON.stringify(logs)}`);
+});
+
+test('normalizeAiEvent strips leading date segments and every separator/month spelling variant', () => {
+  const parser = createParser();
+  const cases = [
+    ['Saturday July 25th - CHUNK DORE ALLEY', '2026-07-25', 'CHUNK DORE ALLEY'],
+    ['CHUNK PDX | Aug 22nd', '2026-08-22', 'CHUNK PDX'],
+    ['CHUNK PDX – Aug. 22', '2026-08-22', 'CHUNK PDX'],
+    ['CHUNK Chicago, September 19th, 2026', '2026-09-19', 'CHUNK Chicago'],
+    ['CHUNK - 7/25', '2026-07-25', 'CHUNK']
+  ];
+  for (const [title, startDate, expected] of cases) {
+    const event = parser.normalizeAiEvent(
+      { title, startDate, timezone: 'America/Los_Angeles' }, {}, null, null, null);
+    assert.equal(event.title, expected, `"${title}" should strip to "${expected}"`);
+  }
+});
+
+test('normalizeAiEvent KEEPS a title date that mismatches startDate and flags it for manual review', () => {
+  const parser = createParser();
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let event;
+  try {
+    event = parser.normalizeAiEvent(
+      { title: 'CHUNK Chicago - September 19th', startDate: '2026-09-26', timezone: 'America/Chicago' },
+      {}, null, null, null);
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(event.title, 'CHUNK Chicago - September 19th', 'mismatching printed date is never stripped');
+  assert.ok(logs.includes(
+    '🤖 AI Web: Title contains a date that does not match startDate ("CHUNK Chicago - September 19th" vs 2026-09-26) — kept, verify manually'
+  ), `verify-manually log line expected, got: ${JSON.stringify(logs)}`);
+});
+
+test('normalizeAiEvent never treats edition years or short remainders as date segments', () => {
+  const parser = createParser();
+
+  // Edition year attached to a word: a bare year without month+day never qualifies
+  const decadence = parser.normalizeAiEvent(
+    { title: 'DECADENCE 2026', startDate: '2026-08-30', timezone: 'America/Chicago' }, {}, null, null, null);
+  assert.equal(decadence.title, 'DECADENCE 2026');
+  const pride = parser.normalizeAiEvent(
+    { title: 'Pride 2027', startDate: '2027-06-26', timezone: 'America/New_York' }, {}, null, null, null);
+  assert.equal(pride.title, 'Pride 2027');
+
+  // Remainder after removal too short (<3 chars) → untouched
+  const shortBase = parser.normalizeAiEvent(
+    { title: 'GO - July 25th', startDate: '2026-07-25', timezone: 'America/New_York' }, {}, null, null, null);
+  assert.equal(shortBase.title, 'GO - July 25th');
+
+  // No startDate at all → the strip never runs; normalization still fails
+  // closed on the missing date exactly as before (pre-existing behavior).
+  assert.equal(parser.normalizeAiEvent({ title: 'CHUNK - July 25th' }, {}, null, null, null), null);
+});
+
+test('normalizeAiEvent title date-strip matches the PRINTED local date even when UTC rolls past midnight', () => {
+  const parser = createParser();
+  // 21:00 in LA is 04:00 UTC the NEXT day — the comparison must use the
+  // original extracted startDate string, not the rolled timestamp.
+  const event = parser.normalizeAiEvent(
+    { title: 'CHUNK DORE ALLEY - July 25th', startDate: '2026-07-25', startTime: '21:00', timezone: 'America/Los_Angeles' },
+    {}, null, null, null);
+  assert.equal(event.startDate.toISOString(), '2026-07-26T04:00:00.000Z', 'the stored instant really is past midnight UTC');
+  assert.equal(event.title, 'CHUNK DORE ALLEY', 'the printed date still matches its local calendar date');
+});
+
+test('extraction prompt description instruction tells the model not to lead with the date', () => {
+  global.EventSchema = EventSchema; // earlier tests leak a mocked schema — pin the real one
+  const parser = createParser();
+  const prompt = parser.buildExtractionPrompt(null, {}, null, {}, ['title', 'description'], 'SNIPPET', 'default', {});
+  assert.match(prompt,
+    /- description: Event description\/tagline from source text; do not invent details\. Do not lead with the event's date\/time \(those are captured separately\) — start from the actual description text\./,
+    'the schema line stays intact with the new sentence appended');
+});
+
 test('the JSON-LD fast path applies the bare-city organizer prefix too', async () => {
   const parser = createParser();
   const html = `

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -843,6 +843,72 @@ class SharedCore {
         return candidates.has(normalizedTitle);
     }
 
+    // A leading or trailing DATE-ONLY title segment ("CHUNK DORE ALLEY -
+    // Saturday July 25th", "Sept. 19 | CHUNK Chicago", "CHUNK - 7/25"):
+    // separator ([-–—|:•] or comma) + optional weekday + month name (full or
+    // 3-letter, optional period) + day number with optional ordinal + optional
+    // year — or a pure numeric M/D(/YYYY) form attached by separator. On a
+    // calendar the printed date is pure redundancy (startDate carries it), and
+    // a dated variant could beat the clean one in title merges under the
+    // more-descriptive rule. Edition years attached to words ("DECADENCE
+    // 2026", "Pride 2027") are NOT date segments — a bare year without a
+    // month+day never matches. Returns { base, month, day, year } — base is
+    // the remainder with leftover separators/whitespace collapsed, guaranteed
+    // non-empty and ≥3 chars; year is null when the title prints none — or
+    // null when no such segment exists (fail open on any parse uncertainty).
+    // Static + pure string logic so the ai-web parser's extraction-time strip
+    // shares this ONE implementation via the module export (shared-core is
+    // upstream of the parsers).
+    static detectTitleDateSegment(title) {
+        if (typeof title !== 'string') return null;
+        const text = title.replace(/\s+/g, ' ').trim();
+        if (!text) return null;
+        const MONTH_NUMBERS = {
+            jan: 1, january: 1, feb: 2, february: 2, mar: 3, march: 3,
+            apr: 4, april: 4, may: 5, jun: 6, june: 6, jul: 7, july: 7,
+            aug: 8, august: 8, sep: 9, sept: 9, september: 9,
+            oct: 10, october: 10, nov: 11, november: 11, dec: 12, december: 12
+        };
+        const weekdayPart = '(?:(?:mon(?:day)?|tue(?:s(?:day)?)?|wed(?:nesday)?|thu(?:r(?:s(?:day)?)?)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?)\\.?,?\\s+)?';
+        const monthPart = '(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|june?|july?|aug(?:ust)?|sept?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\\.?';
+        const dayPart = '(\\d{1,2})(?:st|nd|rd|th)?';
+        const yearPart = '(?:,?\\s+(\\d{4}))?';
+        const wordySegment = `${weekdayPart}${monthPart}\\s+${dayPart}${yearPart}`;
+        const numericSegment = '(\\d{1,2})\\s*\\/\\s*(\\d{1,2})(?:\\s*\\/\\s*(\\d{4}))?';
+        const separatorPart = '\\s*(?:[-–—|:•]|,)\\s*';
+        const attempts = [
+            { regex: new RegExp(`^(.*?)${separatorPart}${wordySegment}$`, 'i'), wordy: true, base: 1, month: 2, day: 3, year: 4 },
+            { regex: new RegExp(`^(.*?)${separatorPart}${numericSegment}$`, 'i'), wordy: false, base: 1, month: 2, day: 3, year: 4 },
+            { regex: new RegExp(`^${wordySegment}${separatorPart}(.*)$`, 'i'), wordy: true, base: 4, month: 1, day: 2, year: 3 },
+            { regex: new RegExp(`^${numericSegment}${separatorPart}(.*)$`, 'i'), wordy: false, base: 4, month: 1, day: 2, year: 3 }
+        ];
+        for (const attempt of attempts) {
+            const match = text.match(attempt.regex);
+            if (!match) continue;
+            const month = attempt.wordy
+                ? (MONTH_NUMBERS[String(match[attempt.month] || '').toLowerCase()] || null)
+                : parseInt(match[attempt.month], 10);
+            const day = parseInt(match[attempt.day], 10);
+            const year = match[attempt.year] ? parseInt(match[attempt.year], 10) : null;
+            if (!month || month < 1 || month > 12) continue;
+            if (!day || day < 1 || day > 31) continue;
+            if (year !== null && (year < 1900 || year > 2100)) continue;
+            const base = String(match[attempt.base] || '')
+                .replace(/^[\s\-–—|:•,]+|[\s\-–—|:•,]+$/g, '')
+                .replace(/\s+/g, ' ')
+                .trim();
+            if (!base || base.length < 3) continue;
+            return { base, month, day, year };
+        }
+        return null;
+    }
+
+    // Instance view of the static detector — merge rungs and downstream
+    // callers hold a SharedCore instance.
+    detectTitleDateSegment(title) {
+        return SharedCore.detectTitleDateSegment(title);
+    }
+
     // A value shaped like a street address is NEVER a venue name. Anchored on
     // a leading house number (incl. hyphenated Queens style "10-90") with a
     // street-type word appearing somewhere after it. The leading-number anchor
@@ -1234,6 +1300,36 @@ class SharedCore {
                     reason: 'emoji title variant beats its emoji-stripped twin'
                 };
             }
+            // A date-only segment welded onto the title ("CHUNK Chicago -
+            // September 19th" vs "CHUNK Chicago") is pure redundancy on a
+            // calendar — the date lives in startDate — and the arbitration
+            // model's more-descriptive preference could otherwise let the
+            // dated variant win. When the two candidates are IDENTICAL after
+            // removing such a segment (detectTitleDateSegment, the SAME
+            // detector the ai-web parser's extraction-time strip uses) and
+            // exactly one side carries it, the DATELESS side wins. The
+            // identical-after-removal requirement is the whole justification:
+            // both sides already agree on the base name, so no startDate
+            // validation is needed here (merge-side startDates are combined,
+            // possibly past-midnight-rolled UTC instants that cannot be
+            // compared to the printed local date reliably). Both dated, both
+            // dateless, or genuinely different base names fall through (AI
+            // arbitrates, with a prompt rule as backstop). MUST run before
+            // the bare-city rule below: a dated bare-city twin ("New Orleans
+            // - July 25" vs "New Orleans") should resolve dateless-first,
+            // not count as a "named" title.
+            const dateSegmentA = SharedCore.detectTitleDateSegment(valueA);
+            const dateSegmentB = SharedCore.detectTitleDateSegment(valueB);
+            if (Boolean(dateSegmentA) !== Boolean(dateSegmentB)) {
+                const datedSegment = dateSegmentA || dateSegmentB;
+                const datelessTitle = (dateSegmentA ? valueB : valueA).replace(/\s+/g, ' ').trim();
+                if (datedSegment.base === datelessTitle) {
+                    return {
+                        winner: dateSegmentA ? 'b' : 'a',
+                        reason: 'date-only suffix is redundant, kept the dateless title'
+                    };
+                }
+            }
             // A bare city is not an event name: when exactly one side's title is
             // just the event's city (per isCityOnlyTitle), the named side wins.
             // MUST run after the emoji-twin rule above — twins like "New Orleans"
@@ -1508,6 +1604,7 @@ class SharedCore {
             '- For "title", when both variants name the same event, prefer the MORE DESCRIPTIVE one — a subtitle, theme, edition, or anniversary (e.g. "Treasure Trail Seattle: Summer Sausage" over "Treasure Trail Seattle") is part of the event\'s identity, not noise.',
             '- For "title", extra text does NOT count as descriptive when it is only status text (e.g. sold-out notices) or site branding — never prefer a variant for those.',
             '- For "title", a bare city name is not an event name — prefer the variant that names the event or its organizer.',
+            '- For "title", the event\'s own date is NOT descriptive — never prefer a variant because it contains a date; prefer the dateless variant of an otherwise-equal name.',
             '- For "image", prefer event-specific promotional artwork over site or ticketing-service logos.',
             `- "pick" must be "${labelA}" or "${labelB}".`,
             'Return JSON only:',
@@ -8052,7 +8149,13 @@ SharedCore.PROVENANCE_TRUST_TIERS = Object.freeze({
 
 // Export for both environments
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { SharedCore, PROVENANCE_COMPANION_FIELDS: SharedCore.PROVENANCE_COMPANION_FIELDS };
+    module.exports = {
+        SharedCore,
+        PROVENANCE_COMPANION_FIELDS: SharedCore.PROVENANCE_COMPANION_FIELDS,
+        // Pure title date-segment detector, shared with the ai-web parser's
+        // extraction-time strip (one implementation, defined upstream here).
+        detectTitleDateSegment: SharedCore.detectTitleDateSegment
+    };
 } else if (typeof window !== 'undefined') {
     window.SharedCore = SharedCore;
 } else {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -872,6 +872,50 @@ test('guardrail: emoji twin detection covers ⚜️, ⚓ and ⛓️ in both dire
   assert.equal(core.resolveConflictDeterministically('title', '🐻', '⚓'), null, 'pure-emoji titles are not twins');
 });
 
+test('guardrail: a dateless title beats its dated twin in both directions; both dated or different names fall through', () => {
+  const core = createCore();
+  assert.deepEqual(
+    core.resolveConflictDeterministically('title', 'CHUNK Chicago - September 19th', 'CHUNK Chicago'),
+    { winner: 'b', reason: 'date-only suffix is redundant, kept the dateless title' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('title', 'CHUNK DORE ALLEY', 'CHUNK DORE ALLEY - Saturday July 25th'),
+    { winner: 'a', reason: 'date-only suffix is redundant, kept the dateless title' });
+  // Both candidates dated → a genuine question, falls through to existing behavior
+  assert.equal(core.resolveConflictDeterministically('title', 'CHUNK - July 25th', 'CHUNK - Jul 25'), null,
+    'both dated → arbitrate');
+  // Genuinely different base names keep existing behavior
+  assert.equal(core.resolveConflictDeterministically('title', 'CHUNK Chicago - September 19th', 'CHUNK Portland'), null,
+    'different names → arbitrate');
+  // Edition years attached to words are not date segments
+  assert.equal(core.resolveConflictDeterministically('title', 'DECADENCE 2026', 'DECADENCE'), null,
+    'a bare year is part of the name, not a date segment');
+});
+
+test('guardrail: dated vs dateless same-name title resolves without AI, with the stable 🔒 line', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  existing.title = 'CHUNK Chicago - September 19th';
+  scraped.title = 'CHUNK Chicago';
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'a redundant date suffix is not a conflict — zero AI requests');
+  assert.equal(finalEvent.title, 'CHUNK Chicago', 'the dateless title wins');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['title']);
+  assert.ok(logLines.includes(
+    '🔒 MERGE: "CHUNK Chicago" field=title resolved deterministically — date-only suffix is redundant, kept the dateless title'
+  ), `stable 🔒 log line expected, got: ${JSON.stringify(logLines)}`);
+});
+
 // ---------------------------------------------------------------------------
 // url/website canonicalization (ONE logical field: website is canonical and
 // round-trips via the "website:" notes line; url is an output view of it) and
@@ -4144,6 +4188,20 @@ test('arbitration prompt omits the organizer line when no event carries _organiz
 
   assert.equal(adapter.calls.length, 1);
   assert.ok(!/KNOWN ORGANIZER/.test(adapter.calls[0].prompt));
+});
+
+test('arbitration prompt carries the dates-are-not-descriptive title rule', async () => {
+  const core = createCore();
+  const { scraped, existing } = buildArbitrationPair(); // genuine title conflict reaches the AI
+  const adapter = buildArbitrationAdapter({});
+
+  await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 1);
+  assert.match(
+    adapter.calls[0].prompt,
+    /- For "title", the event's own date is NOT descriptive — never prefer a variant because it contains a date; prefer the dateless variant of an otherwise-equal name\./,
+    'the backstop rule guards dated titles the deterministic rung cannot settle');
 });
 
 test('mergeParsedEvents passes the organizer to arbitration and carries _organizer across merges', async () => {


### PR DESCRIPTION
## Problem (real CHUNK events, run 20260723-113920)
Source sites bake dates into titles: "CHUNK DORE ALLEY - Saturday July 25th", "CHUNK Chicago - September 19th". On a calendar that's pure redundancy, and dated variants could wrongly beat clean ones in title merges.

## Fix
1. **Verification-gated strip at extraction**: a leading/trailing DATE-ONLY segment (separator + optional weekday + month + day + optional year; numeric M/D/YYYY) is removed **only when it matches the event's own start date** — compared against the ORIGINAL extracted date string, so past-midnight UTC rollovers can't cause false mismatches (tested: a 21:00 LA start stored as next-day-UTC still strips its printed date). Mismatch → title kept + `Title contains a date that does not match startDate … verify manually` (a disagreeing date is evidence of a problem, not noise). Edition years ("DECADENCE 2026") never qualify — month+day required.
2. **Deterministic merge rung**: two titles identical after removing such a segment → the dateless one wins (🔒, zero AI). Placed before the bare-city rule so dated bare-city twins resolve dateless-first. Existing calendar titles self-heal on next scrape.
3. **Prompt guidance** (exactly two additions): titles — a redundant date is not 'descriptive'; descriptions — don't lead with the event's date/time (captured separately).

+9 tests incl. both real CHUNK cases and the rollover case. Suite: **644 pass / 0 fail**.

📲 After merge, download to phone: `scripts/shared-core.js`, `scripts/parsers/ai-web-parser.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP