### PR TITLE
fix(scraper): address plausibility gate + venue-POI address adoption + fusion flags — and exorcise the city-append ghost

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -1289,6 +1289,117 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         return poiStripped === barFull || poiFull === barStripped || poiStripped === barStripped;
     }
 
+    // Street address assembled from a Nominatim result's addressdetails
+    // components: house number + road, then locality (city/town/village/
+    // municipality), then state when present. Returns '' when the details name
+    // no road — a POI without a street line is not adoptable address material.
+    assembleNominatimPoiAddress(result) {
+        const details = result && typeof result.address === 'object' && result.address ? result.address : {};
+        const clean = value => (typeof value === 'string' || typeof value === 'number') ? String(value).trim() : '';
+        const road = clean(details.road);
+        if (!road) return '';
+        const houseNumber = clean(details.house_number);
+        const streetLine = houseNumber ? `${houseNumber} ${road}` : road;
+        const locality = clean(details.city) || clean(details.town) || clean(details.village) || clean(details.municipality);
+        return [streetLine, locality, clean(details.state)].filter(Boolean).join(', ');
+    }
+
+    // Photon flavor of the same assembly: street/housenumber/city properties.
+    assemblePhotonPoiAddress(props) {
+        const clean = value => (typeof value === 'string' || typeof value === 'number') ? String(value).trim() : '';
+        const street = clean(props && props.street);
+        if (!street) return '';
+        const houseNumber = clean(props && props.housenumber);
+        const streetLine = houseNumber ? `${houseNumber} ${street}` : street;
+        return [streetLine, clean(props && props.city)].filter(Boolean).join(', ');
+    }
+
+    // In-range venue-rescue candidates ordered nearest-first. Mirrors
+    // pickNearestGeocodeCandidate's distance rule when the city has known
+    // center coordinates; otherwise the textual city check applies and the
+    // response order is kept. Input entries are { result, grade } pairs that
+    // already passed the grade gate (coarse candidates never reach here).
+    rankVenueRescueCandidates(gradedEntries, cityCenter, eventCity) {
+        const ranked = [];
+        for (const entry of Array.isArray(gradedEntries) ? gradedEntries : []) {
+            if (!entry || !entry.result) continue;
+            const lat = Number(entry.result.lat);
+            const lon = Number(entry.result.lon);
+            if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+            if (cityCenter) {
+                const distanceKm = this.haversineDistanceKm(lat, lon, cityCenter.lat, cityCenter.lng);
+                if (distanceKm > CITY_CENTER_RADIUS_KM) continue;
+                ranked.push({ result: entry.result, grade: entry.grade, distanceKm });
+            } else {
+                if (eventCity && !this.geocodeResultMatchesCity(entry.result, eventCity)) continue;
+                ranked.push({ result: entry.result, grade: entry.grade, distanceKm: 0 });
+            }
+        }
+        ranked.sort((a, b) => a.distanceKm - b.distanceKm);
+        return ranked;
+    }
+
+    // Venue-POI adoption pick (Part of the venue+city rescue rung): the
+    // nearest in-range candidate whose map POI name MATCHES the bar
+    // (poiNameMatchesBar — full-name equality with symmetric generic-suffix
+    // stripping, never prefix/substring). Returns { candidate, result,
+    // poiName } or null. Generic/administrative hits can never reach here —
+    // the grade gate already refused them as coarse.
+    findVenuePoiAdoption(rankedEntries, barName) {
+        const bar = typeof barName === 'string' ? barName.trim() : '';
+        if (!bar) return null;
+        for (const entry of Array.isArray(rankedEntries) ? rankedEntries : []) {
+            const poiName = this.extractNominatimPoiName(entry.result);
+            if (poiName && this.poiNameMatchesBar(poiName, bar)) {
+                return {
+                    candidate: { lat: entry.result.lat, lon: entry.result.lon, grade: entry.grade },
+                    result: entry.result,
+                    poiName
+                };
+            }
+        }
+        return null;
+    }
+
+    // Venue-name fusion detection (flag-only, run 20260723-140457: the flyer
+    // listed the venues AQUA and EMPORIO on adjacent lines and extraction
+    // fused them into bar "Aqua Emporio" — a venue that does not exist, while
+    // the map knows "Aqua Club" ~40 m from the pin). When the FULL bar name
+    // fails POI matching but a token PREFIX of it (first 1..n-1 whitespace
+    // tokens, ≥3 chars, longest first) matches a returned POI name under the
+    // same poiNameMatchesBar semantics, flag it for manual review — NO
+    // auto-correction, and only candidates from queries ALREADY made are
+    // consulted (zero extra requests). Single-token bars never flag; a
+    // full-name match never flags. Fires at most once per event (flags) and
+    // records `_geoPoiFusion` for the results-UI evidence panel.
+    maybeFlagVenueNameFusion(event, poiNames, flags) {
+        if (!event || typeof event !== 'object') return;
+        if (flags && flags.fusionFlagged) return;
+        const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+        if (!bar) return;
+        const barTokens = bar.split(/\s+/).filter(Boolean);
+        if (barTokens.length < 2) return;
+        const names = [];
+        for (const name of Array.isArray(poiNames) ? poiNames : []) {
+            const cleanName = typeof name === 'string' ? name.trim() : '';
+            if (cleanName && !names.includes(cleanName)) names.push(cleanName);
+        }
+        if (names.length === 0) return;
+        if (names.some(name => this.poiNameMatchesBar(name, bar))) return;
+        for (let count = barTokens.length - 1; count >= 1; count -= 1) {
+            const prefix = barTokens.slice(0, count).join(' ');
+            if (prefix.replace(/[^A-Za-z0-9]/g, '').length < 3) continue;
+            const matchedName = names.find(name => this.poiNameMatchesBar(name, prefix));
+            if (matchedName) {
+                if (flags) flags.fusionFlagged = true;
+                event._geoPoiFusion = { poi: matchedName, prefix };
+                const title = event.title || 'unknown';
+                console.warn(`🗺️ GEOCODE VERIFY: "${title}" bar "${bar}" may fuse multiple venue names — map knows "${matchedName}" (matches "${prefix}"); verify manually`);
+                return;
+            }
+        }
+    }
+
     // After a pin is accepted, map POI names vouch for the event's bar:
     //   match → an unstamped or `uncorroborated` bar upgrades to
     //           barSource 'geo-poi'; the equal-or-higher-trust stamps
@@ -1491,13 +1602,18 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             variants.push(trimmed);
         };
 
+        // Address-derived rungs only exist when there IS an address — a
+        // no-address event (venue-POI rescue) must not emit a junk ", <city>"
+        // query; its ladder is the venue+city rescue rung alone.
         const baseAddress = String(address || '').trim();
-        push(anchorToCity(baseAddress));
-        const unitStripped = this.stripUnitTokens(baseAddress);
-        if (unitStripped && unitStripped !== baseAddress) push(anchorToCity(unitStripped));
-        const postalStripped = this.stripPostalCodeAndCountry(baseAddress);
-        if (postalStripped) push(anchorToCity(postalStripped));
-        push(anchorToCity(this.stripTrailingDirectionals(baseAddress)));
+        if (baseAddress) {
+            push(anchorToCity(baseAddress));
+            const unitStripped = this.stripUnitTokens(baseAddress);
+            if (unitStripped && unitStripped !== baseAddress) push(anchorToCity(unitStripped));
+            const postalStripped = this.stripPostalCodeAndCountry(baseAddress);
+            if (postalStripped) push(anchorToCity(postalStripped));
+            push(anchorToCity(this.stripTrailingDirectionals(baseAddress)));
+        }
         const barName = typeof bar === 'string' ? bar.trim() : '';
         if (barName && city) {
             push(`${barName}, ${city}`);
@@ -1532,8 +1648,14 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             isCacheableResponse: (responseData) => this.isCacheableGeocodeResponse(responseData)
         };
 
-        if (hasAddress && !hasLocation) {
-            const address = event.address.trim();
+        // Venue-POI rescue eligibility: an event with a bar but NO usable
+        // address (missing entirely, dropped by the extraction plausibility
+        // gate, or refused as generic by every rung below) can still earn a
+        // pin AND a street address from the venue+city lookup — but ONLY when
+        // the hit's map POI name matches the bar (see findVenuePoiAdoption).
+        const rescueBarName = typeof event.bar === 'string' ? event.bar.trim() : '';
+        if (!hasLocation && (hasAddress || rescueBarName)) {
+            const address = hasAddress ? event.address.trim() : '';
             // Bare street strings geocode anywhere on the planet: a flyer-OCR typo like
             // "922 E. BURNSIDE" (real address: 722 E Burnside, Portland) resolved to
             // Burnside, Michigan. When the event knows its city, anchor the query to it.
@@ -1547,6 +1669,14 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             const title = event.title || 'unknown';
             const inputHasHouseNumber = GEOCODE_HOUSE_NUMBER_RE.test(address);
             const streetSpecific = this.isStreetSpecificAddress(address);
+            // The venue+city rescue query exactly as buildGeocodeQueryVariants
+            // builds it — used to recognize the venue-rescue rung inside the
+            // ladder and as the Photon query when the event has no address.
+            const cityAnchor = this.geocodeCityAnchorName(eventCity);
+            const venueRescueQuery = rescueBarName && cityAnchor ? `${rescueBarName}, ${cityAnchor}` : '';
+            // Address adoption is only allowed when the event has no usable
+            // street-specific address of its own (missing/gate-dropped/vague).
+            const addressAdoptable = !address || !this.isStreetSpecificAddress(address);
             // flags carries the once-per-event verification flag lines across
             // ladder rungs (the per-rung spreads copy this same object reference).
             const verifyContext = { title, address, inputHasHouseNumber, verifyMode, streetSpecific, flags: {} };
@@ -1611,9 +1741,37 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                         graded.push({ result, grade });
                     }
                     if (graded.length > 0) {
+                        // Venue-POI adoption scan (venue-rescue rung only): the
+                        // nearest in-range hit whose map POI name MATCHES the
+                        // bar vouches for pin AND address; a non-matching set
+                        // of candidates instead feeds fusion detection.
+                        const isVenueRescueRung = Boolean(venueRescueQuery) && queryText === venueRescueQuery;
+                        let venuePoiPick = null;
+                        if (isVenueRescueRung) {
+                            const rankedVenueCandidates = this.rankVenueRescueCandidates(graded, cityCenter, eventCity);
+                            venuePoiPick = this.findVenuePoiAdoption(rankedVenueCandidates, rescueBarName);
+                            if (!venuePoiPick) {
+                                this.maybeFlagVenueNameFusion(
+                                    event,
+                                    rankedVenueCandidates.map(entry => this.extractNominatimPoiName(entry.result)),
+                                    verifyContext.flags
+                                );
+                            }
+                        }
+                        const adoption = venuePoiPick && addressAdoptable
+                            ? { poiName: venuePoiPick.poiName, address: this.assembleNominatimPoiAddress(venuePoiPick.result) }
+                            : null;
                         let pickedCandidate = null;
                         let pickedResult = null;
-                        if (cityCenter) {
+                        if (adoption) {
+                            pickedCandidate = venuePoiPick.candidate;
+                            pickedResult = venuePoiPick.result;
+                        } else if (!hasAddress) {
+                            // Venue-only lookup (no usable address at all):
+                            // nothing vouches for a hit whose POI name is NOT
+                            // the bar — never pin from it (today's no-address
+                            // behavior, fail open).
+                        } else if (cityCenter) {
                             // Distance-ranked selection: nearest candidate within the radius wins
                             const picked = this.pickNearestGeocodeCandidate(graded.map(entry => entry.result), cityCenter, eventCity, queryText);
                             if (picked) {
@@ -1632,18 +1790,31 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                             }
                         }
                         if (pickedCandidate) {
-                            const confirmed = await this.confirmGeocodeCandidate(
-                                pickedCandidate,
-                                { ...verifyContext, source: 'nominatim', rung: i + 1 },
-                                httpAdapter
-                            );
+                            // Adoption context: the POI-name match IS the
+                            // positive verification for this candidate, and
+                            // the address the cross-check compares against is
+                            // the one assembled from the hit itself — the
+                            // vague-input rule must not refuse what the map
+                            // just positively named (streetSpecific: true).
+                            const confirmContext = adoption
+                                ? { ...verifyContext, address: adoption.address || address, streetSpecific: true, source: 'nominatim', rung: i + 1 }
+                                : { ...verifyContext, source: 'nominatim', rung: i + 1 };
+                            const confirmed = await this.confirmGeocodeCandidate(pickedCandidate, confirmContext, httpAdapter);
                             if (confirmed.location) {
                                 resolvedLocation = confirmed.location;
                                 resolvedVerdict = { grade: pickedCandidate.grade, crossCheck: confirmed.crossCheck, source: 'nominatim', rung: i + 1 };
                                 resolvedPoiNames = this.collectAcceptedPoiNames(
-                                    pickedCandidate.grade === 'exact' ? this.extractNominatimPoiName(pickedResult) : '',
+                                    adoption
+                                        ? venuePoiPick.poiName
+                                        : (pickedCandidate.grade === 'exact' ? this.extractNominatimPoiName(pickedResult) : ''),
                                     confirmed
                                 );
+                                if (adoption && adoption.address) {
+                                    event.address = adoption.address;
+                                    event.addressSource = 'geo-poi';
+                                    modified = true;
+                                    console.log(`🗺️ GEOCODE VERIFY: "${title}" adopted address "${adoption.address}" from map POI "${venuePoiPick.poiName}" (venue+city lookup)`);
+                                }
                             } else if (!rejectedVerdict) {
                                 // enforce-mode rejection: 'fail' for a failed
                                 // cross-check, 'skipped' for a vague input or
@@ -1719,12 +1890,15 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                     console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
                 }
             }
-            if (!resolvedLocation) {
+            if (!resolvedLocation && (hasAddress || venueRescueQuery)) {
                 // Photon rescue rung: a second geocoder with a friendlier free-text
                 // parser, tried once after every Nominatim rung (and the Census
                 // rescue, when eligible) failed. Same rate limiter, same caches.
-                // GeoJSON coordinates are [lon, lat].
-                const photonUrl = `https://photon.komoot.io/api/?q=${encodeURIComponent(address)}&limit=1`;
+                // GeoJSON coordinates are [lon, lat]. Events with NO usable
+                // address query the venue+city string instead — pin/address may
+                // then only be adopted from a hit whose POI name matches the bar.
+                const photonQuery = hasAddress ? address : venueRescueQuery;
+                const photonUrl = `https://photon.komoot.io/api/?q=${encodeURIComponent(photonQuery)}&limit=1`;
                 attempts += 1;
                 try {
                     const data = await this.fetchDataWithCacheAndRateLimit(photonUrl, options, httpAdapter);
@@ -1739,29 +1913,59 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                         const grade = this.classifyGeocodeGrade(props.osm_key, props.osm_value, props.osm_value, !!props.housenumber);
                         const withinRadius = !cityCenter ||
                             this.haversineDistanceKm(lat, lon, cityCenter.lat, cityCenter.lng) <= CITY_CENTER_RADIUS_KM;
+                        const photonPoiName = this.extractNominatimPoiName({ name: props.name });
+                        const photonPoiMatchesBar = Boolean(photonPoiName && rescueBarName
+                            && this.poiNameMatchesBar(photonPoiName, rescueBarName));
+                        const adoption = photonPoiMatchesBar && addressAdoptable && withinRadius && grade !== 'coarse'
+                            ? { poiName: photonPoiName, address: this.assemblePhotonPoiAddress(props) }
+                            : null;
                         if (grade === 'coarse') {
                             console.warn(`🗺️ GEOCODE VERIFY: "${title}" refused generic pin (${props.osm_value || 'unknown'}) for address "${address}"`);
+                        } else if (!hasAddress && !adoption) {
+                            // Venue-only lookup: a hit whose POI name is NOT the
+                            // bar has nothing vouching for it — never pin
+                            // (today's no-address behavior, fail open).
                         } else if (grade === 'street' && inputHasHouseNumber && verifyMode === 'enforce') {
                             // enforce demands house-number quality; stay unpinned
                             if (!rejectedVerdict) {
                                 rejectedVerdict = { grade: 'street', crossCheck: 'skipped', source: 'photon', rung: attempts };
                             }
                         } else if (withinRadius) {
+                            // Adoption context mirrors the Nominatim venue rung:
+                            // the POI-name match is the positive verification.
+                            const confirmContext = adoption
+                                ? { ...verifyContext, address: adoption.address || address, streetSpecific: true, source: 'photon', rung: attempts }
+                                : { ...verifyContext, source: 'photon', rung: attempts };
                             const confirmed = await this.confirmGeocodeCandidate(
                                 { lat: coords[1], lon: coords[0], grade },
-                                { ...verifyContext, source: 'photon', rung: attempts },
+                                confirmContext,
                                 httpAdapter
                             );
                             if (confirmed.location) {
                                 resolvedLocation = confirmed.location;
                                 resolvedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
                                 resolvedPoiNames = this.collectAcceptedPoiNames(
-                                    grade === 'exact' ? this.extractNominatimPoiName({ name: props.name }) : '',
+                                    adoption
+                                        ? adoption.poiName
+                                        : (grade === 'exact' ? this.extractNominatimPoiName({ name: props.name }) : ''),
                                     confirmed
                                 );
+                                if (adoption && adoption.address) {
+                                    event.address = adoption.address;
+                                    event.addressSource = 'geo-poi';
+                                    modified = true;
+                                    console.log(`🗺️ GEOCODE VERIFY: "${title}" adopted address "${adoption.address}" from map POI "${adoption.poiName}" (venue+city lookup)`);
+                                }
                             } else if (!rejectedVerdict) {
                                 rejectedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
                             }
+                        }
+                        // Fusion detection (flag-only) on the candidate this
+                        // already-made query returned: a non-generic POI that
+                        // matches only a PREFIX of the bar name suggests the
+                        // bar fused multiple venue names.
+                        if (photonPoiName && !photonPoiMatchesBar && grade !== 'coarse') {
+                            this.maybeFlagVenueNameFusion(event, [photonPoiName], verifyContext.flags);
                         }
                     }
                 } catch (err) {
@@ -1811,8 +2015,11 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 // accepted pin's own responses vouch for (or question) the bar.
                 this.corroborateBarWithGeoPoi(event, resolvedPoiNames);
             }
-            if (!resolvedLocation) {
-                // Exact shape counted by run-log-summary's geocodeNoResults guard.
+            if (!resolvedLocation && hasAddress) {
+                // Exact shape counted by run-log-summary's geocodeNoResults
+                // guard. Only address-bearing events emit it — the no-address
+                // venue-POI lookup never logged before and stays quiet when it
+                // finds nothing adoptable.
                 console.warn(`🗺️ OpenStreetMapNormalizer: No geocode results for "${address}" (${eventCity || 'no city'}) after ${attempts} ${attempts === 1 ? 'query' : 'queries'} — leaving location empty`);
                 if (inputHasHouseNumber) {
                     console.warn(`🗺️ GEOCODE VERIFY: "${title}" full address but no usable geocoordinate — left unpinned`);

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -1863,3 +1863,272 @@ test('LocationNormalizer leaves complete addresses and their maps links untouche
   assert.equal(event.address, '125 Christopher St, New York, NY 10014');
   assert.ok(String(event.gmaps || '').includes(encodeURIComponent('125 Christopher St, New York, NY 10014')));
 });
+
+// ---------------------------------------------------------------------------
+// Venue-POI adoption + fusion detection (run 20260723-140457: "FURBALL Boston"
+// lost its address to the plausibility gate — bar "Legacy" resolves exactly on
+// the map; "FURBALL MAD.BEAR" fused AQUA + EMPORIO into a nonexistent venue)
+// ---------------------------------------------------------------------------
+
+const CITIES_WITH_BOSTON = {
+  boston: {
+    timezone: 'America/New_York',
+    patterns: ['boston'],
+    coordinates: { lat: 42.3601, lng: -71.0589 }
+  }
+};
+
+const CITIES_WITH_TORREMOLINOS = {
+  torremolinos: {
+    timezone: 'Europe/Madrid',
+    patterns: ['torremolinos'],
+    coordinates: { lat: 36.6203, lng: -4.4998 }
+  }
+};
+
+function createOsmNormalizerFor(cities) {
+  const core = new SharedCore(cities, { eventSchema: EventSchema });
+  const normalizer = new OpenStreetMapNormalizer(core);
+  normalizer.delayForRateLimit = async () => {};
+  return normalizer;
+}
+
+function captureConsole(fn) {
+  const lines = [];
+  const original = { log: console.log, warn: console.warn };
+  console.log = (...args) => { lines.push(args.join(' ')); };
+  console.warn = (...args) => { lines.push(args.join(' ')); };
+  const restore = () => { console.log = original.log; console.warn = original.warn; };
+  return { lines, restore };
+}
+
+// Nightclub "Legacy", 79 Warrenton Street, Boston — exact-grade venue hit.
+const LEGACY_NIGHTCLUB_RESULT = {
+  lat: '42.3499',
+  lon: '-71.0648',
+  class: 'amenity',
+  type: 'nightclub',
+  addresstype: 'amenity',
+  name: 'Legacy',
+  display_name: 'Legacy, 79, Warrenton Street, Boston, Suffolk County, Massachusetts, 02116, United States',
+  address: { house_number: '79', road: 'Warrenton Street', city: 'Boston', state: 'Massachusetts' }
+};
+
+test('venue-POI adoption: a bar with no address gains pin + street address from a bar-matching map POI', async () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_BOSTON);
+  const httpAdapter = createSequencedStubAdapter([[LEGACY_NIGHTCLUB_RESULT]]);
+  const event = { title: 'FURBALL Boston', bar: 'Legacy', city: 'boston' };
+
+  const captured = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(httpAdapter.requests.length, 1, 'exactly one venue+city Nominatim request');
+  assert.equal(decodeQueryParam(httpAdapter.requests[0]), 'Legacy, boston');
+  assert.ok(httpAdapter.requests[0].includes('&addressdetails=1'), 'the venue rescue request carries addressdetails');
+  assert.equal(event.location, '42.3499, -71.0648', 'the POI-matching hit pins the event');
+  assert.equal(event.pinSource, 'geocoded-exact', 'exact grade rules apply as today');
+  assert.equal(event.address, '79 Warrenton Street, Boston, Massachusetts', 'street address assembled from addressdetails');
+  assert.equal(event.addressSource, 'geo-poi', 'adopted address carries geo-poi provenance');
+  assert.equal(event.barSource, 'geo-poi', 'the matching POI also corroborates the bar');
+  assert.ok(
+    captured.lines.some(line => line.includes('🗺️ GEOCODE VERIFY: "FURBALL Boston" adopted address "79 Warrenton Street, Boston, Massachusetts" from map POI "Legacy" (venue+city lookup)')),
+    `adoption log expected, got:\n${captured.lines.join('\n')}`
+  );
+});
+
+test('venue-POI adoption: a POI that does not match the bar is never adopted (no pin, no address)', async () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_BOSTON);
+  const otherVenue = { ...LEGACY_NIGHTCLUB_RESULT, name: 'The Alley Bar', display_name: 'The Alley Bar, 79, Warrenton Street, Boston' };
+  const httpAdapter = createSequencedStubAdapter([[otherVenue]]);
+  const event = { title: 'FURBALL Boston', bar: 'Legacy', city: 'boston' };
+
+  const captured = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(event.location, undefined, 'a non-matching POI must not pin a no-address event');
+  assert.equal(event.address, undefined, 'no address is adopted from a non-matching POI');
+  assert.equal(event.addressSource, undefined);
+});
+
+test('venue-POI adoption: generic/administrative hits never adopt, even when the name matches', async () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_BOSTON);
+  const genericHit = {
+    lat: '42.3601',
+    lon: '-71.0589',
+    class: 'place',
+    type: 'locality',
+    addresstype: 'locality',
+    name: 'Legacy',
+    display_name: 'Legacy, Boston, Massachusetts',
+    address: { city: 'Boston', state: 'Massachusetts' }
+  };
+  const httpAdapter = createSequencedStubAdapter([[genericHit]]);
+  const event = { title: 'FURBALL Boston', bar: 'Legacy', city: 'boston' };
+
+  const captured = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(event.location, undefined, 'a place/locality hit never becomes a pin');
+  assert.equal(event.address, undefined, 'a generic hit never supplies an address');
+  assert.ok(
+    captured.lines.some(line => line.includes('refused generic pin (locality)')),
+    'the grade gate refusal stays visible'
+  );
+});
+
+test('venue-POI adoption via the Photon rescue when Nominatim finds nothing', async () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_BOSTON);
+  const photonResponse = {
+    features: [{
+      geometry: { coordinates: [-71.0648, 42.3499] },
+      properties: {
+        name: 'Legacy',
+        osm_key: 'amenity',
+        osm_value: 'nightclub',
+        housenumber: '79',
+        street: 'Warrenton Street',
+        city: 'Boston'
+      }
+    }]
+  };
+  const httpAdapter = createSequencedStubAdapter([[], photonResponse]);
+  const event = { title: 'FURBALL Boston', bar: 'Legacy', city: 'boston' };
+
+  const captured = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(httpAdapter.requests.length, 2, 'Nominatim venue rung then the Photon rescue');
+  assert.ok(httpAdapter.requests[1].includes('photon.komoot.io'), 'second request is Photon');
+  assert.equal(decodeQueryParam(httpAdapter.requests[1]), 'Legacy, boston', 'Photon queries the venue+city string when no address exists');
+  assert.equal(event.location, '42.3499, -71.0648');
+  assert.equal(event.pinSource, 'geocoded-exact');
+  assert.equal(event.address, '79 Warrenton Street, Boston', 'address assembled from Photon street/housenumber/city');
+  assert.equal(event.addressSource, 'geo-poi');
+});
+
+test('fusion detection: a POI matching only a bar-name prefix flags, never corrects', async () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_TORREMOLINOS);
+  // Aqua Club, ~200 m from Torremolinos center — exact-grade nightclub.
+  const aquaClub = {
+    lat: '36.6218328',
+    lon: '-4.4982728',
+    class: 'amenity',
+    type: 'nightclub',
+    addresstype: 'amenity',
+    name: 'Aqua Club',
+    display_name: 'Aqua Club, Calle Casablanca, Torremolinos, Málaga, Spain',
+    address: { road: 'Calle Casablanca', town: 'Torremolinos' }
+  };
+  const httpAdapter = createSequencedStubAdapter([[aquaClub], {}]);
+  const event = { title: 'FURBALL MAD.BEAR', bar: 'Aqua Emporio', city: 'torremolinos' };
+
+  const captured = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(event.location, undefined, 'no auto-correction: the prefix match never pins');
+  assert.equal(event.address, undefined, 'no address is adopted on a fusion flag');
+  assert.deepEqual(event._geoPoiFusion, { poi: 'Aqua Club', prefix: 'Aqua' }, 'fusion evidence recorded for the results UI');
+  assert.ok(
+    captured.lines.some(line => line.includes('🗺️ GEOCODE VERIFY: "FURBALL MAD.BEAR" bar "Aqua Emporio" may fuse multiple venue names — map knows "Aqua Club" (matches "Aqua"); verify manually')),
+    `fusion flag log expected, got:\n${captured.lines.join('\n')}`
+  );
+});
+
+test('fusion detection unit rules: single-token bars and full matches never flag; short prefixes skip', () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_TORREMOLINOS);
+
+  const singleToken = { title: 'X', bar: 'Legacy' };
+  normalizer.maybeFlagVenueNameFusion(singleToken, ['Legacy Creek Cafe'], {});
+  assert.equal(singleToken._geoPoiFusion, undefined, 'single-token bars never flag');
+
+  const fullMatch = { title: 'X', bar: 'Aqua Club' };
+  normalizer.maybeFlagVenueNameFusion(fullMatch, ['Aqua Club'], {});
+  assert.equal(fullMatch._geoPoiFusion, undefined, 'a full-name match never flags');
+
+  const strippedFullMatch = { title: 'X', bar: 'Aqua Emporio' };
+  normalizer.maybeFlagVenueNameFusion(strippedFullMatch, ['Aqua Emporio Nightclub'], {});
+  assert.equal(strippedFullMatch._geoPoiFusion, undefined, 'generic-suffix full matches never flag');
+
+  const shortPrefix = { title: 'X', bar: 'Le Grand Room' };
+  normalizer.maybeFlagVenueNameFusion(shortPrefix, ['Le'], {});
+  assert.equal(shortPrefix._geoPoiFusion, undefined, 'prefixes under 3 chars never flag');
+
+  const flags = {};
+  const flagged = { title: 'X', bar: 'Aqua Emporio' };
+  const captured = captureConsole(() => {});
+  try {
+    normalizer.maybeFlagVenueNameFusion(flagged, ['Aqua Club'], flags);
+    normalizer.maybeFlagVenueNameFusion(flagged, ['Aqua Club'], flags);
+  } finally {
+    captured.restore();
+  }
+  assert.deepEqual(flagged._geoPoiFusion, { poi: 'Aqua Club', prefix: 'Aqua' });
+  assert.equal(captured.lines.filter(line => line.includes('may fuse multiple venue names')).length, 1, 'flags at most once per event');
+});
+
+test('Mad.Bear ladder regression: generic refusals stay refused and the vague address is never mutated', async () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_TORREMOLINOS);
+  // Query 1 ("LA NOGALERA, torremolinos"): the locality centroid — refused.
+  const nogaleraLocality = {
+    lat: '36.6225097',
+    lon: '-4.4987054',
+    class: 'place',
+    type: 'locality',
+    addresstype: 'locality',
+    name: 'La Nogalera',
+    display_name: 'La Nogalera, Torremolinos, Málaga, Spain',
+    address: { town: 'Torremolinos', state: 'Andalusia' }
+  };
+  // Query 2 (venue rescue "Aqua Emporio, torremolinos"): nothing — the fused
+  // venue does not exist. Query 3 (Photon, address): a hamlet — refused.
+  const photonHamlet = {
+    features: [{
+      geometry: { coordinates: [-4.4987054, 36.6225097] },
+      properties: { name: 'La Nogalera', osm_key: 'place', osm_value: 'hamlet' }
+    }]
+  };
+  const httpAdapter = createSequencedStubAdapter([[nogaleraLocality], [], photonHamlet]);
+  const event = { title: 'FURBALL MAD.BEAR', address: 'LA NOGALERA', city: 'torremolinos', bar: 'Aqua Emporio' };
+
+  const captured = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(httpAdapter.requests.length, 3, 'address rung, venue rescue rung, Photon rescue');
+  assert.equal(decodeQueryParam(httpAdapter.requests[0]), 'LA NOGALERA, torremolinos', 'city anchoring stays QUERY-only');
+  assert.equal(decodeQueryParam(httpAdapter.requests[1]), 'Aqua Emporio, torremolinos');
+  assert.equal(event.address, 'LA NOGALERA', 'the persisted address is never mutated with the resolved city');
+  assert.equal(event.location, undefined, 'generic locality/hamlet pins stay refused — no unstamped pin');
+  assert.equal(event.pinSource, undefined, 'no pin means no pinSource stamp');
+  assert.ok(
+    captured.lines.some(line => line.includes('refused generic pin (locality) for address "LA NOGALERA"')),
+    'the locality refusal stays visible'
+  );
+  assert.ok(
+    captured.lines.some(line => line.includes('refused generic pin (hamlet) for address "LA NOGALERA"')),
+    'the hamlet refusal stays visible'
+  );
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -660,6 +660,11 @@ class AiWebParser {
             console.warn('🤖 AI Web: AI output missing required title/startDate after normalization');
             return null;
         }
+        // Address plausibility gate: a venue name is not an address (run
+        // 20260723-140457: extraction stored address "Legacy" — the bar's own
+        // name — and it sailed through to geocoding). Runs BEFORE the bar
+        // corroboration stamp so a dropped address never feeds adjacency.
+        this.applyAddressPlausibilityGate(event, promptHtmlData);
         // Bar corroboration stamp (barSource): checks the final bar+address
         // pair against the same corpora the evidence gate uses (page text,
         // OCR text, segment text). Flag-don't-drop: values are never changed.
@@ -9379,6 +9384,68 @@ TEXT:
             }
         }
         return candidates.size === 1 ? candidates.values().next().value : '';
+    }
+
+    // Address-shape plausibility for the post-extraction gate. A value counts
+    // as address-shaped when ANY of these hold (fail open — keep when unsure):
+    //   - it looks like a street address (shared-core's looksLikeStreetAddress:
+    //     leading house number + street-type word);
+    //   - it carries a standalone house-number token anywhere ("Calle X 12");
+    //   - it contains a street-type word on its own boundary ("Warrenton St");
+    //   - it is a comma-separated "Place, Place"/"Place, ST" form;
+    //   - it is a multi-word value with none of the above — a place name like
+    //     "LA NOGALERA" (vague but real; the geocode grade gate handles it).
+    // Only a single bare word with no address signal at all ("Legacy") fails —
+    // that shape is a name, never an address.
+    isPlausiblyAddressShaped(value) {
+        const text = String(value || '').trim();
+        if (!text) return false;
+        if (this.core && typeof this.core.looksLikeStreetAddress === 'function'
+            && this.core.looksLikeStreetAddress(text)) return true;
+        // Standalone (house) number token anywhere in the value.
+        if (/(^|[\s,])\d{1,6}[a-z]?(?:-\d{1,6})?(?=$|[\s,])/i.test(text)) return true;
+        // Street-type word on a word boundary.
+        if (/(?:^|[\s,])(?:St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Ln|Lane|Way|Pl|Place|Ct|Court|Pkwy|Parkway|Hwy|Highway)\.?(?:$|[\s,])/i.test(text)) return true;
+        // "Place, Place" / "Place, ST" comma form.
+        if (text.split(',').map(part => part.trim()).filter(Boolean).length >= 2) return true;
+        // Multi-word place name — vague but real, keep (fail open).
+        return text.split(/\s+/).filter(Boolean).length >= 2;
+    }
+
+    // Post-extraction address plausibility gate (flag-and-drop, additive log):
+    // the extracted address is removed when it is (a) normalized-equal to the
+    // bar name or the page's derived organizer/brand (a venue name is not an
+    // address), or (b) not address-shaped per isPlausiblyAddressShaped. The
+    // event is otherwise untouched; downstream the venue-POI adoption rung in
+    // the geocode flow can rebuild a real address from the bar name. Fails
+    // open: no address, no signals, or any uncertainty → left as-is.
+    applyAddressPlausibilityGate(event, htmlData) {
+        if (!event || typeof event !== 'object') return event;
+        const address = typeof event.address === 'string' ? event.address.trim() : '';
+        if (!address) return event;
+        const normalizedAddress = this.normalizeAdjacencyText(address);
+        if (!normalizedAddress) return event;
+        let reason = '';
+        const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+        if (bar && this.normalizeAdjacencyText(bar) === normalizedAddress) {
+            reason = 'matches venue name';
+        }
+        if (!reason) {
+            const organizer = typeof event._organizer === 'string' ? event._organizer.trim() : '';
+            const brandNames = this.getPageBrandNames(htmlData);
+            const knownNames = [organizer, ...(Array.isArray(brandNames) ? brandNames : [])]
+                .filter(name => typeof name === 'string' && name.trim());
+            if (knownNames.some(name => this.normalizeAdjacencyText(name) === normalizedAddress)) {
+                reason = 'matches organizer/brand name';
+            }
+        }
+        if (!reason && !this.isPlausiblyAddressShaped(address)) {
+            reason = 'not address-shaped';
+        }
+        if (!reason) return event;
+        console.log(`🤖 AI Web: Dropped implausible address "${address}" (${reason})`);
+        delete event.address;
+        return event;
     }
 
     // barSource provenance stamp (notes-serialized like imageSource, excluded

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -3853,3 +3853,98 @@ test('prompt capture: city guidance and strengthened context header are present,
     `- city: ${schemaDescription} The promoter's home city in branding, logos, or website domains (e.g. a .nyc domain) is NOT the event city — use explicit location statements (e.g. "Torremolinos, Spain") near the venue/address.`
   );
 });
+
+// ---------------------------------------------------------------------------
+// Address plausibility gate (run 20260723-140457: extraction stored
+// address "Legacy" — the venue's own name — for FURBALL Boston)
+// ---------------------------------------------------------------------------
+
+function captureGateLogs() {
+  const lines = [];
+  const original = console.log;
+  console.log = (...args) => { lines.push(args.join(' ')); };
+  return { lines, restore: () => { console.log = original; } };
+}
+
+test('address gate: an address equal to the bar name is dropped with the additive log', () => {
+  const parser = createParser();
+  const event = { title: 'FURBALL Boston', bar: 'Legacy', address: 'Legacy', city: 'boston' };
+
+  const captured = captureGateLogs();
+  try {
+    parser.applyAddressPlausibilityGate(event, {});
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(event.address, undefined, 'a venue name is not an address');
+  assert.ok(
+    captured.lines.some(line => line.includes('🤖 AI Web: Dropped implausible address "Legacy" (matches venue name)')),
+    `drop log expected, got:\n${captured.lines.join('\n')}`
+  );
+  assert.equal(event.bar, 'Legacy', 'the bar itself is untouched');
+});
+
+test('address gate: an address equal to the derived organizer/brand is dropped', () => {
+  const parser = createParser();
+  const organizerEqual = { title: 'X', bar: 'The Eagle', address: 'Bearracuda', _organizer: 'Bearracuda' };
+  const captured = captureGateLogs();
+  try {
+    parser.applyAddressPlausibilityGate(organizerEqual, {});
+    const brandEqual = { title: 'Y', bar: 'The Eagle', address: 'FURBALL' };
+    parser.applyAddressPlausibilityGate(brandEqual, { pageBrandNames: ['Furball'] });
+    assert.equal(brandEqual.address, undefined, 'page brand names count as organizer names');
+  } finally {
+    captured.restore();
+  }
+  assert.equal(organizerEqual.address, undefined);
+  assert.ok(captured.lines.some(line => line.includes('Dropped implausible address "Bearracuda" (matches organizer/brand name)')));
+});
+
+test('address gate: vague-but-real place names and street addresses are kept; unsure fails open', () => {
+  const parser = createParser();
+  const captured = captureGateLogs();
+  try {
+    const placeName = { title: 'FURBALL MAD.BEAR', bar: 'Aqua Emporio', address: 'LA NOGALERA' };
+    parser.applyAddressPlausibilityGate(placeName, {});
+    assert.equal(placeName.address, 'LA NOGALERA', 'a multi-word place name is vague but real — kept');
+
+    const street = { title: 'FURBALL Boston', bar: 'Legacy', address: '79 Warrenton St' };
+    parser.applyAddressPlausibilityGate(street, {});
+    assert.equal(street.address, '79 Warrenton St', 'a street address never drops');
+
+    const commaForm = { title: 'FURBALL Boston', bar: 'Legacy', address: 'Legacy, Boston' };
+    parser.applyAddressPlausibilityGate(commaForm, {});
+    assert.equal(commaForm.address, 'Legacy, Boston', 'a "Place, Place" comma form is kept (fail open)');
+
+    const noBar = { title: 'X', address: 'Somewhere Nice' };
+    parser.applyAddressPlausibilityGate(noBar, {});
+    assert.equal(noBar.address, 'Somewhere Nice', 'nothing to compare against and multi-word → kept');
+  } finally {
+    captured.restore();
+  }
+});
+
+test('address gate: a bare single word with no address signal drops even when it is not the bar', () => {
+  const parser = createParser();
+  const captured = captureGateLogs();
+  try {
+    const event = { title: 'X', bar: 'The Eagle', address: 'Legacy' };
+    parser.applyAddressPlausibilityGate(event, {});
+    assert.equal(event.address, undefined, 'a lone name-shaped word is never an address');
+    assert.ok(captured.lines.some(line => line.includes('Dropped implausible address "Legacy" (not address-shaped)')));
+  } finally {
+    captured.restore();
+  }
+});
+
+test('address gate shape rules: isPlausiblyAddressShaped', () => {
+  const parser = createParser();
+  assert.equal(parser.isPlausiblyAddressShaped('Legacy'), false, 'single bare word fails all three signals');
+  assert.equal(parser.isPlausiblyAddressShaped('LA NOGALERA'), true, 'multi-word place name passes');
+  assert.equal(parser.isPlausiblyAddressShaped('79 Warrenton St'), true, 'house number + street word');
+  assert.equal(parser.isPlausiblyAddressShaped('Warrenton Street'), true, 'street-type word alone');
+  assert.equal(parser.isPlausiblyAddressShaped('Brooklyn, NY'), true, 'Place, ST comma form');
+  assert.equal(parser.isPlausiblyAddressShaped('Calle Casablanca 12'), true, 'standalone house-number token anywhere');
+  assert.equal(parser.isPlausiblyAddressShaped(''), false);
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1018,6 +1018,52 @@ class SharedCore {
         return Math.max(0, segments.length - 1) + (parsed.zips.length > 0 ? 1 : 0);
     }
 
+    // True when a comma-separated address tail names the event's resolved
+    // city: the raw key itself (dashes/underscores as spaces) or any
+    // configured name/pattern/alias via isCityOnlyTitle. Pure string logic;
+    // an unknown city fails open (false).
+    addressTailNamesCity(tail, cityKey) {
+        const text = String(tail || '').replace(/\s+/g, ' ').trim().toLowerCase();
+        const key = String(cityKey || '').trim().toLowerCase();
+        if (!text || !key) return false;
+        if (text === key || text === key.replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim()) return true;
+        return this.isCityOnlyTitle(tail, cityKey);
+    }
+
+    // City-suffix twin detection for the deterministic address ladder: when
+    // exactly one candidate equals the other plus a trailing ", <city>"
+    // segment naming the event's own city, the UNSUFFIXED candidate wins —
+    // a resolution-derived city appended to an address is query decoration,
+    // never data (see #1525; the persisted address must stay unmutated).
+    // Returns { winner, reason } or null (fail open: no city context, no
+    // suffix relationship, or both/neither side suffixed).
+    resolveCitySuffixedAddressTwin(valueA, valueB, context) {
+        const cityKey = context && context.cityKey ? String(context.cityKey) : '';
+        if (!cityKey) return null;
+        const collapse = value => String(value === null || value === undefined ? '' : value)
+            .replace(/\s+/g, ' ').trim().toLowerCase();
+        const stripCitySuffix = (value) => {
+            const parts = String(value === null || value === undefined ? '' : value)
+                .split(',').map(part => part.trim()).filter(Boolean);
+            if (parts.length < 2) return null;
+            if (!this.addressTailNamesCity(parts[parts.length - 1], cityKey)) return null;
+            return parts.slice(0, -1).join(', ');
+        };
+        const collapsedA = collapse(valueA);
+        const collapsedB = collapse(valueB);
+        if (!collapsedA || !collapsedB || collapsedA === collapsedB) return null;
+        const reason = 'city-suffixed twin — a resolution-appended city is query decoration, kept the unsuffixed address';
+        const strippedA = stripCitySuffix(valueA);
+        if (strippedA !== null && collapse(strippedA) === collapsedB) {
+            return { winner: 'b', reason };
+        }
+        const strippedB = stripCitySuffix(valueB);
+        if (strippedB !== null && collapse(strippedB) === collapsedA) {
+            return { winner: 'a', reason };
+        }
+        return null;
+    }
+
     // Curated bars for a merge-context city — shared by the curated-bar-name
     // rule and the curated-address rung in resolveConflictDeterministically.
     // Returns a non-empty array or null (missing city/bars data fails open).
@@ -1502,6 +1548,20 @@ class SharedCore {
                         };
                     }
                 }
+                // City-suffix twin rung: one candidate is EXACTLY the other
+                // plus a trailing ", <city>" naming the event's own resolved
+                // city ("LA NOGALERA, Torremolinos" vs "LA NOGALERA"). The
+                // suffixed form is the fingerprint of the pre-#1525 append bug
+                // (city RESOLUTION leaking into the persisted address) and the
+                // suffix adds nothing the city field doesn't already carry —
+                // city-qualified strings are QUERIES only. The unsuffixed form
+                // wins deterministically so AI arbitration can never re-cement
+                // the mutation ("more complete" reasoning did exactly that on
+                // run 20260723-140457). House-numbered street addresses never
+                // reach here — the same-address rung above already resolved
+                // them (keeping the more complete, city-bearing form).
+                const citySuffixTwin = this.resolveCitySuffixedAddressTwin(valueA, valueB, context);
+                if (citySuffixTwin) return citySuffixTwin;
                 // Rung 3 (evidence). Case-only twins are NOT a street
                 // mismatch — they fall through untouched so the case-only
                 // rule below keeps deciding them; empty candidates belong to
@@ -2475,6 +2535,17 @@ class SharedCore {
             } else {
                 lines.push(`map POI at pin: "${poiName}"`);
             }
+        }
+
+        // Venue-name fusion flag from the geocode venue lookup
+        // (_geoPoiFusion — underscore field, never serialized; set by
+        // OpenStreetMapNormalizer.maybeFlagVenueNameFusion when a map POI
+        // matched only a PREFIX of the bar name). Flag-only: verify manually.
+        const fusion = event._geoPoiFusion && typeof event._geoPoiFusion === 'object' ? event._geoPoiFusion : null;
+        const fusionPoi = fusion && typeof fusion.poi === 'string' ? fusion.poi.trim() : '';
+        if (bar && fusionPoi) {
+            const fusionPrefix = typeof fusion.prefix === 'string' ? fusion.prefix.trim() : '';
+            lines.push(`⚠️ bar "${bar}" may fuse venue names — map knows "${fusionPoi}"${fusionPrefix ? ` (matches "${fusionPrefix}")` : ''}`);
         }
 
         // Bar corroboration verdict from barSource provenance.
@@ -4957,6 +5028,26 @@ class SharedCore {
         this.setProvenanceSource(mergedObject, 'address', 'addressSource', scraperObject, calendarObject);
         this.setProvenanceSource(mergedObject, 'image', 'imageSource', scraperObject, calendarObject);
         this.setProvenanceSource(mergedObject, 'bar', 'barSource', scraperObject, calendarObject);
+
+        // Stamp guard for the city-append fingerprint: when the address was
+        // settled by the city-suffix twin rung, the calendar record was
+        // machine-written by the pre-#1525 append path — and that path also
+        // accepted its pin WITHOUT a pinSource stamp (run 20260723-140457
+        // persisted 36.6225097, -4.4987054 stamp-less). Such a pin's real
+        // provenance is a geocode of a vague place name, which grades approx
+        // — never exact — so stamp it geocoded-approx instead of letting it
+        // round-trip unstamped forever. Deliberately NARROW: an unstamped pin
+        // on a record without the append fingerprint may be a hand-fixed pin
+        // and stays absent → absent (see setProvenanceSource).
+        const citySuffixTwinResolvedAddress = aiDecisionRecords.some(record => record
+            && record.field === 'address' && typeof record.reason === 'string'
+            && record.reason.startsWith('city-suffixed twin'));
+        if (citySuffixTwinResolvedAddress
+            && this.isCoordinatePair(mergedObject.location)
+            && !(typeof mergedObject.pinSource === 'string' && mergedObject.pinSource.trim().length > 0)) {
+            mergedObject.pinSource = 'geocoded-approx';
+            console.log(`📍 MERGE: "${mergeTitle}" kept pin from a city-suffixed record had no pinSource stamp — stamped geocoded-approx (append-path pins are never exact)`);
+        }
 
         // STEP 4: regenerate gmaps from the FINAL merged bar + address. gmaps
         // is a derived field — a pure function of bar + address — so merging or
@@ -8125,7 +8216,10 @@ SharedCore.PROVENANCE_COMPANION_FIELDS = Object.freeze([
 // the REAL vocabularies stamped by the pipeline:
 //   - pinSource:     normalizers.js (page/geocoded-exact/geocoded-approx,
 //                    curated via bar-data), scriptable-adapter review-apply
-//   - addressSource: normalizers.js (page/curated/inferred),
+//   - addressSource: normalizers.js (page/curated/inferred, plus geo-poi
+//                    from the venue-POI adoption rung — a map POI whose name
+//                    matched the bar supplied the street address; tiered
+//                    with 'page', below 'curated'),
 //                    scriptable-adapter review-apply (curated/inferred)
 //   - barSource:     ai-web-parser.js (curated/venue-site/page-adjacent/
 //                    uncorroborated), normalizers.js (geo-poi); the three
@@ -8141,7 +8235,7 @@ SharedCore.PROVENANCE_COMPANION_FIELDS = Object.freeze([
 // Values absent from a family rank null (fail open); blank ranks 0 (unstamped).
 SharedCore.PROVENANCE_TRUST_TIERS = Object.freeze({
     pinSource: Object.freeze({ 'curated': 4, 'geocoded-exact': 3, 'geocoded-approx': 2, 'page': 1 }),
-    addressSource: Object.freeze({ 'curated': 3, 'page': 2, 'inferred': 1 }),
+    addressSource: Object.freeze({ 'curated': 3, 'geo-poi': 2, 'page': 2, 'inferred': 1 }),
     barSource: Object.freeze({ 'curated': 3, 'venue-site': 2, 'page-adjacent': 2, 'geo-poi': 2, 'uncorroborated': 1 }),
     imageSource: Object.freeze({ 'og-image': 2, 'jsonld': 2, 'page': 1 }),
     bearSource: Object.freeze({ 'manual-bear': 2, 'manual-not-bear': 2, 'keyword': 1, 'ai': 1, 'config': 1 })

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -7128,3 +7128,147 @@ test('new venue candidates carry a computed evidence panel from the same builder
   assert.ok(!('_geoPoiName' in candidate),
     'raw POI underscore fields never land on the candidate itself');
 });
+
+// ---------------------------------------------------------------------------
+// City-suffix append hole (run 20260723-140457: the calendar carried the
+// pre-#1525 mutation "LA NOGALERA, Torremolinos" plus an unstamped pin, and
+// AI arbitration re-cemented both every run)
+// ---------------------------------------------------------------------------
+
+function createCoreWithTorremolinos() {
+  return new SharedCore(
+    { torremolinos: { timezone: 'Europe/Madrid', patterns: ['torremolinos'] } },
+    { eventSchema: EventSchema }
+  );
+}
+
+test('address ladder: city-suffixed twins resolve deterministically to the unsuffixed address', () => {
+  const core = createCoreWithTorremolinos();
+  const context = { cityKey: 'torremolinos' };
+
+  const suffixedCalendar = core.resolveConflictDeterministically(
+    'address', 'LA NOGALERA, Torremolinos', 'LA NOGALERA', context);
+  assert.ok(suffixedCalendar, 'the twin must resolve without AI');
+  assert.equal(suffixedCalendar.winner, 'b', 'the unsuffixed side wins');
+  assert.match(suffixedCalendar.reason, /city-suffixed twin/);
+
+  const suffixedScraped = core.resolveConflictDeterministically(
+    'address', 'LA NOGALERA', 'LA NOGALERA, Torremolinos', context);
+  assert.ok(suffixedScraped);
+  assert.equal(suffixedScraped.winner, 'a', 'direction-symmetric');
+
+  // A tail naming some OTHER place is NOT the resolution fingerprint.
+  assert.equal(
+    core.resolveConflictDeterministically('address', 'LA NOGALERA, Marbella', 'LA NOGALERA', context),
+    null,
+    'a non-city tail falls through to evidence/AI exactly as before'
+  );
+  // No city context → fail open.
+  assert.equal(
+    core.resolveConflictDeterministically('address', 'LA NOGALERA, Torremolinos', 'LA NOGALERA', {}),
+    null
+  );
+});
+
+test('address ladder: house-numbered street twins keep the more complete (city-bearing) form as before', () => {
+  const core = createCore();
+  const resolved = core.resolveConflictDeterministically(
+    'address', '3911 Cedar Springs Rd, Dallas', '3911 Cedar Springs Rd', { cityKey: 'dallas' });
+  assert.ok(resolved, 'the same-address rung still settles street twins');
+  assert.equal(resolved.winner, 'a', 'the more complete street address still wins');
+  assert.match(resolved.reason, /more complete/);
+});
+
+test('merge regression (Mad.Bear): the appended calendar address loses, the kept append-path pin gets stamped approx', async () => {
+  const core = createCoreWithTorremolinos();
+  const adapter = buildArbitrationAdapter({});
+  const scraped = {
+    title: 'FURBALL MAD.BEAR',
+    startDate: new Date('2026-08-15T23:00:00.000Z'),
+    endDate: new Date('2026-08-15T23:00:00.000Z'),
+    bar: 'Aqua Emporio',
+    address: 'LA NOGALERA',
+    addressSource: 'page',
+    city: 'torremolinos',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const existing = {
+    title: 'FURBALL MAD.BEAR',
+    startDate: new Date('2026-08-15T23:00:00.000Z'),
+    endDate: new Date('2026-08-15T23:00:00.000Z'),
+    location: '36.6225097, -4.4987054',
+    url: '',
+    notes: ['bar: Aqua Emporio', 'address: LA NOGALERA, Torremolinos'].join('\n')
+  };
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(finalEvent.address, 'LA NOGALERA', 'the unmutated address wins deterministically');
+  assert.ok(
+    adapter.calls.every(call => !String(call.prompt || '').includes('field: address')),
+    'the address conflict never reaches AI arbitration'
+  );
+  assert.equal(finalEvent.location, '36.6225097, -4.4987054', 'the calendar pin is kept (scrape found none)');
+  assert.equal(finalEvent.pinSource, 'geocoded-approx', 'append-path pins are stamped approx, never left stamp-less');
+  assert.equal(finalEvent.addressSource, 'page', 'addressSource follows the winning scraped address');
+  assert.match(core.parseNotesIntoFields(finalEvent.notes).pinSource || '', /geocoded-approx/);
+});
+
+test('merge: the approx stamp is scoped to the append fingerprint — a stored pinSource is never overwritten', async () => {
+  const core = createCoreWithTorremolinos();
+  const adapter = buildArbitrationAdapter({});
+  const scraped = {
+    title: 'FURBALL MAD.BEAR',
+    startDate: new Date('2026-08-15T23:00:00.000Z'),
+    endDate: new Date('2026-08-15T23:00:00.000Z'),
+    address: 'LA NOGALERA',
+    city: 'torremolinos',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const existing = {
+    title: 'FURBALL MAD.BEAR',
+    startDate: new Date('2026-08-15T23:00:00.000Z'),
+    endDate: new Date('2026-08-15T23:00:00.000Z'),
+    location: '36.6225097, -4.4987054',
+    url: '',
+    notes: ['address: LA NOGALERA, Torremolinos', 'pinSource: curated'].join('\n')
+  };
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+
+  assert.equal(finalEvent.address, 'LA NOGALERA');
+  assert.equal(finalEvent.pinSource, 'curated', 'a stored stamp always wins over the guard');
+});
+
+// ---------------------------------------------------------------------------
+// geo-poi addressSource tier + fusion evidence line
+// ---------------------------------------------------------------------------
+
+test('addressSource trust tiers: geo-poi slots equal to page, below curated', () => {
+  const tier = (value) => SharedCore.getProvenanceTrustTier('addressSource', value);
+  assert.equal(tier('geo-poi'), 2, 'geo-poi is tier 2');
+  assert.equal(tier('geo-poi'), tier('page'), 'equal to page');
+  assert.ok(tier('curated') > tier('geo-poi'), 'below curated');
+  assert.ok(tier('geo-poi') > tier('inferred'), 'above inferred');
+});
+
+test('evidence: a venue-name fusion flag renders its line and never serializes into notes', () => {
+  const core = createCore();
+  const event = {
+    title: 'FURBALL MAD.BEAR',
+    bar: 'Aqua Emporio',
+    city: 'dallas',
+    _geoPoiFusion: { poi: 'Aqua Club', prefix: 'Aqua' }
+  };
+  const lines = core.buildEventEvidenceLines(event);
+  assert.ok(
+    lines.includes('⚠️ bar "Aqua Emporio" may fuse venue names — map knows "Aqua Club" (matches "Aqua")'),
+    `fusion evidence line expected, got: ${JSON.stringify(lines)}`
+  );
+  assert.ok(!/(_geoPoiFusion|Aqua Club)/.test(core.formatEventNotes(event)), 'underscore fields never serialize into notes');
+
+  const barless = core.buildEventEvidenceLines({ title: 'X', _geoPoiFusion: { poi: 'Aqua Club', prefix: 'Aqua' } });
+  assert.ok(!barless.some(line => line.includes('may fuse')), 'no bar → no fusion line (fail open)');
+});


### PR DESCRIPTION
## The three Furball incidents (run 20260723-140457), each with its fix

### 1. "Legacy / Legacy" — venue name as address
**Address plausibility gate**: an extracted address that equals the bar/organizer name, or is a single bare word with no address signal, is dropped with a log. Then the new **venue-POI adoption rung** repairs the hole: for events reaching geocoding with a bar but no usable address, the venue+city lookup (existing rescue infra — with-address events make ZERO extra requests; no-address events reuse the same rate-limited/cached query types) adopts a POI's street address AND pin when the POI name matches the bar. Boston end-to-end: bar "Legacy" → adopts `79 Warrenton Street, Boston 02116` + exact pin + `addressSource: geo-poi`. Street-specific addresses that merely failed to geocode are never overwritten; coarse/admin hits never adopt.

### 2. "Aqua Emporio" — fused venue names
**Fusion flags (no guessing)**: when the full bar fails POI matching but a token prefix matches an already-fetched candidate, one warn + an evidence line: `⚠️ bar "Aqua Emporio" may fuse venue names — map knows "Aqua Club" (matches "Aqua")`. Your call from there; the growth loop is the durable fix once the real venues are confirmed.

### 3. "LA NOGALERA, Torremolinos" + unstamped pin — the ghost
Root cause was NOT a second append path: this run's extraction and geocoding were clean. The **calendar record** still carried the pre-#1525 mutation, and AI arbitration re-adopted it every run as 'more complete'. Fixes:
- **City-suffix twin rung** (deterministic): one address candidate = the other + trailing `, <event's own city>` → the unsuffixed side wins. The ghost self-heals on the next run and the pattern can never re-enter via merges.
- **Scoped pinSource repair**: pins kept from provably append-bug records get stamped `geocoded-approx` (never exact); deliberately NOT a blanket stamp — a hand-fixed pin must never be mislabeled (doctrine test kept passing).
- Bonus latent-bug fix: empty addresses can no longer emit junk `", boston"` geocode queries.

+18 tests incl. the full Mad.Bear and Boston regressions. Suite: **671 pass / 0 fail**.

📲 After merge, download to phone: `scripts/parsers/ai-web-parser.js`, `scripts/normalizers.js`, `scripts/shared-core.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP