### PR TITLE
fix(scraper): '404' image filter ate flyers whose hex asset IDs contain "404"

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -3560,7 +3560,6 @@ class AiWebParser {
             'empty',          // Empty state images
             'null',           // Null state images
             'missing',        // Missing state images
-            '404',            // 404 images
             'coming-soon',    // Coming soon images
             'under-construction',
             'maintenance',    // Maintenance pages
@@ -3576,6 +3575,11 @@ class AiWebParser {
         for (const pattern of uninterestingPatterns) {
             if (lowerUrl.includes(pattern)) return true;
         }
+        // '404' only counts when it stands alone between non-alphanumerics
+        // ("/404.png", "error-404.jpg") — as a bare substring it matches
+        // random hex asset IDs (a Wix flyer named "238fae_c4047c55…" was
+        // flagged as a 404 image and never OCR'd) and pixel sizes ("w_1404").
+        if (/(^|[^0-9a-z])404(?![0-9a-z])/.test(lowerUrl)) return true;
         return false;
     }
 
@@ -3738,7 +3742,15 @@ class AiWebParser {
             if (hasCoverage) continue;
 
             const candidate = normalizedUrls.find(url => !this.isLikelyUninterestingImageUrl(url));
-            if (!candidate) continue;
+            if (!candidate) {
+                // A segment whose images ALL look uninteresting gets no OCR at
+                // all — say so instead of silently skipping (this hid the run
+                // where a flyer's hex asset ID tripped the old '404' pattern).
+                if (normalizedUrls.length > 0) {
+                    console.log(`🤖 AI Web: OCR top-up skipped a segment — all ${normalizedUrls.length} of its image(s) look uninteresting (first: ${normalizedUrls[0]})`);
+                }
+                continue;
+            }
             const strippedCandidate = this.stripSizeParams(candidate);
             if (targetStrippedUrls.has(strippedCandidate)) continue;
             targetStrippedUrls.add(strippedCandidate);

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1059,6 +1059,21 @@ test('embedded Google Maps URLs are uninteresting images', () => {
   assert.equal(parser.isLikelyUninterestingImageUrl('https://x.example/images/flyer.jpg'), false);
 });
 
+test("'404' flags standalone segments only, never hex asset IDs or pixel sizes", () => {
+  const parser = createParser();
+  // Regression (run 20260723-152928): the Boston flyer's Wix asset ID contains
+  // "c4047c55" — the old bare-substring '404' pattern flagged the flyer as a
+  // 404-error image, so it was never OCR'd and the event lost its start time.
+  assert.equal(
+    parser.isLikelyUninterestingImageUrl('https://static.wixstatic.com/media/238fae_c4047c55f4534a0990b2b7fdc19dab8f~mv2.png/v1/fill/w_577,h_1027,al_c,q_90,usm_0.66_1.00_0.01,enc_avif,quality_auto/238fae_c4047c55f4534a0990b2b7fdc19dab8f~mv2.png'),
+    false
+  );
+  assert.equal(parser.isLikelyUninterestingImageUrl('https://x.example/img/w_1404,h_900/flyer.jpg'), false);
+  assert.equal(parser.isLikelyUninterestingImageUrl('https://x.example/404.png'), true);
+  assert.equal(parser.isLikelyUninterestingImageUrl('https://x.example/assets/error-404.jpg'), true);
+  assert.equal(parser.isLikelyUninterestingImageUrl('https://x.example/404/not-found.png'), true);
+});
+
 test('normalizeAiEvent rolls past-midnight end times to the next day', () => {
   const parser = createParser();
   const cityConfig = { nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc'] } };


### PR DESCRIPTION
## What broke
FURBALL Boston saved with **no start time** (calendar defaulted to midnight, shown as "12") even though the flyer says 10PM.

Root cause chain, from run 20260723-152928:
1. The furball.nyc Boston segment's only time source is its flyer image — the page text has no time, and Furball runs with `urlDiscoveryDepth: 0` so the TicketWeb page (which has the time) is never crawled.
2. The flyer's Wix asset ID is `238fae_`**`c404`**`7c55f4534a…` — the uninteresting-image filter matched the pattern `'404'` as a bare substring inside the random hex hash and classified the flyer as a **404-error image**.
3. That excluded it from the page-level OCR pass AND from the segment OCR top-up (whose only candidate it was), so the top-up silently skipped the segment. `Segment failed to match any of the 7 OCR results` → no OCR text → `startTime` empty → midnight.

Reproduced locally against the live furball.nyc page: segment 0 (Boston) had `candidate: NONE` before the fix, a valid candidate after.

## Fix
- `'404'` now only matches as a standalone segment between non-alphanumerics (`/404.png`, `error-404.jpg`, `/404/…`) — never inside hex asset IDs or pixel sizes (`w_1404`). It's the only pattern in the list that can occur inside a hex hash (all other patterns contain non-hex letters).
- The segment OCR top-up logs `OCR top-up skipped a segment — all N of its image(s) look uninteresting` instead of silently skipping, so this failure mode is visible in run logs from now on.

## Tests
672 pass (671 baseline + 1 new): the exact Boston flyer URL passes the filter, `w_1404` sizes pass, `/404.png`, `error-404.jpg`, and `/404/` still get flagged.

## After merge
Re-run Furball: the Boston flyer gets OCR'd (fresh vision request — it was never cached), the 10PM should extract, and executing the run will correct the calendar event's time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP