### PR TITLE
fix(scraper): results-UI white screen (page size) + curated bar-name canonicalization + title steering

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -4791,10 +4791,14 @@ class ScriptableAdapter {
   // Rich UI presentation using WebView with HTML
   async presentRichResults(results) {
     try {
-      console.log("📱 Scriptable: Presenting results UI...");
-
-      // Generate HTML for rich display
+      // Generate HTML for rich display (before the presenting log so the
+      // size line lands next to it — WebView.loadHTML fails SILENTLY with a
+      // white screen past ~1 MB, so the size must be in the log by itself)
       const html = await this.generateRichHTML(results);
+      console.log(
+        `📱 Scriptable: Results HTML size: ${Math.round(html.length / 1024)} KB`,
+      );
+      console.log("📱 Scriptable: Presenting results UI...");
 
       // Present using an instance WebView so page buttons can signal native
       // via shouldAllowRequest (assigned BEFORE present() — the reliable
@@ -8591,48 +8595,9 @@ class ScriptableAdapter {
                             <button onclick="copyEventJSON(this)" 
                                     style="padding: 4px 8px; font-size: 11px; background: var(--primary-color); color: var(--text-inverse); border: none; border-radius: 8px; cursor: pointer; font-family: 'Poppins', sans-serif; font-weight: 500; transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);"
                                     data-event-json='${this.escapeHtml(
-                                      JSON.stringify(
-                                        event,
-                                        (key, value) => {
-                                          if (
-                                            key === "_parserConfig" &&
-                                            value
-                                          ) {
-                                            return {
-                                              name: value.name,
-                                              parser: value.parser,
-                                            };
-                                          }
-                                          if (
-                                            key === "_existingEvent" &&
-                                            value
-                                          ) {
-                                            return {
-                                              title: value.title,
-                                              identifier: value.identifier,
-                                            };
-                                          }
-                                          if (
-                                            key === "_conflicts" &&
-                                            value &&
-                                            Array.isArray(value)
-                                          ) {
-                                            return value.map((c) => ({
-                                              title: c.title,
-                                              startDate: c.startDate,
-                                              identifier: c.identifier,
-                                            }));
-                                          }
-                                          if (key === "placeId") {
-                                            return undefined; // Hide placeId from debug display
-                                          }
-                                          if (typeof value === "function") {
-                                            return "[Function]";
-                                          }
-                                          return value;
-                                        },
-                                        2,
-                                      ),
+                                      this.buildEmbeddedEventJson(event, {
+                                        includeOriginal: false,
+                                      }),
                                     )}'>
                                 📋 Copy JSON
                             </button>
@@ -8728,81 +8693,19 @@ class ScriptableAdapter {
             
             <div class="raw-display">
                 <pre style="font-size: 11px; background: #333; color: #fff; padding: 10px; border-radius: 5px; overflow-x: auto;">${this.escapeHtml(
-                  JSON.stringify(
-                    event,
-                    (key, value) => {
-                      // Keep full object for debugging, only filter out circular references and functions
-                      if (key === "_parserConfig" && value) {
-                        return { name: value.name, parser: value.parser };
-                      }
-                      if (key === "_existingEvent" && value) {
-                        return {
-                          title: value.title,
-                          identifier: value.identifier,
-                        };
-                      }
-                      if (
-                        key === "_conflicts" &&
-                        value &&
-                        Array.isArray(value)
-                      ) {
-                        return value.map((c) => ({
-                          title: c.title,
-                          startDate: c.startDate,
-                          identifier: c.identifier,
-                        }));
-                      }
-                      if (key === "placeId") {
-                        return undefined; // Hide placeId from debug display
-                      }
-                      if (typeof value === "function") {
-                        return "[Function]"; // Show functions exist but don't break JSON
-                      }
-                      return value;
-                    },
-                    2,
-                  ),
+                  // Keeps _original (merge provenance) but drops the AI
+                  // prompt/validation blobs — see buildEmbeddedEventJson
+                  this.buildEmbeddedEventJson(event, {
+                    includeOriginal: true,
+                  }),
                 )}</pre>
                 <div style="margin-top: 8px; text-align: right;">
                     <button onclick="copyEventJSON(this)" 
                             style="padding: 4px 8px; font-size: 11px; background: var(--primary-color); color: var(--text-inverse); border: none; border-radius: 8px; cursor: pointer; font-family: 'Poppins', sans-serif; font-weight: 500; transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);"
                             data-event-json='${this.escapeHtml(
-                              JSON.stringify(
-                                event,
-                                (key, value) => {
-                                  if (key === "_parserConfig" && value) {
-                                    return {
-                                      name: value.name,
-                                      parser: value.parser,
-                                    };
-                                  }
-                                  if (key === "_existingEvent" && value) {
-                                    return {
-                                      title: value.title,
-                                      identifier: value.identifier,
-                                    };
-                                  }
-                                  if (
-                                    key === "_conflicts" &&
-                                    value &&
-                                    Array.isArray(value)
-                                  ) {
-                                    return value.map((c) => ({
-                                      title: c.title,
-                                      startDate: c.startDate,
-                                      identifier: c.identifier,
-                                    }));
-                                  }
-                                  if (key === "placeId") {
-                                    return undefined; // Hide placeId from debug display
-                                  }
-                                  if (typeof value === "function") {
-                                    return "[Function]";
-                                  }
-                                  return value;
-                                },
-                                2,
-                              ),
+                              this.buildEmbeddedEventJson(event, {
+                                includeOriginal: false,
+                              }),
                             )}'>
                         📋 Copy JSON
                     </button>
@@ -8812,6 +8715,58 @@ class ScriptableAdapter {
         `;
 
     return html;
+  }
+
+  // Shared serializer for every place a full event is embedded into the
+  // results HTML (the two "Copy JSON" button attributes and the raw <pre>
+  // debug dump). ONE replacer so the slimming rules live in one place:
+  //   - _aiPrompts/_aiValidation are dropped at ANY depth — the full AI
+  //     prompt texts are already surfaced via the dedicated "🤖 AI Prompts"
+  //     button, and duplicating ~20 KB of them per event 2-3x per card is
+  //     what pushed the Bearracuda run's page (1.76 MB) past
+  //     WebView.loadHTML's silent ~1 MB white-screen threshold
+  //     (runs 20260725-205758/210227).
+  //   - _original is dropped entirely from the BUTTON embeds
+  //     (includeOriginal: false); the raw <pre> keeps it (minus the AI
+  //     blobs) since that's where a human reads the merge provenance.
+  //   - _parserConfig/_existingEvent/_conflicts/placeId/function slimming
+  //     is unchanged from the previous inline replacers.
+  buildEmbeddedEventJson(event, { includeOriginal = true } = {}) {
+    return JSON.stringify(
+      event,
+      (key, value) => {
+        if (key === "_aiPrompts" || key === "_aiValidation") {
+          return undefined; // Already available via the AI Prompts button
+        }
+        if (!includeOriginal && key === "_original") {
+          return undefined;
+        }
+        if (key === "_parserConfig" && value) {
+          return { name: value.name, parser: value.parser };
+        }
+        if (key === "_existingEvent" && value) {
+          return {
+            title: value.title,
+            identifier: value.identifier,
+          };
+        }
+        if (key === "_conflicts" && value && Array.isArray(value)) {
+          return value.map((c) => ({
+            title: c.title,
+            startDate: c.startDate,
+            identifier: c.identifier,
+          }));
+        }
+        if (key === "placeId") {
+          return undefined; // Hide placeId from debug display
+        }
+        if (typeof value === "function") {
+          return "[Function]";
+        }
+        return value;
+      },
+      2,
+    );
   }
 
   // Helper to escape HTML

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -2440,3 +2440,101 @@ test('run id backfill preserves history, skips foreign entries, and fails open',
   assert.equal(adapter.fm.files.get(adapter.getBarAdditionsFilePath()), before,
     'nothing rewritten without both a run id and session keys');
 });
+
+// ---------------------------------------------------------------------------
+// Embedded-event JSON slimming (runs 20260725-205758/210227: the Bearracuda
+// results page hit 1.76 MB — dominated by per-event _aiPrompts/_aiValidation
+// blobs embedded 2-3x per card — and WebView.loadHTML white-screened
+// silently. buildEmbeddedEventJson is the ONE serializer for all three embed
+// sites: the two Copy JSON button attributes and the raw <pre> dump.)
+// ---------------------------------------------------------------------------
+
+function buildSyntheticAnalyzedEvent() {
+  // Shaped like a real analyzed event (~32 KB): the AI prompt/validation
+  // texts live under _original.scraper and are ~10 KB each.
+  const bigPrompt = 'PROMPT '.repeat(1500);      // ~10.5 KB
+  const bigValidation = 'VALIDATE '.repeat(1200); // ~10.8 KB
+  return {
+    title: 'BEARRACUDA: Seattle',
+    bar: 'Massive',
+    city: 'seattle',
+    startDate: '2026-08-01T02:00:00.000Z',
+    placeId: 'ChIJexample',
+    _action: 'merge',
+    _parserConfig: {
+      name: 'bearracuda',
+      parser: 'ai-web',
+      urls: ['https://bearracuda.com/'],
+      alwaysBear: true,
+      maxAdditionalUrls: 20
+    },
+    _existingEvent: {
+      title: 'BEARRACUDA: Seattle',
+      identifier: 'CAL-123',
+      notes: 'existing notes blob',
+      save: function () {}
+    },
+    _original: {
+      scraper: {
+        title: 'BEARRACUDA: Seattle',
+        _aiPrompts: { extraction: bigPrompt, arbitration: bigPrompt },
+        _aiValidation: { report: bigValidation }
+      },
+      calendar: { title: 'BEARRACUDA: Seattle' },
+      merged: { title: 'BEARRACUDA: Seattle', _aiValidation: { report: bigValidation } }
+    }
+  };
+}
+
+test('buildEmbeddedEventJson: button embeds drop _original and the AI blobs; pre embed keeps _original minus the AI blobs', () => {
+  const adapter = buildAdapter();
+  const event = buildSyntheticAnalyzedEvent();
+  const fullSize = JSON.stringify(event, (k, v) => typeof v === 'function' ? '[Function]' : v, 2).length;
+  assert.ok(fullSize > 30000, `synthetic event is real-run sized (~32 KB), got ${fullSize}`);
+
+  const buttonJson = adapter.buildEmbeddedEventJson(event, { includeOriginal: false });
+  const preJson = adapter.buildEmbeddedEventJson(event, { includeOriginal: true });
+
+  // The AI prompt/validation blobs are gone from EVERY embed, at any depth.
+  for (const [label, json] of [['button', buttonJson], ['pre', preJson]]) {
+    const parsed = JSON.parse(json);
+    const hasKeyDeep = (value, key) => {
+      if (!value || typeof value !== 'object') return false;
+      if (Object.prototype.hasOwnProperty.call(value, key)) return true;
+      return Object.values(value).some(child => hasKeyDeep(child, key));
+    };
+    assert.equal(hasKeyDeep(parsed, '_aiPrompts'), false, `${label}: no _aiPrompts at any depth`);
+    assert.equal(hasKeyDeep(parsed, '_aiValidation'), false, `${label}: no _aiValidation at any depth`);
+    assert.equal(hasKeyDeep(parsed, 'placeId'), false, `${label}: placeId stays hidden`);
+    // Existing _parserConfig/_existingEvent slimming is preserved.
+    assert.deepEqual(parsed._parserConfig, { name: 'bearracuda', parser: 'ai-web' },
+      `${label}: _parserConfig slimmed to name+parser`);
+    assert.deepEqual(parsed._existingEvent, { title: 'BEARRACUDA: Seattle', identifier: 'CAL-123' },
+      `${label}: _existingEvent slimmed to title+identifier`);
+  }
+
+  // _original is dropped from the button embeds but kept in the pre embed
+  // (that's where a human reads the merge provenance).
+  assert.equal('_original' in JSON.parse(buttonJson), false, 'button embed has no _original');
+  const preParsed = JSON.parse(preJson);
+  assert.ok(preParsed._original && preParsed._original.scraper && preParsed._original.calendar,
+    'pre embed keeps _original scraper/calendar provenance');
+
+  // The size win is what un-white-screens the page: the button embed sheds
+  // the whole _original subtree, the pre embed sheds the ~20 KB of AI blobs.
+  assert.ok(buttonJson.length < fullSize / 10,
+    `button embed well under 10% of full event (${buttonJson.length} vs ${fullSize})`);
+  assert.ok(preJson.length < fullSize / 3,
+    `pre embed sheds the AI blobs (${preJson.length} vs ${fullSize})`);
+});
+
+test('generateEventCard embeds are all built by the shared serializer (no AI blobs or button _original in the card HTML)', () => {
+  const adapter = buildAdapter();
+  const event = buildSyntheticAnalyzedEvent();
+  const html = adapter.generateEventCard(event, { runId: '20260725-210227' });
+  assert.ok(!html.includes('PROMPT PROMPT'), 'no AI prompt text anywhere in the card HTML');
+  assert.ok(!html.includes('VALIDATE VALIDATE'), 'no AI validation text anywhere in the card HTML');
+  assert.ok(html.includes('data-event-json'), 'copy buttons still carry event JSON');
+  assert.ok(html.includes('&quot;_original&quot;'), 'the raw <pre> dump still shows _original provenance');
+}
+);

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -275,6 +275,28 @@ class BarDataNormalizer extends BaseNormalizer {
                 modified = true;
             }
 
+            // Canonicalize a PRESENT bar name to the curated display name when
+            // it matches a curated bar by strict full-name equality
+            // (findCuratedBarByName / normalizeBarNameKey — the #1536/#1537
+            // contract; "Massive Club" ≠ "Massive", never substring, so only
+            // spelling/casing/punctuation variants of the SAME name rewrite).
+            // Run 20260725-210227 shipped bar "MASSIVE" (BEARRACUDA: Seattle)
+            // next to "Massive" (Treasure Trail Seattle) for the same venue.
+            // Complements the rewrite above, which only fires when event.bar
+            // was empty or came from title/description. Uncurated bars never
+            // reach here (no strict match) and are left untouched.
+            if (typeof event.bar === 'string' && event.bar.trim() !== ''
+                && typeof this.core.findCuratedBarByName === 'function') {
+                const curatedBar = this.core.findCuratedBarByName(cityBars, event.bar);
+                if (curatedBar && typeof curatedBar.name === 'string'
+                    && curatedBar.name.trim() !== ''
+                    && event.bar !== curatedBar.name) {
+                    console.log(`🐻 BarDataNormalizer: Canonicalized bar name "${event.bar}" → "${curatedBar.name}" (curated)`);
+                    event.bar = curatedBar.name;
+                    modified = true;
+                }
+            }
+
             // Remove description if it was just the venue name
             if (descriptionWasVenue && event.description) {
                 delete event.description;

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -1556,18 +1556,71 @@ test('district upgrade rung: curated pin adoption still fires for the Mad.Bear s
   assert.equal(event.instagram, 'https://www.instagram.com/aquatorremolinos', 'curated instagram fills the blank');
 });
 
-test('bar casing: an already-set bar keeps its casing — curated casing adoption lives only in the convergence rescue', () => {
+test('bar casing: an already-set bar that strictly matches a curated bar is canonicalized to the curated display name', () => {
   const normalizer = createTorremolinosBarNormalizer();
   const event = { title: 'FURBALL MAD.BEAR', city: 'torremolinos', bar: 'AQUA EMPORIO', address: 'LA NOGALERA' };
 
-  captureConsoleLog(() => normalizer.normalize(event));
+  const lines = captureConsoleLog(() => normalizer.normalize(event));
 
-  // Documented current behavior: BarDataNormalizer only writes the curated
-  // name into an EMPTY bar (or when title/description was the venue). An
-  // event that already carries "AQUA EMPORIO" keeps that casing here; the
-  // curated-casing adoption exists only in the ai-web parser's bar-convergence
-  // rescue, and the merge's case-only rung prefers the less-uppercased twin.
-  assert.equal(event.bar, 'AQUA EMPORIO');
+  // Run 20260725-210227 shipped "MASSIVE" and "Massive" for the same venue.
+  // BarDataNormalizer now canonicalizes a PRESENT bar to the curated display
+  // name whenever it matches by strict normalizeBarNameKey equality, so every
+  // event at a curated venue shows the curated spelling/casing.
+  assert.equal(event.bar, 'Aqua Emporio');
+  assert.ok(lines.includes(
+    '🐻 BarDataNormalizer: Canonicalized bar name "AQUA EMPORIO" → "Aqua Emporio" (curated)'
+  ), `canonicalization log line expected, got: ${JSON.stringify(lines)}`);
+});
+
+// ---------------------------------------------------------------------------
+// Curated bar-name canonicalization (run 20260725-210227: "MASSIVE" from
+// BEARRACUDA: Seattle vs "Massive" from Treasure Trail Seattle — same venue,
+// two spellings on the site)
+// ---------------------------------------------------------------------------
+
+function createSeattleBarNormalizer() {
+  const core = new SharedCore(
+    { seattle: { timezone: 'America/Los_Angeles', patterns: ['seattle'] } },
+    {
+      eventSchema: EventSchema,
+      bars: { seattle: [{ name: 'Massive', address: '619 E Pine St, Seattle, WA 98122' }] }
+    }
+  );
+  return new BarDataNormalizer(core);
+}
+
+test('bar canonicalization: MASSIVE is rewritten to the curated display name Massive', () => {
+  const normalizer = createSeattleBarNormalizer();
+  const event = { title: 'BEARRACUDA: Seattle', city: 'seattle', bar: 'MASSIVE' };
+
+  const lines = captureConsoleLog(() => normalizer.normalize(event));
+
+  assert.equal(event.bar, 'Massive');
+  assert.ok(lines.includes(
+    '🐻 BarDataNormalizer: Canonicalized bar name "MASSIVE" → "Massive" (curated)'
+  ), `canonicalization log line expected, got: ${JSON.stringify(lines)}`);
+});
+
+test('bar canonicalization: "Massive Club" is NOT rewritten — strict full-name equality only, never substring', () => {
+  const normalizer = createSeattleBarNormalizer();
+  const event = { title: 'Some Party', city: 'seattle', bar: 'Massive Club' };
+
+  const lines = captureConsoleLog(() => normalizer.normalize(event));
+
+  assert.equal(event.bar, 'Massive Club', '"Massive Club" ≠ "Massive" under the #1536/#1537 contract');
+  assert.ok(!lines.some(line => line.includes('Canonicalized bar name')),
+    `no canonicalization log expected, got: ${JSON.stringify(lines)}`);
+});
+
+test('bar canonicalization: an uncurated bar is never touched', () => {
+  const normalizer = createSeattleBarNormalizer();
+  const event = { title: 'Warehouse Party', city: 'seattle', bar: 'KREMWERK' };
+
+  const lines = captureConsoleLog(() => normalizer.normalize(event));
+
+  assert.equal(event.bar, 'KREMWERK');
+  assert.ok(!lines.some(line => line.includes('Canonicalized bar name')),
+    `no canonicalization log expected, got: ${JSON.stringify(lines)}`);
 });
 
 test('district upgrade rung: an address already identical to curated is a no-op', () => {

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -6556,6 +6556,15 @@ class AiWebParser {
         if (normalized === 'bar') {
             description += ` A street address is never a venue name.`;
         }
+        // Prompt-only steering (run 20260725-205217 findings): sources whose
+        // listing "title" is a flyer/social caption got adopted wholesale
+        // ("D>U>R>O is back NEW OUTDOOR LOCATION _ NIGHT FOAM PARTY and
+        // SPECIAL GUEST"; "Thighs out for the guys yall, it's Singlet Night
+        // at the Dallas Eagle 🤼‍♂️🦅"). Appended to the schema line so the
+        // schema text itself stays byte-identical.
+        if (normalized === 'title') {
+            description += ` The title is the event's NAME — short and reusable, exactly as it appears in the source. When the source text is an announcement sentence or caption that contains the event name, extract just the name portion (it must still appear verbatim within the source). Never include venue, city, date, or marketing phrases in the title.`;
+        }
         // Prompt-only steering (run 20260724-155934 findings): thedallaseagle.com
         // listings print "End at: August 1, 2026 - 2:00 am" and extraction kept
         // assigning those END values to start fields (events shipped starting

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -5050,6 +5050,21 @@ test('getFieldContext bar steering: the address-shape sentence is appended, exis
   assert.ok(context.startsWith(schemaText), 'the schema description itself stays byte-identical');
 });
 
+test('getFieldContext title steering: the caption-vs-name sentences are appended, existing schema text unchanged, other fields unaffected', () => {
+  const parser = createParser();
+  const steering = ` The title is the event's NAME — short and reusable, exactly as it appears in the source. When the source text is an announcement sentence or caption that contains the event name, extract just the name portion (it must still appear verbatim within the source). Never include venue, city, date, or marketing phrases in the title.`;
+  const context = parser.getFieldContext('title', null);
+  assert.ok(context.endsWith(steering),
+    `the title steering is appended, got: ${JSON.stringify(context)}`);
+  const schemaText = parser.getEventSchemaPromptFieldDescription('title');
+  assert.ok(context.startsWith(schemaText), 'the schema description itself stays byte-identical');
+  // Other fields never pick up the title steering.
+  for (const field of ['bar', 'description', 'city', 'startDate', 'shortName']) {
+    assert.ok(!parser.getFieldContext(field, null).includes("The title is the event's NAME"),
+      `${field} context is unaffected by title steering`);
+  }
+});
+
 test('confidence-retry feedback: buildRetryDropFeedback returns plain not-verbatim drops only', () => {
   const parser = createParser();
   const merged = {


### PR DESCRIPTION
One batched PR, three fixes from the 2026-07-25 evening runs.

## 1. Blank results screen on Bearracuda (runs 205758/210227)

The run completed; the results page didn't render — twice. Measured against the real run JSONs: the Bearracuda page was **1.76 MB** while every page that displayed was ≤0.94 MB (Dallas 924 KB, massive 943 KB, Megawoof 346 KB) — Scriptable's WebView.loadHTML fails silently above ~1 MB. 1.36 MB of the page was duplicated debug JSON: each event embeds `_original.scraper._aiPrompts` (~10 KB) + `_aiValidation` (~10 KB), serialized 3× per event (two Copy-JSON buttons + raw <pre>).

Fix: the three drifted-but-identical inline replacers are unified into `buildEmbeddedEventJson(event, {includeOriginal})` — `_aiPrompts`/`_aiValidation` dropped at any depth (they remain fully available via the dedicated 🤖 AI Prompts button), `_original` kept only in the human-readable <pre>, all existing slimming (`_parserConfig`, `_existingEvent`, `_conflicts`) preserved. New additive log `📱 Scriptable: Results HTML size: <N> KB` right before the untouched "Presenting results UI..." line, so the next size problem is diagnosable from the log alone.

**Verified on the literal blank-screen run: 1,757,111 → 734,602 chars.** Per-event embeds: 130,503 → 1,128 chars.

## 2. Inconsistent venue names ("MASSIVE" vs "Massive", same night)

When `event.bar` matches a curated bar by strict `normalizeBarNameKey` equality, the display name is rewritten to the curated spelling — every event at a curated venue now shows one consistent name. Fail closed: "Massive Club" is a different key and is never rewritten; uncurated bars untouched. Log fires only on actual change: `🐻 BarDataNormalizer: Canonicalized bar name "MASSIVE" → "Massive" (curated)`. (This unifies two pre-existing partial paths that already adopted curated casing in narrower cases.)

## 3. Caption titles ("D>U>R>O is back NEW OUTDOOR LOCATION _ NIGHT FOAM PARTY and SPECIAL GUEST")

Additive title steering in `getFieldContext` (existing schema text byte-identical): the title is the event's NAME — short, reusable, verbatim in source; when the source is an announcement sentence containing the name, extract just the name portion; never venue/city/date/marketing phrases. Steering-only by design (fail closed); a deterministic layer can follow if real runs still misbehave.

## Tests

792 pass / 0 fail (baseline 786/786). New: helper contract (deep-key absence, button-vs-pre `_original`, size bounds), HTML-level proof no AI blob text reaches any card embed, canonicalization matrix, steering presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP