### PR TITLE
fix(scraper): crawl hygiene — asset filter at fetch time, learned 403 dead-ends, www dedup, entity fixes

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -2245,7 +2245,16 @@ class AiWebParser {
             }
             return parsed.toString().replace(/\/$/, '').toLowerCase();
         } catch (_) {
-            return String(url || '').replace(/#.*$/, '').replace(/\/$/, '').toLowerCase();
+            // iOS JavaScriptCore has no URL global, so this fallback is the
+            // ONLY path on-device — it must apply the same www-stripping the
+            // URL branch does or www/bare-host variants dedupe differently on
+            // the phone than in Node (run 20260724-161423 crawled both
+            // massive.club variants because of exactly that gap).
+            return String(url || '')
+                .replace(/#.*$/, '')
+                .replace(/^(https?:\/\/)www\./i, '$1')
+                .replace(/\/$/, '')
+                .toLowerCase();
         }
     }
 
@@ -4155,7 +4164,8 @@ class AiWebParser {
             return { valid: false, reason: 'fragment-only-root-url' };
         }
         const staticAssetExtensions = [
-            '.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.ico', '.bmp', '.tif', '.tiff',
+            '.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.avif', '.heic', '.heif',
+            '.ico', '.bmp', '.tif', '.tiff',
             '.css', '.js', '.mjs', '.map', '.json', '.xml', '.txt', '.pdf', '.zip', '.gz', '.tgz',
             '.mp3', '.m4a', '.wav', '.mp4', '.webm', '.mov', '.avi', '.woff', '.woff2', '.ttf'
         ];
@@ -4416,13 +4426,30 @@ class AiWebParser {
         for (const source of htmlSources) {
             for (const pattern of patterns) {
                 for (const match of source.matchAll(pattern)) {
-                    const candidate = match[1] || match[0];
+                    const candidate = this.truncateAtEncodedDelimiter(match[1] || match[0]);
                     if (candidate) candidates.add(candidate);
                 }
             }
         }
 
         return Array.from(candidates);
+    }
+
+    // In the RAW (undecoded) scan the quote that ends an attribute value is
+    // "&quot;" (or &#34;/&#39;/&lt;/…), which the bare-URL patterns treat as
+    // URL characters — the candidate then bleeds past the attribute boundary
+    // into the following markup (run 20260724-161423 captured
+    // "…&destination=…98122\" target=\"_blank\">Get Directions…" this way, and
+    // an image URL's "….webp&quot;" tail hid its extension from the
+    // static-asset filter). Cut candidates at the first entity-encoded
+    // delimiter so they stop at the same " / ' / whitespace / < boundaries the
+    // literal characters already enforce; &amp; is NOT a delimiter and is
+    // still decoded exactly once downstream (normalizeUrl).
+    truncateAtEncodedDelimiter(candidate) {
+        const text = String(candidate || '');
+        if (text.indexOf('&') === -1) return text;
+        const match = text.match(/&(?:quot|apos|lt|gt|#0*3[49]|#0*6[02]|#x0*2[27]|#x0*3[ce]);/i);
+        return match ? text.slice(0, match.index) : text;
     }
 
     extractUrlsFromJsonLd(html, diagnostics = null) {
@@ -10772,13 +10799,47 @@ TEXT:
         return false;
     }
 
+    // Single decoding layer for page text (prompt sections, segment lines, meta
+    // content) AND the evidence corpus — both derive from extractBodyParts /
+    // getPromptSectionBundle, so extending the decode here keeps the verbatim
+    // evidence gate symmetric: values the model copies from the decoded prompt
+    // match the identically-decoded corpus. Numeric references (&#8217;/&#x2019;)
+    // and the common named typographic entities are covered so titles like
+    // "It&#8217;s PET NIGHT at the Dallas Eagle!" (run 20260724-155934) no
+    // longer ship with raw entities. &amp; deliberately stays encoded here
+    // (URL-candidate scanning depends on it; normalizeUrl decodes it exactly
+    // once), so its numeric forms (&#38;/&#x26;) are skipped too.
     decodeBasicEntities(text) {
         return String(text || '')
             .replace(/&nbsp;/gi, ' ')
             .replace(/&quot;/gi, '"')
             .replace(/&#39;/gi, "'")
             .replace(/&lt;/gi, '<')
-            .replace(/&gt;/gi, '>');
+            .replace(/&gt;/gi, '>')
+            .replace(/&apos;/gi, "'")
+            .replace(/&lsquo;/gi, '‘')
+            .replace(/&rsquo;/gi, '’')
+            .replace(/&ldquo;/gi, '“')
+            .replace(/&rdquo;/gi, '”')
+            .replace(/&ndash;/gi, '–')
+            .replace(/&mdash;/gi, '—')
+            .replace(/&hellip;/gi, '…')
+            .replace(/&#(\d{1,7});/g, (entity, dec) => this.decodeNumericEntity(Number(dec), entity))
+            .replace(/&#x([0-9a-f]{1,6});/gi, (entity, hex) => this.decodeNumericEntity(parseInt(hex, 16), entity));
+    }
+
+    // Numeric character reference → character, decoded at most once. Invalid
+    // code points, surrogates, and the ampersand itself (38/0x26 — kept
+    // encoded, same as &amp;) fall back to the original entity text.
+    decodeNumericEntity(code, fallback) {
+        if (!Number.isFinite(code) || code <= 0 || code > 0x10ffff) return fallback;
+        if (code === 38) return fallback;
+        if (code >= 0xd800 && code <= 0xdfff) return fallback;
+        try {
+            return String.fromCodePoint(code);
+        } catch (_) {
+            return fallback;
+        }
     }
 
     stripTags(text) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -5109,3 +5109,112 @@ test('confidence-retry feedback: dropped-reason memos accumulate first-drop-wins
   assert.deepEqual(merged.__droppedFieldValues, { bar: 'first', city: 'x' }, 'earlier value wins');
   assert.deepEqual(merged.__droppedFieldReasons, { bar: '', city: '' }, 'the reason follows its value');
 });
+
+// ---------------------------------------------------------------------------
+// Crawl hygiene fixes from phone run 20260724-161423 (massive.club, ai-web)
+// ---------------------------------------------------------------------------
+
+test('extractUrlCandidatesFromRawHtml stops candidates at entity-encoded attribute boundaries', () => {
+  const parser = createParser();
+  // Literal shape from the run: the Get Directions anchor lives inside an
+  // entity-encoded attribute, so the raw scan used to bleed past &quot; into
+  // the following attribute and tag text.
+  const html = '<div data-widget="&lt;a href=&quot;https://www.google.com/maps/dir/?api=1&amp;destination=619+E+Pine+St%2C+Seattle%2C+WA+98122&quot; target=&quot;_blank&quot;&gt;Get Directions&lt;/a&gt;"></div>';
+  const candidates = parser.extractUrlCandidatesFromRawHtml(html);
+  assert.ok(candidates.length > 0, 'the URL is still discovered');
+  for (const candidate of candidates) {
+    const text = String(candidate.url || candidate);
+    assert.ok(!text.includes('"'), `candidate must stop at quotes: ${text}`);
+    assert.ok(!/target=/.test(text), `candidate must not bleed into the next attribute: ${text}`);
+    assert.ok(!/Get Directions/.test(text), `candidate must not swallow tag text: ${text}`);
+    assert.ok(!/&quot;|&gt;|&lt;/i.test(text), `candidate must stop at encoded delimiters: ${text}`);
+  }
+  assert.ok(
+    candidates.includes('https://www.google.com/maps/dir/?api=1&amp;destination=619+E+Pine+St%2C+Seattle%2C+WA+98122'),
+    `clean candidate expected (with &amp; still encoded — normalizeUrl decodes it exactly once), got: ${JSON.stringify(candidates)}`
+  );
+});
+
+test('entity-mangled image candidates can no longer hide their extension from the static-asset filter', () => {
+  // Production wiring: the parser normalizes through SharedCore.normalizeUrl
+  const core = new SharedCore({}, { eventSchema: EventSchema });
+  const parser = new AiWebParser({ normalizeUrl: core.normalizeUrl.bind(core) });
+  parser.core = core;
+  // Literal .webp/.avif URLs from the run, embedded behind &quot; boundaries
+  // the way Webflow's JSON blobs carry them. Before the fix the candidate kept
+  // a trailing quote ("….webp\"") so validateEventUrl's extension check missed.
+  const html = [
+    '<script>{"gallery":[',
+    '&quot;https://cdn.prod.website-files.com/659447a9dbb86fcea688b307/675a7570f4832bc60bb6ddb2_image-0004.webp&quot;,',
+    '&quot;https://cdn.prod.website-files.com/659447a9dbb86fcea688b307/6765bd9509d17cbbf6cc31d5_massive-0016.avif&quot;',
+    ']}</script>'
+  ].join('');
+  const links = parser.extractAdditionalUrls(html, 'https://www.massive.club/news', {});
+  assert.deepEqual(links.slice(), [], `no CDN asset may survive discovery, got: ${JSON.stringify(links.slice())}`);
+});
+
+test('validateEventUrl rejects .avif assets (literal URL fetched as a crawl page in the run)', () => {
+  const parser = createParser();
+  const result = parser.validateEventUrl(
+    'https://cdn.prod.website-files.com/659447a9dbb86fcea688b307/6765bd9509d17cbbf6cc31d5_massive-0016.avif',
+    'https://www.massive.club/news'
+  );
+  assert.deepEqual(result, { valid: false, reason: 'static-asset-extension' });
+});
+
+test('getUrlDedupeKey fallback (no URL global, as on iOS JavaScriptCore) still merges www and bare-host variants', () => {
+  const parser = createParser();
+  const originalUrl = global.URL;
+  delete global.URL;
+  try {
+    assert.equal(
+      parser.getUrlDedupeKey('https://www.massive.club/monthly-events'),
+      parser.getUrlDedupeKey('https://massive.club/monthly-events')
+    );
+    assert.notEqual(
+      parser.getUrlDedupeKey('https://massive.club/monthly-events'),
+      parser.getUrlDedupeKey('https://massive.club/calendar')
+    );
+  } finally {
+    global.URL = originalUrl;
+  }
+});
+
+test('decodeBasicEntities decodes numeric and hex entities and common named typography, exactly once', () => {
+  const parser = createParser();
+  // Literal title that shipped with a raw entity in the run
+  assert.equal(
+    parser.decodeBasicEntities('It&#8217;s PET NIGHT at the Dallas Eagle!'),
+    'It’s PET NIGHT at the Dallas Eagle!'
+  );
+  assert.equal(parser.decodeBasicEntities('Womxn&#8217;s Night'), 'Womxn’s Night');
+  assert.equal(parser.decodeBasicEntities('It&#x2019;s time'), 'It’s time');
+  assert.equal(parser.decodeBasicEntities('Doors 9PM&#8211;2AM &mdash; free before 10'), 'Doors 9PM–2AM — free before 10');
+  assert.equal(parser.decodeBasicEntities('&ldquo;BRUT&rdquo; &hellip;'), '“BRUT” …');
+  // &amp; (and its numeric forms) stay encoded at this layer — URL-candidate
+  // scanning depends on it; normalizeUrl decodes it exactly once downstream.
+  assert.equal(parser.decodeBasicEntities('Rock &amp; Roll'), 'Rock &amp; Roll');
+  assert.equal(parser.decodeBasicEntities('Rock &#38; Roll'), 'Rock &#38; Roll');
+  // Invalid references are left untouched rather than corrupted
+  assert.equal(parser.decodeBasicEntities('bad &#xD800; ref'), 'bad &#xD800; ref');
+  assert.equal(parser.decodeBasicEntities('bad &#99999999; ref'), 'bad &#99999999; ref');
+});
+
+test('numeric entities are decoded in the corpus BEFORE the verbatim evidence gate, symmetrically with the prompt', () => {
+  const parser = createParser();
+  const html = '<html><head><title>Dallas Eagle Events</title></head><body><p>It&#8217;s PET NIGHT at the Dallas Eagle! Get ready to unleash your inner pup.</p></body></html>';
+
+  // The prompt payload (extractBodyParts → sections) carries the decoded line…
+  const bodyLines = parser.extractBodyParts(html);
+  assert.ok(
+    bodyLines.some(line => line.includes('It’s PET NIGHT at the Dallas Eagle!')),
+    `decoded line expected in body parts, got: ${JSON.stringify(bodyLines)}`
+  );
+  assert.ok(!bodyLines.some(line => line.includes('&#8217;')), 'no raw numeric entity survives into the prompt corpus');
+
+  // …and the evidence corpus is built from the SAME decoded sections, so a
+  // model value copied verbatim from the decoded prompt passes the gate.
+  const evidenceContext = parser.buildAiEvidenceContext({ html }, {});
+  assert.ok(evidenceContext.raw.includes('It’s PET NIGHT at the Dallas Eagle!'), 'evidence corpus sees the decoded text');
+  assert.equal(parser.hasExactEvidence(evidenceContext, 'It’s PET NIGHT at the Dallas Eagle!'), true, 'decoded title is verbatim in the corpus');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2994,6 +2994,22 @@ class SharedCore {
 
             this.markProcessedUrl(processedUrls, url);
 
+            // Processing-time hygiene for DISCOVERED URLs (configured roots are
+            // left alone): both checks run against the normalized URL that is
+            // about to be fetched, because enqueue-time filtering sees the raw
+            // discovered string, which can differ (entity-mangled tails).
+            if (currentDepth > 0 && this.isStaticAssetUrl(url)) {
+                await displayAdapter.logInfo(`SYSTEM: Skipping static-asset URL in crawl queue: ${url}`);
+                continue;
+            }
+            if (currentDepth > 0) {
+                const deadEndEntry = this.getSkippableDeadEndEntry(url, discoveryOnly);
+                if (deadEndEntry) {
+                    await displayAdapter.logInfo(`SYSTEM: Skipping known dead-end URL (${Number(deadEndEntry.misses) || 0} prior misses): ${url}`);
+                    continue;
+                }
+            }
+
             try {
                 const shouldUseInlineInput = includeInlineInput &&
                     currentDepth === 0 &&
@@ -3208,6 +3224,15 @@ class SharedCore {
                 }
             } catch (error) {
                 const message = error?.message || 'Unknown error';
+                // Bot-wall responses (401/403) are permanent for this client:
+                // learn them as dead ends so later runs skip the fetch entirely.
+                // Generic status check — no host list. Cached-failure replays
+                // count too (the failure cache would otherwise mask the store
+                // from ever learning the URL).
+                const failureStatusCode = this.extractHttpStatusCodeFromError(error);
+                if (failureStatusCode === 403 || failureStatusCode === 401) {
+                    this.recordDeadEndFetchFailure({ url, currentDepth, statusCode: failureStatusCode });
+                }
                 try {
                     if (!(error && error.cachedFailure === true)) {
                         await this.saveNonRetryableFailureNote(
@@ -3292,7 +3317,9 @@ class SharedCore {
     // Learned dead-end store (pure logic — persistence lives in adapters).
     // A URL is a dead end only if it FETCHED successfully AND produced 0 raw
     // events (pre future/bear filtering), 0 segments, AND 0 valid discovered
-    // links. Fetch failures and configured root URLs are never dead-ended.
+    // links. Fetch failures are never dead-ended, with one exception: bot-wall
+    // statuses (401/403) are recorded via recordDeadEndFetchFailure below.
+    // Configured root URLs are never dead-ended.
     // ------------------------------------------------------------------
 
     createDeadEndRunContext(config) {
@@ -3353,6 +3380,62 @@ class SharedCore {
             allowed.push(url);
         }
         return allowed;
+    }
+
+    // Processing-time twin of filterKnownDeadEndUrls for a single URL: the
+    // enqueue-time filter keys the store by the QUEUED string, but the crawl
+    // loop fetches the string after another normalizeUrl pass — when the two
+    // differ (entity-mangled candidates), a recorded dead end sails through
+    // the enqueue filter. Re-checking here against the fetch-time URL closes
+    // that gap (run 20260724-161423: dead-ends.json held the exact .webp URLs
+    // with misses: 3 and they were still refetched every run).
+    getSkippableDeadEndEntry(url, discoveryOnly = false, nowMs = Date.now()) {
+        const context = this.deadEndRunContext;
+        if (!context || !context.enabled || discoveryOnly || !url) {
+            return null;
+        }
+        const entry = context.store[url];
+        const lastSeenMs = entry && entry.lastSeen ? Date.parse(entry.lastSeen) : NaN;
+        const retryMs = context.retryDays * 24 * 60 * 60 * 1000;
+        if (entry && Number.isFinite(lastSeenMs) && (nowMs - lastSeenMs) < retryMs) {
+            context.skippedCount += 1;
+            if (context.skippedSamples.length < 3 && !context.skippedSamples.includes(url)) {
+                context.skippedSamples.push(url);
+            }
+            return entry;
+        }
+        return null;
+    }
+
+    // Learned dead ends from FETCH FAILURES are limited to statuses that are
+    // effectively permanent for this client (bot walls: 401/403 — e.g. tixr.com
+    // 403'd every one of its event pages in run 20260724-161423 and always
+    // will). Other failures stay un-learned: they may be transient and the
+    // non-retryable failure cache already throttles them. Entries share the
+    // normal store retention (retryDays window, pruned at 2×), so a page that
+    // ever recovers self-heals out via recordDeadEndObservation. This only
+    // stops CRAWLING such URLs — ticketUrl fields on events are untouched.
+    recordDeadEndFetchFailure({ url, currentDepth, statusCode, nowMs = Date.now() }) {
+        const context = this.deadEndRunContext;
+        if (!context || !context.enabled || !url) {
+            return;
+        }
+        if (currentDepth === 0) {
+            // Configured root URLs are never dead-ended
+            return;
+        }
+        const nowIso = new Date(nowMs).toISOString();
+        const entry = context.store[url];
+        if (entry) {
+            entry.lastSeen = nowIso;
+            entry.misses = (Number(entry.misses) || 0) + 1;
+            entry.lastStatus = statusCode;
+            context.dirty = true;
+        } else {
+            context.store[url] = { firstSeen: nowIso, lastSeen: nowIso, misses: 1, lastStatus: statusCode };
+            context.dirty = true;
+            context.learned.push(url);
+        }
     }
 
     // Record the outcome of a successfully-fetched page. Productive pages are
@@ -3679,7 +3762,7 @@ class SharedCore {
         const normalized = this.normalizeUrl(url) || String(url);
         const parsed = this.parseUrl(normalized);
         if (!parsed) {
-            const trimmed = String(normalized).trim().replace(/#.*$/, '');
+            const trimmed = String(normalized).trim().replace(/#.*$/, '').replace(/^(https?:\/\/)www\./i, '$1');
             const queryIndex = trimmed.indexOf('?');
             const path = (queryIndex >= 0 ? trimmed.slice(0, queryIndex) : trimmed).replace(/\/$/, '');
             const search = queryIndex >= 0 ? this.stripTrackingSearch(trimmed.slice(queryIndex)) : '';
@@ -3687,7 +3770,12 @@ class SharedCore {
         }
 
         const protocol = String(parsed.protocol || '').toLowerCase();
-        const host = String(parsed.host || parsed.hostname || '').toLowerCase();
+        // www and bare-host variants of the same page are the same page —
+        // the crawl queue must not fetch https://www.X/p and https://X/p twice
+        // (run 20260724-161423 crawled both massive.club variants separately).
+        // Only the DEDUP KEY is normalized; callers keep the original URL
+        // string for fetching and cache keys.
+        const host = String(parsed.host || parsed.hostname || '').toLowerCase().replace(/^www\./, '');
         let pathname = String(parsed.pathname || '/');
         pathname = pathname.replace(/\/+$/, '');
         if (!pathname) pathname = '/';
@@ -5595,6 +5683,28 @@ class SharedCore {
         }
     }
     
+    // Crawl-queue guard: obvious static assets are never pages, so the crawl
+    // loop must never fetch them. URL discovery (ai-web-parser validateEventUrl)
+    // already rejects these, but a candidate whose entity-mangled tail hides the
+    // extension at validation time (e.g. "….webp&quot;" → validated as "….webp\"")
+    // only becomes a clean asset URL after the crawl loop's own normalizeUrl
+    // pass — so the check is re-applied here against the URL actually fetched
+    // (run 20260724-161423 fetched .avif/.webp/.jpg CDN images as crawl pages).
+    isStaticAssetUrl(url) {
+        const staticAssetExtensions = [
+            '.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.avif', '.heic', '.heif',
+            '.ico', '.bmp', '.tif', '.tiff',
+            '.css', '.js', '.mjs', '.map', '.json', '.xml', '.txt', '.pdf', '.zip', '.gz', '.tgz',
+            '.mp3', '.m4a', '.wav', '.mp4', '.webm', '.mov', '.avi', '.woff', '.woff2', '.ttf'
+        ];
+        const parsed = this.parseUrl(url);
+        const path = parsed
+            ? String(parsed.pathname || '')
+            : String(url || '').replace(/[?#].*$/, '');
+        const lowerPath = path.toLowerCase();
+        return staticAssetExtensions.some(ext => lowerPath.endsWith(ext));
+    }
+
     extractUrls(html, patterns, baseUrl) {
         const urls = new Set();
         

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -5397,6 +5397,150 @@ test('dead-end store: maxAdditionalUrls 0 cannot fake a dead end when the parser
   core.deadEndRunContext = null;
 });
 
+// ---------------------------------------------------------------------------
+// Crawl-queue hygiene (run 20260724-161423: raw CDN images fetched as pages,
+// recorded dead ends refetched, www/non-www double-crawled, tixr 403 walls)
+// ---------------------------------------------------------------------------
+
+test('crawl queue: static-asset URLs that slip past discovery are skipped at processing time, never fetched', async () => {
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  // Literal asset URLs the phone run fetched as crawl pages
+  const assetUrls = [
+    'https://cdn.prod.website-files.com/659447a9dbb86fcea688b307/6765bd9509d17cbbf6cc31d5_massive-0016.avif',
+    'https://cdn.prod.website-files.com/659447a9dbb86fcea688b307/675a769ae3ac8d25a81f9936_image-0001.webp',
+    'https://cdn.prod.website-files.com/659447a9dbb86fcea688b307/659474124df37d0bd876efab_Massive-Seattle-Nightclub-Blog-Header-Introducing.jpg'
+  ];
+  const pages = {
+    'https://hub.example/': { additionalLinks: [...assetUrls, 'https://site.example/party'] },
+    'https://site.example/party': {}
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  await core.processEvents(deadEndConfig({}), httpAdapter, display, parsers);
+
+  for (const assetUrl of assetUrls) {
+    assert.ok(!fetched.includes(assetUrl), `static asset must not be fetched: ${assetUrl}`);
+    assert.ok(
+      display.logs.includes(`SYSTEM: Skipping static-asset URL in crawl queue: ${assetUrl}`),
+      `skip log expected for ${assetUrl}`
+    );
+  }
+  assert.ok(fetched.includes('https://site.example/party'), 'real pages still crawled');
+});
+
+test('crawl queue: a recorded dead end is skipped even when the queued string differs from the fetch-time URL', async () => {
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  const youngLastSeen = new Date(Date.now() - 1 * DAY_MS).toISOString();
+  // dead-ends.json holds the CLEAN URL (recorded after the crawl loop's own
+  // normalizeUrl pass)…
+  const store = {
+    'https://site.example/gallery': { firstSeen: youngLastSeen, lastSeen: youngLastSeen, misses: 3 }
+  };
+  const pages = {
+    // …but the queued candidate carries an entity-mangled tail, so the
+    // enqueue-time filter cannot see the match — only the processing-time
+    // check against the fetch-time URL can.
+    'https://hub.example/': { additionalLinks: ['https://site.example/gallery"'] },
+    'https://site.example/gallery': {}
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
+
+  assert.ok(!fetched.includes('https://site.example/gallery'), 'known dead end is not refetched');
+  assert.ok(
+    display.logs.includes('SYSTEM: Skipping known dead-end URL (3 prior misses): https://site.example/gallery'),
+    `expected processing-time skip log, got: ${JSON.stringify(display.logs.filter(line => line.includes('dead-end')))}`
+  );
+});
+
+test('crawl queue: HTTP 403 crawl pages are learned as dead ends (tixr bot wall) and skipped on the next run', async () => {
+  const tixrUrl = 'https://tixr.com/e/199620';
+  const failure = `HTTP request failed for ${tixrUrl}: HTTP 403 error from ${tixrUrl}`;
+
+  // Run 1: the 403 is learned
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  const pages = {
+    'https://hub.example/': { additionalLinks: [tixrUrl] },
+    [tixrUrl]: { fail: failure }
+  };
+  const { httpAdapter, parsers } = createCrawlHarness(pages);
+  const results = await core.processEvents(deadEndConfig({}), httpAdapter, display, parsers);
+
+  const entry = results.deadEndStore[tixrUrl];
+  assert.ok(entry, '403 page recorded in the dead-end store');
+  assert.equal(entry.misses, 1);
+  assert.equal(entry.lastStatus, 403);
+  assert.ok(display.logs.includes(`SYSTEM: Learned 1 new dead-end URL(s): ${tixrUrl}`));
+  assert.ok(display.logs.some(line => line.includes(`Failed to process crawl page ${tixrUrl}`)), 'run 1 still surfaces the fetch error');
+
+  // Run 2 with the persisted store: the URL is skipped, no fetch error
+  const core2 = deadEndCore();
+  const display2 = createDisplayAdapterStub();
+  const harness2 = createCrawlHarness(pages);
+  await core2.processEvents(deadEndConfig({ store: results.deadEndStore }), harness2.httpAdapter, display2, harness2.parsers);
+
+  assert.ok(!display2.logs.some(line => line.includes(`Failed to process crawl page ${tixrUrl}`)), 'run 2 does not retry the bot wall');
+  assert.ok(display2.logs.some(line => line.startsWith('SYSTEM: Skipped 1 known dead-end URL(s)')), 'run 2 reports the skip');
+});
+
+test('crawl queue: non-bot-wall fetch failures (503) are still never dead-ended', async () => {
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  const pages = {
+    'https://hub.example/': { additionalLinks: ['https://site.example/flaky'] },
+    'https://site.example/flaky': { fail: 'HTTP request failed: HTTP 503 error' }
+  };
+  const { httpAdapter, parsers } = createCrawlHarness(pages);
+  const results = await core.processEvents(deadEndConfig({}), httpAdapter, display, parsers);
+  assert.ok(!('https://site.example/flaky' in results.deadEndStore), 'transient failure is not learned');
+});
+
+test('crawl queue: www and bare-host variants of the same path are one queue entry (first queued wins)', async () => {
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  // Literal pair from the phone run — both were separately fetched and AI-classified
+  const pages = {
+    'https://hub.example/': {
+      additionalLinks: [
+        'https://www.massive.club/monthly-events',
+        'https://massive.club/monthly-events'
+      ]
+    },
+    'https://www.massive.club/monthly-events': {},
+    'https://massive.club/monthly-events': {}
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  await core.processEvents(deadEndConfig({}), httpAdapter, display, parsers);
+
+  assert.ok(fetched.includes('https://www.massive.club/monthly-events'), 'first queued variant is fetched with its ORIGINAL URL string');
+  assert.ok(!fetched.includes('https://massive.club/monthly-events'), 'second variant is deduplicated');
+
+  // Unit level: only the dedup KEY is normalized
+  assert.equal(
+    core.getUrlDedupeKey('https://www.massive.club/monthly-events'),
+    core.getUrlDedupeKey('https://massive.club/monthly-events')
+  );
+  assert.notEqual(
+    core.getUrlDedupeKey('https://massive.club/monthly-events'),
+    core.getUrlDedupeKey('https://massive.club/calendar')
+  );
+});
+
+test('isStaticAssetUrl flags asset paths (including .avif) and leaves pages and bare hosts alone', () => {
+  const core = deadEndCore();
+  assert.equal(core.isStaticAssetUrl('https://cdn.prod.website-files.com/659447a9dbb86fcea688b307/6765bd9509d17cbbf6cc31d5_massive-0016.avif'), true);
+  assert.equal(core.isStaticAssetUrl('https://cdn.prod.website-files.com/659447a9dbb86fcea688b302/css/massive-club.shared.98617f967.min.css'), true);
+  assert.equal(core.isStaticAssetUrl('https://www.massive.club/monthly-events'), false);
+  assert.equal(core.isStaticAssetUrl('https://tixr.com/e/199620'), false);
+  // Bare CDN hosts are NOT asset paths — the learned 403 dead-end path handles those
+  assert.equal(core.isStaticAssetUrl('https://cdn.prod.website-files.com'), false);
+});
+
 test('prepareParsedEvents threads the geocodeVerification knob into the normalizer pipeline', async () => {
   const core = createCore();
   let capturedOptions = null;


### PR DESCRIPTION
## Problems (run 20260724-161423, massive.club; run 20260724-155934, Dallas Eagle)

1. Crawler fetched raw images as pages (`massive-0016.avif`, `image-0001.webp`, … → "Cannot parse response to a string") and a bare CDN host.
2. `dead-ends.json` already contained those exact URLs with `misses: 3` — recorded three runs in a row, refetched anyway.
3. All 11 tixr.com event pages 403'd (bot wall) and will forever; re-crawled and re-errored every run.
4. `www.massive.club/monthly-events` and `massive.club/monthly-events` each fetched + AI-classified separately.
5. URL candidates bled past attribute boundaries (`…98122" target="_blank">Get Directions…`).
6. Titles shipped with raw entities (`It&#8217;s PET NIGHT at the Dallas Eagle!`).

## Root cause (1, 2, 5 are the same bug)

In raw HTML the attribute-closing quote is `&quot;`, which the bare-URL patterns treat as URL characters. The candidate is normalized once at validation (`&quot;` → `"`), so the static-asset check saw `….webp"` — extension hidden, accepted. The crawl loop then normalizes a **second** time, stripping the trailing quote → clean asset URL fetched. Same key mismatch defeated the dead-end store: entries are keyed by the fetch-time URL, the enqueue filter checks the queued string.

## Fixes

- **Candidate truncation at entity-encoded delimiters** (`&quot; &apos; &lt; &#34; …`) in raw-HTML extraction; `&amp;` is NOT a delimiter and still decodes exactly once downstream.
- **`.avif/.heic/.heif`** added to the static-asset extension list; defense-in-depth `isStaticAssetUrl()` re-check in the crawl loop against the URL actually fetched (discovered URLs only — configured roots untouched).
- **Dead-end store consulted at processing time** (`getSkippableDeadEndEntry`) against the fetch-time URL → `SYSTEM: Skipping known dead-end URL (N prior misses): <url>`.
- **401/403 fetch failures learned as dead ends** (`recordDeadEndFetchFailure`) — generic status check, no host list (automation over hardcoding). Never for configured roots; entries share the existing retryDays=30 retention and self-heal on any later successful fetch, so a transiently-403ing page recovers after the window. ticketUrl fields untouched — tixr links stay on events; we just stop crawling them.
- **www-stripped dedup key** in `getUrlDedupeKey` (both shared-core and the parser's iOS-only fallback path, which is the branch that actually runs on the phone). Dedup key only — original URL kept for fetch/cache.
- **Numeric + typographic entity decoding** in the existing `decodeBasicEntities` layer, upstream of both the AI prompt and the evidence corpus so the verbatim gate stays symmetric (tested). `&amp;`/`&#38;` deliberately stay encoded at that layer.

## Tests

748 tests, 747 pass, 1 fail — the failure is the **pre-existing stale-twins failure on origin/main** (verified identical before this change). **Merge #1537 first** (its regeneration heals that test), then re-run checks here → green. 12 new tests, all using the literal URLs/strings from the run logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP