### PR TITLE
feat(tools): Mac server v2 — real MERGE/NEW analysis from published calendar ICS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A modern static website for chunky.dad",
   "main": "index.html",
   "scripts": {
-    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/metrics-sections.test.js scripts/event-provenance.test.js scripts/adapters/scriptable-adapter.test.js scripts/promoter-registry.test.js scripts/golden-pipeline.test.js scripts/calendar-contract.test.js scripts/replay-run.test.js scripts/tools-serve-results.test.js",
+    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/metrics-sections.test.js scripts/event-provenance.test.js scripts/adapters/scriptable-adapter.test.js scripts/adapters/web-adapter.test.js scripts/promoter-registry.test.js scripts/golden-pipeline.test.js scripts/calendar-contract.test.js scripts/replay-run.test.js scripts/tools-serve-results.test.js",
     "start": "python3 -m http.server 8000",
     "serve": "python3 -m http.server 8000",
     "scraper-server": "node tools/serve-results.js",

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -702,11 +702,198 @@ async saveFailureNote(url, error, metadata = {}) {
         return lines.filter(line => line).join('\r\n');
     }
 
-    // Get existing events for a specific event (called by shared-core for analysis)
-    // In web environment, we can't access real calendar data, so return empty array
-    async getExistingEvents(event) {
+    // SharedCore class reference: browser runs load it as a script-tag global;
+    // Node runs require it lazily (never at module load, so browser bundling
+    // of this file stays require-free on the hot path).
+    getSharedCoreRef() {
+        if (typeof SharedCore !== 'undefined') return SharedCore;
+        if (this.isNode && typeof require !== 'undefined') {
+            try {
+                return require('../shared-core').SharedCore;
+            } catch (error) {
+                console.log(`🖥️ WebAdapter: SharedCore unavailable: ${error.message}`);
+                return null;
+            }
+        }
+        return null;
+    }
 
-        return [];
+    // Fetch + parse the published calendar ICS for one city
+    // (https://chunky.dad/data/calendars/<cityKey>.ics, refreshed ~2-hourly).
+    // Mirrors ScriptableAdapter.getPublishedRecurringUids' fetch/cache shape:
+    // per-run memo + the Node page cache with a short TTL (0.25 days). Returns
+    // { records, fetchedAt } or null on any failure (callers degrade to NEW,
+    // with one warn per city per run).
+    async getPublishedCalendarEvents(cityKey) {
+        const key = String(cityKey || '').trim();
+        if (!key) return null;
+        if (!this._publishedCalendarByCity) this._publishedCalendarByCity = {};
+        if (Object.prototype.hasOwnProperty.call(this._publishedCalendarByCity, key)) {
+            return this._publishedCalendarByCity[key];
+        }
+        if (!this._publishedCalendarSnapshots) this._publishedCalendarSnapshots = {};
+        let entry = null;
+        try {
+            const core = this.getSharedCoreRef();
+            const url = `https://chunky.dad/data/calendars/${encodeURIComponent(key)}.ics`;
+            const icsCacheConfig = {
+                enabled: this.getPageCacheConfig().enabled,
+                ttlDays: 0.25
+            };
+            let body = null;
+            let fetchedAt = null;
+            const cached = await this.readCachedPage(url, icsCacheConfig);
+            if (cached && typeof cached.html === 'string') {
+                body = cached.html;
+                fetchedAt = cached.fetchedAt ||
+                    (Number.isFinite(cached.modifiedAtMs) ? new Date(cached.modifiedAtMs).toISOString() : null);
+            } else {
+                const responseData = await this.fetchData(url, {
+                    headers: { Accept: 'text/calendar' },
+                    isCacheableResponse: () => false
+                });
+                if (responseData && typeof responseData.html === 'string') {
+                    body = responseData.html;
+                    fetchedAt = new Date().toISOString();
+                    await this.writeCachedPage(url, responseData, icsCacheConfig);
+                }
+            }
+            const records = (body && core) ? core.parsePublishedCalendarIcs(body) : null;
+            if (Array.isArray(records)) {
+                entry = { records, fetchedAt };
+            }
+        } catch (error) {
+            entry = null;
+        }
+        if (entry) {
+            this._publishedCalendarSnapshots[key] = { status: 'ok', fetchedAt: entry.fetchedAt };
+        } else {
+            console.warn(`🖥️ WebAdapter: published calendar unavailable for ${key} — merge analysis degraded to NEW`);
+            this._publishedCalendarSnapshots[key] = { status: 'unavailable', fetchedAt: null };
+        }
+        this._publishedCalendarByCity[key] = entry;
+        return entry;
+    }
+
+    // Get existing events for a specific event (called by shared-core for
+    // analysis). Node/Mac runs have no EventKit, so the published per-city
+    // calendar ICS is the existing-events source: fetch + parse the event's
+    // city file, expand recurring series into the same search window the
+    // Scriptable adapter uses, and return plain event objects in the shape
+    // the merge machinery consumes. Read-only by design — this adapter never
+    // gains executeCalendarActions, so no write path exists.
+    async getExistingEvents(event) {
+        try {
+            const city = event.city || 'default';
+
+            const coerceDate = (value) => {
+                if (!value) return null;
+                if (value instanceof Date) {
+                    return isNaN(value.getTime()) ? null : value;
+                }
+                const parsed = new Date(value);
+                return isNaN(parsed.getTime()) ? null : parsed;
+            };
+
+            const identifierRaw = event && (event.identifier || event.id)
+                ? String(event.identifier || event.id).trim()
+                : '';
+            const hasIdentifier = Boolean(identifierRaw);
+
+            const startDate = coerceDate(event.startDate);
+            const endDate = coerceDate(event.endDate || event.startDate);
+            const searchStartDate = coerceDate(event.searchStartDate);
+            const searchEndDate = coerceDate(event.searchEndDate);
+            const dateCandidates = hasIdentifier
+                ? [searchStartDate, searchEndDate].filter(Boolean)
+                : [startDate, endDate].filter(Boolean);
+
+            if (dateCandidates.length === 0) {
+                return [];
+            }
+
+            // Same window math as ScriptableAdapter.getExistingEvents: one
+            // day-aligned window around the event dates (expanded only when
+            // the parser configures calendarSearchRangeDays) for scraper
+            // events; per-date windows of ±rangeDays for identifier edits.
+            const configuredRangeDays = Number(event._parserConfig?.calendarSearchRangeDays || 0);
+            const rangeDays = Number.isFinite(configuredRangeDays) && configuredRangeDays > 0
+                ? configuredRangeDays
+                : 2;
+            const buildWindow = (date, days) => {
+                const start = new Date(date);
+                start.setHours(0, 0, 0, 0);
+                start.setDate(start.getDate() - days);
+                const end = new Date(date);
+                end.setHours(23, 59, 59, 999);
+                end.setDate(end.getDate() + days);
+                return { start, end };
+            };
+
+            const windows = [];
+            if (!hasIdentifier) {
+                const earliestTime = Math.min(...dateCandidates.map((date) => date.getTime()));
+                const latestTime = Math.max(...dateCandidates.map((date) => date.getTime()));
+                const searchStart = new Date(earliestTime);
+                searchStart.setHours(0, 0, 0, 0);
+                const searchEnd = new Date(latestTime);
+                searchEnd.setHours(23, 59, 59, 999);
+                if (Number.isFinite(configuredRangeDays) && configuredRangeDays > 0) {
+                    searchStart.setDate(searchStart.getDate() - configuredRangeDays);
+                    searchEnd.setDate(searchEnd.getDate() + configuredRangeDays);
+                }
+                windows.push({ start: searchStart, end: searchEnd });
+            } else {
+                const windowKeys = new Set();
+                dateCandidates.forEach((date) => {
+                    const windowKey = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+                    if (windowKeys.has(windowKey)) return;
+                    windowKeys.add(windowKey);
+                    windows.push(buildWindow(date, rangeDays));
+                });
+            }
+            if (windows.length === 0) {
+                return [];
+            }
+
+            const published = await this.getPublishedCalendarEvents(city);
+            if (!published) {
+                return [];
+            }
+
+            const core = this.getSharedCoreRef();
+            if (!core) {
+                return [];
+            }
+
+            const overallStart = new Date(Math.min(...windows.map((w) => w.start.getTime())));
+            const overallEnd = new Date(Math.max(...windows.map((w) => w.end.getTime())));
+            const expansion = core.expandPublishedCalendarEventsInWindow(
+                published.records, overallStart, overallEnd
+            );
+
+            // Unsupported RRULE shapes degrade to non-recurring; log once per uid.
+            if (!this._unsupportedRruleLoggedUids) this._unsupportedRruleLoggedUids = new Set();
+            for (const unsupported of expansion.unsupportedRrules) {
+                if (this._unsupportedRruleLoggedUids.has(unsupported.uid)) continue;
+                this._unsupportedRruleLoggedUids.add(unsupported.uid);
+                console.log(`🖥️ WebAdapter: unsupported RRULE for uid ${unsupported.uid} — treated as non-recurring`);
+            }
+
+            const inAnyWindow = (existingEvent) => windows.some((w) => {
+                const eventStart = existingEvent.startDate;
+                const eventEnd = existingEvent.endDate || existingEvent.startDate;
+                return eventStart.getTime() <= w.end.getTime() && eventEnd.getTime() >= w.start.getTime();
+            });
+            const matched = expansion.events.filter(inAnyWindow);
+            console.log(
+                `🖥️ WebAdapter: Existing event search city=${city} window=${overallStart.toISOString()} → ${overallEnd.toISOString()} found=${matched.length} (published VEVENTs=${published.records.length})`
+            );
+            return matched;
+        } catch (error) {
+            console.log(`🖥️ WebAdapter: ✗ Failed to get existing events: ${error.message}`);
+            return [];
+        }
     }
 
     // Display/Logging Adapter Implementation
@@ -732,6 +919,12 @@ async saveFailureNote(url, error, metadata = {}) {
             // Store results for use in other methods
             this.lastResults = results;
             results.runContext = results.runContext || this.getRunContext();
+            // Published-calendar snapshot info (which city ICS files fed the
+            // merge analysis, and how fresh each fetch was) rides along in the
+            // results so the Mac server header can surface staleness.
+            if (this._publishedCalendarSnapshots && Object.keys(this._publishedCalendarSnapshots).length > 0) {
+                results.publishedCalendarSnapshots = { ...this._publishedCalendarSnapshots };
+            }
             console.log(`Run Type: ${results.runContext.type} (${results.runContext.trigger})`);
             
             // Show enhanced display features in console for debugging

--- a/scripts/adapters/web-adapter.test.js
+++ b/scripts/adapters/web-adapter.test.js
@@ -1,0 +1,253 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { WebAdapter } = require('./web-adapter');
+const { SharedCore } = require('../shared-core');
+const { EventSchema } = require('../event-schema');
+
+// ---------------------------------------------------------------------------
+// Mac-server v2: WebAdapter.getExistingEvents against the published per-city
+// calendar ICS (https://chunky.dad/data/calendars/<cityKey>.ics). Every test
+// stubs global fetch — nothing here touches the network.
+// ---------------------------------------------------------------------------
+
+const CITIES = {
+  la: { calendar: 'chunky-dad-la', timezone: 'America/Los_Angeles', patterns: ['los angeles'] }
+};
+
+// Compact stand-in for the real la.ics: one plain timed event (the canonical
+// D>U>R>O merge target), one MONTHLY;BYDAY=3SU series (Club Chub), and one
+// unsupported YEARLY rule.
+const LA_ICS_FIXTURE = [
+  'BEGIN:VCALENDAR',
+  'VERSION:2.0',
+  'BEGIN:VEVENT',
+  'UID:duro-la@test',
+  'DTSTART:20260802T050000Z',
+  'DTEND:20260802T100000Z',
+  'SUMMARY:D>U>R>O is back NEW OUTDOOR LOCATION',
+  'DESCRIPTION:bar: Precinct DTLA\\nwebsite: https://example.com/duro',
+  'LOCATION:34.04\\, -118.25',
+  'END:VEVENT',
+  'BEGIN:VEVENT',
+  'UID:chub-la@test',
+  'DTSTART;TZID=America/Los_Angeles:20250720T150000',
+  'DTEND;TZID=America/Los_Angeles:20250720T210000',
+  'RRULE:FREQ=MONTHLY;BYDAY=3SU',
+  'SUMMARY:Club Chub',
+  'DESCRIPTION:bar: The Bullet Bar',
+  'END:VEVENT',
+  'BEGIN:VEVENT',
+  'UID:gala-la@test',
+  'DTSTART:20260809T010000Z',
+  'DTEND:20260809T040000Z',
+  'RRULE:FREQ=YEARLY;BYMONTH=8;BYDAY=1SA',
+  'SUMMARY:Annual Gala',
+  'END:VEVENT',
+  'END:VCALENDAR'
+].join('\r\n');
+
+// fetch stub returning `icsText`; returns a call counter accessor. Restore is
+// the caller's job (each test uses withFetchStub).
+function withFetchStub(icsText, run) {
+  const originalFetch = global.fetch;
+  let calls = 0;
+  global.fetch = async () => {
+    calls += 1;
+    if (icsText instanceof Error) throw icsText;
+    return {
+      ok: true,
+      status: 200,
+      headers: new Map(),
+      text: async () => icsText
+    };
+  };
+  const done = () => { global.fetch = originalFetch; };
+  return run(() => calls).finally(done);
+}
+
+function makeAdapter(overrides = {}) {
+  return new WebAdapter({ cities: CITIES, ...overrides });
+}
+
+function scrapedDuroEvent() {
+  return {
+    title: 'D>U>R>O',
+    city: 'la',
+    timezone: 'America/Los_Angeles',
+    startDate: new Date('2026-08-02T05:00:00.000Z'),
+    endDate: new Date('2026-08-02T10:00:00.000Z'),
+    isBearEvent: true
+  };
+}
+
+test('getExistingEvents returns window-filtered events from the published calendar (per-run memo: one fetch)', async () => {
+  await withFetchStub(LA_ICS_FIXTURE, async (fetchCalls) => {
+    const adapter = makeAdapter();
+
+    const matched = await adapter.getExistingEvents(scrapedDuroEvent());
+    assert.equal(matched.length, 1, 'only the event inside the search window');
+    assert.equal(matched[0].identifier, 'duro-la@test', 'identifier is the raw ICS UID');
+    assert.equal(matched[0].title, 'D>U>R>O is back NEW OUTDOOR LOCATION');
+    assert.equal(matched[0].startDate.toISOString(), '2026-08-02T05:00:00.000Z');
+    assert.equal(matched[0].location, '34.04, -118.25', 'LOCATION string unescaped');
+    assert.match(matched[0].notes, /bar: Precinct DTLA\nwebsite:/, 'DESCRIPTION rides in notes');
+
+    // Different date, same city: series occurrence via RRULE expansion
+    // (3rd Sunday of August 2026 = Aug 16, 15:00 Los Angeles = 22:00Z).
+    const seriesWindow = await adapter.getExistingEvents({
+      title: 'Club Chub',
+      city: 'la',
+      startDate: new Date('2026-08-16T22:00:00.000Z'),
+      endDate: new Date('2026-08-17T02:00:00.000Z')
+    });
+    assert.equal(seriesWindow.length, 1);
+    assert.equal(seriesWindow[0].identifier, 'chub-la@test');
+    assert.equal(seriesWindow[0].recurrence, 'FREQ=MONTHLY;BYDAY=3SU', 'occurrence carries the series RRULE');
+    assert.equal(seriesWindow[0].startDate.toISOString(), '2026-08-16T22:00:00.000Z');
+
+    // A week with no calendar activity → empty.
+    const emptyWindow = await adapter.getExistingEvents({
+      title: 'Nothing here',
+      city: 'la',
+      startDate: new Date('2026-09-05T02:00:00.000Z'),
+      endDate: new Date('2026-09-05T05:00:00.000Z')
+    });
+    assert.deepEqual(emptyWindow, []);
+
+    assert.equal(fetchCalls(), 1, 'one ICS fetch per city per run (memoized)');
+    assert.equal(adapter._publishedCalendarSnapshots.la.status, 'ok', 'snapshot recorded for the header');
+  });
+});
+
+test('disk cache honors the 0.25-day TTL across adapter instances', async () => {
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chunky-ics-cache-'));
+  const pageCache = { enabled: true, ttlDays: 3 };
+  try {
+    await withFetchStub(LA_ICS_FIXTURE, async (fetchCalls) => {
+      const first = makeAdapter({ pageCache });
+      first.pageStorageDir = cacheDir;
+      await first.getExistingEvents(scrapedDuroEvent());
+      assert.equal(fetchCalls(), 1, 'cold cache fetches');
+
+      const second = makeAdapter({ pageCache });
+      second.pageStorageDir = cacheDir;
+      const cachedResult = await second.getExistingEvents(scrapedDuroEvent());
+      assert.equal(cachedResult.length, 1, 'cache hit still yields events');
+      assert.equal(fetchCalls(), 1, 'fresh disk cache serves the second run without a fetch');
+
+      // Age the cached file beyond the 6h (0.25d) ICS TTL → refetch.
+      const cachedFiles = fs.readdirSync(cacheDir, { recursive: true })
+        .map(String)
+        .filter((name) => name.endsWith('.json'));
+      assert.equal(cachedFiles.length, 1, 'one cached ICS payload on disk');
+      const cachedPath = path.join(cacheDir, cachedFiles[0]);
+      const staleTime = new Date(Date.now() - 7 * 60 * 60 * 1000);
+      fs.utimesSync(cachedPath, staleTime, staleTime);
+
+      const third = makeAdapter({ pageCache });
+      third.pageStorageDir = cacheDir;
+      await third.getExistingEvents(scrapedDuroEvent());
+      assert.equal(fetchCalls(), 2, 'stale cache (7h > 6h TTL) triggers a refetch');
+    });
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+});
+
+test('published calendar unavailable → [] and exactly one warn per city per run', async () => {
+  const warns = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warns.push(String(message));
+  try {
+    await withFetchStub(new Error('network down'), async () => {
+      const adapter = makeAdapter();
+      assert.deepEqual(await adapter.getExistingEvents(scrapedDuroEvent()), []);
+      assert.deepEqual(await adapter.getExistingEvents(scrapedDuroEvent()), [], 'second lookup degrades the same way');
+      const degraded = warns.filter((message) =>
+        message.includes('published calendar unavailable for la — merge analysis degraded to NEW'));
+      assert.equal(degraded.length, 1, 'one warn per city per run');
+      assert.equal(adapter._publishedCalendarSnapshots.la.status, 'unavailable');
+    });
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test('unsupported RRULE degrades to non-recurring and logs once per uid', async () => {
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (message) => logs.push(String(message));
+  try {
+    await withFetchStub(LA_ICS_FIXTURE, async () => {
+      const adapter = makeAdapter();
+      const query = {
+        title: 'Annual Gala',
+        city: 'la',
+        startDate: new Date('2026-08-09T01:00:00.000Z'),
+        endDate: new Date('2026-08-09T04:00:00.000Z')
+      };
+      const first = await adapter.getExistingEvents(query);
+      const gala = first.find((event) => event.identifier === 'gala-la@test');
+      assert.ok(gala, 'the unsupported series still surfaces as a plain one-off event');
+      assert.equal(gala.recurrence, undefined, 'treated as non-recurring');
+      await adapter.getExistingEvents(query);
+      const unsupportedLogs = logs.filter((message) =>
+        message.includes('unsupported RRULE for uid gala-la@test — treated as non-recurring'));
+      assert.equal(unsupportedLogs.length, 1, 'logged once per uid per run');
+    });
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+test('merge analysis over ICS-derived existing events: matching pair produces MERGE, not NEW', async () => {
+  await withFetchStub(LA_ICS_FIXTURE, async () => {
+    const adapter = makeAdapter();
+    const core = new SharedCore(CITIES, { eventSchema: EventSchema });
+    const analyzed = await core.prepareEventsForCalendar([scrapedDuroEvent()], adapter, {});
+    assert.equal(analyzed.length, 1);
+    assert.equal(analyzed[0]._action, 'merge', 'published calendar match upgrades NEW → MERGE');
+  });
+});
+
+test('recurring series match routes to the hands-off override path (no series mutation intent)', async () => {
+  await withFetchStub(LA_ICS_FIXTURE, async () => {
+    const adapter = makeAdapter();
+    const core = new SharedCore(CITIES, { eventSchema: EventSchema });
+    const scraped = {
+      title: 'Club Chub',
+      city: 'la',
+      timezone: 'America/Los_Angeles',
+      startDate: new Date('2026-08-16T22:00:00.000Z'),
+      endDate: new Date('2026-08-17T02:00:00.000Z')
+    };
+    const existing = await adapter.getExistingEvents(scraped);
+    const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(scraped, existing, 'upsert', adapter);
+    assert.equal(analysis.action, 'new', 'series master is never merged into');
+    assert.match(analysis.reason, /creating override/, 'routes to override creation');
+    assert.equal(analysis.overrideIdentity.overrideUid, 'chub-la@test');
+    assert.equal(analysis.overrideIdentity.overrideRecurrenceId, '20260816T220000Z');
+  });
+});
+
+test('web adapter never gains a calendar write path', () => {
+  const adapter = makeAdapter();
+  assert.equal(typeof adapter.executeCalendarActions, 'undefined',
+    'orchestrator typeof-check must keep skipping calendar execution on Node/Mac');
+});
+
+test('displayResults attaches the published-calendar snapshot info for the server header', async () => {
+  await withFetchStub(LA_ICS_FIXTURE, async () => {
+    const adapter = makeAdapter();
+    await adapter.getExistingEvents(scrapedDuroEvent());
+    const results = { totalEvents: 0, bearEvents: 0, calendarEvents: 0, parserResults: [], errors: [] };
+    await adapter.displayResults(results);
+    assert.ok(results.publishedCalendarSnapshots, 'snapshots ride along in the results');
+    assert.equal(results.publishedCalendarSnapshots.la.status, 'ok');
+    assert.ok(results.publishedCalendarSnapshots.la.fetchedAt, 'fetch age source for "calendar snapshot: la …"');
+  });
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -7386,6 +7386,432 @@ class SharedCore {
         return uids;
     }
 
+    // -------------------------------------------------------------------------
+    // Published-calendar ICS parsing + RRULE expansion (pure string/date work).
+    // The Mac/Node web adapter reads the published per-city calendar files
+    // (https://chunky.dad/data/calendars/<cityKey>.ics) as its "existing
+    // events" source so merge/enrich/conflict analysis works without EventKit.
+    // Everything here is dependency-free (Intl + Date only) and platform-pure.
+    // -------------------------------------------------------------------------
+
+    // RFC 5545 TEXT unescaping: \\ -> \, \n or \N -> newline, \, -> comma,
+    // \; -> semicolon. Single pass so "\\n" correctly yields "\n" (literal).
+    static unescapeIcsText(value) {
+        if (value === null || value === undefined) return '';
+        return String(value).replace(/\\([\\;,nN])/g, (match, escaped) =>
+            (escaped === 'n' || escaped === 'N') ? '\n' : escaped);
+    }
+
+    // Offset (minutes) of an IANA timezone from UTC at an instant. Static
+    // sibling of the instance getTimezoneOffsetMinutes (which stays untouched)
+    // for the pure ICS helpers below. Bare "GMT" (UTC's longOffset) → 0.
+    static getIcsTimezoneOffsetMinutes(date, timezone) {
+        try {
+            const formatter = new Intl.DateTimeFormat('en', {
+                timeZone: timezone,
+                timeZoneName: 'longOffset'
+            });
+            const parts = formatter.formatToParts(date);
+            const offsetPart = parts.find(part => part.type === 'timeZoneName');
+            const offsetText = offsetPart && typeof offsetPart.value === 'string' ? offsetPart.value : '';
+            if (/^(GMT|UTC)$/i.test(offsetText.trim())) return 0;
+            const offsetMatch = offsetText.match(/GMT([+-])(\d{1,2})(?::(\d{2}))?/);
+            if (!offsetMatch) return null;
+            const sign = offsetMatch[1] === '+' ? 1 : -1;
+            return sign * ((parseInt(offsetMatch[2], 10) * 60) + (offsetMatch[3] ? parseInt(offsetMatch[3], 10) : 0));
+        } catch (_) {
+            return null;
+        }
+    }
+
+    // Wall-clock components in an IANA timezone → the UTC instant they name.
+    // Iterates because the offset guess can be wrong near DST transitions
+    // (same algorithm as the instance convertWallClockDateToUtc).
+    static zonedWallClockToUtc(wall, timezone) {
+        if (!wall || typeof wall !== 'object') return null;
+        const base = Date.UTC(
+            wall.year, (wall.month || 1) - 1, wall.day || 1,
+            wall.hour || 0, wall.minute || 0, wall.second || 0
+        );
+        if (!Number.isFinite(base)) return null;
+        if (!timezone || /^(UTC|GMT|Z)$/i.test(String(timezone))) return new Date(base);
+        let utcMillis = base;
+        for (let i = 0; i < 4; i++) {
+            const offsetMinutes = SharedCore.getIcsTimezoneOffsetMinutes(new Date(utcMillis), timezone);
+            if (!Number.isFinite(offsetMinutes)) return null;
+            const nextUtcMillis = base - (offsetMinutes * 60 * 1000);
+            if (nextUtcMillis === utcMillis) break;
+            utcMillis = nextUtcMillis;
+        }
+        return new Date(utcMillis);
+    }
+
+    // One ICS date/date-time property value → { date, wall, tzid, isDateOnly }.
+    // `params` is the raw parameter run between the property name and ':'
+    // (e.g. ";TZID=America/Los_Angeles" or ";VALUE=DATE"); `value` the text
+    // after ':'. Handles the three published shapes: TZID wall clock, UTC "Z",
+    // and VALUE=DATE (all-day, midnight UTC). Floating times are read as UTC.
+    static parseIcsDateValue(params, value) {
+        const text = String(value === null || value === undefined ? '' : value).trim();
+        const paramText = String(params || '');
+        const tzidMatch = paramText.match(/TZID=([^;:]+)/i);
+        const tzid = tzidMatch ? tzidMatch[1].trim() : null;
+        if (/VALUE=DATE(?!-TIME)/i.test(paramText) || /^\d{8}$/.test(text)) {
+            const dateMatch = text.match(/^(\d{4})(\d{2})(\d{2})$/);
+            if (!dateMatch) return null;
+            const wall = {
+                year: parseInt(dateMatch[1], 10), month: parseInt(dateMatch[2], 10), day: parseInt(dateMatch[3], 10),
+                hour: 0, minute: 0, second: 0
+            };
+            const date = new Date(Date.UTC(wall.year, wall.month - 1, wall.day));
+            return isNaN(date.getTime()) ? null : { date, wall, tzid: null, isDateOnly: true };
+        }
+        const dateTimeMatch = text.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})?(Z)?$/);
+        if (!dateTimeMatch) return null;
+        const wall = {
+            year: parseInt(dateTimeMatch[1], 10), month: parseInt(dateTimeMatch[2], 10), day: parseInt(dateTimeMatch[3], 10),
+            hour: parseInt(dateTimeMatch[4], 10), minute: parseInt(dateTimeMatch[5], 10),
+            second: dateTimeMatch[6] ? parseInt(dateTimeMatch[6], 10) : 0
+        };
+        const isUtc = Boolean(dateTimeMatch[7]);
+        const date = (isUtc || !tzid)
+            ? new Date(Date.UTC(wall.year, wall.month - 1, wall.day, wall.hour, wall.minute, wall.second))
+            : SharedCore.zonedWallClockToUtc(wall, tzid);
+        if (!date || isNaN(date.getTime())) return null;
+        return { date, wall, tzid: isUtc ? 'UTC' : tzid, isDateOnly: false };
+    }
+
+    // Fuller (but still light) VEVENT scanner than extractRecurringUidsFromIcs:
+    // per VEVENT extracts UID, SUMMARY, DTSTART/DTEND (TZID= and VALUE=DATE
+    // variants), RRULE, DESCRIPTION (unfolded + unescaped), LOCATION, URL,
+    // EXDATE list and RECURRENCE-ID. Returns an array of plain records, or
+    // null for non-string/empty input (callers fail open). VTIMEZONE blocks
+    // (whose DST rules also say "RRULE:") are naturally skipped because only
+    // BEGIN:VEVENT…END:VEVENT blocks are walked.
+    static parsePublishedCalendarIcs(icsText) {
+        if (typeof icsText !== 'string' || icsText.trim() === '') return null;
+        // Unfold RFC 5545 folded lines (CRLF/LF followed by space or tab).
+        const unfolded = icsText.replace(/\r?\n[ \t]/g, '');
+        const records = [];
+        const blockRegex = /BEGIN:VEVENT([\s\S]*?)END:VEVENT/g;
+        let match;
+        while ((match = blockRegex.exec(unfolded)) !== null) {
+            // VALARM sub-blocks carry DESCRIPTION lines of their own — strip them.
+            const block = match[1].replace(/BEGIN:VALARM[\s\S]*?END:VALARM/g, '');
+            const record = {
+                uid: '', summary: '', description: '', location: '', url: '',
+                rrule: '', start: null, end: null, exdates: [], recurrenceId: null
+            };
+            for (const rawLine of block.split(/\r?\n/)) {
+                const line = rawLine.trim() === '' ? null : rawLine;
+                if (!line) continue;
+                const propMatch = line.match(/^([A-Za-z0-9-]+)((?:;[^:]*)?):(.*)$/);
+                if (!propMatch) continue;
+                const name = propMatch[1].toUpperCase();
+                const params = propMatch[2] || '';
+                const value = propMatch[3];
+                switch (name) {
+                    case 'UID': record.uid = value.trim(); break;
+                    case 'SUMMARY': record.summary = SharedCore.unescapeIcsText(value).trim(); break;
+                    case 'DESCRIPTION': record.description = SharedCore.unescapeIcsText(value); break;
+                    case 'LOCATION': record.location = SharedCore.unescapeIcsText(value).trim(); break;
+                    case 'URL': record.url = value.trim(); break;
+                    case 'RRULE': record.rrule = value.trim(); break;
+                    case 'DTSTART': record.start = SharedCore.parseIcsDateValue(params, value); break;
+                    case 'DTEND': record.end = SharedCore.parseIcsDateValue(params, value); break;
+                    case 'RECURRENCE-ID': record.recurrenceId = SharedCore.parseIcsDateValue(params, value); break;
+                    case 'EXDATE':
+                        for (const exValue of value.split(',')) {
+                            const parsed = SharedCore.parseIcsDateValue(params, exValue);
+                            if (parsed) record.exdates.push(parsed);
+                        }
+                        break;
+                    default: break;
+                }
+            }
+            if (!record.uid || !record.start) continue;
+            record.isAllDay = Boolean(record.start.isDateOnly);
+            records.push(record);
+        }
+        return records;
+    }
+
+    // RRULE text → uppercase part map ({ FREQ, BYDAY, … }), or null when empty.
+    static parseRruleParts(rrule) {
+        const text = String(rrule || '').replace(/^RRULE[:;]/i, '').trim();
+        if (!text) return null;
+        const parts = {};
+        for (const chunk of text.split(';')) {
+            const eqIndex = chunk.indexOf('=');
+            if (eqIndex <= 0) continue;
+            parts[chunk.slice(0, eqIndex).trim().toUpperCase()] = chunk.slice(eqIndex + 1).trim().toUpperCase();
+        }
+        return Object.keys(parts).length > 0 ? parts : null;
+    }
+
+    // Expand a recurring series' occurrence START instants into a window.
+    // Supports exactly the shapes the published calendars contain (verified
+    // inventory: FREQ=WEEKLY[;BYDAY=…], FREQ=MONTHLY;BYDAY=nXX) plus DAILY,
+    // plain MONTHLY (day-of-month), INTERVAL, COUNT and UNTIL. Anything else
+    // returns null and the caller treats the event as non-recurring.
+    //
+    // `seriesStart` is a parsed date record from parseIcsDateValue ({ date,
+    // wall, tzid, isDateOnly }) or a plain Date (read as UTC wall clock).
+    // Iteration happens in the series' own wall-clock domain and each
+    // occurrence converts wall clock + TZID → instant, so weekly series keep
+    // their local start time across DST transitions.
+    static expandRruleOccurrencesInWindow(rrule, seriesStart, windowStart, windowEnd) {
+        const startRecord = seriesStart instanceof Date
+            ? {
+                date: seriesStart,
+                wall: {
+                    year: seriesStart.getUTCFullYear(), month: seriesStart.getUTCMonth() + 1, day: seriesStart.getUTCDate(),
+                    hour: seriesStart.getUTCHours(), minute: seriesStart.getUTCMinutes(), second: seriesStart.getUTCSeconds()
+                },
+                tzid: 'UTC', isDateOnly: false
+            }
+            : seriesStart;
+        if (!startRecord || !(startRecord.date instanceof Date) || isNaN(startRecord.date.getTime()) || !startRecord.wall) {
+            return null;
+        }
+        const parts = SharedCore.parseRruleParts(rrule);
+        if (!parts || !parts.FREQ) return null;
+        const supportedKeys = new Set(['FREQ', 'INTERVAL', 'BYDAY', 'COUNT', 'UNTIL', 'WKST']);
+        for (const key of Object.keys(parts)) {
+            if (!supportedKeys.has(key)) return null;
+        }
+        const freq = parts.FREQ;
+        if (freq !== 'DAILY' && freq !== 'WEEKLY' && freq !== 'MONTHLY') return null;
+        const interval = parts.INTERVAL === undefined ? 1 : parseInt(parts.INTERVAL, 10);
+        if (!Number.isFinite(interval) || interval < 1) return null;
+        const count = parts.COUNT === undefined ? null : parseInt(parts.COUNT, 10);
+        if (count !== null && (!Number.isFinite(count) || count < 1)) return null;
+        let untilMs = null;
+        if (parts.UNTIL !== undefined) {
+            const untilRecord = SharedCore.parseIcsDateValue('', parts.UNTIL);
+            if (!untilRecord) return null;
+            // Date-only UNTIL bounds the whole final day.
+            untilMs = untilRecord.date.getTime() + (untilRecord.isDateOnly ? (24 * 60 * 60 * 1000) - 1 : 0);
+        }
+
+        const WEEKDAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+        const DAY_MS = 24 * 60 * 60 * 1000;
+        const wall = startRecord.wall;
+        const startDayMs = Date.UTC(wall.year, wall.month - 1, wall.day);
+        const startWeekday = new Date(startDayMs).getUTCDay();
+
+        // BYDAY handling per FREQ.
+        let weeklyWeekdays = null;   // sorted array of weekday numbers (0=SU)
+        let monthlyOrdinal = null;   // { ordinal, weekday } or null (day-of-month monthly)
+        if (parts.BYDAY !== undefined) {
+            const tokens = parts.BYDAY.split(',').map(token => token.trim()).filter(Boolean);
+            if (tokens.length === 0) return null;
+            if (freq === 'WEEKLY' || freq === 'DAILY') {
+                const weekdays = [];
+                for (const token of tokens) {
+                    const weekday = WEEKDAY_CODES.indexOf(token);
+                    if (weekday === -1) return null; // ordinal BYDAY is not a weekly shape
+                    weekdays.push(weekday);
+                }
+                if (freq === 'DAILY') {
+                    // BYDAY on DAILY is out of published scope — unsupported.
+                    return null;
+                }
+                weeklyWeekdays = Array.from(new Set(weekdays)).sort((a, b) => a - b);
+            } else {
+                if (tokens.length !== 1) return null;
+                const ordinalMatch = tokens[0].match(/^(-?\d)(SU|MO|TU|WE|TH|FR|SA)$/);
+                if (!ordinalMatch) return null;
+                const ordinal = parseInt(ordinalMatch[1], 10);
+                if (!Number.isFinite(ordinal) || ordinal === 0 || Math.abs(ordinal) > 5) return null;
+                monthlyOrdinal = { ordinal, weekday: WEEKDAY_CODES.indexOf(ordinalMatch[2]) };
+            }
+        }
+        if (freq === 'WEEKLY' && !weeklyWeekdays) {
+            weeklyWeekdays = [startWeekday];
+        }
+
+        const windowStartMs = (windowStart instanceof Date ? windowStart : new Date(windowStart)).getTime();
+        const windowEndMs = (windowEnd instanceof Date ? windowEnd : new Date(windowEnd)).getTime();
+        if (!Number.isFinite(windowStartMs) || !Number.isFinite(windowEndMs) || windowEndMs < windowStartMs) {
+            return [];
+        }
+
+        // Candidate wall-clock DAYS (ms at UTC midnight of the wall date), in
+        // order from the series start. Generation stops past the window end
+        // (with a 2-day margin for timezone skew) or at the iteration cap.
+        const marginMs = 2 * DAY_MS;
+        const maxCandidates = 5000;
+        const candidateDays = [];
+        if (freq === 'DAILY') {
+            for (let i = 0; ; i++) {
+                const dayMs = startDayMs + (i * interval * DAY_MS);
+                if (dayMs > windowEndMs + marginMs || candidateDays.length >= maxCandidates) break;
+                candidateDays.push(dayMs);
+            }
+        } else if (freq === 'WEEKLY') {
+            // Weeks count from the series start's week (WKST=MO, Google's default).
+            const weekStartMs = startDayMs - ((((startWeekday - 1) % 7) + 7) % 7) * DAY_MS;
+            outerWeekly:
+            for (let week = 0; ; week++) {
+                const thisWeekStartMs = weekStartMs + (week * interval * 7 * DAY_MS);
+                if (thisWeekStartMs > windowEndMs + marginMs) break;
+                for (const weekday of weeklyWeekdays) {
+                    // Offset of `weekday` within a MO-started week.
+                    const offsetDays = (((weekday - 1) % 7) + 7) % 7;
+                    const dayMs = thisWeekStartMs + (offsetDays * DAY_MS);
+                    if (dayMs < startDayMs) continue; // before DTSTART
+                    if (dayMs > windowEndMs + marginMs) continue;
+                    if (candidateDays.length >= maxCandidates) break outerWeekly;
+                    candidateDays.push(dayMs);
+                }
+            }
+        } else { // MONTHLY
+            const monthIndexOf = (year, month) => (year * 12) + (month - 1);
+            const startMonthIndex = monthIndexOf(wall.year, wall.month);
+            for (let step = 0; ; step++) {
+                const monthIndex = startMonthIndex + (step * interval);
+                const year = Math.floor(monthIndex / 12);
+                const month = (monthIndex % 12) + 1;
+                const monthStartMs = Date.UTC(year, month - 1, 1);
+                if (monthStartMs > windowEndMs + marginMs || candidateDays.length >= maxCandidates) break;
+                const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+                let day = null;
+                if (monthlyOrdinal) {
+                    const { ordinal, weekday } = monthlyOrdinal;
+                    if (ordinal > 0) {
+                        const firstWeekday = new Date(monthStartMs).getUTCDay();
+                        day = 1 + ((weekday - firstWeekday + 7) % 7) + ((ordinal - 1) * 7);
+                    } else {
+                        const lastWeekday = new Date(Date.UTC(year, month - 1, daysInMonth)).getUTCDay();
+                        day = daysInMonth - ((lastWeekday - weekday + 7) % 7) + ((ordinal + 1) * 7);
+                    }
+                    if (day < 1 || day > daysInMonth) continue; // no such ordinal this month
+                } else {
+                    day = wall.day;
+                    if (day > daysInMonth) continue; // RFC: skip months without the day
+                }
+                const dayMs = Date.UTC(year, month - 1, day);
+                if (dayMs < startDayMs) continue;
+                candidateDays.push(dayMs);
+            }
+        }
+
+        // Wall date → occurrence instant; apply COUNT/UNTIL from the series
+        // start (both bound the whole series, not just the window slice).
+        const occurrences = [];
+        let occurrenceIndex = 0;
+        for (const dayMs of candidateDays) {
+            const dayDate = new Date(dayMs);
+            const occurrenceWall = {
+                year: dayDate.getUTCFullYear(), month: dayDate.getUTCMonth() + 1, day: dayDate.getUTCDate(),
+                hour: wall.hour || 0, minute: wall.minute || 0, second: wall.second || 0
+            };
+            const instant = startRecord.isDateOnly
+                ? new Date(Date.UTC(occurrenceWall.year, occurrenceWall.month - 1, occurrenceWall.day))
+                : SharedCore.zonedWallClockToUtc(occurrenceWall, startRecord.tzid);
+            if (!instant || isNaN(instant.getTime())) continue;
+            occurrenceIndex += 1;
+            if (count !== null && occurrenceIndex > count) break;
+            if (untilMs !== null && instant.getTime() > untilMs) break;
+            const instantMs = instant.getTime();
+            if (instantMs >= windowStartMs && instantMs <= windowEndMs) {
+                occurrences.push(instant);
+            }
+        }
+        return occurrences;
+    }
+
+    // Parsed VEVENT records + a window → the flat existing-event objects the
+    // merge machinery consumes (same shape ScriptableAdapter.getExistingEvents
+    // returns from EventKit): identifier (raw ICS UID; series occurrences all
+    // share their series UID, matching how EventKit surfaces instances),
+    // title, startDate/endDate (Date instants), notes (DESCRIPTION — the
+    // calendar-as-database key:value format), location, isAllDay, url, plus
+    // `recurrence` on series occurrences so the hands-off recurring path fires
+    // even when the window holds a single instance. EXDATEs are excluded and
+    // RECURRENCE-ID override VEVENTs replace their matching occurrence.
+    // Series with an unsupported RRULE are listed in `unsupportedRrules` and
+    // included as plain one-off events (fail toward today's behavior).
+    static expandPublishedCalendarEventsInWindow(records, windowStart, windowEnd) {
+        const result = { events: [], unsupportedRrules: [] };
+        if (!Array.isArray(records)) return result;
+        const windowStartDate = windowStart instanceof Date ? windowStart : new Date(windowStart);
+        const windowEndDate = windowEnd instanceof Date ? windowEnd : new Date(windowEnd);
+        if (isNaN(windowStartDate.getTime()) || isNaN(windowEndDate.getTime())) return result;
+
+        const overlapsWindow = (start, end) => {
+            if (!(start instanceof Date) || isNaN(start.getTime())) return false;
+            const effectiveEnd = end instanceof Date && !isNaN(end.getTime()) ? end : start;
+            return start.getTime() <= windowEndDate.getTime() && effectiveEnd.getTime() >= windowStartDate.getTime();
+        };
+        const toEvent = (record, startDate, endDate, extra) => ({
+            identifier: record.uid,
+            title: record.summary || '',
+            startDate,
+            endDate,
+            location: record.location || '',
+            notes: record.description || '',
+            url: record.url || '',
+            isAllDay: Boolean(record.isAllDay),
+            ...(extra || {})
+        });
+        const recordEnd = (record) => (record.end && record.end.date) ? record.end.date : record.start.date;
+
+        // Override instants per series UID (RECURRENCE-ID VEVENTs replace the
+        // matching expanded occurrence).
+        const overrideInstantsByUid = new Map();
+        for (const record of records) {
+            if (!record || !record.uid || !record.recurrenceId || !record.recurrenceId.date) continue;
+            if (!overrideInstantsByUid.has(record.uid)) overrideInstantsByUid.set(record.uid, new Set());
+            overrideInstantsByUid.get(record.uid).add(record.recurrenceId.date.getTime());
+        }
+
+        for (const record of records) {
+            if (!record || !record.uid || !record.start || !(record.start.date instanceof Date)) continue;
+
+            if (record.recurrenceId) {
+                // Override instance: stands on its own dates (its expanded
+                // source occurrence is suppressed via overrideInstantsByUid).
+                if (overlapsWindow(record.start.date, recordEnd(record))) {
+                    result.events.push(toEvent(record, record.start.date, recordEnd(record)));
+                }
+                continue;
+            }
+
+            if (record.rrule) {
+                const occurrenceStarts = SharedCore.expandRruleOccurrencesInWindow(
+                    record.rrule, record.start, windowStartDate, windowEndDate
+                );
+                if (occurrenceStarts === null) {
+                    result.unsupportedRrules.push({ uid: record.uid, rrule: record.rrule });
+                    if (overlapsWindow(record.start.date, recordEnd(record))) {
+                        result.events.push(toEvent(record, record.start.date, recordEnd(record)));
+                    }
+                    continue;
+                }
+                const durationMs = Math.max(0, recordEnd(record).getTime() - record.start.date.getTime());
+                const excludedInstants = new Set((record.exdates || [])
+                    .filter(exdate => exdate && exdate.date)
+                    .map(exdate => exdate.date.getTime()));
+                const overrideInstants = overrideInstantsByUid.get(record.uid) || new Set();
+                for (const occurrenceStart of occurrenceStarts) {
+                    const startMs = occurrenceStart.getTime();
+                    if (excludedInstants.has(startMs) || overrideInstants.has(startMs)) continue;
+                    result.events.push(toEvent(
+                        record, occurrenceStart, new Date(startMs + durationMs), { recurrence: record.rrule }
+                    ));
+                }
+                continue;
+            }
+
+            if (overlapsWindow(record.start.date, recordEnd(record))) {
+                result.events.push(toEvent(record, record.start.date, recordEnd(record)));
+            }
+        }
+        return result;
+    }
+
     // Pure decision for the wide-window identifier probe: ≥2 calendar
     // instances sharing the matched identifier means the identifier belongs
     // to a recurring series (occurrences of a series share one identifier).

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -9316,3 +9316,234 @@ test('noteConfirmedRecurringSeries feeds shouldCreateOverrideFromRecurringMatch'
   assert.equal(core.shouldCreateOverrideFromRecurringMatch(existingEvent, [existingEvent]), true,
     'confirmed identifier flips the hands-off path');
 });
+
+// ---------------------------------------------------------------------------
+// Published-calendar ICS parsing + RRULE expansion (Mac/Node merge fidelity)
+// ---------------------------------------------------------------------------
+
+// Fixture mirroring the real published-calendar shapes (Google Calendar
+// export): TZID timed event, VALUE=DATE all-day, WEEKLY;BYDAY series with one
+// EXDATE and one RECURRENCE-ID override, MONTHLY;BYDAY=1FR series, and one
+// unsupported YEARLY rule. The plain event's DESCRIPTION is 75-octet folded.
+const PUBLISHED_ICS_FIXTURE = [
+  'BEGIN:VCALENDAR',
+  'VERSION:2.0',
+  'PRODID:-//Test//Test//EN',
+  'BEGIN:VTIMEZONE',
+  'TZID:America/New_York',
+  'BEGIN:DAYLIGHT',
+  'DTSTART:19700308T020000',
+  'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU',
+  'END:DAYLIGHT',
+  'END:VTIMEZONE',
+  'BEGIN:VEVENT',
+  'UID:plain-timed@test',
+  'DTSTART;TZID=America/New_York:20260710T210000',
+  'DTEND;TZID=America/New_York:20260711T010000',
+  'SUMMARY:Plain Timed\\, Event',
+  'DESCRIPTION:bar: The Eagle\\nwebsite: https://example.com/events?id=1\\ndesc',
+  ' ription: Line one\; folded tail\\\\not-a-newline',
+  'LOCATION:40.7\\, -73.9',
+  'END:VEVENT',
+  'BEGIN:VEVENT',
+  'UID:allday@test',
+  'DTSTART;VALUE=DATE:20260620',
+  'DTEND;VALUE=DATE:20260621',
+  'SUMMARY:All Day Fair',
+  'END:VEVENT',
+  'BEGIN:VEVENT',
+  'UID:weekly@test',
+  'DTSTART;TZID=America/New_York:20260705T170000',
+  'DTEND;TZID=America/New_York:20260705T200000',
+  'RRULE:FREQ=WEEKLY;BYDAY=SU',
+  'EXDATE;TZID=America/New_York:20260719T170000',
+  'SUMMARY:Weekly Beer Blast',
+  'DESCRIPTION:bar: Rebar',
+  'END:VEVENT',
+  'BEGIN:VEVENT',
+  'UID:weekly@test',
+  'RECURRENCE-ID;TZID=America/New_York:20260726T170000',
+  'DTSTART;TZID=America/New_York:20260726T180000',
+  'DTEND;TZID=America/New_York:20260726T210000',
+  'SUMMARY:Beer Blast (Special)',
+  'DESCRIPTION:overrideUid: weekly@test\\noverrideRecurrenceId: 20260726T210000Z',
+  'END:VEVENT',
+  'BEGIN:VEVENT',
+  'UID:monthly@test',
+  'DTSTART;TZID=America/New_York:20250801T220000',
+  'DTEND;TZID=America/New_York:20250802T020000',
+  'RRULE:FREQ=MONTHLY;BYDAY=1FR',
+  'SUMMARY:First Friday',
+  'END:VEVENT',
+  'BEGIN:VEVENT',
+  'UID:unsupported@test',
+  'DTSTART;TZID=America/New_York:20260701T190000',
+  'DTEND;TZID=America/New_York:20260701T220000',
+  'RRULE:FREQ=YEARLY;BYMONTH=7;BYDAY=1WE',
+  'SUMMARY:Annual Gala',
+  'END:VEVENT',
+  'END:VCALENDAR'
+].join('\r\n');
+
+test('parsePublishedCalendarIcs: per-VEVENT fields, folding, unescaping, TZID and all-day dates', () => {
+  const records = SharedCore.parsePublishedCalendarIcs(PUBLISHED_ICS_FIXTURE);
+  assert.equal(records.length, 6, 'six VEVENTs (VTIMEZONE DST rules are not events)');
+
+  const plain = records.find(record => record.uid === 'plain-timed@test');
+  assert.equal(plain.summary, 'Plain Timed, Event', 'SUMMARY comma unescaped');
+  assert.equal(plain.location, '40.7, -73.9', 'LOCATION comma unescaped');
+  assert.equal(
+    plain.description,
+    'bar: The Eagle\nwebsite: https://example.com/events?id=1\ndescription: Line one; folded tail\\not-a-newline',
+    'DESCRIPTION unfolded across the 75-octet break, \\n/\;/\\\\ unescaped in one pass'
+  );
+  // 21:00 America/New_York (EDT, UTC-4) → 01:00Z next day.
+  assert.equal(plain.start.date.toISOString(), '2026-07-11T01:00:00.000Z', 'TZID wall clock → correct instant');
+  assert.equal(plain.end.date.toISOString(), '2026-07-11T05:00:00.000Z');
+  assert.equal(plain.isAllDay, false);
+  assert.equal(plain.rrule, '');
+
+  const allDay = records.find(record => record.uid === 'allday@test');
+  assert.equal(allDay.isAllDay, true, 'VALUE=DATE → all-day');
+  assert.equal(allDay.start.date.toISOString(), '2026-06-20T00:00:00.000Z');
+
+  const weekly = records.find(record => record.uid === 'weekly@test' && record.rrule);
+  assert.equal(weekly.rrule, 'FREQ=WEEKLY;BYDAY=SU');
+  assert.equal(weekly.exdates.length, 1);
+  assert.equal(weekly.exdates[0].date.toISOString(), '2026-07-19T21:00:00.000Z', 'EXDATE TZID-aware');
+
+  const override = records.find(record => record.uid === 'weekly@test' && record.recurrenceId);
+  assert.equal(override.recurrenceId.date.toISOString(), '2026-07-26T21:00:00.000Z');
+
+  assert.equal(SharedCore.parsePublishedCalendarIcs(''), null, 'empty input fails open as null');
+  assert.equal(SharedCore.parsePublishedCalendarIcs(null), null);
+});
+
+test('expandRruleOccurrencesInWindow: weekly, monthly-ordinal, daily, INTERVAL, COUNT/UNTIL, DST wall-clock', () => {
+  const records = SharedCore.parsePublishedCalendarIcs(PUBLISHED_ICS_FIXTURE);
+  const windowStart = new Date('2026-07-01T00:00:00.000Z');
+  const windowEnd = new Date('2026-07-31T23:59:59.999Z');
+
+  const weekly = records.find(record => record.uid === 'weekly@test' && record.rrule);
+  const weeklyStarts = SharedCore.expandRruleOccurrencesInWindow(weekly.rrule, weekly.start, windowStart, windowEnd);
+  assert.deepEqual(
+    weeklyStarts.map(date => date.toISOString()),
+    ['2026-07-05T21:00:00.000Z', '2026-07-12T21:00:00.000Z', '2026-07-19T21:00:00.000Z', '2026-07-26T21:00:00.000Z'],
+    'every July Sunday at 17:00 New York (raw expansion; EXDATE applies at the event layer)'
+  );
+
+  const monthly = records.find(record => record.uid === 'monthly@test');
+  const monthlyStarts = SharedCore.expandRruleOccurrencesInWindow(
+    monthly.rrule, monthly.start, new Date('2026-08-01T00:00:00.000Z'), new Date('2026-08-31T23:59:59.999Z')
+  );
+  assert.deepEqual(
+    monthlyStarts.map(date => date.toISOString()),
+    ['2026-08-08T02:00:00.000Z'],
+    'first Friday of August 2026 (Aug 7) at 22:00 New York'
+  );
+
+  // Weekly series crossing the March 2026 DST transition keeps its wall-clock
+  // start: 17:00 EST (22:00Z) before, 17:00 EDT (21:00Z) after March 8.
+  const dstStart = SharedCore.parseIcsDateValue(';TZID=America/New_York', '20260301T170000');
+  const dstStarts = SharedCore.expandRruleOccurrencesInWindow(
+    'FREQ=WEEKLY;BYDAY=SU', dstStart, new Date('2026-03-01T00:00:00.000Z'), new Date('2026-03-16T00:00:00.000Z')
+  );
+  assert.deepEqual(
+    dstStarts.map(date => date.toISOString()),
+    ['2026-03-01T22:00:00.000Z', '2026-03-08T21:00:00.000Z', '2026-03-15T21:00:00.000Z'],
+    'wall-clock time preserved across the DST jump'
+  );
+
+  // INTERVAL=2 weekly: every other week from the series start's week.
+  const biweeklyStarts = SharedCore.expandRruleOccurrencesInWindow(
+    'FREQ=WEEKLY;INTERVAL=2', weekly.start, windowStart, windowEnd
+  );
+  assert.deepEqual(
+    biweeklyStarts.map(date => date.toISOString()),
+    ['2026-07-05T21:00:00.000Z', '2026-07-19T21:00:00.000Z'],
+    'INTERVAL=2 skips alternate weeks (BYDAY defaults to the DTSTART weekday)'
+  );
+
+  const dailyStarts = SharedCore.expandRruleOccurrencesInWindow(
+    'FREQ=DAILY', weekly.start, new Date('2026-07-05T00:00:00.000Z'), new Date('2026-07-07T23:59:59.999Z')
+  );
+  assert.equal(dailyStarts.length, 3, 'daily expansion');
+
+  const countedStarts = SharedCore.expandRruleOccurrencesInWindow(
+    'FREQ=WEEKLY;BYDAY=SU;COUNT=2', weekly.start, windowStart, windowEnd
+  );
+  assert.equal(countedStarts.length, 2, 'COUNT bounds the whole series from DTSTART');
+
+  const untilStarts = SharedCore.expandRruleOccurrencesInWindow(
+    'FREQ=WEEKLY;BYDAY=SU;UNTIL=20260713T000000Z', weekly.start, windowStart, windowEnd
+  );
+  assert.deepEqual(
+    untilStarts.map(date => date.toISOString()),
+    ['2026-07-05T21:00:00.000Z', '2026-07-12T21:00:00.000Z'],
+    'UNTIL cuts the series'
+  );
+
+  // Unsupported shapes → null (callers treat the event as non-recurring).
+  assert.equal(SharedCore.expandRruleOccurrencesInWindow('FREQ=YEARLY;BYMONTH=7;BYDAY=1WE', weekly.start, windowStart, windowEnd), null);
+  assert.equal(SharedCore.expandRruleOccurrencesInWindow('FREQ=MONTHLY;BYDAY=1FR,3FR', weekly.start, windowStart, windowEnd), null);
+  assert.equal(SharedCore.expandRruleOccurrencesInWindow('FREQ=MONTHLY;BYSETPOS=1;BYDAY=FR', weekly.start, windowStart, windowEnd), null);
+  assert.equal(SharedCore.expandRruleOccurrencesInWindow('', weekly.start, windowStart, windowEnd), null);
+});
+
+test('expandPublishedCalendarEventsInWindow: EXDATE excluded, override replaces its occurrence, unsupported listed as non-recurring', () => {
+  const records = SharedCore.parsePublishedCalendarIcs(PUBLISHED_ICS_FIXTURE);
+  const windowStart = new Date('2026-07-01T00:00:00.000Z');
+  const windowEnd = new Date('2026-07-31T23:59:59.999Z');
+  const { events, unsupportedRrules } = SharedCore.expandPublishedCalendarEventsInWindow(records, windowStart, windowEnd);
+
+  assert.deepEqual(unsupportedRrules, [{ uid: 'unsupported@test', rrule: 'FREQ=YEARLY;BYMONTH=7;BYDAY=1WE' }],
+    'unsupported RRULE reported for the adapter to log');
+
+  const titles = events.map(event => `${event.title}@${event.startDate.toISOString()}`).sort();
+  assert.deepEqual(titles, [
+    'Annual Gala@2026-07-01T23:00:00.000Z',            // unsupported series → plain one-off on its DTSTART
+    'Beer Blast (Special)@2026-07-26T22:00:00.000Z',   // override replaces the Jul 26 occurrence, own start time
+    'First Friday@2026-07-04T02:00:00.000Z',           // monthly 1FR: Jul 3 22:00 New York
+    'Plain Timed, Event@2026-07-11T01:00:00.000Z',
+    'Weekly Beer Blast@2026-07-05T21:00:00.000Z',
+    'Weekly Beer Blast@2026-07-12T21:00:00.000Z'       // Jul 19 EXDATE excluded, Jul 26 replaced by the override
+  ]);
+
+  const occurrence = events.find(event => event.title === 'Weekly Beer Blast');
+  assert.equal(occurrence.identifier, 'weekly@test', 'series occurrences share the raw ICS UID');
+  assert.equal(occurrence.recurrence, 'FREQ=WEEKLY;BYDAY=SU', 'occurrences carry the series RRULE for the hands-off path');
+  assert.equal(occurrence.notes, 'bar: Rebar', 'DESCRIPTION rides in notes (calendar-as-database format)');
+  assert.equal(occurrence.endDate.toISOString(), '2026-07-06T00:00:00.000Z', 'series duration preserved per occurrence');
+
+  const override = events.find(event => event.title === 'Beer Blast (Special)');
+  assert.equal(override.identifier, 'weekly@test', 'override shares the series UID');
+  assert.equal(override.recurrence, undefined, 'override instances are standalone events');
+  assert.match(override.notes, /overrideUid: weekly@test/);
+
+  const allDayWindow = SharedCore.expandPublishedCalendarEventsInWindow(
+    records, new Date('2026-06-19T00:00:00.000Z'), new Date('2026-06-21T00:00:00.000Z')
+  );
+  const allDay = allDayWindow.events.find(event => event.identifier === 'allday@test');
+  assert.equal(allDay.isAllDay, true);
+  assert.equal(allDay.startDate.toISOString(), '2026-06-20T00:00:00.000Z');
+});
+
+test('expanded series occurrences drive the recurring hands-off path in analyzeEventAction', () => {
+  const core = createCore();
+  const records = SharedCore.parsePublishedCalendarIcs(PUBLISHED_ICS_FIXTURE);
+  const { events } = SharedCore.expandPublishedCalendarEventsInWindow(
+    records, new Date('2026-07-05T00:00:00.000Z'), new Date('2026-07-05T23:59:59.999Z')
+  );
+  const existing = events.filter(event => event.identifier === 'weekly@test');
+  assert.equal(existing.length, 1, 'narrow window sees a single series instance');
+
+  const scraped = {
+    title: 'Weekly Beer Blast',
+    startDate: new Date('2026-07-05T21:00:00.000Z'),
+    endDate: new Date('2026-07-06T00:00:00.000Z')
+  };
+  const analysis = core.analyzeEventAction(scraped, existing, 'upsert');
+  assert.equal(analysis.action, 'new', 'series match never merges into the series master');
+  assert.match(analysis.reason, /creating override/, 'routes to override creation');
+  assert.equal(analysis.overrideIdentity.overrideUid, 'weekly@test');
+});

--- a/scripts/tools-serve-results.test.js
+++ b/scripts/tools-serve-results.test.js
@@ -41,6 +41,7 @@ const {
   listParserNames,
   rewriteBridgeHtml,
   injectHeaderBar,
+  formatCalendarSnapshotLabel,
   buildEventIcs,
   tailLines,
   renderRunFormPage,
@@ -249,6 +250,29 @@ test('injectHeaderBar inserts once after <body> and is idempotent', () => {
   const twice = injectHeaderBar(injected, { savedAt: 'other' });
   assert.equal(twice, injected, 'second injection is a no-op');
   assert.equal((twice.match(new RegExp(HEADER_BAR_MARKER, 'g')) || []).length, 1);
+});
+
+test('header bar surfaces published-calendar snapshot ages per consulted city (v2)', () => {
+  const nowMs = Date.parse('2026-07-28T12:00:00Z');
+  const label = formatCalendarSnapshotLabel({
+    seattle: { status: 'ok', fetchedAt: '2026-07-28T11:26:00Z' },   // 34m old
+    nyc: { status: 'ok', fetchedAt: '2026-07-28T10:00:00Z' },       // 2h old
+    la: { status: 'unavailable', fetchedAt: null }
+  }, nowMs);
+  assert.equal(label, 'calendar snapshot: la unavailable · nyc 2.0h old · seattle 34m old');
+
+  assert.equal(formatCalendarSnapshotLabel(null), '', 'pre-v2 runs render no snapshot segment');
+  assert.equal(formatCalendarSnapshotLabel({}), '');
+
+  const html = '<html><head></head><body><p>results</p></body></html>';
+  const injected = injectHeaderBar(html, {
+    savedAt: '2026-07-28T00:00:00Z',
+    calendarSnapshots: { seattle: { status: 'ok', fetchedAt: new Date(Date.now() - 34 * 60 * 1000).toISOString() } }
+  });
+  assert.ok(injected.includes('calendar snapshot: seattle 34m old'), 'snapshot segment rides in the header bar');
+
+  const withoutSnapshots = injectHeaderBar(html, { savedAt: '2026-07-28T00:00:00Z' });
+  assert.ok(!withoutSnapshots.includes('calendar snapshot:'), 'no segment without snapshot data');
 });
 
 // ---------------------------------------------------------------------------

--- a/tools/serve-results.js
+++ b/tools/serve-results.js
@@ -253,6 +253,36 @@ function queueVenueCandidate() {}
 
 const HEADER_BAR_MARKER = 'chunky-server-header-bar';
 
+// "34m" / "1.5h" / "2.1d" age label for the calendar-snapshot header segment.
+function formatSnapshotAge(ageMs) {
+    if (!Number.isFinite(ageMs) || ageMs < 0) return null;
+    const minutes = ageMs / (60 * 1000);
+    if (minutes < 60) return `${Math.round(minutes)}m`;
+    const hours = minutes / 60;
+    if (hours < 24) return `${hours.toFixed(1)}h`;
+    return `${(hours / 24).toFixed(1)}d`;
+}
+
+// v2: published-calendar snapshot freshness per consulted city, e.g.
+// "calendar snapshot: seattle 34m old · nyc unavailable". Empty string when
+// the run consulted no published calendars (pre-v2 runs, or no events).
+function formatCalendarSnapshotLabel(snapshots, nowMs = Date.now()) {
+    if (!snapshots || typeof snapshots !== 'object') return '';
+    const segments = [];
+    for (const city of Object.keys(snapshots).sort()) {
+        const snapshot = snapshots[city];
+        if (!snapshot || typeof snapshot !== 'object') continue;
+        if (snapshot.status === 'ok' && snapshot.fetchedAt) {
+            const fetchedMs = Date.parse(snapshot.fetchedAt);
+            const age = Number.isFinite(fetchedMs) ? formatSnapshotAge(nowMs - fetchedMs) : null;
+            segments.push(`${city} ${age ? `${age} old` : 'fresh'}`);
+        } else {
+            segments.push(`${city} unavailable`);
+        }
+    }
+    return segments.length > 0 ? `calendar snapshot: ${segments.join(' · ')}` : '';
+}
+
 // Small server header bar injected right after <body>. Idempotent: a page
 // that already carries the marker is returned unchanged.
 function injectHeaderBar(html, info = {}) {
@@ -266,10 +296,14 @@ function injectHeaderBar(html, info = {}) {
     const parserLabel = info.parserFilter
         ? ` · parser: ${escapeHtmlText(info.parserFilter)}`
         : ' · all enabled parsers';
+    const snapshotLabel = formatCalendarSnapshotLabel(info.calendarSnapshots);
+    const snapshotSpan = snapshotLabel
+        ? `\n    <span style="opacity:0.85;">${escapeHtmlText(snapshotLabel)}</span>`
+        : '';
     const bar = `
 <div id="${HEADER_BAR_MARKER}" style="position:sticky; top:0; z-index:9999; display:flex; gap:14px; align-items:center; flex-wrap:wrap; padding:8px 14px; background:#1c1c1e; color:#f2f2f7; font:13px -apple-system, sans-serif; border-bottom:2px solid #ff6b35;">
     <span style="font-weight:700;">chunky.dad scraper server</span>
-    <span>${runLabel}${parserLabel}</span>
+    <span>${runLabel}${parserLabel}</span>${snapshotSpan}
     <a href="/run-form" style="color:#ffd60a; font-weight:600; text-decoration:none;">▶ Run scraper</a>
     <a href="/log" style="color:#ffd60a; text-decoration:none;">Log</a>
     <span style="opacity:0.7;">ICS links belong to this render — after a new run, reload before saving events.</span>
@@ -453,7 +487,8 @@ async function renderLatestResults(state, saved) {
     let out = rewriteBridgeHtml(html, registries);
     out = injectHeaderBar(out, {
         savedAt: saved.savedAt || '',
-        parserFilter: saved.parserFilter || ''
+        parserFilter: saved.parserFilter || '',
+        calendarSnapshots: (saved.results && saved.results.publishedCalendarSnapshots) || null
     });
     return out;
 }
@@ -660,6 +695,7 @@ module.exports = {
     jsonForInlineScript,
     rewriteBridgeHtml,
     injectHeaderBar,
+    formatCalendarSnapshotLabel,
     buildEventIcs,
     tailLines,
     renderRunFormPage,


### PR DESCRIPTION
Follows #1564. Makes Mac runs merge-aware:

- `WebAdapter.getExistingEvents` reads the **published** `chunky.dad/data/calendars/<city>.ics` (6h disk cache, per-run memo, fail-open to NEW with a per-city warning) — no calendar API, no keys, phone remains the only writer.
- Pure shared-core ICS parser + RRULE expander (weekly/monthly-ordinal/daily + INTERVAL/COUNT/UNTIL, EXDATE, RECURRENCE-ID overrides, DST-safe). Expanded occurrences share the series UID and carry `recurrence`, so recurring matches route to the existing hands-off/override path even when only one monthly instance is in the window.
- Results header shows calendar-snapshot staleness per city (`seattle 34m old · houston unavailable`).

**Live proof:** real Megawoof run on the Mac → **D>U>R>O LA = merge** (the canonical case that was NEW in v1), Phoenix = merge, Houston = degraded-NEW because its calendar isn't published (houston isn't a visible site city — expected, warned). Real seattle/nyc/la ICS files contain **zero unsupported RRULEs** — the expander covers everything that actually exists.

Tests 953 → 966. Mac-side only — nothing phone-side changes, nothing can write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP