### PR TITLE
feat(scraper): registry ENFORCE (battery-proven) + trim merge-persistence + Sitges/Spooky onboarding

### DIFF
--- a/data/promoters.json
+++ b/data/promoters.json
@@ -1,7 +1,9 @@
 [
   {
     "name": "Megawoof America",
-    "aliases": ["MEGAWOOF"],
+    "aliases": [
+      "MEGAWOOF"
+    ],
     "shortName": "MEGA-WOOF",
     "instagram": "https://www.instagram.com/megawoof_america",
     "website": "https://linktr.ee/megawoof_america",
@@ -16,30 +18,41 @@
   {
     "name": "BEEFWITCH",
     "parent": "Coach After Dark",
-    "keywords": ["beefwitch"],
+    "keywords": [
+      "beefwitch"
+    ],
     "shortName": "BEEFWITCH",
     "instagram": "https://www.instagram.com/thebeefwitch",
     "bearAffinity": "always"
   },
   {
     "name": "Bearracuda",
-    "aliases": ["Bearracuda Events"],
+    "aliases": [
+      "Bearracuda Events"
+    ],
     "shortName": "Bear-rac-uda",
     "instagram": "https://www.instagram.com/bearracuda",
     "website": "https://bearracuda.com/",
-    "urlPatterns": ["bearracuda.com", "eventbrite.com/o/bearracuda-21867032189"],
+    "urlPatterns": [
+      "bearracuda.com",
+      "eventbrite.com/o/bearracuda-21867032189"
+    ],
     "bearAffinity": "usually"
   },
   {
     "name": "HOT TAKE",
     "parent": "Bearracuda",
-    "keywords": ["hot take"],
+    "keywords": [
+      "hot take"
+    ],
     "shortName": "HOT TAKE"
   },
   {
     "name": "TREASURE TRAIL",
     "parent": "Bearracuda",
-    "keywords": ["treasure trail"],
+    "keywords": [
+      "treasure trail"
+    ],
     "shortName": "TREAS-URE TRAIL"
   },
   {
@@ -69,7 +82,9 @@
     "shorterName": "GLX",
     "instagram": "https://www.instagram.com/goldiloxx__",
     "matchKey": "goldiloxx*|${year}-${month}-*|*",
-    "urlPatterns": ["goldiloxx"],
+    "urlPatterns": [
+      "goldiloxx"
+    ],
     "bearAffinity": "always"
   },
   {
@@ -81,7 +96,9 @@
   },
   {
     "name": "CubScout LA",
-    "aliases": ["CUBSCOUT"],
+    "aliases": [
+      "CUBSCOUT"
+    ],
     "bearAffinity": "always"
   },
   {
@@ -92,12 +109,16 @@
   {
     "name": "SPOOKMINCE",
     "parent": "BEEFMINCE",
-    "keywords": ["spookmince"]
+    "keywords": [
+      "spookmince"
+    ]
   },
   {
     "name": "BOATMINCE",
     "parent": "BEEFMINCE",
-    "keywords": ["boatmince"]
+    "keywords": [
+      "boatmince"
+    ]
   },
   {
     "name": "BeefDip",
@@ -118,22 +139,64 @@
     "name": "Fat Dad",
     "instagram": "https://www.instagram.com/fatdadnyc",
     "website": "https://events.humanitix.com/fatdad",
-    "urlPatterns": ["fatdad"],
+    "urlPatterns": [
+      "fatdad"
+    ],
     "bearAffinity": "always"
   },
   {
     "name": "Horse Meat Disco",
     "instagram": "https://www.instagram.com/horsemeatdisco",
     "website": "https://horsemeatdisco.net",
-    "urlPatterns": ["horsemeatdisco"],
+    "urlPatterns": [
+      "horsemeatdisco"
+    ],
     "bearAffinity": "usually"
   },
   {
     "name": "South Seattle Bear Social",
-    "aliases": ["SSBS"],
+    "aliases": [
+      "SSBS"
+    ],
     "instagram": "https://www.instagram.com/southseattlebearsocial",
     "website": "https://events.ticketleap.com/events/southseattlebearsocial",
-    "urlPatterns": ["southseattlebearsocial"],
+    "urlPatterns": [
+      "southseattlebearsocial"
+    ],
     "bearAffinity": "always"
+  },
+  {
+    "name": "Bears Sitges Club",
+    "aliases": [
+      "Bears Sitges",
+      "Bears Sitges Week",
+      "Bears Week Sitges",
+      "Bears Sitges Meeting"
+    ],
+    "instagram": "https://www.instagram.com/bearssitgesofficial",
+    "facebook": "https://www.facebook.com/BearsSitges",
+    "website": "https://bearssitges.org",
+    "bearAffinity": "always",
+    "urlPatterns": [
+      "bearssitges"
+    ]
+  },
+  {
+    "name": "Northeast Ursamen",
+    "aliases": [
+      "Spooky Bear",
+      "NE Ursamen",
+      "Ursamen",
+      "Out of Hibernation",
+      "Connecticut Bear"
+    ],
+    "instagram": "https://www.instagram.com/ne.ursamen",
+    "facebook": "https://www.facebook.com/NEUrsamen",
+    "website": "https://www.ursamen.org",
+    "bearAffinity": "always",
+    "urlPatterns": [
+      "ursamen",
+      "spookybear"
+    ]
   }
 ]

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -21,7 +21,7 @@ const scraperConfig = {
     },
     // deadEndRetryDays: 30, // Learned dead-end URLs (fetched fine but yielded nothing) are skipped for this many days, then retried once; 0 disables the store (default: 30)
     geocodeVerification: { mode: "enforce" }, // verify geocoded pins: grade-gate + Apple reverse cross-check. "report" (default) flags suspects in logs, "enforce" refuses suspect pins, "off" skips extra checks. Generic city-level pins are always refused.
-    promoterRegistry: { mode: "report" }, // Curated promoter identity matching — see data/promoters.json; "enforce" stamps matched metadata + bearAffinity
+    promoterRegistry: { mode: "enforce" }, // Curated promoter identity matching — see data/promoters.json; enforce stamps matched metadata + bearAffinity (flipped 2026-07-28: verification battery — 37 matches, 0 false positives, 100% precision)
     // NOTE: Eventbrite /e/ confidence defaults (JSON-LD cover/image/ticketUrl,
     // meta location) are built into shared-core now — an aiConfidenceDefaults
     // block here is only needed to extend or override them.
@@ -293,6 +293,46 @@ const scraperConfig = {
       },
     },
     { name: "massive.club", enabled: true, urls: ["https://www.massive.club"], alwaysBear: false },
+    // ── Festival-week schedules 2026-07-28 (recon-verified) ─────────────
+    {
+      name: "Bears Sitges Week",
+      enabled: false,
+      automationEnabled: false,
+      // Official Bears Sitges Club programme — one long WordPress page,
+      // ~45 timed activities Sept 3-13 with venues inline. Spanish text;
+      // day headers carry day-of-month only (month/year stated once).
+      urls: ["https://bearssitges.org/bears-sitges-week/"],
+      alwaysBear: true,
+      urlDiscoveryDepth: 0, // everything on one page; discovery wanders into store/news
+      ai: { classifyPages: false }, // heuristic multi-event-page is CORRECT here; the AI
+      // second opinion sees "one overarching event" (festival-programme trap) and
+      // reroutes to single-event extraction, whose payload window misses the schedule
+      metadata: {
+        shortName: { value: "BEARS SITGES" },
+        website: { value: "https://bearssitges.org" },
+        instagram: { value: "https://www.instagram.com/bearssitgesofficial" },
+        facebook: { value: "https://www.facebook.com/BearsSitges" },
+      },
+    },
+    {
+      name: "Spooky Bear",
+      enabled: false,
+      automationEnabled: false,
+      // Northeast Ursamen's Provincetown Halloween weekend. 2026 schedule
+      // publishes on THIS url ~Sept/Oct (2025 precedent: full text schedule,
+      // venues inline, weekday-only headers — dates anchor to the announced
+      // range). Idles harmlessly until then.
+      urls: ["https://www.ursamen.org/spookybear"],
+      alwaysBear: true,
+      urlDiscoveryDepth: 1, // follow Zeffy/ThunderTix ticket links
+      discoveryBlockedPatterns: ["ursamen.org/about", "ursamen.org/contact", "ursamen.org/the-board", "ursamen.org/our-sponsors", "ursamen.org/general-events", "coming-soon", "zeffy.com/donation-form"],
+      metadata: {
+        shortName: { value: "SPOOKY BEAR" },
+        website: { value: "https://www.ursamen.org/spookybear" },
+        instagram: { value: "https://www.instagram.com/ne.ursamen" },
+        facebook: { value: "https://www.facebook.com/NEUrsamen" },
+      },
+    },
     // ── Onboarding batch 2026-07-27 (recon-verified) — each ships disabled;
     // run one at a time via the parser picker, review, then enable. ──────
     {

--- a/scripts/scraper-promoters.js
+++ b/scripts/scraper-promoters.js
@@ -173,6 +173,40 @@ const scraperPromoters = [
       "southseattlebearsocial"
     ],
     "bearAffinity": "always"
+  },
+  {
+    "name": "Bears Sitges Club",
+    "aliases": [
+      "Bears Sitges",
+      "Bears Sitges Week",
+      "Bears Week Sitges",
+      "Bears Sitges Meeting"
+    ],
+    "instagram": "https://www.instagram.com/bearssitgesofficial",
+    "facebook": "https://www.facebook.com/BearsSitges",
+    "website": "https://bearssitges.org",
+    "bearAffinity": "always",
+    "urlPatterns": [
+      "bearssitges"
+    ]
+  },
+  {
+    "name": "Northeast Ursamen",
+    "aliases": [
+      "Spooky Bear",
+      "NE Ursamen",
+      "Ursamen",
+      "Out of Hibernation",
+      "Connecticut Bear"
+    ],
+    "instagram": "https://www.instagram.com/ne.ursamen",
+    "facebook": "https://www.facebook.com/NEUrsamen",
+    "website": "https://www.ursamen.org",
+    "bearAffinity": "always",
+    "urlPatterns": [
+      "ursamen",
+      "spookybear"
+    ]
   }
 ];
 

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1887,6 +1887,45 @@ class SharedCore {
                     reason: 'emoji title variant beats its emoji-stripped twin'
                 };
             }
+            // Trim persistence rung: when one side's title IS the AI-trimmed
+            // form of the other — strict attribution: that side's own
+            // _fieldTrims carries a status 'trimmed' title record whose
+            // trimmedValue is exactly this candidate, and the other side is a
+            // longer verbatim superset containing it — the trimmed side wins
+            // deterministically. Without this, arbitration's more-descriptive
+            // preference resurrects the untrimmed superset the field-trim
+            // pass already shortened (observed 2026-07-28: club-chub "DURO"
+            // merged back to 73 chars after a 73 → 55 enforce trim). MUST run
+            // after the emoji-twin rule (twins keep the emoji doctrine). No
+            // trim record, non-substring pairs, or both sides trimmed → fall
+            // through (AI arbitrates as before).
+            const trimContextRecords = context && context.records && typeof context.records === 'object'
+                ? context.records : null;
+            if (trimContextRecords) {
+                const hasOwnTitleTrimRecord = (record, value) => {
+                    if (!record || !Array.isArray(record._fieldTrims)) return false;
+                    const candidate = typeof value === 'string' ? value.trim() : '';
+                    if (!candidate) return false;
+                    return record._fieldTrims.some(trim => trim && trim.field === 'title'
+                        && trim.status === 'trimmed' && trim.trimmedValue === candidate);
+                };
+                const isUntrimmedSuperset = (supersetValue, trimmedValue) => {
+                    const superset = typeof supersetValue === 'string' ? supersetValue.trim() : '';
+                    const trimmed = typeof trimmedValue === 'string' ? trimmedValue.trim() : '';
+                    return Boolean(superset && trimmed) && superset.length > trimmed.length
+                        && superset.includes(trimmed);
+                };
+                const trimmedWinsA = hasOwnTitleTrimRecord(trimContextRecords.a, valueA)
+                    && isUntrimmedSuperset(valueB, valueA);
+                const trimmedWinsB = hasOwnTitleTrimRecord(trimContextRecords.b, valueB)
+                    && isUntrimmedSuperset(valueA, valueB);
+                if (trimmedWinsA !== trimmedWinsB) {
+                    return {
+                        winner: trimmedWinsA ? 'a' : 'b',
+                        reason: 'trimmed title beats its own untrimmed superset'
+                    };
+                }
+            }
             // A date-only segment welded onto the title ("CHUNK Chicago -
             // September 19th" vs "CHUNK Chicago") is pure redundancy on a
             // calendar — the date lives in startDate — and the arbitration
@@ -5162,6 +5201,44 @@ class SharedCore {
         return list;
     }
 
+    // Final trim pass over ONE analyzed event (post-merge/calendar analysis).
+    // The per-parser pass above runs BEFORE dedup/merge, so a merge that
+    // keeps the longer side (calendar value, or arbitration's more-
+    // descriptive pick) can resurrect an untrimmed value on the FINAL
+    // object. Same config, same AI path as the pre-merge pass —
+    // callAiGenerate responses are cached, so repeating an identical prompt
+    // is deterministic and free. Idempotent: when the pre-merge trim
+    // survived (nothing overlong on the final object),
+    // trimOverlongFieldsForEvent returns before touching _fieldTrims — no
+    // AI call, no duplicate records. When it does re-trim, this pass's
+    // record REPLACES the earlier record for the same field (the value that
+    // record described did not survive the merge) and every other field's
+    // record is kept, so evidence lines describe each final value exactly
+    // once. The batch summary line reuses the pre-merge shape — it can fire
+    // once per re-trimmed event in addition to the per-parser summary.
+    async applyFinalOverlongFieldTrims(event, parserConfig, httpAdapter) {
+        if (!event || typeof event !== 'object') return [];
+        const trimConfig = this.getTrimConfig(parserConfig);
+        if (trimConfig.mode === 'off') return [];
+        const rawAi = parserConfig && parserConfig.ai && typeof parserConfig.ai === 'object' ? parserConfig.ai : {};
+        if (rawAi.enabled === false) return [];
+        if (!httpAdapter || typeof httpAdapter.postJson !== 'function') return [];
+        const aiConfig = this.resolveAiConfig(rawAi);
+        if (!aiConfig.enabled || !aiConfig.endpoint) return [];
+
+        const priorRecords = Array.isArray(event._fieldTrims) ? event._fieldTrims : [];
+        const records = await this.trimOverlongFieldsForEvent(event, trimConfig, aiConfig, httpAdapter);
+        if (records.length === 0) return records;
+        const finalPassFields = new Set(records.map(record => record && record.field).filter(Boolean));
+        event._fieldTrims = [
+            ...priorRecords.filter(record => record && record.field && !finalPassFields.has(record.field)),
+            ...records
+        ];
+        const trimmedCount = records.filter(record => record.status === 'trimmed').length;
+        console.log(`✂️ TRIM: 1 event(s) checked, ${records.length} overlong field(s), ${trimmedCount} trimmed, ${records.length - trimmedCount} flagged`);
+        return records;
+    }
+
     async deduplicateEvents(events, httpAdapter, globalConfig = null) {
         const seen = new Map();
         const deduplicated = [];
@@ -6475,6 +6552,16 @@ class SharedCore {
         // before the evidence lines render.
         if (Array.isArray(newEvent._fieldTrims) && newEvent._fieldTrims.length > 0) {
             finalEvent._fieldTrims = newEvent._fieldTrims;
+        }
+        // Same carry for the registry identity stamp and derived organizer
+        // (mirrors mergeParsedEvents): the enforce-mode _promoter stamp must
+        // stay visible on the FINAL analyzed event for display/metrics, not
+        // just on the pre-merge scraped record.
+        if (typeof newEvent._promoter === 'string' && newEvent._promoter) {
+            finalEvent._promoter = newEvent._promoter;
+        }
+        if (typeof newEvent._organizer === 'string' && newEvent._organizer) {
+            finalEvent._organizer = newEvent._organizer;
         }
         
         // STEP 6: Pass all three objects to rich display for comparison
@@ -8424,6 +8511,32 @@ class SharedCore {
                 analyzedEvent.notes = this.formatEventNotes(analyzedEvent);
             }
 
+            // Final overlong-field trim pass: field-trim runs in processParser
+            // BEFORE dedup/merge, so the final object can carry an untrimmed
+            // value back (observed 2026-07-28: goldiloxx final title 72 chars
+            // despite a logged 72 → 58 enforce trim — the merge kept the
+            // longer side). Re-apply the trim to whatever the FINAL value is,
+            // but ONLY for actions with a scraped contribution ('merge' and
+            // 'new', both built by createFinalEventObject from the scraped
+            // record). Any other action is treated as a pure calendar-side
+            // preserve of the record's values (conservative: 'conflict'
+            // carries exactly the scraped values the pre-merge pass already
+            // handled) — those stay flag-only via the detection loop below,
+            // never AI-trimmed here. Runs BEFORE _evidenceLines so the
+            // updated _fieldTrims records render on the card.
+            const trimParserConfig = analyzedEvent._parserConfig || (config && config.ai ? { ai: config.ai } : null);
+            if (analyzedEvent._action === 'merge' || analyzedEvent._action === 'new') {
+                const finalTrimRecords = await this.applyFinalOverlongFieldTrims(analyzedEvent, trimParserConfig, calendarAdapter);
+                // title lives in a native calendar field, but description/
+                // shortName are serialized INTO notes — and notes were built
+                // from the pre-trim values above, so an enforce trim of a
+                // notes-carried field must rebuild them or the untrimmed
+                // value would still be written to the calendar.
+                if (finalTrimRecords.some(record => record && record.status === 'trimmed' && record.field !== 'title')) {
+                    analyzedEvent.notes = this.formatEventNotes(analyzedEvent);
+                }
+            }
+
             // Computed evidence panel for the results-UI event card (underscore
             // field: display-only, systematically excluded from notes/merge
             // serialization). Computed AFTER the final merged object exists so
@@ -8435,9 +8548,7 @@ class SharedCore {
             // with _fieldTrims), so a final value that exceeds its limit on a
             // field WITHOUT a trim record came through the calendar side —
             // which is never AI-trimmed. No AI call here, just visibility.
-            const overlongTrimConfig = this.getTrimConfig(
-                analyzedEvent._parserConfig || (config && config.ai ? { ai: config.ai } : null)
-            );
+            const overlongTrimConfig = this.getTrimConfig(trimParserConfig);
             if (overlongTrimConfig.mode !== 'off') {
                 const recordedTrimFields = new Set(
                     (Array.isArray(analyzedEvent._fieldTrims) ? analyzedEvent._fieldTrims : [])

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -8574,6 +8574,193 @@ test('_fieldTrims survives createFinalEventObject like _organizer', async () => 
   assert.deepEqual(finalEvent._fieldTrims, fieldTrims);
 });
 
+test('_promoter and _organizer survive createFinalEventObject like _fieldTrims', async () => {
+  const core = createCore();
+  const scraped = buildScrapedEvent({ _promoter: 'Goldiloxx', _organizer: 'Goldiloxx' });
+  const finalEvent = await core.createFinalEventObject(buildCalendarEvent(), scraped, {});
+  assert.equal(finalEvent._promoter, 'Goldiloxx', 'enforce-mode registry stamp stays on the final analyzed event');
+  assert.equal(finalEvent._organizer, 'Goldiloxx');
+});
+
+// ---------------------------------------------------------------------------
+// Final trim pass (applyFinalOverlongFieldTrims): the per-parser trim runs
+// BEFORE dedup/merge, so a merge that keeps the longer side resurrects the
+// untrimmed value on the FINAL analyzed object — the final pass re-trims it.
+// ---------------------------------------------------------------------------
+
+const TRIMMED_TITLE_RECORD = Object.freeze({
+  field: 'title', status: 'trimmed', originalLength: 74, trimmedLength: 7, trimmedValue: 'D>U>R>O', maxChars: 60
+});
+
+// Calendar adapter for final-trim tests: canned existing events plus a
+// postJson transport that answers the trim prompt (and counts calls).
+function buildFinalTrimAdapter(records, trimCalls = []) {
+  const adapter = buildPrepCalendarAdapter(records);
+  adapter.postJson = async (endpoint, payload) => {
+    trimCalls.push({ endpoint, payload });
+    return { ok: true, status: 200, text: buildOpenAiResponsePayload('{"trims":{"title":{"value":"D>U>R>O"}}}') };
+  };
+  return adapter;
+}
+
+function buildFinalTrimScrapedEvent(overrides = {}) {
+  return {
+    title: 'D>U>R>O',
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    bar: 'Precinct DTLA',
+    city: 'dallas',
+    ticketUrl: 'https://tickets.example/duro-la',
+    _parserConfig: buildTrimParserConfig(),
+    _fieldTrims: [{ ...TRIMMED_TITLE_RECORD }],
+    ...overrides
+  };
+}
+
+test('final trim pass: a merge that resurrects the untrimmed title is re-trimmed on the analyzed event', async () => {
+  const core = createCore();
+  const calendarRecord = {
+    title: OVERLONG_TITLE, // upsert keeps the calendar title → 74 chars come back post-merge
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    location: '',
+    notes: 'bar: Precinct DTLA\nticketUrl: https://tickets.example/duro-la'
+  };
+  const trimCalls = [];
+  const adapter = buildFinalTrimAdapter([calendarRecord], trimCalls);
+  const scraped = buildFinalTrimScrapedEvent();
+
+  const analyzed = await core.prepareEventsForCalendar([scraped], adapter, {});
+
+  assert.equal(analyzed.length, 1);
+  assert.equal(analyzed[0]._action, 'merge');
+  assert.equal(analyzed[0].title, 'D>U>R>O', 'the final analyzed title is the trimmed form, within the limit');
+  assert.equal(trimCalls.length, 1, 'one trim call for the resurrected overlong title');
+  assert.ok(String(trimCalls[0].payload.messages[0].content).includes('You are shortening overlong text fields for one event.'));
+
+  // The final-pass record REPLACES the pre-merge title record — never a duplicate
+  const titleRecords = analyzed[0]._fieldTrims.filter(record => record.field === 'title');
+  assert.equal(titleRecords.length, 1);
+  assert.equal(titleRecords[0].status, 'trimmed');
+  assert.equal(titleRecords[0].originalLength, 74);
+  assert.equal(titleRecords[0].trimmedValue, 'D>U>R>O');
+  assert.ok(analyzed[0]._evidenceLines.includes('title trimmed: 74 → 7 chars — "D>U>R>O"'),
+    `got: ${JSON.stringify(analyzed[0]._evidenceLines)}`);
+});
+
+test('final trim pass is idempotent: a pre-merge trim that survived the merge makes zero AI calls and keeps one record', async () => {
+  const core = createCore();
+  const calendarRecord = {
+    title: 'D>U>R>O', // calendar already carries the trimmed form — nothing overlong post-merge
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    location: '',
+    notes: 'bar: Precinct DTLA\nticketUrl: https://tickets.example/duro-la'
+  };
+  const trimCalls = [];
+  const adapter = buildFinalTrimAdapter([calendarRecord], trimCalls);
+  const scraped = buildFinalTrimScrapedEvent();
+
+  const analyzed = await core.prepareEventsForCalendar([scraped], adapter, {});
+
+  assert.equal(analyzed.length, 1);
+  assert.equal(analyzed[0]._action, 'merge');
+  assert.equal(analyzed[0].title, 'D>U>R>O');
+  assert.equal(trimCalls.length, 0, 'an under-limit final value never calls the AI');
+  assert.deepEqual(analyzed[0]._fieldTrims, [TRIMMED_TITLE_RECORD], 'the pre-merge record is kept, no duplicates');
+});
+
+test('final trim pass: NEW-path events keep their pre-merge trim untouched (no AI calls)', async () => {
+  const core = createCore();
+  const trimCalls = [];
+  const adapter = buildFinalTrimAdapter([], trimCalls); // no existing events → action new
+  const scraped = buildFinalTrimScrapedEvent();
+
+  const analyzed = await core.prepareEventsForCalendar([scraped], adapter, {});
+
+  assert.equal(analyzed.length, 1);
+  assert.equal(analyzed[0]._action, 'new');
+  assert.equal(analyzed[0].title, 'D>U>R>O');
+  assert.equal(trimCalls.length, 0);
+  assert.deepEqual(analyzed[0]._fieldTrims, [TRIMMED_TITLE_RECORD]);
+});
+
+test('final trim pass: an action without scraped contribution is flagged, never AI-trimmed', async () => {
+  const core = createCore();
+  const trimCalls = [];
+  const adapter = buildFinalTrimAdapter([], trimCalls);
+  // 'conflict' is the no-scraped-contribution shape at prep time (the pure
+  // calendar-side preserve of the record's values): the final pass must not
+  // fire — the detection-only evidence flag covers visibility.
+  const event = {
+    title: OVERLONG_TITLE,
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    city: 'dallas',
+    _parserConfig: buildTrimParserConfig()
+  };
+  const analysis = { action: 'conflict', reason: 'Identifier match not found', sourceEvent: null, overrideIdentity: null };
+
+  const analyzedEvent = await core.buildAnalyzedCalendarEvent(event, analysis, adapter, {});
+
+  assert.equal(analyzedEvent._action, 'conflict');
+  assert.equal(analyzedEvent.title, OVERLONG_TITLE, 'value untouched');
+  assert.equal(trimCalls.length, 0, 'no AI call for a preserve-shaped action');
+  assert.ok(analyzedEvent._evidenceLines.includes('⚠️ title overlong (74 > 60 chars) — calendar-sourced, not trimmed'),
+    `got: ${JSON.stringify(analyzedEvent._evidenceLines)}`);
+});
+
+test('applyFinalOverlongFieldTrims merges records: a re-trim replaces the same field, other fields keep theirs', async () => {
+  const core = createCore();
+  const trimCalls = [];
+  const adapter = buildTrimAnswerAdapter('{"trims":{"title":{"value":"D>U>R>O"}}}', trimCalls);
+  const event = {
+    title: OVERLONG_TITLE,
+    _fieldTrims: [
+      { field: 'title', status: 'trimmed', originalLength: 74, trimmedLength: 7, trimmedValue: 'D>U>R>O', maxChars: 60 },
+      { field: 'shortName', status: 'trimmed', originalLength: 39, trimmedLength: 7, trimmedValue: 'D>U>R>O', maxChars: 30 }
+    ]
+  };
+
+  const records = await core.applyFinalOverlongFieldTrims(event, buildTrimParserConfig(), adapter);
+
+  assert.equal(event.title, 'D>U>R>O');
+  assert.equal(records.length, 1);
+  assert.equal(trimCalls.length, 1);
+  assert.equal(event._fieldTrims.length, 2, 'shortName record kept, title record replaced');
+  assert.equal(event._fieldTrims.filter(record => record.field === 'title').length, 1);
+  assert.ok(event._fieldTrims.some(record => record.field === 'shortName' && record.trimmedLength === 7));
+});
+
+test('deterministic rung: trimmed title beats its own untrimmed superset, both directions', () => {
+  const core = createCore();
+  const trimRecords = [{ ...TRIMMED_TITLE_RECORD }];
+
+  const scrapedSide = core.resolveConflictDeterministically('title', OVERLONG_TITLE, 'D>U>R>O',
+    { records: { a: {}, b: { _fieldTrims: trimRecords } } });
+  assert.deepEqual(scrapedSide, { winner: 'b', reason: 'trimmed title beats its own untrimmed superset' });
+
+  const mirrored = core.resolveConflictDeterministically('title', 'D>U>R>O', OVERLONG_TITLE,
+    { records: { a: { _fieldTrims: trimRecords }, b: {} } });
+  assert.deepEqual(mirrored, { winner: 'a', reason: 'trimmed title beats its own untrimmed superset' });
+});
+
+test('deterministic rung: non-substring pairs and unattributed supersets fall through to arbitration', () => {
+  const core = createCore();
+  const trimRecords = [{ ...TRIMMED_TITLE_RECORD }];
+
+  // The trimmed side's value is NOT a substring of the other title → no rung
+  assert.equal(core.resolveConflictDeterministically('title', 'Completely different night', 'D>U>R>O',
+    { records: { a: {}, b: { _fieldTrims: trimRecords } } }), null);
+
+  // A superset pair WITHOUT a trim record never triggers the rung (strict attribution)
+  assert.equal(core.resolveConflictDeterministically('title', OVERLONG_TITLE, 'D>U>R>O',
+    { records: { a: {}, b: {} } }), null);
+
+  // A trim record for a DIFFERENT value than the candidate does not vouch for it
+  assert.equal(core.resolveConflictDeterministically('title', OVERLONG_TITLE, 'D>U>R>O — Precinct DTLA',
+    { records: { a: {}, b: { _fieldTrims: trimRecords } } }), null);
+});
+
 // ---------------------------------------------------------------------------
 // Active-config summary: pure builders behind the results-UI "Active config"
 // section — effective global values, per-parser override diffs (only
@@ -8743,6 +8930,15 @@ test('promoter registry mode reader mirrors getBearCheckMode (unset/invalid → 
   assert.equal(core.getPromoterRegistryMode({ config: { promoterRegistry: { mode: 'ENFORCE' } } }), 'enforce');
   assert.equal(core.getPromoterRegistryMode({ config: { promoterRegistry: { mode: 'off' } } }), 'off');
   assert.equal(core.getPromoterRegistryMode({ config: { promoterRegistry: { mode: 'bogus' } } }), 'report');
+});
+
+test('the repo scraper-input config resolves the promoter registry to enforce mode', () => {
+  // Flipped 2026-07-28 after the verification battery (37 matches, 0 false
+  // positives): the shipped config must resolve to enforce, so a regression
+  // back to report (or a typo'd mode falling back to report) fails here.
+  const core = createCore();
+  const repoConfig = require('./scraper-input');
+  assert.equal(core.getPromoterRegistryMode(repoConfig), 'enforce');
 });
 
 test('matcher: padded-token title containment matches a full name, never a bare substring', () => {


### PR DESCRIPTION
## Registry enforce — the gate is passed

Verification battery on merged main: **37 matches, 0 false positives, 100% precision** — circular url-evidence eliminated, MEGAWOOF/SPOOKMINCE/BOATMINCE aliases firing, junk stubs gone. `promoterRegistry.mode` → **enforce**. Live proof: a real Goldiloxx run stamps `shortName GOLDI-LOXX` + `_promoter` onto the final analyzed event (the carry through `createFinalEventObject` was the one missing wire — added and tested).

## Trim now survives merges (battery defect d1)

Two-layer fix, live-proven on the same run: a deterministic arbitration rung — **trimmed title beats its own untrimmed superset** (strict attribution via `_fieldTrims`) — plus a final re-trim pass on analyzed merge/new events (cached AI → free and deterministic). The Goldiloxx title now lands at its 58-char trimmed form through a real calendar merge.

## New parsers (both `enabled: false`)

- **Bears Sitges Week** — the official programme is live (~45 activities, Sept 3–13, venues inline). Two findings encoded in the config: `ai.classifyPages: false` (the AI second-opinion reclassifies festival programmes to single-event — the "one overarching event" flyer-rule trap; the heuristic's multi-event verdict is correct), and a **known blocker**: segment discovery finds 1 segment on the 11-day Spanish page — the date-signal vocabulary is English-only. **Multilingual segment vocabulary is the next fix wave**; the config idles until it lands.
- **Spooky Bear** (Northeast Ursamen, Provincetown) — 2026 schedule publishes ~Sept/Oct on exactly this URL (2025 precedent verified via archive); idles harmlessly until then.
- Registry entries: **Bears Sitges Club**, **Northeast Ursamen** (aliases incl. Spooky Bear).

**Two date discrepancies for your festivals calendar** (phone-edit): official Sitges programme says **Sept 3–13** (calendar has 4–13); Spooky Bear's save-the-date suggests **Oct 31–Nov 2** (calendar has Oct 29–Nov 1 — confirm against the graphic).

Tests **985 → 994**.

## After merge (updater pull)
`scripts/shared-core.js`, `scripts/scraper-input.js`, `scripts/scraper-promoters.js`. Registry and trim are LIVE (enforce) after this pull — 🪪 lines will say `stamped:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP