### PR TITLE
feat(scraper): active-config visibility + overlong-field trim pipeline (report mode)

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -4814,6 +4814,13 @@ class ScriptableAdapter {
       // webview→native pattern, see presentReviewResults). Currently used by
       // the discovered-venue "Copy parser entry" buttons (chunkyscrape://).
       const venueEntrySnippets = this.collectVenueEntrySnippets(results);
+      // Effective (redacted) config JSON for the Active-config copy button;
+      // "" when this run/saved run carries no config snapshot.
+      const activeConfigSummary = this.buildActiveConfigSummaryForResults(results);
+      const activeConfigJson =
+        activeConfigSummary && typeof activeConfigSummary.json === "string"
+          ? activeConfigSummary.json
+          : "";
       // Manual bear/not-bear override taps recorded during the WebView session,
       // applied after dismissal. Keyed by row id so repeat taps stay idempotent.
       const bearOverridePending = { markedBear: {}, markedNotBear: {} };
@@ -4833,6 +4840,11 @@ class ScriptableAdapter {
           if (typeof snippet === "string" && snippet.length > 0) {
             // Fire-and-forget: the handler must return a bool synchronously
             this.copyVenueEntryAndReport(snippet, params.id, webView);
+          }
+        } else if (params.a === "copy-config") {
+          if (activeConfigJson.length > 0) {
+            // Fire-and-forget: the handler must return a bool synchronously
+            this.copyActiveConfigAndReport(activeConfigJson, webView);
           }
         } else if (params.a === "mark-bear" || params.a === "mark-not-bear") {
           // Fire-and-forget: records the override natively; the page gets
@@ -6366,6 +6378,8 @@ class ScriptableAdapter {
 
     ${this.generateDiscoverySection(results)}
 
+    ${this.generateActiveConfigSection(results)}
+
     ${insightSectionsHtml}
 
     ${logSectionHtml}
@@ -6388,6 +6402,22 @@ class ScriptableAdapter {
                 if (btn) {
                     btn.textContent = '✅ Copied!';
                     setTimeout(function () { btn.textContent = '📋 Copy parser entry'; }, 2000);
+                }
+            } catch (ignore) {}
+        }
+
+        // Active-config copy button rides the same chunkyscrape:// navigation
+        // bridge (shouldAllowRequest, set before present()) and reuses the
+        // venue-copy nonce counter; the JSON payload stays native-side.
+        function copyActiveConfig(btn) {
+            window.location.href = 'chunkyscrape://act?a=copy-config&n=' + (++window.__venueCopyNonce);
+        }
+        function markConfigCopied() {
+            try {
+                var btn = document.querySelector('.config-copy-btn');
+                if (btn) {
+                    btn.textContent = 'Copied ✓';
+                    setTimeout(function () { btn.textContent = '📋 Copy effective config JSON'; }, 2000);
                 }
             } catch (ignore) {}
         }
@@ -7549,6 +7579,134 @@ class ScriptableAdapter {
     const feedbackJs = `markVenueEntryCopied(${JSON.stringify(String(venueIndex))})`;
     try {
       await webView.evaluateJavaScript(feedbackJs, false);
+    } catch (error) {
+      /* button feedback is optional polish; the copy already happened */
+    }
+  }
+
+  // Redacted active-config summary for the results UI, or null when this
+  // run carries no config snapshot (old saved runs may lack results.config)
+  // or the pure builder is unavailable. Null-guards every path so saved-run
+  // display never breaks.
+  buildActiveConfigSummaryForResults(results) {
+    if (!results || !results.config || typeof results.config !== "object") {
+      return null;
+    }
+    const core = this.getIdentityCore();
+    if (!core || typeof core.buildActiveConfigSummary !== "function") {
+      return null;
+    }
+    try {
+      return core.buildActiveConfigSummary(results.config);
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Could not build active-config summary: ${error.message}`,
+      );
+      return null;
+    }
+  }
+
+  // Active config section: the effective run settings this run executed with
+  // (values-only, secret-redacted) plus each parser's explicit overrides
+  // diffed against the global effective values. The copy button signals
+  // native via the chunkyscrape:// scheme handled in presentRichResults
+  // (shouldAllowRequest → Pasteboard.copy) — WKWebView has no reliable
+  // navigator.clipboard.
+  generateActiveConfigSection(results) {
+    const summary = this.buildActiveConfigSummaryForResults(results);
+    if (!summary) return "";
+    const core = this.getIdentityCore();
+    if (!core || typeof core.flattenConfigForDiff !== "function") return "";
+
+    const globalFlat = core.flattenConfigForDiff(
+      summary.global && typeof summary.global === "object" ? summary.global : {},
+    );
+    const globalRows = Object.entries(globalFlat)
+      .map(
+        ([key, value]) =>
+          `<tr><td style="padding:2px 10px 2px 0; font-family:monospace; font-size:11px; color:var(--text-secondary); vertical-align:top; white-space:nowrap;">${this.escapeHtml(key)}</td><td style="padding:2px 0; font-family:monospace; font-size:11px; word-break:break-all;">${this.escapeHtml(String(value))}</td></tr>`,
+      )
+      .join("");
+
+    const parsers = Array.isArray(summary.parsers) ? summary.parsers : [];
+    const parserBlocks = parsers
+      .map((parser) => {
+        const entry = parser && typeof parser === "object" ? parser : {};
+        const overrideEntries = Object.entries(
+          entry.overrides && typeof entry.overrides === "object"
+            ? entry.overrides
+            : {},
+        );
+        const overridesHtml =
+          overrideEntries.length === 0
+            ? '<div style="font-size:12px; color:var(--text-secondary);">no overrides</div>'
+            : `<div style="font-size:12px;"><div style="font-weight:600; margin-bottom:2px;">Overrides (${overrideEntries.length})</div>${overrideEntries
+                .map(([key, diff]) => {
+                  const value =
+                    diff && diff.value !== undefined ? String(diff.value) : "unset";
+                  const globalValue =
+                    diff && diff.globalValue !== undefined
+                      ? String(diff.globalValue)
+                      : "unset";
+                  return `<div style="font-family:monospace; font-size:11px; word-break:break-all;">${this.escapeHtml(key)}: ${this.escapeHtml(value)} (global: ${this.escapeHtml(globalValue)})</div>`;
+                })
+                .join("")}</div>`;
+        const enabledBadge = entry.enabled
+          ? '<span style="font-size:11px; font-weight:600; color:#34c759;">enabled</span>'
+          : '<span style="font-size:11px; opacity:0.6;">disabled</span>';
+        const urls = Array.isArray(entry.urls) ? entry.urls : [];
+        const urlsHtml =
+          urls.length > 0
+            ? `<div style="font-size:11px; font-family:monospace; opacity:0.7; word-break:break-all; margin:2px 0 4px 0;">${urls.map((url) => this.escapeHtml(String(url))).join("<br>")}</div>`
+            : "";
+        const parserLabel = entry.parser
+          ? ` <span style="font-weight:400; opacity:0.7;">(${this.escapeHtml(entry.parser)} parser)</span>`
+          : "";
+        return `
+        <div style="margin-bottom:12px; padding:10px; background:var(--background-light); border-radius:8px;">
+            <div style="font-weight:600; margin-bottom:2px;">${this.escapeHtml(entry.name || "(unnamed)")}${parserLabel} ${enabledBadge}</div>
+            ${urlsHtml}
+            ${overridesHtml}
+        </div>`;
+      })
+      .join("");
+
+    return `
+    <div class="section">
+        <div class="section-header">
+            <span class="section-icon">⚙️</span>
+            <span class="section-title">Active config</span>
+            <span class="section-count">${parsers.length}</span>
+        </div>
+        <details style="margin-bottom:12px;">
+            <summary>Run settings</summary>
+            <div style="overflow-x:auto;"><table style="border-collapse:collapse;">${globalRows}</table></div>
+        </details>
+        ${parserBlocks}
+        <div style="display:flex; gap:6px; margin-bottom:6px; flex-wrap:wrap; align-items:center;">
+            <button onclick="copyActiveConfig(this)" class="log-copy-btn config-copy-btn">📋 Copy effective config JSON</button>
+            <span style="font-size:12px; color:var(--text-secondary);">Secrets are redacted in the copied JSON</span>
+        </div>
+    </div>
+    `;
+  }
+
+  // Copy the effective (redacted) config JSON natively and (best-effort)
+  // flash the button. Called fire-and-forget from shouldAllowRequest, which
+  // must synchronously return a bool — so the await lives here, not in the
+  // handler.
+  async copyActiveConfigAndReport(activeConfigJson, webView) {
+    try {
+      Pasteboard.copy(activeConfigJson);
+      console.log("📱 Scriptable: Copied active config JSON to clipboard");
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Failed to copy active config JSON: ${error.message}`,
+      );
+      return;
+    }
+    try {
+      await webView.evaluateJavaScript("markConfigCopied()", false);
     } catch (error) {
       /* button feedback is optional polish; the copy already happened */
     }

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -2538,3 +2538,88 @@ test('generateEventCard embeds are all built by the shared serializer (no AI blo
   assert.ok(html.includes('&quot;_original&quot;'), 'the raw <pre> dump still shows _original provenance');
 }
 );
+
+// ---------------------------------------------------------------------------
+// Active config section: effective run settings + per-parser override diffs
+// rendered from results.config (SharedCore.buildActiveConfigSummary), with a
+// native copy-config bridge for the redacted JSON payload.
+// ---------------------------------------------------------------------------
+
+function buildActiveConfigResultsFixture() {
+  return {
+    config: {
+      config: {
+        daysToLookAhead: 30,
+        dryRun: true,
+        pageCache: { enabled: true, ttlDays: 3 },
+        geocodeVerification: { mode: 'enforce' },
+        ai: {
+          provider: 'openai',
+          endpoint: 'http://rybook.example:8000/v1/chat/completions',
+          model: 'global-model',
+          bearCheck: { mode: 'enforce' }
+        },
+        ocr: { enabled: true, endpoint: 'http://rybook.example:8001/v1/chat/completions', model: 'vision-model', maxImages: 2 }
+      },
+      parsers: [
+        {
+          name: 'Megawoof <b>America</b>',
+          enabled: true,
+          parser: 'ai-web',
+          urls: ['https://www.eventbrite.com/o/megawoof-america'],
+          alwaysBear: true,
+          ai: { model: 'parser-model' }
+        },
+        { name: 'Furball', enabled: false, urls: ['https://furball.nyc'] }
+      ]
+    }
+  };
+}
+
+test('generateActiveConfigSection renders run settings, override diffs, and the copy button only when config exists', () => {
+  const adapter = buildAdapter();
+
+  assert.equal(adapter.generateActiveConfigSection({}), '', 'no section without results.config');
+  assert.equal(adapter.generateActiveConfigSection(null), '', 'no section for null results');
+  assert.equal(adapter.generateActiveConfigSection({ config: null }), '', 'no section for a null config snapshot');
+
+  const html = adapter.generateActiveConfigSection(buildActiveConfigResultsFixture());
+  assert.ok(html.includes('Active config'), 'section title present');
+  assert.ok(html.includes('<span class="section-count">2</span>'), 'count is the parser count');
+
+  // Run settings live in a collapsed <details> with flattened global rows
+  assert.ok(html.includes('<summary>Run settings</summary>'), 'run-settings details present');
+  assert.ok(!html.includes('<details open'), 'details collapsed by default');
+  assert.ok(html.includes('ai.model'), 'flattened global keys rendered');
+  assert.ok(html.includes('global-model'), 'global values rendered');
+  assert.ok(html.includes('geocodeVerification.mode'), 'run-level knobs rendered');
+
+  // Per-parser rows: escaped name, enabled badge, urls, override diffs
+  assert.ok(html.includes('Megawoof &lt;b&gt;America&lt;/b&gt;'), 'parser names are escaped');
+  assert.ok(!html.includes('<b>America</b>'), 'raw markup never reaches the page');
+  assert.ok(html.includes('>enabled</span>'), 'enabled badge rendered');
+  assert.ok(html.includes('>disabled</span>'), 'disabled badge rendered');
+  assert.ok(html.includes('https://www.eventbrite.com/o/megawoof-america'), 'parser urls surfaced');
+  assert.ok(html.includes('Overrides (2)'), 'override count rendered');
+  assert.ok(html.includes('ai.model: parser-model (global: global-model)'), 'diff rendered value (global: value)');
+  assert.ok(html.includes('alwaysBear: true (global: unset)'), 'explicit knob with no global value says unset');
+  assert.ok(html.includes('no overrides'), 'parser without explicit knobs says no overrides');
+
+  // Copy button signals native (Pasteboard) — never navigator.clipboard
+  assert.ok(html.includes('copyActiveConfig(this)'), 'copy button wired to the custom-scheme signal');
+  assert.ok(html.includes('📋 Copy effective config JSON'), 'copy button label present');
+});
+
+test('generateRichHTML embeds the active-config section and the copy-config handler once', async () => {
+  const adapter = buildAdapter();
+  const results = { ...buildResultsStub(), ...buildActiveConfigResultsFixture() };
+  const html = await adapter.generateRichHTML(results);
+
+  assert.ok(html.includes('Active config'), 'section present when config exists');
+  assert.equal((html.match(/a=copy-config/g) || []).length, 1, 'copy-config bridge navigation defined exactly once');
+  assert.equal((html.match(/function copyActiveConfig\(/g) || []).length, 1, 'page handler defined exactly once');
+  assert.equal((html.match(/function markConfigCopied\(/g) || []).length, 1, 'feedback handler defined exactly once');
+
+  const withoutConfig = await adapter.generateRichHTML(buildResultsStub());
+  assert.ok(!withoutConfig.includes('Active config'), 'no section without a config snapshot');
+});

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -49,6 +49,18 @@ const scraperConfig = {
       // parsers; per-parser ai.arbitrateMerges overrides. Set false to disable.
       arbitrateMerges: true,
       bearCheck: { mode: "enforce" }, // Bear-check cascade: keywords → AI verdict with promoter context. "report" logs decisions without changing behavior; "enforce" flags/rescues/drops; "off" = legacy alwaysBear/keyword behavior. (Also accepted as a top-level config.bearCheck, like geocodeVerification; canonical location is here under ai.)
+      // Overlong-field trim pipeline: one AI call per event batches every
+      // overlong scraped field (title/description/shortName); answers are
+      // accepted only as VERBATIM contiguous substrings of the original.
+      // "report" (default) logs would-trim decisions without changing values;
+      // "enforce" replaces; "off" disables. Calendar-sourced values are never
+      // AI-trimmed — they are only flagged in the event evidence panel.
+      trim: {
+        mode: "report", // "report" (default) | "enforce" | "off"
+        titleMaxChars: 60, // data: title p95=48, p99=72, max=74
+        descriptionMaxChars: 600, // data: description p95=491, max=846
+        shortNameMaxChars: 30, // data: shortName max=20
+      },
       // extraContext (override-only): free-form text appended VERBATIM to the
       // context of every AI extraction prompt. Organizer/brand context is
       // normally derived automatically from each page's own metadata (JSON-LD

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2308,6 +2308,9 @@ class SharedCore {
         const bearDropCollector = [];
         const futureEvents = this.filterFutureEvents(allEvents, effectiveParserConfig.daysToLookAhead, effectiveParserConfig.allowPastEvents);
         const bearEvents = await this.filterBearEvents(futureEvents, effectiveParserConfig, httpAdapter, bearDropCollector);
+        // Overlong-field trims run before dedup so trimmed values feed the
+        // dedup keys/merges (report mode by default; see getTrimConfig).
+        await this.applyOverlongFieldTrims(bearEvents, effectiveParserConfig, httpAdapter);
         const deduplicatedEvents = await this.deduplicateEvents(bearEvents, httpAdapter, mainConfig?.config || mainConfig || null);
         
         // Calculate deduplication stats
@@ -2758,6 +2761,24 @@ class SharedCore {
             lines.push(`${rescueField} rescue candidate (log-only): "${rescueCandidate}"${rescueModelValue ? ` — model wrote "${rescueModelValue}"` : ''}`);
         });
 
+        // Overlong-field trim outcomes (_fieldTrims — underscore field, never
+        // serialized; stamped by trimOverlongFieldsForEvent). Rendered so
+        // every trim / would-trim / failed-gate outcome stays visible in the
+        // results UI next to the value it describes.
+        const fieldTrims = Array.isArray(event._fieldTrims) ? event._fieldTrims : [];
+        fieldTrims.forEach(trim => {
+            if (!trim || typeof trim !== 'object') return;
+            const trimField = typeof trim.field === 'string' ? trim.field.trim() : '';
+            if (!trimField) return;
+            if (trim.status === 'trimmed') {
+                lines.push(`${trimField} trimmed: ${trim.originalLength} → ${trim.trimmedLength} chars — "${trim.trimmedValue}"`);
+            } else if (trim.status === 'would-trim') {
+                lines.push(`${trimField} would trim: ${trim.originalLength} → ${trim.trimmedLength} chars — "${trim.trimmedValue}" (report mode)`);
+            } else if (trim.status === 'failed-gate') {
+                lines.push(`⚠️ ${trimField} overlong (${trim.originalLength} > ${trim.maxChars} chars) — trim failed verbatim gate, original kept`);
+            }
+        });
+
         // Deterministic bar-convergence rescue (_barRescue — underscore
         // field, never serialized; stamped by ai-web-parser's
         // applyBarConvergenceRescue when extraction produced no bar and a
@@ -3019,6 +3040,156 @@ class SharedCore {
             effective.discoveryBlockedPatterns = [...globalBlockedPatterns, ...parserPatterns];
         }
         return effective;
+    }
+
+    // ------------------------------------------------------------------
+    // Active-config summary for the results UI: pure builders that turn the
+    // loaded scraper config into (a) the effective global run settings, (b)
+    // per-parser override diffs against those settings, and (c) a redacted
+    // JSON payload for the copy button. No I/O, no platform APIs.
+    // ------------------------------------------------------------------
+
+    // Recursive secret scrub: any key that looks credential-shaped is masked.
+    // Applied before render AND before the copy payload is built.
+    redactConfigSecrets(obj) {
+        if (Array.isArray(obj)) {
+            return obj.map(item => this.redactConfigSecrets(item));
+        }
+        if (!obj || typeof obj !== 'object' || obj instanceof RegExp) {
+            return obj;
+        }
+        const redacted = {};
+        for (const [key, value] of Object.entries(obj)) {
+            redacted[key] = /key|secret|token|password|authorization/i.test(key)
+                ? '•••'
+                : this.redactConfigSecrets(value);
+        }
+        return redacted;
+    }
+
+    // Dotted-key flattener for override diffs: plain objects are walked,
+    // everything else (arrays, regexes) is stringified into a single leaf.
+    flattenConfigForDiff(obj, prefix = '') {
+        const flat = {};
+        if (!obj || typeof obj !== 'object' || Array.isArray(obj) || obj instanceof RegExp) {
+            return flat;
+        }
+        for (const [key, value] of Object.entries(obj)) {
+            const dottedKey = prefix ? `${prefix}.${key}` : key;
+            if (value && typeof value === 'object' && !Array.isArray(value) && !(value instanceof RegExp)) {
+                Object.assign(flat, this.flattenConfigForDiff(value, dottedKey));
+            } else if (Array.isArray(value) || value instanceof RegExp) {
+                flat[dottedKey] = String(value);
+            } else {
+                flat[dottedKey] = value;
+            }
+        }
+        return flat;
+    }
+
+    // { global, parsers, json }: global = values-only effective run settings,
+    // parsers = per-entry override diffs (ONLY explicitly-set values that
+    // differ from the global effective value), json = the redacted copy
+    // payload. Both returned structures are already redacted.
+    buildActiveConfigSummary(scraperConfig) {
+        const globalConfig = scraperConfig && scraperConfig.config && typeof scraperConfig.config === 'object'
+            ? scraperConfig.config
+            : {};
+        const rawGlobalAi = globalConfig.ai && typeof globalConfig.ai === 'object' ? globalConfig.ai : {};
+        const rawGlobalOcr = globalConfig.ocr && typeof globalConfig.ocr === 'object' ? globalConfig.ocr : {};
+        const resolvedAi = this.resolveAiConfig(rawGlobalAi);
+        const pageCache = globalConfig.pageCache && typeof globalConfig.pageCache === 'object' ? globalConfig.pageCache : {};
+        const pageCacheTtl = Number(pageCache.ttlDays);
+        const geocodeVerification = globalConfig.geocodeVerification && typeof globalConfig.geocodeVerification === 'object'
+            ? globalConfig.geocodeVerification
+            : {};
+        // Same top-level bearCheck alias fold resolveEffectiveParserConfig does
+        const bearCheckAi = rawGlobalAi.bearCheck || !globalConfig.bearCheck
+            ? rawGlobalAi
+            : { ...rawGlobalAi, bearCheck: globalConfig.bearCheck };
+
+        const global = {
+            daysToLookAhead: globalConfig.daysToLookAhead !== undefined ? globalConfig.daysToLookAhead : null,
+            dryRun: globalConfig.dryRun === true,
+            pageCache: {
+                enabled: pageCache.enabled === true,
+                ttlDays: Number.isFinite(pageCacheTtl) && pageCacheTtl > 0 ? pageCacheTtl : 3
+            },
+            geocodeVerification: {
+                mode: String(geocodeVerification.mode || 'report')
+            },
+            ai: {
+                enabled: resolvedAi.enabled,
+                endpoint: resolvedAi.endpoint,
+                model: resolvedAi.model,
+                provider: resolvedAi.provider,
+                payloadMode: resolvedAi.payloadMode,
+                numCtx: resolvedAi.numCtx,
+                numPredict: resolvedAi.numPredict,
+                temperature: resolvedAi.temperature,
+                timeoutSeconds: resolvedAi.timeoutSeconds,
+                cacheEnabled: resolvedAi.cacheEnabled,
+                arbitrateMerges: resolvedAi.arbitrateMerges,
+                bearCheck: { mode: this.getBearCheckMode({ ai: bearCheckAi }) },
+                trim: this.getTrimConfig({ ai: rawGlobalAi })
+            },
+            ocr: {
+                enabled: rawGlobalOcr.enabled === true,
+                endpoint: typeof rawGlobalOcr.endpoint === 'string' ? rawGlobalOcr.endpoint : '',
+                model: typeof rawGlobalOcr.model === 'string' ? rawGlobalOcr.model : '',
+                maxImages: Number.isFinite(Number(rawGlobalOcr.maxImages)) ? Number(rawGlobalOcr.maxImages) : null,
+                cache: rawGlobalOcr.cache !== false,
+                cacheRetentionDays: Number.isFinite(Number(rawGlobalOcr.cacheRetentionDays)) ? Number(rawGlobalOcr.cacheRetentionDays) : 90
+            }
+        };
+
+        // Comparison base for override diffs: raw global keys win (they share
+        // the parser blocks' key space exactly); the resolved effective values
+        // fill in for keys the raw global config never set.
+        const globalComparisonFlat = {
+            ...this.flattenConfigForDiff({ ai: global.ai, ocr: global.ocr }),
+            ...this.flattenConfigForDiff({ ai: rawGlobalAi, ocr: rawGlobalOcr })
+        };
+        const scalarKnobs = ['alwaysBear', 'siteRole', 'dryRun', 'daysToLookAhead', 'urlDiscoveryDepth',
+            'maxAdditionalUrls', 'discoveryOnly', 'calendarSearchRangeDays'];
+
+        const parsers = (Array.isArray(scraperConfig && scraperConfig.parsers) ? scraperConfig.parsers : [])
+            .filter(entry => entry && typeof entry === 'object')
+            .map(entry => {
+                const overrides = {};
+                for (const knob of scalarKnobs) {
+                    if (!Object.prototype.hasOwnProperty.call(entry, knob)) continue;
+                    const value = entry[knob];
+                    const globalValue = Object.prototype.hasOwnProperty.call(globalConfig, knob)
+                        ? globalConfig[knob]
+                        : undefined;
+                    if (value === globalValue) continue;
+                    overrides[knob] = { value, globalValue };
+                }
+                const parserBlockFlat = {
+                    ...this.flattenConfigForDiff(entry.ai && typeof entry.ai === 'object' ? entry.ai : {}, 'ai'),
+                    ...this.flattenConfigForDiff(entry.ocr && typeof entry.ocr === 'object' ? entry.ocr : {}, 'ocr')
+                };
+                for (const [key, value] of Object.entries(parserBlockFlat)) {
+                    const globalValue = globalComparisonFlat[key];
+                    if (value === globalValue) continue;
+                    overrides[key] = { value, globalValue };
+                }
+                return {
+                    name: typeof entry.name === 'string' ? entry.name : '',
+                    enabled: entry.enabled === true,
+                    urls: Array.isArray(entry.urls) ? entry.urls.map(url => String(url)) : [],
+                    parser: typeof entry.parser === 'string' ? entry.parser : '',
+                    overrides
+                };
+            });
+
+        const redacted = this.redactConfigSecrets({ global, parsers });
+        return {
+            global: redacted.global,
+            parsers: redacted.parsers,
+            json: JSON.stringify(redacted, null, 2)
+        };
     }
 
     extractHttpStatusCodeFromError(error) {
@@ -4238,6 +4409,200 @@ class SharedCore {
         return pending;
     }
 
+    // ------------------------------------------------------------------
+    // Overlong-field trim pipeline: scraped title/description/shortName
+    // values that exceed their display limits are shortened by ONE batched
+    // AI call per event — answers are accepted only when they are VERBATIM
+    // contiguous substrings of the original (never paraphrase, never a
+    // deterministic mid-word truncation). Mode knob (parserConfig.ai.trim.mode):
+    // 'report' (default) logs would-trim decisions without changing values;
+    // 'enforce' replaces the value; 'off' disables the pipeline entirely.
+    // Calendar-sourced values are never AI-trimmed (see
+    // buildAnalyzedCalendarEvent's detection-only evidence line).
+    // ------------------------------------------------------------------
+
+    // { mode, limits: { title, description, shortName } } from
+    // parserConfig.ai.trim. Mirrors getBearCheckMode: unset/invalid → 'report'.
+    getTrimConfig(parserConfig) {
+        const trim = parserConfig && parserConfig.ai && parserConfig.ai.trim && typeof parserConfig.ai.trim === 'object'
+            ? parserConfig.ai.trim
+            : null;
+        const mode = trim ? String(trim.mode || '').trim().toLowerCase() : '';
+        const limitOf = (raw, fallback) => {
+            const value = Number(raw);
+            return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+        };
+        return {
+            mode: mode === 'enforce' || mode === 'off' ? mode : 'report',
+            limits: {
+                title: limitOf(trim && trim.titleMaxChars, 60),
+                description: limitOf(trim && trim.descriptionMaxChars, 600),
+                shortName: limitOf(trim && trim.shortNameMaxChars, 30)
+            }
+        };
+    }
+
+    // Pure detection: [{ field, value, maxChars }] for every trim-target field
+    // whose trimmed string value exceeds its limit. Targets are the canonical
+    // schema fields only — 'shorttitle' is a notes alias of shortName
+    // (event-schema.js), so shortName is the field that exists on events.
+    findOverlongFields(event, trimConfig) {
+        const overlong = [];
+        if (!event || typeof event !== 'object' || !trimConfig || !trimConfig.limits) return overlong;
+        for (const field of ['title', 'description', 'shortName']) {
+            const maxChars = trimConfig.limits[field];
+            if (!Number.isFinite(maxChars) || maxChars <= 0) continue;
+            const raw = event[field];
+            if (raw === null || raw === undefined) continue;
+            const value = String(raw).trim();
+            if (value.length > maxChars) {
+                overlong.push({ field, value, maxChars });
+            }
+        }
+        return overlong;
+    }
+
+    // Prompt for one event's batched trim request. EVENT carries the title
+    // only (no dates) so the AI-response cache key stays stable across runs.
+    buildFieldTrimPrompt({ eventTitle, entries }) {
+        const fieldLines = (Array.isArray(entries) ? entries : []).map(entry =>
+            `- field: ${entry.field}\n  max_chars: ${entry.maxChars}\n  value: ${JSON.stringify(entry.value)}`
+        );
+        return [
+            'You are shortening overlong text fields for one event.',
+            `EVENT: ${eventTitle}`,
+            'Each field below exceeds its maximum display length. Return a shorter version of each.',
+            'FIELDS:',
+            ...fieldLines,
+            'Rules:',
+            '- Each answer MUST be an EXACT contiguous substring of that field\'s original value — copy characters verbatim; never paraphrase, reorder, re-case, merge parts, or add words.',
+            '- Each answer must be at most max_chars characters long.',
+            '- For "title", keep the portion that names the event itself — drop venue, city, date, status text, and marketing phrases.',
+            '- For "description", keep the most informative complete sentences; start at a sentence start and end at a natural boundary.',
+            '- For "shortName", keep the shortest recognizable brand name.',
+            '- Never cut a word in the middle.',
+            'Return JSON only:',
+            '{"trims": {"<field>": {"value": "<exact contiguous substring>", "reason": "<one short sentence>"}}}'
+        ].join('\n');
+    }
+
+    // Deterministic anti-hallucination gate: an answer is usable only when it
+    // is non-empty, fits the limit, is strictly shorter than the original, and
+    // is a case-sensitive contiguous substring of the original value.
+    isVerbatimTrimAnswer(originalValue, answerText, maxChars) {
+        const answer = String(answerText === null || answerText === undefined ? '' : answerText).trim();
+        if (!answer) return false;
+        return answer.length <= maxChars
+            && answer.length < String(originalValue).trim().length
+            && String(originalValue).includes(answer);
+    }
+
+    // ONE AI call per event batching all overlong fields (passLabel
+    // 'field-trim', same callAiGenerate path arbitration uses — so the
+    // response cache applies). Gate pass + mode 'enforce' → value replaced;
+    // mode 'report' → value kept; gate fail / no answer → value kept. Every
+    // outcome is recorded on event._fieldTrims for evidence-line rendering.
+    // NEVER falls back to deterministic mid-word truncation.
+    async trimOverlongFieldsForEvent(event, trimConfig, aiConfig, httpAdapter) {
+        const overlong = this.findOverlongFields(event, trimConfig);
+        if (overlong.length === 0) return [];
+
+        const title = String(event.title || 'Unknown');
+        const prompt = this.buildFieldTrimPrompt({ eventTitle: title, entries: overlong });
+        const trimAiConfig = { ...aiConfig, numPredict: Math.min(Number(aiConfig.numPredict) || 800, 800) };
+        const rawResponse = await this.callAiGenerate(trimAiConfig, prompt, 'field-trim', httpAdapter);
+
+        let parsed = null;
+        if (rawResponse) {
+            try {
+                parsed = JSON.parse(this.extractFirstJsonObject(rawResponse) || rawResponse);
+            } catch (_) {
+                parsed = null;
+            }
+        }
+        const trims = parsed && typeof parsed === 'object'
+            ? (parsed.trims && typeof parsed.trims === 'object' ? parsed.trims : parsed)
+            : {};
+
+        const records = [];
+        for (const entry of overlong) {
+            const answerEntry = trims[entry.field];
+            const answerText = answerEntry && typeof answerEntry === 'object' ? answerEntry.value : answerEntry;
+            const answer = String(answerText === null || answerText === undefined ? '' : answerText).trim();
+            if (this.isVerbatimTrimAnswer(entry.value, answer, entry.maxChars)) {
+                if (trimConfig.mode === 'enforce') {
+                    event[entry.field] = answer;
+                    records.push({
+                        field: entry.field,
+                        status: 'trimmed',
+                        originalLength: entry.value.length,
+                        trimmedLength: answer.length,
+                        trimmedValue: answer,
+                        maxChars: entry.maxChars
+                    });
+                    console.log(`✂️ TRIM: "${title}" — ${entry.field} ${entry.value.length} → ${answer.length} chars (verbatim substring)`);
+                } else {
+                    records.push({
+                        field: entry.field,
+                        status: 'would-trim',
+                        originalLength: entry.value.length,
+                        trimmedLength: answer.length,
+                        trimmedValue: answer,
+                        maxChars: entry.maxChars
+                    });
+                    console.log(`✂️ TRIM [report]: "${title}" — ${entry.field} would trim ${entry.value.length} → ${answer.length} chars`);
+                }
+            } else {
+                records.push({
+                    field: entry.field,
+                    status: 'failed-gate',
+                    originalLength: entry.value.length,
+                    maxChars: entry.maxChars
+                });
+                console.log(`✂️ TRIM: "${title}" — ${entry.field} answer failed verbatim gate ("${answer.slice(0, 80)}") — original kept`);
+            }
+        }
+        event._fieldTrims = records;
+        return records;
+    }
+
+    // Trim pass over one parser's bear events (processParser: after the bear
+    // filter, before dedup — so trimmed values feed dedup keys and merges).
+    // Zero AI calls when mode is 'off', AI is unavailable, or nothing is
+    // overlong. NOTE: report mode still fires AI calls for overlong values —
+    // a future golden-fixture text exceeding a limit would fire AI calls
+    // against the fixture transport in report mode.
+    async applyOverlongFieldTrims(events, parserConfig, httpAdapter) {
+        const list = Array.isArray(events) ? events : [];
+        if (list.length === 0) return list;
+        const trimConfig = this.getTrimConfig(parserConfig);
+        if (trimConfig.mode === 'off') return list;
+        const rawAi = parserConfig && parserConfig.ai && typeof parserConfig.ai === 'object' ? parserConfig.ai : {};
+        if (rawAi.enabled === false) return list;
+        if (!httpAdapter || typeof httpAdapter.postJson !== 'function') return list;
+        const aiConfig = this.resolveAiConfig(rawAi);
+        if (!aiConfig.enabled || !aiConfig.endpoint) return list;
+
+        let overlongCount = 0;
+        let trimmedCount = 0;
+        let flaggedCount = 0;
+        for (const event of list) {
+            const records = await this.trimOverlongFieldsForEvent(event, trimConfig, aiConfig, httpAdapter);
+            for (const record of records) {
+                overlongCount++;
+                if (record.status === 'trimmed') {
+                    trimmedCount++;
+                } else {
+                    flaggedCount++;
+                }
+            }
+        }
+        if (overlongCount > 0) {
+            console.log(`✂️ TRIM: ${list.length} event(s) checked, ${overlongCount} overlong field(s), ${trimmedCount} trimmed, ${flaggedCount} flagged`);
+        }
+        return list;
+    }
+
     async deduplicateEvents(events, httpAdapter, globalConfig = null) {
         const seen = new Map();
         const deduplicated = [];
@@ -4536,6 +4901,11 @@ class SharedCore {
         // by the field loop below, so an existing-only _organizer would be lost.
         if (!mergedEvent._organizer && existingEvent && typeof existingEvent._organizer === 'string' && existingEvent._organizer) {
             mergedEvent._organizer = existingEvent._organizer;
+        }
+        // Same carry for field-trim records: an existing-only _fieldTrims
+        // would otherwise be lost before evidence lines render.
+        if (!mergedEvent._fieldTrims && existingEvent && Array.isArray(existingEvent._fieldTrims) && existingEvent._fieldTrims.length > 0) {
+            mergedEvent._fieldTrims = existingEvent._fieldTrims;
         }
 
         // Helper function to check if a value is empty/null/undefined
@@ -5494,6 +5864,14 @@ class SharedCore {
             _parserConfig: newEvent._parserConfig,
             _fieldPriorities: newEvent._fieldPriorities
         };
+
+        // Carry field-trim records across the calendar merge (like _organizer
+        // in mergeParsedEvents): underscore fields are skipped by the merge
+        // loop, so the scraped side's _fieldTrims would otherwise be lost
+        // before the evidence lines render.
+        if (Array.isArray(newEvent._fieldTrims) && newEvent._fieldTrims.length > 0) {
+            finalEvent._fieldTrims = newEvent._fieldTrims;
+        }
         
         // STEP 6: Pass all three objects to rich display for comparison
         
@@ -6855,6 +7233,26 @@ class SharedCore {
             // serialization). Computed AFTER the final merged object exists so
             // the lines describe exactly what will be written.
             analyzedEvent._evidenceLines = this.buildEventEvidenceLines(analyzedEvent, { cityKey: analyzedEvent.city });
+
+            // Detection-only overlong flag for calendar-sourced values: the
+            // trim pipeline only ever sees scraped values (and stamps them
+            // with _fieldTrims), so a final value that exceeds its limit on a
+            // field WITHOUT a trim record came through the calendar side —
+            // which is never AI-trimmed. No AI call here, just visibility.
+            const overlongTrimConfig = this.getTrimConfig(
+                analyzedEvent._parserConfig || (config && config.ai ? { ai: config.ai } : null)
+            );
+            if (overlongTrimConfig.mode !== 'off') {
+                const recordedTrimFields = new Set(
+                    (Array.isArray(analyzedEvent._fieldTrims) ? analyzedEvent._fieldTrims : [])
+                        .map(trim => trim && trim.field)
+                        .filter(Boolean)
+                );
+                for (const overlong of this.findOverlongFields(analyzedEvent, overlongTrimConfig)) {
+                    if (recordedTrimFields.has(overlong.field)) continue;
+                    analyzedEvent._evidenceLines.push(`⚠️ ${overlong.field} overlong (${overlong.value.length} > ${overlong.maxChars} chars) — calendar-sourced, not trimmed`);
+                }
+            }
 
             return analyzedEvent;
         }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -8232,3 +8232,308 @@ test('venue-site-identity: corroborated in the bar demotion rung and rendered in
   }, { cityKey: 'seattle' });
   assert.ok(unstampedLines.includes('bar corrected to venue-site identity — extracted "Shore Thing" (unstamped)'));
 });
+
+// ---------------------------------------------------------------------------
+// Overlong-field trim pipeline: detection is pure, trimming is one batched AI
+// call per event gated on VERBATIM contiguous substrings, and every outcome
+// (trimmed / would-trim / failed-gate) is stamped on _fieldTrims and rendered
+// in the evidence panel. Never a deterministic mid-word truncation.
+// ---------------------------------------------------------------------------
+
+// 74 characters, trims to the 7-char brand "D>U>R>O" (title p99=72, max=74).
+const OVERLONG_TITLE = 'D>U>R>O — Precinct DTLA Los Angeles — Saturday — SOLD OUT — merch inside!!';
+
+function buildTrimParserConfig(trimOverrides = {}) {
+  return {
+    name: 'Trim Test',
+    ai: {
+      enabled: true,
+      provider: 'openai',
+      endpoint: 'http://rybook.example:8000/v1/chat/completions',
+      model: 'test-model',
+      openai: {},
+      trim: { mode: 'enforce', ...trimOverrides }
+    }
+  };
+}
+
+function buildTrimAnswerAdapter(content, calls = []) {
+  return {
+    postJson: async (endpoint, payload) => {
+      calls.push({ endpoint, payload });
+      return { ok: true, status: 200, text: buildOpenAiResponsePayload(content) };
+    }
+  };
+}
+
+test('getTrimConfig defaults: unset/invalid mode → report with the documented limits', () => {
+  const core = createCore();
+  assert.deepEqual(core.getTrimConfig(null), {
+    mode: 'report',
+    limits: { title: 60, description: 600, shortName: 30 }
+  });
+  assert.equal(core.getTrimConfig({ ai: { trim: { mode: 'ENFORCE' } } }).mode, 'enforce');
+  assert.equal(core.getTrimConfig({ ai: { trim: { mode: 'bogus' } } }).mode, 'report');
+  assert.equal(core.getTrimConfig({ ai: { trim: { mode: 'off' } } }).mode, 'off');
+});
+
+test('findOverlongFields: under-limit events are empty, overlong titles are detected, per-parser limits override', () => {
+  const core = createCore();
+  assert.equal(OVERLONG_TITLE.length, 74, 'fixture must match the real-world max');
+
+  const defaults = core.getTrimConfig(buildTrimParserConfig());
+  assert.deepEqual(core.findOverlongFields({ title: 'FURBALL', description: 'short', shortName: 'FUR' }, defaults), []);
+
+  const overlong = core.findOverlongFields({ title: OVERLONG_TITLE }, defaults);
+  assert.deepEqual(overlong, [{ field: 'title', value: OVERLONG_TITLE, maxChars: 60 }]);
+
+  // A per-parser titleMaxChars above the value's length silences the finding
+  const relaxed = core.getTrimConfig(buildTrimParserConfig({ titleMaxChars: 100 }));
+  assert.deepEqual(core.findOverlongFields({ title: OVERLONG_TITLE }, relaxed), []);
+
+  // shortName is the canonical target (shorttitle is only a notes alias)
+  const shortNames = core.findOverlongFields({ shortName: 'AN ABSURDLY LONG SHORT NAME FOR A PARTY' }, defaults);
+  assert.equal(shortNames.length, 1);
+  assert.equal(shortNames[0].field, 'shortName');
+  assert.equal(shortNames[0].maxChars, 30);
+});
+
+test('isVerbatimTrimAnswer: case-sensitive contiguous substring, non-empty, within limit, strictly shorter', () => {
+  const core = createCore();
+  assert.equal(core.isVerbatimTrimAnswer(OVERLONG_TITLE, 'D>U>R>O', 60), true);
+  assert.equal(core.isVerbatimTrimAnswer(OVERLONG_TITLE, 'd>u>r>o', 60), false, 're-cased answers fail');
+  assert.equal(core.isVerbatimTrimAnswer(OVERLONG_TITLE, '', 60), false, 'empty answers fail');
+  assert.equal(core.isVerbatimTrimAnswer(OVERLONG_TITLE, OVERLONG_TITLE, 90), false, 'not-shorter answers fail');
+  assert.equal(core.isVerbatimTrimAnswer(OVERLONG_TITLE, 'D>U>R>O — Precinct DTLA', 10), false, 'over-limit answers fail');
+  assert.equal(core.isVerbatimTrimAnswer(OVERLONG_TITLE, 'DURO at Precinct', 60), false, 'paraphrases fail');
+});
+
+test('trimOverlongFieldsForEvent replaces a verbatim answer in enforce mode and stamps _fieldTrims', async () => {
+  const core = createCore();
+  const parserConfig = buildTrimParserConfig();
+  const trimConfig = core.getTrimConfig(parserConfig);
+  const calls = [];
+  const adapter = buildTrimAnswerAdapter('{"trims":{"title":{"value":"D>U>R>O","reason":"brand name"}}}', calls);
+
+  const event = { title: OVERLONG_TITLE, description: 'fine', city: 'dallas' };
+  const records = await core.trimOverlongFieldsForEvent(event, trimConfig, buildAiTestConfig(), adapter);
+
+  assert.equal(event.title, 'D>U>R>O', 'enforce mode replaces the value');
+  assert.equal(calls.length, 1, 'one batched request per event');
+  assert.ok(String(calls[0].payload.messages[0].content).includes('You are shortening overlong text fields for one event.'));
+  assert.deepEqual(records, event._fieldTrims);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].field, 'title');
+  assert.equal(records[0].status, 'trimmed');
+  assert.equal(records[0].originalLength, 74);
+  assert.equal(records[0].trimmedLength, 7);
+  assert.equal(records[0].trimmedValue, 'D>U>R>O');
+});
+
+test('trimOverlongFieldsForEvent keeps the original on paraphrased, re-cased, or over-limit answers (failed-gate)', async () => {
+  const core = createCore();
+  const trimConfig = core.getTrimConfig(buildTrimParserConfig());
+  for (const badAnswer of ['DURO at Precinct DTLA', 'd>u>r>o', OVERLONG_TITLE]) {
+    const adapter = buildTrimAnswerAdapter(JSON.stringify({ trims: { title: { value: badAnswer } } }));
+    const event = { title: OVERLONG_TITLE };
+    const records = await core.trimOverlongFieldsForEvent(event, trimConfig, buildAiTestConfig(), adapter);
+    assert.equal(event.title, OVERLONG_TITLE, `original kept for answer ${JSON.stringify(badAnswer)}`);
+    assert.equal(records[0].status, 'failed-gate');
+    assert.equal(records[0].originalLength, 74);
+    assert.equal(records[0].maxChars, 60);
+  }
+
+  // No usable response at all → failed-gate, original kept, never truncated
+  const emptyAdapter = { postJson: async () => ({ ok: true, status: 200, text: buildOpenAiResponsePayload('') }) };
+  const event = { title: OVERLONG_TITLE };
+  const records = await core.trimOverlongFieldsForEvent(event, trimConfig, buildAiTestConfig(), emptyAdapter);
+  assert.equal(event.title, OVERLONG_TITLE);
+  assert.equal(records[0].status, 'failed-gate');
+});
+
+test('trimOverlongFieldsForEvent report mode records would-trim without changing the value', async () => {
+  const core = createCore();
+  const trimConfig = core.getTrimConfig(buildTrimParserConfig({ mode: 'report' }));
+  const adapter = buildTrimAnswerAdapter('{"trims":{"title":{"value":"D>U>R>O"}}}');
+  const event = { title: OVERLONG_TITLE };
+  const records = await core.trimOverlongFieldsForEvent(event, trimConfig, buildAiTestConfig(), adapter);
+  assert.equal(event.title, OVERLONG_TITLE, 'report mode never mutates');
+  assert.equal(records[0].status, 'would-trim');
+  assert.equal(records[0].trimmedValue, 'D>U>R>O');
+});
+
+test('applyOverlongFieldTrims: mode off and under-limit events make zero AI calls', async () => {
+  const core = createCore();
+  const calls = [];
+  const adapter = buildTrimAnswerAdapter('{"trims":{}}', calls);
+
+  const offEvents = [{ title: OVERLONG_TITLE }];
+  await core.applyOverlongFieldTrims(offEvents, buildTrimParserConfig({ mode: 'off' }), adapter);
+  assert.equal(calls.length, 0, 'mode off never calls the AI');
+  assert.equal(offEvents[0]._fieldTrims, undefined);
+  assert.equal(offEvents[0].title, OVERLONG_TITLE);
+
+  await core.applyOverlongFieldTrims([{ title: 'FURBALL' }], buildTrimParserConfig(), adapter);
+  assert.equal(calls.length, 0, 'nothing overlong never calls the AI');
+
+  // AI unavailable (no adapter) → no calls, no records
+  const noAdapterEvents = [{ title: OVERLONG_TITLE }];
+  await core.applyOverlongFieldTrims(noAdapterEvents, buildTrimParserConfig(), null);
+  assert.equal(noAdapterEvents[0]._fieldTrims, undefined);
+});
+
+test('applyOverlongFieldTrims shares the AI response cache: two identical runs, one transport call', async () => {
+  const core = createCore();
+  const store = new Map();
+  core.aiResponseCache = {
+    read: async (aiConfig, prompt) => store.get(prompt) || null,
+    write: async (aiConfig, prompt, passLabel, text) => { store.set(prompt, text); },
+    stats: { hits: 0, misses: 0, writes: 0 }
+  };
+  const calls = [];
+  const adapter = buildTrimAnswerAdapter('{"trims":{"title":{"value":"D>U>R>O"}}}', calls);
+  const parserConfig = buildTrimParserConfig();
+
+  const firstRun = [{ title: OVERLONG_TITLE }];
+  await core.applyOverlongFieldTrims(firstRun, parserConfig, adapter);
+  assert.equal(firstRun[0].title, 'D>U>R>O');
+
+  const secondRun = [{ title: OVERLONG_TITLE }];
+  await core.applyOverlongFieldTrims(secondRun, parserConfig, adapter);
+  assert.equal(secondRun[0].title, 'D>U>R>O');
+  assert.equal(calls.length, 1, 'the second run must be served from the cache');
+});
+
+test('buildEventEvidenceLines renders the trimmed, would-trim, and failed-gate shapes', () => {
+  const core = createCore();
+  const lines = core.buildEventEvidenceLines({
+    title: 'D>U>R>O',
+    _fieldTrims: [
+      { field: 'title', status: 'trimmed', originalLength: 74, trimmedLength: 7, trimmedValue: 'D>U>R>O', maxChars: 60 },
+      { field: 'description', status: 'would-trim', originalLength: 846, trimmedLength: 491, trimmedValue: 'Doors at 9.', maxChars: 600 },
+      { field: 'shortName', status: 'failed-gate', originalLength: 39, maxChars: 30 }
+    ]
+  }, { cityKey: 'dallas' });
+  assert.ok(lines.includes('title trimmed: 74 → 7 chars — "D>U>R>O"'), `got: ${JSON.stringify(lines)}`);
+  assert.ok(lines.includes('description would trim: 846 → 491 chars — "Doors at 9." (report mode)'), `got: ${JSON.stringify(lines)}`);
+  assert.ok(lines.includes('⚠️ shortName overlong (39 > 30 chars) — trim failed verbatim gate, original kept'), `got: ${JSON.stringify(lines)}`);
+});
+
+test('_fieldTrims survives createFinalEventObject like _organizer', async () => {
+  const core = createCore();
+  const fieldTrims = [{ field: 'title', status: 'would-trim', originalLength: 74, trimmedLength: 7, trimmedValue: 'D>U>R>O', maxChars: 60 }];
+  const scraped = buildScrapedEvent({ _fieldTrims: fieldTrims });
+  const finalEvent = await core.createFinalEventObject(buildCalendarEvent(), scraped, {});
+  assert.deepEqual(finalEvent._fieldTrims, fieldTrims);
+});
+
+// ---------------------------------------------------------------------------
+// Active-config summary: pure builders behind the results-UI "Active config"
+// section — effective global values, per-parser override diffs (only
+// explicitly-set values that differ), and a secret-redacted copy payload.
+// ---------------------------------------------------------------------------
+
+function buildActiveConfigFixture() {
+  return {
+    config: {
+      daysToLookAhead: 30,
+      dryRun: true,
+      pageCache: { enabled: true, ttlDays: 3 },
+      geocodeVerification: { mode: 'enforce' },
+      ai: {
+        enabled: true,
+        provider: 'openai',
+        endpoint: 'http://rybook.example:8000/v1/chat/completions',
+        model: 'global-model',
+        apiKey: 'super-secret-global',
+        bearCheck: { mode: 'enforce' },
+        trim: { mode: 'report', titleMaxChars: 60 }
+      },
+      ocr: {
+        enabled: true,
+        endpoint: 'http://rybook.example:8001/v1/chat/completions',
+        model: 'vision-model',
+        maxImages: 2,
+        cache: true,
+        cacheRetentionDays: 90
+      }
+    },
+    parsers: [
+      {
+        name: 'Megawoof America',
+        enabled: true,
+        parser: 'ai-web',
+        urls: ['https://www.eventbrite.com/o/megawoof-america'],
+        alwaysBear: true,
+        ai: {
+          model: 'parser-model',
+          endpoint: 'http://rybook.example:8000/v1/chat/completions',
+          apiKey: 'super-secret-parser'
+        }
+      },
+      { name: 'Furball', enabled: false, urls: ['https://furball.nyc'] }
+    ]
+  };
+}
+
+test('buildActiveConfigSummary surfaces effective global values and parser identity', () => {
+  const core = createCore();
+  const summary = core.buildActiveConfigSummary(buildActiveConfigFixture());
+
+  assert.equal(summary.global.daysToLookAhead, 30);
+  assert.equal(summary.global.dryRun, true);
+  assert.deepEqual(summary.global.pageCache, { enabled: true, ttlDays: 3 });
+  assert.equal(summary.global.geocodeVerification.mode, 'enforce');
+  assert.equal(summary.global.ai.model, 'global-model');
+  assert.equal(summary.global.ai.provider, 'openai');
+  assert.equal(summary.global.ai.bearCheck.mode, 'enforce');
+  assert.deepEqual(summary.global.ai.trim, {
+    mode: 'report',
+    limits: { title: 60, description: 600, shortName: 30 }
+  });
+  assert.equal(summary.global.ocr.model, 'vision-model');
+  assert.equal(summary.global.ocr.maxImages, 2);
+
+  assert.equal(summary.parsers.length, 2);
+  assert.equal(summary.parsers[0].name, 'Megawoof America');
+  assert.equal(summary.parsers[0].enabled, true);
+  assert.equal(summary.parsers[0].parser, 'ai-web');
+  assert.deepEqual(summary.parsers[0].urls, ['https://www.eventbrite.com/o/megawoof-america']);
+  assert.equal(summary.parsers[1].enabled, false);
+});
+
+test('buildActiveConfigSummary overrides contain ONLY explicitly-set values that differ from global', () => {
+  const core = createCore();
+  const summary = core.buildActiveConfigSummary(buildActiveConfigFixture());
+  const overrides = summary.parsers[0].overrides;
+
+  assert.deepEqual(overrides['ai.model'], { value: 'parser-model', globalValue: 'global-model' });
+  assert.deepEqual(overrides.alwaysBear, { value: true, globalValue: undefined });
+  assert.equal(overrides['ai.endpoint'], undefined, 'same-as-global values are not overrides');
+  assert.equal(overrides['ai.provider'], undefined, 'unset parser keys are not overrides');
+  assert.deepEqual(summary.parsers[1].overrides, {}, 'a parser with no explicit knobs has no overrides');
+});
+
+test('buildActiveConfigSummary redacts secrets from the rendered structures and the copy JSON', () => {
+  const core = createCore();
+  const summary = core.buildActiveConfigSummary(buildActiveConfigFixture());
+
+  assert.ok(!summary.json.includes('super-secret-global'), 'global secrets never reach the copy payload');
+  assert.ok(!summary.json.includes('super-secret-parser'), 'parser secrets never reach the copy payload');
+  assert.equal(summary.parsers[0].overrides['ai.apiKey'], '•••', 'credential-shaped override keys are masked');
+
+  // The recursive scrub itself: credential-shaped keys at any depth
+  assert.deepEqual(
+    core.redactConfigSecrets({ apiKey: 'x', nested: { authToken: 'y', list: [{ password: 'z' }] }, model: 'ok' }),
+    { apiKey: '•••', nested: { authToken: '•••', list: [{ password: '•••' }] }, model: 'ok' }
+  );
+});
+
+test('flattenConfigForDiff walks plain objects and stringifies arrays/regexes as leaves', () => {
+  const core = createCore();
+  assert.deepEqual(
+    core.flattenConfigForDiff({ ai: { model: 'm', openai: { responseFormat: 'json_object' } }, list: [1, 2], pattern: /furball/i }),
+    { 'ai.model': 'm', 'ai.openai.responseFormat': 'json_object', list: '1,2', pattern: '/furball/i' }
+  );
+  assert.deepEqual(core.flattenConfigForDiff(null), {});
+});


### PR DESCRIPTION
## Feature 1 — ⚙️ Active config section (results UI)

Collapsed section showing what actually governed the run:
- **Run settings**: resolved effective globals — ai endpoint/model/cache, pageCache, OCR, geocode mode, bear-check mode, trim thresholds. Values only; anything credential-shaped is redacted (`•••`).
- **Per parser**: enabled badge, URLs, and **only the overrides that differ from global defaults**, rendered `ai.model: X (global: Y)` — the drift view, so config sprawl is visible at a glance.
- **📋 Copy effective config JSON** via the native `chunkyscrape://` → `Pasteboard.copy` bridge (the proven venue-copy pattern — not WKWebView clipboard).

~3–6 KB of HTML — negligible against the 1MB WebView budget.

## Feature 2 — overlong-field trim pipeline

Your titles run p95=48 / max=74 chars (the 74 is literally "D>U>R>O is back NEW OUTDOOR LOCATION…"). After bear filtering, before dedup:

1. Deterministic detection: `title > 60`, `description > 600`, `shortName > 30` (configurable, `ai.trim`).
2. **One** batched AI call per overlong event (passLabel `field-trim` — rides the AI response cache).
3. **Verbatim gate**: the answer must be an exact contiguous case-sensitive substring of the original and within the limit. Pass → value replaced (in enforce mode). Fail → original kept + flagged. Never mid-word truncation, never invented text — a trimmed value is byte-for-byte source text.
4. Everything surfaces in the event evidence panel: `title trimmed: 74 → 12 chars — "D>U>R>O"` / `would trim …` / `⚠️ … trim failed verbatim gate, original kept`.

**Ships in `mode: "report"`** — the next runs log and display would-trim decisions without changing any values. Review them, then flip `ai.trim.mode: "enforce"` in scraper-input.js: because trim prompts are cached, enforce replays *exactly the trims you reviewed*, not fresh rolls. Calendar-sourced values are never AI-trimmed (flag-only).

## Notes
- 958 insertions, **0 deletions** — no existing log line, prompt line, or behavior changed while in report mode.
- Tests 818 → 834 (gate matrix incl. paraphrase/re-case/over-limit rejections, report/off modes, cache single-call, config diff/redaction, section rendering).

## After merge
Download `scripts/shared-core.js`, `scripts/adapters/scriptable-adapter.js`, `scripts/scraper-input.js` (or just add the `ai.trim` block to your local copy — defaults apply even without it). Any run now shows the ⚙️ section; runs with overlong fields show `✂️ TRIM [report]` lines to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP