### PR TITLE
fix(site): pin maplibre-gl to 5.24.0 — v6 release broke every map on the site

### DIFF
--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/bear-directory.html
+++ b/bear-directory.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Leaflet CSS for map -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""/>
 </head>
@@ -100,7 +100,7 @@
     <script src="js/filename-utils.js"></script>
     <script src="js/bear-directory.js"></script>
     <!-- Leaflet JS -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin=""></script>
     <script src="js/app.js"></script>

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/boston/index.html
+++ b/boston/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/city.html
+++ b/city.html
@@ -74,7 +74,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -173,7 +173,7 @@
     <script src="js/event-schema.js"></script>
     <script src="js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/dallas/index.html
+++ b/dallas/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/dc/index.html
+++ b/dc/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/denver/index.html
+++ b/denver/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     
     <link rel="stylesheet" href="styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css">
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css">
 
 </head>
 <body class="index-page">
@@ -158,7 +158,7 @@
         </div>
     </footer>
 
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"></script>
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"></script>
     <script src="js/logger.js"></script>
     <script src="js/navigation.js"></script>
     <script src="js/dad-jokes.js"></script>

--- a/la/index.html
+++ b/la/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/london/index.html
+++ b/london/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/nola/index.html
+++ b/nola/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/nyc/index.html
+++ b/nyc/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/philly/index.html
+++ b/philly/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/phoenix/index.html
+++ b/phoenix/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/portland/index.html
+++ b/portland/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/ptown/index.html
+++ b/ptown/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/san-diego/index.html
+++ b/san-diego/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/sf/index.html
+++ b/sf/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/testing/test-calendar-logging.html
+++ b/testing/test-calendar-logging.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Permanent+Marker&family=Roboto+Condensed:wght@400;700&family=Poppins:wght@400;700&display=swap" rel="stylesheet">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""/>
     <style>
@@ -738,7 +738,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin=""></script>
     <script src="../js/navigation.js"></script>

--- a/testing/test-google-sheets-loader.html
+++ b/testing/test-google-sheets-loader.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="../styles.css">
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Permanent+Marker&family=Roboto+Condensed:wght@400;700&family=Poppins:wght@400;700&display=swap" rel="stylesheet">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""/>
     <!-- Logger -->
@@ -477,7 +477,7 @@
     <!-- Scripts -->
     <script src="../js/navigation.js"></script>
     <!-- Leaflet JS -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin=""></script>
     

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -75,7 +75,7 @@
           onload="if(window.logger){logger.debug('SYSTEM', 'Bootstrap Icons loaded successfully');}else{console.log('Bootstrap Icons loaded successfully');}"
           onerror="if(window.logger){logger.warn('SYSTEM', 'Failed to load Bootstrap Icons');}else{console.warn('Failed to load Bootstrap Icons');}">
     <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css"
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
 
           crossorigin=""
           onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet CSS loaded successfully');}else{console.log('Leaflet CSS loaded successfully');}"
@@ -284,7 +284,7 @@
     <script src="../js/event-schema.js"></script>
     <script src="../js/calendar-core.js"></script>
     <!-- Leaflet JavaScript -->
-    <script src="https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js"
+    <script src="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js"
 
             crossorigin="anonymous"
             onload="if(window.logger){logger.debug('SYSTEM', 'Leaflet.js loaded successfully');}else{console.log('Leaflet.js loaded successfully');}"


### PR DESCRIPTION
## Why the maps died

Not our code — **MapLibre GL JS released v6.0.0, which removed the UMD bundle** (`dist/maplibre-gl.js` is now a 404; v6 is ESM-only). All our pages load `unpkg.com/maplibre-gl@latest/dist/maplibre-gl.js`, so the moment v6 published, the `maplibregl` global stopped existing:

- Main page: `js/home-map.js` throws `ReferenceError: maplibregl is not defined` (swallowed by its try/catch) → `#homeMap` stays empty.
- City pages: `js/dynamic-calendar-loader.js` hits its `typeof maplibregl === 'undefined'` guard and returns early → `#events-map` stays empty.

No commit on our side broke anything — `git log` around the map code is clean. The latent bug was the unpinned `@latest`.

## Fix

Pin all 54 references across 27 HTML files (main page, every per-city page, bear-directory, testing pages) to **5.24.0** — the last v5 release. Verified live: `unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js` and `.css` both return HTTP 200 with the UMD build that defines the global. Zero JS changes needed.

Deliberately NOT bumping to v6: that requires converting every loader to `<script type="module">` + imports — a separate migration if ever wanted. `@latest` on a runtime CDN dependency was the real footgun; it's gone now.

## Verify after deploy

Open chunky.dad and any city page — maps should render again immediately (may need a hard refresh to bypass cached HTML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP