### PR TITLE
feat(scraper): parser picker at run start + six new recon-verified parsers

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2253,6 +2253,25 @@ class ScriptableAdapter {
         );
       }
 
+      if (
+        !parserNameOverride &&
+        !urlInput &&
+        this.shouldPresentParserPicker(config)
+      ) {
+        // Total captured before the selection replaces the array
+        const parserPickerTotal = config.parsers.length;
+        const picked = await this.presentParserPicker(config);
+        if (picked) {
+          config.parsers = this.applyParserPickerSelection(
+            config.parsers,
+            picked,
+          );
+          console.log(
+            `📱 Scriptable: Parser picker: running ${picked.size} of ${parserPickerTotal} parsers`,
+          );
+        }
+      }
+
       this.applyLogConfig(config);
 
       return config;
@@ -9114,6 +9133,241 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         `📱 Scriptable: ✗ Failed to present UITable: ${error.message}`,
       );
       throw error;
+    }
+  }
+
+  // ── Parser picker (run-start parser selection UI) ─────────────────────────
+  // Staleness helpers ported from scripts/stale-parsers.js (not imported —
+  // that script self-executes on load). Kept pure so they test headlessly.
+
+  parseMetricsNdjsonForPicker(text) {
+    const lines = String(text || "")
+      .split("\n")
+      .filter((line) => line.trim().length > 0);
+    if (lines.length === 0) return [];
+
+    const records = [];
+    lines.forEach((line) => {
+      try {
+        const record = JSON.parse(line);
+        if (record) records.push(record);
+      } catch (_) {
+        // skip malformed lines
+      }
+    });
+
+    records.sort((a, b) => {
+      const aTime = a?.finished_at ? new Date(a.finished_at).getTime() : 0;
+      const bTime = b?.finished_at ? new Date(b.finished_at).getTime() : 0;
+      return aTime - bTime;
+    });
+
+    return records;
+  }
+
+  getLastCalendarWriteAtForPicker(records, parserName) {
+    for (let i = records.length - 1; i >= 0; i -= 1) {
+      const record = records[i];
+      const parserRecords = Array.isArray(record?.parsers) ? record.parsers : [];
+      const match = parserRecords.find((pr) => pr?.parser_name === parserName);
+      if (!match) continue;
+      const ca = match.calendar_actions || {};
+      if ((ca.create || 0) > 0 || (ca.update || 0) > 0) {
+        return record.finished_at || null;
+      }
+    }
+    return null;
+  }
+
+  formatDaysSinceForPicker(daysSince) {
+    if (daysSince === null || daysSince === undefined) return "never";
+    const d = Math.floor(daysSince);
+    if (d <= 0) return "today";
+    if (d === 1) return "1d ago";
+    return `${d}d ago`;
+  }
+
+  async readMetricsRecordsForPicker() {
+    try {
+      const fm = this.fm || FileManager.iCloud();
+      const path = this.getMetricsFilePath();
+      if (!fm.fileExists(path)) return [];
+      try {
+        await fm.downloadFileFromiCloud(path);
+      } catch (_) {
+        // fall through to reading whatever local copy exists
+      }
+      return this.parseMetricsNdjsonForPicker(fm.readString(path) || "");
+    } catch (_) {
+      return [];
+    }
+  }
+
+  // Manual runs only: knob must be explicitly on, and no automation/widget/
+  // action-extension context (mirrors the runtime checks in shouldSkipResultsUi).
+  shouldPresentParserPicker(config) {
+    return (
+      config?.config?.pickParsers === true &&
+      !config?.runtime?.automationRun &&
+      !config?.runtime?.runsInWidget &&
+      !config?.runtime?.runsInActionExtension
+    );
+  }
+
+  // Spread copies only — never mutates the importModule'd parser objects.
+  // Unknown names in the set are ignored naturally (no parser matches them).
+  applyParserPickerSelection(parsers, pickedSet) {
+    return parsers.map((p) => ({ ...p, enabled: pickedSet.has(p.name) }));
+  }
+
+  // Stalest-first ordering (ports computeStaleStatus's sort semantics from
+  // stale-parsers.js): never-written → Infinity → top, then descending
+  // days-since-last-write, name as tiebreak.
+  buildParserPickerEntries(parsers, records, now = Date.now()) {
+    const entries = parsers.map((parser) => {
+      const lastWriteAt = this.getLastCalendarWriteAtForPicker(
+        records,
+        parser.name,
+      );
+      let daysSince = null;
+      if (lastWriteAt) {
+        const writeTime = new Date(lastWriteAt).getTime();
+        if (Number.isFinite(writeTime) && writeTime > 0) {
+          daysSince = (now - writeTime) / (24 * 60 * 60 * 1000);
+        }
+      }
+      return {
+        name: parser.name,
+        enabled: parser.enabled !== false,
+        daysSince,
+        lastWriteAt,
+      };
+    });
+
+    entries.sort((a, b) => {
+      const aDays =
+        a.daysSince === null ? Number.POSITIVE_INFINITY : a.daysSince;
+      const bDays =
+        b.daysSince === null ? Number.POSITIVE_INFINITY : b.daysSince;
+      if (bDays !== aDays) return bDays - aDays;
+      return String(a.name).localeCompare(String(b.name));
+    });
+
+    return entries;
+  }
+
+  // Presents a UITable listing all configured parsers (stalest-first) with
+  // checkmark toggles. Resolves with a Set of picked parser names, or null on
+  // swipe-down dismissal / any error (fail open — run proceeds unchanged).
+  async presentParserPicker(config) {
+    try {
+      const parsers = Array.isArray(config?.parsers) ? config.parsers : [];
+      if (parsers.length === 0) return null;
+
+      const records = await this.readMetricsRecordsForPicker();
+      const entries = this.buildParserPickerEntries(parsers, records);
+
+      // Default pre-selection: config-enabled parsers
+      const selected = new Set(
+        entries.filter((entry) => entry.enabled).map((entry) => entry.name),
+      );
+
+      let resolved = false;
+      let resolveSelection;
+      const selectionPromise = new Promise((resolve) => {
+        resolveSelection = resolve;
+      });
+      const finish = (value) => {
+        if (resolved) return;
+        resolved = true;
+        resolveSelection(value);
+      };
+
+      const table = new UITable();
+      table.showSeparators = true;
+
+      const rebuild = () => {
+        table.removeAllRows();
+
+        // Header row
+        const headerRow = new UITableRow();
+        headerRow.isHeader = true;
+        headerRow.height = 50;
+
+        const headerCell = headerRow.addText("🐻 Pick Parsers");
+        headerCell.titleFont = Font.boldSystemFont(18);
+        headerCell.titleColor = Color.white();
+        headerCell.backgroundColor = Color.brown();
+
+        table.addRow(headerRow);
+
+        // Action rows (default dismissOnSelect: tapping dismisses the table)
+        const runSelectedRow = new UITableRow();
+        runSelectedRow.height = 50;
+        const runSelectedCell = runSelectedRow.addText(
+          `▶ Run selected (${selected.size})`,
+        );
+        runSelectedCell.titleFont = Font.boldSystemFont(16);
+        runSelectedCell.titleColor = Color.blue();
+        runSelectedRow.onSelect = () => {
+          finish(new Set(selected));
+        };
+        table.addRow(runSelectedRow);
+
+        const runAllRow = new UITableRow();
+        runAllRow.height = 50;
+        const runAllCell = runAllRow.addText(`▶ Run all (${entries.length})`);
+        runAllCell.titleFont = Font.boldSystemFont(16);
+        runAllCell.titleColor = Color.blue();
+        runAllRow.onSelect = () => {
+          finish(new Set(entries.map((entry) => entry.name)));
+        };
+        table.addRow(runAllRow);
+
+        // One row per parser, stalest-first
+        entries.forEach((entry) => {
+          const row = new UITableRow();
+          row.height = 50;
+          row.dismissOnSelect = false;
+
+          const isPicked = selected.has(entry.name);
+          const cell = row.addText(
+            `${isPicked ? "☑" : "☐"} ${entry.name}`,
+          );
+          cell.titleFont = Font.systemFont(14);
+          cell.subtitleText = `${this.formatDaysSinceForPicker(entry.daysSince)} (last write) · ${entry.enabled ? "enabled" : "disabled"} in config`;
+          cell.subtitleColor = Color.gray();
+
+          row.onSelect = () => {
+            if (selected.has(entry.name)) {
+              selected.delete(entry.name);
+            } else {
+              selected.add(entry.name);
+            }
+            rebuild();
+            table.reload();
+          };
+
+          table.addRow(row);
+        });
+      };
+
+      rebuild();
+
+      // present() resolves when the table is dismissed — by an action row
+      // (finish already ran; this finish(null) is a no-op) or by swipe-down
+      // (no selection was made → resolve null).
+      table.present(false).then(
+        () => finish(null),
+        () => finish(null),
+      );
+
+      return await selectionPromise;
+    } catch (error) {
+      console.log(
+        `📱 Scriptable: ✗ Parser picker failed: ${error.message}`,
+      );
+      return null;
     }
   }
 

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -2623,3 +2623,161 @@ test('generateRichHTML embeds the active-config section and the copy-config hand
   const withoutConfig = await adapter.generateRichHTML(buildResultsStub());
   assert.ok(!withoutConfig.includes('Active config'), 'no section without a config snapshot');
 });
+
+// ---------------------------------------------------------------------------
+// Parser picker: guard, selection application, staleness helpers, ordering.
+// The native UITable presentation itself is not headlessly testable — these
+// cover the pure parts presentParserPicker is built on.
+// ---------------------------------------------------------------------------
+
+test('shouldPresentParserPicker: knob off or non-manual runtime → false; on+manual → true', () => {
+  const adapter = buildAdapter();
+  const manual = { automationRun: false, runsInWidget: false, runsInActionExtension: false };
+
+  assert.equal(
+    adapter.shouldPresentParserPicker({ config: {}, runtime: manual }),
+    false,
+    'knob absent → false'
+  );
+  assert.equal(
+    adapter.shouldPresentParserPicker({ config: { pickParsers: 'yes' }, runtime: manual }),
+    false,
+    'non-boolean truthy knob → false (requires === true)'
+  );
+  assert.equal(
+    adapter.shouldPresentParserPicker({ config: { pickParsers: true }, runtime: manual }),
+    true,
+    'knob on + manual run → true'
+  );
+  assert.equal(
+    adapter.shouldPresentParserPicker({
+      config: { pickParsers: true },
+      runtime: { ...manual, automationRun: true }
+    }),
+    false,
+    'automation run → false'
+  );
+  assert.equal(
+    adapter.shouldPresentParserPicker({
+      config: { pickParsers: true },
+      runtime: { ...manual, runsInWidget: true }
+    }),
+    false,
+    'widget run → false'
+  );
+  assert.equal(
+    adapter.shouldPresentParserPicker({
+      config: { pickParsers: true },
+      runtime: { ...manual, runsInActionExtension: true }
+    }),
+    false,
+    'action-extension run → false'
+  );
+});
+
+test('applyParserPickerSelection flips enabled by membership without mutating originals', () => {
+  const adapter = buildAdapter();
+  const original = [
+    { name: 'Alpha', enabled: false, url: 'https://a.example' },
+    { name: 'Beta', enabled: true },
+    { name: 'Gamma' }
+  ];
+
+  const applied = adapter.applyParserPickerSelection(
+    original,
+    new Set(['Alpha', 'Ghost'])
+  );
+
+  assert.deepEqual(
+    applied.map((p) => p.enabled),
+    [true, false, false],
+    'selected → enabled true, unselected → false; unknown names ignored'
+  );
+  assert.equal(applied[0].url, 'https://a.example', 'other fields carried over');
+
+  // Originals unmutated (spread copies only)
+  assert.equal(original[0].enabled, false);
+  assert.equal(original[1].enabled, true);
+  assert.equal(original[2].enabled, undefined);
+  assert.notEqual(applied[0], original[0], 'copies, not the same objects');
+});
+
+const PICKER_METRICS_FIXTURE = [
+  '{"finished_at":"2026-07-20T03:00:00.000Z","parsers":[{"parser_name":"Alpha","calendar_actions":{"create":2,"update":0}}]}',
+  'not json at all {{{',
+  '{"finished_at":"2026-07-10T03:00:00.000Z","parsers":[{"parser_name":"Beta","calendar_actions":{"create":0,"update":1}}]}',
+  '{"finished_at":"2026-07-25T03:00:00.000Z","parsers":[{"parser_name":"Alpha","calendar_actions":{"create":0,"update":0}},{"parser_name":"Beta","calendar_actions":{"create":0,"update":0}}]}',
+  ''
+].join('\n');
+
+test('parseMetricsNdjsonForPicker skips malformed lines and sorts ascending by finished_at', () => {
+  const adapter = buildAdapter();
+  const records = adapter.parseMetricsNdjsonForPicker(PICKER_METRICS_FIXTURE);
+
+  assert.equal(records.length, 3, 'malformed and blank lines skipped');
+  assert.deepEqual(
+    records.map((r) => r.finished_at),
+    [
+      '2026-07-10T03:00:00.000Z',
+      '2026-07-20T03:00:00.000Z',
+      '2026-07-25T03:00:00.000Z'
+    ],
+    'ascending by finished_at'
+  );
+  assert.deepEqual(adapter.parseMetricsNdjsonForPicker(''), []);
+});
+
+test('getLastCalendarWriteAtForPicker counts only create/update > 0 and returns null for absent parsers', () => {
+  const adapter = buildAdapter();
+  const records = adapter.parseMetricsNdjsonForPicker(PICKER_METRICS_FIXTURE);
+
+  // Newest Alpha record (07-25) has 0/0 calendar actions — must NOT count;
+  // the older 07-20 record with create:2 is the last real write.
+  assert.equal(
+    adapter.getLastCalendarWriteAtForPicker(records, 'Alpha'),
+    '2026-07-20T03:00:00.000Z'
+  );
+  assert.equal(
+    adapter.getLastCalendarWriteAtForPicker(records, 'Beta'),
+    '2026-07-10T03:00:00.000Z',
+    'update > 0 counts as a write'
+  );
+  assert.equal(
+    adapter.getLastCalendarWriteAtForPicker(records, 'Nope'),
+    null,
+    'absent parser → null'
+  );
+});
+
+test('formatDaysSinceForPicker labels: never / today / 1d ago / Nd ago', () => {
+  const adapter = buildAdapter();
+  assert.equal(adapter.formatDaysSinceForPicker(null), 'never');
+  assert.equal(adapter.formatDaysSinceForPicker(undefined), 'never');
+  assert.equal(adapter.formatDaysSinceForPicker(0.4), 'today');
+  assert.equal(adapter.formatDaysSinceForPicker(1.7), '1d ago');
+  assert.equal(adapter.formatDaysSinceForPicker(12.2), '12d ago');
+});
+
+test('buildParserPickerEntries orders stalest-first: never-written, then stale, then fresh', () => {
+  const adapter = buildAdapter();
+  const now = new Date('2026-07-27T03:00:00.000Z').getTime();
+  const records = adapter.parseMetricsNdjsonForPicker(PICKER_METRICS_FIXTURE);
+  const parsers = [
+    { name: 'Alpha', enabled: true }, // last write 7d ago (fresh-ish)
+    { name: 'Beta', enabled: false }, // last write 17d ago (stale)
+    { name: 'Nope' } // never written, enabled defaults on
+  ];
+
+  const entries = adapter.buildParserPickerEntries(parsers, records, now);
+
+  assert.deepEqual(
+    entries.map((e) => e.name),
+    ['Nope', 'Beta', 'Alpha'],
+    'never-written ranks before stale ranks before fresh'
+  );
+  assert.equal(entries[0].daysSince, null);
+  assert.equal(entries[0].enabled, true, 'enabled !== false defaults to selected-eligible');
+  assert.equal(entries[1].enabled, false);
+  assert.equal(Math.floor(entries[1].daysSince), 17);
+  assert.equal(Math.floor(entries[2].daysSince), 7);
+});

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -11,6 +11,7 @@ const scraperConfig = {
   config: {
     daysToLookAhead: null,
     // dryRun: true, // Preview mode: analyze + display without writing to the calendar (default: false)
+    pickParsers: true, // Parser picker at run start (manual runs only; automation/widget runs skip it; selection is session-scoped — never edits this file) (default: false)
     pageCache: {
       enabled: true,
       ttlDays: 3,
@@ -253,6 +254,71 @@ const scraperConfig = {
         facebook: { value: "https://www.facebook.com/lonestareagle" },
         instagram: { value: "https://www.instagram.com/thedallaseagle/" },
         mastodon: { value: "https://mastodon.social/@dallaseagle" },
+      },
+    },
+    // ── Onboarding batch 2026-07-27 (recon-verified) — each ships disabled;
+    // run one at a time via the parser picker, review, then enable. ──────
+    {
+      name: "The Lumberyard",
+      enabled: false,
+      urls: ["https://www.thelumberyardbar.com/events"],
+      // Seattle bear-friendly bar (9630 16th Ave SW) with general weekly
+      // programming — bear check filters, not alwaysBear.
+      alwaysBear: false,
+      metadata: {
+        website: { value: "https://www.thelumberyardbar.com" },
+      },
+    },
+    {
+      name: "CubScout LA",
+      enabled: false,
+      // Eagle LA's recurring bear party page (The Events Calendar, JSON-LD).
+      urls: ["https://eaglela.com/events/cub-scout-3/"],
+      alwaysBear: true,
+    },
+    {
+      name: "BEEFMINCE",
+      enabled: false,
+      // Multi-city UK (London/Brighton/Manchester/Birmingham + Sitges);
+      // per-event city comes from event text; tickets link out to dice.fm.
+      urls: ["https://beefmince.com/events"],
+      alwaysBear: true,
+      metadata: {
+        website: { value: "https://beefmince.com" },
+      },
+    },
+    {
+      name: "BeefDip",
+      enabled: false,
+      // Puerto Vallarta bear week; single schedule page, venues appear as
+      // Google Maps links (maps-link address harvesting applies).
+      urls: ["https://beefdip.com/planned-events/"],
+      alwaysBear: true,
+      metadata: {
+        website: { value: "https://beefdip.com" },
+      },
+    },
+    {
+      name: "Bear it MTL",
+      enabled: false,
+      // Montreal (Sugar Bear Weekend organizer); The Events Calendar with
+      // JSON-LD + Offers; also lists Toronto/Paris events — city per event.
+      urls: ["https://www.bearitmtl.com/events/"],
+      alwaysBear: true,
+      metadata: {
+        website: { value: "https://www.bearitmtl.com" },
+      },
+    },
+    {
+      name: "Club Chub",
+      enabled: false,
+      // Touring chub/chaser series; Eventbrite links sit in the site's own
+      // static HTML. Do NOT use the Eventbrite org page — it's CCBC Resort's
+      // venue account and would pull non-Club-Chub events.
+      urls: ["https://www.clubchubusa.com/event-list"],
+      alwaysBear: true,
+      metadata: {
+        instagram: { value: "https://www.instagram.com/clubchubparty" },
       },
     },
     {


### PR DESCRIPTION
## Parser picker — no more flag-flipping between runs

On every **manual** run, a native picker appears first, listing all parsers **stalest-first** — staleness is *days since the parser last wrote to a calendar*, from `metrics.ndjson`, computed exactly like the stale-parsers widget (its logic ported into the adapter). Rows read like:

```
☑ massive.club        2d ago (last write) · enabled in config
☐ BeefDip             never (last write) · disabled in config
```

- Tap a row to toggle. Config-enabled parsers come pre-selected, so plain "▶ Run selected" behaves like today in one tap; running the next stale parser is two taps.
- **Session-scoped**: your `scraper-input.js` is never modified — unselected parsers just flow into the existing "Skipped disabled parsers" logging for this run.
- **Automation-safe**: scheduled/widget/action-extension runs skip the picker entirely (same runtime detection as the results-UI skip); the `parserName` deep link (stale-parsers widget) and URL-input runs bypass it too. Swipe-down = run as configured. Any error fails open.
- Knob: `pickParsers` (code default OFF; turned on in the template since this is the requested workflow).

Note: "never" means no calendar write within the ~30-day metrics retention window.

## Six new parsers (all `enabled: false` — first runs are deliberate picks in the new UI)

| Parser | Source | Notes |
|---|---|---|
| The Lumberyard | thelumberyardbar.com/events | **Seattle** (not Palm Springs!), general programming → bear check filters |
| CubScout LA | eaglela.com/events/cub-scout-3/ | JSON-LD Event, next edition Sep 4 |
| BEEFMINCE | beefmince.com/events | Multi-city UK, city per event |
| BeefDip | beefdip.com/planned-events/ | PV bear week; venues are Google-Maps links (address harvesting applies) |
| Bear it MTL | bearitmtl.com/events/ | Sugar Bear organizer; JSON-LD + Offers; also Toronto/Paris events |
| Club Chub | clubchubusa.com/event-list | Touring; deliberately NOT its Eventbrite org (CCBC Resort's venue account) |

Blocked in recon (not onboarded): Rockbar (mid-redesign, placeholder calendar — recheck in a few weeks), Horse Meat Disco (JS-only Bandsintown widget), Lodge NY (empty React SPA), THCKBOYZ (t-shirt shop), Cake Bangkok (directory profile, no events), Fat Dad (one-shot past humanitix event), Glow/SSBS (JS shell; partially covered via Lumberyard).

## Testing

835 → **841** (picker guard matrix, session-override immutability, ndjson parsing/staleness/ordering, formatting). The UITable itself needs one on-device check: toggling should update rows in place without re-presenting — if toggles feel broken on your phone, tell me and I'll adjust the reload flow.

## After merge

Download `scripts/adapters/scriptable-adapter.js` and `scripts/scraper-input.js` (the picker knob + new parsers live there — merge with your local copy if it has personal edits). First run shows the picker; try running one new parser (BeefDip is a good first pick) and review its preview before executing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP