### PR TITLE
fix(scraper): recurring-event UX — ICS calendar preview, builder prefill sample leak, CUB-SCOUT shortName, ticketUrl dedup

### DIFF
--- a/data/promoters.json
+++ b/data/promoters.json
@@ -97,6 +97,7 @@
   },
   {
     "name": "CubScout LA",
+    "shortName": "CUB-SCOUT",
     "aliases": [
       "CUBSCOUT"
     ],

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -8216,20 +8216,48 @@ class ScriptableAdapter {
         SharedEventSchema.slugifyIcsText(event.title || event.name || "") ||
         "chunky-dad-recurring";
       const fileName = `${slug}.ics`;
-      if (
-        typeof DocumentPicker !== "undefined" &&
-        DocumentPicker &&
-        typeof DocumentPicker.exportString === "function"
-      ) {
-        await DocumentPicker.exportString(icsText, fileName);
-      } else {
-        const fm = FileManager.local();
-        const filePath = fm.joinPath(fm.temporaryDirectory(), fileName);
-        fm.writeString(filePath, icsText);
-        await ShareSheet.present([filePath]);
+      // QuickLook first: iOS previews an .ics as its calendar import sheet
+      // ("Add All" + per-event add), which is the point of the button —
+      // DocumentPicker.exportString only offered a save-to-Files dialog and
+      // the events never reached the calendar without a second trip through
+      // the Files app. QuickLook's own share button still reaches Files for
+      // anyone who wants the raw file. DocumentPicker stays as the fallback
+      // when QuickLook is unavailable or refuses the file.
+      let exportedVia = "";
+      if (typeof QuickLook !== "undefined" && QuickLook && typeof QuickLook.present === "function") {
+        try {
+          const fm = FileManager.local();
+          const filePath = fm.joinPath(fm.temporaryDirectory(), fileName);
+          fm.writeString(filePath, icsText);
+          await QuickLook.present(filePath, false);
+          exportedVia = "QuickLook";
+        } catch (quickLookError) {
+          console.warn(
+            `📱 Scriptable: QuickLook ICS preview failed (${quickLookError.message}) — falling back to DocumentPicker`,
+          );
+        }
+      }
+      if (!exportedVia) {
+        if (
+          typeof DocumentPicker !== "undefined" &&
+          DocumentPicker &&
+          typeof DocumentPicker.exportString === "function"
+        ) {
+          await DocumentPicker.exportString(icsText, fileName);
+          exportedVia = "DocumentPicker";
+        } else {
+          const fm = FileManager.local();
+          const filePath = fm.joinPath(fm.temporaryDirectory(), fileName);
+          fm.writeString(filePath, icsText);
+          await ShareSheet.present([filePath]);
+          exportedVia = "ShareSheet";
+        }
       }
       console.log(
         `📱 Scriptable: Exported recurring event ICS "${fileName}" (#${id})`,
+      );
+      console.log(
+        `📱 Scriptable: Recurring ICS handed off via ${exportedVia}`,
       );
     } catch (error) {
       console.warn(

--- a/scripts/scraper-promoters.js
+++ b/scripts/scraper-promoters.js
@@ -106,6 +106,7 @@ const scraperPromoters = [
   },
   {
     "name": "CubScout LA",
+    "shortName": "CUB-SCOUT",
     "aliases": [
       "CUBSCOUT"
     ],

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -8672,6 +8672,24 @@ class SharedCore {
                 }
             }
 
+            // ticketUrl dedup (run 20260729-125247: CubScout's notes carried
+            // the same eaglela.com link three ways — url, website, ticketUrl).
+            // url/website are ONE canonical field by design; a ticketUrl that
+            // is byte-identical to it adds nothing and reads as clutter, so
+            // it is dropped. A ticketUrl pointing anywhere else is a real
+            // ticketing link and always survives.
+            {
+                const canonicalWebsite = typeof analyzedEvent.website === 'string' && analyzedEvent.website.trim()
+                    ? analyzedEvent.website.trim()
+                    : (typeof analyzedEvent.url === 'string' ? analyzedEvent.url.trim() : '');
+                const ticketUrl = typeof analyzedEvent.ticketUrl === 'string' ? analyzedEvent.ticketUrl.trim() : '';
+                if (ticketUrl && canonicalWebsite && ticketUrl === canonicalWebsite) {
+                    delete analyzedEvent.ticketUrl;
+                    notesNeedRebuild = true;
+                    console.log(`🔗 LINKS: dropped ticketUrl duplicating website for "${analyzedEvent.title || 'event'}"`);
+                }
+            }
+
             // gmaps rebuild from settled facts (run 20260729-125201: events
             // finished with precise geocode-verified coords in `location`
             // while gmaps still carried the EARLY text-search form built from

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -10137,3 +10137,52 @@ test('final build never rebuilds a parser-static gmaps value or a coord-less eve
   assert.equal(analyzedNoCoords.gmaps, 'https://www.google.com/maps/search/?api=1&query=Eden%20Birmingham', 'no coords → untouched');
   assert.equal(lines.some(line => line.startsWith('🗺️ GMAPS:')), false, 'no rebuild logs fired');
 });
+
+test('final build drops a ticketUrl byte-identical to the canonical website', async () => {
+  const core = createFinalBuildCore();
+  const link = 'https://eaglela.com/events/cub-scout-3/';
+  const event = {
+    title: 'CUBSCOUT',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    city: 'la',
+    website: link,
+    url: link,
+    ticketUrl: link
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.ticketUrl, undefined, 'duplicate ticketUrl deleted');
+  assert.equal(analyzed.website, link, 'canonical website untouched');
+  assert.ok(!analyzed.notes.includes('ticketUrl:'), `notes drop the duplicate line: ${JSON.stringify(analyzed.notes)}`);
+  assert.ok(lines.includes('🔗 LINKS: dropped ticketUrl duplicating website for "CUBSCOUT"'),
+    `got: ${JSON.stringify(lines)}`);
+});
+
+test('final build keeps a ticketUrl that differs from the website', async () => {
+  const core = createFinalBuildCore();
+  const event = {
+    title: 'FURBALL',
+    startDate: new Date('2026-08-07T02:00:00.000Z'),
+    city: 'chicago',
+    website: 'https://www.furball.nyc/',
+    ticketUrl: 'https://www.eventbrite.com/e/furball-chicago-tickets-123'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.ticketUrl, 'https://www.eventbrite.com/e/furball-chicago-tickets-123', 'real ticket link survives');
+  assert.equal(lines.some(line => line.startsWith('🔗 LINKS:')), false, 'no dedup log');
+});

--- a/testing/event-builder.html
+++ b/testing/event-builder.html
@@ -2998,6 +2998,17 @@
         populateCityOptions();
         const baseState = createDefaultState();
         const urlState = loadStateFromUrl(baseState);
+        if (urlState.sawEventParam) {
+          // A prefill link provided real event data — the demo sample values
+          // must not leak into fields the link didn't cover (a scraper
+          // prefill without shortName was showing "Bearracuda" as the short
+          // name). Blank the sample-only fields; dates/city defaults stay.
+          baseState.name = '';
+          baseState.shortName = '';
+          baseState.venue = '';
+          baseState.address = '';
+          baseState.description = '';
+        }
         state = { ...baseState, ...urlState.overrides };
         state.timezone = state.timezone || browserTimezone;
         normalizeStateLinks();
@@ -7371,11 +7382,12 @@ Example output:
         const schema = getRequiredEventSchema();
         const params = new URLSearchParams(window.location.search);
         const overrides = {};
-        const parseContext = { sawEditFlag: false };
+        const parseContext = { sawEditFlag: false, sawEventParam: false };
         params.forEach((value, key) => {
           if (value == null) return;
           const stateKey = schema.getEventBuilderStateKey(key);
           if (stateKey) {
+            parseContext.sawEventParam = true;
             if (stateKey === 'start' || stateKey === 'end') {
               const sanitized = sanitizeDateTimeInput(value);
               if (sanitized) overrides[stateKey] = sanitized;
@@ -7410,7 +7422,7 @@ Example output:
         if (!overrides.end) overrides.end = baseState.end;
         if (!overrides.city) overrides.city = baseState.city;
         if (!overrides.recurrenceMode) overrides.recurrenceMode = baseState.recurrenceMode;
-        return { overrides };
+        return { overrides, sawEventParam: parseContext.sawEventParam };
       }
 
       function applyStateToForm() {


### PR DESCRIPTION
Fixes the four defects from the CubScout recurring-event flow (run `20260729-125247`):

1. **ICS export opens the calendar preview** — the button now writes a temp file and presents it via QuickLook, which iOS renders as the calendar import sheet ("Add All"), instead of DocumentPicker's save-to-Files dialog. QuickLook's share button still reaches Files for anyone who wants the raw file; DocumentPicker/ShareSheet remain as fallbacks, with an additive log line saying which path ran. *If QuickLook on-device shows raw text instead of the calendar preview, say so — next step would be serving the ICS over https, but preview-first is worth trying.*
2. **Builder prefill no longer leaks sample data** — prefill was working (name/venue/dates/RRULE all arrived); the "BEARRACUDA" you saw was the builder's demo default showing through the one field the link didn't provide (shortName). With any prefill param present, sample-only fields now start blank; bare opens keep the demo. Verified headless in both modes.
3. **shortName** — `CubScout LA` registry entry now carries `"CUB-SCOUT"`; the stamping path already handles shortName (Cubhouse proves it), and the adapter already forwards it into the builder link. Twin regenerated.
4. **Duplicate links** — a `ticketUrl` byte-identical to the canonical website is dropped at final build (your notes had the same eaglela.com link three times: url, website, ticketUrl). Real ticket links (different URL) always survive.

Not touched by design: the single-occurrence link question (eaglela.com creates a per-occurrence post, `cub-scout-3`) and the broader "related links" idea — parked per your call to not complicate links yet.

Runtime files touched: `scripts/adapters/scriptable-adapter.js`, `scripts/shared-core.js`, `scripts/scraper-promoters.js` (all already in your updater list), `data/promoters.json` + `testing/event-builder.html` (deploy with the site). No new runtime files.

Suite: **1044/1044 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP