### PR TITLE
fix(scraper): Montréal diacritics, postal-code phantom gate, PUP dedup, ical crawl block

### DIFF
--- a/js/city-config.js
+++ b/js/city-config.js
@@ -387,7 +387,7 @@ const CITY_CONFIG = {
         calendarId: '5078d3d007dd706a267fa06b5659d2dba9ba56b6760e99bdfaf704baa8e7cf6d@group.calendar.google.com',
         calendar: 'chunky-dad-montreal',
         timezone: 'America/Toronto',
-        patterns: ['montreal'],
+        patterns: ['montreal', 'mtl'],
         coordinates: { lat: 45.5019, lng: -73.5674 },
         mapZoom: 11,
         visible: false

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -79,6 +79,22 @@ class BaseNormalizer {
         this.core = core;
     }
 
+    // Diacritic-folded lowercase view of city-ish text ("Montréal" →
+    // "montreal") so accented extractions match the unaccented city config
+    // patterns (run 20260727-145617). Canonical implementation lives in
+    // SharedCore.foldDiacritics; the inline fallback keeps normalizers pure
+    // when constructed without a core (keep the transform in sync).
+    foldDiacritics(value) {
+        if (this.core && typeof this.core.foldDiacritics === 'function') {
+            return this.core.foldDiacritics(value);
+        }
+        return String(value || '')
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .toLowerCase()
+            .trim();
+    }
+
     normalize(event) {
         return event;
     }
@@ -426,7 +442,9 @@ class LocationNormalizer extends BaseNormalizer {
         this.backfillCityFromCuratedBar(event);
 
         // Warn when the event references a city we have no config for
-        if (!event.timezone && event.city && this.core.cities && !this.core.cities[event.city]) {
+        // (diacritic-folded lookup so "Montréal" counts as configured)
+        if (!event.timezone && event.city && this.core.cities
+            && !this.core.cities[event.city] && !this.core.cities[this.foldDiacritics(event.city)]) {
             const title = event.title || 'unknown';
             this.core.warnOnce(
                 `timezone:${event.city}`,
@@ -686,12 +704,15 @@ class LocationNormalizer extends BaseNormalizer {
     extractCityFromAddress(address) {
         if (!address || typeof address !== 'string' || !this.core || !this.core.cityMappings) return null;
 
-        const lowerAddress = address.toLowerCase();
+        // Diacritic-folded on BOTH sides so "Montréal, QC" matches the
+        // unaccented "montreal" pattern (run 20260727-145617)
+        const lowerAddress = this.foldDiacritics(address);
 
         for (const [patterns, city] of Object.entries(this.core.cityMappings)) {
             const patternList = patterns.split('|');
             for (const pattern of patternList) {
-                const regex = new RegExp(`\\b${pattern.replace(/\s+/g, '\\s+')}\\b`, 'i');
+                const foldedPattern = this.foldDiacritics(pattern);
+                const regex = new RegExp(`\\b${foldedPattern.replace(/\s+/g, '\\s+')}\\b`, 'i');
                 if (regex.test(lowerAddress)) {
                     return city;
                 }
@@ -701,15 +722,16 @@ class LocationNormalizer extends BaseNormalizer {
         const addressParts = address.split(',').map(part => part.trim());
 
         for (const part of addressParts) {
-            const cityName = part.toLowerCase();
+            const cityName = this.foldDiacritics(part);
 
             for (const [patterns, city] of Object.entries(this.core.cityMappings)) {
                 const patternList = patterns.split('|');
                 for (const pattern of patternList) {
-                    if (cityName === pattern) {
+                    const foldedPattern = this.foldDiacritics(pattern);
+                    if (cityName === foldedPattern) {
                         return city;
                     }
-                    const regex = new RegExp(`\\b${pattern.replace(/\s+/g, '\\s+')}\\b`, 'i');
+                    const regex = new RegExp(`\\b${foldedPattern.replace(/\s+/g, '\\s+')}\\b`, 'i');
                     if (regex.test(cityName)) {
                         return city;
                     }
@@ -741,12 +763,14 @@ class LocationNormalizer extends BaseNormalizer {
     extractCityFromText(text) {
         if (!text || typeof text !== 'string' || !this.core || !this.core.cityMappings) return null;
 
-        const lowerText = text.toLowerCase();
+        // Diacritic-folded on BOTH sides (see extractCityFromAddress)
+        const lowerText = this.foldDiacritics(text);
 
         for (const [patterns, city] of Object.entries(this.core.cityMappings)) {
             const patternList = patterns.split('|');
             for (const pattern of patternList) {
-                const regex = new RegExp(`\\b${pattern.replace(/\s+/g, '\\s+')}\\b`, 'i');
+                const foldedPattern = this.foldDiacritics(pattern);
+                const regex = new RegExp(`\\b${foldedPattern.replace(/\s+/g, '\\s+')}\\b`, 'i');
                 if (regex.test(lowerText)) {
                     return city;
                 }
@@ -815,22 +839,24 @@ class LocationNormalizer extends BaseNormalizer {
 
         if (!this.core || !this.core.cityMappings) return 'unknown';
 
-        const title = String(event.title || '').toLowerCase();
+        // Diacritic-folded on BOTH sides so "Montréal" in a title/venue
+        // matches the unaccented "montreal" pattern (run 20260727-145617)
+        const title = this.foldDiacritics(event.title);
 
         for (const [patterns, city] of Object.entries(this.core.cityMappings)) {
             const cityPatterns = patterns.split('|');
             for (const pattern of cityPatterns) {
-                if (title.includes(pattern)) {
+                if (title.includes(this.foldDiacritics(pattern))) {
                     return city;
                 }
             }
         }
 
-        const venue = String(event.bar || '').toLowerCase();
+        const venue = this.foldDiacritics(event.bar);
         for (const [patterns, city] of Object.entries(this.core.cityMappings)) {
             const cityPatterns = patterns.split('|');
             for (const pattern of cityPatterns) {
-                if (venue.includes(pattern)) {
+                if (venue.includes(this.foldDiacritics(pattern))) {
                     return city;
                 }
             }
@@ -865,15 +891,19 @@ class LocationNormalizer extends BaseNormalizer {
         if (!cityName || typeof cityName !== 'string' || !this.core || !this.core.cityMappings) return null;
 
         const normalized = cityName.toLowerCase().trim();
+        // Diacritic-folded on BOTH sides: "Montréal"/"MONTRÉAL" must resolve
+        // to the montreal key (run 20260727-145617); unaccented input folds
+        // to itself so ASCII matching is byte-identical.
+        const folded = this.foldDiacritics(cityName);
 
         for (const [patterns, city] of Object.entries(this.core.cityMappings)) {
             const patternList = patterns.split('|');
-            if (patternList.includes(normalized)) {
+            if (patternList.includes(normalized) || patternList.some(pattern => this.foldDiacritics(pattern) === folded)) {
                 return city;
             }
         }
 
-        if (normalized && this.core.cities && !this.core.cities[normalized]) {
+        if (normalized && this.core.cities && !this.core.cities[normalized] && !this.core.cities[folded]) {
             this.core.warnOnce(`city:${normalized}`, `⚠️ LocationNormalizer: Unknown city "${normalized}" (no mapping or timezone)`);
         }
         return normalized;
@@ -1169,7 +1199,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     getCityCenterCoordinates(city) {
         const key = String(city || '').trim();
         if (!key || !this.core || !this.core.cities) return null;
-        const cityConfig = this.core.cities[key];
+        const cityConfig = this.core.cities[key] || this.core.cities[this.foldDiacritics(key)];
         const coords = cityConfig && cityConfig.coordinates;
         if (!coords) return null;
         const lat = Number(coords.lat);
@@ -1749,7 +1779,7 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     geocodeCityAnchorName(cityKey) {
         const key = String(cityKey || '').trim();
         if (!key || !this.core || !this.core.cities) return key;
-        const cityConfig = this.core.cities[key];
+        const cityConfig = this.core.cities[key] || this.core.cities[this.foldDiacritics(key)];
         const patterns = cityConfig && Array.isArray(cityConfig.patterns) ? cityConfig.patterns : [];
         const displayName = typeof patterns[0] === 'string' ? patterns[0].trim() : '';
         return displayName || key;

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -2795,3 +2795,64 @@ test('corroborateBarWithGeoPoi never overwrites the venue-site-identity stamp', 
   normalizer.corroborateBarWithGeoPoi(unstampedEvent, ['Massive']);
   assert.equal(unstampedEvent.barSource, 'geo-poi');
 });
+
+// ===========================================================================
+// run 20260727-145617: diacritic folding in city resolution — "montréal" and
+// accented address text must resolve the montreal config key (Fix 1)
+// ===========================================================================
+
+const MONTREAL_CITIES = {
+  montreal: { name: 'Montreal', timezone: 'America/Toronto', patterns: ['montreal', 'mtl'] },
+  portland: { timezone: 'America/Los_Angeles', patterns: ['portland', 'pdx'] }
+};
+
+function createMontrealLocationNormalizer() {
+  const core = new SharedCore(MONTREAL_CITIES, { eventSchema: EventSchema });
+  return new LocationNormalizer(core);
+}
+
+test('normalizeCityName resolves accented "montréal"/"Montréal"/"MONTRÉAL" to the montreal key; unaccented byte-identical', () => {
+  const normalizer = createMontrealLocationNormalizer();
+  // Literal run 20260727-145617 value that logged: Unknown city "montréal"
+  assert.equal(normalizer.normalizeCityName('montréal'), 'montreal');
+  assert.equal(normalizer.normalizeCityName('Montréal'), 'montreal');
+  assert.equal(normalizer.normalizeCityName('MONTRÉAL'), 'montreal');
+  // Unaccented regression: identical to pre-fix behavior
+  assert.equal(normalizer.normalizeCityName('montreal'), 'montreal');
+  assert.equal(normalizer.normalizeCityName('Portland'), 'portland');
+  // Unmapped input still echoes back lowercased, exactly as before
+  assert.equal(normalizer.normalizeCityName('atlantis'), 'atlantis');
+});
+
+test('extractCityFromAddress resolves accented address text containing "Montréal" (literal run address shape)', () => {
+  const normalizer = createMontrealLocationNormalizer();
+  assert.equal(normalizer.extractCityFromAddress('2915 Rue Ontario E, Montréal, QC H2K 1X7'), 'montreal');
+  assert.equal(normalizer.extractCityFromAddress('2915 Rue Ontario E, Montreal, QC H2K 1X7'), 'montreal');
+  // A bare street line still yields NO city (the 2026-07-13 guard holds)
+  assert.equal(normalizer.extractCityFromAddress('2915 Rue Ontario E'), null);
+});
+
+test('extractCityFromEvent resolves an accented city field and accented title/venue text', () => {
+  const normalizer = createMontrealLocationNormalizer();
+  assert.equal(normalizer.extractCityFromEvent({ city: 'montréal' }), 'montreal');
+  assert.equal(normalizer.extractCityFromEvent({ title: 'Concours PUP Montréal' }), 'montreal');
+  assert.equal(normalizer.extractCityFromEvent({ title: 'Bear Night', bar: 'Bar Le Cocktail Montréal' }), 'montreal');
+  // Unaccented regression
+  assert.equal(normalizer.extractCityFromEvent({ title: 'Portland Bear Night' }), 'portland');
+});
+
+test('LocationNormalizer end-to-end: accented city resolves timezone — no Unknown-city warn, dates re-anchor', () => {
+  const normalizer = createMontrealLocationNormalizer();
+  const event = {
+    title: 'Concours PUP MTL',
+    city: 'montréal',
+    startDate: new Date('2026-07-27T22:00:00.000Z'),
+    endDate: new Date('2026-07-27T22:00:00.000Z'),
+    _timezoneUnresolved: true
+  };
+  const normalized = normalizer.normalize(event);
+  assert.equal(normalized.city, 'montreal');
+  assert.equal(normalized.timezone, 'America/Toronto');
+  // 10pm EDT (UTC-4) = 2am UTC next day — no longer wall-clock UTC
+  assert.equal(normalized.startDate.toISOString(), '2026-07-28T02:00:00.000Z');
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -787,6 +787,16 @@ class AiWebParser {
             console.log(`🤖 AI Web: Skipped venue-hours notice "${event.title}" — not an event`);
             return null;
         }
+        // Postal-code title guard (run 20260727-145617: a Canadian postal
+        // code "H2K 1X7" scraped off an address block became a calendar-bound
+        // "event" — bar "Bear-IT", city "canada", zero duration — and sailed
+        // through to preview). Same linguistic-generic contract as the
+        // venue-hours gate above: shape classes only, no site rules, and only
+        // a title that is NOTHING but a postal code is rejected.
+        if (this.isPostalCodeOnlyTitle(event.title)) {
+            console.log(`🤖 AI Web: Skipped degenerate event "${event.title}" — title is a postal code, not an event`);
+            return null;
+        }
         // Address plausibility gate: a venue name is not an address (run
         // 20260723-140457: extraction stored address "Legacy" — the bar's own
         // name — and it sailed through to geocoding). Runs BEFORE the bar
@@ -902,6 +912,27 @@ class AiWebParser {
             return false;
         }
         return weekdayCount > 0 && closedCount > 0;
+    }
+
+    // Deterministic degenerate-title detector: true when the trimmed title is
+    // NOTHING but a postal-code shape — Canadian "A1A 1A1" (space/hyphen
+    // optional), US ZIP 5 or 5+4, or a FULL UK postcode (outward + inward).
+    // Linguistic-generic like the venue-hours detector above: shape classes
+    // only, no site rules. Fail closed: any other text keeps the event
+    // ("Party at H2K 1X7" is a real title), and outward-only UK forms ("SW4")
+    // are common area shorthands, never rejected.
+    isPostalCodeOnlyTitle(title) {
+        const text = String(title || '').trim();
+        if (!text) return false;
+        // Canadian: letter-digit-letter [space/hyphen] digit-letter-digit
+        if (/^[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d$/.test(text)) return true;
+        // US ZIP: 5 digits, optional +4
+        if (/^\d{5}(?:-\d{4})?$/.test(text)) return true;
+        // Full UK postcode: outward (1-2 letters, digit, optional alnum) +
+        // inward (digit + 2 letters); the inward part is REQUIRED so short
+        // outward-only forms ("SW4") survive
+        if (/^[A-Za-z]{1,2}\d[A-Za-z\d]?[ -]?\d[A-Za-z]{2}$/.test(text)) return true;
+        return false;
     }
 
     // One-line info summary of a finalized extraction: only fields that are set,
@@ -5094,6 +5125,18 @@ class AiWebParser {
         const lowerUrl = url.toLowerCase();
         if (lowerPath === '/empty' || lowerUrl.endsWith('/empty')) {
             return { valid: false, reason: 'empty-placeholder-url' };
+        }
+        // Calendar-export URLs (run 20260727-145617: the crawler followed The
+        // Events Calendar's ?ical=1 / ?outlook-ical=1 export links and
+        // tribe-bar-date filter links off event pages — every fetch returned
+        // an empty non-HTML response with a stack trace). Generic patterns
+        // only: the ical/outlook-ical query flags, the tribe-bar-date query
+        // param, and a .ics path suffix. The [?&] anchor keeps slugs like
+        // "musical=1" or paths containing "ical" valid.
+        if (lowerPath.endsWith('.ics')
+            || /[?&](?:outlook-)?ical=1(?!\d)/.test(lowerUrl)
+            || /[?&]tribe-bar-date=/.test(lowerUrl)) {
+            return { valid: false, reason: 'calendar-export-url' };
         }
         const blockedPattern = invalidUrlPatterns.find(invalid => {
             if (invalid instanceof RegExp) return invalid.test(lowerUrl);
@@ -9757,6 +9800,21 @@ TEXT:
         return cityConfig;
     }
 
+    // Diacritic-folded lowercase view for city comparisons — identical to
+    // SharedCore.foldDiacritics (parsers are standalone and cannot import
+    // shared code, so the transform is deliberately duplicated; keep the two
+    // in sync). "Montréal"/"MONTRÉAL" → "montreal" so accented page/address
+    // text matches the unaccented city config patterns (run 20260727-145617:
+    // "Unknown city montréal" left events wall-clock UTC). Unaccented ASCII
+    // input is byte-identical to plain lowercase+trim.
+    foldDiacritics(value) {
+        return String(value || '')
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .toLowerCase()
+            .trim();
+    }
+
     getTimezoneForCity(city, cityConfig) {
         const map = this.getCityConfigMap(cityConfig);
         if (!map || typeof map !== 'object') return '';
@@ -9768,14 +9826,16 @@ TEXT:
             return direct.timezone.trim();
         }
 
-        const normalizedCity = cityText.toLowerCase();
+        // Diacritic-folded on BOTH sides so "Montréal" resolves montreal's
+        // timezone (run 20260727-145617)
+        const normalizedCity = this.foldDiacritics(cityText);
         const matchedKey = Object.keys(map).find(key => {
-            if (String(key).toLowerCase() === normalizedCity) return true;
+            if (this.foldDiacritics(key) === normalizedCity) return true;
             const cityData = map[key];
             if (!cityData || typeof cityData !== 'object') return false;
-            if (cityData.name && String(cityData.name).toLowerCase() === normalizedCity) return true;
-            if (Array.isArray(cityData.patterns) && cityData.patterns.some(p => String(p).toLowerCase() === normalizedCity)) return true;
-            if (Array.isArray(cityData.aliases) && cityData.aliases.some(a => String(a).toLowerCase() === normalizedCity)) return true;
+            if (cityData.name && this.foldDiacritics(cityData.name) === normalizedCity) return true;
+            if (Array.isArray(cityData.patterns) && cityData.patterns.some(p => this.foldDiacritics(p) === normalizedCity)) return true;
+            if (Array.isArray(cityData.aliases) && cityData.aliases.some(a => this.foldDiacritics(a) === normalizedCity)) return true;
             return false;
         });
         if (!matchedKey) return '';
@@ -9788,7 +9848,8 @@ TEXT:
     getCityAliasList(cityKey, cityData) {
         const aliases = new Set();
         const add = value => {
-            const text = String(value || '').trim().toLowerCase();
+            // Diacritic-folded so accented config names match folded text
+            const text = this.foldDiacritics(value);
             if (text) aliases.add(text);
         };
         add(cityKey);
@@ -9803,7 +9864,9 @@ TEXT:
     findCityConfigEntry(cityValue, cityConfig) {
         const map = this.getCityConfigMap(cityConfig);
         if (!map || typeof map !== 'object') return null;
-        const normalizedCity = String(cityValue || '').trim().toLowerCase();
+        // Diacritic-folded so "Montréal" finds the montreal entry (aliases
+        // from getCityAliasList are already folded)
+        const normalizedCity = this.foldDiacritics(cityValue);
         if (!normalizedCity) return null;
         for (const [key, cityData] of Object.entries(map)) {
             const aliases = this.getCityAliasList(key, cityData);
@@ -9815,11 +9878,13 @@ TEXT:
     }
 
     textContainsCityAlias(normalizedText, alias) {
-        const normalizedAlias = this.normalizeEvidenceText(alias);
+        // Diacritic-folded on BOTH sides: accented evidence ("Montréal, QC")
+        // must contain the unaccented config alias (run 20260727-145617)
+        const normalizedAlias = this.foldDiacritics(this.normalizeEvidenceText(alias));
         if (!normalizedAlias) return false;
         const escaped = normalizedAlias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         const pattern = new RegExp(`(^|[^a-z0-9])${escaped}($|[^a-z0-9])`);
-        return pattern.test(normalizedText);
+        return pattern.test(this.foldDiacritics(normalizedText));
     }
 
     // The AI canonicalizes city names (e.g. "NYC" -> "new york"), so verbatim evidence

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -6573,3 +6573,98 @@ test('linearizeJsonForPrompt emits keyPath lines for scalar leaves, skipping nul
     'note: bold text'
   ]);
 });
+
+// ===========================================================================
+// run 20260727-145617 fixes: diacritic-folded city matching (Fix 1),
+// postal-code degenerate-event gate (Fix 2), calendar-export crawl block (Fix 4)
+// ===========================================================================
+
+test('city matching folds diacritics: "Montréal" text and city values resolve the montreal config entry', () => {
+  const parser = createParser();
+  const cityConfig = {
+    montreal: { name: 'Montreal', timezone: 'America/Toronto', patterns: ['montreal', 'mtl'] },
+    nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc'] }
+  };
+  // Literal run 20260727-145617 address shape (accented city inside free text)
+  assert.equal(parser.findCityKeyInText('Bain Mathieu, 2915 Rue Ontario E, Montréal, QC H2K 1X7', cityConfig), 'montreal');
+  // Accented city value → timezone (the run left these wall-clock UTC)
+  assert.equal(parser.getTimezoneForCity('montréal', cityConfig), 'America/Toronto');
+  assert.equal(parser.getTimezoneForCity('Montréal', cityConfig), 'America/Toronto');
+  assert.equal(parser.getTimezoneForCity('MONTRÉAL', cityConfig), 'America/Toronto');
+  // findCityConfigEntry folds too
+  assert.equal(parser.findCityConfigEntry('Montréal', cityConfig).key, 'montreal');
+  // Unaccented regression: byte-identical to pre-fix behavior
+  assert.equal(parser.findCityKeyInText('123 Main St, Montreal, QC', cityConfig), 'montreal');
+  assert.equal(parser.getTimezoneForCity('montreal', cityConfig), 'America/Toronto');
+  assert.equal(parser.getTimezoneForCity('new york', cityConfig), 'America/New_York');
+  assert.equal(parser.getTimezoneForCity('atlantis', cityConfig), '');
+});
+
+test('postal-code titles: only a title that is NOTHING but a postal code is degenerate', () => {
+  const parser = createParser();
+  // Literal run title (Canadian postal code) plus the stated shapes
+  assert.equal(parser.isPostalCodeOnlyTitle('H2K 1X7'), true);
+  assert.equal(parser.isPostalCodeOnlyTitle('h2k 1x7'), true);
+  assert.equal(parser.isPostalCodeOnlyTitle('H2K-1X7'), true);
+  assert.equal(parser.isPostalCodeOnlyTitle('90210'), true);
+  assert.equal(parser.isPostalCodeOnlyTitle('90210-1234'), true);
+  assert.equal(parser.isPostalCodeOnlyTitle('SW1A 1AA'), true);
+  // Titles containing anything else survive (fail closed)
+  assert.equal(parser.isPostalCodeOnlyTitle('Party at H2K 1X7'), false);
+  assert.equal(parser.isPostalCodeOnlyTitle('SW4'), false, 'outward-only UK shorthand is not a full postcode');
+  assert.equal(parser.isPostalCodeOnlyTitle('Bear Night'), false);
+  assert.equal(parser.isPostalCodeOnlyTitle('Furball 2026'), false);
+  assert.equal(parser.isPostalCodeOnlyTitle(''), false);
+  assert.equal(parser.isPostalCodeOnlyTitle(null), false);
+});
+
+test('postal-code gate: extractSingleEvent skips the literal "H2K 1X7" extraction with the skip log', async () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  // Mirrors the run: an address block's postal code became a fully-formed
+  // "event" (bar "Bear-IT", city "canada", zero duration) and reached preview.
+  parser.getAiEvent = async () => ({
+    title: 'H2K 1X7',
+    startDate: '2026-07-27',
+    __preValidatedFields: ['startDate']
+  });
+  let event = 'unset';
+  const logs = await captureLogsAsync(async () => {
+    event = await parser.extractSingleEvent(
+      { html: 'Bear-IT\n2915 Rue Ontario E, Montréal, QC H2K 1X7\nJuly 27 2026', url: 'https://bear-it.example/events' },
+      {}, null, ['title', 'startDate']
+    );
+  });
+  assert.equal(event, null, 'a postal-code title never becomes an event');
+  assert.ok(
+    logs.includes('🤖 AI Web: Skipped degenerate event "H2K 1X7" — title is a postal code, not an event'),
+    `skip log expected, got: ${JSON.stringify(logs.filter(line => line.includes('AI Web')))}`
+  );
+});
+
+test('validateEventUrl rejects calendar-export URLs (literal run URLs) but keeps date-in-path event URLs', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://bear-it.example/events/';
+  // The three literal shapes the crawler followed into empty responses
+  assert.equal(
+    parser.validateEventUrl('https://bear-it.example/events/2026-07-27/?ical=1/', sourceUrl, {}).reason,
+    'calendar-export-url');
+  assert.equal(
+    parser.validateEventUrl('https://bear-it.example/events/mois/?ical=1', sourceUrl, {}).reason,
+    'calendar-export-url');
+  assert.equal(
+    parser.validateEventUrl('https://bear-it.example/events/2026-07-27/?outlook-ical=1', sourceUrl, {}).reason,
+    'calendar-export-url');
+  // The Events Calendar date-filter links and .ics exports are also blocked
+  assert.equal(
+    parser.validateEventUrl('https://bear-it.example/events/?tribe-bar-date=2026-07-27', sourceUrl, {}).reason,
+    'calendar-export-url');
+  assert.equal(
+    parser.validateEventUrl('https://bear-it.example/events/export.ics', sourceUrl, {}).reason,
+    'calendar-export-url');
+  // Normal event URLs with dates in the path stay valid
+  assert.equal(parser.validateEventUrl('https://bear-it.example/events/2026-07-27/', sourceUrl, {}).valid, true);
+  assert.equal(parser.validateEventUrl('https://bear-it.example/events/bear-night-2026-07-27', sourceUrl, {}).valid, true);
+  // "ical" inside a slug or query VALUE is not an export flag
+  assert.equal(parser.validateEventUrl('https://bear-it.example/events/musical-bears?musical=1', sourceUrl, {}).valid, true);
+});

--- a/scripts/scraper-cities.js
+++ b/scripts/scraper-cities.js
@@ -391,7 +391,8 @@ const scraperCities = {
     "calendar": "chunky-dad-montreal",
     "timezone": "America/Toronto",
     "patterns": [
-      "montreal"
+      "montreal",
+      "mtl"
     ],
     "coordinates": {
       "lat": 45.5019,

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -218,6 +218,49 @@ class SharedCore {
         return cityMappings;
     }
 
+    // Diacritic-folded lowercase view of city-ish text: NFD-decompose, strip
+    // combining marks (U+0300–U+036F), lowercase, trim — "Montréal"/"MONTRÉAL"
+    // → "montreal" so accented page/address text matches the unaccented city
+    // config patterns (run 20260727-145617: city "montréal" failed the
+    // montreal key lookup and timezone resolution). Unaccented ASCII input is
+    // byte-identical to plain lowercase+trim. String.prototype.normalize is
+    // ES6 and available on iOS JavaScriptCore. ai-web-parser.js duplicates
+    // this as foldDiacritics (parsers are standalone and cannot import shared
+    // code; keep the two in sync); normalizers.js reaches it via this.core.
+    foldDiacritics(value) {
+        return String(value || '')
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .toLowerCase()
+            .trim();
+    }
+
+    // Timezone for a city value that may be a config KEY, an accented/cased
+    // variant of one ("Montréal"), or any configured name/pattern/alias.
+    // Diacritic-folded comparison on BOTH sides. Null when unknown — callers
+    // keep their own fallbacks (this is the shared timezone-config-lookup-by-
+    // city rung behind every `event.city → timezone` resolution).
+    getCityTimezone(city) {
+        if (!city || !this.cities || typeof this.cities !== 'object') return null;
+        const direct = this.cities[city];
+        if (direct && typeof direct === 'object' && typeof direct.timezone === 'string' && direct.timezone.trim()) {
+            return direct.timezone.trim();
+        }
+        const folded = this.foldDiacritics(city);
+        if (!folded) return null;
+        for (const [key, cityData] of Object.entries(this.cities)) {
+            if (!cityData || typeof cityData !== 'object') continue;
+            const names = [key, cityData.name]
+                .concat(Array.isArray(cityData.patterns) ? cityData.patterns : [])
+                .concat(Array.isArray(cityData.aliases) ? cityData.aliases : []);
+            if (!names.some(name => this.foldDiacritics(name) === folded)) continue;
+            return typeof cityData.timezone === 'string' && cityData.timezone.trim()
+                ? cityData.timezone.trim()
+                : null;
+        }
+        return null;
+    }
+
     warnOnce(key, message) {
         if (!this.loggedWarnings) {
             this.loggedWarnings = new Set();
@@ -922,13 +965,14 @@ class SharedCore {
     isCityOnlyTitle(title, cityKey) {
         if (!title || !cityKey || !this.cities || typeof this.cities !== 'object') return false;
         const normalizedKey = String(cityKey).trim().toLowerCase();
-        const cityData = this.cities[cityKey] || this.cities[normalizedKey];
+        // Accented city values ("Montréal") fold to the config key (Fix: run 20260727-145617)
+        const cityData = this.cities[cityKey] || this.cities[normalizedKey] || this.cities[this.foldDiacritics(cityKey)];
         if (!cityData || typeof cityData !== 'object') return false;
-        const normalizedTitle = this.stripEmojiForTitleTwin(title).replace(/\s+/g, ' ').trim().toLowerCase();
+        const normalizedTitle = this.foldDiacritics(this.stripEmojiForTitleTwin(title).replace(/\s+/g, ' '));
         if (!normalizedTitle) return false;
         const candidates = new Set();
         const addCandidate = value => {
-            const text = String(value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+            const text = this.foldDiacritics(String(value || '').replace(/\s+/g, ' '));
             if (!text) return;
             candidates.add(text);
             candidates.add(text.replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim());
@@ -1547,7 +1591,7 @@ class SharedCore {
     getCityCenterCoordinatePair(cityKey) {
         const key = cityKey ? String(cityKey).trim() : '';
         if (!key || !this.cities || typeof this.cities !== 'object') return null;
-        const cityConfig = this.cities[key] || this.cities[key.toLowerCase()];
+        const cityConfig = this.cities[key] || this.cities[key.toLowerCase()] || this.cities[this.foldDiacritics(key)];
         const coords = cityConfig && cityConfig.coordinates;
         if (!coords) return null;
         const lat = Number(coords.lat);
@@ -5330,7 +5374,7 @@ class SharedCore {
         let key = format;
         
         const useLocalDate = options.useLocalDate === true;
-        const eventTimezone = event.timezone || (event.city && this.cities[event.city]?.timezone) || null;
+        const eventTimezone = event.timezone || this.getCityTimezone(event.city) || null;
         const dateValue = useLocalDate
             ? this.normalizeEventDateLocal(event.startDate, eventTimezone)
             : this.normalizeEventDate(event.startDate);
@@ -6594,7 +6638,7 @@ class SharedCore {
         if (!event || !event._timezoneUnresolved) return event;
 
         const timezone = event.timezone
-            || (event.city && this.cities && this.cities[event.city]?.timezone)
+            || this.getCityTimezone(event.city)
             || '';
         if (!timezone) {
             const title = event.title || 'unknown';
@@ -8090,7 +8134,7 @@ class SharedCore {
         }
         
         const fallbackDate = this.normalizeEventDate(event?.startDate);
-        const timezone = event?.timezone || (event?.city && this.cities[event.city]?.timezone) || null;
+        const timezone = event?.timezone || this.getCityTimezone(event ? event.city : null) || null;
         const localDate = this.normalizeEventDateLocal(event?.startDate, timezone);
         const date = localDate || fallbackDate;
         
@@ -8148,7 +8192,7 @@ class SharedCore {
             .replace(/[\s\-]+/g, '-')
             .replace(/^-+|-+$/g, '');
         
-        const eventTimezone = event.timezone || (event.city && this.cities[event.city]?.timezone) || null;
+        const eventTimezone = event.timezone || this.getCityTimezone(event.city) || null;
         const date = this.normalizeEventDateLocal(event.startDate, eventTimezone);
         const venue = String(event.bar || '').toLowerCase().trim();
         if (!normalizedTitle || !date) return null;
@@ -8476,7 +8520,7 @@ class SharedCore {
             timezone: event.timezone
                 || fields.timezone
                 || event.calendarTimezone
-                || (event.city && this.cities[event.city]?.timezone)
+                || this.getCityTimezone(event.city)
                 || null,
             ticketUrl: this.normalizeTicketUrlForIdentity(event.ticketUrl || fields.ticketUrl),
             names: [...new Set(names)],
@@ -8667,7 +8711,7 @@ class SharedCore {
         if (!date || isNaN(date.getTime())) return '';
         const timezone = event._timezoneUnresolved
             ? null
-            : (event.timezone || (event.city && this.cities && this.cities[event.city]?.timezone) || null);
+            : (event.timezone || this.getCityTimezone(event.city) || null);
         let year = date.getUTCFullYear();
         let month = date.getUTCMonth() + 1;
         let day = date.getUTCDate();
@@ -8720,14 +8764,33 @@ class SharedCore {
     // strings, or the same venue-site page host tag (#1539's
     // _venueSitePageHost — the run's "Eagle Karaoke" record carried no bar at
     // all but was scraped from thedallaseagle.com just like its twin).
+    // A fourth axis, bar-in-address, covers one side's MULTI-WORD bar name
+    // appearing verbatim as a contiguous token run inside the other side's
+    // address (run 20260727-145617: bar "Bain Mathieu" vs an address that
+    // literally named the venue — "Bain Mathieu, 2915 Rue Ontario E").
+    // Multi-token names only, fail closed: single-word bar names like
+    // "Eagle" collide with street names.
     getCrossSourceVenueIdentity(eventA, eventB) {
         if (!eventA || !eventB) return null;
         const barA = this.normalizeBarNameKey(eventA.bar);
         const barB = this.normalizeBarNameKey(eventB.bar);
         if (barA && barB && barA === barB) return 'bar';
-        const addressA = this.normalizeAddressTokens(eventA.address).join(' ');
-        const addressB = this.normalizeAddressTokens(eventB.address).join(' ');
+        const addressTokensA = this.normalizeAddressTokens(eventA.address);
+        const addressTokensB = this.normalizeAddressTokens(eventB.address);
+        const addressA = addressTokensA.join(' ');
+        const addressB = addressTokensB.join(' ');
         if (addressA && addressB && addressA === addressB) return 'address';
+        const containsTokenRun = (haystack, needle) => {
+            if (needle.length < 2 || haystack.length < needle.length) return false;
+            for (let start = 0; start + needle.length <= haystack.length; start++) {
+                if (needle.every((token, offset) => haystack[start + offset] === token)) return true;
+            }
+            return false;
+        };
+        if (containsTokenRun(addressTokensB, this.normalizeAddressTokens(eventA.bar))
+            || containsTokenRun(addressTokensA, this.normalizeAddressTokens(eventB.bar))) {
+            return 'bar-in-address';
+        }
         const hostA = String(eventA._venueSitePageHost || '').trim().toLowerCase();
         const hostB = String(eventB._venueSitePageHost || '').trim().toLowerCase();
         if (hostA && hostB && hostA === hostB) return 'venue-site';
@@ -8741,10 +8804,16 @@ class SharedCore {
     // debris, and the venue's own name tokens are dropped. venueKeys are
     // normalizeBarNameKey-style strings ("dallaseagle", "thedallaseagle") —
     // a token is a venue token when a key contains it.
+    // City-name tokens are ALSO dropped (run 20260727-145617: "Concours PUP
+    // Montréal" vs "Concours PUP MTL" failed the subset test on montréal ≠
+    // mtl — the city suffix is branding, not identity). Diacritics are folded
+    // BEFORE tokenization so "Montréal" is one token ("montreal"), and city
+    // stripping never empties the set (a title that is nothing but city names
+    // keeps its tokens — fail closed).
     getCrossSourceTitleTokens(title, venueKeys = []) {
-        const text = this.stripEmojiForTitleTwin(
+        const text = this.foldDiacritics(this.stripEmojiForTitleTwin(
             String(title || '').replace(/&#?[0-9a-z]+;/gi, '')
-        ).toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim();
+        )).replace(/[^a-z0-9]+/g, ' ').trim();
         if (!text) return [];
         const rawTokens = text.split(/\s+/);
         const performerMarkers = new Set(['with', 'featuring', 'feat', 'ft', 'w']);
@@ -8756,13 +8825,46 @@ class SharedCore {
             'to', 'too', 'with', 'yall', 'you', 'your'
         ]);
         const keys = (Array.isArray(venueKeys) ? venueKeys : []).filter(Boolean);
+        const cityTokens = this.getCityAliasTokenSet();
         const tokens = [];
+        const tokensWithCity = [];
         for (const token of scopedTokens) {
             if (token.length <= 1) continue;
             if (stopwords.has(token)) continue;
             if (token.length >= 3 && keys.some(key => key.includes(token))) continue;
+            if (!tokensWithCity.includes(token)) tokensWithCity.push(token);
+            if (token.length >= 3 && cityTokens.has(token)) continue;
             if (!tokens.includes(token)) tokens.push(token);
         }
+        return tokens.length > 0 ? tokens : tokensWithCity;
+    }
+
+    // Folded single-word city-name tokens from the configured cities: every
+    // key, display name, pattern, and alias that reduces to ONE token of >= 3
+    // chars after diacritic folding ("montreal", "mtl", "nyc"). Multi-word
+    // names ("new york", "fire-island") are skipped so generic words like
+    // "new" are never treated as city tokens, and 2-char forms ("la") are
+    // skipped so French/Spanish articles in titles survive. Cached per cities
+    // object (set once in the constructor).
+    getCityAliasTokenSet() {
+        const source = this.cities && typeof this.cities === 'object' ? this.cities : null;
+        if (!source) return new Set();
+        if (this._cityAliasTokenSet && this._cityAliasTokenSetSource === source) {
+            return this._cityAliasTokenSet;
+        }
+        const tokens = new Set();
+        for (const [key, cityData] of Object.entries(source)) {
+            const names = [key]
+                .concat(cityData && typeof cityData === 'object' ? [cityData.name] : [])
+                .concat(cityData && Array.isArray(cityData.patterns) ? cityData.patterns : [])
+                .concat(cityData && Array.isArray(cityData.aliases) ? cityData.aliases : []);
+            for (const name of names) {
+                const folded = this.foldDiacritics(name).replace(/[^a-z0-9]+/g, ' ').trim();
+                if (folded && folded.length >= 3 && !folded.includes(' ')) tokens.add(folded);
+            }
+        }
+        this._cityAliasTokenSet = tokens;
+        this._cityAliasTokenSetSource = source;
         return tokens;
     }
 
@@ -8821,7 +8923,7 @@ class SharedCore {
             if (!date || isNaN(date.getTime())) return false;
             const timezone = event._timezoneUnresolved
                 ? null
-                : (event.timezone || (event.city && this.cities && this.cities[event.city]?.timezone) || null);
+                : (event.timezone || this.getCityTimezone(event.city) || null);
             if (timezone && typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function') {
                 try {
                     const formatter = new Intl.DateTimeFormat('en-CA', {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -8890,3 +8890,103 @@ test('_promoter carries across dedup merges like _organizer', async () => {
   assert.equal(merged._promoter, 'Bearracuda');
   assert.equal(merged._organizer, 'Bearracuda');
 });
+
+// ===========================================================================
+// run 20260727-145617 fixes: diacritic folding in city resolution (Fix 1) and
+// city-alias tokens in cross-source title dedup (Fix 3)
+// ===========================================================================
+
+const MONTREAL_CITIES = {
+  montreal: { name: 'Montreal', timezone: 'America/Toronto', patterns: ['montreal', 'mtl'] },
+  nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc'] }
+};
+
+function createMontrealCore() {
+  return new SharedCore(MONTREAL_CITIES, { eventSchema: EventSchema });
+}
+
+test('foldDiacritics: accented city text folds to the config key; unaccented ASCII is byte-identical to lowercase+trim', () => {
+  const core = createMontrealCore();
+  assert.equal(core.foldDiacritics('montréal'), 'montreal');
+  assert.equal(core.foldDiacritics('Montréal'), 'montreal');
+  assert.equal(core.foldDiacritics('MONTRÉAL'), 'montreal');
+  assert.equal(core.foldDiacritics('  Montreal  '), 'montreal');
+  assert.equal(core.foldDiacritics('new york'), 'new york');
+  assert.equal(core.foldDiacritics(null), '');
+});
+
+test('getCityTimezone: accented "montréal" resolves montreal timezone (literal run city value); unaccented unchanged', () => {
+  const core = createMontrealCore();
+  // Literal run 20260727-145617 value that failed: city "montréal"
+  assert.equal(core.getCityTimezone('montréal'), 'America/Toronto');
+  assert.equal(core.getCityTimezone('Montréal'), 'America/Toronto');
+  assert.equal(core.getCityTimezone('MONTRÉAL'), 'America/Toronto');
+  // Unaccented key and pattern lookups stay byte-identical
+  assert.equal(core.getCityTimezone('montreal'), 'America/Toronto');
+  assert.equal(core.getCityTimezone('mtl'), 'America/Toronto');
+  assert.equal(core.getCityTimezone('nyc'), 'America/New_York');
+  assert.equal(core.getCityTimezone('new york'), 'America/New_York');
+  // Unknown cities still resolve nothing
+  assert.equal(core.getCityTimezone('atlantis'), null);
+  assert.equal(core.getCityTimezone(''), null);
+});
+
+test('resolveWallClockDates: city "montréal" re-anchors wall-clock dates via the folded timezone lookup', () => {
+  const core = createMontrealCore();
+  const event = {
+    title: 'Concours PUP MTL',
+    city: 'montréal',
+    startDate: new Date('2026-07-27T22:00:00.000Z'),
+    endDate: new Date('2026-07-27T22:00:00.000Z'),
+    _timezoneUnresolved: true
+  };
+  core.resolveWallClockDates(event);
+  // 10pm EDT (UTC-4) = 2am UTC next day — no longer stuck wall-clock UTC
+  assert.equal(event.startDate.toISOString(), '2026-07-28T02:00:00.000Z');
+  assert.equal(event._timezoneUnresolved, undefined);
+});
+
+test('cross-source tokens: city-alias tokens (folded "montréal", "mtl") are stripped; other tokens untouched', () => {
+  const core = createMontrealCore();
+  // Diacritics fold BEFORE tokenization: "Montréal" is ONE token, then stripped as a city alias
+  assert.deepEqual(core.getCrossSourceTitleTokens('Concours PUP Montréal'), ['concours', 'pup']);
+  assert.deepEqual(core.getCrossSourceTitleTokens('Concours PUP MTL'), ['concours', 'pup']);
+  // Multi-word city names are never token-stripped ("new" and "york" survive)
+  assert.deepEqual(core.getCrossSourceTitleTokens('New York Underwear Party'), ['new', 'york', 'underwear', 'party']);
+  // Unaffected titles are byte-identical to the pre-fix behavior
+  assert.deepEqual(core.getCrossSourceTitleTokens('Singlet Night with DJ Drew G'), ['singlet', 'night']);
+});
+
+test('cross-source tokens: city stripping never EMPTIES the significant-token set (fail closed)', () => {
+  const core = createMontrealCore();
+  // A title that is NOTHING but city names keeps its tokens
+  assert.deepEqual(core.getCrossSourceTitleTokens('Montréal'), ['montreal']);
+  assert.deepEqual(core.getCrossSourceTitleTokens('MTL'), ['mtl']);
+});
+
+test('cross-source signal: literal Concours PUP pair (run 20260727-145617) pairs across the Montréal/MTL title gap', () => {
+  const core = createMontrealCore();
+  // Faithful shapes: one record carries the venue as its bar, the twin names
+  // the venue INSIDE its address while its bar is a different extraction
+  const montrealRecord = {
+    title: 'Concours PUP Montréal', bar: 'Bain Mathieu', city: 'montreal',
+    timezone: 'America/Toronto', startDate: new Date('2026-07-28T02:00:00.000Z')
+  };
+  const mtlRecord = {
+    title: 'Concours PUP MTL', bar: 'Aigle Noir', city: 'montréal',
+    address: 'Bain Mathieu, 2915 Rue Ontario E, Montréal, QC H2K 1X7',
+    startDate: new Date('2026-07-28T02:00:00.000Z')
+  };
+  assert.equal(core.getCrossSourceVenueIdentity(montrealRecord, mtlRecord), 'bar-in-address');
+  assert.equal(core.getCrossSourceDuplicateSignal(montrealRecord, mtlRecord), 'venue+night+title-subset');
+});
+
+test('cross-source venue identity: single-word bar names never match inside addresses (fail closed)', () => {
+  const core = createMontrealCore();
+  const barRecord = { title: 'Eagle Party', bar: 'Eagle', startDate: new Date('2026-07-28T02:00:00.000Z') };
+  const addressRecord = {
+    title: 'Eagle Party', address: '500 Eagle Street, Montreal',
+    startDate: new Date('2026-07-28T02:00:00.000Z')
+  };
+  assert.equal(core.getCrossSourceVenueIdentity(barRecord, addressRecord), null);
+});


### PR DESCRIPTION
Four fixes from the Bear it MTL run (20260727-145617) findings:

## 1. Diacritic folding in city resolution [the HIGH one]
"montréal" matched nothing, so every Bear it MTL event lost its timezone ("dates remain wall-clock UTC and may be wrong"). The bug lived in **eleven** raw-lowercase comparison sites — including seven separate `cities[event.city]?.timezone` lookups. Now every city comparison folds diacritics (NFD + strip combining marks) on both sides via a canonical `foldDiacritics` + new `getCityTimezone` helper. "montréal"/"MONTRÉAL" → `montreal` → America/Toronto. Unaccented behavior byte-identical (the fold is identity on ASCII). **Bear it MTL events are now safe to execute to the calendar.**

## 2. Postal-code phantom gate
The "H2K 1X7" event (a postal code as a title, address "15472", zero duration) is now rejected at the same choke point as the venue-hours gate — conservative shapes only (full CA/US/UK postal codes as the *entire* title). "Party at H2K 1X7" and short fragments like "SW4" are untouched.

## 3. PUP Montréal / PUP MTL dedup
Cross-source title tokens now strip single-word city keys/names/aliases (diacritic-folded, ≥3 chars, never emptying the set) — both titles reduce to {concours, pup}. "mtl" added as a montreal pattern (source-edited in js/city-config.js, twin regenerated — generator confirms sync). Two bonus finds: the tokenizer itself mangled "Montréal" into `montr`+`al` (fixed by folding before tokenization), and the pair matched **no** existing venue-identity axis, so a conservative fourth axis was added: one side's multi-token bar name appearing as a contiguous run in the other's address (single-word bar names fail closed — "Eagle" can't bridge).

## 4. Calendar-export crawl block
`?ical=1`, `?outlook-ical=1`, `tribe-bar-date=`, and `.ics` URLs are builtin-blocked from the crawl frontier (reason `calendar-export-url`) — ends the empty-response ERROR spam from The Events Calendar export links.

Tests **884 → 899**; fixtures are the literal run cases. All log/prompt lines additive.

## After merge
Changed runtime files for your updater to pull: `scripts/shared-core.js`, `scripts/normalizers.js`, `scripts/parsers/ai-web-parser.js`, `scripts/scraper-cities.js` (no NEW files). Then rerun Bear it MTL: expect resolved Montréal timezones, no H2K 1X7, and the PUP pair merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP