### PR TITLE
chore(scraper): repo scraper-input.js becomes the live pullable config

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -1,3 +1,6 @@
+// Variables used by Scriptable.
+// These must be at the very top of the file. Do not edit.
+// icon-color: purple; icon-glyph: magic;
 // Bear Event Scraper Configuration
 // This file contains the runtime configuration for the bear event scraper system.
 //
@@ -161,7 +164,7 @@ const scraperConfig = {
     },
     {
       name: "Bearracuda Events",
-      enabled: true,
+      enabled: false,
       urls: [
         "https://bearracuda.com/",
         "https://www.eventbrite.com/o/bearracuda-21867032189",
@@ -287,6 +290,7 @@ const scraperConfig = {
         mastodon: { value: "https://mastodon.social/@dallaseagle" },
       },
     },
+    { name: "massive.club", enabled: true, urls: ["https://www.massive.club"], alwaysBear: false },
     // ── Onboarding batch 2026-07-27 (recon-verified) — each ships disabled;
     // run one at a time via the parser picker, review, then enable. ──────
     {


### PR DESCRIPTION
One deployment, one operator — so the repo copy of `scraper-input.js` now IS the live config, byte-identical to your phone's (Scriptable banner, Bearracuda disabled, your massive.club parser included). 

**After merging: add `scripts/scraper-input.js` to your scriptable-script-updater config** (raw URL, same as the other files) and pull. From now on every config change ships as a PR to this file and your updater picks it up — no more merged-file attachments, ever.

(If you someday want a personal setting kept out of the repo, say so and we'll design for it then — today there's nothing in your config that can't live here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP