### PR TITLE
feat(scraper): curated-bar → city backfill + curate Dallas Eagle

### DIFF
--- a/data/bars/dallas.json
+++ b/data/bars/dallas.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "Dallas Eagle",
+    "city": "dallas",
+    "address": "525 S Riverfront Blvd, Dallas, TX 75207",
+    "coordinates": "32.7693483, -96.8112576",
+    "website": "https://www.thedallaseagle.com",
+    "instagram": "https://www.instagram.com/thedallaseagle",
+    "facebook": "https://www.facebook.com/lonestareagle",
+    "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJU843NR6cToYROpJZCM8p4-I"
+  },
+  {
     "name": "Station 4",
     "city": "dallas",
     "address": "3911 Cedar Springs Rd, Dallas, TX 75219",

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -117,6 +117,16 @@
   ],
   "dallas": [
     {
+      "name": "Dallas Eagle",
+      "city": "dallas",
+      "address": "525 S Riverfront Blvd, Dallas, TX 75207",
+      "coordinates": "32.7693483, -96.8112576",
+      "website": "https://www.thedallaseagle.com",
+      "instagram": "https://www.instagram.com/thedallaseagle",
+      "facebook": "https://www.facebook.com/lonestareagle",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJU843NR6cToYROpJZCM8p4-I"
+    },
+    {
       "name": "Station 4",
       "city": "dallas",
       "address": "3911 Cedar Springs Rd, Dallas, TX 75219",
@@ -783,7 +793,9 @@
       "address": "Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos",
       "coordinates": "36.6218328, -4.4982728",
       "website": "https://aquatorremolinos.com",
-      "instagram": "https://www.instagram.com/aquatorremolinos"
+      "instagram": "https://www.instagram.com/aquatorremolinos",
+      "faviconBg": "#4f4d4c",
+      "faviconFg": "#e5e4e4"
     }
   ],
   "vegas": [

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -396,6 +396,13 @@ class LocationNormalizer extends BaseNormalizer {
             event.city = extractedCity;
         }
 
+        // Curated-bar → city backfill: an event whose page never names its
+        // city (run 20260724-161423: massive.club events came out
+        // city "unknown") can still resolve when its bar is a curated bar.
+        // Runs BEFORE resolveWallClockDates below so the recovered city lets
+        // timezone resolution re-anchor the wall-clock dates.
+        this.backfillCityFromCuratedBar(event);
+
         // Warn when the event references a city we have no config for
         if (!event.timezone && event.city && this.core.cities && !this.core.cities[event.city]) {
             const title = event.title || 'unknown';
@@ -738,6 +745,33 @@ class LocationNormalizer extends BaseNormalizer {
         // behavior (merges can resolve a city AFTER this normalizer already ran).
         if (!this.core || typeof this.core.resolveWallClockDates !== 'function') return event;
         return this.core.resolveWallClockDates(event);
+    }
+
+    // Curated-bar → city backfill (fail closed everywhere): fills event.city
+    // ONLY when it is missing/empty/"unknown" AND the event's bar matches a
+    // curated bar by strict full-name equality (normalizeBarNameKey — the
+    // findCuratedBarByName contract, so "Eagle" never claims "Dallas Eagle")
+    // in exactly ONE city. A name curated in multiple cities is ambiguous and
+    // is never backfilled. A present city that differs is NEVER overwritten.
+    // Provenance is stamped via the existing _citySource convention
+    // (underscore fields stay out of serialized output).
+    backfillCityFromCuratedBar(event) {
+        if (!event || !this.core || typeof this.core.findCuratedBarCityByName !== 'function') return event;
+        const currentCity = typeof event.city === 'string' ? event.city.trim().toLowerCase() : '';
+        if (currentCity && currentCity !== 'unknown') return event;
+        const barName = typeof event.bar === 'string' ? event.bar.trim() : '';
+        if (!barName) return event;
+        const result = this.core.findCuratedBarCityByName(barName);
+        if (!result) return event;
+        const title = event.title || 'unknown';
+        if (result.ambiguousCities) {
+            console.log(`🗺️ LocationNormalizer: City backfill skipped for "${title}" — bar "${barName}" is curated in multiple cities (${result.ambiguousCities.join(', ')})`);
+            return event;
+        }
+        event.city = result.city;
+        event._citySource = 'curated-bar';
+        console.log(`🗺️ LocationNormalizer: Backfilled city "${result.city}" from curated bar "${result.bar.name}" for "${title}"`);
+        return event;
     }
 
     extractCityFromEvent(event) {

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -2507,3 +2507,148 @@ test('fusion via the Photon venue follow-up: empty Nominatim venue rescue + Phot
     `fusion flag log expected, got:\n${captured.lines.join('\n')}`
   );
 });
+
+// ---------------------------------------------------------------------------
+// Curated-bar → city backfill (run 20260724-161423: massive.club events came
+// out bar="Massive"/city="unknown" — the page never says "Seattle" — so
+// timezone resolution failed and dates stayed wall-clock UTC). When the bar
+// matches a curated bar by strict full-name equality in exactly ONE city, the
+// city is backfilled BEFORE resolveWallClockDates so re-anchoring runs.
+// ---------------------------------------------------------------------------
+
+const BACKFILL_CITIES = {
+  seattle: { timezone: 'America/Los_Angeles', patterns: ['seattle'] },
+  portland: { timezone: 'America/Los_Angeles', patterns: ['portland'] },
+  dallas: { timezone: 'America/Chicago', patterns: ['dallas'] }
+};
+
+const MASSIVE_SEATTLE_BAR = {
+  name: 'Massive',
+  city: 'seattle',
+  address: '1428 Broadway, Seattle, WA 98122',
+  website: 'https://www.massive.club'
+};
+
+function createBackfillNormalizer(bars) {
+  const core = new SharedCore(BACKFILL_CITIES, { eventSchema: EventSchema, bars });
+  return new LocationNormalizer(core);
+}
+
+test('curated-bar city backfill: literal massive.club repro — city resolves and wall-clock dates re-anchor', () => {
+  const normalizer = createBackfillNormalizer({ seattle: [MASSIVE_SEATTLE_BAR] });
+  const event = {
+    title: 'Massive Saturday: Bimbo Hypnosis b2b Poof',
+    bar: 'Massive',
+    city: 'unknown',
+    // Wall-clock 10pm local stored as 10pm UTC by the parser's timezone-less fallback
+    startDate: '2026-07-25T22:00:00.000Z',
+    endDate: '2026-07-26T02:00:00.000Z',
+    _timezoneUnresolved: true
+  };
+
+  const lines = captureConsoleLog(() => { normalizer.normalize(event); });
+
+  assert.equal(event.city, 'seattle');
+  assert.equal(event._citySource, 'curated-bar');
+  assert.equal(event.timezone, 'America/Los_Angeles');
+  // 10pm PDT (UTC-7) is 5am UTC the next day — the actual anchored instant
+  assert.equal(event.startDate, '2026-07-26T05:00:00.000Z');
+  assert.equal(event.endDate, '2026-07-26T09:00:00.000Z');
+  assert.equal(event._timezoneUnresolved, undefined, 'flag cleared once dates are anchored');
+  assert.ok(
+    lines.includes('🗺️ LocationNormalizer: Backfilled city "seattle" from curated bar "Massive" for "Massive Saturday: Bimbo Hypnosis b2b Poof"'),
+    `backfill log line expected, got:\n${lines.join('\n')}`
+  );
+});
+
+test('curated-bar city backfill: ALL-CAPS bar "MASSIVE" matches via normalizeBarNameKey and re-anchors too', () => {
+  const normalizer = createBackfillNormalizer({ seattle: [MASSIVE_SEATTLE_BAR] });
+  const event = {
+    title: 'PACK PARTY',
+    bar: 'MASSIVE',
+    city: 'unknown',
+    startDate: '2026-07-25T22:00:00.000Z',
+    _timezoneUnresolved: true
+  };
+
+  captureConsoleLog(() => { normalizer.normalize(event); });
+
+  assert.equal(event.city, 'seattle');
+  assert.equal(event.timezone, 'America/Los_Angeles');
+  assert.equal(event.startDate, '2026-07-26T05:00:00.000Z');
+  assert.equal(event._timezoneUnresolved, undefined);
+});
+
+test('curated-bar city backfill: a present differing city is NEVER overwritten (no backfill log)', () => {
+  const normalizer = createBackfillNormalizer({ seattle: [MASSIVE_SEATTLE_BAR] });
+  const event = {
+    title: 'Make Out Party w/ Hyeonje',
+    bar: 'Massive',
+    city: 'portland'
+  };
+
+  const lines = captureConsoleLog(() => { normalizer.normalize(event); });
+
+  assert.equal(event.city, 'portland', 'the present city must stay');
+  assert.equal(event._citySource, undefined, 'no provenance stamp when nothing was backfilled');
+  assert.ok(
+    !lines.some(line => line.includes('Backfilled city')),
+    `no backfill log expected, got:\n${lines.join('\n')}`
+  );
+});
+
+test('curated-bar city backfill: a bar name curated in TWO cities is ambiguous — no backfill, one skip log', () => {
+  const normalizer = createBackfillNormalizer({
+    seattle: [MASSIVE_SEATTLE_BAR],
+    portland: [{ name: 'Massive', city: 'portland' }]
+  });
+  const event = {
+    title: 'Butt Blast - Guys Underwear Social',
+    bar: 'Massive',
+    city: 'unknown',
+    startDate: '2026-07-25T22:00:00.000Z',
+    _timezoneUnresolved: true
+  };
+
+  const lines = captureConsoleLog(() => { normalizer.normalize(event); });
+
+  assert.equal(event.city, 'unknown', 'ambiguity fails closed — city stays unknown');
+  assert.equal(event._citySource, undefined);
+  assert.equal(event.startDate, '2026-07-25T22:00:00.000Z', 'dates stay wall-clock — nothing to anchor to');
+  assert.equal(event._timezoneUnresolved, true, 'flag remains so the gap stays visible');
+  assert.ok(
+    lines.includes('🗺️ LocationNormalizer: City backfill skipped for "Butt Blast - Guys Underwear Social" — bar "Massive" is curated in multiple cities (seattle, portland)'),
+    `ambiguity log line expected, got:\n${lines.join('\n')}`
+  );
+});
+
+test('curated-bar city backfill: "Eagle" must NOT match curated "Dallas Eagle" (full-name equality only)', () => {
+  const normalizer = createBackfillNormalizer({
+    dallas: [{ name: 'Dallas Eagle', city: 'dallas', address: '525 S Riverfront Blvd, Dallas, TX 75207' }]
+  });
+  const event = { title: 'Gear Night', bar: 'Eagle', city: 'unknown' };
+
+  const lines = captureConsoleLog(() => { normalizer.normalize(event); });
+
+  assert.equal(event.city, 'unknown', 'partial names never claim a curated bar');
+  assert.equal(event._citySource, undefined);
+  assert.ok(!lines.some(line => line.includes('Backfilled city')), 'no backfill log for a non-match');
+});
+
+test('curated-bar city backfill: an uncurated bar is a no-op', () => {
+  const normalizer = createBackfillNormalizer({ seattle: [MASSIVE_SEATTLE_BAR] });
+  const event = {
+    title: 'Hostile Noise',
+    bar: 'Some Warehouse',
+    city: 'unknown',
+    startDate: '2026-07-25T22:00:00.000Z',
+    _timezoneUnresolved: true
+  };
+
+  const lines = captureConsoleLog(() => { normalizer.normalize(event); });
+
+  assert.equal(event.city, 'unknown');
+  assert.equal(event._timezoneUnresolved, true);
+  assert.equal(event.startDate, '2026-07-25T22:00:00.000Z');
+  assert.ok(!lines.some(line => line.includes('Backfilled city')), 'no backfill log for an uncurated bar');
+});

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -126,6 +126,16 @@ const scraperBars = {
   ],
   "dallas": [
     {
+      "name": "Dallas Eagle",
+      "city": "dallas",
+      "address": "525 S Riverfront Blvd, Dallas, TX 75207",
+      "coordinates": "32.7693483, -96.8112576",
+      "website": "https://www.thedallaseagle.com",
+      "instagram": "https://www.instagram.com/thedallaseagle",
+      "facebook": "https://www.facebook.com/lonestareagle",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJU843NR6cToYROpJZCM8p4-I"
+    },
+    {
       "name": "Station 4",
       "city": "dallas",
       "address": "3911 Cedar Springs Rd, Dallas, TX 75219",
@@ -792,7 +802,9 @@ const scraperBars = {
       "address": "Calle Danza Invisible, La Nogalera 710, 29620 Torremolinos",
       "coordinates": "36.6218328, -4.4982728",
       "website": "https://aquatorremolinos.com",
-      "instagram": "https://www.instagram.com/aquatorremolinos"
+      "instagram": "https://www.instagram.com/aquatorremolinos",
+      "faviconBg": "#4f4d4c",
+      "faviconFg": "#e5e4e4"
     }
   ],
   "vegas": [

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1086,6 +1086,30 @@ class SharedCore {
             && this.normalizeBarNameKey(bar.name) === normalized) || null;
     }
 
+    // Cross-city curated-bar lookup for city backfill: when an event's city is
+    // unknown we don't know WHICH city's bars to search, so scan every city's
+    // curated bars for a full-name match (normalizeBarNameKey equality — the
+    // exact same strictness as findCuratedBarByName above; never substring).
+    // Fail closed everywhere:
+    //   { city, bar }              — exactly one city curates this bar name
+    //   { ambiguousCities: [...] } — the name is curated in MORE than one city
+    //   null                       — no match anywhere, or bars data missing
+    findCuratedBarCityByName(barName) {
+        const normalized = this.normalizeBarNameKey(barName);
+        if (!normalized || !this.bars || typeof this.bars !== 'object') return null;
+        const matches = [];
+        for (const cityKey of Object.keys(this.bars)) {
+            const cityBars = this.bars[cityKey];
+            if (!Array.isArray(cityBars) || cityBars.length === 0) continue;
+            const curatedBar = this.findCuratedBarByName(cityBars, barName);
+            if (curatedBar) matches.push({ city: cityKey, bar: curatedBar });
+        }
+        if (matches.length === 0) return null;
+        const cities = [...new Set(matches.map(match => match.city))];
+        if (cities.length > 1) return { ambiguousCities: cities };
+        return matches[0];
+    }
+
     // The bar-name identity key shared by curated matching (above) and the
     // new-venue-candidate dedup key: lowercase, drop a leading "the ", strip
     // non-alphanumerics — so "The Eagle" / "EAGLE!" collapse to one venue.

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -7582,3 +7582,38 @@ test('curated bars: boston.json carries Legacy and the generated scraper-bars tw
   const match = core.findCuratedBarByName(core.getCuratedCityBars('boston'), 'LEGACY');
   assert.ok(match && match.name === 'Legacy', 'curated lookup resolves the rescue candidate');
 });
+
+// ---------------------------------------------------------------------------
+// findCuratedBarCityByName — cross-city curated-bar lookup backing the
+// LocationNormalizer city backfill (run 20260724-161423). Fail closed: one
+// city → match, several cities → ambiguous, none/no-bars → null.
+// ---------------------------------------------------------------------------
+
+test('findCuratedBarCityByName: unique match, ambiguity, partial-name miss, and missing bars data', () => {
+  const bars = {
+    seattle: [{ name: 'Massive', city: 'seattle' }],
+    dallas: [{ name: 'Dallas Eagle', city: 'dallas' }],
+    nyc: [{ name: 'Eagle NYC', city: 'nyc' }]
+  };
+  const core = new SharedCore({}, { eventSchema: EventSchema, bars });
+
+  // Unique full-name match (case-insensitive via normalizeBarNameKey)
+  assert.deepEqual(core.findCuratedBarCityByName('MASSIVE'), { city: 'seattle', bar: bars.seattle[0] });
+
+  // Partial names never match: "Eagle" claims neither "Dallas Eagle" nor "Eagle NYC"
+  assert.equal(core.findCuratedBarCityByName('Eagle'), null);
+  // Different keys never match: "Massive Club" is not "Massive"
+  assert.equal(core.findCuratedBarCityByName('Massive Club'), null);
+
+  // Same normalized name curated in two cities → ambiguous, never a pick
+  const twoCities = new SharedCore({}, {
+    eventSchema: EventSchema,
+    bars: { seattle: [{ name: 'Massive' }], portland: [{ name: 'The Massive' }] }
+  });
+  assert.deepEqual(twoCities.findCuratedBarCityByName('Massive'), { ambiguousCities: ['seattle', 'portland'] });
+
+  // No bars data at all → null (fail closed)
+  const noBars = new SharedCore({}, { eventSchema: EventSchema });
+  assert.equal(noBars.findCuratedBarCityByName('Massive'), null);
+  assert.equal(core.findCuratedBarCityByName(''), null);
+});


### PR DESCRIPTION
## Problem (run 20260724-161423, massive.club; run 20260724-155934, Dallas Eagle)

Bar-site events routinely come out with \`city: "unknown"\` because the page never states the city and the model's inference ("Dallas Eagle implies Dallas") is correctly rejected by the evidence gate. Result: **timezone unresolved → dates stored wall-clock UTC → wrong calendar times**. This hit 5 Massive events and ~6 Dallas Eagle events in yesterday's runs — including one (PACK PARTY) that had an exact pin and POI corroboration and *still* had no city.

## Fix

**Curated-bar → city backfill** (fail closed everywhere):
- New \`SharedCore.findCuratedBarCityByName(barName)\`: scans every city's curated bars with the same strict \`normalizeBarNameKey\` full-name equality as \`findCuratedBarByName\` ("Eagle" never claims "Dallas Eagle"). Returns the unique \`{city, bar}\`, an \`ambiguousCities\` marker when the name is curated in >1 city, or null.
- New \`LocationNormalizer.backfillCityFromCuratedBar(event)\`: fills \`event.city\` **only** when missing/empty/"unknown"; never overwrites a differing city; ambiguity = no action + log. Runs before \`resolveWallClockDates\`, so the recovered city resolves the timezone and the existing wall-clock re-anchoring machinery fixes the dates (proven end-to-end in tests down to the anchored timestamp). Provenance: \`_citySource = 'curated-bar'\` (existing underscore convention, unserialized).
- Bonus ordering win: LocationNormalizer runs before BarDataNormalizer, so the backfilled city also unlocks curated address/coordinate enrichment in the same pass.

New log lines (additive only):
- \`🗺️ LocationNormalizer: Backfilled city "seattle" from curated bar "Massive" for "<title>"\`
- \`🗺️ LocationNormalizer: City backfill skipped for "<title>" — bar "<bar>" is curated in multiple cities (…)\`

**Curate Dallas Eagle** into \`data/bars/dallas.json\` + regenerated twins:
- **525 S Riverfront Blvd, Dallas, TX 75207** — the *revived* Dallas Eagle (verified: the bar's own site footer, current Yelp listing, Google Maps place). Most directories and the OSM POI still carry the old closed 5740 Maple Ave location / previous tenant's name, so geocoders get this wrong — exactly the case curated data exists for.

## Tests

743 pass / 0 fail (baseline on origin/main: 735/736 — the 1 pre-existing failure is the twins-sync test, stale since the favicon-colors commit; the regeneration here heals it). New coverage: literal Massive repro (city unknown → seattle, tz America/Los_Angeles, 10pm wall-clock → correct UTC), ALL-CAPS bar, no-overwrite, two-city ambiguity, "Eagle" vs "Dallas Eagle" non-match, uncurated no-op, SharedCore lookup return shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP