### PR TITLE
feat(scraper): JSON-API extraction pathway, discovery allowlist, Goldiloxx multi-platform tracking

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -378,15 +378,35 @@ class AiWebParser {
         var ocrResults = [];
         try {
             this.aiPromptHistory = [];
-            const html = htmlData && htmlData.html ? htmlData.html : '';
             const sourceUrl = htmlData && htmlData.url ? htmlData.url : '';
+
+            // JSON-API pathway: some parser targets are raw JSON endpoints
+            // (api.redeyetickets.com), not HTML pages. Detect that ONCE here —
+            // the parsed payload feeds the deterministic structured extraction
+            // below, and the linearized `keyPath: value` text replaces the page
+            // html for EVERY downstream consumer (additional-URL harvest, OCR
+            // image harvest, prompt sections, verbatim evidence gate) so the
+            // HTML-oriented machinery sees real lines instead of an opaque blob.
+            const jsonApiPayload = this.detectJsonApiPayload(htmlData && htmlData.html ? htmlData.html : '');
+            const jsonApiCandidates = jsonApiPayload !== null
+                ? this.collectJsonApiEventCandidates(jsonApiPayload)
+                : [];
+            if (jsonApiPayload !== null) {
+                console.log(`🤖 AI Web: JSON API response detected (${jsonApiCandidates.length} candidate event object(s))`);
+            }
+            // Same object reference when no payload was detected — page-level
+            // caches (pageSiteRole, brand names) are stamped onto this object.
+            const effectiveHtmlData = jsonApiPayload !== null
+                ? { ...htmlData, html: this.linearizeJsonForPrompt(jsonApiPayload) }
+                : htmlData;
+            const html = effectiveHtmlData && effectiveHtmlData.html ? effectiveHtmlData.html : '';
             const additionalLinks = this.extractAdditionalUrls(html, sourceUrl, parserConfig);
 
             // Derive the page's organizer/site brand ONCE per page (from JSON-LD
             // Organization/WebSite and og:site_name). Extraction prompts, the
             // post-extraction guard in normalizeAiEvent, and downstream merge
             // arbitration all reuse this cached result instead of re-parsing HTML.
-            const pageBrandNames = this.getPageBrandNames(htmlData);
+            const pageBrandNames = this.getPageBrandNames(effectiveHtmlData);
             if (pageBrandNames.length > 0) {
                 console.log(`🤖 AI Web: Page organizer/brand derived from metadata: ${pageBrandNames.map(name => `"${name}"`).join(', ')}`);
             }
@@ -396,7 +416,7 @@ class AiWebParser {
             // (segment-derived facts are layered in on multi-event pages).
             // 'venue' switches extraction steering from KNOWN ORGANIZER to
             // KNOWN VENUE; undetermined changes nothing (fail open).
-            this.resolvePageSiteRole(htmlData, parserConfig);
+            this.resolvePageSiteRole(effectiveHtmlData, parserConfig);
 
             // Deterministic venue-site address harvest (no AI): map-directions
             // links (Google/Apple) on ANY fetched page of a site feed a
@@ -404,7 +424,7 @@ class AiWebParser {
             // site's own events — applyVenueSiteAddressConsensus judges it
             // after the whole crawl (fail closed: two distinct addresses, or
             // siteRole 'organizer', derive nothing).
-            this.harvestVenueSiteAddresses(htmlData);
+            this.harvestVenueSiteAddresses(effectiveHtmlData);
 
             // Deterministic extraction from schema.org Event JSON-LD. Ticketing pages
             // (sickening.events, tryst.events, Eventbrite) hand us complete structured
@@ -412,21 +432,38 @@ class AiWebParser {
             // cost without adding trust, so use the structured data directly.
             const jsonLdEvents = this.extractEventsFromJsonLd(html, sourceUrl, cityConfig);
             const completeJsonLdEvents = jsonLdEvents.filter(event => event.bar || event.address);
-            const useJsonLdEvents = parserConfig.discoveryOnly !== true
+            // JSON-API structured events run through the SAME completeness gate
+            // and the SAME enrichment/stamping as JSON-LD (structured data
+            // enriches, never bypasses). JSON-LD wins when both exist — in
+            // practice they are mutually exclusive: a raw JSON body carries no
+            // <script> tags, so its JSON-LD set is always empty.
+            const jsonApiEvents = jsonApiPayload !== null
+                ? this.extractEventsFromJsonApiPayload(jsonApiPayload, sourceUrl, cityConfig)
+                : [];
+            const completeJsonApiEvents = jsonApiEvents.filter(event => event.bar || event.address);
+            const structuredSource = completeJsonLdEvents.length > 0
+                ? 'jsonld'
+                : (completeJsonApiEvents.length > 0 ? 'json-api' : null);
+            const structuredEvents = structuredSource === 'jsonld' ? completeJsonLdEvents : completeJsonApiEvents;
+            const useStructuredEvents = parserConfig.discoveryOnly !== true
                 && pageClassification !== 'link-aggregator'
-                && completeJsonLdEvents.length > 0
-                // A multi-event page with a single JSON-LD node likely marks up only its
+                && structuredEvents.length > 0
+                // A multi-event page with a single structured node likely marks up only its
                 // featured event — fall through to segment extraction for full coverage.
-                && (pageClassification !== 'multi-event-page' || completeJsonLdEvents.length >= 2);
-            if (useJsonLdEvents) {
-                console.log(`🤖 AI Web: Extracted ${completeJsonLdEvents.length} event(s) from JSON-LD structured data — skipping OCR and AI extraction`);
+                && (pageClassification !== 'multi-event-page' || structuredEvents.length >= 2);
+            if (useStructuredEvents) {
+                if (structuredSource === 'json-api') {
+                    console.log(`🤖 AI Web: Extracted ${structuredEvents.length} event(s) from JSON API structured data — skipping OCR and AI extraction`);
+                } else {
+                    console.log(`🤖 AI Web: Extracted ${structuredEvents.length} event(s) from JSON-LD structured data — skipping OCR and AI extraction`);
+                }
                 if (pageBrandNames.length > 0) {
-                    completeJsonLdEvents.forEach(event => {
+                    structuredEvents.forEach(event => {
                         event._organizer = pageBrandNames[0];
-                        // JSON-LD events skip normalizeAiEvent, so the bare-city
+                        // Structured-data events skip normalizeAiEvent, so the bare-city
                         // title rule (organizer prefix) is applied here too.
                         const prefixedTitle = this.buildOrganizerPrefixedTitle(
-                            event.title, event.city, pageBrandNames, htmlData, cityConfig);
+                            event.title, event.city, pageBrandNames, effectiveHtmlData, cityConfig);
                         if (prefixedTitle) {
                             console.log(`🤖 AI Web: Title "${event.title}" is just the event's city — prefixed known organizer → "${prefixedTitle}"`);
                             event.title = prefixedTitle;
@@ -435,33 +472,45 @@ class AiWebParser {
                 }
                 // Enrichment only: fills empty fields from the Wix warmup blob,
                 // never skips or replaces an extraction step.
-                this.applyWixServerDataEnrichment(completeJsonLdEvents, htmlData, cityConfig);
-                await this.applyJsonLdGapFill(completeJsonLdEvents, htmlData, parserConfig, cityConfig, httpAdapter);
-                // A single JSON-LD event whose node carried no image adopts
+                this.applyWixServerDataEnrichment(structuredEvents, effectiveHtmlData, cityConfig);
+                await this.applyJsonLdGapFill(structuredEvents, effectiveHtmlData, parserConfig, cityConfig, httpAdapter);
+                // A single structured event whose node carried no image adopts
                 // the page's own og:image artwork (multi-event pages never do:
                 // one shared meta image cannot be attributed to one event).
-                if (completeJsonLdEvents.length === 1) {
-                    this.fillImageFromPageMetaArtwork(completeJsonLdEvents[0], htmlData);
+                if (structuredEvents.length === 1) {
+                    this.fillImageFromPageMetaArtwork(structuredEvents[0], effectiveHtmlData);
                 }
-                // Images the JSON-LD nodes carried are already stamped 'jsonld';
-                // an image the gap-fill pulled from page content gets its own
-                // og-image/page provenance here (no image → no stamp).
-                completeJsonLdEvents.forEach(event => this.stampImageProvenance(event, htmlData));
+                // Images the structured nodes carried are already stamped
+                // 'jsonld'/'json-api'; an image the gap-fill pulled from page
+                // content gets its own og-image/page provenance here (no image
+                // → no stamp).
+                structuredEvents.forEach(event => this.stampImageProvenance(event, effectiveHtmlData));
                 // Bar provenance for the structured-data path: curated/
                 // venue-site stamps only — there is no extraction evidence
                 // corpus here, so the adjacency check never runs (fail open).
-                completeJsonLdEvents.forEach(event => this.stampBarSourceProvenance(event, null, htmlData));
+                structuredEvents.forEach(event => this.stampBarSourceProvenance(event, null, effectiveHtmlData));
                 // Attribute the events to this page's site so the post-crawl
                 // venue-site address consensus can fill their blanks.
-                this.tagEventsWithVenueSitePage(completeJsonLdEvents, htmlData);
+                this.tagEventsWithVenueSitePage(structuredEvents, effectiveHtmlData);
                 return {
-                    events: completeJsonLdEvents,
+                    events: structuredEvents,
                     additionalLinks: additionalLinks,
                     discoveredSegments: null,
                     ocrResults: [],
+                    extractionSummary: { source: structuredSource, aiPasses: this.aiPromptHistory.length, ocrImages: 0 },
                     source: this.config.source,
                     url: sourceUrl
                 };
+            }
+
+            // Falling through to OCR/AI with a detected JSON payload whose
+            // structured conversion came up short: announce the linearized
+            // substitution and WHY (the forensic gap — this failure mode used
+            // to be invisible in persisted logs).
+            if (jsonApiPayload !== null && completeJsonApiEvents.length === 0) {
+                const lineCount = html ? html.split('\n').length : 0;
+                const missingFields = jsonApiEvents.length === 0 ? 'title, startDate' : 'bar, address';
+                console.log(`🤖 AI Web: JSON API payload linearized to ${lineCount} line(s) for AI extraction (structured conversion incomplete: missing ${missingFields})`);
             }
 
             // Extract OCR from ALL images FIRST - we need it for consistent segment-to-image
@@ -478,7 +527,7 @@ class AiWebParser {
             // so respect the configured per-page image budget there.
             const ocrImageCap = pageClassification === 'multi-event-page' ? 10 : ocrConfig.maxImages;
             ocrResults = runOcr
-                ? await this.extractOcrFromAllImages(htmlData, ocrConfig, httpAdapter, ocrImageCap)
+                ? await this.extractOcrFromAllImages(effectiveHtmlData, ocrConfig, httpAdapter, ocrImageCap)
                 : [];
             if (ocrResults.length > 0) {
                 console.log(`🤖 AI Web: Extracted OCR from ${ocrResults.length} image(s)`);
@@ -556,24 +605,32 @@ class AiWebParser {
             const dataFlags = this.getDataFlagsForPartition(sectionBundle, payloadMode, '');
             const promptFields = this.getAiPromptFields(parserConfig, dataFlags, sourceUrl);
             const events = pageClassification === 'multi-event-page'
-                ? await this.extractEventsFromMultiEventPage(htmlData, parserConfig, cityConfig, promptFields, ocrResults, httpAdapter)
-                : await this.extractEventsFromSinglePage(htmlData, parserConfig, cityConfig, promptFields, ocrResults, httpAdapter);
+                ? await this.extractEventsFromMultiEventPage(effectiveHtmlData, parserConfig, cityConfig, promptFields, ocrResults, httpAdapter)
+                : await this.extractEventsFromSinglePage(effectiveHtmlData, parserConfig, cityConfig, promptFields, ocrResults, httpAdapter);
 
             // Enrichment only: fills empty fields on the finished AI/OCR events
             // from the Wix warmup blob, never skips or replaces an extraction step.
-            this.applyWixServerDataEnrichment(events, htmlData, cityConfig);
+            this.applyWixServerDataEnrichment(events, effectiveHtmlData, cityConfig);
+
+            // JSON-API structured events that could not clear the completeness
+            // gate above still enrich: fill blanks on the AI-extracted events
+            // (mirrors the Wix warmup enrichment — enrich, never bypass).
+            if (jsonApiEvents.length > 0) {
+                this.applyJsonApiStructuredEnrichment(events, jsonApiEvents, sourceUrl);
+            }
 
             // Attribute the events to this page's site so the post-crawl
             // venue-site address consensus can fill their blanks.
-            this.tagEventsWithVenueSitePage(events, htmlData);
+            this.tagEventsWithVenueSitePage(events, effectiveHtmlData);
 
             return {
                 events,
                 additionalLinks,
                 discoveredSegments,
                 ocrResults: ocrResults,
+                extractionSummary: { source: 'ai', aiPasses: this.aiPromptHistory.length, ocrImages: ocrResults.length },
                 source: this.config.source,
-                url: htmlData && htmlData.url ? htmlData.url : ''
+                url: sourceUrl
             };
         } catch (error) {
             console.warn(`🤖 AI Web: Failed to parse AI event: ${error}`);
@@ -3603,6 +3660,379 @@ class AiWebParser {
             : `${formatAmount(min)}-${formatAmount(max)} ${currency}`;
     }
 
+    // ============================================================================
+    // JSON-API DETERMINISTIC EVENT EXTRACTION
+    // ============================================================================
+    // Some parser targets are raw JSON API endpoints (api.redeyetickets.com),
+    // not HTML pages. The pathway is fully generic — key-shape recognition
+    // only, NO site-specific logic: a structured conversion mirrors the
+    // JSON-LD fast path (same completeness gate, same enrichment/stamping),
+    // and when it comes up short the payload is linearized to `keyPath: value`
+    // lines so the HTML-oriented AI machinery still sees real content
+    // (fail open, never fail silent).
+
+    // Trimmed body that IS a JSON document ({...} or [...]) → parsed value;
+    // anything else (HTML, scalars, malformed JSON) → null. Cheap and safe to
+    // run on every fetched page.
+    detectJsonApiPayload(html) {
+        const text = String(html || '').trim();
+        if (!text || (text[0] !== '{' && text[0] !== '[')) return null;
+        try {
+            const parsed = JSON.parse(text);
+            return parsed && typeof parsed === 'object' ? parsed : null;
+        } catch (_) {
+            return null;
+        }
+    }
+
+    // camelCase → snake_case, lowercased ('startDate' → 'start_date';
+    // 'venue_time_zone' unchanged). All JSON-API key matching happens on this
+    // normalized form so case/snake/camel spellings are interchangeable.
+    normalizeJsonApiKey(key) {
+        return String(key || '').replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+    }
+
+    // ISO-8601-ish string check (date prefix is enough; parseJsonLdDateValue
+    // does the strict parse and timezone-resolution bookkeeping).
+    jsonApiValueIsIsoDateish(value) {
+        return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}/.test(value.trim());
+    }
+
+    // "Event-like" = carries a name/title key AND some start/date-ish key
+    // holding an ISO-8601-ish string. Mirrored (in compact form) by
+    // SharedCore.countJsonApiEventObjects for deterministic page
+    // classification — keep the two in sync.
+    jsonApiObjectLooksEventLike(obj) {
+        if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
+        const keys = Object.keys(obj);
+        const hasTitle = keys.some(key => /^(name|title)$/.test(this.normalizeJsonApiKey(key))
+            && typeof obj[key] === 'string' && obj[key].trim() !== '');
+        if (!hasTitle) return false;
+        return keys.some(key => /(^|_)(start|date|datetime)/.test(this.normalizeJsonApiKey(key))
+            && this.jsonApiValueIsIsoDateish(obj[key]));
+    }
+
+    // Candidate event objects inside a parsed JSON payload, generically:
+    //   1. the payload itself when it is an array of objects;
+    //   2. else the first array-of-objects under a data/events/items/results
+    //      wrapper key (a single object there — detail endpoints — counts too);
+    //   3. else any top-level array whose objects look event-like.
+    collectJsonApiEventCandidates(parsed) {
+        const isPlainObject = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+        const isArrayOfObjects = (value) => Array.isArray(value) && value.length > 0 && value.every(isPlainObject);
+        if (isArrayOfObjects(parsed)) {
+            return parsed.filter(item => this.jsonApiObjectLooksEventLike(item));
+        }
+        if (!isPlainObject(parsed)) return [];
+        for (const key of Object.keys(parsed)) {
+            if (!/^(data|events|items|results)$/.test(this.normalizeJsonApiKey(key))) continue;
+            const value = parsed[key];
+            if (isArrayOfObjects(value)) return value.filter(item => this.jsonApiObjectLooksEventLike(item));
+            // Detail-shaped payload: ONE object (possibly carrying a
+            // performances-style array with the actual dates).
+            if (isPlainObject(value)
+                && (this.jsonApiObjectLooksEventLike(value) || this.findJsonApiPerformancesArray(value))) {
+                return [value];
+            }
+        }
+        for (const value of Object.values(parsed)) {
+            if (!isArrayOfObjects(value)) continue;
+            const eventLike = value.filter(item => this.jsonApiObjectLooksEventLike(item));
+            if (eventLike.length > 0) return eventLike;
+        }
+        return [];
+    }
+
+    // First array-of-objects value whose EVERY entry carries a start-ish
+    // ISO-dated key — the shape performance/occurrence lists take on detail
+    // endpoints. Null when the object has no such array.
+    findJsonApiPerformancesArray(obj) {
+        if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+        for (const value of Object.values(obj)) {
+            if (!Array.isArray(value) || value.length === 0) continue;
+            const everyEntryHasStart = value.every(entry => entry && typeof entry === 'object' && !Array.isArray(entry)
+                && Object.keys(entry).some(key => /(^|_)start/.test(this.normalizeJsonApiKey(key))
+                    && this.jsonApiValueIsIsoDateish(entry[key])));
+            if (everyEntryHasStart) return value;
+        }
+        return null;
+    }
+
+    // A single object carrying a performances-like array yields one event per
+    // entry: outer scalar fields are shared, but outer date fields
+    // (first_performance_start_at …) describe the series, not the individual
+    // performance — each entry's own start/end wins.
+    expandJsonApiPerformances(candidate) {
+        const performances = this.findJsonApiPerformancesArray(candidate);
+        if (!performances) return [candidate];
+        const shared = {};
+        for (const [key, value] of Object.entries(candidate)) {
+            if (value === performances) continue;
+            if (/(^|_)(start|end)/.test(this.normalizeJsonApiKey(key)) && this.jsonApiValueIsIsoDateish(value)) continue;
+            shared[key] = value;
+        }
+        return performances.map(entry => ({ ...shared, ...entry }));
+    }
+
+    // Generic recognizer over a parsed JSON API payload — the JSON-API
+    // counterpart of extractEventsFromJsonLd (same dedupe key, same defensive
+    // posture: any failure returns [] and the AI pathway takes over).
+    extractEventsFromJsonApiPayload(parsed, sourceUrl, cityConfig = null) {
+        try {
+            const candidates = this.collectJsonApiEventCandidates(parsed);
+            const events = [];
+            const seen = new Set();
+            for (const candidate of candidates) {
+                for (const entry of this.expandJsonApiPerformances(candidate)) {
+                    const event = this.buildEventFromJsonApiObject(entry, sourceUrl, cityConfig);
+                    if (!event) continue;
+                    const key = `${event.title.toLowerCase()}|${event.startDate.toISOString()}`;
+                    if (seen.has(key)) continue;
+                    seen.add(key);
+                    events.push(event);
+                }
+            }
+            return events;
+        } catch (error) {
+            console.warn(`🤖 AI Web: JSON API structured extraction failed: ${error.message}`);
+            return [];
+        }
+    }
+
+    // Field mapping from one event-like JSON object, case/snake/camel-
+    // insensitive first match. Shares the JSON-LD path's cleaning
+    // (tag-strip + entity-decode), date parsing (trailing-Z instants are
+    // authoritative — no _timezoneUnresolved), street-address-shaped venue
+    // gate, and address→city resolution. NEVER fabricates a public URL from a
+    // slug: url is always the fetched sourceUrl.
+    buildEventFromJsonApiObject(obj, sourceUrl, cityConfig = null) {
+        if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+        const clean = (value) => this.normalizeWhitespace(
+            this.decodeBasicEntities(this.stripTags(String(value || ''))).replace(/&amp;/gi, '&')
+        );
+        const keys = Object.keys(obj);
+        const isHttpString = (value) => typeof value === 'string' && /^https?:\/\//i.test(value.trim());
+        const isNonEmptyString = (value) => typeof value === 'string' && value.trim() !== '';
+        // First value whose normalized key matches keyPattern (and does not
+        // match excludePattern) and whose value passes the predicate.
+        const firstValue = (keyPattern, predicate, excludePattern = null) => {
+            for (const key of keys) {
+                const normalizedKey = this.normalizeJsonApiKey(key);
+                if (!keyPattern.test(normalizedKey)) continue;
+                if (excludePattern && excludePattern.test(normalizedKey)) continue;
+                if (predicate(obj[key])) return obj[key];
+            }
+            return '';
+        };
+        const firstDateValue = (keyPattern) => {
+            for (const key of keys) {
+                if (!keyPattern.test(this.normalizeJsonApiKey(key))) continue;
+                if (!this.jsonApiValueIsIsoDateish(obj[key])) continue;
+                const parsedDate = this.parseJsonLdDateValue(obj[key]);
+                if (parsedDate.date) return parsedDate;
+            }
+            return { date: null, timezoneUnresolved: false };
+        };
+
+        const title = clean(firstValue(/^(name|title)$/, isNonEmptyString));
+        // Explicit start-ish keys first (first_performance_start_at, start_at,
+        // startDate …), then bare date/datetime keys.
+        let start = firstDateValue(/(^|_)start/);
+        if (!start.date) start = firstDateValue(/(^|_)(date|datetime)(_|$)/);
+        if (!title || !start.date) return null;
+        const end = firstDateValue(/(^|_)end/);
+
+        // Address composed from street + locality + state + postal style keys,
+        // with the JSON-LD path's duplicate-part guard.
+        const addressParts = [
+            clean(firstValue(/(^|_)(address_line_?1|street_address|street|address)$/, isNonEmptyString)),
+            clean(firstValue(/(^|_)(city|locality)$/, isNonEmptyString)),
+            clean(firstValue(/(^|_)(state|region|province)$/, isNonEmptyString)),
+            clean(firstValue(/(^|_)(postal_code|postal|zip_code|zip)$/, isNonEmptyString))
+        ];
+        const accumulated = [];
+        for (const part of addressParts) {
+            if (part && !this.addressAlreadyContainsPart(accumulated.join(', '), part)) {
+                accumulated.push(part);
+            }
+        }
+        const address = accumulated.join(', ');
+
+        let bar = clean(firstValue(/^(venue|venue_name|location_name)$/, isNonEmptyString));
+        if (bar && this.venueNameLooksLikeStreetAddress(bar, address)) {
+            console.log(`🤖 AI Web: JSON API venue name "${bar}" looks like a street address — not using it as bar`);
+            bar = '';
+        }
+
+        const imageKeyPattern = /(^|_)(flyer|image|cover|photo|poster)/;
+        const rawImage = firstValue(imageKeyPattern, isHttpString);
+        const image = rawImage
+            ? (this.upgradeCdnThumbnailUrl(this.normalizeHttpUrlValue(rawImage) || '') || '')
+            : '';
+        // Ticket link: absolute http(s) only, image-ish keys excluded (a
+        // flyer_url must never become the ticketUrl). Slugs and other relative
+        // fragments never qualify — no public URL is ever fabricated.
+        const rawTicketUrl = firstValue(/(^|_)(ticket|url|link|website)/, isHttpString, imageKeyPattern);
+        const ticketUrl = rawTicketUrl ? (this.normalizeHttpUrlValue(rawTicketUrl) || '') : '';
+
+        const event = {
+            title,
+            description: clean(firstValue(/^(description|summary)$/, isNonEmptyString)),
+            startDate: start.date,
+            endDate: end.date || null,
+            bar,
+            address,
+            url: sourceUrl,
+            ticketUrl,
+            image,
+            source: this.config.source
+        };
+        // The payload's own structured data named this venue and it survived
+        // the address-shaped-name gate — same protection as JSON-LD bars: the
+        // venue-site identity pass never overrides it (internal field).
+        if (event.bar) {
+            event._barFromJsonLd = true;
+        }
+        // imageSource provenance (notes-serialized like pinSource): structured
+        // data the API itself published. Absent image → no stamp (fail open).
+        if (event.image) {
+            event.imageSource = 'json-api';
+        }
+        // Timezone: an IANA name in the payload is authoritative; otherwise the
+        // address→city resolution below may supply the city's timezone.
+        const timezoneValue = firstValue(/time_?zone/,
+            (value) => typeof value === 'string' && /^[A-Za-z]+\/[A-Za-z0-9_+\-/]+$/.test(value.trim()));
+        if (timezoneValue) {
+            event.timezone = timezoneValue.trim();
+        }
+        if (address && cityConfig) {
+            const cityKey = this.findCityKeyInText(address, cityConfig);
+            if (cityKey) {
+                event.city = cityKey;
+                if (!event.timezone) {
+                    const timezone = this.getTimezoneForCity(cityKey, cityConfig);
+                    if (timezone) event.timezone = timezone;
+                }
+            }
+        }
+        // Trailing-Z/offset instants are exact; offset-less values are
+        // wall-clock guesses flagged for normalizer re-anchoring (same
+        // semantics as the JSON-LD path).
+        if (start.timezoneUnresolved || (end.date && end.timezoneUnresolved)) {
+            event._timezoneUnresolved = true;
+        }
+        return event;
+    }
+
+    // Depth-first `keyPath: value` lines for scalar leaves (null/empty
+    // skipped; HTML tags stripped from strings). This becomes the page "html"
+    // whenever a JSON payload is detected, so extractBodyParts gets real
+    // lines, URL/image harvesting keeps working, and the verbatim-evidence
+    // gate stays symmetric with what the extraction prompt saw.
+    linearizeJsonForPrompt(parsed) {
+        const lines = [];
+        const visit = (value, path) => {
+            if (value === null || value === undefined) return;
+            if (Array.isArray(value)) {
+                value.forEach((item, index) => visit(item, path ? `${path}[${index}]` : `[${index}]`));
+                return;
+            }
+            if (typeof value === 'object') {
+                for (const [key, child] of Object.entries(value)) {
+                    visit(child, path ? `${path}.${key}` : key);
+                }
+                return;
+            }
+            const text = typeof value === 'string'
+                ? this.normalizeWhitespace(this.stripTags(value))
+                : String(value);
+            if (text.trim() === '') return;
+            lines.push(`${path}: ${text}`);
+        };
+        visit(parsed, '');
+        return lines.join('\n');
+    }
+
+    // ENRICHMENT ONLY — the JSON-API sibling of applyWixServerDataEnrichment:
+    // when the structured conversion could not clear the completeness gate,
+    // the payload's values still fill ONLY-empty fields on the AI-extracted
+    // events. Matching is conservative (normalized-title equality, or the
+    // unambiguous 1↔1 pairing); the sole overwrite is the established date
+    // exception — exact instants replace _timezoneUnresolved wall-clock
+    // guesses. Any failure leaves the events unchanged.
+    applyJsonApiStructuredEnrichment(events, jsonApiEvents, sourceUrl) {
+        try {
+            if (!Array.isArray(events) || events.length === 0) return events;
+            if (!Array.isArray(jsonApiEvents) || jsonApiEvents.length === 0) return events;
+            const filledFields = new Set();
+            let enrichedCount = 0;
+            for (const event of events) {
+                if (!event || typeof event !== 'object') continue;
+                const record = this.findJsonApiRecordForEvent(event, events.length, jsonApiEvents);
+                if (!record) continue;
+                const filled = this.fillEventFromJsonApiRecord(event, record);
+                if (filled.length > 0) {
+                    enrichedCount += 1;
+                    filled.forEach(field => filledFields.add(field));
+                }
+            }
+            if (filledFields.size > 0) {
+                console.log(`🤖 AI Web: JSON API structured data enriched ${enrichedCount} event(s) for ${sourceUrl}: filled=[${Array.from(filledFields).join(', ')}]`);
+            }
+        } catch (error) {
+            console.warn(`🤖 AI Web: JSON API enrichment failed — events unchanged: ${error.message}`);
+        }
+        return events;
+    }
+
+    // Conservative same-event check for enrichment: normalized-title match, or
+    // the unambiguous single-record/single-event pairing. Ambiguity → null.
+    findJsonApiRecordForEvent(event, eventCount, jsonApiEvents) {
+        const eventTitle = event && event.title ? this.normalizeEvidenceText(event.title) : '';
+        if (eventTitle) {
+            const titleMatch = jsonApiEvents.find(record => record && record.title
+                && this.normalizeEvidenceText(record.title) === eventTitle);
+            if (titleMatch) return titleMatch;
+        }
+        return eventCount === 1 && jsonApiEvents.length === 1 ? jsonApiEvents[0] : null;
+    }
+
+    fillEventFromJsonApiRecord(event, record) {
+        const filled = [];
+        const isEmpty = (value) => value === null || value === undefined || String(value).trim() === '';
+        const fill = (field, value) => {
+            if (value && isEmpty(event[field])) {
+                event[field] = value;
+                filled.push(field);
+            }
+        };
+        fill('description', record.description);
+        fill('bar', record.bar);
+        fill('address', record.address);
+        fill('city', record.city);
+        fill('timezone', record.timezone);
+        fill('ticketUrl', record.ticketUrl);
+        if (record.image && isEmpty(event.image)) {
+            event.image = record.image;
+            event.imageSource = 'json-api';
+            filled.push('image');
+        }
+        // Same precedent as the Wix warmup enrichment: exact instants replace
+        // wall-clock guesses, and the start/end pair is never split across
+        // anchoring schemes.
+        if (event._timezoneUnresolved && !record._timezoneUnresolved && record.startDate
+            && (record.endDate || isEmpty(event.endDate))) {
+            event.startDate = record.startDate;
+            filled.push('startDate');
+            if (record.endDate) {
+                event.endDate = record.endDate;
+                filled.push('endDate');
+            }
+            delete event._timezoneUnresolved;
+        }
+        return filled;
+    }
+
     // ENRICHMENT ONLY — runs on the parser's finished events just before they
     // are returned (both the JSON-LD fast path and the AI-extraction path) and
     // never influences which extraction steps run. Each field fills only when
@@ -4698,6 +5128,27 @@ class AiWebParser {
                 ? configBlockedPattern
                 : configBlockedPattern.source;
             return { valid: false, reason: `config-blocked-pattern:${configBlockedPatternReason}` };
+        }
+        // Per-config discovery ALLOW patterns — the allow-side twin of
+        // discoveryBlockedPatterns, for promoter-search-on-platform-listing
+        // configs (e.g. a ticketing site's all-events page where only links
+        // matching the promoter name should be followed). When the list is
+        // non-empty, a DISCOVERED url must match at least one entry (same
+        // dual string-substring / RegExp semantics as the blocked list).
+        // Configured start URLs never pass through this function, so the
+        // listing page itself is unaffected. Blocks still win over allows.
+        const configAllowedPatterns = Array.isArray(parserConfig.discoveryAllowedPatterns) ? parserConfig.discoveryAllowedPatterns : [];
+        if (configAllowedPatterns.length > 0) {
+            const matchesAllowed = configAllowedPatterns.some(pattern => {
+                if (pattern instanceof RegExp) return pattern.test(lowerUrl);
+                if (typeof pattern !== 'string') return false;
+                const normalizedPattern = pattern.trim().toLowerCase();
+                if (!normalizedPattern) return false;
+                return lowerUrl.includes(normalizedPattern);
+            });
+            if (!matchesAllowed) {
+                return { valid: false, reason: 'not-in-allowed-patterns' };
+            }
         }
         const lowerSearch = String(parsedUrl.search || '').toLowerCase();
         if (/^\/(?:sharer(?:\.php)?|share(?:\/url)?|dialog\/send)$/i.test(lowerPath)) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -672,6 +672,30 @@ test('validateEventUrl applies global + parser discoveryBlockedPatterns unioned 
   assert.match(shop.reason, /^blocked-pattern:/);
 });
 
+test('validateEventUrl discoveryAllowedPatterns: only matching discovered links survive; blocks still win', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://sickening.events/events';
+  const config = { name: 'Goldiloxx', discoveryAllowedPatterns: ['goldiloxx'] };
+
+  // Matching links pass (case-insensitive substring)
+  assert.equal(parser.validateEventUrl('https://sickening.events/e/GOLDILOXX-chicago', sourceUrl, config).valid, true);
+  // Non-matching links from the same listing are rejected with the new reason
+  const other = parser.validateEventUrl('https://sickening.events/e/some-other-party', sourceUrl, config);
+  assert.equal(other.valid, false);
+  assert.equal(other.reason, 'not-in-allowed-patterns');
+  // RegExp entries work with the same dual semantics as the blocked list
+  const rx = { name: 'RX', discoveryAllowedPatterns: [/\/e\/goldiloxx(-|$)/] };
+  assert.equal(parser.validateEventUrl('https://sickening.events/e/goldiloxx-chicago-2', sourceUrl, rx).valid, true);
+  assert.equal(parser.validateEventUrl('https://sickening.events/e/notgoldiloxxish', sourceUrl, rx).valid, false);
+  // Blocks win over allows
+  const both = { name: 'Both', discoveryAllowedPatterns: ['goldiloxx'], discoveryBlockedPatterns: ['chicago'] };
+  const blocked = parser.validateEventUrl('https://sickening.events/e/goldiloxx-chicago', sourceUrl, both);
+  assert.equal(blocked.valid, false);
+  assert.match(blocked.reason, /^config-blocked-pattern:/);
+  // Empty/absent list changes nothing
+  assert.equal(parser.validateEventUrl('https://sickening.events/e/some-other-party', sourceUrl, { name: 'N', discoveryAllowedPatterns: [] }).valid, true);
+});
+
 test('parseOcrResponseWithClassification salvages OCR text from truncated/degenerate JSON', () => {
   const parser = createParser();
 
@@ -6319,4 +6343,213 @@ test('KNOWN VENUE curated-match prompt line appears only with a unique curated m
   const barePrompt = bareParser.buildExtractionPrompt(bareData, {}, null, {}, ['title', 'bar'], 'SNIPPET', 'default', {});
   assert.match(barePrompt, /KNOWN VENUE \(this is the venue's own site\): "MASSIVE"/);
   assert.ok(!barePrompt.includes('KNOWN VENUE (curated match):'), 'no unique curated match → no extra line');
+});
+
+// ============================================================================
+// JSON-API EXTRACTION PATHWAY
+// ============================================================================
+// Abridged REAL search payload shape from api.redeyetickets.com (the Goldiloxx
+// forensic run that extracted 0 events because no JSON pathway existed).
+const REDEYE_SEARCH_PAYLOAD = {
+  data: [{
+    id: '08125f3d-x',
+    slug: 'goldiloxx-july',
+    name: 'GOLDILOXX JULY ',
+    headline: '',
+    description: '<p>DJ JOE MICHAEL and DJ BOOMER BANKS</p>',
+    venue: 'Red Eye NY',
+    venue_city: 'New York',
+    venue_state: 'NY',
+    venue_country: 'US',
+    venue_time_zone: 'America/New_York',
+    first_performance_start_at: '2026-07-26T01:00:00Z',
+    first_performance_end_at: '2026-07-26T08:00:00Z',
+    flyer_url: 'https://redeye-event-flyers.s3.amazonaws.com/img_9849-optimized.jpg',
+    status: 'published'
+  }],
+  meta: { pagination: { per_page: 20 } }
+};
+const REDEYE_SOURCE_URL = 'https://api.redeyetickets.com/api/v2/events/search?venue=red-eye-ny';
+
+test('parseEvents extracts the Red Eye search payload via the JSON-API structured path with zero AI/OCR calls', async () => {
+  const parser = createParser();
+  let aiCalls = 0;
+  let ocrCalls = 0;
+  parser.core.callAiGenerate = async () => { aiCalls += 1; return null; };
+  parser.extractOcrFromAllImages = async () => { ocrCalls += 1; return []; };
+  const cityConfig = { nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc'] } };
+
+  let result;
+  const logs = await captureLogsAsync(async () => {
+    result = await parser.parseEvents(
+      { url: REDEYE_SOURCE_URL, html: JSON.stringify(REDEYE_SEARCH_PAYLOAD) },
+      {},
+      cityConfig,
+      'event-page',
+      null
+    );
+  });
+
+  assert.equal(result.events.length, 1);
+  const event = result.events[0];
+  assert.equal(event.title, 'GOLDILOXX JULY', 'title is trimmed');
+  assert.equal(event.startDate.toISOString(), '2026-07-26T01:00:00.000Z');
+  assert.equal(event.endDate.toISOString(), '2026-07-26T08:00:00.000Z');
+  assert.equal(event._timezoneUnresolved, undefined, 'trailing-Z instants are authoritative');
+  assert.equal(event.bar, 'Red Eye NY');
+  assert.equal(event.timezone, 'America/New_York', 'IANA venue_time_zone wins');
+  assert.equal(event.address, 'New York, NY');
+  assert.equal(event.city, 'nyc', 'city resolved from the composed address');
+  assert.equal(event.image, 'https://redeye-event-flyers.s3.amazonaws.com/img_9849-optimized.jpg');
+  assert.equal(event.imageSource, 'json-api');
+  assert.equal(event.description, 'DJ JOE MICHAEL and DJ BOOMER BANKS', 'description is tag-stripped');
+  assert.equal(event.url, REDEYE_SOURCE_URL, 'no public URL is ever fabricated from the slug');
+  assert.equal(event.ticketUrl, '', 'slug never becomes a ticket URL');
+
+  assert.equal(aiCalls, 0, 'no extraction AI on the structured path');
+  assert.equal(ocrCalls, 0, 'no OCR on the structured path');
+  assert.deepEqual(result.extractionSummary, { source: 'json-api', aiPasses: 0, ocrImages: 0 });
+  assert.ok(logs.includes('🤖 AI Web: JSON API response detected (1 candidate event object(s))'));
+  assert.ok(logs.includes('🤖 AI Web: Extracted 1 event(s) from JSON API structured data — skipping OCR and AI extraction'));
+});
+
+test('extractEventsFromJsonApiPayload expands a detail-shaped payload into one event per performance', () => {
+  const parser = createParser();
+  const detailPayload = {
+    data: {
+      ...REDEYE_SEARCH_PAYLOAD.data[0],
+      performances: [
+        { start_at: '2026-07-26T01:00:00Z', end_at: '2026-07-26T08:00:00Z' },
+        { start_at: '2026-08-02T01:00:00Z' }
+      ]
+    }
+  };
+
+  const events = parser.extractEventsFromJsonApiPayload(detailPayload, REDEYE_SOURCE_URL, null);
+  assert.equal(events.length, 2);
+  assert.equal(events[0].title, 'GOLDILOXX JULY');
+  assert.equal(events[0].startDate.toISOString(), '2026-07-26T01:00:00.000Z');
+  assert.equal(events[0].endDate.toISOString(), '2026-07-26T08:00:00.000Z');
+  assert.equal(events[1].startDate.toISOString(), '2026-08-02T01:00:00.000Z');
+  assert.equal(events[1].endDate, null);
+  // Shared outer fields reach every performance
+  assert.equal(events[0].bar, 'Red Eye NY');
+  assert.equal(events[1].bar, 'Red Eye NY');
+  assert.equal(events[1].url, REDEYE_SOURCE_URL);
+});
+
+test('parseEvents handles an empty JSON API payload: detection logged, zero events, no throw', async () => {
+  const parser = createParser();
+  parser.extractOcrFromAllImages = async () => [];
+  let extractionAttempts = 0;
+  parser.extractEventsFromSinglePage = async () => { extractionAttempts += 1; return []; };
+
+  let result;
+  const logs = await captureLogsAsync(async () => {
+    result = await parser.parseEvents(
+      { url: 'https://api.redeyetickets.com/api/v2/events/search?venue=empty', html: '{"data":[],"meta":{}}' },
+      {},
+      null,
+      'event-page',
+      null
+    );
+  });
+
+  assert.equal(result.events.length, 0);
+  assert.ok(extractionAttempts >= 1, 'the AI pathway still runs on an empty payload (fail open)');
+  assert.ok(logs.includes('🤖 AI Web: JSON API response detected (0 candidate event object(s))'));
+});
+
+test('parseEvents fails open on unrecognizable JSON: linearized lines feed the AI pathway', async () => {
+  const parser = createParser();
+  parser.extractOcrFromAllImages = async () => [];
+  let extractionAttempts = 0;
+  let receivedHtml = null;
+  parser.extractEventsFromSinglePage = async (htmlData) => {
+    extractionAttempts += 1;
+    receivedHtml = htmlData && htmlData.html ? htmlData.html : '';
+    return [];
+  };
+
+  let result;
+  const logs = await captureLogsAsync(async () => {
+    result = await parser.parseEvents(
+      { url: 'https://api.example/v1/things', html: '{"foo":[{"bar":1,"baz":"qux"}],"note":"hello"}' },
+      {},
+      null,
+      'event-page',
+      null
+    );
+  });
+
+  assert.equal(result.events.length, 0);
+  assert.ok(extractionAttempts >= 1, 'AI extraction must still be attempted (fail open)');
+  const lines = String(receivedHtml).split('\n');
+  assert.ok(lines.length > 1, 'linearized content has more than one line');
+  assert.ok(lines.includes('foo[0].bar: 1'));
+  assert.ok(lines.includes('foo[0].baz: qux'));
+  assert.ok(lines.includes('note: hello'));
+  assert.ok(logs.includes('🤖 AI Web: JSON API response detected (0 candidate event object(s))'));
+  assert.ok(logs.includes('🤖 AI Web: JSON API payload linearized to 3 line(s) for AI extraction (structured conversion incomplete: missing title, startDate)'));
+});
+
+test('detectJsonApiPayload ignores HTML and malformed JSON; the JSON-LD fast path is unchanged', async () => {
+  const parser = createParser();
+  assert.equal(parser.detectJsonApiPayload(SICKENING_JSONLD_HTML), null);
+  assert.equal(parser.detectJsonApiPayload('  <html><body>{"not":"the start"}</body></html>'), null);
+  assert.equal(parser.detectJsonApiPayload('{"unterminated": '), null);
+  assert.equal(parser.detectJsonApiPayload('"just a string"'), null);
+  assert.equal(parser.detectJsonApiPayload(''), null);
+
+  // Regression: the existing HTML fixture still takes the JSON-LD structured
+  // path with the exact same outcome as before the JSON-API pathway existed.
+  parser.extractOcrFromAllImages = async () => {
+    throw new Error('OCR should not run when JSON-LD covers the event');
+  };
+  parser.core.callAiGenerate = async () => {
+    throw new Error('AI should not be called when JSON-LD covers the event');
+  };
+  const result = await parser.parseEvents(
+    { url: 'https://sickening.events/e/bearracuda-portland-pridefriday', html: SICKENING_JSONLD_HTML },
+    {},
+    null,
+    'event-page',
+    null
+  );
+  assert.equal(result.events.length, 1);
+  assert.equal(result.events[0].title, 'Bearracuda Portland:PRIDE FRIDAY');
+  assert.equal(result.events[0].bar, 'Nova PDX');
+  assert.equal(result.extractionSummary.source, 'jsonld');
+});
+
+test('buildEventFromJsonApiObject strips HTML from descriptions and never invents ticket URLs from slugs', () => {
+  const parser = createParser();
+  const event = parser.buildEventFromJsonApiObject({
+    name: 'BEAR NIGHT',
+    slug: 'bear-night-august',
+    description: '<div><strong>Go-go bears</strong> &amp; friends</div>',
+    start_at: '2026-08-08T02:00:00Z',
+    flyer_url: 'https://cdn.example/flyer.jpg'
+  }, 'https://api.example/v1/events/bear-night-august', null);
+
+  assert.equal(event.title, 'BEAR NIGHT');
+  assert.equal(event.description, 'Go-go bears & friends');
+  assert.ok(!/</.test(event.description), 'tags are stripped');
+  assert.equal(event.url, 'https://api.example/v1/events/bear-night-august');
+  assert.equal(event.ticketUrl, '', 'a slug is not an absolute URL — nothing is fabricated');
+  assert.equal(event.image, 'https://cdn.example/flyer.jpg');
+  assert.equal(event.imageSource, 'json-api');
+});
+
+test('linearizeJsonForPrompt emits keyPath lines for scalar leaves, skipping null/empty and stripping tags', () => {
+  const parser = createParser();
+  const linearized = parser.linearizeJsonForPrompt({
+    data: [{ name: 'GOLDILOXX', empty: '', missing: null, nested: { count: 2 } }],
+    note: '<b>bold</b> text'
+  });
+  assert.deepEqual(linearized.split('\n'), [
+    'data[0].name: GOLDILOXX',
+    'data[0].nested.count: 2',
+    'note: bold text'
+  ]);
 });

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -218,9 +218,18 @@ const scraperConfig = {
     {
       name: "Goldiloxx",
       enabled: false,
+      // Homeless promoter — events scatter across ticketing platforms (links
+      // rotate in their Instagram bio). Stable doors: the RedEye JSON API
+      // search (self-refreshing; JSON-API pathway extracts it structurally)
+      // and Sickening's all-platform listing filtered to goldiloxx links.
       urls: [
         "https://api.redeyetickets.com/api/v1/events/search?q=goldiloxx&per_page=25",
+        "https://sickening.events/events",
       ],
+      // Only follow discovered links naming the promoter — the listing has
+      // ~900 events. Note: sickening JSON-LD "organizer" is the VENUE, and
+      // the site soft-404s (every URL returns 200 with an empty shell).
+      discoveryAllowedPatterns: ["goldiloxx"],
       alwaysBear: true,
       calendarSearchRangeDays: 40, // Look +/- days for wildcard key matches
       metadata: {
@@ -228,6 +237,21 @@ const scraperConfig = {
         shorterName: { value: "GLX" },
         instagram: { value: "https://www.instagram.com/goldiloxx__" },
         matchKey: { value: "goldiloxx*|${year}-${month}-*|*" },
+      },
+    },
+    {
+      name: "3 Dollar Bill",
+      enabled: false,
+      // Brooklyn queer venue (260 Meserole St; second space The Yard @ 270
+      // Meserole Ave — per-event JSON-LD location is authoritative).
+      // Squarespace, server-rendered listing, JSON-LD Event on event pages.
+      // Heavy queer programming, bear events (Bear Tea) are a subset —
+      // bear check filters, not alwaysBear.
+      urls: ["https://www.3dollarbillbk.com/rsvp"],
+      alwaysBear: false,
+      metadata: {
+        website: { value: "https://www.3dollarbillbk.com" },
+        instagram: { value: "https://www.instagram.com/3dollarbillbk" },
       },
     },
     {
@@ -343,6 +367,7 @@ const scraperConfig = {
       // urlDiscoveryDepth: 2, // Omit → adaptive crawling (each page's type decides what gets followed); set a number to pin exact depth, 0 = never crawl (default: adaptive)
       // maxAdditionalUrls: 15, // Budget of discovered URLs followed per page (default: 15)
       // discoveryBlockedPatterns: ["example.com/members-only"], // Deliberate exclusions only — generic junk is blocked built-in and dead ends are learned + auto-retried (default: none)
+      // discoveryAllowedPatterns: ["promoter-name"], // When set, ONLY follow discovered links matching an entry (string substring or RegExp) — for promoter searches on big platform listings; start URLs unaffected; blocks win over allows (default: none)
       // discoveryBlockedHosts: ["example.com"], // Suppress ALL discovered links to these hostnames (default: none)
       //
       // Extraction steering:

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -263,6 +263,16 @@ class SharedCore {
             if (jsonLdEventCount >= 2) return { classification: 'multi-event-page', signal: 'json-ld' };
         }
 
+        // 2.5 Raw JSON API bodies (deterministic). A body that IS a JSON document
+        //     with recognizable event-shaped objects classifies by object count —
+        //     month-name heuristics and the AI second opinion are meaningless on a
+        //     payload that contains no prose.
+        if (html) {
+            const jsonApiEventCount = this.countJsonApiEventObjects(html);
+            if (jsonApiEventCount === 1) return { classification: 'event-page', signal: 'json-api' };
+            if (jsonApiEventCount >= 2) return { classification: 'multi-event-page', signal: 'json-api' };
+        }
+
         // 3. HTML heuristics for unknown URLs
         if (html) {
             // Reset lastIndex since the patterns are reused across calls (global flag)
@@ -284,6 +294,53 @@ class SharedCore {
         }
 
         return { classification: 'unknown', signal: 'none' };
+    }
+
+    // Count event-shaped objects in a raw JSON API response body (non-JSON or
+    // unrecognizable shapes → 0). Deterministic and platform-pure. Compact
+    // mirror of the ai-web parser's JSON-API recognizer (detectJsonApiPayload +
+    // collectJsonApiEventCandidates) — keep the two in sync: an object is
+    // event-like when it carries a name/title key plus a start/date-ish key
+    // holding an ISO-8601-ish string; candidates come from the payload itself
+    // (array), a data/events/items/results wrapper key, or any top-level array
+    // of event-like objects; a detail-shaped single object counts as one.
+    countJsonApiEventObjects(html) {
+        const text = String(html || '').trim();
+        if (!text || (text[0] !== '{' && text[0] !== '[')) return 0;
+        let parsed;
+        try {
+            parsed = JSON.parse(text);
+        } catch (_) {
+            return 0;
+        }
+        const normalizeKey = (key) => String(key || '').replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+        const isPlainObject = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+        const isArrayOfObjects = (value) => Array.isArray(value) && value.length > 0 && value.every(isPlainObject);
+        const isIsoDateish = (value) => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}/.test(value.trim());
+        const looksEventLike = (obj) => {
+            if (!isPlainObject(obj)) return false;
+            const keys = Object.keys(obj);
+            const hasTitle = keys.some(key => /^(name|title)$/.test(normalizeKey(key))
+                && typeof obj[key] === 'string' && obj[key].trim() !== '');
+            if (!hasTitle) return false;
+            return keys.some(key => /(^|_)(start|date|datetime)/.test(normalizeKey(key)) && isIsoDateish(obj[key]));
+        };
+        if (isArrayOfObjects(parsed)) {
+            return parsed.filter(looksEventLike).length;
+        }
+        if (!isPlainObject(parsed)) return 0;
+        for (const key of Object.keys(parsed)) {
+            if (!/^(data|events|items|results)$/.test(normalizeKey(key))) continue;
+            const value = parsed[key];
+            if (isArrayOfObjects(value)) return value.filter(looksEventLike).length;
+            if (isPlainObject(value) && looksEventLike(value)) return 1;
+        }
+        for (const value of Object.values(parsed)) {
+            if (!isArrayOfObjects(value)) continue;
+            const eventLikeCount = value.filter(looksEventLike).length;
+            if (eventLikeCount > 0) return eventLikeCount;
+        }
+        return 0;
     }
 
     // Compact text summary of a page for the AI classification prompt: title, meta
@@ -3369,6 +3426,18 @@ class SharedCore {
                 const linkSuffix = linkCount > 0 ? `, ${linkCount} link${linkCount === 1 ? '' : 's'}` : '';
                 const segmentSuffix = segmentCount > 0 ? `, ${segmentCount} segment${segmentCount === 1 ? '' : 's'}` : '';
                 await displayAdapter.logInfo(`SYSTEM: Parsed ${url} → ${eventCount} event${eventCount === 1 ? '' : 's'}${linkSuffix}${segmentSuffix}`);
+
+                // Observability: which extraction pathway produced this page's
+                // events (structured json-api/jsonld fast path vs AI), with the
+                // AI-pass and OCR-image counts the parser reported. Additive —
+                // parsers that don't report a summary log nothing extra.
+                const extractionSummary = !discoveryOnly
+                    && parseResult && parseResult.extractionSummary && typeof parseResult.extractionSummary === 'object'
+                    ? parseResult.extractionSummary
+                    : null;
+                if (extractionSummary && extractionSummary.source) {
+                    await displayAdapter.logInfo(`SYSTEM: ${url} extraction summary: source=${extractionSummary.source}, aiPasses=${Number(extractionSummary.aiPasses) || 0}, ocrImages=${Number(extractionSummary.ocrImages) || 0} → ${eventCount} event${eventCount === 1 ? '' : 's'}`);
+                }
 
                 if (discoveryTreeCollector && segmentCount > 0) {
                     discoveryTreeCollector.segmentsByUrl[url] = parseResult.discoveredSegments;

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -375,6 +375,33 @@ test('classifyPageWithSignal reports which tier decided', () => {
   assert.deepEqual(ruledCore.classifyPageWithSignal('https://x.example/hub', jsonLdHtml), { classification: 'link-aggregator', signal: 'url-rule' });
 });
 
+test('classifyPageWithSignal classifies raw JSON API bodies deterministically by event-object count', () => {
+  const core = createCore();
+  const eventObject = { name: 'GOLDILOXX JULY', first_performance_start_at: '2026-07-26T01:00:00Z' };
+
+  assert.deepEqual(
+    core.classifyPageWithSignal('https://api.example/v2/events/search', JSON.stringify({ data: [eventObject], meta: {} })),
+    { classification: 'event-page', signal: 'json-api' }
+  );
+  assert.deepEqual(
+    core.classifyPageWithSignal('https://api.example/v2/events/search', JSON.stringify({
+      data: [eventObject, { title: 'BEAR NIGHT', startDate: '2026-08-08T02:00:00Z' }]
+    })),
+    { classification: 'multi-event-page', signal: 'json-api' }
+  );
+  // A bare array payload and a detail-shaped single object both count
+  assert.equal(core.countJsonApiEventObjects(JSON.stringify([eventObject, eventObject])), 2);
+  assert.equal(core.countJsonApiEventObjects(JSON.stringify({ data: eventObject })), 1);
+  // Unrecognizable JSON, empty payloads, and HTML never classify via json-api
+  assert.equal(core.countJsonApiEventObjects('{"foo":[{"bar":1}]}'), 0);
+  assert.equal(core.countJsonApiEventObjects('{"data":[],"meta":{}}'), 0);
+  assert.equal(core.countJsonApiEventObjects('<html><body>July 17</body></html>'), 0);
+  assert.deepEqual(
+    core.classifyPageWithSignal('https://api.example/misc', '{"foo":[{"bar":1}]}'),
+    { classification: 'unknown', signal: 'none' }
+  );
+});
+
 test('classifyPageWithAi accepts confident valid labels and rejects everything else', async () => {
   const core = createCore();
   const aiConfig = {


### PR DESCRIPTION
## Why Goldiloxx extracted 0 events

Forensic reconstruction (from cache files — the run log was silent): the RedEye API **did** return "GOLDILOXX JULY" with venue, dates, and flyers; OCR even read the flyers. But ai-web is HTML-oriented — a JSON body has no title tags, no segments, no `<script type="application/ld+json">`, so the structured data was invisible and extraction died in a console-only catch 39ms after the last OCR write. Two side findings: a working `redeyetickets-parser.js` exists in-repo but is **unreachable dead code** (dispatch defaults everything to ai-web), and only SYSTEM/📱 lines persist to run logs — every 🤖 AI Web decision vanishes, which is why this needed archaeology.

## The fix — a generic JSON-API pathway (no RedEye-specific logic)

1. **Detect**: any response body that parses as JSON.
2. **Structured extraction first**: generically-recognized event objects (name/title + ISO start key; detail payloads expand `performances[]`) map deterministically — ISO datetimes with their IANA timezone (trailing-Z authoritative), venue through the street-address gate, composed address, flyer (`imageSource: 'json-api'`), ticket URL. Flows through the **same completeness gate and enrichment as JSON-LD**: complete events skip OCR/AI entirely (zero AI calls for Goldiloxx's payload — asserted in tests); incomplete ones gap-fill blanks on AI events. Nothing is ever fabricated from slugs.
3. **Fail-open fallback**: unrecognized JSON linearizes to `keyPath: value` lines for normal AI extraction — never worse than today.
4. **Observability**: new persisted `SYSTEM: <url> extraction summary: source=..., aiPasses=N, ocrImages=N → N events` line so the next silent failure is diagnosable from the log alone. Plus a deterministic `json-api` classification tier (one less AI call).

## Long-term Goldiloxx tracking (the "promoter with no home" problem)

New **`discoveryAllowedPatterns`** — allow-side twin of `discoveryBlockedPatterns`: when set, discovered links must match (string/RegExp); start URLs unaffected; blocks win. This makes "crawl a platform's big listing, follow only links naming the promoter" a one-line config.

- **Goldiloxx** now watches two self-refreshing doors: the RedEye API search (structural extraction) + sickening.events' server-rendered all-platform listing (~900 links) filtered to `goldiloxx`. Recon notes encoded in config: sickening's JSON-LD `organizer` is the *venue*, and the site soft-404s (every URL 200s).
- **3 Dollar Bill** (new venue parser): Brooklyn queer venue, server-rendered Squarespace with per-event JSON-LD including addresses — it operates **two spaces** (260 Meserole St + The Yard, 270 Meserole Ave; per-event location is authoritative). Bear Tea and friends; bear check filters (not alwaysBear).

Both ship `enabled: false` — first runs are deliberate picks in the parser picker.

## Tests

841 → **850**. JSON-API fixtures are the literal captured RedEye payload (structured path with AI/OCR counters = 0, performances expansion, empty payload, fail-open linearization, HTML regression byte-identical, no slug-URL fabrication) + the allowlist matrix (match/reject/RegExp/blocks-win/empty-list-no-op).

## After merge

Download `scripts/parsers/ai-web-parser.js`, `scripts/shared-core.js`, `scripts/scraper-input.js`. Pick Goldiloxx in the picker — expect `JSON API response detected`, structural extraction with zero extraction AI calls (note: the RedEye search is empty right now since the July event passed — the sickening door has the live Chicago event). And try 3 Dollar Bill for the Brooklyn bear scene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP