### PR TITLE
feat(scraper): curate Aqua Emporio (Torremolinos) + district-address upgrade to curated street address

### DIFF
--- a/data/bars/torremolinos.json
+++ b/data/bars/torremolinos.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Aqua Emporio",
+    "city": "torremolinos",
+    "address": "Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos",
+    "coordinates": "36.6218328, -4.4982728",
+    "website": "https://aquatorremolinos.com",
+    "instagram": "https://www.instagram.com/aquatorremolinos"
+  }
+]

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -55,7 +55,9 @@
       "address": "79 Warrenton St, Boston, MA 02116",
       "coordinates": "42.3499063, -71.0658453",
       "website": "https://legacybos.com",
-      "instagram": "https://www.instagram.com/legacybos"
+      "instagram": "https://www.instagram.com/legacybos",
+      "faviconBg": "#b47d04",
+      "faviconFg": "#c38703"
     }
   ],
   "chicago": [
@@ -772,6 +774,16 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJVVvvklSNGGAR4pCosef9zpQ",
       "gayCities": "https://tokyo.gaycities.com/bars/312380-eagle-tokyo-blue",
       "gayCitiesLastScrapedAt": "2026-06-14T09:13:55.162Z"
+    }
+  ],
+  "torremolinos": [
+    {
+      "name": "Aqua Emporio",
+      "city": "torremolinos",
+      "address": "Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos",
+      "coordinates": "36.6218328, -4.4982728",
+      "website": "https://aquatorremolinos.com",
+      "instagram": "https://www.instagram.com/aquatorremolinos"
     }
   ],
   "vegas": [

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -281,13 +281,26 @@ class BarDataNormalizer extends BaseNormalizer {
                 modified = true;
             }
 
-            // Prefer the bar's full address if missing or short in event
-            if (matchedBar.address) {
-                if (!event.address || event.address.length < matchedBar.address.length) {
-                    event.address = matchedBar.address;
-                    event.addressSource = 'curated';
-                    modified = true;
-                }
+            // Prefer the bar's full address if missing in event. A PRESENT
+            // address is only ever replaced by the district-fragment upgrade
+            // rung below — never on length alone (fail closed: a shorter but
+            // non-contained address like "Calle Casablanca 5" may be a genuine
+            // contradiction of curated data and must survive to the merge).
+            if (matchedBar.address && !event.address) {
+                event.address = matchedBar.address;
+                event.addressSource = 'curated';
+                modified = true;
+            }
+
+            // District-to-curated address upgrade rung: the event's address is
+            // a bare district/neighborhood fragment of the curated bar's
+            // street address ("LA NOGALERA" ⊂ "Calle Danza Invisible, La
+            // Nogalera 710, 29620 Torremolinos") — upgrade it to the curated
+            // street address. Strictly gated on the event's BAR matching a
+            // curated bar (findCuratedBarByName full-name equality), so
+            // containment is only ever checked against that one bar's address.
+            if (this.upgradeDistrictAddressToCurated(event)) {
+                modified = true;
             }
 
             // Prefer the bar's coordinates if missing in event
@@ -315,6 +328,55 @@ class BarDataNormalizer extends BaseNormalizer {
         }
 
         return event;
+    }
+
+    // Deterministic district-to-curated address upgrade. Fires only when ALL
+    // of the following hold (anything else returns false — fail closed):
+    //   1. the event carries a non-empty bar that matches a curated bar for
+    //      its city via SharedCore.findCuratedBarByName (full-name equality —
+    //      the bar match is strictly the gate; a district address is NEVER
+    //      compared against curated bars the event's bar does not name);
+    //   2. the event's current address, normalized with the same token family
+    //      the merge address rungs use (SharedCore.normalizeAddressTokens —
+    //      case-insensitive, whitespace/punctuation/diacritic tolerant,
+    //      abbreviations expanded), is a PROPER contiguous fragment of that
+    //      one curated bar's normalized address. Identical addresses need no
+    //      upgrade; a non-contained address is a potential contradiction of
+    //      curated data and is never replaced.
+    // On upgrade: address becomes the curated street address, addressSource
+    // is stamped 'curated', and an additive 🗺️ GEOCODE VERIFY line records
+    // the replacement. Returns true when the event was modified.
+    upgradeDistrictAddressToCurated(event) {
+        if (!event || !this.core) return false;
+        if (typeof this.core.findCuratedBarByName !== 'function'
+            || typeof this.core.getCuratedCityBars !== 'function'
+            || typeof this.core.normalizeAddressTokens !== 'function') return false;
+        const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+        const address = typeof event.address === 'string' ? event.address.trim() : '';
+        if (!bar || !address) return false;
+        const cityBars = this.core.getCuratedCityBars(event.city);
+        if (!cityBars) return false;
+        const curatedBar = this.core.findCuratedBarByName(cityBars, bar);
+        if (!curatedBar || typeof curatedBar.address !== 'string' || curatedBar.address.trim() === '') return false;
+        const eventTokens = this.core.normalizeAddressTokens(address);
+        const curatedTokens = this.core.normalizeAddressTokens(curatedBar.address);
+        // Proper fragment only: an equal-or-longer token sequence is either
+        // already the curated address or something the rung must not touch.
+        if (eventTokens.length === 0 || eventTokens.length >= curatedTokens.length) return false;
+        let contained = false;
+        for (let start = 0; start + eventTokens.length <= curatedTokens.length && !contained; start++) {
+            let matches = true;
+            for (let offset = 0; offset < eventTokens.length; offset++) {
+                if (curatedTokens[start + offset] !== eventTokens[offset]) { matches = false; break; }
+            }
+            contained = matches;
+        }
+        if (!contained) return false;
+        const title = typeof event.title === 'string' && event.title.trim() ? event.title.trim() : 'event';
+        event.address = curatedBar.address;
+        event.addressSource = 'curated';
+        console.log(`🗺️ GEOCODE VERIFY: "${title}" upgraded district address "${address}" to curated bar address "${curatedBar.address}" (bar: ${curatedBar.name})`);
+        return true;
     }
 }
 

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -1479,8 +1479,179 @@ test('BarDataNormalizer does not stamp curated for a value it did not write', ()
 
   assert.equal(event.location, '41.0, -73.0', 'existing pin is kept');
   assert.equal(event.pinSource, 'page', 'pinSource is untouched when bar coordinates are not applied');
-  // Bar address is longer than none → address (and its source) do get written.
+  // Bar address fills a missing one → address (and its source) do get written.
   assert.equal(event.addressSource, 'curated');
+});
+
+// ---------------------------------------------------------------------------
+// District-to-curated address upgrade rung (Aqua Emporio / Torremolinos)
+// ---------------------------------------------------------------------------
+
+const TORREMOLINOS_CITIES = {
+  torremolinos: { timezone: 'Europe/Madrid', patterns: ['torremolinos'] }
+};
+
+const AQUA_EMPORIO_CURATED = {
+  name: 'Aqua Emporio',
+  city: 'torremolinos',
+  address: 'Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos',
+  coordinates: '36.6218328, -4.4982728',
+  website: 'https://aquatorremolinos.com',
+  instagram: 'https://www.instagram.com/aquatorremolinos'
+};
+
+// A second curated bar in the SAME compact district — its address also
+// contains "La Nogalera", so these tests prove containment is only ever
+// checked against the ONE bar the event's bar name matches.
+const EDEN_CURATED = {
+  name: 'Eden',
+  city: 'torremolinos',
+  address: 'Plaza La Nogalera 12, 29620 Torremolinos'
+};
+
+function createTorremolinosBarNormalizer(bars = [AQUA_EMPORIO_CURATED]) {
+  const core = new SharedCore(TORREMOLINOS_CITIES, {
+    eventSchema: EventSchema,
+    bars: { torremolinos: bars }
+  });
+  return new BarDataNormalizer(core);
+}
+
+function captureConsoleLog(fn) {
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (message) => { lines.push(String(message)); };
+  try { fn(); } finally { console.log = originalLog; }
+  return lines;
+}
+
+test('district upgrade rung: the Mad.Bear shape upgrades "LA NOGALERA" to the curated street address', () => {
+  const normalizer = createTorremolinosBarNormalizer();
+  const event = {
+    title: 'FURBALL MAD.BEAR',
+    city: 'torremolinos',
+    bar: 'AQUA EMPORIO',
+    address: 'LA NOGALERA',
+    addressSource: 'page'
+  };
+
+  const lines = captureConsoleLog(() => normalizer.normalize(event));
+
+  assert.equal(event.address, 'Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos',
+    'the district fragment is upgraded to the curated street address');
+  assert.equal(event.addressSource, 'curated', 'the upgrade stamps addressSource curated');
+  assert.ok(lines.includes(
+    '🗺️ GEOCODE VERIFY: "FURBALL MAD.BEAR" upgraded district address "LA NOGALERA" to curated bar address "Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos" (bar: Aqua Emporio)'
+  ), `upgrade log line expected, got: ${JSON.stringify(lines)}`);
+});
+
+test('district upgrade rung: curated pin adoption still fires for the Mad.Bear shape (regression)', () => {
+  const normalizer = createTorremolinosBarNormalizer();
+  const event = { title: 'FURBALL MAD.BEAR', city: 'torremolinos', bar: 'AQUA EMPORIO', address: 'LA NOGALERA' };
+
+  captureConsoleLog(() => normalizer.normalize(event));
+
+  assert.equal(event.location, '36.6218328, -4.4982728', 'curated coordinates adopted for the pinless event');
+  assert.equal(event.pinSource, 'curated');
+  assert.equal(event.instagram, 'https://www.instagram.com/aquatorremolinos', 'curated instagram fills the blank');
+});
+
+test('bar casing: an already-set bar keeps its casing — curated casing adoption lives only in the convergence rescue', () => {
+  const normalizer = createTorremolinosBarNormalizer();
+  const event = { title: 'FURBALL MAD.BEAR', city: 'torremolinos', bar: 'AQUA EMPORIO', address: 'LA NOGALERA' };
+
+  captureConsoleLog(() => normalizer.normalize(event));
+
+  // Documented current behavior: BarDataNormalizer only writes the curated
+  // name into an EMPTY bar (or when title/description was the venue). An
+  // event that already carries "AQUA EMPORIO" keeps that casing here; the
+  // curated-casing adoption exists only in the ai-web parser's bar-convergence
+  // rescue, and the merge's case-only rung prefers the less-uppercased twin.
+  assert.equal(event.bar, 'AQUA EMPORIO');
+});
+
+test('district upgrade rung: an address already identical to curated is a no-op', () => {
+  const normalizer = createTorremolinosBarNormalizer();
+  const event = {
+    title: 'FURBALL MAD.BEAR',
+    city: 'torremolinos',
+    bar: 'AQUA EMPORIO',
+    address: 'Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos',
+    addressSource: 'page'
+  };
+
+  const lines = captureConsoleLog(() => normalizer.normalize(event));
+
+  assert.equal(event.address, 'Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos');
+  assert.equal(event.addressSource, 'page', 'no upgrade happened, so the stamp is untouched');
+  assert.ok(!lines.some(line => line.includes('upgraded district address')), 'identical address logs nothing');
+});
+
+test('district upgrade rung: a non-contained address is NEVER replaced (fail closed)', () => {
+  const normalizer = createTorremolinosBarNormalizer();
+  const event = {
+    title: 'FURBALL MAD.BEAR',
+    city: 'torremolinos',
+    bar: 'AQUA EMPORIO',
+    address: 'Calle Casablanca 5',
+    addressSource: 'page'
+  };
+
+  const lines = captureConsoleLog(() => normalizer.normalize(event));
+
+  assert.equal(event.address, 'Calle Casablanca 5',
+    'a shorter but non-contained address may contradict curated data — it survives to the merge');
+  assert.equal(event.addressSource, 'page');
+  assert.ok(!lines.some(line => line.includes('upgraded district address')));
+});
+
+test('district upgrade rung: no curated match for the bar → no upgrade', () => {
+  const normalizer = createTorremolinosBarNormalizer();
+  const event = {
+    title: 'FURBALL MAD.BEAR',
+    city: 'torremolinos',
+    bar: 'SOME RANDOM CLUB',
+    address: 'LA NOGALERA',
+    addressSource: 'page'
+  };
+
+  captureConsoleLog(() => normalizer.normalize(event));
+
+  assert.equal(event.address, 'LA NOGALERA');
+  assert.equal(event.addressSource, 'page');
+});
+
+test('district upgrade rung: missing or empty bar → no upgrade, even with multiple La Nogalera bars curated', () => {
+  const normalizer = createTorremolinosBarNormalizer([AQUA_EMPORIO_CURATED, EDEN_CURATED]);
+
+  const noBar = { title: 'FURBALL MAD.BEAR', city: 'torremolinos', address: 'LA NOGALERA', addressSource: 'page' };
+  captureConsoleLog(() => normalizer.normalize(noBar));
+  assert.equal(noBar.address, 'LA NOGALERA', 'no bar → the district address is never compared to curated bars');
+  assert.equal(noBar.addressSource, 'page');
+
+  const emptyBar = { title: 'FURBALL MAD.BEAR', city: 'torremolinos', bar: '   ', address: 'LA NOGALERA', addressSource: 'page' };
+  captureConsoleLog(() => normalizer.normalize(emptyBar));
+  assert.equal(emptyBar.address, 'LA NOGALERA');
+  assert.equal(emptyBar.addressSource, 'page');
+});
+
+test('district upgrade rung: containment is keyed on the matched bar — each bar upgrades to ITS OWN address', () => {
+  const normalizer = createTorremolinosBarNormalizer([AQUA_EMPORIO_CURATED, EDEN_CURATED]);
+
+  const aquaEvent = { title: 'FURBALL MAD.BEAR', city: 'torremolinos', bar: 'AQUA EMPORIO', address: 'LA NOGALERA' };
+  captureConsoleLog(() => normalizer.normalize(aquaEvent));
+  assert.equal(aquaEvent.address, 'Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos',
+    'AQUA EMPORIO upgrades to Aqua Emporio\'s address, never Eden\'s');
+  assert.equal(aquaEvent.addressSource, 'curated');
+
+  const edenEvent = { title: 'GARDEN PARTY', city: 'torremolinos', bar: 'EDEN', address: 'LA NOGALERA' };
+  const edenLines = captureConsoleLog(() => normalizer.normalize(edenEvent));
+  assert.equal(edenEvent.address, 'Plaza La Nogalera 12, 29620 Torremolinos',
+    'EDEN upgrades to Eden\'s address, never Aqua Emporio\'s');
+  assert.equal(edenEvent.addressSource, 'curated');
+  assert.ok(edenLines.includes(
+    '🗺️ GEOCODE VERIFY: "GARDEN PARTY" upgraded district address "LA NOGALERA" to curated bar address "Plaza La Nogalera 12, 29620 Torremolinos" (bar: Eden)'
+  ), `Eden upgrade log expected, got: ${JSON.stringify(edenLines)}`);
 });
 
 // Nominatim result with a house number → grade 'exact'. Coordinates sit within

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -64,7 +64,9 @@ const scraperBars = {
       "address": "79 Warrenton St, Boston, MA 02116",
       "coordinates": "42.3499063, -71.0658453",
       "website": "https://legacybos.com",
-      "instagram": "https://www.instagram.com/legacybos"
+      "instagram": "https://www.instagram.com/legacybos",
+      "faviconBg": "#b47d04",
+      "faviconFg": "#c38703"
     }
   ],
   "chicago": [
@@ -781,6 +783,16 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJVVvvklSNGGAR4pCosef9zpQ",
       "gayCities": "https://tokyo.gaycities.com/bars/312380-eagle-tokyo-blue",
       "gayCitiesLastScrapedAt": "2026-06-14T09:13:55.162Z"
+    }
+  ],
+  "torremolinos": [
+    {
+      "name": "Aqua Emporio",
+      "city": "torremolinos",
+      "address": "Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos",
+      "coordinates": "36.6218328, -4.4982728",
+      "website": "https://aquatorremolinos.com",
+      "instagram": "https://www.instagram.com/aquatorremolinos"
     }
   ],
   "vegas": [

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1558,6 +1558,30 @@ class SharedCore {
                             reason: `matches curated bar address (${curatedBar.name})`
                         };
                     }
+                } else if (curatedAddress) {
+                    // A curated address WITHOUT a leading house number (e.g.
+                    // Spanish "Calle Danza Invisible, La Nogalera 710, 29620
+                    // Torremolinos") never parses for the street rung above,
+                    // which left the curated street address losing to a stale
+                    // district-only calendar value via AI coin flips. Fall
+                    // back to normalized-token equality (the same
+                    // normalizeAddressTokens family): exactly one candidate
+                    // IS the curated bar's address token-for-token → it wins,
+                    // with the SAME fail-closed guard — the other candidate
+                    // must not itself be a parseable street address (a
+                    // parseable contradiction of curated data is never
+                    // silently resolved).
+                    const curatedTokenKey = this.normalizeAddressTokens(curatedAddress).join(' ');
+                    const equalsCurated = value => curatedTokenKey !== ''
+                        && this.normalizeAddressTokens(value).join(' ') === curatedTokenKey;
+                    const equalsCuratedA = equalsCurated(valueA);
+                    const equalsCuratedB = equalsCurated(valueB);
+                    if (equalsCuratedA !== equalsCuratedB && !(equalsCuratedA ? parsedB : parsedA)) {
+                        return {
+                            winner: equalsCuratedA ? 'a' : 'b',
+                            reason: `matches curated bar address (${curatedBar.name})`
+                        };
+                    }
                 }
                 // City-suffix twin rung: one candidate is EXACTLY the other
                 // plus a trailing ", <city>" naming the event's own resolved
@@ -8000,14 +8024,31 @@ class SharedCore {
                 };
                 barNormalizer.normalize(probe);
                 if (this.isCoordinatePair(probe.location)) {
-                    const curatedAddress = typeof probe.address === 'string' ? probe.address.trim() : '';
+                    const probeAddress = typeof probe.address === 'string' ? probe.address.trim() : '';
+                    // The scraper normalizer only fills a MISSING address or
+                    // upgrades a district FRAGMENT of the curated address (its
+                    // rung is deliberately fail-closed), but review findings
+                    // are human-approved proposals — here curated bar data
+                    // stays authoritative for vague stored addresses too
+                    // ("Poconos, PA" can never geocode to the venue): when the
+                    // event's bar resolves to a curated bar, propose the
+                    // curated address whenever the stored one is missing or
+                    // shorter (the review pass's own heuristic, unchanged
+                    // behavior for Apply).
+                    const cityBars = this.getCuratedCityBars(city);
+                    const curatedBar = cityBars && typeof probe.bar === 'string' && probe.bar.trim()
+                        ? this.findCuratedBarByName(cityBars, probe.bar) : null;
+                    const curatedBarAddress = curatedBar && typeof curatedBar.address === 'string'
+                        ? curatedBar.address.trim() : '';
+                    let proposedAddress = probeAddress && probeAddress !== eventAddress ? probeAddress : '';
+                    if (!proposedAddress && curatedBarAddress && curatedBarAddress !== eventAddress
+                        && eventAddress.length < curatedBarAddress.length) {
+                        proposedAddress = curatedBarAddress;
+                    }
                     barMatchByEvent.set(event, {
                         barName: typeof probe.bar === 'string' && probe.bar.trim() ? probe.bar.trim() : 'curated bar',
                         location: probe.location.trim(),
-                        // The normalizer already applied its own address heuristic
-                        // (missing or shorter event address loses to the curated
-                        // one), so any difference here IS a material upgrade.
-                        address: curatedAddress && curatedAddress !== eventAddress ? curatedAddress : ''
+                        address: proposedAddress
                     });
                 }
             }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -7291,6 +7291,180 @@ test('merge: the approx stamp is scoped to the append fingerprint — a stored p
 });
 
 // ---------------------------------------------------------------------------
+// Curated Aqua Emporio (Torremolinos): non-parsing curated address anchors the
+// merge, and the curated-upgraded scrape beats the stale district calendar value
+// ---------------------------------------------------------------------------
+
+const AQUA_EMPORIO_ADDRESS = 'Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos';
+
+function createCoreWithTorremolinosBars() {
+  return new SharedCore(
+    {
+      torremolinos: {
+        timezone: 'Europe/Madrid',
+        patterns: ['torremolinos'],
+        coordinates: { lat: 36.6213, lng: -4.4998 }
+      }
+    },
+    {
+      eventSchema: EventSchema,
+      bars: {
+        torremolinos: [{
+          name: 'Aqua Emporio',
+          city: 'torremolinos',
+          address: AQUA_EMPORIO_ADDRESS,
+          coordinates: '36.6218328, -4.4982728'
+        }]
+      }
+    }
+  );
+}
+
+test('address rung 2 fallback: a curated address without a leading house number anchors by token equality', () => {
+  const core = createCoreWithTorremolinosBars();
+  const context = { cityKey: 'torremolinos', barNames: ['AQUA EMPORIO'] };
+
+  // The Spanish-format curated address never parses for the street rung
+  // (number follows the street name) — token equality decides instead, in
+  // both directions.
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', 'LA NOGALERA, Torremolinos', AQUA_EMPORIO_ADDRESS, context),
+    { winner: 'b', reason: 'matches curated bar address (Aqua Emporio)' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', AQUA_EMPORIO_ADDRESS, 'LA NOGALERA, Torremolinos', context),
+    { winner: 'a', reason: 'matches curated bar address (Aqua Emporio)' });
+  // Format-tolerant: an abbreviation/case/punctuation twin of the curated
+  // address still counts as the curated address.
+  assert.deepEqual(
+    core.resolveConflictDeterministically('address', 'LA NOGALERA', 'calle danza invisible la nogalera 710 29620 torremolinos', context),
+    { winner: 'b', reason: 'matches curated bar address (Aqua Emporio)' });
+  // Fail closed: a PARSEABLE street address contradicting curated data is
+  // never silently resolved — the AI sees it.
+  assert.equal(
+    core.resolveConflictDeterministically('address', '5 Calle Casablanca, Torremolinos', AQUA_EMPORIO_ADDRESS, context),
+    null, 'a parseable contradiction of curated data still arbitrates');
+  // Neither candidate is the curated address → arbitrate as before.
+  assert.equal(
+    core.resolveConflictDeterministically('address', 'somewhere else entirely', 'LA NOGALERA', context),
+    null);
+  // No bar context → rung inert.
+  assert.equal(
+    core.resolveConflictDeterministically('address', 'LA NOGALERA, Torremolinos', AQUA_EMPORIO_ADDRESS,
+      { cityKey: 'torremolinos' }),
+    null);
+});
+
+test('merge survival (Mad.Bear): the curated-upgraded address beats the calendar\'s stale district address', async () => {
+  const core = createCoreWithTorremolinosBars();
+  const adapter = buildArbitrationAdapter({});
+  // The scraped record as the normalizers now produce it: district address
+  // upgraded to the curated street address, curated pin adopted.
+  const scraped = {
+    title: 'FURBALL MAD.BEAR',
+    startDate: new Date('2026-08-15T23:00:00.000Z'),
+    endDate: new Date('2026-08-16T05:00:00.000Z'),
+    bar: 'AQUA EMPORIO',
+    address: AQUA_EMPORIO_ADDRESS,
+    addressSource: 'curated',
+    location: '36.6218328, -4.4982728',
+    pinSource: 'curated',
+    city: 'torremolinos',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const existing = {
+    title: 'FURBALL MAD.BEAR',
+    startDate: new Date('2026-08-15T23:00:00.000Z'),
+    endDate: new Date('2026-08-16T05:00:00.000Z'),
+    location: '36.6225097, -4.4987054',
+    url: '',
+    notes: [
+      'bar: AQUA EMPORIO',
+      'address: LA NOGALERA, Torremolinos',
+      'addressSource: page',
+      'pinSource: geocoded-approx'
+    ].join('\n')
+  };
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'the curated address settles the only conflict — no AI request');
+  assert.equal(finalEvent.address, AQUA_EMPORIO_ADDRESS, 'the curated-upgraded address wins the merge');
+  assert.equal(finalEvent.addressSource, 'curated', 'addressSource follows the winning scraped address');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['address']);
+  assert.ok(logLines.includes(
+    '🔒 MERGE: "FURBALL MAD.BEAR" field=address resolved deterministically — matches curated bar address (Aqua Emporio)'
+  ), `stable 🔒 log line expected, got: ${JSON.stringify(logLines)}`);
+  // The address changed, so the fresh curated pin replaces the stale
+  // neighborhood-centroid pin, and pinSource follows it.
+  assert.equal(finalEvent.location, '36.6218328, -4.4982728');
+  assert.equal(finalEvent.pinSource, 'curated');
+});
+
+test('merge survival (enrich flow): the curated-upgraded address beats a same-priority district scrape without AI', async () => {
+  const core = createCoreWithTorremolinosBars();
+  const priorities = { address: { priority: ['ai-web'], merge: 'ai' } };
+  const aiParserConfig = { ai: { provider: 'ollama', endpoint: 'http://ai.example', model: 'm' } };
+  const existing = {
+    title: 'FURBALL MAD.BEAR',
+    bar: 'AQUA EMPORIO',
+    address: 'LA NOGALERA, Torremolinos',
+    city: 'torremolinos',
+    source: 'ai-web',
+    _fieldPriorities: priorities
+  };
+  const incoming = {
+    title: 'FURBALL MAD.BEAR',
+    bar: 'AQUA EMPORIO',
+    address: AQUA_EMPORIO_ADDRESS,
+    city: 'torremolinos',
+    source: 'ai-web',
+    _parserConfig: aiParserConfig,
+    _fieldPriorities: priorities
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'the curated rung decides the same-priority conflict — no AI request');
+  assert.equal(merged.address, AQUA_EMPORIO_ADDRESS, 'the curated address wins in the enrich flow too');
+});
+
+test('curated bars: torremolinos.json carries Aqua Emporio and the generated scraper-bars twins are in sync', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const torremolinosBars = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'bars', 'torremolinos.json'), 'utf8'));
+  const aqua = torremolinosBars.find(bar => bar && bar.name === 'Aqua Emporio');
+  assert.ok(aqua, 'Aqua Emporio curated in data/bars/torremolinos.json');
+  assert.equal(aqua.city, 'torremolinos');
+  assert.equal(aqua.address, AQUA_EMPORIO_ADDRESS);
+  assert.equal(aqua.coordinates, '36.6218328, -4.4982728');
+  assert.equal(aqua.website, 'https://aquatorremolinos.com');
+  assert.equal(aqua.instagram, 'https://www.instagram.com/aquatorremolinos');
+
+  // Generated module twin (scripts/scraper-bars.js) is committed in sync.
+  const scraperBars = require('./scraper-bars');
+  assert.deepEqual(scraperBars.torremolinos, torremolinosBars, 'scripts/scraper-bars.js regenerated after the torremolinos.json edit');
+
+  // Pure-JSON twin served by the site.
+  const jsonTwin = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'scraper-bars.json'), 'utf8'));
+  assert.deepEqual(jsonTwin.torremolinos, torremolinosBars, 'data/scraper-bars.json regenerated after the torremolinos.json edit');
+
+  // The event's ALL-CAPS bar resolves to the curated record (normalizeBarNameKey).
+  const core = new SharedCore({}, { eventSchema: EventSchema, bars: scraperBars });
+  const match = core.findCuratedBarByName(core.getCuratedCityBars('torremolinos'), 'AQUA EMPORIO');
+  assert.ok(match && match.name === 'Aqua Emporio', 'curated lookup resolves the ALL-CAPS event bar');
+});
+
+// ---------------------------------------------------------------------------
 // geo-poi addressSource tier + fusion evidence line
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why
FURBALL MAD.BEAR's map-verify Route was long: bar "AQUA EMPORIO" anchors nowhere on Google (not a mapped name), address "LA NOGALERA" is the whole gay district, pin was a neighborhood-centroid approx. Research settled the old fusion question: **"AQUA EMPORIO" is one real venue** — AQUA Torremolinos' larger room (venue's own branding). Verified across the official site (aquatorremolinos.com), TravelGay's venue page, GayTravelr, The Gay Passport, and the OSM nightclub POI.

## Part 1 — curate the venue
New `data/bars/torremolinos.json`: Aqua Emporio, `Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos`, OSM POI coordinates `36.6218328, -4.4982728`, aquatorremolinos.com, @aquatorremolinos. Generated twins regenerated (which also heals a pre-existing twins-sync break from the favicon-color bot commit). One venue, one entry — "Aqua"/"Aqua Club" are the same club, not separate rows.

With #1535's union fix this reaches the phone runtime immediately: the existing bars-beat-geocoders machinery snaps the pin to the club (`pinSource: curated`) with no further code.

## Part 2 — district-to-curated address upgrade (deterministic, fail closed)
New rung in BarDataNormalizer (same pass as curated pin adoption): when the event's **bar matches a curated bar** (full-name equality — the bar match is strictly the gate) AND the current address is a proper contiguous token-fragment of *that one bar's* curated address (`LA NOGALERA` ⊂ `…La Nogalera 710…`), the address upgrades to the curated street address, `addressSource: curated`, with an additive log line. Identical → no-op. **A non-contained address is never replaced** — a concrete different address (beach edition, pop-up) is a potential truth, not a typo; it survives to the existing conflict/flag machinery.

Owner-requested multi-bar safety, regression-locked: with several curated bars all in La Nogalera, containment is only ever checked against the bar the event names; no bar / uncurated bar → no upgrade, ever.

Two pre-existing hazards fixed en route:
- BarDataNormalizer had a **length-based** address replacement (shorter → clobbered by curated) — not fail-closed; it would have destroyed "Calle Casablanca 5". Scrape pipeline now: fill-when-missing + containment-upgrade only. The calendar-review proposal flow keeps its prior curated-proposal behavior (human-approved there).
- The merge's curated-address rung was **dead for addresses without a leading house number** (Spanish format "…La Nogalera 710"): `parseAddressForComparison` never parsed it. Minimal fallback: a candidate equal to the curated address token-for-token wins (same fail-closed guard + existing reason string). Without it, the calendar's stale "LA NOGALERA, Torremolinos" would have out-lived the upgrade — and the evidence rung can't decide this case (the old centroid pin is ~85 m from the bar, inside the 150 m proximity radius).

End-to-end (tested with the real generated bars): the literal Mad.Bear event → address `Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos` (curated), pin `36.6218328, -4.4982728` (curated), Instagram filled — all three Route legs converge on the club's doorstep.

## Tests
736 pass, 0 fail (origin/main baseline was 723 pass / 1 pre-existing twins-sync fail — healed here). +12 new: upgrade matrix (upgrade/identical/non-contained/no-curated/no-bar), the multi-bar district safety trio, merge-survival in both flows, curated-pin regression, twins sync, bar-casing behavior documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP