### PR TITLE
fix(scraper): battery findings — recurrence persists, registry de-circularized, stub dedup, trim enforce ON

### DIFF
--- a/data/promoters.json
+++ b/data/promoters.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "Megawoof America",
+    "aliases": ["MEGAWOOF"],
     "shortName": "MEGA-WOOF",
     "instagram": "https://www.instagram.com/megawoof_america",
     "website": "https://linktr.ee/megawoof_america",
@@ -87,6 +88,16 @@
     "name": "BEEFMINCE",
     "website": "https://beefmince.com",
     "bearAffinity": "always"
+  },
+  {
+    "name": "SPOOKMINCE",
+    "parent": "BEEFMINCE",
+    "keywords": ["spookmince"]
+  },
+  {
+    "name": "BOATMINCE",
+    "parent": "BEEFMINCE",
+    "keywords": ["boatmince"]
   },
   {
     "name": "BeefDip",

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -728,7 +728,15 @@ class AiWebParser {
                 }
                 if (hasOcrContent || hasBodyContent) {
                     console.log('🤖 AI Web: No valid segments on multi-event page — falling back to whole-page extraction');
-                    return this.extractEventsFromSinglePage(htmlData, parserConfig, cityConfig, promptFields, ocrResults, httpAdapter);
+                    // The fallback marker scopes the page-title-echo junk gate
+                    // (rejectPageTitleEchoPassFields): only whole-page fallbacks
+                    // on multi-event-classified pages can stitch a sibling
+                    // event's schedule onto a title echoed from the page's own
+                    // og:title (battery run 20260728, The Lumberyard "White
+                    // Center"). Ordinary single-event pages never carry it.
+                    return this.extractEventsFromSinglePage(
+                        { ...htmlData, _wholePageFallback: true },
+                        parserConfig, cityConfig, promptFields, ocrResults, httpAdapter);
                 }
             }
             return [];
@@ -6583,6 +6591,68 @@ class AiWebParser {
         return guarded;
     }
 
+    // Whole-page-fallback junk gate (battery run 20260728, The Lumberyard):
+    // the homepage og:title "White Center | United States | Lumber Yard Bar"
+    // — a neighborhood, not an event — was echoed back as the title by a
+    // meta-content pass carrying no date/time at all, and later OCR passes
+    // stitched a SIBLING event's schedule onto it, producing the run's only
+    // surviving "event". Reject a pass-result title that (a) matches a
+    // segment of the page's own og:title/site-title via padded-token
+    // containment AND (b) arrives without any date/time evidence in the SAME
+    // pass — that combination is a page label, not an event name. The field
+    // stays open for content/OCR passes that name the real event, and a pass
+    // that carries the title TOGETHER with its schedule always passes (the
+    // no-time-evidence condition is the discriminator, protecting legitimate
+    // single-event pages whose og:title IS the event name). Scoped to the
+    // whole-page fallback (htmlData._wholePageFallback) — only multi-event-
+    // classified pages that failed segmentation can stitch sibling schedules
+    // onto a page-title echo.
+    rejectPageTitleEchoPassFields(partial, htmlData) {
+        if (!partial || typeof partial !== 'object') return partial;
+        if (!htmlData || htmlData._wholePageFallback !== true) return partial;
+        const titleKey = Object.keys(partial).find(key => !this.isInternalAiFieldKey(key)
+            && this.normalizePromptFieldName(key) === 'title'
+            && typeof partial[key] === 'string' && partial[key].trim());
+        if (titleKey === undefined) return partial;
+        const title = partial[titleKey].trim();
+        if (!this.titleEchoesPageTitleSegment(title, htmlData)) return partial;
+        const timeFieldNames = new Set(['startdate', 'starttime', 'enddate', 'endtime', 'start', 'end']);
+        const passHasTimeEvidence = Object.keys(partial).some(key => !this.isInternalAiFieldKey(key)
+            && timeFieldNames.has(this.normalizePromptFieldName(key))
+            && this.isUsableAiFieldValue(partial[key]));
+        if (passHasTimeEvidence) return partial;
+        console.log(`🤖 AI Web: Skipped page-title echo "${title}" — not an event`);
+        const guarded = { ...partial };
+        delete guarded[titleKey];
+        return guarded;
+    }
+
+    // Padded-token containment of a candidate title in any '|'-separated
+    // segment of the page's own og:title or <title> tag. Case-insensitive,
+    // punctuation-collapsed; empty inputs never match.
+    titleEchoesPageTitleSegment(title, htmlData) {
+        const normalize = (value) => String(value || '')
+            .toLowerCase()
+            .replace(/[^\p{L}\p{N}]+/gu, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        const normalizedTitle = normalize(title);
+        if (!normalizedTitle) return false;
+        const pageTitles = [
+            this.getPageOgTitle(htmlData),
+            this.extractTitlePart(htmlData && typeof htmlData.html === 'string' ? htmlData.html : '')
+        ];
+        for (const pageTitle of pageTitles) {
+            if (!pageTitle) continue;
+            for (const segment of String(pageTitle).split('|')) {
+                const normalizedSegment = normalize(segment);
+                if (!normalizedSegment) continue;
+                if (` ${normalizedSegment} `.includes(` ${normalizedTitle} `)) return true;
+            }
+        }
+        return false;
+    }
+
     // A jsonld extraction pass on a page whose JSON-LD carries no Event-typed node
     // (WebPage/ImageObject/BreadcrumbList/Organization boilerplate) is a wasted AI
     // request — the model has nothing to extract and returns {}. Detect Event-typed
@@ -6742,6 +6812,12 @@ class AiWebParser {
             // keeps the field open; normalizeAiEvent keeps the same guards as an
             // end-of-pipeline backstop.
             validatedPartial = this.rejectBrandLikePassFields(validatedPartial, htmlData, passLabel);
+
+            // Whole-page-fallback junk gate (see rejectPageTitleEchoPassFields):
+            // a pass-result title that merely echoes a segment of the page's
+            // own og:title/site-title with no date/time evidence in the SAME
+            // pass is a page label, not an event name.
+            validatedPartial = this.rejectPageTitleEchoPassFields(validatedPartial, htmlData);
 
             // Track field sources for traceability
             const validatedFields = validationState ? validationState.validatedFields : new Set();
@@ -9666,11 +9742,18 @@ TEXT:
         const aiPrompts = Array.isArray(aiEvent.__aiPrompts) ? aiEvent.__aiPrompts.filter(entry => entry && entry.prompt) : [];
         // Pass dataFlags from htmlData if available, otherwise default to empty object
         const dataFlags = htmlData && htmlData.dataFlags ? htmlData.dataFlags : {};
+        // The pass-merge stores AI-returned rrule/recurrence values under the
+        // CANONICAL schema key 'recurrence' (mergeAiEventFields canonicalizes
+        // every response key, and canonicalizeEventKey maps rrule →
+        // recurrence), so the pickup must read that name too — battery run
+        // 20260728: CubScout's validated FREQ=MONTHLY;BYDAY=1FR sat on
+        // aiEvent.recurrence and never reached event.recurrenceRule.
         const recurrenceRule = this.isPromptFieldRequested('rrule', parserConfig, promptFields, dataFlags)
             ? this.normalizeRruleValue(this.firstNonEmpty(
                 aiEvent.recurrenceRule,
+                aiEvent.recurrence,
                 aiEvent.rrule,
-                this.getResolvedParserMetadataFieldValue(parserConfig, ['recurrenceRule', 'rrule'], aiEvent),
+                this.getResolvedParserMetadataFieldValue(parserConfig, ['recurrenceRule', 'recurrence', 'rrule'], aiEvent),
                 ''
             ))
             : '';

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -6833,6 +6833,116 @@ test('rrule survives the evidence gate when its schedule evidence is verbatim an
   assert.deepEqual(result.report.dropped, [], 'nothing dropped');
 });
 
+test('merge-canonicalized recurrence reaches event.recurrenceRule under both response namings', () => {
+  // Battery run 20260728 (CubScout): the schedule-evidence gate KEPT the
+  // extracted rrule, but the pass merge stores it under the canonical
+  // 'recurrence' key and normalizeAiEvent only read recurrenceRule/rrule —
+  // so ZERO events battery-wide ever carried recurrence. Replay the literal
+  // CubScout response shape through validation → merge → assembly for both
+  // prompt namings ('rrule' and 'recurrence').
+  global.EventSchema = EventSchema;
+  for (const keyName of ['rrule', 'recurrence']) {
+    const parser = createParser();
+    parser.now = () => new Date(2026, 6, 22, 15, 0, 0); // Wed 2026-07-22 local
+    const partial = {
+      title: 'CUBSCOUT',
+      [keyName]: 'FREQ=MONTHLY;BYDAY=1FR',
+      __fieldEvidence: { [keyName]: '1ST FRIDAY OF THE MONTH' }
+    };
+    const validated = runRruleValidation(parser, partial);
+    assert.equal(validated.event[keyName], 'FREQ=MONTHLY;BYDAY=1FR',
+      `${keyName}: the schedule-evidence gate keeps the corroborated rule`);
+    const merged = parser.mergeAiEventFields({}, validated.event);
+    assert.equal(merged.recurrence, 'FREQ=MONTHLY;BYDAY=1FR',
+      `${keyName}: the pass merge stores the canonical recurrence key`);
+    const logs = [];
+    const originalLog = console.log;
+    console.log = (...args) => { logs.push(args.join(' ')); };
+    let event;
+    try {
+      event = parser.normalizeAiEvent(merged, {}, null, null, null);
+    } finally {
+      console.log = originalLog;
+    }
+    assert.ok(event, `${keyName}: the recurring event survives assembly`);
+    assert.equal(event.recurrenceRule, 'FREQ=MONTHLY;BYDAY=1FR',
+      `${keyName}: the canonical recurrence value lands on event.recurrenceRule`);
+    assert.ok(logs.some(line => line.startsWith('🔁 RECURRING: derived next occurrence')),
+      `${keyName}: the recurring derivation log fires`);
+  }
+});
+
+test('whole-page fallback rejects page-title echoes without same-pass time evidence', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  // Battery run 20260728 (The Lumberyard): the homepage og:title
+  // "White Center | United States | Lumber Yard Bar" (a neighborhood) became
+  // the surviving event's title via a meta pass that carried no date/time.
+  const html = '<html><head><meta property="og:title" content="White Center | United States | Lumber Yard Bar" />'
+    + '<title>White Center | United States | Lumber Yard Bar</title></head><body>events</body></html>';
+  const fallbackHtmlData = { html, url: 'https://www.thelumberyardbar.com/', _wholePageFallback: true };
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let guarded;
+  let withSchedule;
+  let notFallback;
+  try {
+    guarded = parser.rejectPageTitleEchoPassFields(
+      { title: 'White Center', url: 'https://www.thelumberyardbar.com/' },
+      fallbackHtmlData
+    );
+    // A pass carrying the title TOGETHER with its schedule always passes —
+    // the goldiloxx-chicago class (og:title IS the event name, full schedule).
+    withSchedule = parser.rejectPageTitleEchoPassFields(
+      { title: 'White Center', startDate: '2026-07-31', startTime: '21:00' },
+      fallbackHtmlData
+    );
+    // Ordinary (non-fallback) pages are untouched.
+    notFallback = parser.rejectPageTitleEchoPassFields(
+      { title: 'White Center' },
+      { html, url: 'https://www.thelumberyardbar.com/' }
+    );
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(guarded.title, undefined, 'the og:title echo is rejected on the fallback path');
+  assert.equal(guarded.url, 'https://www.thelumberyardbar.com/', 'other fields survive');
+  assert.ok(logs.includes('🤖 AI Web: Skipped page-title echo "White Center" — not an event'),
+    `the junk-gate log fires, got: ${JSON.stringify(logs)}`);
+  assert.equal(withSchedule.title, 'White Center', 'a title with same-pass time evidence is kept');
+  assert.equal(notFallback.title, 'White Center', 'non-fallback extraction is untouched');
+
+  // A real event name absent from the page's own titles is never rejected.
+  const realEvent = parser.rejectPageTitleEchoPassFields(
+    { title: 'GLOW: THE SEQUEL' },
+    fallbackHtmlData
+  );
+  assert.equal(realEvent.title, 'GLOW: THE SEQUEL');
+});
+
+test('the schedule-evidence gate drops mismatched rules under the recurrence naming too', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let mismatch;
+  try {
+    mismatch = runRruleValidation(parser, {
+      recurrence: 'FREQ=WEEKLY;BYDAY=FR',
+      __fieldEvidence: { recurrence: 'every Tuesday' }
+    });
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(mismatch.event.recurrence, undefined, 'weekday mismatch fails closed for the recurrence key');
+  assert.equal(mismatch.report.dropped[0].reason, 'rrule-schedule-evidence');
+  assert.ok(logs.includes('🤖 AI Web: Dropped rrule "FREQ=WEEKLY;BYDAY=FR" — schedule words in evidence do not corroborate the rule'),
+    `the corroboration drop log fires on the recurrence-named path, got: ${JSON.stringify(logs)}`);
+});
+
 test('rrule validation rejects non-RRULE values, unverbatim evidence, and schedule mismatches', () => {
   global.EventSchema = EventSchema;
   const parser = createParser();

--- a/scripts/promoter-registry.test.js
+++ b/scripts/promoter-registry.test.js
@@ -152,3 +152,50 @@ test('matcher: the title "CUBSCOUT" matches CubScout LA via the same-entry alias
   const fullName = core.matchEventToPromoter({ title: 'CubScout LA: Woof Edition' });
   assert.ok(fullName && fullName.entry && fullName.entry.name === 'CubScout LA');
 });
+
+test('matcher: MEGAWOOF alias and the new BEEFMINCE sub-brands match their titles', () => {
+  const { SharedCore } = require('./shared-core');
+  const { EventSchema } = require('./event-schema');
+  const core = new SharedCore({}, { eventSchema: EventSchema, promoters: loadRegistry() });
+  // Battery run 20260728 (The Bear Calendar): "MEGAWOOF HOUSTON @ RICHs"
+  // carried no registry evidence — only the full "Megawoof America" name was
+  // known. The same-entry substring alias closes the recall gap.
+  const megawoof = core.matchEventToPromoter({ title: 'MEGAWOOF HOUSTON @ RICHs' });
+  assert.ok(megawoof && megawoof.entry, `expected a match, got ${JSON.stringify(megawoof)}`);
+  assert.equal(megawoof.entry.name, 'Megawoof America');
+  assert.equal(megawoof.evidence, 'title');
+
+  const spook = core.matchEventToPromoter({ title: 'SPOOKMINCE' });
+  assert.ok(spook && spook.entry, `expected a match, got ${JSON.stringify(spook)}`);
+  assert.equal(spook.entry.name, 'SPOOKMINCE');
+  assert.equal(spook.entry.parent, 'BEEFMINCE');
+
+  const boat = core.matchEventToPromoter({ title: 'BOATMINCE — September 2026' });
+  assert.ok(boat && boat.entry, `expected a match, got ${JSON.stringify(boat)}`);
+  assert.equal(boat.entry.name, 'BOATMINCE');
+  assert.equal(boat.entry.parent, 'BEEFMINCE');
+});
+
+test('matcher: statically stamped url-ish fields are never registry evidence (de-circularization)', () => {
+  const { SharedCore } = require('./shared-core');
+  const { EventSchema } = require('./event-schema');
+  const core = new SharedCore({}, { eventSchema: EventSchema, promoters: loadRegistry() });
+  // Battery run 20260728 (Club Chub): the parser's own static metadata
+  // stamped instagram.com/clubchubparty onto every event it emitted, and
+  // DURO then "matched" Club Chub on the parser's own stamp — circular.
+  const stamped = core.matchEventToPromoter({
+    title: 'D>U>R>O is back NEW OUTDOOR LOCATION',
+    instagram: 'https://www.instagram.com/clubchubparty',
+    _staticFields: { instagram: 'https://www.instagram.com/clubchubparty' }
+  });
+  assert.equal(stamped, null, 'a parser-stamped instagram is not evidence');
+  // The SAME event with the instagram organically extracted (no
+  // _staticFields entry) still matches.
+  const organic = core.matchEventToPromoter({
+    title: 'D>U>R>O is back NEW OUTDOOR LOCATION',
+    instagram: 'https://www.instagram.com/clubchubparty'
+  });
+  assert.ok(organic && organic.entry, `expected an organic match, got ${JSON.stringify(organic)}`);
+  assert.equal(organic.entry.name, 'Club Chub');
+  assert.equal(organic.evidence, 'url:instagram.com/clubchubparty');
+});

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -57,11 +57,13 @@ const scraperConfig = {
       // Overlong-field trim pipeline: one AI call per event batches every
       // overlong scraped field (title/description/shortName); answers are
       // accepted only as VERBATIM contiguous substrings of the original.
-      // "report" (default) logs would-trim decisions without changing values;
+      // "report" logs would-trim decisions without changing values;
       // "enforce" replaces; "off" disables. Calendar-sourced values are never
       // AI-trimmed — they are only flagged in the event evidence panel.
+      // Enforce since battery run 20260728: every proposal was clean and the
+      // verbatim gate correctly rejected non-substring description trims.
       trim: {
-        mode: "report", // "report" (default) | "enforce" | "off"
+        mode: "enforce", // "report" | "enforce" | "off"
         titleMaxChars: 60, // data: title p95=48, p99=72, max=74
         descriptionMaxChars: 600, // data: description p95=491, max=846
         shortNameMaxChars: 30, // data: shortName max=20

--- a/scripts/scraper-promoters.js
+++ b/scripts/scraper-promoters.js
@@ -10,6 +10,9 @@
 const scraperPromoters = [
   {
     "name": "Megawoof America",
+    "aliases": [
+      "MEGAWOOF"
+    ],
     "shortName": "MEGA-WOOF",
     "instagram": "https://www.instagram.com/megawoof_america",
     "website": "https://linktr.ee/megawoof_america",
@@ -111,6 +114,20 @@ const scraperPromoters = [
     "name": "BEEFMINCE",
     "website": "https://beefmince.com",
     "bearAffinity": "always"
+  },
+  {
+    "name": "SPOOKMINCE",
+    "parent": "BEEFMINCE",
+    "keywords": [
+      "spookmince"
+    ]
+  },
+  {
+    "name": "BOATMINCE",
+    "parent": "BEEFMINCE",
+    "keywords": [
+      "boatmince"
+    ]
   },
   {
     "name": "BeefDip",

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1455,12 +1455,25 @@ class SharedCore {
                 if (paddedTitle.includes(` ${phrase} `)) return { evidence: 'title' };
             }
         }
+        // De-circularization (battery run 20260728, Club Chub): parser static
+        // metadata stamps url-ish fields (instagram/website/url/facebook) onto
+        // EVERY event the parser emits — matching a registry entry on a value
+        // the pipeline itself stamped is circular, not evidence. Statically
+        // stamped fields (tracked in _staticFields by applyStaticMetadataBlock)
+        // are excluded; only organically-extracted URLs count. ticketUrl and
+        // _sourcePageUrl always come from the page, never from static
+        // metadata, so they remain valid evidence. url/website are ONE field
+        // (aliases), so a stamp under either key covers both.
+        const staticFields = event && event._staticFields && typeof event._staticFields === 'object'
+            ? event._staticFields
+            : {};
+        const isStaticStamped = (...keys) => keys.some(key => Object.prototype.hasOwnProperty.call(staticFields, key));
         const urlValues = [
-            event && event.url,
+            isStaticStamped('url', 'website') ? '' : (event && event.url),
             event && event.ticketUrl,
-            event && event.website,
-            event && event.instagram,
-            event && event.facebook,
+            isStaticStamped('website', 'url') ? '' : (event && event.website),
+            isStaticStamped('instagram') ? '' : (event && event.instagram),
+            isStaticStamped('facebook') ? '' : (event && event.facebook),
             event && event._sourcePageUrl
         ];
         for (const value of urlValues) {
@@ -2736,6 +2749,15 @@ class SharedCore {
             aiWebParser.applyVenueSiteIdentityCorrections(allEvents, mainConfig?.cities || null);
         }
 
+        // Aggregator website pointer (trust the pointer, not the copy —
+        // battery run 20260728: all 42 The Bear Calendar events carried
+        // website = the aggregator's own event page): when a configured root
+        // classified 'link-aggregator', an event whose website still points
+        // at its own source page on that aggregator's host but whose
+        // ticketUrl points at a DIFFERENT host gets website = ticketUrl (the
+        // original source). Generic signal only — no per-site rules.
+        this.applyAggregatorWebsitePointers(allEvents, urlClassifications);
+
         // Metadata is applied dynamically by parsers using the {value, merge} format
 
         // Filter and process events. Enforce-mode bear-check drops are carried
@@ -2801,6 +2823,39 @@ class SharedCore {
         }
 
         return result;
+    }
+
+    // Aggregator website pointer pass (see the processParser call site): for
+    // events extracted from a site whose configured root classified as
+    // 'link-aggregator', a website that merely points back at the event's own
+    // aggregator page is a copy, not the pointer — prefer the ticketUrl when
+    // it leads OFF the aggregator's host. Fails closed on any missing piece:
+    // no website, no ticketUrl, same-host ticketUrl, or a website that is not
+    // the event's own source page all leave the event untouched.
+    applyAggregatorWebsitePointers(events, urlClassifications) {
+        if (!Array.isArray(events) || events.length === 0) return;
+        const classifications = urlClassifications && typeof urlClassifications === 'object' ? urlClassifications : {};
+        const aggregatorHosts = new Set();
+        for (const url of Object.keys(classifications)) {
+            if (classifications[url] !== 'link-aggregator') continue;
+            const host = this.getHostFromUrl(url).toLowerCase().replace(/^www\./, '');
+            if (host) aggregatorHosts.add(host);
+        }
+        if (aggregatorHosts.size === 0) return;
+        for (const event of events) {
+            if (!event || typeof event !== 'object') continue;
+            const website = typeof event.website === 'string' ? event.website.trim() : '';
+            const ticketUrl = typeof event.ticketUrl === 'string' ? event.ticketUrl.trim() : '';
+            const sourcePageUrl = typeof event._sourcePageUrl === 'string' ? event._sourcePageUrl.trim() : '';
+            if (!website || !ticketUrl || !sourcePageUrl) continue;
+            const sourceHost = this.getHostFromUrl(sourcePageUrl).toLowerCase().replace(/^www\./, '');
+            if (!sourceHost || !aggregatorHosts.has(sourceHost)) continue;
+            if (this.getUrlDedupeKey(website) !== this.getUrlDedupeKey(sourcePageUrl)) continue;
+            const ticketHost = this.getHostFromUrl(ticketUrl);
+            if (!ticketHost || this.areUrlHostsSameSite(ticketHost, sourceHost)) continue;
+            event.website = ticketUrl;
+            console.log(`🤖 AI Web: website set to original source ${ticketHost} (aggregator page pointer)`);
+        }
     }
 
     // Paste-ready parser entry printed after discoveryOnly runs. Only
@@ -5211,6 +5266,14 @@ class SharedCore {
         // A URL shared by 3+ records in one run is a listing/hub page (an events
         // calendar, a linktree with a path), not an event page — never merge on it.
         // Event-detail URLs are one-per-event; only a listing produces that fan-in.
+        // Pathed-URL equality alone is the identity — no title compatibility
+        // check (battery run 20260728: listing stubs titled with the VENUE —
+        // "Nova PDX", "The Godfrey Rooftop", "CCBC Resort" — shared the exact
+        // event-page URL with their properly-titled detail twins and the old
+        // title veto kept all three pairs as duplicates). Homepage-root URLs
+        // never qualify (getEventUrlIdentityKey requires a path segment), so a
+        // parser whose events all carry the site root (e.g. furball.nyc) is
+        // untouched.
         const urlKeyCounts = new Map();
         for (const event of deduplicated) {
             const urlKey = this.getEventUrlIdentityKey(event && event.url);
@@ -5233,8 +5296,7 @@ class SharedCore {
                 continue;
             }
             const holder = eventsByUrl.get(urlKey);
-            if (holder && this.areStartDatesWithinDays(holder, event, 7)
-                && this.areTitlesCompatibleForUrlMerge(holder.title, event.title)) {
+            if (holder && this.areStartDatesWithinDays(holder, event, 7)) {
                 console.log(`🔄 SharedCore: Same event URL — merging "${holder.title || 'event'}" and "${event.title || 'event'}" despite city/venue mismatch`);
                 // Identity fields (key/city/timezone) must come from the richer
                 // record — corrupted identity fields are exactly why these records
@@ -8838,23 +8900,6 @@ class SharedCore {
         const path = String(parsed.pathname || '').replace(/\/+$/, '');
         if (!path) return null; // domain root — no meaningful path segment
         return `${parsed.protocol.toLowerCase()}//${parsed.host.toLowerCase()}${path}${parsed.search || ''}`;
-    }
-
-    // Same-URL merges additionally require compatible titles: two records of one
-    // event title it the same way or one is a prefixed/suffixed variant of the
-    // other ("SPRING THAW" vs "CHUNK CHICAGO presents SPRING THAW!"), while two
-    // DIFFERENT parties that happen to share a listing-page URL name themselves
-    // differently. Empty titles stay conservative (no merge).
-    areTitlesCompatibleForUrlMerge(titleA, titleB) {
-        const normalize = (value) => this.stripEmojiForTitleTwin(String(value || ''))
-            .toLowerCase()
-            .replace(/[^\p{L}\p{N}]+/gu, ' ')
-            .replace(/\s+/g, ' ')
-            .trim();
-        const a = normalize(titleA);
-        const b = normalize(titleB);
-        if (!a || !b) return false;
-        return a === b || a.includes(b) || b.includes(a);
     }
 
     // Sanity window for same-URL dedup: recurring events reuse their event page,

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4708,31 +4708,121 @@ test('deduplicateEvents treats a URL shared by 3+ events as a listing page (no s
   assert.equal(result.length, 3, 'a URL shared by 3+ events must never trigger the same-URL merge');
 });
 
-test('deduplicateEvents does not merge same-URL records with incompatible titles', async () => {
+test('deduplicateEvents merges venue-titled listing stubs with their same-URL detail twins', async () => {
   const core = createCore();
-  // Two DIFFERENT parties whose records both point at a shared path'd listing URL
-  // (e.g. a weekend calendar) on close dates: titles disagree, so no merge.
-  const friday = {
-    title: 'BEAR NIGHT',
-    bar: 'Cell Block',
-    city: 'chicago',
-    timezone: 'America/Chicago',
-    startDate: new Date('2026-07-24T21:00:00.000Z'),
-    url: 'https://venue-site.com/weekend-lineup',
-    source: 'ai-web'
-  };
-  const saturday = {
-    title: 'UNDERWEAR PARTY',
-    bar: 'Cell Block',
-    city: 'chicago',
-    timezone: 'America/Chicago',
-    startDate: new Date('2026-07-25T21:00:00.000Z'),
-    url: 'https://venue-site.com/weekend-lineup',
-    source: 'ai-web'
-  };
+  // Battery run 20260728: three unmerged pairs where a listing stub (VENUE as
+  // title, midnight date, unknown city — so no key/identity signal can fire)
+  // shares the EXACT event-page URL with its detail twin. Pathed-URL equality
+  // alone is identity; the old title-compatibility veto kept all three pairs
+  // as duplicates.
+  const pairs = [
+    [
+      { title: 'Nova PDX', startDate: new Date('2026-08-22T00:00:00.000Z'),
+        url: 'https://www.chunk-party.com/event-details/chunk-portland-summer-blow-out', source: 'ai-web' },
+      { title: 'CHUNK Portland - SUMMER BLOW OUT!', bar: 'Nova PDX', city: 'portland',
+        address: '1035 SE Stark St, Portland, OR', timezone: 'America/Los_Angeles',
+        startDate: new Date('2026-08-23T04:00:00.000Z'),
+        url: 'https://www.chunk-party.com/event-details/chunk-portland-summer-blow-out', source: 'ai-web' }
+    ],
+    [
+      { title: 'The Godfrey Rooftop', startDate: new Date('2026-08-22T00:00:00.000Z'),
+        url: 'https://www.eventbrite.com/e/quenchd-tickets-1993587626256', source: 'ai-web' },
+      { title: 'QUENCHD', bar: 'The Godfrey Rooftop', city: 'chicago',
+        address: '127 W Huron St, Chicago, IL', timezone: 'America/Chicago',
+        startDate: new Date('2026-08-22T20:00:00.000Z'),
+        url: 'https://www.eventbrite.com/e/quenchd-tickets-1993587626256', source: 'ai-web' }
+    ],
+    [
+      { title: 'CCBC Resort', startDate: new Date('2026-09-11T00:00:00.000Z'),
+        url: 'https://www.eventbrite.com/e/club-chub-weekend-2026-the-ultimate-celebration-tickets-1975884326209', source: 'ai-web' },
+      { title: 'Club Chub Weekend 2026 — The Ultimate Celebration!', bar: 'CCBC Resort', city: 'palm springs',
+        address: '68300 Gay Resort Dr, Cathedral City, CA', timezone: 'America/Los_Angeles',
+        startDate: new Date('2026-09-11T18:00:00.000Z'),
+        url: 'https://www.eventbrite.com/e/club-chub-weekend-2026-the-ultimate-celebration-tickets-1975884326209', source: 'ai-web' }
+    ]
+  ];
+  for (const [stub, detail] of pairs) {
+    const result = await core.deduplicateEvents([stub, detail], null);
+    assert.equal(result.length, 1, `"${stub.title}" / "${detail.title}" must merge on their shared event-page URL`);
+    assert.equal(result[0].title, detail.title, 'the complete/dated detail record supplies the title');
+  }
+});
 
-  const result = await core.deduplicateEvents([friday, saturday], null);
-  assert.equal(result.length, 2, 'same URL with unrelated titles must stay separate events');
+test('applyAggregatorWebsitePointers prefers the cross-host ticketUrl over the aggregator page copy', () => {
+  const core = createCore();
+  // Battery run 20260728: all 42 The Bear Calendar events carried
+  // website=url=their thebearcalendar.com page while ticketUrl pointed at
+  // the ORIGINAL ticketing host. Trust the pointer, not the copy.
+  const urlClassifications = { 'https://thebearcalendar.com/events/': 'link-aggregator' };
+  const aggregatorEvent = {
+    title: 'D>U>R>O',
+    website: 'https://thebearcalendar.com/events/d-u-r-o-2026/',
+    ticketUrl: 'https://dice.fm/event/duro-la-2026',
+    _sourcePageUrl: 'https://thebearcalendar.com/events/d-u-r-o-2026/'
+  };
+  // Non-aggregator page: untouched even with a cross-host ticketUrl.
+  const venueEvent = {
+    title: 'CUBSCOUT',
+    website: 'https://eaglela.com/events/cub-scout-3/',
+    ticketUrl: 'https://dice.fm/event/cubscout',
+    _sourcePageUrl: 'https://eaglela.com/events/cub-scout-3/'
+  };
+  // Same-host ticketUrl on the aggregator: no better pointer exists — untouched.
+  const sameHostEvent = {
+    title: 'BEAR NIGHT',
+    website: 'https://thebearcalendar.com/events/bear-night-2026/',
+    ticketUrl: 'https://www.thebearcalendar.com/tickets/bear-night-2026',
+    _sourcePageUrl: 'https://thebearcalendar.com/events/bear-night-2026/'
+  };
+  // Website already points off the aggregator: never clobbered.
+  const alreadyOriginalEvent = {
+    title: 'MEGAWOOF',
+    website: 'https://megawoof.com/houston',
+    ticketUrl: 'https://dice.fm/event/megawoof-houston',
+    _sourcePageUrl: 'https://thebearcalendar.com/events/megawoof-houston-richs-2026/'
+  };
+  core.applyAggregatorWebsitePointers(
+    [aggregatorEvent, venueEvent, sameHostEvent, alreadyOriginalEvent],
+    urlClassifications
+  );
+  assert.equal(aggregatorEvent.website, 'https://dice.fm/event/duro-la-2026',
+    'aggregator-page website is replaced by the original ticketing URL');
+  assert.equal(venueEvent.website, 'https://eaglela.com/events/cub-scout-3/',
+    'non-aggregator pages are unchanged');
+  assert.equal(sameHostEvent.website, 'https://thebearcalendar.com/events/bear-night-2026/',
+    'a same-host ticketUrl never rewrites website');
+  assert.equal(alreadyOriginalEvent.website, 'https://megawoof.com/houston',
+    'a website already pointing at the original source is untouched');
+});
+
+test('deduplicateEvents never same-URL-merges root-URL events or distinct per-event paths', async () => {
+  const core = createCore();
+  // Furball: every event carries the site ROOT as its url — where they were
+  // found, not what they are. Zero path segments → no url identity key.
+  const furball = ['FURBALL Asbury Park Beach', 'FURBALL Chicago', 'FURBALL MAD.BEAR', 'FURBALL CAMP', 'FURBALL']
+    .map((title, index) => ({
+      title,
+      city: 'new york',
+      timezone: 'America/New_York',
+      startDate: new Date(`2026-08-${String(10 + index).padStart(2, '0')}T02:00:00.000Z`),
+      url: 'https://www.furball.nyc',
+      source: 'ai-web'
+    }));
+  const furballResult = await core.deduplicateEvents(furball, null);
+  assert.equal(furballResult.length, 5, 'shared homepage-root URLs must never merge events');
+
+  // Aggregator (The Bear Calendar): distinct per-event paths on one host must
+  // not cross-merge even on close dates.
+  const tbc = [
+    { title: 'BEEFMINCE x RVT', city: 'london', timezone: 'Europe/London',
+      startDate: new Date('2026-08-15T21:00:00.000Z'),
+      url: 'https://thebearcalendar.com/events/beefmince-x-rvt-2026-4/', source: 'ai-web' },
+    { title: 'MEGAWOOF HOUSTON @ RICHs', city: 'houston', timezone: 'America/Chicago',
+      startDate: new Date('2026-08-16T03:00:00.000Z'),
+      url: 'https://thebearcalendar.com/events/megawoof-houston-richs-2026/', source: 'ai-web' }
+  ];
+  const tbcResult = await core.deduplicateEvents(tbc, null);
+  assert.equal(tbcResult.length, 2, 'distinct per-event paths must stay separate events');
 });
 
 test('deduplicateEvents merges same-URL records whose titles are prefixed variants', async () => {


### PR DESCRIPTION
The 7-parser Mac evidence battery surfaced these; every fix was **re-verified with live reruns** before this PR:

| Finding | Root cause | Fix | Live proof |
|---|---|---|---|
| Recurrence never persisted (battery-wide zero) | Merge canonicalizes `rrule`→`recurrence`; assembly pickup only read `recurrenceRule`/`rrule` | Pickup includes the canonical name | CubScout rerun: `FREQ=MONTHLY;BYDAY=1FR` + `_recurring` + 🔁 withheld-from-write, end to end |
| DURO→Club Chub registry false positive | **Circular evidence**: parser-stamped `instagram=clubchubparty` counted as the event's own URL evidence | `_staticFields`-applied url fields excluded from matcher evidence | Rerun: circular matches gone (0 url-evidence matches) |
| Registry recall misses | Literal title matching needs full keys | `MEGAWOOF` alias; `SPOOKMINCE`/`BOATMINCE` children under BEEFMINCE | Title tests |
| Listing-stub duplicates (CCBC ×2, QUENCHD ×2, Nova PDX) | Same-URL dedup had a title-compatibility veto; stubs (venue-as-title) never satisfy it | Veto removed — pathed-URL equality is identity (root-URL and fan-in protections keep Furball/TBC safe) | Club Chub rerun: 6 → 4, exactly one QUENCHD + one CCBC Weekend |
| Trim gate | — | **`ai.trim.mode` → enforce** (battery: all proposals clean; descriptions correctly gate-protected) | — |
| TBC `website` = aggregator self-page ×42 | No pointer preference | Link-aggregator events with off-host ticketUrl get `website` = original source | 4-case test |
| "White Center" neighborhood-as-event | Whole-page fallback accepted an og:title echo; a later OCR pass stitched a sibling's time onto it | Per-pass echo gate (title ⊂ og:title AND no date/time in the same pass) | Lumberyard case fixture |

One nuance for the registry-enforce decision (not a blocker, disclosed): an Eventbrite-side DURO record still matches Club Chub via **organic organizer evidence** — Eventbrite's own page says "in collaboration with CLUB CHUB", so that attribution is defensible for a collab event; the Megawoof-side records match Megawoof, and the merged event's identity resolves through arbitration.

Tests **965 → 972**.

## After merge
Phone updater pull: `shared-core.js`, `parsers/ai-web-parser.js`, `event-schema.js`, `scraper-promoters.js`, `scraper-input.js` (trim now enforced). Next: I'll rerun the full battery on the merged build — if registry precision holds with the circular matches gone, the enforce flip PR follows with that evidence attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP