### PR TITLE
fix(scraper): cross-source event dedup + generic-stem backfill guard + venue-hours junk filter

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -752,7 +752,10 @@ class LocationNormalizer extends BaseNormalizer {
     // curated bar by strict full-name equality (normalizeBarNameKey — the
     // findCuratedBarByName contract, so "Eagle" never claims "Dallas Eagle")
     // in exactly ONE city. A name curated in multiple cities is ambiguous and
-    // is never backfilled. A present city that differs is NEVER overwritten.
+    // is never backfilled; a name that is a generic franchise stem (contained
+    // inside another curated bar's name key, e.g. "Eagle" ⊂ "Dallas Eagle")
+    // is never backfilled either. A present city that differs is NEVER
+    // overwritten.
     // Provenance is stamped via the existing _citySource convention
     // (underscore fields stay out of serialized output).
     backfillCityFromCuratedBar(event) {
@@ -766,6 +769,14 @@ class LocationNormalizer extends BaseNormalizer {
         const title = event.title || 'unknown';
         if (result.ambiguousCities) {
             console.log(`🗺️ LocationNormalizer: City backfill skipped for "${title}" — bar "${barName}" is curated in multiple cities (${result.ambiguousCities.join(', ')})`);
+            return event;
+        }
+        // Generic-name-stem refusal (run 20260725-170926: truncated bar "Eagle"
+        // uniquely matched fort-lauderdale's curated "Eagle" and backfilled
+        // that city onto Dallas Eagle events). The curated corpus itself flags
+        // the stem — no word lists — so fail closed and leave city unknown.
+        if (result.genericStem) {
+            console.log(`🗺️ LocationNormalizer: City backfill skipped for "${title}" — bar "${barName}" is a generic name stem (contained in: ${result.containedIn.join(', ')})`);
             return event;
         }
         event.city = result.city;

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -2652,3 +2652,77 @@ test('curated-bar city backfill: an uncurated bar is a no-op', () => {
   assert.equal(event.startDate, '2026-07-25T22:00:00.000Z');
   assert.ok(!lines.some(line => line.includes('Backfilled city')), 'no backfill log for an uncurated bar');
 });
+
+test('curated-bar city backfill: generic-name-stem repro — "Eagle" must NOT backfill fort-lauderdale onto Dallas Eagle events', () => {
+  // Literal run 20260725-170926: the extracted bar was the truncation "Eagle";
+  // fort-lauderdale's curated bar is literally named "Eagle" — the ONLY
+  // "Eagle" in curated data — and the uniqueness rule backfilled
+  // "fort-lauderdale" onto "Thursday Karaoke"/"Karaoke". "eagle" is contained
+  // in "dallaseagle", so the corpus itself proves the name is a family stem.
+  const normalizer = createBackfillNormalizer({
+    'fort-lauderdale': [{ name: 'Eagle', city: 'fort-lauderdale' }],
+    dallas: [{ name: 'Dallas Eagle', city: 'dallas', address: '525 S Riverfront Blvd, Dallas, TX 75207' }]
+  });
+  const event = {
+    title: 'Thursday Karaoke',
+    bar: 'Eagle',
+    city: 'unknown',
+    startDate: '2026-07-24T19:00:00.000Z',
+    _timezoneUnresolved: true
+  };
+
+  const lines = captureConsoleLog(() => { normalizer.normalize(event); });
+
+  assert.equal(event.city, 'unknown', 'a generic stem never claims a city');
+  assert.equal(event._citySource, undefined);
+  assert.equal(event._timezoneUnresolved, true, 'dates stay wall-clock — nothing to anchor to');
+  assert.ok(
+    lines.includes('🗺️ LocationNormalizer: City backfill skipped for "Thursday Karaoke" — bar "Eagle" is a generic name stem (contained in: Dallas Eagle)'),
+    `stem skip log expected, got:\n${lines.join('\n')}`
+  );
+  assert.ok(!lines.some(line => line.includes('Backfilled city')), 'no backfill log');
+});
+
+test('curated-bar city backfill: "Massive" (contained in no other curated name) still backfills alongside the stem guard', () => {
+  const normalizer = createBackfillNormalizer({
+    seattle: [MASSIVE_SEATTLE_BAR],
+    'fort-lauderdale': [{ name: 'Eagle', city: 'fort-lauderdale' }],
+    dallas: [{ name: 'Dallas Eagle', city: 'dallas' }]
+  });
+  const event = {
+    title: 'PACK PARTY',
+    bar: 'Massive',
+    city: 'unknown',
+    startDate: '2026-07-25T22:00:00.000Z',
+    _timezoneUnresolved: true
+  };
+
+  captureConsoleLog(() => { normalizer.normalize(event); });
+
+  assert.equal(event.city, 'seattle', 'non-stem unique names keep backfilling');
+  assert.equal(event._citySource, 'curated-bar');
+  assert.equal(event.startDate, '2026-07-26T05:00:00.000Z', 're-anchoring still runs');
+});
+
+test('curated-bar city backfill: containment is one-way — the longer unique name "Dallas Eagle" still backfills', () => {
+  const normalizer = createBackfillNormalizer({
+    'fort-lauderdale': [{ name: 'Eagle', city: 'fort-lauderdale' }],
+    dallas: [{ name: 'Dallas Eagle', city: 'dallas' }]
+  });
+  const event = {
+    title: 'Underwear Night',
+    bar: 'Dallas Eagle',
+    city: 'unknown',
+    startDate: '2026-07-30T02:00:00.000Z',
+    _timezoneUnresolved: true
+  };
+
+  const lines = captureConsoleLog(() => { normalizer.normalize(event); });
+
+  assert.equal(event.city, 'dallas', 'a longer name containing someone else\'s stem matches exactly');
+  assert.equal(event._citySource, 'curated-bar');
+  assert.ok(
+    lines.includes('🗺️ LocationNormalizer: Backfilled city "dallas" from curated bar "Dallas Eagle" for "Underwear Night"'),
+    `backfill log expected, got:\n${lines.join('\n')}`
+  );
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -705,6 +705,17 @@ class AiWebParser {
             console.warn('🤖 AI Web: AI output missing required title/startDate after normalization');
             return null;
         }
+        // Venue-hours notice guard (runs 20260724-161423 / 20260725-170031:
+        // massive.club's "Hours … Tuesday Closed …" block became a segment,
+        // and extraction bound a startDate hallucinated from the adjacent
+        // listing — a calendar-bound "event" titled "Tuesday Closed"). A
+        // schedule notice is not an event; reject it here at the single
+        // normalization choke point so every extraction path (segments,
+        // single pages, detail crawls) is covered.
+        if (this.isVenueHoursNoticeTitle(event.title)) {
+            console.log(`🤖 AI Web: Skipped venue-hours notice "${event.title}" — not an event`);
+            return null;
+        }
         // Address plausibility gate: a venue name is not an address (run
         // 20260723-140457: extraction stored address "Legacy" — the bar's own
         // name — and it sailed through to geocoding). Runs BEFORE the bar
@@ -786,6 +797,40 @@ class AiWebParser {
             }
         }
         return event;
+    }
+
+    // Deterministic venue-hours notice detector: true when a title consists of
+    // NOTHING but weekday name(s)/abbreviation(s) (day ranges like "Mon-Tue"
+    // tokenize into two weekday tokens) plus a closed-notice word — "closed",
+    // "dark" (the theater term), or the phrase "no events". Any other
+    // significant token keeps the event (fail closed: "Closed Party" and
+    // "Dark Disco" are real event names), and a closed-word alone without a
+    // weekday is not a notice either. Token classes only — no per-venue rules,
+    // no position heuristics.
+    isVenueHoursNoticeTitle(title) {
+        const normalized = String(title || '')
+            .toLowerCase()
+            .replace(/&#?[0-9a-z]+;/gi, ' ')
+            .replace(/[^a-z0-9]+/g, ' ')
+            .replace(/\bno\s+events?\b/g, ' closed ')
+            .trim();
+        if (!normalized) return false;
+        const weekdayPattern = /^(?:mon|monday|mondays|tue|tues|tuesday|tuesdays|wed|weds|wednesday|wednesdays|thu|thur|thurs|thursday|thursdays|fri|friday|fridays|sat|saturday|saturdays|sun|sunday|sundays)$/;
+        const closedPattern = /^(?:closed|dark)$/;
+        let weekdayCount = 0;
+        let closedCount = 0;
+        for (const token of normalized.split(/\s+/)) {
+            if (weekdayPattern.test(token)) {
+                weekdayCount++;
+                continue;
+            }
+            if (closedPattern.test(token)) {
+                closedCount++;
+                continue;
+            }
+            return false;
+        }
+        return weekdayCount > 0 && closedCount > 0;
     }
 
     // One-line info summary of a finalized extraction: only fields that are set,

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -5659,3 +5659,56 @@ test('end-marker steering: getFieldContext appends the END-line sentence to star
   }
   assert.ok(!parser.getFieldContext('endTime', null).includes('never its start'), 'end fields are not steered');
 });
+
+// ---------------------------------------------------------------------------
+// Venue-hours notice guard (runs 20260724-161423 / 20260725-170031:
+// massive.club's "Hours … Tuesday Closed …" block became a calendar-bound
+// bear event titled "Tuesday Closed" with a startDate hallucinated from the
+// adjacent "Bearracuda | Seattle Sep 12" listing). A title that is ONLY
+// weekday token(s) + a closed-notice word is a schedule notice, never an
+// event; anything else significant keeps the event (fail closed).
+// ---------------------------------------------------------------------------
+
+test('venue-hours notice: weekday+closed titles are notices, titles with any other significant token are not', () => {
+  const parser = createParser();
+  // Rejected notices — literal run title plus the stated variants
+  assert.equal(parser.isVenueHoursNoticeTitle('Tuesday Closed'), true);
+  assert.equal(parser.isVenueHoursNoticeTitle('Closed Mondays'), true);
+  assert.equal(parser.isVenueHoursNoticeTitle('Mon-Tue Closed'), true);
+  assert.equal(parser.isVenueHoursNoticeTitle('Tuesday: Dark'), true);
+  assert.equal(parser.isVenueHoursNoticeTitle('TUESDAYS: CLOSED'), true);
+  assert.equal(parser.isVenueHoursNoticeTitle('Monday no events'), true);
+  // Real events keep living: closed/dark + other significant tokens
+  assert.equal(parser.isVenueHoursNoticeTitle('Closed Party'), false);
+  assert.equal(parser.isVenueHoursNoticeTitle('Dark Disco'), false);
+  // A weekday alone or a closed-word alone is not a notice (fail closed)
+  assert.equal(parser.isVenueHoursNoticeTitle('Tuesday'), false);
+  assert.equal(parser.isVenueHoursNoticeTitle('Closed'), false);
+  assert.equal(parser.isVenueHoursNoticeTitle(''), false);
+  assert.equal(parser.isVenueHoursNoticeTitle(null), false);
+});
+
+test('venue-hours notice: extractSingleEvent skips the literal "Tuesday Closed" extraction with the skip log', async () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  // Mirrors the run: the AI bound the hours notice to the adjacent listing's
+  // date, producing a fully-formed "event".
+  parser.getAiEvent = async () => ({
+    title: 'Tuesday Closed',
+    startDate: '2026-09-12',
+    city: 'seattle',
+    __preValidatedFields: ['startDate', 'city']
+  });
+  let event = 'unset';
+  const logs = await captureLogsAsync(async () => {
+    event = await parser.extractSingleEvent(
+      { html: 'Tuesday Closed\nBearracuda | Seattle Sep 12, 2026 9:00 PM', url: 'https://massive.club/calendar' },
+      {}, null, ['title', 'startDate', 'city']
+    );
+  });
+  assert.equal(event, null, 'a venue-hours notice never becomes an event');
+  assert.ok(
+    logs.includes('🤖 AI Web: Skipped venue-hours notice "Tuesday Closed" — not an event'),
+    `skip log expected, got: ${JSON.stringify(logs.filter(line => line.includes('AI Web')))}`
+  );
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1093,6 +1093,16 @@ class SharedCore {
     // Fail closed everywhere:
     //   { city, bar }              — exactly one city curates this bar name
     //   { ambiguousCities: [...] } — the name is curated in MORE than one city
+    //   { genericStem: true, containedIn: [...] } — the name is a generic
+    //     franchise stem (run 20260725-170926: the extracted bar "Eagle"
+    //     uniquely matched fort-lauderdale's curated "Eagle" and backfilled
+    //     that city onto Dallas Eagle events). Uniqueness is NOT identity when
+    //     the matched name key is a contained substring of ANOTHER curated
+    //     bar's name key anywhere in the data ("eagle" ⊂ "dallaseagle") — the
+    //     name is a family stem that exists in cities we merely don't curate
+    //     yet. Data-driven: no hardcoded word list, the curated corpus itself
+    //     decides. One-way only — a LONGER unique name ("Dallas Eagle") that
+    //     happens to contain someone else's stem still matches exactly.
     //   null                       — no match anywhere, or bars data missing
     findCuratedBarCityByName(barName) {
         const normalized = this.normalizeBarNameKey(barName);
@@ -1107,6 +1117,20 @@ class SharedCore {
         if (matches.length === 0) return null;
         const cities = [...new Set(matches.map(match => match.city))];
         if (cities.length > 1) return { ambiguousCities: cities };
+        const containedIn = [];
+        for (const cityKey of Object.keys(this.bars)) {
+            const cityBars = this.bars[cityKey];
+            if (!Array.isArray(cityBars)) continue;
+            for (const bar of cityBars) {
+                if (!bar || typeof bar.name !== 'string') continue;
+                const otherKey = this.normalizeBarNameKey(bar.name);
+                if (otherKey && otherKey !== normalized && otherKey.includes(normalized)
+                    && !containedIn.includes(bar.name)) {
+                    containedIn.push(bar.name);
+                }
+            }
+        }
+        if (containedIn.length > 0) return { genericStem: true, containedIn };
         return matches[0];
     }
 
@@ -4267,14 +4291,55 @@ class SharedCore {
             }
         }
 
-        // Log results for large batches
-        if (logProgress) {
-            const duplicatesFound = events.length - urlDeduplicated.length;
-            const duplicateSummary = duplicatesFound > 0 ? ` (removed ${duplicatesFound})` : '';
-            console.log(`🔄 SharedCore: Deduplicated ${events.length} → ${urlDeduplicated.length}${duplicateSummary}`);
+        // Third pass: cross-source duplicates WITHIN one parser run (runs
+        // 20260724-155934 / 20260725-170926: a parser crawling both a venue
+        // site and a ticketing/organizer page received the same event twice
+        // with variant titles — "Thighs out for the guys yall, it's Singlet
+        // Night…" vs "Singlet Night with DJ Drew G" — and the passes above
+        // missed them: keys diverge, name similarity is containment-based,
+        // and one record may carry its venue only as a _venueSitePageHost
+        // tag). Pair only on same venue identity + same event night +
+        // title-token subset (see getCrossSourceDuplicateSignal — every step
+        // fails closed), then MERGE (never drop) through the same
+        // mergeParsedEvents machinery as the passes above so per-field
+        // conflict rules and arbitration apply. Runs AFTER the wall-clock
+        // re-anchor so nights are computed on the best-known instants, and
+        // iterates until stable so chains (A⊂B, B⊂C) collapse to one event.
+        let crossSourceDeduplicated = urlDeduplicated;
+        let crossSourcePassMerged = true;
+        let crossSourcePassCount = 0;
+        while (crossSourcePassMerged && crossSourcePassCount <= events.length) {
+            crossSourcePassMerged = false;
+            crossSourcePassCount++;
+            const kept = [];
+            for (const event of crossSourceDeduplicated) {
+                const match = kept.find(existing => this.getCrossSourceDuplicateSignal(event, existing));
+                if (!match) {
+                    kept.push(event);
+                    continue;
+                }
+                const primary = this.pickCrossSourcePrimary(match, event);
+                const secondary = primary === match ? event : match;
+                console.log(`🔀 MERGE: cross-source duplicate "${secondary.title || 'event'}" merged into "${primary.title || 'event'}" (venue+night+title-subset)`);
+                const merged = await this.mergeParsedEvents(secondary, primary, { httpAdapter, globalConfig });
+                merged.key = primary.key;
+                if (merged._timezoneUnresolved) {
+                    this.resolveWallClockDates(merged);
+                }
+                kept[kept.indexOf(match)] = merged;
+                crossSourcePassMerged = true;
+            }
+            crossSourceDeduplicated = kept;
         }
 
-        return urlDeduplicated;
+        // Log results for large batches
+        if (logProgress) {
+            const duplicatesFound = events.length - crossSourceDeduplicated.length;
+            const duplicateSummary = duplicatesFound > 0 ? ` (removed ${duplicatesFound})` : '';
+            console.log(`🔄 SharedCore: Deduplicated ${events.length} → ${crossSourceDeduplicated.length}${duplicateSummary}`);
+        }
+
+        return crossSourceDeduplicated;
     }
 
     createEventKey(event, format = null) {
@@ -7597,6 +7662,218 @@ class SharedCore {
 
     areEventsSameIdentity(newEvent, existingEvent) {
         return Boolean(this.getSameEventIdentitySignal(newEvent, existingEvent));
+    }
+
+    // === Cross-source duplicate detection (within one parser run) ===
+    // A parser that crawls BOTH a venue site and a ticketing/organizer page
+    // receives the same real-world event twice with variant titles ("Pet Night
+    // with DJ Boost" vs "It's PET NIGHT at the Dallas Eagle! …" — runs
+    // 20260724-155934 / 20260725-170926). The identity signals above miss those
+    // pairs: name similarity is containment-based and one record may carry no
+    // bar/address at all (only a _venueSitePageHost tag). These helpers add a
+    // stricter-scoped signal — same venue identity AND same event night AND
+    // title-token subset — used ONLY by the cross-source pass inside
+    // deduplicateEvents, never for scraped-vs-calendar decisions.
+
+    // The local "night" an event belongs to, as YYYY-MM-DD, or '' when the
+    // start date is missing/unparseable (fail closed: nightless events never
+    // pair). Convention mirrors the #1540 end-marker rollover: a start in the
+    // wee hours (strictly after local midnight, before 04:00) belongs to the
+    // PREVIOUS night. A start at exactly local midnight is the missing-time
+    // default (extraction found only a date), so it stays on its stated date —
+    // the site said "July 31", meaning the night of July 31. Events flagged
+    // _timezoneUnresolved store wall-clock components labeled UTC, so their
+    // UTC components ARE the local reading; the same applies when no timezone
+    // is resolvable at all.
+    getEventNightKey(event) {
+        if (!event || typeof event !== 'object') return '';
+        const date = event.startDate instanceof Date ? event.startDate : this.parseDate(event.startDate);
+        if (!date || isNaN(date.getTime())) return '';
+        const timezone = event._timezoneUnresolved
+            ? null
+            : (event.timezone || (event.city && this.cities && this.cities[event.city]?.timezone) || null);
+        let year = date.getUTCFullYear();
+        let month = date.getUTCMonth() + 1;
+        let day = date.getUTCDate();
+        let hour = date.getUTCHours();
+        let minute = date.getUTCMinutes();
+        if (timezone && typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function') {
+            try {
+                const formatter = new Intl.DateTimeFormat('en-CA', {
+                    timeZone: timezone,
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    hourCycle: 'h23'
+                });
+                const parts = formatter.formatToParts(date);
+                const read = (type) => {
+                    const part = parts.find(entry => entry.type === type);
+                    return part ? parseInt(part.value, 10) : NaN;
+                };
+                const localYear = read('year');
+                const localMonth = read('month');
+                const localDay = read('day');
+                const localHour = read('hour');
+                const localMinute = read('minute');
+                if ([localYear, localMonth, localDay, localHour, localMinute].every(Number.isFinite)) {
+                    year = localYear;
+                    month = localMonth;
+                    day = localDay;
+                    hour = localHour % 24;
+                    minute = localMinute;
+                }
+            } catch (_) {
+                // Unresolvable timezone → fall through to the UTC components.
+            }
+        }
+        let nightUtc = Date.UTC(year, month - 1, day);
+        if ((hour > 0 || minute > 0) && hour < 4) {
+            nightUtc -= 24 * 60 * 60 * 1000;
+        }
+        const night = new Date(nightUtc);
+        const pad = (value) => String(value).padStart(2, '0');
+        return `${night.getUTCFullYear()}-${pad(night.getUTCMonth() + 1)}-${pad(night.getUTCDate())}`;
+    }
+
+    // Positive same-venue identity for the cross-source pass. Requires the SAME
+    // axis populated on BOTH sides — missing-vs-present is never a match (fail
+    // closed). Axes: equal bar-name keys, equal normalized address token
+    // strings, or the same venue-site page host tag (#1539's
+    // _venueSitePageHost — the run's "Eagle Karaoke" record carried no bar at
+    // all but was scraped from thedallaseagle.com just like its twin).
+    getCrossSourceVenueIdentity(eventA, eventB) {
+        if (!eventA || !eventB) return null;
+        const barA = this.normalizeBarNameKey(eventA.bar);
+        const barB = this.normalizeBarNameKey(eventB.bar);
+        if (barA && barB && barA === barB) return 'bar';
+        const addressA = this.normalizeAddressTokens(eventA.address).join(' ');
+        const addressB = this.normalizeAddressTokens(eventB.address).join(' ');
+        if (addressA && addressB && addressA === addressB) return 'address';
+        const hostA = String(eventA._venueSitePageHost || '').trim().toLowerCase();
+        const hostB = String(eventB._venueSitePageHost || '').trim().toLowerCase();
+        if (hostA && hostB && hostA === hostB) return 'venue-site';
+        return null;
+    }
+
+    // Significant title tokens for the cross-source subset test: HTML-entity
+    // leftovers and emoji stripped, lowercased, punctuation collapsed; a
+    // trailing performer clause ("with DJ Boost", "featuring Stevie Licks",
+    // "w/ Hyeonje") is cut at its lexical marker; stopwords, single-character
+    // debris, and the venue's own name tokens are dropped. venueKeys are
+    // normalizeBarNameKey-style strings ("dallaseagle", "thedallaseagle") —
+    // a token is a venue token when a key contains it.
+    getCrossSourceTitleTokens(title, venueKeys = []) {
+        const text = this.stripEmojiForTitleTwin(
+            String(title || '').replace(/&#?[0-9a-z]+;/gi, '')
+        ).toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+        if (!text) return [];
+        const rawTokens = text.split(/\s+/);
+        const performerMarkers = new Set(['with', 'featuring', 'feat', 'ft', 'w']);
+        const markerIndex = rawTokens.findIndex(token => performerMarkers.has(token));
+        const scopedTokens = markerIndex > 0 ? rawTokens.slice(0, markerIndex) : rawTokens;
+        const stopwords = new Set([
+            'a', 'an', 'and', 'are', 'as', 'at', 'be', 'by', 'for', 'from', 'in',
+            'into', 'is', 'it', 'its', 'of', 'on', 'or', 'our', 'the', 'this',
+            'to', 'too', 'with', 'yall', 'you', 'your'
+        ]);
+        const keys = (Array.isArray(venueKeys) ? venueKeys : []).filter(Boolean);
+        const tokens = [];
+        for (const token of scopedTokens) {
+            if (token.length <= 1) continue;
+            if (stopwords.has(token)) continue;
+            if (token.length >= 3 && keys.some(key => key.includes(token))) continue;
+            if (!tokens.includes(token)) tokens.push(token);
+        }
+        return tokens;
+    }
+
+    // Returns 'venue+night+title-subset' when two records from ONE parser run
+    // describe the same event across sources, else null. Every step fails
+    // closed: no venue identity, no/mismatched night, or an empty/disjoint
+    // token set never pairs — same venue + same night with disjoint titles is
+    // two REAL events (an early show and a late party are common).
+    getCrossSourceDuplicateSignal(eventA, eventB) {
+        if (!eventA || typeof eventA !== 'object' || !eventB || typeof eventB !== 'object') return null;
+        if (!this.getCrossSourceVenueIdentity(eventA, eventB)) return null;
+        const nightA = this.getEventNightKey(eventA);
+        if (!nightA) return null;
+        const nightB = this.getEventNightKey(eventB);
+        if (!nightB || nightA !== nightB) return null;
+        const venueKeys = [
+            this.normalizeBarNameKey(eventA.bar),
+            this.normalizeBarNameKey(eventB.bar),
+            String(eventA._venueSitePageHost || '').toLowerCase().replace(/[^a-z0-9]/g, ''),
+            String(eventB._venueSitePageHost || '').toLowerCase().replace(/[^a-z0-9]/g, '')
+        ].filter(Boolean);
+        const tokensA = this.getCrossSourceTitleTokens(eventA.title, venueKeys);
+        if (tokensA.length === 0) return null;
+        const tokensB = this.getCrossSourceTitleTokens(eventB.title, venueKeys);
+        if (tokensB.length === 0) return null;
+        const [shorter, longer] = tokensA.length <= tokensB.length ? [tokensA, tokensB] : [tokensB, tokensA];
+        const longerSet = new Set(longer);
+        if (!shorter.every(token => longerSet.has(token))) return null;
+        return 'venue+night+title-subset';
+    }
+
+    // Primary designation for a cross-source merge: the record with more
+    // populated (evidence-gate-surviving) fields wins; tie → the one whose
+    // start carries an explicit time of day (not the midnight missing-time
+    // default); further tie → the longer normalized title; final tie → the
+    // first argument (the already-kept record).
+    pickCrossSourcePrimary(eventA, eventB) {
+        const populatedFields = (event) => {
+            const fields = ['title', 'description', 'startDate', 'endDate', 'bar', 'address',
+                'location', 'city', 'url', 'ticketUrl', 'image', 'cover', 'instagram',
+                'facebook', 'website', 'gmaps', 'timezone'];
+            return fields.filter(field => {
+                const value = event[field];
+                if (value === null || value === undefined) return false;
+                const text = String(value).trim();
+                if (!text) return false;
+                if (field === 'city' && text.toLowerCase() === 'unknown') return false;
+                return true;
+            }).length;
+        };
+        const countA = populatedFields(eventA);
+        const countB = populatedFields(eventB);
+        if (countA !== countB) return countA > countB ? eventA : eventB;
+        const hasExplicitStartTime = (event) => {
+            const date = event.startDate instanceof Date ? event.startDate : this.parseDate(event.startDate);
+            if (!date || isNaN(date.getTime())) return false;
+            const timezone = event._timezoneUnresolved
+                ? null
+                : (event.timezone || (event.city && this.cities && this.cities[event.city]?.timezone) || null);
+            if (timezone && typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function') {
+                try {
+                    const formatter = new Intl.DateTimeFormat('en-CA', {
+                        timeZone: timezone, hour: '2-digit', minute: '2-digit', hourCycle: 'h23'
+                    });
+                    const parts = formatter.formatToParts(date);
+                    const read = (type) => {
+                        const part = parts.find(entry => entry.type === type);
+                        return part ? parseInt(part.value, 10) : NaN;
+                    };
+                    const hour = read('hour');
+                    const minute = read('minute');
+                    if (Number.isFinite(hour) && Number.isFinite(minute)) {
+                        return (hour % 24) !== 0 || minute !== 0;
+                    }
+                } catch (_) { /* fall through to UTC components */ }
+            }
+            return date.getUTCHours() !== 0 || date.getUTCMinutes() !== 0;
+        };
+        const explicitA = hasExplicitStartTime(eventA);
+        const explicitB = hasExplicitStartTime(eventB);
+        if (explicitA !== explicitB) return explicitA ? eventA : eventB;
+        const titleLength = (event) => this.stripEmojiForTitleTwin(String(event.title || ''))
+            .replace(/\s+/g, ' ').trim().length;
+        if (titleLength(eventA) !== titleLength(eventB)) {
+            return titleLength(eventA) > titleLength(eventB) ? eventA : eventB;
+        }
+        return eventA;
     }
 
     // Process event with conflicts - extract and merge based on strategies

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -7768,3 +7768,204 @@ test('findCuratedBarCityByName: unique match, ambiguity, partial-name miss, and 
   assert.equal(noBars.findCuratedBarCityByName('Massive'), null);
   assert.equal(core.findCuratedBarCityByName(''), null);
 });
+
+// ---------------------------------------------------------------------------
+// findCuratedBarCityByName — generic-name-stem guard (run 20260725-170926:
+// the truncated bar "Eagle" uniquely matched fort-lauderdale's curated
+// "Eagle" and backfilled fort-lauderdale onto Dallas Eagle events).
+// Uniqueness is NOT identity when the name is a franchise stem: the curated
+// corpus itself flags it via containment, no word lists.
+// ---------------------------------------------------------------------------
+
+test('findCuratedBarCityByName: a unique match whose key is contained in another curated name is a generic stem', () => {
+  const bars = {
+    'fort-lauderdale': [{ name: 'Eagle', city: 'fort-lauderdale' }],
+    dallas: [{ name: 'Dallas Eagle', city: 'dallas' }],
+    seattle: [{ name: 'Massive', city: 'seattle' }]
+  };
+  const core = new SharedCore({}, { eventSchema: EventSchema, bars });
+
+  // The literal repro: "Eagle" IS uniquely curated (fort-lauderdale) but its
+  // key is contained in "dallaseagle" → refuse with the stem shape.
+  assert.deepEqual(core.findCuratedBarCityByName('Eagle'), {
+    genericStem: true,
+    containedIn: ['Dallas Eagle']
+  });
+
+  // "Massive" is contained in no other curated name → still backfills.
+  assert.deepEqual(core.findCuratedBarCityByName('Massive'), { city: 'seattle', bar: bars.seattle[0] });
+
+  // Containment is one-way: the LONGER unique name "Dallas Eagle" contains
+  // someone else's stem but is itself contained in nothing → exact match wins.
+  assert.deepEqual(core.findCuratedBarCityByName('Dallas Eagle'), { city: 'dallas', bar: bars.dallas[0] });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-source duplicate detection (runs 20260724-155934 / 20260725-170926:
+// the Dallas Eagle parser crawls both an Eventbrite organizer page and
+// thedallaseagle.com/events, so the same event arrives twice with variant
+// titles). Signal = venue identity + same event night + title-token subset;
+// every step fails closed.
+// ---------------------------------------------------------------------------
+
+const DALLAS_CITIES = { dallas: { timezone: 'America/Chicago', patterns: ['dallas'] } };
+const EAGLE_HOST = 'thedallaseagle.com';
+
+function createDallasCore() {
+  return new SharedCore(DALLAS_CITIES, { eventSchema: EventSchema });
+}
+
+test('getEventNightKey: anchored evenings, wee-hour rollover, midnight date-only default, wall-clock and missing dates', () => {
+  const core = createDallasCore();
+  // 2026-08-01T02:00Z = Jul 31 21:00 in America/Chicago → the night of Jul 31
+  assert.equal(core.getEventNightKey({ startDate: new Date('2026-08-01T02:00:00.000Z'), timezone: 'America/Chicago' }), '2026-07-31');
+  // 2026-07-26T07:00Z = Jul 26 02:00 local — a wee-hour start belongs to the PREVIOUS night
+  assert.equal(core.getEventNightKey({ startDate: new Date('2026-07-26T07:00:00.000Z'), timezone: 'America/Chicago' }), '2026-07-25');
+  // 2026-07-31T05:00Z = Jul 31 00:00 local EXACTLY — the missing-time midnight
+  // default means "the event is ON July 31", so no rollover (literal "Thighs
+  // out…" shape from run 20260725-170926)
+  assert.equal(core.getEventNightKey({ startDate: new Date('2026-07-31T05:00:00.000Z'), timezone: 'America/Chicago' }), '2026-07-31');
+  // A timezone resolved from the city works like an explicit timezone field
+  assert.equal(core.getEventNightKey({ startDate: new Date('2026-08-01T02:00:00.000Z'), city: 'dallas' }), '2026-07-31');
+  // Wall-clock (_timezoneUnresolved) components are already the local reading
+  assert.equal(core.getEventNightKey({ startDate: new Date('2026-07-30T19:00:00.000Z'), _timezoneUnresolved: true, timezone: 'America/Chicago' }), '2026-07-30');
+  // No/invalid start date → no night, never pairs
+  assert.equal(core.getEventNightKey({}), '');
+  assert.equal(core.getEventNightKey({ startDate: 'not a date' }), '');
+});
+
+test('cross-source signal: literal Singlet pair (run 20260725-170926) pairs across the midnight-default gap', () => {
+  const core = createDallasCore();
+  const singlet = {
+    title: 'Singlet Night with DJ Drew G', bar: 'Dallas Eagle', city: 'dallas',
+    timezone: 'America/Chicago', startDate: new Date('2026-08-01T02:00:00.000Z'), _venueSitePageHost: EAGLE_HOST
+  };
+  const thighs = {
+    title: 'Thighs out for the guys yall, it’s Singlet Night at the Dallas Eagle 🤼‍♂️🦅',
+    bar: 'Dallas Eagle', city: 'dallas', timezone: 'America/Chicago',
+    startDate: new Date('2026-07-31T05:00:00.000Z'), _venueSitePageHost: EAGLE_HOST
+  };
+  assert.equal(core.getCrossSourceDuplicateSignal(singlet, thighs), 'venue+night+title-subset');
+});
+
+test('cross-source signal: venue identity via _venueSitePageHost when one record has no bar at all (literal Karaoke pair)', () => {
+  const core = createDallasCore();
+  const detail = {
+    title: 'Karaoke featuring Stevie Licks', bar: 'Dallas Eagle', city: 'dallas',
+    timezone: 'America/Chicago', startDate: new Date('2026-07-31T00:00:00.000Z'), _venueSitePageHost: EAGLE_HOST
+  };
+  const listing = {
+    title: 'Eagle Karaoke featuring Stevie Licks', city: 'unknown',
+    startDate: new Date('2026-07-30T19:00:00.000Z'), _timezoneUnresolved: true, _venueSitePageHost: EAGLE_HOST
+  };
+  assert.equal(core.getCrossSourceDuplicateSignal(detail, listing), 'venue+night+title-subset');
+  // Without the host tag the barless record has NO venue identity — never pairs
+  assert.equal(core.getCrossSourceDuplicateSignal(detail, { ...listing, _venueSitePageHost: undefined }), null);
+});
+
+test('cross-source signal: fails closed on disjoint titles, different nights, and empty titles', () => {
+  const core = createDallasCore();
+  const base = { bar: 'Dallas Eagle', city: 'dallas', timezone: 'America/Chicago', _venueSitePageHost: EAGLE_HOST };
+  // Literal same-night same-venue pair that is TWO REAL events (early happy
+  // hour + night party, run 20260725-170926) — disjoint significant tokens
+  const underwearNight = { ...base, title: 'Underwear Night and Contest with DJ Michael Jon', startDate: new Date('2026-07-30T02:00:00.000Z') };
+  const happyHour = { ...base, title: 'UNDERWEAR HAPPY HOUR', startDate: new Date('2026-07-30T00:00:00.000Z') };
+  assert.equal(core.getCrossSourceDuplicateSignal(underwearNight, happyHour), null);
+  // Literal 20260724-155934 Pet Night shapes: extraction put them on DIFFERENT
+  // nights (Jul 24 wall-clock vs Jul 25 local) — fail closed, keep both
+  const petListing = { ...base, title: 'It’s PET NIGHT at the Dallas Eagle! Get ready to unleash your inner pup…', startDate: new Date('2026-07-26T01:00:00.000Z') };
+  const petDetail = { title: 'Pet Night with DJ Boost', startDate: new Date('2026-07-24T21:00:00.000Z'), _timezoneUnresolved: true, _venueSitePageHost: EAGLE_HOST };
+  assert.equal(core.getCrossSourceDuplicateSignal(petListing, petDetail), null);
+  // Titles that normalize to nothing never pair
+  assert.equal(core.getCrossSourceDuplicateSignal({ ...base, title: '🔥🔥', startDate: new Date('2026-07-30T02:00:00.000Z') }, happyHour), null);
+  // Missing start date never pairs
+  assert.equal(core.getCrossSourceDuplicateSignal({ ...base, title: 'UNDERWEAR HAPPY HOUR' }, happyHour), null);
+});
+
+test('cross-source dedup: secondary ticketUrl/image enrich the primary through the existing merge machinery', async () => {
+  const core = createDallasCore();
+  const primary = {
+    title: 'Karaoke featuring Stevie Licks', bar: 'Dallas Eagle', city: 'dallas',
+    timezone: 'America/Chicago', source: 'ai-web',
+    startDate: new Date('2026-07-31T00:00:00.000Z'), endDate: new Date('2026-07-31T03:00:00.000Z'),
+    description: 'Join us for a very special Eagle Karaoke featuring Stevie Licks!',
+    _venueSitePageHost: EAGLE_HOST
+  };
+  // Barless listing record (the existing identity pass cannot see its place —
+  // only the host tag proves the venue), carrying fields the primary lacks.
+  const secondary = {
+    title: 'Eagle Karaoke featuring Stevie Licks', source: 'ai-web',
+    startDate: new Date('2026-07-30T19:00:00.000Z'), _timezoneUnresolved: true,
+    ticketUrl: 'https://www.thedallaseagle.com/events/karaoke-featuring-stevie-licks/',
+    image: 'https://img.example/karaoke.jpg',
+    _venueSitePageHost: EAGLE_HOST
+  };
+  let result = null;
+  const originalLog = console.log;
+  const lines = [];
+  console.log = (message) => { lines.push(String(message)); };
+  try {
+    result = await core.deduplicateEvents([primary, secondary], null);
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(result.length, 1, 'the pair collapses to one event');
+  assert.equal(result[0].title, 'Karaoke featuring Stevie Licks', 'the richer record is the primary');
+  assert.equal(result[0].ticketUrl, secondary.ticketUrl, 'secondary ticketUrl enriches the primary');
+  assert.equal(result[0].image, secondary.image, 'secondary image enriches the primary');
+  assert.ok(
+    lines.includes('🔀 MERGE: cross-source duplicate "Eagle Karaoke featuring Stevie Licks" merged into "Karaoke featuring Stevie Licks" (venue+night+title-subset)'),
+    `cross-source merge log expected, got:\n${lines.join('\n')}`
+  );
+});
+
+test('cross-source dedup: the literal Dallas Eagle clusters collapse through the real dedup path (5 clusters → 5 events, non-duplicates stay)', async () => {
+  const core = createDallasCore();
+  const anchored = { city: 'dallas', timezone: 'America/Chicago', source: 'ai-web', _venueSitePageHost: EAGLE_HOST };
+  const raw = [
+    // Pet Night cluster (2) — night of Jul 25
+    { ...anchored, title: 'It’s PET NIGHT at the Dallas Eagle! Get ready to unleash your inner pup and join us for a night of tail-wagging fun 🐶🦅', bar: 'Dallas Eagle', startDate: new Date('2026-07-26T01:00:00.000Z'), endDate: new Date('2026-07-26T07:00:00.000Z'), url: 'https://www.thedallaseagle.com' },
+    { title: 'Pet Night with DJ Boost', source: 'ai-web', startDate: new Date('2026-07-25T21:00:00.000Z'), _timezoneUnresolved: true, _venueSitePageHost: EAGLE_HOST, url: 'https://www.thedallaseagle.com/events/pet-night-with-dj-boost/', image: 'https://img.example/pet.jpg' },
+    // Gear Night cluster (3) — night of Jul 25; "GEAR NIGHT!" starts at
+    // Jul 26 02:00 local, exercising the wee-hour rollover
+    { ...anchored, title: 'Grab your gear, it’s time for GEAR NIGHT!', bar: 'Dallas Eagle', startDate: new Date('2026-07-26T02:00:00.000Z') },
+    { ...anchored, title: 'GEAR NIGHT!', bar: 'Dallas Eagle', startDate: new Date('2026-07-26T07:00:00.000Z') },
+    { title: 'Gear Night with DJ Drew G', source: 'ai-web', startDate: new Date('2026-07-25T21:00:00.000Z'), _timezoneUnresolved: true, _venueSitePageHost: EAGLE_HOST },
+    // Karaoke cluster (2, literal 20260725-170926 shapes) — night of Jul 30
+    { ...anchored, title: 'Karaoke featuring Stevie Licks', bar: 'Dallas Eagle', startDate: new Date('2026-07-31T00:00:00.000Z'), endDate: new Date('2026-07-31T03:00:00.000Z'), ticketUrl: 'https://www.thedallaseagle.com/events/karaoke-featuring-stevie-licks/', url: 'https://www.thedallaseagle.com/events/karaoke-featuring-stevie-licks/' },
+    { title: 'Eagle Karaoke featuring Stevie Licks', source: 'ai-web', city: 'unknown', startDate: new Date('2026-07-30T19:00:00.000Z'), endDate: new Date('2026-07-30T22:00:00.000Z'), _timezoneUnresolved: true, _venueSitePageHost: EAGLE_HOST, cover: 'No cover', url: 'https://www.thedallaseagle.com' },
+    // Literal "Karaoke" (run 20260724-155934): bar truncated to "Eagle", no
+    // host tag, wall-clock Jul 24 — a DIFFERENT night, so fail-closed keeps it
+    { title: 'Karaoke', source: 'ai-web', bar: 'Eagle', startDate: new Date('2026-07-24T21:00:00.000Z'), _timezoneUnresolved: true },
+    // FREQUENCY cluster (2, literal bars "Eagle" vs "Dallas Eagle") — night of Jul 30
+    { ...anchored, title: 'George Flores presents: FREQUENCY at the Dallas Eagle, every last Thursday of the month! 🔥', bar: 'Eagle', startDate: new Date('2026-07-31T03:00:00.000Z') },
+    { ...anchored, title: 'FREQUENCY', bar: 'Dallas Eagle', startDate: new Date('2026-07-31T03:00:00.000Z') },
+    // Singlet cluster (2, literal 20260725-170926 shapes) — night of Jul 31
+    { ...anchored, title: 'Singlet Night with DJ Drew G', bar: 'Dallas Eagle', startDate: new Date('2026-08-01T02:00:00.000Z'), endDate: new Date('2026-08-01T07:00:00.000Z'), cover: 'free', ticketUrl: 'https://www.thedallaseagle.com/events/singlet-night/' },
+    { ...anchored, title: 'Thighs out for the guys yall, it’s Singlet Night at the Dallas Eagle 🤼‍♂️🦅', bar: 'Dallas Eagle', startDate: new Date('2026-07-31T05:00:00.000Z'), endDate: new Date('2026-08-01T07:00:00.000Z') },
+    // Legit non-duplicates: same venue, same night (Jul 29), disjoint titles
+    { ...anchored, title: 'Underwear Night and Contest with DJ Michael Jon', bar: 'Dallas Eagle', startDate: new Date('2026-07-30T02:00:00.000Z') },
+    { ...anchored, title: 'UNDERWEAR HAPPY HOUR', bar: 'Dallas Eagle', startDate: new Date('2026-07-30T00:00:00.000Z') }
+  ];
+
+  const result = await core.deduplicateEvents(raw, null);
+
+  const titles = result.map(event => event.title).sort();
+  assert.equal(result.length, 8, `5 collapsed clusters + 3 kept singles, got: ${titles.join(' | ')}`);
+  // Every cluster collapsed to exactly one survivor
+  assert.equal(result.filter(event => /pet night/i.test(event.title)).length, 1, 'Pet Night cluster → 1');
+  assert.equal(result.filter(event => /gear night/i.test(event.title)).length, 1, 'Gear Night chain of 3 → 1');
+  assert.equal(result.filter(event => /stevie licks/i.test(event.title)).length, 1, 'Karaoke pair → 1');
+  assert.equal(result.filter(event => /frequency/i.test(event.title)).length, 1, 'FREQUENCY pair → 1');
+  assert.equal(result.filter(event => /singlet|thighs/i.test(event.title)).length, 1, 'Singlet pair → 1');
+  // Fail-closed keeps: the different-night "Karaoke" and the two real events
+  assert.ok(titles.includes('Karaoke'), 'the Jul 24 "Karaoke" is a different night — kept');
+  assert.ok(titles.includes('Underwear Night and Contest with DJ Michael Jon'), 'real event kept');
+  assert.ok(titles.includes('UNDERWEAR HAPPY HOUR'), 'real same-night event with disjoint title kept');
+  // Enrichment flowed through the existing merge machinery
+  const karaoke = result.find(event => /stevie licks/i.test(event.title));
+  assert.equal(karaoke.cover, 'No cover', 'secondary cover enriches the Karaoke primary');
+  assert.equal(karaoke.startDate.toISOString(), '2026-07-31T00:00:00.000Z', 'timezone-anchored start wins over wall-clock');
+  const pet = result.find(event => /pet night/i.test(event.title));
+  assert.equal(pet.image, 'https://img.example/pet.jpg', 'secondary image enriches the Pet Night primary');
+});


### PR DESCRIPTION
One batched PR, three fixes from the 2026-07-25 phone runs (170031 massive.club, 170926 Dallas Eagle).

## 1. Curated-bar city backfill: generic-name-stem guard (real bug)

Run 170926 backfilled **fort-lauderdale** onto two Dallas Eagle events: their extracted bar was the truncation "Eagle", and Fort Lauderdale's curated bar is literally named "Eagle" — the only one in curated data, so #1537's uniqueness rule was satisfied. Uniqueness ≠ identity for franchise stems. New data-driven guard (no word lists): a uniquely-matched name whose key is a contained substring of any OTHER curated bar's key ("eagle" ⊂ "dallaseagle") is a family stem → refuse + log. Against the real corpus: "Eagle" now refused (contained in 8 curated names), "Massive" still backfills, "Dallas Eagle" still matches exactly.

## 2. Cross-source duplicate events

A parser crawling both a venue site and its Eventbrite/ticketing pages received the same event 2–3× with variant titles ("Pet Night with DJ Boost" vs "It's PET NIGHT at the Dallas Eagle!…"; three GEAR NIGHT variants; etc). New third pass inside the existing `deduplicateEvents` (after wall-clock re-anchoring, iterating until stable for chains), pairing ONLY on **all three** of:
- same venue identity (bar-name key, normalized address, or same `_venueSitePageHost`) — missing vs present never matches;
- same event night (00:01–03:59 local rolls to the previous night, mirroring #1540; exact-midnight defaults stay on their stated date);
- title-token subset after stripping emoji/stopwords/venue-name tokens — disjoint titles NEVER pair (same bar + same night with different titles is two real events).

Merges go through the existing `mergeParsedEvents` per-field rules/arbitration — enrich, never drop. E2E on 14 literal run events → 8 final: all 5 duplicate clusters collapse, the legit same-night pair (Underwear Night / UNDERWEAR HAPPY HOUR) stays 2, and "Karaoke" (genuinely a different night in the real data) correctly survives alone.

## 3. Venue-hours notices are not events

"Tuesday Closed" became a Sept 13 calendar-bound bear event (and the venue-site consensus then gave it a street address). Language-generic guard at `extractSingleEvent`: titles that are ONLY weekday(s) + closed-notice word ("Tuesday Closed", "Closed Mondays", "TUESDAYS: CLOSED", "Tuesday: Dark") are skipped + logged; titles with any other significant token ("Closed Party", "Dark Disco") are untouched.

New log lines (all additive): generic-stem skip, `🔀 MERGE: cross-source duplicate "…" merged into "…" (venue+night+title-subset)`, venue-hours skip.

## Tests

786 pass / 0 fail (baseline 774/774 on main; +12). Includes the literal Eagle repro, real-corpus stem checks, all five cluster collapses, fails-closed night/venue/title refusals on real data shapes, enrichment flow, chain collapse, and the rollover matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP