### PR TITLE
feat(scraper): recurring events — rrule extraction, ICS export, layered series detection (never auto-write)

### DIFF
--- a/js/event-schema.js
+++ b/js/event-schema.js
@@ -49,6 +49,7 @@ const EVENT_KEY_ALIASES = {
 
     recurrence: 'recurrence',
     rrule: 'recurrence',
+    recurrencerule: 'recurrence',
     type: 'type',
     eventtype: 'type',
     recurrenceid: 'recurrenceId',
@@ -141,7 +142,7 @@ const DEFAULT_NOTES_EXCLUDED_FIELDS = new Set([
     'placeId',
     'matchKey',
     'links', 'durationMinutes',
-    'time', 'day', 'recurring', 'recurrence',
+    'time', 'day', 'recurring', 'recurrence', 'recurrenceRule',
     'isDeletingOverride'
 ]);
 
@@ -495,6 +496,169 @@ const AI_FIELD_SIGNAL_REGEXES = {
     ]
 };
 
+// ============================================================================
+// RECURRING-EVENT ICS EXPORT (pure helpers)
+// ============================================================================
+// The scraper NEVER writes or mutates recurring series in the calendar.
+// Detected series are surfaced in the results UI and exported as an .ics the
+// owner imports manually — these helpers build that ICS. Conventions mirror
+// testing/event-builder.html generateICS (UID shape, TZID local wall-clock
+// datetimes, PRODID), plus RFC 5545 75-octet line folding.
+
+function escapeIcsText(text) {
+    return String(text)
+        .replace(/\\/g, '\\\\')
+        .replace(/\r\n|\r|\n/g, '\\n')
+        .replace(/,/g, '\\,')
+        .replace(/;/g, '\\;');
+}
+
+// RFC 5545 §3.1: content lines SHOULD NOT exceed 75 octets (excluding CRLF);
+// longer lines fold onto continuation lines that begin with a single space.
+// Counts UTF-8 octets and never splits inside a code point.
+function foldIcsLine(line) {
+    const text = String(line);
+    const octetsOf = (codePoint) => {
+        if (codePoint <= 0x7f) return 1;
+        if (codePoint <= 0x7ff) return 2;
+        if (codePoint <= 0xffff) return 3;
+        return 4;
+    };
+    const folded = [];
+    let current = '';
+    let currentOctets = 0;
+    for (const char of text) {
+        const octets = octetsOf(char.codePointAt(0));
+        if (currentOctets + octets > 75) {
+            folded.push(current);
+            current = ' ';
+            currentOctets = 1;
+        }
+        current += char;
+        currentOctets += octets;
+    }
+    folded.push(current);
+    return folded.join('\r\n');
+}
+
+function formatIcsDateUtc(date) {
+    const parsed = date instanceof Date ? date : new Date(date);
+    if (isNaN(parsed.getTime())) return '';
+    return parsed.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+}
+
+// Local wall-clock YYYYMMDDTHHMMSS in an IANA timezone (no trailing Z) —
+// paired with ;TZID= on DTSTART/DTEND. Returns '' when the timezone cannot
+// be resolved so callers can fall back to UTC-Z values.
+function formatIcsDateInTimezone(date, timezone) {
+    const parsed = date instanceof Date ? date : new Date(date);
+    if (isNaN(parsed.getTime()) || !timezone) return '';
+    try {
+        const parts = new Intl.DateTimeFormat('en-US', {
+            timeZone: timezone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false
+        }).formatToParts(parsed);
+        const values = {};
+        parts.forEach(part => {
+            if (part.type !== 'literal') {
+                values[part.type] = part.value;
+            }
+        });
+        if (!values.year || !values.month || !values.day) return '';
+        const hour = values.hour === '24' ? '00' : (values.hour || '00');
+        const minute = values.minute || '00';
+        const second = values.second || '00';
+        return `${values.year}${values.month}${values.day}T${hour}${minute}${second}`;
+    } catch (error) {
+        return '';
+    }
+}
+
+// Same slug rules as the event-builder UID slug (testing/event-builder.html).
+function slugifyIcsText(value) {
+    return String(value || '')
+        .toLowerCase()
+        .trim()
+        .replace(/[\s_]+/g, '-')
+        .replace(/[^\w-]+/g, '')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '')
+        .slice(0, 60);
+}
+
+// Build a complete VCALENDAR/VEVENT for one recurring event. DESCRIPTION is
+// the event's standard notes (EventSchema.formatEventNotes) PLUS an explicit
+// `recurrence: <rrule>` line — the notes key the merge machinery reads as a
+// series-detection signal once the owner has imported the ICS. (The default
+// notes-exclusion list applies to scraper CALENDAR writes; this ICS is the
+// deliberate, owner-driven channel, so the line is appended explicitly.)
+// options: { timezone, now } — now is injectable for deterministic tests.
+function buildRecurringEventIcs(event, options = {}) {
+    if (!event || typeof event !== 'object') return '';
+    const rrule = String(event.recurrenceRule || event.recurrence || '')
+        .replace(/^RRULE\s*:/i, '')
+        .trim();
+    const title = String(event.title || event.name || '').trim() || 'chunky-dad';
+    const timezone = String(options.timezone || event.timezone || '').trim();
+    const now = options.now instanceof Date ? options.now : new Date();
+
+    // UID matches the event-builder style: <slug>-<utcstamp>@chunky.dad
+    // (e.g. fuzzy-20260503T203532Z@chunky.dad).
+    const uid = `${slugifyIcsText(title) || 'chunky-dad'}-${formatIcsDateUtc(now)}@chunky.dad`;
+
+    const dateProperty = (name, date) => {
+        const local = timezone ? formatIcsDateInTimezone(date, timezone) : '';
+        if (local) return `${name};TZID=${timezone}:${local}`;
+        const utc = formatIcsDateUtc(date);
+        return utc ? `${name}:${utc}` : '';
+    };
+
+    const lines = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//chunky.dad//Event Builder//EN',
+        'CALSCALE:GREGORIAN',
+        'METHOD:PUBLISH',
+        'BEGIN:VEVENT',
+        `UID:${uid}`,
+        `DTSTAMP:${formatIcsDateUtc(now)}`
+    ];
+    const dtStart = dateProperty('DTSTART', event.startDate);
+    if (dtStart) lines.push(dtStart);
+    const dtEnd = event.endDate ? dateProperty('DTEND', event.endDate) : '';
+    if (dtEnd) lines.push(dtEnd);
+    lines.push(`SUMMARY:${escapeIcsText(title)}`);
+
+    const notes = formatEventNotes(event);
+    const descriptionText = rrule
+        ? `${notes ? `${notes}\n` : ''}recurrence: ${escapeText(rrule)}`
+        : notes;
+    if (descriptionText) {
+        lines.push(`DESCRIPTION:${escapeIcsText(descriptionText)}`);
+    }
+    const website = String(event.website || event.url || '').trim();
+    if (website) {
+        lines.push(`URL:${escapeIcsText(website)}`);
+    }
+    lines.push('STATUS:CONFIRMED');
+    lines.push('TRANSP:OPAQUE');
+    if (rrule) {
+        lines.push(`RRULE:${rrule}`);
+    }
+    const location = String(event.location || '').trim();
+    if (location) {
+        lines.push(`LOCATION:${escapeIcsText(location)}`);
+    }
+    lines.push('END:VEVENT', 'END:VCALENDAR');
+    return lines.map(foldIcsLine).join('\r\n');
+}
+
 const EventSchema = {
     EVENT_KEY_ALIASES,
     URL_LIKE_FIELDS,
@@ -512,7 +676,13 @@ const EventSchema = {
     isUrlLikeField,
     parseNotesIntoFields,
     formatEventNotes,
-    getEventBuilderStateKey
+    getEventBuilderStateKey,
+    escapeIcsText,
+    foldIcsLine,
+    formatIcsDateUtc,
+    formatIcsDateInTimezone,
+    slugifyIcsText,
+    buildRecurringEventIcs
 };
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2347,6 +2347,163 @@ class ScriptableAdapter {
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Recurring-series detection (merge safety). Scriptable exposes NO
+  // recurrence reads on CalendarEvent, so occurrences of a series are
+  // individually indistinguishable from normal events — a narrow search
+  // window can see exactly ONE instance of a MONTHLY series and let it
+  // masquerade as a normal event. Two adapter-side layers close the hole
+  // when SharedCore's own signals (notes `recurrence:` key, identifier RID
+  // patterns, multi-instance UID in the candidate set) have not fired:
+  //   1. Published calendar ICS: CI publishes each calendar to
+  //      https://chunky.dad/data/calendars/<cityKey>.ics with RRULEs intact,
+  //      and the identifier suffix after the first colon IS the ICS UID
+  //      verbatim — an authoritative series lookup.
+  //   2. Fallback: ONE targeted wide-window identifier probe
+  //      (CalendarEvent.between over now-35d..now+70d) — ≥2 instances
+  //      sharing the matched identifier means a series.
+  // Both layers fail open (any error → today's behavior) and cache per run.
+  // ---------------------------------------------------------------------------
+
+  // Fetch + light-scan the published calendar ICS for one city: Map of ICS
+  // UID → has-RRULE, or null on any failure (callers fall back to the
+  // wide-window probe). Uses the same page-cache machinery as the remote
+  // bars fetch; the published file refreshes ~2-hourly, so a ~6h TTL
+  // (0.25 days) keeps repeat runs cheap. Cached per run per city.
+  async getPublishedRecurringUids(cityKey) {
+    try {
+      const key = String(cityKey || "").trim();
+      if (!key) return null;
+      if (!this._publishedRecurringUidsByCity) {
+        this._publishedRecurringUidsByCity = {};
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(
+          this._publishedRecurringUidsByCity,
+          key,
+        )
+      ) {
+        return this._publishedRecurringUidsByCity[key];
+      }
+      const url = `https://chunky.dad/data/calendars/${encodeURIComponent(key)}.ics`;
+      const icsCacheConfig = {
+        enabled: this.getPageCacheConfig().enabled,
+        ttlDays: 0.25,
+      };
+      let body = null;
+      const cached = await this.readCachedPage(url, icsCacheConfig);
+      if (cached && typeof cached.html === "string") {
+        body = cached.html;
+      } else {
+        const responseData = await this.fetchData(url, {
+          headers: { Accept: "text/calendar" },
+          isCacheableResponse: () => false,
+        });
+        if (responseData && typeof responseData.html === "string") {
+          body = responseData.html;
+          await this.writeCachedPage(url, responseData, icsCacheConfig);
+        }
+      }
+      const uids = body ? SharedCore.extractRecurringUidsFromIcs(body) : null;
+      this._publishedRecurringUidsByCity[key] = uids;
+      return uids;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  // Targeted wide-window identifier probe (fallback layer): count calendar
+  // instances sharing the matched identifier across now-35d..now+70d.
+  // Decision logic is pure (SharedCore.resolveSeriesProbeDecision).
+  async probeSeriesByWideWindow(identifier, cityKey, title) {
+    try {
+      const calendarName = this.getCalendarName(cityKey || "default");
+      const calendar = await this.getOrCreateCalendar(calendarName);
+      const now = new Date();
+      const windowStart = new Date(now.getTime() - 35 * 24 * 60 * 60 * 1000);
+      const windowEnd = new Date(now.getTime() + 70 * 24 * 60 * 60 * 1000);
+      const instances = await CalendarEvent.between(windowStart, windowEnd, [
+        calendar,
+      ]);
+      const decision = SharedCore.resolveSeriesProbeDecision(
+        instances,
+        identifier,
+      );
+      if (decision.isSeries) {
+        console.log(
+          `🔁 RECURRING: series detected via wide-window identifier probe for "${title}" (${decision.instanceCount} instances)`,
+        );
+      }
+      return decision.isSeries;
+    } catch (error) {
+      // Fail open — probe errors never change merge behavior.
+      return false;
+    }
+  }
+
+  // SharedCore calls this (when defined) after a scraped event merge-matched
+  // an existing calendar event WITHOUT any series signal firing. Decision
+  // ordering: published calendar ICS first (authoritative both ways — a UID
+  // present WITHOUT an RRULE is confirmed NOT a series and skips the probe),
+  // then the wide-window identifier probe. Cached per identifier per run;
+  // fails open.
+  async probeRecurringSeries(existingEvent, scrapedEvent = null) {
+    try {
+      const identifier =
+        existingEvent && existingEvent.identifier
+          ? String(existingEvent.identifier).trim()
+          : "";
+      if (!identifier) return false;
+      if (!this._seriesProbeCache) this._seriesProbeCache = {};
+      if (
+        Object.prototype.hasOwnProperty.call(this._seriesProbeCache, identifier)
+      ) {
+        return this._seriesProbeCache[identifier];
+      }
+      const title =
+        (existingEvent && existingEvent.title) ||
+        (scrapedEvent && scrapedEvent.title) ||
+        "Unknown";
+      const cityKey =
+        (scrapedEvent && scrapedEvent.city) ||
+        (existingEvent && existingEvent.city) ||
+        "";
+      let decision = null;
+
+      // Layer 1: published calendar ICS lookup.
+      const uid = SharedCore.extractIcsUidFromIdentifier(identifier);
+      if (uid) {
+        const publishedUids = await this.getPublishedRecurringUids(cityKey);
+        if (publishedUids instanceof Map && publishedUids.has(uid)) {
+          if (publishedUids.get(uid) === true) {
+            console.log(
+              `🔁 RECURRING: series confirmed via published calendar ICS for "${title}"`,
+            );
+            decision = true;
+          } else {
+            decision = false;
+          }
+        }
+      }
+
+      // Layer 2 (fallback): wide-window identifier probe.
+      if (decision === null) {
+        decision = await this.probeSeriesByWideWindow(
+          identifier,
+          cityKey,
+          title,
+        );
+      }
+      this._seriesProbeCache[identifier] = decision === true;
+      return this._seriesProbeCache[identifier];
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Recurring series probe failed (fail open): ${error.message}`,
+      );
+      return false;
+    }
+  }
+
   // Bar data merged on the website is the source of truth; the phone's local
   // scraper-bars.js copy goes stale the moment a bar edit lands. Try the
   // combined file FIRST — one fetch of data/scraper-bars.json covers every
@@ -4956,6 +5113,11 @@ class ScriptableAdapter {
           // Fire-and-forget: opens the registered map verify link in Safari
           // ON TOP of the results sheet (the WebView never navigates).
           this.openMapVerifyUrl(params.id);
+        } else if (params.a === "export-ics") {
+          // Fire-and-forget: builds the recurring event's ICS natively and
+          // hands it to DocumentPicker/ShareSheet (the WebView never
+          // navigates; recurring series are export-only, never auto-written).
+          this.exportRecurringEventIcs(params.id);
         }
         return false; // cancel the fake navigation; the page stays put
       };
@@ -5017,6 +5179,9 @@ class ScriptableAdapter {
     // link rendered below registers its real URL natively and embeds only
     // the returned id, so ids in this HTML always match the handler's map.
     this.resetMapVerifyUrls();
+    // Same per-render pattern for the recurring-ICS export bridge: each
+    // recurring card registers its event natively and embeds only the id.
+    this.resetIcsExportEvents();
     const allEvents = this.getAllEventsFromResults(results);
     const availableCalendars = await Calendar.forEvents();
 
@@ -6562,6 +6727,17 @@ class ScriptableAdapter {
             return false;
         }
 
+        // "Save recurring (.ics)" buttons ride the same chunkyscrape://
+        // navigation bridge (shouldAllowRequest, set before present()); the
+        // ICS itself is built native-side from the registered event — only
+        // the integer id travels. Per-tap nonce keeps repeat taps firing.
+        window.__icsExportNonce = 0;
+        function exportRecurringIcs(btn) {
+            var id = btn ? (btn.getAttribute('data-ics-export-id') || '') : '';
+            window.location.href = 'chunkyscrape://act?a=export-ics&id=' +
+                encodeURIComponent(id) + '&n=' + (window.__icsExportNonce++);
+        }
+
         // Inline OSM map toggle — pure page JS, no bridge. Lazy by design:
         // the iframe src is only assigned on the FIRST tap (no map tiles
         // load until asked), later taps just show/hide the already-loaded
@@ -8003,6 +8179,139 @@ class ScriptableAdapter {
     return `<div class="evidence-block" style="font-size:11px; color:var(--text-secondary); margin:4px 0; line-height:1.6;"><div style="font-weight:600;">Evidence</div>${rows}</div>`;
   }
 
+  // ---------------------------------------------------------------------------
+  // Recurring-event ICS export (results-UI ↔ chunkyscrape:// bridge).
+  // Recurring series are display+export only: the scraper never writes them
+  // to the calendar. Each recurring card gets a "Save recurring (.ics)"
+  // button; a tap builds the ICS natively and hands it to DocumentPicker.
+  // Same per-render registry pattern as the map-verify links: events stay
+  // native-side, only integer ids travel through the bridge URL.
+  // ---------------------------------------------------------------------------
+  resetIcsExportEvents() {
+    this._icsExportEvents = {};
+    this._icsExportNextId = 0;
+  }
+
+  registerIcsExportEvent(event) {
+    if (!this._icsExportEvents || typeof this._icsExportNextId !== "number") {
+      this.resetIcsExportEvents();
+    }
+    const id = String(this._icsExportNextId++);
+    this._icsExportEvents[id] = event;
+    return id;
+  }
+
+  // Build the ICS for one registered recurring event and hand it off via
+  // DocumentPicker.exportString (fallback: temp file + ShareSheet). Called
+  // fire-and-forget from shouldAllowRequest (which must synchronously return
+  // false to cancel the fake navigation).
+  async exportRecurringEventIcs(id) {
+    try {
+      const event = this._icsExportEvents
+        ? this._icsExportEvents[String(id)]
+        : undefined;
+      if (!event || typeof event !== "object") return;
+      const timezone = this.getTimezoneForCityOrUtc(event.city);
+      const icsText = SharedEventSchema.buildRecurringEventIcs(event, {
+        timezone,
+      });
+      if (!icsText) return;
+      const slug =
+        SharedEventSchema.slugifyIcsText(event.title || event.name || "") ||
+        "chunky-dad-recurring";
+      const fileName = `${slug}.ics`;
+      if (
+        typeof DocumentPicker !== "undefined" &&
+        DocumentPicker &&
+        typeof DocumentPicker.exportString === "function"
+      ) {
+        await DocumentPicker.exportString(icsText, fileName);
+      } else {
+        const fm = FileManager.local();
+        const filePath = fm.joinPath(fm.temporaryDirectory(), fileName);
+        fm.writeString(filePath, icsText);
+        await ShareSheet.present([filePath]);
+      }
+      console.log(
+        `📱 Scriptable: Exported recurring event ICS "${fileName}" (#${id})`,
+      );
+    } catch (error) {
+      console.warn(
+        `📱 Scriptable: Failed to export recurring event ICS: ${error.message}`,
+      );
+    }
+  }
+
+  // Prefill link into the website's event-builder page for one event card.
+  // Params ride loadStateFromUrl's alias map (event-schema): name, startDate/
+  // endDate (local wall-clock YYYY-MM-DDTHH:MM — the builder rejects zoned
+  // datetimes), city, venue, address, description, cover, website,
+  // recurrence, socials. Built by string concat + encodeURIComponent — no
+  // new URL()/URLSearchParams in this runtime.
+  buildEventBuilderUrl(event) {
+    if (!event || typeof event !== "object") return "";
+    const timezone = this.getTimezoneForCityOrUtc(event.city);
+    const formatLocalDateTime = (value) => {
+      if (!value) return "";
+      const date = value instanceof Date ? value : new Date(value);
+      if (isNaN(date.getTime())) return "";
+      // Reuse the ICS wall-clock formatter (YYYYMMDDTHHMMSS) and reshape to
+      // the builder's datetime-local format.
+      const compact = SharedEventSchema.formatIcsDateInTimezone(
+        date,
+        timezone,
+      );
+      if (!compact) return "";
+      return `${compact.slice(0, 4)}-${compact.slice(4, 6)}-${compact.slice(6, 8)}T${compact.slice(9, 11)}:${compact.slice(11, 13)}`;
+    };
+    const params = [];
+    const addParam = (key, value) => {
+      const text =
+        value === null || value === undefined ? "" : String(value).trim();
+      if (!text) return;
+      params.push(`${key}=${encodeURIComponent(text)}`);
+    };
+    addParam("name", event.title || event.name);
+    addParam("startDate", formatLocalDateTime(event.startDate));
+    addParam("endDate", formatLocalDateTime(event.endDate));
+    addParam("city", event.city);
+    addParam("venue", event.bar || event.venue);
+    addParam("address", event.address);
+    addParam("description", event.description);
+    addParam("cover", event.cover);
+    addParam("website", event.website || event.url);
+    addParam("recurrence", event.recurrenceRule || event.recurrence);
+    addParam("instagram", event.instagram);
+    addParam("facebook", event.facebook);
+    addParam("gmaps", event.gmaps);
+    addParam("image", event.image);
+    addParam("shortName", event.shortName);
+    const query = params.length > 0 ? `?${params.join("&")}` : "";
+    return `https://chunky.dad/testing/event-builder.html${query}`;
+  }
+
+  // Per-card actions row: an Event Builder prefill link on EVERY card (rides
+  // the existing open-url bridge), plus the ICS export button on recurring
+  // cards. "" only when no builder URL could be built.
+  buildEventCardActionsHtml(event) {
+    const parts = [];
+    const builderUrl = this.buildEventBuilderUrl(event);
+    if (builderUrl) {
+      const id = this.registerMapVerifyUrl(builderUrl);
+      parts.push(
+        `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="event-builder-link" style="color:var(--primary-color); text-decoration:none; font-size:12px;">🛠 Event Builder</a>`,
+      );
+    }
+    if (SharedCore.isRecurringSeriesEvent(event)) {
+      const exportId = this.registerIcsExportEvent(event);
+      parts.push(
+        `<button onclick="exportRecurringIcs(this)" class="log-copy-btn ics-export-btn" data-ics-export-id="${exportId}">💾 Save recurring (.ics)</button>`,
+      );
+    }
+    if (parts.length === 0) return "";
+    return `<div class="event-actions-row" style="display:flex; gap:12px; align-items:center; margin:6px 0;">${parts.join("")}</div>`;
+  }
+
   // Open one registered verify link in Safari, on top of the results sheet.
   // Called fire-and-forget from shouldAllowRequest (which must synchronously
   // return false to cancel the fake navigation) — Safari opens over the
@@ -8536,6 +8845,11 @@ class ScriptableAdapter {
           '<span class="action-badge badge-error">MISSING CALENDAR</span>',
       }[intentAction] ||
       '<span class="action-badge badge-warning">OTHER</span>';
+    // Recurring series are display+export only (never auto-written): badge
+    // the card and offer the ICS export instead of a calendar write.
+    const recurringBadge = SharedCore.isRecurringSeriesEvent(event)
+      ? '<span class="action-badge badge-warning recurring-badge">🔁 recurring — save via ICS</span>'
+      : "";
     const actionNote = `<div class="write-action-note">Intent: ${this.formatIntentActionLabel(intentAction)} • Write: ${this.formatWriteActionLabel(writeAction)}</div>`;
 
     const eventDate = new Date(event.startDate);
@@ -8595,10 +8909,12 @@ class ScriptableAdapter {
     // Computed evidence panel (SharedCore attaches _evidenceLines during
     // calendar prep); "" when absent — e.g. saved-run display (fail open).
     const evidenceBlock = this.buildEvidenceLinesHtml(event._evidenceLines);
+    // Event Builder prefill link (every card) + ICS export (recurring cards).
+    const eventActionsRow = this.buildEventCardActionsHtml(event);
 
     let html = `
         <div class="event-card">
-            ${actionBadge}
+            ${actionBadge}${recurringBadge}
             ${actionNote}
             <div class="event-title">${this.escapeHtml(event.title || event.name)}</div>
             
@@ -8635,6 +8951,7 @@ class ScriptableAdapter {
                     : ""
                 }
                 ${mapVerifyRow}
+                ${eventActionsRow}
                 ${evidenceBlock}
                 <div class="event-detail">
                     <span>📅</span>

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -2869,3 +2869,182 @@ test('buildParserPickerEntries orders stalest-first: never-written, then stale, 
   assert.equal(Math.floor(entries[1].daysSince), 17);
   assert.equal(Math.floor(entries[2].daysSince), 7);
 });
+
+// ---------------------------------------------------------------------------
+// Recurring events: event-builder link, ICS export bridge, series probe
+// ---------------------------------------------------------------------------
+
+function buildRecurringCardEvent(overrides = {}) {
+  return {
+    title: 'FUZZY',
+    _action: 'new',
+    startDate: '2026-08-08T02:00:00.000Z',
+    endDate: '2026-08-08T07:00:00.000Z',
+    bar: 'Dallas Eagle',
+    city: 'dallas',
+    recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR',
+    _recurring: true,
+    _recurringExport: true,
+    ...overrides
+  };
+}
+
+test('event card: every event gets an Event Builder prefill link', () => {
+  const adapter = buildAdapter();
+  adapter.resetMapVerifyUrls();
+  adapter.resetIcsExportEvents();
+  const html = adapter.generateEventCard({
+    title: 'One Off',
+    _action: 'new',
+    startDate: '2026-08-01T02:00:00.000Z',
+    city: 'dallas',
+    website: 'https://example.com/one-off'
+  });
+
+  assert.ok(html.includes('🛠 Event Builder'), 'builder link rendered on a plain card');
+  assert.ok(!html.includes('Save recurring'), 'no ICS export button on a plain card');
+  assert.ok(!html.includes('recurring — save via ICS'), 'no recurring badge on a plain card');
+
+  const registeredUrls = Object.values(adapter._mapVerifyUrls);
+  const builderUrl = registeredUrls.find((url) =>
+    url.startsWith('https://chunky.dad/testing/event-builder.html?'),
+  );
+  assert.ok(builderUrl, 'builder URL registered through the open-url bridge');
+  assert.ok(builderUrl.includes('name=One%20Off'), 'title prefilled');
+  assert.ok(builderUrl.includes('city=dallas'));
+  assert.ok(builderUrl.includes('website=https%3A%2F%2Fexample.com%2Fone-off'));
+  assert.ok(!builderUrl.includes('recurrence='), 'no recurrence param without an rrule');
+});
+
+test('event card: recurring events get the badge, the builder link, and the ICS export button', () => {
+  const adapter = buildAdapter();
+  adapter.resetMapVerifyUrls();
+  adapter.resetIcsExportEvents();
+  const html = adapter.generateEventCard(buildRecurringCardEvent());
+
+  assert.ok(html.includes('🔁 recurring — save via ICS'), 'recurring badge present');
+  assert.ok(html.includes('🛠 Event Builder'), 'builder link present');
+  assert.ok(html.includes('💾 Save recurring (.ics)'), 'ICS export button present');
+  assert.match(html, /data-ics-export-id="\d+"/, 'export button carries a registered id');
+
+  const registeredUrls = Object.values(adapter._mapVerifyUrls);
+  const builderUrl = registeredUrls.find((url) =>
+    url.startsWith('https://chunky.dad/testing/event-builder.html?'),
+  );
+  assert.ok(builderUrl.includes('recurrence=FREQ%3DWEEKLY%3BBYDAY%3DFR'), 'rrule prefills the builder');
+  assert.ok(!builderUrl.includes('new URL'), 'sanity');
+});
+
+test('export-ics bridge: the handler builds the ICS for the registered event and hands it off', async () => {
+  const adapter = buildAdapter();
+  adapter.resetIcsExportEvents();
+  const event = buildRecurringCardEvent();
+  const id = adapter.registerIcsExportEvent(event);
+
+  const exported = [];
+  global.DocumentPicker = {
+    exportString: async (content, name) => {
+      exported.push({ content, name });
+      return [name];
+    }
+  };
+  try {
+    await adapter.exportRecurringEventIcs(id);
+  } finally {
+    delete global.DocumentPicker;
+  }
+
+  assert.equal(exported.length, 1, 'DocumentPicker.exportString called once');
+  assert.equal(exported[0].name, 'fuzzy.ics', 'slugged filename');
+  const unfolded = exported[0].content.replace(/\r\n[ \t]/g, '');
+  assert.ok(unfolded.includes('BEGIN:VCALENDAR'));
+  assert.ok(unfolded.includes('RRULE:FREQ=WEEKLY;BYDAY=FR'), 'ICS built from the registered event');
+  assert.ok(unfolded.includes('SUMMARY:FUZZY'));
+  assert.ok(unfolded.includes('recurrence: FREQ=WEEKLY\\;BYDAY=FR'), 'detection line in DESCRIPTION');
+});
+
+test('export-ics bridge: shouldAllowRequest dispatches a=export-ics to the ICS handler', () => {
+  const fs = require('node:fs');
+  const source = fs.readFileSync(path.join(__dirname, 'scriptable-adapter.js'), 'utf8');
+  const branchMatch = source.match(/params\.a === "export-ics"[\s\S]{0,500}?exportRecurringEventIcs\(params\.id\)/);
+  assert.ok(branchMatch, 'export-ics action branch wired to exportRecurringEventIcs');
+  assert.ok(source.includes("'chunkyscrape://act?a=export-ics&id='"), 'page JS builds the export-ics bridge URL');
+});
+
+test('probeRecurringSeries: published-ICS confirmation short-circuits the wide-window probe', async () => {
+  const adapter = buildAdapter();
+  adapter.getPublishedRecurringUids = async () => new Map([['fuzzy-uid@chunky.dad', true]]);
+  let wideWindowCalls = 0;
+  adapter.probeSeriesByWideWindow = async () => {
+    wideWindowCalls += 1;
+    return false;
+  };
+  const result = await adapter.probeRecurringSeries(
+    { identifier: 'CAL-UUID:fuzzy-uid@chunky.dad', title: 'FUZZY' },
+    { city: 'dallas' }
+  );
+  assert.equal(result, true, 'published RRULE UID confirms the series');
+  assert.equal(wideWindowCalls, 0, 'wide-window probe skipped');
+});
+
+test('probeRecurringSeries: published UID WITHOUT an RRULE is confirmed not-a-series (probe skipped)', async () => {
+  const adapter = buildAdapter();
+  adapter.getPublishedRecurringUids = async () => new Map([['fuzzy-uid@chunky.dad', false]]);
+  let wideWindowCalls = 0;
+  adapter.probeSeriesByWideWindow = async () => {
+    wideWindowCalls += 1;
+    return true;
+  };
+  const result = await adapter.probeRecurringSeries(
+    { identifier: 'CAL-UUID:fuzzy-uid@chunky.dad', title: 'FUZZY' },
+    { city: 'dallas' }
+  );
+  assert.equal(result, false);
+  assert.equal(wideWindowCalls, 0, 'probe never runs when the published calendar settles it');
+});
+
+test('probeRecurringSeries: published fetch failure falls through to the wide-window probe', async () => {
+  const adapter = buildAdapter();
+  adapter.getPublishedRecurringUids = async () => null; // fetch failed / no published calendar
+  let wideWindowCalls = 0;
+  adapter.probeSeriesByWideWindow = async () => {
+    wideWindowCalls += 1;
+    return true;
+  };
+  const result = await adapter.probeRecurringSeries(
+    { identifier: 'CAL-UUID:fuzzy-uid@chunky.dad', title: 'FUZZY' },
+    { city: 'dallas' }
+  );
+  assert.equal(result, true, 'fallback probe decision used');
+  assert.equal(wideWindowCalls, 1);
+});
+
+test('probeRecurringSeries: decisions are cached per identifier per run', async () => {
+  const adapter = buildAdapter();
+  adapter.getPublishedRecurringUids = async () => null;
+  let wideWindowCalls = 0;
+  adapter.probeSeriesByWideWindow = async () => {
+    wideWindowCalls += 1;
+    return true;
+  };
+  const existingEvent = { identifier: 'CAL-UUID:fuzzy-uid@chunky.dad', title: 'FUZZY' };
+  await adapter.probeRecurringSeries(existingEvent, { city: 'dallas' });
+  await adapter.probeRecurringSeries(existingEvent, { city: 'dallas' });
+  assert.equal(wideWindowCalls, 1, 'second call served from the per-run cache');
+});
+
+test('probeRecurringSeries fails open on errors and without an identifier', async () => {
+  const adapter = buildAdapter();
+  adapter.getPublishedRecurringUids = async () => {
+    throw new Error('network down');
+  };
+  adapter.probeSeriesByWideWindow = async () => {
+    throw new Error('calendar unavailable');
+  };
+  assert.equal(
+    await adapter.probeRecurringSeries({ identifier: 'CAL-UUID:x@y', title: 'X' }, { city: 'dallas' }),
+    false,
+    'errors → false (today\'s behavior)'
+  );
+  assert.equal(await adapter.probeRecurringSeries({ title: 'no identifier' }, {}), false);
+});

--- a/scripts/event-schema.js
+++ b/scripts/event-schema.js
@@ -49,6 +49,7 @@ const EVENT_KEY_ALIASES = {
 
     recurrence: 'recurrence',
     rrule: 'recurrence',
+    recurrencerule: 'recurrence',
     type: 'type',
     eventtype: 'type',
     recurrenceid: 'recurrenceId',
@@ -141,7 +142,7 @@ const DEFAULT_NOTES_EXCLUDED_FIELDS = new Set([
     'placeId',
     'matchKey',
     'links', 'durationMinutes',
-    'time', 'day', 'recurring', 'recurrence',
+    'time', 'day', 'recurring', 'recurrence', 'recurrenceRule',
     'isDeletingOverride'
 ]);
 
@@ -495,6 +496,169 @@ const AI_FIELD_SIGNAL_REGEXES = {
     ]
 };
 
+// ============================================================================
+// RECURRING-EVENT ICS EXPORT (pure helpers)
+// ============================================================================
+// The scraper NEVER writes or mutates recurring series in the calendar.
+// Detected series are surfaced in the results UI and exported as an .ics the
+// owner imports manually — these helpers build that ICS. Conventions mirror
+// testing/event-builder.html generateICS (UID shape, TZID local wall-clock
+// datetimes, PRODID), plus RFC 5545 75-octet line folding.
+
+function escapeIcsText(text) {
+    return String(text)
+        .replace(/\\/g, '\\\\')
+        .replace(/\r\n|\r|\n/g, '\\n')
+        .replace(/,/g, '\\,')
+        .replace(/;/g, '\\;');
+}
+
+// RFC 5545 §3.1: content lines SHOULD NOT exceed 75 octets (excluding CRLF);
+// longer lines fold onto continuation lines that begin with a single space.
+// Counts UTF-8 octets and never splits inside a code point.
+function foldIcsLine(line) {
+    const text = String(line);
+    const octetsOf = (codePoint) => {
+        if (codePoint <= 0x7f) return 1;
+        if (codePoint <= 0x7ff) return 2;
+        if (codePoint <= 0xffff) return 3;
+        return 4;
+    };
+    const folded = [];
+    let current = '';
+    let currentOctets = 0;
+    for (const char of text) {
+        const octets = octetsOf(char.codePointAt(0));
+        if (currentOctets + octets > 75) {
+            folded.push(current);
+            current = ' ';
+            currentOctets = 1;
+        }
+        current += char;
+        currentOctets += octets;
+    }
+    folded.push(current);
+    return folded.join('\r\n');
+}
+
+function formatIcsDateUtc(date) {
+    const parsed = date instanceof Date ? date : new Date(date);
+    if (isNaN(parsed.getTime())) return '';
+    return parsed.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+}
+
+// Local wall-clock YYYYMMDDTHHMMSS in an IANA timezone (no trailing Z) —
+// paired with ;TZID= on DTSTART/DTEND. Returns '' when the timezone cannot
+// be resolved so callers can fall back to UTC-Z values.
+function formatIcsDateInTimezone(date, timezone) {
+    const parsed = date instanceof Date ? date : new Date(date);
+    if (isNaN(parsed.getTime()) || !timezone) return '';
+    try {
+        const parts = new Intl.DateTimeFormat('en-US', {
+            timeZone: timezone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false
+        }).formatToParts(parsed);
+        const values = {};
+        parts.forEach(part => {
+            if (part.type !== 'literal') {
+                values[part.type] = part.value;
+            }
+        });
+        if (!values.year || !values.month || !values.day) return '';
+        const hour = values.hour === '24' ? '00' : (values.hour || '00');
+        const minute = values.minute || '00';
+        const second = values.second || '00';
+        return `${values.year}${values.month}${values.day}T${hour}${minute}${second}`;
+    } catch (error) {
+        return '';
+    }
+}
+
+// Same slug rules as the event-builder UID slug (testing/event-builder.html).
+function slugifyIcsText(value) {
+    return String(value || '')
+        .toLowerCase()
+        .trim()
+        .replace(/[\s_]+/g, '-')
+        .replace(/[^\w-]+/g, '')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '')
+        .slice(0, 60);
+}
+
+// Build a complete VCALENDAR/VEVENT for one recurring event. DESCRIPTION is
+// the event's standard notes (EventSchema.formatEventNotes) PLUS an explicit
+// `recurrence: <rrule>` line — the notes key the merge machinery reads as a
+// series-detection signal once the owner has imported the ICS. (The default
+// notes-exclusion list applies to scraper CALENDAR writes; this ICS is the
+// deliberate, owner-driven channel, so the line is appended explicitly.)
+// options: { timezone, now } — now is injectable for deterministic tests.
+function buildRecurringEventIcs(event, options = {}) {
+    if (!event || typeof event !== 'object') return '';
+    const rrule = String(event.recurrenceRule || event.recurrence || '')
+        .replace(/^RRULE\s*:/i, '')
+        .trim();
+    const title = String(event.title || event.name || '').trim() || 'chunky-dad';
+    const timezone = String(options.timezone || event.timezone || '').trim();
+    const now = options.now instanceof Date ? options.now : new Date();
+
+    // UID matches the event-builder style: <slug>-<utcstamp>@chunky.dad
+    // (e.g. fuzzy-20260503T203532Z@chunky.dad).
+    const uid = `${slugifyIcsText(title) || 'chunky-dad'}-${formatIcsDateUtc(now)}@chunky.dad`;
+
+    const dateProperty = (name, date) => {
+        const local = timezone ? formatIcsDateInTimezone(date, timezone) : '';
+        if (local) return `${name};TZID=${timezone}:${local}`;
+        const utc = formatIcsDateUtc(date);
+        return utc ? `${name}:${utc}` : '';
+    };
+
+    const lines = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//chunky.dad//Event Builder//EN',
+        'CALSCALE:GREGORIAN',
+        'METHOD:PUBLISH',
+        'BEGIN:VEVENT',
+        `UID:${uid}`,
+        `DTSTAMP:${formatIcsDateUtc(now)}`
+    ];
+    const dtStart = dateProperty('DTSTART', event.startDate);
+    if (dtStart) lines.push(dtStart);
+    const dtEnd = event.endDate ? dateProperty('DTEND', event.endDate) : '';
+    if (dtEnd) lines.push(dtEnd);
+    lines.push(`SUMMARY:${escapeIcsText(title)}`);
+
+    const notes = formatEventNotes(event);
+    const descriptionText = rrule
+        ? `${notes ? `${notes}\n` : ''}recurrence: ${escapeText(rrule)}`
+        : notes;
+    if (descriptionText) {
+        lines.push(`DESCRIPTION:${escapeIcsText(descriptionText)}`);
+    }
+    const website = String(event.website || event.url || '').trim();
+    if (website) {
+        lines.push(`URL:${escapeIcsText(website)}`);
+    }
+    lines.push('STATUS:CONFIRMED');
+    lines.push('TRANSP:OPAQUE');
+    if (rrule) {
+        lines.push(`RRULE:${rrule}`);
+    }
+    const location = String(event.location || '').trim();
+    if (location) {
+        lines.push(`LOCATION:${escapeIcsText(location)}`);
+    }
+    lines.push('END:VEVENT', 'END:VCALENDAR');
+    return lines.map(foldIcsLine).join('\r\n');
+}
+
 const EventSchema = {
     EVENT_KEY_ALIASES,
     URL_LIKE_FIELDS,
@@ -512,7 +676,13 @@ const EventSchema = {
     isUrlLikeField,
     parseNotesIntoFields,
     formatEventNotes,
-    getEventBuilderStateKey
+    getEventBuilderStateKey,
+    escapeIcsText,
+    foldIcsLine,
+    formatIcsDateUtc,
+    formatIcsDateInTimezone,
+    slugifyIcsText,
+    buildRecurringEventIcs
 };
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/scripts/event-schema.test.js
+++ b/scripts/event-schema.test.js
@@ -224,3 +224,109 @@ test('formatEventNotes honors a custom excludeFields set', () => {
   const notes = EventSchema.formatEventNotes(event, { excludeFields: new Set(['cover']) });
   assert.equal(notes, 'bar: STATION 4');
 });
+
+// ---------------------------------------------------------------------------
+// Recurring-event ICS export (buildRecurringEventIcs)
+// ---------------------------------------------------------------------------
+
+function buildRecurringFixtureEvent(overrides = {}) {
+  return {
+    title: 'FUZZY',
+    startDate: new Date('2026-08-08T02:00:00.000Z'), // Fri 2026-08-07 21:00 America/Chicago (CDT)
+    endDate: new Date('2026-08-08T07:00:00.000Z'),   // Sat 2026-08-08 02:00 America/Chicago
+    recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR',
+    bar: 'Dallas Eagle',
+    cover: '$10',
+    website: 'https://example.com/fuzzy',
+    location: '32.7767,-96.797',
+    city: 'dallas',
+    ...overrides
+  };
+}
+
+const RECURRING_ICS_NOW = new Date('2026-05-03T20:35:32.000Z');
+
+test('buildRecurringEventIcs: RRULE line, UID shape, and TZID-correct DTSTART/DTEND', () => {
+  const ics = EventSchema.buildRecurringEventIcs(buildRecurringFixtureEvent(), {
+    timezone: 'America/Chicago',
+    now: RECURRING_ICS_NOW
+  });
+  const unfolded = ics.replace(/\r\n[ \t]/g, '');
+  assert.ok(unfolded.includes('BEGIN:VCALENDAR'), 'VCALENDAR wrapper present');
+  assert.ok(unfolded.includes('BEGIN:VEVENT'), 'VEVENT present');
+  assert.ok(unfolded.includes('RRULE:FREQ=WEEKLY;BYDAY=FR'), 'RRULE emitted verbatim');
+  // UID matches the event-builder style: <slug>-<utcstamp>@chunky.dad
+  assert.ok(unfolded.includes('UID:fuzzy-20260503T203532Z@chunky.dad'), `UID shape (got: ${unfolded.match(/UID:[^\r\n]*/)})`);
+  assert.match(unfolded, /UID:[a-z0-9-]+-\d{8}T\d{6}Z@chunky\.dad/);
+  // TZID correctness: 02:00Z / 07:00Z on Aug 8 are 21:00 / 02:00 wall-clock in Chicago (CDT, UTC-5)
+  assert.ok(unfolded.includes('DTSTART;TZID=America/Chicago:20260807T210000'), 'DTSTART local wall-clock with TZID');
+  assert.ok(unfolded.includes('DTEND;TZID=America/Chicago:20260808T020000'), 'DTEND local wall-clock with TZID');
+  assert.ok(unfolded.includes('SUMMARY:FUZZY'));
+  assert.ok(unfolded.includes('LOCATION:32.7767\\,-96.797'), 'LOCATION comma is ICS-escaped');
+});
+
+test('buildRecurringEventIcs: DESCRIPTION carries standard notes plus the recurrence detection line', () => {
+  const ics = EventSchema.buildRecurringEventIcs(buildRecurringFixtureEvent(), {
+    timezone: 'America/Chicago',
+    now: RECURRING_ICS_NOW
+  });
+  const unfolded = ics.replace(/\r\n[ \t]/g, '');
+  const descriptionMatch = unfolded.match(/DESCRIPTION:([^\r\n]*)/);
+  assert.ok(descriptionMatch, 'DESCRIPTION present');
+  const description = descriptionMatch[1];
+  // Standard notes lines (EventSchema.formatEventNotes) survive, newline-escaped
+  assert.ok(description.includes('bar: Dallas Eagle'), 'standard notes present');
+  assert.ok(description.includes('cover: $10'));
+  assert.ok(description.includes('website: https://example.com/fuzzy'));
+  // The detection channel: an explicit canonical recurrence line (the default
+  // notes-exclusion list applies to scraper calendar writes, not this ICS)
+  assert.ok(description.includes('recurrence: FREQ=WEEKLY\\;BYDAY=FR'), 'recurrence line present (ICS-escaped)');
+  // recurrenceRule itself never leaks as a raw notes key
+  assert.ok(!description.includes('recurrenceRule:'), 'no duplicate raw recurrenceRule key');
+});
+
+test('buildRecurringEventIcs: ICS escaping and 75-octet folding', () => {
+  const event = buildRecurringFixtureEvent({
+    title: 'FUZZY; the big, hairy\nparty',
+    description: 'A very long description that keeps going and going to force RFC 5545 line folding, with commas, semicolons; and more text well past seventy-five octets total.'
+  });
+  const ics = EventSchema.buildRecurringEventIcs(event, { timezone: 'America/Chicago', now: RECURRING_ICS_NOW });
+  const lines = ics.split('\r\n');
+  for (const line of lines) {
+    assert.ok(Buffer.byteLength(line, 'utf8') <= 75, `line exceeds 75 octets: ${line}`);
+  }
+  assert.ok(lines.some(line => line.startsWith(' ')), 'long content folded onto continuation lines');
+  const unfolded = ics.replace(/\r\n[ \t]/g, '');
+  assert.ok(unfolded.includes('SUMMARY:FUZZY\\; the big\\, hairy\\nparty'), 'SUMMARY escaped');
+});
+
+test('buildRecurringEventIcs: UTC fallback when no timezone is resolvable', () => {
+  const ics = EventSchema.buildRecurringEventIcs(buildRecurringFixtureEvent(), { now: RECURRING_ICS_NOW });
+  const unfolded = ics.replace(/\r\n[ \t]/g, '');
+  assert.ok(unfolded.includes('DTSTART:20260808T020000Z'), 'DTSTART falls back to UTC-Z');
+  assert.ok(!unfolded.includes('TZID='), 'no TZID without a timezone');
+});
+
+test('round-trip: js/calendar-core.js parseICalData parses the generated ICS and reports recurrence', () => {
+  const noop = () => {};
+  globalThis.logger = {
+    componentInit: noop, componentLoad: noop, componentError: noop,
+    apiCall: noop, debug: noop, info: noop, warn: noop, time: noop, timeEnd: noop
+  };
+  const CalendarCore = require('../js/calendar-core.js');
+  const ics = EventSchema.buildRecurringEventIcs(buildRecurringFixtureEvent(), {
+    timezone: 'America/Chicago',
+    now: RECURRING_ICS_NOW
+  });
+  const core = new CalendarCore();
+  const events = core.parseICalData(ics);
+  assert.equal(events.length, 1, 'one VEVENT parsed');
+  const parsed = events[0];
+  assert.equal(parsed.name, 'FUZZY');
+  assert.equal(parsed.recurring, true, 'parser reports the event as recurring');
+  assert.equal(parsed.recurrence, 'FREQ=WEEKLY;BYDAY=FR', 'RRULE round-trips verbatim');
+  assert.equal(parsed.eventType, 'weekly');
+  assert.equal(parsed.uid, 'fuzzy-20260503T203532Z@chunky.dad');
+  assert.equal(parsed.startTimezone, 'America/Chicago', 'TZID round-trips');
+  assert.equal(parsed.bar, 'Dallas Eagle', 'DESCRIPTION notes fields round-trip');
+});

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -112,6 +112,15 @@ class BasicDataNormalizer extends BaseNormalizer {
         // when the corresponding value is present.
         event = this.stampPageProvenanceDefaults(event);
 
+        // Recurring-series stamp: a non-empty recurrenceRule (AI-extracted
+        // RRULE) marks this event as a series definition. Series are
+        // display+export only — the calendar-write path withholds _recurring
+        // events (owner imports the ICS instead; the scraper never writes
+        // recurring series). Pure and idempotent.
+        if (typeof event.recurrenceRule === 'string' && event.recurrenceRule.trim() !== '') {
+            event._recurring = true;
+        }
+
         if (!this.core) return event;
         // Sync URL and website fields
         event = this.syncUrlAndWebsiteFields(event);

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -2873,3 +2873,15 @@ test('cathedral city (city value and address) resolves to palm-springs via the r
   // Word-boundary safety: a multi-word alias never matches inside other words
   assert.equal(normalizer.extractCityFromAddress('123 Main St, Cathedralton, TX'), null);
 });
+
+test('BasicDataNormalizer stamps _recurring for a non-empty recurrenceRule (series are display+export only)', () => {
+  const normalizer = new BasicDataNormalizer();
+  const recurring = normalizer.normalize({ title: 'FUZZY', recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR' });
+  assert.equal(recurring._recurring, true);
+
+  const emptyRule = normalizer.normalize({ title: 'ONE-OFF', recurrenceRule: '' });
+  assert.equal(emptyRule._recurring, undefined, 'empty rrule never stamps');
+
+  const plain = normalizer.normalize({ title: 'PLAIN' });
+  assert.equal(plain._recurring, undefined);
+});

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -6792,3 +6792,14 @@ test('normalizeAiEvent rejects a city matching a registry promoter name, keeps r
     {}, null, null, null);
   assert.equal(noRegistry.city, 'biggercity');
 });
+
+test('getAiPromptFields: rrule is requested from the default field priorities', () => {
+  // Ensure the real schema is active (an earlier test swaps in a mock).
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  const fields = parser.getAiPromptFields({}, {});
+  const normalized = fields.map(f => parser.normalizePromptFieldName(f));
+  assert.ok(normalized.includes('recurrence'), 'rrule (canonical: recurrence) is requested by default');
+  assert.equal(parser.isPromptFieldRequested('rrule', {}), true,
+    'normalizeAiEvent will map the extracted rrule into event.recurrenceRule');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -7168,6 +7168,14 @@ class SharedCore {
             return normalized.length > 0 ? normalized : null;
         };
         const eventIdentifierRaw = normalizeIdentifier(existingEvent.identifier || '');
+        // Adapter-confirmed series (published-ICS lookup or wide-window
+        // identifier probe): the identifier was positively established as a
+        // recurring series this run — hands off, create overrides instead.
+        if (eventIdentifierRaw &&
+            this._confirmedSeriesIdentifiers &&
+            this._confirmedSeriesIdentifiers.has(eventIdentifierRaw)) {
+            return true;
+        }
         const eventIdentifierInfo = this.parseScriptableIdentifier(eventIdentifierRaw);
         if (eventIdentifierInfo.recurrenceDate) {
             return true;
@@ -7225,6 +7233,49 @@ class SharedCore {
         return false;
     }
 
+    // Record an identifier positively confirmed as a recurring series this
+    // run (published-ICS lookup or wide-window probe). Consulted by
+    // shouldCreateOverrideFromRecurringMatch so series never masquerade as
+    // normal events when the narrow search window saw only one instance.
+    noteConfirmedRecurringSeries(identifier) {
+        const normalized = identifier === null || identifier === undefined
+            ? ''
+            : String(identifier).trim();
+        if (!normalized) return;
+        if (!this._confirmedSeriesIdentifiers) {
+            this._confirmedSeriesIdentifiers = new Set();
+        }
+        this._confirmedSeriesIdentifiers.add(normalized);
+    }
+
+    // Analyze one event, then — when it merge-matched an existing calendar
+    // event WITHOUT any series signal firing — ask the adapter for a targeted
+    // series probe (published calendar ICS first, wide-window identifier
+    // probe as fallback; both adapter-side). A confirmed series feeds back
+    // into the existing shouldCreateOverrideFromRecurringMatch hands-off path
+    // via noteConfirmedRecurringSeries + re-analysis. Fail open: probe
+    // absence or errors leave today's behavior untouched.
+    async resolveCalendarAnalysisWithSeriesProbe(event, existingEventsData, mergeMode, calendarAdapter) {
+        let analysis = this.analyzeEventAction(event, existingEventsData, mergeMode);
+        if (analysis.action !== 'merge' || !analysis.existingEvent) {
+            return analysis;
+        }
+        if (!calendarAdapter || typeof calendarAdapter.probeRecurringSeries !== 'function') {
+            return analysis;
+        }
+        try {
+            const isSeries = await calendarAdapter.probeRecurringSeries(analysis.existingEvent, event);
+            if (isSeries === true) {
+                const identifier = analysis.existingEvent.identifier || analysis.existingEvent.id || '';
+                this.noteConfirmedRecurringSeries(identifier);
+                analysis = this.analyzeEventAction(event, existingEventsData, mergeMode);
+            }
+        } catch (error) {
+            // Fail open — probe errors never change merge behavior.
+        }
+        return analysis;
+    }
+
     resolveRecurringMergeCandidate(existingEventsData, existingEvent) {
         if (!this.shouldCreateOverrideFromRecurringMatch(existingEvent, existingEventsData)) {
             return null;
@@ -7278,10 +7329,84 @@ class SharedCore {
     // -------------------------------------------------------------------------
 
     // Events from parsers marked dryRun must never reach calendar writes,
-    // regardless of which path (automation or interactive prompt) executes them
+    // regardless of which path (automation or interactive prompt) executes them.
+    // Recurring series events are equally withheld: they are display+export
+    // only (owner imports the ICS; the scraper never writes recurring series).
     static filterEventsForExecution(analyzedEvents) {
         if (!Array.isArray(analyzedEvents)) return [];
-        return analyzedEvents.filter(event => event?._parserConfig?.dryRun !== true);
+        return analyzedEvents.filter(event =>
+            event?._parserConfig?.dryRun !== true &&
+            !SharedCore.isRecurringSeriesEvent(event));
+    }
+
+    // An event that DEFINES a recurring series: stamped _recurring in
+    // normalization, or carrying a non-empty extracted RRULE.
+    static isRecurringSeriesEvent(event) {
+        if (!event || typeof event !== 'object') return false;
+        if (event._recurring === true) return true;
+        return typeof event.recurrenceRule === 'string' && event.recurrenceRule.trim() !== '';
+    }
+
+    // Scriptable identifiers look like `<calendarUUID>:<icsUid>` — the suffix
+    // after the FIRST colon is the ICS UID verbatim (device-verified for both
+    // `…:6thhos5ct3pllq5kmvsp7infd8@google.com` and
+    // `…:fuzzy-20260503T203532Z@chunky.dad`). Returns null when there is no
+    // colon-separated suffix to extract.
+    static extractIcsUidFromIdentifier(identifier) {
+        if (identifier === null || identifier === undefined) return null;
+        const text = String(identifier).trim();
+        const colonIndex = text.indexOf(':');
+        if (colonIndex < 0) return null;
+        const uid = text.slice(colonIndex + 1).trim();
+        return uid.length > 0 ? uid : null;
+    }
+
+    // Light regex-level scan of a published calendar ICS (no full parser):
+    // walks BEGIN:VEVENT blocks after unfolding continuation lines and maps
+    // each UID to whether that block carries an RRULE. Returns null for
+    // non-string/empty input (callers fail open).
+    static extractRecurringUidsFromIcs(icsText) {
+        if (typeof icsText !== 'string' || icsText.trim() === '') return null;
+        // Unfold RFC 5545 folded lines (CRLF/LF followed by space or tab).
+        const unfolded = icsText.replace(/\r?\n[ \t]/g, '');
+        const uids = new Map();
+        const blockRegex = /BEGIN:VEVENT([\s\S]*?)END:VEVENT/g;
+        let match;
+        while ((match = blockRegex.exec(unfolded)) !== null) {
+            const block = match[1];
+            const uidMatch = block.match(/^UID[^:]*:(.+)$/m);
+            if (!uidMatch) continue;
+            const uid = uidMatch[1].trim();
+            if (!uid) continue;
+            const hasRrule = /^RRULE[:;]/m.test(block);
+            // A series' own VEVENT wins over override instances that share
+            // the UID but carry no RRULE.
+            uids.set(uid, hasRrule || uids.get(uid) === true);
+        }
+        return uids;
+    }
+
+    // Pure decision for the wide-window identifier probe: ≥2 calendar
+    // instances sharing the matched identifier means the identifier belongs
+    // to a recurring series (occurrences of a series share one identifier).
+    static resolveSeriesProbeDecision(events, identifier) {
+        const normalized = identifier === null || identifier === undefined
+            ? ''
+            : String(identifier).trim();
+        if (!normalized || !Array.isArray(events)) {
+            return { instanceCount: 0, isSeries: false };
+        }
+        let instanceCount = 0;
+        for (const candidate of events) {
+            if (!candidate) continue;
+            const candidateIdentifier = candidate.identifier === null || candidate.identifier === undefined
+                ? ''
+                : String(candidate.identifier).trim();
+            if (candidateIdentifier === normalized) {
+                instanceCount += 1;
+            }
+        }
+        return { instanceCount, isSeries: instanceCount >= 2 };
     }
 
     static normalizeOverrideUid(value) {
@@ -7490,6 +7615,11 @@ class SharedCore {
             facebook: { priority: ["ai-web"], merge: "ai" },
             website: { priority: ["ai-web"], merge: "ai" },
             description: { priority: ["ai-web"], merge: "ai" },
+            // rrule → event.recurrenceRule: extraction is anti-hallucination
+            // gated in the schema prompt line (explicit repeat schedules only).
+            // Recurring events are display+export only — never auto-written to
+            // the calendar (see prepareEventsForCalendar RECURRING withhold).
+            rrule: { priority: ["ai-web"], merge: "ai" },
             bar: { priority: ["ai-web"], merge: "ai" },
             address: { priority: ["ai-web"], merge: "ai" },
             startDate: { priority: ["ai-web"], merge: "ai" },
@@ -7616,8 +7746,9 @@ class SharedCore {
             // Get existing events from the adapter
             const existingEvents = await calendarAdapter.getExistingEvents(event);
 
-            // Analyze what action to take
-            const analysis = this.analyzeEventAction(event, existingEvents, mergeMode);
+            // Analyze what action to take (with the adapter-side recurring
+            // series probe when a merge match carries no series signal yet)
+            const analysis = await this.resolveCalendarAnalysisWithSeriesProbe(event, existingEvents, mergeMode, calendarAdapter);
 
             // Manual override, demote direction: a kept event whose identity-
             // matched calendar record carries `bearSource: manual-not-bear…` is
@@ -7659,7 +7790,7 @@ class SharedCore {
                 const droppedEvent = dropped && dropped.event;
                 if (!droppedEvent || dropped.rescued) continue;
                 const existingEvents = await calendarAdapter.getExistingEvents(droppedEvent);
-                const analysis = this.analyzeEventAction(droppedEvent, existingEvents, mergeMode);
+                const analysis = await this.resolveCalendarAnalysisWithSeriesProbe(droppedEvent, existingEvents, mergeMode, calendarAdapter);
                 const matchedRecord = analysis.existingEvent || analysis.sourceEvent || null;
                 if (!matchedRecord || this.getManualBearVerdictFromRecord(matchedRecord) !== 'manual-bear') continue;
                 console.log(`🐻 BEAR CHECK: "${droppedEvent.title || 'Unknown'}" → bear (manual override on calendar record)`);
@@ -7829,6 +7960,19 @@ class SharedCore {
                     if (recordedTrimFields.has(overlong.field)) continue;
                     analyzedEvent._evidenceLines.push(`⚠️ ${overlong.field} overlong (${overlong.value.length} > ${overlong.maxChars} chars) — calendar-sourced, not trimmed`);
                 }
+            }
+
+            // Recurring series are display+export only: keep the card in the
+            // results UI (flag-don't-drop) but withhold it from calendar
+            // execution — the owner saves the series via the ICS export
+            // button instead (the scraper never writes recurring series).
+            if (SharedCore.isRecurringSeriesEvent(event)) {
+                analyzedEvent._recurring = true;
+                analyzedEvent._recurringExport = true;
+                if (!analyzedEvent.recurrenceRule && typeof event.recurrenceRule === 'string') {
+                    analyzedEvent.recurrenceRule = event.recurrenceRule;
+                }
+                console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" withheld from calendar write — save via ICS export`);
             }
 
             return analyzedEvent;

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -9085,3 +9085,209 @@ test('greater palm springs aliases resolve the palm-springs timezone via the rea
   // Bare "coachella" is deliberately NOT an alias (festival-name collision)
   assert.equal(core.getCityTimezone('coachella'), null);
 });
+
+// Recurring events: display+export only, never auto-written (series wave)
+// ---------------------------------------------------------------------------
+
+test('getResolvedFieldPriorities: rrule is requested from AI extraction by default', () => {
+  const core = createCore();
+  const priorities = core.getResolvedFieldPriorities({});
+  assert.ok(priorities.rrule, 'rrule default priority entry exists');
+  assert.deepEqual(priorities.rrule.priority, ['ai-web'], 'rrule rides the ai-web extraction path');
+  assert.equal(priorities.rrule.merge, 'ai', 'merge strategy parallels description');
+  // Explicit parser config still overrides the default (hardcoded config is the override)
+  const overridden = core.getResolvedFieldPriorities({
+    fieldPriorities: { rrule: { priority: ['static'], merge: 'clobber' } }
+  });
+  assert.deepEqual(overridden.rrule.priority, ['static']);
+});
+
+test('isRecurringSeriesEvent: _recurring stamp or non-empty recurrenceRule', () => {
+  assert.equal(SharedCore.isRecurringSeriesEvent({ recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR' }), true);
+  assert.equal(SharedCore.isRecurringSeriesEvent({ _recurring: true }), true);
+  assert.equal(SharedCore.isRecurringSeriesEvent({ recurrenceRule: '' }), false);
+  assert.equal(SharedCore.isRecurringSeriesEvent({ recurrenceRule: '   ' }), false);
+  assert.equal(SharedCore.isRecurringSeriesEvent({ title: 'plain' }), false);
+  assert.equal(SharedCore.isRecurringSeriesEvent(null), false);
+});
+
+test('recurring events are excluded from calendar-write execution but present in results', async () => {
+  const core = createCore();
+  const adapter = buildPrepCalendarAdapter([]);
+  const recurring = {
+    title: 'FUZZY',
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    bar: 'Dallas Eagle',
+    city: 'dallas',
+    recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR'
+  };
+  const plain = {
+    title: 'ONE-OFF',
+    startDate: new Date('2026-08-09T02:00:00.000Z'),
+    city: 'dallas'
+  };
+
+  const analyzed = await core.prepareEventsForCalendar([recurring, plain], adapter, {});
+
+  assert.equal(analyzed.length, 2, "flag-don't-drop: the recurring event stays in the results");
+  const analyzedRecurring = analyzed.find(event => event.title === 'FUZZY');
+  assert.equal(analyzedRecurring._recurring, true);
+  assert.equal(analyzedRecurring._recurringExport, true, 'stamped display+export only');
+  assert.equal(analyzedRecurring.recurrenceRule, 'FREQ=WEEKLY;BYDAY=FR', 'rrule survives for the ICS export');
+
+  const executable = SharedCore.filterEventsForExecution(analyzed);
+  assert.deepEqual(executable.map(event => event.title), ['ONE-OFF'],
+    'recurring events never reach calendar writes');
+});
+
+test('wide-window probe decision: ≥2 instances sharing the identifier → series', () => {
+  const identifier = 'CAL-UUID:fuzzy-20260503T203532Z@chunky.dad';
+  const one = SharedCore.resolveSeriesProbeDecision([{ identifier }], identifier);
+  assert.deepEqual(one, { instanceCount: 1, isSeries: false }, 'a single instance is not a series');
+  const many = SharedCore.resolveSeriesProbeDecision([
+    { identifier },
+    { identifier: 'CAL-UUID:other@chunky.dad' },
+    { identifier },
+    null
+  ], identifier);
+  assert.deepEqual(many, { instanceCount: 2, isSeries: true });
+  assert.deepEqual(SharedCore.resolveSeriesProbeDecision(null, identifier), { instanceCount: 0, isSeries: false });
+  assert.deepEqual(SharedCore.resolveSeriesProbeDecision([{ identifier }], ''), { instanceCount: 0, isSeries: false });
+});
+
+test('extractIcsUidFromIdentifier: UID suffix from both device identifier shapes', () => {
+  assert.equal(
+    SharedCore.extractIcsUidFromIdentifier('1A2B3C4D-5E6F:6thhos5ct3pllq5kmvsp7infd8@google.com'),
+    '6thhos5ct3pllq5kmvsp7infd8@google.com'
+  );
+  assert.equal(
+    SharedCore.extractIcsUidFromIdentifier('1A2B3C4D-5E6F:fuzzy-20260503T203532Z@chunky.dad'),
+    'fuzzy-20260503T203532Z@chunky.dad'
+  );
+  assert.equal(SharedCore.extractIcsUidFromIdentifier('no-colon-identifier'), null);
+  assert.equal(SharedCore.extractIcsUidFromIdentifier(''), null);
+  assert.equal(SharedCore.extractIcsUidFromIdentifier(null), null);
+});
+
+test('extractRecurringUidsFromIcs: light scan maps UIDs to RRULE presence (folded lines included)', () => {
+  const ics = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'BEGIN:VEVENT',
+    'UID:weekly-1@chunky.dad',
+    'RRULE:FREQ=WEEKLY;BYD',
+    ' AY=FR',
+    'SUMMARY:Weekly thing',
+    'END:VEVENT',
+    'BEGIN:VEVENT',
+    'UID:oneoff-2@chunky.dad',
+    'SUMMARY:One off',
+    'END:VEVENT',
+    'BEGIN:VEVENT',
+    'UID:folded-3@chunky.',
+    ' dad',
+    'RRULE:FREQ=MONTHLY;BYDAY=2SA',
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ].join('\r\n');
+  const uids = SharedCore.extractRecurringUidsFromIcs(ics);
+  assert.ok(uids instanceof Map);
+  assert.equal(uids.get('weekly-1@chunky.dad'), true, 'folded RRULE still detected');
+  assert.equal(uids.get('oneoff-2@chunky.dad'), false, 'UID present WITHOUT an RRULE');
+  assert.equal(uids.get('folded-3@chunky.dad'), true, 'folded UID reassembled');
+  assert.equal(SharedCore.extractRecurringUidsFromIcs(''), null, 'empty input fails open as null');
+  assert.equal(SharedCore.extractRecurringUidsFromIcs(null), null);
+});
+
+test('series probe integration: a confirmed series flips a plain merge into the recurring hands-off path', async () => {
+  const core = createCore();
+  const startDate = new Date('2026-08-08T02:00:00.000Z');
+  const calendarRecord = {
+    title: 'FUZZY',
+    startDate,
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    location: '',
+    identifier: 'CAL-UUID:fuzzy-uid@chunky.dad',
+    notes: 'bar: Dallas Eagle'
+  };
+  const adapter = buildPrepCalendarAdapter([calendarRecord]);
+  const probeCalls = [];
+  adapter.probeRecurringSeries = async (existingEvent) => {
+    probeCalls.push(existingEvent.identifier);
+    return true;
+  };
+  const scraped = { title: 'FUZZY', startDate, bar: 'Dallas Eagle', city: 'dallas' };
+
+  const analyzed = await core.prepareEventsForCalendar([scraped], adapter, {});
+
+  assert.deepEqual(probeCalls, ['CAL-UUID:fuzzy-uid@chunky.dad'], 'the probe ran once for the merge match');
+  assert.equal(analyzed.length, 1);
+  assert.equal(analyzed[0]._action, 'new', 'series match creates an override instead of mutating the series');
+  assert.match(String(analyzed[0]._existingKey || ''), /^fuzzy-uid@chunky\.dad::/,
+    'the existing recurring hands-off path keyed an override for the confirmed series');
+});
+
+test('series probe integration: probe errors and negative probes fail open to a plain merge', async () => {
+  const startDate = new Date('2026-08-08T02:00:00.000Z');
+  const calendarRecord = {
+    title: 'FUZZY',
+    startDate,
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    location: '',
+    identifier: 'CAL-UUID:fuzzy-uid@chunky.dad',
+    notes: 'bar: Dallas Eagle'
+  };
+  const scraped = { title: 'FUZZY', startDate, bar: 'Dallas Eagle', city: 'dallas' };
+
+  const throwingCore = createCore();
+  const throwingAdapter = buildPrepCalendarAdapter([{ ...calendarRecord }]);
+  throwingAdapter.probeRecurringSeries = async () => { throw new Error('calendar unavailable'); };
+  const throwingAnalyzed = await throwingCore.prepareEventsForCalendar([{ ...scraped }], throwingAdapter, {});
+  assert.equal(throwingAnalyzed[0]._action, 'merge', 'probe error → today\'s behavior');
+
+  const negativeCore = createCore();
+  const negativeAdapter = buildPrepCalendarAdapter([{ ...calendarRecord }]);
+  negativeAdapter.probeRecurringSeries = async () => false;
+  const negativeAnalyzed = await negativeCore.prepareEventsForCalendar([{ ...scraped }], negativeAdapter, {});
+  assert.equal(negativeAnalyzed[0]._action, 'merge', 'negative probe keeps the plain merge');
+});
+
+test('series decision ordering: an existing notes recurrence key fires before any adapter probe', async () => {
+  const core = createCore();
+  const startDate = new Date('2026-08-08T02:00:00.000Z');
+  const calendarRecord = {
+    title: 'FUZZY',
+    startDate,
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    location: '',
+    identifier: 'CAL-UUID:fuzzy-uid@chunky.dad',
+    notes: 'bar: Dallas Eagle\nrecurrence: FREQ=WEEKLY;BYDAY=FR'
+  };
+  const adapter = buildPrepCalendarAdapter([calendarRecord]);
+  adapter.probeRecurringSeries = async () => {
+    throw new Error('probe must not run when the notes key already fired');
+  };
+  const scraped = { title: 'FUZZY', startDate, bar: 'Dallas Eagle', city: 'dallas' };
+
+  const analyzed = await core.prepareEventsForCalendar([scraped], adapter, {});
+
+  assert.equal(analyzed[0]._action, 'new', 'notes key alone routes to the recurring hands-off path');
+  assert.match(String(analyzed[0]._existingKey || ''), /^fuzzy-uid@chunky\.dad::/,
+    'override identity derived without ever consulting the probe');
+});
+
+test('noteConfirmedRecurringSeries feeds shouldCreateOverrideFromRecurringMatch', () => {
+  const core = createCore();
+  const existingEvent = {
+    title: 'FUZZY',
+    identifier: 'CAL-UUID:fuzzy-uid@chunky.dad',
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    notes: 'bar: Dallas Eagle'
+  };
+  assert.equal(core.shouldCreateOverrideFromRecurringMatch(existingEvent, [existingEvent]), false,
+    'no series signal before confirmation');
+  core.noteConfirmedRecurringSeries('CAL-UUID:fuzzy-uid@chunky.dad');
+  assert.equal(core.shouldCreateOverrideFromRecurringMatch(existingEvent, [existingEvent]), true,
+    'confirmed identifier flips the hands-off path');
+});


### PR DESCRIPTION
## Doctrine (from the #927 postmortem + the live device probe)

The probe settled it: Scriptable exposes **zero** recurrence reads — occurrences are individually indistinguishable from plain events. So the rule this PR enforces everywhere: **the scraper never writes or mutates a recurring series.** Series enter calendars only via your ICS import; the scraper detects and keeps hands off.

## What's new

- **Recurrence is finally extracted**: the schema's existing `rrule` field (explicit-schedule-only wording) is now requested by default → Lumberyard-class weeklies become representable.
- **Recurring events are display+export only**: 🔁 badge in results, withheld from both calendar-execution paths (flag-don't-drop, with a per-event log line), and a **💾 Save recurring (.ics)** button → native `DocumentPicker.exportString` → you import into the right calendar. The generated ICS mirrors event-builder's conventions (+ RFC 5545 folding) and embeds `recurrence: <rrule>` in DESCRIPTION — the notes channel the probe proved round-trips (your festivals' `recurring: annual` arrived in `event.notes` verbatim).
- **🛠 Event Builder link on every card** (as requested) — prefilled URL through the existing open-url bridge.
- **Layered series detection, each level failing open to the next**:
  1. notes `recurrence:` key (the channel we write),
  2. **published calendar ICS** — `chunky.dad/data/calendars/<city>.ics` (6h cache); the Scriptable identifier's UID-suffix IS the ICS UID (device-verified), so a light regex scan gives authoritative "is this UID a series?" including monthly series with one visible instance,
  3. wide-window identifier probe (−35d/+70d, ≥2 instances share the identifier) — the offline fallback that closes the masquerading-monthly hole (your live Club Chub series in chunky-dad-la is the canonical case).
  Confirmed series route into the existing hands-off/override machinery; native CalendarEvent objects are never mutated or stamped.

## Verification

**911 → 937 tests**, including a full round-trip: the generated weekly ICS parses through `js/calendar-core` reporting `recurring: true`, `eventType: weekly`, TZID and notes intact. Sample ICS in the commit history/agent report.

## After merge (updater pull)

Changed runtime files: `shared-core.js`, `normalizers.js`, `event-schema.js`, `adapters/scriptable-adapter.js` (+ `parsers/ai-web-parser` tests only — no parser runtime change). **No new files.** Then rerun The Lumberyard (post-#1561 it extracts; now its Sunday hangout should carry an rrule, show the 🔁 badge, and offer the ICS save) and any parser to see the Event Builder links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP