### PR TITLE
feat(scraper): picker owns run selection — enabled flags removed, last-run memory, dismissal cancels

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2271,15 +2271,11 @@ class ScriptableAdapter {
         // Total captured before the selection replaces the array
         const parserPickerTotal = config.parsers.length;
         const picked = await this.presentParserPicker(config);
-        if (picked) {
-          config.parsers = this.applyParserPickerSelection(
-            config.parsers,
-            picked,
-          );
-          console.log(
-            `📱 Scriptable: Parser picker: running ${picked.size} of ${parserPickerTotal} parsers`,
-          );
-        }
+        config.parsers = this.applyParserPickerOutcome(
+          config.parsers,
+          picked,
+          parserPickerTotal,
+        );
       }
 
       this.applyLogConfig(config);
@@ -9609,8 +9605,90 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
 
   // Spread copies only — never mutates the importModule'd parser objects.
   // Unknown names in the set are ignored naturally (no parser matches them).
+  // The `enabled` flags written here are SESSION-SCOPED: parser entries in
+  // scraper-input.js carry no static enabled flags anymore — the picker owns
+  // manual run selection, and shared-core's manual enabled filter acts only
+  // on these per-session values.
   applyParserPickerSelection(parsers, pickedSet) {
     return parsers.map((p) => ({ ...p, enabled: pickedSet.has(p.name) }));
+  }
+
+  // The picker OWNS manual run selection. A confirmed selection runs exactly
+  // those parsers; null (swipe-down dismissal or a picker error) CANCELS the
+  // run by disabling every parser for the session — with no static enabled
+  // flags left in config, "run as configured" would mean run-ALL by accident.
+  applyParserPickerOutcome(parsers, picked, total = parsers.length) {
+    if (picked) {
+      console.log(
+        `📱 Scriptable: Parser picker: running ${picked.size} of ${total} parsers`,
+      );
+      return this.applyParserPickerSelection(parsers, picked);
+    }
+    console.log(
+      "📱 Scriptable: Parser picker dismissed — run cancelled (no parsers selected)",
+    );
+    return this.applyParserPickerSelection(parsers, new Set());
+  }
+
+  // ── Picker-state persistence (pre-selection = last run's selection) ───────
+
+  getPickerStatePath() {
+    return this.fm.joinPath(this.baseDir, "picker-state.json");
+  }
+
+  // Pure: parse a persisted picker-state payload ({ selected: [names] }) and
+  // return the selected names filtered to currently-known parser names.
+  // Missing/corrupt/misshapen input → [] (nothing pre-selected).
+  parsePickerState(text, knownNames) {
+    try {
+      const parsed = JSON.parse(String(text));
+      const selected = Array.isArray(parsed?.selected) ? parsed.selected : null;
+      if (!selected) return [];
+      const known = new Set(knownNames || []);
+      return selected.filter(
+        (name) => typeof name === "string" && known.has(name),
+      );
+    } catch (_) {
+      return [];
+    }
+  }
+
+  async loadPickerState(knownNames) {
+    try {
+      const fm = this.fm || FileManager.iCloud();
+      const path = this.getPickerStatePath();
+      if (!fm.fileExists(path)) return [];
+      try {
+        await fm.downloadFileFromiCloud(path);
+      } catch (_) {
+        // fall through to reading whatever local copy exists
+      }
+      return this.parsePickerState(fm.readString(path) || "", knownNames);
+    } catch (_) {
+      return [];
+    }
+  }
+
+  // Persist a confirmed selection (Run selected / Run all). Best-effort:
+  // failure only costs the next run's pre-selection.
+  async savePickerState(names) {
+    try {
+      const fm = this.fm || FileManager.iCloud();
+      if (!fm.fileExists(this.baseDir)) {
+        fm.createDirectory(this.baseDir, true);
+      }
+      const payload = {
+        selected: Array.from(names || []),
+        savedAt: new Date().toISOString(),
+      };
+      fm.writeString(
+        this.getPickerStatePath(),
+        JSON.stringify(payload, null, 2),
+      );
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 
   // Stalest-first ordering (ports computeStaleStatus's sort semantics from
@@ -9631,7 +9709,6 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       }
       return {
         name: parser.name,
-        enabled: parser.enabled !== false,
         daysSince,
         lastWriteAt,
       };
@@ -9651,7 +9728,8 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
 
   // Presents a UITable listing all configured parsers (stalest-first) with
   // checkmark toggles. Resolves with a Set of picked parser names, or null on
-  // swipe-down dismissal / any error (fail open — run proceeds unchanged).
+  // swipe-down dismissal / any error — the caller treats null as CANCEL (no
+  // parsers run), never as run-as-configured.
   async presentParserPicker(config) {
     try {
       const parsers = Array.isArray(config?.parsers) ? config.parsers : [];
@@ -9660,9 +9738,10 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       const records = await this.readMetricsRecordsForPicker();
       const entries = this.buildParserPickerEntries(parsers, records);
 
-      // Default pre-selection: config-enabled parsers
+      // Pre-selection = the previous run's confirmed selection (persisted in
+      // picker-state.json; first run / missing / corrupt → none pre-selected)
       const selected = new Set(
-        entries.filter((entry) => entry.enabled).map((entry) => entry.name),
+        await this.loadPickerState(entries.map((entry) => entry.name)),
       );
 
       let resolved = false;
@@ -9728,7 +9807,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
             `${isPicked ? "☑" : "☐"} ${entry.name}`,
           );
           cell.titleFont = Font.systemFont(14);
-          cell.subtitleText = `${this.formatDaysSinceForPicker(entry.daysSince)} (last write) · ${entry.enabled ? "enabled" : "disabled"} in config`;
+          cell.subtitleText = `${this.formatDaysSinceForPicker(entry.daysSince)} (last write)`;
           cell.subtitleColor = Color.gray();
 
           row.onSelect = () => {
@@ -9755,7 +9834,13 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         () => finish(null),
       );
 
-      return await selectionPromise;
+      const picked = await selectionPromise;
+      // Persist confirmed selections only (Run selected / Run all) — the next
+      // run's picker pre-selects them. Dismissal keeps the previous state.
+      if (picked) {
+        await this.savePickerState(Array.from(picked));
+      }
+      return picked;
     } catch (error) {
       console.log(
         `📱 Scriptable: ✗ Parser picker failed: ${error.message}`,

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -2788,6 +2788,162 @@ test('applyParserPickerSelection flips enabled by membership without mutating or
   assert.equal(original[1].enabled, true);
   assert.equal(original[2].enabled, undefined);
   assert.notEqual(applied[0], original[0], 'copies, not the same objects');
+
+  // Empty selection → every parser session-disabled (this is the dismissal
+  // outcome: with no static enabled flags in config, empty means run nothing)
+  const none = adapter.applyParserPickerSelection(original, new Set());
+  assert.deepEqual(
+    none.map((p) => p.enabled),
+    [false, false, false],
+    'empty Set disables every parser'
+  );
+});
+
+test('applyParserPickerOutcome: null (dismissal) cancels the run and logs it; a selection applies + logs the run line', () => {
+  const adapter = buildAdapter();
+  const parsers = [{ name: 'Alpha' }, { name: 'Beta' }, { name: 'Gamma' }];
+
+  const logged = [];
+  const originalLog = console.log;
+  console.log = (...args) => logged.push(args.join(' '));
+  try {
+    const cancelled = adapter.applyParserPickerOutcome(parsers, null, 3);
+    assert.deepEqual(
+      cancelled.map((p) => p.enabled),
+      [false, false, false],
+      'null → zero-parser session (all session-disabled)'
+    );
+    assert.ok(
+      logged.includes(
+        '📱 Scriptable: Parser picker dismissed — run cancelled (no parsers selected)'
+      ),
+      'dismissal log line emitted'
+    );
+
+    const picked = adapter.applyParserPickerOutcome(parsers, new Set(['Beta']), 3);
+    assert.deepEqual(
+      picked.map((p) => p.enabled),
+      [false, true, false],
+      'selection applied per-session'
+    );
+    assert.ok(
+      logged.includes('📱 Scriptable: Parser picker: running 1 of 3 parsers'),
+      'existing running-X-of-Y log shape preserved'
+    );
+  } finally {
+    console.log = originalLog;
+  }
+
+  // Originals never mutated
+  assert.equal(parsers[0].enabled, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Picker-state persistence: pre-selection = the last run's confirmed picks.
+// ---------------------------------------------------------------------------
+
+// Memory-backed FileManager stub for the picker-state round-trip.
+function installMemoryFm(adapter) {
+  const files = new Map();
+  adapter.fm = {
+    joinPath: (a, b) => `${a}/${b}`,
+    fileExists: (p) => files.has(p) || p === adapter.baseDir,
+    createDirectory: () => {},
+    readString: (p) => (files.has(p) ? files.get(p) : null),
+    writeString: (p, text) => {
+      files.set(p, text);
+    },
+    downloadFileFromiCloud: async () => {}
+  };
+  return files;
+}
+
+test('picker-state: save/load round-trip; unknown names filtered on load', async () => {
+  const adapter = buildAdapter();
+  const files = installMemoryFm(adapter);
+
+  assert.deepEqual(
+    await adapter.loadPickerState(['Alpha', 'Beta']),
+    [],
+    'no state file → empty pre-selection (first run)'
+  );
+
+  assert.equal(await adapter.savePickerState(['Alpha', 'Ghost']), true);
+  assert.ok(files.has(adapter.getPickerStatePath()), 'state file written');
+  const payload = JSON.parse(files.get(adapter.getPickerStatePath()));
+  assert.deepEqual(payload.selected, ['Alpha', 'Ghost'], 'selection persisted verbatim');
+
+  assert.deepEqual(
+    await adapter.loadPickerState(['Alpha', 'Beta']),
+    ['Alpha'],
+    'round-trip keeps known names, filters unknown (removed/renamed parsers)'
+  );
+});
+
+test('picker-state: corrupt or misshapen file → empty pre-selection', async () => {
+  const adapter = buildAdapter();
+  const files = installMemoryFm(adapter);
+  const statePath = adapter.getPickerStatePath();
+
+  files.set(statePath, 'not json {{{');
+  assert.deepEqual(await adapter.loadPickerState(['Alpha']), [], 'corrupt JSON → []');
+
+  files.set(statePath, JSON.stringify({ selected: 'Alpha' }));
+  assert.deepEqual(await adapter.loadPickerState(['Alpha']), [], 'non-array selected → []');
+
+  files.set(statePath, JSON.stringify({ selected: [42, null, 'Alpha'] }));
+  assert.deepEqual(
+    await adapter.loadPickerState(['Alpha']),
+    ['Alpha'],
+    'non-string entries dropped'
+  );
+
+  assert.deepEqual(adapter.parsePickerState(null, ['Alpha']), [], 'null text → []');
+  assert.deepEqual(adapter.parsePickerState('null', ['Alpha']), [], 'JSON null → []');
+});
+
+test('presentParserPicker: swipe-down dismissal resolves null and persists nothing (headless UITable)', async () => {
+  const adapter = buildAdapter();
+  const files = installMemoryFm(adapter);
+
+  // Minimal UITable stubs: present() resolves immediately without any action
+  // row being tapped — exactly the swipe-down dismissal path.
+  const originalUITable = global.UITable;
+  const originalUITableRow = global.UITableRow;
+  const originalFont = global.Font;
+  const originalColor = global.Color;
+  global.UITable = class {
+    addRow() {}
+    removeAllRows() {}
+    reload() {}
+    present() {
+      return Promise.resolve();
+    }
+  };
+  global.UITableRow = class {
+    addText() {
+      return {};
+    }
+  };
+  global.Font = { boldSystemFont: () => ({}), systemFont: () => ({}) };
+  global.Color = { white: () => ({}), brown: () => ({}), blue: () => ({}), gray: () => ({}) };
+
+  try {
+    const picked = await adapter.presentParserPicker({
+      parsers: [{ name: 'Alpha' }, { name: 'Beta' }]
+    });
+    assert.equal(picked, null, 'dismissal → null');
+    assert.equal(
+      files.has(adapter.getPickerStatePath()),
+      false,
+      'no picker-state written on dismissal'
+    );
+  } finally {
+    global.UITable = originalUITable;
+    global.UITableRow = originalUITableRow;
+    global.Font = originalFont;
+    global.Color = originalColor;
+  }
 });
 
 const PICKER_METRICS_FIXTURE = [
@@ -2851,9 +3007,9 @@ test('buildParserPickerEntries orders stalest-first: never-written, then stale, 
   const now = new Date('2026-07-27T03:00:00.000Z').getTime();
   const records = adapter.parseMetricsNdjsonForPicker(PICKER_METRICS_FIXTURE);
   const parsers = [
-    { name: 'Alpha', enabled: true }, // last write 7d ago (fresh-ish)
-    { name: 'Beta', enabled: false }, // last write 17d ago (stale)
-    { name: 'Nope' } // never written, enabled defaults on
+    { name: 'Alpha' }, // last write 7d ago (fresh-ish)
+    { name: 'Beta' }, // last write 17d ago (stale)
+    { name: 'Nope' } // never written
   ];
 
   const entries = adapter.buildParserPickerEntries(parsers, records, now);
@@ -2864,8 +3020,6 @@ test('buildParserPickerEntries orders stalest-first: never-written, then stale, 
     'never-written ranks before stale ranks before fresh'
   );
   assert.equal(entries[0].daysSince, null);
-  assert.equal(entries[0].enabled, true, 'enabled !== false defaults to selected-eligible');
-  assert.equal(entries[1].enabled, false);
   assert.equal(Math.floor(entries[1].daysSince), 17);
   assert.equal(Math.floor(entries[2].daysSince), 7);
 });

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -14,7 +14,15 @@ const scraperConfig = {
   config: {
     daysToLookAhead: null,
     // dryRun: true, // Preview mode: analyze + display without writing to the calendar (default: false)
-    pickParsers: true, // Parser picker at run start (manual runs only; automation/widget runs skip it; selection is session-scoped — never edits this file) (default: false)
+    // Parser picker at run start OWNS run selection (default: false).
+    // Manual Scriptable runs only; the selection is session-scoped and never
+    // edits this file. It pre-selects the previous run's confirmed picks
+    // (persisted in picker-state.json); dismissing the picker CANCELS the run.
+    // ⚠️ Parser entries carry NO static enabled flags anymore: with this set
+    // to false — or on manual runs outside Scriptable (web/server) — a manual
+    // run executes ALL parsers. Scheduled automation is unaffected (no picker;
+    // per-parser automationEnabled governs what automation runs).
+    pickParsers: true,
     pageCache: {
       enabled: true,
       ttlDays: 3,
@@ -137,7 +145,6 @@ const scraperConfig = {
   parsers: [
     {
       name: "Megawoof America",
-      enabled: false,
       urls: ["https://www.eventbrite.com/o/megawoof-america-18118978189"],
       alwaysBear: true,
       metadata: {
@@ -148,7 +155,6 @@ const scraperConfig = {
     },
     {
       name: "Coach After Dark",
-      enabled: false,
       urls: ["https://www.eventbrite.com/o/bear-happy-hour-87043830313"],
       alwaysBear: true,
       metadata: {
@@ -166,7 +172,6 @@ const scraperConfig = {
     },
     {
       name: "Bearracuda Events",
-      enabled: false,
       urls: [
         "https://bearracuda.com/",
         "https://www.eventbrite.com/o/bearracuda-21867032189",
@@ -188,7 +193,6 @@ const scraperConfig = {
     },
     {
       name: "CHUNK",
-      enabled: false,
       urls: ["https://www.chunk-party.com"],
       // Deliberate exclusions only — /shop, /contact, /_api/ are blocked built-in
       discoveryBlockedPatterns: [
@@ -204,7 +208,6 @@ const scraperConfig = {
     },
     {
       name: "Furball",
-      enabled: false,
       urls: ["https://www.furball.nyc"],
       alwaysBear: true,
       urlDiscoveryDepth: 0,
@@ -217,7 +220,6 @@ const scraperConfig = {
     },
     {
       name: "Cubhouse",
-      enabled: false,
       urls: ["https://linktr.ee/cubhouse"],
       discoveryBlockedPatterns: ["www.eventbrite.com/o/", "linktr.ee"],
       alwaysBear: true,
@@ -229,7 +231,6 @@ const scraperConfig = {
     },
     {
       name: "Goldiloxx",
-      enabled: false,
       // Homeless promoter — events scatter across ticketing platforms (links
       // rotate in their Instagram bio). Stable doors: the RedEye JSON API
       // search (self-refreshing; JSON-API pathway extracts it structurally)
@@ -253,7 +254,6 @@ const scraperConfig = {
     },
     {
       name: "3 Dollar Bill",
-      enabled: false,
       // Brooklyn queer venue (260 Meserole St; second space The Yard @ 270
       // Meserole Ave — per-event JSON-LD location is authoritative).
       // Squarespace, server-rendered listing, JSON-LD Event on event pages.
@@ -268,7 +268,6 @@ const scraperConfig = {
     },
     {
       name: "Twisted Bear",
-      enabled: false,
       // discoveryOnly: true,
       urls: [
         "https://www.eventbrite.com/o/nab-events-llc-51471535173",
@@ -283,7 +282,6 @@ const scraperConfig = {
     },
     {
       name: "Dallas Eagle",
-      enabled: false,
       urls: ["https://www.eventbrite.com/o/77139864473"],
       metadata: {
         website: { value: "https://www.thedallaseagle.com" },
@@ -292,11 +290,10 @@ const scraperConfig = {
         mastodon: { value: "https://mastodon.social/@dallaseagle" },
       },
     },
-    { name: "massive.club", enabled: true, urls: ["https://www.massive.club"], alwaysBear: false },
+    { name: "massive.club", urls: ["https://www.massive.club"], alwaysBear: false },
     // ── Festival-week schedules 2026-07-28 (recon-verified) ─────────────
     {
       name: "Bears Sitges Week",
-      enabled: false,
       automationEnabled: false,
       // Official Bears Sitges Club programme — one long WordPress page,
       // ~45 timed activities Sept 3-13 with venues inline. Spanish text;
@@ -316,7 +313,6 @@ const scraperConfig = {
     },
     {
       name: "Spooky Bear",
-      enabled: false,
       automationEnabled: false,
       // Northeast Ursamen's Provincetown Halloween weekend. 2026 schedule
       // publishes on THIS url ~Sept/Oct (2025 precedent: full text schedule,
@@ -333,11 +329,10 @@ const scraperConfig = {
         facebook: { value: "https://www.facebook.com/NEUrsamen" },
       },
     },
-    // ── Onboarding batch 2026-07-27 (recon-verified) — each ships disabled;
-    // run one at a time via the parser picker, review, then enable. ──────
+    // ── Onboarding batch 2026-07-27 (recon-verified) — run each one alone
+    // via the parser picker and review before including it in bigger runs. ──
     {
       name: "The Lumberyard",
-      enabled: false,
       urls: ["https://www.thelumberyardbar.com/events"],
       // Seattle bear-friendly bar (9630 16th Ave SW) with general weekly
       // programming — bear check filters, not alwaysBear.
@@ -348,14 +343,12 @@ const scraperConfig = {
     },
     {
       name: "CubScout LA",
-      enabled: false,
       // Eagle LA's recurring bear party page (The Events Calendar, JSON-LD).
       urls: ["https://eaglela.com/events/cub-scout-3/"],
       alwaysBear: true,
     },
     {
       name: "BEEFMINCE",
-      enabled: false,
       // Multi-city UK (London/Brighton/Manchester/Birmingham + Sitges);
       // per-event city comes from event text; tickets link out to dice.fm.
       urls: ["https://beefmince.com/events"],
@@ -366,7 +359,6 @@ const scraperConfig = {
     },
     {
       name: "BeefDip",
-      enabled: false,
       // Puerto Vallarta bear week; single schedule page, venues appear as
       // Google Maps links (maps-link address harvesting applies).
       urls: ["https://beefdip.com/planned-events/"],
@@ -377,7 +369,6 @@ const scraperConfig = {
     },
     {
       name: "Bear it MTL",
-      enabled: false,
       // Montreal (Sugar Bear Weekend organizer); The Events Calendar with
       // JSON-LD + Offers; also lists Toronto/Paris events — city per event.
       urls: ["https://www.bearitmtl.com/events/"],
@@ -388,7 +379,6 @@ const scraperConfig = {
     },
     {
       name: "Club Chub",
-      enabled: false,
       // Touring chub/chaser series; Eventbrite links sit in the site's own
       // static HTML. Do NOT use the Eventbrite org page — it's CCBC Resort's
       // venue account and would pull non-Club-Chub events.
@@ -400,7 +390,6 @@ const scraperConfig = {
     },
     {
       name: "The Bear Calendar",
-      enabled: false,
       automationEnabled: false,
       // Aggregator (Astro, server-rendered; ~52 events). Per-event pages carry
       // complete JSON-LD; offers.url IS the original ticketing/promoter URL.
@@ -419,7 +408,6 @@ const scraperConfig = {
       // 📋 SUGGESTED CONFIG block (with harvested instagram/facebook/website)
       // you can paste right back here.
       name: "New Site Template",
-      enabled: false, // flip on after a dry-run preview looks right
       urls: ["https://example.com/events"],
       alwaysBear: false, // set true for trusted bear promoters (AI trust context)
       metadata: {

--- a/scripts/tools-serve-results.test.js
+++ b/scripts/tools-serve-results.test.js
@@ -123,6 +123,30 @@ test('listParserNames reads the real scraper-input config', () => {
   assert.ok(entries.some((entry) => entry.name === 'Bearracuda Events'), 'known parser present');
 });
 
+test('the repo scraper-input parsers carry no static enabled flags (picker owns run selection)', () => {
+  const { parsers } = require('./scraper-input');
+  assert.ok(Array.isArray(parsers) && parsers.length > 5, 'real config lists parsers');
+
+  const withEnabled = parsers.filter((parser) => parser && 'enabled' in parser);
+  assert.deepEqual(
+    withEnabled.map((parser) => parser.name),
+    [],
+    'no parser entry declares enabled — manual selection is the picker\'s job'
+  );
+
+  // automationEnabled is a different knob (scheduled runs have no picker) and
+  // must survive: these festival/aggregator entries opt out of automation.
+  const automationOptOuts = parsers
+    .filter((parser) => parser && parser.automationEnabled === false)
+    .map((parser) => parser.name)
+    .sort();
+  assert.deepEqual(
+    automationOptOuts,
+    ['Bears Sitges Week', 'Spooky Bear', 'The Bear Calendar'],
+    'automationEnabled: false preserved where it was'
+  );
+});
+
 // ---------------------------------------------------------------------------
 // Bridge rewrite — real adapter fragments
 // ---------------------------------------------------------------------------
@@ -335,7 +359,11 @@ test('renderRunFormPage lists parsers escaped and posts to /run', () => {
   assert.ok(html.includes('method="POST"'));
   assert.ok(html.includes('action="/run"'));
   assert.ok(html.includes('A &amp; B &lt;Bears&gt;'), 'names HTML-escaped');
-  assert.ok(html.includes('(disabled in config)'));
+  assert.ok(html.includes('>All parsers<'), 'everything option says All parsers');
+  assert.ok(
+    !html.includes('disabled in config') && !html.includes('All enabled parsers'),
+    'no enabled-in-config annotations — parser entries carry no enabled flags'
+  );
   assert.ok(html.includes('report-only'), 'dry-run promise stated');
 });
 

--- a/tools/serve-results.js
+++ b/tools/serve-results.js
@@ -340,11 +340,10 @@ function tailLines(text, maxLines = LOG_TAIL_LINES) {
 // Minimal run-form page: parser dropdown + POST /run.
 function renderRunFormPage(parserEntries, options = {}) {
     const entries = Array.isArray(parserEntries) ? parserEntries : [];
-    const optionsHtml = ['<option value="">All enabled parsers</option>']
+    const optionsHtml = ['<option value="">All parsers</option>']
         .concat(entries.map((entry) => {
             const name = escapeHtmlText(entry.name);
-            const suffix = entry.enabled ? '' : ' (disabled in config)';
-            return `<option value="${name}">${name}${suffix}</option>`;
+            return `<option value="${name}">${name}</option>`;
         }))
         .join('\n');
     const notice = options.notice


### PR DESCRIPTION
Your call: "we can get rid of enabled:true ... and let us decide which to run on start."

- **All 21 `enabled:` lines removed** from parser entries (`automationEnabled` stays — automation has no picker).
- **Picker pre-selects your last run's picks** (persisted to `picker-state.json`; first run pre-selects nothing) — re-running yesterday's parser is one tap.
- **Swipe-down = cancel** (zero parsers, logged) — with no flags, "run as configured" would otherwise mean *run all 21* by accident. "Run all" stays as the explicit button.
- Back-compat: stale `enabled` keys in a lagging phone config are harmlessly ignored on picker runs; shared-core untouched; automation unchanged (`automationEnabled: false` preserved exactly on Bears Sitges Week, Spooky Bear, The Bear Calendar).
- Documented accepted behavior: with `pickParsers: false` (or non-Scriptable manual runs without a parser filter), a manual run executes **all** parsers.
- Server form says "All parsers".

Tests **1000 → 1005** (state round-trip/corruption, dismissal path with stubbed UITable, config validation, zero-parser run gracefulness verified against the real config).

## After merge (updater pull)
`scripts/scraper-input.js`, `scripts/adapters/scriptable-adapter.js` (+ `tools/serve-results.js` is Mac-side). First picker after the pull pre-selects nothing — pick once and it remembers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP