### PR TITLE
data(bars): promote 3 verified venues from the bar-additions queue (Metro, Rich's Houston, Paradise)

### DIFF
--- a/data/bars/asbury-park.json
+++ b/data/bars/asbury-park.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "Paradise Night Club",
+    "city": "asbury-park",
+    "address": "101 Asbury Ave, Asbury Park, NJ 07712",
+    "coordinates": "40.2184550, -74.0015495",
+    "website": "https://paradisenj.com",
+    "instagram": "https://www.instagram.com/paradisenj"
+  }
+]

--- a/data/bars/chicago.json
+++ b/data/bars/chicago.json
@@ -31,7 +31,7 @@
     "gayCitiesLastScrapedAt": "2026-06-13T18:37:40.195Z"
   },
   {
-    "name": "Touché",
+    "name": "Touch\u00e9",
     "city": "chicago",
     "address": "6412 N Clark St, Chicago, IL 60626",
     "coordinates": "41.9985708, -87.670974",
@@ -51,5 +51,14 @@
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJP1xBx7DTD4gR1jLvMA_vZss",
     "gayCities": "https://chicago.gaycities.com/bars/145-cell-block",
     "gayCitiesLastScrapedAt": "2026-06-14T01:14:36.735Z"
+  },
+  {
+    "name": "Metro",
+    "city": "chicago",
+    "address": "3730 N Clark St, Chicago, IL 60613",
+    "coordinates": "41.9497837, -87.6590034",
+    "website": "https://metrochicago.com",
+    "instagram": "https://www.instagram.com/metrochicago",
+    "facebook": "https://www.facebook.com/MetroChicago"
   }
 ]

--- a/data/bars/houston.json
+++ b/data/bars/houston.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "Rich's Houston",
+    "city": "houston",
+    "address": "2401 San Jacinto St, Houston, TX 77002",
+    "coordinates": "29.7451002, -95.3715298",
+    "website": "https://richshtx.com",
+    "instagram": "https://www.instagram.com/richshtx",
+    "facebook": "https://www.facebook.com/richshtx"
+  }
+]

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -1,4 +1,14 @@
 {
+  "asbury-park": [
+    {
+      "name": "Paradise Night Club",
+      "city": "asbury-park",
+      "address": "101 Asbury Ave, Asbury Park, NJ 07712",
+      "coordinates": "40.2184550, -74.0015495",
+      "website": "https://paradisenj.com",
+      "instagram": "https://www.instagram.com/paradisenj"
+    }
+  ],
   "atlanta": [
     {
       "name": "The Heretic",
@@ -113,19 +123,18 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJP1xBx7DTD4gR1jLvMA_vZss",
       "gayCities": "https://chicago.gaycities.com/bars/145-cell-block",
       "gayCitiesLastScrapedAt": "2026-06-14T01:14:36.735Z"
+    },
+    {
+      "name": "Metro",
+      "city": "chicago",
+      "address": "3730 N Clark St, Chicago, IL 60613",
+      "coordinates": "41.9497837, -87.6590034",
+      "website": "https://metrochicago.com",
+      "instagram": "https://www.instagram.com/metrochicago",
+      "facebook": "https://www.facebook.com/MetroChicago"
     }
   ],
   "dallas": [
-    {
-      "name": "Dallas Eagle",
-      "city": "dallas",
-      "address": "525 S Riverfront Blvd, Dallas, TX 75207",
-      "coordinates": "32.7693483, -96.8112576",
-      "website": "https://www.thedallaseagle.com",
-      "instagram": "https://www.instagram.com/thedallaseagle",
-      "facebook": "https://www.facebook.com/lonestareagle",
-      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJU843NR6cToYROpJZCM8p4-I"
-    },
     {
       "name": "Station 4",
       "city": "dallas",
@@ -136,6 +145,18 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJd6m0dcmeToYR3R7XzdFC07U",
       "gayCities": "https://dallas.gaycities.com/bars/213-station",
       "gayCitiesLastScrapedAt": "2026-06-26T15:16:43.357Z"
+    },
+    {
+      "name": "Dallas Eagle",
+      "city": "dallas",
+      "address": "525 S Riverfront Blvd, Dallas, TX 75207",
+      "coordinates": "32.7693483, -96.8112576",
+      "website": "https://www.thedallaseagle.com",
+      "instagram": "https://www.instagram.com/thedallaseagle",
+      "facebook": "https://www.facebook.com/lonestareagle",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJU843NR6cToYROpJZCM8p4-I",
+      "faviconBg": "#ffffff",
+      "faviconFg": "#fefefe"
     }
   ],
   "fort-lauderdale": [
@@ -219,6 +240,17 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJK93OZIptAHwRwR-r34F8Zj4",
       "gayCities": "https://hawaii.gaycities.com/bars/277-in-between",
       "gayCitiesLastScrapedAt": "2026-06-14T07:46:32.659Z"
+    }
+  ],
+  "houston": [
+    {
+      "name": "Rich's Houston",
+      "city": "houston",
+      "address": "2401 San Jacinto St, Houston, TX 77002",
+      "coordinates": "29.7451002, -95.3715298",
+      "website": "https://richshtx.com",
+      "instagram": "https://www.instagram.com/richshtx",
+      "facebook": "https://www.facebook.com/richshtx"
     }
   ],
   "la": [

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -8,6 +8,16 @@
 // - Can be imported in both Scriptable and web environments
 // - Keep this file environment-agnostic (no Scriptable or DOM APIs)
 const scraperBars = {
+  "asbury-park": [
+    {
+      "name": "Paradise Night Club",
+      "city": "asbury-park",
+      "address": "101 Asbury Ave, Asbury Park, NJ 07712",
+      "coordinates": "40.2184550, -74.0015495",
+      "website": "https://paradisenj.com",
+      "instagram": "https://www.instagram.com/paradisenj"
+    }
+  ],
   "atlanta": [
     {
       "name": "The Heretic",
@@ -122,19 +132,18 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJP1xBx7DTD4gR1jLvMA_vZss",
       "gayCities": "https://chicago.gaycities.com/bars/145-cell-block",
       "gayCitiesLastScrapedAt": "2026-06-14T01:14:36.735Z"
+    },
+    {
+      "name": "Metro",
+      "city": "chicago",
+      "address": "3730 N Clark St, Chicago, IL 60613",
+      "coordinates": "41.9497837, -87.6590034",
+      "website": "https://metrochicago.com",
+      "instagram": "https://www.instagram.com/metrochicago",
+      "facebook": "https://www.facebook.com/MetroChicago"
     }
   ],
   "dallas": [
-    {
-      "name": "Dallas Eagle",
-      "city": "dallas",
-      "address": "525 S Riverfront Blvd, Dallas, TX 75207",
-      "coordinates": "32.7693483, -96.8112576",
-      "website": "https://www.thedallaseagle.com",
-      "instagram": "https://www.instagram.com/thedallaseagle",
-      "facebook": "https://www.facebook.com/lonestareagle",
-      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJU843NR6cToYROpJZCM8p4-I"
-    },
     {
       "name": "Station 4",
       "city": "dallas",
@@ -145,6 +154,18 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJd6m0dcmeToYR3R7XzdFC07U",
       "gayCities": "https://dallas.gaycities.com/bars/213-station",
       "gayCitiesLastScrapedAt": "2026-06-26T15:16:43.357Z"
+    },
+    {
+      "name": "Dallas Eagle",
+      "city": "dallas",
+      "address": "525 S Riverfront Blvd, Dallas, TX 75207",
+      "coordinates": "32.7693483, -96.8112576",
+      "website": "https://www.thedallaseagle.com",
+      "instagram": "https://www.instagram.com/thedallaseagle",
+      "facebook": "https://www.facebook.com/lonestareagle",
+      "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJU843NR6cToYROpJZCM8p4-I",
+      "faviconBg": "#ffffff",
+      "faviconFg": "#fefefe"
     }
   ],
   "fort-lauderdale": [
@@ -228,6 +249,17 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJK93OZIptAHwRwR-r34F8Zj4",
       "gayCities": "https://hawaii.gaycities.com/bars/277-in-between",
       "gayCitiesLastScrapedAt": "2026-06-14T07:46:32.659Z"
+    }
+  ],
+  "houston": [
+    {
+      "name": "Rich's Houston",
+      "city": "houston",
+      "address": "2401 San Jacinto St, Houston, TX 77002",
+      "coordinates": "29.7451002, -95.3715298",
+      "website": "https://richshtx.com",
+      "instagram": "https://www.instagram.com/richshtx",
+      "facebook": "https://www.facebook.com/richshtx"
     }
   ],
   "la": [


### PR DESCRIPTION
First "check the queue" pass over the growth-loop dossiers (7 entries, 6 unique venues, single sightings each from Bearracuda/Furball/Megawoof runs).

## Rejected as duplicates (3)
The Heretic (atlanta), Joy Theater (nola), Public Works (sf) — each already curated with **identical address and coordinates**. (Worth watching: the queue collected venues that were already curated — if that recurs, the dossier-collection guard needs a look.)

## Promoted (3) — each verified by the venue's own site + an OSM POI at exactly the dossier's pin

| Venue | City | Address | Evidence |
|---|---|---|---|
| Metro | chicago | 3730 N Clark St | metrochicago.com footer; OSM POI exact match; hosts FURBALL Chicago (same precedent as curated Joy Theater/Public Works) |
| Rich's Houston | houston *(new city file)* | 2401 San Jacinto St | richshtx.com; OSM POI literally "Rich's Houston"; Yelp + VisitHouston corroborate; the historic Houston gay club, reopened 2023 |
| Paradise Night Club | asbury-park *(new city file)* | 101 Asbury Ave | paradisenj.com (explicitly LGBTQ+, hosts "Bear Invasion"); OSM POI exact match |

Notes: the dossiers' website/instagram fields carried the **party producers'** links (bearracuda.com, linktr.ee/megawoof) — the entries use verified venue-own links instead. Both new cities were already registered in `scripts/scraper-cities.js`. Twins regenerated (`scripts/scraper-bars.js`, `data/scraper-bars.json`). Suite 835/835.

These directly extend the venue-identity guard's reach — e.g. richshtx.com can now qualify for venue-site identity once crawled.

After merge: the runtime pulls bars from chunky.dad's deployed JSON (1-day cache), so the scraper sees these after the site deploys + cache rolls; no phone file download needed for bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP