### PR TITLE
fix(scraper): discovery allowlist scopes extraction too — foreign events stop leaking off shared listings

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -489,11 +489,12 @@ class AiWebParser {
                 // venue-site stamps only — there is no extraction evidence
                 // corpus here, so the adjacency check never runs (fail open).
                 structuredEvents.forEach(event => this.stampBarSourceProvenance(event, null, effectiveHtmlData));
+                const keptStructuredEvents = this.filterEventsByDiscoveryAllowlist(structuredEvents, sourceUrl, parserConfig);
                 // Attribute the events to this page's site so the post-crawl
                 // venue-site address consensus can fill their blanks.
-                this.tagEventsWithVenueSitePage(structuredEvents, effectiveHtmlData);
+                this.tagEventsWithVenueSitePage(keptStructuredEvents, effectiveHtmlData);
                 return {
-                    events: structuredEvents,
+                    events: keptStructuredEvents,
                     additionalLinks: additionalLinks,
                     discoveredSegments: null,
                     ocrResults: [],
@@ -619,12 +620,13 @@ class AiWebParser {
                 this.applyJsonApiStructuredEnrichment(events, jsonApiEvents, sourceUrl);
             }
 
+            const keptEvents = this.filterEventsByDiscoveryAllowlist(events, sourceUrl, parserConfig);
             // Attribute the events to this page's site so the post-crawl
             // venue-site address consensus can fill their blanks.
-            this.tagEventsWithVenueSitePage(events, effectiveHtmlData);
+            this.tagEventsWithVenueSitePage(keptEvents, effectiveHtmlData);
 
             return {
-                events,
+                events: keptEvents,
                 additionalLinks,
                 discoveredSegments,
                 ocrResults: ocrResults,
@@ -5138,17 +5140,8 @@ class AiWebParser {
         // Configured start URLs never pass through this function, so the
         // listing page itself is unaffected. Blocks still win over allows.
         const configAllowedPatterns = Array.isArray(parserConfig.discoveryAllowedPatterns) ? parserConfig.discoveryAllowedPatterns : [];
-        if (configAllowedPatterns.length > 0) {
-            const matchesAllowed = configAllowedPatterns.some(pattern => {
-                if (pattern instanceof RegExp) return pattern.test(lowerUrl);
-                if (typeof pattern !== 'string') return false;
-                const normalizedPattern = pattern.trim().toLowerCase();
-                if (!normalizedPattern) return false;
-                return lowerUrl.includes(normalizedPattern);
-            });
-            if (!matchesAllowed) {
-                return { valid: false, reason: 'not-in-allowed-patterns' };
-            }
+        if (configAllowedPatterns.length > 0 && !this.matchesDiscoveryAllowedPattern(lowerUrl, configAllowedPatterns)) {
+            return { valid: false, reason: 'not-in-allowed-patterns' };
         }
         const lowerSearch = String(parsedUrl.search || '').toLowerCase();
         if (/^\/(?:sharer(?:\.php)?|share(?:\/url)?|dialog\/send)$/i.test(lowerPath)) {
@@ -5167,6 +5160,49 @@ class AiWebParser {
         }
 
         return { valid: true, reason: 'valid' };
+    }
+
+    // Does a value match any discoveryAllowedPatterns entry (same dual
+    // string-substring / RegExp semantics as validateEventUrl's checks)?
+    matchesDiscoveryAllowedPattern(value, patterns) {
+        const lowerValue = String(value || '').toLowerCase();
+        if (!lowerValue) return false;
+        return patterns.some(pattern => {
+            if (pattern instanceof RegExp) return pattern.test(lowerValue);
+            if (typeof pattern !== 'string') return false;
+            const normalizedPattern = pattern.trim().toLowerCase();
+            if (!normalizedPattern) return false;
+            return lowerValue.includes(normalizedPattern);
+        });
+    }
+
+    // discoveryAllowedPatterns scopes EXTRACTION too, not just crawling: a
+    // promoter-search parser pointed at a shared platform listing (hundreds of
+    // unrelated events) must not adopt foreign events off the listing page —
+    // they'd inherit this parser's alwaysBear/metadata identity. Pages whose
+    // own URL matches the allowlist (the promoter's API search, followed event
+    // pages) extract freely; on non-matching pages each extracted event must
+    // itself match (title or any of its URLs). No patterns configured → no-op.
+    filterEventsByDiscoveryAllowlist(events, sourceUrl, parserConfig) {
+        const patterns = Array.isArray(parserConfig && parserConfig.discoveryAllowedPatterns)
+            ? parserConfig.discoveryAllowedPatterns
+            : [];
+        if (patterns.length === 0 || !Array.isArray(events) || events.length === 0) return events;
+        if (this.matchesDiscoveryAllowedPattern(sourceUrl, patterns)) return events;
+        const kept = [];
+        for (const event of events) {
+            if (!event || typeof event !== 'object') continue;
+            const haystacks = [event.title, event.url, event.ticketUrl, event.website];
+            if (haystacks.some(value => this.matchesDiscoveryAllowedPattern(value, patterns))) {
+                kept.push(event);
+            } else {
+                console.log(`🤖 AI Web: Dropped "${event.title || 'untitled'}" — listing page is not allowlist-matched and the event does not match discoveryAllowedPatterns`);
+            }
+        }
+        if (kept.length !== events.length) {
+            console.log(`🤖 AI Web: Discovery allowlist kept ${kept.length} of ${events.length} extracted event(s) from ${sourceUrl}`);
+        }
+        return kept;
     }
 
     recordRejectedCandidate(discoveryStats, reason, rawUrl, normalizedUrl = null) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -696,6 +696,30 @@ test('validateEventUrl discoveryAllowedPatterns: only matching discovered links 
   assert.equal(parser.validateEventUrl('https://sickening.events/e/some-other-party', sourceUrl, { name: 'N', discoveryAllowedPatterns: [] }).valid, true);
 });
 
+test('discoveryAllowedPatterns scopes extraction: foreign events on a shared listing page are dropped, promoter-matched pages extract freely', () => {
+  const parser = createParser();
+  const config = { name: 'Goldiloxx', discoveryAllowedPatterns: ['goldiloxx'] };
+  const events = [
+    { title: 'GOLDILOXX CHICAGO', url: 'https://sickening.events/events' },
+    { title: 'Some Other Party', url: 'https://sickening.events/events', ticketUrl: 'https://sickening.events/e/other-party/tickets' },
+    { title: 'Untitled-ish', ticketUrl: 'https://sickening.events/e/goldiloxx-chicago-2/tickets' }
+  ];
+
+  // Shared listing page (URL does not match): only promoter-matched events survive
+  const kept = parser.filterEventsByDiscoveryAllowlist(events, 'https://sickening.events/events', config);
+  assert.deepEqual(kept.map(e => e.title), ['GOLDILOXX CHICAGO', 'Untitled-ish'],
+    'title match and ticketUrl match keep; foreign event dropped');
+
+  // A page whose own URL matches (the promoter's API search / a followed event page) extracts freely
+  const apiKept = parser.filterEventsByDiscoveryAllowlist(events,
+    'https://api.redeyetickets.com/api/v1/events/search?q=goldiloxx&per_page=25', config);
+  assert.equal(apiKept.length, 3, 'promoter-matched source page keeps everything');
+
+  // No patterns configured → no-op (other parsers unaffected)
+  const noop = parser.filterEventsByDiscoveryAllowlist(events, 'https://sickening.events/events', { name: 'Plain' });
+  assert.equal(noop.length, 3);
+});
+
 test('parseOcrResponseWithClassification salvages OCR text from truncated/degenerate JSON', () => {
   const parser = createParser();
 


### PR DESCRIPTION
## The leak (reported from the first Goldiloxx run on #1555)

`discoveryAllowedPatterns` gated which discovered **links** get crawled — but the sickening.events listing page itself is a multi-event page, so extraction ran directly on it and adopted other promoters' events, which then inherited Goldiloxx's `alwaysBear`/metadata identity.

## Fix

The allowlist now scopes **extraction** as well:
- A page whose own URL matches a pattern (the promoter's API search, a followed `/e/goldiloxx-*` page) extracts freely.
- On a non-matching page (the shared listing), each extracted event must itself match — title or any of its URLs — or it's dropped, visibly:
  ```
  🤖 AI Web: Dropped "Some Other Party" — listing page is not allowlist-matched and the event does not match discoveryAllowedPatterns
  🤖 AI Web: Discovery allowlist kept 1 of 14 extracted event(s) from https://sickening.events/events
  ```
- Applies to both the structured (JSON-LD/JSON-API) fast path and the AI path. Parsers without allowlist patterns are completely untouched.

Dropped foreign events aren't lost — they belong to their own parsers/sources (e.g. the Bearracuda event on that listing is already covered by the Bearracuda parser).

## Note

This papers over the deeper issue discussed today: parser configs carry promoter *identity* that stamps onto whatever the source yields. The systematic fix is the curated promoter registry (identity by evidence-matching, parser configs become pure sources) — separate wave, pending owner go-ahead.

Tests 850 → 851.

## After merge
Download `scripts/parsers/ai-web-parser.js`, rerun Goldiloxx — expect only goldiloxx-matched events plus the kept/dropped log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP