### PR TITLE
feat(scraper): bar rescue by signal convergence + curate Legacy (Boston)

### DIFF
--- a/data/bars/boston.json
+++ b/data/bars/boston.json
@@ -8,5 +8,13 @@
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJDzxFQ4Rw44kRAxo45UBkJKM",
     "gayCities": "https://boston.gaycities.com/bars/127-the-alley-bar",
     "gayCitiesLastScrapedAt": "2026-06-13T20:34:56.886Z"
+  },
+  {
+    "name": "Legacy",
+    "city": "boston",
+    "address": "79 Warrenton St, Boston, MA 02116",
+    "coordinates": "42.3499063, -71.0658453",
+    "website": "https://legacybos.com",
+    "instagram": "https://www.instagram.com/legacybos"
   }
 ]

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -5,7 +5,9 @@
       "city": "atlanta",
       "address": "2069 Cheshire Bridge Rd NE, Atlanta, GA 30324",
       "coordinates": "33.8115012, -84.3552779",
-      "website": "https://hereticatlanta.com"
+      "website": "https://hereticatlanta.com",
+      "faviconBg": "#481818",
+      "faviconFg": "#a09f9f"
     }
   ],
   "bangkok": [
@@ -46,6 +48,14 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJDzxFQ4Rw44kRAxo45UBkJKM",
       "gayCities": "https://boston.gaycities.com/bars/127-the-alley-bar",
       "gayCitiesLastScrapedAt": "2026-06-13T20:34:56.886Z"
+    },
+    {
+      "name": "Legacy",
+      "city": "boston",
+      "address": "79 Warrenton St, Boston, MA 02116",
+      "coordinates": "42.3499063, -71.0658453",
+      "website": "https://legacybos.com",
+      "instagram": "https://www.instagram.com/legacybos"
     }
   ],
   "chicago": [
@@ -326,7 +336,9 @@
       "city": "nola",
       "address": "1200 Canal St, New Orleans, LA 70112",
       "coordinates": "29.9559524, -90.0738975",
-      "website": "https://thejoytheater.com"
+      "website": "https://thejoytheater.com",
+      "faviconBg": "#f22922",
+      "faviconFg": "#221e1f"
     }
   ],
   "nyc": [
@@ -630,6 +642,8 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJOcPt38pqkFQRWmTOs3bUrgk",
       "wikipedia": "https://en.wikipedia.org/wiki/Seattle_Eagle",
       "gayCities": "https://seattle.gaycities.com/bars/506-seattle-eagle",
+      "faviconBg": "#20201f",
+      "faviconFg": "#8a836c",
       "gayCitiesLastScrapedAt": "2026-06-26T17:08:43.316Z",
       "wikipediaLastScrapedAt": "2026-06-26T15:16:42.842Z"
     },
@@ -733,7 +747,9 @@
       "city": "sf",
       "address": "161 Erie St, San Francisco, CA 94103",
       "coordinates": "37.7688931, -122.4192651",
-      "website": "https://publicsf.com"
+      "website": "https://publicsf.com",
+      "faviconBg": "#f35425",
+      "faviconFg": "#fd5825"
     }
   ],
   "tokyo": [

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -679,6 +679,13 @@ class AiWebParser {
         // name — and it sailed through to geocoding). Runs BEFORE the bar
         // corroboration stamp so a dropped address never feeds adjacency.
         this.applyAddressPlausibilityGate(event, promptHtmlData);
+        // Deterministic venue-line bar rescue: only when extraction left NO
+        // bar (including a gate-dropped one). Scans the segment/page text —
+        // never the OCR prepend — for the venue line above a "City, ST" line
+        // and adopts it ONLY with independent corroboration (curated/OCR).
+        // Runs BEFORE the barSource stamp so an adopted bar carries its own
+        // provenance; a model-returned surviving bar makes this a no-op.
+        this.applyVenueLineBarRescue(event, htmlData, parserConfig, cityConfig);
         // Bar corroboration stamp (barSource): checks the final bar+address
         // pair against the same corpora the evidence gate uses (page text,
         // OCR text, segment text). Flag-don't-drop: values are never changed.
@@ -809,6 +816,10 @@ class AiWebParser {
         return {
             ...htmlData,
             html: contextLines.length > 0 ? `${contextLines.join('\n')}\n${segmentContent}` : segmentContent,
+            // The segment's own page text WITHOUT the resource/OCR context
+            // lines — the venue-line bar rescue scans this so OCR text stays
+            // an independent corroboration signal, never the scan source.
+            segmentText: segmentContent,
             aiEvent: null,
             aiExtraction: null,
             ocrResults: segmentOcrResults,
@@ -9753,6 +9764,148 @@ TEXT:
         console.log(`🤖 AI Web: Dropped implausible address "${address}" (${reason})`);
         delete event.address;
         return event;
+    }
+
+    // Deterministic venue-line bar rescue (run 20260723-224434: the FURBALL
+    // Boston segment plainly listed its venue "Legacy" on its own line
+    // directly above "Boston, MA", but the model returned the street address
+    // as the bar and the verbatim gate dropped it — leaving no bar, and
+    // therefore no venue-POI address or pin; earlier runs extracted "Legacy"
+    // from the very same text, i.e. pure model nondeterminism). When
+    // extraction produced NO bar, scan the segment's page text (for
+    // single-page events, the page text — never the OCR prepend, so OCR
+    // stays an independent corroboration signal) for a "City, ST" location
+    // line and take the nearest non-empty line ABOVE it as the venue
+    // candidate. Candidates that can never be a venue name are rejected
+    // deterministically (see getVenueLineCandidateRejection). Adoption
+    // REQUIRES independent corroboration — core doctrine: never a bar from a
+    // single signal:
+    //   - curated: candidate matches a curated bar for the event's city →
+    //     curated casing, barSource 'curated';
+    //   - ocr: candidate appears whole-word (case-insensitive) in the
+    //     event's OCR image text → barSource 'page-adjacent'.
+    // Neither signal → log-only (flag-don't-drop), nothing adopted. Never
+    // runs when a model-returned bar survived the gate (a surviving
+    // extraction is not second-guessed), and operates purely on the scraped
+    // event pre-merge — calendar-side bars are untouched.
+    applyVenueLineBarRescue(event, htmlData, parserConfig, cityConfig) {
+        if (!event || typeof event !== 'object') return event;
+        const existingBar = typeof event.bar === 'string' ? event.bar.trim() : '';
+        if (existingBar) return event;
+        const segmentText = htmlData && typeof htmlData.segmentText === 'string' ? htmlData.segmentText : '';
+        const scanText = segmentText.trim()
+            ? segmentText
+            : (this.buildAiEvidenceContext(htmlData, parserConfig).raw || '');
+        if (!scanText.trim()) return event;
+        const lines = scanText.split('\n').map(line => line.trim());
+        let candidate = '';
+        let locationLine = '';
+        let locationCityKey = '';
+        for (let i = 1; i < lines.length; i++) {
+            const line = lines[i];
+            if (!line) continue;
+            // Location-form line: an explicit "<Place>, <Place>" pair that
+            // also resolves to a configured city ("Boston, MA" → boston).
+            if (!this.extractAdjacentLocationPlacePair(line, event)) continue;
+            const cityKey = this.findCityKeyInText(line, cityConfig);
+            if (!cityKey) continue;
+            for (let j = i - 1; j >= 0; j -= 1) {
+                if (lines[j]) {
+                    candidate = lines[j];
+                    break;
+                }
+            }
+            locationLine = line;
+            locationCityKey = cityKey;
+            break; // first location line only — a noisy segment proves nothing
+        }
+        if (!candidate || !locationLine) return event;
+        if (this.getVenueLineCandidateRejection(candidate, event, htmlData)) return event;
+
+        // Corroboration signals — each independent of the page line itself.
+        const signals = [];
+        let curatedBar = null;
+        const curatedCityKey = (typeof event.city === 'string' && event.city.trim())
+            ? event.city.trim()
+            : locationCityKey;
+        if (this.core && typeof this.core.getCuratedCityBars === 'function'
+            && typeof this.core.findCuratedBarByName === 'function') {
+            try {
+                const cityBars = this.core.getCuratedCityBars(curatedCityKey);
+                curatedBar = cityBars ? this.core.findCuratedBarByName(cityBars, candidate) : null;
+            } catch (_) {
+                curatedBar = null; // curated matching is best-effort — fail open to OCR
+            }
+        }
+        if (curatedBar) signals.push('curated');
+        const ocrResults = htmlData && Array.isArray(htmlData.ocrResults) ? htmlData.ocrResults : [];
+        const escapedCandidate = candidate
+            .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            .replace(/\s+/g, '\\s+');
+        const wholeWordPattern = new RegExp(`(?:^|[^A-Za-z0-9])${escapedCandidate}(?=$|[^A-Za-z0-9])`, 'i');
+        if (ocrResults.some(ocr => ocr && typeof ocr.text === 'string' && wholeWordPattern.test(ocr.text))) {
+            signals.push('ocr');
+        }
+        if (signals.length === 0) {
+            console.log(`🤖 AI Web: Venue-line candidate "${candidate}" found above city line but uncorroborated — not adopted`);
+            return event;
+        }
+        event.bar = curatedBar ? curatedBar.name : candidate;
+        event.barSource = curatedBar ? 'curated' : 'page-adjacent';
+        // Underscore field — internal metadata, never serialized into notes;
+        // shared-core's buildEventEvidenceLines renders it in the evidence
+        // panel so a rescued bar is always visible in the results UI.
+        event._barRescue = {
+            candidate: candidate,
+            locationLine: locationLine,
+            signals: signals
+        };
+        console.log(`🤖 AI Web: Rescued bar "${event.bar}" from venue line above city line (corroborated: ${signals.join(', ')})`);
+        return event;
+    }
+
+    // '' when the venue-line candidate could plausibly be a venue name;
+    // otherwise the deterministic reason it can never be one. Rejection is
+    // silent — an unusable line above the city line is the common case, not a
+    // signal worth logging.
+    getVenueLineCandidateRejection(candidate, event, htmlData) {
+        const text = String(candidate || '').trim();
+        if (!text) return 'empty';
+        if (text.length > 40) return 'too long';
+        if (/(?:https?:\/\/|www\.)/i.test(text)) return 'url';
+        if (/[$€£]\s*\d/.test(text) || /\b\d+\s*(?:dollars|usd)\b/i.test(text)) return 'price';
+        if (/\b\d{1,2}:\d{2}\b/.test(text) || /\b\d{1,2}\s*(?:am|pm)\b/i.test(text)) return 'time';
+        if (/\b(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|june?|july?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\b[\s.,]*\d{1,2}/i.test(text)
+            || /\b\d{1,2}\/\d{1,2}(?:\/\d{2,4})?\b/.test(text)
+            || /\b(?:mon|tues?|wednes|thurs?|fri|satur|sun)day\b/i.test(text)
+            || /\b20\d{2}\b/.test(text)) return 'date';
+        const normalized = this.normalizeAdjacencyText(text);
+        if (!normalized) return 'empty';
+        const stopwords = new Set([
+            'tickets', 'ticket', 'info', 'rsvp', 'free', 'doors', 'details',
+            'presents', 'vip', 'admission', 'cover', 'ages', 'buy', 'get',
+            'more', 'here', 'tba', 'tbd'
+        ]);
+        if (normalized.split(' ').every(token => stopwords.has(token) || /^\d+$/.test(token))) {
+            return 'generic';
+        }
+        const title = this.normalizeAdjacencyText(event && event.title);
+        if (title && normalized === title) return 'matches event title';
+        const organizer = event && typeof event._organizer === 'string' ? event._organizer.trim() : '';
+        const brandNames = this.getPageBrandNames(htmlData);
+        const knownNames = [organizer, ...(Array.isArray(brandNames) ? brandNames : [])]
+            .filter(name => typeof name === 'string' && name.trim());
+        if (knownNames.length > 0 && this.matchesPageBrandName(text, knownNames)) {
+            return 'matches organizer/brand';
+        }
+        if (this.core && typeof this.core.looksLikeStreetAddress === 'function'
+            && this.core.looksLikeStreetAddress(text)) return 'address-shaped';
+        if (/\d/.test(text)
+            && /(?:^|\s)(?:St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Ln|Lane|Way|Hwy|Pl|Place|Ct|Court)\.?(?:\s|$)/i.test(text)) {
+            return 'address-shaped';
+        }
+        if (this.extractAdjacentLocationPlacePair(text, event)) return 'location line';
+        return '';
     }
 
     // barSource provenance stamp (notes-serialized like imageSource, excluded

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -679,13 +679,14 @@ class AiWebParser {
         // name — and it sailed through to geocoding). Runs BEFORE the bar
         // corroboration stamp so a dropped address never feeds adjacency.
         this.applyAddressPlausibilityGate(event, promptHtmlData);
-        // Deterministic venue-line bar rescue: only when extraction left NO
-        // bar (including a gate-dropped one). Scans the segment/page text —
-        // never the OCR prepend — for the venue line above a "City, ST" line
-        // and adopts it ONLY with independent corroboration (curated/OCR).
+        // Deterministic bar-convergence rescue: only when extraction left NO
+        // bar (including a gate-dropped one). Every plausible name line from
+        // the page text, the OCR text, and the curated bars corpus is a
+        // candidate; adoption requires >= 2 independent signals (curated,
+        // page, ocr) — position is only a tie-breaker, never an anchor.
         // Runs BEFORE the barSource stamp so an adopted bar carries its own
         // provenance; a model-returned surviving bar makes this a no-op.
-        this.applyVenueLineBarRescue(event, htmlData, parserConfig, cityConfig);
+        this.applyBarConvergenceRescue(event, htmlData, parserConfig, cityConfig);
         // Bar corroboration stamp (barSource): checks the final bar+address
         // pair against the same corpora the evidence gate uses (page text,
         // OCR text, segment text). Flag-don't-drop: values are never changed.
@@ -817,8 +818,8 @@ class AiWebParser {
             ...htmlData,
             html: contextLines.length > 0 ? `${contextLines.join('\n')}\n${segmentContent}` : segmentContent,
             // The segment's own page text WITHOUT the resource/OCR context
-            // lines — the venue-line bar rescue scans this so OCR text stays
-            // an independent corroboration signal, never the scan source.
+            // lines — the bar-convergence rescue's PAGE corpus, so OCR text
+            // stays an independent signal instead of leaking into the page.
             segmentText: segmentContent,
             aiEvent: null,
             aiExtraction: null,
@@ -9766,108 +9767,211 @@ TEXT:
         return event;
     }
 
-    // Deterministic venue-line bar rescue (run 20260723-224434: the FURBALL
-    // Boston segment plainly listed its venue "Legacy" on its own line
-    // directly above "Boston, MA", but the model returned the street address
-    // as the bar and the verbatim gate dropped it — leaving no bar, and
-    // therefore no venue-POI address or pin; earlier runs extracted "Legacy"
-    // from the very same text, i.e. pure model nondeterminism). When
-    // extraction produced NO bar, scan the segment's page text (for
-    // single-page events, the page text — never the OCR prepend, so OCR
-    // stays an independent corroboration signal) for a "City, ST" location
-    // line and take the nearest non-empty line ABOVE it as the venue
-    // candidate. Candidates that can never be a venue name are rejected
-    // deterministically (see getVenueLineCandidateRejection). Adoption
-    // REQUIRES independent corroboration — core doctrine: never a bar from a
-    // single signal:
-    //   - curated: candidate matches a curated bar for the event's city →
-    //     curated casing, barSource 'curated';
-    //   - ocr: candidate appears whole-word (case-insensitive) in the
-    //     event's OCR image text → barSource 'page-adjacent'.
-    // Neither signal → log-only (flag-don't-drop), nothing adopted. Never
-    // runs when a model-returned bar survived the gate (a surviving
-    // extraction is not second-guessed), and operates purely on the scraped
-    // event pre-merge — calendar-side bars are untouched.
-    applyVenueLineBarRescue(event, htmlData, parserConfig, cityConfig) {
+    // Deterministic bar-convergence rescue (run 20260723-224434: the FURBALL
+    // Boston segment plainly listed its venue "Legacy", the flyer OCR read
+    // "LEGACY", and Legacy is a curated Boston bar — but the model returned
+    // the street address as the bar and the verbatim gate dropped it,
+    // leaving no bar, no venue-POI address, no pin). When extraction
+    // produced NO bar, three independent corpora vote:
+    //   - PAGE:    every line of the segment's page text (single-page events
+    //              fall back to the page evidence text — never the OCR
+    //              prepend, so OCR stays an independent signal);
+    //   - OCR:     every line of the event's OCR image text;
+    //   - CURATED: every curated bar name for the event's city (event.city,
+    //              else any city key resolvable from the page text).
+    // PAGE/OCR lines become candidates only when the deterministic
+    // could-be-a-name filter passes (getVenueLineCandidateRejection);
+    // curated names are always candidates. Candidates that normalize to the
+    // same bar-name key (normalizeBarNameKey: "LEGACY"/"Legacy"/"The
+    // Legacy") are ONE candidate. Each candidate then carries up to three
+    // signals — curated match, whole-word presence in PAGE, whole-word
+    // presence in OCR — and is adopted only with >= 2 of the 3. Never one
+    // signal alone: core doctrine, a bar is never invented from a single
+    // corpus. No positional anchor anywhere; position appears only as a
+    // ranking tie-breaker (proximity to a location/address-shaped PAGE
+    // line), so layout changes — venue below the city line, venue only on
+    // the flyer, extra noise — cannot break the rescue. A still-tied top
+    // pair adopts nothing (ambiguity is logged, never guessed). Never runs
+    // when a model-returned bar survived the gate (a surviving extraction is
+    // not second-guessed), and operates purely on the scraped event
+    // pre-merge — calendar-side bars are untouched.
+    applyBarConvergenceRescue(event, htmlData, parserConfig, cityConfig) {
         if (!event || typeof event !== 'object') return event;
         const existingBar = typeof event.bar === 'string' ? event.bar.trim() : '';
         if (existingBar) return event;
+
+        // Corpus PAGE — the segment's own text, page evidence text fallback.
         const segmentText = htmlData && typeof htmlData.segmentText === 'string' ? htmlData.segmentText : '';
-        const scanText = segmentText.trim()
+        const pageText = segmentText.trim()
             ? segmentText
             : (this.buildAiEvidenceContext(htmlData, parserConfig).raw || '');
-        if (!scanText.trim()) return event;
-        const lines = scanText.split('\n').map(line => line.trim());
-        let candidate = '';
-        let locationLine = '';
-        let locationCityKey = '';
-        for (let i = 1; i < lines.length; i++) {
-            const line = lines[i];
-            if (!line) continue;
-            // Location-form line: an explicit "<Place>, <Place>" pair that
-            // also resolves to a configured city ("Boston, MA" → boston).
-            if (!this.extractAdjacentLocationPlacePair(line, event)) continue;
-            const cityKey = this.findCityKeyInText(line, cityConfig);
-            if (!cityKey) continue;
-            for (let j = i - 1; j >= 0; j -= 1) {
-                if (lines[j]) {
-                    candidate = lines[j];
-                    break;
-                }
-            }
-            locationLine = line;
-            locationCityKey = cityKey;
-            break; // first location line only — a noisy segment proves nothing
-        }
-        if (!candidate || !locationLine) return event;
-        if (this.getVenueLineCandidateRejection(candidate, event, htmlData)) return event;
+        // Corpus OCR — every OCR result's text for this event.
+        const ocrResults = htmlData && Array.isArray(htmlData.ocrResults) ? htmlData.ocrResults : [];
+        const ocrCorpus = ocrResults
+            .map(ocr => (ocr && typeof ocr.text === 'string' ? ocr.text : ''))
+            .filter(text => text.trim())
+            .join('\n');
+        if (!pageText.trim() && !ocrCorpus) return event;
+        const pageLines = pageText.split('\n').map(line => line.trim());
+        const ocrLines = ocrCorpus.split('\n').map(line => line.trim());
 
-        // Corroboration signals — each independent of the page line itself.
-        const signals = [];
-        let curatedBar = null;
+        // Corpus CURATED — the event's city first, else any city key the
+        // page text itself resolves to (best-effort: no city, no curated
+        // corpus, but PAGE+OCR convergence still works).
         const curatedCityKey = (typeof event.city === 'string' && event.city.trim())
             ? event.city.trim()
-            : locationCityKey;
+            : this.findCityKeyInText(pageText, cityConfig);
+        let cityBars = null;
         if (this.core && typeof this.core.getCuratedCityBars === 'function'
             && typeof this.core.findCuratedBarByName === 'function') {
             try {
-                const cityBars = this.core.getCuratedCityBars(curatedCityKey);
-                curatedBar = cityBars ? this.core.findCuratedBarByName(cityBars, candidate) : null;
+                cityBars = this.core.getCuratedCityBars(curatedCityKey);
             } catch (_) {
-                curatedBar = null; // curated matching is best-effort — fail open to OCR
+                cityBars = null; // curated corpus is best-effort — fail open
             }
         }
-        if (curatedBar) signals.push('curated');
-        const ocrResults = htmlData && Array.isArray(htmlData.ocrResults) ? htmlData.ocrResults : [];
-        const escapedCandidate = candidate
-            .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-            .replace(/\s+/g, '\\s+');
-        const wholeWordPattern = new RegExp(`(?:^|[^A-Za-z0-9])${escapedCandidate}(?=$|[^A-Za-z0-9])`, 'i');
-        if (ocrResults.some(ocr => ocr && typeof ocr.text === 'string' && wholeWordPattern.test(ocr.text))) {
-            signals.push('ocr');
+
+        // Candidate pool, deduped on the shared bar-name identity key so
+        // "LEGACY" (OCR) + "Legacy" (page) + curated "Legacy" are ONE
+        // candidate accumulating all three signals.
+        const normalizeKey = value => (this.core && typeof this.core.normalizeBarNameKey === 'function'
+            ? this.core.normalizeBarNameKey(value)
+            : String(value || '').toLowerCase().replace(/^\s*the\s+/, '').replace(/[^a-z0-9]/g, ''));
+        const candidates = new Map();
+        const addCandidate = (text, origin) => {
+            const form = String(text || '').trim();
+            const key = normalizeKey(form);
+            if (!key) return;
+            let entry = candidates.get(key);
+            if (!entry) {
+                entry = { forms: [], pageForm: '', ocrForm: '' };
+                candidates.set(key, entry);
+            }
+            if (!entry.forms.includes(form)) entry.forms.push(form);
+            if (origin === 'page' && !entry.pageForm) entry.pageForm = form;
+            if (origin === 'ocr' && !entry.ocrForm) entry.ocrForm = form;
+        };
+        // The could-be-a-name filter runs BEFORE signals: an organizer brand
+        // or address line never becomes a candidate no matter how many
+        // corpora repeat it. Curated names are trusted venue names, so the
+        // shape rejections don't apply to them — but the organizer/brand and
+        // event-title guards are absolute: the promoter is never rescued as
+        // the venue, curated or not.
+        pageLines.forEach(line => {
+            if (line && !this.getVenueLineCandidateRejection(line, event, htmlData)) addCandidate(line, 'page');
+        });
+        ocrLines.forEach(line => {
+            if (line && !this.getVenueLineCandidateRejection(line, event, htmlData)) addCandidate(line, 'ocr');
+        });
+        (Array.isArray(cityBars) ? cityBars : []).forEach(bar => {
+            if (!bar || typeof bar.name !== 'string') return;
+            const rejection = this.getVenueLineCandidateRejection(bar.name, event, htmlData);
+            if (rejection === 'matches organizer/brand' || rejection === 'matches event title') return;
+            addCandidate(bar.name, 'curated');
+        });
+        if (candidates.size === 0) return event;
+
+        // Whole-word, case-insensitive, flexible-whitespace presence test —
+        // every surface form of the candidate counts, so a curated "The
+        // Eagle" still finds the page's plain "Eagle" line.
+        const buildWholeWordPattern = form => {
+            const escaped = form
+                .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+                .replace(/\s+/g, '\\s+');
+            return new RegExp(`(?:^|[^A-Za-z0-9])${escaped}(?=$|[^A-Za-z0-9])`, 'i');
+        };
+
+        // Proximity anchors for the tie-break: location-form or
+        // address-shaped PAGE lines. Position's ONLY appearance.
+        const anchorIndexes = [];
+        pageLines.forEach((line, index) => {
+            if (line && this.isLocationAnchorLine(line, event)) anchorIndexes.push(index);
+        });
+
+        const scored = [];
+        for (const entry of candidates.values()) {
+            const patterns = entry.forms.map(buildWholeWordPattern);
+            const pageIndexes = [];
+            pageLines.forEach((line, index) => {
+                if (line && patterns.some(pattern => pattern.test(line))) pageIndexes.push(index);
+            });
+            const curatedBar = cityBars ? this.core.findCuratedBarByName(cityBars, entry.forms[0]) : null;
+            const signals = [];
+            if (curatedBar) signals.push('curated');
+            if (pageIndexes.length > 0) signals.push('page');
+            if (ocrCorpus && patterns.some(pattern => pattern.test(ocrCorpus))) signals.push('ocr');
+            scored.push({
+                curatedBar,
+                signals,
+                // Fewest lines from any anchor, over every PAGE occurrence;
+                // candidates absent from PAGE rank last here.
+                proximity: (pageIndexes.length > 0 && anchorIndexes.length > 0)
+                    ? Math.min(...pageIndexes.map(i => Math.min(...anchorIndexes.map(a => Math.abs(i - a)))))
+                    : Infinity,
+                firstPageIndex: pageIndexes.length > 0 ? pageIndexes[0] : Infinity,
+                // Adopted casing: curated wins, else the page's, else OCR's.
+                name: curatedBar ? curatedBar.name : (entry.pageForm || entry.ocrForm || entry.forms[0]),
+                // The raw observed text (page first) for provenance.
+                candidateForm: entry.pageForm || entry.ocrForm || entry.forms[0]
+            });
         }
-        if (signals.length === 0) {
-            console.log(`🤖 AI Web: Venue-line candidate "${candidate}" found above city line but uncorroborated — not adopted`);
+        // Ranking: curated signal, then signal count, then anchor proximity,
+        // then earliest PAGE appearance. 0 = genuinely indistinguishable.
+        const compareCandidates = (a, b) => {
+            if ((a.curatedBar ? 1 : 0) !== (b.curatedBar ? 1 : 0)) return (b.curatedBar ? 1 : 0) - (a.curatedBar ? 1 : 0);
+            if (a.signals.length !== b.signals.length) return b.signals.length - a.signals.length;
+            if (a.proximity !== b.proximity) return a.proximity - b.proximity;
+            if (a.firstPageIndex !== b.firstPageIndex) return a.firstPageIndex - b.firstPageIndex;
+            return 0;
+        };
+        scored.sort(compareCandidates);
+        const qualified = scored.filter(candidate => candidate.signals.length >= 2);
+        if (qualified.length === 0) {
+            // Log-only (flag-don't-drop): name the best candidate actually
+            // observed in a text corpus. A curated name absent from both
+            // texts is not worth naming — the page never hinted at it.
+            const observed = scored.find(candidate =>
+                candidate.signals.includes('page') || candidate.signals.includes('ocr'));
+            if (observed) {
+                console.log(`🤖 AI Web: Bar rescue candidate "${observed.name}" carries only one signal (${observed.signals.join(', ')}) — not adopted`);
+            }
             return event;
         }
-        event.bar = curatedBar ? curatedBar.name : candidate;
-        event.barSource = curatedBar ? 'curated' : 'page-adjacent';
+        const top = qualified[0];
+        if (qualified.length > 1 && compareCandidates(top, qualified[1]) === 0) {
+            console.log(`🤖 AI Web: Bar rescue ambiguous between "${top.name}" and "${qualified[1].name}" — not adopted`);
+            return event;
+        }
+        event.bar = top.name;
+        event.barSource = top.curatedBar ? 'curated' : 'page-adjacent';
         // Underscore field — internal metadata, never serialized into notes;
         // shared-core's buildEventEvidenceLines renders it in the evidence
         // panel so a rescued bar is always visible in the results UI.
         event._barRescue = {
-            candidate: candidate,
-            locationLine: locationLine,
-            signals: signals
+            candidate: top.candidateForm,
+            signals: top.signals
         };
-        console.log(`🤖 AI Web: Rescued bar "${event.bar}" from venue line above city line (corroborated: ${signals.join(', ')})`);
+        console.log(`🤖 AI Web: Rescued bar "${event.bar}" via signal convergence (signals: ${top.signals.join(', ')})`);
         return event;
     }
 
-    // '' when the venue-line candidate could plausibly be a venue name;
-    // otherwise the deterministic reason it can never be one. Rejection is
-    // silent — an unusable line above the city line is the common case, not a
-    // signal worth logging.
+    // A PAGE line that anchors the bar-rescue proximity tie-break: an
+    // explicit "<Place>, <Place>" location line or an address-shaped line
+    // (same shapes getVenueLineCandidateRejection rejects as candidates).
+    isLocationAnchorLine(line, event) {
+        const text = String(line || '').trim();
+        if (!text) return false;
+        if (this.extractAdjacentLocationPlacePair(text, event)) return true;
+        if (this.core && typeof this.core.looksLikeStreetAddress === 'function'
+            && this.core.looksLikeStreetAddress(text)) return true;
+        return /\d/.test(text)
+            && /(?:^|\s)(?:St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Ln|Lane|Way|Hwy|Pl|Place|Ct|Court)\.?(?:\s|$)/i.test(text);
+    }
+
+    // '' when a corpus line could plausibly be a venue name; otherwise the
+    // deterministic reason it can never be one. Rejection is silent — an
+    // unusable line is the common case in any corpus, not a signal worth
+    // logging.
     getVenueLineCandidateRejection(candidate, event, htmlData) {
         const text = String(candidate || '').trim();
         if (!text) return 'empty';

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -4181,3 +4181,184 @@ test('evidence-pointer rescue: snippet-pass memos concatenate through mergeAiEve
     { field: 'bar', candidate: 'B', modelValue: 'b', corpus: 'page' }
   ]);
 });
+
+// Deterministic venue-line bar rescue (run 20260723-224434: the FURBALL
+// Boston segment listed the venue "Legacy" on its own line directly above
+// "Boston, MA", but the model returned the street address as the bar and the
+// verbatim gate dropped it — no bar, so no venue-POI address/pin either).
+// The rescue is corroboration-gated: curated and/or OCR, never the page line
+// alone, and it never runs over a surviving model-returned bar.
+// ---------------------------------------------------------------------------
+
+const RESCUE_CITY_CONFIG = {
+  cities: {
+    boston: { name: 'Boston', patterns: ['boston'], timezone: 'America/New_York' }
+  }
+};
+
+// The real segment shape from furball.nyc.
+const FURBALL_BOSTON_SEGMENT = [
+  'FURBALL Boston',
+  'Bear Week Return',
+  'Legacy',
+  'Boston, MA',
+  'July 25, 2026'
+].join('\n');
+
+// The flyer OCR independently names the venue and its street.
+const FURBALL_BOSTON_OCR = 'FURBALL BOSTON\nBEAR WEEK RETURN\nLEGACY\n79 WARRENTON\nJULY 25 2026';
+
+const BOSTON_CURATED_BARS = {
+  boston: [{ name: 'Legacy', city: 'boston', address: '79 Warrenton St, Boston, MA 02116' }]
+};
+
+function createRescueParser(bars) {
+  const parser = createParser();
+  parser.core = new SharedCore({}, { eventSchema: EventSchema, bars: bars || {} });
+  return parser;
+}
+
+function rescueHtmlData(overrides = {}) {
+  return {
+    url: 'https://furball.nyc/events',
+    html: '<html><body>multi-event page</body></html>',
+    segmentText: FURBALL_BOSTON_SEGMENT,
+    ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: FURBALL_BOSTON_OCR }],
+    pageBrandNames: ['FURBALL'],
+    ...overrides
+  };
+}
+
+test('venue-line rescue: the FURBALL Boston segment rescues "Legacy" (curated + ocr), barSource curated, downstream stamp untouched', () => {
+  const parser = createRescueParser(BOSTON_CURATED_BARS);
+  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  const logs = captureLogs(() => {
+    parser.applyVenueLineBarRescue(event, rescueHtmlData(), {}, RESCUE_CITY_CONFIG);
+  });
+  assert.equal(event.bar, 'Legacy');
+  assert.equal(event.barSource, 'curated');
+  assert.deepEqual(event._barRescue, {
+    candidate: 'Legacy',
+    locationLine: 'Boston, MA',
+    signals: ['curated', 'ocr']
+  });
+  assert.ok(logs.includes(
+    '🤖 AI Web: Rescued bar "Legacy" from venue line above city line (corroborated: curated, ocr)'
+  ), `rescue log expected, got: ${JSON.stringify(logs)}`);
+
+  // The existing barSource stamp is already-stamped-aware: no re-stamp.
+  parser.stampBarSourceProvenance(event, parser.buildAiEvidenceContextFromText(FURBALL_BOSTON_SEGMENT), null);
+  assert.equal(event.barSource, 'curated');
+
+  // Curated casing wins over the page line's casing.
+  const shouting = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  parser.applyVenueLineBarRescue(
+    shouting,
+    rescueHtmlData({ segmentText: FURBALL_BOSTON_SEGMENT.replace('Legacy', 'LEGACY') }),
+    {},
+    RESCUE_CITY_CONFIG
+  );
+  assert.equal(shouting.bar, 'Legacy', 'curated casing adopted');
+  assert.equal(shouting.barSource, 'curated');
+});
+
+test('venue-line rescue: OCR-only corroboration (candidate not curated) adopts with barSource page-adjacent', () => {
+  const parser = createRescueParser({});
+  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  const logs = captureLogs(() => {
+    parser.applyVenueLineBarRescue(event, rescueHtmlData(), {}, RESCUE_CITY_CONFIG);
+  });
+  assert.equal(event.bar, 'Legacy', 'page-line casing kept without a curated record');
+  assert.equal(event.barSource, 'page-adjacent');
+  assert.deepEqual(event._barRescue.signals, ['ocr']);
+  assert.ok(logs.includes(
+    '🤖 AI Web: Rescued bar "Legacy" from venue line above city line (corroborated: ocr)'
+  ), `rescue log expected, got: ${JSON.stringify(logs)}`);
+});
+
+test('venue-line rescue: no corroboration → not adopted, log-only (flag-don\'t-drop)', () => {
+  const parser = createRescueParser({});
+  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  const logs = captureLogs(() => {
+    parser.applyVenueLineBarRescue(event, rescueHtmlData({ ocrResults: [] }), {}, RESCUE_CITY_CONFIG);
+  });
+  assert.equal('bar' in event, false, 'never adopted on the page line alone');
+  assert.equal('barSource' in event, false);
+  assert.equal('_barRescue' in event, false);
+  assert.ok(logs.includes(
+    '🤖 AI Web: Venue-line candidate "Legacy" found above city line but uncorroborated — not adopted'
+  ), `log-only line expected, got: ${JSON.stringify(logs)}`);
+});
+
+test('venue-line rescue: the organizer brand above the city line is never adopted, even fully corroborated', () => {
+  // Corroboration is deliberately available (curated + OCR both know
+  // "Furball") to prove the organizer guard fires BEFORE corroboration.
+  const parser = createRescueParser({ boston: [{ name: 'Furball', city: 'boston' }] });
+  const segment = [
+    'Bear Week Return',
+    'FURBALL',
+    'Boston, MA',
+    'July 25, 2026'
+  ].join('\n');
+  const event = { title: 'Bear Week Return', city: 'boston', _organizer: 'FURBALL' };
+  const logs = captureLogs(() => {
+    parser.applyVenueLineBarRescue(event, rescueHtmlData({ segmentText: segment }), {}, RESCUE_CITY_CONFIG);
+  });
+  assert.equal('bar' in event, false, 'the promoter is never rescued as the venue');
+  assert.equal('_barRescue' in event, false);
+  assert.ok(!logs.some(line => line.includes('Rescued bar')), `no adoption log, got: ${JSON.stringify(logs)}`);
+});
+
+test('venue-line rescue: address-shaped and date lines above the city line are never bar candidates', () => {
+  const parser = createRescueParser(BOSTON_CURATED_BARS);
+  const addressAbove = [
+    'FURBALL Boston',
+    'Legacy',
+    '79 Warrenton St',
+    'Boston, MA'
+  ].join('\n');
+  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  const logs = captureLogs(() => {
+    parser.applyVenueLineBarRescue(event, rescueHtmlData({ segmentText: addressAbove }), {}, RESCUE_CITY_CONFIG);
+  });
+  assert.equal('bar' in event, false, 'an address is not a venue name — and no hunting past it');
+  assert.ok(!logs.some(line => line.includes('Rescued bar')), `no adoption log, got: ${JSON.stringify(logs)}`);
+
+  const dateAbove = [
+    'FURBALL Boston',
+    'Legacy',
+    'July 25, 2026',
+    'Boston, MA'
+  ].join('\n');
+  const dated = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  parser.applyVenueLineBarRescue(dated, rescueHtmlData({ segmentText: dateAbove }), {}, RESCUE_CITY_CONFIG);
+  assert.equal('bar' in dated, false, 'a date line is not a venue name');
+});
+
+test('venue-line rescue: a model-returned surviving bar makes the rescue a no-op', () => {
+  const parser = createRescueParser(BOSTON_CURATED_BARS);
+  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston', bar: 'Club Cafe' };
+  const logs = captureLogs(() => {
+    parser.applyVenueLineBarRescue(event, rescueHtmlData(), {}, RESCUE_CITY_CONFIG);
+  });
+  assert.equal(event.bar, 'Club Cafe', 'a surviving extraction is never second-guessed');
+  assert.equal('barSource' in event, false, 'no stamp from the rescue');
+  assert.equal('_barRescue' in event, false);
+  assert.equal(logs.length, 0, `rescue must be silent, got: ${JSON.stringify(logs)}`);
+});
+
+test('venue-line rescue: single-page events fall back to the page text when no segmentText exists', () => {
+  const parser = createRescueParser(BOSTON_CURATED_BARS);
+  const html = '<html><head><title>FURBALL</title></head><body>'
+    + '<p>FURBALL Boston</p><p>Bear Week Return</p><p>Legacy</p><p>Boston, MA</p><p>July 25, 2026</p>'
+    + '</body></html>';
+  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  parser.applyVenueLineBarRescue(
+    event,
+    { url: 'https://furball.nyc/boston', html, ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: FURBALL_BOSTON_OCR }] },
+    {},
+    RESCUE_CITY_CONFIG
+  );
+  assert.equal(event.bar, 'Legacy');
+  assert.equal(event.barSource, 'curated');
+});

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -3964,6 +3964,7 @@ test('address gate shape rules: isPlausiblyAddressShaped', () => {
   assert.equal(parser.isPlausiblyAddressShaped(''), false);
 });
 
+
 // ---------------------------------------------------------------------------
 // Evidence-pointer rescue (LOG-ONLY observation phase): "trust the pointer,
 // not the copy". The extraction model is a good FINDER and a bad COPIER —
@@ -4182,12 +4183,14 @@ test('evidence-pointer rescue: snippet-pass memos concatenate through mergeAiEve
   ]);
 });
 
-// Deterministic venue-line bar rescue (run 20260723-224434: the FURBALL
-// Boston segment listed the venue "Legacy" on its own line directly above
-// "Boston, MA", but the model returned the street address as the bar and the
-// verbatim gate dropped it — no bar, so no venue-POI address/pin either).
-// The rescue is corroboration-gated: curated and/or OCR, never the page line
-// alone, and it never runs over a surviving model-returned bar.
+// Bar-convergence rescue (run 20260723-224434: the FURBALL Boston segment
+// plainly named its venue "Legacy" — page text, flyer OCR, and curated bars
+// all agreed — but the model returned the street address as the bar and the
+// verbatim gate dropped it; no bar, so no venue-POI address/pin either).
+// Systematic rule: every plausible name line from PAGE / OCR / CURATED is a
+// candidate, adoption requires >= 2 independent signals, and position is only
+// a ranking tie-breaker — so layout (venue above, below, flyer-only, noise in
+// between) never decides whether the rescue works.
 // ---------------------------------------------------------------------------
 
 const RESCUE_CITY_CONFIG = {
@@ -4229,21 +4232,20 @@ function rescueHtmlData(overrides = {}) {
   };
 }
 
-test('venue-line rescue: the FURBALL Boston segment rescues "Legacy" (curated + ocr), barSource curated, downstream stamp untouched', () => {
+test('bar convergence: the real FURBALL Boston segment rescues "Legacy" on all three signals, barSource curated, downstream stamp untouched', () => {
   const parser = createRescueParser(BOSTON_CURATED_BARS);
   const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
   const logs = captureLogs(() => {
-    parser.applyVenueLineBarRescue(event, rescueHtmlData(), {}, RESCUE_CITY_CONFIG);
+    parser.applyBarConvergenceRescue(event, rescueHtmlData(), {}, RESCUE_CITY_CONFIG);
   });
   assert.equal(event.bar, 'Legacy');
   assert.equal(event.barSource, 'curated');
   assert.deepEqual(event._barRescue, {
     candidate: 'Legacy',
-    locationLine: 'Boston, MA',
-    signals: ['curated', 'ocr']
+    signals: ['curated', 'page', 'ocr']
   });
   assert.ok(logs.includes(
-    '🤖 AI Web: Rescued bar "Legacy" from venue line above city line (corroborated: curated, ocr)'
+    '🤖 AI Web: Rescued bar "Legacy" via signal convergence (signals: curated, page, ocr)'
   ), `rescue log expected, got: ${JSON.stringify(logs)}`);
 
   // The existing barSource stamp is already-stamped-aware: no re-stamp.
@@ -4252,7 +4254,7 @@ test('venue-line rescue: the FURBALL Boston segment rescues "Legacy" (curated + 
 
   // Curated casing wins over the page line's casing.
   const shouting = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
-  parser.applyVenueLineBarRescue(
+  parser.applyBarConvergenceRescue(
     shouting,
     rescueHtmlData({ segmentText: FURBALL_BOSTON_SEGMENT.replace('Legacy', 'LEGACY') }),
     {},
@@ -4262,84 +4264,233 @@ test('venue-line rescue: the FURBALL Boston segment rescues "Legacy" (curated + 
   assert.equal(shouting.barSource, 'curated');
 });
 
-test('venue-line rescue: OCR-only corroboration (candidate not curated) adopts with barSource page-adjacent', () => {
+test('bar convergence: layout independence — the venue line BELOW the city line still converges via page + ocr', () => {
   const parser = createRescueParser({});
+  const below = [
+    'FURBALL Boston',
+    'Boston, MA',
+    'Legacy',
+    'July 25, 2026'
+  ].join('\n');
   const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
   const logs = captureLogs(() => {
-    parser.applyVenueLineBarRescue(event, rescueHtmlData(), {}, RESCUE_CITY_CONFIG);
+    parser.applyBarConvergenceRescue(
+      event,
+      rescueHtmlData({ segmentText: below, ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: 'LEGACY\n79 WARRENTON' }] }),
+      {},
+      RESCUE_CITY_CONFIG
+    );
   });
-  assert.equal(event.bar, 'Legacy', 'page-line casing kept without a curated record');
+  assert.equal(event.bar, 'Legacy', 'position is not an anchor — below the city line works too');
   assert.equal(event.barSource, 'page-adjacent');
-  assert.deepEqual(event._barRescue.signals, ['ocr']);
+  assert.deepEqual(event._barRescue.signals, ['page', 'ocr']);
   assert.ok(logs.includes(
-    '🤖 AI Web: Rescued bar "Legacy" from venue line above city line (corroborated: ocr)'
+    '🤖 AI Web: Rescued bar "Legacy" via signal convergence (signals: page, ocr)'
   ), `rescue log expected, got: ${JSON.stringify(logs)}`);
 });
 
-test('venue-line rescue: no corroboration → not adopted, log-only (flag-don\'t-drop)', () => {
-  const parser = createRescueParser({});
+test('bar convergence: layout independence — noise between the venue and the city line no longer breaks the rescue', () => {
+  const parser = createRescueParser(BOSTON_CURATED_BARS);
+  const noisy = [
+    'FURBALL Boston',
+    'Legacy',
+    '79 Warrenton St',
+    '',
+    'Boston, MA'
+  ].join('\n');
   const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
-  const logs = captureLogs(() => {
-    parser.applyVenueLineBarRescue(event, rescueHtmlData({ ocrResults: [] }), {}, RESCUE_CITY_CONFIG);
-  });
-  assert.equal('bar' in event, false, 'never adopted on the page line alone');
-  assert.equal('barSource' in event, false);
-  assert.equal('_barRescue' in event, false);
-  assert.ok(logs.includes(
-    '🤖 AI Web: Venue-line candidate "Legacy" found above city line but uncorroborated — not adopted'
-  ), `log-only line expected, got: ${JSON.stringify(logs)}`);
+  parser.applyBarConvergenceRescue(event, rescueHtmlData({ segmentText: noisy }), {}, RESCUE_CITY_CONFIG);
+  assert.equal(event.bar, 'Legacy', 'an address line between venue and city is just noise now');
+  assert.equal(event.barSource, 'curated');
 });
 
-test('venue-line rescue: the organizer brand above the city line is never adopted, even fully corroborated', () => {
-  // Corroboration is deliberately available (curated + OCR both know
-  // "Furball") to prove the organizer guard fires BEFORE corroboration.
+test('bar convergence: venue only in OCR but curated → adopted (curated + ocr) with curated casing', () => {
+  const parser = createRescueParser(BOSTON_CURATED_BARS);
+  const noVenueOnPage = [
+    'FURBALL Boston',
+    'Bear Week Return',
+    'Boston, MA',
+    'July 25, 2026'
+  ].join('\n');
+  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  const logs = captureLogs(() => {
+    parser.applyBarConvergenceRescue(
+      event,
+      rescueHtmlData({ segmentText: noVenueOnPage, ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: 'LEGACY\n79 WARRENTON' }] }),
+      {},
+      RESCUE_CITY_CONFIG
+    );
+  });
+  assert.equal(event.bar, 'Legacy', 'flyer-only venues are reachable — curated casing adopted');
+  assert.equal(event.barSource, 'curated');
+  assert.deepEqual(event._barRescue.signals, ['curated', 'ocr']);
+  assert.ok(logs.includes(
+    '🤖 AI Web: Rescued bar "Legacy" via signal convergence (signals: curated, ocr)'
+  ), `rescue log expected, got: ${JSON.stringify(logs)}`);
+});
+
+test('bar convergence: casing variants normalize to ONE candidate with deduped signals', () => {
+  const parser = createRescueParser({});
+  // "The Legacy" (page) and "LEGACY" (page + OCR) share one bar-name key.
+  // If dedup failed, the OCR form alone would qualify and its casing would
+  // be adopted; merged, the page's first form wins.
+  const segment = [
+    'The Legacy',
+    'Boston, MA',
+    'LEGACY'
+  ].join('\n');
+  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  parser.applyBarConvergenceRescue(
+    event,
+    rescueHtmlData({ segmentText: segment, ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: 'LEGACY' }] }),
+    {},
+    RESCUE_CITY_CONFIG
+  );
+  assert.equal(event.bar, 'The Legacy', 'merged candidate adopts the first page casing');
+  assert.deepEqual(event._barRescue.signals, ['page', 'ocr'], 'each signal counted once');
+});
+
+test('bar convergence: one signal alone never adopts — page-only, ocr-only, curated-only all log-only', () => {
+  // Page only.
+  const pageOnly = createRescueParser({});
+  const pageEvent = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  const pageLogs = captureLogs(() => {
+    pageOnly.applyBarConvergenceRescue(
+      pageEvent,
+      rescueHtmlData({ segmentText: 'Legacy\nBoston, MA', ocrResults: [] }),
+      {},
+      RESCUE_CITY_CONFIG
+    );
+  });
+  assert.equal('bar' in pageEvent, false, 'never adopted from the page corpus alone');
+  assert.equal('_barRescue' in pageEvent, false);
+  assert.ok(pageLogs.includes(
+    '🤖 AI Web: Bar rescue candidate "Legacy" carries only one signal (page) — not adopted'
+  ), `log-only line expected, got: ${JSON.stringify(pageLogs)}`);
+
+  // OCR only.
+  const ocrOnly = createRescueParser({});
+  const ocrEvent = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  const ocrLogs = captureLogs(() => {
+    ocrOnly.applyBarConvergenceRescue(
+      ocrEvent,
+      rescueHtmlData({ segmentText: 'Boston, MA\nJuly 25, 2026', ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: 'LEGACY' }] }),
+      {},
+      RESCUE_CITY_CONFIG
+    );
+  });
+  assert.equal('bar' in ocrEvent, false, 'never adopted from the OCR corpus alone');
+  assert.ok(ocrLogs.includes(
+    '🤖 AI Web: Bar rescue candidate "LEGACY" carries only one signal (ocr) — not adopted'
+  ), `log-only line expected, got: ${JSON.stringify(ocrLogs)}`);
+
+  // Curated only — the name appears in NEITHER text corpus: never adopted,
+  // and never even named (the page gave no hint of it).
+  const curatedOnly = createRescueParser({ boston: [{ name: 'Alley Cat', city: 'boston' }] });
+  const curatedEvent = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  const curatedLogs = captureLogs(() => {
+    curatedOnly.applyBarConvergenceRescue(
+      curatedEvent,
+      rescueHtmlData({ segmentText: 'FURBALL Boston\nBoston, MA', ocrResults: [] }),
+      {},
+      RESCUE_CITY_CONFIG
+    );
+  });
+  assert.equal('bar' in curatedEvent, false, 'a curated name absent from page and OCR is never adopted');
+  assert.ok(!curatedLogs.some(line => line.includes('Alley Cat')),
+    `an unobserved curated bar is never named, got: ${JSON.stringify(curatedLogs)}`);
+  assert.ok(!curatedLogs.some(line => line.includes('Rescued bar')), 'no adoption log');
+});
+
+test('bar convergence: two qualifying candidates — the curated one wins', () => {
+  const parser = createRescueParser(BOSTON_CURATED_BARS);
+  const segment = [
+    'Alley Cat',
+    'Legacy',
+    'Boston, MA'
+  ].join('\n');
+  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  parser.applyBarConvergenceRescue(
+    event,
+    rescueHtmlData({ segmentText: segment, ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: 'ALLEY CAT\nLEGACY' }] }),
+    {},
+    RESCUE_CITY_CONFIG
+  );
+  assert.equal(event.bar, 'Legacy', 'curated signal outranks an equally-corroborated uncurated candidate');
+  assert.equal(event.barSource, 'curated');
+});
+
+test('bar convergence: two curated candidates — proximity to a location/address line breaks the tie; a true tie refuses', () => {
+  const twoCurated = {
+    boston: [
+      { name: 'Legacy', city: 'boston', address: '79 Warrenton St, Boston, MA 02116' },
+      { name: 'Alley Cat', city: 'boston', address: '1 Boylston Pl, Boston, MA 02116' }
+    ]
+  };
+  // Both curated + page (2 signals each): the one nearest the location line wins.
+  const parser = createRescueParser(twoCurated);
+  const segment = [
+    'Alley Cat',
+    'Bear Week Return',
+    'Legacy',
+    'Boston, MA'
+  ].join('\n');
+  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  parser.applyBarConvergenceRescue(
+    event,
+    rescueHtmlData({ segmentText: segment, ocrResults: [] }),
+    {},
+    RESCUE_CITY_CONFIG
+  );
+  assert.equal(event.bar, 'Legacy', 'fewest lines from the location line — position as tie-breaker only');
+
+  // True tie: both curated + ocr, neither in the page text at all — nothing
+  // distinguishes them, so nothing is adopted.
+  const tied = createRescueParser(twoCurated);
+  const tiedEvent = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
+  const tiedLogs = captureLogs(() => {
+    tied.applyBarConvergenceRescue(
+      tiedEvent,
+      rescueHtmlData({ segmentText: 'Boston, MA', ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: 'LEGACY\nALLEY CAT' }] }),
+      {},
+      RESCUE_CITY_CONFIG
+    );
+  });
+  assert.equal('bar' in tiedEvent, false, 'a genuine tie adopts nothing');
+  assert.equal('_barRescue' in tiedEvent, false);
+  assert.ok(tiedLogs.includes(
+    '🤖 AI Web: Bar rescue ambiguous between "Legacy" and "Alley Cat" — not adopted'
+  ), `ambiguous log expected, got: ${JSON.stringify(tiedLogs)}`);
+});
+
+test('bar convergence: the organizer brand is never rescued as the venue — the name filter runs before signals, curated included', () => {
+  // Corroboration is deliberately maximal (page + OCR + even a curated
+  // record) to prove the organizer guard fires BEFORE any signal counting.
   const parser = createRescueParser({ boston: [{ name: 'Furball', city: 'boston' }] });
   const segment = [
     'Bear Week Return',
     'FURBALL',
-    'Boston, MA',
-    'July 25, 2026'
+    'Boston, MA'
   ].join('\n');
-  const event = { title: 'Bear Week Return', city: 'boston', _organizer: 'FURBALL' };
+  const event = { title: 'Bear Week Return: A Party', city: 'boston', _organizer: 'FURBALL' };
   const logs = captureLogs(() => {
-    parser.applyVenueLineBarRescue(event, rescueHtmlData({ segmentText: segment }), {}, RESCUE_CITY_CONFIG);
+    parser.applyBarConvergenceRescue(
+      event,
+      rescueHtmlData({ segmentText: segment, ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: 'FURBALL' }] }),
+      {},
+      RESCUE_CITY_CONFIG
+    );
   });
   assert.equal('bar' in event, false, 'the promoter is never rescued as the venue');
   assert.equal('_barRescue' in event, false);
   assert.ok(!logs.some(line => line.includes('Rescued bar')), `no adoption log, got: ${JSON.stringify(logs)}`);
 });
 
-test('venue-line rescue: address-shaped and date lines above the city line are never bar candidates', () => {
-  const parser = createRescueParser(BOSTON_CURATED_BARS);
-  const addressAbove = [
-    'FURBALL Boston',
-    'Legacy',
-    '79 Warrenton St',
-    'Boston, MA'
-  ].join('\n');
-  const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
-  const logs = captureLogs(() => {
-    parser.applyVenueLineBarRescue(event, rescueHtmlData({ segmentText: addressAbove }), {}, RESCUE_CITY_CONFIG);
-  });
-  assert.equal('bar' in event, false, 'an address is not a venue name — and no hunting past it');
-  assert.ok(!logs.some(line => line.includes('Rescued bar')), `no adoption log, got: ${JSON.stringify(logs)}`);
-
-  const dateAbove = [
-    'FURBALL Boston',
-    'Legacy',
-    'July 25, 2026',
-    'Boston, MA'
-  ].join('\n');
-  const dated = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
-  parser.applyVenueLineBarRescue(dated, rescueHtmlData({ segmentText: dateAbove }), {}, RESCUE_CITY_CONFIG);
-  assert.equal('bar' in dated, false, 'a date line is not a venue name');
-});
-
-test('venue-line rescue: a model-returned surviving bar makes the rescue a no-op', () => {
+test('bar convergence: a model-returned surviving bar makes the rescue a no-op', () => {
   const parser = createRescueParser(BOSTON_CURATED_BARS);
   const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston', bar: 'Club Cafe' };
   const logs = captureLogs(() => {
-    parser.applyVenueLineBarRescue(event, rescueHtmlData(), {}, RESCUE_CITY_CONFIG);
+    parser.applyBarConvergenceRescue(event, rescueHtmlData(), {}, RESCUE_CITY_CONFIG);
   });
   assert.equal(event.bar, 'Club Cafe', 'a surviving extraction is never second-guessed');
   assert.equal('barSource' in event, false, 'no stamp from the rescue');
@@ -4347,13 +4498,13 @@ test('venue-line rescue: a model-returned surviving bar makes the rescue a no-op
   assert.equal(logs.length, 0, `rescue must be silent, got: ${JSON.stringify(logs)}`);
 });
 
-test('venue-line rescue: single-page events fall back to the page text when no segmentText exists', () => {
+test('bar convergence: single-page events fall back to the page text when no segmentText exists', () => {
   const parser = createRescueParser(BOSTON_CURATED_BARS);
   const html = '<html><head><title>FURBALL</title></head><body>'
     + '<p>FURBALL Boston</p><p>Bear Week Return</p><p>Legacy</p><p>Boston, MA</p><p>July 25, 2026</p>'
     + '</body></html>';
   const event = { title: 'FURBALL Boston: Bear Week Return', city: 'boston' };
-  parser.applyVenueLineBarRescue(
+  parser.applyBarConvergenceRescue(
     event,
     { url: 'https://furball.nyc/boston', html, ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: FURBALL_BOSTON_OCR }] },
     {},

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -14,7 +14,9 @@ const scraperBars = {
       "city": "atlanta",
       "address": "2069 Cheshire Bridge Rd NE, Atlanta, GA 30324",
       "coordinates": "33.8115012, -84.3552779",
-      "website": "https://hereticatlanta.com"
+      "website": "https://hereticatlanta.com",
+      "faviconBg": "#481818",
+      "faviconFg": "#a09f9f"
     }
   ],
   "bangkok": [
@@ -55,6 +57,14 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJDzxFQ4Rw44kRAxo45UBkJKM",
       "gayCities": "https://boston.gaycities.com/bars/127-the-alley-bar",
       "gayCitiesLastScrapedAt": "2026-06-13T20:34:56.886Z"
+    },
+    {
+      "name": "Legacy",
+      "city": "boston",
+      "address": "79 Warrenton St, Boston, MA 02116",
+      "coordinates": "42.3499063, -71.0658453",
+      "website": "https://legacybos.com",
+      "instagram": "https://www.instagram.com/legacybos"
     }
   ],
   "chicago": [
@@ -335,7 +345,9 @@ const scraperBars = {
       "city": "nola",
       "address": "1200 Canal St, New Orleans, LA 70112",
       "coordinates": "29.9559524, -90.0738975",
-      "website": "https://thejoytheater.com"
+      "website": "https://thejoytheater.com",
+      "faviconBg": "#f22922",
+      "faviconFg": "#221e1f"
     }
   ],
   "nyc": [
@@ -639,6 +651,8 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJOcPt38pqkFQRWmTOs3bUrgk",
       "wikipedia": "https://en.wikipedia.org/wiki/Seattle_Eagle",
       "gayCities": "https://seattle.gaycities.com/bars/506-seattle-eagle",
+      "faviconBg": "#20201f",
+      "faviconFg": "#8a836c",
       "gayCitiesLastScrapedAt": "2026-06-26T17:08:43.316Z",
       "wikipediaLastScrapedAt": "2026-06-26T15:16:42.842Z"
     },
@@ -742,7 +756,9 @@ const scraperBars = {
       "city": "sf",
       "address": "161 Erie St, San Francisco, CA 94103",
       "coordinates": "37.7688931, -122.4192651",
-      "website": "https://publicsf.com"
+      "website": "https://publicsf.com",
+      "faviconBg": "#f35425",
+      "faviconFg": "#fd5825"
     }
   ],
   "tokyo": [

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2585,18 +2585,19 @@ class SharedCore {
             lines.push(`${rescueField} rescue candidate (log-only): "${rescueCandidate}"${rescueModelValue ? ` — model wrote "${rescueModelValue}"` : ''}`);
         });
 
-        // Deterministic venue-line rescue (_barRescue — underscore field,
-        // never serialized; stamped by ai-web-parser's applyVenueLineBarRescue
-        // when extraction produced no bar and the venue line above the
-        // segment's city line was independently corroborated). Rendered so a
-        // rescued bar is always visible in the results UI.
+        // Deterministic bar-convergence rescue (_barRescue — underscore
+        // field, never serialized; stamped by ai-web-parser's
+        // applyBarConvergenceRescue when extraction produced no bar and a
+        // candidate converged on >= 2 independent signals out of curated /
+        // page / ocr). Rendered so a rescued bar is always visible in the
+        // results UI.
         const barRescue = event._barRescue && typeof event._barRescue === 'object' ? event._barRescue : null;
         if (bar && barRescue) {
             const rescueSignals = Array.isArray(barRescue.signals)
                 ? barRescue.signals.filter(signal => typeof signal === 'string' && signal.trim())
                 : [];
-            const suffix = rescueSignals.length > 0 ? ` (corroborated: ${rescueSignals.join(', ')})` : '';
-            lines.push(`bar rescued from venue line above city line${suffix}`);
+            const suffix = rescueSignals.length > 0 ? ` (${rescueSignals.join(', ')})` : '';
+            lines.push(`bar rescued by signal convergence${suffix}`);
         }
 
         // Compact provenance summary of whichever companion stamps exist.

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2585,6 +2585,20 @@ class SharedCore {
             lines.push(`${rescueField} rescue candidate (log-only): "${rescueCandidate}"${rescueModelValue ? ` — model wrote "${rescueModelValue}"` : ''}`);
         });
 
+        // Deterministic venue-line rescue (_barRescue — underscore field,
+        // never serialized; stamped by ai-web-parser's applyVenueLineBarRescue
+        // when extraction produced no bar and the venue line above the
+        // segment's city line was independently corroborated). Rendered so a
+        // rescued bar is always visible in the results UI.
+        const barRescue = event._barRescue && typeof event._barRescue === 'object' ? event._barRescue : null;
+        if (bar && barRescue) {
+            const rescueSignals = Array.isArray(barRescue.signals)
+                ? barRescue.signals.filter(signal => typeof signal === 'string' && signal.trim())
+                : [];
+            const suffix = rescueSignals.length > 0 ? ` (corroborated: ${rescueSignals.join(', ')})` : '';
+            lines.push(`bar rescued from venue line above city line${suffix}`);
+        }
+
         // Compact provenance summary of whichever companion stamps exist.
         const provenance = [
             ['bar', 'barSource'],

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -7352,3 +7352,59 @@ test('evidence: pointer-rescue candidates render their panel line and never seri
   });
   assert.ok(!junk.some(line => line.includes('rescue candidate')), 'malformed rescue entries render nothing');
 });
+
+// ---------------------------------------------------------------------------
+// Venue-line bar rescue: evidence panel rendering + curated Legacy (Boston)
+// data sync (run 20260723-224434).
+// ---------------------------------------------------------------------------
+
+test('evidence: a rescued bar renders the venue-line rescue line; _barRescue never serializes into notes', () => {
+  const core = createEvidencePanelCore();
+  const event = {
+    bar: 'Legacy',
+    barSource: 'curated',
+    city: 'boston',
+    _barRescue: { candidate: 'Legacy', locationLine: 'Boston, MA', signals: ['curated', 'ocr'] }
+  };
+  const lines = core.buildEventEvidenceLines(event);
+  assert.ok(lines.includes('bar rescued from venue line above city line (corroborated: curated, ocr)'),
+    `rescue evidence line expected, got: ${JSON.stringify(lines)}`);
+  assert.ok(lines.includes('bar corroborated: curated'),
+    'the ordinary barSource verdict still renders alongside the rescue line');
+
+  const notes = core.formatEventNotes(event);
+  assert.ok(notes.includes('bar: Legacy'), 'real fields serialize');
+  assert.ok(!notes.includes('_barRescue') && !notes.includes('locationLine'),
+    'underscore rescue metadata never serializes into notes');
+
+  // No bar (rescue metadata without an adopted bar) → no line (fail open).
+  const barless = core.buildEventEvidenceLines({
+    title: 'X',
+    _barRescue: { candidate: 'Legacy', signals: ['ocr'] }
+  });
+  assert.ok(!barless.some(line => line.includes('rescued')), 'no bar → no rescue line');
+});
+
+test('curated bars: boston.json carries Legacy and the generated scraper-bars twins are in sync', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const bostonBars = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'bars', 'boston.json'), 'utf8'));
+  const legacy = bostonBars.find(bar => bar && bar.name === 'Legacy');
+  assert.ok(legacy, 'Legacy curated in data/bars/boston.json');
+  assert.equal(legacy.city, 'boston');
+  assert.equal(legacy.address, '79 Warrenton St, Boston, MA 02116');
+  assert.equal(legacy.coordinates, '42.3499063, -71.0658453');
+
+  // Generated module twin (scripts/scraper-bars.js) is committed in sync.
+  const scraperBars = require('./scraper-bars');
+  assert.deepEqual(scraperBars.boston, bostonBars, 'scripts/scraper-bars.js regenerated after the boston.json edit');
+
+  // Pure-JSON twin served by the site.
+  const jsonTwin = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'scraper-bars.json'), 'utf8'));
+  assert.deepEqual(jsonTwin.boston, bostonBars, 'data/scraper-bars.json regenerated after the boston.json edit');
+
+  // The curated record is what findCuratedBarByName resolves for the rescue.
+  const core = new SharedCore({}, { eventSchema: EventSchema, bars: scraperBars });
+  const match = core.findCuratedBarByName(core.getCuratedCityBars('boston'), 'LEGACY');
+  assert.ok(match && match.name === 'Legacy', 'curated lookup resolves the rescue candidate');
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -7354,27 +7354,27 @@ test('evidence: pointer-rescue candidates render their panel line and never seri
 });
 
 // ---------------------------------------------------------------------------
-// Venue-line bar rescue: evidence panel rendering + curated Legacy (Boston)
+// Bar-convergence rescue: evidence panel rendering + curated Legacy (Boston)
 // data sync (run 20260723-224434).
 // ---------------------------------------------------------------------------
 
-test('evidence: a rescued bar renders the venue-line rescue line; _barRescue never serializes into notes', () => {
+test('evidence: a rescued bar renders the signal-convergence line; _barRescue never serializes into notes', () => {
   const core = createEvidencePanelCore();
   const event = {
     bar: 'Legacy',
     barSource: 'curated',
     city: 'boston',
-    _barRescue: { candidate: 'Legacy', locationLine: 'Boston, MA', signals: ['curated', 'ocr'] }
+    _barRescue: { candidate: 'Legacy', signals: ['curated', 'page', 'ocr'] }
   };
   const lines = core.buildEventEvidenceLines(event);
-  assert.ok(lines.includes('bar rescued from venue line above city line (corroborated: curated, ocr)'),
+  assert.ok(lines.includes('bar rescued by signal convergence (curated, page, ocr)'),
     `rescue evidence line expected, got: ${JSON.stringify(lines)}`);
   assert.ok(lines.includes('bar corroborated: curated'),
     'the ordinary barSource verdict still renders alongside the rescue line');
 
   const notes = core.formatEventNotes(event);
   assert.ok(notes.includes('bar: Legacy'), 'real fields serialize');
-  assert.ok(!notes.includes('_barRescue') && !notes.includes('locationLine'),
+  assert.ok(!notes.includes('_barRescue') && !notes.includes('signal convergence'),
     'underscore rescue metadata never serializes into notes');
 
   // No bar (rescue metadata without an adopted bar) → no line (fail open).


### PR DESCRIPTION
## What broke (run 20260723-224434)
With OCR finally reading the Boston flyer (#1531), the model got the times right (10pm–3am ✓) but returned the STREET ADDRESS as the bar ("79 Warren"/"79 Warrenon" — not even verbatim). The evidence gate correctly dropped it — but nothing could recover the real venue, so the event saved with no bar, and since venue-POI adoption needs a bar name, no address and no pin either. The venue is stated plainly in THREE independent places: the segment page text has `Legacy` on its own line, the flyer OCR reads `LEGACY`, and Legacy is a real curated-able Boston bar. Earlier runs extracted "Legacy" from this exact text — pure model nondeterminism the pipeline shouldn't depend on.

## Part 1 — curate Legacy
`data/bars/boston.json` += Legacy, 79 Warrenton St, Boston, MA 02116 (coordinates from the OSM nightclub POI "Legacy" at that address). Independently verified: legacybos.com, OSM POI, do617.com/venues/legacy-boston — and it is the home club of the flyer's own promoters (Gay Mafia Boston / Rafael Sanchez / Bobby Kelley). Generated twins (`scripts/scraper-bars.js`, `data/scraper-bars.json`) regenerated via the tool.

## Part 2 — bar rescue by signal convergence (no positional rules)
When extraction leaves NO bar (including gate-dropped), three independent corpora vote:
- **PAGE** — every line of the segment's own page text (never the OCR prepend)
- **OCR** — every line of the event's flyer OCR text
- **CURATED** — every curated bar name for the event's city

PAGE/OCR lines become candidates only if they pass the deterministic could-be-a-name filter (rejects dates, times, prices, URLs, address-shaped lines, the event title, the organizer/page brand, location lines, generic words); curated names are always candidates but the organizer/title guards stay absolute — the promoter is never rescued as the venue. Candidates that normalize to the same bar-name key ("LEGACY"/"Legacy"/"The Legacy") are ONE candidate accumulating all signals.

**Adoption requires ≥ 2 of the 3 signals** (curated match, whole-word PAGE presence, whole-word OCR presence) — a name appearing in a single corpus is never adopted, per the standing corroboration doctrine. Ranking when several qualify: curated signal → signal count → proximity to a location/address line (position's ONLY role, a tie-breaker) → earliest appearance; a genuinely tied top pair adopts nothing and logs the ambiguity. There is no "line above the city line" or any other layout assumption — venue below the city, venue only on the flyer, noisy segments all resolve by the same rule.

Rescued bars flow into the untouched downstream machinery: `barSource: curated`/`page-adjacent` stamping, venue-POI adoption (which for Boston supplies 79 Warrenton Street + pin under #1530's tolerance), and the evidence panel renders `bar rescued by signal convergence (curated, page, ocr)`.

## Boston outcome (verified against the real segment shape)
"Legacy" converges with all three signals → `bar: "Legacy"`, `barSource: curated` → downstream address + pin.

## Tests
691 pass (678 baseline + 13): real FURBALL segment; venue BELOW the city line; noise-tolerant layouts; OCR-only+curated; casing dedup to one candidate; all three one-signal variants refused; curated-beats-uncurated; proximity tie-break and a constructed true tie refusing with the ambiguity log; fully-corroborated organizer brand still rejected; surviving model bar untouched; single-page fallback; evidence-panel rendering + notes exclusion; curated-bars generator sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP