### PR TITLE
feat(scraper): promoters own identity — configs become pure sources + Brighton/Birmingham cities

### DIFF
--- a/data/promoters.json
+++ b/data/promoters.json
@@ -67,6 +67,7 @@
     "shortName": "FUR-BALL",
     "instagram": "https://instagram.com/furballnyc/",
     "website": "https://www.furball.nyc",
+    "favicon": "https://linktr.ee/furballnyc",
     "bearAffinity": "always"
   },
   {
@@ -111,14 +112,16 @@
     "parent": "BEEFMINCE",
     "keywords": [
       "spookmince"
-    ]
+    ],
+    "bearAffinity": "always"
   },
   {
     "name": "BOATMINCE",
     "parent": "BEEFMINCE",
     "keywords": [
       "boatmince"
-    ]
+    ],
+    "bearAffinity": "always"
   },
   {
     "name": "BeefDip",
@@ -173,6 +176,7 @@
       "Bears Week Sitges",
       "Bears Sitges Meeting"
     ],
+    "shortName": "BEARS SITGES",
     "instagram": "https://www.instagram.com/bearssitgesofficial",
     "facebook": "https://www.facebook.com/BearsSitges",
     "website": "https://bearssitges.org",
@@ -184,7 +188,6 @@
   {
     "name": "Northeast Ursamen",
     "aliases": [
-      "Spooky Bear",
       "NE Ursamen",
       "Ursamen",
       "Out of Hibernation",
@@ -195,8 +198,21 @@
     "website": "https://www.ursamen.org",
     "bearAffinity": "always",
     "urlPatterns": [
-      "ursamen",
-      "spookybear"
+      "ursamen"
     ]
+  },
+  {
+    "name": "Spooky Bear",
+    "parent": "Northeast Ursamen",
+    "keywords": [
+      "spooky bear",
+      "spookybear"
+    ],
+    "shortName": "SPOOKY BEAR",
+    "website": "https://www.ursamen.org/spookybear",
+    "urlPatterns": [
+      "spookybear"
+    ],
+    "bearAffinity": "always"
   }
 ]

--- a/js/city-config.js
+++ b/js/city-config.js
@@ -452,6 +452,32 @@ const CITY_CONFIG = {
         mapZoom: 11,
         visible: false
     },
+    'brighton': {
+        name: 'Brighton',
+        emoji: '🌈',
+        tagline: 'Seaside bears by the pier',
+        // pending calendar creation — flip visible + set ID when chunky-dad-brighton exists
+        calendarId: '',
+        calendar: 'chunky-dad-brighton',
+        timezone: 'Europe/London',
+        patterns: ['brighton', 'brighton and hove'],
+        coordinates: { lat: 50.8225, lng: -0.1372 },
+        mapZoom: 11,
+        visible: false
+    },
+    'birmingham': {
+        name: 'Birmingham',
+        emoji: '🐂',
+        tagline: 'Midlands bear scene',
+        // pending calendar creation — flip visible + set ID when chunky-dad-birmingham exists
+        calendarId: '',
+        calendar: 'chunky-dad-birmingham',
+        timezone: 'Europe/London',
+        patterns: ['birmingham'],
+        coordinates: { lat: 52.4862, lng: -1.8904 },
+        mapZoom: 11,
+        visible: false
+    },
     'dublin': {
         name: 'Dublin',
         emoji: '☘️',

--- a/scripts/promoter-registry.test.js
+++ b/scripts/promoter-registry.test.js
@@ -176,6 +176,86 @@ test('matcher: MEGAWOOF alias and the new BEEFMINCE sub-brands match their title
   assert.equal(boat.entry.parent, 'BEEFMINCE');
 });
 
+// ── Promoters own identity (2026-07 migration) ─────────────────────────────
+// Identity metadata (shortName/socials/matchKey/favicon) and bear trust
+// (bearAffinity) moved OUT of parser configs into this registry. A parser
+// entry whose name (or a registry alias of it) IS a curated promoter identity
+// must be a pure source: no metadata block, no alwaysBear. Venue parsers
+// (Dallas Eagle, 3 Dollar Bill, The Lumberyard, massive.club) are not
+// registry identities and keep their venue-fact metadata untouched.
+test('repo scraper-input: registry-identity parsers carry no metadata or alwaysBear', () => {
+  const registry = loadRegistry();
+  const registryKeys = new Set();
+  for (const entry of registry) {
+    for (const name of [entry.name, ...(Array.isArray(entry.aliases) ? entry.aliases : [])]) {
+      registryKeys.add(nameKey(name));
+    }
+  }
+  const { parsers } = require('./scraper-input');
+  const promoterParsers = parsers.filter((parser) => registryKeys.has(nameKey(parser.name)));
+  assert.ok(promoterParsers.length >= 15,
+    `expected at least the 15 migrated promoter parsers, found ${promoterParsers.length}`);
+  for (const parser of promoterParsers) {
+    assert.ok(!('metadata' in parser),
+      `promoter parser "${parser.name}" must not carry metadata — promoter identity lives in data/promoters.json`);
+    assert.ok(!('alwaysBear' in parser),
+      `promoter parser "${parser.name}" must not carry alwaysBear — set bearAffinity in data/promoters.json`);
+  }
+});
+
+// Registry-application parity for a migrated field that previously lived only
+// in the parser config: Furball's favicon. On match the registry must stamp
+// the exact facts the old config metadata stamped, through the same static
+// machinery, and the removed parser-level alwaysBear must be replaced by the
+// entry's bearAffinity trust.
+test('migrated Furball identity (incl. favicon) stamps on match exactly like the old parser metadata', () => {
+  const { SharedCore } = require('./shared-core');
+  const { EventSchema } = require('./event-schema');
+  const core = new SharedCore({}, { eventSchema: EventSchema, promoters: loadRegistry() });
+  const enforceConfig = { config: { promoterRegistry: { mode: 'enforce' } } };
+  const event = { title: 'FURBALL Chicago', startDate: new Date('2026-08-01T21:00:00.000Z') };
+  core.applyPromoterRegistryMatches([event], { name: 'Furball' }, enforceConfig);
+  assert.equal(event._promoter, 'Furball');
+  // The exact values the removed parser-config metadata block used to stamp
+  assert.equal(event.shortName, 'FUR-BALL');
+  assert.equal(event.instagram, 'https://instagram.com/furballnyc/');
+  assert.equal(event.url, 'https://www.furball.nyc', 'website maps to the canonical url field');
+  assert.equal(event.favicon, 'https://linktr.ee/furballnyc', 'favicon migrated into the registry');
+  // Same static machinery: stamped fields are tracked for de-circularization
+  assert.equal(event._staticFields.favicon, 'https://linktr.ee/furballnyc');
+  assert.equal(event._staticFields.shortName, 'FUR-BALL');
+  // Bear trust now comes from the entry, with the parser carrying no alwaysBear
+  const trust = core.getEventBearTrust(event, { name: 'Furball' });
+  assert.equal(trust.trusted, true);
+  assert.equal(trust.affinity, 'always');
+});
+
+// The other config-only facts found by the migration inventory: Bears Sitges
+// Week's shortName moved onto Bears Sitges Club, and Spooky Bear became a
+// sub-brand of Northeast Ursamen carrying its old config identity (shortName,
+// spookybear website, explicit always-trust); socials inherit from the parent.
+test('migrated festival identities: Bears Sitges shortName and the Spooky Bear sub-brand', () => {
+  const { SharedCore } = require('./shared-core');
+  const { EventSchema } = require('./event-schema');
+  const core = new SharedCore({}, { eventSchema: EventSchema, promoters: loadRegistry() });
+  const sitges = core.matchEventToPromoter({ title: 'Bears Sitges Week — Opening Party' });
+  assert.ok(sitges && sitges.entry, `expected a Sitges match, got ${JSON.stringify(sitges)}`);
+  assert.equal(sitges.entry.name, 'Bears Sitges Club');
+  assert.equal(core.promoterEntryToMetadataBlock(sitges.entry).shortName.value, 'BEARS SITGES');
+
+  const spooky = core.matchEventToPromoter({ title: 'SPOOKY BEAR 2026 Kickoff' });
+  assert.ok(spooky && spooky.entry, `expected a Spooky Bear match, got ${JSON.stringify(spooky)}`);
+  assert.equal(spooky.entry.name, 'Spooky Bear');
+  assert.equal(spooky.entry.parent, 'Northeast Ursamen');
+  const block = core.promoterEntryToMetadataBlock(spooky.entry);
+  assert.equal(block.shortName.value, 'SPOOKY BEAR');
+  assert.equal(block.url.value, 'https://www.ursamen.org/spookybear');
+  assert.equal(block.instagram.value, 'https://www.instagram.com/ne.ursamen', 'inherited from Northeast Ursamen');
+  assert.equal(block.facebook.value, 'https://www.facebook.com/NEUrsamen', 'inherited from Northeast Ursamen');
+  assert.equal(spooky.entry.bearAffinity, 'always',
+    'sub-brand carries explicit always-trust now that the parser has no alwaysBear');
+});
+
 test('matcher: statically stamped url-ish fields are never registry evidence (de-circularization)', () => {
   const { SharedCore } = require('./shared-core');
   const { EventSchema } = require('./event-schema');

--- a/scripts/scraper-cities.js
+++ b/scripts/scraper-cities.js
@@ -466,6 +466,29 @@ const scraperCities = {
       "lng": -2.2426
     }
   },
+  "brighton": {
+    "calendar": "chunky-dad-brighton",
+    "timezone": "Europe/London",
+    "patterns": [
+      "brighton",
+      "brighton and hove"
+    ],
+    "coordinates": {
+      "lat": 50.8225,
+      "lng": -0.1372
+    }
+  },
+  "birmingham": {
+    "calendar": "chunky-dad-birmingham",
+    "timezone": "Europe/London",
+    "patterns": [
+      "birmingham"
+    ],
+    "coordinates": {
+      "lat": 52.4862,
+      "lng": -1.8904
+    }
+  },
   "dublin": {
     "calendar": "chunky-dad-dublin",
     "timezone": "Europe/Dublin",

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -143,32 +143,18 @@ const scraperConfig = {
     ],
   },
   parsers: [
+    // NOTE: Promoter identity (shortName/socials/matchKey) and bear trust
+    // (bearAffinity) live in data/promoters.json now — the enforce-mode
+    // promoter registry stamps them on matched events. Parser entries here
+    // are pure SOURCES (name/urls/crawl knobs); only VENUE parsers still
+    // carry a metadata block (venue facts, not promoter identity).
     {
       name: "Megawoof America",
       urls: ["https://www.eventbrite.com/o/megawoof-america-18118978189"],
-      alwaysBear: true,
-      metadata: {
-        shortName: { value: "MEGA-WOOF" },
-        instagram: { value: "https://www.instagram.com/megawoof_america" },
-        url: { value: "https://linktr.ee/megawoof_america" },
-      },
     },
     {
       name: "Coach After Dark",
       urls: ["https://www.eventbrite.com/o/bear-happy-hour-87043830313"],
-      alwaysBear: true,
-      metadata: {
-        shortName: {
-          value: "COACH",
-          conditionalValues: [{ keywords: ["beefwitch"], value: "BEEFWITCH" }],
-        },
-        instagram: {
-          value: "https://www.instagram.com/coachafterdark",
-          conditionalValues: [
-            { keywords: ["beefwitch"], value: "https://www.instagram.com/thebeefwitch" },
-          ],
-        },
-      },
     },
     {
       name: "Bearracuda Events",
@@ -176,20 +162,6 @@ const scraperConfig = {
         "https://bearracuda.com/",
         "https://www.eventbrite.com/o/bearracuda-21867032189",
       ],
-      // NOT alwaysBear: Bearracuda also throws non-bear events (e.g. HOT TAKE) —
-      // enforce-mode bear check judges each event with promoter context instead.
-      alwaysBear: false,
-      metadata: {
-        shortName: {
-          value: "Bear-rac-uda",
-          conditionalValues: [
-            { keywords: ["hot take"], value: "HOT TAKE" },
-            { keywords: ["treasure trail"], value: "TREAS-URE TRAIL" },
-          ],
-        },
-        instagram: { value: "https://www.instagram.com/bearracuda" },
-        url: { value: "https://bearracuda.com/" },
-      },
     },
     {
       name: "CHUNK",
@@ -199,35 +171,16 @@ const scraperConfig = {
         "chunk-party.com/chunkbearandcubsocial",
         "chunk-party.com/chunk",
       ],
-      alwaysBear: true,
-      metadata: {
-        shortName: { value: "CHUNK" },
-        instagram: { value: "https://www.instagram.com/chunkparty" },
-        website: { value: "https://www.chunk-party.com" },
-      },
     },
     {
       name: "Furball",
       urls: ["https://www.furball.nyc"],
-      alwaysBear: true,
       urlDiscoveryDepth: 0,
-      metadata: {
-        shortName: { value: "FUR-BALL" },
-        instagram: { value: "https://instagram.com/furballnyc/" },
-        url: { value: "https://www.furball.nyc" },
-        favicon: { value: "https://linktr.ee/furballnyc" },
-      },
     },
     {
       name: "Cubhouse",
       urls: ["https://linktr.ee/cubhouse"],
       discoveryBlockedPatterns: ["www.eventbrite.com/o/", "linktr.ee"],
-      alwaysBear: true,
-      metadata: {
-        shortName: { value: "CUB-HOUSE" },
-        instagram: { value: "https://www.instagram.com/cubhouse.philly" },
-        url: { value: "https://linktr.ee/cubhouse" },
-      },
     },
     {
       name: "Goldiloxx",
@@ -243,14 +196,7 @@ const scraperConfig = {
       // ~900 events. Note: sickening JSON-LD "organizer" is the VENUE, and
       // the site soft-404s (every URL returns 200 with an empty shell).
       discoveryAllowedPatterns: ["goldiloxx"],
-      alwaysBear: true,
-      calendarSearchRangeDays: 40, // Look +/- days for wildcard key matches
-      metadata: {
-        shortName: { value: "GOLDI-LOXX" },
-        shorterName: { value: "GLX" },
-        instagram: { value: "https://www.instagram.com/goldiloxx__" },
-        matchKey: { value: "goldiloxx*|${year}-${month}-*|*" },
-      },
+      calendarSearchRangeDays: 40, // Look +/- days for wildcard key matches (pairs with the registry's wildcard matchKey)
     },
     {
       name: "3 Dollar Bill",
@@ -273,12 +219,6 @@ const scraperConfig = {
         "https://www.eventbrite.com/o/nab-events-llc-51471535173",
         "https://www.eventbrite.com/o/121474797695",
       ],
-      alwaysBear: true,
-      metadata: {
-        shortName: { value: "TWIST-ED BEAR" },
-        instagram: { value: "https://www.instagram.com/twistedbearparty" },
-        facebook: { value: "https://www.facebook.com/twistedglobal/" },
-      },
     },
     {
       name: "Dallas Eagle",
@@ -299,17 +239,10 @@ const scraperConfig = {
       // ~45 timed activities Sept 3-13 with venues inline. Spanish text;
       // day headers carry day-of-month only (month/year stated once).
       urls: ["https://bearssitges.org/bears-sitges-week/"],
-      alwaysBear: true,
       urlDiscoveryDepth: 0, // everything on one page; discovery wanders into store/news
       ai: { classifyPages: false }, // heuristic multi-event-page is CORRECT here; the AI
       // second opinion sees "one overarching event" (festival-programme trap) and
       // reroutes to single-event extraction, whose payload window misses the schedule
-      metadata: {
-        shortName: { value: "BEARS SITGES" },
-        website: { value: "https://bearssitges.org" },
-        instagram: { value: "https://www.instagram.com/bearssitgesofficial" },
-        facebook: { value: "https://www.facebook.com/BearsSitges" },
-      },
     },
     {
       name: "Spooky Bear",
@@ -319,15 +252,8 @@ const scraperConfig = {
       // venues inline, weekday-only headers — dates anchor to the announced
       // range). Idles harmlessly until then.
       urls: ["https://www.ursamen.org/spookybear"],
-      alwaysBear: true,
       urlDiscoveryDepth: 1, // follow Zeffy/ThunderTix ticket links
       discoveryBlockedPatterns: ["ursamen.org/about", "ursamen.org/contact", "ursamen.org/the-board", "ursamen.org/our-sponsors", "ursamen.org/general-events", "coming-soon", "zeffy.com/donation-form"],
-      metadata: {
-        shortName: { value: "SPOOKY BEAR" },
-        website: { value: "https://www.ursamen.org/spookybear" },
-        instagram: { value: "https://www.instagram.com/ne.ursamen" },
-        facebook: { value: "https://www.facebook.com/NEUrsamen" },
-      },
     },
     // ── Onboarding batch 2026-07-27 (recon-verified) — run each one alone
     // via the parser picker and review before including it in bigger runs. ──
@@ -345,37 +271,24 @@ const scraperConfig = {
       name: "CubScout LA",
       // Eagle LA's recurring bear party page (The Events Calendar, JSON-LD).
       urls: ["https://eaglela.com/events/cub-scout-3/"],
-      alwaysBear: true,
     },
     {
       name: "BEEFMINCE",
       // Multi-city UK (London/Brighton/Manchester/Birmingham + Sitges);
       // per-event city comes from event text; tickets link out to dice.fm.
       urls: ["https://beefmince.com/events"],
-      alwaysBear: true,
-      metadata: {
-        website: { value: "https://beefmince.com" },
-      },
     },
     {
       name: "BeefDip",
       // Puerto Vallarta bear week; single schedule page, venues appear as
       // Google Maps links (maps-link address harvesting applies).
       urls: ["https://beefdip.com/planned-events/"],
-      alwaysBear: true,
-      metadata: {
-        website: { value: "https://beefdip.com" },
-      },
     },
     {
       name: "Bear it MTL",
       // Montreal (Sugar Bear Weekend organizer); The Events Calendar with
       // JSON-LD + Offers; also lists Toronto/Paris events — city per event.
       urls: ["https://www.bearitmtl.com/events/"],
-      alwaysBear: true,
-      metadata: {
-        website: { value: "https://www.bearitmtl.com" },
-      },
     },
     {
       name: "Club Chub",
@@ -383,10 +296,6 @@ const scraperConfig = {
       // static HTML. Do NOT use the Eventbrite org page — it's CCBC Resort's
       // venue account and would pull non-Club-Chub events.
       urls: ["https://www.clubchubusa.com/event-list"],
-      alwaysBear: true,
-      metadata: {
-        instagram: { value: "https://www.instagram.com/clubchubparty" },
-      },
     },
     {
       name: "The Bear Calendar",

--- a/scripts/scraper-promoters.js
+++ b/scripts/scraper-promoters.js
@@ -76,6 +76,7 @@ const scraperPromoters = [
     "shortName": "FUR-BALL",
     "instagram": "https://instagram.com/furballnyc/",
     "website": "https://www.furball.nyc",
+    "favicon": "https://linktr.ee/furballnyc",
     "bearAffinity": "always"
   },
   {
@@ -120,14 +121,16 @@ const scraperPromoters = [
     "parent": "BEEFMINCE",
     "keywords": [
       "spookmince"
-    ]
+    ],
+    "bearAffinity": "always"
   },
   {
     "name": "BOATMINCE",
     "parent": "BEEFMINCE",
     "keywords": [
       "boatmince"
-    ]
+    ],
+    "bearAffinity": "always"
   },
   {
     "name": "BeefDip",
@@ -182,6 +185,7 @@ const scraperPromoters = [
       "Bears Week Sitges",
       "Bears Sitges Meeting"
     ],
+    "shortName": "BEARS SITGES",
     "instagram": "https://www.instagram.com/bearssitgesofficial",
     "facebook": "https://www.facebook.com/BearsSitges",
     "website": "https://bearssitges.org",
@@ -193,7 +197,6 @@ const scraperPromoters = [
   {
     "name": "Northeast Ursamen",
     "aliases": [
-      "Spooky Bear",
       "NE Ursamen",
       "Ursamen",
       "Out of Hibernation",
@@ -204,9 +207,22 @@ const scraperPromoters = [
     "website": "https://www.ursamen.org",
     "bearAffinity": "always",
     "urlPatterns": [
-      "ursamen",
-      "spookybear"
+      "ursamen"
     ]
+  },
+  {
+    "name": "Spooky Bear",
+    "parent": "Northeast Ursamen",
+    "keywords": [
+      "spooky bear",
+      "spookybear"
+    ],
+    "shortName": "SPOOKY BEAR",
+    "website": "https://www.ursamen.org/spookybear",
+    "urlPatterns": [
+      "spookybear"
+    ],
+    "bearAffinity": "always"
   }
 ];
 

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1529,7 +1529,7 @@ class SharedCore {
             return inherited;
         };
         const block = {};
-        for (const field of ['shortName', 'shorterName', 'instagram', 'facebook', 'matchKey']) {
+        for (const field of ['shortName', 'shorterName', 'instagram', 'facebook', 'favicon', 'matchKey']) {
             const value = pick(field);
             if (value) block[field] = { value };
         }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -9217,6 +9217,29 @@ test('getCityTimezone: accented "montréal" resolves montreal timezone (literal 
   assert.equal(core.getCityTimezone(''), null);
 });
 
+// Brighton + Birmingham onboarding (BEEFMINCE runs monthly in both; runs
+// logged `No timezone config for city "brighton"/"birmingham"`). The cities
+// ship visible:false with an empty calendarId — off the website and out of CI
+// calendar fetches — but the GENERATED scraper config must already resolve
+// their keys, patterns, and timezone.
+test('generated cities config: brighton and birmingham resolve to their keys and Europe/London', () => {
+  const cities = require('./scraper-cities');
+  const core = new SharedCore(cities, { eventSchema: EventSchema });
+  for (const cityKey of ['brighton', 'birmingham']) {
+    assert.ok(cities[cityKey], `generated scraper-cities carries the ${cityKey} key`);
+    assert.equal(cities[cityKey].timezone, 'Europe/London');
+    assert.ok(cities[cityKey].coordinates, `${cityKey} carries city-center coordinates`);
+  }
+  assert.deepEqual(cities.brighton.patterns, ['brighton', 'brighton and hove']);
+  assert.deepEqual(cities.birmingham.patterns, ['birmingham']);
+  // Key, pattern, and cased/alias variants all resolve the timezone
+  assert.equal(core.getCityTimezone('brighton'), 'Europe/London');
+  assert.equal(core.getCityTimezone('Brighton'), 'Europe/London');
+  assert.equal(core.getCityTimezone('Brighton and Hove'), 'Europe/London');
+  assert.equal(core.getCityTimezone('birmingham'), 'Europe/London');
+  assert.equal(core.getCityTimezone('Birmingham'), 'Europe/London');
+});
+
 test('resolveWallClockDates: city "montréal" re-anchors wall-clock dates via the folded timezone lookup', () => {
   const core = createMontrealCore();
   const event = {


### PR DESCRIPTION
## Your call, executed

"The bear flag should be set on promoters... move over the logic like 'short name = XXX'."

- **All 15 promoter parser entries** lose `metadata` + `alwaysBear` — the registry is the sole identity source, applied **only on evidence match**. Unmatched events carry no promoter trust (the dice.fm bleed class dies architecturally — junk that matches no promoter gets no bear-trust to leak). Venue parsers keep their venue facts.
- **Migration gaps closed** (full diff table audited): Furball `favicon` → registry (+ application field list); Bears Sitges Club gains its shortName; **Spooky Bear became a sub-brand child** of Northeast Ursamen — stamping the org entry would have mislabeled their other brands; SPOOKMINCE/BOATMINCE get explicit `bearAffinity` now that parser trust is gone. `calendarSearchRangeDays` deliberately stays parser-level (search knob, not identity).
- **Live proof**: Goldiloxx stamps GOLDI-LOXX/GLX/instagram/matchKey purely from the registry, byte-equivalent to baseline (one benign one-time reorder of notes lines — expect a single notes-only UPDATE per existing event on its next merge); Furball 5/5 matched with the registry favicon.

## Brighton + Birmingham

City configs added (Europe/London, "brighton and hove" alias, coords) as `visible: false` with empty calendarId — **BEEFMINCE's UK events immediately get real timezones** instead of wall-clock warnings. CI fetch and the website verified to ignore them until the flip.

**Your two steps to complete the cities**: create `chunky-dad-brighton` and `chunky-dad-birmingham` calendars, make each public, send me both Calendar IDs (Settings → Integrate calendar) — the follow-up PR flips `visible: true` + sets the IDs and they go live end to end.

Tests **1017 → 1021**. After merge: updater pulls `scraper-input.js`, `scraper-promoters.js`, `scraper-cities.js`, `shared-core.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP