### PR TITLE
perf(scraper): persistent AI-response cache — repeat runs drop from ~4-5 min to seconds

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -4227,6 +4227,15 @@ class ScriptableAdapter {
               `📱 Scriptable: Pruned ${prunedClassification} classification cache entries unused for ${ocrRetentionDays}d`,
             );
           }
+          const prunedAiResponses = await this.cleanupOldFiles(
+            "chunky-dad-scraper/storage/ai-responses",
+            { maxAgeDays: unusedCutoffDays, recurse: true },
+          );
+          if (prunedAiResponses > 0) {
+            console.log(
+              `📱 Scriptable: Pruned ${prunedAiResponses} AI response cache entries unused for ${ocrRetentionDays}d`,
+            );
+          }
         } catch (pruneErr) {
           console.log(
             `📱 Scriptable: Cache prune failed: ${pruneErr.message}`,

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -309,6 +309,7 @@ class BearEventScraperOrchestrator {
                             normalizeUrl: sharedCore.normalizeUrl.bind(sharedCore)
                         });
                         aiParser.core = sharedCore;
+                        sharedCore.aiResponseCache = aiParser.getAiResponseCache();
                         parsers[name] = aiParser;
                     } else {
                         parsers[name] = new ParserClass();
@@ -426,6 +427,13 @@ class BearEventScraperOrchestrator {
                 }
 
                 results.calendarEvents = calendarEvents;
+            }
+
+            // After calendar prep/dedup so merge-arbitration hits are counted too
+            const aiWebParser = parsers['ai-web'];
+            if (aiWebParser && aiWebParser.aiResponseCacheStats) {
+                const { hits, misses, writes } = aiWebParser.aiResponseCacheStats;
+                console.log(`🤖 AI Web: AI response cache summary — ${hits} hits, ${misses} misses, ${writes} writes`);
             }
 
             // Display results

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -315,6 +315,7 @@ class AiWebParser {
         // byte-identical context-prep prompt, so the HTTP round-trip can be reused.
         // In-memory only, scoped to this parser instance (one run).
         this.contextPrepResponseCache = new Map();
+        this.aiResponseCacheStats = { hits: 0, misses: 0, writes: 0 };
         this.defaultOcrModel = 'qwen3-vl:4b-instruct';
         this.defaultOcrPrompt = "You are performing OCR on an event flyer.\n\nSTEP 1: OCR\nExtract ALL visible text from the image.\n\nRules:\n- Copy text exactly as shown.\n- Preserve line breaks when possible.\n- Do not summarize.\n- Do not interpret.\n- Do not correct spelling.\n- Do not infer missing words.\n\nSTEP 2: Classification\n\nClassify the image into ONE category:\n\nad-banner: Advertisement or promotional banner (usually has \"buy\", \"get tickets\", \"sale\")\nevent-flyer: Single event poster/flyer - ONE primary event with ONE title, ONE venue, and ONE date or continuous date range. May contain schedules, activities, DJs, performers, or sub-events that are clearly part of the same event. Examples: Bear Week, Bear Weekend, Pride Festival, Camp Weekend, Resort Weekend Package.\nmulti-event-flyer: Two or more independent events with different titles, different dates/times, and separate ticketing. Often appears as a calendar, event listing, or monthly schedule.\nlogo: Brand or organization logo (minimal text, just brand name)\nthumbnail: Small preview image (low detail)\nhero-banner: Large header/banner image (prominent on page)\n\nDecision rule: If there is ONE overarching event name and the listed activities appear to belong to that event, classify as event-flyer. Only classify as multi-event-flyer when multiple independent events are advertised that require separate tickets.\n\nIMPORTANT CONTEXT: This is for a gay bear community travel guide. Events may be part of:\n- \"Bear Week\" or \"Bear Weekend\" themed events\n- Annual bear gatherings (e.g., \"Puerto Vallarta Bear Week\", \"Sitges Bear Week\")\n- Regular bear-themed parties or meetups\n- Events at bear-owned businesses or bear-friendly venues\n\nSTEP 3: Event Analysis\n\nDetermine:\n- eventName: The primary event title\n- venue: The venue or venue group name\n- startDate: Start date/time if visible\n- endDate: End date/time if visible\n\nUse only information visible in the image.\n\nSTEP 4: Summary\n\nCreate a concise summary describing:\n- event name\n- venue\n- date/time\n- why it may be relevant to the bear community\n\nReturn JSON only with these fields:\n{\n  \"text\": \"full extracted text\",\n  \"imageClassification\": \"ad-banner|event-flyer|multi-event-flyer|logo|thumbnail|hero-banner\",\n  \"eventSummary\": \"a concise 1-2 sentence summary of the event including: event name, venue, date/time, and any bear-week context if applicable. Focus on what makes this event notable for the bear community.\",\n  \"confidence\": 0-100,\n  \"reason\": \"brief explanation for classification\"\n}";
         // When an image overflows the vision model's context, retry once at this
@@ -2544,6 +2545,10 @@ class AiWebParser {
         return this.getCacheRuntime('classification', this.config.classificationCacheDir);
     }
 
+    getAiResponseCacheRuntime() {
+        return this.getCacheRuntime('ai-responses', this.config.aiResponseCacheDir);
+    }
+
     getCacheRuntime(subdir, overrideDir = null) {
         if (typeof FileManager !== 'undefined') {
             try {
@@ -2882,6 +2887,143 @@ class AiWebParser {
             return cachePath;
         } catch (error) {
             console.log(`🤖 AI Web: OCR cache write failed for ${imageUrl}: ${error.message}`);
+            return null;
+        }
+    }
+
+    // Persistent cache of raw AI response text keyed by request content (not URL —
+    // extraction prompts embed the page content, so the prompt IS the identity).
+    // SharedCore stays free of filesystem access, so callAiGenerate consumes this
+    // via the injected getAiResponseCache() provider, same as classification.
+    getAiResponseCache() {
+        return {
+            read: (aiConfig, prompt, passLabel) => this.readCachedAiResponse(aiConfig, prompt, passLabel),
+            write: (aiConfig, prompt, passLabel, text) => this.writeCachedAiResponse(aiConfig, prompt, passLabel, text),
+            stats: this.aiResponseCacheStats
+        };
+    }
+
+    getAiResponseCachePathParts(aiConfig, prompt, passLabel) {
+        const config = aiConfig && typeof aiConfig === 'object' ? aiConfig : {};
+        // Endpoint deliberately excluded from the signature (recorded in the
+        // payload only) so re-homing the same model still hits.
+        const responseFormat = config.provider === 'openai'
+            ? String((config.openai && config.openai.responseFormat) || 'json_object')
+            : 'json';
+        const options = {
+            numCtx: Number.isFinite(Number(config.numCtx)) ? Number(config.numCtx) : null,
+            numPredict: Number.isFinite(Number(config.numPredict)) ? Number(config.numPredict) : null,
+            temperature: Number.isFinite(Number(config.temperature)) ? Number(config.temperature) : null,
+            think: Boolean(config.think),
+            keepAlive: String(config.keepAlive || ''),
+            responseFormat
+        };
+        const requestSignature = JSON.stringify({
+            provider: String(config.provider || ''),
+            model: String(config.model || ''),
+            prompt: String(prompt),
+            options
+        });
+        const signatureHash = this.hashCacheValue(requestSignature);
+        return {
+            dirSegments: [passLabel ? this.sanitizeCacheSegment(passLabel) : 'general'],
+            fileName: `${signatureHash}.json`,
+            signatureHash,
+            options
+        };
+    }
+
+    async readCachedAiResponse(aiConfig, prompt, passLabel) {
+        if (!aiConfig || aiConfig.cacheEnabled === false) return null;
+        const runtime = this.getAiResponseCacheRuntime();
+        if (!runtime) return null;
+        const { dirSegments, fileName } = this.getAiResponseCachePathParts(aiConfig, prompt, passLabel);
+
+        try {
+            let cachePath;
+            let rawPayload = null;
+            if (runtime.type === 'scriptable') {
+                const passDirPath = runtime.fm.joinPath(runtime.baseDir, dirSegments[0]);
+                cachePath = runtime.fm.joinPath(passDirPath, fileName);
+                if (!runtime.fm.fileExists(cachePath)) {
+                    this.aiResponseCacheStats.misses += 1;
+                    return null;
+                }
+                try {
+                    await runtime.fm.downloadFileFromiCloud(cachePath);
+                } catch (_) {}
+                rawPayload = runtime.fm.readString(cachePath);
+            } else {
+                cachePath = runtime.path.join(runtime.baseDir, dirSegments[0], fileName);
+                rawPayload = await runtime.fs.promises.readFile(cachePath, 'utf8');
+            }
+            const cached = JSON.parse(rawPayload);
+            const responseText = cached && cached.response && typeof cached.response.text === 'string'
+                ? cached.response.text
+                : '';
+            // The filename is only a 32-bit hash — verify the stored prompt so a
+            // hash collision can never serve another request's response.
+            const promptMatches = cached && cached.request && cached.request.prompt === String(prompt);
+            if (!responseText || !promptMatches) {
+                this.aiResponseCacheStats.misses += 1;
+                return null;
+            }
+            await this.touchCacheEntryOnHit(runtime, cachePath, cached);
+            this.aiResponseCacheStats.hits += 1;
+            return responseText;
+        } catch (error) {
+            const missingFile = error && (error.code === 'ENOENT' || /does not exist/i.test(String(error.message || '')));
+            if (!missingFile) {
+                console.log(`🤖 AI Web: AI response cache read failed: ${error.message}`);
+            }
+            this.aiResponseCacheStats.misses += 1;
+            return null;
+        }
+    }
+
+    async writeCachedAiResponse(aiConfig, prompt, passLabel, responseText) {
+        if (!aiConfig || aiConfig.cacheEnabled === false) return null;
+        const text = typeof responseText === 'string' ? responseText : '';
+        if (!text) return null;
+        const runtime = this.getAiResponseCacheRuntime();
+        if (!runtime) return null;
+        const { dirSegments, fileName, signatureHash, options } = this.getAiResponseCachePathParts(aiConfig, prompt, passLabel);
+        const payload = {
+            cachedAt: new Date().toISOString(),
+            cacheKeyVersion: 1,
+            passLabel: String(passLabel || ''),
+            request: {
+                endpoint: String(aiConfig.endpoint || ''),
+                provider: String(aiConfig.provider || ''),
+                model: String(aiConfig.model || ''),
+                signatureHash,
+                prompt: String(prompt),
+                options
+            },
+            response: {
+                text
+            },
+            lastUsedAt: new Date().toISOString().slice(0, 10)
+        };
+
+        try {
+            let cachePath;
+            if (runtime.type === 'scriptable') {
+                const passDirPath = runtime.fm.joinPath(runtime.baseDir, dirSegments[0]);
+                if (!runtime.fm.fileExists(runtime.baseDir)) runtime.fm.createDirectory(runtime.baseDir, true);
+                if (!runtime.fm.fileExists(passDirPath)) runtime.fm.createDirectory(passDirPath, true);
+                cachePath = runtime.fm.joinPath(passDirPath, fileName);
+                runtime.fm.writeString(cachePath, JSON.stringify(payload, null, 2));
+            } else {
+                const passDirPath = runtime.path.join(runtime.baseDir, dirSegments[0]);
+                await runtime.fs.promises.mkdir(passDirPath, { recursive: true });
+                cachePath = runtime.path.join(passDirPath, fileName);
+                await runtime.fs.promises.writeFile(cachePath, JSON.stringify(payload, null, 2), 'utf8');
+            }
+            this.aiResponseCacheStats.writes += 1;
+            return cachePath;
+        } catch (error) {
+            console.log(`🤖 AI Web: AI response cache write failed: ${error.message}`);
             return null;
         }
     }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -3005,6 +3005,139 @@ test('classification cache hits refresh lastUsedAt through the same touch helper
 });
 
 // ---------------------------------------------------------------------------
+// Persistent AI-response cache: raw response text keyed by request signature
+// (provider+model+prompt+options), filed under the pass label
+// ---------------------------------------------------------------------------
+
+function buildAiResponseCacheConfig(overrides = {}) {
+  return {
+    cacheEnabled: true,
+    provider: 'openai',
+    endpoint: 'http://rybook.example:8000/v1/chat/completions',
+    model: 'test-model',
+    numCtx: 2048,
+    numPredict: 2000,
+    temperature: 0,
+    think: false,
+    keepAlive: '5m',
+    openai: { responseFormat: 'json_object' },
+    ...overrides
+  };
+}
+
+test('AI response cache round-trips raw text and misses when the request signature changes', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-response-cache-test-'));
+
+  const parser = new AiWebParser({ normalizeUrl, aiResponseCacheDir: cacheDir });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+
+  const aiConfig = buildAiResponseCacheConfig();
+  const prompt = 'Extract the event from this page text: BEAR NIGHT at The Eagle';
+  const responseText = '{"title": "BEAR NIGHT", "bar": "The Eagle"}';
+
+  const cachePath = await parser.writeCachedAiResponse(aiConfig, prompt, 'extraction', responseText);
+  assert.ok(cachePath, 'cache write should return the entry path');
+  assert.ok(cachePath.includes(`${path.sep}extraction${path.sep}`), 'entries are filed under the pass label');
+  assert.equal(parser.aiResponseCacheStats.writes, 1);
+
+  const payload = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  assert.equal(payload.cacheKeyVersion, 1);
+  assert.equal(payload.passLabel, 'extraction');
+  assert.equal(payload.request.prompt, prompt);
+  assert.equal(payload.request.model, 'test-model');
+  assert.ok(payload.request.signatureHash, 'payload records the signature hash');
+  assert.equal(payload.response.text, responseText);
+
+  const hit = await parser.readCachedAiResponse(aiConfig, prompt, 'extraction');
+  assert.equal(hit, responseText);
+  assert.equal(parser.aiResponseCacheStats.hits, 1);
+
+  // Signature sensitivity: model, prompt, temperature, and numPredict each
+  // produce a different cache path, so a stale entry can never be returned
+  const variants = [
+    [buildAiResponseCacheConfig({ model: 'other-model' }), prompt],
+    [aiConfig, `${prompt} — different page`],
+    [buildAiResponseCacheConfig({ temperature: 0.5 }), prompt],
+    [buildAiResponseCacheConfig({ numPredict: 1000 }), prompt]
+  ];
+  for (const [variantConfig, variantPrompt] of variants) {
+    assert.equal(await parser.readCachedAiResponse(variantConfig, variantPrompt, 'extraction'), null);
+  }
+  assert.equal(parser.aiResponseCacheStats.misses, variants.length);
+
+  // Endpoint is deliberately NOT part of the signature — re-homing the model hits
+  const rehomed = buildAiResponseCacheConfig({ endpoint: 'http://desktop.example:8000/v1/chat/completions' });
+  assert.equal(await parser.readCachedAiResponse(rehomed, prompt, 'extraction'), responseText);
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+test('AI response cache is inert when resolved cacheEnabled is false', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-response-cache-off-test-'));
+
+  const parser = new AiWebParser({ normalizeUrl, aiResponseCacheDir: cacheDir });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+
+  // ai.cache: false resolves to cacheEnabled: false and disables both directions
+  const aiConfig = parser.core.resolveAiConfig({ cache: false });
+  assert.equal(aiConfig.cacheEnabled, false);
+
+  const written = await parser.writeCachedAiResponse(aiConfig, 'prompt', 'extraction', '{"title": "x"}');
+  assert.equal(written, null);
+  assert.equal(await parser.readCachedAiResponse(aiConfig, 'prompt', 'extraction'), null);
+  assert.deepEqual(fs.readdirSync(cacheDir), [], 'no files may be created while disabled');
+  assert.deepEqual(parser.aiResponseCacheStats, { hits: 0, misses: 0, writes: 0 });
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+test('AI response cache hits refresh lastUsedAt at most once per 7 days', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-response-touch-test-'));
+
+  const parser = new AiWebParser({ normalizeUrl, aiResponseCacheDir: cacheDir });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+
+  const aiConfig = buildAiResponseCacheConfig();
+  const prompt = 'Extract the recurring event';
+  const responseText = '{"title": "RECURRING BEAR NIGHT"}';
+  const today = new Date().toISOString().slice(0, 10);
+
+  const cachePath = await parser.writeCachedAiResponse(aiConfig, prompt, 'extraction', responseText);
+  assert.equal(JSON.parse(fs.readFileSync(cachePath, 'utf8')).lastUsedAt, today);
+
+  // A fresh (same-day) marker is rate-limited: NO rewrite on hit (sentinel survives)
+  const sameDay = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  sameDay._sentinel = 'untouched';
+  fs.writeFileSync(cachePath, JSON.stringify(sameDay, null, 2), 'utf8');
+  assert.equal(await parser.readCachedAiResponse(aiConfig, prompt, 'extraction'), responseText);
+  assert.equal(
+    JSON.parse(fs.readFileSync(cachePath, 'utf8'))._sentinel,
+    'untouched',
+    'a same-day hit must not rewrite the entry'
+  );
+
+  // A marker older than the 7-day rate limit is refreshed on hit
+  const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  sameDay.lastUsedAt = eightDaysAgo;
+  fs.writeFileSync(cachePath, JSON.stringify(sameDay, null, 2), 'utf8');
+  assert.equal(await parser.readCachedAiResponse(aiConfig, prompt, 'extraction'), responseText);
+  const refreshed = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+  assert.equal(refreshed.lastUsedAt, today);
+  assert.equal(refreshed.response.text, responseText, 'touching must preserve the cached payload');
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
 // Built-in generic blocked patterns (segment-anchored, accuracy first)
 // ---------------------------------------------------------------------------
 

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -40,6 +40,7 @@ const scraperConfig = {
       think: false,
       timeoutSeconds: 120,
       keepAlive: "5m",
+      cache: true, // AI response cache — key is model+prompt+options; set false to disable
       // AI merge arbitration (default: true). When two records of the same event
       // genuinely conflict on a field (both non-empty, different), the AI picks the
       // better value — accepted only when its answer is a VERBATIM copy of one of
@@ -296,6 +297,7 @@ const scraperConfig = {
       //   think: false,
       //   timeoutSeconds: 120,
       //   keepAlive: "5m",
+      //   cache: true, // AI response cache — key is model+prompt+options; set false to disable
       //   classifyPages: true, // AI second opinion when URL rules/JSON-LD can't classify a page (default: true)
       //   // OCR override lives INSIDE `ai` (canonical spot: ai.ocr). Default is
       //   // the rybook VISION server on :8001 — text models reject images.

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -130,6 +130,10 @@ class SharedCore {
         // Per-run learned dead-end context (created by processEvents from the
         // store the orchestrator loaded; null outside a run = feature inert)
         this.deadEndRunContext = null;
+        // Persistent AI-response cache provider (read/write/stats), injected by
+        // the orchestrator from AiWebParser.getAiResponseCache() — persistence
+        // stays out of shared-core. Null = no caching.
+        this.aiResponseCache = null;
         this.trackingParamPattern = /^(aff|affix|affiliate|utm_source|utm_medium|utm_campaign|utm_content|utm_term|ref|referral|fbclid|gclid|msclkid|dclid|source|mc_cid|mc_eid)$/i;
         
         // URL-to-parser mapping for automatic parser detection
@@ -8075,6 +8079,7 @@ class SharedCore {
             think: Object.prototype.hasOwnProperty.call(aiConfig, 'think') ? Boolean(aiConfig.think) : false,
             timeoutSeconds: Number.isFinite(Number(aiConfig.timeoutSeconds)) ? Number(aiConfig.timeoutSeconds) : 120,
             keepAlive: Object.prototype.hasOwnProperty.call(aiConfig, 'keepAlive') ? String(aiConfig.keepAlive) : '5m',
+            cacheEnabled: aiConfig.cache !== false,
             arbitrateMerges: aiConfig.arbitrateMerges !== false,
             // Override-only: extra text appended verbatim to extraction prompt
             // context. Organizer context is normally derived from page metadata.
@@ -8252,6 +8257,16 @@ class SharedCore {
             promptHistoryRecorder(prompt, passLabel, aiConfig);
         }
 
+        // Image requests bypass the response cache — the prompt alone does not
+        // identify them (the image bytes do), and OCR has its own URL-keyed cache.
+        if (!base64Image && this.aiResponseCache) {
+            const cachedText = await this.aiResponseCache.read(aiConfig, prompt, passLabel);
+            if (typeof cachedText === 'string' && cachedText.length > 0) {
+                console.log(`🤖 AI Web: AI response cache hit${label} — response: ${cachedText.length} chars`);
+                return cachedText;
+            }
+        }
+
         console.log(`🤖 AI Web: Sending AI request${label} to ${aiConfig.endpoint} — model: ${aiConfig.model}, provider: ${aiConfig.provider}, prompt: ${promptChars} chars`);
         this.logAiPayloadDebug(`🤖 AI Web: Full prompt${label}`, prompt, aiConfig);
 
@@ -8290,6 +8305,9 @@ class SharedCore {
             if (responseContent && typeof responseContent === 'string' && responseContent.length > 0) {
                 console.log(`🤖 AI Web: AI request${label} succeeded in ${elapsed}ms — response: ${responseContent.length} chars`);
                 this.logAiPayloadDebug(`🤖 AI Web: Model response text${label}`, responseContent, aiConfig);
+                if (!base64Image && this.aiResponseCache) {
+                    await this.aiResponseCache.write(aiConfig, prompt, passLabel, responseContent);
+                }
                 return responseContent;
             }
 

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -160,6 +160,133 @@ test('callAiGenerate flags zero-token finish_reason=length image requests as con
   assert.equal(textDiag.failureKind, undefined);
 });
 
+// Persistent AI-response cache: callAiGenerate consults the injected provider
+// before the transport and stores accepted responses after it. The provider
+// itself is filesystem-backed (see ai-web-parser tests); here it is faked.
+
+function buildAiTestConfig(overrides = {}) {
+  return {
+    provider: 'openai',
+    endpoint: 'http://rybook.example:8000/v1/chat/completions',
+    model: 'test-model',
+    temperature: 0,
+    numPredict: 2000,
+    timeoutSeconds: 120,
+    cacheEnabled: true,
+    openai: {},
+    ...overrides
+  };
+}
+
+function buildOpenAiResponsePayload(content) {
+  return JSON.stringify({
+    choices: [{ index: 0, message: { role: 'assistant', content }, finish_reason: 'stop' }]
+  });
+}
+
+test('callAiGenerate returns cached responses without touching the transport', async () => {
+  const core = createCore();
+  let writeCalls = 0;
+  core.aiResponseCache = {
+    read: async () => 'CACHED',
+    write: async () => { writeCalls++; },
+    stats: { hits: 0, misses: 0, writes: 0 }
+  };
+  const adapter = {
+    postJson: async () => {
+      throw new Error('transport must not be called on a cache hit');
+    }
+  };
+  const result = await core.callAiGenerate(buildAiTestConfig(), 'extract prompt', 'extraction', adapter);
+  assert.equal(result, 'CACHED');
+  assert.equal(writeCalls, 0, 'a cache hit must not be re-written');
+});
+
+test('callAiGenerate writes the exact accepted response to the cache on a miss', async () => {
+  const core = createCore();
+  const writeArgs = [];
+  core.aiResponseCache = {
+    read: async () => null,
+    write: async (...args) => { writeArgs.push(args); },
+    stats: { hits: 0, misses: 0, writes: 0 }
+  };
+  let transportCalls = 0;
+  const adapter = {
+    postJson: async () => {
+      transportCalls++;
+      return { ok: true, status: 200, text: buildOpenAiResponsePayload('{"title": "FURBALL"}') };
+    }
+  };
+  const result = await core.callAiGenerate(buildAiTestConfig(), 'extract prompt', 'extraction', adapter);
+  assert.equal(result, '{"title": "FURBALL"}');
+  assert.equal(transportCalls, 1);
+  assert.equal(writeArgs.length, 1);
+  assert.equal(writeArgs[0][1], 'extract prompt');
+  assert.equal(writeArgs[0][2], 'extraction');
+  assert.equal(writeArgs[0][3], '{"title": "FURBALL"}');
+});
+
+test('callAiGenerate never caches HTTP errors, empty responses, or transport failures', async () => {
+  const core = createCore();
+  let writeCalls = 0;
+  core.aiResponseCache = {
+    read: async () => null,
+    write: async () => { writeCalls++; },
+    stats: { hits: 0, misses: 0, writes: 0 }
+  };
+
+  const httpErrorAdapter = { postJson: async () => ({ ok: false, status: 500, text: 'boom' }) };
+  assert.equal(await core.callAiGenerate(buildAiTestConfig(), 'p', 'extraction', httpErrorAdapter), null);
+
+  const emptyAdapter = { postJson: async () => ({ ok: true, status: 200, text: buildOpenAiResponsePayload('') }) };
+  assert.equal(await core.callAiGenerate(buildAiTestConfig(), 'p', 'extraction', emptyAdapter), null);
+
+  const throwingAdapter = { postJson: async () => { throw new Error('connection refused'); } };
+  assert.equal(await core.callAiGenerate(buildAiTestConfig(), 'p', 'extraction', throwingAdapter), null);
+
+  assert.equal(writeCalls, 0, 'failure paths must never populate the cache');
+});
+
+test('callAiGenerate bypasses the response cache for image requests', async () => {
+  const core = createCore();
+  let readCalls = 0;
+  let writeCalls = 0;
+  core.aiResponseCache = {
+    read: async () => { readCalls++; return 'CACHED'; },
+    write: async () => { writeCalls++; },
+    stats: { hits: 0, misses: 0, writes: 0 }
+  };
+  const adapter = {
+    postJson: async () => ({ ok: true, status: 200, text: buildOpenAiResponsePayload('{"text": "OCR TEXT"}') })
+  };
+  const result = await core.callAiGenerate(buildAiTestConfig(), 'ocr prompt', 'ocr-all', adapter, null, 'base64image');
+  assert.equal(result, '{"text": "OCR TEXT"}');
+  assert.equal(readCalls, 0, 'image requests must not read the response cache');
+  assert.equal(writeCalls, 0, 'image requests must not write the response cache');
+});
+
+test('callAiGenerate without an injected cache calls the transport directly', async () => {
+  const core = createCore();
+  assert.equal(core.aiResponseCache, null, 'cache is opt-in via injection');
+  let transportCalls = 0;
+  const adapter = {
+    postJson: async () => {
+      transportCalls++;
+      return { ok: true, status: 200, text: buildOpenAiResponsePayload('{"title": "x"}') };
+    }
+  };
+  const result = await core.callAiGenerate(buildAiTestConfig(), 'p', 'extraction', adapter);
+  assert.equal(result, '{"title": "x"}');
+  assert.equal(transportCalls, 1);
+});
+
+test('resolveAiConfig defaults the response cache on and honors cache: false', () => {
+  const core = createCore();
+  assert.equal(core.resolveAiConfig({}).cacheEnabled, true, 'absent key defaults ON');
+  assert.equal(core.resolveAiConfig({ cache: true }).cacheEnabled, true);
+  assert.equal(core.resolveAiConfig({ cache: false }).cacheEnabled, false);
+});
+
 test('extractJsonLdEventNodes finds Event nodes in plain, @graph, and list containers', () => {
   const core = createCore();
 


### PR DESCRIPTION
## Why

Timing analysis of the 5 most recent phone runs: **AI calls are 89–99% of all compute** — 195–310s per run across 60–100 calls — while pages (3-day cache), OCR, and classification already hit their caches 100% of the time. The three recent Bearracuda runs served byte-identical cached pages and produced identical output, yet each re-ran the full ~62-call AI stack. Repeat runs are ~100% redundant compute.

## What

Cache raw AI response **text** at the single `callAiGenerate` choke point, keyed by FNV-1a hash of `{provider, model, prompt, options}` — the same content-signature pattern the OCR cache uses. No code hashing, no TTL logic:

- Page content or prompt-building code changes → prompt changes → automatic miss.
- Validation / gates / merge code stays **uncached** and re-runs against cached responses every run — new gates apply to old answers immediately, no staleness.
- Prompt audit found zero volatile content (no dates/run IDs in any prompt builder; all `new Date()` logic is post-response), so cache hits survive across days — confirmed empirically by identical 7/25 vs 7/26 run outputs.

### Pieces
- **ai-web-parser**: `getAiResponseCache()` provider cloning the OCR cache runtime (Scriptable iCloud / Node fs, browser degrades to no-cache). Storage: `storage/ai-responses/<pass>/<hash>.json`. Stored prompt is compared on read, so a 32-bit hash collision can never serve another request's response. Touch-on-hit for retention.
- **shared-core** (stays platform-pure — provider injected): read before send, write only on accepted non-empty responses. Errors, empty responses, and context-overflows are never cached. `base64Image` requests bypass (OCR has its own cache). `resolveAiConfig` gains `cacheEnabled` (`ai.cache`, **default ON** — no phone config change needed).
- **orchestrator**: injects the provider; end-of-run line `🤖 AI Web: AI response cache summary — H hits, M misses, W writes`.
- **scriptable-adapter**: `ai-responses/` joins the existing end-of-run prune sweep (90d unused cutoff).

New per-hit log line: `🤖 AI Web: AI response cache hit (extraction pass) — response: N chars`. All log/prompt changes are additive; no existing line shapes touched.

### Intended behavior change
Byte-identical same-prompt re-rolls (e.g. pass-2 alternate inside a confidence retry) now replay the cached answer instead of re-rolling. At temperature 0 that variance was server noise, and run-to-run stability is the goal. Kill switch: `ai: { cache: false }`.

## Expected impact
Repeat run on unchanged pages: ~200–310s of AI → file reads. Total run ~4–5.5 min → seconds-to-~30s. First runs on new/changed pages cost the same as today.

## Testing
- 792 → **801 tests**, all green (quiet runner): hit returns cached text without touching transport; miss calls transport then writes exact text; HTTP-error/empty/thrown never write; base64 bypasses; signature sensitivity (model/prompt/temperature/numPredict each re-key); disabled gate no-ops; lastUsedAt touch.
- Zero `new URL(`/`URLSearchParams` in the diff; `node --check` clean on all modified files.

## After merge (Stanley)
Download `scripts/shared-core.js`, `scripts/parsers/ai-web-parser.js`, `scripts/bear-event-scraper-unified.js`, `scripts/adapters/scriptable-adapter.js` (scraper-input change is comment-only — optional). Run any parser **twice**: run 1 is normal speed and writes (~60 writes in the summary line); run 2 should collapse to seconds with a hits-dominated summary and identical results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP