### PR TITLE
feat(scraper): AI segment-boundary fallback — trust-the-pointer segmentation for any language

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -419,13 +419,15 @@ class AiWebParser {
             fuzzyDescriptionTokenMatchRatio: 0.45,
             validationReportValueMaxLength: 140,
             multiEventScanLineLimit: 500,
-            // 14 (was 12): an 11-day festival programme is intro + 11 day
-            // sections + interleaved continuation segments — 12 cut the final
-            // day of Bears Sitges Week (run 20260728) once the day sections
-            // segmented correctly. Stale trailing noise past the cap (news
-            // bylines) costs at most the extra extractions; past-dated
-            // results are dropped by shared-core's filterFutureEvents.
-            multiEventMaxSegments: 14,
+            // 16 (was 12, then 14): an 11-day festival programme is intro +
+            // 11 day sections + interleaved continuation segments — 12 cut
+            // the final day of Bears Sitges Week (run 20260728); 16 adds
+            // buffer for one or two junk splits (e.g. the English `mar`
+            // false positive in Spanish text). Stale trailing noise past the
+            // cap costs at most the extra extractions; past-dated results
+            // are dropped by shared-core's filterFutureEvents. The AI
+            // boundary pass interpolates this cap as its upper bound.
+            multiEventMaxSegments: 16,
             multiEventMinSegmentLines: 2,
             multiEventMaxSegmentLines: 24,
             multiEventMinSegmentChars: 25,
@@ -837,7 +839,16 @@ class AiWebParser {
         const html = htmlData && htmlData.html ? htmlData.html : '';
         const sourceUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
 
-        const segments = this.buildMultiEventSegments(html, sourceUrl, ocrResults);
+        let segments = this.buildMultiEventSegments(html, sourceUrl, ocrResults);
+        if (segments.length < 2 && parserConfig.discoveryOnly !== true) {
+            // Tier 2: the page was CLASSIFIED multi-event but deterministic
+            // segmentation could not find two sections (vocabulary-blind
+            // language, unusual heading shapes). Ask the model to point at
+            // section-start lines; every proposal is verified verbatim
+            // against the scanned lines before it can influence slicing.
+            const aiSegments = await this.runAiBoundarySegmentation(html, sourceUrl, ocrResults, parserConfig, httpAdapter, segments.length);
+            if (aiSegments.length >= 2) segments = aiSegments;
+        }
         if (segments.length === 0) {
             console.warn('🤖 AI Web: multi-event-page classification produced no valid segments; returning no events');
             // Lumberyard-class pages: the multi-event classifier fired but no
@@ -1379,6 +1390,203 @@ class AiWebParser {
         return this.attachSequentialImageHintsToSegments(html, uniqueSegments, sourceUrl, ocrResults);
     }
 
+    // ── Tier-2 AI segment-boundary fallback ──────────────────────────────
+    // Fires only when the deterministic splitter (tier 1) found fewer than
+    // two segments on a classified multi-event page. The model never writes
+    // content: it may only CHOOSE existing lines, each proposal must
+    // reproduce a scanned line verbatim (case/diacritic/zero-width
+    // tolerant) or it is dropped, and slicing from the verified indices is
+    // fully deterministic.
+
+    // Schedule-time lines ("23:00", "9pm", "20.30 h") are the strongest
+    // cheap signal that a programme page really lists multiple timed
+    // sections worth an AI boundary pass.
+    countScheduleTimeLines(lines) {
+        const timePattern = /\b\d{1,2}(?:[:.h]\d{2})?\s*(?:h\b|am|pm)\b/i;
+        return (Array.isArray(lines) ? lines : []).filter(line => timePattern.test(String(line || ''))).length;
+    }
+
+    // Verification key for boundary echoes: "verbatim" means the line a
+    // human would read, so case, diacritics, whitespace runs, HTML entities
+    // and invisible marks must not break the match while every visible
+    // character still has to agree. The zero-width strip is load-bearing:
+    // real Sitges lines embed U+200E, which normalizeWhitespace does not
+    // remove.
+    getBoundaryVerificationKey(value) {
+        return this.foldDiacritics(this.normalizeEvidenceText(value)).replace(/[​-‏﻿]/g, '');
+    }
+
+    async runAiBoundarySegmentation(html, sourceUrl, ocrResults, parserConfig, httpAdapter, deterministicSegmentCount = 0) {
+        const aiConfig = this.getAiConfig(parserConfig);
+        if (aiConfig.enabled === false || !httpAdapter) return [];
+
+        // Mirror of the deterministic splitter's line corpus, so verified
+        // boundary indices address the exact lines tier 1 scanned.
+        const scannedLines = this.trimLeadingMultiEventNoise(
+            this.extractBodyParts(html).slice(0, this.extractionLimits.multiEventScanLineLimit)
+        );
+        const timeLines = this.countScheduleTimeLines(scannedLines);
+        const scannedChars = scannedLines.join('\n').length;
+        const hasSubstantialContent = timeLines >= 3
+            || scannedChars >= 1500
+            || (Array.isArray(ocrResults) && ocrResults.length >= 2);
+        if (!hasSubstantialContent) {
+            console.log('🤖 AI Web: Skipping AI boundary pass — page content too thin for multiple events');
+            return [];
+        }
+        console.log(`🤖 AI Web: Deterministic segmentation found ${deterministicSegmentCount} segment(s) on classified multi-event page (${timeLines} time-line(s), ${scannedChars} chars) — running AI boundary pass`);
+
+        // Listing shown to the model: each line capped at 160 chars, whole
+        // listing capped at 24,000 chars. Listed lines are a prefix of
+        // scannedLines (never filtered), so listed index i IS scanned
+        // index i; verification matches the listed strings, segments are
+        // built from the untruncated scanned lines.
+        const listingLineMaxChars = 160;
+        const listingMaxChars = 24000;
+        const listedLines = [];
+        let listedChars = 0;
+        for (const line of scannedLines) {
+            const listed = this.trimToMaxLength(line, listingLineMaxChars);
+            const separator = listedLines.length === 0 ? 0 : 1;
+            if (listedChars + separator + listed.length > listingMaxChars) break;
+            listedLines.push(listed);
+            listedChars += separator + listed.length;
+        }
+        if (listedLines.length < scannedLines.length) {
+            console.log(`🤖 AI Web: AI boundary pass listing truncated to ${listedLines.length} line(s) / ${listedChars} chars`);
+        }
+        if (listedLines.length < 2) {
+            console.log('🤖 AI Web: AI boundary pass yielded <2 verified boundaries — falling through to whole-page fallback');
+            return [];
+        }
+
+        const prompt = [
+            'You are segmenting a web page that lists MULTIPLE distinct events, or one festival programme with multiple day sections.',
+            '',
+            'PAGE LINES (one per line, exactly as extracted):',
+            listedLines.join('\n'),
+            '',
+            'TASK: Identify where each distinct event or day section STARTS. For each one, return the VERBATIM FIRST LINE of that section, copied EXACTLY as it appears in PAGE LINES above — same characters, same order, no translation, no paraphrase, no merging of lines, no added or removed words. A section-start line is typically a day/date heading or an event title, never a sentence from the middle of a description.',
+            '',
+            `Return between 2 and ${this.extractionLimits.multiEventMaxSegments} lines. If the page really describes only ONE event, return an empty list.`,
+            '',
+            'Return JSON only, no other text:',
+            '{"boundaries": ["<first line of section 1>", "<first line of section 2>", ...]}'
+        ].join('\n');
+
+        const configuredNumPredict = Number.isFinite(Number(aiConfig.numPredict)) && Number(aiConfig.numPredict) > 0
+            ? Number(aiConfig.numPredict)
+            : 1200;
+        const boundaryConfig = { ...aiConfig, temperature: 0, numPredict: Math.min(configuredNumPredict, 1200) };
+        const rawResponse = await this.core.callAiGenerate(boundaryConfig, prompt, 'segment-boundaries', httpAdapter, this.recordAiPrompt.bind(this));
+
+        let proposedBoundaries = null;
+        if (rawResponse) {
+            try {
+                const parsed = JSON.parse(this.core.extractFirstJsonObject(rawResponse) || rawResponse);
+                if (parsed && Array.isArray(parsed.boundaries)) proposedBoundaries = parsed.boundaries;
+            } catch (_) {
+                proposedBoundaries = null;
+            }
+        }
+        if (!proposedBoundaries) {
+            console.log('🤖 AI Web: AI boundary pass yielded <2 verified boundaries — falling through to whole-page fallback');
+            return [];
+        }
+
+        // Verbatim verification: every proposed boundary must reproduce a
+        // listed line (fold-tolerant). Exact matches claim the first
+        // unclaimed occurrence; long candidates (≥20 key chars) may salvage
+        // a listed line whose key merely STARTS with theirs (the model or
+        // the 160-char listing cap trimmed a long line's tail). Anything
+        // else is dropped — hallucinated headings never steer slicing.
+        const indicesByKey = new Map();
+        for (let i = 0; i < listedLines.length; i++) {
+            const key = this.getBoundaryVerificationKey(listedLines[i]);
+            if (!key) continue;
+            if (!indicesByKey.has(key)) indicesByKey.set(key, []);
+            indicesByKey.get(key).push(i);
+        }
+        const claimed = new Set();
+        const verifiedIndices = [];
+        let droppedCount = 0;
+        for (const rawBoundary of proposedBoundaries) {
+            const candidateKey = this.getBoundaryVerificationKey(rawBoundary);
+            let matchedIndex = -1;
+            if (candidateKey && indicesByKey.has(candidateKey)) {
+                for (const index of indicesByKey.get(candidateKey)) {
+                    if (claimed.has(index)) continue;
+                    matchedIndex = index;
+                    break;
+                }
+            }
+            if (matchedIndex < 0 && candidateKey.length >= 20) {
+                for (let i = 0; i < listedLines.length; i++) {
+                    if (claimed.has(i)) continue;
+                    if (this.getBoundaryVerificationKey(listedLines[i]).startsWith(candidateKey)) {
+                        matchedIndex = i;
+                        break;
+                    }
+                }
+            }
+            if (matchedIndex < 0) {
+                droppedCount++;
+                console.log(`🤖 AI Web: AI boundary pass dropped unverifiable line: "${String(rawBoundary == null ? '' : rawBoundary).slice(0, 120)}"`);
+                continue;
+            }
+            claimed.add(matchedIndex);
+            verifiedIndices.push(matchedIndex);
+        }
+        console.log(`🤖 AI Web: AI boundary pass proposed ${proposedBoundaries.length} line(s); ${verifiedIndices.length} verified verbatim, ${droppedCount} dropped`);
+
+        const uniqueIndices = Array.from(new Set(verifiedIndices)).sort((a, b) => a - b);
+        if (uniqueIndices.length < 2) {
+            console.log('🤖 AI Web: AI boundary pass yielded <2 verified boundaries — falling through to whole-page fallback');
+            return [];
+        }
+
+        const segments = this.buildSegmentsFromBoundaryIndices(scannedLines, uniqueIndices, html, sourceUrl, ocrResults);
+        console.log(`🤖 AI Web: AI boundary pass built ${segments.length} segment(s) from ${uniqueIndices.length} verified boundaries`);
+        return segments;
+    }
+
+    // Deterministic slicing from verified boundary indices — the interface a
+    // future structural proposer would target too. Reuses the deterministic
+    // splitter's construction tail (line cap, char trim, min-chars gate,
+    // lowercase dedupe, raw-HTML recovery, segment cap) but DELIBERATELY
+    // skips the segmentHasDateSignal/segmentHasTitleSignal gates: that
+    // vocabulary blindness is exactly what tier 2 exists to bypass.
+    buildSegmentsFromBoundaryIndices(scannedLines, indices, html, sourceUrl = '', ocrResults = []) {
+        const lines = Array.isArray(scannedLines) ? scannedLines : [];
+        const boundaryIndices = Array.from(new Set(
+            (Array.isArray(indices) ? indices : []).filter(index => Number.isInteger(index) && index >= 0 && index < lines.length)
+        )).sort((a, b) => a - b);
+
+        const maxSegmentLines = this.extractionLimits.multiEventMaxSegmentLines;
+        const uniqueSegments = [];
+        const seen = new Set();
+        for (let k = 0; k < boundaryIndices.length; k++) {
+            const start = boundaryIndices[k];
+            const end = k + 1 < boundaryIndices.length ? boundaryIndices[k + 1] : lines.length;
+            // Preamble before the first boundary is deliberately discarded.
+            const sliceLines = lines.slice(start, end)
+                .map(line => this.trimToMaxLength(this.normalizeWhitespace(line), this.extractionLimits.multiEventLineMaxChars))
+                .filter(Boolean)
+                .slice(0, maxSegmentLines);
+            const trimmedLines = this.trimSegmentLinesToChars(sliceLines, this.extractionLimits.multiEventMaxSegmentChars);
+            const segmentText = trimmedLines.join('\n');
+            if (segmentText.length < this.extractionLimits.multiEventMinSegmentChars) continue;
+            const dedupeKey = segmentText.toLowerCase();
+            if (seen.has(dedupeKey)) continue;
+            seen.add(dedupeKey);
+            uniqueSegments.push({
+                lines: trimmedLines,
+                html: this.extractRawHtmlForMultiEventSegment(html, trimmedLines)
+            });
+            if (uniqueSegments.length >= this.extractionLimits.multiEventMaxSegments) break;
+        }
+        return this.attachSequentialImageHintsToSegments(html, uniqueSegments, sourceUrl, ocrResults);
+    }
 
     buildStructuredMultiEventSegments(html) {
         const groups = this.extractRepeatedMultiEventStructureGroups(html);

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -7390,3 +7390,224 @@ test('day-programme prompt steering: flag rides the segment htmlData and adds th
   const plainPrompt = parser.buildExtractionPrompt(plainHtmlData, {}, null, {}, ['title', 'startDate'], 'SNIPPET', 'default', { segment: true, ocr: true });
   assert.ok(!plainPrompt.includes('ONE DAY of a longer programme'), 'rule line absent for ordinary segments');
 });
+
+// ── Tier-2 AI segment-boundary fallback ─────────────────────────────────────
+// Fixtures are blind-by-language: Dutch is NOT in DATE_VOCABULARY_LOCALES, so
+// the deterministic splitter genuinely finds nothing — no monkeypatching of
+// vocabulary internals.
+
+const DUTCH_PROGRAMME_HTML = `
+  <html><body>
+    <article>
+      <h1>BEREN WEEKEND PROGRAMMA</h1>
+      <p>Het volledige programma van het grote berenweekend in de stad, met feesten en borrels voor alle beren en hun vrienden.</p>
+      <h2>DONDERDAG- 03</h2>
+      <p>WELKOMSTBORREL IN DE KROEG</p>
+      <p>20:00 h. Welkomstborrel met live muziek en gratis hapjes voor alle bezoekers van het festival.</p>
+      <h2>VRIJDAG- 04</h2>
+      <p>LEREN NACHT IN DE KELDER</p>
+      <p>23:00 h. Leren nacht met strikte kledingvoorschriften en twee dansvloeren vol stevige muziek.</p>
+      <h2>ZATERDAG- 05</h2>
+      <p>GROTE SLOTFEEST AVOND</p>
+      <p>22:00 h. Het grote slotfeest met internationale gasten en een spectaculaire show om middernacht.</p>
+    </article>
+  </body></html>
+`;
+
+test('AI boundary pass segments a vocabulary-blind Dutch programme from verbatim headers', async () => {
+  const parser = createParser();
+  const sourceUrl = 'https://berenfest.example/programma';
+
+  // Tier-1 blindness by construction: Dutch headings carry no supported
+  // date vocabulary, so deterministic segmentation finds <2 segments.
+  assert.ok(parser.buildMultiEventSegments(DUTCH_PROGRAMME_HTML, sourceUrl).length < 2);
+
+  const labels = [];
+  let promptSeen = '';
+  let configSeen = null;
+  parser.core.callAiGenerate = async (config, prompt, label) => {
+    labels.push(label);
+    promptSeen = prompt;
+    configSeen = config;
+    return JSON.stringify({ boundaries: ['DONDERDAG- 03', 'VRIJDAG- 04', 'ZATERDAG- 05'] });
+  };
+
+  const segments = await parser.runAiBoundarySegmentation(DUTCH_PROGRAMME_HTML, sourceUrl, [], {}, {}, 0);
+  assert.equal(segments.length, 3);
+  assert.deepEqual(labels, ['segment-boundaries'], 'boundary pass uses the segment-boundaries pass label');
+  assert.equal(configSeen.temperature, 0);
+  assert.ok(configSeen.numPredict <= 1200, 'numPredict is clamped to 1200');
+  assert.ok(promptSeen.includes('PAGE LINES (one per line, exactly as extracted):'));
+  assert.ok(promptSeen.includes(`Return between 2 and ${parser.extractionLimits.multiEventMaxSegments} lines.`));
+
+  // Each day section starts at its verbatim header and keeps its own timed line
+  assert.equal(segments[0].lines[0], 'DONDERDAG- 03');
+  assert.equal(segments[1].lines[0], 'VRIJDAG- 04');
+  assert.equal(segments[2].lines[0], 'ZATERDAG- 05');
+  assert.ok(segments[0].lines.some(line => line.includes('20:00')));
+  assert.ok(segments[1].lines.some(line => line.includes('23:00')));
+  assert.ok(segments[2].lines.some(line => line.includes('22:00')));
+  assert.ok(!segments[0].lines.some(line => line.includes('23:00')), 'time lines stay in their own segment');
+  // The preamble before the first boundary is discarded
+  assert.ok(!segments[0].lines.includes('BEREN WEEKEND PROGRAMMA'));
+
+  // Wiring: extractEventsFromMultiEventPage adopts the AI segments
+  const extractedSegments = [];
+  parser.extractSingleEvent = async (segmentHtmlData) => {
+    extractedSegments.push(segmentHtmlData);
+    return { title: `event ${extractedSegments.length}` };
+  };
+  const events = await parser.extractEventsFromMultiEventPage(
+    { html: DUTCH_PROGRAMME_HTML, url: sourceUrl }, {}, {}, [], [], {});
+  assert.equal(events.length, 3);
+  assert.deepEqual(events.map(event => event._multiEventSegment.total), [3, 3, 3]);
+});
+
+test('AI boundary pass drops hallucinated boundaries and falls through to whole-page fallback', async () => {
+  const parser = createParser();
+  const sourceUrl = 'https://berenfest.example/programma';
+
+  // All-fake proposals: nothing verifies, the pass yields nothing
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); originalLog(...args); };
+  try {
+    parser.core.callAiGenerate = async () => JSON.stringify({
+      boundaries: ['MEGA BEAR BLOWOUT NIGHT', 'AFTERPARTY AT THE DOCKS']
+    });
+    const segments = await parser.runAiBoundarySegmentation(DUTCH_PROGRAMME_HTML, sourceUrl, [], {}, {}, 0);
+    assert.deepEqual(segments, []);
+    assert.ok(logs.some(line => line.includes('dropped unverifiable line') && line.includes('MEGA BEAR BLOWOUT NIGHT')));
+    assert.ok(logs.some(line => line.includes('proposed 2 line(s); 0 verified verbatim, 2 dropped')));
+    assert.ok(logs.some(line => line.includes('yielded <2 verified boundaries')));
+  } finally {
+    console.log = originalLog;
+  }
+
+  // One real + one fake → 1 verified < 2 → the multi-event flow takes the
+  // existing whole-page fallback path
+  parser.core.callAiGenerate = async () => JSON.stringify({
+    boundaries: ['DONDERDAG- 03', 'MEGA BEAR BLOWOUT NIGHT']
+  });
+  let fallbackHtmlData = null;
+  parser.extractEventsFromSinglePage = async (htmlData) => {
+    fallbackHtmlData = htmlData;
+    return [];
+  };
+  const events = await parser.extractEventsFromMultiEventPage(
+    { html: DUTCH_PROGRAMME_HTML, url: sourceUrl }, {}, {}, [], [], {});
+  assert.deepEqual(events, []);
+  assert.ok(fallbackHtmlData, 'whole-page fallback ran');
+  assert.equal(fallbackHtmlData._wholePageFallback, true);
+});
+
+test('AI boundary verification tolerates case, diacritic and zero-width drift', async () => {
+  const parser = createParser();
+  const sourceUrl = 'https://berenfest.example/programma';
+  parser.core.callAiGenerate = async () => JSON.stringify({
+    boundaries: [
+      '‎donderdag- 03',        // lowercase + leading zero-width mark
+      'VRÍJDAG​- 04',          // added diacritic + embedded zero-width space
+      'Záterdag- 05'           // mixed case + added diacritic
+    ]
+  });
+  const segments = await parser.runAiBoundarySegmentation(DUTCH_PROGRAMME_HTML, sourceUrl, [], {}, {}, 0);
+  assert.equal(segments.length, 3);
+  assert.equal(segments[0].lines[0], 'DONDERDAG- 03');
+  assert.equal(segments[2].lines[0], 'ZATERDAG- 05');
+});
+
+const ENGLISH_HEALTHY_MULTI_HTML = `
+  <html><body>
+    <p>FURBALL BLACKOUT PARTY</p>
+    <p>July 10, 2026 at the Eagle</p>
+    <p>Doors open at nine with two floors of music and a late night patio.</p>
+    <p>FURBALL POOL SPLASH</p>
+    <p>July 24, 2026 at Elsewhere Rooftop</p>
+    <p>Swim and dance all afternoon with resident selectors on the deck.</p>
+  </body></html>
+`;
+
+test('AI boundary pass never runs when tier 1 already found segments or the page is thin', async () => {
+  const parser = createParser();
+  const sourceUrl = 'https://furball.example/events';
+
+  // Healthy page: deterministic segmentation succeeds, the throwing stub
+  // proves the boundary pass is never consulted.
+  assert.ok(parser.buildMultiEventSegments(ENGLISH_HEALTHY_MULTI_HTML, sourceUrl).length >= 2);
+  parser.core.callAiGenerate = async () => {
+    throw new Error('AI boundary pass must not run when tier 1 found segments');
+  };
+  parser.extractSingleEvent = async () => ({ title: 'x' });
+  const events = await parser.extractEventsFromMultiEventPage(
+    { html: ENGLISH_HEALTHY_MULTI_HTML, url: sourceUrl }, {}, {}, [], [], {});
+  assert.ok(events.length >= 2);
+
+  // Thin page: no time lines, <1500 chars, no OCR → skip log + whole-page fallback
+  const thinHtml = `
+    <html><body>
+      <p>BEER BUST ZONDAG</p>
+      <p>Kom langs voor bier en gezelligheid met alle beren van de stad, iedereen is welkom bij ons.</p>
+    </body></html>
+  `;
+  const thinParser = createParser();
+  thinParser.core.callAiGenerate = async () => {
+    throw new Error('AI boundary pass must not run on a thin page');
+  };
+  let fallbackHtmlData = null;
+  thinParser.extractEventsFromSinglePage = async (htmlData) => {
+    fallbackHtmlData = htmlData;
+    return [];
+  };
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); originalLog(...args); };
+  try {
+    const thinEvents = await thinParser.extractEventsFromMultiEventPage(
+      { html: thinHtml, url: sourceUrl }, {}, {}, [], [], {});
+    assert.deepEqual(thinEvents, []);
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(logs.some(line => line.includes('Skipping AI boundary pass — page content too thin')));
+  assert.ok(fallbackHtmlData, 'thin page still takes the whole-page fallback');
+  assert.equal(fallbackHtmlData._wholePageFallback, true);
+});
+
+test('AI boundary segments cap at multiEventMaxSegments and the raised cap fits a 13-day programme', async () => {
+  const parser = createParser();
+  assert.equal(parser.extractionLimits.multiEventMaxSegments, 16);
+
+  // 20 verified boundaries → capped at 16 segments
+  const sectionCount = 20;
+  const headers = [];
+  const sections = [];
+  for (let i = 1; i <= sectionCount; i++) {
+    const header = `SECTIE ${String(i).padStart(2, '0')} BERENAVOND`;
+    headers.push(header);
+    sections.push(`<h2>${header}</h2><p>21:00 h. Speciale berenavond nummer ${i} met muziek en dans in de grote zaal.</p>`);
+  }
+  const bigHtml = `<html><body><h1>GROOT BEREN FESTIVAL WEEKEND</h1>${sections.join('')}</body></html>`;
+  parser.core.callAiGenerate = async () => JSON.stringify({ boundaries: headers });
+  const segments = await parser.runAiBoundarySegmentation(bigHtml, 'https://berenfest.example/alles', [], {}, {}, 0);
+  assert.equal(segments.length, 16);
+  assert.equal(segments[0].lines[0], 'SECTIE 01 BERENAVOND');
+  assert.equal(segments[15].lines[0], 'SECTIE 16 BERENAVOND');
+
+  // Deterministic tier 1: a Sitges-schedule-shaped 13-day programme now
+  // survives whole (it silently lost days under the old cap of 12).
+  const dayHeaders = [
+    'JUEVES- 03', 'VIERNES- 04', 'SABADO- 05', 'DOMINGO- 06', 'LUNES- 07',
+    'MARTES- 08', 'MIERCOLES- 09', 'JUEVES- 10', 'VIERNES- 11', 'SABADO- 12',
+    'DOMINGO- 13', 'LUNES- 14', 'MARTES- 15'
+  ];
+  const daySections = dayHeaders.map((header, index) => `
+    <h2>${header}</h2>
+    <p>FIESTA DE OSOS ${index + 1}</p>
+    <p>Gran fiesta numero ${index + 1} con musica y muchos osos en el bar principal.</p>
+  `);
+  const sitgesHtml = `<html><body><h1>BEARS SITGES WEEK 2026</h1>${daySections.join('')}</body></html>`;
+  const sitgesParser = createParser();
+  const sitgesSegments = sitgesParser.buildMultiEventSegments(sitgesHtml, 'https://bearssitges.example/programa');
+  assert.equal(sitgesSegments.length, 13);
+});


### PR DESCRIPTION
The generic segmentation answer ("I thought AI could help"): a three-tier ladder where **the AI may only point, never invent**.

1. **Tier 1 (unchanged, free)**: structural + date/time signals, vocabulary now Intl-derived.
2. **Tier 2 (new)**: when a multi-event page yields <2 segments despite real content, one AI call returns *the verbatim first line of each section*. Deterministic verification then requires every returned line to exist in the page (diacritic-folded, zero-width-stripped — real pages embed invisible U+200E marks), drops anything unverifiable with an audit log, and slices between verified boundaries through the existing machinery. A hallucinated boundary is structurally unfindable. Cached, temperature 0.
3. **Tier 3 (unchanged)**: the whole-page fallback, for <2 verified boundaries.

**Economy proven live**: zero `boundary pass` lines on healthy runs (Sitges — tier 1 handles it; Club Chub — never consulted). The pass exists purely for languages/formats the deterministic tiers can't see (the pre-#1568 Sitges/Lumberyard class), priced at nothing otherwise.

**Cap 14 → 16** (12 was silently cutting Sitges's farewell day; 16 buffers junk splits). Combined acceptance on this tree: **16 segments, 11 events spanning the full Sept 3–13 week** — including the previously-cut final day (PREMIOS Mr. BEAR, BEARS SITGES MARKET) — every title a real activity.

`buildSegmentsFromBoundaryIndices` ships as a standalone interface so a future structural (repeated-heading) proposer plugs in without touching the verification logic.

Tests **1012 → 1017**; the tier-2 fixture is blind-by-language (Dutch day headers) so it tests the mechanism, not the vocabulary.

## After merge (updater pull)
`scripts/parsers/ai-web-parser.js` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP