### PR TITLE
feat(scraper): AI shortName derivation — every event gets a chip name, verbatim-gated

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -5384,6 +5384,186 @@ class SharedCore {
         return records;
     }
 
+    // ------------------------------------------------------------------
+    // AI shortName DERIVATION pass: events without a shortName make ugly
+    // city-page calendar chips (dynamic-calendar-loader falls back to the
+    // full title). The promoter registry stamps curated shortNames for
+    // matched promoters; this pass covers everything else (venue one-offs,
+    // aggregator finds) at the FINAL analyzed-event build, guarded by a
+    // deterministic anti-hallucination gate. Convention: an unescaped `-`
+    // in shortName is a LINE-BREAK HINT (rendered as a soft hyphen), e.g.
+    // curated "BEEF-MINCE", "CUB-HOUSE", "MEGA-WOOF".
+    // ------------------------------------------------------------------
+
+    // Prompt for one event's shortName derivation. Carries the TITLE only —
+    // no dates/venue/city — so the AI-response cache key stays stable
+    // across runs (passLabel 'short-name').
+    buildShortNamePrompt({ eventTitle, maxChars }) {
+        return [
+            'You are naming a compact calendar chip for one event.',
+            `TITLE: ${eventTitle}`,
+            'Return the shortest recognizable display name for this event.',
+            'Rules:',
+            '- The answer MUST be taken verbatim from the title: one contiguous run of characters — never paraphrase, reorder, merge parts, or add words.',
+            `- At most ${maxChars} characters.`,
+            '- UPPERCASE preferred (you may uppercase the copied characters).',
+            '- You MAY insert hyphens inside a long word as line-break hints, e.g. "CUBSCOUT" → "CUB-SCOUT".',
+            'Return JSON only:',
+            '{"shortName": {"value": "<display name>", "reason": "<one short sentence>"}}'
+        ].join('\n');
+    }
+
+    // Deterministic anti-hallucination gate for a derived shortName. Pure.
+    // Usable only when ALL hold: non-empty after trim; length ≤ maxChars;
+    // after removing hyphens and case/diacritic-folding BOTH sides, the
+    // answer is a CONTIGUOUS substring of the title (spaces count as
+    // characters — "BEEFMINCE MEET MARKET" can yield "MEET MARKET" or
+    // "BEEFMINCE" but never "BEEF MARKET") — this permits hyphen insertion
+    // and case-lifting but forbids invented/reordered words; and the answer
+    // is not the title verbatim (an exact copy adds nothing — the site
+    // fallback already shows the title — but a case-lift or an added
+    // line-break hyphen IS a display change and is stored).
+    // Returns { ok: true, value } or { ok: false, reason } where reason is
+    // one of 'unusable response' | 'too long' | 'not a verbatim substring'
+    // | 'equals title'.
+    evaluateDerivedShortName(title, answerText, maxChars) {
+        const answer = typeof answerText === 'string' ? answerText.trim() : '';
+        if (!answer) return { ok: false, reason: 'unusable response' };
+        if (answer.length > maxChars) return { ok: false, reason: 'too long' };
+        const strippedFoldedAnswer = this.foldDiacritics(answer.replace(/-/g, ''));
+        const strippedFoldedTitle = this.foldDiacritics(String(title).replace(/-/g, ''));
+        // The occurrence must align on WORD BOUNDARIES in the title: "BEEF"
+        // inside "BEEFMINCE" is a contiguous substring but a mid-word cut
+        // that makes a wrong-looking chip ("Never cut a word in the middle",
+        // same rule as the trim pipeline). Any one aligned occurrence
+        // suffices.
+        const isWordChar = (ch) => /[a-z0-9]/.test(ch);
+        let aligned = false;
+        if (strippedFoldedAnswer) {
+            let from = 0;
+            for (;;) {
+                const at = strippedFoldedTitle.indexOf(strippedFoldedAnswer, from);
+                if (at === -1) break;
+                const beforeOk = at === 0 || !isWordChar(strippedFoldedTitle[at - 1]) || !isWordChar(strippedFoldedAnswer[0]);
+                const endIndex = at + strippedFoldedAnswer.length;
+                const afterOk = endIndex === strippedFoldedTitle.length
+                    || !isWordChar(strippedFoldedTitle[endIndex])
+                    || !isWordChar(strippedFoldedAnswer[strippedFoldedAnswer.length - 1]);
+                if (beforeOk && afterOk) { aligned = true; break; }
+                from = at + 1;
+            }
+        }
+        if (!aligned) {
+            return { ok: false, reason: 'not a verbatim substring' };
+        }
+        if (answer === String(title).trim()) {
+            return { ok: false, reason: 'equals title' };
+        }
+        return { ok: true, value: answer };
+    }
+
+    // Derive a shortName for one FINAL analyzed event that lacks one. All
+    // trigger guards live here: existing/static shortName, empty title, AI
+    // disabled (`ai: { shortNames: false }` or `enabled: false`), or no
+    // transport → no AI call, event untouched. Resilient by design: AI
+    // transport error / non-JSON / missing field → rejected log (reason
+    // 'unusable response') and the event ships without shortName exactly as
+    // today. No retry ladder — the pass is cheap and optional. Returns true
+    // only when a gated value was stored (caller rebuilds notes).
+    async deriveShortNameForEvent(event, parserConfig, httpAdapter) {
+        if (!event || typeof event !== 'object') return false;
+        const existing = event.shortName === null || event.shortName === undefined
+            ? ''
+            : String(event.shortName).trim();
+        if (existing) return false;
+        const staticFields = event._staticFields && typeof event._staticFields === 'object'
+            ? event._staticFields
+            : {};
+        if (Object.prototype.hasOwnProperty.call(staticFields, 'shortName')) return false;
+        const title = typeof event.title === 'string' ? event.title.trim() : '';
+        if (!title) return false;
+        const rawAi = parserConfig && parserConfig.ai && typeof parserConfig.ai === 'object' ? parserConfig.ai : {};
+        if (rawAi.enabled === false) return false;
+        if (!httpAdapter || typeof httpAdapter.postJson !== 'function') return false;
+        const aiConfig = this.resolveAiConfig(rawAi);
+        if (!aiConfig.enabled || !aiConfig.endpoint || !aiConfig.shortNamesEnabled) return false;
+
+        const maxChars = aiConfig.shortNameDeriveMaxChars;
+        const prompt = this.buildShortNamePrompt({ eventTitle: title, maxChars });
+        const shortNameAiConfig = { ...aiConfig, numPredict: Math.min(Number(aiConfig.numPredict) || 200, 200) };
+
+        let rawResponse = null;
+        try {
+            rawResponse = await this.callAiGenerate(shortNameAiConfig, prompt, 'short-name', httpAdapter);
+        } catch (_) {
+            rawResponse = null;
+        }
+
+        let parsed = null;
+        if (rawResponse) {
+            try {
+                parsed = JSON.parse(this.extractFirstJsonObject(rawResponse) || rawResponse);
+            } catch (_) {
+                parsed = null;
+            }
+        }
+        const answerEntry = parsed && typeof parsed === 'object' ? parsed.shortName : null;
+        const answerText = answerEntry && typeof answerEntry === 'object' ? answerEntry.value : answerEntry;
+        if (typeof answerText !== 'string') {
+            console.log(`🏷️ SHORTNAME: rejected AI answer for "${title}" — unusable response`);
+            return false;
+        }
+
+        const verdict = this.evaluateDerivedShortName(title, answerText, maxChars);
+        if (!verdict.ok) {
+            // Deterministic salvage before giving up — every real rejection
+            // class from the live batteries (2026-07-29) has a mechanical
+            // repair that stays inside the verbatim gate (no extra AI call,
+            // no new trust):
+            //   - hyphens used as SPACE replacements ("BEEFMINCE-X-RVT",
+            //     "BEEFMINCE-BRIGHTON") → try the answer with hyphens turned
+            //     back into spaces first;
+            //   - merged/invented tails ("CLUB CHUB 2026", "CLUB CHUB
+            //     FT-LA") and overlong answers ("BEEFMINCE: THE BIG BALL")
+            //     → drop trailing whitespace tokens until the remainder
+            //     passes, stripping trailing punctuation and never ending on
+            //     a stopword ("BEEFMINCE: THE" must fall through to
+            //     "BEEFMINCE").
+            if (verdict.reason === 'not a verbatim substring' || verdict.reason === 'too long') {
+                const trailingStopwords = new Set(['the', 'a', 'an', 'and', 'or', 'of', 'at', 'in', 'on', 'for', 'with', 'x', 'y', 'en', 'de', 'la', 'el', 'les', 'los']);
+                const candidates = [];
+                const spaced = answerText.trim().replace(/-/g, ' ').replace(/\s+/g, ' ');
+                if (spaced !== answerText.trim()) candidates.push(spaced);
+                for (const base of [spaced, answerText.trim()]) {
+                    const tokens = base.split(/\s+/);
+                    for (let keep = tokens.length - 1; keep >= 1; keep--) {
+                        candidates.push(tokens.slice(0, keep).join(' '));
+                    }
+                }
+                const seenCandidates = new Set();
+                for (const rawCandidate of candidates) {
+                    const candidate = rawCandidate.replace(/[\s:;,.!–—-]+$/, '');
+                    if (!candidate || seenCandidates.has(candidate)) continue;
+                    seenCandidates.add(candidate);
+                    const lastToken = candidate.split(/\s+/).pop().toLowerCase();
+                    if (trailingStopwords.has(lastToken)) continue;
+                    const salvage = this.evaluateDerivedShortName(title, candidate, maxChars);
+                    if (salvage.ok) {
+                        event.shortName = salvage.value;
+                        console.log(`🏷️ SHORTNAME: salvaged "${salvage.value}" from rejected answer for "${title}"`);
+                        return true;
+                    }
+                }
+            }
+            console.log(`🏷️ SHORTNAME: rejected AI answer for "${title}" — ${verdict.reason}`);
+            return false;
+        }
+
+        event.shortName = verdict.value;
+        console.log(`🏷️ SHORTNAME: derived "${verdict.value}" for "${title}"`);
+        return true;
+    }
+
     async deduplicateEvents(events, httpAdapter, globalConfig = null) {
         const seen = new Map();
         const deduplicated = [];
@@ -8736,6 +8916,22 @@ class SharedCore {
                 }
             }
 
+            // AI shortName derivation: an event that reaches the final build
+            // without a shortName renders its full title on the city-page
+            // calendar chip. Derive one from the title (passLabel
+            // 'short-name', cached — the prompt carries the title only, so
+            // repeat runs hit the cache), guarded by the deterministic
+            // verbatim gate in evaluateDerivedShortName. Parser-stamped
+            // static shortNames (_staticFields) are curated config and never
+            // derived over; every gate/transport failure leaves the event
+            // exactly as today.
+            {
+                const shortNameParserConfig = analyzedEvent._parserConfig || (config && config.ai ? { ai: config.ai } : null);
+                if (await this.deriveShortNameForEvent(analyzedEvent, shortNameParserConfig, calendarAdapter)) {
+                    notesNeedRebuild = true;
+                }
+            }
+
             if (notesNeedRebuild && analyzedEvent.notes) {
                 analyzedEvent.notes = this.formatEventNotes(analyzedEvent);
             }
@@ -10183,6 +10379,14 @@ class SharedCore {
             keepAlive: Object.prototype.hasOwnProperty.call(aiConfig, 'keepAlive') ? String(aiConfig.keepAlive) : '5m',
             cacheEnabled: aiConfig.cache !== false,
             arbitrateMerges: aiConfig.arbitrateMerges !== false,
+            // shortName derivation pass (default ON, like the response cache):
+            // `ai: { shortNames: false }` disables it. shortNameDeriveMaxChars
+            // caps DERIVED values (16) — separate from the trim pipeline's
+            // shortNameMaxChars (30), which governs trimming existing values.
+            shortNamesEnabled: aiConfig.shortNames !== false,
+            shortNameDeriveMaxChars: Number.isFinite(Number(aiConfig.shortNameDeriveMaxChars)) && Number(aiConfig.shortNameDeriveMaxChars) > 0
+                ? Math.floor(Number(aiConfig.shortNameDeriveMaxChars))
+                : 16,
             // Override-only: extra text appended verbatim to extraction prompt
             // context. Organizer context is normally derived from page metadata.
             extraContext: typeof aiConfig.extraContext === 'string' ? aiConfig.extraContext : '',

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -8611,6 +8611,9 @@ function buildFinalTrimScrapedEvent(overrides = {}) {
     bar: 'Precinct DTLA',
     city: 'dallas',
     ticketUrl: 'https://tickets.example/duro-la',
+    // shortName present so the shortName derivation pass stays inert —
+    // these tests count TRIM AI calls only.
+    shortName: 'DURO',
     _parserConfig: buildTrimParserConfig(),
     _fieldTrims: [{ ...TRIMMED_TITLE_RECORD }],
     ...overrides
@@ -8696,6 +8699,9 @@ test('final trim pass: an action without scraped contribution is flagged, never 
     title: OVERLONG_TITLE,
     startDate: new Date('2026-08-08T02:00:00.000Z'),
     city: 'dallas',
+    // shortName present so the shortName derivation pass stays inert —
+    // this test counts TRIM AI calls only.
+    shortName: 'DURO',
     _parserConfig: buildTrimParserConfig()
   };
   const analysis = { action: 'conflict', reason: 'Identifier match not found', sourceEvent: null, overrideIdentity: null };
@@ -10185,4 +10191,253 @@ test('final build keeps a ticketUrl that differs from the website', async () => 
 
   assert.equal(analyzed.ticketUrl, 'https://www.eventbrite.com/e/furball-chicago-tickets-123', 'real ticket link survives');
   assert.equal(lines.some(line => line.startsWith('🔗 LINKS:')), false, 'no dedup log');
+});
+
+// ---------------------------------------------------------------------------
+// AI shortName derivation pass (final-build): events lacking a shortName make
+// ugly city-page calendar chips (the site falls back to the full title).
+// Derived from the title only, guarded by the deterministic verbatim gate in
+// evaluateDerivedShortName. Unescaped `-` in shortName = line-break hint.
+// ---------------------------------------------------------------------------
+
+function createShortNameAdapter(content) {
+  const adapter = { calls: [] };
+  adapter.postJson = async (endpoint, payload) => {
+    adapter.calls.push(payload);
+    return { ok: true, status: 200, text: buildOpenAiResponsePayload(content) };
+  };
+  return adapter;
+}
+
+test('shortName gate: hyphen insertion and case-lift accepted, invented text rejected', () => {
+  const core = createCore();
+
+  // Hyphen insertion as a line-break hint (whole title + added hyphen stores)
+  assert.deepEqual(core.evaluateDerivedShortName('CUBSCOUT', 'CUB-SCOUT', 16),
+    { ok: true, value: 'CUB-SCOUT' });
+
+  // Contiguous-substring rule: spaces count as characters — "BEEF MARKET"
+  // splices two words together and must be rejected.
+  assert.deepEqual(core.evaluateDerivedShortName('BEEFMINCE MEET MARKET', 'BEEF MARKET', 16),
+    { ok: false, reason: 'not a verbatim substring' });
+  assert.deepEqual(core.evaluateDerivedShortName('BEEFMINCE MEET MARKET', 'MEET MARKET', 16),
+    { ok: true, value: 'MEET MARKET' });
+  assert.deepEqual(core.evaluateDerivedShortName('BEEFMINCE MEET MARKET', 'BEEFMINCE', 16),
+    { ok: true, value: 'BEEFMINCE' });
+
+  // Too long: a verbatim substring over the cap is still rejected.
+  assert.deepEqual(core.evaluateDerivedShortName('BEEFMINCE MEET MARKET', 'BEEFMINCE MEET MA', 16),
+    { ok: false, reason: 'too long' });
+
+  // Whole title unchanged adds nothing — the site fallback already shows it.
+  assert.deepEqual(core.evaluateDerivedShortName('BEEFMINCE', 'BEEFMINCE', 16),
+    { ok: false, reason: 'equals title' });
+
+  // Case-lift IS a display change and is stored.
+  assert.deepEqual(core.evaluateDerivedShortName('Beefmince', 'BEEFMINCE', 16),
+    { ok: true, value: 'BEEFMINCE' });
+
+  // Diacritic fold: the answer may drop accents the title carries.
+  assert.deepEqual(core.evaluateDerivedShortName('OSOS Café Night', 'CAFE', 16),
+    { ok: true, value: 'CAFE' });
+
+  // Empty / non-string answers are unusable.
+  assert.deepEqual(core.evaluateDerivedShortName('BEEFMINCE', '   ', 16),
+    { ok: false, reason: 'unusable response' });
+});
+
+test('shortName prompt: identical across builds, title only — no volatile content', () => {
+  const core = createCore();
+  const first = core.buildShortNamePrompt({ eventTitle: 'BEEFMINCE MEET MARKET', maxChars: 16 });
+  const second = core.buildShortNamePrompt({ eventTitle: 'BEEFMINCE MEET MARKET', maxChars: 16 });
+  assert.equal(first, second, 'cache-key stability: byte-identical prompts');
+  assert.ok(first.includes('BEEFMINCE MEET MARKET'), 'title present');
+  assert.ok(!/\b20\d\d\b/.test(first), 'no year/date strings in the prompt');
+  assert.ok(first.includes('16 characters'), 'max chars stated');
+});
+
+test('final build derives a shortName via AI for an event lacking one', async () => {
+  const core = createFinalBuildCore();
+  const adapter = createShortNameAdapter('{"shortName": {"value": "BEEFMINCE", "reason": "recognizable brand"}}');
+  const event = {
+    title: 'BEEFMINCE MEET MARKET',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    city: 'dallas'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, adapter, { ai: {} });
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.shortName, 'BEEFMINCE');
+  const noteFields = core.parseNotesIntoFields(analyzed.notes || '');
+  assert.equal(noteFields.shortName, 'BEEFMINCE', 'notes serialize the derived shortName');
+  assert.ok(lines.includes('🏷️ SHORTNAME: derived "BEEFMINCE" for "BEEFMINCE MEET MARKET"'),
+    `got: ${JSON.stringify(lines.filter(line => line.includes('SHORTNAME')))}`);
+  assert.equal(adapter.calls.length, 1, 'exactly one AI call');
+  const prompt = adapter.calls[0].messages[0].content;
+  assert.ok(prompt.includes('BEEFMINCE MEET MARKET'), 'prompt carries the title');
+  assert.ok(!prompt.includes('2026'), 'prompt carries no dates');
+  assert.ok(!prompt.toLowerCase().includes('dallas'), 'prompt carries no city');
+});
+
+test('final build makes no shortName AI call when one exists, is static, or the pass is off', async () => {
+  const core = createFinalBuildCore();
+  const explodingAdapter = { postJson: async () => { throw new Error('AI must not be called'); } };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let withShortName;
+  let staticShortName;
+  let passDisabled;
+  try {
+    withShortName = await core.buildAnalyzedCalendarEvent({
+      title: 'BEEFMINCE MEET MARKET',
+      shortName: 'BEEF-MINCE',
+      startDate: new Date('2026-08-01T21:00:00.000Z')
+    }, NEW_ACTION_ANALYSIS, explodingAdapter, { ai: {} });
+
+    staticShortName = await core.buildAnalyzedCalendarEvent({
+      title: 'STATIC SHORT NAME NIGHT',
+      startDate: new Date('2026-08-01T21:00:00.000Z'),
+      _staticFields: { shortName: 'CURATED' }
+    }, NEW_ACTION_ANALYSIS, explodingAdapter, { ai: {} });
+
+    passDisabled = await core.buildAnalyzedCalendarEvent({
+      title: 'NO DERIVE NIGHT',
+      startDate: new Date('2026-08-01T21:00:00.000Z')
+    }, NEW_ACTION_ANALYSIS, explodingAdapter, { ai: { shortNames: false } });
+  } finally {
+    restore();
+  }
+
+  assert.equal(withShortName.shortName, 'BEEF-MINCE', 'existing shortName untouched');
+  assert.equal(staticShortName.shortName, undefined, 'static-stamped field never derived over');
+  assert.equal(passDisabled.shortName, undefined, 'ai.shortNames: false disables the pass');
+  assert.equal(lines.some(line => line.startsWith('🏷️ SHORTNAME:')), false, 'no shortName logs fired');
+});
+
+test('final build survives shortName transport failure and gate rejection unchanged', async () => {
+  const core = createFinalBuildCore();
+
+  // Transport throws → callAiGenerate returns null → unusable response.
+  const throwingAdapter = { postJson: async () => { throw new Error('connection refused'); } };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let transportFailed;
+  let gateRejected;
+  try {
+    transportFailed = await core.buildAnalyzedCalendarEvent({
+      title: 'BEEFMINCE MEET MARKET',
+      startDate: new Date('2026-08-01T21:00:00.000Z')
+    }, NEW_ACTION_ANALYSIS, throwingAdapter, { ai: {} });
+
+    // Gate rejection: spliced words are not a contiguous substring.
+    const splicedAdapter = createShortNameAdapter('{"shortName": {"value": "BEEF MARKET"}}');
+    gateRejected = await core.buildAnalyzedCalendarEvent({
+      title: 'BEEFMINCE MEET MARKET',
+      startDate: new Date('2026-08-01T21:00:00.000Z')
+    }, NEW_ACTION_ANALYSIS, splicedAdapter, { ai: {} });
+  } finally {
+    restore();
+  }
+
+  assert.equal(transportFailed.shortName, undefined, 'event ships without shortName');
+  assert.ok(lines.includes('🏷️ SHORTNAME: rejected AI answer for "BEEFMINCE MEET MARKET" — unusable response'),
+    `got: ${JSON.stringify(lines.filter(line => line.includes('SHORTNAME')))}`);
+  assert.equal(gateRejected.shortName, undefined, 'gated answer not stored');
+  assert.ok(lines.includes('🏷️ SHORTNAME: rejected AI answer for "BEEFMINCE MEET MARKET" — not a verbatim substring'));
+});
+
+test('shortName salvage: valid prefix of a rejected answer is kept', async () => {
+  const core = createFinalBuildCore();
+  const title = 'Club Chub Weekend 2026 — The Ultimate Celebration!';
+  const calls = [];
+  const baseAdapter = createShortNameAdapter('{"shortName": {"value": "CLUB CHUB 2026", "reason": "merged"}}');
+  const adapter = { postJson: async (...args) => { calls.push(1); return baseAdapter.postJson(...args); } };
+  const event = {
+    title,
+    startDate: new Date('2026-10-09T21:00:00.000Z'),
+    city: 'fort lauderdale'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, adapter, { ai: {} });
+  } finally {
+    restore();
+  }
+  assert.equal(analyzed.shortName, 'CLUB CHUB', 'trailing non-contiguous token dropped');
+  assert.equal(calls.length, 1, 'no extra AI call for salvage');
+  assert.ok(lines.includes(`🏷️ SHORTNAME: salvaged "CLUB CHUB" from rejected answer for "${title}"`),
+    `got: ${JSON.stringify(lines.filter(l => l.includes('SHORTNAME')))}`);
+});
+
+test('shortName salvage: fully invented answer still rejects', async () => {
+  const core = createFinalBuildCore();
+  const title = 'Bear Happy Hour';
+  const adapter = createShortNameAdapter('{"shortName": {"value": "BHH SOCIAL", "reason": "abbrev"}}');
+  const event = {
+    title,
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    city: 'seattle'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, adapter, { ai: {} });
+  } finally {
+    restore();
+  }
+  assert.equal(analyzed.shortName, undefined, 'nothing stored');
+  assert.ok(lines.includes(`🏷️ SHORTNAME: rejected AI answer for "${title}" — not a verbatim substring`));
+});
+
+test('shortName salvage: hyphens-as-spaces answer is repaired to the spaced form', async () => {
+  const core = createFinalBuildCore();
+  const title = 'BEEFMINCE x RVT';
+  const adapter = createShortNameAdapter('{"shortName": {"value": "BEEFMINCE-X-RVT"}}');
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent({
+      title,
+      startDate: new Date('2026-09-19T21:00:00.000Z')
+    }, NEW_ACTION_ANALYSIS, adapter, { ai: {} });
+  } finally {
+    restore();
+  }
+  assert.equal(analyzed.shortName, 'BEEFMINCE X RVT', 'hyphens turned back into spaces (case-lift stored)');
+  assert.ok(lines.includes(`🏷️ SHORTNAME: salvaged "BEEFMINCE X RVT" from rejected answer for "${title}"`));
+});
+
+test('shortName salvage: overlong answer drops tokens past punctuation and stopwords', async () => {
+  const core = createFinalBuildCore();
+  const title = 'Saturday 12th September – BEEFMINCE: THE BIG BALL';
+  const adapter = createShortNameAdapter('{"shortName": {"value": "BEEFMINCE: THE BIG BALL"}}');
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent({
+      title,
+      startDate: new Date('2026-09-12T21:00:00.000Z')
+    }, NEW_ACTION_ANALYSIS, adapter, { ai: {} });
+  } finally {
+    restore();
+  }
+  assert.equal(analyzed.shortName, 'BEEFMINCE', 'never ends on ": THE" — falls through to the brand');
+  assert.ok(lines.includes(`🏷️ SHORTNAME: salvaged "BEEFMINCE" from rejected answer for "${title}"`));
+});
+
+test('shortName gate: mid-word cut is not a verbatim substring', () => {
+  const core = createFinalBuildCore();
+  assert.equal(core.evaluateDerivedShortName('BEEFMINCE MEET MARKET', 'BEEF', 16).ok, false, 'mid-word cut rejected');
+  assert.equal(core.evaluateDerivedShortName('BEEFMINCE MEET MARKET', 'BEEFMINCE', 16).ok, true, 'word-aligned accepted');
 });


### PR DESCRIPTION
The broader half of the shortName story (curated registry shortNames for all 24 promoter entries went onto #1577): events the registry doesn't cover — venue one-offs, aggregator finds — now derive a display shortName from their title at final analyzed-event build.

## Design
- **Prompt** (new pass, passLabel `short-name`): title only — no dates/venue — so the AI response cache makes repeat runs free. Asks for ≤16 chars, uppercase preferred, verbatim from the title, hyphens allowed inside long words as line-break hints (the site's existing soft-hyphen chip convention).
- **Deterministic gate**: hyphen-stripped + case/diacritic-folded, the answer must be a **word-boundary-aligned contiguous substring** of the title. Case-lift and hyphen insertion allowed; invented words, reordering, and mid-word cuts structurally impossible.
- **Deterministic salvage** (no extra AI call): hyphens-as-spaces repaired first (`BEEFMINCE-X-RVT` → `BEEFMINCE X RVT`), then trailing-token dropping with punctuation stripping and a no-trailing-stopword guard (`BEEFMINCE: THE BIG BALL` → `BEEFMINCE`, never `BEEFMINCE: THE`).
- **Precedence**: registry stamp > parser static field > derivation; the pass only fires when shortName is absent. Any failure ships the event exactly as today.
- Config: default ON; `ai: { shortNames: false }` kill switch; `shortNameDeriveMaxChars` (16) separate from trim's 30. No scraper-input.js change needed.

## Live battery (Mac, report-only)
BEEFMINCE (13 events), Club Chub (5), CubScout: **13 sensible chip names stored** (`BEEFMINCE`, `BEEFMINCE X RVT`, `BEEFMINCE DISCO`, `CLUB CHUB` ×2, …), **0 hallucinations stored** — the gate killed `CLUB CHUB FT-LA` (invented abbreviation), `CLUB CHUB 2026` (merged non-contiguous words) and salvaged both to `CLUB CHUB`; equals-title answers (QUENCHD, BOATMINCE, SPOOKMINCE) correctly skip since the site already falls back to the title.

New log lines (additive only): `🏷️ SHORTNAME: derived/salvaged/rejected …`. Suite: **1052/1052**.

Runtime files touched: `scripts/shared-core.js` only (already in the updater list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP