### PR TITLE
feat(scraper): registry shortName fills (stranded by #1577's squash merge)

### DIFF
--- a/data/promoters.json
+++ b/data/promoters.json
@@ -105,11 +105,13 @@
   },
   {
     "name": "BEEFMINCE",
+    "shortName": "BEEF-MINCE",
     "website": "https://beefmince.com",
     "bearAffinity": "always"
   },
   {
     "name": "SPOOKMINCE",
+    "shortName": "SPOOK-MINCE",
     "parent": "BEEFMINCE",
     "keywords": [
       "spookmince"
@@ -118,6 +120,7 @@
   },
   {
     "name": "BOATMINCE",
+    "shortName": "BOAT-MINCE",
     "parent": "BEEFMINCE",
     "keywords": [
       "boatmince"
@@ -126,21 +129,25 @@
   },
   {
     "name": "BeefDip",
+    "shortName": "BEEF-DIP",
     "website": "https://beefdip.com",
     "bearAffinity": "always"
   },
   {
     "name": "Bear it MTL",
+    "shortName": "BEAR IT",
     "website": "https://www.bearitmtl.com",
     "bearAffinity": "always"
   },
   {
     "name": "Club Chub",
+    "shortName": "CLUB CHUB",
     "instagram": "https://www.instagram.com/clubchubparty",
     "bearAffinity": "always"
   },
   {
     "name": "Fat Dad",
+    "shortName": "FAT DAD",
     "instagram": "https://www.instagram.com/fatdadnyc",
     "website": "https://events.humanitix.com/fatdad",
     "urlPatterns": [
@@ -150,6 +157,7 @@
   },
   {
     "name": "Horse Meat Disco",
+    "shortName": "HORSE MEAT DISCO",
     "instagram": "https://www.instagram.com/horsemeatdisco",
     "website": "https://horsemeatdisco.net",
     "urlPatterns": [
@@ -159,6 +167,7 @@
   },
   {
     "name": "South Seattle Bear Social",
+    "shortName": "BEAR SOCIAL",
     "aliases": [
       "SSBS"
     ],
@@ -188,6 +197,7 @@
   },
   {
     "name": "Northeast Ursamen",
+    "shortName": "URSA-MEN",
     "aliases": [
       "NE Ursamen",
       "Ursamen",

--- a/scripts/scraper-promoters.js
+++ b/scripts/scraper-promoters.js
@@ -114,11 +114,13 @@ const scraperPromoters = [
   },
   {
     "name": "BEEFMINCE",
+    "shortName": "BEEF-MINCE",
     "website": "https://beefmince.com",
     "bearAffinity": "always"
   },
   {
     "name": "SPOOKMINCE",
+    "shortName": "SPOOK-MINCE",
     "parent": "BEEFMINCE",
     "keywords": [
       "spookmince"
@@ -127,6 +129,7 @@ const scraperPromoters = [
   },
   {
     "name": "BOATMINCE",
+    "shortName": "BOAT-MINCE",
     "parent": "BEEFMINCE",
     "keywords": [
       "boatmince"
@@ -135,21 +138,25 @@ const scraperPromoters = [
   },
   {
     "name": "BeefDip",
+    "shortName": "BEEF-DIP",
     "website": "https://beefdip.com",
     "bearAffinity": "always"
   },
   {
     "name": "Bear it MTL",
+    "shortName": "BEAR IT",
     "website": "https://www.bearitmtl.com",
     "bearAffinity": "always"
   },
   {
     "name": "Club Chub",
+    "shortName": "CLUB CHUB",
     "instagram": "https://www.instagram.com/clubchubparty",
     "bearAffinity": "always"
   },
   {
     "name": "Fat Dad",
+    "shortName": "FAT DAD",
     "instagram": "https://www.instagram.com/fatdadnyc",
     "website": "https://events.humanitix.com/fatdad",
     "urlPatterns": [
@@ -159,6 +166,7 @@ const scraperPromoters = [
   },
   {
     "name": "Horse Meat Disco",
+    "shortName": "HORSE MEAT DISCO",
     "instagram": "https://www.instagram.com/horsemeatdisco",
     "website": "https://horsemeatdisco.net",
     "urlPatterns": [
@@ -168,6 +176,7 @@ const scraperPromoters = [
   },
   {
     "name": "South Seattle Bear Social",
+    "shortName": "BEAR SOCIAL",
     "aliases": [
       "SSBS"
     ],
@@ -197,6 +206,7 @@ const scraperPromoters = [
   },
   {
     "name": "Northeast Ursamen",
+    "shortName": "URSA-MEN",
     "aliases": [
       "NE Ursamen",
       "Ursamen",


### PR DESCRIPTION
**Recovers a commit that got left behind.** I pushed the shortName fills to #1577's branch shortly before it was squash-merged, so only the first commit made it into main — `CubScout LA` got `CUB-SCOUT`, but the other ten entries stayed empty. This re-lands them on a fresh branch, unchanged.

Fills: `BEEF-MINCE`, `SPOOK-MINCE`, `BOAT-MINCE`, `BEEF-DIP`, `BEAR IT`, `CLUB CHUB`, `FAT DAD`, `HORSE MEAT DISCO`, `BEAR SOCIAL`, `URSA-MEN`. All 24 registry entries now carry a shortName; hyphens follow the site's soft-hyphen line-break convention.

**Live verification** (BEEFMINCE, report-only on rybook) — the whole chain works end to end:
```
🪪 PROMOTER REGISTRY: "BEEFMINCE x RVT" -> BEEFMINCE (evidence: title) stamped: shortName, url
```
and all 13 events land with `BEEF-MINCE` / `BOAT-MINCE` / `SPOOK-MINCE` on the analyzed events. Before this branch the same run stamped `url` only.

Suite: **1044/1044**. Data + generated twin only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP