### PR TITLE
fix(scraper): word-boundary verbatim gate + address-shaped bar drop

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -679,6 +679,13 @@ class AiWebParser {
         // name — and it sailed through to geocoding). Runs BEFORE the bar
         // corroboration stamp so a dropped address never feeds adjacency.
         this.applyAddressPlausibilityGate(event, promptHtmlData);
+        // Bar plausibility gate: an address-shaped bar is never a valid
+        // extraction (run 20260724-115423: bar "79 Warren" — the flyer's
+        // street line — survived and blocked the convergence rescue). Runs
+        // AFTER the address gate (so a matching address twin still drops via
+        // "matches venue name") and BEFORE the convergence rescue (so a
+        // dropped bar frees the rescue to adopt the real venue).
+        this.applyBarPlausibilityGate(event);
         // Deterministic bar-convergence rescue: only when extraction left NO
         // bar (including a gate-dropped one). Every plausible name line from
         // the page text, the OCR text, and the curated bars corpus is a
@@ -6965,10 +6972,79 @@ TEXT:
     hasExactEvidence(evidenceContext, value) {
         const normalizedValue = this.normalizeEvidenceText(value);
         if (!normalizedValue) return false;
-        if (evidenceContext.normalized.includes(normalizedValue)) return true;
+        if (this.corpusIncludesOnWordBoundary(evidenceContext.normalized, normalizedValue)) return true;
         const compactValue = normalizedValue.replace(/[^a-z0-9]+/g, '');
-        return compactValue.length >= this.extractionLimits.evidenceCompactMinLength && evidenceContext.compact.includes(compactValue);
+        if (compactValue.length < this.extractionLimits.evidenceCompactMinLength) return false;
+        // Cheap pre-check against the precomputed compact corpus before the
+        // boundary-mapped scan.
+        if (!evidenceContext.compact.includes(compactValue)) return false;
+        return this.compactIncludesOnWordBoundary(evidenceContext.normalized, compactValue);
+    }
 
+    // Truncation is not verbatim (run 20260724-115423: model bar "79 Warren"
+    // passed the gate because it is a PREFIX of the corpus's "79 WARRENTON
+    // TICKETS: ..." — a copy that stops mid-word counted as verbatim). A
+    // containment hit only counts when the matched span sits on WORD
+    // BOUNDARIES in the corpus: no alphanumeric-to-alphanumeric junction at
+    // either edge of the span. A span edge that is itself non-alphanumeric
+    // (quotes, apostrophes) needs no boundary on that side. So "legacy" in
+    // "legacy's" passes (apostrophe bounds), "eagle" in "eagle bar" passes
+    // (space bounds), "79 warren" in "79 warrenton" fails (the span runs
+    // straight into "ton"). Case-insensitivity and whitespace flexibility are
+    // unchanged — both strings are already normalizeEvidenceText output.
+    corpusIncludesOnWordBoundary(corpus, needle) {
+        const haystack = String(corpus || '');
+        const target = String(needle || '');
+        if (!target) return false;
+        const wordChar = /[a-z0-9]/;
+        const needsLeftBoundary = wordChar.test(target[0]);
+        const needsRightBoundary = wordChar.test(target[target.length - 1]);
+        let from = 0;
+        let index;
+        while ((index = haystack.indexOf(target, from)) !== -1) {
+            const leftOk = !needsLeftBoundary || index === 0 || !wordChar.test(haystack[index - 1]);
+            const end = index + target.length;
+            const rightOk = !needsRightBoundary || end === haystack.length || !wordChar.test(haystack[end]);
+            if (leftOk && rightOk) return true;
+            from = index + 1;
+        }
+        return false;
+    }
+
+    // The compact fallback (all non-alphanumerics stripped) must not
+    // reintroduce the truncation hole: every compact hit is mapped back to
+    // its span in the NORMALIZED corpus — where separators still exist — and
+    // the same word-boundary rule is applied at the span's edges there.
+    // "79warren" inside "79warrenton..." maps to a normalized span followed
+    // by "t" and fails; "rockbar" matching the corpus's "rock bar" still
+    // passes (the mapped span is space-bounded).
+    compactIncludesOnWordBoundary(normalizedCorpus, compactValue) {
+        const corpus = String(normalizedCorpus || '');
+        const target = String(compactValue || '');
+        if (!target) return false;
+        const wordChar = /[a-z0-9]/;
+        // Map every compact character back to its index in the normalized
+        // corpus (compact is normalized with [^a-z0-9] stripped, by
+        // construction — see buildAiEvidenceContext).
+        const map = [];
+        let compact = '';
+        for (let i = 0; i < corpus.length; i++) {
+            if (wordChar.test(corpus[i])) {
+                compact += corpus[i];
+                map.push(i);
+            }
+        }
+        let from = 0;
+        let index;
+        while ((index = compact.indexOf(target, from)) !== -1) {
+            const start = map[index];
+            const end = map[index + target.length - 1];
+            const leftOk = start === 0 || !wordChar.test(corpus[start - 1]);
+            const rightOk = end === corpus.length - 1 || !wordChar.test(corpus[end + 1]);
+            if (leftOk && rightOk) return true;
+            from = index + 1;
+        }
+        return false;
     }
 
     hasFuzzyEvidence(evidenceContext, value) {
@@ -7690,6 +7766,11 @@ TEXT:
             if (this.evidenceCitesAdditionalContext(evidence)) return;
             const rescue = this.deriveEvidencePointerRescue(String(value), evidence, evidenceContext, rescueContext);
             if (!rescue || !rescue.candidate) return;
+            // An address-shaped candidate is useless FOR THE BAR FIELD (a
+            // bar rescue candidate "79 WARRENTON" could never be adopted —
+            // the bar plausibility gate would drop it): suppress silently.
+            // Address-field candidates are unaffected.
+            if (rule.field === 'bar' && this.isAddressShapedBarValue(rescue.candidate)) return;
             const entry = {
                 field: rule.field,
                 candidate: this.trimToMaxLength(rescue.candidate, this.extractionLimits.validationReportValueMaxLength),
@@ -7800,6 +7881,11 @@ TEXT:
     // variants are tolerated char-for-char (curly vs straight). Returns the
     // corpus-cased span or null. HTML-entity-encoded corpus occurrences are a
     // known acceptable miss (silent no-op) in this log-only phase.
+    // A fragment located mid-word is NOT located: the same word-boundary rule
+    // the gate applies (see corpusIncludesOnWordBoundary) guards both edges,
+    // so "79 WARREN" never locates inside "79 WARRENTON". Guards apply only
+    // where the fragment's own edge is alphanumeric — a fragment starting or
+    // ending in punctuation carries its own boundary.
     locateEvidenceFragmentSpan(fragment, rawCorpus) {
         const corpus = String(rawCorpus || '');
         if (!corpus) return null;
@@ -7811,12 +7897,14 @@ TEXT:
             const pattern = tokens
                 .map(token => this.escapeRegex(token).replace(/['’‘]/g, "['’‘]").replace(/["“”]/g, '["“”]'))
                 .join('\\s+');
-            matcher = new RegExp(pattern, 'i');
+            const leftGuard = /^[a-z0-9]/.test(tokens[0]) ? '(?:^|[^A-Za-z0-9])' : '';
+            const rightGuard = /[a-z0-9]$/.test(tokens[tokens.length - 1]) ? '(?=$|[^A-Za-z0-9])' : '';
+            matcher = new RegExp(`${leftGuard}(${pattern})${rightGuard}`, 'i');
         } catch (_) {
             return null;
         }
         const match = matcher.exec(corpus);
-        return match ? match[0] : null;
+        return match ? match[1] : null;
     }
 
     // Simple deterministic token alignment of the model's mangled value inside
@@ -9764,6 +9852,53 @@ TEXT:
         if (!reason) return event;
         console.log(`🤖 AI Web: Dropped implausible address "${address}" (${reason})`);
         delete event.address;
+        return event;
+    }
+
+    // Address-shape test for a BAR value (run 20260724-115423: extraction
+    // returned bar "79 Warren" off the flyer's street line and no gate
+    // guarded the bar the way applyAddressPlausibilityGate guards the
+    // address). Address-shaped means a street-address pattern, NEVER merely
+    // "contains a digit" — venue names legitimately carry numbers ("Bar 32",
+    // "Studio 54", "700 Club" all keep). True when ANY of:
+    //   - shared-core's looksLikeStreetAddress: leading house number +
+    //     street-type word ("79 Warrenton St");
+    //   - the digit + street-type-word shape the convergence rescue's
+    //     candidate filter rejects (getVenueLineCandidateRejection);
+    //   - a leading house number followed by a SINGLE bare word that is not
+    //     a venue-type word — the truncated street line off a flyer
+    //     ("79 WARRENTON"); a venue-type word stays a name ("700 Club").
+    isAddressShapedBarValue(value) {
+        const text = String(value || '').trim();
+        if (!text) return false;
+        if (this.core && typeof this.core.looksLikeStreetAddress === 'function'
+            && this.core.looksLikeStreetAddress(text)) return true;
+        if (/\d/.test(text)
+            && /(?:^|\s)(?:St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Ln|Lane|Way|Hwy|Pl|Place|Ct|Court)\.?(?:\s|$)/i.test(text)) return true;
+        const truncatedStreetLine = text.match(/^\d{1,6}(?:-\d{1,6})?\s+([A-Za-z][A-Za-z'’.-]*)$/);
+        if (truncatedStreetLine) {
+            const venueTypeWord = /^(?:club|bar|lounge|pub|tavern|saloon|cafe|café|grill|restaurant|studio|hall|house|room|theater|theatre|cabaret|hotel|inn|brewery|taproom|eatery|bistro|diner|kitchen)$/i;
+            return !venueTypeWord.test(truncatedStreetLine[1]);
+        }
+        return false;
+    }
+
+    // Post-extraction bar plausibility gate (mirror of
+    // applyAddressPlausibilityGate: flag-and-drop, additive log): an
+    // address-shaped bar VALUE is never a valid extraction. Run
+    // 20260724-115423 kept bar "79 Warren" (a truncated street line that
+    // slipped the verbatim gate) and the surviving garbage then — correctly,
+    // by design — blocked the bar-convergence rescue from adopting the real
+    // venue "Legacy". Runs BEFORE applyBarConvergenceRescue so a dropped bar
+    // frees the rescue to fire. Fails open: no bar, or not address-shaped →
+    // untouched.
+    applyBarPlausibilityGate(event) {
+        if (!event || typeof event !== 'object') return event;
+        const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+        if (!bar) return event;
+        if (!this.isAddressShapedBarValue(bar)) return event;
+        console.log(`🤖 AI Web: Dropped implausible bar "${bar}" (address-shaped)`);
+        delete event.bar;
         return event;
     }
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -4513,3 +4513,237 @@ test('bar convergence: single-page events fall back to the page text when no seg
   assert.equal(event.bar, 'Legacy');
   assert.equal(event.barSource, 'curated');
 });
+
+// ---------------------------------------------------------------------------
+// Word-boundary verbatim gate + address-shaped bar drop (run 20260724-115423:
+// FURBALL Boston — model bar "79 Warren" with evidence "79 WARRENTON" PASSED
+// the gate because "79 Warren" is a PREFIX of the corpus's "79 WARRENTON
+// TICKETS: ..."; the surviving garbage bar then correctly blocked the
+// convergence rescue from adopting the real venue "Legacy").
+// ---------------------------------------------------------------------------
+
+// The incident flyer OCR: the street line runs straight into the ticket text.
+const INCIDENT_20260724_OCR = 'FURBALL BOSTON\nBEAR WEEK RETURN\nLEGACY\n79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC';
+
+test('verbatim gate word boundaries: a truncated mid-word span is not verbatim', () => {
+  const parser = createParser();
+  const ctx = text => parser.buildAiEvidenceContextFromText(text);
+  const incident = 'LEGACY\nBEFFYBOY\n79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC';
+
+  // The incident shape: a copy that stops mid-word is not verbatim.
+  assert.equal(parser.hasExactEvidence(ctx(incident), '79 Warren'), false, '"79 Warren" is a prefix of "79 WARRENTON"');
+  // Truncation of the corpus word at either end fails.
+  assert.equal(parser.hasExactEvidence(ctx('THE WARRENTONS'), 'Warrenton'), false, 'span followed by "S"');
+  assert.equal(parser.hasExactEvidence(ctx('79 WARRENTON'), 'RENTON'), false, 'span preceded by "WAR"');
+  assert.equal(parser.hasExactEvidence(ctx('790 MAIN'), '79'), false, 'digit runs are words too');
+
+  // Legitimate boundaries keep passing: newline, space, apostrophe, dot,
+  // string edges — with the same case-insensitivity as before.
+  assert.equal(parser.hasExactEvidence(ctx(incident), 'Legacy'), true, 'newline-bounded ALL-CAPS corpus line');
+  assert.equal(parser.hasExactEvidence(ctx('THE WARRENTON'), 'Warrenton'), true, 'whole word matches');
+  assert.equal(parser.hasExactEvidence(ctx('Eagle Bar'), 'Eagle'), true, 'space boundary');
+  assert.equal(parser.hasExactEvidence(ctx("Legacy's"), 'Legacy'), true, 'apostrophe boundary');
+  assert.equal(parser.hasExactEvidence(ctx(incident), 'FURBALL'), true, 'dot boundary');
+  assert.equal(parser.hasExactEvidence(ctx('BEAR   WEEK\nRETURN'), 'Bear Week Return'), true, 'whitespace flexibility unchanged');
+
+  // The compact fallback (punctuation/whitespace variants) still passes on
+  // boundaries — and must not reopen the truncation hole.
+  assert.equal(parser.hasExactEvidence(ctx('ROCKBAR NYC'), 'Rock Bar'), true, 'compact join, bounded span');
+  assert.equal(parser.hasExactEvidence(ctx('ROCK BAR'), 'Rockbar'), true, 'compact split, bounded span');
+  assert.equal(parser.hasExactEvidence(ctx('79 WARRENTON'), '79-Warren'), false, 'compact path is boundary-checked too');
+
+  // A mid-word first occurrence does not mask a bounded later one.
+  assert.equal(parser.hasExactEvidence(ctx('WARRENTON AND WARREN ST'), 'Warren'), true, 'scan continues past mid-word hits');
+});
+
+test('verbatim gate: the incident bar "79 Warren" with evidence "79 WARRENTON" now drops', () => {
+  const parser = createParser();
+  // The real run's evidence string was exactly "79 WARRENTON" (log line
+  // ~320 of 20260724-115423).
+  const result = runFurballGate(parser, {
+    bar: '79 Warren',
+    __fieldEvidence: { bar: '79 WARRENTON' }
+  });
+  assert.equal(result.event.bar, undefined, 'the truncated copy is no longer verbatim');
+  assert.deepEqual(result.report.dropped, [{ field: 'bar', key: 'bar', mode: 'exact', value: '79 Warren' }]);
+  // The pointer locates, but the derived candidate "79 WARRENTON" is
+  // address-shaped and useless FOR THE BAR FIELD — suppressed silently.
+  assert.equal(result.report.evidenceRescues, undefined, 'no address-shaped bar candidate is stashed');
+});
+
+test('locateEvidenceFragmentSpan: a fragment located mid-word is not located', () => {
+  const parser = createParser();
+  const corpus = '79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC';
+  assert.equal(parser.locateEvidenceFragmentSpan('79 WARREN', corpus), null, 'truncated fragment does not locate');
+  assert.equal(parser.locateEvidenceFragmentSpan('79 WARRENTON', corpus), '79 WARRENTON', 'whole-word fragment locates');
+  // The regex scans past a mid-word hit to a bounded later occurrence.
+  assert.equal(parser.locateEvidenceFragmentSpan('WARREN', 'WARRENTON AND WARREN ST'), 'WARREN');
+});
+
+test('evidence-pointer rescue: address-shaped BAR candidates are suppressed; address candidates still log', () => {
+  const parser = createParser();
+  const captured = captureGateLogs();
+  let result;
+  try {
+    result = runFurballGate(parser, {
+      bar: '79 Warrenon',
+      address: '79 Warrenon',
+      __fieldEvidence: {
+        bar: '79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC',
+        address: '79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC'
+      }
+    });
+  } finally {
+    captured.restore();
+  }
+  assert.equal(result.event.bar, undefined);
+  assert.equal(result.event.address, undefined);
+  assert.deepEqual(result.report.evidenceRescues, [
+    { field: 'address', candidate: '79 WARRENTON', modelValue: '79 Warrenon', corpus: 'ocr' }
+  ], 'only the address entry is stashed — the bar candidate is address-shaped');
+  assert.ok(
+    captured.lines.some(line => line.includes('Evidence-pointer rescue (log-only) for address')),
+    'the address candidate still logs'
+  );
+  assert.ok(
+    !captured.lines.some(line => line.includes('Evidence-pointer rescue (log-only) for bar')),
+    'the bar candidate is suppressed silently'
+  );
+});
+
+test('bar plausibility shapes: leading house number + street-ish continuation, never "contains a digit"', () => {
+  const parser = createParser();
+  // Address-shaped: dropped.
+  assert.equal(parser.isAddressShapedBarValue('79 Warrenton St'), true, 'house number + street-type word');
+  assert.equal(parser.isAddressShapedBarValue('79 WARRENTON'), true, 'truncated street line: house number + single bare word');
+  assert.equal(parser.isAddressShapedBarValue('10-90 Wyckoff Ave'), true, 'hyphenated Queens-style house number');
+  // Venue names that merely contain numbers: kept (owner doctrine — venue
+  // names CAN legitimately contain numbers).
+  assert.equal(parser.isAddressShapedBarValue('Bar 32'), false, 'trailing number is not a house number');
+  assert.equal(parser.isAddressShapedBarValue('Studio 54'), false);
+  assert.equal(parser.isAddressShapedBarValue('700 Club'), false, 'leading number + venue-type word stays a name');
+  assert.equal(parser.isAddressShapedBarValue('3 Dollar Bill'), false, 'leading number + multi-word name stays a name');
+  assert.equal(parser.isAddressShapedBarValue('Legacy'), false);
+  assert.equal(parser.isAddressShapedBarValue(''), false);
+});
+
+test('bar plausibility gate: an address-shaped bar is dropped with the additive log; numbered venue names keep', () => {
+  const parser = createParser();
+  const event = { title: 'FURBALL Boston', bar: '79 WARRENTON', city: 'boston' };
+  const logs = captureLogs(() => { parser.applyBarPlausibilityGate(event); });
+  assert.equal('bar' in event, false, 'the address-shaped bar is cleared');
+  assert.ok(
+    logs.includes('🤖 AI Web: Dropped implausible bar "79 WARRENTON" (address-shaped)'),
+    `expected the new drop line, got: ${JSON.stringify(logs)}`
+  );
+
+  const keep = { title: 'Underbear', bar: '700 Club' };
+  const keepLogs = captureLogs(() => { parser.applyBarPlausibilityGate(keep); });
+  assert.equal(keep.bar, '700 Club', 'numbered venue names are untouched');
+  assert.equal(keepLogs.length, 0, 'no log when nothing drops');
+});
+
+test('incident 20260724-115423 end-to-end: truncated bar+address drop, bar rescue candidate suppressed, convergence adopts curated "Legacy"', async () => {
+  global.EventSchema = EventSchema; // earlier tests leak a mocked schema — pin the real one
+  const parser = createRescueParser(BOSTON_CURATED_BARS);
+  // The real run shape: model returns bar/address "79 Warren" with evidence
+  // "79 WARRENTON"; corpus carries the flyer OCR (street line + LEGACY),
+  // the segment text (Legacy above Boston, MA), curated boston bars carry
+  // Legacy.
+  parser.getAiEvent = async () => ({
+    title: 'FURBALL Boston',
+    startDate: '2026-07-25',
+    city: 'boston',
+    bar: '79 Warren',
+    address: '79 Warren',
+    __fieldEvidence: { bar: '79 WARRENTON', address: '79 WARRENTON' }
+  });
+  const htmlData = {
+    url: 'https://www.furball.nyc',
+    html: `${INCIDENT_20260724_OCR}\n\n${FURBALL_BOSTON_SEGMENT}`,
+    segmentText: FURBALL_BOSTON_SEGMENT,
+    ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: INCIDENT_20260724_OCR }],
+    pageBrandNames: ['FURBALL']
+  };
+  let event;
+  const warns = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => { warns.push(String(message)); };
+  let logs;
+  try {
+    logs = await captureLogsAsync(async () => {
+      event = await parser.extractSingleEvent(htmlData, {}, RESCUE_CITY_CONFIG, ['title', 'bar', 'address', 'city', 'startDate']);
+    });
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.ok(event, 'extraction yields an event');
+
+  // Stage 1: the gate drops BOTH truncated copies (mid-word is not
+  // verbatim). The drop summary is a console.warn line.
+  assert.ok(
+    warns.some(line => line.includes('Dropped 2 field(s) lacking source evidence: bar, address')),
+    `gate drop line expected, got: ${JSON.stringify(warns)}`
+  );
+
+  // Stage 2: the pointer rescue logs the ADDRESS candidate but never an
+  // address-shaped BAR candidate.
+  assert.ok(
+    logs.some(line => line.includes('Evidence-pointer rescue (log-only) for address: corpus has "79 WARRENTON"')),
+    'address candidate is observed'
+  );
+  assert.ok(
+    !logs.some(line => line.includes('Evidence-pointer rescue (log-only) for bar')),
+    'bar candidate is suppressed'
+  );
+  assert.deepEqual(event._evidenceRescues, [
+    { field: 'address', candidate: '79 WARRENTON', modelValue: '79 Warren', corpus: 'ocr' }
+  ]);
+
+  // Stage 3: with no surviving garbage bar, the convergence rescue adopts
+  // the curated venue on all three signals.
+  assert.ok(
+    logs.some(line => line.includes('Rescued bar "Legacy" via signal convergence')),
+    `convergence rescue line expected, got: ${JSON.stringify(logs)}`
+  );
+  assert.equal(event.bar, 'Legacy');
+  assert.equal(event.barSource, 'curated');
+  assert.equal(event.address || '', '', 'the address twin stays dropped');
+});
+
+test('bar plausibility gate runs BEFORE the convergence rescue: a verbatim address-shaped bar drops and "Legacy" is rescued', async () => {
+  global.EventSchema = EventSchema;
+  const parser = createRescueParser(BOSTON_CURATED_BARS);
+  // Variant: the model copies the street line VERBATIM ("79 WARRENTON"), so
+  // the evidence gate keeps it — the deterministic bar plausibility gate is
+  // the only guard, and it must fire before the convergence rescue.
+  parser.getAiEvent = async () => ({
+    title: 'FURBALL Boston',
+    startDate: '2026-07-25',
+    city: 'boston',
+    bar: '79 WARRENTON',
+    __fieldEvidence: { bar: '79 WARRENTON' }
+  });
+  const htmlData = {
+    url: 'https://www.furball.nyc',
+    html: `${INCIDENT_20260724_OCR}\n\n${FURBALL_BOSTON_SEGMENT}`,
+    segmentText: FURBALL_BOSTON_SEGMENT,
+    ocrResults: [{ url: 'https://furball.nyc/flyer.jpg', text: INCIDENT_20260724_OCR }],
+    pageBrandNames: ['FURBALL']
+  };
+  let event;
+  const logs = await captureLogsAsync(async () => {
+    event = await parser.extractSingleEvent(htmlData, {}, RESCUE_CITY_CONFIG, ['title', 'bar', 'city', 'startDate']);
+  });
+  assert.ok(event, 'extraction yields an event');
+  assert.ok(
+    logs.includes('🤖 AI Web: Dropped implausible bar "79 WARRENTON" (address-shaped)'),
+    `plausibility drop line expected, got: ${JSON.stringify(logs)}`
+  );
+  assert.ok(
+    logs.some(line => line.includes('Rescued bar "Legacy" via signal convergence')),
+    'the freed rescue adopts the real venue'
+  );
+  assert.equal(event.bar, 'Legacy');
+  assert.equal(event.barSource, 'curated');
+});


### PR DESCRIPTION
## The incident (run 20260724-115423 — first run with #1530–#1533 deployed)
FURBALL Boston came out as bar "79 Warren". The model returned `bar: {"value": "79 Warren", "evidence": "79 WARRENTON"}` and the verbatim gate PASSED it: the value-in-corpus check was substring-based, and "79 Warren" is a prefix of the corpus's `79 WARRENTON TICKETS: ...` — a copy truncated MID-WORD counted as verbatim. The surviving garbage bar then (correctly, by design) blocked the bar-convergence rescue, so the rescueable "Legacy" (curated + page text + flyer OCR, all agreeing) never got adopted. The address twin was already caught by the existing plausibility gate; the bar had no equivalent guard. The owner spotted it via the evidence panel's log-only rescue lines — the observability doing exactly its job.

## Fix 1 — truncation is not verbatim
`hasExactEvidence`'s two containment paths (normalized substring + compact fallback) now require **word boundaries**: a match only counts when neither span edge has an alphanumeric-to-alphanumeric junction. "79 Warren" in "79 WARRENTON" fails (runs into "TON"); "Legacy" in "LEGACY" / "Eagle" in "Eagle Bar" / "Legacy" in "Legacy's" all still pass; the compact path ("rockbar" ↔ "rock bar") keeps its punctuation flexibility by mapping compact hits back to normalized-corpus spans and boundary-checking there. The scan skips past mid-word hits to later bounded occurrences. The evidence-pointer rescue's fragment locator had the same hole and got the same boundary guards. **Zero baseline tests newly failed** — nothing legitimate relied on mid-word matching.

## Fix 2 — an address-shaped bar is never a valid extraction
New `applyBarPlausibilityGate` (mirror of the address gate, fail-open): a bar value shaped like a street address — `looksLikeStreetAddress`, the digit+street-type pattern, or leading-house-number + single bare non-venue word (the truncated street line "79 WARRENTON") — is dropped with the additive log `Dropped implausible bar "..." (address-shaped)`. Runs after the address gate and BEFORE the convergence rescue, so dropping the garbage frees the rescue. Venue names that legitimately contain numbers are protected both directions in tests: "Bar 32", "Studio 54", "700 Club", "3 Dollar Bill" all keep. The evidence-pointer rescue also stops emitting address-shaped candidates for the bar field (an address candidate for the ADDRESS field still logs).

## End-to-end (the real run's literal values, asserted stage by stage)
bar "79 Warren" / evidence "79 WARRENTON" → gate drops bar AND address (truncation) → address rescue candidate "79 WARRENTON" logged, no bar candidate → convergence rescue adopts **Legacy** (signals: curated, page, ocr), `barSource: curated` → venue-POI machinery downstream supplies 79 Warrenton Street + pin.

## Tests
710 pass (702 baseline + 8, zero baseline changes): boundary matrix (prefix/suffix truncation, digit runs, compact-path hole, scan-past-mid-word, apostrophe/space boundaries), bar shape matrix both directions, gate placement e2e ×2, rescue-locator boundaries, bar-candidate suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP