### PR TITLE
fix(scraper): cross-host crawl scope — the dice.fm bleed class dies

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -5819,6 +5819,46 @@ class AiWebParser {
         return score;
     }
 
+    // Registrable-domain approximation (platform-pure, no URL global):
+    // hostname lowercased, port and leading www. stripped; last two labels,
+    // or three when the second-level label is a common short registry suffix
+    // under a 2-letter ccTLD (co.uk, com.au, ...). Duplicated from
+    // SharedCore.getRegistrableDomainFromUrl (parsers are standalone and
+    // cannot import shared code) — keep the two in sync.
+    getRegistrableDomainFromUrl(url) {
+        const hostMatch = String(url || '').match(/^https?:\/\/([^/?#]+)/i);
+        const host = String(hostMatch ? hostMatch[1] : '')
+            .toLowerCase()
+            .split(':')[0]
+            .replace(/^www\./, '')
+            .replace(/\.$/, '');
+        if (!host || !host.includes('.')) return host;
+        // IP literals have no registrable domain — compare them whole
+        if (/^[\d.]+$/.test(host) || host.includes('[')) return host;
+        const labels = host.split('.').filter(Boolean);
+        if (labels.length <= 2) return labels.join('.');
+        const tld = labels[labels.length - 1];
+        const sld = labels[labels.length - 2];
+        const compoundSuffix = tld.length === 2 && /^(?:co|com|net|org|gov|edu|ac|mil|sch)$/.test(sld);
+        return labels.slice(compoundSuffix ? -3 : -2).join('.');
+    }
+
+    // Is the page the discovery candidates came FROM on a different
+    // registrable domain than every configured parser URL? Configured-host
+    // pages (and configs without URLs, e.g. inline input) answer false —
+    // cross-host-only rules must never fire there.
+    isCrossHostSourcePage(sourceUrl, parserConfig = {}) {
+        const configuredUrls = Array.isArray(parserConfig && parserConfig.urls) ? parserConfig.urls : [];
+        if (configuredUrls.length === 0) return false;
+        const sourceDomain = this.getRegistrableDomainFromUrl(sourceUrl);
+        if (!sourceDomain) return false;
+        const configuredDomains = configuredUrls
+            .map(configuredUrl => this.getRegistrableDomainFromUrl(configuredUrl))
+            .filter(Boolean);
+        if (configuredDomains.length === 0) return false;
+        return !configuredDomains.includes(sourceDomain);
+    }
+
     validateEventUrl(url, sourceUrl, parserConfig = {}) {
         if (!url || typeof url !== 'string') return { valid: false, reason: 'missing-or-invalid-url' };
 
@@ -5980,6 +6020,23 @@ class AiWebParser {
                 ? blockedPattern
                 : blockedPattern.source;
             return { valid: false, reason: `blocked-pattern:${blockedPatternReason}` };
+        }
+        // Platform-chrome path segments blocked on CROSS-HOST pages only (the
+        // source page's registrable domain matches none of the parser's
+        // configured URLs): help centers (/hc/, Zendesk convention),
+        // change_language switchers, /legal/, /cookies, /careers. BEEFMINCE
+        // run 20260729-100804: dice.fm/hc/change_language/* links produced 12
+        // [ERROR] 404 fetches. Whole-segment matches only, so slugs merely
+        // containing these words survive. On a configured host these paths
+        // stay crawlable (a venue's own site is trusted); /about, /terms and
+        // /privacy are already blocked globally by the patterns above.
+        if (this.isCrossHostSourcePage(sourceUrl, parserConfig)) {
+            const crossHostChromeSegments = ['hc', 'change_language', 'legal', 'cookies', 'careers'];
+            const pathSegments = lowerPath.split('/').filter(Boolean);
+            const chromeSegment = pathSegments.find(segment => crossHostChromeSegments.includes(segment));
+            if (chromeSegment) {
+                return { valid: false, reason: `cross-host-chrome:${chromeSegment}` };
+            }
         }
         const hostname = String(parsedUrl.hostname || '').toLowerCase();
         if (this.isGoogleMapsUrl(parsedUrl)) return { valid: false, reason: 'google-maps-url' };
@@ -10455,6 +10512,58 @@ TEXT:
         return requestedSet.has(this.normalizePromptFieldName(fieldName));
     }
 
+    // URL-field sanity gate for AI-extracted url/ticketUrl/website values.
+    // A plausible event URL is an http(s) URL — or a scheme-less value —
+    // whose host is a dotted hostname of valid label characters. Rejects:
+    //   (1) XML/SVG namespace URLs (host w3.org + namespace-shaped path like
+    //       /2000/svg or /1999/xhtml) — SPA markup xmlns attributes leak
+    //       these into extraction verbatim, so the evidence gate passes them;
+    //   (2) values that cannot be an http(s) URL with a dotted host: inner
+    //       whitespace, invalid host characters ("BASTILLE'S POOL.COM"),
+    //       non-http schemes, hostless fragments.
+    // Platform-pure string/regex parsing only (no URL global on iOS
+    // JavaScriptCore).
+    isPlausibleEventUrlValue(value) {
+        const text = String(value || '').trim();
+        if (!text) return false;
+        if (/\s/.test(text)) return false;
+        let host = '';
+        let path = '';
+        const schemeMatch = text.match(/^([a-z][a-z0-9+.-]*):/i);
+        if (schemeMatch) {
+            if (!/^https?$/i.test(schemeMatch[1])) return false;
+            const withScheme = text.match(/^https?:\/\/([^/?#]*)([^?#]*)/i);
+            if (!withScheme) return false;
+            host = withScheme[1];
+            path = withScheme[2] || '';
+        } else {
+            const schemeless = text.match(/^([^/?#]*)([^?#]*)/);
+            host = schemeless ? schemeless[1] : '';
+            path = schemeless ? (schemeless[2] || '') : '';
+        }
+        host = String(host || '').toLowerCase().replace(/:\d+$/, '');
+        // Dotted hostname of valid label characters — apostrophes, spaces,
+        // userinfo@ and empty hosts all fail here
+        if (!/^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)+$/.test(host)) return false;
+        if (!/\.[a-z]{2,}$/.test(host)) return false;
+        const bareHost = host.replace(/^www\./, '');
+        if ((bareHost === 'w3.org' || bareHost.endsWith('.w3.org')) && /^\/(?:19|20)\d{2}(?:\/|$)/.test(path)) {
+            return false;
+        }
+        return true;
+    }
+
+    // Gate one AI-extracted URL-ish field value: pass it through when
+    // plausible, otherwise log and return '' so firstNonEmpty falls through
+    // to the next candidate (ultimately the configured metadata value).
+    sanitizeExtractedUrlField(field, value) {
+        const text = String(value === null || value === undefined ? '' : value).trim();
+        if (!text) return '';
+        if (this.isPlausibleEventUrlValue(text)) return text;
+        console.log(`🤖 AI Web: Rejected ${field} "${text}" — not a plausible event URL`);
+        return '';
+    }
+
     normalizeAiEvent(aiEvent, parserConfig, htmlData = null, cityConfig = null, promptFields = null) {
         const scrapedLinks = this.extractLinksFromPage(
             htmlData && typeof htmlData.html === 'string' ? htmlData.html : '',
@@ -10555,16 +10664,22 @@ TEXT:
             this.getTimezoneForCity(this.findCityKeyInText(address, cityConfig), cityConfig),
             ''
         );
+        // URL-field sanity gate (see isPlausibleEventUrlValue): only
+        // AI-extracted candidates are gated — a configured metadata URL is a
+        // deliberate override and survives untouched. BEEFMINCE run
+        // 20260729-100804: SPA markup fed SEGMENT_LINK_URL
+        // "http://www.w3.org/2000/svg" into url/ticketUrl ×4, and OCR
+        // hallucinated ticketUrl "BASTILLE'S POOL.COM".
         const url = this.firstNonEmpty(
-            aiEvent.url,
-            aiEvent.web,
-            aiEvent.website,
+            this.sanitizeExtractedUrlField('url', aiEvent.url),
+            this.sanitizeExtractedUrlField('url', aiEvent.web),
+            this.sanitizeExtractedUrlField('website', aiEvent.website),
             this.getResolvedParserMetadataFieldValue(parserConfig, ['url', 'web', 'website'], aiEvent),
             ''
         );
         const ticketUrl = this.firstNonEmpty(
-            aiEvent.ticketUrl,
-            aiEvent.tickets,
+            this.sanitizeExtractedUrlField('ticketUrl', aiEvent.ticketUrl),
+            this.sanitizeExtractedUrlField('ticketUrl', aiEvent.tickets),
             this.getResolvedParserMetadataFieldValue(parserConfig, ['ticketUrl', 'tickets'], aiEvent),
             ''
         );

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -7611,3 +7611,102 @@ test('AI boundary segments cap at multiEventMaxSegments and the raised cap fits 
   const sitgesSegments = sitgesParser.buildMultiEventSegments(sitgesHtml, 'https://bearssitges.example/programa');
   assert.equal(sitgesSegments.length, 13);
 });
+
+// ---------------------------------------------------------------------------
+// Cross-host platform-chrome blocked segments (Fix B, run 20260729-100804:
+// dice.fm/hc/change_language/* produced 12 [ERROR] 404 fetches).
+// ---------------------------------------------------------------------------
+
+test('validateEventUrl blocks platform-chrome path segments on cross-host pages only', () => {
+  const parser = createParser();
+  const config = { urls: ['https://beefmince.example/events'] };
+  const crossHostSource = 'https://dice.example/ticket_purchase_terms.html';
+
+  const hc = parser.validateEventUrl(
+    'https://dice.example/hc/change_language/ca?return_to=%2Fhc%2Fca', crossHostSource, config);
+  assert.equal(hc.valid, false);
+  assert.equal(hc.reason, 'cross-host-chrome:hc');
+
+  const legal = parser.validateEventUrl('https://dice.example/legal/notices', crossHostSource, config);
+  assert.equal(legal.valid, false);
+  assert.equal(legal.reason, 'cross-host-chrome:legal');
+
+  const careers = parser.validateEventUrl('https://dice.example/careers', crossHostSource, config);
+  assert.equal(careers.valid, false);
+  assert.equal(careers.reason, 'cross-host-chrome:careers');
+
+  // Real event-detail pages on the cross-host platform still pass
+  assert.equal(parser.validateEventUrl(
+    'https://dice.example/event/8er825-beefmince-brighton-pride-tickets',
+    'https://dice.example/promoters/beefmince', config).valid, true);
+
+  // The same segments on the CONFIGURED host stay crawlable
+  const configuredSource = 'https://beefmince.example/events';
+  assert.equal(parser.validateEventUrl('https://beefmince.example/legal/notices', configuredSource, config).valid, true);
+  assert.equal(parser.validateEventUrl('https://beefmince.example/careers', configuredSource, config).valid, true);
+
+  // /about was already blocked GLOBALLY before this change — reason unchanged
+  const about = parser.validateEventUrl('https://beefmince.example/about', configuredSource, config);
+  assert.equal(about.valid, false);
+  assert.ok(about.reason.startsWith('blocked-pattern:'), `expected the pre-existing blocked-pattern reason, got ${about.reason}`);
+
+  // Slugs merely CONTAINING a chrome word survive (whole-segment matches only)
+  assert.equal(parser.validateEventUrl('https://dice.example/event/legal-tender-party', crossHostSource, config).valid, true);
+});
+
+// ---------------------------------------------------------------------------
+// URL-field sanity gate (Fix C, run 20260729-100804: SPA markup leaked
+// "http://www.w3.org/2000/svg" into url/ticketUrl x4 and OCR hallucinated
+// ticketUrl "BASTILLE'S POOL.COM").
+// ---------------------------------------------------------------------------
+
+test('isPlausibleEventUrlValue rejects namespace URLs and non-URL text, keeps real event URLs', () => {
+  const parser = createParser();
+  // Namespace URLs: host w3.org + namespace-shaped path
+  assert.equal(parser.isPlausibleEventUrlValue('http://www.w3.org/2000/svg'), false);
+  assert.equal(parser.isPlausibleEventUrlValue('http://www.w3.org/1999/xhtml'), false);
+  // Not parseable as an http(s) URL with a dotted host
+  assert.equal(parser.isPlausibleEventUrlValue("BASTILLE'S POOL.COM"), false);
+  assert.equal(parser.isPlausibleEventUrlValue('mailto:info@bears.example'), false);
+  assert.equal(parser.isPlausibleEventUrlValue('Free'), false);
+  assert.equal(parser.isPlausibleEventUrlValue(''), false);
+  // Real values pass
+  assert.equal(parser.isPlausibleEventUrlValue(
+    'https://dice.fm/event/8er825-beefmince-brighton-pride-1st-aug-horizon-brighton-tickets'), true);
+  assert.equal(parser.isPlausibleEventUrlValue('https://www.eventbrite.com/e/party-1?aff=x'), true);
+  // Scheme-less dotted hosts stay plausible (later normalization adds https)
+  assert.equal(parser.isPlausibleEventUrlValue('sitgesbearcave.com'), true);
+});
+
+test('normalizeAiEvent drops implausible url/ticketUrl values and logs the rejection', () => {
+  const parser = createParser();
+  const logged = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logged.push(args.join(' ')); };
+  let event;
+  try {
+    event = parser.normalizeAiEvent({
+      title: 'BASTID FIXTURE',
+      startDate: '2026-08-08',
+      url: 'http://www.w3.org/2000/svg',
+      ticketUrl: "BASTILLE'S POOL.COM"
+    }, {}, null, null, null);
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(event, 'event should normalize');
+  assert.equal(event.url, '');
+  assert.equal(event.ticketUrl, '');
+  assert.ok(logged.includes('🤖 AI Web: Rejected url "http://www.w3.org/2000/svg" — not a plausible event URL'),
+    `expected url rejection log, got: ${JSON.stringify(logged.filter(l => l.includes('Rejected')))}`);
+  assert.ok(logged.includes(`🤖 AI Web: Rejected ticketUrl "BASTILLE'S POOL.COM" — not a plausible event URL`),
+    'expected ticketUrl rejection log');
+
+  // A real event URL survives normalization untouched
+  const clean = parser.normalizeAiEvent({
+    title: 'BEEFMINCE BRIGHTON PRIDE',
+    startDate: '2026-08-01',
+    url: 'https://dice.fm/event/8er825-beefmince-brighton-pride-1st-aug-horizon-brighton-tickets'
+  }, {}, null, null, null);
+  assert.equal(clean.url, 'https://dice.fm/event/8er825-beefmince-brighton-pride-1st-aug-horizon-brighton-tickets');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -3995,6 +3995,10 @@ class SharedCore {
 
                 const additionalLinks = parseResult?.additionalLinks || [];
                 let linksToConsider = additionalLinks;
+                // Tracks whether an adaptive-mode branch below already logged WHY
+                // links are not being followed (enrich-only / chain cap), so the
+                // following/stopping logs further down don't double-report.
+                let adaptiveFollowBlocked = false;
                 if (adaptiveCrawl) {
                     // The page's own classification decides which links (if any)
                     // are followed; a hard hop cap bounds runaway chains.
@@ -4006,10 +4010,37 @@ class SharedCore {
                             await displayAdapter.logInfo(`SYSTEM: Enrich-only crawl: not following ${linksToConsider.length} link(s) from ${url}`);
                         }
                         linksToConsider = [];
+                        adaptiveFollowBlocked = true;
                     } else if (linksToConsider.length > 0 && currentDepth >= ADAPTIVE_CRAWL_MAX_HOPS) {
                         await displayAdapter.logInfo(`SYSTEM: Adaptive crawl: chain cap (${ADAPTIVE_CRAWL_MAX_HOPS} hops) reached at ${url} — not following ${linksToConsider.length} link(s)`);
                         linksToConsider = [];
-                    } else if (linksToConsider.length > 0) {
+                        adaptiveFollowBlocked = true;
+                    }
+                }
+                const shouldFollowLinks = adaptiveCrawl || currentDepth < maxDepth;
+                // Cross-host crawl scoping (generic — BEEFMINCE run 20260729-100804:
+                // dice.fm's promoter page exposed platform chrome that the adaptive
+                // crawl followed to the geolocated NYC browse catalog): crossing to
+                // a registrable domain outside the parser's configured URLs consumes
+                // the crawl's trust — see applyCrossHostCrawlScope for the rule.
+                // Adaptive event-pages whose links go enrich-only are exempt: their
+                // selection is already narrowed to rule-classified event links plus
+                // their own ticketUrls, and enrich-only children can neither spawn
+                // events nor fan out.
+                const adaptiveEnrichOnlyEventPage = adaptiveCrawl && pageClassification === 'event-page'
+                    && (discoveryOnly || pageEventsForEnrich.length > 0);
+                if (linksToConsider.length > 0 && shouldFollowLinks && !adaptiveEnrichOnlyEventPage) {
+                    const scope = this.applyCrossHostCrawlScope(linksToConsider, url, parserConfig);
+                    if (scope.rejected.length > 0) {
+                        for (const rejection of scope.rejected) {
+                            await displayAdapter.logInfo(`SYSTEM: Cross-host scope: rejecting ${rejection.url} from ${url} — ${rejection.detail} (cross-host-scope)`);
+                        }
+                        await displayAdapter.logInfo(`SYSTEM: Cross-host crawl scope at ${url} (host ${scope.pageDomain}, configured ${scope.configuredDomains.join(', ')}): kept ${scope.allowed.length} of ${linksToConsider.length} link(s), rejected ${scope.rejected.length} (cross-host-scope)`);
+                        linksToConsider = scope.allowed;
+                    }
+                }
+                if (adaptiveCrawl && !adaptiveFollowBlocked) {
+                    if (linksToConsider.length > 0) {
                         await displayAdapter.logInfo(`SYSTEM: Adaptive crawl: following ${linksToConsider.length} links from ${url} (${pageClassification})`);
                     } else if (additionalLinks.length > 0) {
                         await displayAdapter.logInfo(`SYSTEM: Adaptive crawl: stopping at ${url} (${pageClassification})`);
@@ -4020,7 +4051,6 @@ class SharedCore {
                 }
 
                 const deduplicatedUrls = this.deduplicateUrls(linksToConsider, processedUrls);
-                const shouldFollowLinks = adaptiveCrawl || currentDepth < maxDepth;
 
                 if (shouldFollowLinks) {
                     if (discoveryTreeCollector) {
@@ -4170,6 +4200,121 @@ class SharedCore {
             }
         }
         return selected;
+    }
+
+    // ------------------------------------------------------------------
+    // Cross-host crawl scoping (generic — no per-site rules).
+    // Crossing to a registrable domain outside the parser's configured URLs
+    // consumes the crawl's trust: pages on a configured domain may discover
+    // anything (that hop IS discovery), but on a page whose registrable
+    // domain matches no configured URL only links that
+    //   (a) point BACK to a configured domain, or
+    //   (b) stay on the page's own domain AND are event-DETAIL-shaped —
+    //       URL-rule classified 'event-page', an event-detail path
+    //       (/event/<slug> and friends), or sharing the page's own first
+    //       path segment (path-similar continuation)
+    // may be followed. A cross-host page can never lead to ANOTHER new
+    // registrable domain. Evidence: BEEFMINCE run 20260729-100804, where
+    // dice.fm's promoter page (correct, 9 real events) fanned out through
+    // help/terms chrome into the geolocated NYC browse catalog (~14
+    // unrelated events in the CREATE plan).
+    // ------------------------------------------------------------------
+
+    // Registrable-domain approximation (platform-pure, no URL global):
+    // hostname lowercased, port and leading www. stripped; last two labels,
+    // or three when the second-level label is a common short registry suffix
+    // under a 2-letter ccTLD (co.uk, com.au, ...). Duplicated in
+    // ai-web-parser (parsers are standalone and cannot import shared code) —
+    // keep the two in sync.
+    getRegistrableDomainFromUrl(url) {
+        const host = String(this.getHostFromUrl(url) || '')
+            .toLowerCase()
+            .split(':')[0]
+            .replace(/^www\./, '')
+            .replace(/\.$/, '');
+        if (!host || !host.includes('.')) return host;
+        // IP literals have no registrable domain — compare them whole
+        if (/^[\d.]+$/.test(host) || host.includes('[')) return host;
+        const labels = host.split('.').filter(Boolean);
+        if (labels.length <= 2) return labels.join('.');
+        const tld = labels[labels.length - 1];
+        const sld = labels[labels.length - 2];
+        const compoundSuffix = tld.length === 2 && /^(?:co|com|net|org|gov|edu|ac|mil|sch)$/.test(sld);
+        return labels.slice(compoundSuffix ? -3 : -2).join('.');
+    }
+
+    // First path segment of an absolute http(s) URL, lowercased ('' when the
+    // URL has no path or is not absolute http(s)).
+    getFirstPathSegmentFromUrl(url) {
+        const match = String(url || '').match(/^https?:\/\/[^/?#]+\/([^/?#]+)/i);
+        return match ? match[1].toLowerCase() : '';
+    }
+
+    // Generic event-detail URL shape: an absolute http(s) URL whose path is
+    // an event noun segment followed by a concrete slug (/event/<slug>,
+    // /events/<slug>, /e/<id>, /show/<slug>, /tickets/<slug>). Platform-
+    // agnostic on purpose — no host names.
+    isEventDetailShapedUrl(url) {
+        const match = String(url || '').match(/^https?:\/\/[^/?#]+(\/[^?#]*)/i);
+        const path = match ? match[1] : '';
+        return /^\/(?:events?|e|shows?|tickets?)\/[^/?#]+/i.test(path);
+    }
+
+    // Apply the cross-host crawl scope to a page's follow candidates.
+    // Returns { pageIsCrossHost, pageDomain, configuredDomains, allowed,
+    // rejected: [{ url, detail }] }. Pages on a configured registrable domain
+    // (or runs with no configured URLs, e.g. inline input) pass everything
+    // through untouched.
+    applyCrossHostCrawlScope(links, pageUrl, parserConfig) {
+        const list = Array.isArray(links) ? links : [];
+        const configuredUrls = Array.isArray(parserConfig && parserConfig.urls) ? parserConfig.urls : [];
+        const configuredDomains = [];
+        for (const configuredUrl of configuredUrls) {
+            const domain = this.getRegistrableDomainFromUrl(configuredUrl);
+            if (domain && !configuredDomains.includes(domain)) {
+                configuredDomains.push(domain);
+            }
+        }
+        const pageDomain = this.getRegistrableDomainFromUrl(pageUrl);
+        const result = {
+            pageIsCrossHost: false,
+            pageDomain,
+            configuredDomains,
+            allowed: list,
+            rejected: []
+        };
+        if (!pageDomain || configuredDomains.length === 0 || configuredDomains.includes(pageDomain)) {
+            return result;
+        }
+        result.pageIsCrossHost = true;
+        const pageFirstSegment = this.getFirstPathSegmentFromUrl(this.normalizeUrl(pageUrl, pageUrl) || pageUrl);
+        const allowed = [];
+        const rejected = [];
+        for (const link of list) {
+            const normalized = this.normalizeUrl(link, pageUrl || link) || String(link || '');
+            const linkDomain = this.getRegistrableDomainFromUrl(normalized);
+            if (linkDomain && configuredDomains.includes(linkDomain)) {
+                // Pointing back to a configured host is always in scope
+                allowed.push(link);
+                continue;
+            }
+            if (linkDomain !== pageDomain) {
+                rejected.push({ url: link, detail: `links to a third host (${linkDomain || 'unknown host'})` });
+                continue;
+            }
+            const ruleClassification = this.classifyUrlByRules(normalized);
+            const eventDetailShaped = ruleClassification === 'event-page'
+                || this.isEventDetailShapedUrl(normalized)
+                || (Boolean(pageFirstSegment) && this.getFirstPathSegmentFromUrl(normalized) === pageFirstSegment);
+            if (eventDetailShaped) {
+                allowed.push(link);
+            } else {
+                rejected.push({ url: link, detail: 'not event-detail-shaped on an off-host page' });
+            }
+        }
+        result.allowed = allowed;
+        result.rejected = rejected;
+        return result;
     }
 
     // ------------------------------------------------------------------

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -9833,3 +9833,122 @@ test('expanded series occurrences drive the recurring hands-off path in analyzeE
   assert.match(analysis.reason, /creating override/, 'routes to override creation');
   assert.equal(analysis.overrideIdentity.overrideUid, 'weekly@test');
 });
+
+// ---------------------------------------------------------------------------
+// Cross-host crawl scoping (BEEFMINCE run 20260729-100804: dice.fm's promoter
+// page fanned out through platform chrome into the NYC browse catalog).
+// ---------------------------------------------------------------------------
+
+test('getRegistrableDomainFromUrl: registrable-domain approximation (www/port/subdomain/ccTLD)', () => {
+  const core = createCore();
+  assert.equal(core.getRegistrableDomainFromUrl('https://beefmince.com/events'), 'beefmince.com');
+  assert.equal(core.getRegistrableDomainFromUrl('https://www.dice.fm/browse'), 'dice.fm');
+  assert.equal(core.getRegistrableDomainFromUrl('https://link.dice.fm/T1d30c84b47d'), 'dice.fm');
+  assert.equal(core.getRegistrableDomainFromUrl('https://tickets.example.co.uk:8080/x'), 'example.co.uk');
+  assert.equal(core.getRegistrableDomainFromUrl('not a url'), '');
+});
+
+test('cross-host crawl scope: off-host pages follow only event-detail links and links back to the configured host', async () => {
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    pageClassificationRules: [
+      { pattern: /promoter\.example\/events/i, classification: 'multi-event-page' },
+      { pattern: /platform\.example\/promoters\//i, classification: 'multi-event-page' }
+    ]
+  });
+  const display = createDisplayAdapterStub();
+  const promoterPage = 'https://platform.example/promoters/promo-1';
+  const pages = {
+    'https://promoter.example/events': { additionalLinks: [promoterPage] },
+    [promoterPage]: {
+      additionalLinks: [
+        'https://platform.example/event/party-one-tickets',   // event-detail shape → followed
+        'https://tickets.platform.example/event/party-two',   // same registrable domain + detail shape → followed
+        'https://promoter.example/gallery',                   // back to the configured host → followed
+        'https://platform.example/browse',                    // platform catalog chrome → rejected
+        'https://platform.example/help/refunds',              // help chrome → rejected
+        'https://elsewhere.example/whatever'                  // third host → rejected
+      ]
+    },
+    'https://platform.example/event/party-one-tickets': {},
+    'https://tickets.platform.example/event/party-two': {},
+    'https://promoter.example/gallery': {},
+    'https://platform.example/browse': {},
+    'https://platform.example/help/refunds': {},
+    'https://elsewhere.example/whatever': {}
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+
+  await core.processParser(
+    { name: 'Cross Host Scope', urls: ['https://promoter.example/events'], ai: CRAWL_AI },
+    {}, httpAdapter, display, parsers
+  );
+
+  assert.ok(fetched.includes(promoterPage), 'the configured host may discover the off-host promoter page');
+  assert.ok(fetched.includes('https://platform.example/event/party-one-tickets'), 'event-detail links on the off-host page are followed');
+  assert.ok(fetched.includes('https://tickets.platform.example/event/party-two'), 'same registrable domain subdomain event links are followed');
+  assert.ok(fetched.includes('https://promoter.example/gallery'), 'links back to the configured host are followed');
+  assert.ok(!fetched.includes('https://platform.example/browse'), 'platform browse chrome is not followed');
+  assert.ok(!fetched.includes('https://platform.example/help/refunds'), 'platform help chrome is not followed');
+  assert.ok(!fetched.includes('https://elsewhere.example/whatever'), 'a cross-host page may not lead to another new host');
+
+  assert.ok(display.logs.includes(
+    `SYSTEM: Cross-host scope: rejecting https://platform.example/browse from ${promoterPage} — not event-detail-shaped on an off-host page (cross-host-scope)`
+  ), `expected per-rejection cross-host-scope log, got: ${JSON.stringify(display.logs.filter(l => l.includes('Cross-host')))}`);
+  assert.ok(display.logs.includes(
+    `SYSTEM: Cross-host scope: rejecting https://elsewhere.example/whatever from ${promoterPage} — links to a third host (elsewhere.example) (cross-host-scope)`
+  ), 'third-host rejections name the host');
+  assert.ok(display.logs.includes(
+    `SYSTEM: Cross-host crawl scope at ${promoterPage} (host platform.example, configured promoter.example): kept 3 of 6 link(s), rejected 3 (cross-host-scope)`
+  ), 'summary line reports kept/rejected counts');
+});
+
+test('cross-host crawl scope: path-similar continuation on the off-host page is followed; configured-host pages are never scoped', () => {
+  const core = createCore();
+  // Off-host listing page whose detail pages share its first path segment
+  const scoped = core.applyCrossHostCrawlScope(
+    [
+      'https://platform.example/whats-on/city/venue/123',
+      'https://platform.example/venues/some-club'
+    ],
+    'https://platform.example/whats-on',
+    { urls: ['https://promoter.example/events'] }
+  );
+  assert.equal(scoped.pageIsCrossHost, true);
+  assert.deepEqual(scoped.allowed, ['https://platform.example/whats-on/city/venue/123']);
+  assert.equal(scoped.rejected.length, 1);
+  assert.equal(scoped.rejected[0].url, 'https://platform.example/venues/some-club');
+
+  // Configured-host page: everything passes through untouched
+  const unscoped = core.applyCrossHostCrawlScope(
+    ['https://anywhere.example/anything', 'https://platform.example/browse'],
+    'https://promoter.example/events',
+    { urls: ['https://promoter.example/events'] }
+  );
+  assert.equal(unscoped.pageIsCrossHost, false);
+  assert.equal(unscoped.allowed.length, 2);
+  assert.equal(unscoped.rejected.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Bear keyword audit (Fix D, run 20260729-100804): "BASTID'S BBQ - NEW YORK
+// '26" was kept bear via `keyword: bear` — the match came from the
+// OCR-derived DESCRIPTION ("Good Music. Good Food. Good Bears."), not the
+// title, and 'bbq' is deliberately NOT a bear keyword in either tier. Lock
+// both directions.
+// ---------------------------------------------------------------------------
+
+test("bear keywords: 'bbq' alone is not a bear signal; explicit bear context is", () => {
+  const core = createCore();
+  // A bare BBQ party title matches NO keyword in either tier
+  assert.deepEqual(core.matchBearKeywords("BASTID'S BBQ - NEW YORK '26"), []);
+  assert.equal(core.isBearEvent({ title: "BASTID'S BBQ - NEW YORK '26" }, {}), false);
+  // A real bear BBQ (community event with bear context) still passes
+  assert.ok(core.matchBearKeywords('BEAR BBQ — a cookout for the bear community').includes('bear'));
+  assert.equal(core.isBearEvent({ title: 'BEAR BBQ', description: 'Bears, cubs and friends cookout' }, {}), true);
+  // The incident's actual trigger: 'bear' inside the OCR-derived description
+  assert.deepEqual(
+    core.matchBearKeywords("BASTID'S BBQ - NEW YORK '26 Good Music. Good Food. Good Bears."),
+    ['bear']
+  );
+});


### PR DESCRIPTION
## The incident

BEEFMINCE's first run correctly followed beefmince.com → dice.fm's promoter page (9 real events) — then dice's help/terms links classified as link-aggregators and fanned out to the **global NYC browse catalog**: 14 unrelated events (Saint Vitus metal shows, Time Warp, Alesso) in the CREATE plan, SVG-namespace ticketUrls, 12 help-center 404s.

## The rule (generic — no dice-specific logic)

**Crossing hosts consumes the crawl's trust.** On a page whose registrable domain matches none of the parser's configured URLs: only links *back* to a configured domain, or same-domain **event-detail-shaped** links, survive; a cross-host page can never reach a third domain. Enrich-only links stay exempt (they can't spawn events). Plus: platform chrome segments (`/hc/`, `change_language`, `legal`, `cookies`, `careers`) rejected on off-host pages only, and a plausibility gate on extracted URLs (kills `w3.org/2000/svg` and the hallucinated `BASTILLE'S POOL.COM`).

## Investigation bonus

BASTID'S BBQ's false bear-positive wasn't a keyword-list problem — 'bbq' isn't a keyword; OCR misread the flyer as "Good Music. Good Food. Good **Bears**." and the match was honest on garbage input. The scope fix removes the event entirely; tests lock keyword behavior both ways.

## Live acceptance

BEEFMINCE rerun → **exactly the 13 real events** (RVT residency, BOATMINCE, SPOOKMINCE, Brighton/Birmingham dates + the four Sitges Bear Cave parties). Promoter page: kept 9 of 15 links, rejected help/terms/browse/partners/cdn-cgi/root — every rejection logged with its reason. All 9 dice event pages still crawled.

Tests **1017 → 1024**. After merge: updater pulls `shared-core.js` + `parsers/ai-web-parser.js`. Then BEEFMINCE is safe to run and execute — the 13 events are ready for your calendars (Brighton/Birmingham dates go live once their calendars exist per #1573).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP