### PR TITLE
fix(scraper): rrule validated by schedule evidence — CubScout recurring recognized, Lumberyard events survive

### DIFF
--- a/data/promoters.json
+++ b/data/promoters.json
@@ -80,6 +80,7 @@
   },
   {
     "name": "CubScout LA",
+    "aliases": ["CUBSCOUT"],
     "bearAffinity": "always"
   },
   {

--- a/js/event-schema.js
+++ b/js/event-schema.js
@@ -659,6 +659,75 @@ function buildRecurringEventIcs(event, options = {}) {
     return lines.map(foldIcsLine).join('\r\n');
 }
 
+// Deterministic next-occurrence date for the practical RRULE subset a
+// recurring-but-dateless event needs to survive normalization (run
+// 20260728-113040: The Lumberyard's events are recurring with no printed
+// date — without a derived startDate the required-field guard discarded
+// them all). Supported forms:
+//   - FREQ=DAILY (no BYDAY filter)
+//   - FREQ=WEEKLY with BYDAY of one or more plain weekday codes → nearest
+//   - FREQ=MONTHLY with a single ordinal BYDAY (1FR..5SU, -1 for last)
+// Anything else — unknown FREQ, INTERVAL>1 (no DTSTART anchor to phase it),
+// missing/ordinal-free BYDAY where required — returns null and the caller
+// keeps today's discard behavior. Pure local-calendar date math on the
+// injected `fromDate` (today counts as an occurrence); returns a local
+// YYYY-MM-DD string, never a time.
+function computeNextRruleOccurrence(rrule, fromDate) {
+    const text = String(rrule || '').replace(/^RRULE\s*:/i, '').trim().toUpperCase();
+    if (!text || !(fromDate instanceof Date) || Number.isNaN(fromDate.getTime())) return null;
+    const parts = {};
+    for (const segment of text.split(';')) {
+        const eq = segment.indexOf('=');
+        if (eq <= 0) continue;
+        parts[segment.slice(0, eq)] = segment.slice(eq + 1);
+    }
+    if (parts.INTERVAL !== undefined && Number(parts.INTERVAL) !== 1) return null;
+    const WEEKDAY_INDEX = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
+    const pad2 = (value) => String(value).padStart(2, '0');
+    const formatLocalDate = (date) => `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+    const today = new Date(fromDate.getFullYear(), fromDate.getMonth(), fromDate.getDate());
+    if (parts.FREQ === 'DAILY') {
+        return parts.BYDAY === undefined ? formatLocalDate(today) : null;
+    }
+    if (parts.FREQ === 'WEEKLY') {
+        const codes = String(parts.BYDAY || '').split(',').map(code => code.trim()).filter(Boolean);
+        if (codes.length === 0) return null;
+        let best = null;
+        for (const code of codes) {
+            const weekday = WEEKDAY_INDEX[code];
+            if (weekday === undefined) return null;
+            const delta = (weekday - today.getDay() + 7) % 7;
+            if (best === null || delta < best) best = delta;
+        }
+        return formatLocalDate(new Date(today.getFullYear(), today.getMonth(), today.getDate() + best));
+    }
+    if (parts.FREQ === 'MONTHLY') {
+        const codes = String(parts.BYDAY || '').split(',').map(code => code.trim()).filter(Boolean);
+        if (codes.length !== 1) return null;
+        const match = codes[0].match(/^(-?\d)(SU|MO|TU|WE|TH|FR|SA)$/);
+        if (!match) return null;
+        const ordinal = Number(match[1]);
+        const weekday = WEEKDAY_INDEX[match[2]];
+        if (ordinal === 0 || ordinal > 5 || ordinal < -1) return null;
+        const ordinalWeekdayOfMonth = (year, month) => {
+            if (ordinal > 0) {
+                const first = new Date(year, month, 1);
+                const day = 1 + ((weekday - first.getDay() + 7) % 7) + (ordinal - 1) * 7;
+                const candidate = new Date(year, month, day);
+                return candidate.getMonth() === first.getMonth() ? candidate : null;
+            }
+            const last = new Date(year, month + 1, 0);
+            return new Date(year, month, last.getDate() - ((last.getDay() - weekday + 7) % 7));
+        };
+        for (let offset = 0; offset < 3; offset++) {
+            const candidate = ordinalWeekdayOfMonth(today.getFullYear(), today.getMonth() + offset);
+            if (candidate && candidate.getTime() >= today.getTime()) return formatLocalDate(candidate);
+        }
+        return null;
+    }
+    return null;
+}
+
 const EventSchema = {
     EVENT_KEY_ALIASES,
     URL_LIKE_FIELDS,
@@ -682,7 +751,8 @@ const EventSchema = {
     formatIcsDateUtc,
     formatIcsDateInTimezone,
     slugifyIcsText,
-    buildRecurringEventIcs
+    buildRecurringEventIcs,
+    computeNextRruleOccurrence
 };
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -8303,10 +8303,19 @@ class ScriptableAdapter {
       );
     }
     if (SharedCore.isRecurringSeriesEvent(event)) {
-      const exportId = this.registerIcsExportEvent(event);
-      parts.push(
-        `<button onclick="exportRecurringIcs(this)" class="log-copy-btn ics-export-btn" data-ics-export-id="${exportId}">💾 Save recurring (.ics)</button>`,
-      );
+      // A derived-occurrence series with no stated start time cannot build a
+      // meaningful ICS (the export needs a real time): the card offers only
+      // the Event Builder link, where the owner supplies the time.
+      if (event._recurringNoStartTime === true) {
+        console.log(
+          `🔁 RECURRING: "${event.title || event.name || "Unknown"}" has no start time — ICS export disabled, use Event Builder`,
+        );
+      } else {
+        const exportId = this.registerIcsExportEvent(event);
+        parts.push(
+          `<button onclick="exportRecurringIcs(this)" class="log-copy-btn ics-export-btn" data-ics-export-id="${exportId}">💾 Save recurring (.ics)</button>`,
+        );
+      }
     }
     if (parts.length === 0) return "";
     return `<div class="event-actions-row" style="display:flex; gap:12px; align-items:center; margin:6px 0;">${parts.join("")}</div>`;

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -2935,6 +2935,30 @@ test('event card: recurring events get the badge, the builder link, and the ICS 
   assert.ok(!builderUrl.includes('new URL'), 'sanity');
 });
 
+test('event card: a recurring event with no start time gets the builder link but no ICS export button', () => {
+  const adapter = buildAdapter();
+  adapter.resetMapVerifyUrls();
+  adapter.resetIcsExportEvents();
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let html;
+  try {
+    html = adapter.generateEventCard(buildRecurringCardEvent({
+      title: 'DRINK AND DRAW',
+      recurrenceRule: 'FREQ=WEEKLY;BYDAY=TU',
+      _recurringNoStartTime: true
+    }));
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.ok(html.includes('🛠 Event Builder'), 'builder link still present');
+  assert.ok(!html.includes('💾 Save recurring (.ics)'), 'no ICS export button without a start time');
+  assert.ok(logs.includes('🔁 RECURRING: "DRINK AND DRAW" has no start time — ICS export disabled, use Event Builder'),
+    `gating log expected, got: ${JSON.stringify(logs.filter((l) => l.includes('RECURRING')))}`);
+});
+
 test('export-ics bridge: the handler builds the ICS for the registered event and hands it off', async () => {
   const adapter = buildAdapter();
   adapter.resetIcsExportEvents();

--- a/scripts/event-schema.js
+++ b/scripts/event-schema.js
@@ -659,6 +659,75 @@ function buildRecurringEventIcs(event, options = {}) {
     return lines.map(foldIcsLine).join('\r\n');
 }
 
+// Deterministic next-occurrence date for the practical RRULE subset a
+// recurring-but-dateless event needs to survive normalization (run
+// 20260728-113040: The Lumberyard's events are recurring with no printed
+// date — without a derived startDate the required-field guard discarded
+// them all). Supported forms:
+//   - FREQ=DAILY (no BYDAY filter)
+//   - FREQ=WEEKLY with BYDAY of one or more plain weekday codes → nearest
+//   - FREQ=MONTHLY with a single ordinal BYDAY (1FR..5SU, -1 for last)
+// Anything else — unknown FREQ, INTERVAL>1 (no DTSTART anchor to phase it),
+// missing/ordinal-free BYDAY where required — returns null and the caller
+// keeps today's discard behavior. Pure local-calendar date math on the
+// injected `fromDate` (today counts as an occurrence); returns a local
+// YYYY-MM-DD string, never a time.
+function computeNextRruleOccurrence(rrule, fromDate) {
+    const text = String(rrule || '').replace(/^RRULE\s*:/i, '').trim().toUpperCase();
+    if (!text || !(fromDate instanceof Date) || Number.isNaN(fromDate.getTime())) return null;
+    const parts = {};
+    for (const segment of text.split(';')) {
+        const eq = segment.indexOf('=');
+        if (eq <= 0) continue;
+        parts[segment.slice(0, eq)] = segment.slice(eq + 1);
+    }
+    if (parts.INTERVAL !== undefined && Number(parts.INTERVAL) !== 1) return null;
+    const WEEKDAY_INDEX = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
+    const pad2 = (value) => String(value).padStart(2, '0');
+    const formatLocalDate = (date) => `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+    const today = new Date(fromDate.getFullYear(), fromDate.getMonth(), fromDate.getDate());
+    if (parts.FREQ === 'DAILY') {
+        return parts.BYDAY === undefined ? formatLocalDate(today) : null;
+    }
+    if (parts.FREQ === 'WEEKLY') {
+        const codes = String(parts.BYDAY || '').split(',').map(code => code.trim()).filter(Boolean);
+        if (codes.length === 0) return null;
+        let best = null;
+        for (const code of codes) {
+            const weekday = WEEKDAY_INDEX[code];
+            if (weekday === undefined) return null;
+            const delta = (weekday - today.getDay() + 7) % 7;
+            if (best === null || delta < best) best = delta;
+        }
+        return formatLocalDate(new Date(today.getFullYear(), today.getMonth(), today.getDate() + best));
+    }
+    if (parts.FREQ === 'MONTHLY') {
+        const codes = String(parts.BYDAY || '').split(',').map(code => code.trim()).filter(Boolean);
+        if (codes.length !== 1) return null;
+        const match = codes[0].match(/^(-?\d)(SU|MO|TU|WE|TH|FR|SA)$/);
+        if (!match) return null;
+        const ordinal = Number(match[1]);
+        const weekday = WEEKDAY_INDEX[match[2]];
+        if (ordinal === 0 || ordinal > 5 || ordinal < -1) return null;
+        const ordinalWeekdayOfMonth = (year, month) => {
+            if (ordinal > 0) {
+                const first = new Date(year, month, 1);
+                const day = 1 + ((weekday - first.getDay() + 7) % 7) + (ordinal - 1) * 7;
+                const candidate = new Date(year, month, day);
+                return candidate.getMonth() === first.getMonth() ? candidate : null;
+            }
+            const last = new Date(year, month + 1, 0);
+            return new Date(year, month, last.getDate() - ((last.getDay() - weekday + 7) % 7));
+        };
+        for (let offset = 0; offset < 3; offset++) {
+            const candidate = ordinalWeekdayOfMonth(today.getFullYear(), today.getMonth() + offset);
+            if (candidate && candidate.getTime() >= today.getTime()) return formatLocalDate(candidate);
+        }
+        return null;
+    }
+    return null;
+}
+
 const EventSchema = {
     EVENT_KEY_ALIASES,
     URL_LIKE_FIELDS,
@@ -682,7 +751,8 @@ const EventSchema = {
     formatIcsDateUtc,
     formatIcsDateInTimezone,
     slugifyIcsText,
-    buildRecurringEventIcs
+    buildRecurringEventIcs,
+    computeNextRruleOccurrence
 };
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/scripts/event-schema.test.js
+++ b/scripts/event-schema.test.js
@@ -330,3 +330,45 @@ test('round-trip: js/calendar-core.js parseICalData parses the generated ICS and
   assert.equal(parsed.startTimezone, 'America/Chicago', 'TZID round-trips');
   assert.equal(parsed.bar, 'Dallas Eagle', 'DESCRIPTION notes fields round-trip');
 });
+
+// ---------------------------------------------------------------------------
+// computeNextRruleOccurrence — deterministic next-occurrence date math for
+// dateless recurring events (practical subset; unsupported forms → null)
+// ---------------------------------------------------------------------------
+
+test('computeNextRruleOccurrence: weekly, monthly-ordinal, and daily forms from an injected now', () => {
+  const f = EventSchema.computeNextRruleOccurrence;
+  const wedJul22 = new Date(2026, 6, 22, 15, 30, 0); // Wed 2026-07-22, local
+
+  // weekly, single BYDAY: nearest Friday
+  assert.equal(f('FREQ=WEEKLY;BYDAY=FR', wedJul22), '2026-07-24');
+  // today counts as an occurrence
+  assert.equal(f('FREQ=WEEKLY;BYDAY=WE', wedJul22), '2026-07-22');
+  // weekly, multiple BYDAY: nearest of the set (Fri Jul 24 beats Tue Jul 28)
+  assert.equal(f('FREQ=WEEKLY;BYDAY=TU,FR', wedJul22), '2026-07-24');
+  // monthly ordinal: July's 1st Friday (Jul 3) is past → Aug 7
+  assert.equal(f('FREQ=MONTHLY;BYDAY=1FR', wedJul22), '2026-08-07');
+  // monthly ordinal still ahead in the current month
+  assert.equal(f('FREQ=MONTHLY;BYDAY=2FR', new Date(2026, 6, 1)), '2026-07-10');
+  // last-weekday form (-1)
+  assert.equal(f('FREQ=MONTHLY;BYDAY=-1FR', wedJul22), '2026-07-31');
+  // daily: today
+  assert.equal(f('FREQ=DAILY', wedJul22), '2026-07-22');
+  // an RRULE: prefix is tolerated (normalizeRruleValue strips it upstream)
+  assert.equal(f('RRULE:FREQ=WEEKLY;BYDAY=FR', wedJul22), '2026-07-24');
+});
+
+test('computeNextRruleOccurrence: unsupported forms return null (event stays discarded)', () => {
+  const f = EventSchema.computeNextRruleOccurrence;
+  const now = new Date(2026, 6, 22);
+  assert.equal(f('FREQ=WEEKLY', now), null, 'weekly without BYDAY has no anchor');
+  assert.equal(f('FREQ=MONTHLY;BYDAY=FR', now), null, 'monthly needs an ordinal BYDAY');
+  assert.equal(f('FREQ=MONTHLY;BYDAY=1FR,3FR', now), null, 'multiple monthly ordinals are out of subset');
+  assert.equal(f('FREQ=WEEKLY;INTERVAL=2;BYDAY=FR', now), null, 'INTERVAL>1 has no DTSTART to phase it');
+  assert.equal(f('FREQ=YEARLY', now), null, 'unknown FREQ');
+  assert.equal(f('1ST FRIDAY OF THE MONTH', now), null, 'prose is not an RRULE');
+  assert.equal(f('', now), null);
+  assert.equal(f('FREQ=WEEKLY;BYDAY=FR', new Date('nonsense')), null, 'invalid fromDate');
+  assert.equal(f('FREQ=WEEKLY;BYDAY=XX', now), null, 'unknown weekday code');
+  assert.equal(f('FREQ=DAILY;BYDAY=FR', now), null, 'filtered daily rules are out of subset');
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -87,6 +87,34 @@ const END_MARKER_START_FIELDS = new Map([
     ['starttime', 'endtime']
 ]);
 
+// rrule rejection class (run 20260728-113040, CubScout): an iCal RRULE is a
+// DERIVED TRANSLATION of schedule prose ("1ST FRIDAY OF THE MONTH" →
+// FREQ=MONTHLY;BYDAY=1FR) and is never verbatim on the page, so the default
+// 'exact' gate dropped 100% of correct rrules — and the "copy the exact
+// text" retry line then steered the model into returning prose that
+// normalizeRruleValue rejects. Its own validation mode ('schedule-evidence',
+// see validateRruleScheduleEvidence) checks the model's EVIDENCE phrase
+// against the corpus instead, and its own retry line asks for a valid RRULE
+// rather than a verbatim copy.
+const RRULE_SCHEDULE_REASON = 'rrule-schedule-evidence';
+
+// Weekday named in schedule evidence, per BYDAY code — abbreviations and
+// plurals included ("FRI", "Fridays"), linguistic-generic (no per-site
+// vocabulary).
+const RRULE_BYDAY_EVIDENCE_REGEXES = {
+    MO: /\bmon(?:day)?s?\b/i,
+    TU: /\btue(?:s(?:day)?)?s?\b/i,
+    WE: /\bwed(?:nesday)?s?\b/i,
+    TH: /\bthu(?:r(?:s(?:day)?)?)?s?\b/i,
+    FR: /\bfri(?:day)?s?\b/i,
+    SA: /\bsat(?:urday)?s?\b/i,
+    SU: /\bsun(?:day)?s?\b/i
+};
+
+// Ordinal-position words ("1ST FRIDAY", "last Tuesday") — a monthly-pattern
+// signal in schedule prose.
+const RRULE_ORDINAL_WORD_REGEX = /\b(?:1st|first|2nd|second|3rd|third|4th|fourth|5th|fifth|last)\b/i;
+
 // ============================================================================
 // NORMALIZATION HELPERS
 // ============================================================================
@@ -6769,6 +6797,12 @@ class AiWebParser {
                 if (reasons[matchKey] === END_MARKER_CITED_REASON) {
                     feedback[normalizedField] = { value, reason: END_MARKER_CITED_REASON };
                 }
+                // rrule drops are likewise worth echoing with their own
+                // correction line: the retry must return a valid RRULE that
+                // matches the stated schedule, never a verbatim copy.
+                if (reasons[matchKey] === RRULE_SCHEDULE_REASON) {
+                    feedback[normalizedField] = { value, reason: RRULE_SCHEDULE_REASON };
+                }
                 return; // tagged reason = evidence-quality drop
             }
             feedback[normalizedField] = value;
@@ -7593,6 +7627,16 @@ ${String(snippet || '')}`;
                     retryFeedbackContext += `Your previous value "${value.value}" for ${field} came from an "End at" line — that is the event's END, not its start. Find the START, or leave it blank.\n`;
                     return;
                 }
+                // rrule corrections ride the same { value, reason } shape:
+                // an RRULE is a derived translation and is NEVER verbatim in
+                // the source, so the "copy the exact text" line would steer
+                // the retry into returning schedule prose that the rrule
+                // normalizer rejects. Ask for a valid RRULE instead.
+                if (value && typeof value === 'object' && value.reason === RRULE_SCHEDULE_REASON) {
+                    if (typeof value.value !== 'string' || !value.value.trim()) return;
+                    retryFeedbackContext += `Your previous value "${value.value}" for ${field} was rejected — return a valid iCal RRULE (FREQ=...) that matches the schedule stated in the source, and cite the schedule wording as evidence.\n`;
+                    return;
+                }
                 if (typeof value !== 'string' || !value.trim()) return;
                 retryFeedbackContext += `Your previous value "${value}" for ${field} was rejected — it is not verbatim in the source. Copy the exact text.\n`;
             });
@@ -8079,6 +8123,7 @@ TEXT:
             else if (normalizedField === 'cover') mode = 'cover';
             else if (normalizedField === 'description') mode = validationConfig.fuzzyDescription ? 'fuzzy' : 'exact';
             else if (normalizedField === 'city') mode = 'city';
+            else if (normalizedField === 'recurrence') mode = 'schedule-evidence';
             else if (normalizedField === 'image') mode = 'image';
             else if (normalizedField === 'url' || normalizedField === 'website' || normalizedField === 'ticketurl' || normalizedField === 'instagram' || normalizedField === 'facebook' || normalizedField === 'gmaps') mode = 'url';
             else mode = 'exact';
@@ -8899,6 +8944,82 @@ TEXT:
     }
 
     /**
+     * Schedule vocabulary in an evidence phrase — the linguistic-generic
+     * signal that the model quoted an actual repeat-schedule statement:
+     * weekday names/abbreviations, frequency words (every/weekly/monthly/
+     * daily/biweekly), or an ordinal + of-the-month form. One conservative
+     * regex family, no site-specific rules.
+     */
+    evidenceContainsScheduleVocabulary(evidence) {
+        const text = String(evidence || '');
+        if (!text.trim()) return false;
+        if (Object.values(RRULE_BYDAY_EVIDENCE_REGEXES).some(regex => regex.test(text))) return true;
+        if (/\b(?:every|weekly|monthly|daily|biweekly|bi-weekly)\b/i.test(text)) return true;
+        return RRULE_ORDINAL_WORD_REGEX.test(text) && /\bof\s+the\s+month\b|\bmonth\b/i.test(text);
+    }
+
+    /**
+     * Deterministic evidence↔value consistency for an rrule, conservative
+     * and minimal (no full RRULE semantics):
+     *   - every BYDAY weekday code in the value (plain or ordinal form,
+     *     "FR"/"1FR"/"-1FR") must have its weekday named in the evidence;
+     *   - FREQ=MONTHLY needs an ordinal/monthly word in the evidence;
+     *   - FREQ=WEEKLY needs a weekly/every-ish signal AND must not sit on
+     *     ordinal-weekday prose ("EVERY 2ND FRIDAY" is a monthly pattern —
+     *     the Lumberyard model error shipped it as FREQ=WEEKLY; ambiguous
+     *     source, fail closed).
+     * Unparseable BYDAY tokens fail closed.
+     */
+    rruleMatchesScheduleEvidence(normalizedRrule, evidence) {
+        const text = String(evidence || '');
+        const parts = {};
+        String(normalizedRrule || '').split(';').forEach(segment => {
+            const eq = segment.indexOf('=');
+            if (eq > 0) parts[segment.slice(0, eq)] = segment.slice(eq + 1);
+        });
+        const bydayTokens = parts.BYDAY ? parts.BYDAY.split(',').map(token => token.trim()).filter(Boolean) : [];
+        for (const token of bydayTokens) {
+            const match = token.match(/^(?:[+-]?\d)?(MO|TU|WE|TH|FR|SA|SU)$/);
+            if (!match) return false;
+            if (!RRULE_BYDAY_EVIDENCE_REGEXES[match[1]].test(text)) return false;
+        }
+        const ordinalWeekdayProse = RRULE_ORDINAL_WORD_REGEX.test(text)
+            && Object.values(RRULE_BYDAY_EVIDENCE_REGEXES).some(regex => regex.test(text));
+        if (parts.FREQ === 'MONTHLY') {
+            return RRULE_ORDINAL_WORD_REGEX.test(text) || /\bmonth(?:ly)?\b/i.test(text);
+        }
+        if (parts.FREQ === 'WEEKLY') {
+            if (ordinalWeekdayProse) return false;
+            return /\b(?:every|weekly|each|all)\b/i.test(text)
+                || Object.values(RRULE_BYDAY_EVIDENCE_REGEXES).some(regex => {
+                    const match = text.match(regex);
+                    return match && /s$/i.test(match[0]); // plural weekday ("Tuesdays") implies weekly
+                });
+        }
+        return true;
+    }
+
+    /**
+     * The rrule/recurrence validation class ('schedule-evidence' mode): the
+     * VALUE is a derived translation, never verbatim, so the gate checks the
+     * model's EVIDENCE phrase instead — it must be a verbatim corpus quote
+     * (the same check other fields apply to values), contain schedule
+     * vocabulary, the value must parse as an RRULE, and the schedule words
+     * must corroborate the rule. Returns { valid, reason }.
+     */
+    validateRruleScheduleEvidence(value, modelEvidence, evidenceContext) {
+        const normalizedRrule = this.normalizeRruleValue(value);
+        if (!normalizedRrule) return { valid: false, reason: 'not-an-rrule' };
+        const evidence = String(modelEvidence || '').trim();
+        if (!evidence) return { valid: false, reason: 'no-evidence' };
+        if (this.evidenceAdmitsInference(evidence)) return { valid: false, reason: 'inference-evidence' };
+        if (!this.hasExactEvidence(evidenceContext, evidence)) return { valid: false, reason: 'evidence-not-verbatim' };
+        if (!this.evidenceContainsScheduleVocabulary(evidence)) return { valid: false, reason: 'no-schedule-vocabulary' };
+        if (!this.rruleMatchesScheduleEvidence(normalizedRrule, evidence)) return { valid: false, reason: 'schedule-mismatch' };
+        return { valid: true, reason: '' };
+    }
+
+    /**
      * Validate a single field value against evidence.
      * Returns true if valid, false if should be dropped.
      */
@@ -8929,11 +9050,19 @@ TEXT:
         const endMarkerStart = !citesForbiddenContext
             && END_MARKER_START_FIELDS.has(rule.field)
             && this.evidenceCitesEndMarker(modelEvidence);
+        // rrule/recurrence ('schedule-evidence' mode): the value is a derived
+        // translation, never verbatim — validated against the model's cited
+        // EVIDENCE phrase instead (see validateRruleScheduleEvidence).
+        const scheduleEvidence = rule.mode === 'schedule-evidence'
+            ? this.validateRruleScheduleEvidence(value, modelEvidence, evidenceContext)
+            : null;
         const hasEvidence = !citesForbiddenContext
             && !brandOnlyCityEvidence
             && !inventedTime
             && !endMarkerStart
-            && this.hasFieldEvidence(evidenceContext, value, rule.mode, validationContext);
+            && (scheduleEvidence
+                ? scheduleEvidence.valid
+                : this.hasFieldEvidence(evidenceContext, value, rule.mode, validationContext));
         if (!hasEvidence) {
             const droppedEntry = {
                 field: rule.field,
@@ -8946,6 +9075,15 @@ TEXT:
             if (citesForbiddenContext) droppedEntry.reason = 'context-cited-evidence';
             else if (brandOnlyCityEvidence) droppedEntry.reason = 'brand-cited-evidence';
             else if (endMarkerStart) droppedEntry.reason = END_MARKER_CITED_REASON;
+            else if (scheduleEvidence && !scheduleEvidence.valid) {
+                // Tagged so the retry prompt renders the rrule-specific
+                // correction line instead of "copy the exact text" (an RRULE
+                // is never verbatim — that instruction can only mislead).
+                droppedEntry.reason = RRULE_SCHEDULE_REASON;
+                if (scheduleEvidence.reason === 'schedule-mismatch') {
+                    console.log(`🤖 AI Web: Dropped rrule "${value}" — schedule words in evidence do not corroborate the rule`);
+                }
+            }
             report.dropped.push(droppedEntry);
             // Reassignment candidate (reassign, don't discard): the dropped
             // start value is evidence-cited END data — but only when the
@@ -9657,8 +9795,40 @@ TEXT:
             end: Boolean(weekdayPinnedYears.end) || (!endProvided && !endDateRaw && Boolean(weekdayPinnedYears.start))
         };
 
-        const { startDate, endDate } = this.normalizeEventDates(finalStartDate, finalEndDate, effectivePinnedYears);
+        let { startDate, endDate } = this.normalizeEventDates(finalStartDate, finalEndDate, effectivePinnedYears);
         console.log(`🤖 AI Web: Normalized dates — startDate=${startDate instanceof Date ? startDate.toISOString() : startDate}, endDate=${endDate instanceof Date ? endDate.toISOString() : endDate}`);
+
+        // Recurring events survive without a concrete date (run
+        // 20260728-113040: The Lumberyard's events are recurring+dateless —
+        // every one died on the required-startDate guard below). A VALID
+        // extracted RRULE deterministically yields the series' next
+        // occurrence (EventSchema.computeNextRruleOccurrence, practical
+        // subset only), which stands in as startDate: an extracted startTime
+        // combines as usual; with no startTime the date sits at the
+        // invented-midnight placeholder ("no time stated") and the event is
+        // flagged so the ICS export — which needs a real time — steps aside
+        // for the Event Builder link. _recurring semantics are unchanged:
+        // these events stay withheld from calendar writes (display + ICS/
+        // Builder export only). Unsupported rrule forms return null and the
+        // event is discarded exactly as before.
+        let recurringDerivedNoStartTime = false;
+        if (!startDate && title && recurrenceRule) {
+            const schema = this.getEventSchema();
+            const nextOccurrence = schema && typeof schema.computeNextRruleOccurrence === 'function'
+                ? schema.computeNextRruleOccurrence(recurrenceRule, this.now())
+                : null;
+            if (nextOccurrence) {
+                const derivedStart = this.convertLocalDateTimeToUtc(`${nextOccurrence} ${startTimeRaw || '00:00:00'}`, timezone)
+                    || combineDateAndTime(nextOccurrence, startTimeRaw || '00:00')
+                    || null;
+                if (derivedStart instanceof Date && !Number.isNaN(derivedStart.getTime())) {
+                    startDate = derivedStart;
+                    if (!endDate) endDate = new Date(derivedStart);
+                    recurringDerivedNoStartTime = !startTimeRaw;
+                    console.log(`🔁 RECURRING: derived next occurrence ${nextOccurrence} from rrule for "${title}"`);
+                }
+            }
+        }
 
         if (!title || !startDate) {
             console.warn(`🤖 AI Web: Normalization failed — title=${title}, startDate=${startDate}`);
@@ -9731,6 +9901,14 @@ TEXT:
             source: this.config.source,
             isBearEvent: false
         };
+
+        // Derived-occurrence recurring event with no stated start time: the
+        // ICS export needs a real time, so the results card must offer only
+        // the Event Builder link (see buildEventCardActionsHtml). Internal
+        // underscore field — display gating only, never serialized to notes.
+        if (recurringDerivedNoStartTime) {
+            event._recurringNoStartTime = true;
+        }
 
         // AI free-text hygiene: the model copies JSON-LD/HTML descriptions
         // verbatim, markup included (CubScout shipped a raw <img …> tag as its

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -6803,3 +6803,165 @@ test('getAiPromptFields: rrule is requested from the default field priorities', 
   assert.equal(parser.isPromptFieldRequested('rrule', {}), true,
     'normalizeAiEvent will map the extracted rrule into event.recurrenceRule');
 });
+
+// ---------------------------------------------------------------------------
+// rrule validation ('schedule-evidence' mode): an RRULE is a derived
+// translation, never verbatim — the gate checks the model's EVIDENCE phrase
+// against the corpus instead (run 20260728-113040, CubScout / The Lumberyard)
+// ---------------------------------------------------------------------------
+
+const RRULE_TEST_CORPUS = 'CUBSCOUT — A NIGHT FOR CUBS, SCOUTS AND EVERYONE ELSE. 1ST FRIDAY OF THE MONTH AT THE EAGLE LA. EVERY 2ND FRIDAY karaoke night. every Tuesday trivia with the pack.';
+
+function runRruleValidation(parser, aiEvent) {
+  const evidenceContext = parser.buildAiEvidenceContextFromText(RRULE_TEST_CORPUS);
+  const validationContext = { imageEvidenceUrls: new Set() };
+  return parser.validateAiEventEvidence(aiEvent, { html: RRULE_TEST_CORPUS }, {}, null, {
+    evidenceContext,
+    validationContext
+  });
+}
+
+test('rrule survives the evidence gate when its schedule evidence is verbatim and corroborates the rule', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  // The literal CubScout case the exact-mode gate used to drop 100% of the time.
+  const result = runRruleValidation(parser, {
+    rrule: 'FREQ=MONTHLY;BYDAY=1FR',
+    __fieldEvidence: { rrule: '1ST FRIDAY OF THE MONTH' }
+  });
+  assert.equal(result.event.rrule, 'FREQ=MONTHLY;BYDAY=1FR', 'a correct derived RRULE is kept');
+  assert.deepEqual(result.report.dropped, [], 'nothing dropped');
+});
+
+test('rrule validation rejects non-RRULE values, unverbatim evidence, and schedule mismatches', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+
+  // Value without FREQ= (schedule prose echoed back) → rejected.
+  const prose = runRruleValidation(parser, {
+    rrule: '1ST FRIDAY OF THE MONTH',
+    __fieldEvidence: { rrule: '1ST FRIDAY OF THE MONTH' }
+  });
+  assert.equal(prose.event.rrule, undefined, 'prose is not an RRULE');
+  assert.equal(prose.report.dropped[0].reason, 'rrule-schedule-evidence');
+
+  // Evidence absent from the corpus → rejected.
+  const absent = runRruleValidation(parser, {
+    rrule: 'FREQ=MONTHLY;BYDAY=1FR',
+    __fieldEvidence: { rrule: 'FIRST SATURDAY MONTHLY MEETUP' }
+  });
+  assert.equal(absent.event.rrule, undefined, 'evidence must be a verbatim corpus quote');
+  assert.equal(absent.report.dropped[0].reason, 'rrule-schedule-evidence');
+
+  // Weekday mismatch (BYDAY=FR, evidence names Tuesday) → rejected with the
+  // distinct corroboration log line.
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let mismatch;
+  try {
+    mismatch = runRruleValidation(parser, {
+      rrule: 'FREQ=WEEKLY;BYDAY=FR',
+      __fieldEvidence: { rrule: 'every Tuesday' }
+    });
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(mismatch.event.rrule, undefined, 'weekday mismatch fails closed');
+  assert.ok(logs.includes('🤖 AI Web: Dropped rrule "FREQ=WEEKLY;BYDAY=FR" — schedule words in evidence do not corroborate the rule'),
+    `distinct mismatch log expected, got: ${JSON.stringify(logs)}`);
+
+  // FREQ=WEEKLY on ordinal-weekday prose ("EVERY 2ND FRIDAY" is a monthly
+  // pattern — the Lumberyard model error) → rejected, ambiguous source.
+  const ordinalWeekly = runRruleValidation(parser, {
+    rrule: 'FREQ=WEEKLY;BYDAY=FR',
+    __fieldEvidence: { rrule: 'EVERY 2ND FRIDAY' }
+  });
+  assert.equal(ordinalWeekly.event.rrule, undefined, 'ordinal prose contradicts FREQ=WEEKLY');
+
+  // Sanity: a genuinely weekly statement passes.
+  const weekly = runRruleValidation(parser, {
+    rrule: 'FREQ=WEEKLY;BYDAY=TU',
+    __fieldEvidence: { rrule: 'every Tuesday' }
+  });
+  assert.equal(weekly.event.rrule, 'FREQ=WEEKLY;BYDAY=TU');
+});
+
+test('rrule retry feedback uses the RRULE-specific correction line, never "copy the exact text"', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  const merged = {
+    __droppedFieldValues: { recurrence: 'FREQ=MONTHLY;BYDAY=1FR' },
+    __droppedFieldReasons: { recurrence: 'rrule-schedule-evidence' }
+  };
+  const feedback = parser.buildRetryDropFeedback(['rrule'], merged);
+  assert.deepEqual(feedback, {
+    recurrence: { value: 'FREQ=MONTHLY;BYDAY=1FR', reason: 'rrule-schedule-evidence' }
+  }, 'rrule drops ride the tagged { value, reason } shape');
+
+  const prompt = parser.buildExtractionPrompt(
+    { html: 'x', url: 'https://a.example/' },
+    parser.getAiConfig({}),
+    null, {}, ['rrule'], 'SNIPPET', 'alternate', {}, feedback
+  );
+  assert.ok(prompt.includes('Your previous value "FREQ=MONTHLY;BYDAY=1FR" for recurrence was rejected — return a valid iCal RRULE (FREQ=...) that matches the schedule stated in the source, and cite the schedule wording as evidence.'),
+    'the class-specific retry line is emitted');
+  assert.ok(!prompt.includes('Copy the exact text'),
+    'the not-verbatim line never fires for the rrule class');
+});
+
+// ---------------------------------------------------------------------------
+// Dateless recurring events: a valid RRULE derives the next occurrence as
+// startDate instead of dying on the required-field guard (The Lumberyard)
+// ---------------------------------------------------------------------------
+
+test('normalizeAiEvent derives the next occurrence for a dateless recurring event', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 6, 22, 15, 0, 0); // Wed 2026-07-22 local
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let event;
+  try {
+    event = parser.normalizeAiEvent(
+      { title: 'DRINK AND DRAW', rrule: 'FREQ=WEEKLY;BYDAY=TU' },
+      {}, null, null, null
+    );
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(event, 'the recurring event survives normalization');
+  assert.equal(event.recurrenceRule, 'FREQ=WEEKLY;BYDAY=TU');
+  assert.ok(event.startDate instanceof Date, 'derived startDate is a Date');
+  assert.equal(event.startDate.toISOString().slice(0, 10), '2026-07-28', 'next Tuesday from the injected now');
+  assert.equal(event._recurringNoStartTime, true, 'no stated start time → flagged for ICS gating');
+  assert.ok(logs.includes('🔁 RECURRING: derived next occurrence 2026-07-28 from rrule for "DRINK AND DRAW"'),
+    `derivation log expected, got: ${JSON.stringify(logs.filter(l => l.includes('RECURRING')))}`);
+});
+
+test('normalizeAiEvent combines an extracted startTime with the derived occurrence date', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 6, 22, 15, 0, 0);
+  const cityConfig = { la: { timezone: 'America/Los_Angeles', patterns: ['los angeles'] } };
+  const event = parser.normalizeAiEvent(
+    { title: 'CUBSCOUT', rrule: 'FREQ=MONTHLY;BYDAY=1FR', startTime: '21:00', city: 'los angeles' },
+    {}, null, cityConfig, null
+  );
+  assert.ok(event, 'survives with a derived date');
+  // 1st Friday after Wed Jul 22 is Aug 7; 9pm PDT = Aug 8 04:00 UTC
+  assert.equal(event.startDate.toISOString(), '2026-08-08T04:00:00.000Z');
+  assert.equal(event._recurringNoStartTime, undefined, 'a stated start time keeps the ICS export');
+});
+
+test('normalizeAiEvent still discards dateless events with unsupported or missing rrules', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 6, 22, 15, 0, 0);
+  assert.equal(parser.normalizeAiEvent({ title: 'X', rrule: 'FREQ=YEARLY' }, {}, null, null, null), null,
+    'unsupported rrule form → discarded exactly as before');
+  assert.equal(parser.normalizeAiEvent({ title: 'Y' }, {}, null, null, null), null,
+    'no rrule, no date → discarded exactly as before');
+});

--- a/scripts/promoter-registry.test.js
+++ b/scripts/promoter-registry.test.js
@@ -120,3 +120,35 @@ test('the generated twin exports the same registry object', () => {
   const twin = require('./scraper-promoters');
   assert.deepEqual(twin, registry);
 });
+
+// Run 20260728-113040: the title "CUBSCOUT" failed to match because padded
+// title containment needs the full "cubscoutla" key. The same-entry alias
+// "CUBSCOUT" fixes it — and the matcher's generic-stem guard only refuses
+// keys contained in OTHER entries' keys, so an alias that is a substring of
+// its own entry's name key stays matchable.
+test('CubScout LA carries the CUBSCOUT alias and passes registry hygiene', () => {
+  const registry = loadRegistry();
+  const entry = registry.find((candidate) => candidate.name === 'CubScout LA');
+  assert.ok(entry, 'CubScout LA entry exists');
+  assert.ok(Array.isArray(entry.aliases) && entry.aliases.includes('CUBSCOUT'),
+    'the CUBSCOUT alias is present');
+  // The alias key must be claimed by no other entry (the uniqueness test
+  // covers the general rule; this pins the specific pair).
+  const claimants = registry.filter((candidate) =>
+    [candidate.name, ...(Array.isArray(candidate.aliases) ? candidate.aliases : [])]
+      .some((name) => nameKey(name) === 'cubscout'));
+  assert.deepEqual(claimants.map((candidate) => candidate.name), ['CubScout LA']);
+});
+
+test('matcher: the title "CUBSCOUT" matches CubScout LA via the same-entry alias', () => {
+  const { SharedCore } = require('./shared-core');
+  const { EventSchema } = require('./event-schema');
+  const core = new SharedCore({}, { eventSchema: EventSchema, promoters: loadRegistry() });
+  const match = core.matchEventToPromoter({ title: 'CUBSCOUT' });
+  assert.ok(match && match.entry, `expected a match, got ${JSON.stringify(match)}`);
+  assert.equal(match.entry.name, 'CubScout LA');
+  assert.equal(match.evidence, 'title');
+  // The full name still matches too.
+  const fullName = core.matchEventToPromoter({ title: 'CubScout LA: Woof Edition' });
+  assert.ok(fullName && fullName.entry && fullName.entry.name === 'CubScout LA');
+});

--- a/scripts/scraper-promoters.js
+++ b/scripts/scraper-promoters.js
@@ -102,6 +102,9 @@ const scraperPromoters = [
   },
   {
     "name": "CubScout LA",
+    "aliases": [
+      "CUBSCOUT"
+    ],
     "bearAffinity": "always"
   },
   {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -7972,6 +7972,12 @@ class SharedCore {
                 if (!analyzedEvent.recurrenceRule && typeof event.recurrenceRule === 'string') {
                     analyzedEvent.recurrenceRule = event.recurrenceRule;
                 }
+                // No stated start time (derived-occurrence series): the ICS
+                // export needs a real time — the card gates the 💾 button off
+                // and leaves the Event Builder link (scriptable-adapter).
+                if (event._recurringNoStartTime === true) {
+                    analyzedEvent._recurringNoStartTime = true;
+                }
                 console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" withheld from calendar write — save via ICS export`);
             }
 

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -9141,6 +9141,31 @@ test('recurring events are excluded from calendar-write execution but present in
     'recurring events never reach calendar writes');
 });
 
+test('dateless recurring event with a derived occurrence stays in results, withheld from execution, and keeps its no-start-time flag', async () => {
+  const core = createCore();
+  const adapter = buildPrepCalendarAdapter([]);
+  // The shape normalizeAiEvent produces for a recurring+dateless page (The
+  // Lumberyard): startDate derived from the rrule's next occurrence, no
+  // stated start time (_recurringNoStartTime stamps the ICS gating).
+  const derived = {
+    title: 'DRINK AND DRAW',
+    startDate: new Date('2026-07-28T00:00:00.000Z'),
+    endDate: new Date('2026-07-28T00:00:00.000Z'),
+    city: 'dallas',
+    recurrenceRule: 'FREQ=WEEKLY;BYDAY=TU',
+    _recurringNoStartTime: true
+  };
+
+  const analyzed = await core.prepareEventsForCalendar([derived], adapter, {});
+  assert.equal(analyzed.length, 1, 'the derived-date recurring event survives to the results');
+  assert.equal(analyzed[0]._recurring, true);
+  assert.equal(analyzed[0]._recurringExport, true);
+  assert.equal(analyzed[0]._recurringNoStartTime, true,
+    'the no-start-time flag rides through to the analyzed event for card gating');
+  assert.deepEqual(SharedCore.filterEventsForExecution(analyzed), [],
+    'derived-date recurring events are still withheld from calendar writes');
+});
+
 test('wide-window probe decision: ≥2 instances sharing the identifier → series', () => {
   const identifier = 'CAL-UUID:fuzzy-20260503T203532Z@chunky.dad';
   const one = SharedCore.resolveSeriesProbeDecision([{ identifier }], identifier);


### PR DESCRIPTION
## The structural bug (device-run proof)

CubScout's model answer was perfect — `FREQ=MONTHLY;BYDAY=1FR`, evidence `"1ST FRIDAY OF THE MONTH"`, confidence 100 — and the verbatim gate dropped it, because **a derived iCal RRULE string is never verbatim in page text**. The retry feedback then instructed "copy the exact text"; the model complied with natural language, which the RRULE normalizer rejects. Unwinnable by construction. The same bug silently zeroed The Lumberyard: its recurring, dateless events lost their rrules, then the required-startDate guard discarded every one.

## Fixes

1. **`schedule-evidence` validation mode** for recurrence: the *value* must parse as an RRULE; the *evidence phrase* is what gets the verbatim-corpus check, plus schedule-vocabulary and evidence↔rule corroboration (every `BYDAY` weekday must be named in the evidence; `MONTHLY` needs ordinal/monthly wording; `WEEKLY` needs weekly-ish wording — and fails closed on ordinal prose, catching the real observed model error where "EVERY 2ND FRIDAY" produced `FREQ=WEEKLY`). A class-specific retry line replaces the self-defeating "copy the exact text" for this field.
2. **Dateless recurring events survive**: `computeNextRruleOccurrence` (pure, event-schema twins; WEEKLY/MONTHLY-ordinal/DAILY, unsupported → null) derives the next occurrence as the display date. No startTime → `_recurringNoStartTime`: the 💾 ICS button is gated off (no invented times ever exported) and the 🛠 Event Builder link remains. Recurring events stay withheld from calendar writes per the #1562 doctrine.
3. **Registry**: `CUBSCOUT` alias on CubScout LA (title matching needs the full name key; the run showed `0 of 1 matched`).

## Expected on rerun

- **CubScout**: recurrence recognized (🔁 badge, monthly first-Friday), 🪪 registry match fires.
- **The Lumberyard**: its weeklies (Trivia Tuesdays, EXPOSED, the Sunday hangout if extraction carves it) surface as recurring events with derived next-occurrence dates instead of vanishing — exportable via ICS where a time is known, Event Builder otherwise.

Tests **937 → 949**; the literal run evidence is the fixture set. All log/prompt changes additive.

## After merge (updater pull)
Changed runtime files: `parsers/ai-web-parser.js`, `event-schema.js`, `shared-core.js`, `adapters/scriptable-adapter.js`, `scraper-promoters.js`. No new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP