### PR TITLE
fix(scraper): bar-quality wave — venue identity guard, image/OCR consistency, merge authority rungs

### DIFF
--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -2779,3 +2779,19 @@ test('curated-bar city backfill: containment is one-way — the longer unique na
     `backfill log expected, got:\n${lines.join('\n')}`
   );
 });
+
+test('corroborateBarWithGeoPoi never overwrites the venue-site-identity stamp', () => {
+  const normalizer = createOsmNormalizer();
+  // A matching POI corroborates but must not restamp an identity-corrected bar
+  const identityEvent = { title: 'PERVERT', bar: 'Massive', barSource: 'venue-site-identity' };
+  normalizer.corroborateBarWithGeoPoi(identityEvent, ['Massive']);
+  assert.equal(identityEvent.barSource, 'venue-site-identity');
+
+  // Empty and uncorroborated stamps still upgrade to geo-poi as before
+  const uncorroboratedEvent = { title: 'PERVERT', bar: 'Massive', barSource: 'uncorroborated' };
+  normalizer.corroborateBarWithGeoPoi(uncorroboratedEvent, ['Massive']);
+  assert.equal(uncorroboratedEvent.barSource, 'geo-poi');
+  const unstampedEvent = { title: 'PERVERT', bar: 'Massive' };
+  normalizer.corroborateBarWithGeoPoi(unstampedEvent, ['Massive']);
+  assert.equal(unstampedEvent.barSource, 'geo-poi');
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -437,6 +437,12 @@ class AiWebParser {
                 // never skips or replaces an extraction step.
                 this.applyWixServerDataEnrichment(completeJsonLdEvents, htmlData, cityConfig);
                 await this.applyJsonLdGapFill(completeJsonLdEvents, htmlData, parserConfig, cityConfig, httpAdapter);
+                // A single JSON-LD event whose node carried no image adopts
+                // the page's own og:image artwork (multi-event pages never do:
+                // one shared meta image cannot be attributed to one event).
+                if (completeJsonLdEvents.length === 1) {
+                    this.fillImageFromPageMetaArtwork(completeJsonLdEvents[0], htmlData);
+                }
                 // Images the JSON-LD nodes carried are already stamped 'jsonld';
                 // an image the gap-fill pulled from page content gets its own
                 // og-image/page provenance here (no image → no stamp).
@@ -621,6 +627,11 @@ class AiWebParser {
 
         // OCR any segment images the capped page-level pass missed
         await this.ensureSegmentOcrCoverage(segments, ocrResults, parserConfig, sourceUrl, httpAdapter);
+
+        // Title↔OCR consistency gate: with OCR coverage complete, correct
+        // flyer↔segment pairings whose flyer text names a sibling listing —
+        // BEFORE any per-segment prompt content is built below.
+        this.applySegmentOcrConsistencyGate(segments, ocrResults, sourceUrl);
 
         // Segment-derived site-role facts (multiple distinct addresses →
         // organizer; one recurring address that also appears outside the
@@ -878,6 +889,15 @@ class AiWebParser {
         return '';
     }
 
+    // A segment whose listing title is a venue-hours notice ("Tuesday Closed")
+    // describes no event — it must never claim a page image, or a real
+    // sibling's flyer gets attached to the phantom row and the real event goes
+    // imageless. Gates BOTH image matchers; a segment with no derivable title
+    // stays eligible (fail open).
+    isSegmentEligibleForImagePairing(segment) {
+        return !this.isVenueHoursNoticeTitle(this.deriveSegmentListingTitle(segment));
+    }
+
     buildMultiEventSegmentHtmlData(htmlData, segment, index, totalSegments, ocrResults = []) {
         const sourceUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
         const segmentHtml = segment && typeof segment.html === 'string' ? segment.html : '';
@@ -891,7 +911,8 @@ class AiWebParser {
             segmentHtml,
             sourceUrl,
             segment && Array.isArray(segment.imageHintUrls) ? segment.imageHintUrls : [],
-            segmentOcrResults
+            segmentOcrResults,
+            segment && segment.ocrExcludedUrlKeys instanceof Set ? segment.ocrExcludedUrlKeys : null
         );
         const contextLines = [
             `SEGMENT_INDEX: ${index + 1}/${totalSegments}`,
@@ -1327,10 +1348,20 @@ class AiWebParser {
             return bounds;
         });
 
+        // Venue-hours notice segments ("Tuesday Closed") never take part in
+        // image pairing — a claimed flyer would be stolen from a real sibling.
+        const segmentEligibility = sourceSegments.map((segment, index) => {
+            const eligible = this.isSegmentEligibleForImagePairing(segment);
+            if (!eligible) {
+                console.log(`🤖 AI Web: Segment ${index + 1} ("${this.deriveSegmentListingTitle(segment)}") is a venue-hours notice — not eligible for image pairing`);
+            }
+            return eligible;
+        });
+
         // Use OCR results for better image-segment pairing if available
         const matchedImageUrls = ocrResults && ocrResults.length > 0
-            ? this.matchOrderedImagesToSegmentsWithOcr(sourceSegments, segmentBounds, pageImageRecords, ocrResults)
-            : this.matchOrderedImagesToSegments(segmentBounds, pageImageRecords);
+            ? this.matchOrderedImagesToSegmentsWithOcr(sourceSegments, segmentBounds, pageImageRecords, ocrResults, segmentEligibility)
+            : this.matchOrderedImagesToSegments(segmentBounds, pageImageRecords, segmentEligibility);
 
         // Deduplicate matchedImageUrls by stripped URL to prevent same image at different sizes
         // from being assigned to different segments. This is a safety net since pageImageRecords
@@ -1370,9 +1401,10 @@ class AiWebParser {
         });
     }
 
-    matchOrderedImagesToSegments(segmentBounds, imageRecords) {
+    matchOrderedImagesToSegments(segmentBounds, imageRecords, segmentEligibility = null) {
         const boundsList = Array.isArray(segmentBounds) ? segmentBounds : [];
         const records = Array.isArray(imageRecords) ? imageRecords : [];
+        const eligibility = Array.isArray(segmentEligibility) ? segmentEligibility : null;
         if (boundsList.length === 0 || records.length === 0) return [];
         if (!boundsList.some(bounds => bounds && Number.isFinite(bounds.rawStart) && Number.isFinite(bounds.rawEnd))) {
             return [];
@@ -1418,7 +1450,10 @@ class AiWebParser {
                     });
                 }
 
-                if (segmentIndex < boundsList.length && imageIndex < records.length) {
+                // An ineligible (venue-hours notice) segment may be skipped but
+                // never takes the 'match' action — it cannot claim an image.
+                if (segmentIndex < boundsList.length && imageIndex < records.length
+                    && (!eligibility || eligibility[segmentIndex] !== false)) {
                     const pairingCost = this.getSegmentImagePairingCost(boundsList[segmentIndex], records[imageIndex]);
                     if (Number.isFinite(pairingCost)) {
                         dp[segmentIndex + 1][imageIndex + 1] = betterState(dp[segmentIndex + 1][imageIndex + 1], {
@@ -1449,10 +1484,11 @@ class AiWebParser {
         return matchedUrls;
     }
 
-    matchOrderedImagesToSegmentsWithOcr(segments, segmentBounds, imageRecords, ocrResults) {
+    matchOrderedImagesToSegmentsWithOcr(segments, segmentBounds, imageRecords, ocrResults, segmentEligibility = null) {
         const sourceSegments = Array.isArray(segments) ? segments : [];
         const boundsList = Array.isArray(segmentBounds) ? segmentBounds : [];
         const records = Array.isArray(imageRecords) ? imageRecords : [];
+        const eligibility = Array.isArray(segmentEligibility) ? segmentEligibility : null;
         if (boundsList.length === 0 || records.length === 0) return [];
         if (!boundsList.some(bounds => bounds && Number.isFinite(bounds.rawStart) && Number.isFinite(bounds.rawEnd))) {
             return [];
@@ -1476,6 +1512,11 @@ class AiWebParser {
 
         const pairings = [];
         for (let i = 0; i < boundsList.length; i++) {
+            // Ineligible (venue-hours notice) segments never enter the pairing
+            // pool at all — the similarity override in
+            // getSegmentImagePairingCostWithOcr could otherwise hand a phantom
+            // row a real sibling's flyer.
+            if (eligibility && eligibility[i] === false) continue;
             for (let j = 0; j < records.length; j++) {
                 const imageRecord = records[j];
                 const normalizedUrl = this.normalizeHttpUrlValue(imageRecord.url);
@@ -1900,7 +1941,7 @@ class AiWebParser {
         return match ? match.index : -1;
     }
 
-    extractMultiEventSegmentResourceLines(html, sourceUrl = '', hintedImageUrls = [], ocrResults = []) {
+    extractMultiEventSegmentResourceLines(html, sourceUrl = '', hintedImageUrls = [], ocrResults = [], excludedUrlKeys = null) {
         const source = String(html || '');
         const lines = [];
         const seen = new Set();
@@ -1912,6 +1953,15 @@ class AiWebParser {
             if (!finalUrl) return;
             // Check for duplicates using stripped URL to handle same image at different sizes
             const strippedUrl = this.stripSizeParams(finalUrl);
+            // Consistency-gate exclusions: an image reassigned/detached from
+            // this segment never lands in its SEGMENT_IMAGE_* prompt lines
+            // (checked in both stripped and CDN-upgraded key forms, matching
+            // getSegmentImageUrlKeys).
+            if (excludedUrlKeys instanceof Set && excludedUrlKeys.size > 0) {
+                if (excludedUrlKeys.has(strippedUrl)) return;
+                const upgraded = this.upgradeCdnThumbnailUrl(finalUrl);
+                if (upgraded && upgraded !== finalUrl && excludedUrlKeys.has(this.stripSizeParams(upgraded))) return;
+            }
             if (seenStripped.has(strippedUrl)) return;
             seen.add(finalUrl);
             seenStripped.add(strippedUrl);
@@ -3143,6 +3193,12 @@ class AiWebParser {
             image: this.pickJsonLdImage(node.image),
             source: this.config.source
         };
+        // The page's own structured data named this venue and it survived the
+        // address-shaped-name gate above — the venue-site identity pass never
+        // overrides a structured-data bar (underscore field, internal only).
+        if (event.bar) {
+            event._barFromJsonLd = true;
+        }
         // imageSource provenance (notes-serialized like pinSource): structured
         // data the page itself published — its own value, distinct from
         // 'og-image'/'page', but og-grade in shared-core's image provenance
@@ -4051,9 +4107,14 @@ class AiWebParser {
         return ocrResults;
     }
 
-    filterOcrResultsForSegment(ocrResults, segment, sourceUrl = '') {
-        if (!Array.isArray(ocrResults) || ocrResults.length === 0) return [];
-        if (!segment || typeof segment !== 'object') return [];
+    // The URL keys a segment claims OCR results with — normalized exact URLs
+    // plus size-stripped (and CDN-upgraded) keys. Shared by
+    // filterOcrResultsForSegment and the OCR-consistency gate so both judge
+    // image ownership identically.
+    getSegmentImageUrlKeys(segment, sourceUrl = '') {
+        if (!segment || typeof segment !== 'object') {
+            return { normalized: new Set(), stripped: new Set() };
+        }
 
         // Extract segment's image URLs
         const segmentImageUrls = new Set([
@@ -4066,7 +4127,7 @@ class AiWebParser {
         ]);
 
         // Normalize segment image URLs for comparison
-        const normalizedSegmentImageSet = new Set(
+        const normalized = new Set(
             Array.from(segmentImageUrls)
                 .map(u => this.normalizeHttpUrlValue(u))
                 .filter(Boolean)
@@ -4076,16 +4137,27 @@ class AiWebParser {
         // upgradeCdnThumbnailUrl first: OCR results are keyed by the upgraded bare
         // asset URL, so segment thumbnail variants must collapse to the same key
         // even if a future transform shape slips past stripSizeParams.
-        const strippedSegmentImageSet = new Set();
-        for (const u of normalizedSegmentImageSet) {
-            const stripped = this.stripSizeParams(u);
-            if (stripped) strippedSegmentImageSet.add(stripped);
+        const stripped = new Set();
+        for (const u of normalized) {
+            const strippedUrl = this.stripSizeParams(u);
+            if (strippedUrl) stripped.add(strippedUrl);
             const upgraded = this.upgradeCdnThumbnailUrl(u);
             if (upgraded && upgraded !== u) {
                 const strippedUpgraded = this.stripSizeParams(upgraded);
-                if (strippedUpgraded) strippedSegmentImageSet.add(strippedUpgraded);
+                if (strippedUpgraded) stripped.add(strippedUpgraded);
             }
         }
+
+        return { normalized, stripped };
+    }
+
+    filterOcrResultsForSegment(ocrResults, segment, sourceUrl = '') {
+        if (!Array.isArray(ocrResults) || ocrResults.length === 0) return [];
+        if (!segment || typeof segment !== 'object') return [];
+
+        const { normalized: normalizedSegmentImageSet, stripped: strippedSegmentImageSet } =
+            this.getSegmentImageUrlKeys(segment, sourceUrl);
+        const excludedUrlKeys = segment.ocrExcludedUrlKeys instanceof Set ? segment.ocrExcludedUrlKeys : null;
 
         console.log(`🤖 AI Web: Filtering OCR results against ${normalizedSegmentImageSet.size} segment images (${strippedSegmentImageSet.size} stripped)`);
 
@@ -4093,6 +4165,10 @@ class AiWebParser {
         const matchedOcrResults = ocrResults.filter(ocr => {
             const ocrUrl = this.normalizeHttpUrlValue(ocr.url);
             const strippedOcrUrl = this.stripSizeParams(ocrUrl);
+
+            // Consistency-gate exclusions first: an image the gate reassigned
+            // or detached from this segment never matches, even via exact URL.
+            if (excludedUrlKeys && strippedOcrUrl && excludedUrlKeys.has(strippedOcrUrl)) return false;
 
             const exactMatch = normalizedSegmentImageSet.has(ocrUrl);
             const strippedMatch = strippedOcrUrl && strippedSegmentImageSet.has(strippedOcrUrl);
@@ -4114,6 +4190,85 @@ class AiWebParser {
         }
 
         return matchedOcrResults;
+    }
+
+    // Post-pairing title↔OCR consistency gate: once segment OCR coverage is
+    // complete, every OCR flyer's text is checked against its owner segment's
+    // listing title. A flyer sharing NO title token with its owner that
+    // clearly names exactly one ELIGIBLE sibling (≥ 2 matched title tokens, or
+    // full coverage of a 1-token title) is reassigned there; one matching
+    // several siblings equally is detached (assigned to nobody). A flyer that
+    // matches its owner at all — or matches nobody — is left alone, so correct
+    // exact-URL pairings can never thrash (fail open). Ownership is judged by
+    // getSegmentImageUrlKeys, the SAME keys filterOcrResultsForSegment uses.
+    applySegmentOcrConsistencyGate(segments, ocrResults, sourceUrl = '') {
+        const sourceSegments = Array.isArray(segments) ? segments : [];
+        const ocrList = Array.isArray(ocrResults) ? ocrResults : [];
+        if (sourceSegments.length < 2 || ocrList.length === 0) return sourceSegments;
+        if (!this.core || typeof this.core.getCrossSourceTitleTokens !== 'function') return sourceSegments;
+
+        const segmentInfos = sourceSegments.map(segment => {
+            const title = this.deriveSegmentListingTitle(segment);
+            return {
+                segment,
+                title,
+                titleTokens: this.core.getCrossSourceTitleTokens(title),
+                eligible: this.isSegmentEligibleForImagePairing(segment),
+                keys: this.getSegmentImageUrlKeys(segment, sourceUrl)
+            };
+        });
+
+        for (const ocr of ocrList) {
+            if (!ocr || typeof ocr.text !== 'string' || ocr.text.trim() === '') continue;
+            const ocrUrl = this.normalizeHttpUrlValue(ocr.url);
+            const strippedOcrUrl = this.stripSizeParams(ocrUrl);
+            if (!strippedOcrUrl) continue;
+            const ocrTokens = new Set(this.core.getCrossSourceTitleTokens(
+                `${String(ocr.text || '')} ${String(ocr.eventSummary || '')}`));
+            const matchedCount = info => info.titleTokens.filter(token => ocrTokens.has(token)).length;
+
+            for (let i = 0; i < segmentInfos.length; i++) {
+                const owner = segmentInfos[i];
+                const ownsImage = owner.keys.normalized.has(ocrUrl) || owner.keys.stripped.has(strippedOcrUrl);
+                if (!ownsImage) continue;
+                // Any title-token overlap corroborates the current pairing.
+                if (matchedCount(owner) > 0) continue;
+                const candidates = [];
+                for (let j = 0; j < segmentInfos.length; j++) {
+                    if (j === i) continue;
+                    const sibling = segmentInfos[j];
+                    if (!sibling.eligible) continue;
+                    const matched = matchedCount(sibling);
+                    const coversSingleTokenTitle = sibling.titleTokens.length === 1 && matched === 1;
+                    if (matched >= 2 || coversSingleTokenTitle) {
+                        candidates.push({ index: j, matched });
+                    }
+                }
+                if (candidates.length === 0) continue; // names nobody → leave alone
+                const maxMatched = Math.max(...candidates.map(candidate => candidate.matched));
+                const topCandidates = candidates.filter(candidate => candidate.matched === maxMatched);
+                if (!(owner.segment.ocrExcludedUrlKeys instanceof Set)) {
+                    owner.segment.ocrExcludedUrlKeys = new Set();
+                }
+                owner.segment.ocrExcludedUrlKeys.add(strippedOcrUrl);
+                if (topCandidates.length === 1) {
+                    const target = segmentInfos[topCandidates[0].index];
+                    if (!Array.isArray(target.segment.imageHintUrls)) {
+                        target.segment.imageHintUrls = [];
+                    }
+                    if (!target.segment.imageHintUrls.includes(ocr.url)) {
+                        target.segment.imageHintUrls.push(ocr.url);
+                    }
+                    // Refresh the target's ownership keys so later OCR results
+                    // judge the moved image against its NEW owner.
+                    target.keys = this.getSegmentImageUrlKeys(target.segment, sourceUrl);
+                    console.log(`🤖 AI Web: Reassigned OCR image ${ocr.url} from segment ${i + 1} ("${owner.title}") to segment ${topCandidates[0].index + 1} ("${target.title}") — flyer text matches sibling listing title`);
+                } else {
+                    console.log(`🤖 AI Web: Detached OCR image ${ocr.url} from segment ${i + 1} ("${owner.title}") — flyer text matches multiple sibling titles`);
+                }
+            }
+        }
+        return sourceSegments;
     }
 
     buildOcrSnippet(imageUrl, text, eventSummary = null) {
@@ -6830,6 +6985,16 @@ ${String(snippet || '')}`;
         const knownVenueName = siteRole === 'venue' ? this.getPageVenueName(htmlData) : '';
         if (knownVenueName) {
             steeringContext += `KNOWN VENUE (this is the venue's own site): "${knownVenueName}" — events on this page take place AT this venue unless the page states another location; DJ names, taglines, and edition subtitles are NOT the venue.\n`;
+            // Additive strengthening line, only when the venue name uniquely
+            // matches ONE curated bar (never for ambiguous cities or generic
+            // franchise stems) — guest-host brand names on flyers must not
+            // displace the site's own venue.
+            const curatedVenueMatch = this.core && typeof this.core.findCuratedBarCityByName === 'function'
+                ? this.core.findCuratedBarCityByName(knownVenueName)
+                : null;
+            if (curatedVenueMatch && curatedVenueMatch.city && curatedVenueMatch.bar) {
+                steeringContext += `KNOWN VENUE (curated match): "${knownVenueName}" is the venue for every event on this site. Other bar or brand names printed on a flyer are guest hosts or co-presenters, NOT the venue — never return them as "bar" unless the page states the event happens at a different street address.\n`;
+            }
         } else if (pageBrandNames.length > 0 && siteRole !== 'venue') {
             const aliasSuffix = pageBrandNames.length > 1
                 ? ` (also appears as ${pageBrandNames.slice(1).map(name => `"${name}"`).join(', ')})`
@@ -9001,6 +9166,13 @@ TEXT:
             });
         }
 
+        // A single-event page (never a multi-event segment — one shared meta
+        // image cannot be attributed to one segment) whose extraction found no
+        // image adopts the page's own og:image artwork.
+        if (!dataFlags.segment) {
+            this.fillImageFromPageMetaArtwork(event, htmlData);
+        }
+
         // Provenance stamp for the FINAL image value (after any parser-config
         // metadata override): 'og-image' when it is the page's own artwork,
         // 'page' otherwise; no image → no stamp.
@@ -9954,6 +10126,38 @@ TEXT:
     // An already-stamped or absent image is left untouched (fail open), so the
     // JSON-LD path's 'jsonld' stamp and other parsers' unstamped images are
     // never relabeled.
+    // og:image fill for imageless single-event pages: when a page produced
+    // EXACTLY ONE event and extraction found no image, the page's own
+    // og:image/twitter:image meta IS that event's artwork — adopt it. Uses the
+    // RAW meta value run through the standard storage pipeline
+    // (normalizeHttpUrlValue → unwrapImageProxyUrl → upgradeCdnThumbnailUrl),
+    // never the lowercased comparison form getPageMetaImageUrls builds.
+    // Obvious non-artwork URLs (logos/icons per isLikelyUninterestingImageUrl)
+    // are skipped; an event that already has an image is left untouched.
+    fillImageFromPageMetaArtwork(event, htmlData) {
+        if (!event || typeof event !== 'object') return event;
+        const existingImage = typeof event.image === 'string' ? event.image.trim() : '';
+        if (existingImage) return event;
+        const html = htmlData && typeof htmlData.html === 'string' ? htmlData.html : '';
+        if (!html) return event;
+        const metaKeys = ['og:image', 'og:image:url', 'og:image:secure_url', 'twitter:image', 'twitter:image:src'];
+        for (const metaKey of metaKeys) {
+            // Same explicit &amp; second decode as getPageMetaImageUrls.
+            const content = this.extractOgMetaContent(html, metaKey).replace(/&amp;/gi, '&');
+            if (!content) continue;
+            const normalized = this.normalizeHttpUrlValue(content);
+            if (!normalized) continue;
+            const unwrapped = this.unwrapImageProxyUrl(normalized) || normalized;
+            const upgraded = this.upgradeCdnThumbnailUrl(unwrapped);
+            if (!upgraded || this.isLikelyUninterestingImageUrl(upgraded)) continue;
+            event.image = upgraded;
+            event.imageSource = 'og-image';
+            console.log(`🤖 AI Web: Filled image from page og:image for "${event.title}"`);
+            return event;
+        }
+        return event;
+    }
+
     stampImageProvenance(event, htmlData) {
         if (!event || typeof event !== 'object') return event;
         if (event.imageSource) return event;
@@ -10140,10 +10344,22 @@ TEXT:
             this.venueSiteHarvest[host] = {
                 addresses: Object.create(null),
                 pages: new Set(),
-                blocked: false
+                blocked: false,
+                venueRoleSeen: false,
+                venueName: ''
             };
         }
         return this.venueSiteHarvest[host];
+    }
+
+    // Identity facts for the venue-site identity pass: remember that SOME page
+    // of this host resolved siteRole 'venue', and the venue name that page
+    // declared (first non-empty wins). Organizer pages still block via the
+    // existing veto — identity is only ever established on unblocked hosts.
+    recordVenueSiteRoleFacts(entry, htmlData) {
+        if (!entry || this.getPageSiteRole(htmlData) !== 'venue') return;
+        entry.venueRoleSeen = true;
+        if (!entry.venueName) entry.venueName = this.getPageVenueName(htmlData);
     }
 
     // Collect this page's map-directions addresses into the per-host harvest
@@ -10158,6 +10374,7 @@ TEXT:
         if (!host) return;
         const entry = this.getVenueSiteHarvestEntry(host);
         if (this.getPageSiteRole(htmlData) === 'organizer') entry.blocked = true;
+        this.recordVenueSiteRoleFacts(entry, htmlData);
         if (entry.pages.has(pageUrl)) return;
         entry.pages.add(pageUrl);
         const seenKeys = new Set();
@@ -10184,6 +10401,9 @@ TEXT:
         if (this.getPageSiteRole(htmlData) === 'organizer') {
             this.getVenueSiteHarvestEntry(host).blocked = true;
         }
+        if (this.getPageSiteRole(htmlData) === 'venue') {
+            this.recordVenueSiteRoleFacts(this.getVenueSiteHarvestEntry(host), htmlData);
+        }
         for (const event of events) {
             if (event && typeof event === 'object' && !event._venueSitePageHost) {
                 event._venueSitePageHost = host;
@@ -10206,6 +10426,22 @@ TEXT:
         const harvest = this.venueSiteHarvest;
         this.venueSiteHarvest = null;
         if (!harvest) return;
+        // Stash the per-host harvest outcomes for the identity pass that runs
+        // right after this one (applyVenueSiteIdentityCorrections consumes and
+        // clears it) — consensus first, identity second.
+        this.lastVenueSiteConsensus = Object.create(null);
+        for (const host of Object.keys(harvest)) {
+            const entry = harvest[host];
+            const hostKeys = Object.keys(entry.addresses);
+            const consensusKey = !entry.blocked && hostKeys.length === 1 ? hostKeys[0] : '';
+            this.lastVenueSiteConsensus[host] = {
+                consensusKey,
+                consensusAddress: consensusKey ? entry.addresses[consensusKey].display : '',
+                blocked: entry.blocked === true,
+                venueRoleSeen: entry.venueRoleSeen === true,
+                venueName: typeof entry.venueName === 'string' ? entry.venueName : ''
+            };
+        }
         const eventList = Array.isArray(events) ? events : [];
         for (const host of Object.keys(harvest)) {
             const entry = harvest[host];
@@ -10240,6 +10476,158 @@ TEXT:
                 if (cityKey && (!existingCity || existingCity === 'unknown')) {
                     event.city = cityKey;
                     console.log(`🤖 AI Web: Filled city "${cityKey}" from venue-site consensus for "${title}"`);
+                }
+            }
+        }
+    }
+
+    // Same-address test for identity establishment and its multi-venue skip:
+    // parsed street-line comparison first (parseAddressForComparison +
+    // isSameStreetAddress), with normalized-token join equality as the
+    // fallback when either side does not parse. Fails closed on blanks.
+    venueSiteIdentityAddressesAgree(addressA, addressB) {
+        const a = String(addressA || '').trim();
+        const b = String(addressB || '').trim();
+        if (!a || !b || !this.core) return false;
+        const parsedA = this.core.parseAddressForComparison(a);
+        const parsedB = this.core.parseAddressForComparison(b);
+        if (parsedA && parsedB) return this.core.isSameStreetAddress(parsedA, parsedB);
+        const tokensA = this.core.normalizeAddressTokens(a).join(' ');
+        const tokensB = this.core.normalizeAddressTokens(b).join(' ');
+        return Boolean(tokensA) && tokensA === tokensB;
+    }
+
+    // WHO a crawled site is — established only when independent hard facts
+    // converge, failing closed on ANY miss:
+    //   1. some page of the host resolved siteRole 'venue' AND no page ever
+    //      resolved 'organizer' (blocked — the same veto the address
+    //      consensus honors);
+    //   2. the harvested venue name uniquely matches ONE curated bar
+    //      (findCuratedBarCityByName — ambiguous cities and generic franchise
+    //      stems never establish identity);
+    //   3. address agreement, either level: the host's address consensus IS
+    //      the curated bar's address (whole-host identity, hostLevel: true),
+    //      or — when the host produced no consensus at all — identity applies
+    //      per-event only (hostLevel: false; the caller requires the event's
+    //      own _geoPoiName to equal the bar's name key). A consensus that
+    //      CONTRADICTS the curated address establishes nothing.
+    // Ticketing-platform org pages (eventbrite.com) can never establish
+    // identity: the registrable host is the platform's, so its venue name
+    // resolves to the platform brand ("Eventbrite") and matches no curated
+    // bar — the curated-name condition is the structural guard.
+    getEstablishedVenueSiteIdentity(entry, consensusKey = '') {
+        if (!entry || typeof entry !== 'object') return null;
+        if (entry.venueRoleSeen !== true || entry.blocked !== false) return null;
+        const venueName = typeof entry.venueName === 'string' ? entry.venueName.trim() : '';
+        if (!venueName) return null;
+        if (!this.core || typeof this.core.findCuratedBarCityByName !== 'function') return null;
+        const match = this.core.findCuratedBarCityByName(venueName);
+        if (!match || !match.city || !match.bar) return null;
+        const curatedBar = match.bar;
+        if (consensusKey) {
+            const consensusAddress = typeof entry.consensusAddress === 'string' ? entry.consensusAddress.trim() : '';
+            const curatedAddress = typeof curatedBar.address === 'string' ? curatedBar.address.trim() : '';
+            if (!curatedAddress || !this.venueSiteIdentityAddressesAgree(consensusAddress, curatedAddress)) {
+                return null;
+            }
+            return { name: curatedBar.name, city: match.city, curatedBar, hostLevel: true };
+        }
+        return { name: curatedBar.name, city: match.city, curatedBar, hostLevel: false };
+    }
+
+    // Deterministic KNOWN-VENUE replacement pass, run by shared-core's
+    // processParser immediately AFTER applyVenueSiteAddressConsensus (which
+    // stashes lastVenueSiteConsensus for it). On a host whose identity is
+    // established, an event's bar that is really a flyer subtitle or guest
+    // brand is corrected to the curated venue name — with per-event skips
+    // that keep multi-venue announcements (off-site street address), bars the
+    // curated data or the page's own structured data corroborates, and the
+    // venue's own name (casing normalized only) untouched.
+    applyVenueSiteIdentityCorrections(events, cityConfig = null) {
+        const consensusByHost = this.lastVenueSiteConsensus;
+        this.lastVenueSiteConsensus = null;
+        if (!consensusByHost || !this.core) return;
+        const eventList = Array.isArray(events) ? events : [];
+        for (const host of Object.keys(consensusByHost)) {
+            const entry = consensusByHost[host];
+            const identity = this.getEstablishedVenueSiteIdentity(entry, entry.consensusKey);
+            if (!identity) continue;
+            const curatedBar = identity.curatedBar;
+            const identityKey = this.core.normalizeBarNameKey(curatedBar.name);
+            const cityBars = typeof this.core.getCuratedCityBars === 'function'
+                ? this.core.getCuratedCityBars(identity.city)
+                : null;
+            const signals = identity.hostLevel
+                ? ['venue-role', 'curated-name', 'address-consensus']
+                : ['venue-role', 'curated-name', 'geo-poi'];
+            let identityLogged = false;
+            const logIdentityOnce = () => {
+                if (identityLogged) return;
+                identityLogged = true;
+                console.log(`🤖 AI Web: Venue-site identity for ${host} established: "${curatedBar.name}" (${identity.city}) — signals: ${signals.join(', ')}`);
+            };
+            if (identity.hostLevel) logIdentityOnce();
+            for (const event of eventList) {
+                if (!event || typeof event !== 'object' || event._venueSitePageHost !== host) continue;
+                if (!identity.hostLevel) {
+                    // POI promotion: without an address consensus, identity
+                    // applies only to events whose accepted pin's map POI IS
+                    // this venue.
+                    const poiName = typeof event._geoPoiName === 'string' ? event._geoPoiName.trim() : '';
+                    if (!poiName || this.core.normalizeBarNameKey(poiName) !== identityKey) continue;
+                }
+                // Multi-venue skip: a party at ANOTHER street address
+                // announced on this site keeps its own bar untouched.
+                const existingAddress = typeof event.address === 'string' ? event.address.trim() : '';
+                if (existingAddress
+                    && this.normalizeVenueSiteAddressKey(existingAddress) !== entry.consensusKey
+                    && !this.venueSiteIdentityAddressesAgree(existingAddress, curatedBar.address)) {
+                    continue;
+                }
+                logIdentityOnce();
+                const title = typeof event.title === 'string' && event.title.trim() ? event.title.trim() : 'unknown';
+                const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+                const barSource = typeof event.barSource === 'string' ? event.barSource.trim() : '';
+                // Already the venue: normalize casing to the curated name only.
+                if (bar && this.core.normalizeBarNameKey(bar) === identityKey) {
+                    if (bar !== curatedBar.name) event.bar = curatedBar.name;
+                    continue;
+                }
+                // Corroborated elsewhere: a DIFFERENT curated bar of this
+                // city, or a curated stamp, outranks identity — flag only.
+                const otherCurated = bar && cityBars ? this.core.findCuratedBarByName(cityBars, bar) : null;
+                if (bar && (otherCurated || barSource === 'curated')) {
+                    console.log(`🤖 AI Web: Kept bar "${bar}" for "${title}" — matches another curated ${identity.city} bar; venue-site identity not applied`);
+                    continue;
+                }
+                // The page's own structured data named this bar — never
+                // overridden here.
+                if (event._barFromJsonLd === true) continue;
+                if (!bar) {
+                    event.bar = curatedBar.name;
+                    event.barSource = 'venue-site-identity';
+                    console.log(`🤖 AI Web: Filled bar "${curatedBar.name}" from venue-site identity for "${title}"`);
+                } else {
+                    event._venueIdentityCorrection = {
+                        original: bar,
+                        originalSource: barSource,
+                        signals
+                    };
+                    // A convergence rescue that adopted the replaced value is
+                    // stale evidence for a bar that no longer exists.
+                    if (event._barRescue && typeof event._barRescue === 'object'
+                        && this.core.normalizeBarNameKey(event._barRescue.candidate) === this.core.normalizeBarNameKey(bar)) {
+                        delete event._barRescue;
+                    }
+                    event.bar = curatedBar.name;
+                    event.barSource = 'venue-site-identity';
+                    console.log(`🤖 AI Web: Replaced bar "${bar}" with venue-site identity "${curatedBar.name}" for "${title}" (was ${barSource || 'unstamped'})`);
+                }
+                // City knock-on: the dedup re-anchor pass then resolves any
+                // timezone-unresolved dates — no new timezone code here.
+                const existingCity = typeof event.city === 'string' ? event.city.trim().toLowerCase() : '';
+                if (!existingCity || existingCity === 'unknown') {
+                    event.city = identity.city;
                 }
             }
         }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -334,9 +334,17 @@ test('normalizeAiEvent stamps imageSource og-image for the page\'s own meta artw
     { ...base, image: 'https://static.wixstatic.com/media/8ff085_massiveparty~mv2.webp' }, {}, htmlData, null, null);
   assert.equal(pageEvent.imageSource, 'page');
 
-  // No image → no stamp at all (fail open)
+  // No extracted image → a single-event page adopts its own og:image artwork
   const bareEvent = parser.normalizeAiEvent({ ...base }, {}, htmlData, null, null);
-  assert.equal('imageSource' in bareEvent, false);
+  assert.equal(bareEvent.imageSource, 'og-image');
+  assert.equal(
+    parser.canonicalizeImageUrlForComparison(bareEvent.image),
+    parser.canonicalizeImageUrlForComparison('https://bearracuda.com/wp-content/uploads/sausageweb.jpg'));
+
+  // No image and no page meta artwork → no stamp at all (fail open)
+  const bareNoMetaEvent = parser.normalizeAiEvent(
+    { ...base }, {}, { url: htmlData.url, html: '<html><head></head><body></body></html>' }, null, null);
+  assert.equal('imageSource' in bareNoMetaEvent, false);
 
   // No htmlData (no meta to compare against) → the AI-web default, page
   const noHtmlEvent = parser.normalizeAiEvent(
@@ -5859,4 +5867,424 @@ test('venue-hours notice: extractSingleEvent skips the literal "Tuesday Closed" 
     logs.includes('🤖 AI Web: Skipped venue-hours notice "Tuesday Closed" — not an event'),
     `skip log expected, got: ${JSON.stringify(logs.filter(line => line.includes('AI Web')))}`
   );
+});
+
+// ---------------------------------------------------------------------------
+// Image-pairing eligibility: a venue-hours notice segment ("Tuesday Closed")
+// describes no event and must never claim a page image in EITHER matcher.
+// ---------------------------------------------------------------------------
+
+test('image pairing: a "Tuesday Closed" phantom segment never takes an image in the ordered matcher', () => {
+  const parser = createParser();
+  const bounds = [
+    { rawStart: 0, rawEnd: 100 },
+    { rawStart: 5000, rawEnd: 6000 }
+  ];
+  const records = [{ url: 'https://img.example/flyer.jpg', start: 40, end: 60 }];
+
+  // Without eligibility the image lands on the phantom (overlap, cost 0)
+  assert.deepEqual(
+    parser.matchOrderedImagesToSegments(bounds, records),
+    ['https://img.example/flyer.jpg']);
+
+  // With the phantom marked ineligible the real sibling gets it instead
+  const matched = parser.matchOrderedImagesToSegments(bounds, records, [false, true]);
+  assert.equal(matched[0], undefined, 'phantom claims nothing');
+  assert.equal(matched[1], 'https://img.example/flyer.jpg');
+});
+
+test('image pairing: a "Tuesday Closed" phantom segment never takes an image in the OCR matcher, even via similarity', () => {
+  const parser = createParser();
+  const segments = [
+    { lines: ['Tuesday Closed'] },
+    { lines: ['HOSTILE NOISE', 'July 10, 2026'] }
+  ];
+  const bounds = [
+    { rawStart: 0, rawEnd: 100, matchedRecords: [{ text: 'Tuesday Closed' }] },
+    { rawStart: 5000, rawEnd: 6000, matchedRecords: [{ text: 'HOSTILE NOISE July 10, 2026' }] }
+  ];
+  const records = [{ url: 'https://img.example/flyer.jpg', start: 40, end: 60 }];
+  // OCR text mirrors the phantom's row text — the similarity override would
+  // otherwise bind the flyer to the phantom
+  const ocrResults = [{
+    url: 'https://img.example/flyer.jpg',
+    text: 'Tuesday Closed',
+    imageClassification: 'event-flyer'
+  }];
+
+  const unguarded = parser.matchOrderedImagesToSegmentsWithOcr(segments, bounds, records, ocrResults);
+  assert.equal(unguarded[0], 'https://img.example/flyer.jpg', 'without eligibility the phantom wins');
+
+  const guarded = parser.matchOrderedImagesToSegmentsWithOcr(segments, bounds, records, ocrResults, [false, true]);
+  assert.equal(guarded[0], null, 'phantom claims nothing');
+  assert.equal(guarded[1], 'https://img.example/flyer.jpg', 'the real sibling gets the flyer');
+});
+
+test('image pairing: eligibility follows the venue-hours notice detector, failing open without a title', () => {
+  const parser = createParser();
+  assert.equal(parser.isSegmentEligibleForImagePairing({ lines: ['Tuesday Closed'] }), false);
+  assert.equal(parser.isSegmentEligibleForImagePairing({ lines: ['HOSTILE NOISE'] }), true);
+  assert.equal(parser.isSegmentEligibleForImagePairing({ lines: [] }), true, 'no derivable title stays eligible');
+});
+
+// ---------------------------------------------------------------------------
+// Post-pairing title↔OCR consistency gate (run 20260725: the Hostile Noise
+// flyer was paired to the Treasure Trail segment).
+// ---------------------------------------------------------------------------
+
+function buildOcrGateSegments() {
+  return [
+    {
+      lines: ['Treasure Trail', 'July 10, 2026'],
+      html: '',
+      imageHintUrls: ['https://img.example/hostile-noise.jpg']
+    },
+    { lines: ['Hostile Noise', 'July 11, 2026'], html: '', imageHintUrls: [] }
+  ];
+}
+
+test('OCR consistency gate: the Hostile Noise flyer is reassigned from the Treasure Trail segment to its own listing', () => {
+  const parser = createParser();
+  const segments = buildOcrGateSegments();
+  const ocrResults = [{
+    url: 'https://img.example/hostile-noise.jpg',
+    text: 'HOSTILE NOISE presents a night of mayhem',
+    eventSummary: ''
+  }];
+
+  const logs = captureLogs(() => {
+    parser.applySegmentOcrConsistencyGate(segments, ocrResults, 'https://venue.example/events');
+  });
+
+  assert.ok(segments[1].imageHintUrls.includes('https://img.example/hostile-noise.jpg'),
+    'target segment adopts the flyer');
+  assert.ok(segments[0].ocrExcludedUrlKeys instanceof Set && segments[0].ocrExcludedUrlKeys.size === 1,
+    'owner segment excludes the flyer');
+  assert.ok(logs.some(line => line.includes('Reassigned OCR image https://img.example/hostile-noise.jpg')
+    && line.includes('flyer text matches sibling listing title')), `reassign log expected, got: ${JSON.stringify(logs)}`);
+
+  // The filter judges ownership with the same keys: owner no longer matches,
+  // target now does
+  assert.deepEqual(parser.filterOcrResultsForSegment(ocrResults, segments[0], 'https://venue.example/events'), []);
+  assert.equal(parser.filterOcrResultsForSegment(ocrResults, segments[1], 'https://venue.example/events').length, 1);
+});
+
+test('OCR consistency gate: any title-token overlap with the owner keeps the pairing (thrash-proof)', () => {
+  const parser = createParser();
+  const segments = [
+    {
+      lines: ['Treasure Trail Party', 'July 10, 2026'],
+      html: '',
+      imageHintUrls: ['https://img.example/flyer.jpg']
+    },
+    { lines: ['Hostile Noise', 'July 11, 2026'], html: '', imageHintUrls: [] }
+  ];
+  // One owner token ("trail") appears in the flyer text → owner keeps it even
+  // though the sibling matches two tokens
+  const ocrResults = [{
+    url: 'https://img.example/flyer.jpg',
+    text: 'Trail mix at the HOSTILE NOISE afterparty',
+    eventSummary: ''
+  }];
+
+  parser.applySegmentOcrConsistencyGate(segments, ocrResults, 'https://venue.example/events');
+
+  assert.equal(segments[0].ocrExcludedUrlKeys, undefined, 'owner keeps its flyer');
+  assert.deepEqual(segments[1].imageHintUrls, [], 'sibling adopts nothing');
+});
+
+test('OCR consistency gate: a flyer naming multiple siblings equally is detached, owning nobody', () => {
+  const parser = createParser();
+  const segments = [
+    {
+      lines: ['Treasure Trail', 'July 10, 2026'],
+      html: '',
+      imageHintUrls: ['https://img.example/flyer.jpg']
+    },
+    { lines: ['Hostile Noise', 'July 11, 2026'], html: '', imageHintUrls: [] },
+    { lines: ['Noise Hostile', 'July 12, 2026'], html: '', imageHintUrls: [] }
+  ];
+  const ocrResults = [{
+    url: 'https://img.example/flyer.jpg',
+    text: 'HOSTILE NOISE weekend takeover',
+    eventSummary: ''
+  }];
+
+  const logs = captureLogs(() => {
+    parser.applySegmentOcrConsistencyGate(segments, ocrResults, 'https://venue.example/events');
+  });
+
+  assert.ok(segments[0].ocrExcludedUrlKeys instanceof Set && segments[0].ocrExcludedUrlKeys.size === 1,
+    'owner is detached from the flyer');
+  assert.deepEqual(segments[1].imageHintUrls, []);
+  assert.deepEqual(segments[2].imageHintUrls, []);
+  assert.ok(logs.some(line => line.includes('Detached OCR image https://img.example/flyer.jpg')
+    && line.includes('flyer text matches multiple sibling titles')), `detach log expected, got: ${JSON.stringify(logs)}`);
+  assert.deepEqual(parser.filterOcrResultsForSegment(ocrResults, segments[0], 'https://venue.example/events'), [],
+    'detached flyer no longer reaches the former owner');
+});
+
+test('OCR consistency gate: an excluded flyer\'s OCR text and image lines never reach the former owner\'s prompt content', () => {
+  const parser = createParser();
+  const segments = buildOcrGateSegments();
+  const ocrResults = [{
+    url: 'https://img.example/hostile-noise.jpg',
+    text: 'HOSTILE NOISE presents a night of mayhem',
+    eventSummary: ''
+  }];
+  const htmlData = { url: 'https://venue.example/events', html: '<html><body></body></html>' };
+
+  parser.applySegmentOcrConsistencyGate(segments, ocrResults, htmlData.url);
+
+  const ownerData = parser.buildMultiEventSegmentHtmlData(htmlData, segments[0], 0, 2, ocrResults);
+  assert.ok(!ownerData.html.includes('HOSTILE NOISE presents'), 'OCR text stays out of the owner prompt');
+  assert.ok(!ownerData.html.includes('https://img.example/hostile-noise.jpg'),
+    'no SEGMENT_IMAGE_HINT_URL/SEGMENT_IMAGE_URL line for the excluded image');
+  assert.deepEqual(ownerData.ocrResults, []);
+
+  const targetData = parser.buildMultiEventSegmentHtmlData(htmlData, segments[1], 1, 2, ocrResults);
+  assert.ok(targetData.html.includes('HOSTILE NOISE presents'), 'OCR text reaches the new owner');
+  assert.ok(targetData.html.includes('https://img.example/hostile-noise.jpg'));
+});
+
+// ---------------------------------------------------------------------------
+// og:image fill for imageless single-event pages (2c): a page that produced
+// exactly one event adopts its own og:image; multi-event segments never do.
+// ---------------------------------------------------------------------------
+
+test('og:image fill: an imageless single JSON-LD event adopts the page og:image; multi-event pages never do', () => {
+  const parser = createParser();
+  const htmlData = {
+    url: 'https://venue.example/events/big-night',
+    html: `<html><head>
+      <meta property="og:image" content="https://venue.example/artwork/big-night.jpg" />
+    </head><body></body></html>`
+  };
+
+  const event = { title: 'BIG NIGHT', image: '' };
+  const logs = captureLogs(() => {
+    parser.fillImageFromPageMetaArtwork(event, htmlData);
+  });
+  assert.equal(event.image, 'https://venue.example/artwork/big-night.jpg');
+  assert.equal(event.imageSource, 'og-image');
+  assert.ok(logs.includes('🤖 AI Web: Filled image from page og:image for "BIG NIGHT"'),
+    `fill log expected, got: ${JSON.stringify(logs)}`);
+
+  // An event that already has an image is never overwritten
+  const withImage = { title: 'BIG NIGHT', image: 'https://venue.example/other.jpg' };
+  parser.fillImageFromPageMetaArtwork(withImage, htmlData);
+  assert.equal(withImage.image, 'https://venue.example/other.jpg');
+  assert.equal(withImage.imageSource, undefined);
+
+  // Uninteresting meta URLs (logo shapes) are skipped
+  const logoData = {
+    url: htmlData.url,
+    html: '<html><head><meta property="og:image" content="https://venue.example/assets/logo.png" /></head><body></body></html>'
+  };
+  const logoEvent = { title: 'BIG NIGHT', image: '' };
+  parser.fillImageFromPageMetaArtwork(logoEvent, logoData);
+  assert.equal(logoEvent.image, '', 'a logo og:image is never adopted');
+
+  // Multi-event segments never adopt the page-level meta image
+  const segmentEvent = parser.normalizeAiEvent(
+    { title: 'SEGMENT EVENT', startDate: '2026-08-01', startTime: '21:00' },
+    {},
+    { ...htmlData, dataFlags: { ocr: true, segment: true } },
+    null, null);
+  assert.equal(segmentEvent.image, '', 'segment events never inherit og:image');
+});
+
+// ---------------------------------------------------------------------------
+// Venue-site identity (KNOWN VENUE guard): establishment fails closed on any
+// missing fact; the replacement pass corrects flyer-subtitle bars only.
+// ---------------------------------------------------------------------------
+
+function createIdentityParser() {
+  const parser = new AiWebParser({ normalizeUrl });
+  parser.core = new SharedCore(
+    { seattle: { timezone: 'America/Los_Angeles', patterns: ['seattle'] } },
+    {
+      eventSchema: EventSchema,
+      bars: {
+        seattle: [
+          { name: 'Massive', city: 'seattle', address: '1620 Broadway, Seattle, WA 98122' },
+          { name: 'The Cuff Complex', city: 'seattle', address: '1533 13th Ave, Seattle, WA 98122' },
+          { name: 'Rockbar', city: 'seattle', address: '1 Rock Ave, Seattle, WA' }
+        ],
+        dallas: [
+          { name: 'Dallas Eagle', city: 'dallas', address: '525 S Riverfront Blvd, Dallas, TX' },
+          { name: 'Rockbar', city: 'dallas', address: '2 Rock St, Dallas, TX' }
+        ],
+        'fort-lauderdale': [
+          { name: 'Eagle', city: 'fort-lauderdale', address: '1951 NW 9th Ave, Fort Lauderdale, FL' }
+        ]
+      }
+    }
+  );
+  return parser;
+}
+
+test('venue-site identity: established for the massive-shaped host, fails closed on blocks, ambiguity, stems, and platforms', () => {
+  const parser = createIdentityParser();
+  const entry = {
+    consensusKey: parser.normalizeVenueSiteAddressKey('1620 Broadway, Seattle, WA 98122'),
+    consensusAddress: '1620 Broadway, Seattle, WA 98122',
+    blocked: false,
+    venueRoleSeen: true,
+    venueName: 'Massive'
+  };
+  const identity = parser.getEstablishedVenueSiteIdentity(entry, entry.consensusKey);
+  assert.ok(identity, 'all facts converge → identity established');
+  assert.equal(identity.name, 'Massive');
+  assert.equal(identity.city, 'seattle');
+  assert.equal(identity.hostLevel, true);
+
+  // Any organizer-resolved page on the host blocks
+  assert.equal(parser.getEstablishedVenueSiteIdentity({ ...entry, blocked: true }, entry.consensusKey), null);
+  // No page ever resolved venue role
+  assert.equal(parser.getEstablishedVenueSiteIdentity({ ...entry, venueRoleSeen: false }, entry.consensusKey), null);
+  // A consensus address CONTRADICTING the curated address establishes nothing
+  assert.equal(parser.getEstablishedVenueSiteIdentity(
+    { ...entry, consensusAddress: '525 S Riverfront Blvd, Dallas, TX' }, entry.consensusKey), null);
+  // Ambiguous curated name (curated in two cities) never establishes
+  assert.equal(parser.getEstablishedVenueSiteIdentity({ ...entry, venueName: 'Rockbar' }, entry.consensusKey), null);
+  // Generic franchise stem ("Eagle" ⊂ "Dallas Eagle") never establishes
+  assert.equal(parser.getEstablishedVenueSiteIdentity({ ...entry, venueName: 'Eagle' }, entry.consensusKey), null);
+  // Ticketing-platform brand matches no curated bar — the structural guard
+  assert.equal(parser.getEstablishedVenueSiteIdentity({ ...entry, venueName: 'Eventbrite' }, entry.consensusKey), null);
+  // No consensus at all → identity applies per-event only (POI promotion)
+  const eventLevel = parser.getEstablishedVenueSiteIdentity(
+    { ...entry, consensusKey: '', consensusAddress: '' }, '');
+  assert.ok(eventLevel);
+  assert.equal(eventLevel.hostLevel, false);
+});
+
+test('venue-site identity: the replacement matrix — replace, fill, and every skip shape', () => {
+  const parser = createIdentityParser();
+  parser.lastVenueSiteConsensus = {
+    'massive.club': {
+      consensusKey: parser.normalizeVenueSiteAddressKey('1620 Broadway, Seattle, WA 98122'),
+      consensusAddress: '1620 Broadway, Seattle, WA 98122',
+      blocked: false,
+      venueRoleSeen: true,
+      venueName: 'Massive'
+    }
+  };
+  const events = [
+    // PERVERT/Villa Señor shape: uncorroborated flyer subtitle → replaced
+    {
+      title: 'PERVERT', bar: 'Villa Señor', barSource: 'uncorroborated', city: '',
+      _venueSitePageHost: 'massive.club',
+      _barRescue: { candidate: 'Villa Señor', signals: ['page', 'ocr'] }
+    },
+    // Empty bar → filled
+    { title: 'PACK', bar: '', city: 'seattle', _venueSitePageHost: 'massive.club' },
+    // Off-site street address → untouched (multi-venue announcement)
+    {
+      title: 'OFFSITE', bar: 'Somewhere Else', barSource: 'uncorroborated',
+      address: '4216 University Way NE, Seattle, WA', _venueSitePageHost: 'massive.club'
+    },
+    // A DIFFERENT curated bar of the city → untouched (flag-only log)
+    { title: 'CUFF TAKEOVER', bar: 'The Cuff Complex', _venueSitePageHost: 'massive.club' },
+    // Structured-data bar → untouched
+    { title: 'JSONLD NIGHT', bar: 'Some Hall', _barFromJsonLd: true, _venueSitePageHost: 'massive.club' },
+    // Venue's own name in another casing → casing normalized only
+    { title: 'HOUSE NIGHT', bar: 'MASSIVE', barSource: 'venue-site', _venueSitePageHost: 'massive.club' },
+    // Different host → untouched
+    { title: 'ELSEWHERE', bar: 'Shore Thing', _venueSitePageHost: 'other.example' }
+  ];
+
+  const logs = captureLogs(() => parser.applyVenueSiteIdentityCorrections(events, null));
+
+  assert.equal(events[0].bar, 'Massive');
+  assert.equal(events[0].barSource, 'venue-site-identity');
+  assert.deepEqual(events[0]._venueIdentityCorrection, {
+    original: 'Villa Señor',
+    originalSource: 'uncorroborated',
+    signals: ['venue-role', 'curated-name', 'address-consensus']
+  });
+  assert.equal('_barRescue' in events[0], false, 'a rescue of the replaced value is stale evidence');
+  assert.equal(events[0].city, 'seattle', 'blank city backfilled from the identity');
+  assert.equal(events[1].bar, 'Massive');
+  assert.equal(events[1].barSource, 'venue-site-identity');
+  assert.equal(events[2].bar, 'Somewhere Else', 'off-site address keeps its own bar');
+  assert.equal(events[3].bar, 'The Cuff Complex');
+  assert.equal(events[3].barSource, undefined, 'other curated bar untouched');
+  assert.equal(events[4].bar, 'Some Hall', 'structured-data bar untouched');
+  assert.equal(events[5].bar, 'Massive', 'casing normalized to the curated name');
+  assert.equal(events[5].barSource, 'venue-site', 'barSource untouched on a casing normalization');
+  assert.equal(events[6].bar, 'Shore Thing', 'other hosts untouched');
+
+  assert.ok(logs.some(line => line.includes(
+    '🤖 AI Web: Venue-site identity for massive.club established: "Massive" (seattle) — signals: venue-role, curated-name, address-consensus')),
+    `identity log expected, got: ${JSON.stringify(logs)}`);
+  assert.ok(logs.some(line => line.includes(
+    '🤖 AI Web: Replaced bar "Villa Señor" with venue-site identity "Massive" for "PERVERT" (was uncorroborated)')));
+  assert.ok(logs.some(line => line.includes(
+    '🤖 AI Web: Filled bar "Massive" from venue-site identity for "PACK"')));
+  assert.ok(logs.some(line => line.includes(
+    '🤖 AI Web: Kept bar "The Cuff Complex" for "CUFF TAKEOVER" — matches another curated seattle bar; venue-site identity not applied')));
+  assert.equal(parser.lastVenueSiteConsensus, null, 'the stash is consumed and cleared');
+});
+
+test('venue-site identity: POI promotion applies per-event when the host has no address consensus', () => {
+  const parser = createIdentityParser();
+  parser.lastVenueSiteConsensus = {
+    'massive.club': {
+      consensusKey: '', consensusAddress: '',
+      blocked: false, venueRoleSeen: true, venueName: 'Massive'
+    }
+  };
+  const events = [
+    {
+      title: 'SHORE THING', bar: 'Shore Thing', barSource: 'uncorroborated',
+      _geoPoiName: 'Massive', _venueSitePageHost: 'massive.club'
+    },
+    { title: 'NO POI', bar: 'Shore Thing', barSource: 'uncorroborated', _venueSitePageHost: 'massive.club' }
+  ];
+  parser.applyVenueSiteIdentityCorrections(events, null);
+  assert.equal(events[0].bar, 'Massive');
+  assert.equal(events[0].barSource, 'venue-site-identity');
+  assert.deepEqual(events[0]._venueIdentityCorrection.signals, ['venue-role', 'curated-name', 'geo-poi']);
+  assert.equal(events[1].bar, 'Shore Thing', 'without a matching map POI the identity never applies');
+});
+
+test('venue-site identity: harvest records venue-role facts and the consensus pass stashes them per host', () => {
+  const parser = createIdentityParser();
+  const venueData = { url: 'https://massive.club/events', html: VENUE_SITE_HTML };
+  parser.resolvePageSiteRole(venueData, {});
+  parser.harvestVenueSiteAddresses(venueData);
+  parser.tagEventsWithVenueSitePage([{ title: 'X' }], venueData);
+  const entry = parser.venueSiteHarvest['massive.club'];
+  assert.equal(entry.venueRoleSeen, true);
+  assert.equal(entry.venueName, 'MASSIVE');
+
+  parser.applyVenueSiteAddressConsensus([], null);
+  const stashed = parser.lastVenueSiteConsensus['massive.club'];
+  assert.equal(stashed.venueRoleSeen, true);
+  assert.equal(stashed.venueName, 'MASSIVE');
+  assert.equal(stashed.blocked, false);
+  assert.equal(stashed.consensusKey, '', 'no map-directions addresses → no consensus');
+  assert.equal(parser.venueSiteHarvest, null, 'harvest still resets per run');
+});
+
+test('KNOWN VENUE curated-match prompt line appears only with a unique curated match; the base line stays byte-identical', () => {
+  const curatedMatchLine = 'KNOWN VENUE (curated match): "MASSIVE" is the venue for every event on this site. Other bar or brand names printed on a flyer are guest hosts or co-presenters, NOT the venue — never return them as "bar" unless the page states the event happens at a different street address.';
+
+  const parser = createIdentityParser();
+  const venueData = { url: 'https://massive.club/events', html: VENUE_SITE_HTML };
+  parser.resolvePageSiteRole(venueData, {});
+  const prompt = parser.buildExtractionPrompt(venueData, {}, null, {}, ['title', 'bar'], 'SNIPPET', 'default', {});
+  assert.match(prompt,
+    /KNOWN VENUE \(this is the venue's own site\): "MASSIVE" — events on this page take place AT this venue unless the page states another location; DJ names, taglines, and edition subtitles are NOT the venue\./,
+    'the existing line is unchanged');
+  assert.ok(prompt.includes(curatedMatchLine), 'curated match → the strengthening line is appended');
+
+  // No curated bars data → no curated-match line, base line still present
+  const bareParser = createParser();
+  const bareData = { url: 'https://massive.club/events', html: VENUE_SITE_HTML };
+  bareParser.resolvePageSiteRole(bareData, {});
+  const barePrompt = bareParser.buildExtractionPrompt(bareData, {}, null, {}, ['title', 'bar'], 'SNIPPET', 'default', {});
+  assert.match(barePrompt, /KNOWN VENUE \(this is the venue's own site\): "MASSIVE"/);
+  assert.ok(!barePrompt.includes('KNOWN VENUE (curated match):'), 'no unique curated match → no extra line');
 });

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1301,6 +1301,47 @@ class SharedCore {
                     return { winner: 'a', reason: 'same-host deeper URL beats domain root' };
                 }
             }
+            // Cross-host website/url rungs. Rung 1: a bare homepage never
+            // beats an event-specific page even ACROSS hosts — the deeper URL
+            // is the one that describes THIS event. Rung 2: both pathed —
+            // prefer the candidate that is a page this run actually crawled:
+            // its host matches its own record's _sourcePageUrl (stamped at
+            // fetch time) AND that record's own website/url field IS the
+            // candidate value (strict attribution, like the image/bar
+            // provenance rungs). Both bare roots, both/neither crawled, or no
+            // records context → fall through to AI arbitration (fail open).
+            if ((fieldName === 'website' || fieldName === 'url') && urlA.host !== urlB.host) {
+                const bareRootA = urlA.segments.length === 0 && !urlA.hasQuery;
+                const bareRootB = urlB.segments.length === 0 && !urlB.hasQuery;
+                if (bareRootA && !bareRootB && urlB.segments.length > 0) {
+                    return { winner: 'b', reason: 'event-specific URL beats bare homepage' };
+                }
+                if (bareRootB && !bareRootA && urlA.segments.length > 0) {
+                    return { winner: 'a', reason: 'event-specific URL beats bare homepage' };
+                }
+                if (urlA.segments.length > 0 && urlB.segments.length > 0) {
+                    const urlContextRecords = context && context.records && typeof context.records === 'object'
+                        ? context.records : null;
+                    if (urlContextRecords) {
+                        const isOwnCrawledPage = (record, parts, value) => {
+                            if (!record || typeof record !== 'object') return false;
+                            const candidate = typeof value === 'string' ? value.trim() : '';
+                            if (!candidate) return false;
+                            const ownWebsite = typeof record.website === 'string' ? record.website.trim() : '';
+                            const ownUrl = typeof record.url === 'string' ? record.url.trim() : '';
+                            if (ownWebsite !== candidate && ownUrl !== candidate) return false;
+                            const sourceHost = this.getHostFromUrl(record._sourcePageUrl)
+                                .toLowerCase().replace(/^www\./, '');
+                            return Boolean(sourceHost) && parts.host === sourceHost;
+                        };
+                        const crawledA = isOwnCrawledPage(urlContextRecords.a, urlA, valueA);
+                        const crawledB = isOwnCrawledPage(urlContextRecords.b, urlB, valueB);
+                        if (crawledA !== crawledB) {
+                            return { winner: crawledA ? 'a' : 'b', reason: 'URL is a page this run actually crawled' };
+                        }
+                    }
+                }
+            }
             // Cross-host ticketUrl: a candidate on a known ticketing platform
             // (TICKETING_PLATFORM_HOSTS — a preference heuristic, not a gate)
             // beats a BARE domain root on a non-ticketing host: the root of an
@@ -1445,6 +1486,41 @@ class SharedCore {
                     };
                 }
             }
+            // Title doctrine rung: the venue's name belongs in the bar field,
+            // not the title (run 20260725-170926: "…Singlet Night at the
+            // Dallas Eagle" vs "Singlet Night with DJ Drew G" — the venue-free
+            // title is the event's name). When exactly one side's compact
+            // title contains a FULL venue-name key (normalizeBarNameKey of a
+            // context bar name, ≥ 4 chars — full-key containment only, never a
+            // stem, so "Eagle Karaoke" does not contain "dallaseagle") and the
+            // venue-free side still has at least one significant token, the
+            // venue-free side wins. Calendar merges are exempt — calendar
+            // titles are curated-by-usage and may deliberately carry the
+            // venue. Both/neither containing → fall through (AI arbitrates).
+            const titleSideLabels = context && context.sideLabels && typeof context.sideLabels === 'object'
+                ? context.sideLabels : null;
+            const titleVenueKeys = (context && Array.isArray(context.barNames) ? context.barNames : [])
+                .map(name => this.normalizeBarNameKey(name))
+                .filter(key => key.length >= 4);
+            if ((!titleSideLabels || titleSideLabels.a !== 'calendar') && titleVenueKeys.length > 0) {
+                const compactTitle = value => this.stripEmojiForTitleTwin(String(value || ''))
+                    .toLowerCase().replace(/[^a-z0-9]/g, '');
+                const containsVenueKey = value => {
+                    const compact = compactTitle(value);
+                    return Boolean(compact) && titleVenueKeys.some(key => compact.includes(key));
+                };
+                const venueInA = containsVenueKey(valueA);
+                const venueInB = containsVenueKey(valueB);
+                if (venueInA !== venueInB) {
+                    const venueFreeValue = venueInA ? valueB : valueA;
+                    if (this.getCrossSourceTitleTokens(venueFreeValue, titleVenueKeys).length > 0) {
+                        return {
+                            winner: venueInA ? 'b' : 'a',
+                            reason: 'title doctrine: venue name belongs in bar, not title'
+                        };
+                    }
+                }
+            }
         }
         // A street address is never a venue name: Eventbrite JSON-LD shipped
         // location.name as the street line ("10-90 Wyckoff Ave") and AI
@@ -1518,7 +1594,7 @@ class SharedCore {
                 };
                 const isCorroboratedStamp = stamp =>
                     stamp === 'page-adjacent' || stamp === 'venue-site' || stamp === 'curated'
-                    || stamp === 'geo-poi';
+                    || stamp === 'geo-poi' || stamp === 'venue-site-identity';
                 const matchesCuratedBar = value =>
                     Boolean(cityBars && this.findCuratedBarByName(cityBars, value));
                 const provenanceA = getBarProvenance(barContextRecords.a, valueA);
@@ -2215,6 +2291,15 @@ class SharedCore {
         if (aiWebParser && typeof aiWebParser.applyVenueSiteAddressConsensus === 'function') {
             aiWebParser.applyVenueSiteAddressConsensus(allEvents, mainConfig?.cities || null);
         }
+        // Venue-site identity corrections (deterministic, curated-anchored):
+        // when a crawled site's identity is established — venue role seen,
+        // unique curated-bar name match, address agreement — flyer-subtitle
+        // bars on that site's events are corrected to the curated venue name
+        // ('venue-site-identity' provenance). Consensus first, identity
+        // second: the pass consumes the consensus stash the call above left.
+        if (aiWebParser && typeof aiWebParser.applyVenueSiteIdentityCorrections === 'function') {
+            aiWebParser.applyVenueSiteIdentityCorrections(allEvents, mainConfig?.cities || null);
+        }
 
         // Metadata is applied dynamically by parsers using the {value, merge} format
 
@@ -2650,7 +2735,7 @@ class SharedCore {
         // Bar corroboration verdict from barSource provenance.
         const barSource = typeof event.barSource === 'string' ? event.barSource.trim() : '';
         if (bar && barSource) {
-            if (['page-adjacent', 'venue-site', 'geo-poi', 'curated'].includes(barSource)) {
+            if (['page-adjacent', 'venue-site', 'geo-poi', 'curated', 'venue-site-identity'].includes(barSource)) {
                 lines.push(`bar corroborated: ${barSource}`);
             } else if (barSource === 'uncorroborated') {
                 lines.push('⚠️ bar uncorroborated (not found near address in source)');
@@ -2686,6 +2771,23 @@ class SharedCore {
                 : [];
             const suffix = rescueSignals.length > 0 ? ` (${rescueSignals.join(', ')})` : '';
             lines.push(`bar rescued by signal convergence${suffix}`);
+        }
+
+        // Venue-site identity correction (_venueIdentityCorrection —
+        // underscore field, never serialized; stamped by ai-web-parser's
+        // applyVenueSiteIdentityCorrections when an established site identity
+        // replaced an extracted flyer-subtitle bar) — rendered so every
+        // correction stays visible in the results UI.
+        const identityCorrection = event._venueIdentityCorrection && typeof event._venueIdentityCorrection === 'object'
+            ? event._venueIdentityCorrection : null;
+        if (bar && identityCorrection) {
+            const correctedOriginal = typeof identityCorrection.original === 'string'
+                ? identityCorrection.original.trim() : '';
+            const correctedSource = typeof identityCorrection.originalSource === 'string' && identityCorrection.originalSource.trim()
+                ? identityCorrection.originalSource.trim() : 'unstamped';
+            if (correctedOriginal) {
+                lines.push(`bar corrected to venue-site identity — extracted "${correctedOriginal}" (${correctedSource})`);
+            }
         }
 
         // Compact provenance summary of whichever companion stamps exist.
@@ -8763,7 +8865,7 @@ SharedCore.PROVENANCE_COMPANION_FIELDS = Object.freeze([
 SharedCore.PROVENANCE_TRUST_TIERS = Object.freeze({
     pinSource: Object.freeze({ 'curated': 4, 'geocoded-exact': 3, 'geocoded-approx': 2, 'page': 1 }),
     addressSource: Object.freeze({ 'curated': 3, 'geo-poi': 2, 'page': 2, 'venue-site': 2, 'inferred': 1 }),
-    barSource: Object.freeze({ 'curated': 3, 'venue-site': 2, 'page-adjacent': 2, 'geo-poi': 2, 'uncorroborated': 1 }),
+    barSource: Object.freeze({ 'curated': 3, 'venue-site': 2, 'venue-site-identity': 2, 'page-adjacent': 2, 'geo-poi': 2, 'uncorroborated': 1 }),
     imageSource: Object.freeze({ 'og-image': 2, 'jsonld': 2, 'page': 1 }),
     bearSource: Object.freeze({ 'manual-bear': 2, 'manual-not-bear': 2, 'keyword': 1, 'ai': 1, 'config': 1 })
 });

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -931,20 +931,18 @@ test('guardrail: deterministic field is excluded from the AI batch; genuine conf
   assert.deepEqual(finalEvent._original.aiArbitration.arbitrated.sort(), ['bar', 'startDate', 'title']);
 });
 
-test('guardrail: cross-host root-vs-deep URLs still go to the AI', async () => {
+test('guardrail: cross-host root-vs-deep website resolves deterministically — event page beats bare homepage', async () => {
   const core = createCore();
   const { scraped, existing } = buildAlignedArbitrationPair();
   scraped.website = 'https://ticketmaster.com/';
   existing.notes += '\nwebsite: https://bearracuda.com/events/portland-pridefriday/';
-  const adapter = buildArbitrationAdapter({
-    website: { pick: 'calendar', value: 'https://bearracuda.com/events/portland-pridefriday/' }
-  });
+  const adapter = buildArbitrationAdapter({});
 
   const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
 
-  assert.equal(adapter.calls.length, 1, 'different hosts are a genuine question for the AI');
-  assert.match(adapter.calls[0].prompt, /field: website/);
+  assert.equal(adapter.calls.length, 0, 'a bare homepage never beats an event page, even cross-host');
   assert.equal(finalEvent.website, 'https://bearracuda.com/events/portland-pridefriday/');
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['website']);
 });
 
 test('guardrail: same-host deep-vs-deep and root-vs-root URLs still go to the AI', () => {
@@ -1214,6 +1212,42 @@ test('guardrail: a named title beats a bare city title in both directions; ties 
     'two bare-city variants still arbitrate');
   // No city context → the rule never fires
   assert.equal(core.resolveConflictDeterministically('title', 'FURBALL', 'New Orleans'), null);
+});
+
+test('guardrail: title doctrine — the venue-bearing title loses to the venue-free named title (Singlet pair, run 20260725-170926)', () => {
+  const core = createCore();
+  const venueTitle = "Thighs out for the guys yall, it's Singlet Night at the Dallas Eagle";
+  const freeTitle = 'Singlet Night with DJ Drew G';
+  const context = { barNames: ['Dallas Eagle', 'Dallas Eagle'], sideLabels: { a: 'existing', b: 'incoming' } };
+  assert.deepEqual(
+    core.resolveConflictDeterministically('title', venueTitle, freeTitle, context),
+    { winner: 'b', reason: 'title doctrine: venue name belongs in bar, not title' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('title', freeTitle, venueTitle, context),
+    { winner: 'a', reason: 'title doctrine: venue name belongs in bar, not title' });
+  // Calendar merges are exempt: calendar titles are curated-by-usage
+  assert.equal(
+    core.resolveConflictDeterministically('title', venueTitle, freeTitle,
+      { barNames: ['Dallas Eagle', 'Dallas Eagle'], sideLabels: { a: 'calendar', b: 'scraped' } }),
+    null, 'calendar flow falls through to AI');
+  // Full-key containment only: "Eagle Karaoke" does NOT contain "dallaseagle"
+  assert.equal(
+    core.resolveConflictDeterministically('title', 'Eagle Karaoke', 'Karaoke with Dee Ranged', context),
+    null, 'a venue stem is never venue containment');
+  // Both titles carrying the venue → a genuine question
+  assert.equal(
+    core.resolveConflictDeterministically('title',
+      'Singlet Night at the Dallas Eagle', 'Dallas Eagle Singlet Night', context),
+    null, 'both venue-bearing → arbitrate');
+  // The venue-free side must still have a significant token of its own
+  assert.equal(
+    core.resolveConflictDeterministically('title', 'Karaoke at the Dallas Eagle', 'Eagle', context),
+    null, 'a venue-token-only title cannot win the rung');
+  // Short keys never fire: normalizeBarNameKey("TMC") is under 4 chars
+  assert.equal(
+    core.resolveConflictDeterministically('title', 'Bear Night at TMC', 'Bear Night with DJ Boost',
+      { barNames: ['TMC'], sideLabels: { a: 'existing', b: 'incoming' } }),
+    null, 'venue keys shorter than 4 chars are ignored');
 });
 
 test('guardrail: calendar bare-city title loses to the scraped named title without AI', async () => {
@@ -1581,11 +1615,70 @@ test('guardrail: conservative ticketUrl fall-throughs still go to the AI', () =>
     core.resolveConflictDeterministically('ticketUrl',
       'https://www.eventbrite.com/e/tickets-1234', 'https://dice.fm/event/abcdef'),
     null, 'both-ticketing still arbitrates');
-  // The rung is ticketUrl-only: website keeps today's cross-host AI behavior
-  assert.equal(
+  // The ticketing rung is ticketUrl-only: for website the same pair resolves
+  // through the cross-host root-vs-deep rung instead, not the ticketing one
+  assert.deepEqual(
     core.resolveConflictDeterministically('website',
       'https://www.eventbrite.com/e/tickets-1234', 'https://megawoof.com/'),
-    null, 'website is not a ticket field');
+    { winner: 'a', reason: 'event-specific URL beats bare homepage' },
+    'website is not a ticket field');
+});
+
+// ---------------------------------------------------------------------------
+// Deterministic cross-host website/url rungs: an event-specific page beats a
+// bare homepage across hosts; when both are pathed, the candidate whose host
+// this run actually crawled (its own record's _sourcePageUrl) wins. Both
+// bare roots, or unattributable pathed pairs, still arbitrate.
+// ---------------------------------------------------------------------------
+
+test('guardrail: cross-host website rungs — event page beats bare homepage, crawled host settles pathed pairs, roots arbitrate', () => {
+  const core = createCore();
+  // Rung 1: bare homepage vs event page, both directions, both aliases
+  assert.deepEqual(
+    core.resolveConflictDeterministically('website',
+      'https://thedallaseagle.com/', 'https://www.eventbrite.com/e/singlet-night-tickets-1234'),
+    { winner: 'b', reason: 'event-specific URL beats bare homepage' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('url',
+      'https://www.eventbrite.com/e/singlet-night-tickets-1234', 'https://thedallaseagle.com/'),
+    { winner: 'a', reason: 'event-specific URL beats bare homepage' });
+  // Rung 2: both pathed — the candidate that IS its own record's crawled page wins
+  const crawledContext = {
+    records: {
+      a: {
+        website: 'https://thedallaseagle.com/events/singlet-night/',
+        _sourcePageUrl: 'https://www.thedallaseagle.com/events'
+      },
+      b: { website: 'https://linktr.ee/dallaseagle/latest' }
+    }
+  };
+  assert.deepEqual(
+    core.resolveConflictDeterministically('website',
+      'https://thedallaseagle.com/events/singlet-night/', 'https://linktr.ee/dallaseagle/latest', crawledContext),
+    { winner: 'a', reason: 'URL is a page this run actually crawled' });
+  // Attribution is strict: the record's own website/url must BE the candidate
+  const unattributedContext = {
+    records: {
+      a: {
+        website: 'https://thedallaseagle.com/some-other-page/',
+        _sourcePageUrl: 'https://www.thedallaseagle.com/events'
+      },
+      b: { website: 'https://linktr.ee/dallaseagle/latest' }
+    }
+  };
+  assert.equal(
+    core.resolveConflictDeterministically('website',
+      'https://thedallaseagle.com/events/singlet-night/', 'https://linktr.ee/dallaseagle/latest', unattributedContext),
+    null, 'an unattributed candidate cannot claim its record\'s crawl');
+  // Both bare roots on different hosts → a genuine question
+  assert.equal(
+    core.resolveConflictDeterministically('website', 'https://thedallaseagle.com/', 'https://megawoof.com/'),
+    null, 'two bare homepages still arbitrate');
+  // Both pathed with no records context → arbitrate as today
+  assert.equal(
+    core.resolveConflictDeterministically('website',
+      'https://thedallaseagle.com/events/singlet-night/', 'https://linktr.ee/dallaseagle/latest'),
+    null, 'both pathed without crawl attribution → arbitrate');
 });
 
 // ---------------------------------------------------------------------------
@@ -8095,4 +8188,47 @@ test('cross-source dedup: the literal Dallas Eagle clusters collapse through the
   assert.equal(karaoke.startDate.toISOString(), '2026-07-31T00:00:00.000Z', 'timezone-anchored start wins over wall-clock');
   const pet = result.find(event => /pet night/i.test(event.title));
   assert.equal(pet.image, 'https://img.example/pet.jpg', 'secondary image enriches the Pet Night primary');
+});
+
+// ---------------------------------------------------------------------------
+// venue-site-identity barSource plumbing: the stamp is corroborated in the
+// merge demotion rung, and a correction renders its evidence line.
+// ---------------------------------------------------------------------------
+
+test('venue-site-identity: corroborated in the bar demotion rung and rendered in evidence lines', () => {
+  const core = createCore();
+  // Demotion rung: an identity-stamped bar beats an uncorroborated one
+  const context = {
+    records: {
+      a: { bar: 'Massive', barSource: 'venue-site-identity' },
+      b: { bar: 'Shore Thing', barSource: 'uncorroborated' }
+    }
+  };
+  assert.deepEqual(
+    core.resolveConflictDeterministically('bar', 'Massive', 'Shore Thing', context),
+    { winner: 'a', reason: 'corroborated bar beats uncorroborated' });
+
+  // Evidence panel: corroboration verdict + the correction line
+  const lines = core.buildEventEvidenceLines({
+    title: 'PERVERT',
+    bar: 'Massive',
+    barSource: 'venue-site-identity',
+    _venueIdentityCorrection: {
+      original: 'Villa Señor',
+      originalSource: 'uncorroborated',
+      signals: ['venue-role', 'curated-name', 'address-consensus']
+    }
+  }, { cityKey: 'seattle' });
+  assert.ok(lines.includes('bar corroborated: venue-site-identity'), `got: ${JSON.stringify(lines)}`);
+  assert.ok(lines.includes('bar corrected to venue-site identity — extracted "Villa Señor" (uncorroborated)'),
+    `got: ${JSON.stringify(lines)}`);
+  assert.ok(lines.includes('provenance: bar=venue-site-identity'));
+
+  // A missing original source renders as unstamped, never as an empty label
+  const unstampedLines = core.buildEventEvidenceLines({
+    title: 'PACK',
+    bar: 'Massive',
+    _venueIdentityCorrection: { original: 'Shore Thing', originalSource: '', signals: [] }
+  }, { cityKey: 'seattle' });
+  assert.ok(unstampedLines.includes('bar corrected to venue-site identity — extracted "Shore Thing" (unstamped)'));
 });


### PR DESCRIPTION
## The three diseases (from the 7/25–7/27 runs)

1. **Wrong bars**: PERVERT shipped `bar="Villa Señor"` (a co-presenter brand printed on the flyer) in every run including the latest; "PACK" and "Shore Thing" were the same failure, only healed when JSON-LD or a cross-source merge happened to exist. The geocode POI-mismatch flag ("address POI is Massive but bar is Shore Thing") detected it — but was log-only.
2. **Wrong images**: the Bearracuda flyer attached to a phantom "Tuesday Closed" listing in one run and the right event in the next; "Hostile Noise" carried the Treasure Trail flyer's description text. Separately, Dallas Eagle (eventbrite) events have **never had an image** — no code path ever adopted og:image as a value.
3. **Merge coin-flips**: same run chose `bearracuda.com` over `massive.club` for one merged event's website and the reverse for another; a title arbitration picked one title while its own reasoning praised the other.

## Fix 1 — KNOWN VENUE guard (deterministic, fail-closed)

A prompt-only KNOWN VENUE line already existed and Villa Señor still shipped — steering isn't enough. A host now establishes **venue-site identity** only when ALL hold:
- a page resolved `siteRole=venue` and **no** page resolved organizer;
- the page's venue name **uniquely** matches a curated bar (ambiguous / generic-stem / platform brands fail closed — eventbrite org pages structurally cannot qualify: their host brand is "Eventbrite", which matches no curated bar);
- the harvested address consensus matches the curated bar's address (host-level), or the specific event's geocode POI name equals the identity (per-event — **promotes the long log-only POI-mismatch flag**).

With identity established: uncorroborated/flyer-brand bars are **replaced** (or blanks filled) with the curated venue name — `barSource='venue-site-identity'`, original preserved in `_venueIdentityCorrection` and rendered in the results-UI evidence lines (flag-don't-drop). Never touched: JSON-LD-asserted bars, bars matching a *different* curated bar, events whose address disagrees with the consensus (off-site parties). City fills unlock timezone re-anchoring, which also clears the Dallas tz-unresolved warnings. One additive `KNOWN VENUE (curated match): …` prompt line reinforces extraction on qualifying sites.

On the run evidence: massive.club qualifies (venue role + curated "Massive" + footer consensus = curated address + POI agreement); bearracuda.com and eventbrite org pages cannot.

## Fix 2 — image/OCR consistency gate

- Venue-hours phantom listings ("Tuesday Closed") are **ineligible for image pairing** in both matchers — the Bearracuda flyer can no longer land on them.
- Post-pairing gate: a flyer whose OCR text has **zero** token overlap with its owner's title but clearly names **exactly one** sibling segment gets reassigned there (ties detach; any owner overlap → untouched, so correct pairings can't thrash). The moved flyer's OCR text and hint lines are excluded from the loser's extraction prompt — this kills the Hostile Noise description bleed.
- Single-event pages with no image adopt the page's own og:image/twitter:image (`imageSource='og-image'`, uninteresting-URL filter applied) — eventbrite `/e/` pages finally produce images, which merge onto the Dallas events.

## Fix 3 — deterministic merge authority rungs

In `resolveConflictDeterministically`: cross-host **website/url** — an event-specific URL beats a bare homepage; between two pathed URLs, the one matching its own record's crawled source page wins. **Title** — between duplicate sources, the venue-free named title beats the venue-bearing one (title doctrine: venue belongs in `bar`; calendar-side titles exempt). Genuine ties still go to AI arbitration.

## Notes
- All log/prompt changes additive; three pre-existing tests that pinned the old coin-flip/no-image behavior were updated to pin the new deterministic outcomes.
- The new prompt line changes AI-response-cache keys on qualifying venue sites → one-time cache misses there (expected).
- Tests **801 → 818**, fixtures are the literal run cases: Villa Señor, PACK, Shore Thing/POI, Tuesday Closed, Hostile Noise, the Singlet pair, eventbrite og:image.

## After merge
Download `scripts/shared-core.js` + `scripts/parsers/ai-web-parser.js`, rerun **massive.club** and **Dallas Eagle**. Expect: PERVERT → bar "Massive" with a "Replaced bar" log line and an evidence note; no flyer on phantom listings; Dallas events with images and resolved timezones; consistent website/title picks on merged duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP