### PR TITLE
feat(tools): Mac/tailnet scraper server — local runs, phone-browser preview, ICS saves via Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "A modern static website for chunky.dad",
   "main": "index.html",
   "scripts": {
-    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/metrics-sections.test.js scripts/event-provenance.test.js scripts/adapters/scriptable-adapter.test.js scripts/promoter-registry.test.js scripts/golden-pipeline.test.js scripts/calendar-contract.test.js scripts/replay-run.test.js",
+    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/metrics-sections.test.js scripts/event-provenance.test.js scripts/adapters/scriptable-adapter.test.js scripts/promoter-registry.test.js scripts/golden-pipeline.test.js scripts/calendar-contract.test.js scripts/replay-run.test.js scripts/tools-serve-results.test.js",
     "start": "python3 -m http.server 8000",
     "serve": "python3 -m http.server 8000",
+    "scraper-server": "node tools/serve-results.js",
     "dev": "python3 -m http.server 8000",
     "update-test-index": "cd testing && node generate-file-list.js",
     "update-test-manifest": "cd testing && node generate-manifest.js",

--- a/scripts/tools-serve-results.test.js
+++ b/scripts/tools-serve-results.test.js
@@ -1,0 +1,331 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// ---------------------------------------------------------------------------
+// Tests for the Mac/tailnet results server's pure helpers
+// (tools/serve-results.js — Node-only, never ships to the phone).
+//
+// The bridge-rewrite tests exercise the REAL Scriptable adapter render, so
+// the same headless stub harness as scripts/adapters/scriptable-adapter.test.js
+// is installed before requiring it. The stubs live only in this test process;
+// the server itself installs them the same way (render side only — pipeline
+// runs happen in a child process with clean globals).
+// ---------------------------------------------------------------------------
+global.importModule = (name) => require(path.join(__dirname, name));
+global.Calendar = { forEvents: async () => [] };
+global.Device = { isUsingDarkAppearance: () => false };
+
+const fileManagerStub = {
+  documentsDirectory: () => '/tmp/chunky-dad-serve-results-test',
+  joinPath: (a, b) => `${a}/${b}`,
+  fileExists: () => false,
+  isDirectory: () => false,
+  createDirectory: () => {},
+  fileName: (filePath) => String(filePath).split('/').pop(),
+  readString: () => null,
+  writeString: () => {},
+  downloadFileFromiCloud: async () => {}
+};
+global.FileManager = {
+  iCloud: () => fileManagerStub,
+  local: () => fileManagerStub
+};
+
+const { ScriptableAdapter } = require('./adapters/scriptable-adapter');
+const { EventSchema } = require('./event-schema');
+
+const {
+  parseRequestUrl,
+  createRunLock,
+  listParserNames,
+  rewriteBridgeHtml,
+  injectHeaderBar,
+  buildEventIcs,
+  tailLines,
+  renderRunFormPage,
+  parsePortFromArgv,
+  lookupIcsEvent,
+  BRIDGE_SHIM_MARKER,
+  HEADER_BAR_MARKER
+} = require('../tools/serve-results');
+
+// ---------------------------------------------------------------------------
+// parseRequestUrl (house-style: no `new URL`/URLSearchParams)
+// ---------------------------------------------------------------------------
+
+test('parseRequestUrl splits path and decodes query params', () => {
+  assert.deepEqual(parseRequestUrl('/run'), { pathname: '/run', query: {} });
+
+  const parsed = parseRequestUrl('/run?parser=Megawoof%20America&x=a+b&flag');
+  assert.equal(parsed.pathname, '/run');
+  assert.equal(parsed.query.parser, 'Megawoof America');
+  assert.equal(parsed.query.x, 'a b');
+  assert.equal(parsed.query.flag, '');
+});
+
+test('parseRequestUrl survives malformed percent-encoding', () => {
+  const parsed = parseRequestUrl('/x?bad=%E0%A4%A');
+  assert.equal(parsed.pathname, '/x');
+  assert.ok('bad' in parsed.query);
+});
+
+// ---------------------------------------------------------------------------
+// Single-flight run lock (409 semantics)
+// ---------------------------------------------------------------------------
+
+test('run lock is single-flight: second acquire fails until release', () => {
+  const lock = createRunLock();
+  assert.equal(lock.isActive(), false);
+
+  const first = lock.tryAcquire({ parser: 'A' });
+  assert.ok(first, 'first acquire succeeds');
+  assert.equal(lock.isActive(), true);
+  assert.equal(lock.current().parser, 'A');
+
+  assert.equal(lock.tryAcquire({ parser: 'B' }), null, 'second acquire is refused');
+  assert.equal(lock.current().parser, 'A', 'active run is unchanged');
+
+  assert.equal(lock.release(), true);
+  assert.equal(lock.isActive(), false);
+  assert.ok(lock.tryAcquire({ parser: 'B' }), 'acquire works again after release');
+  assert.equal(lock.release(), true);
+  assert.equal(lock.release(), false, 'releasing an idle lock reports no-op');
+});
+
+// ---------------------------------------------------------------------------
+// Parser-name extraction from config
+// ---------------------------------------------------------------------------
+
+test('listParserNames extracts named parsers with enabled flags', () => {
+  const names = listParserNames({
+    parsers: [
+      { name: 'One', enabled: true },
+      { name: 'Two', enabled: false },
+      { name: 'Three' }, // enabled defaults true
+      { enabled: true }, // nameless → skipped
+      { name: '   ' } // blank → skipped
+    ]
+  });
+  assert.deepEqual(names, [
+    { name: 'One', enabled: true },
+    { name: 'Two', enabled: false },
+    { name: 'Three', enabled: true }
+  ]);
+  assert.deepEqual(listParserNames(null), []);
+});
+
+test('listParserNames reads the real scraper-input config', () => {
+  const entries = listParserNames(require('./scraper-input'));
+  assert.ok(entries.length > 5, 'real config lists parsers');
+  assert.ok(entries.every((entry) => typeof entry.name === 'string' && entry.name.trim()));
+  assert.ok(entries.some((entry) => entry.name === 'Bearracuda Events'), 'known parser present');
+});
+
+// ---------------------------------------------------------------------------
+// Bridge rewrite — real adapter fragments
+// ---------------------------------------------------------------------------
+
+function buildRecurringEvent() {
+  return {
+    title: 'Bear Happy Hour',
+    _action: 'new',
+    city: 'nola',
+    bar: 'Oak Barrel Saloon',
+    address: '800 Bourbon St, New Orleans, LA',
+    location: '29.9611, -90.0645',
+    startDate: '2026-09-04T21:00:00.000Z',
+    endDate: '2026-09-05T02:00:00.000Z',
+    recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR'
+  };
+}
+
+function buildServerResultsStub() {
+  return {
+    analyzedEvents: [
+      buildRecurringEvent(),
+      { title: 'One-Off Party', _action: 'new', startDate: '2026-08-01T02:00:00.000Z', city: 'nola' }
+    ],
+    discoveredVenueCalendars: [
+      {
+        host: 'www.massive.club',
+        origin: 'https://www.massive.club',
+        suggestedName: 'massive.club',
+        parentTitle: 'BEARRACUDA: LA',
+        droppedCount: 9,
+        sampleTitles: ['Butt Blast (Jul 23)'],
+        parserEntrySnippet: '{ name: "massive.club", enabled: false, urls: ["https://www.massive.club"] },'
+      }
+    ],
+    config: {
+      config: { dryRun: true },
+      parsers: [{ name: 'Fixture', parser: 'ai-web', enabled: true, urls: ['https://fixture.example/'] }]
+    }
+  };
+}
+
+function buildAdapter() {
+  return new ScriptableAdapter({ cities: { nola: { timezone: 'America/Chicago', patterns: ['new orleans'] } } });
+}
+
+test('rewriteBridgeHtml turns real map-verify bridge anchors into plain target=_blank links', () => {
+  const adapter = buildAdapter();
+  adapter.resetMapVerifyUrls();
+  const fragment = adapter.buildMapVerifyLinksHtml({
+    bar: 'Oak Barrel Saloon',
+    city: 'nola',
+    address: '800 Bourbon St, New Orleans, LA',
+    coordinates: '29.9611, -90.0645'
+  });
+  assert.ok(fragment.includes('openMapVerify(this)'), 'real fragment uses the bridge');
+
+  const html = `<html><body>${fragment}</body></html>`;
+  const rewritten = rewriteBridgeHtml(html, { mapVerifyUrls: adapter._mapVerifyUrls });
+
+  assert.ok(!rewritten.includes('onclick="return openMapVerify(this)"'), 'bridge onclick removed');
+  assert.ok(rewritten.includes('target="_blank"'), 'anchors open a new tab');
+  assert.ok(rewritten.includes('rel="noopener noreferrer"'));
+  assert.ok(/href="https:\/\/[^"]+"/.test(rewritten), 'real https URL restored into href');
+  assert.ok(!rewritten.includes('href="#"'), 'no dead placeholder hrefs remain');
+});
+
+test('rewriteBridgeHtml on a full generateRichHTML render removes every chunkyscrape:// and installs the shim', async () => {
+  const adapter = buildAdapter();
+  const results = buildServerResultsStub();
+  const html = await adapter.generateRichHTML(results);
+  assert.ok(html.includes('chunkyscrape://'), 'precondition: raw render uses the bridge');
+  assert.ok(html.includes('data-ics-export-id='), 'precondition: recurring card has an export button');
+
+  const registries = {
+    mapVerifyUrls: adapter._mapVerifyUrls || {},
+    venueSnippets: adapter.collectVenueEntrySnippets(results),
+    activeConfigJson: (adapter.buildActiveConfigSummaryForResults(results) || {}).json || ''
+  };
+  const rewritten = rewriteBridgeHtml(html, registries);
+
+  // The v1 bridge-shim contract, end to end:
+  assert.ok(!rewritten.includes('chunkyscrape://'), 'no chunkyscrape:// left anywhere');
+  assert.ok(rewritten.includes(BRIDGE_SHIM_MARKER), 'shim marker present');
+  // copy → clipboard with non-secure-context fallback
+  assert.ok(rewritten.includes('navigator.clipboard'), 'clipboard API used when secure');
+  assert.ok(rewritten.includes("execCommand('copy')"), 'textarea fallback for plain-HTTP tailnet');
+  assert.ok(rewritten.includes('massive.club'), 'venue snippet payload embedded for browser copy');
+  // export-ics → served /ics/<id> route
+  assert.ok(rewritten.includes("'/ics/' + encodeURIComponent(id)"), 'export button navigates to /ics/<id>');
+  // open-url → plain anchors (event-builder links ride the same registry)
+  assert.ok(rewritten.includes('target="_blank"'), 'bridge links became plain anchors');
+  // mark-bear / queue-venue → phone-only
+  assert.ok(rewritten.includes('phone-only in v1'), 'phone-only buttons labeled');
+  assert.ok(rewritten.includes('.bear-override-btn, .venue-queue-btn'), 'phone-only buttons disabled by selector');
+
+  // Idempotent: rewriting a rewritten page is a no-op.
+  assert.equal(rewriteBridgeHtml(rewritten, registries), rewritten);
+});
+
+test('rewriteBridgeHtml escapes payloads that could break out of the inline script', () => {
+  const rewritten = rewriteBridgeHtml('<html><body></body></html>', {
+    venueSnippets: { 0: 'evil </script><script>alert(1)</script>' },
+    activeConfigJson: '{"a":"</script>"}'
+  });
+  assert.ok(!rewritten.includes('</script><script>alert(1)'), 'payload cannot terminate the shim script');
+  assert.ok(rewritten.includes('\\u003c/script'), 'angle brackets JSON-escaped');
+});
+
+// ---------------------------------------------------------------------------
+// Header bar injection
+// ---------------------------------------------------------------------------
+
+test('injectHeaderBar inserts once after <body> and is idempotent', () => {
+  const html = '<html><head></head><body class="x"><p>results</p></body></html>';
+  const injected = injectHeaderBar(html, { savedAt: '2026-07-28T00:00:00Z', parserFilter: 'Fixture' });
+
+  assert.ok(injected.includes(HEADER_BAR_MARKER));
+  assert.ok(injected.indexOf(HEADER_BAR_MARKER) > injected.indexOf('<body class="x">'), 'bar sits inside body');
+  assert.ok(injected.includes('2026-07-28T00:00:00Z'));
+  assert.ok(injected.includes('parser: Fixture'));
+  assert.ok(injected.includes('href="/run-form"'), 'run button links to the form');
+  assert.ok(/ICS links/.test(injected), 'ICS staleness note present');
+
+  const twice = injectHeaderBar(injected, { savedAt: 'other' });
+  assert.equal(twice, injected, 'second injection is a no-op');
+  assert.equal((twice.match(new RegExp(HEADER_BAR_MARKER, 'g')) || []).length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// ICS building (shared builder from event-schema — untouched by the server)
+// ---------------------------------------------------------------------------
+
+const CITIES = { nola: { timezone: 'America/Chicago' } };
+
+test('buildEventIcs exports a one-off event without any RRULE', () => {
+  const built = buildEventIcs(
+    { title: 'One-Off Party', city: 'nola', startDate: '2026-08-01T02:00:00.000Z' },
+    CITIES,
+    EventSchema
+  );
+  assert.ok(built, 'builder returns a payload');
+  assert.ok(built.icsText.startsWith('BEGIN:VCALENDAR'));
+  assert.ok(built.icsText.includes('BEGIN:VEVENT'));
+  assert.ok(!built.icsText.includes('RRULE'), 'no recurrence → no RRULE line');
+  assert.ok(built.icsText.includes('DTSTART;TZID=America/Chicago'), 'city timezone applied');
+  assert.equal(built.fileName, 'one-off-party.ics');
+});
+
+test('buildEventIcs keeps the RRULE for recurring events and falls back to UTC for unknown cities', () => {
+  const built = buildEventIcs(buildRecurringEvent(), {}, EventSchema);
+  assert.ok(built.icsText.includes('RRULE:FREQ=WEEKLY;BYDAY=FR'));
+  // Unknown city → UTC (mirrors the adapter's getTimezoneForCityOrUtc fallback)
+  assert.ok(/DTSTART;TZID=UTC:\d{8}T\d{6}/.test(built.icsText), 'UTC fallback timestamps');
+});
+
+test('buildEventIcs returns null for junk input', () => {
+  assert.equal(buildEventIcs(null, CITIES, EventSchema), null);
+  assert.equal(buildEventIcs({ title: 'x' }, CITIES, null), null);
+});
+
+// ---------------------------------------------------------------------------
+// ICS route lookup: per-render registry first, analyzedEvents fallback
+// ---------------------------------------------------------------------------
+
+test('lookupIcsEvent prefers the render registry and falls back to analyzedEvents by index', () => {
+  const registryEvent = buildRecurringEvent();
+  const state = {
+    icsRegistry: { 0: registryEvent },
+    lastRenderResults: { analyzedEvents: [{ title: 'Fallback A' }, { title: 'Fallback B' }] }
+  };
+  assert.equal(lookupIcsEvent(state, '0'), registryEvent, 'registry id wins');
+  assert.equal(lookupIcsEvent(state, '1').title, 'Fallback B', 'numeric fallback to analyzedEvents');
+  assert.equal(lookupIcsEvent(state, '99'), null);
+  assert.equal(lookupIcsEvent(state, 'nope'), null);
+});
+
+// ---------------------------------------------------------------------------
+// Small pages + argv parsing
+// ---------------------------------------------------------------------------
+
+test('renderRunFormPage lists parsers escaped and posts to /run', () => {
+  const html = renderRunFormPage(
+    [{ name: 'A & B <Bears>', enabled: true }, { name: 'Off', enabled: false }],
+    { hasRun: false }
+  );
+  assert.ok(html.includes('method="POST"'));
+  assert.ok(html.includes('action="/run"'));
+  assert.ok(html.includes('A &amp; B &lt;Bears&gt;'), 'names HTML-escaped');
+  assert.ok(html.includes('(disabled in config)'));
+  assert.ok(html.includes('report-only'), 'dry-run promise stated');
+});
+
+test('parsePortFromArgv reads both flag styles and defaults to 8734', () => {
+  assert.equal(parsePortFromArgv([]), 8734);
+  assert.equal(parsePortFromArgv(['--port', '9001']), 9001);
+  assert.equal(parsePortFromArgv(['--port=9002']), 9002);
+  assert.equal(parsePortFromArgv(['--port', 'bogus']), 8734);
+});
+
+test('tailLines keeps only the last N lines', () => {
+  const text = Array.from({ length: 600 }, (_, i) => `line ${i}`).join('\n');
+  const tail = tailLines(text, 500);
+  assert.equal(tail.split('\n').length, 500);
+  assert.ok(tail.startsWith('line 100'));
+  assert.ok(tail.endsWith('line 599'));
+});

--- a/tools/run-once.js
+++ b/tools/run-once.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// ============================================================================
+// RUN-ONCE PIPELINE RUNNER (Node-only; never ships to the phone)
+// ============================================================================
+// Child-process entry point used by tools/serve-results.js: drives the real
+// scraper pipeline programmatically (the same orchestrator `node
+// scripts/bear-event-scraper-unified.js` runs) and persists the results JSON
+// so the parent server can render them with the Scriptable results UI.
+//
+// Design constraints honored here:
+// - scripts/scraper-input.js and the shared scripts/ files are NEVER edited.
+//   Configuration injection happens by wrapping WebAdapter.prototype
+//   .loadConfiguration in THIS process only (require-cache shared with the
+//   orchestrator's own require of web-adapter).
+// - dryRun is FORCED on: v1 of the server is report-only, no calendar writes.
+// - This file must be run in a CHILD process, never required by the server:
+//   the orchestrator/pipeline expects clean globals (no Scriptable stubs),
+//   and the server parent installs Scriptable stubs for rendering.
+//
+// Env contract (all optional):
+//   CHUNKY_RUN_PARSER    — run only the parser with this exact name
+//   CHUNKY_RUN_OUT       — output JSON path
+//                          (default ~/.chunky-dad-scraper/server/latest-run.json)
+//   CHUNKY_RUN_OVERRIDES — JSON deep-merged into the loaded config AFTER the
+//                          dryRun/parser-filter safety overrides (objects merge
+//                          key-wise, arrays/scalars replace). Used by the smoke
+//                          test to point parsers/AI at local fixture servers.
+//                          NOTE: config.config.dryRun is re-forced to true
+//                          after the merge — overrides cannot disable it.
+// ============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+// Plain-object deep merge: objects merge key-wise, arrays and scalars replace.
+function deepMergeInto(target, source) {
+    if (!source || typeof source !== 'object' || Array.isArray(source)) {
+        return target;
+    }
+    for (const [key, value] of Object.entries(source)) {
+        const existing = target[key];
+        if (
+            value && typeof value === 'object' && !Array.isArray(value) &&
+            existing && typeof existing === 'object' && !Array.isArray(existing)
+        ) {
+            deepMergeInto(existing, value);
+        } else {
+            target[key] = value;
+        }
+    }
+    return target;
+}
+
+// Circular-safe JSON.stringify (results objects are large and occasionally
+// self-referential; a dropped "[Circular]" branch beats a crashed dump).
+function safeStringify(value) {
+    const seen = new WeakSet();
+    return JSON.stringify(value, (key, val) => {
+        if (val && typeof val === 'object') {
+            if (seen.has(val)) return '[Circular]';
+            seen.add(val);
+        }
+        return val;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Config injection: wrap the Node loadConfiguration path. The orchestrator's
+// own `require('./adapters/web-adapter')` returns this same patched module.
+// ---------------------------------------------------------------------------
+const { WebAdapter } = require(path.join(repoRoot, 'scripts', 'adapters', 'web-adapter'));
+const originalLoadConfiguration = WebAdapter.prototype.loadConfiguration;
+
+WebAdapter.prototype.loadConfiguration = async function patchedLoadConfiguration(...args) {
+    const config = await originalLoadConfiguration.apply(this, args);
+    config.config = config.config || {};
+
+    // Test/smoke overrides FIRST (fixture URLs, stub AI endpoint, cache
+    // toggles) — they may replace the parsers array, and the parser filter
+    // below must see the final list.
+    const overridesRaw = String(process.env.CHUNKY_RUN_OVERRIDES || '').trim();
+    if (overridesRaw) {
+        deepMergeInto(config, JSON.parse(overridesRaw));
+    }
+
+    // Parser filter: run exactly the named parser (even if disabled in the
+    // checked-in config — picking it in the UI is an explicit request).
+    const parserFilter = String(process.env.CHUNKY_RUN_PARSER || '').trim();
+    if (parserFilter && Array.isArray(config.parsers)) {
+        config.parsers = config.parsers.map((parser) => ({
+            ...parser,
+            enabled: parser && parser.name === parserFilter
+        }));
+        const matched = config.parsers.some((parser) => parser.enabled);
+        if (!matched) {
+            throw new Error(`run-once: no parser named "${parserFilter}" in the configuration`);
+        }
+    }
+
+    // SAFETY LAST: v1 server runs are report-only, no calendar writes —
+    // forced after the override merge so nothing can switch it back off.
+    config.config.dryRun = true;
+
+    return config;
+};
+
+// Safe to require AFTER the patch above: the orchestrator only auto-executes
+// when it is the require.main module (here, run-once.js is).
+const { BearEventScraperOrchestrator } = require(
+    path.join(repoRoot, 'scripts', 'bear-event-scraper-unified')
+);
+
+(async () => {
+    const startedAt = new Date().toISOString();
+    const parserFilter = String(process.env.CHUNKY_RUN_PARSER || '').trim();
+    console.log(`run-once: starting pipeline (dryRun forced)${parserFilter ? ` — parser filter: ${parserFilter}` : ''}`);
+
+    const orchestrator = new BearEventScraperOrchestrator();
+    const results = await orchestrator.run();
+
+    const outPath = process.env.CHUNKY_RUN_OUT ||
+        path.join(os.homedir(), '.chunky-dad-scraper', 'server', 'latest-run.json');
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+
+    const payload = {
+        savedAt: new Date().toISOString(),
+        startedAt,
+        parserFilter,
+        results
+    };
+    // Write-then-rename so the parent never reads a half-written dump.
+    const tmpPath = `${outPath}.tmp`;
+    fs.writeFileSync(tmpPath, safeStringify(payload));
+    fs.renameSync(tmpPath, outPath);
+    console.log(`run-once: results written to ${outPath}`);
+})().catch((error) => {
+    console.error(`run-once: pipeline failed: ${error && error.stack ? error.stack : error}`);
+    process.exitCode = 1;
+});

--- a/tools/serve-results.js
+++ b/tools/serve-results.js
@@ -1,0 +1,674 @@
+#!/usr/bin/env node
+// ============================================================================
+// MAC/TAILNET RESULTS SERVER (Node-only; lives in tools/ so it NEVER ships to
+// the phone — nothing under scripts/ may depend on this file)
+// ============================================================================
+// v1 of the "run the scraper from the couch" server:
+//
+//   RUN in a child process — POST /run spawns `node tools/run-once.js`, which
+//   drives the real orchestrator with clean globals (the orchestrator sniffs
+//   `typeof importModule` at require time, so the pipeline must never see the
+//   Scriptable stubs this parent installs for rendering) and dumps results
+//   JSON to ~/.chunky-dad-scraper/server/latest-run.json. dryRun is FORCED —
+//   v1 is report-only.
+//
+//   RENDER in the parent — GET / loads the latest results dump, installs the
+//   ~25-line Scriptable global stubs (same pattern as
+//   scripts/adapters/scriptable-adapter.test.js), requires the untouched
+//   scriptable-adapter, and calls generateRichHTML(results) to get the real
+//   results UI. The chunkyscrape:// webview→native bridge dead-ends in a
+//   browser, so the rendered HTML is post-processed (rewriteBridgeHtml):
+//     copy buttons   → navigator.clipboard with a textarea/execCommand
+//                      fallback (plain-HTTP tailnet = non-secure context)
+//     open-url links → plain <a target="_blank"> with the real URL
+//     export-ics     → navigates to /ics/<id> (served below)
+//     mark-bear / queue-venue → disabled, title "phone-only in v1"
+//
+// Endpoints: GET / (results or run form) · GET/POST /run · GET /run-form ·
+// GET /log · GET /ics/<id>
+//
+// House style: no `new URL` / URLSearchParams anywhere (matches the iOS-shared
+// scripts even though this file is Node-only). Pure helpers are exported for
+// scripts/tools-serve-results.test.js.
+// ============================================================================
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const http = require('http');
+const { spawn } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const serverDir = path.join(os.homedir(), '.chunky-dad-scraper', 'server');
+const latestRunPath = path.join(serverDir, 'latest-run.json');
+
+const DEFAULT_PORT = 8734;
+const LOG_TAIL_LINES = 500;
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+// Minimal request-URL parser — path + query map — built with split/
+// decodeURIComponent only (house style: no `new URL`, no URLSearchParams).
+function parseRequestUrl(rawUrl) {
+    const url = String(rawUrl || '');
+    const queryIndex = url.indexOf('?');
+    const pathname = queryIndex === -1 ? url : url.slice(0, queryIndex);
+    const query = {};
+    if (queryIndex !== -1) {
+        const pairs = url.slice(queryIndex + 1).split('&');
+        for (const pair of pairs) {
+            if (!pair) continue;
+            const eqIndex = pair.indexOf('=');
+            const rawKey = eqIndex === -1 ? pair : pair.slice(0, eqIndex);
+            const rawValue = eqIndex === -1 ? '' : pair.slice(eqIndex + 1);
+            try {
+                query[decodeURIComponent(rawKey)] = decodeURIComponent(rawValue.replace(/\+/g, ' '));
+            } catch (error) {
+                query[rawKey] = rawValue;
+            }
+        }
+    }
+    return { pathname, query };
+}
+
+// Single-flight run lock: one pipeline run at a time; a second acquire fails
+// (the server answers 409). Pure state machine so tests can drive it.
+function createRunLock() {
+    let active = null;
+    return {
+        tryAcquire(meta = {}) {
+            if (active) return null;
+            active = { startedAt: new Date().toISOString(), ...meta };
+            return active;
+        },
+        release() {
+            const wasActive = active !== null;
+            active = null;
+            return wasActive;
+        },
+        isActive() {
+            return active !== null;
+        },
+        current() {
+            return active;
+        }
+    };
+}
+
+// Parser names from a scraper-input-shaped config ({ parsers: [{name, enabled}] }).
+function listParserNames(config) {
+    const parsers = config && Array.isArray(config.parsers) ? config.parsers : [];
+    return parsers
+        .filter((parser) => parser && typeof parser.name === 'string' && parser.name.trim())
+        .map((parser) => ({ name: parser.name, enabled: parser.enabled !== false }));
+}
+
+function escapeHtmlText(value) {
+    return String(value == null ? '' : value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+// JSON destined for an inline <script> — escape `<` so `</script>` in payload
+// text can never terminate the block.
+function jsonForInlineScript(value) {
+    return JSON.stringify(value == null ? null : value).replace(/</g, '\\u003c');
+}
+
+const BRIDGE_SHIM_MARKER = 'chunky-server-bridge-shim';
+
+// ---------------------------------------------------------------------------
+// Bridge rewrite: adapt the chunkyscrape:// webview→native handlers for a
+// plain browser over the tailnet. Registries come from the adapter instance
+// right after generateRichHTML (same per-render maps native reads on-device).
+//   registries = {
+//     mapVerifyUrls:   { id → real https URL }   (open-url bridge)
+//     venueSnippets:   { index → parser entry }  (copy-venue bridge)
+//     activeConfigJson: string                   (copy-config bridge)
+//   }
+// ---------------------------------------------------------------------------
+function rewriteBridgeHtml(html, registries = {}) {
+    let out = String(html || '');
+    if (out.includes(BRIDGE_SHIM_MARKER)) {
+        return out; // idempotent: already rewritten
+    }
+    const mapVerifyUrls = registries.mapVerifyUrls && typeof registries.mapVerifyUrls === 'object'
+        ? registries.mapVerifyUrls
+        : {};
+    const venueSnippets = registries.venueSnippets && typeof registries.venueSnippets === 'object'
+        ? registries.venueSnippets
+        : {};
+    const activeConfigJson = typeof registries.activeConfigJson === 'string'
+        ? registries.activeConfigJson
+        : '';
+
+    // 1) open-url → plain anchors: swap the bridge onclick for the real URL
+    //    from the per-render registry, opening in a new tab.
+    out = out.replace(
+        /href="#" onclick="return openMapVerify\(this\)" data-map-url-id="([^"]*)"/g,
+        (match, id) => {
+            const realUrl = mapVerifyUrls[id];
+            if (typeof realUrl !== 'string' || !realUrl) {
+                return `href="#" data-map-url-id="${id}"`;
+            }
+            return `href="${escapeHtmlText(realUrl)}" target="_blank" rel="noopener noreferrer" data-map-url-id="${id}"`;
+        }
+    );
+
+    // 2) Neutralize every literal chunkyscrape:// left in the original page
+    //    scripts. The handlers are also redefined below, so this is belt and
+    //    suspenders: even a missed call path can only hit an inert scheme.
+    out = out.split('chunkyscrape://').join('bridge-disabled://');
+
+    // 3) Append the shim script: later function declarations override the
+    //    originals for every subsequent onclick dispatch.
+    const shim = `
+<!-- ${BRIDGE_SHIM_MARKER} -->
+<script>
+(function () {
+    window.__serverBridgeData = {
+        venueSnippets: ${jsonForInlineScript(venueSnippets)},
+        activeConfigJson: ${jsonForInlineScript(activeConfigJson)}
+    };
+})();
+// Clipboard with non-secure-context fallback: navigator.clipboard only exists
+// on HTTPS/localhost, and this page is usually plain HTTP on the tailnet —
+// so fall back to a hidden textarea + document.execCommand('copy').
+function serverCopyText(text, done) {
+    function finish(ok) { if (typeof done === 'function') done(ok); }
+    if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(text).then(function () { finish(true); }, function () { fallback(); });
+        return;
+    }
+    fallback();
+    function fallback() {
+        try {
+            var area = document.createElement('textarea');
+            area.value = text;
+            area.setAttribute('readonly', '');
+            area.style.position = 'fixed';
+            area.style.left = '-9999px';
+            document.body.appendChild(area);
+            area.select();
+            var ok = document.execCommand('copy');
+            document.body.removeChild(area);
+            finish(ok);
+        } catch (error) {
+            finish(false);
+        }
+    }
+}
+// copy-venue: snippet text is injected server-side (native kept it in a
+// Pasteboard registry; the browser gets the same map inline).
+function copyVenueEntry(btn) {
+    var idx = btn ? (btn.getAttribute('data-venue-index') || '') : '';
+    var snippet = window.__serverBridgeData.venueSnippets[idx];
+    if (typeof snippet !== 'string' || !snippet) return;
+    serverCopyText(snippet, function (ok) {
+        if (ok && typeof markVenueEntryCopied === 'function') markVenueEntryCopied(idx);
+        if (!ok) window.prompt('Copy manually (clipboard needs HTTPS — try tailscale serve):', snippet);
+    });
+}
+// copy-config: same story with the redacted effective-config JSON.
+function copyActiveConfig(btn) {
+    var json = window.__serverBridgeData.activeConfigJson;
+    if (typeof json !== 'string' || !json) return;
+    serverCopyText(json, function (ok) {
+        if (ok && typeof markConfigCopied === 'function') markConfigCopied();
+        if (!ok) window.prompt('Copy manually (clipboard needs HTTPS — try tailscale serve):', json);
+    });
+}
+// export-ics: native built the ICS and opened DocumentPicker; the browser
+// just downloads it from the server's per-render registry.
+function exportRecurringIcs(btn) {
+    var id = btn ? (btn.getAttribute('data-ics-export-id') || '') : '';
+    if (id === '') return;
+    window.location.href = '/ics/' + encodeURIComponent(id);
+}
+// mark-bear / queue-venue write to on-device state (calendar overrides, the
+// gathering-only venue queue) — phone-only in v1, so the buttons go inert.
+function markBearOverride() {}
+function queueVenueCandidate() {}
+(function disablePhoneOnlyButtons() {
+    var buttons = document.querySelectorAll('.bear-override-btn, .venue-queue-btn');
+    for (var i = 0; i < buttons.length; i++) {
+        buttons[i].disabled = true;
+        buttons[i].title = 'phone-only in v1';
+    }
+})();
+</script>`;
+
+    const bodyCloseIndex = out.lastIndexOf('</body>');
+    if (bodyCloseIndex === -1) {
+        return out + shim;
+    }
+    return out.slice(0, bodyCloseIndex) + shim + out.slice(bodyCloseIndex);
+}
+
+const HEADER_BAR_MARKER = 'chunky-server-header-bar';
+
+// Small server header bar injected right after <body>. Idempotent: a page
+// that already carries the marker is returned unchanged.
+function injectHeaderBar(html, info = {}) {
+    let out = String(html || '');
+    if (out.includes(HEADER_BAR_MARKER)) {
+        return out;
+    }
+    const runLabel = info.savedAt
+        ? `Run saved ${escapeHtmlText(info.savedAt)}`
+        : 'No run metadata';
+    const parserLabel = info.parserFilter
+        ? ` · parser: ${escapeHtmlText(info.parserFilter)}`
+        : ' · all enabled parsers';
+    const bar = `
+<div id="${HEADER_BAR_MARKER}" style="position:sticky; top:0; z-index:9999; display:flex; gap:14px; align-items:center; flex-wrap:wrap; padding:8px 14px; background:#1c1c1e; color:#f2f2f7; font:13px -apple-system, sans-serif; border-bottom:2px solid #ff6b35;">
+    <span style="font-weight:700;">chunky.dad scraper server</span>
+    <span>${runLabel}${parserLabel}</span>
+    <a href="/run-form" style="color:#ffd60a; font-weight:600; text-decoration:none;">▶ Run scraper</a>
+    <a href="/log" style="color:#ffd60a; text-decoration:none;">Log</a>
+    <span style="opacity:0.7;">ICS links belong to this render — after a new run, reload before saving events.</span>
+</div>`;
+    const bodyMatch = out.match(/<body[^>]*>/i);
+    if (!bodyMatch) {
+        return bar + out;
+    }
+    const insertAt = bodyMatch.index + bodyMatch[0].length;
+    return out.slice(0, insertAt) + bar + out.slice(insertAt);
+}
+
+// Per-event ICS via the shared builder (scripts/event-schema.js — untouched:
+// buildRecurringEventIcs already omits RRULE when the event has no
+// recurrence rule, so one-off events export as plain single VEVENTs).
+function buildEventIcs(event, cities, eventSchema) {
+    if (!event || typeof event !== 'object' || !eventSchema) return null;
+    const cityConfig = cities && event.city ? cities[event.city] : null;
+    const timezone = (cityConfig && cityConfig.timezone) || event.timezone || 'UTC';
+    const icsText = eventSchema.buildRecurringEventIcs(event, { timezone });
+    if (!icsText) return null;
+    const slug = typeof eventSchema.slugifyIcsText === 'function'
+        ? eventSchema.slugifyIcsText(event.title || event.name || '')
+        : '';
+    return { icsText, fileName: `${slug || 'chunky-dad-event'}.ics` };
+}
+
+// Last N lines of a (possibly large) log text.
+function tailLines(text, maxLines = LOG_TAIL_LINES) {
+    const lines = String(text || '').split('\n');
+    return lines.slice(Math.max(0, lines.length - maxLines)).join('\n');
+}
+
+// Minimal run-form page: parser dropdown + POST /run.
+function renderRunFormPage(parserEntries, options = {}) {
+    const entries = Array.isArray(parserEntries) ? parserEntries : [];
+    const optionsHtml = ['<option value="">All enabled parsers</option>']
+        .concat(entries.map((entry) => {
+            const name = escapeHtmlText(entry.name);
+            const suffix = entry.enabled ? '' : ' (disabled in config)';
+            return `<option value="${name}">${name}${suffix}</option>`;
+        }))
+        .join('\n');
+    const notice = options.notice
+        ? `<p style="color:#b25000; font-weight:600;">${escapeHtmlText(options.notice)}</p>`
+        : '';
+    const hasRun = options.hasRun
+        ? '<p><a href="/">← Back to latest results</a></p>'
+        : '<p>No results yet — run the scraper to render the results UI here.</p>';
+    return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>chunky.dad scraper server</title></head>
+<body style="font:15px -apple-system, sans-serif; max-width:640px; margin:40px auto; padding:0 16px;">
+<h1>🐻 chunky.dad scraper server</h1>
+${notice}
+<p>Runs are <strong>report-only</strong> (dryRun forced) in v1 — no calendar writes.</p>
+<form method="POST" action="/run">
+    <label>Parser: <select name="parser">${optionsHtml}</select></label>
+    <button type="submit" style="margin-left:10px; padding:6px 18px; font-weight:700;">Run scraper</button>
+</form>
+${hasRun}
+<p><a href="/log">View latest run log</a></p>
+</body></html>`;
+}
+
+// GET /run browser-convenience confirm page (never runs on GET).
+function renderConfirmRunPage(parserName) {
+    const label = parserName ? `parser <strong>${escapeHtmlText(parserName)}</strong>` : 'all enabled parsers';
+    const hiddenValue = escapeHtmlText(parserName || '');
+    return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Confirm run</title></head>
+<body style="font:15px -apple-system, sans-serif; max-width:640px; margin:40px auto; padding:0 16px;">
+<h1>Start a scraper run?</h1>
+<p>This will run ${label} (report-only, dryRun forced).</p>
+<form method="POST" action="/run">
+    <input type="hidden" name="parser" value="${hiddenValue}">
+    <button type="submit" style="padding:6px 18px; font-weight:700;">Yes, run now</button>
+    <a href="/" style="margin-left:14px;">Cancel</a>
+</form>
+</body></html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Server internals (not exercised by unit tests; smoke-tested live)
+// ---------------------------------------------------------------------------
+
+// Scriptable global stubs — the same ~25-line harness the adapter unit tests
+// use (scripts/adapters/scriptable-adapter.test.js). Installed ONCE in this
+// parent process, and ONLY here: the pipeline always runs in a child process
+// with clean globals, so the orchestrator's `typeof importModule` environment
+// sniffing never sees these.
+let scriptableAdapterModule = null;
+function requireScriptableAdapterWithStubs() {
+    if (scriptableAdapterModule) return scriptableAdapterModule;
+    global.importModule = (name) => require(path.join(repoRoot, 'scripts', name));
+    global.Calendar = { forEvents: async () => [] };
+    global.Device = { isUsingDarkAppearance: () => false };
+    const fileManagerStub = {
+        documentsDirectory: () => path.join(os.tmpdir(), 'chunky-dad-server-render'),
+        joinPath: (a, b) => `${a}/${b}`,
+        fileExists: () => false,
+        isDirectory: () => false,
+        createDirectory: () => {},
+        fileName: (filePath) => String(filePath).split('/').pop(),
+        readString: () => null,
+        writeString: () => {},
+        downloadFileFromiCloud: async () => {}
+    };
+    global.FileManager = {
+        iCloud: () => fileManagerStub,
+        local: () => fileManagerStub
+    };
+    scriptableAdapterModule = require(path.join(repoRoot, 'scripts', 'adapters', 'scriptable-adapter'));
+    return scriptableAdapterModule;
+}
+
+function loadEventSchema() {
+    return require(path.join(repoRoot, 'scripts', 'event-schema')).EventSchema;
+}
+
+// Fresh parser list straight from the checked-in config (cache-busted so a
+// config edit between runs shows up without restarting the server).
+function loadParserEntries() {
+    const configPath = path.join(repoRoot, 'scripts', 'scraper-input.js');
+    delete require.cache[require.resolve(configPath)];
+    return listParserNames(require(configPath));
+}
+
+function loadLatestRun() {
+    try {
+        const raw = fs.readFileSync(latestRunPath, 'utf8');
+        return JSON.parse(raw);
+    } catch (error) {
+        return null;
+    }
+}
+
+function findLatestLogPath() {
+    try {
+        const files = fs.readdirSync(serverDir)
+            .filter((name) => /^run-.*\.log$/.test(name))
+            .sort();
+        if (files.length === 0) return null;
+        return path.join(serverDir, files[files.length - 1]);
+    } catch (error) {
+        return null;
+    }
+}
+
+function createServerState() {
+    return {
+        lock: createRunLock(),
+        icsRegistry: {}, // id → event, captured from the adapter per render
+        lastRenderResults: null
+    };
+}
+
+// Render the latest run through the real Scriptable results UI, then adapt
+// the bridge for browsers. Also refreshes the server-side ICS registry so
+// /ics/<id> ids always match the ids embedded in the served page.
+async function renderLatestResults(state, saved) {
+    const { ScriptableAdapter } = requireScriptableAdapterWithStubs();
+    const results = saved.results || {};
+    const cities = (results.config && results.config.cities) || {};
+    const adapter = new ScriptableAdapter({ cities });
+    const html = await adapter.generateRichHTML(results);
+    const registries = {
+        mapVerifyUrls: adapter._mapVerifyUrls || {},
+        venueSnippets: typeof adapter.collectVenueEntrySnippets === 'function'
+            ? adapter.collectVenueEntrySnippets(results)
+            : {},
+        activeConfigJson: (() => {
+            const summary = typeof adapter.buildActiveConfigSummaryForResults === 'function'
+                ? adapter.buildActiveConfigSummaryForResults(results)
+                : null;
+            return summary && typeof summary.json === 'string' ? summary.json : '';
+        })()
+    };
+    state.icsRegistry = adapter._icsExportEvents || {};
+    state.lastRenderResults = results;
+    let out = rewriteBridgeHtml(html, registries);
+    out = injectHeaderBar(out, {
+        savedAt: saved.savedAt || '',
+        parserFilter: saved.parserFilter || ''
+    });
+    return out;
+}
+
+// /ics/<id>: the per-render recurring-export registry first (ids embedded in
+// the served page), then analyzedEvents[<id>] as a numeric fallback so every
+// event in the latest run is exportable, recurring or not.
+function lookupIcsEvent(state, id) {
+    if (state.icsRegistry && state.icsRegistry[id]) {
+        return state.icsRegistry[id];
+    }
+    const results = state.lastRenderResults || (loadLatestRun() || {}).results || {};
+    const analyzed = Array.isArray(results.analyzedEvents) ? results.analyzedEvents : [];
+    const index = /^\d+$/.test(id) ? Number(id) : -1;
+    if (index >= 0 && index < analyzed.length) {
+        return analyzed[index];
+    }
+    return null;
+}
+
+function readRequestBody(req) {
+    return new Promise((resolve) => {
+        let body = '';
+        req.on('data', (chunk) => {
+            body += chunk;
+            if (body.length > 1024 * 1024) req.destroy();
+        });
+        req.on('end', () => resolve(body));
+        req.on('error', () => resolve(''));
+    });
+}
+
+function sendHtml(res, status, html) {
+    res.writeHead(status, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(html);
+}
+
+function sendText(res, status, text) {
+    res.writeHead(status, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end(text);
+}
+
+// Spawn the pipeline child (RUN side of the run/render split). stdout+stderr
+// stream into a timestamped log under ~/.chunky-dad-scraper/server/.
+function startRun(state, parserName, extraEnv = {}) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const logPath = path.join(serverDir, `run-${stamp}.log`);
+    const logStream = fs.createWriteStream(logPath);
+    const child = spawn(process.execPath, [path.join(repoRoot, 'tools', 'run-once.js')], {
+        cwd: repoRoot,
+        env: {
+            ...process.env,
+            ...extraEnv,
+            CHUNKY_RUN_PARSER: parserName || '',
+            CHUNKY_RUN_OUT: latestRunPath
+        },
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+    child.stdout.pipe(logStream);
+    child.stderr.pipe(logStream, { end: false });
+    child.on('close', (code) => {
+        logStream.end(`\nrun-once exited with code ${code}\n`);
+        console.log(`Run finished (exit ${code}) — log: ${logPath}`);
+        state.lock.release();
+    });
+    child.on('error', (error) => {
+        logStream.end(`\nrun-once spawn failed: ${error.message}\n`);
+        state.lock.release();
+    });
+    return { child, logPath };
+}
+
+async function handleRequest(state, req, res) {
+    const { pathname, query } = parseRequestUrl(req.url);
+
+    if (pathname === '/' && req.method === 'GET') {
+        const saved = loadLatestRun();
+        if (!saved) {
+            return sendHtml(res, 200, renderRunFormPage(loadParserEntries(), {
+                hasRun: false,
+                notice: state.lock.isActive() ? 'A run is currently in progress — refresh in a bit.' : ''
+            }));
+        }
+        try {
+            const html = await renderLatestResults(state, saved);
+            return sendHtml(res, 200, html);
+        } catch (error) {
+            console.error(`Render failed: ${error.stack || error}`);
+            return sendText(res, 500, `Render failed: ${error.message}`);
+        }
+    }
+
+    if (pathname === '/run-form' && req.method === 'GET') {
+        return sendHtml(res, 200, renderRunFormPage(loadParserEntries(), {
+            hasRun: Boolean(loadLatestRun()),
+            notice: state.lock.isActive() ? 'A run is currently in progress.' : ''
+        }));
+    }
+
+    if (pathname === '/run') {
+        if (req.method === 'GET') {
+            // Browser convenience: never trigger on GET, show a confirm form.
+            return sendHtml(res, 200, renderConfirmRunPage(query.parser || ''));
+        }
+        if (req.method === 'POST') {
+            const body = await readRequestBody(req);
+            const bodyParams = parseRequestUrl(`?${body}`).query;
+            const parserName = (query.parser || bodyParams.parser || '').trim();
+            const acquired = state.lock.tryAcquire({ parser: parserName || '(all)' });
+            if (!acquired) {
+                return sendText(res, 409, `A run is already active (started ${state.lock.current().startedAt}). Try again when it finishes — watch /log.`);
+            }
+            const { logPath } = startRun(state, parserName);
+            console.log(`Run started (parser: ${parserName || 'all enabled'}) — log: ${logPath}`);
+            return sendHtml(res, 202, `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Run started</title></head>
+<body style="font:15px -apple-system, sans-serif; max-width:640px; margin:40px auto; padding:0 16px;">
+<h1>Run started</h1>
+<p>Parser: ${escapeHtmlText(parserName || 'all enabled parsers')} (report-only).</p>
+<p><a href="/log">Watch the log</a> · <a href="/">Results (reload when the run finishes)</a></p>
+</body></html>`);
+        }
+    }
+
+    if (pathname === '/log' && req.method === 'GET') {
+        const logPath = findLatestLogPath();
+        if (!logPath) {
+            return sendText(res, 404, 'No run log yet.');
+        }
+        try {
+            const text = fs.readFileSync(logPath, 'utf8');
+            return sendText(res, 200, `# ${logPath} (last ${LOG_TAIL_LINES} lines)\n${tailLines(text)}`);
+        } catch (error) {
+            return sendText(res, 500, `Could not read log: ${error.message}`);
+        }
+    }
+
+    if (pathname.startsWith('/ics/') && req.method === 'GET') {
+        const id = pathname.slice('/ics/'.length);
+        const event = lookupIcsEvent(state, id);
+        if (!event) {
+            return sendText(res, 404, `No event with ICS id "${id}" in the latest render.`);
+        }
+        const results = state.lastRenderResults || (loadLatestRun() || {}).results || {};
+        const cities = (results.config && results.config.cities) || {};
+        const built = buildEventIcs(event, cities, loadEventSchema());
+        if (!built) {
+            return sendText(res, 500, 'ICS build failed for that event.');
+        }
+        res.writeHead(200, {
+            'Content-Type': 'text/calendar; charset=utf-8',
+            'Content-Disposition': `attachment; filename="${built.fileName}"`
+        });
+        return res.end(built.icsText);
+    }
+
+    return sendText(res, 404, 'Not found. Endpoints: / /run /run-form /log /ics/<id>');
+}
+
+function parsePortFromArgv(argv) {
+    const args = Array.isArray(argv) ? argv : [];
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--port' && args[i + 1]) {
+            const parsed = Number(args[i + 1]);
+            if (Number.isFinite(parsed) && parsed > 0) return parsed;
+        }
+        const match = /^--port=(\d+)$/.exec(args[i]);
+        if (match) return Number(match[1]);
+    }
+    return DEFAULT_PORT;
+}
+
+function startServer(port = DEFAULT_PORT) {
+    fs.mkdirSync(serverDir, { recursive: true });
+    const state = createServerState();
+    const server = http.createServer((req, res) => {
+        handleRequest(state, req, res).catch((error) => {
+            console.error(`Request failed: ${error.stack || error}`);
+            try {
+                sendText(res, 500, `Server error: ${error.message}`);
+            } catch (ignore) { /* response already gone */ }
+        });
+    });
+    server.listen(port, '0.0.0.0', () => {
+        const hostname = os.hostname().replace(/\.local$/, '');
+        console.log('chunky.dad scraper server (v1, report-only)');
+        console.log(`  Local:    http://localhost:${port}/`);
+        console.log(`  Tailnet:  http://${hostname}:${port}/  (MagicDNS name if this Mac is on your tailnet)`);
+        console.log('  Clipboard copy buttons need a secure context — for HTTPS on the tailnet run:');
+        console.log(`    tailscale serve --bg ${port}`);
+        console.log(`  Results dump + run logs: ${serverDir}`);
+    });
+    return { server, state };
+}
+
+module.exports = {
+    DEFAULT_PORT,
+    BRIDGE_SHIM_MARKER,
+    HEADER_BAR_MARKER,
+    parseRequestUrl,
+    createRunLock,
+    listParserNames,
+    escapeHtmlText,
+    jsonForInlineScript,
+    rewriteBridgeHtml,
+    injectHeaderBar,
+    buildEventIcs,
+    tailLines,
+    renderRunFormPage,
+    renderConfirmRunPage,
+    parsePortFromArgv,
+    lookupIcsEvent,
+    startServer
+};
+
+if (require.main === module) {
+    startServer(parsePortFromArgv(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Your idea, v1

Run the scraper on the Mac; open results on your phone over Tailscale.

```
npm run scraper-server        # on the Mac
http://<mac>.taila7523c.ts.net:8734   # on the phone
```

- **Structurally report-only**: every run spawns in a child process with `dryRun` forced *last* (no override can undo it). The Mac never writes calendars — the phone stays the single writer, and the same rybook AI endpoint + on-disk caches (`~/.chunky-dad-scraper/`) serve both.
- **The real results UI**, not a knock-off: the server renders through the actual `generateRichHTML` (scriptable-adapter untouched, loaded behind the test-harness stubs), then translates the native bridge for browsers — copy buttons work (clipboard with plain-HTTP fallbacks), map-verify and Event Builder links become real links, bear-override/venue-queue buttons are cleanly disabled ("phone-only in v1").
- **The sleeper feature — `GET /ics/<id>`**: tap an ICS button in Safari and iOS opens the **native Add-to-Calendar flow**. That's a nicer save path than Scriptable's DocumentPicker, for recurring events *and* one-offs (index fallback). Calendar writes still happen only through your explicit import.
- Endpoints: `/` (latest results + run header with staleness note), `POST /run?parser=` (single-flight, 409 when busy), `/run-form` (parser dropdown), `/log` (tail).

## Verification

- Suite **953/953** (+16; the bridge-rewrite tests render through the real adapter).
- **Live smoke 14/14**: fixture site + canned AI stub → real child pipeline extracted and deduped 2 events → rendered page with **zero** `chunkyscrape://` remnants → `/ics/0` served `text/calendar` → lock lifecycle correct.

## Deployment notes

- **Nothing on the phone changes** — all three new files are Mac-side (`tools/`), so your updater config needs no new entries.
- For clipboard buttons over the tailnet, `tailscale serve` in front gives HTTPS (secure context); without it the fallback path still works.
- v2 (specced, not built): `getExistingEvents` from the published calendar ICS so Mac previews show real NEW/MERGE analysis instead of everything-NEW. Say go when v1 feels right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP