### PR TITLE
fix(scraper): OCR must not evict page text; curated bars survive remote refresh; rescue guards + url-slug signal + retry feedback

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2325,18 +2325,56 @@ class ScriptableAdapter {
   // per-city fetching would mean ~45 requests with many 404s on a fresh
   // day) — and fall back to the per-city files (data/bars/<city>.json) when
   // the combined fetch fails. cityKeys is the array of cities to refresh, or
-  // null for "all cities": the whole combined object replaces local
-  // wholesale, with local-only cities kept as fallback entries (per-city
-  // fetching is impossible without a city list, so a combined failure
-  // returns the local bars unchanged). Any per-city failure quietly keeps
-  // the local entry. Returns { bars, counts } — counts feed the review UI's
+  // null for "all cities". Each remote-served city is a per-city UNION with
+  // the local list (mergeRemoteAndLocalCityBars: remote wins for a shared
+  // bar-name key, local-only bars are appended), local-only cities are kept
+  // as fallback entries (per-city fetching is impossible without a city
+  // list, so a combined failure returns the local bars unchanged). Any
+  // per-city failure quietly keeps the local entry. Returns
+  // { bars, counts } — counts feed the review UI's
   // freshness line (remote = cities served from website data, combined or
   // per-city; local = kept from the local file; unavailable = neither).
+  // The bar-name identity key — mirrors SharedCore.normalizeBarNameKey
+  // (shared-core is not importable from the adapter layer): lowercase, drop
+  // a leading "the ", strip non-alphanumerics.
+  normalizeRemoteBarNameKey(name) {
+    return String(name || "")
+      .toLowerCase()
+      .replace(/^\s*the\s+/, "")
+      .replace(/[^a-z0-9]/g, "");
+  }
+
+  // Per-city UNION of remote and local bar lists (mirrors tools/sync-bars.js
+  // mergeBars semantics; curated-data-beats-derived, fail closed): remote
+  // entries win for a shared bar-name key (freshest enrichment), local-only
+  // entries are appended — a bar curated in the local scraper-bars.js must
+  // survive until the site deploys it (run 20260724-122902: the wholesale
+  // replace discarded the locally curated "Legacy" through a 1-day cache).
+  // Nameless local entries have no identity key and are skipped.
+  mergeRemoteAndLocalCityBars(remoteList, localList) {
+    const merged = Array.isArray(remoteList) ? remoteList.slice() : [];
+    const seenKeys = new Set(
+      merged
+        .map((bar) => this.normalizeRemoteBarNameKey(bar && bar.name))
+        .filter(Boolean),
+    );
+    let appended = 0;
+    for (const bar of Array.isArray(localList) ? localList : []) {
+      const key = this.normalizeRemoteBarNameKey(bar && bar.name);
+      if (!key || seenKeys.has(key)) continue;
+      seenKeys.add(key);
+      merged.push(bar);
+      appended += 1;
+    }
+    return { merged, appended };
+  }
+
   async refreshRemoteBars(cityKeys, localBars) {
     const merged = {
       ...(localBars && typeof localBars === "object" ? localBars : {}),
     };
     const counts = { remote: 0, local: 0, unavailable: 0 };
+    let localOnlyMerged = 0;
     const barsCacheConfig = {
       enabled: this.getPageCacheConfig().enabled,
       ttlDays: 1,
@@ -2362,7 +2400,12 @@ class ScriptableAdapter {
             : [];
       for (const cityKey of keys) {
         if (Array.isArray(combinedBars[cityKey])) {
-          merged[cityKey] = combinedBars[cityKey];
+          const union = this.mergeRemoteAndLocalCityBars(
+            combinedBars[cityKey],
+            merged[cityKey],
+          );
+          merged[cityKey] = union.merged;
+          localOnlyMerged += union.appended;
           counts.remote += 1;
         } else if (merged[cityKey]) {
           counts.local += 1;
@@ -2380,7 +2423,12 @@ class ScriptableAdapter {
         const url = `https://chunky.dad/data/bars/${encodeURIComponent(cityKey)}.json`;
         const parsed = await this.fetchRemoteBarsJson(url, barsCacheConfig);
         if (Array.isArray(parsed)) {
-          merged[cityKey] = parsed;
+          const union = this.mergeRemoteAndLocalCityBars(
+            parsed,
+            merged[cityKey],
+          );
+          merged[cityKey] = union.merged;
+          localOnlyMerged += union.appended;
           counts.remote += 1;
         } else if (merged[cityKey]) {
           counts.local += 1;
@@ -2392,6 +2440,13 @@ class ScriptableAdapter {
     console.log(
       `📱 Scriptable: Bars data — ${counts.remote} cities from chunky.dad, ${counts.local} from local file, ${counts.unavailable} unavailable`,
     );
+    // Additive line (the freshness line above keeps its exact shape): how
+    // many locally curated bars were appended to remote-served cities.
+    if (localOnlyMerged > 0) {
+      console.log(
+        `📱 Scriptable: Bars data — merged ${localOnlyMerged} local-only bar(s)`,
+      );
+    }
     return { bars: merged, counts };
   }
 

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -955,8 +955,11 @@ test('refreshRemoteBars falls back per city when the combined file 404s, keeping
   const result = await adapter.refreshRemoteBars(['poconos', 'nyc', 'bogota'], localBars);
 
   assert.equal(adapter.fetches[0].url, COMBINED_BARS_URL, 'the combined file is tried first');
-  assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Camp Out'],
-    'remote city replaces the local entry wholesale');
+  // Union semantics (was: wholesale replace — the replace was the bug that
+  // discarded locally curated bars, run 20260724-122902): remote entries
+  // lead, local entries with a bar-name key absent from remote survive.
+  assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Camp Out', 'Stale Camp Out'],
+    'remote city leads; the local-only entry survives the refresh');
   assert.deepEqual(result.bars.nyc.map((b) => b.name), ['Eagle NYC'],
     'fetch failure keeps the local entry');
   assert.deepEqual(result.bars.seattle.map((b) => b.name), ['The Cuff'],
@@ -1012,8 +1015,12 @@ test('refreshRemoteBars serves requested cities from the combined file with a si
 
   assert.equal(adapter.fetches.length, 1, 'one combined fetch, no per-city fetches');
   assert.equal(adapter.fetches[0].url, COMBINED_BARS_URL);
-  assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Camp Out'], 'a combined city replaces local wholesale');
-  assert.deepEqual(result.bars.nyc.map((b) => b.name), ['Eagle NYC'], 'the combined file wins over a stale local entry');
+  assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Camp Out'], 'a combined-only city arrives as-is');
+  // Union semantics (was: wholesale replace — the bug that discarded
+  // locally curated bars): the combined file leads, but a local entry whose
+  // bar-name key is absent from it is appended, not discarded.
+  assert.deepEqual(result.bars.nyc.map((b) => b.name), ['Eagle NYC', 'Stale Eagle'],
+    'the combined file leads; the local-only entry survives');
   assert.deepEqual(result.bars.seattle.map((b) => b.name), ['The Cuff'],
     'a city absent from the combined file falls back to local');
   assert.equal(result.bars.bogota, undefined, 'neither combined nor local stays absent');
@@ -1034,7 +1041,10 @@ test('refreshRemoteBars with null cityKeys refreshes ALL cities from the combine
   const result = await adapter.refreshRemoteBars(null, localBars);
 
   assert.equal(adapter.fetches.length, 1, 'null cityKeys never triggers per-city fetches');
-  assert.deepEqual(result.bars.nyc.map((b) => b.name), ['Eagle NYC'], 'the combined object replaces local wholesale');
+  // Union semantics (was: wholesale replace — the bug that discarded
+  // locally curated bars): remote leads, local-only entries survive.
+  assert.deepEqual(result.bars.nyc.map((b) => b.name), ['Eagle NYC', 'Stale Eagle'],
+    'the combined object leads; the local-only entry survives');
   assert.deepEqual(result.bars.poconos.map((b) => b.name), ['Camp Out'], 'combined-only cities appear');
   assert.deepEqual(result.bars['local-only'].map((b) => b.name), ['Local Hold Out'],
     'local-only cities are kept as fallback entries');
@@ -1051,6 +1061,75 @@ test('refreshRemoteBars with null cityKeys and no combined file returns local ba
   assert.equal(adapter.fetches.length, 1, 'only the combined fetch is attempted');
   assert.deepEqual(result.bars, localBars);
   assert.deepEqual(result.counts, { remote: 0, local: 2, unavailable: 0 });
+});
+
+// The bars-wiring regression (run 20260724-122902): "Legacy" was curated in
+// the local scraper-bars.js, but the remote combined file — served through a
+// 1-day cache — didn't have it yet, and the wholesale replace threw the
+// local entry away ("Bars data — 23 cities from chunky.dad, 0 from local
+// file"). The refresh is now a per-city UNION: remote entries win for a
+// shared bar-name key (freshest enrichment), local-only entries survive.
+test('refreshRemoteBars union matrix: locally curated bars survive the remote refresh', async () => {
+  const localBars = {
+    // boston: remote lacks the locally curated Legacy → appended.
+    boston: [
+      { name: 'Legacy', city: 'boston', address: '79 Warrenton St, Boston, MA 02116' },
+      // Same bar-name key as remote "Eagle" ("The " strips) → remote wins.
+      { name: 'The Eagle', notes: 'stale local copy' },
+      // Nameless entries have no identity key and are skipped.
+      { address: 'no name at all' }
+    ],
+    // seattle: absent from remote → kept as the local fallback city.
+    seattle: [{ name: 'The Cuff' }]
+  };
+  const adapter = buildRemoteBarsAdapter({}, {
+    boston: [
+      { name: 'Eagle', notes: 'remote enrichment wins for the shared key' },
+      { name: 'Alley Cat' }
+    ],
+    // chicago: remote-only city → arrives untouched.
+    chicago: [{ name: 'Metro' }]
+  });
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let result;
+  try {
+    result = await adapter.refreshRemoteBars(null, localBars);
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.deepEqual(result.bars.boston.map((b) => b.name), ['Eagle', 'Alley Cat', 'Legacy'],
+    'remote order leads, the locally curated Legacy is appended, nameless entries are skipped');
+  assert.deepEqual(result.bars.boston[0], { name: 'Eagle', notes: 'remote enrichment wins for the shared key' },
+    'for a shared bar-name key the remote entry is kept as-is');
+  assert.deepEqual(result.bars.chicago.map((b) => b.name), ['Metro'], 'remote-only cities arrive untouched');
+  assert.deepEqual(result.bars.seattle.map((b) => b.name), ['The Cuff'], 'local-only cities are kept');
+  // The freshness line keeps its exact shape; the merge note is additive.
+  assert.ok(logLines.includes(
+    '📱 Scriptable: Bars data — 2 cities from chunky.dad, 1 from local file, 0 unavailable'
+  ), `freshness line shape unchanged, got: ${JSON.stringify(logLines)}`);
+  assert.ok(logLines.includes(
+    '📱 Scriptable: Bars data — merged 1 local-only bar(s)'
+  ), `additive merge line expected, got: ${JSON.stringify(logLines)}`);
+});
+
+test('refreshRemoteBars union: no local-only bars means no merge log line', async () => {
+  const adapter = buildRemoteBarsAdapter({}, { boston: [{ name: 'Legacy' }] });
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let result;
+  try {
+    result = await adapter.refreshRemoteBars(null, { boston: [{ name: 'Legacy', notes: 'stale' }] });
+  } finally {
+    console.log = originalLog;
+  }
+  assert.deepEqual(result.bars.boston, [{ name: 'Legacy' }], 'remote wins for the shared key');
+  assert.ok(!logLines.some((line) => line.includes('merged')),
+    `no merge line when nothing was appended, got: ${JSON.stringify(logLines)}`);
 });
 
 test('supportsReverseGeocode reflects Location API availability', () => {

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -690,7 +690,7 @@ class AiWebParser {
         // bar (including a gate-dropped one). Every plausible name line from
         // the page text, the OCR text, and the curated bars corpus is a
         // candidate; adoption requires >= 2 independent signals (curated,
-        // page, ocr) — position is only a tie-breaker, never an anchor.
+        // page, ocr, url) — position is only a tie-breaker, never an anchor.
         // Runs BEFORE the barSource stamp so an adopted bar carries its own
         // provenance; a model-returned surviving bar makes this a no-op.
         this.applyBarConvergenceRescue(event, htmlData, parserConfig, cityConfig);
@@ -5528,6 +5528,15 @@ class AiWebParser {
                 };
                 return;
             }
+            // The parallel reason memo follows the same earlier-passes-win
+            // union so a field's reason always describes its recorded value.
+            if (key === '__droppedFieldReasons' && value && typeof value === 'object') {
+                merged.__droppedFieldReasons = {
+                    ...value,
+                    ...(merged.__droppedFieldReasons && typeof merged.__droppedFieldReasons === 'object' ? merged.__droppedFieldReasons : {})
+                };
+                return;
+            }
             if (!this.isUsableAiFieldValue(value)) return;
             const normalizedName = this.normalizePromptFieldName(key);
             if (this.hasResolvedFieldValue(merged, normalizedName)) return;
@@ -5720,6 +5729,17 @@ class AiWebParser {
                 if (!(entry.field in validatedPartial.__droppedFieldValues)) {
                     validatedPartial.__droppedFieldValues[entry.field] = entry.value;
                 }
+                // Parallel reason memo (same first-drop-wins rule): the
+                // confidence-retry feedback needs to tell plain
+                // not-verbatim drops (reason untagged → '') apart from
+                // evidence-quality drops (tagged reason) — only the former
+                // are worth echoing back to the retry prompt.
+                if (!validatedPartial.__droppedFieldReasons || typeof validatedPartial.__droppedFieldReasons !== 'object') {
+                    validatedPartial.__droppedFieldReasons = {};
+                }
+                if (!(entry.field in validatedPartial.__droppedFieldReasons)) {
+                    validatedPartial.__droppedFieldReasons[entry.field] = typeof entry.reason === 'string' ? entry.reason : '';
+                }
             });
             // Evidence-pointer rescue memo (internal, additive, LOG-ONLY):
             // per-snippet reports are discarded, so rescue candidates ride an
@@ -5762,6 +5782,35 @@ class AiWebParser {
 
         // === STEP 3: Return Merged Results ===
         return merged;
+    }
+
+    // Confidence-retry feedback map ({ field: droppedValue }) for the fields
+    // being retried, sourced from the dropped-value/reason memos the earlier
+    // passes accumulated. Only PLAIN not-verbatim drops qualify (reason
+    // untagged — the value pointed at real text but wasn't copied exactly);
+    // evidence-quality drops (context-cited/brand-cited) mean the value
+    // itself is rotten, so echoing it back would steer the retry wrong.
+    // null when no target field has a qualifying drop.
+    buildRetryDropFeedback(fields, merged) {
+        const values = merged && merged.__droppedFieldValues && typeof merged.__droppedFieldValues === 'object'
+            ? merged.__droppedFieldValues
+            : null;
+        if (!values) return null;
+        const reasons = merged.__droppedFieldReasons && typeof merged.__droppedFieldReasons === 'object'
+            ? merged.__droppedFieldReasons
+            : {};
+        const feedback = {};
+        (Array.isArray(fields) ? fields : []).forEach(field => {
+            const normalizedField = this.normalizePromptFieldName(field);
+            if (!normalizedField) return;
+            const matchKey = Object.keys(values).find(key => this.normalizePromptFieldName(key) === normalizedField);
+            if (matchKey === undefined) return;
+            if (reasons[matchKey]) return; // tagged reason = evidence-quality drop
+            const value = values[matchKey];
+            if (typeof value !== 'string' || !value.trim()) return;
+            feedback[normalizedField] = value;
+        });
+        return Object.keys(feedback).length > 0 ? feedback : null;
     }
 
     async extractEventWithAiStrategy(htmlData, aiConfig, cityConfig, parserConfig, fields, httpAdapter = null) {
@@ -5897,11 +5946,18 @@ class AiWebParser {
                     .map(field => this.normalizePromptFieldName(field));
                 const targetFields = entry.fields.filter(field => missingNow.includes(field));
                 if (targetFields.length === 0) continue;
+                // Feed the retry what the last roll got wrong: each target
+                // field's previously dropped not-verbatim value rides into
+                // the alternate prompt as an additive correction line
+                // instead of re-rolling blind (buildRetryDropFeedback).
+                const retryFeedback = this.buildRetryDropFeedback(targetFields, merged);
                 const partial = await runPartitionExtraction(
                     targetFields,
                     entry.partition,
                     `confidence retry ${cycle + 1} ${entry.partition}`,
-                    { promptVariant: 'alternate' }
+                    retryFeedback
+                        ? { promptVariant: 'alternate', retryFeedback }
+                        : { promptVariant: 'alternate' }
                 );
                 const beforeMissing = this.getRemainingPromptFields(promptFields, merged)
                     .map(field => this.normalizePromptFieldName(field));
@@ -6304,6 +6360,14 @@ class AiWebParser {
         if (normalized === 'city') {
             description += ` The promoter's home city in branding, logos, or website domains (e.g. a .nyc domain) is NOT the event city — use explicit location statements (e.g. "Torremolinos, Spain") near the venue/address.`;
         }
+        // Prompt-only steering (run 20260724-122902 findings): the model
+        // returned the flyer's street line ("79 WARRENTON") as the bar. The
+        // organizer/promoter/brand rule is already part of the schema
+        // description; the address-shape rule is the addition. Appended to
+        // the schema line so the schema text itself stays byte-identical.
+        if (normalized === 'bar') {
+            description += ` A street address is never a venue name.`;
+        }
         return description;
     }
 
@@ -6348,7 +6412,7 @@ TEXT:
 ${String(snippet || '')}`;
     }
 
-    buildExtractionPrompt(htmlData, aiConfig, cityConfig, parserConfig, fields, snippet, variant = 'default', dataFlags = {}) {
+    buildExtractionPrompt(htmlData, aiConfig, cityConfig, parserConfig, fields, snippet, variant = 'default', dataFlags = {}, retryFeedback = null) {
         const promptFields = Array.isArray(fields) && fields.length > 0
             ? fields
             : this.getAiPromptFields(parserConfig, dataFlags, htmlData && htmlData.url ? htmlData.url : '');
@@ -6446,6 +6510,21 @@ ${String(snippet || '')}`;
             ? `\n- For "title", prefer SEGMENT_LISTING_TITLE or a fuller variant of the same name from the flyer; flyer text that does not contain it (taglines, DJ names, stylized graphics text) is NOT the title.`
             : '';
 
+        // Confidence-retry feedback (additive, alternate template only —
+        // retries always run the alternate variant): one correction line per
+        // retried field naming the previously rejected not-verbatim value,
+        // so the retry copies exact source text instead of re-rolling blind.
+        // Empty when no feedback rides in — existing prompts stay
+        // byte-identical.
+        let retryFeedbackContext = '';
+        if (retryFeedback && typeof retryFeedback === 'object') {
+            Object.entries(retryFeedback).forEach(([field, value]) => {
+                if (typeof value !== 'string' || !value.trim()) return;
+                retryFeedbackContext += `Your previous value "${value}" for ${field} was rejected — it is not verbatim in the source. Copy the exact text.\n`;
+            });
+            if (retryFeedbackContext) retryFeedbackContext += `\n`;
+        }
+
         const exampleOutput = `EXAMPLE OUTPUT FORMAT (structure only, not real data):\n{"city": {"value": "miami", "evidence": "Miami, FL", "confidence": 90}, "bar": {"value": "Eagle Bar", "evidence": "@ Eagle Bar", "confidence": 95}}`;
 
         const templates = {
@@ -6467,7 +6546,7 @@ ${exampleOutput}
 
 Format the output as a single JSON object where each requested key maps to an object containing "value", "evidence", and "confidence".
 
-${dataProvided}${sourceData}${additionalContext}${steeringContext}${segmentListingContext}Fields to find:
+${dataProvided}${sourceData}${additionalContext}${steeringContext}${segmentListingContext}${retryFeedbackContext}Fields to find:
 ${fieldContext}
 Rules:
 - Return a single JSON object only
@@ -6664,7 +6743,10 @@ TEXT:
 
         // PASS 1: Try standard extraction
         console.log(`🤖 AI Web: Starting extraction pass${passSuffix}`);
-        let extractPrompt = this.buildExtractionPrompt(htmlData, aiConfig, cityConfig, parserConfig, fields, processedSnippet, useAlternate ? 'alternate' : 'default', dataFlags);
+        const retryFeedback = options && options.retryFeedback && typeof options.retryFeedback === 'object'
+            ? options.retryFeedback
+            : null;
+        let extractPrompt = this.buildExtractionPrompt(htmlData, aiConfig, cityConfig, parserConfig, fields, processedSnippet, useAlternate ? 'alternate' : 'default', dataFlags, retryFeedback);
         let rawResponse = await this.core.callAiGenerate(aiConfig, extractPrompt, 'extraction', httpAdapter, this.recordAiPrompt.bind(this));
         if (!rawResponse) return null;
         let event = parseAndFilterConfidence(rawResponse);
@@ -6676,7 +6758,7 @@ TEXT:
         // PASS 2: Try alternate extraction if first pass failed and alternate is enabled
         if (useAlternate) {
             console.log(`🤖 AI Web: Standard pass${passSuffix} failed; trying alternate prompt`);
-            extractPrompt = this.buildExtractionPrompt(htmlData, aiConfig, cityConfig, parserConfig, fields, processedSnippet, 'alternate', dataFlags);
+            extractPrompt = this.buildExtractionPrompt(htmlData, aiConfig, cityConfig, parserConfig, fields, processedSnippet, 'alternate', dataFlags, retryFeedback);
             rawResponse = await this.core.callAiGenerate(aiConfig, extractPrompt, 'extraction', httpAdapter, this.recordAiPrompt.bind(this));
             if (!rawResponse) return null;
             event = parseAndFilterConfidence(rawResponse);
@@ -9902,6 +9984,30 @@ TEXT:
         return event;
     }
 
+    // Slug tokens from a URL's path — tiny local tokenizer (normalizers'
+    // tokenizePoiBarName is out of reach: platform purity only allows the
+    // normalizers→core direction, and no new URL() anywhere): strip
+    // query/hash, split every path segment on non-alphanumerics, lowercase,
+    // drop empties. Returns every single token plus every joined run of two
+    // adjacent tokens within a segment ("legacy"; "bearweek" from
+    // ".../furball-boston-725-bear-week-legacy-tickets/14269444") — the
+    // same identity space as normalizeBarNameKey output.
+    buildUrlSlugTokens(url) {
+        const text = String(url || '').split(/[?#]/)[0];
+        const schemeIndex = text.indexOf('://');
+        const pathStart = text.indexOf('/', schemeIndex >= 0 ? schemeIndex + 3 : 0);
+        if (pathStart < 0) return [];
+        const tokens = [];
+        for (const segment of text.slice(pathStart).split('/')) {
+            const segmentTokens = segment.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+            for (let i = 0; i < segmentTokens.length; i++) {
+                tokens.push(segmentTokens[i]);
+                if (i + 1 < segmentTokens.length) tokens.push(segmentTokens[i] + segmentTokens[i + 1]);
+            }
+        }
+        return tokens;
+    }
+
     // Deterministic bar-convergence rescue (run 20260723-224434: the FURBALL
     // Boston segment plainly listed its venue "Legacy", the flyer OCR read
     // "LEGACY", and Legacy is a curated Boston bar — but the model returned
@@ -9918,9 +10024,10 @@ TEXT:
     // could-be-a-name filter passes (getVenueLineCandidateRejection);
     // curated names are always candidates. Candidates that normalize to the
     // same bar-name key (normalizeBarNameKey: "LEGACY"/"Legacy"/"The
-    // Legacy") are ONE candidate. Each candidate then carries up to three
+    // Legacy") are ONE candidate. Each candidate then carries up to four
     // signals — curated match, whole-word presence in PAGE, whole-word
-    // presence in OCR — and is adopted only with >= 2 of the 3. Never one
+    // presence in OCR, bar-name key present in a ticket-link URL slug
+    // (URL) — and is adopted only with >= 2 of them. Never one
     // signal alone: core doctrine, a bar is never invented from a single
     // corpus. No positional anchor anywhere; position appears only as a
     // ranking tie-breaker (proximity to a location/address-shaped PAGE
@@ -9966,9 +10073,29 @@ TEXT:
             }
         }
 
+        // Corpus URL — deterministic slug signal (run 20260724-122902: the
+        // ticket link ".../furball-boston-725-bear-week-legacy-tickets"
+        // plainly named the venue but reached nothing): slug tokens come
+        // from the segment's SEGMENT_LINK_URL resource lines and the
+        // event's extracted ticketUrl; a candidate whose bar-name key
+        // equals a single slug token or a joined run of two adjacent
+        // tokens ("legacy"; "bearweek") carries the 'url' signal. Adoption
+        // still requires >= 2 signals — a slug alone never invents a bar.
+        const slugUrls = (htmlData && typeof htmlData.html === 'string' ? htmlData.html.split('\n') : [])
+            .map(line => {
+                const match = line.match(/^SEGMENT_LINK_URL:\s*(\S+)/);
+                return match ? match[1] : '';
+            })
+            .filter(Boolean);
+        if (event && typeof event.ticketUrl === 'string' && event.ticketUrl.trim()) {
+            slugUrls.push(event.ticketUrl.trim());
+        }
+        const slugTokenKeys = new Set();
+        slugUrls.forEach(url => this.buildUrlSlugTokens(url).forEach(token => slugTokenKeys.add(token)));
+
         // Candidate pool, deduped on the shared bar-name identity key so
         // "LEGACY" (OCR) + "Legacy" (page) + curated "Legacy" are ONE
-        // candidate accumulating all three signals.
+        // candidate accumulating all of its signals.
         const normalizeKey = value => (this.core && typeof this.core.normalizeBarNameKey === 'function'
             ? this.core.normalizeBarNameKey(value)
             : String(value || '').toLowerCase().replace(/^\s*the\s+/, '').replace(/[^a-z0-9]/g, ''));
@@ -9993,14 +10120,14 @@ TEXT:
         // event-title guards are absolute: the promoter is never rescued as
         // the venue, curated or not.
         pageLines.forEach(line => {
-            if (line && !this.getVenueLineCandidateRejection(line, event, htmlData)) addCandidate(line, 'page');
+            if (line && !this.getVenueLineCandidateRejection(line, event, htmlData, cityConfig, parserConfig)) addCandidate(line, 'page');
         });
         ocrLines.forEach(line => {
-            if (line && !this.getVenueLineCandidateRejection(line, event, htmlData)) addCandidate(line, 'ocr');
+            if (line && !this.getVenueLineCandidateRejection(line, event, htmlData, cityConfig, parserConfig)) addCandidate(line, 'ocr');
         });
         (Array.isArray(cityBars) ? cityBars : []).forEach(bar => {
             if (!bar || typeof bar.name !== 'string') return;
-            const rejection = this.getVenueLineCandidateRejection(bar.name, event, htmlData);
+            const rejection = this.getVenueLineCandidateRejection(bar.name, event, htmlData, cityConfig, parserConfig);
             if (rejection === 'matches organizer/brand' || rejection === 'matches event title') return;
             addCandidate(bar.name, 'curated');
         });
@@ -10024,7 +10151,7 @@ TEXT:
         });
 
         const scored = [];
-        for (const entry of candidates.values()) {
+        for (const [candidateKey, entry] of candidates.entries()) {
             const patterns = entry.forms.map(buildWholeWordPattern);
             const pageIndexes = [];
             pageLines.forEach((line, index) => {
@@ -10035,6 +10162,7 @@ TEXT:
             if (curatedBar) signals.push('curated');
             if (pageIndexes.length > 0) signals.push('page');
             if (ocrCorpus && patterns.some(pattern => pattern.test(ocrCorpus))) signals.push('ocr');
+            if (slugTokenKeys.has(candidateKey)) signals.push('url');
             scored.push({
                 curatedBar,
                 signals,
@@ -10103,11 +10231,41 @@ TEXT:
             && /(?:^|\s)(?:St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Ln|Lane|Way|Hwy|Pl|Place|Ct|Court)\.?(?:\s|$)/i.test(text);
     }
 
+    // Conservative brand-stem containment for the venue-candidate guard
+    // (matchesPageBrandName is whole-value equality, so the flyer's bare
+    // "FURBALL" slipped past the page brand "furballnyc" — run
+    // 20260724-122902): compact each brand variant (spaces stripped) and
+    // match when one is a prefix of the other with a remainder of <= 4
+    // chars ("furball" ⊂ "furballnyc", remainder "nyc"). A minimum 4-char
+    // stem keeps short fragments from ever matching.
+    matchesBrandNameStem(value, brandNames) {
+        const valueVariants = Array.from(this.getBrandNameVariants(value))
+            .map(variant => variant.replace(/\s+/g, ''))
+            .filter(Boolean);
+        if (valueVariants.length === 0) return false;
+        return (Array.isArray(brandNames) ? brandNames : []).some(brand => {
+            for (const brandVariant of this.getBrandNameVariants(brand)) {
+                const compactBrand = brandVariant.replace(/\s+/g, '');
+                if (!compactBrand) continue;
+                for (const compactValue of valueVariants) {
+                    const shorter = compactValue.length <= compactBrand.length ? compactValue : compactBrand;
+                    const longer = compactValue.length <= compactBrand.length ? compactBrand : compactValue;
+                    if (shorter.length >= 4
+                        && longer.startsWith(shorter)
+                        && longer.length - shorter.length <= 4) return true;
+                }
+            }
+            return false;
+        });
+    }
+
     // '' when a corpus line could plausibly be a venue name; otherwise the
     // deterministic reason it can never be one. Rejection is silent — an
     // unusable line is the common case in any corpus, not a signal worth
-    // logging.
-    getVenueLineCandidateRejection(candidate, event, htmlData) {
+    // logging. cityConfig/parserConfig are optional context (threaded from
+    // applyBarConvergenceRescue): configured city names and the parser's own
+    // configured name are never venue candidates.
+    getVenueLineCandidateRejection(candidate, event, htmlData, cityConfig = null, parserConfig = null) {
         const text = String(candidate || '').trim();
         if (!text) return 'empty';
         if (text.length > 40) return 'too long';
@@ -10120,21 +10278,50 @@ TEXT:
             || /\b20\d{2}\b/.test(text)) return 'date';
         const normalized = this.normalizeAdjacencyText(text);
         if (!normalized) return 'empty';
+        // Bare calendar words join the date rejection (run 20260724-122902:
+        // flyer lines "SAT" and "JULY" qualified as venue candidates): a
+        // candidate made ONLY of month names, weekday names/abbreviations
+        // (including plurals like "SATURDAYS"), and digits is a date line.
+        const calendarWord = /^(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|june?|july?|aug(?:ust)?|sep(?:t|tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?|(?:mon|tues?|wednes|thurs?|fri|satur|sun)days?|mon|tues?|wed|thur?s?|fri|sat|sun)$/;
+        if (normalized.split(' ').every(token => calendarWord.test(token) || /^\d+$/.test(token))) {
+            return 'date';
+        }
         const stopwords = new Set([
             'tickets', 'ticket', 'info', 'rsvp', 'free', 'doors', 'details',
             'presents', 'vip', 'admission', 'cover', 'ages', 'buy', 'get',
-            'more', 'here', 'tba', 'tbd'
+            'more', 'here', 'tba', 'tbd',
+            // Hype/status words observed qualifying on real flyers — never
+            // venue names on their own.
+            'tonight', 'live', 'party', 'presale'
         ]);
         if (normalized.split(' ').every(token => stopwords.has(token) || /^\d+$/.test(token))) {
             return 'generic';
         }
+        // "sold out" as a phrase (the bare tokens stay off the stopword set
+        // so a venue actually named "Out" is never a casualty).
+        if (normalized === 'sold out') return 'generic';
         const title = this.normalizeAdjacencyText(event && event.title);
         if (title && normalized === title) return 'matches event title';
+        // A bare city is never a venue: reject a candidate whose WHOLE value
+        // resolves to a configured city (key/name/pattern/alias equality —
+        // containment would reject legitimate names like "SF Eagle") or to
+        // the event's own city (run 20260724-122902: flyer line "BOSTON"
+        // tied the rescue into refusing).
+        if (this.findCityConfigEntry(normalized, cityConfig)) return 'city name';
+        const barNameKey = value => (this.core && typeof this.core.normalizeBarNameKey === 'function'
+            ? this.core.normalizeBarNameKey(value)
+            : String(value || '').toLowerCase().replace(/^\s*the\s+/, '').replace(/[^a-z0-9]/g, ''));
+        const eventCity = event && typeof event.city === 'string' ? event.city.trim() : '';
+        if (eventCity && barNameKey(text) && barNameKey(text) === barNameKey(eventCity)) {
+            return 'city name';
+        }
         const organizer = event && typeof event._organizer === 'string' ? event._organizer.trim() : '';
         const brandNames = this.getPageBrandNames(htmlData);
-        const knownNames = [organizer, ...(Array.isArray(brandNames) ? brandNames : [])]
+        const parserName = parserConfig && typeof parserConfig.name === 'string' ? parserConfig.name.trim() : '';
+        const knownNames = [organizer, parserName, ...(Array.isArray(brandNames) ? brandNames : [])]
             .filter(name => typeof name === 'string' && name.trim());
-        if (knownNames.length > 0 && this.matchesPageBrandName(text, knownNames)) {
+        if (knownNames.length > 0
+            && (this.matchesPageBrandName(text, knownNames) || this.matchesBrandNameStem(text, knownNames))) {
             return 'matches organizer/brand';
         }
         if (this.core && typeof this.core.looksLikeStreetAddress === 'function'
@@ -10371,32 +10558,90 @@ TEXT:
         return `${organizerDisplay}: ${baseTitle}`;
     }
 
+    // Split a combined OCR+page stream into ordered corpus chunks so the
+    // dedup in extractBodyParts can scope itself per corpus. OCR snippets
+    // (buildOcrSnippet) are machine-embedded into the stream: prepended
+    // ahead of the page text (extractSingleEvent) and inside segment
+    // resource lines (extractMultiEventSegmentResourceLines). An OCR region
+    // starts at an OCR_IMAGE_URL:/OCR_IMAGE_TEXT marker line and ends at
+    // the next SEGMENT_* marker line or the first line that contains an
+    // HTML tag — both boundaries are machine-emitted, so detection is
+    // reliable. A plain-text page tail directly after an OCR block with no
+    // marker between them is indistinguishable and stays in the OCR region
+    // (same corpus-sharing behavior as before this split — never worse).
+    // Inputs without OCR markers return one page chunk, byte-identical to
+    // the un-split processing.
+    splitOcrAndPageChunks(text) {
+        const source = String(text);
+        if (!/^OCR_IMAGE_(?:URL:|TEXT)/m.test(source)) {
+            return [{ corpus: 'page', text: source }];
+        }
+        const chunks = [];
+        let currentCorpus = 'page';
+        let currentLines = [];
+        const push = () => {
+            if (currentLines.length > 0) {
+                chunks.push({ corpus: currentCorpus, text: currentLines.join('\n') });
+                currentLines = [];
+            }
+        };
+        for (const line of source.split('\n')) {
+            let corpus = currentCorpus;
+            if (/^OCR_IMAGE_(?:URL:|TEXT)/.test(line)) {
+                corpus = 'ocr';
+            } else if (currentCorpus === 'ocr') {
+                if (/^SEGMENT_[A-Z_]+/.test(line) || /<[a-zA-Z!/]/.test(line)) {
+                    corpus = 'page';
+                }
+            }
+            if (corpus !== currentCorpus) {
+                push();
+                currentCorpus = corpus;
+            }
+            currentLines.push(line);
+        }
+        push();
+        return chunks;
+    }
+
     extractBodyParts(html) {
-        let text = String(html);
-        text = text.replace(/<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi, ' ');
-        text = text.replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi, ' ');
-        text = text.replace(/<!--[\s\S]*?-->/g, ' ');
-        text = text.replace(/<(nav|header|footer|aside|noscript|form|button)\b[^>]*>[\s\S]*?<\/\1[^>]*>/gi, ' ');
-        text = text.replace(/<[a-z0-9]+\b[^>]*(?:class|id)=["'][^"']*(nav|menu|footer|header|share|social|recommend|carousel|cta|newsletter|breadcrumb)[^"']*["'][^>]*>[\s\S]{0,12000}?<\/[a-z0-9]+>/gi, ' ');
-        text = text.replace(/<(br|\/p|\/div|\/li|\/section|\/article|\/h[1-6]|\/tr|\/td)\b[^>]*>/gi, '\n');
-        text = text.replace(/<[^>]+>/g, ' ');
-
-        const lines = text
-            .split('\n')
-            .map(line => this.normalizeWhitespace(this.decodeBasicEntities(line)))
-            .filter(Boolean);
-
-        const seen = new Set();
+        // Dedup is scoped PER CORPUS (OCR vs page): flyer OCR text is
+        // prepended ahead of the page text, so a single shared seen-set let
+        // OCR lines evict the page's own lines — run 20260724-122902 lost
+        // the page lines "Legacy" / "Bear Week Return" to the flyer's
+        // "LEGACY" / "BEAR WEEK RETURN" and the model never saw the venue
+        // in page context. OCR lines dedup only against OCR lines, page
+        // lines only against page lines; intra-corpus duplicates (repeated
+        // boilerplate, the segment's embedded second OCR copy) still
+        // collapse, and the maxBodyParts cap stays global.
+        const seenByCorpus = { ocr: new Set(), page: new Set() };
         const results = [];
-        for (const line of lines) {
-            const lower = line.toLowerCase();
-            if (line.length < 3) continue;
-            if (this.noiseLineRegex.test(line)) continue;
-            if (this.looksLikeCssContent(line)) continue;
-            if (seen.has(lower)) continue;
-            seen.add(lower);
-            results.push(line);
-            if (results.length >= this.extractionLimits.maxBodyParts) break;
+        for (const chunk of this.splitOcrAndPageChunks(String(html))) {
+            const seen = seenByCorpus[chunk.corpus];
+            let text = chunk.text;
+            text = text.replace(/<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi, ' ');
+            text = text.replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi, ' ');
+            text = text.replace(/<!--[\s\S]*?-->/g, ' ');
+            text = text.replace(/<(nav|header|footer|aside|noscript|form|button)\b[^>]*>[\s\S]*?<\/\1[^>]*>/gi, ' ');
+            text = text.replace(/<[a-z0-9]+\b[^>]*(?:class|id)=["'][^"']*(nav|menu|footer|header|share|social|recommend|carousel|cta|newsletter|breadcrumb)[^"']*["'][^>]*>[\s\S]{0,12000}?<\/[a-z0-9]+>/gi, ' ');
+            text = text.replace(/<(br|\/p|\/div|\/li|\/section|\/article|\/h[1-6]|\/tr|\/td)\b[^>]*>/gi, '\n');
+            text = text.replace(/<[^>]+>/g, ' ');
+
+            const lines = text
+                .split('\n')
+                .map(line => this.normalizeWhitespace(this.decodeBasicEntities(line)))
+                .filter(Boolean);
+
+            for (const line of lines) {
+                const lower = line.toLowerCase();
+                if (line.length < 3) continue;
+                if (this.noiseLineRegex.test(line)) continue;
+                if (this.looksLikeCssContent(line)) continue;
+                if (seen.has(lower)) continue;
+                seen.add(lower);
+                results.push(line);
+                if (results.length >= this.extractionLimits.maxBodyParts) return results;
+            }
         }
         return results;
     }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -4747,3 +4747,365 @@ test('bar plausibility gate runs BEFORE the convergence rescue: a verbatim addre
   assert.equal(event.bar, 'Legacy');
   assert.equal(event.barSource, 'curated');
 });
+
+// ---------------------------------------------------------------------------
+// Run 20260724-122902 root-cause fixes. The full causal chain of the FURBALL
+// Boston failure:
+//   1. extractBodyParts deduped OCR and page lines against ONE shared seen
+//      set, so the prepended flyer OCR ("LEGACY" / "BEAR WEEK RETURN")
+//      evicted the page's own "Legacy" / "Bear Week Return" lines — the
+//      model never saw the venue in page context.
+//   2. The candidate guard leaked FURBALL (brand-stem miss vs "furballnyc")
+//      and BOSTON (no city rule), tying the convergence rescue into
+//      "ambiguous — not adopted".
+//   3. The ticket URL slug (".../bear-week-legacy-tickets") named the venue
+//      but was never a signal.
+// The fixtures below are the literal corpus from the run log.
+// ---------------------------------------------------------------------------
+
+const RUN_122902_OCR = [
+  'JOE FIORE RAFAEL SANCHEZ & BOBBY KELLEY PRESENT',
+  'FURBALL',
+  'BOSTON',
+  '10pm-3am',
+  'SAT, JULY 25',
+  'BEAR WEEK RETURN',
+  'UNDER',
+  'WEAR & GEAR',
+  'PARTY',
+  'CLOTHES',
+  'CHECK',
+  'LEGACY',
+  'BEFFYBOY',
+  'GAY MAFIA',
+  'BEAR SKM',
+  'mistr',
+  '79 WARRENTON TICKETS: GAYMAFIABOSTON.COM FURBALL.NYC',
+  'JOSHUA',
+  'RUIZ'
+].join('\n');
+
+// The page's own segment lines (segment discovery log, 16:26:48.943).
+const RUN_122902_SEGMENT = [
+  'FURBALL Boston',
+  'Bear Week Return',
+  'July 25, 2026',
+  'Legacy',
+  'Boston, MA',
+  'Get Your Tickets Today!'
+].join('\n');
+
+const RUN_122902_TICKET_URL = 'https://www.ticketweb.com/event/furball-boston-725-bear-week-legacy-tickets/14269444?REFERRAL_ID=tmfeed';
+const RUN_122902_FLYER_URL = 'https://static.wixstatic.com/media/238fae_c4047c55f4534a0990b2b7fdc19dab8f~mv2.png';
+
+// The combined prompt stream exactly as extractSingleEvent builds it for the
+// segment: prepended OCR snippet, then the segment htmlData (SEGMENT_INDEX,
+// the resource lines' embedded second OCR copy, SEGMENT_LINK_URL, segment
+// content).
+function buildRun122902CombinedStream() {
+  return [
+    `OCR_IMAGE_URL: ${RUN_122902_FLYER_URL}`,
+    'OCR_IMAGE_TEXT',
+    RUN_122902_OCR,
+    '',
+    'SEGMENT_INDEX: 1/6',
+    `OCR_IMAGE_URL: ${RUN_122902_FLYER_URL}`,
+    'OCR_IMAGE_TEXT',
+    RUN_122902_OCR,
+    `SEGMENT_LINK_URL: ${RUN_122902_TICKET_URL}`,
+    RUN_122902_SEGMENT
+  ].join('\n');
+}
+
+test('extractBodyParts: OCR lines never evict page lines — the literal run-122902 stream keeps BOTH copies of the venue', () => {
+  const parser = createParser();
+  const parts = parser.extractBodyParts(buildRun122902CombinedStream());
+
+  // The regression: the flyer's LEGACY / BEAR WEEK RETURN used to consume
+  // the shared seen set and the page's own lines vanished from CONTENT.
+  assert.ok(parts.includes('LEGACY'), 'the OCR venue line is present');
+  assert.ok(parts.includes('Legacy'), 'the PAGE venue line is present too — OCR must not evict it');
+  assert.ok(parts.includes('BEAR WEEK RETURN'), 'the OCR tagline is present');
+  assert.ok(parts.includes('Bear Week Return'), 'the PAGE tagline is present too');
+
+  // Intra-corpus dedup still holds: the resource lines embed a second copy
+  // of the whole OCR snippet, and it collapses against the prepended one.
+  assert.equal(parts.filter(line => line === 'LEGACY').length, 1, 'the embedded second OCR copy dedups');
+  assert.equal(parts.filter(line => line === 'FURBALL').length, 1);
+  assert.equal(parts.filter(line => line.startsWith('OCR_IMAGE_URL:')).length, 1);
+});
+
+test('extractBodyParts: intra-page dedup and the maxBodyParts cap are unchanged', () => {
+  const parser = createParser();
+
+  // Intra-page duplicates still collapse (case-insensitively).
+  const withPageDupes = `${buildRun122902CombinedStream()}\nGet Your Tickets Today!\nGET YOUR TICKETS TODAY!`;
+  const parts = parser.extractBodyParts(withPageDupes);
+  assert.equal(
+    parts.filter(line => line.toLowerCase() === 'get your tickets today!').length,
+    1,
+    'repeated page boilerplate still dedups within the page corpus'
+  );
+
+  // The cap stays global across both corpora.
+  const manyLines = [];
+  for (let i = 0; i < parser.extractionLimits.maxBodyParts + 50; i++) {
+    manyLines.push(`Unique page line number ${i}`);
+  }
+  const capped = parser.extractBodyParts(
+    `OCR_IMAGE_URL: https://x.example/a.png\nOCR_IMAGE_TEXT\nFLYER LINE\n\n<html><body>${manyLines.map(l => `<p>${l}</p>`).join('')}</body></html>`
+  );
+  assert.equal(capped.length, parser.extractionLimits.maxBodyParts, 'the cap is enforced across OCR + page');
+  assert.equal(capped[0], 'OCR_IMAGE_URL: https://x.example/a.png', 'order is preserved — OCR first');
+});
+
+test('extractBodyParts: inputs without OCR markers behave exactly as before (single page corpus)', () => {
+  const parser = createParser();
+  const html = '<html><body><p>Legacy</p><p>legacy</p><p>Boston, MA</p></body></html>';
+  assert.deepEqual(parser.extractBodyParts(html), ['Legacy', 'Boston, MA'],
+    'page-vs-page dedup is untouched for plain pages');
+});
+
+test('guard matrix on the run-122902 corpus: brand stem, parser name, city, calendar words, and hype words all reject; real venue names pass', () => {
+  const parser = createRescueParser({});
+  const event = { title: 'FURBALL Boston', city: 'boston' };
+  const htmlData = { pageBrandNames: ['furballnyc'] };
+  const parserConfig = { name: 'Furball' };
+
+  // The two candidates that tied the real run into refusal.
+  assert.equal(
+    parser.getVenueLineCandidateRejection('FURBALL', event, htmlData, RESCUE_CITY_CONFIG, parserConfig),
+    'matches organizer/brand',
+    'brand stem: "furball" is a prefix of "furballnyc" with a <= 4 char remainder'
+  );
+  assert.equal(
+    parser.getVenueLineCandidateRejection('BOSTON', event, htmlData, RESCUE_CITY_CONFIG, parserConfig),
+    'city name',
+    'a bare configured city is never a venue candidate'
+  );
+  // The parser's own configured name alone also rejects (no page brands).
+  assert.equal(
+    parser.getVenueLineCandidateRejection('FURBALL', event, {}, RESCUE_CITY_CONFIG, parserConfig),
+    'matches organizer/brand',
+    'parserConfig.name joins the known names'
+  );
+  // event.city equality rejects even without a cityConfig entry.
+  assert.equal(
+    parser.getVenueLineCandidateRejection('Boston', event, {}, null, null),
+    'city name',
+    'the event\'s own city is never the venue'
+  );
+
+  // Calendar words join the date rejection.
+  for (const word of ['SAT', 'FRI', 'SATURDAYS', 'JULY', 'AUG']) {
+    assert.equal(
+      parser.getVenueLineCandidateRejection(word, event, htmlData, RESCUE_CITY_CONFIG, parserConfig),
+      'date',
+      `bare calendar word ${word} rejects`
+    );
+  }
+
+  // Stoplist additions.
+  for (const word of ['TONIGHT', 'LIVE', 'PARTY', 'SOLD OUT', 'PRESALE']) {
+    assert.equal(
+      parser.getVenueLineCandidateRejection(word, event, htmlData, RESCUE_CITY_CONFIG, parserConfig),
+      'generic',
+      `hype/status word ${word} rejects`
+    );
+  }
+
+  // Legitimate venue names still pass every guard.
+  for (const name of ['Legacy', 'The Eagle', 'SF Eagle', 'Alley Cat', 'Metro']) {
+    assert.equal(
+      parser.getVenueLineCandidateRejection(name, event, htmlData, RESCUE_CITY_CONFIG, parserConfig),
+      '',
+      `venue name ${name} must never be a casualty`
+    );
+  }
+});
+
+test('curated-name sweep: every bar name in data/bars/*.json survives the candidate guards (zero new false positives)', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const parser = createRescueParser({});
+  const realCityConfig = require('../scraper-cities');
+  const barsDir = path.join(__dirname, '..', '..', 'data', 'bars');
+  // Neutral context: no page brands, no event city/title — the sweep tests
+  // the shape rules (city names, calendar words, stoplist, address shapes)
+  // against every curated name with the REAL cities config.
+  const rejections = [];
+  let total = 0;
+  for (const file of fs.readdirSync(barsDir)) {
+    if (!file.endsWith('.json')) continue;
+    const bars = JSON.parse(fs.readFileSync(path.join(barsDir, file), 'utf8'));
+    for (const bar of Array.isArray(bars) ? bars : []) {
+      if (!bar || typeof bar.name !== 'string') continue;
+      total += 1;
+      const rejection = parser.getVenueLineCandidateRejection(bar.name, {}, {}, realCityConfig, {});
+      if (rejection) rejections.push(`${file}: ${JSON.stringify(bar.name)} -> ${rejection}`);
+    }
+  }
+  assert.ok(total >= 50, `the sweep saw a real corpus (${total} names)`);
+  // Pre-existing exception (predates this PR's rules): "9th Avenue Saloon"
+  // trips the address-shape rule. Nothing else may be rejected — if a new
+  // rule catches a curated name, narrow the rule, don't drop the name.
+  assert.deepEqual(rejections, ['nyc.json: "9th Avenue Saloon" -> address-shaped'],
+    `only the known pre-existing exception may reject, got: ${JSON.stringify(rejections)}`);
+});
+
+test('bar convergence on the run-122902 corpus with curated data: FURBALL/BOSTON rejected, "Legacy" adopted on curated+page+ocr+url', () => {
+  const parser = createRescueParser(BOSTON_CURATED_BARS);
+  const event = { title: 'FURBALL Boston', city: 'boston' };
+  const logs = captureLogs(() => {
+    parser.applyBarConvergenceRescue(
+      event,
+      {
+        url: 'https://www.furball.nyc',
+        html: buildRun122902CombinedStream(),
+        segmentText: RUN_122902_SEGMENT,
+        ocrResults: [{ url: RUN_122902_FLYER_URL, text: RUN_122902_OCR }],
+        pageBrandNames: ['furballnyc']
+      },
+      { name: 'Furball' },
+      RESCUE_CITY_CONFIG
+    );
+  });
+  assert.equal(event.bar, 'Legacy', 'the real corpus now rescues the venue');
+  assert.equal(event.barSource, 'curated');
+  assert.deepEqual(event._barRescue.signals, ['curated', 'page', 'ocr', 'url']);
+  assert.ok(!logs.some(line => line.includes('ambiguous')),
+    `no ambiguity refusal any more, got: ${JSON.stringify(logs)}`);
+});
+
+test('bar convergence url slug signal: with curated data absent and the venue missing from the page, ocr + url still adopt "Legacy"', () => {
+  // The stale-bars-wiring belt-and-braces case: curated corpus empty (the
+  // remote refresh served a stale list) AND the page text degraded to the
+  // deployed run's CONTENT (venue line evicted). The flyer OCR and the
+  // ticket-URL slug both name the venue: 2 independent signals.
+  const parser = createRescueParser({});
+  const degradedSegment = [
+    'FURBALL Boston',
+    'July 25, 2026',
+    'Boston, MA',
+    'Get Your Tickets Today!',
+    'UPCOMING EVENTS!'
+  ].join('\n');
+  const event = { title: 'FURBALL Boston', city: 'boston' };
+  const logs = captureLogs(() => {
+    parser.applyBarConvergenceRescue(
+      event,
+      {
+        url: 'https://www.furball.nyc',
+        html: `SEGMENT_INDEX: 1/6\nSEGMENT_LINK_URL: ${RUN_122902_TICKET_URL}\n${degradedSegment}`,
+        segmentText: degradedSegment,
+        ocrResults: [{ url: RUN_122902_FLYER_URL, text: RUN_122902_OCR }],
+        pageBrandNames: ['furballnyc']
+      },
+      { name: 'Furball' },
+      RESCUE_CITY_CONFIG
+    );
+  });
+  assert.equal(event.bar, 'LEGACY', 'adopted with the OCR casing — no curated or page form exists');
+  assert.equal(event.barSource, 'page-adjacent');
+  assert.deepEqual(event._barRescue.signals, ['ocr', 'url']);
+  assert.ok(logs.includes(
+    '🤖 AI Web: Rescued bar "LEGACY" via signal convergence (signals: ocr, url)'
+  ), `rescue log expected, got: ${JSON.stringify(logs)}`);
+});
+
+test('bar convergence url slug signal: adjacent slug tokens join ("bear week" -> "bearweek"); the event ticketUrl is a slug source too', () => {
+  const parser = createRescueParser({});
+  assert.ok(parser.buildUrlSlugTokens(RUN_122902_TICKET_URL).includes('legacy'), 'single token');
+  assert.ok(parser.buildUrlSlugTokens(RUN_122902_TICKET_URL).includes('bearweek'), 'joined adjacent pair');
+  assert.ok(!parser.buildUrlSlugTokens('https://x.example').length, 'no path, no tokens');
+
+  // ticketUrl (no SEGMENT_LINK_URL line) also feeds the slug signal.
+  const event = {
+    title: 'FURBALL Boston',
+    city: 'boston',
+    ticketUrl: RUN_122902_TICKET_URL
+  };
+  parser.applyBarConvergenceRescue(
+    event,
+    {
+      url: 'https://www.furball.nyc',
+      html: '<html><body>multi-event page</body></html>',
+      segmentText: 'FURBALL Boston\nJuly 25, 2026\nBoston, MA',
+      ocrResults: [{ url: RUN_122902_FLYER_URL, text: RUN_122902_OCR }],
+      pageBrandNames: ['furballnyc']
+    },
+    { name: 'Furball' },
+    RESCUE_CITY_CONFIG
+  );
+  assert.equal(event.bar, 'LEGACY');
+  assert.deepEqual(event._barRescue.signals, ['ocr', 'url']);
+});
+
+test('getFieldContext bar steering: the address-shape sentence is appended, existing schema text unchanged', () => {
+  const parser = createParser();
+  const context = parser.getFieldContext('bar', null);
+  assert.ok(context.endsWith(' A street address is never a venue name.'),
+    `the steering sentence is appended, got: ${JSON.stringify(context)}`);
+  const schemaText = parser.getEventSchemaPromptFieldDescription('bar');
+  assert.ok(context.startsWith(schemaText), 'the schema description itself stays byte-identical');
+});
+
+test('confidence-retry feedback: buildRetryDropFeedback returns plain not-verbatim drops only', () => {
+  const parser = createParser();
+  const merged = {
+    __droppedFieldValues: {
+      bar: '79 Warrenon',
+      city: 'new york',
+      endTime: '   '
+    },
+    __droppedFieldReasons: {
+      bar: '',                          // plain not-verbatim → feedback
+      city: 'brand-cited-evidence',     // evidence-quality → never echoed
+      endTime: ''                       // blank value → nothing to echo
+    }
+  };
+  assert.deepEqual(
+    parser.buildRetryDropFeedback(['bar', 'city', 'endTime'], merged),
+    { bar: '79 Warrenon' }
+  );
+  assert.equal(parser.buildRetryDropFeedback(['city'], merged), null, 'tagged-only fields yield no feedback');
+  assert.equal(parser.buildRetryDropFeedback(['bar'], {}), null, 'no memo, no feedback');
+  // Field-name matching is normalization-aware (retry passes use lowercased
+  // names like "starttime").
+  assert.deepEqual(
+    parser.buildRetryDropFeedback(['BAR'], merged),
+    { bar: '79 Warrenon' }
+  );
+});
+
+test('confidence-retry feedback: the correction line appears in the alternate prompt only when feedback rides in', () => {
+  const parser = createParser();
+  const feedback = { bar: '79 Warrenon' };
+  const expectedLine = 'Your previous value "79 Warrenon" for bar was rejected — it is not verbatim in the source. Copy the exact text.';
+
+  const withFeedback = parser.buildExtractionPrompt(null, {}, null, {}, ['bar'], 'SNIPPET', 'alternate', {}, feedback);
+  assert.ok(withFeedback.includes(expectedLine), 'the alternate retry prompt carries the correction line');
+
+  const withoutFeedback = parser.buildExtractionPrompt(null, {}, null, {}, ['bar'], 'SNIPPET', 'alternate', {});
+  assert.ok(!withoutFeedback.includes('was rejected'), 'no feedback, no line');
+  assert.equal(
+    withFeedback.replace(`${expectedLine}\n\n`, ''),
+    withoutFeedback,
+    'the correction block is purely additive — removing it restores the existing prompt byte-for-byte'
+  );
+
+  // The default template never carries it (feedback only flows on retries,
+  // which always use the alternate variant).
+  const defaultVariant = parser.buildExtractionPrompt(null, {}, null, {}, ['bar'], 'SNIPPET', 'default', {}, feedback);
+  assert.ok(!defaultVariant.includes('was rejected'), 'default template is untouched');
+});
+
+test('confidence-retry feedback: dropped-reason memos accumulate first-drop-wins and merge like the value memos', () => {
+  const parser = createParser();
+  const merged = parser.mergeAiEventFields(
+    { __droppedFieldValues: { bar: 'first' }, __droppedFieldReasons: { bar: '' } },
+    { __droppedFieldValues: { bar: 'second', city: 'x' }, __droppedFieldReasons: { bar: 'context-cited-evidence', city: '' } }
+  );
+  assert.deepEqual(merged.__droppedFieldValues, { bar: 'first', city: 'x' }, 'earlier value wins');
+  assert.deepEqual(merged.__droppedFieldReasons, { bar: '', city: '' }, 'the reason follows its value');
+});


### PR DESCRIPTION
## Why FURBALL Boston kept failing (the approved root-cause plan)
Five runs, five downstream fixes — and the model was never the problem. Live prompt replays on the local AI (temp 0): exact deployed prompt → `79 Warrenon` 2/2; same prompt with the page text the site actually renders → **`Legacy` 2/2**. The pipeline was starving the model:

1. **OCR evicted page text.** OCR is prepended ahead of page text and `extractBodyParts` deduped whole lines across the combined stream — flyer OCR's `LEGACY`/`BEAR WEEK RETURN` claimed the seen-set first, so the page's own `Legacy`/`Bear Week Return` lines were dropped as duplicates. (Why it "used to work": before #1531, OCR failed to pair with this segment, so nothing evicted the page lines. Each fix exposed the next bug.)
2. **Curated bars were discarded at runtime.** `refreshRemoteBars` wholesale-replaced every city's local list with the remote `chunky.dad/data/scraper-bars.json` (1-day cached). Log proof: `Bars data — 23 cities from chunky.dad, 0 from local file`. Curating Legacy locally could never reach the scrape until a site deploy + cache expiry.
3. **Rescue guard leaks.** Brand check was whole-value equality (`furballnyc` ≠ `FURBALL`), no city-name guard (`BOSTON` qualified) → `Bar rescue ambiguous between "FURBALL" and "BOSTON"`.
4. **Free signal unused.** The ticket slug `furball-boston-725-bear-week-legacy-tickets` names the venue.

## Fixes
- **Corpus integrity**: `extractBodyParts` now dedups with two independent seen-sets — OCR-vs-OCR and page-vs-page (OCR regions detected via the machine-emitted `OCR_IMAGE_URL:`/`OCR_IMAGE_TEXT` markers). Intra-corpus dedup, noise/CSS filters, and the cap unchanged; no-OCR inputs byte-identical.
- **Bars union**: per-city UNION (remote wins per bar-name key — freshest enrichment; local-only appended — curated survives; mirrors `tools/sync-bars.js` semantics). Existing log line shape untouched; additive `merged N local-only bar(s)` line.
- **Guards**: brand stem match (compact-prefix, remainder ≤4 → FURBALL⊂furballnyc), `parserConfig.name` joins the known-brand list, whole-value city rejection (deliberately NOT containment — "SF Eagle" stays safe), bare month/weekday words, stoplist += tonight/live/party/presale + exact-phrase "sold out" (a venue named "Out" stays safe). **Zero-false-positive sweep**: every curated bar name in `data/bars/*.json` runs through the new rules; none rejected.
- **URL-slug signal**: ticket-link slug tokens (all path segments + adjacent-pair joins) give candidates a 4th signal `url`; threshold stays ≥2 — Legacy now carries `curated, page, ocr, url`.
- **AI steering**: `bar` field instruction gains "A street address is never a venue name."; the confidence retry now tells the model what was rejected: `Your previous value "X" for <field> was rejected — it is not verbatim in the source. Copy the exact text.` (plain not-verbatim drops only; additive, alternate template only).

## Replay evidence (fixed pipeline, real page + real flyer OCR, local model @ temp 0)
- CONTENT block now contains page `Legacy` AND page `Bear Week Return` AND OCR `LEGACY` — the eviction is gone.
- First pass: still `79 Warren` 3/3 — traced to the cached OCR eventSummary in ADDITIONAL CONTEXT (stale model output saying "at 79 Warrenon") biasing the value; control without it → `Legacy`. The word-boundary gate (#1534) drops that value in production…
- **Retry with the new feedback line: `Legacy` 3/3.** And independent of any model behavior, the convergence rescue adopts Legacy deterministically (4 signals) on the literal run-122902 corpus (unit-tested).

## Tests
724 pass (710 baseline + 14). Three pre-existing `refreshRemoteBars` tests asserted the wholesale replace as spec — that replace IS bug #2; updated to expect the union, with comments. New: Boston-stream dedup regression, bars union matrix, guard matrix on the real corpus, curated-name sweep, slug tokenizer, steering + retry-feedback prompt tests.

## Follow-up (PR 2, deferred per plan)
Constrained bar-select call (arbitration pattern), persistent extraction-result cache, and reviewing the cached OCR eventSummary's role in ADDITIONAL CONTEXT (it is stale model output that biases values — the gates catch it, but it shouldn't be pulling in the first place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP