### PR TITLE
fix(scraper): description formatting, venue-site identity via curated bars, precise gmaps pins + Brighton/Birmingham/Sitges venues

### DIFF
--- a/data/bars/birmingham.json
+++ b/data/bars/birmingham.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "Eden",
+    "city": "birmingham",
+    "address": "116 Sherlock Street, Birmingham B5 6NB",
+    "coordinates": "52.4714027, -1.8936278",
+    "facebook": "https://www.facebook.com/eden.bar.birmingham/"
+  }
+]

--- a/data/bars/brighton.json
+++ b/data/bars/brighton.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "Horizon",
+    "city": "brighton",
+    "address": "29-31 New Steine, Marine Parade, Brighton",
+    "coordinates": "50.8196107, -0.1315114",
+    "instagram": "horizon.brighton"
+  },
+  {
+    "name": "Concorde 2",
+    "city": "brighton",
+    "address": "Madeira Shelter Hall, Madeira Drive, Brighton BN2 1EN",
+    "coordinates": "50.8172912, -0.1225875"
+  }
+]

--- a/data/bars/sitges.json
+++ b/data/bars/sitges.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "The Bear Cave",
+    "city": "sitges",
+    "address": "Carrer de Bonaire 12, 08870 Sitges",
+    "coordinates": "41.2360385, 1.8079068"
+  }
+]

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -48,6 +48,15 @@
       "googleMaps": "https://maps.app.goo.gl/V96bZYM6qBm8tqQs5"
     }
   ],
+  "birmingham": [
+    {
+      "name": "Eden",
+      "city": "birmingham",
+      "address": "116 Sherlock Street, Birmingham B5 6NB",
+      "coordinates": "52.4714027, -1.8936278",
+      "facebook": "https://www.facebook.com/eden.bar.birmingham/"
+    }
+  ],
   "boston": [
     {
       "name": "The Alley Bar",
@@ -68,6 +77,21 @@
       "instagram": "https://www.instagram.com/legacybos",
       "faviconBg": "#b47d04",
       "faviconFg": "#c38703"
+    }
+  ],
+  "brighton": [
+    {
+      "name": "Horizon",
+      "city": "brighton",
+      "address": "29-31 New Steine, Marine Parade, Brighton",
+      "coordinates": "50.8196107, -0.1315114",
+      "instagram": "horizon.brighton"
+    },
+    {
+      "name": "Concorde 2",
+      "city": "brighton",
+      "address": "Madeira Shelter Hall, Madeira Drive, Brighton BN2 1EN",
+      "coordinates": "50.8172912, -0.1225875"
     }
   ],
   "chicago": [
@@ -437,6 +461,8 @@
       "facebook": "https://www.facebook.com/3dollarbillbk",
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ7zm6H3JbwokR3ui1wTNr6Xc",
       "gayCities": "https://newyork.gaycities.com/bars/309059-dollar-bill",
+      "faviconBg": "#190832",
+      "faviconFg": "#c5c5e9",
       "gayCitiesLastScrapedAt": "2026-06-14T16:38:18.601Z"
     },
     {
@@ -518,7 +544,9 @@
       "name": "The Yard at 9 Bob Note",
       "city": "nyc",
       "address": "270 Meserole Ave, Brooklyn, NY 11222",
-      "website": "https://www.3dollarbillbk.com"
+      "website": "https://www.3dollarbillbk.com",
+      "faviconBg": "#190832",
+      "faviconFg": "#c5c5e9"
     }
   ],
   "palm-springs": [
@@ -805,6 +833,14 @@
       "website": "https://publicsf.com",
       "faviconBg": "#f35425",
       "faviconFg": "#fd5825"
+    }
+  ],
+  "sitges": [
+    {
+      "name": "The Bear Cave",
+      "city": "sitges",
+      "address": "Carrer de Bonaire 12, 08870 Sitges",
+      "coordinates": "41.2360385, 1.8079068"
     }
   ],
   "tokyo": [

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -2341,15 +2341,137 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     }
 }
 
+// ----------------------------------------------------------------------------
+// DESCRIPTION FORMATTING SANITIZER (pure, standalone)
+// ----------------------------------------------------------------------------
+// Event descriptions arrive carrying raw formatting from the source platform
+// (run 20260729-125201: dice.fm shipped markdown "**BEEFMINCE | The UK's
+// Tastiest Bear Club** **\*Now on Saturdays\***"; a Wix site shipped raw HTML
+// with a LITERAL backslash-n "<p>Dress the part ... </p>\n"). This strips
+// HTML tags (block-level boundaries become newlines), decodes common HTML
+// entities, converts literal two-character "\n" sequences into real newlines,
+// removes markdown emphasis runs (** / *** / __), heading markers, link
+// syntax, and backslash-escaped punctuation, then collapses whitespace.
+// Single "*" characters are deliberately left alone — they appear
+// legitimately in event text as bullets/emphasis of unknown intent.
+//
+// Runs to a fixed point (bounded), so the function is idempotent:
+// sanitizeDescriptionFormatting(sanitizeDescriptionFormatting(x)) ===
+// sanitizeDescriptionFormatting(x). Plain text passes through byte-identical.
+
+// Block-level tags whose boundaries read as line breaks in plain text.
+const SANITIZE_BLOCK_TAG_PATTERN = /<\/?(?:p|div|li|ul|ol|br|hr|h[1-6]|tr|table|thead|tbody|section|article|header|footer|blockquote|pre)\b[^<>]*\/?>/gi;
+// Known inline/void HTML tags (stripped to nothing). A KNOWN-NAME whitelist,
+// not "anything tag-shaped": legitimate text like "<3", "a < b", or an
+// entity-decoded "<here>" must survive — critically, that also keeps the
+// sanitizer idempotent (a decoded "&lt;here&gt;" is never re-eaten as a tag
+// on the next pass).
+const SANITIZE_INLINE_TAG_PATTERN = /<\/?(?:a|abbr|b|bdi|bdo|big|button|center|cite|code|data|dfn|em|figcaption|figure|font|form|i|iframe|img|input|ins|del|kbd|label|main|mark|nav|aside|option|picture|q|rb|rp|rt|ruby|s|samp|select|small|source|span|strike|strong|style|sub|sup|textarea|time|u|var|video|audio|wbr|script|noscript|svg|path|html|head|body|meta|link|title)\b[^<>]*\/?>/gi;
+// Placeholders (private-use codepoints) protecting backslash-escaped emphasis
+// characters while emphasis RUNS are deleted, so "\*\*TBC\*\**" never has its
+// escaped asterisks miscounted as markdown runs.
+const SANITIZE_ESCAPED_ASTERISK_PLACEHOLDER = '\uE000';
+const SANITIZE_ESCAPED_UNDERSCORE_PLACEHOLDER = '\uE001';
+
+function sanitizeDescriptionFormattingOnce(text) {
+    let result = text;
+
+    // Literal escaped line breaks — the two characters backslash+n (run
+    // evidence: a Wix description ended in a literal "\n"), not real
+    // newlines. Runs before markdown unescaping so "\n" is never mistaken
+    // for an escape of "n".
+    result = result
+        .replace(/\\r\\n/g, '\n')
+        .replace(/\\n/g, '\n')
+        .replace(/\\r/g, '');
+
+    // HTML: comments vanish, block-tag boundaries become newlines, remaining
+    // inline tags vanish.
+    result = result.replace(/<!--[\s\S]*?-->/g, '');
+    result = result.replace(SANITIZE_BLOCK_TAG_PATTERN, '\n');
+    result = result.replace(SANITIZE_INLINE_TAG_PATTERN, '');
+
+    // Common HTML entities. &amp; decodes FIRST so double-encoded entities
+    // ("&amp;lt;") resolve within the fixed-point loop instead of leaking.
+    result = result
+        .replace(/&amp;/gi, '&')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/&lt;/gi, '<')
+        .replace(/&gt;/gi, '>')
+        .replace(/&quot;/gi, '"')
+        .replace(/&(?:#39|#039|apos);/gi, "'")
+        .replace(/&#(\d+);/g, (match, code) => {
+            const codePoint = parseInt(code, 10);
+            return codePoint > 0 && codePoint < 0x110000 ? String.fromCodePoint(codePoint) : match;
+        })
+        .replace(/&#x([0-9a-f]+);/gi, (match, code) => {
+            const codePoint = parseInt(code, 16);
+            return codePoint > 0 && codePoint < 0x110000 ? String.fromCodePoint(codePoint) : match;
+        });
+
+    // Markdown links: [text](url) → text.
+    result = result.replace(/\[([^\[\]\n]*)\]\([^()\n]*\)/g, '$1');
+
+    // Markdown heading markers at line start ("# Heading"). The
+    // required trailing whitespace keeps hashtags ("#bear") intact.
+    result = result.replace(/^[ \t]*#{1,6}[ \t]+/gm, '');
+
+    // Markdown emphasis runs: protect backslash-escaped characters, delete
+    // runs of ** / *** / __ entirely, restore escapes as the bare character
+    // (which unescapes \* and \_ in the same motion). Single unescaped "*"
+    // characters are never touched.
+    result = result
+        .split('\\*').join(SANITIZE_ESCAPED_ASTERISK_PLACEHOLDER)
+        .split('\\_').join(SANITIZE_ESCAPED_UNDERSCORE_PLACEHOLDER)
+        .replace(/\*{2,}/g, '')
+        .replace(/_{2,}/g, '')
+        .split(SANITIZE_ESCAPED_ASTERISK_PLACEHOLDER).join('*')
+        .split(SANITIZE_ESCAPED_UNDERSCORE_PLACEHOLDER).join('_');
+
+    // Remaining backslash escapes of markdown punctuation → bare character.
+    result = result.replace(/\\([#\[\].])/g, '$1');
+
+    // Whitespace: real carriage returns normalize away, spaces collapse,
+    // line-edge spaces trim, 3+ newlines collapse to a paragraph break.
+    result = result
+        .replace(/\r\n?/g, '\n')
+        .replace(/[ \t]{2,}/g, ' ')
+        .replace(/[ \t]+\n/g, '\n')
+        .replace(/\n[ \t]+/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+
+    return result;
+}
+
+function sanitizeDescriptionFormatting(text) {
+    if (typeof text !== 'string' || text === '') return text;
+    let current = text;
+    for (let pass = 0; pass < 5; pass++) {
+        const next = sanitizeDescriptionFormattingOnce(current);
+        if (next === current) break;
+        current = next;
+    }
+    return current;
+}
+
+// Instance-reachable delegate: shared-core holds only the injected pipeline
+// instance (never this module), so the final analyzed-event build calls the
+// sanitizer through it.
+NormalizerPipeline.prototype.sanitizeDescriptionFormatting = function (text) {
+    return sanitizeDescriptionFormatting(text);
+};
+
 // Export for both environments
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { NormalizerPipeline, BasicDataNormalizer, LocationNormalizer, BarDataNormalizer, OpenStreetMapNormalizer };
+    module.exports = { NormalizerPipeline, BasicDataNormalizer, LocationNormalizer, BarDataNormalizer, OpenStreetMapNormalizer, sanitizeDescriptionFormatting };
 } else if (typeof window !== 'undefined') {
     window.NormalizerPipeline = NormalizerPipeline;
     window.BasicDataNormalizer = BasicDataNormalizer;
     window.LocationNormalizer = LocationNormalizer;
     window.BarDataNormalizer = BarDataNormalizer;
     window.OpenStreetMapNormalizer = OpenStreetMapNormalizer;
+    window.sanitizeDescriptionFormatting = sanitizeDescriptionFormatting;
 } else {
     // Scriptable environment
     this.NormalizerPipeline = NormalizerPipeline;
@@ -2357,6 +2479,7 @@ if (typeof module !== 'undefined' && module.exports) {
     this.LocationNormalizer = LocationNormalizer;
     this.BarDataNormalizer = BarDataNormalizer;
     this.OpenStreetMapNormalizer = OpenStreetMapNormalizer;
+    this.sanitizeDescriptionFormatting = sanitizeDescriptionFormatting;
 }
 
 // Scriptable gives every imported module its own console binding, so the

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -2885,3 +2885,60 @@ test('BasicDataNormalizer stamps _recurring for a non-empty recurrenceRule (seri
   const plain = normalizer.normalize({ title: 'PLAIN' });
   assert.equal(plain._recurring, undefined);
 });
+
+// ---------------------------------------------------------------------------
+// sanitizeDescriptionFormatting (run 20260729-125201: dice.fm markdown and
+// Wix raw-HTML descriptions reached notes verbatim)
+// ---------------------------------------------------------------------------
+
+const { sanitizeDescriptionFormatting } = require('./normalizers');
+
+// Exact evidence string from the phone run (BEEFMINCE via dice.fm):
+// double-asterisk bold runs plus backslash-escaped asterisks.
+const DICE_MARKDOWN_DESCRIPTION = "**BEEFMINCE | The UK's Tastiest Bear Club** **\\*Now on Saturdays\\***";
+// Exact evidence string from the phone run (The Bear Cave via a Wix site):
+// raw HTML plus a LITERAL backslash-n (two characters), not a newline.
+const WIX_HTML_DESCRIPTION = '<p>Dress the part, flash your sticker and let the lights guide your night. </p>\\n';
+
+test('sanitizeDescriptionFormatting strips dice.fm markdown emphasis but keeps the words', () => {
+  const sanitized = sanitizeDescriptionFormatting(DICE_MARKDOWN_DESCRIPTION);
+
+  assert.ok(!sanitized.includes('**'), `no double-asterisk runs survive: ${JSON.stringify(sanitized)}`);
+  assert.ok(!sanitized.includes('\\*'), `no backslash-escaped asterisks survive: ${JSON.stringify(sanitized)}`);
+  assert.ok(sanitized.includes("BEEFMINCE | The UK's Tastiest Bear Club"), 'the words are kept');
+  assert.ok(sanitized.includes('Now on Saturdays'), 'the escaped-run words are kept');
+});
+
+test('sanitizeDescriptionFormatting turns Wix raw HTML + literal backslash-n into plain text', () => {
+  const sanitized = sanitizeDescriptionFormatting(WIX_HTML_DESCRIPTION);
+
+  assert.equal(sanitized, 'Dress the part, flash your sticker and let the lights guide your night.');
+  assert.ok(!sanitized.includes('<p>') && !sanitized.includes('</p>'), 'no HTML tags survive');
+  assert.ok(!sanitized.includes('\\n'), 'no literal backslash-n survives');
+});
+
+test('sanitizeDescriptionFormatting is idempotent on the evidence fixtures', () => {
+  for (const fixture of [DICE_MARKDOWN_DESCRIPTION, WIX_HTML_DESCRIPTION]) {
+    const once = sanitizeDescriptionFormatting(fixture);
+    assert.equal(sanitizeDescriptionFormatting(once), once, `sanitize(sanitize(x)) === sanitize(x) for ${JSON.stringify(fixture)}`);
+  }
+});
+
+test('sanitizeDescriptionFormatting passes a plain description through byte-identical', () => {
+  const plain = 'Bears, beers, and DJs from 9pm. $10 at the door.\n\nHosted by the CubScout crew * 21+ only.';
+  assert.equal(sanitizeDescriptionFormatting(plain), plain, 'plain text (including a single *) is untouched');
+});
+
+test('sanitizeDescriptionFormatting handles block tags, entities, links, headings, and escaped punctuation', () => {
+  const html = '<div>Doors &amp; drinks at 9pm<br>DJ set till late</div><p>Tickets &lt;here&gt;</p>';
+  assert.equal(
+    sanitizeDescriptionFormatting(html),
+    'Doors & drinks at 9pm\nDJ set till late\n\nTickets <here>');
+
+  assert.equal(
+    sanitizeDescriptionFormatting('# BIG NIGHT\n***Get*** [tickets](https://tix.example/ev) now\\. __Really__'),
+    'BIG NIGHT\nGet tickets now. Really');
+
+  // Escaped-asterisk runs collapse over the fixed point: \*\*TBC\*\** → TBC
+  assert.equal(sanitizeDescriptionFormatting('\\*\\*TBC\\*\\**'), 'TBC');
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -12097,11 +12097,51 @@ TEXT:
             : '';
     }
 
+    // Curated-bar match for a page's derived brand names (run 20260729-125247:
+    // eaglela.com carries no venue-ish JSON-LD @type, so siteRole stayed
+    // undetermined and rejectBrandLikePassFields threw away bar "Eagle LA"
+    // twice — but the page brand IS a curated bar, hard curated fact that the
+    // site is the venue's own). Matching is the curated machinery's own
+    // strictness (normalizeBarNameKey full-name equality via
+    // findCuratedBarByName — case-insensitive, "The " tolerant, never
+    // substring/fuzzy). City scope, fail closed:
+    //   - parser config carries a city → only THAT city's curated bars;
+    //   - no configured city → cross-city lookup (findCuratedBarCityByName),
+    //     which resolves only a UNIQUE name hit (ambiguous multi-city names
+    //     and generic franchise stems resolve nothing).
+    // Returns the curated bar entry or null.
+    findCuratedBarMatchingPageBrand(htmlData, parserConfig) {
+        if (!this.core) return null;
+        const brandNames = this.getPageBrandNames(htmlData);
+        if (!Array.isArray(brandNames) || brandNames.length === 0) return null;
+        const cityKey = parserConfig && typeof parserConfig.city === 'string'
+            ? parserConfig.city.trim().toLowerCase()
+            : '';
+        for (const brandName of brandNames) {
+            if (cityKey) {
+                const cityBars = typeof this.core.getCuratedCityBars === 'function'
+                    ? this.core.getCuratedCityBars(cityKey)
+                    : null;
+                const curatedBar = cityBars && typeof this.core.findCuratedBarByName === 'function'
+                    ? this.core.findCuratedBarByName(cityBars, brandName)
+                    : null;
+                if (curatedBar) return curatedBar;
+            } else if (typeof this.core.findCuratedBarCityByName === 'function') {
+                const match = this.core.findCuratedBarCityByName(brandName);
+                if (match && match.bar && match.city) return match.bar;
+            }
+        }
+        return null;
+    }
+
     // Resolve who this SITE is, hard facts in precedence order:
     //   1) parser config override `siteRole: "venue" | "organizer"`;
     //   2) the page's own JSON-LD @type being venue-ish (NightClub/BarOrPub/
     //      EventVenue/MusicVenue) → venue;
-    //   3) segment-derived facts when segments are provided (multi-event
+    //   3) a derived page brand name that IS a curated bar for the parser's
+    //      configured city (or a unique cross-city curated hit when no city
+    //      is configured) → venue;
+    //   4) segment-derived facts when segments are provided (multi-event
     //      pages): a JSON-LD Organization/PerformingGroup whose listings sit
     //      at MULTIPLE distinct street addresses → organizer; a single
     //      recurring street address that ALSO appears outside the listings
@@ -12125,6 +12165,18 @@ TEXT:
             if (Object.isExtensible(htmlData)) {
                 htmlData.pageSiteRole = role;
                 htmlData.pageSiteRoleReason = role ? `json-ld @type ${signals.venueType}` : '';
+            }
+        }
+        // Curated-bar rung: still undetermined, but a derived page brand name
+        // IS a curated bar (scope rules in findCuratedBarMatchingPageBrand) —
+        // the page is that venue's own site.
+        if (htmlData.pageSiteRole === '' && !htmlData.pageSiteRoleCuratedBarChecked
+            && Object.isExtensible(htmlData)) {
+            htmlData.pageSiteRoleCuratedBarChecked = true;
+            const curatedBar = this.findCuratedBarMatchingPageBrand(htmlData, parserConfig);
+            if (curatedBar && typeof curatedBar.name === 'string' && curatedBar.name.trim()) {
+                htmlData.pageSiteRole = 'venue';
+                htmlData.pageSiteRoleReason = `curated bar "${curatedBar.name}"`;
             }
         }
         if (htmlData.pageSiteRole === '' && Array.isArray(segments) && segments.length > 0

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -7710,3 +7710,86 @@ test('normalizeAiEvent drops implausible url/ticketUrl values and logs the rejec
   }, {}, null, null, null);
   assert.equal(clean.url, 'https://dice.fm/event/8er825-beefmince-brighton-pride-1st-aug-horizon-brighton-tickets');
 });
+
+// ---------------------------------------------------------------------------
+// siteRole via curated bars (run 20260729-125247: eaglela.com has no venue-ish
+// JSON-LD, siteRole stayed undetermined, and rejectBrandLikePassFields threw
+// away bar "Eagle LA" twice)
+// ---------------------------------------------------------------------------
+
+const EAGLE_LA_CURATED_BAR = {
+  name: 'Eagle LA',
+  city: 'la',
+  coordinates: '34.0912127, -118.2840632',
+  address: '4219 Santa Monica Blvd, Los Angeles, CA 90029'
+};
+
+const EAGLE_LA_SITE_HTML = `<html><head>
+  <meta property="og:site_name" content="Eagle LA" />
+</head><body>CUB SCOUT — EVERY THIRD SATURDAY</body></html>`;
+
+function createEagleLaParser(bars) {
+  const parser = new AiWebParser({ normalizeUrl });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema, bars });
+  return parser;
+}
+
+test('siteRole: a page brand matching a curated bar for the parser city resolves venue; the bar survives the brand guard', () => {
+  const parser = createEagleLaParser({ la: [EAGLE_LA_CURATED_BAR] });
+  const htmlData = { url: 'https://eaglela.com/events/cub-scout-3/', html: EAGLE_LA_SITE_HTML };
+
+  assert.equal(parser.resolvePageSiteRole(htmlData, { city: 'la' }), 'venue');
+  assert.equal(htmlData.pageSiteRoleReason, 'curated bar "Eagle LA"');
+
+  // The existing siteRole log line prints the curated reason — no new shape.
+  const logs = captureLogs(() => parser.logPageSiteRoleOnce(htmlData));
+  assert.deepEqual(logs, ['🤖 AI Web: siteRole for eaglela.com: venue (curated bar "Eagle LA")']);
+
+  // Downstream: the pass-level brand guard keeps the bar on a venue site.
+  const guarded = parser.rejectBrandLikePassFields({ bar: 'Eagle LA' }, htmlData, 'test');
+  assert.equal(guarded.bar, 'Eagle LA', 'venue site: the page brand IS the venue, never rejected');
+});
+
+test('siteRole: a page brand with no curated bar match stays undetermined', () => {
+  const parser = createEagleLaParser({ la: [EAGLE_LA_CURATED_BAR] });
+  const htmlData = {
+    url: 'https://bearracuda.example/events',
+    html: '<html><head><meta property="og:site_name" content="Bearracuda" /></head><body></body></html>'
+  };
+  assert.equal(parser.resolvePageSiteRole(htmlData, { city: 'la' }), '');
+  assert.equal(htmlData.pageSiteRoleReason, '');
+});
+
+test('siteRole: without a configured city an ambiguous multi-city curated name stays undetermined; a unique hit resolves venue', () => {
+  // "Eagle" is curated in two cities → fail closed.
+  const ambiguousParser = createEagleLaParser({
+    la: [{ name: 'Eagle', city: 'la' }],
+    sf: [{ name: 'Eagle', city: 'sf' }]
+  });
+  const ambiguousData = {
+    url: 'https://eagle.example/events',
+    html: '<html><head><meta property="og:site_name" content="Eagle" /></head><body></body></html>'
+  };
+  assert.equal(ambiguousParser.resolvePageSiteRole(ambiguousData, {}), '');
+
+  // The same lookup with a UNIQUE cross-city hit resolves venue.
+  const uniqueParser = createEagleLaParser({ la: [EAGLE_LA_CURATED_BAR] });
+  const uniqueData = { url: 'https://eaglela.com/events/', html: EAGLE_LA_SITE_HTML };
+  assert.equal(uniqueParser.resolvePageSiteRole(uniqueData, {}), 'venue');
+  assert.equal(uniqueData.pageSiteRoleReason, 'curated bar "Eagle LA"');
+});
+
+test('curated-bar venue chain: BarDataNormalizer canonicalizes the kept bar and adopts curated coordinates + address for an unpinned event', () => {
+  const { BarDataNormalizer } = require('../normalizers');
+  const core = new SharedCore({}, { eventSchema: EventSchema, bars: { la: [EAGLE_LA_CURATED_BAR] } });
+  const normalizer = new BarDataNormalizer(core);
+
+  const event = { title: 'CubScout LA', bar: 'EAGLE LA', city: 'la' };
+  normalizer.normalize(event);
+
+  assert.equal(event.bar, 'Eagle LA', 'canonicalized to the curated display name');
+  assert.equal(event.location, '34.0912127, -118.2840632', 'curated coordinates adopted for the unpinned event');
+  assert.equal(event.pinSource, 'curated');
+  assert.equal(event.address, '4219 Santa Monica Blvd, Los Angeles, CA 90029');
+  assert.equal(event.addressSource, 'curated');
+});

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -57,6 +57,15 @@ const scraperBars = {
       "googleMaps": "https://maps.app.goo.gl/V96bZYM6qBm8tqQs5"
     }
   ],
+  "birmingham": [
+    {
+      "name": "Eden",
+      "city": "birmingham",
+      "address": "116 Sherlock Street, Birmingham B5 6NB",
+      "coordinates": "52.4714027, -1.8936278",
+      "facebook": "https://www.facebook.com/eden.bar.birmingham/"
+    }
+  ],
   "boston": [
     {
       "name": "The Alley Bar",
@@ -77,6 +86,21 @@ const scraperBars = {
       "instagram": "https://www.instagram.com/legacybos",
       "faviconBg": "#b47d04",
       "faviconFg": "#c38703"
+    }
+  ],
+  "brighton": [
+    {
+      "name": "Horizon",
+      "city": "brighton",
+      "address": "29-31 New Steine, Marine Parade, Brighton",
+      "coordinates": "50.8196107, -0.1315114",
+      "instagram": "horizon.brighton"
+    },
+    {
+      "name": "Concorde 2",
+      "city": "brighton",
+      "address": "Madeira Shelter Hall, Madeira Drive, Brighton BN2 1EN",
+      "coordinates": "50.8172912, -0.1225875"
     }
   ],
   "chicago": [
@@ -446,6 +470,8 @@ const scraperBars = {
       "facebook": "https://www.facebook.com/3dollarbillbk",
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ7zm6H3JbwokR3ui1wTNr6Xc",
       "gayCities": "https://newyork.gaycities.com/bars/309059-dollar-bill",
+      "faviconBg": "#190832",
+      "faviconFg": "#c5c5e9",
       "gayCitiesLastScrapedAt": "2026-06-14T16:38:18.601Z"
     },
     {
@@ -527,7 +553,9 @@ const scraperBars = {
       "name": "The Yard at 9 Bob Note",
       "city": "nyc",
       "address": "270 Meserole Ave, Brooklyn, NY 11222",
-      "website": "https://www.3dollarbillbk.com"
+      "website": "https://www.3dollarbillbk.com",
+      "faviconBg": "#190832",
+      "faviconFg": "#c5c5e9"
     }
   ],
   "palm-springs": [
@@ -814,6 +842,14 @@ const scraperBars = {
       "website": "https://publicsf.com",
       "faviconBg": "#f35425",
       "faviconFg": "#fd5825"
+    }
+  ],
+  "sitges": [
+    {
+      "name": "The Bear Cave",
+      "city": "sitges",
+      "address": "Carrer de Bonaire 12, 08870 Sitges",
+      "coordinates": "41.2360385, 1.8079068"
     }
   ],
   "tokyo": [

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -8649,7 +8649,79 @@ class SharedCore {
                 // Process conflicts to extract important information
                 analyzedEvent = this.processEventWithConflicts(analyzedEvent);
             }
-            
+
+            // Final-stage field cleanups. Both run at the FINAL analyzed-event
+            // build (so every parser, merge result, and cached AI response
+            // passes through them) and BEFORE the notes generation/rebuild
+            // below, so the cleaned values are what notes serialize.
+            let notesNeedRebuild = false;
+
+            // Description formatting sanitizer (run 20260729-125201: dice.fm
+            // shipped markdown "**BEEFMINCE ...**" and a Wix site shipped raw
+            // HTML + a literal "\n" — both reached notes verbatim). Pure
+            // function lives in normalizers.js; reached via the injected
+            // pipeline (shared-core never loads modules itself).
+            if (this.normalizerPipeline
+                && typeof this.normalizerPipeline.sanitizeDescriptionFormatting === 'function'
+                && typeof analyzedEvent.description === 'string' && analyzedEvent.description) {
+                const sanitizedDescription = this.normalizerPipeline.sanitizeDescriptionFormatting(analyzedEvent.description);
+                if (sanitizedDescription !== analyzedEvent.description) {
+                    analyzedEvent.description = sanitizedDescription;
+                    notesNeedRebuild = true;
+                    console.log(`🧼 DESCRIPTION: stripped formatting markup for "${analyzedEvent.title || 'event'}"`);
+                }
+            }
+
+            // gmaps rebuild from settled facts (run 20260729-125201: events
+            // finished with precise geocode-verified coords in `location`
+            // while gmaps still carried the EARLY text-search form built from
+            // vague venue text, e.g. query=Horizon%2C%20Brighton%20and%20Hove
+            // — Google renders a wide multi-result area for those). Curated
+            // data beats derived: a curated bar's googleMaps link wins, then
+            // final coordinates; with neither, the existing value stands.
+            // Parser-stamped static gmaps (tracked in _staticFields by
+            // applyStaticMetadataBlock) is curated config and never rebuilt;
+            // a link already anchored to a place_id is more precise than bare
+            // coords and is never downgraded (curated adoption still applies).
+            {
+                const staticFields = analyzedEvent._staticFields && typeof analyzedEvent._staticFields === 'object'
+                    ? analyzedEvent._staticFields
+                    : {};
+                const existingGmaps = typeof analyzedEvent.gmaps === 'string' ? analyzedEvent.gmaps.trim() : '';
+                if (!Object.prototype.hasOwnProperty.call(staticFields, 'gmaps')) {
+                    const cityBars = this.getCuratedCityBars(analyzedEvent.city);
+                    const curatedBar = cityBars && typeof analyzedEvent.bar === 'string' && analyzedEvent.bar.trim()
+                        ? this.findCuratedBarByName(cityBars, analyzedEvent.bar)
+                        : null;
+                    const curatedGmaps = curatedBar && typeof curatedBar.googleMaps === 'string'
+                        ? curatedBar.googleMaps.trim()
+                        : '';
+                    const finalCoordinates = this.parseCoordinatePair(analyzedEvent.location);
+                    if (curatedGmaps && curatedGmaps !== existingGmaps) {
+                        analyzedEvent.gmaps = curatedGmaps;
+                        notesNeedRebuild = true;
+                        console.log(`🗺️ GMAPS: adopted curated googleMaps link for "${analyzedEvent.title || 'event'}"`);
+                    } else if (!curatedGmaps && finalCoordinates && !existingGmaps.includes('place_id')) {
+                        const coordinateGmaps = SharedCore.generateGoogleMapsUrl({
+                            coordinates: finalCoordinates,
+                            placeId: null,
+                            address: null,
+                            venueName: null,
+                            cityName: null
+                        }) || '';
+                        if (coordinateGmaps && coordinateGmaps !== existingGmaps) {
+                            analyzedEvent.gmaps = coordinateGmaps;
+                            notesNeedRebuild = true;
+                            console.log(`🗺️ GMAPS: rebuilt link from verified coordinates for "${analyzedEvent.title || 'event'}"`);
+                        }
+                    }
+                }
+            }
+
+            if (notesNeedRebuild && analyzedEvent.notes) {
+                analyzedEvent.notes = this.formatEventNotes(analyzedEvent);
+            }
+
             // Generate notes for ALL events to ensure consistent preview display
             // This ensures new, merge, and conflict events all have notes for the preview
             if (!analyzedEvent.notes) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -9975,3 +9975,165 @@ test("bear keywords: 'bbq' alone is not a bear signal; explicit bear context is"
     ['bear']
   );
 });
+
+// ---------------------------------------------------------------------------
+// Final-build field cleanups in buildAnalyzedCalendarEvent: description
+// formatting sanitizer (run 20260729-125201, dice.fm/Wix markup in notes) and
+// gmaps rebuild from settled facts (same run: text-search links next to
+// geocode-verified coords).
+// ---------------------------------------------------------------------------
+
+const { NormalizerPipeline } = require('./normalizers');
+
+function createFinalBuildCore(options = {}) {
+  return new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    normalizerPipeline: new NormalizerPipeline(),
+    ...options
+  });
+}
+
+function captureFinalBuildLogs(lines) {
+  const originalLog = console.log;
+  console.log = (message) => { lines.push(String(message)); };
+  return () => { console.log = originalLog; };
+}
+
+const NEW_ACTION_ANALYSIS = { action: 'new', reason: 'No existing event found', sourceEvent: null, overrideIdentity: null };
+
+test('final build sanitizes description formatting markup and logs once', async () => {
+  const core = createFinalBuildCore();
+  const event = {
+    title: 'BEEFMINCE',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    city: 'dallas',
+    description: "**BEEFMINCE | The UK's Tastiest Bear Club** **\\*Now on Saturdays\\***"
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.ok(!analyzed.description.includes('**'), `markdown runs stripped: ${JSON.stringify(analyzed.description)}`);
+  assert.ok(!analyzed.description.includes('\\*'), 'escaped asterisks stripped');
+  assert.ok(analyzed.description.includes("BEEFMINCE | The UK's Tastiest Bear Club"), 'words kept');
+  assert.ok(analyzed.notes.includes(analyzed.description), 'notes serialize the sanitized description');
+  assert.deepEqual(
+    lines.filter(line => line.startsWith('🧼 DESCRIPTION:')),
+    ['🧼 DESCRIPTION: stripped formatting markup for "BEEFMINCE"']);
+});
+
+test('final build leaves a plain description byte-identical and stays silent', async () => {
+  const core = createFinalBuildCore();
+  const plain = 'Bears, beers, and DJs from 9pm. 21+ only.';
+  const event = {
+    title: 'CUB NIGHT',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    city: 'dallas',
+    description: plain
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.description, plain, 'byte-identical passthrough');
+  assert.equal(lines.some(line => line.startsWith('🧼 DESCRIPTION:')), false, 'no sanitizer log for clean text');
+});
+
+test('final build rebuilds a vague text-query gmaps link from verified coordinates', async () => {
+  const core = createFinalBuildCore();
+  const event = {
+    title: 'HORIZON BEAR NIGHT',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    location: '50.8196107, -0.1315114',
+    gmaps: 'https://www.google.com/maps/search/?api=1&query=Horizon%2C%20Brighton%20and%20Hove'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.gmaps, 'https://www.google.com/maps/search/?api=1&query=50.8196107%2C-0.1315114');
+  assert.ok(lines.includes('🗺️ GMAPS: rebuilt link from verified coordinates for "HORIZON BEAR NIGHT"'),
+    `got: ${JSON.stringify(lines)}`);
+});
+
+test('final build prefers a curated bar googleMaps link over the coordinate rebuild', async () => {
+  const CURATED_EAGLE_GMAPS = 'https://www.google.com/maps/place/?q=place_id:ChIJLwuhHU_HwoARdQQ1PfOn6B4';
+  const core = createFinalBuildCore({
+    bars: {
+      la: [{
+        name: 'Eagle LA',
+        city: 'la',
+        coordinates: '34.0912127, -118.2840632',
+        googleMaps: CURATED_EAGLE_GMAPS
+      }]
+    }
+  });
+  const event = {
+    title: 'CUBSCOUT LA',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    bar: 'Eagle LA',
+    city: 'la',
+    location: '34.0912127, -118.2840632',
+    gmaps: 'https://www.google.com/maps/search/?api=1&query=Eagle%20LA'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.gmaps, CURATED_EAGLE_GMAPS, 'curated link wins verbatim');
+  assert.ok(lines.includes('🗺️ GMAPS: adopted curated googleMaps link for "CUBSCOUT LA"'));
+});
+
+test('final build never rebuilds a parser-static gmaps value or a coord-less event', async () => {
+  const core = createFinalBuildCore();
+
+  // Static-stamped gmaps is curated parser config — untouched even with coords.
+  const staticEvent = {
+    title: 'STATIC MAPS',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    location: '50.8196107, -0.1315114',
+    gmaps: 'https://maps.example/curated-by-config',
+    _staticFields: { gmaps: 'https://maps.example/curated-by-config' }
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzedStatic;
+  let analyzedNoCoords;
+  try {
+    analyzedStatic = await core.buildAnalyzedCalendarEvent(staticEvent, NEW_ACTION_ANALYSIS, {}, {});
+
+    // No usable final coordinates → existing link stands.
+    const noCoordsEvent = {
+      title: 'NO COORDS',
+      startDate: new Date('2026-08-01T21:00:00.000Z'),
+      gmaps: 'https://www.google.com/maps/search/?api=1&query=Eden%20Birmingham'
+    };
+    analyzedNoCoords = await core.buildAnalyzedCalendarEvent(noCoordsEvent, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzedStatic.gmaps, 'https://maps.example/curated-by-config', 'static gmaps untouched');
+  assert.equal(analyzedNoCoords.gmaps, 'https://www.google.com/maps/search/?api=1&query=Eden%20Birmingham', 'no coords → untouched');
+  assert.equal(lines.some(line => line.startsWith('🗺️ GMAPS:')), false, 'no rebuild logs fired');
+});


### PR DESCRIPTION
Findings wave from today's phone runs (BEEFMINCE `20260729-125201`, CubScout `20260729-125247`).

## Investigated and cleared
**Horizon and Concorde 2 location data is correct.** Horizon is Brighton's new seafront club at 29-31 New Steine/Marine Parade ([horizonbrighton.com](https://horizonbrighton.com/)); the Concorde 2 pin matches OSM's own POI, the venue postcode block, and reverse geocode. The "wide" Google Maps views came from the links, not the pins — see fix 3.

## Fixes
1. **Description formatting sanitizer** — dice.fm ships markdown (`**bold**`, `\*` escapes), Wix ships raw `<p>` + literal `\n` characters; all reached calendar notes verbatim. New pure, idempotent `sanitizeDescriptionFormatting` in normalizers.js, applied at final analyzed-event build (covers every parser, merges, cached AI responses). Evidence strings from the runs are the test fixtures.
2. **siteRole 'venue' via curated bars** — extraction found bar "Eagle LA" twice on eaglela.com and the organizer-brand guard rejected it both times (siteRole undetermined: no venue-ish JSON-LD). New rung: page brand name that IS a curated bar for the parser's city → site is the venue's own; the guard's existing venue exception then keeps the bar, and curated coords/address adopt. Fail-closed on ambiguity; no fuzzy matching.
3. **gmaps links rebuilt from settled facts** — links were built early from vague venue text (`query=Horizon, Brighton and Hove` → wide multi-result view) and never rebuilt after geocode verification. Now at final build: curated bar `googleMaps` link → verified-coordinate pin → leave as-is. Parser-stamped static gmaps and place_id links are never downgraded.
4. **Curated venues (nominatim-verified coords)** — `data/bars/brighton.json` (Horizon, Concorde 2), `birmingham.json` (Eden — fun fact: the geocoder had actually found Eden and refused its own correct pin because the venue's three street frontages disagree), `sitges.json` (The Bear Cave). Generated twins regenerated via the generator; it auto-discovers `data/bars/*.json`, no manifest to touch.

## Runtime notes
- No NEW runtime files — `scripts/scraper-bars.js` twin regenerated (already in your updater list).
- New cities' bars go live for the phone once the site deploys `data/scraper-bars.json` (1-day cache).
- Next BEEFMINCE/CubScout runs should show: clean descriptions, CubScout pinned at Eagle LA, coords-anchored gmaps pins for Horizon/Concorde 2/Eden, and the four Sitges Bear Cave events pinned.

Suite: **1042/1042 green**. No `new URL(`/`URLSearchParams`; no existing log-line shapes altered (three new lines: `🧼 DESCRIPTION:`, `🗺️ GMAPS:` ×2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP