### PR TITLE
fix(site): bigger event favicon chips (18px floor)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2028,12 +2028,16 @@ body.index-page main {
 
 /* Small venue favicon chip shown inline in event rows and card titles */
 .event-favicon-chip {
-    width: 1em;
-    height: 1em;
+    /* Scales with the surrounding text but never below a legible size —
+       the week-view venue line's small font made 1em chips too tiny */
+    width: 1.25em;
+    height: 1.25em;
+    min-width: 18px;
+    min-height: 18px;
     object-fit: cover;
-    border-radius: 3px;
-    vertical-align: -0.12em;
-    margin-right: 0.35em;
+    border-radius: 4px;
+    vertical-align: -0.25em;
+    margin-right: 0.4em;
     background: #fff;
 }
 


### PR DESCRIPTION
Follow-up to #1546 per feedback: the chips were too small, especially on week-view venue lines where 1em resolved to ~11px. Now 1.25em with an 18px minimum — legible in dense rows, modestly larger next to card titles. `vertical-align` retuned for the bigger box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP