### PR TITLE
feat(scraper): evidence-pointer rescue candidates (log-only) — trust the pointer, not the copy

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -57,6 +57,20 @@ const ImportedDetectTitleDateSegment = (() => {
 // iCloud sync churn).
 const CACHE_TOUCH_INTERVAL_DAYS = 7;
 
+// Evidence-pointer rescue (LOG-ONLY observation phase): the extraction model
+// is a good FINDER and a bad COPIER. When the evidence gate drops a field
+// because the VALUE is not verbatim in the corpus, but the model's own
+// EVIDENCE string IS a verbatim corpus quote, the model located the right
+// text and fumbled the transcription — run 20260723-224434, FURBALL Boston:
+// value "79 Warrenon" cited evidence "79 WARRENTON TICKETS: ..." which sits
+// verbatim in the OCR corpus. "Trust the pointer, not the copy."
+// Scope: text-identity fields ONLY. Date/time fields are excluded on purpose
+// (format conversion is not transcription, and their gates encode inference-
+// safety), city is excluded (normalized key values, not transcriptions) and
+// URL fields are excluded (different validation entirely). Widen HERE once
+// the observation phase proves the heuristic.
+const EVIDENCE_RESCUE_FIELDS = new Set(['bar', 'address', 'cover']);
+
 // ============================================================================
 // NORMALIZATION HELPERS
 // ============================================================================
@@ -703,6 +717,27 @@ class AiWebParser {
                 };
             }
             event._aiValidation = report;
+        }
+        // Evidence-pointer rescue candidates (LOG-ONLY observation phase):
+        // stash on the event as an underscore field (never serialized into
+        // notes — same systematic exclusion as _geoPoi*) so the results-UI
+        // evidence panel can show what the rescue WOULD have adopted. Sources:
+        // snippet-pass memos (__evidenceRescues) plus the final gate's report.
+        const evidenceRescues = []
+            .concat(aiEvent && Array.isArray(aiEvent.__evidenceRescues) ? aiEvent.__evidenceRescues : [])
+            .concat(validationResult.report && Array.isArray(validationResult.report.evidenceRescues) ? validationResult.report.evidenceRescues : []);
+        if (evidenceRescues.length > 0) {
+            const seenRescues = new Set();
+            const dedupedRescues = evidenceRescues.filter(entry => {
+                if (!entry || typeof entry !== 'object') return false;
+                const dedupeKey = `${entry.field}|${entry.candidate}|${entry.modelValue}`;
+                if (seenRescues.has(dedupeKey)) return false;
+                seenRescues.add(dedupeKey);
+                return true;
+            });
+            if (dedupedRescues.length > 0) {
+                event._evidenceRescues = dedupedRescues;
+            }
         }
         return event;
     }
@@ -5457,6 +5492,13 @@ class AiWebParser {
                 };
                 return;
             }
+            // Evidence-pointer rescue memos (LOG-ONLY observation) concatenate
+            // across passes in order — every candidate is surfaced.
+            if (key === '__evidenceRescues' && Array.isArray(value)) {
+                merged.__evidenceRescues = (Array.isArray(merged.__evidenceRescues) ? merged.__evidenceRescues : [])
+                    .concat(value);
+                return;
+            }
             // Dropped-value memos union across passes like the evidence strings
             // above, except EARLIER passes win (the first drop is the one the
             // page-location cross-check anchors on).
@@ -5660,6 +5702,17 @@ class AiWebParser {
                     validatedPartial.__droppedFieldValues[entry.field] = entry.value;
                 }
             });
+            // Evidence-pointer rescue memo (internal, additive, LOG-ONLY):
+            // per-snippet reports are discarded, so rescue candidates ride an
+            // internal field through the merge; extractSingleEvent stamps them
+            // onto the final event as _evidenceRescues for the evidence panel.
+            const partialRescues = partialValidation.report && Array.isArray(partialValidation.report.evidenceRescues)
+                ? partialValidation.report.evidenceRescues
+                : [];
+            if (partialRescues.length > 0) {
+                validatedPartial.__evidenceRescues = (Array.isArray(validatedPartial.__evidenceRescues) ? validatedPartial.__evidenceRescues : [])
+                    .concat(partialRescues);
+            }
 
             // Reject organizer-brand / site-tagline values AT PASS-RESULT TIME:
             // an accepted value consumes the field slot (later passes only ask for
@@ -7541,7 +7594,7 @@ TEXT:
      * Validate a single field value against evidence.
      * Returns true if valid, false if should be dropped.
      */
-    validateFieldValueAgainstEvidence(key, value, rule, evidenceContext, validationContext, report, modelEvidence = '', brandTokens = null) {
+    validateFieldValueAgainstEvidence(key, value, rule, evidenceContext, validationContext, report, modelEvidence = '', brandTokens = null, rescueContext = null) {
         // The ADDITIONAL CONTEXT block carries an explicit DO-NOT-EXTRACT
         // instruction, so evidence citing it fails corroboration for ANY field
         // (see evidenceCitesAdditionalContext).
@@ -7576,10 +7629,248 @@ TEXT:
             if (citesForbiddenContext) droppedEntry.reason = 'context-cited-evidence';
             else if (brandOnlyCityEvidence) droppedEntry.reason = 'brand-cited-evidence';
             report.dropped.push(droppedEntry);
+            // Evidence-pointer rescue (LOG-ONLY observation, additive): runs
+            // AFTER the drop is recorded and never changes it. Eligible only
+            // when the drop's sole cause is "value not verbatim in corpus" —
+            // evidence-quality rejections (context-citing, brand-citing,
+            // invented-time) mean the pointer itself is rotten.
+            this.maybeCollectEvidencePointerRescue(value, rule, report, modelEvidence, evidenceContext, rescueContext, {
+                citesForbiddenContext,
+                brandOnlyCityEvidence,
+                inventedTime
+            });
             return false;
         }
         report.kept.push({ field: rule.field, key, mode: rule.mode });
         return true;
+    }
+
+    // === Evidence-Pointer Rescue (LOG-ONLY observation phase) ===
+    // "Trust the pointer, not the copy": when the gate drops a scoped field
+    // (EVIDENCE_RESCUE_FIELDS) because the VALUE is not verbatim in the
+    // corpus, but the model's EVIDENCE string IS a verbatim corpus quote, a
+    // candidate value is derived from the CORPUS'S OWN characters/casing and
+    // logged + stashed for the results-UI evidence panel. Nothing is adopted
+    // and no event data changes — the gate's accept/reject decisions are
+    // untouched. Bear-website reality shapes this code: broken markup,
+    // ALL-CAPS flyers, OCR noise, curly quotes and typos IN THE SOURCE are
+    // all normal, so matching is case-insensitive and whitespace-flexible,
+    // only raw text corpora are consulted (never structured data), and
+    // "cannot locate the evidence" is a silent no-op — the common case, not
+    // an error.
+
+    // Collect a rescue candidate for a just-dropped field. Additive only:
+    // appends to report.evidenceRescues (lazily created) and logs one line.
+    // Any internal failure is swallowed — observation must never affect the
+    // gate.
+    maybeCollectEvidencePointerRescue(value, rule, report, modelEvidence, evidenceContext, rescueContext, dropFlags = {}) {
+        try {
+            if (!EVIDENCE_RESCUE_FIELDS.has(rule.field)) return;
+            // ONLY the plain "value not verbatim" rejection class qualifies.
+            if (dropFlags && (dropFlags.citesForbiddenContext || dropFlags.brandOnlyCityEvidence || dropFlags.inventedTime)) return;
+            const evidence = String(modelEvidence || '').trim();
+            if (!evidence) return;
+            // Inference language or context citations anywhere in the
+            // evidence = untrustworthy pointer (the first-pass FURBALL shape:
+            // 'OCR_IMAGE_TEXT: "79 WARRENTON"; Additional context clarifies
+            // as "79 Warrenon" — likely a typo for "Warren"'). No rescue.
+            if (this.evidenceAdmitsInference(evidence)) return;
+            if (this.evidenceCitesAdditionalContext(evidence)) return;
+            const rescue = this.deriveEvidencePointerRescue(String(value), evidence, evidenceContext, rescueContext);
+            if (!rescue || !rescue.candidate) return;
+            const entry = {
+                field: rule.field,
+                candidate: this.trimToMaxLength(rescue.candidate, this.extractionLimits.validationReportValueMaxLength),
+                modelValue: this.trimToMaxLength(String(value), this.extractionLimits.validationReportValueMaxLength),
+                corpus: rescue.corpus
+            };
+            if (!Array.isArray(report.evidenceRescues)) report.evidenceRescues = [];
+            report.evidenceRescues.push(entry);
+            console.log(`🤖 AI Web: Evidence-pointer rescue (log-only) for ${entry.field}: corpus has "${entry.candidate}" where model wrote "${entry.modelValue}" (evidence located in ${entry.corpus} text)`);
+        } catch (err) {
+            this.logDebug(`🤖 AI Web: Evidence-pointer rescue observation failed silently: ${err && err.message ? err.message : err}`);
+        }
+    }
+
+    // Derive the candidate from the first evidence fragment that locates in a
+    // corpus: token-align the model's mangled value inside the located span
+    // (corpus casing wins), falling back to the whole located fragment when no
+    // alignment is found. Returns { candidate, corpus } or null.
+    deriveEvidencePointerRescue(modelValue, modelEvidence, evidenceContext, rescueContext) {
+        const fragments = this.extractEvidenceQuoteFragments(modelEvidence);
+        for (const fragment of fragments) {
+            const located = this.locateEvidenceRescueSpan(fragment, evidenceContext, rescueContext);
+            if (!located) continue;
+            const span = located.span.replace(/\s+/g, ' ').trim();
+            if (!span) continue;
+            const aligned = this.alignValueTokensInSpan(modelValue, span);
+            return { candidate: aligned || span, corpus: located.corpus };
+        }
+        return null;
+    }
+
+    // Unwrap citation envelopes: models wrap the real quote in prefixes like
+    // 'OCR_IMAGE_TEXT: "..."', straight AND curly quotes (bear websites and
+    // models are both sloppy), escaped \n, ellipses, and multi-fragment
+    // citations ('"X" and "Y"'). Quoted fragments win; with no quoting the
+    // whole (label-stripped) evidence string is the single fragment. Ellipses
+    // split a fragment into independently-locatable parts.
+    extractEvidenceQuoteFragments(evidence) {
+        const raw = String(evidence || '')
+            .replace(/\\n/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        if (!raw) return [];
+        const quoted = [];
+        const quotePattern = /"([^"]+)"|“([^”]+)”/g;
+        let match;
+        while ((match = quotePattern.exec(raw)) !== null) {
+            const fragment = String(match[1] || match[2] || '').trim();
+            if (fragment) quoted.push(fragment);
+        }
+        const source = quoted.length > 0 ? quoted : [this.stripEvidenceEnvelopeLabel(raw)];
+        const fragments = [];
+        source.forEach(fragment => {
+            String(fragment || '')
+                .split(/\.{3}|…/)
+                .map(part => part.trim())
+                .filter(Boolean)
+                .forEach(part => fragments.push(part));
+        });
+        return fragments;
+    }
+
+    // Strip a LEADING data-marker label ("OCR_IMAGE_TEXT: ", "SEGMENT_LINK_URL: ")
+    // from an unquoted evidence string. Deliberately anchored and uppercase-only
+    // so real content like "79 WARRENTON TICKETS: ..." is never eaten (the
+    // label must be the known marker vocabulary, not any capitalized word).
+    stripEvidenceEnvelopeLabel(text) {
+        return String(text || '').replace(/^(?:OCR|SEGMENT|PAGE|META|JSONLD|JSON_LD|HTML)[A-Z0-9_]*\s*:\s*/, '').trim();
+    }
+
+    // Locate one evidence fragment in the corpora the gate already checks,
+    // most-specific label first: the raw OCR texts (label 'ocr'), then the
+    // gate's own evidence corpus (label 'segment' when it is a multi-event
+    // segment corpus, else 'page'). Returns { span, corpus } or null.
+    locateEvidenceRescueSpan(fragment, evidenceContext, rescueContext) {
+        const ocrCorpus = this.getRescueOcrCorpus(rescueContext);
+        if (ocrCorpus) {
+            const span = this.locateEvidenceFragmentSpan(fragment, ocrCorpus);
+            if (span) return { span, corpus: 'ocr' };
+        }
+        const raw = evidenceContext && typeof evidenceContext.raw === 'string' ? evidenceContext.raw : '';
+        if (raw) {
+            const span = this.locateEvidenceFragmentSpan(fragment, raw);
+            if (span) return { span, corpus: /^SEGMENT_[A-Z_]+/m.test(raw) ? 'segment' : 'page' };
+        }
+        return null;
+    }
+
+    // Raw OCR text corpus for rescue labeling (cached on the rescueContext).
+    // Raw text ONLY — structured data is never consulted for rescues.
+    getRescueOcrCorpus(rescueContext) {
+        if (!rescueContext || typeof rescueContext !== 'object') return '';
+        if (typeof rescueContext.ocrCorpus === 'string') return rescueContext.ocrCorpus;
+        const htmlData = rescueContext.htmlData;
+        const ocrResults = htmlData && Array.isArray(htmlData.ocrResults) ? htmlData.ocrResults : [];
+        const corpus = ocrResults
+            .map(result => result && typeof result.text === 'string' ? result.text : '')
+            .filter(Boolean)
+            .join('\n\n');
+        rescueContext.ocrCorpus = corpus;
+        return corpus;
+    }
+
+    // Case-insensitive, whitespace-flexible verbatim location of a fragment in
+    // a raw corpus — the same matching class the gate's hasExactEvidence uses
+    // (normalizeEvidenceText containment), implemented as a regex so the
+    // CORPUS'S OWN characters/casing can be recovered. Apostrophe/quote
+    // variants are tolerated char-for-char (curly vs straight). Returns the
+    // corpus-cased span or null. HTML-entity-encoded corpus occurrences are a
+    // known acceptable miss (silent no-op) in this log-only phase.
+    locateEvidenceFragmentSpan(fragment, rawCorpus) {
+        const corpus = String(rawCorpus || '');
+        if (!corpus) return null;
+        const tokens = this.normalizeEvidenceText(fragment).split(' ').filter(Boolean);
+        if (tokens.length === 0 || tokens.length > 40) return null;
+        if (tokens.join(' ').length < 4) return null; // too short to be a meaningful pointer
+        let matcher;
+        try {
+            const pattern = tokens
+                .map(token => this.escapeRegex(token).replace(/['’‘]/g, "['’‘]").replace(/["“”]/g, '["“”]'))
+                .join('\\s+');
+            matcher = new RegExp(pattern, 'i');
+        } catch (_) {
+            return null;
+        }
+        const match = matcher.exec(corpus);
+        return match ? match[0] : null;
+    }
+
+    // Simple deterministic token alignment of the model's mangled value inside
+    // the located corpus span: slide a window of the value's token count over
+    // the span's tokens; every value token must match its counterpart (exact,
+    // or near for longer tokens — "Warrenon" ≈ "WARRENTON") and at least one
+    // token must match EXACTLY (the anchor, e.g. "79"). Leftmost full window
+    // wins. Returns the corpus-cased sub-span, or '' when nothing aligns (the
+    // caller then logs the whole fragment — acceptable for log-only).
+    alignValueTokensInSpan(modelValue, span) {
+        const valueTokens = String(modelValue || '').split(/\s+/).filter(Boolean);
+        const spanTokens = String(span || '').split(/\s+/).filter(Boolean);
+        if (valueTokens.length === 0 || spanTokens.length === 0) return '';
+        if (valueTokens.length > spanTokens.length) return '';
+        for (let start = 0; start + valueTokens.length <= spanTokens.length; start++) {
+            let exactAnchors = 0;
+            let allMatch = true;
+            for (let i = 0; i < valueTokens.length; i++) {
+                const kind = this.classifyRescueTokenMatch(valueTokens[i], spanTokens[start + i]);
+                if (kind === 'exact') exactAnchors++;
+                else if (kind !== 'near') { allMatch = false; break; }
+            }
+            if (allMatch && exactAnchors > 0) {
+                return spanTokens.slice(start, start + valueTokens.length).join(' ');
+            }
+        }
+        return '';
+    }
+
+    // Token comparison for alignment: 'exact' on normalized equality; 'near'
+    // when both tokens are 4+ chars and within a small bounded edit distance
+    // (≤ length/4, minimum 1 — covers OCR/transcription slips like
+    // "warrenon" vs "warrenton"); short tokens must anchor exactly.
+    classifyRescueTokenMatch(valueToken, corpusToken) {
+        const a = this.normalizeRescueToken(valueToken);
+        const b = this.normalizeRescueToken(corpusToken);
+        if (!a || !b) return 'none';
+        if (a === b) return 'exact';
+        if (a.length < 4 || b.length < 4) return 'none';
+        const maxDistance = Math.max(1, Math.floor(Math.max(a.length, b.length) / 4));
+        return this.boundedEditDistance(a, b, maxDistance) >= 0 ? 'near' : 'none';
+    }
+
+    normalizeRescueToken(token) {
+        return String(token || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    }
+
+    // Levenshtein distance capped at maxDistance: returns the distance when
+    // within the cap, -1 otherwise. Inputs are short normalized tokens, so the
+    // classic DP is plenty.
+    boundedEditDistance(a, b, maxDistance) {
+        if (Math.abs(a.length - b.length) > maxDistance) return -1;
+        let previous = Array.from({ length: b.length + 1 }, (_, i) => i);
+        for (let i = 1; i <= a.length; i++) {
+            const current = [i];
+            for (let j = 1; j <= b.length; j++) {
+                current[j] = Math.min(
+                    previous[j] + 1,
+                    current[j - 1] + 1,
+                    previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+                );
+            }
+            previous = current;
+        }
+        const distance = previous[b.length];
+        return distance <= maxDistance ? distance : -1;
     }
 
     // === Main Validation Entry Point ===
@@ -7643,6 +7934,10 @@ TEXT:
         // 20260723-123149: WWW.FURBALL.NYC flyer branding produced city
         // "new york" for an event in Torremolinos).
         const brandTokens = this.getPageBrandDomainTokens(htmlData);
+        // Evidence-pointer rescue context (LOG-ONLY observation): carries the
+        // htmlData so the rescue can consult the raw OCR texts for corpus
+        // labeling. Never influences accept/reject decisions.
+        const rescueContext = { htmlData };
         Object.keys(aiEvent).forEach(key => {
             const rule = this.getFieldValidationRule(key, validationConfig);
 
@@ -7659,7 +7954,7 @@ TEXT:
 
             // Validate field value against evidence
             const value = aiEvent[key];
-            const isValid = this.validateFieldValueAgainstEvidence(key, value, rule, evidenceContext, validationContext, report, modelFieldEvidence[key], brandTokens);
+            const isValid = this.validateFieldValueAgainstEvidence(key, value, rule, evidenceContext, validationContext, report, modelFieldEvidence[key], brandTokens, rescueContext);
             if (!isValid) {
                 delete validated[key];
             }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -3963,3 +3963,221 @@ test('address gate shape rules: isPlausiblyAddressShaped', () => {
   assert.equal(parser.isPlausiblyAddressShaped('Calle Casablanca 12'), true, 'standalone house-number token anywhere');
   assert.equal(parser.isPlausiblyAddressShaped(''), false);
 });
+
+// ---------------------------------------------------------------------------
+// Evidence-pointer rescue (LOG-ONLY observation phase): "trust the pointer,
+// not the copy". The extraction model is a good FINDER and a bad COPIER —
+// run 20260723-224434 (FURBALL Boston) dropped address "79 Warrenon" whose
+// evidence "79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC" sits
+// VERBATIM in the OCR corpus. The rescue logs/stashes what the corpus says
+// there; it must NEVER change a gate decision or any event data.
+// ---------------------------------------------------------------------------
+
+const FURBALL_OCR_TEXT = 'FURBALL BOSTON\nBEAR WEEK RETURN\nSAT, JULY 25\n10pm-3am\n79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC';
+const FURBALL_SEGMENT_TEXT = 'SEGMENT_LINK_URL: https://tickets.example/furball-boston\nFURBALL Boston\nJuly 25, 2026\nBoston, MA';
+
+// Gate run with the FURBALL-shaped corpora (OCR text prepended to segment
+// text — the same combined corpus the snippet gate builds).
+function runFurballGate(parser, aiEvent) {
+  const combined = `${FURBALL_OCR_TEXT}\n\n${FURBALL_SEGMENT_TEXT}`;
+  return parser.validateAiEventEvidence(
+    aiEvent,
+    { html: combined, ocrResults: [{ url: 'https://img.example/furball.png', text: FURBALL_OCR_TEXT }] },
+    {}, null,
+    {
+      evidenceContext: parser.buildAiEvidenceContextFromText(combined),
+      validationContext: { imageEvidenceUrls: new Set() }
+    }
+  );
+}
+
+test('evidence-pointer rescue: the canonical retry-pass shape logs the corpus candidate (79 WARRENTON)', () => {
+  const parser = createParser();
+  const captured = captureGateLogs();
+  let result;
+  try {
+    result = runFurballGate(parser, {
+      address: '79 Warrenon',
+      __fieldEvidence: { address: '79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC' }
+    });
+  } finally {
+    captured.restore();
+  }
+
+  // The gate decision is untouched: the field is still dropped, in the
+  // pre-existing report shape (no new keys on the dropped entry).
+  assert.equal(result.event.address, undefined, 'rescue must never resurrect the dropped field');
+  assert.deepEqual(result.report.dropped, [{ field: 'address', key: 'address', mode: 'exact', value: '79 Warrenon' }]);
+
+  // The candidate carries the CORPUS's own casing, aligned to the value's
+  // tokens — "79 WARRENTON", not the whole ticket line.
+  assert.deepEqual(result.report.evidenceRescues, [
+    { field: 'address', candidate: '79 WARRENTON', modelValue: '79 Warrenon', corpus: 'ocr' }
+  ]);
+  assert.ok(
+    captured.lines.includes('🤖 AI Web: Evidence-pointer rescue (log-only) for address: corpus has "79 WARRENTON" where model wrote "79 Warrenon" (evidence located in ocr text)'),
+    `rescue log line expected, got: ${JSON.stringify(captured.lines)}`
+  );
+});
+
+test('evidence-pointer rescue: the first-pass rotten-evidence shape gets NO rescue', () => {
+  const parser = createParser();
+  // Real first-pass evidence from run 20260723-224434: inference language
+  // ("likely a typo") AND an ADDITIONAL CONTEXT citation. The pointer itself
+  // is untrustworthy — this class must stay untouched.
+  const result = runFurballGate(parser, {
+    address: '79 Warren',
+    __fieldEvidence: { address: 'OCR_IMAGE_TEXT: "79 WARRENTON"; Additional context clarifies as "79 Warrenon" — likely a typo for "Warren"' }
+  });
+  assert.equal(result.event.address, undefined, 'the field still drops');
+  assert.equal(result.report.evidenceRescues, undefined, 'nothing is stashed for evidence-quality rejections');
+
+  // Inference language ALONE (no context citation) also blocks the rescue.
+  const inferredOnly = runFurballGate(parser, {
+    address: '79 Warren',
+    __fieldEvidence: { address: 'OCR_IMAGE_TEXT: "79 WARRENTON" — likely a typo for "Warren"' }
+  });
+  assert.equal(inferredOnly.report.evidenceRescues, undefined, 'inference-language evidence is a rotten pointer');
+});
+
+test('evidence-pointer rescue: quoted OCR_IMAGE_TEXT envelope yields the corpus-cased candidate', () => {
+  const parser = createParser();
+  const result = runFurballGate(parser, {
+    address: '79 Warrenon',
+    __fieldEvidence: { address: 'OCR_IMAGE_TEXT: "79 WARRENTON"' }
+  });
+  assert.deepEqual(result.report.evidenceRescues, [
+    { field: 'address', candidate: '79 WARRENTON', modelValue: '79 Warrenon', corpus: 'ocr' }
+  ]);
+});
+
+test('evidence-pointer rescue: curly-quote envelopes and multi-fragment citations locate correctly', () => {
+  const parser = createParser();
+  // Curly quotes (bear websites and models are both sloppy).
+  const curly = runFurballGate(parser, {
+    address: '79 Warrenon',
+    __fieldEvidence: { address: 'OCR_IMAGE_TEXT: “79 WARRENTON”' }
+  });
+  assert.deepEqual(curly.report.evidenceRescues, [
+    { field: 'address', candidate: '79 WARRENTON', modelValue: '79 Warrenon', corpus: 'ocr' }
+  ]);
+
+  // Multi-fragment citation where only the SECOND fragment is in the corpus.
+  const multi = runFurballGate(parser, {
+    address: '79 Warrenon',
+    __fieldEvidence: { address: '"NOT ACTUALLY IN THE CORPUS ANYWHERE" and "79 WARRENTON TICKETS"' }
+  });
+  assert.deepEqual(multi.report.evidenceRescues, [
+    { field: 'address', candidate: '79 WARRENTON', modelValue: '79 Warrenon', corpus: 'ocr' }
+  ]);
+});
+
+test('evidence-pointer rescue: unlocatable evidence is a silent no-op (the common case, not an error)', () => {
+  const parser = createParser();
+  const captured = captureGateLogs();
+  let result;
+  try {
+    result = runFurballGate(parser, {
+      address: '123 Fake Street',
+      __fieldEvidence: { address: 'the flyer says 123 Fake Street near the bottom' }
+    });
+  } finally {
+    captured.restore();
+  }
+  assert.equal(result.event.address, undefined, 'the field still drops');
+  assert.equal(result.report.evidenceRescues, undefined, 'no candidate is stashed');
+  assert.ok(!captured.lines.some(line => line.includes('Evidence-pointer rescue')), 'no rescue line is logged');
+
+  // A field with no evidence string at all: also a silent no-op.
+  const noEvidence = runFurballGate(parser, { address: '123 Fake Street' });
+  assert.equal(noEvidence.report.evidenceRescues, undefined);
+});
+
+test('evidence-pointer rescue: a verbatim value passes the gate and the feature never runs', () => {
+  const parser = createParser();
+  const captured = captureGateLogs();
+  let result;
+  try {
+    result = runFurballGate(parser, {
+      address: '79 WARRENTON',
+      __fieldEvidence: { address: '79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC' }
+    });
+  } finally {
+    captured.restore();
+  }
+  assert.equal(result.event.address, '79 WARRENTON', 'verbatim value is kept as before');
+  assert.equal(result.report.evidenceRescues, undefined, 'no rescue runs on kept fields');
+  assert.ok(!captured.lines.some(line => line.includes('Evidence-pointer rescue')));
+});
+
+test('evidence-pointer rescue: non-scoped fields (startTime) never rescue even with a verbatim pointer', () => {
+  const parser = createParser();
+  // 23:30 is nowhere in the corpus (flyer says 10pm-3am) → dropped; the
+  // evidence quote IS verbatim, but time fields are out of scope on purpose
+  // (format conversion is not transcription).
+  const result = runFurballGate(parser, {
+    startTime: '23:30',
+    __fieldEvidence: { startTime: 'OCR_IMAGE_TEXT: "10pm-3am"' }
+  });
+  assert.equal(result.event.startTime, undefined, 'the field still drops');
+  assert.equal(result.report.evidenceRescues, undefined, 'time fields are excluded from the rescue scope');
+});
+
+test('evidence-pointer rescue: token alignment takes the corpus span, not the whole located line', () => {
+  const parser = createParser();
+  // Long corpus line + mangled two-token value → aligned "79 WARRENTON":
+  // "79" anchors exactly, "Warrenon" ≈ "WARRENTON" within the edit budget.
+  assert.equal(
+    parser.alignValueTokensInSpan('79 Warrenon', '79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC'),
+    '79 WARRENTON'
+  );
+  // No exact anchor anywhere → no alignment (the caller falls back to the
+  // whole fragment, which is acceptable for log-only).
+  assert.equal(parser.alignValueTokensInSpan('Totally Unrelated', '79 WARRENTON TICKETS'), '');
+  // A dissimilar token breaks the window even next to an exact anchor.
+  assert.equal(parser.alignValueTokensInSpan('79 Houston', '79 WARRENTON TICKETS'), '');
+});
+
+test('evidence-pointer rescue: extractSingleEvent stamps deduped _evidenceRescues onto the event', async () => {
+  global.EventSchema = EventSchema; // earlier tests leak a mocked schema — pin the real one
+  const parser = createParser();
+  const combined = `${FURBALL_OCR_TEXT}\n\n${FURBALL_SEGMENT_TEXT}`;
+  // Mocked merged AI result: a snippet-pass rescue memo rides __evidenceRescues
+  // and the final gate re-drops the same mangled address → the two must dedupe
+  // into ONE stashed entry.
+  parser.getAiEvent = async () => ({
+    title: 'FURBALL Boston',
+    startDate: '2026-07-25',
+    address: '79 Warrenon',
+    __fieldEvidence: { address: '79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC' },
+    __evidenceRescues: [
+      { field: 'address', candidate: '79 WARRENTON', modelValue: '79 Warrenon', corpus: 'ocr' }
+    ]
+  });
+
+  const event = await parser.extractSingleEvent(
+    {
+      html: combined,
+      url: 'https://www.furball.nyc',
+      ocrResults: [{ url: 'https://img.example/furball.png', text: FURBALL_OCR_TEXT }]
+    },
+    {}, null, ['title', 'address', 'startDate']
+  );
+  assert.ok(event, 'extraction still yields an event');
+  assert.equal(event.address, '', 'the dropped address stays dropped (log-only)');
+  assert.deepEqual(event._evidenceRescues, [
+    { field: 'address', candidate: '79 WARRENTON', modelValue: '79 Warrenon', corpus: 'ocr' }
+  ], 'snippet memo + final-gate rescue dedupe to one entry');
+});
+
+test('evidence-pointer rescue: snippet-pass memos concatenate through mergeAiEventFields', () => {
+  const parser = createParser();
+  const merged = parser.mergeAiEventFields(
+    { __evidenceRescues: [{ field: 'address', candidate: 'A', modelValue: 'a', corpus: 'ocr' }] },
+    { __evidenceRescues: [{ field: 'bar', candidate: 'B', modelValue: 'b', corpus: 'page' }] }
+  );
+  assert.deepEqual(merged.__evidenceRescues, [
+    { field: 'address', candidate: 'A', modelValue: 'a', corpus: 'ocr' },
+    { field: 'bar', candidate: 'B', modelValue: 'b', corpus: 'page' }
+  ]);
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2569,6 +2569,22 @@ class SharedCore {
             }
         }
 
+        // Evidence-pointer rescue candidates from the AI evidence gate
+        // (_evidenceRescues — underscore field, never serialized; stamped by
+        // AiWebParser.extractSingleEvent). LOG-ONLY observation phase: the
+        // gate dropped these fields, so the event shows no value — each line
+        // surfaces what the rescue WOULD have adopted so real runs can prove
+        // or damn the heuristic before promotion.
+        const evidenceRescues = Array.isArray(event._evidenceRescues) ? event._evidenceRescues : [];
+        evidenceRescues.forEach(rescue => {
+            if (!rescue || typeof rescue !== 'object') return;
+            const rescueField = typeof rescue.field === 'string' ? rescue.field.trim() : '';
+            const rescueCandidate = typeof rescue.candidate === 'string' ? rescue.candidate.trim() : '';
+            if (!rescueField || !rescueCandidate) return;
+            const rescueModelValue = typeof rescue.modelValue === 'string' ? rescue.modelValue.trim() : '';
+            lines.push(`${rescueField} rescue candidate (log-only): "${rescueCandidate}"${rescueModelValue ? ` — model wrote "${rescueModelValue}"` : ''}`);
+        });
+
         // Compact provenance summary of whichever companion stamps exist.
         const provenance = [
             ['bar', 'barSource'],

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -7320,3 +7320,35 @@ test('evidence: a venue-name fusion flag renders its line and never serializes i
   const barless = core.buildEventEvidenceLines({ title: 'X', _geoPoiFusion: { poi: 'Aqua Club', prefix: 'Aqua' } });
   assert.ok(!barless.some(line => line.includes('may fuse')), 'no bar → no fusion line (fail open)');
 });
+
+test('evidence: pointer-rescue candidates render their panel line and never serialize into notes', () => {
+  const core = createCore();
+  // LOG-ONLY observation phase: the gate dropped the field (the event shows
+  // no value) — the line surfaces what the rescue WOULD have adopted so real
+  // runs can prove or damn the heuristic before promotion.
+  const event = {
+    title: 'FURBALL Boston',
+    city: 'dallas',
+    _evidenceRescues: [
+      { field: 'address', candidate: '79 WARRENTON', modelValue: '79 Warrenon', corpus: 'ocr' },
+      { field: 'bar', candidate: 'The Alley Cantina', modelValue: 'Alley Cantena', corpus: 'page' }
+    ]
+  };
+  const lines = core.buildEventEvidenceLines(event);
+  assert.ok(
+    lines.includes('address rescue candidate (log-only): "79 WARRENTON" — model wrote "79 Warrenon"'),
+    `address rescue line expected, got: ${JSON.stringify(lines)}`
+  );
+  assert.ok(
+    lines.includes('bar rescue candidate (log-only): "The Alley Cantina" — model wrote "Alley Cantena"'),
+    'one compact line per rescue entry'
+  );
+  assert.ok(!/(_evidenceRescues|WARRENTON)/.test(core.formatEventNotes(event)), '_evidenceRescues never serializes into notes');
+
+  // Malformed entries fail open: no line, no crash.
+  const junk = core.buildEventEvidenceLines({
+    title: 'X',
+    _evidenceRescues: [null, 42, {}, { field: 'bar' }, { candidate: 'orphan' }]
+  });
+  assert.ok(!junk.some(line => line.includes('rescue candidate')), 'malformed rescue entries render nothing');
+});


### PR DESCRIPTION
## The learning (from run 20260723-224434, FURBALL Boston)
The extraction model is a good FINDER and a bad COPIER. Its retry-pass address cited evidence `79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC` — a verbatim corpus line — but wrote the value "79 Warrenon". The verbatim gate correctly dropped the mangled copy… and with it discarded a perfectly good pointer to the correct text. Same run, same field, the FIRST pass showed the opposite shape: evidence full of inference language ("assumed typo", "Additional context clarifies") — a rotten pointer that deserves no trust at all. Those two shapes define this feature's boundary.

## What this does (LOG-ONLY observation phase — zero behavior change)
When the gate drops a scoped field (`bar`, `address`, `cover`) **solely because the value is not verbatim in the corpus**:
1. The model's evidence string is unwrapped (straight/curly quotes, `OCR_IMAGE_TEXT:`-style marker labels, escaped newlines, ellipses, multi-fragment citations) and located in the raw text corpora the gate already checks — OCR text, then segment/page text. Raw text only; structured data is never consulted (bear websites' JSON-LD is not to be trusted).
2. If the evidence locates, the candidate value is derived from the CORPUS'S own characters/casing — never the model's rendition — by token-aligning the mangled value inside the located span ("79" anchors exactly, "Warrenon"≈"WARRENTON" within bounded edit distance → candidate `79 WARRENTON`, not the whole ticket line).
3. Nothing is adopted. One log line per candidate (`Evidence-pointer rescue (log-only) for address: corpus has "79 WARRENTON" where model wrote "79 Warrenon" (evidence located in ocr text)`) and one evidence-panel line in the results UI (`address rescue candidate (log-only): "79 WARRENTON" — model wrote "79 Warrenon"`), via a non-serialized `_evidenceRescues` underscore field.

**Rescue never fires** for evidence-quality rejections (context-citing, brand-citing, invented-time), for evidence containing inference language or additional-context citations (double-blocked), for out-of-scope fields (date/time = format conversion + inference-safety; city = normalized keys; URLs = different validation), or when the evidence can't be located (silent no-op — the common case). The gate's accept/reject decisions are byte-identical to before; the observation is try/catch-sealed so it can never affect extraction.

## Promotion path
Same as the bar-convergence rescue: watch the candidates in real runs' evidence panels; if the heuristic proves itself, a follow-up PR lets it adopt values (and widens the field scope) — if it misfires, the cost was a log line.

## Tests
689 pass (678 baseline + 11): the canonical run-224434 pair (retry shape → candidate logged/stashed with the drop record byte-identical; first-pass rotten-pointer shape → nothing), quoted/curly/multi-fragment envelopes, marker-label stripping that never eats real content like "79 WARRENTON TICKETS:", unlocatable evidence no-op, verbatim-pass never runs, non-scoped startTime refused, alignment unit cases, snippet-pass memo merge + dedupe end-to-end, panel rendering + notes exclusion + malformed-entry fail-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP