### PR TITLE
feat(cities): add Asbury Park (chunky-dad-asbury-park)

### DIFF
--- a/img/favicons/favicon-bigfunco.myshopify.com-256px.ico.meta
+++ b/img/favicons/favicon-bigfunco.myshopify.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-bigfunco.myshopify.com-256px.ico",
   "size": "256",
-  "failureCount": 25
+  "failureCount": 26
 }

--- a/img/favicons/favicon-bigfunco.myshopify.com-64px.ico.meta
+++ b/img/favicons/favicon-bigfunco.myshopify.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-bigfunco.myshopify.com-64px.ico",
   "size": "64",
-  "failureCount": 25
+  "failureCount": 26
 }

--- a/img/favicons/favicon-noxsatvrn.carrd.co-256px.ico.meta
+++ b/img/favicons/favicon-noxsatvrn.carrd.co-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-noxsatvrn.carrd.co-256px.ico",
   "size": "256",
-  "failureCount": 25
+  "failureCount": 26
 }

--- a/img/favicons/favicon-noxsatvrn.carrd.co-64px.ico.meta
+++ b/img/favicons/favicon-noxsatvrn.carrd.co-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-noxsatvrn.carrd.co-64px.ico",
   "size": "64",
-  "failureCount": 25
+  "failureCount": 26
 }

--- a/img/favicons/favicon-seattleeagle.com-256px.ico.meta
+++ b/img/favicons/favicon-seattleeagle.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-seattleeagle.com-256px.ico",
   "size": "256",
-  "failureCount": 25
+  "failureCount": 26
 }

--- a/img/favicons/favicon-seattleeagle.com-64px.ico.meta
+++ b/img/favicons/favicon-seattleeagle.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-seattleeagle.com-64px.ico",
   "size": "64",
-  "failureCount": 25
+  "failureCount": 26
 }

--- a/img/favicons/favicon-theoldbaby.com-256px.ico.meta
+++ b/img/favicons/favicon-theoldbaby.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-theoldbaby.com-256px.ico",
   "size": "256",
-  "failureCount": 25
+  "failureCount": 26
 }

--- a/img/favicons/favicon-theoldbaby.com-64px.ico.meta
+++ b/img/favicons/favicon-theoldbaby.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-theoldbaby.com-64px.ico",
   "size": "64",
-  "failureCount": 25
+  "failureCount": 26
 }

--- a/img/favicons/favicon-yeahbuzzy.com-256px.ico.meta
+++ b/img/favicons/favicon-yeahbuzzy.com-256px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-yeahbuzzy.com-256px.ico",
   "size": "256",
-  "failureCount": 25
+  "failureCount": 26
 }

--- a/img/favicons/favicon-yeahbuzzy.com-64px.ico.meta
+++ b/img/favicons/favicon-yeahbuzzy.com-64px.ico.meta
@@ -4,5 +4,5 @@
   "type": "favicon",
   "filename": "favicon-yeahbuzzy.com-64px.ico",
   "size": "64",
-  "failureCount": 25
+  "failureCount": 26
 }

--- a/js/city-config.js
+++ b/js/city-config.js
@@ -343,6 +343,18 @@ const CITY_CONFIG = {
         mapZoom: 10,
         visible: false
     },
+    'asbury-park': {
+        name: 'Asbury Park',
+        emoji: '🏖️',
+        tagline: 'Jersey Shore bear beach',
+        calendarId: '2da5ea7c34b3280c8b09f21f16f3c1e44a71838e9e8319009b55facee5ff9e43@group.calendar.google.com',
+        calendar: 'chunky-dad-asbury-park',
+        timezone: 'America/New_York',
+        patterns: ['asbury park', 'asbury'],
+        coordinates: { lat: 40.2204, lng: -74.0121 },
+        mapZoom: 13,
+        visible: false
+    },
     'torremolinos': {
         name: 'Torremolinos',
         emoji: '🌞',

--- a/scripts/scraper-cities.js
+++ b/scripts/scraper-cities.js
@@ -351,6 +351,18 @@ const scraperCities = {
       "lng": -75.3188
     }
   },
+  "asbury-park": {
+    "calendar": "chunky-dad-asbury-park",
+    "timezone": "America/New_York",
+    "patterns": [
+      "asbury park",
+      "asbury"
+    ],
+    "coordinates": {
+      "lat": 40.2204,
+      "lng": -74.0121
+    }
+  },
   "torremolinos": {
     "calendar": "chunky-dad-torremolinos",
     "timezone": "Europe/Madrid",


### PR DESCRIPTION
Adds **Asbury Park** to `js/city-config.js` with the calendar ID you provided, and regenerates `scripts/scraper-cities.js` (46 cities, 96 patterns).

Entry follows the poconos/torremolinos template: `chunky-dad-asbury-park`, `America/New_York`, patterns `asbury park`/`asbury`, coordinates 40.2204/-74.0121, `visible: false` (flip whenever you want it on the site).

Verified: `node --check` clean, full suite 653 pass / 0 fail, and the pattern matcher resolves `"asbury park"` → `asbury-park` → `chunky-dad-asbury-park`. The calendar-data automation picks up the new calendarId from city-config automatically.

Effect: the **FURBALL Asbury Park Beach** event (Paradise Night Club, geo-poi corroborated) files to its own calendar on the next run instead of wherever it landed before.

📱 One phone-side requirement: the Google calendar with that ID must be visible in iOS Calendar under the name `chunky-dad-asbury-park` (same as your other city calendars) so the Scriptable adapter can find it by name.

📲 After merge, download to phone: `scripts/scraper-cities.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP