### PR TITLE
fix(scraper): venue-site identity fires on undetermined site role (massive.club never resolves 'venue')

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -10353,12 +10353,18 @@ TEXT:
     }
 
     // Identity facts for the venue-site identity pass: remember that SOME page
-    // of this host resolved siteRole 'venue', and the venue name that page
-    // declared (first non-empty wins). Organizer pages still block via the
-    // existing veto — identity is only ever established on unblocked hosts.
+    // of this host resolved siteRole 'venue', and the venue name the host
+    // declares (first non-empty wins). The name is harvested from ANY
+    // non-organizer page — most venue sites never positively resolve 'venue'
+    // (run 20260727-123001: massive.club stayed "undetermined" on every page,
+    // which starved the identity guard of a name it had plainly published).
+    // Recording a name asserts nothing by itself; organizer pages record
+    // nothing and still block via the existing veto.
     recordVenueSiteRoleFacts(entry, htmlData) {
-        if (!entry || this.getPageSiteRole(htmlData) !== 'venue') return;
-        entry.venueRoleSeen = true;
+        if (!entry) return;
+        const role = this.getPageSiteRole(htmlData);
+        if (role === 'organizer') return;
+        if (role === 'venue') entry.venueRoleSeen = true;
         if (!entry.venueName) entry.venueName = this.getPageVenueName(htmlData);
     }
 
@@ -10401,9 +10407,7 @@ TEXT:
         if (this.getPageSiteRole(htmlData) === 'organizer') {
             this.getVenueSiteHarvestEntry(host).blocked = true;
         }
-        if (this.getPageSiteRole(htmlData) === 'venue') {
-            this.recordVenueSiteRoleFacts(this.getVenueSiteHarvestEntry(host), htmlData);
-        }
+        this.recordVenueSiteRoleFacts(this.getVenueSiteHarvestEntry(host), htmlData);
         for (const event of events) {
             if (event && typeof event === 'object' && !event._venueSitePageHost) {
                 event._venueSitePageHost = host;
@@ -10499,9 +10503,13 @@ TEXT:
 
     // WHO a crawled site is — established only when independent hard facts
     // converge, failing closed on ANY miss:
-    //   1. some page of the host resolved siteRole 'venue' AND no page ever
-    //      resolved 'organizer' (blocked — the same veto the address
-    //      consensus honors);
+    //   1. no page of the host ever resolved siteRole 'organizer' (blocked —
+    //      the same veto the address consensus honors). A positive 'venue'
+    //      resolution is NOT required for host-level identity: most venue
+    //      sites stay "undetermined" (run 20260727-123001 — massive.club
+    //      never resolved 'venue' while its curated name and 7-page address
+    //      consensus both held), and the two hard facts below are already
+    //      independent and specific.
     //   2. the harvested venue name uniquely matches ONE curated bar
     //      (findCuratedBarCityByName — ambiguous cities and generic franchise
     //      stems never establish identity);
@@ -10509,7 +10517,8 @@ TEXT:
     //      the curated bar's address (whole-host identity, hostLevel: true),
     //      or — when the host produced no consensus at all — identity applies
     //      per-event only (hostLevel: false; the caller requires the event's
-    //      own _geoPoiName to equal the bar's name key). A consensus that
+    //      own _geoPoiName to equal the bar's name key), and THIS weaker path
+    //      still requires an explicit venue-role page. A consensus that
     //      CONTRADICTS the curated address establishes nothing.
     // Ticketing-platform org pages (eventbrite.com) can never establish
     // identity: the registrable host is the platform's, so its venue name
@@ -10517,22 +10526,30 @@ TEXT:
     // bar — the curated-name condition is the structural guard.
     getEstablishedVenueSiteIdentity(entry, consensusKey = '') {
         if (!entry || typeof entry !== 'object') return null;
-        if (entry.venueRoleSeen !== true || entry.blocked !== false) return null;
+        if (entry.blocked !== false) return null;
         const venueName = typeof entry.venueName === 'string' ? entry.venueName.trim() : '';
         if (!venueName) return null;
         if (!this.core || typeof this.core.findCuratedBarCityByName !== 'function') return null;
         const match = this.core.findCuratedBarCityByName(venueName);
         if (!match || !match.city || !match.bar) return null;
         const curatedBar = match.bar;
+        const roleSignals = entry.venueRoleSeen === true ? ['venue-role'] : [];
         if (consensusKey) {
             const consensusAddress = typeof entry.consensusAddress === 'string' ? entry.consensusAddress.trim() : '';
             const curatedAddress = typeof curatedBar.address === 'string' ? curatedBar.address.trim() : '';
             if (!curatedAddress || !this.venueSiteIdentityAddressesAgree(consensusAddress, curatedAddress)) {
                 return null;
             }
-            return { name: curatedBar.name, city: match.city, curatedBar, hostLevel: true };
+            return {
+                name: curatedBar.name, city: match.city, curatedBar, hostLevel: true,
+                signals: [...roleSignals, 'curated-name', 'address-consensus']
+            };
         }
-        return { name: curatedBar.name, city: match.city, curatedBar, hostLevel: false };
+        if (entry.venueRoleSeen !== true) return null;
+        return {
+            name: curatedBar.name, city: match.city, curatedBar, hostLevel: false,
+            signals: ['venue-role', 'curated-name', 'geo-poi']
+        };
     }
 
     // Deterministic KNOWN-VENUE replacement pass, run by shared-core's
@@ -10557,9 +10574,7 @@ TEXT:
             const cityBars = typeof this.core.getCuratedCityBars === 'function'
                 ? this.core.getCuratedCityBars(identity.city)
                 : null;
-            const signals = identity.hostLevel
-                ? ['venue-role', 'curated-name', 'address-consensus']
-                : ['venue-role', 'curated-name', 'geo-poi'];
+            const signals = identity.signals;
             let identityLogged = false;
             const logIdentityOnce = () => {
                 if (identityLogged) return;

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -6138,11 +6138,21 @@ test('venue-site identity: established for the massive-shaped host, fails closed
   assert.equal(identity.name, 'Massive');
   assert.equal(identity.city, 'seattle');
   assert.equal(identity.hostLevel, true);
+  assert.deepEqual(identity.signals, ['venue-role', 'curated-name', 'address-consensus']);
 
   // Any organizer-resolved page on the host blocks
   assert.equal(parser.getEstablishedVenueSiteIdentity({ ...entry, blocked: true }, entry.consensusKey), null);
-  // No page ever resolved venue role
-  assert.equal(parser.getEstablishedVenueSiteIdentity({ ...entry, venueRoleSeen: false }, entry.consensusKey), null);
+  // Undetermined site role does NOT block host-level identity — curated name
+  // + matching address consensus are the load-bearing facts (run
+  // 20260727-123001: massive.club never resolved 'venue' yet both held)
+  const undeterminedIdentity = parser.getEstablishedVenueSiteIdentity(
+    { ...entry, venueRoleSeen: false }, entry.consensusKey);
+  assert.ok(undeterminedIdentity, 'undetermined role + curated name + address consensus → established');
+  assert.equal(undeterminedIdentity.hostLevel, true);
+  assert.deepEqual(undeterminedIdentity.signals, ['curated-name', 'address-consensus']);
+  // The weaker per-event POI path still REQUIRES an explicit venue-role page
+  assert.equal(parser.getEstablishedVenueSiteIdentity(
+    { ...entry, venueRoleSeen: false, consensusKey: '', consensusAddress: '' }, ''), null);
   // A consensus address CONTRADICTING the curated address establishes nothing
   assert.equal(parser.getEstablishedVenueSiteIdentity(
     { ...entry, consensusAddress: '525 S Riverfront Blvd, Dallas, TX' }, entry.consensusKey), null);
@@ -6266,6 +6276,28 @@ test('venue-site identity: harvest records venue-role facts and the consensus pa
   assert.equal(stashed.blocked, false);
   assert.equal(stashed.consensusKey, '', 'no map-directions addresses → no consensus');
   assert.equal(parser.venueSiteHarvest, null, 'harvest still resets per run');
+});
+
+test('venue-site harvest: an undetermined page records the venue name (not the role); an organizer page records neither', () => {
+  // Undetermined role (pageSiteRole never resolved — the massive.club shape,
+  // run 20260727-123001): the published name is still harvested so identity
+  // can be established from curated-name + address-consensus alone.
+  const parser = createIdentityParser();
+  const undeterminedData = { url: 'https://massive.club/events', html: VENUE_SITE_HTML, pageSiteRole: '' };
+  parser.harvestVenueSiteAddresses(undeterminedData);
+  const entry = parser.venueSiteHarvest['massive.club'];
+  assert.equal(entry.venueRoleSeen, false, 'undetermined never asserts the venue role');
+  assert.equal(entry.venueName, 'MASSIVE', 'the page name is harvested anyway');
+  assert.equal(entry.blocked, false);
+
+  // Organizer role: blocks the host and records no name
+  const organizerParser = createIdentityParser();
+  const organizerData = { url: 'https://massive.club/events', html: VENUE_SITE_HTML, pageSiteRole: 'organizer' };
+  organizerParser.harvestVenueSiteAddresses(organizerData);
+  const blockedEntry = organizerParser.venueSiteHarvest['massive.club'];
+  assert.equal(blockedEntry.blocked, true);
+  assert.equal(blockedEntry.venueRoleSeen, false);
+  assert.equal(blockedEntry.venueName, '', 'organizer pages contribute no identity facts');
 });
 
 test('KNOWN VENUE curated-match prompt line appears only with a unique curated match; the base line stays byte-identical', () => {


### PR DESCRIPTION
## Why the #1545 guard never fired

Fresh-run diagnosis (20260727-123001, confirmed running the full #1545 code): the venue-identity guard required a page to *positively* resolve `siteRole=venue`, but massive.club stays **"undetermined"** on every page — so the guard failed closed at condition 1 while conditions 2 and 3 both held (unique curated match "Massive"; 7-page address consensus = curated address). Worse, the venue *name* was only harvested from venue-role pages, so the guard was starved of a name the site plainly publishes. Result: `PERVERT → "Villa Señor"` survived, unchanged.

Meanwhile the rest of #1545 verified working on that run: the OCR gate reassigned 3 flyers correctly, "Tuesday Closed" was barred from claiming images — and the AI response cache took massive.club from ~13 min to **~51 s** (60 hits).

## The fix

- **Harvest**: venue name recorded from any **non-organizer** page (recording a name asserts nothing); `venueRoleSeen` still requires a positive venue resolution; organizer pages record nothing and still block.
- **Predicate**: host-level identity = not-organizer-blocked + unique curated name + address consensus equal to that bar's curated address. A positive venue-role page is no longer required — those two facts are independent and specific. Unchanged: the organizer block is absolute; the weaker per-event geo-POI path (no consensus) still requires an explicit venue-role page; eventbrite/platform hosts remain structurally excluded. The `signals:` list in the identity log now reflects exactly which facts held.

## Expected on the next massive.club run

```
🤖 AI Web: Venue-site identity for massive.club established: "Massive" (seattle) — signals: curated-name, address-consensus
🤖 AI Web: Replaced bar "Villa Señor" with venue-site identity "Massive" for "PERVERT" (was page-adjacent)
🤖 AI Web: Replaced bar "Massive Club" with venue-site identity "Massive" for "PACK PARTY" (was page-adjacent)
```

Note: Dallas Eagle's last run predates #1545 entirely — rerun it too; its images should start filling via the og:image path, and its two bar-less events need fresh evidence on new code.

Tests 818 → 819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP