### PR TITLE
fix(scraper): POI-pin cross-check tolerance, Photon-backed fusion flags, case-twin bar rule

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -766,6 +766,16 @@ const CITY_CENTER_RADIUS_KM = 50;
 // revisiting the rate-limit budget.
 const MAX_GEOCODE_QUERIES_PER_EVENT = 5;
 
+// POI-adopted pins only: how far apart the reverse-geocoded house number and
+// the adopted address's house number may sit (same street) before the reverse
+// cross-check refuses the pin. Two map providers routinely interpolate the
+// SAME building to nearby numbers (run 20260723-152928: Apple said "75
+// Warrenton St" for OSM's "79 Warrenton Street" — the pin was refused and the
+// event ended with neither address nor pin). 20 covers provider interpolation
+// drift without accepting a different block. Regular address-geocoded pins
+// keep the strict exact-house comparison.
+const POI_PIN_HOUSE_NUMBER_TOLERANCE = 20;
+
 // Street-type words a trailing directional can follow ("Cheshire Bridge Rd NE").
 const GEOCODE_STREET_TYPE_WORDS = 'Street|St|Road|Rd|Avenue|Ave|Boulevard|Blvd|Drive|Dr|Lane|Ln|Way|Place|Pl|Court|Ct|Parkway|Pkwy|Highway|Hwy';
 // Longest alternatives first so "Northeast" matches before "North".
@@ -1161,12 +1171,16 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
 
         // Street-name comparison: at least one distinctive (non-generic,
         // non-numeric) token of the pin's street must appear in the input.
+        // The street-branch result additionally carries streetMatched/
+        // pinHouse/inputHouse (additive fields) so the POI-adoption tolerance
+        // in confirmGeocodeCandidate can tell "same street, different house
+        // number" apart from a genuinely different street.
         const streetTokens = this.expandAddressTokens(pinStreet)
             .filter(token => !GEOCODE_GENERIC_STREET_TOKENS.includes(token) && !/^\d/.test(token));
         if (streetTokens.length > 0 && inputTokens.length > 0) {
             const streetMatch = streetTokens.some(token => inputTokens.includes(token));
             const houseMatch = inputHouse && pinHouse ? inputHouse === pinHouse : true;
-            return { matched: streetMatch && houseMatch, got };
+            return { matched: streetMatch && houseMatch, got, streetMatched: streetMatch, pinHouse, inputHouse };
         }
 
         // No street to compare — fall back to postal code, then locality.
@@ -1431,6 +1445,23 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         }
     }
 
+    // Vetoed adoption fallback: when a venue-POI adoption's PIN is refused by
+    // the reverse cross-check (or the skipped-≠-pass rule), the adopted
+    // ADDRESS must not be discarded with it — the POI-name match already
+    // vouches for the address text (it IS the map's own record of the venue),
+    // while the veto only disputes the coordinates. Keep the address, stamped
+    // geo-poi and flagged for manual review, and leave the event unpinned
+    // (flag-don't-drop; run 20260723-152928 left "FURBALL Boston" with
+    // neither address nor pin). Returns true when the event was modified.
+    keepAdoptedAddressWithoutPin(event, adoption, title) {
+        if (!adoption || !adoption.address) return false;
+        if (event.address === adoption.address && event.addressSource === 'geo-poi') return false;
+        event.address = adoption.address;
+        event.addressSource = 'geo-poi';
+        console.warn(`🗺️ GEOCODE VERIFY: "${title}" POI-adopted address "${adoption.address}" kept without pin — reverse cross-check refused the pin (verify manually)`);
+        return true;
+    }
+
     // Final acceptance for a grade-gate-passing candidate: reverse cross-check
     // against the input address (Apple placemark via the adapter, when that
     // capability exists) plus suspect flagging per verification mode. Returns
@@ -1443,7 +1474,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     // breadcrumb ('fail' for a failed cross-check, 'skipped' for a vague
     // input or an unavailable cross-check).
     async confirmGeocodeCandidate(candidate, context, httpAdapter) {
-        const { title, address, inputHasHouseNumber, verifyMode, streetSpecific, flags, source, rung } = context;
+        const { title, address, inputHasHouseNumber, verifyMode, streetSpecific, flags, source, rung, poiAdopted } = context;
         // Vague-input rule (enforce only): an address without street-level
         // detail ("Poconos, PA") asks a question no geocoder can answer
         // precisely — whatever came back is an arbitrary same-named candidate.
@@ -1472,8 +1503,29 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 poiNames = this.extractPlacemarkPoiNames(placemark);
                 const comparison = this.comparePinToAddress(placemark, address);
                 if (comparison) {
-                    crossCheck = comparison.matched ? 'pass' : 'fail';
-                    if (!comparison.matched) {
+                    let matched = comparison.matched;
+                    // POI-adopted pins only (the venue-POI adoption path —
+                    // addressSource 'geo-poi'): the adopted address and the
+                    // pin come from the SAME map object, so a reverse
+                    // placemark naming the SAME street with a nearby house
+                    // number is two providers interpolating one building, not
+                    // a wrong pin (run 20260723-152928: "75 Warrenton St" vs
+                    // adopted "79 Warrenton Street" vetoed the adoption).
+                    // Different street name, or a gap over the tolerance,
+                    // still refuses exactly as today — as do all
+                    // non-POI-adopted pins.
+                    if (!matched && poiAdopted === true && comparison.streetMatched === true
+                        && comparison.pinHouse && comparison.inputHouse) {
+                        const pinHouseNumber = parseInt(comparison.pinHouse, 10);
+                        const inputHouseNumber = parseInt(comparison.inputHouse, 10);
+                        if (Number.isFinite(pinHouseNumber) && Number.isFinite(inputHouseNumber)
+                            && Math.abs(pinHouseNumber - inputHouseNumber) <= POI_PIN_HOUSE_NUMBER_TOLERANCE) {
+                            matched = true;
+                            console.log(`🗺️ GEOCODE VERIFY: "${title}" POI pin reverse check: same street, house ${comparison.pinHouse} vs ${comparison.inputHouse} — accepted (provider interpolation tolerance)`);
+                        }
+                    }
+                    crossCheck = matched ? 'pass' : 'fail';
+                    if (!matched) {
                         console.warn(`🗺️ GEOCODE VERIFY: "${title}" pin failed reverse cross-check ("${comparison.got}" vs "${address}") — verify pin`);
                         if (verifyMode === 'enforce') return { location: null, crossCheck: 'fail' };
                     }
@@ -1702,6 +1754,12 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             // POI names harvested from the responses that produced/verified the
             // accepted pin (geo-POI bar corroboration; empty when unpinned).
             let resolvedPoiNames = [];
+            // Whether the Nominatim venue+city rescue rung produced ANY usable
+            // (non-coarse, gate-passing) candidate. When it did not — the
+            // venue simply isn't on OSM under that name — the Photon rescue
+            // below additionally runs the venue+city query, whose fuzzy
+            // matcher may still know the venue (adoption + fusion detection).
+            let venueRescueNominatimUsable = false;
             for (let i = 0; i < queryVariants.length && !resolvedLocation; i++) {
                 const queryText = queryVariants[i];
                 const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(queryText)}&limit=${resultLimit}&addressdetails=1`;
@@ -1740,12 +1798,13 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                         }
                         graded.push({ result, grade });
                     }
+                    const isVenueRescueRung = Boolean(venueRescueQuery) && queryText === venueRescueQuery;
+                    if (isVenueRescueRung && graded.length > 0) venueRescueNominatimUsable = true;
                     if (graded.length > 0) {
                         // Venue-POI adoption scan (venue-rescue rung only): the
                         // nearest in-range hit whose map POI name MATCHES the
                         // bar vouches for pin AND address; a non-matching set
                         // of candidates instead feeds fusion detection.
-                        const isVenueRescueRung = Boolean(venueRescueQuery) && queryText === venueRescueQuery;
                         let venuePoiPick = null;
                         if (isVenueRescueRung) {
                             const rankedVenueCandidates = this.rankVenueRescueCandidates(graded, cityCenter, eventCity);
@@ -1797,7 +1856,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                             // vague-input rule must not refuse what the map
                             // just positively named (streetSpecific: true).
                             const confirmContext = adoption
-                                ? { ...verifyContext, address: adoption.address || address, streetSpecific: true, source: 'nominatim', rung: i + 1 }
+                                ? { ...verifyContext, address: adoption.address || address, streetSpecific: true, poiAdopted: true, source: 'nominatim', rung: i + 1 }
                                 : { ...verifyContext, source: 'nominatim', rung: i + 1 };
                             const confirmed = await this.confirmGeocodeCandidate(pickedCandidate, confirmContext, httpAdapter);
                             if (confirmed.location) {
@@ -1815,11 +1874,19 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                                     modified = true;
                                     console.log(`🗺️ GEOCODE VERIFY: "${title}" adopted address "${adoption.address}" from map POI "${venuePoiPick.poiName}" (venue+city lookup)`);
                                 }
-                            } else if (!rejectedVerdict) {
-                                // enforce-mode rejection: 'fail' for a failed
-                                // cross-check, 'skipped' for a vague input or
-                                // an unavailable cross-check
-                                rejectedVerdict = { grade: pickedCandidate.grade, crossCheck: confirmed.crossCheck, source: 'nominatim', rung: i + 1 };
+                            } else {
+                                // Vetoed adoption: the pin is refused but the
+                                // POI-vouched address survives, unpinned and
+                                // flagged (see keepAdoptedAddressWithoutPin).
+                                if (adoption && this.keepAdoptedAddressWithoutPin(event, adoption, title)) {
+                                    modified = true;
+                                }
+                                if (!rejectedVerdict) {
+                                    // enforce-mode rejection: 'fail' for a failed
+                                    // cross-check, 'skipped' for a vague input or
+                                    // an unavailable cross-check
+                                    rejectedVerdict = { grade: pickedCandidate.grade, crossCheck: confirmed.crossCheck, source: 'nominatim', rung: i + 1 };
+                                }
                             }
                         }
                     } else if ((!Array.isArray(data) || data.length === 0) && i < queryVariants.length - 1) {
@@ -1897,84 +1964,114 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 // GeoJSON coordinates are [lon, lat]. Events with NO usable
                 // address query the venue+city string instead — pin/address may
                 // then only be adopted from a hit whose POI name matches the bar.
-                const photonQuery = hasAddress ? address : venueRescueQuery;
-                const photonUrl = `https://photon.komoot.io/api/?q=${encodeURIComponent(photonQuery)}&limit=1`;
-                attempts += 1;
-                try {
-                    const data = await this.fetchDataWithCacheAndRateLimit(photonUrl, options, httpAdapter);
-                    const feature = data && Array.isArray(data.features) && data.features.length > 0 ? data.features[0] : null;
-                    const coords = feature && feature.geometry && Array.isArray(feature.geometry.coordinates)
-                        ? feature.geometry.coordinates
-                        : null;
-                    const lon = coords ? Number(coords[0]) : NaN;
-                    const lat = coords ? Number(coords[1]) : NaN;
-                    if (Number.isFinite(lat) && Number.isFinite(lon)) {
-                        const props = feature.properties && typeof feature.properties === 'object' ? feature.properties : {};
-                        const grade = this.classifyGeocodeGrade(props.osm_key, props.osm_value, props.osm_value, !!props.housenumber);
-                        const withinRadius = !cityCenter ||
-                            this.haversineDistanceKm(lat, lon, cityCenter.lat, cityCenter.lng) <= CITY_CENTER_RADIUS_KM;
-                        const photonPoiName = this.extractNominatimPoiName({ name: props.name });
-                        const photonPoiMatchesBar = Boolean(photonPoiName && rescueBarName
-                            && this.poiNameMatchesBar(photonPoiName, rescueBarName));
-                        const adoption = photonPoiMatchesBar && addressAdoptable && withinRadius && grade !== 'coarse'
-                            ? { poiName: photonPoiName, address: this.assemblePhotonPoiAddress(props) }
-                            : null;
-                        if (grade === 'coarse') {
-                            console.warn(`🗺️ GEOCODE VERIFY: "${title}" refused generic pin (${props.osm_value || 'unknown'}) for address "${address}"`);
-                        } else if (!hasAddress && !adoption) {
-                            // Venue-only lookup: a hit whose POI name is NOT the
-                            // bar has nothing vouching for it — never pin
-                            // (today's no-address behavior, fail open).
-                        } else if (grade === 'street' && inputHasHouseNumber && verifyMode === 'enforce') {
-                            // enforce demands house-number quality; stay unpinned
-                            if (!rejectedVerdict) {
-                                rejectedVerdict = { grade: 'street', crossCheck: 'skipped', source: 'photon', rung: attempts };
-                            }
-                        } else if (withinRadius) {
-                            // Adoption context mirrors the Nominatim venue rung:
-                            // the POI-name match is the positive verification.
-                            const confirmContext = adoption
-                                ? { ...verifyContext, address: adoption.address || address, streetSpecific: true, source: 'photon', rung: attempts }
-                                : { ...verifyContext, source: 'photon', rung: attempts };
-                            const confirmed = await this.confirmGeocodeCandidate(
-                                { lat: coords[1], lon: coords[0], grade },
-                                confirmContext,
-                                httpAdapter
-                            );
-                            if (confirmed.location) {
-                                resolvedLocation = confirmed.location;
-                                resolvedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
-                                resolvedPoiNames = this.collectAcceptedPoiNames(
-                                    adoption
-                                        ? adoption.poiName
-                                        : (grade === 'exact' ? this.extractNominatimPoiName({ name: props.name }) : ''),
-                                    confirmed
-                                );
-                                if (adoption && adoption.address) {
-                                    event.address = adoption.address;
-                                    event.addressSource = 'geo-poi';
-                                    modified = true;
-                                    console.log(`🗺️ GEOCODE VERIFY: "${title}" adopted address "${adoption.address}" from map POI "${adoption.poiName}" (venue+city lookup)`);
-                                }
-                            } else if (!rejectedVerdict) {
-                                rejectedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
-                            }
-                        }
-                        // Fusion detection (flag-only) on the candidate this
-                        // already-made query returned: a non-generic POI that
-                        // matches only a PREFIX of the bar name suggests the
-                        // bar fused multiple venue names.
-                        if (photonPoiName && !photonPoiMatchesBar && grade !== 'coarse') {
-                            this.maybeFlagVenueNameFusion(event, [photonPoiName], verifyContext.flags);
-                        }
-                    }
-                } catch (err) {
-                    console.log(`🗺️ OpenStreetMapNormalizer: Failed to geocode address "${event.address}": ${err.message}`);
+                const photonQueries = [hasAddress ? address : venueRescueQuery];
+                // Venue-name follow-up (run 20260723-152928: bar "AQUA
+                // EMPORIO" — Nominatim's venue+city rescue knew nothing, the
+                // Photon rescue only queried the address, and the fusion
+                // check never saw Photon's "Aqua Club"): when the event HAS
+                // an address (so the primary Photon query above is that
+                // address) and the Nominatim venue+city rescue produced no
+                // usable candidate, additionally run the SAME venue+city
+                // query through Photon — its fuzzy matcher is the last
+                // source that can still name the venue for adoption/fusion
+                // detection. Existing request type, same rate limiter and
+                // caches; only runs while the event is still unpinned.
+                if (hasAddress && venueRescueQuery && !venueRescueNominatimUsable) {
+                    photonQueries.push(venueRescueQuery);
                 }
-                if (resolvedLocation) {
-                    event.location = resolvedLocation;
-                    modified = true;
-                    console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
+                for (const photonQuery of photonQueries) {
+                    if (resolvedLocation) break;
+                    // The venue-name follow-up may only pin via adoption: like the
+                    // no-address venue lookup, nothing vouches for a venue-query
+                    // hit whose POI name is NOT the bar (the event's own address
+                    // rungs already had their chance to pin).
+                    const isVenueFollowUpQuery = hasAddress && Boolean(venueRescueQuery) && photonQuery === venueRescueQuery;
+                    const photonUrl = `https://photon.komoot.io/api/?q=${encodeURIComponent(photonQuery)}&limit=1`;
+                    attempts += 1;
+                    try {
+                        const data = await this.fetchDataWithCacheAndRateLimit(photonUrl, options, httpAdapter);
+                        const feature = data && Array.isArray(data.features) && data.features.length > 0 ? data.features[0] : null;
+                        const coords = feature && feature.geometry && Array.isArray(feature.geometry.coordinates)
+                            ? feature.geometry.coordinates
+                            : null;
+                        const lon = coords ? Number(coords[0]) : NaN;
+                        const lat = coords ? Number(coords[1]) : NaN;
+                        if (Number.isFinite(lat) && Number.isFinite(lon)) {
+                            const props = feature.properties && typeof feature.properties === 'object' ? feature.properties : {};
+                            const grade = this.classifyGeocodeGrade(props.osm_key, props.osm_value, props.osm_value, !!props.housenumber);
+                            const withinRadius = !cityCenter ||
+                                this.haversineDistanceKm(lat, lon, cityCenter.lat, cityCenter.lng) <= CITY_CENTER_RADIUS_KM;
+                            const photonPoiName = this.extractNominatimPoiName({ name: props.name });
+                            const photonPoiMatchesBar = Boolean(photonPoiName && rescueBarName
+                                && this.poiNameMatchesBar(photonPoiName, rescueBarName));
+                            const adoption = photonPoiMatchesBar && addressAdoptable && withinRadius && grade !== 'coarse'
+                                ? { poiName: photonPoiName, address: this.assemblePhotonPoiAddress(props) }
+                                : null;
+                            if (grade === 'coarse') {
+                                console.warn(`🗺️ GEOCODE VERIFY: "${title}" refused generic pin (${props.osm_value || 'unknown'}) for address "${address}"`);
+                            } else if ((!hasAddress || isVenueFollowUpQuery) && !adoption) {
+                                // Venue-only lookup (and the venue-name follow-up):
+                                // a hit whose POI name is NOT the bar has nothing
+                                // vouching for it — never pin (fail open).
+                            } else if (grade === 'street' && inputHasHouseNumber && verifyMode === 'enforce') {
+                                // enforce demands house-number quality; stay unpinned
+                                if (!rejectedVerdict) {
+                                    rejectedVerdict = { grade: 'street', crossCheck: 'skipped', source: 'photon', rung: attempts };
+                                }
+                            } else if (withinRadius) {
+                                // Adoption context mirrors the Nominatim venue rung:
+                                // the POI-name match is the positive verification.
+                                const confirmContext = adoption
+                                    ? { ...verifyContext, address: adoption.address || address, streetSpecific: true, poiAdopted: true, source: 'photon', rung: attempts }
+                                    : { ...verifyContext, source: 'photon', rung: attempts };
+                                const confirmed = await this.confirmGeocodeCandidate(
+                                    { lat: coords[1], lon: coords[0], grade },
+                                    confirmContext,
+                                    httpAdapter
+                                );
+                                if (confirmed.location) {
+                                    resolvedLocation = confirmed.location;
+                                    resolvedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
+                                    resolvedPoiNames = this.collectAcceptedPoiNames(
+                                        adoption
+                                            ? adoption.poiName
+                                            : (grade === 'exact' ? this.extractNominatimPoiName({ name: props.name }) : ''),
+                                        confirmed
+                                    );
+                                    if (adoption && adoption.address) {
+                                        event.address = adoption.address;
+                                        event.addressSource = 'geo-poi';
+                                        modified = true;
+                                        console.log(`🗺️ GEOCODE VERIFY: "${title}" adopted address "${adoption.address}" from map POI "${adoption.poiName}" (venue+city lookup)`);
+                                    }
+                                } else {
+                                    // Vetoed adoption: keep the POI-vouched
+                                    // address, unpinned and flagged (see
+                                    // keepAdoptedAddressWithoutPin).
+                                    if (adoption && this.keepAdoptedAddressWithoutPin(event, adoption, title)) {
+                                        modified = true;
+                                    }
+                                    if (!rejectedVerdict) {
+                                        rejectedVerdict = { grade, crossCheck: confirmed.crossCheck, source: 'photon', rung: attempts };
+                                    }
+                                }
+                            }
+                            // Fusion detection (flag-only) on the candidate this
+                            // already-made query returned: a non-generic POI that
+                            // matches only a PREFIX of the bar name suggests the
+                            // bar fused multiple venue names.
+                            if (photonPoiName && !photonPoiMatchesBar && grade !== 'coarse') {
+                                this.maybeFlagVenueNameFusion(event, [photonPoiName], verifyContext.flags);
+                            }
+                        }
+                    } catch (err) {
+                        console.log(`🗺️ OpenStreetMapNormalizer: Failed to geocode address "${event.address}": ${err.message}`);
+                    }
+                    if (resolvedLocation) {
+                        event.location = resolvedLocation;
+                        modified = true;
+                        console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
+                    }
                 }
             }
             // Geocode verdict metadata for downstream consumers (the calendar

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -399,10 +399,14 @@ test('retry ladder: distance validation still applies to fallback variants', asy
   await normalizer.normalizeAsync(event, httpAdapter);
 
   assert.equal(event.location, undefined, 'a far-away candidate from a simplified query must not win');
-  assert.equal(httpAdapter.requests.length, 4, 'rejection counts as failure and the ladder continues through the Photon rescue');
+  assert.equal(httpAdapter.requests.length, 5, 'rejection counts as failure and the ladder continues through the Photon rescue + venue follow-up');
   assert.ok(
     httpAdapter.requests[3].includes('photon.komoot.io/api/?q='),
-    `the final rung must be the Photon rescue: ${httpAdapter.requests[3]}`
+    `the fourth rung must be the Photon rescue: ${httpAdapter.requests[3]}`
+  );
+  assert.ok(
+    httpAdapter.requests[4].includes('photon.komoot.io/api/?q=') && decodeQueryParam(httpAdapter.requests[4]) === 'The Heretic, atlanta',
+    `the final request is the Photon venue follow-up (empty Nominatim venue rescue): ${httpAdapter.requests[4]}`
   );
 });
 
@@ -535,9 +539,13 @@ test('a simplified-query admin-area match is rejected instead of poisoning coord
     warns.some(w => w.includes('Rejected admin-area result') && w.includes('type=borough')),
     `the rejection must be logged: ${warns.join(' | ')}`
   );
-  assert.equal(httpAdapter.requests.length, 5, 'the ladder continues past the rejected result through the Census and Photon rescues');
+  assert.equal(httpAdapter.requests.length, 6, 'the ladder continues past the rejected result through the Census and Photon rescues + venue follow-up');
   assert.ok(httpAdapter.requests[3].includes('geocoding.geo.census.gov'), 'the US-looking address gets a Census rescue before Photon');
-  assert.ok(httpAdapter.requests[4].includes('photon.komoot.io'), 'the final request is the Photon rescue');
+  assert.ok(httpAdapter.requests[4].includes('photon.komoot.io'), 'the next request is the Photon rescue');
+  assert.ok(
+    httpAdapter.requests[5].includes('photon.komoot.io') && decodeQueryParam(httpAdapter.requests[5]) === "C'mon Everybody, new york",
+    `the final request is the Photon venue follow-up (empty Nominatim venue rescue): ${httpAdapter.requests[5]}`
+  );
 });
 
 test('a venue-name simplified query still resolves through an amenity result', async () => {
@@ -2117,12 +2125,17 @@ test('Mad.Bear ladder regression: generic refusals stay refused and the vague ad
     captured.restore();
   }
 
-  assert.equal(httpAdapter.requests.length, 3, 'address rung, venue rescue rung, Photon rescue');
+  assert.equal(httpAdapter.requests.length, 4, 'address rung, venue rescue rung, Photon rescue, Photon venue follow-up');
   assert.equal(decodeQueryParam(httpAdapter.requests[0]), 'LA NOGALERA, torremolinos', 'city anchoring stays QUERY-only');
   assert.equal(decodeQueryParam(httpAdapter.requests[1]), 'Aqua Emporio, torremolinos');
+  assert.ok(
+    httpAdapter.requests[3].includes('photon.komoot.io') && decodeQueryParam(httpAdapter.requests[3]) === 'Aqua Emporio, torremolinos',
+    `the empty Nominatim venue rescue triggers the Photon venue follow-up: ${httpAdapter.requests[3]}`
+  );
   assert.equal(event.address, 'LA NOGALERA', 'the persisted address is never mutated with the resolved city');
   assert.equal(event.location, undefined, 'generic locality/hamlet pins stay refused — no unstamped pin');
   assert.equal(event.pinSource, undefined, 'no pin means no pinSource stamp');
+  assert.equal(event._geoPoiFusion, undefined, 'a coarse-only Photon follow-up never raises a fusion flag');
   assert.ok(
     captured.lines.some(line => line.includes('refused generic pin (locality) for address "LA NOGALERA"')),
     'the locality refusal stays visible'
@@ -2130,5 +2143,196 @@ test('Mad.Bear ladder regression: generic refusals stay refused and the vague ad
   assert.ok(
     captured.lines.some(line => line.includes('refused generic pin (hamlet) for address "LA NOGALERA"')),
     'the hamlet refusal stays visible'
+  );
+});
+
+// ---------------------------------------------------------------------------
+// POI-pin reverse cross-check tolerance (run 20260723-152928: "FURBALL
+// Boston" adopted "79 Warrenton Street" from the Legacy POI, Apple reversed
+// the same building as "75 Warrenton St", and the pin was vetoed by its own
+// cross-check — the event ended with neither address nor pin). POI-adopted
+// pins tolerate same-street house-number drift ≤ 20; different streets and
+// larger gaps still refuse, and non-POI pins keep today's strict comparison.
+// Vetoed adoptions keep the POI-vouched ADDRESS (unpinned, flagged).
+// ---------------------------------------------------------------------------
+
+// Apple reversing the same building Nominatim pinned: same street, house 75.
+const WARRENTON_75_PLACEMARK = {
+  subThoroughfare: '75',
+  thoroughfare: 'Warrenton St',
+  locality: 'Boston'
+};
+
+test('POI-pin tolerance: same-street house drift within 20 is accepted for an adopted pin (enforce)', async () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_BOSTON);
+  const httpAdapter = {
+    ...createSequencedStubAdapter([[LEGACY_NIGHTCLUB_RESULT]]),
+    reverseGeocodePlacemark: async () => WARRENTON_75_PLACEMARK,
+    supportsReverseGeocode: () => true
+  };
+  const event = { title: 'FURBALL Boston', bar: 'Legacy', city: 'boston' };
+
+  const captured = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } });
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(event.location, '42.3499, -71.0648', 'the tolerance accepts the POI pin');
+  assert.equal(event.address, '79 Warrenton Street, Boston, Massachusetts', 'the adopted address survives with the pin');
+  assert.equal(event.addressSource, 'geo-poi', 'adopted address carries geo-poi provenance');
+  assert.equal(event.pinSource, 'geocoded-exact', 'a tolerated cross-check is a pass — exact grade stamps geocoded-exact');
+  assert.equal(event._geocodeCrossCheck, 'pass', 'the tolerated comparison records a pass verdict');
+  assert.ok(
+    captured.lines.some(line => line.includes('🗺️ GEOCODE VERIFY: "FURBALL Boston" POI pin reverse check: same street, house 75 vs 79 — accepted (provider interpolation tolerance)')),
+    `tolerance log expected, got:\n${captured.lines.join('\n')}`
+  );
+  assert.ok(
+    !captured.lines.some(line => line.includes('pin failed reverse cross-check')),
+    'a tolerated pin is not logged as a cross-check failure'
+  );
+});
+
+test('POI-pin tolerance: a different reverse street still refuses the pin, but the adopted address is kept unpinned', async () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_BOSTON);
+  const httpAdapter = {
+    ...createSequencedStubAdapter([[LEGACY_NIGHTCLUB_RESULT], {}]),
+    reverseGeocodePlacemark: async () => ({ subThoroughfare: '75', thoroughfare: 'Tremont St', locality: 'Boston' }),
+    supportsReverseGeocode: () => true
+  };
+  const event = { title: 'FURBALL Boston', bar: 'Legacy', city: 'boston' };
+
+  const captured = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } });
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(event.location, undefined, 'a different-street reverse refuses the pin exactly as today');
+  assert.equal(event.pinSource, undefined, 'no pin means no pinSource stamp');
+  assert.equal(event.address, '79 Warrenton Street, Boston, Massachusetts', 'the POI-vouched address is NOT discarded with the pin');
+  assert.equal(event.addressSource, 'geo-poi', 'the kept address stays stamped geo-poi');
+  assert.equal(event._geocodeCrossCheck, 'fail', 'the rejection breadcrumb survives for the calendar reviewer');
+  assert.ok(
+    captured.lines.some(line => line.includes('pin failed reverse cross-check')),
+    `the refusal stays visible: ${captured.lines.join('\n')}`
+  );
+  assert.ok(
+    captured.lines.some(line => line.includes('🗺️ GEOCODE VERIFY: "FURBALL Boston" POI-adopted address "79 Warrenton Street, Boston, Massachusetts" kept without pin — reverse cross-check refused the pin (verify manually)')),
+    `the kept-without-pin flag must be logged: ${captured.lines.join('\n')}`
+  );
+  assert.ok(
+    !captured.lines.some(line => line.includes('provider interpolation tolerance')),
+    'no tolerance log on a different street'
+  );
+});
+
+test('POI-pin tolerance: a same-street gap over 20 still refuses the pin; the adopted address is kept unpinned', async () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_BOSTON);
+  const httpAdapter = {
+    ...createSequencedStubAdapter([[LEGACY_NIGHTCLUB_RESULT], {}]),
+    reverseGeocodePlacemark: async () => ({ subThoroughfare: '175', thoroughfare: 'Warrenton St', locality: 'Boston' }),
+    supportsReverseGeocode: () => true
+  };
+  const event = { title: 'FURBALL Boston', bar: 'Legacy', city: 'boston' };
+
+  const captured = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } });
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(event.location, undefined, 'house 175 vs 79 is beyond interpolation drift — refused');
+  assert.equal(event.address, '79 Warrenton Street, Boston, Massachusetts', 'the POI-vouched address is still kept');
+  assert.equal(event.addressSource, 'geo-poi');
+  assert.ok(
+    !captured.lines.some(line => line.includes('provider interpolation tolerance')),
+    'no tolerance log beyond the 20-number gap'
+  );
+  assert.ok(
+    captured.lines.some(line => line.includes('pin failed reverse cross-check')),
+    'the refusal stays visible'
+  );
+});
+
+test('POI-pin tolerance never applies to regular address-geocoded pins (strict house comparison regression lock)', async () => {
+  const normalizer = createOsmNormalizer();
+  normalizer.delayForRateLimit = async () => {};
+  // Same street, house 1180 vs input 1192 — a gap WITHIN the POI tolerance,
+  // but this pin was geocoded from the event's own address, not adopted.
+  const httpAdapter = createRoutedStubAdapter(
+    [['nominatim', [POWERHOUSE_POI_RESULT]]],
+    {
+      reverseGeocodePlacemark: async () => ({ subThoroughfare: '1180', thoroughfare: 'Folsom Street', locality: 'San Francisco' }),
+      supportsReverseGeocode: () => true
+    }
+  );
+  const event = { title: 'CHUNK', address: '1192 Folsom St' };
+
+  const lines = await withCapturedConsole(() =>
+    normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'enforce' } })
+  );
+
+  assert.equal(event.location, undefined, 'a non-POI pin keeps today\'s strict exact-house cross-check');
+  assert.ok(
+    lines.some(l => l.includes('pin failed reverse cross-check')),
+    `the strict refusal must be logged: ${lines.join(' | ')}`
+  );
+  assert.ok(
+    !lines.some(l => l.includes('provider interpolation tolerance')),
+    'the tolerance is POI-adoption-only'
+  );
+});
+
+test('fusion via the Photon venue follow-up: empty Nominatim venue rescue + Photon Aqua Club flags the fused bar', async () => {
+  const normalizer = createOsmNormalizerFor(CITIES_WITH_TORREMOLINOS);
+  const nogaleraLocality = {
+    lat: '36.6225097',
+    lon: '-4.4987054',
+    class: 'place',
+    type: 'locality',
+    addresstype: 'locality',
+    name: 'La Nogalera',
+    display_name: 'La Nogalera, Torremolinos, Málaga, Spain',
+    address: { town: 'Torremolinos', state: 'Andalusia' }
+  };
+  const photonHamlet = {
+    features: [{
+      geometry: { coordinates: [-4.4987054, 36.6225097] },
+      properties: { name: 'La Nogalera', osm_key: 'place', osm_value: 'hamlet' }
+    }]
+  };
+  // Photon's fuzzy venue search DOES know the venue: photon.komoot.io/api/
+  // ?q=Aqua+Emporio+Torremolinos → "Aqua Club" (nightclub, Calle Casablanca).
+  const aquaClubPhoton = {
+    features: [{
+      geometry: { coordinates: [-4.4982728, 36.6218328] },
+      properties: { name: 'Aqua Club', osm_key: 'amenity', osm_value: 'nightclub', street: 'Calle Casablanca', city: 'Torremolinos' }
+    }]
+  };
+  const httpAdapter = createSequencedStubAdapter([[nogaleraLocality], [], photonHamlet, aquaClubPhoton]);
+  const event = { title: 'FURBALL MAD.BEAR', address: 'LA NOGALERA', city: 'torremolinos', bar: 'AQUA EMPORIO' };
+
+  const captured = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    captured.restore();
+  }
+
+  assert.equal(httpAdapter.requests.length, 4, 'address rung, venue rescue, Photon address rescue, Photon venue follow-up');
+  assert.ok(
+    httpAdapter.requests[3].includes('photon.komoot.io') && decodeQueryParam(httpAdapter.requests[3]) === 'AQUA EMPORIO, torremolinos',
+    `the follow-up must be the venue+city query: ${httpAdapter.requests[3]}`
+  );
+  assert.equal(event.location, undefined, 'a non-bar-matching venue hit never pins');
+  assert.equal(event.address, 'LA NOGALERA', 'no address is adopted from a non-matching POI');
+  assert.deepEqual(event._geoPoiFusion, { poi: 'Aqua Club', prefix: 'AQUA' }, 'fusion evidence recorded for the results UI');
+  assert.ok(
+    captured.lines.some(line => line.includes('🗺️ GEOCODE VERIFY: "FURBALL MAD.BEAR" bar "AQUA EMPORIO" may fuse multiple venue names — map knows "Aqua Club" (matches "AQUA"); verify manually')),
+    `fusion flag log expected, got:\n${captured.lines.join('\n')}`
   );
 });

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1445,7 +1445,18 @@ class SharedCore {
             // stamps missing → fall through to today's behavior (fail open).
             const barContextRecords = context && context.records && typeof context.records === 'object'
                 ? context.records : null;
-            if (barContextRecords) {
+            // Case-only twins are the SAME venue spelled louder — provenance
+            // stamps must never pick between them, or the demotion rung
+            // crowns the SHOUTIER twin (e.g. a corroborated "AQUA EMPORIO"
+            // over an uncorroborated "Aqua Emporio") before the case-only
+            // rule below can keep the less-uppercased form. Skipping the
+            // rung for twins applies in BOTH merge flows and regardless of
+            // which stamps the two sides carry.
+            const collapseBarForTwinCheck = value => typeof value === 'string'
+                ? value.replace(/\s+/g, ' ').trim() : '';
+            const caseOnlyBarTwins = collapseBarForTwinCheck(valueA) !== ''
+                && collapseBarForTwinCheck(valueA).toLowerCase() === collapseBarForTwinCheck(valueB).toLowerCase();
+            if (barContextRecords && !caseOnlyBarTwins) {
                 const getBarProvenance = (record, value) => {
                     if (!record || typeof record !== 'object') return '';
                     const recordBar = typeof record.bar === 'string' ? record.bar.trim() : '';

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -6409,6 +6409,54 @@ test('guardrail: corroborated bar beats uncorroborated in both directions; ambig
   assert.equal(core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing'), null);
 });
 
+test('guardrail: case-only bar twins resolve to the less-uppercased form regardless of barSource stamps', () => {
+  const core = createCore();
+  const context = (recordA, recordB, sideLabels = { a: 'existing', b: 'incoming' }) => ({
+    sideLabels,
+    records: { a: recordA, b: recordB }
+  });
+  const CASE_RULE_B = { winner: 'b', reason: 'case-only variants — kept less-uppercased form' };
+  const CASE_RULE_A = { winner: 'a', reason: 'case-only variants — kept less-uppercased form' };
+
+  // Matching stamps: both uncorroborated — the demotion rung falls through
+  // and the case-only rule decides (regression lock)
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'AQUA EMPORIO', 'Aqua Emporio',
+      context({ bar: 'AQUA EMPORIO', barSource: 'uncorroborated' }, { bar: 'Aqua Emporio', barSource: 'uncorroborated' })),
+    CASE_RULE_B);
+  // Matching stamps: both page-adjacent (enrich flow)
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'AQUA EMPORIO', 'Aqua Emporio',
+      context({ bar: 'AQUA EMPORIO', barSource: 'page-adjacent' }, { bar: 'Aqua Emporio', barSource: 'page-adjacent' })),
+    CASE_RULE_B);
+
+  // DIFFERING stamps on case twins must never crown the shoutier twin via
+  // the demotion rung — twins are the SAME venue, provenance decides nothing
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'AQUA EMPORIO', 'Aqua Emporio',
+      context({ bar: 'AQUA EMPORIO', barSource: 'page-adjacent' }, { bar: 'Aqua Emporio', barSource: 'uncorroborated' })),
+    CASE_RULE_B, 'a corroborated caps twin must not beat the uncorroborated mixed-case twin');
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'Aqua Emporio', 'AQUA EMPORIO',
+      context({ bar: 'Aqua Emporio', barSource: 'uncorroborated' }, { bar: 'AQUA EMPORIO', barSource: 'page-adjacent' })),
+    CASE_RULE_A, 'the less-uppercased side wins whichever side it sits on');
+
+  // Calendar flow: an unstamped caps calendar bar vs an uncorroborated
+  // mixed-case scrape is a case twin — the calendar-doctrine branch of the
+  // demotion rung must not re-cement the shouty calendar form
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'AQUA EMPORIO', 'Aqua Emporio',
+      context({ bar: 'AQUA EMPORIO' }, { bar: 'Aqua Emporio', barSource: 'uncorroborated' },
+        { a: 'calendar', b: 'scraped' })),
+    CASE_RULE_B);
+
+  // Genuinely different bars keep the demotion rung untouched
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'MASSIVE', 'Shore Thing',
+      context({ bar: 'MASSIVE', barSource: 'page-adjacent' }, { bar: 'Shore Thing', barSource: 'uncorroborated' })),
+    { winner: 'a', reason: 'corroborated bar beats uncorroborated' });
+});
+
 test('barSource is never arbitration-eligible and round-trips through notes like imageSource', () => {
   const core = createCore();
   assert.equal(core.isArbitrationEligibleField('barSource'), false);


### PR DESCRIPTION
## What broke (run 20260723-152928, post-#1529)

### 1. Boston: our own verification vetoed a correct adoption
The address gate correctly dropped \"Legacy\" (matches venue name), and the venue-POI adoption correctly found Legacy at **79 Warrenton Street, Boston** with a pin. Then the Apple reverse cross-check reported that pin as **75 Warrenton St** — two map providers interpolating the same building to different house numbers — and refused it. The event ended with **no address and no pin**.

### 2. Mad.Bear: the fusion flag never had a chance to fire
Bar \"AQUA EMPORIO\" isn't on OSM, so the Nominatim venue+city rescue returned zero candidates — and because the event HAS an address, the Photon rescue only queried the address (\"LA NOGALERA\"). The venue name never reached Photon, whose fuzzy matcher is the one source that knows **\"Aqua Club\"** (nightclub, Calle Casablanca, Torremolinos). No candidates → no fusion comparison → no flag.

### 3. Latent case-twin hazard
Forensics on the ALL-CAPS bar: run 152928 had no case conflict at all (the calendar already stored \"AQUA EMPORIO\"; the earlier fixed preview was never executed). But the merge ladder has a real hazard: the barSource demotion rung runs before the case-only rule, so differing provenance stamps could crown the SHOUTIER case-twin.

## Fixes

- **POI-pin tolerance** (`confirmGeocodeCandidate`): for POI-adopted pins ONLY (the #1529 adoption paths), a reverse mismatch passes when the street NAME matches and the house numbers differ by ≤ 20 — logged as `POI pin reverse check: same street, house 75 vs 79 — accepted (provider interpolation tolerance)`. Different street or bigger gap refuses exactly as today; non-adopted pins keep strict behavior (regression-locked).
- **Vetoed adoption keeps the address**: when an adoption's pin IS refused, the POI-vouched address is no longer discarded with it — kept unpinned, stamped `addressSource: geo-poi`, flagged `kept without pin — reverse cross-check refused the pin (verify manually)`. The veto disputes coordinates, not the map's own record of the venue's address (flag-don't-drop).
- **Photon venue follow-up**: when the Nominatim venue rescue yields no usable candidate and the event is still unpinned after the Photon address query, the same venue+city query runs through Photon (existing request type, same rate limiter/caches). Its candidate feeds adoption (bar-matching POI only — a non-matching hit never pins) and fusion detection, so \"AQUA EMPORIO\" finally gets its `may fuse venue names` evidence flag from Photon's \"Aqua Club\".
- **Case-twin guard**: case-only bar twins skip the barSource demotion rung entirely — the case-only rule (keep the less-uppercased form) decides in both merge flows regardless of stamps.

## Tests
677 pass (671 baseline + 6 new): tolerance accept/reject boundaries, strict behavior locked for non-adopted pins, vetoed-adoption address retention, Photon follow-up fires only when Nominatim rescue is empty (+ coarse-only never flags), case twins with equal and differing stamps in both flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP