### PR TITLE
feat(site): perceptual palette extraction (flyers + favicons) and display-side markup sanitising

### DIFF
--- a/data/bars/atlanta.json
+++ b/data/bars/atlanta.json
@@ -6,6 +6,10 @@
     "coordinates": "33.8115012, -84.3552779",
     "website": "https://hereticatlanta.com",
     "faviconBg": "#481818",
-    "faviconFg": "#a09f9f"
+    "faviconFg": "#a09f9f",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:38:0 #bdbdbc:16:0 #020101:14:1 #710403:5:14 #c10303:4:21",
+    "accent": "#c10303",
+    "faviconPlate": "#ffffff"
   }
 ]

--- a/data/bars/boston.json
+++ b/data/bars/boston.json
@@ -17,6 +17,10 @@
     "website": "https://legacybos.com",
     "instagram": "https://www.instagram.com/legacybos",
     "faviconBg": "#b47d04",
-    "faviconFg": "#c38703"
+    "faviconFg": "#c38703",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:81:0 #b57e02:9:13 #eaddc1:4:4 #cfae67:3:10 #c8a04b:2:11",
+    "accent": "#b57e02",
+    "faviconPlate": "#ffffff"
   }
 ]

--- a/data/bars/chicago.json
+++ b/data/bars/chicago.json
@@ -61,6 +61,10 @@
     "instagram": "https://www.instagram.com/metrochicago",
     "facebook": "https://www.facebook.com/MetroChicago",
     "faviconBg": "#e10c12",
-    "faviconFg": "#291716"
+    "faviconFg": "#291716",
+    "paletteSource": "favicon",
+    "palette": "#e50b11:57:23 #ffffff:22:0 #0c1514:15:1 #dd8889:2:11 #8f1214:2:16",
+    "accent": "#e50b11",
+    "faviconPlate": "#ffffff"
   }
 ]

--- a/data/bars/dallas.json
+++ b/data/bars/dallas.json
@@ -20,6 +20,9 @@
     "facebook": "https://www.facebook.com/lonestareagle",
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJU843NR6cToYROpJZCM8p4-I",
     "faviconBg": "#ffffff",
-    "faviconFg": "#fefefe"
+    "faviconFg": "#fefefe",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:100:0",
+    "faviconPlate": "#ffffff"
   }
 ]

--- a/data/bars/houston.json
+++ b/data/bars/houston.json
@@ -8,6 +8,10 @@
     "instagram": "https://www.instagram.com/richshtx",
     "facebook": "https://www.facebook.com/richshtx",
     "faviconBg": "#b89c52",
-    "faviconFg": "#caae62"
+    "faviconFg": "#caae62",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:78:0 #e5dabd:21:4 #ccb781:1:7",
+    "accent": "#ccb781",
+    "faviconPlate": "#ffffff"
   }
 ]

--- a/data/bars/nola.json
+++ b/data/bars/nola.json
@@ -6,6 +6,10 @@
     "coordinates": "29.9559524, -90.0738975",
     "website": "https://thejoytheater.com",
     "faviconBg": "#f22922",
-    "faviconFg": "#221e1f"
+    "faviconFg": "#221e1f",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:70:0 #ee2922:22:23 #fbd1cf:3:5 #f36863:2:17 #f8a4a1:2:10",
+    "accent": "#ee2922",
+    "faviconPlate": "#ffffff"
   }
 ]

--- a/data/bars/nyc.json
+++ b/data/bars/nyc.json
@@ -33,6 +33,9 @@
     "gayCities": "https://newyork.gaycities.com/bars/400-eagle-nyc",
     "faviconBg": "#f0f0f0",
     "faviconFg": "#565656",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:74:0 #656565:5:0 #8a8a8a:5:0",
+    "faviconPlate": "#ffffff",
     "gayCitiesLastScrapedAt": "2026-06-26T17:08:38.515Z",
     "wikipediaLastScrapedAt": "2026-06-26T15:16:42.784Z"
   },
@@ -48,6 +51,10 @@
     "gayCities": "https://newyork.gaycities.com/bars/309059-dollar-bill",
     "faviconBg": "#190832",
     "faviconFg": "#c5c5e9",
+    "paletteSource": "favicon",
+    "palette": "#000021:69:8 #eef3fe:7:2 #1633fd:7:29 #eb1c25:5:23 #953f71:4:13",
+    "accent": "#1633fd",
+    "faviconPlate": "#000021",
     "gayCitiesLastScrapedAt": "2026-06-14T16:38:18.601Z"
   },
   {
@@ -131,6 +138,10 @@
     "address": "270 Meserole Ave, Brooklyn, NY 11222",
     "website": "https://www.3dollarbillbk.com",
     "faviconBg": "#190832",
-    "faviconFg": "#c5c5e9"
+    "faviconFg": "#c5c5e9",
+    "paletteSource": "favicon",
+    "palette": "#000021:69:8 #eef3fe:7:2 #1633fd:7:29 #eb1c25:5:23 #953f71:4:13",
+    "accent": "#1633fd",
+    "faviconPlate": "#000021"
   }
 ]

--- a/data/bars/poconos.json
+++ b/data/bars/poconos.json
@@ -9,6 +9,10 @@
     "facebook": "https://www.facebook.com/campout.poconos",
     "googleMaps": "https://maps.app.goo.gl/LYwCKGeMJAJTy8hx9?g_st=ic",
     "faviconBg": "#f4f3ef",
-    "faviconFg": "#60514d"
+    "faviconFg": "#60514d",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:68:0 #000000:8:0 #b5b5b5:7:0 #405fad:6:13 #e84224:3:21",
+    "accent": "#e84224",
+    "faviconPlate": "#ffffff"
   }
 ]

--- a/data/bars/seattle.json
+++ b/data/bars/seattle.json
@@ -10,6 +10,10 @@
     "gayCities": "https://seattle.gaycities.com/bars/302690-diesel",
     "faviconBg": "#335a91",
     "faviconFg": "#c3cbd4",
+    "paletteSource": "favicon",
+    "palette": "#003a73:28:11 #3a63bd:24:15 #ffffff:19:0 #009999:3:11",
+    "accent": "#3a63bd",
+    "faviconPlate": "#3a63bd",
     "gayCitiesLastScrapedAt": "2026-06-26T17:08:40.863Z",
     "wikipediaLastScrapedAt": "2026-06-26T15:16:42.812Z"
   },
@@ -43,6 +47,10 @@
     "gayCities": "https://seattle.gaycities.com/bars/506-seattle-eagle",
     "faviconBg": "#20201f",
     "faviconFg": "#8a836c",
+    "paletteSource": "favicon",
+    "palette": "#1a1a1a:68:0 #ada283:8:4 #7f7864:7:3 #e2d7b0:5:5",
+    "accent": "#e2d7b0",
+    "faviconPlate": "#1a1a1a",
     "gayCitiesLastScrapedAt": "2026-06-26T17:08:43.316Z",
     "wikipediaLastScrapedAt": "2026-06-26T15:16:42.842Z"
   },
@@ -85,6 +93,9 @@
     "gayCities": "https://seattle.gaycities.com/bars/511-massive-nightclub",
     "faviconBg": "#010102",
     "faviconFg": "#535557",
+    "paletteSource": "favicon",
+    "palette": "#000000:91:0 #6f6564:2:1 #838682:1:1",
+    "faviconPlate": "#010101",
     "gayCitiesLastScrapedAt": "2026-07-22T18:31:06.867Z"
   }
 ]

--- a/data/bars/sf.json
+++ b/data/bars/sf.json
@@ -58,6 +58,10 @@
     "coordinates": "37.7688931, -122.4192651",
     "website": "https://publicsf.com",
     "faviconBg": "#f35425",
-    "faviconFg": "#fd5825"
+    "faviconFg": "#fd5825",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:74:0 #f15323:22:20 #f79a80:3:12 #f9b5a2:1:8",
+    "accent": "#f15323",
+    "faviconPlate": "#ffffff"
   }
 ]

--- a/data/bars/torremolinos.json
+++ b/data/bars/torremolinos.json
@@ -7,6 +7,9 @@
     "website": "https://aquatorremolinos.com",
     "instagram": "https://www.instagram.com/aquatorremolinos",
     "faviconBg": "#4f4d4c",
-    "faviconFg": "#e5e4e4"
+    "faviconFg": "#e5e4e4",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:45:0 #494645:39:0 #dddcdc:6:0",
+    "faviconPlate": "#ffffff"
   }
 ]

--- a/data/event-colors/atlanta.json
+++ b/data/event-colors/atlanta.json
@@ -3,25 +3,40 @@
     "slug": "bearracuda-atlanta-16-year-anniversary-520590b4",
     "url": "https://www.eventbrite.com/e/bearracuda-atlanta-16-year-anniversary-tickets-1364601091599",
     "faviconBg": "#ff5e30",
-    "faviconFg": "#ff6333"
+    "faviconFg": "#ff6333",
+    "paletteSource": "flyer",
+    "palette": "#85634b:17:6 #5b4a3c:16:3 #c7b084:15:6 #ad8a6d:15:6",
+    "accent": "#c7b084"
   },
   {
     "slug": "bearracuda-atlanta-17-year-anniversary-6e646344",
     "url": "https://bearracuda.com/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#6abbda:22:9 #c3ccd4:19:1 #6a8eca:18:10 #be9383:12:6 #73e5cc:1:11",
+    "accent": "#6a8eca"
   },
   {
     "slug": "bearracuda-atlanta-bear-pride-2026-3ac2015f",
     "url": "https://bearracuda.com/events/atlantabearpride/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#faf9f6:27:0 #ff5b1e:14:21 #eda761:13:12 #ab7a66:12:7 #76513e:12:6",
+    "accent": "#ff5b1e"
   },
   {
     "slug": "bearracuda-atlanta-bulges-jocks-4b843b95",
     "url": "https://bearracuda.com/events/atlbulge/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#23242c:19:1 #66575a:17:2 #3c3c42:17:1 #a37265:14:7 #efb954:6:13",
+    "accent": "#efb954"
   },
   {
     "slug": "megawoof-1e891b28",
@@ -33,6 +48,10 @@
     "slug": "new-date-bearracuda-atlantawinter-beef-ball-jock-underwear-pa-rty-3d2076fd",
     "url": "https://bearracuda.com/events/atlbulge/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#3b2423:18:4 #5b3b3c:16:5 #7c5454:13:5 #a96f6a:13:7 #e5b4ac:10:6",
+    "accent": "#a96f6a"
   }
 ]

--- a/data/event-colors/boston.json
+++ b/data/event-colors/boston.json
@@ -3,6 +3,10 @@
     "slug": "furball-boston-003b3ace",
     "url": "https://www.furball.nyc",
     "faviconBg": "#2d2c32",
-    "faviconFg": "#f7f7f7"
+    "faviconFg": "#f7f7f7",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#020101:27:1 #130401:20:3 #db8c64:13:11 #a35b3a:12:10 #f4cb5b:5:14",
+    "accent": "#db8c64"
   }
 ]

--- a/data/event-colors/chicago.json
+++ b/data/event-colors/chicago.json
@@ -3,37 +3,60 @@
     "slug": "bear-happy-hour-50e80e42",
     "url": "https://linktr.ee/bearhappyhour",
     "faviconBg": "#fbfbf9",
-    "faviconFg": "#6b6661"
+    "faviconFg": "#6a6661",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:78:0 #010101:5:0 #cdcecf:5:0 #f6e529:1:18 #f2592a:1:20",
+    "accent": "#f2592a"
   },
   {
     "slug": "bearracuda-chicago-jockstrap-party-tix-at-the-door-17cea9ba",
     "url": "https://bearracuda.com/events/chicagoaug/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#13122b:42:5 #591f4f:22:11 #bd317a:11:19 #3feb4b:3:24 #abfa4d:2:21",
+    "accent": "#bd317a"
   },
   {
     "slug": "belly-up-3e6c6e9e",
     "url": "https://jackhammerchicago.com/belly-up",
     "faviconBg": "#0b0b0b",
-    "faviconFg": "#f6f6f6"
+    "faviconFg": "#f6f6f6",
+    "faviconPlate": "#000000",
+    "paletteSource": "favicon",
+    "palette": "#000000:47:0 #ffffff:46:0 #d4d4d4:2:0"
   },
   {
     "slug": "chunk-chicago-presents-sausage-party-55be49fe",
     "url": "https://www.chunk-party.com/event-details/chunk-chicago-presents-sausage-party",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#23232d:45:2 #443b44:34:2 #0a0b0b:9:0 #6d5da6:4:11 #c47092:3:11",
+    "accent": "#6d5da6"
   },
   {
     "slug": "chunk-chicago-presents-spring-thaw-572f1025",
     "url": "https://www.chunk-party.com/event-details/chunk-chicago-presents-spring-thaw",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#d5abe7:40:9 #9454c1:16:17 #b37bd4:15:14 #7132a7:14:18 #471a7f:6:16",
+    "accent": "#7132a7"
   },
   {
     "slug": "chunk-chicago-september-19th-7764acee",
     "url": "https://www.chunk-party.com",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#6c615f:20:1 #1c1b1b:14:0 #dbada2:14:6 #b48275:14:7 #ddef21:4:20",
+    "accent": "#b48275"
   },
   {
     "slug": "chunka-go-7764acee",
@@ -48,46 +71,77 @@
     "faviconFg": "#ff6333"
   },
   {
+    "slug": "coach-after-dark-chicago-78fe7aea",
+    "paletteSource": "flyer",
+    "palette": "#ffffff:57:0 #eaa9a9:11:8 #ff002b:10:26 #c98c75:9:8 #966b54:7:7",
+    "accent": "#ff002b"
+  },
+  {
     "slug": "coach-after-dark-market-days-1945e994",
     "url": "https://www.eventbrite.com/o/bear-happy-hour-87043830313",
     "faviconBg": "#ff5e30",
-    "faviconFg": "#ff6333"
+    "faviconFg": "#ff6333",
+    "paletteSource": "flyer",
+    "palette": "#ffffff:55:0 #e89883:11:10 #b47365:10:9 #7b4b44:9:7 #ea2837:9:22",
+    "accent": "#ea2837"
   },
   {
     "slug": "furball-chicago-market-days-4ca14ebb",
     "url": "https://www.furball.nyc",
-    "faviconBg": "#302f35",
-    "faviconFg": "#f8f8f8"
+    "faviconBg": "#2d2c32",
+    "faviconFg": "#f7f7f7",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#020403:23:1 #1c1322:18:3 #b36364:13:10 #212255:11:9 #6b497b:10:9",
+    "accent": "#b36364"
   },
   {
     "slug": "furball-market-days-78310803",
     "url": "https://www.furball.nyc/",
-    "faviconBg": "#302f35",
-    "faviconFg": "#f8f8f8"
+    "faviconBg": "#2d2c32",
+    "faviconFg": "#f7f7f7",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "favicon",
+    "palette": "#25242b:46:1 #fefefe:45:0 #131216:3:1"
   },
   {
     "slug": "goldiloxx-chicago-nycs-interactive-nightlife-experience-at-jackh-ammer-7c2b222b",
     "url": "https://sickening.events/e/goldiloxx-chicago",
     "faviconBg": "#333333",
-    "faviconFg": "#a0a0a0"
+    "faviconFg": "#a0a0a0",
+    "paletteSource": "flyer",
+    "palette": "#1a0e12:19:2 #6d4443:15:6 #432629:15:4 #b99483:14:5 #d54721:6:18",
+    "accent": "#d54721"
   },
   {
     "slug": "market-day-1-35c3f1a2",
     "url": "https://northalsted.com/main-events/northalsted-market-days/",
     "faviconBg": "#477789",
-    "faviconFg": "#ee791b"
+    "faviconFg": "#ef791b",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:54:0 #1476c0:8:14 #f76021:8:20 #52ba3e:7:19 #e62b29:6:22",
+    "accent": "#e62b29"
   },
   {
     "slug": "market-day-2-115ee9f1",
     "url": "https://northalsted.com/main-events/northalsted-market-days/",
     "faviconBg": "#477789",
-    "faviconFg": "#ee791b"
+    "faviconFg": "#ef791b",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:54:0 #1476c0:8:14 #f76021:8:20 #52ba3e:7:19 #e62b29:6:22",
+    "accent": "#e62b29"
   },
   {
     "slug": "market-day-3-691a9a51",
     "url": "https://northalsted.com/main-events/northalsted-market-days/",
     "faviconBg": "#477789",
-    "faviconFg": "#ee791b"
+    "faviconFg": "#ef791b",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:54:0 #1476c0:8:14 #f76021:8:20 #52ba3e:7:19 #e62b29:6:22",
+    "accent": "#e62b29"
   },
   {
     "slug": "megawoof-15dc597c",
@@ -99,13 +153,21 @@
     "slug": "megawoof-chicago-july-bearwatch-7afede0c",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#ab865a:25:8 #864c3b:19:8 #422924:13:4 #f1592a:11:20 #ddf60d:2:21",
+    "accent": "#f1592a"
   },
   {
     "slug": "treasure-trail-chicago-2519d1b9",
     "url": "https://bearracuda.com/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#ec1414:34:24 #e2e2e2:15:0 #2c2424:13:1 #6c1c1c:10:11 #976767:7:6",
+    "accent": "#ec1414"
   },
   {
     "slug": "treasure-trail-chicago-launch-party-2519d1b9",

--- a/data/event-colors/dallas.json
+++ b/data/event-colors/dallas.json
@@ -2,7 +2,11 @@
   {
     "slug": "furball-442f8415",
     "url": "https://www.furball.nyc",
-    "faviconBg": "#302f35",
-    "faviconFg": "#f8f8f8"
+    "faviconBg": "#2d2c32",
+    "faviconFg": "#f7f7f7",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#130b2b:33:6 #010101:29:1 #3e2845:13:6 #93252e:7:15 #6c5c7c:7:5",
+    "accent": "#93252e"
   }
 ]

--- a/data/event-colors/dc.json
+++ b/data/event-colors/dc.json
@@ -3,6 +3,10 @@
     "slug": "megawoof-5e604137",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#05091c:22:4 #4a1cb2:21:21 #23096c:14:15 #c143d3:12:23 #01f62d:7:28",
+    "accent": "#4a1cb2"
   }
 ]

--- a/data/event-colors/denver.json
+++ b/data/event-colors/denver.json
@@ -3,25 +3,41 @@
     "slug": "bearracuda-0f2c13d7",
     "url": "https://bearracuda.com/events/denverpride/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#1c122a:24:5 #39285c:21:9 #4840c7:12:20 #7c4363:11:9 #d352c8:7:21",
+    "accent": "#4840c7"
   },
   {
     "slug": "denver-39553322",
     "url": "https://bearracuda.com/events/denverjockstrap/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#2a1e20:22:2 #d43332:14:20 #b48b84:14:5 #832b25:10:12 #ddb99f:10:5",
+    "accent": "#d43332"
   },
   {
     "slug": "denver-42126767",
     "url": "https://bearracuda.com/events/denvermarch/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "favicon",
+    "palette": "#ff3c00:72:24 #fffefe:27:0 #ff9f81:1:12",
+    "accent": "#ff3c00"
   },
   {
     "slug": "denver-pride-2021bba4",
     "url": "https://bearracuda.com/events/denverpride26/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#6c5653:18:3 #0a0d0c:17:0 #3b3c44:17:1 #a36e60:15:7",
+    "accent": "#a36e60"
   },
   {
     "slug": "denverpride-2021bba4",
@@ -33,6 +49,15 @@
     "slug": "megawoof-37fcce1a",
     "url": "https://www.eventbrite.com/e/megawoof-america-denver-massive-2-parties-1-ticket-tickets-1381219547849",
     "faviconBg": "#ff5e30",
-    "faviconFg": "#ff6333"
+    "faviconFg": "#ff6333",
+    "paletteSource": "flyer",
+    "palette": "#120c0a:31:1 #2b1b1c:17:3 #4b2e20:15:5 #88301c:11:12 #e37335:8:16",
+    "accent": "#e37335"
+  },
+  {
+    "slug": "twisted-bear-denver-feat-djproducer-matt-consola-0fcf1526",
+    "paletteSource": "flyer",
+    "palette": "#0a0e11:55:1 #362a31:11:2 #ccb9b2:9:2 #ca332c:4:19",
+    "accent": "#ca332c"
   }
 ]

--- a/data/event-colors/festivals.json
+++ b/data/event-colors/festivals.json
@@ -3,31 +3,51 @@
     "slug": "amsterdam-bear-pride-21e45576",
     "url": "https://amsterdambearpride.com/en/",
     "faviconBg": "#121110",
-    "faviconFg": "#968f84"
+    "faviconFg": "#968f84",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:43:0 #0c0c0c:40:0 #acacac:5:0 #d76717:1:16",
+    "accent": "#d76717"
   },
   {
     "slug": "bangkok-songkran-bear-week-2313c0b7",
     "url": "https://www.gaytravel4u.com/event/bangkok-songkran-bear-week/",
     "faviconBg": "#4d5d76",
-    "faviconFg": "#f1831b"
+    "faviconFg": "#f1831b",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:67:0 #fed109:7:18 #ec3e3d:6:21 #204fa1:6:14 #79bf60:4:15",
+    "accent": "#ec3e3d"
   },
   {
     "slug": "bear-carnival-63ef39d1",
     "url": "https://bearcarnival.com/",
     "faviconBg": "#6a432a",
-    "faviconFg": "#e18f46"
+    "faviconFg": "#e18f46",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:56:0 #9a4e2d:10:11 #5b3324:9:6 #ff6131:7:20 #f6bb07:4:17",
+    "accent": "#ff6131"
   },
   {
     "slug": "bear-festival-milano-04aae1fe",
     "url": "https://www.bearfestivalmilano.it/en",
     "faviconBg": "#eac687",
-    "faviconFg": "#855724"
+    "faviconFg": "#855724",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:32:0 #f5d69f:23:8 #e4b863:14:12 #c08b3d:10:11 #985f21:9:11",
+    "accent": "#e4b863"
   },
   {
     "slug": "bear-jamboree-2d6fa172",
     "url": "https://www.bearjamboree.com/",
     "faviconBg": "#a44e04",
-    "faviconFg": "#522702"
+    "faviconFg": "#522702",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:43:0 #8f4201:27:12 #2f1a01:9:5 #b75d04:8:14 #fbe313:1:19",
+    "accent": "#8f4201"
   },
   {
     "slug": "bear-week-provincetown-5317e10e",
@@ -39,84 +59,133 @@
     "slug": "bears-sitges-week-1f250382",
     "url": "https://bearssitges.org/",
     "faviconBg": "#a47a38",
-    "faviconFg": "#395071"
+    "faviconFg": "#395071",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#faf8f6:34:0 #895927:15:9 #bb8446:14:10 #35589f:11:12 #e5da62:4:14",
+    "accent": "#35589f"
   },
   {
     "slug": "beefdip-bear-week-798cbdad",
     "url": "https://beefdip.com/planned-events/",
     "faviconBg": "#e30309",
-    "faviconFg": "#fde524"
+    "faviconFg": "#fde524",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:53:0 #df0209:23:23 #fde224:19:18 #fef4ba:1:7 #e94e4f:1:19",
+    "accent": "#df0209"
   },
   {
     "slug": "fire-island-bear-weekend-4919c361",
     "url": "https://www.theurbanbear.com/fibw",
     "faviconBg": "#141414",
-    "faviconFg": "#dcdcdc"
+    "faviconFg": "#dcdcdc",
+    "faviconPlate": "#000000",
+    "paletteSource": "favicon",
+    "palette": "#000000:54:0 #ffffff:27:0 #d9d9d9:5:0"
   },
   {
     "slug": "folsom-europe-150cffc7",
     "url": "https://folsomeurope.berlin/",
     "faviconBg": "#0b0303",
-    "faviconFg": "#46afe5"
+    "faviconFg": "#46afe5",
+    "faviconPlate": "#000000",
+    "paletteSource": "favicon",
+    "palette": "#000000:60:0 #0098e5:25:15 #ffffff:10:0 #ff0000:2:26",
+    "accent": "#0098e5"
   },
   {
     "slug": "folsom-street-fair-365e5841",
     "url": "https://www.folsomstreet.org/",
     "faviconBg": "#040404",
-    "faviconFg": "#e8e8e8"
+    "faviconFg": "#e8e8e8",
+    "faviconPlate": "#000000",
+    "paletteSource": "favicon",
+    "palette": "#000000:66:0 #ffffff:27:0 #a3a3a3:3:0"
   },
   {
     "slug": "international-bear-convergence-ibc-78757530",
     "url": "https://www.ibc-ps.com/",
     "faviconBg": "#474747",
-    "faviconFg": "#767676"
+    "faviconFg": "#767676",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#545454:33:0 #3a3a3a:30:0 #787878:17:0"
   },
   {
     "slug": "international-mr-leather-iml-0c6aa2b2",
     "url": "https://www.internationalmrleather.com/",
     "faviconBg": "#efefef",
-    "faviconFg": "#414141"
+    "faviconFg": "#414141",
+    "faviconPlate": "#fefefe",
+    "paletteSource": "favicon",
+    "palette": "#fefefe:60:0 #010101:8:0 #e3e3e3:7:0"
   },
   {
     "slug": "lazy-bear-week-129a529c",
     "url": "https://www.lazybearfund.org/events",
     "faviconBg": "#fc6024",
-    "faviconFg": "#fd6224"
+    "faviconFg": "#fd6224",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#fc6124:61:20 #ffffff:35:0 #fd9b74:3:13 #fec8b2:1:7",
+    "accent": "#fc6124"
   },
   {
     "slug": "madbear-madrid-79bce561",
     "url": "https://madbear.org/en",
     "faviconBg": "#d12a26",
-    "faviconFg": "#dc6a25"
+    "faviconFg": "#dc6a25",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:63:0 #cb2026:26:20 #eaaf6c:4:11 #db713d:2:15 #d45228:2:17",
+    "accent": "#cb2026"
   },
   {
     "slug": "mid-atlantic-leather-weekend-mal-65bd7b22",
     "url": "https://www.leatherweekend.org/",
     "faviconBg": "#474747",
-    "faviconFg": "#767676"
+    "faviconFg": "#767676",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#545454:33:0 #3a3a3a:30:0 #787878:17:0"
   },
   {
     "slug": "rome-bears-week-783b3a40",
     "url": "https://www.gaytravel4u.com/event/rome-bears-week/",
     "faviconBg": "#4d5d76",
-    "faviconFg": "#f1831b"
+    "faviconFg": "#f1831b",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:67:0 #fed109:7:18 #ec3e3d:6:21 #204fa1:6:14 #79bf60:4:15",
+    "accent": "#ec3e3d"
   },
   {
     "slug": "southern-decadence-2124d6b9",
     "url": "https://www.southerndecadence.com/",
     "faviconBg": "#253a89",
-    "faviconFg": "#db2332"
+    "faviconFg": "#db2332",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#2c4893:35:13 #ffffff:23:0 #e5222d:22:22 #8f3c71:7:13 #6176ae:4:9",
+    "accent": "#e5222d"
   },
   {
     "slug": "sugar-bear-festival-745a4e20",
     "url": "https://www.bearitmtl.com/",
     "faviconBg": "#1a1a1a",
-    "faviconFg": "#d1d1d1"
+    "faviconFg": "#d1d1d1",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#000000:41:0 #ffffff:41:0 #aaaaaa:4:0"
   },
   {
     "slug": "urban-bear-nyc-68133b4a",
     "url": "https://www.theurbanbear.com/urbanbearnyc",
     "faviconBg": "#141414",
-    "faviconFg": "#dcdcdc"
+    "faviconFg": "#dcdcdc",
+    "faviconPlate": "#000000",
+    "paletteSource": "favicon",
+    "palette": "#000000:54:0 #ffffff:27:0 #d9d9d9:5:0"
   }
 ]

--- a/data/event-colors/la.json
+++ b/data/event-colors/la.json
@@ -3,19 +3,31 @@
     "slug": "bear-happy-hour-67a26f5d",
     "url": "https://linktr.ee/bearhappyhour",
     "faviconBg": "#fbfbf9",
-    "faviconFg": "#6b6661"
+    "faviconFg": "#6a6661",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:78:0 #010101:5:0 #cdcecf:5:0 #f6e529:1:18 #f2592a:1:20",
+    "accent": "#f2592a"
   },
   {
     "slug": "duro-is-back-new-outdoor-location-night-foam-party-and-special-guest-5bba8406",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#010103:71:1 #42262a:7:4 #a52401:6:17 #e45312:6:19 #517e9a:2:7",
+    "accent": "#e45312"
   },
   {
     "slug": "megawoof-33341c08",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#0a041b:57:5 #251343:12:9 #234284:8:12 #5b2597:6:17 #7f77c0:5:11",
+    "accent": "#5b2597"
   },
   {
     "slug": "megawoof-38282c01",
@@ -33,24 +45,38 @@
     "slug": "megawoof-6062add7",
     "url": "https://www.eventbrite.com/e/megawoof-america-bear-watchers-long-beach-tickets-1520432868639",
     "faviconBg": "#ff5e30",
-    "faviconFg": "#ff6333"
+    "faviconFg": "#ff6333",
+    "paletteSource": "flyer",
+    "palette": "#ec8343:22:15 #8a4332:16:10 #ae6a45:15:10 #db461d:13:19 #f7e464:5:15",
+    "accent": "#db461d"
   },
   {
     "slug": "megawoof-69e037bc",
     "url": "https://www.eventbrite.com/e/duro-summer-night-foam-edition-tickets-1446957562019",
     "faviconBg": "#ff5e30",
-    "faviconFg": "#ff6333"
+    "faviconFg": "#ff6333",
+    "paletteSource": "flyer",
+    "palette": "#020a05:41:2 #43754c:15:8 #234a1c:14:9 #122a0b:11:6 #d8f3c6:7:7",
+    "accent": "#43754c"
   },
   {
     "slug": "megawoof-america-long-beach-pride-152ddd6b",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#0a060c:34:2 #2c1d29:19:3 #4d3a3c:18:3 #8a5b4c:13:7 #c58a75:9:8",
+    "accent": "#c58a75"
   },
   {
     "slug": "megawoof-pride-free-june-6th-free-tkts-the-globe-0bb27076",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#131b24:51:2 #3b3d3b:16:0 #62575b:12:2 #9d7657:9:7 #e34367:2:20",
+    "accent": "#e34367"
   }
 ]

--- a/data/event-colors/london.json
+++ b/data/event-colors/london.json
@@ -3,36 +3,59 @@
     "slug": "beefmince-trunk-den-037f084d",
     "url": "https://beefmince.com",
     "faviconBg": "#060606",
-    "faviconFg": "#131313"
+    "faviconFg": "#131313",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#f1eee9:25:1 #114e5b:16:6 #82543c:16:7 #358fa3:13:9 #b2846c:11:7",
+    "accent": "#358fa3"
   },
   {
     "slug": "beefmince-x-rvt-174c5642",
     "url": "https://beefmince.com",
     "faviconBg": "#060606",
-    "faviconFg": "#131313"
+    "faviconFg": "#131313",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#282829:36:0 #3b33d4:35:23 #2a5bf3:12:23 #34297b:4:13 #9fa4db:2:8",
+    "accent": "#3b33d4"
   },
   {
     "slug": "beefmince-x-rvt-1d5ae452",
     "url": "https://beefmince.com",
     "faviconBg": "#060606",
-    "faviconFg": "#131313"
+    "faviconFg": "#131313",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#282829:36:0 #3b33d4:35:23 #2a5bf3:12:23 #34297b:4:13 #9fa4db:2:8",
+    "accent": "#3b33d4"
   },
   {
     "slug": "beefmince-x-rvt-70234e1a",
     "url": "https://beefmince.com",
     "faviconBg": "#060606",
-    "faviconFg": "#131313"
+    "faviconFg": "#131313",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#282829:36:0 #3b33d4:35:23 #2a5bf3:12:23 #34297b:4:13 #9fa4db:2:8",
+    "accent": "#3b33d4"
   },
   {
     "slug": "boatmince-61f25b7e",
     "url": "https://beefmince.com",
     "faviconBg": "#060606",
-    "faviconFg": "#131313"
+    "faviconFg": "#131313",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#1ac1e6:53:13 #292826:23:0 #236bf5:12:22 #13829d:2:10 #1e4d61:1:6",
+    "accent": "#1ac1e6"
   },
   {
     "slug": "twisted-bear-london-the-return-5fafb1d5",
     "url": "https://www.eventbrite.com/e/twisted-bear-london-the-return-tickets-1992217564364",
     "faviconBg": "#ff5e30",
-    "faviconFg": "#ff6333"
+    "faviconFg": "#ff6333",
+    "paletteSource": "flyer",
+    "palette": "#0d100e:43:1 #342c2c:15:1 #5c4a43:9:3 #b59484:9:5 #8c665d:9:5",
+    "accent": "#8c665d"
   }
 ]

--- a/data/event-colors/nola.json
+++ b/data/event-colors/nola.json
@@ -3,7 +3,11 @@
     "slug": "bearracuda-new-orleans-578ac888",
     "url": "https://bearracuda.com/events/decadence/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#5c2b5f:37:10 #221424:14:4 #a8af25:12:15 #714753:10:6 #947b22:7:11",
+    "accent": "#5c2b5f"
   },
   {
     "slug": "new-orleans-578ac888",
@@ -15,6 +19,10 @@
     "slug": "new-orleans-605b589e",
     "url": "https://bearracuda.com/events/new-orleans/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#623a2e:15:6 #1d1212:15:2 #3e221c:14:4 #8e5542:14:8 #bc826d:10:8",
+    "accent": "#8e5542"
   }
 ]

--- a/data/event-colors/nyc.json
+++ b/data/event-colors/nyc.json
@@ -3,43 +3,75 @@
     "slug": "bear-happy-hour-66e240de",
     "url": "https://linktr.ee/bearhappyhour",
     "faviconBg": "#fbfbf9",
-    "faviconFg": "#6b6661"
+    "faviconFg": "#6a6661",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:78:0 #010101:5:0 #cdcecf:5:0 #f6e529:1:18 #f2592a:1:20",
+    "accent": "#f2592a"
   },
   {
     "slug": "bears-are-animals-4cf796ee",
     "url": "https://animal.nyc",
     "faviconBg": "#e51a1a",
-    "faviconFg": "#f31c1c"
+    "faviconFg": "#f31c1c",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:61:0 #e51a1a:36:23 #f8bdbd:2:7 #f39393:1:12 #ef7272:1:15",
+    "accent": "#e51a1a"
   },
   {
     "slug": "bears-night-out-3d00f897",
     "url": "https://www.theurbanbear.com/",
     "faviconBg": "#141414",
-    "faviconFg": "#dcdcdc"
+    "faviconFg": "#dcdcdc",
+    "faviconPlate": "#000000",
+    "paletteSource": "favicon",
+    "palette": "#000000:54:0 #ffffff:27:0 #d9d9d9:5:0"
   },
   {
     "slug": "beer-blast-15963ca2",
     "url": "https://eagle-ny.com",
     "faviconBg": "#f0f0f0",
-    "faviconFg": "#565656"
+    "faviconFg": "#565656",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:74:0 #656565:5:0 #8a8a8a:5:0"
+  },
+  {
+    "slug": "chunk-brooklyn-59-7ffcc74a",
+    "paletteSource": "flyer",
+    "palette": "#442c43:17:5 #130c24:17:5 #8c534b:13:8 #c38363:10:9 #455384:9:8",
+    "accent": "#c38363"
   },
   {
     "slug": "chunk-brooklyn-74-31b4fb03",
     "url": "https://www.chunk-party.com",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#c2a4e4:29:10 #a45ac3:20:17 #623baa:18:17 #2b147c:15:16 #89d242:3:19",
+    "accent": "#a45ac3"
   },
   {
     "slug": "chunk-brooklyn-the-return-5dd73bae",
     "url": "https://www.chunk-party.com/event-details/chunk-brooklyn-the-return",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#ebe49c:24:9 #d3c593:15:7 #b2a489:14:4 #6b4492:11:13 #44356b:7:9",
+    "accent": "#6b4492"
   },
   {
     "slug": "fuzzy-0380f9f1",
     "url": "https://fuzzy.nyc/",
     "faviconBg": "#e69dc7",
-    "faviconFg": "#140b10"
+    "faviconFg": "#140b10",
+    "faviconPlate": "#eba1cc",
+    "paletteSource": "favicon",
+    "palette": "#ea9eca:70:11 #020202:18:0 #c38cab:3:8 #95687f:2:7 #633d54:2:6",
+    "accent": "#ea9eca"
   },
   {
     "slug": "fuzzy-2-1d2fb8ea",
@@ -48,15 +80,29 @@
     "faviconFg": "#140b10"
   },
   {
+    "slug": "goldiloxx-mdw-43e392ec",
+    "paletteSource": "flyer",
+    "palette": "#2b2324:21:1 #130f10:17:1 #c59066:15:9 #965a3c:14:9 #eecc0d:4:17",
+    "accent": "#eecc0d"
+  },
+  {
     "slug": "megawoof-bearmilk-present-megamilk-42f507f5",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#03030b:20:2 #1b1c34:17:4 #493449:14:5 #895f6b:14:6 #3f41a8:5:16",
+    "accent": "#3f41a8"
   },
   {
     "slug": "underbear-leather-kink-3fe96ee0",
     "url": "https://www.furball.nyc",
-    "faviconBg": "#302f35",
-    "faviconFg": "#f8f8f8"
+    "faviconBg": "#2d2c32",
+    "faviconFg": "#f7f7f7",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#000001:26:1 #2c0c11:17:5 #030a34:15:8 #6c2522:10:10 #0b1167:6:14",
+    "accent": "#0b1167"
   }
 ]

--- a/data/event-colors/palm-springs.json
+++ b/data/event-colors/palm-springs.json
@@ -3,6 +3,10 @@
     "slug": "megawoof-22570191",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#0b1c2c:20:4 #030a14:17:3 #50b167:16:14 #2d753b:13:12 #82f38b:10:18",
+    "accent": "#82f38b"
   }
 ]

--- a/data/event-colors/philly.json
+++ b/data/event-colors/philly.json
@@ -3,18 +3,36 @@
     "slug": "cubhouse-philly-halloween-dance-party-7f59fc8c",
     "url": "https://linktr.ee/cubhouse",
     "faviconBg": "#fbd21b",
-    "faviconFg": "#b46f7b"
+    "faviconFg": "#b46f7a",
+    "faviconPlate": "#fed317",
+    "paletteSource": "flyer",
+    "palette": "#b90528:37:20 #624c54:13:3 #432c33:12:4",
+    "accent": "#b90528"
+  },
+  {
+    "slug": "cubhouse-philly-pride-2026-kickoff-dance-party-242e4df9",
+    "paletteSource": "flyer",
+    "palette": "#e44ba2:41:21 #efb6e9:21:9 #ec8cd5:10:15 #c72e7e:7:20 #6d0823:5:13",
+    "accent": "#e44ba2"
   },
   {
     "slug": "cubhouse-philly-summer-dance-party-0a3049d0",
     "url": "https://linktr.ee/cubhouse",
     "faviconBg": "#fbd21b",
-    "faviconFg": "#b46f7a"
+    "faviconFg": "#b46f7a",
+    "faviconPlate": "#fed317",
+    "paletteSource": "flyer",
+    "palette": "#000000:63:0 #141414:10:0 #638a65:7:7 #d6b89b:5:5 #e0849f:5:12",
+    "accent": "#e0849f"
   },
   {
     "slug": "cubhouse-philly-valentines-dance-party-33f308ba",
     "url": "https://linktr.ee/cubhouse",
     "faviconBg": "#fbd21b",
-    "faviconFg": "#b46f7b"
+    "faviconFg": "#b46f7a",
+    "faviconPlate": "#fed317",
+    "paletteSource": "flyer",
+    "palette": "#f5324d:38:23 #f6e1d6:16:3 #ff7265:13:17 #ffa323:9:17 #732325:7:11",
+    "accent": "#f5324d"
   }
 ]

--- a/data/event-colors/phoenix.json
+++ b/data/event-colors/phoenix.json
@@ -3,18 +3,30 @@
     "slug": "bearracuda-phoenix-relaunch-party-320faa75",
     "url": "https://bearracuda.com/events/phoenix/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#1c1412:40:1 #322521:19:2 #c38265:9:9 #8c6248:9:7 #75321f:7:10",
+    "accent": "#c38265"
   },
   {
     "slug": "megawoof-2f8a9cb8",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#13151c:38:1 #3a2a2a:20:2 #952a1a:12:15 #cb5730:11:16 #f4f53c:1:19",
+    "accent": "#cb5730"
   },
   {
     "slug": "megawoof-america-phoenix-summer-woofers-007d0b12",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#c85a5b:14:14 #3c292a:14:3 #ddb5b4:14:5 #7b2d23:12:11",
+    "accent": "#c85a5b"
   }
 ]

--- a/data/event-colors/portland.json
+++ b/data/event-colors/portland.json
@@ -3,19 +3,31 @@
     "slug": "bearracuda-portland-16-year-anniversary-21be21f0",
     "url": "https://bearracuda.com/events/pdx16/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#eec424:22:16 #0a0503:20:1 #2b1c13:13:3 #8c6642:10:7 #c29513:9:14",
+    "accent": "#eec424"
   },
   {
     "slug": "bearracuda-portland-boner-garage-3e1b185e",
     "url": "https://bearracuda.com/events/portland-gear/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#4c2c23:18:5 #130503:17:3 #2b1b14:15:3 #8d644c:12:6 #e5be85:8:9",
+    "accent": "#e5be85"
   },
   {
     "slug": "bearracuda-portland-crotch-carnival-553c66fc",
     "url": "https://bearracuda.com/events/portlandfeb/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#84454c:16:9 #bd6557:15:12 #0c1522:15:3 #6ba8d7:8:9 #cc73e1:7:18",
+    "accent": "#cc73e1"
   },
   {
     "slug": "bearracuda-portland-pride-saturday-17cdfbd9",
@@ -27,13 +39,21 @@
     "slug": "bearracuda-portland-saturday-november-15th-1d72aa2a",
     "url": "https://bearracuda.com/events/portland-50/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#f958b6:25:22 #f4e1cc:21:4 #154d11:13:11 #65c669:8:16 #9d4c7d:6:12",
+    "accent": "#f958b6"
   },
   {
     "slug": "bearracuda-portland-the-great-blumpkin-341d5959",
     "url": "https://bearracuda.com/events/pdx16/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#433c34:22:2 #5c554b:18:2 #847663:15:3 #b19e7d:12:5 #b5db02:4:20",
+    "accent": "#b5db02"
   },
   {
     "slug": "bearracuda-portlandpride-friday-4b51bcfe",
@@ -45,55 +65,91 @@
     "slug": "chunk-portland-523-12aa4185",
     "url": "https://www.chunk-party.com",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#611d22:19:10 #89211b:18:14 #3c1b2b:14:5 #a2423b:13:13 #342d71:12:11",
+    "accent": "#89211b"
   },
   {
     "slug": "chunk-portland-friday-november-7th-34a929ef",
     "url": "https://www.chunk-party.com/event-details/chunk-portland-friday-november-7th",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#3dc6cb:19:11 #5c3334:18:6 #361d70:15:13 #4a5c82:15:7 #629cb4:9:7",
+    "accent": "#361d70"
   },
   {
     "slug": "chunk-portland-summer-blow-out-3a8423bf",
     "url": "https://www.chunk-party.com",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#3c3333:21:1 #654c43:17:4 #bca494:15:4 #345ab4:10:15 #6286db:8:14",
+    "accent": "#345ab4"
   },
   {
     "slug": "chunk-portland-the-return-saturday-march-14th-47dcb647",
     "url": "https://www.chunk-party.com/event-details/chunk-portland-the-return-saturday-march-14th",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#3b3386:23:13 #a98d78:15:5 #52544a:14:2 #4568a8:12:11 #aa546d:9:12",
+    "accent": "#3b3386"
   },
   {
     "slug": "hot-take-portland-46ec04ba",
     "url": "https://bearracuda.com/events/hottakepdx/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#f6caec:41:7 #ed1e22:13:23 #3e1519:11:6 #724446:8:6 #f37d92:7:15",
+    "accent": "#ed1e22"
   },
   {
     "slug": "hot-take-wnini-coco-162bffff",
     "url": "https://bearracuda.com/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#2cb3f4:38:14 #f4f543:15:19 #ddd9d5:11:1 #6dca4c:7:19 #f55bbd:7:21",
+    "accent": "#2cb3f4"
   },
   {
     "slug": "portland-nye-0de4cad8",
     "url": "https://bearracuda.com/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#000000:88:0 #ffffff:4:0 #fe0000:2:26 #8b0000:1:16",
+    "accent": "#fe0000"
   },
   {
     "slug": "portland-pride-friday-4b51bcfe",
     "url": "https://bearracuda.com/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#fd7c23:29:18 #f9eee2:15:2 #562016:13:8 #97634d:10:8 #744533:9:7",
+    "accent": "#fd7c23"
   },
   {
     "slug": "portland-pride-saturday-17cdfbd9",
     "url": "https://bearracuda.com/events/portland-pride-saturday/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#30302e:34:0 #e3e1de:21:0 #a3a3a3:11:0 #fd9554:8:15 #e830ac:7:24",
+    "accent": "#e830ac"
   },
   {
     "slug": "portland-pride-saturday-sold-out-17cdfbd9",
@@ -105,13 +161,21 @@
     "slug": "treasure-trail-portland-1043b353",
     "url": "https://bearracuda.com/events/treasure-trailpdx/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#080702:47:2 #1e210b:30:4 #3a3c14:9:6 #7c6343:4:6",
+    "accent": "#3a3c14"
   },
   {
     "slug": "treasure-trail-portland-backcountry-33f45281",
     "url": "https://bearracuda.com/events/treasure-trail-portland/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#6d624a:20:4 #0a0504:17:1 #ab9e82:14:4 #833618:6:11 #d18620:5:14",
+    "accent": "#d18620"
   },
   {
     "slug": "treasure-trail-portland-pride-0c12f2cc",
@@ -123,12 +187,20 @@
     "slug": "treasure-trail-portland-saturday-jan-24th-50c8389e",
     "url": "https://bearracuda.com/events/treasurepdx/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#412766:20:11 #7b5190:17:11 #492e95:17:16 #1b133d:16:8 #fa120d:6:25",
+    "accent": "#fa120d"
   },
   {
     "slug": "treasure-trail-portland-tix-at-the-door-0c12f2cc",
     "url": "https://bearracuda.com/events/portland-pridefriday/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#250509:35:5 #debd89:15:8 #54352a:14:5 #d888ad:7:11 #62b8ca:6:9",
+    "accent": "#d888ad"
   }
 ]

--- a/data/event-colors/ptown.json
+++ b/data/event-colors/ptown.json
@@ -8,13 +8,21 @@
   {
     "slug": "furball-51be4236",
     "url": "https://www.furball.nyc",
-    "faviconBg": "#302f35",
-    "faviconFg": "#f8f8f8"
+    "faviconBg": "#2d2c32",
+    "faviconFg": "#f7f7f7",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#010101:39:0 #241c13:18:2 #6d452b:14:7 #db7442:10:14 #f3d22b:5:17",
+    "accent": "#db7442"
   },
   {
     "slug": "riptide-3342cdd1",
     "url": "https://www.furball.nyc",
-    "faviconBg": "#302f35",
-    "faviconFg": "#f8f8f8"
+    "faviconBg": "#2d2c32",
+    "faviconFg": "#f7f7f7",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#141b1c:28:1 #2aa4db:21:13 #1d6d92:12:9 #eca48b:7:9 #af694e:7:10",
+    "accent": "#2aa4db"
   }
 ]

--- a/data/event-colors/san-diego.json
+++ b/data/event-colors/san-diego.json
@@ -9,13 +9,21 @@
     "slug": "megawoof-4faca4f4",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#0c2314:28:4 #d39076:18:9 #140b0b:15:2 #856a3b:10:7 #93c65f:2:14",
+    "accent": "#d39076"
   },
   {
     "slug": "megawoof-7025d33f",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#9b5134:17:11 #0b0403:16:2 #2b1514:16:4 #ce7555:14:12 #f2f401:1:20",
+    "accent": "#ce7555"
   },
   {
     "slug": "megawoof-america-san-diego-17095722",
@@ -27,6 +35,10 @@
     "slug": "megawoof-america-san-diego-7cd96d30",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#5a5b5d:20:0 #3f4143:19:0 #837e6b:16:3 #b9d239:2:17",
+    "accent": "#b9d239"
   }
 ]

--- a/data/event-colors/seattle.json
+++ b/data/event-colors/seattle.json
@@ -3,43 +3,83 @@
     "slug": "bearracuda-seattle-283ac3dd",
     "url": "https://bearracuda.com/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#130c14:20:2 #2b1924:17:3 #bc424c:14:16 #843b46:12:10 #d3747b:12:12",
+    "accent": "#bc424c"
   },
   {
     "slug": "bearracuda-seattle-glow-party-43d1597b",
     "url": "https://bearracuda.com/events/seattle-glow/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#43348c:17:14 #151c3d:16:6 #d3ecf5:15:3 #8732c3:10:21 #d753e4:9:23",
+    "accent": "#d753e4"
   },
   {
     "slug": "bearracuda-seattle-serious-wood-4a1720dd",
     "url": "https://bearracuda.com/events/seattlewood/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#211718:33:2 #442c29:18:4 #634333:16:5 #c26b46:11:12 #d29661:7:10",
+    "accent": "#c26b46"
   },
   {
     "slug": "bearracuda-seattle-winter-beef-ball-2026-5d3a67cd",
     "url": "https://bearracuda.com/events/seattlebeef/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#231b14:40:2 #432c1b:19:4 #634534:12:5 #9b442b:9:12 #d26c43:9:14",
+    "accent": "#d26c43"
   },
   {
     "slug": "leather-night-51e2ca8d",
     "url": "https://dieselseattle.com/DIESEL.html",
     "faviconBg": "#335a91",
-    "faviconFg": "#c3cbd4"
+    "faviconFg": "#c3cbd4",
+    "faviconPlate": "#3a63bd",
+    "paletteSource": "favicon",
+    "palette": "#003a73:28:11 #3a63bd:24:15 #ffffff:19:0 #009999:3:11",
+    "accent": "#3a63bd"
+  },
+  {
+    "slug": "seattle-glow-3b330fb1",
+    "paletteSource": "flyer",
+    "palette": "#443484:16:13 #cdecfd:15:4 #151b3c:15:6 #7644bd:13:18 #d14ae5:10:24",
+    "accent": "#d14ae5"
   },
   {
     "slug": "treasure-trail-seattle-2a543921",
     "url": "https://bearracuda.com/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#fa952a:29:16 #fcedc3:15:6 #d92409:11:22 #d37128:10:15 #fcc36c:10:12",
+    "accent": "#fa952a"
   },
   {
     "slug": "treasure-trail-seattle-4a6fa455",
     "url": "https://bearracuda.com/events/treasureseattle/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#2b3512:36:6 #4f582c:17:7 #818541:16:9 #f6e466:8:15 #adab85:5:5",
+    "accent": "#818541"
+  },
+  {
+    "slug": "treasure-trail-seattle-7e9ae5d5",
+    "paletteSource": "flyer",
+    "palette": "#2a0d05:32:5 #753518:20:10 #4d210c:17:7 #a18434:8:10 #deb160:8:11",
+    "accent": "#753518"
   },
   {
     "slug": "treasure-trail-seattle-summer-sausage-2a543921",
@@ -51,12 +91,20 @@
     "slug": "treasure-trail-seattle-wish-boned-422a1406",
     "url": "https://bearracuda.com/events/treasureseattle/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#faf5db:39:3 #09a9ec:12:15 #0c1b0b:10:4 #cac176:9:10 #c96609:6:15",
+    "accent": "#09a9ec"
   },
   {
     "slug": "treasure-trail-seattletrail-head-5f63386f",
     "url": "https://bearracuda.com/events/seattlett/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#f5f9f4:35:1 #011117:12:3 #2c3c2a:12:4 #55c4d5:7:10 #0d8344:6:14",
+    "accent": "#0d8344"
   }
 ]

--- a/data/event-colors/sf.json
+++ b/data/event-colors/sf.json
@@ -3,7 +3,11 @@
     "slug": "bear-happy-hour-67a521bf",
     "url": "https://linktr.ee/bearhappyhour",
     "faviconBg": "#fbfbf9",
-    "faviconFg": "#6b6661"
+    "faviconFg": "#6a6661",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "favicon",
+    "palette": "#ffffff:78:0 #010101:5:0 #cdcecf:5:0 #f6e529:1:18 #f2592a:1:20",
+    "accent": "#f2592a"
   },
   {
     "slug": "bearracuda-folsom-street-horse-meat-disco-6bcb20fd",
@@ -15,19 +19,31 @@
     "slug": "bearracuda-sf-20-year-anniversary-4ae69009",
     "url": "https://bearracuda.com/events/sf20/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#efd98a:31:10 #8d227c:25:17 #eabe3b:14:15 #c88f71:7:8 #7bce41:4:19",
+    "accent": "#8d227c"
   },
   {
     "slug": "bearracuda-sf-beefcake-pride-2d1a3a4d",
     "url": "https://bearracuda.com/events/sf-pride/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#3d45d8:19:22 #1c1323:18:3 #222473:16:13 #572e4e:12:8 #ba4adc:9:23",
+    "accent": "#3d45d8"
   },
   {
     "slug": "bearracuda-sf-presents-horse-meat-disco-151154b5",
     "url": "https://bearracuda.com/events/flsm-friday/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "favicon",
+    "palette": "#ff3c00:72:24 #fffefe:27:0 #ff9f81:1:12",
+    "accent": "#ff3c00"
   },
   {
     "slug": "bearracuda-sf-pride-2026-hold-the-door-2d1a3a4d",
@@ -42,28 +58,55 @@
     "faviconFg": "#2e2933"
   },
   {
+    "slug": "beefwitch-06eb5e73",
+    "paletteSource": "flyer",
+    "palette": "#0b0001:32:4 #240101:23:6 #5b0001:16:12 #930101:11:17 #e30001:7:24",
+    "accent": "#e30001"
+  },
+  {
     "slug": "beefwitch-0e685674",
     "url": "https://www.eventbrite.com/e/beefwitch-tickets-1988340517011",
     "faviconBg": "#ff5e30",
-    "faviconFg": "#ff6333"
+    "faviconFg": "#ff6333",
+    "paletteSource": "flyer",
+    "palette": "#0b0100:33:3 #251a13:19:2 #5c0000:17:12 #ff2319:8:25 #9b100b:7:17",
+    "accent": "#ff2319"
   },
   {
     "slug": "chunk-dore-alley-saturday-july-25th-3bf852a2",
     "url": "https://www.chunk-party.com",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#ececec:31:0 #434343:19:0 #949494:12:0 #4f5b81:8:6",
+    "accent": "#4f5b81"
   },
   {
     "slug": "chunk-presents-folsom-25-6a09272f",
     "url": "https://www.chunk-party.com/event-details/chunk-presents-folsom-25",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#00081c:61:5 #87614c:9:6 #b7886e:9:7 #d52501:4:21 #e95c00:2:19",
+    "accent": "#d52501"
   },
   {
     "slug": "chunk-san-francisco-saturday-january-17th-227d733c",
     "url": "https://www.chunk-party.com/event-details/chunk-san-francisco-saturday-january-17th",
     "faviconBg": "#f6f4f5",
-    "faviconFg": "#2e2933"
+    "faviconFg": "#2e2933",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#a74044:16:14 #51392d:16:4 #ea6d4c:13:16 #e3c98e:11:8 #463a76:8:10",
+    "accent": "#ea6d4c"
+  },
+  {
+    "slug": "chunk-sf-presents-father-figure-305593c7",
+    "paletteSource": "flyer",
+    "palette": "#c3ae82:20:6 #8c639c:20:10 #6b427c:16:10 #ec6a66:12:16 #eadc1e:6:18",
+    "accent": "#ec6a66"
   },
   {
     "slug": "megawoof-39090023",
@@ -75,24 +118,39 @@
     "slug": "megawoof-america-san-francisco-25d83ad3",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#130b1c:24:4 #03010b:19:4 #34223b:14:5 #bd5e4a:12:13 #752b32:10:10",
+    "accent": "#bd5e4a"
   },
   {
     "slug": "sf-flsm-6bcb20fd",
     "url": "https://bearracuda.com/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#1b1533:23:6 #0b030b:17:3 #432c49:15:6 #a532a7:6:20",
+    "accent": "#a532a7"
   },
   {
     "slug": "treasure-trail-san-francisco-1a2ef0fe",
     "url": "https://bearracuda.com/events/treasure-trail-sf/",
     "faviconBg": "#ff1901",
-    "faviconFg": "#ff5000"
+    "faviconFg": "#ff5000",
+    "faviconPlate": "#fffefe",
+    "paletteSource": "flyer",
+    "palette": "#000000:25:0 #9b2314:17:16 #1c1d0a:14:3 #640a0b:11:12 #f2cd86:11:10",
+    "accent": "#9b2314"
   },
   {
     "slug": "twisted-bear-san-francisco-debut-003787d5",
     "url": "https://www.eventbrite.com/e/twisted-bear-san-francisco-debut-tickets-1993746658927",
     "faviconBg": "#ff5e30",
-    "faviconFg": "#ff6333"
+    "faviconFg": "#ff6333",
+    "paletteSource": "flyer",
+    "palette": "#110f12:47:1 #332c2b:17:1 #684a3f:12:4 #a1766d:8:6",
+    "accent": "#a1766d"
   }
 ]

--- a/data/event-colors/sitges.json
+++ b/data/event-colors/sitges.json
@@ -3,24 +3,40 @@
     "slug": "friday-11th-september-beefmince-sports-zone-6972e7c6",
     "url": "https://beefmince.com",
     "faviconBg": "#060606",
-    "faviconFg": "#131313"
+    "faviconFg": "#131313",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#010101:19:0 #998677:15:3 #130d0c:14:1 #dec467:8:12 #8d0b2c:8:16",
+    "accent": "#8d0b2c"
   },
   {
     "slug": "saturday-12th-september-beefmince-the-big-ball-13a48cc3",
     "url": "https://beefmince.com",
     "faviconBg": "#060606",
-    "faviconFg": "#131313"
+    "faviconFg": "#131313",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#000000:44:0 #958971:12:4 #1a1916:10:1 #ecc31d:5:16 #bb132c:2:20",
+    "accent": "#ecc31d"
   },
   {
     "slug": "thursday-10th-september-beefmince-disco-511f64f9",
     "url": "https://beefmince.com",
     "faviconBg": "#060606",
-    "faviconFg": "#131313"
+    "faviconFg": "#131313",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#000000:54:0 #fcf9f6:13:1 #2f2219:9:3 #a43e29:6:14 #eec420:5:16",
+    "accent": "#eec420"
   },
   {
     "slug": "wednesday-9th-september-beefmince-meet-market-795b165c",
     "url": "https://beefmince.com",
     "faviconBg": "#060606",
-    "faviconFg": "#131313"
+    "faviconFg": "#131313",
+    "faviconPlate": "#ffffff",
+    "paletteSource": "flyer",
+    "palette": "#0a2349:23:8 #eb6a43:18:17 #1701aa:14:23 #165a8b:10:10 #e7c41e:6:16",
+    "accent": "#1701aa"
   }
 ]

--- a/data/event-colors/vegas.json
+++ b/data/event-colors/vegas.json
@@ -3,13 +3,20 @@
     "slug": "megawoof-00b39ef8",
     "url": "https://www.eventbrite.com/e/megawoof-america-las-vegas-labor-day-weekend-bears-at-work-tickets-1531257726079",
     "faviconBg": "#ff5e30",
-    "faviconFg": "#ff6333"
+    "faviconFg": "#ff6333",
+    "paletteSource": "flyer",
+    "palette": "#130c0a:45:1 #3b1c11:20:5 #643922:11:7 #d58957:10:11 #876853:9:5",
+    "accent": "#d58957"
   },
   {
     "slug": "megawoof-0bc51ff7",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#131d23:34:2 #424343:14:0 #7d645b:14:4 #c18257:12:10 #eef000:2:20",
+    "accent": "#c18257"
   },
   {
     "slug": "megawoof-296254c9",
@@ -21,6 +28,10 @@
     "slug": "megawoof-las-vegas-memorial-day-weekend--741892f2",
     "url": "https://linktr.ee/megawoof_america",
     "faviconBg": "#575d64",
-    "faviconFg": "#abb2ba"
+    "faviconFg": "#abb2ba",
+    "faviconPlate": "#acb4bc",
+    "paletteSource": "flyer",
+    "palette": "#0b0906:37:1 #301d19:19:3 #543324:14:5 #d1ac80:7:7 #eee3ad:6:7",
+    "accent": "#d1ac80"
   }
 ]

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -17,6 +17,30 @@ const AURORA_CARD_ICONS = {
     ]
 };
 
+// ── Aurora gradient tuning ───────────────────────────────────────────────────
+// The card's base colour, the floor every stop is blended toward (#171a33).
+const AURORA_BASE_RGB = { r: 23, g: 26, b: 51 };
+// Palette entries carry `c` = OKLab chroma ×100 (see tools/extract-favicon-colors.js).
+// Below this a colour is a grey/near-grey and can't carry a gradient stop.
+const AURORA_MIN_CHROMA = 0.05;
+// A second stop has to cover a real part of the artwork; anything smaller is an
+// anti-aliasing fringe (the pale pinks around Animal's red "A") and makes a
+// washed-out blob rather than a second colour.
+// A second stop must be a real presence in the artwork, not a speck: Bear
+// Happy Hour's palette carries a 1%-coverage yellow (#f6e529) that was
+// defining half its card, and orange->yellow blends through olive.
+const AURORA_MIN_STOP_SHARE = 0.10;
+// Below this separation two stops read as one colour and the "gradient" is a
+// flat wash — the Bearracuda/Animal failure the palette was built to fix.
+const AURORA_MIN_SEPARATION = 0.2;
+// Hue rotation (degrees) and lightness factor used to invent a sibling stop when
+// the artwork genuinely has only one colour in it.
+// Single-colour artwork gets a DEEPER sibling of the same hue rather than a
+// rotated one: rotating a warm accent (Animal's red) lands in the yellow-olive
+// band and reads muddy, while darkening stays on-brand.
+const AURORA_SIBLING_LIGHTNESS = 0.55;
+const AURORA_SIBLING_CHROMA_BOOST = 1.12;
+
 // Dynamic Google Calendar Loader - Supports multiple cities and calendars
 class DynamicCalendarLoader extends CalendarCore {
     constructor() {
@@ -1276,6 +1300,15 @@ class DynamicCalendarLoader extends CalendarCore {
                 
                 const el = document.createElement('div');
                 el.className = 'favicon-marker';
+                // Markers use the same plate as the card tiles (Stanley:
+                // "Same for map btw!"), so one favicon looks like one object
+                // wherever it appears.
+                const markerPlate = this.getFaviconPlateForEvent(event);
+                if (markerPlate) el.style.setProperty('--fav-plate', markerPlate);
+                // Markers are often built BEFORE the colour file resolves, and
+                // unlike cards they aren't re-rendered — so tag them with the
+                // slug and let the colour load repaint them in place.
+                if (event.slug) el.setAttribute('data-event-slug', event.slug);
 
                 let onErrorStr = `this.parentElement.innerHTML='<span class=\\'marker-text\\'>${textFallback}</span>'; this.parentElement.classList.add('text-marker');`;
                 if (fallbackFaviconUrl) {
@@ -2146,35 +2179,141 @@ class DynamicCalendarLoader extends CalendarCore {
         return max <= 0 ? 0 : (max - min) / max;
     }
 
-    // Three aurora stops from an event's favicon colors: the background color,
-    // the foreground color, and a darkened blend of both pulled toward the
-    // card's #171a33 base. Returns null when the input isn't a usable hex color
-    // — or when the brand colours carry no colour to build an aurora from, so
-    // the caller's vivid site palette is used instead. Real-data review found
-    // near-white favicons (Eagle NYC #f0f0f0, Bear Happy Hour) clamping into
-    // flat grey cards: brightness-banding a grey can only ever yield grey, and
-    // a grey aurora is no aurora at all.
-    deriveAuroraColors(background, foreground) {
-        const backgroundRgb = this.parseHexColor(background);
+    // A cheap opponent-colour distance: how differently two colours read. The
+    // perceptual work already happened in the extractor (OKLab clustering), so
+    // all that's needed here is "are these two the same colour or not" —
+    // brightness difference plus the two chromatic axes, no colour-space
+    // conversion duplicated into the browser.
+    rgbSeparation(a, b) {
+        const lightness = this.rgbBrightness(a) - this.rgbBrightness(b);
+        const redGreen = ((a.r - a.g) - (b.r - b.g)) / 255;
+        const yellowBlue = (((a.r + a.g) / 2 - a.b) - ((b.r + b.g) / 2 - b.b)) / 255;
+        return Math.sqrt(lightness * lightness + redGreen * redGreen + yellowBlue * yellowBlue);
+    }
+
+    // A deeper, slightly richer version of a colour: same hue, lower lightness,
+    // a touch more saturation. Used as the second stop when artwork has only
+    // one usable colour, so the gradient travels within the brand instead of
+    // wandering into a hue that fights it.
+    deepenRgb(rgb, lightnessFactor, chromaBoost = 1) {
+        const mean = (rgb.r + rgb.g + rgb.b) / 3;
+        const push = (channel) => Math.max(0, Math.min(255,
+            (mean + (channel - mean) * chromaBoost) * lightnessFactor));
+        return { r: push(rgb.r), g: push(rgb.g), b: push(rgb.b) };
+    }
+
+    // Parse the packed `palette` string written by
+    // tools/extract-favicon-colors.js: space-separated `hex:share:chroma`
+    // tokens, ordered by how much of the artwork each colour covers, where
+    // share is a percent and chroma is OKLab chroma ×100. Malformed tokens are
+    // dropped rather than trusted — these colours end up in an inline style
+    // attribute, so parseHexColor stays the gate.
+    parsePaletteEntries(palette) {
+        if (typeof palette !== 'string') return [];
+        const entries = [];
+        palette.trim().split(/\s+/).forEach(token => {
+            const parts = token.split(':');
+            const rgb = this.parseHexColor(parts[0]);
+            if (!rgb) return;
+            entries.push({
+                rgb,
+                share: Math.max(0, Number(parts[1]) || 0) / 100,
+                chroma: Math.max(0, Number(parts[2]) || 0) / 100
+            });
+        });
+        return entries;
+    }
+
+    // Three stops from a rich palette. `accent` (the extractor's most usable
+    // saturated colour) anchors the card; the second stop is the palette entry
+    // that reads most differently from it; the third is a darkened blend pulled
+    // toward the card base. Returns null only when there is nothing usable —
+    // the old "is this pair grey?" sniffing is gone, because the extractor
+    // already answered that question by omitting `accent`.
+    deriveAuroraFromPalette(entries, accentRgb) {
+        if (!accentRgb) return this.deriveAchromaticAurora(entries);
+
+        const candidates = entries
+            .filter(entry => entry.chroma >= AURORA_MIN_CHROMA && entry.share >= AURORA_MIN_STOP_SHARE)
+            .map(entry => ({ rgb: entry.rgb, separation: this.rgbSeparation(entry.rgb, accentRgb) }))
+            .filter(candidate => candidate.separation >= AURORA_MIN_SEPARATION)
+            .sort((a, b) => b.separation - a.separation);
+
+        const second = candidates.length > 0
+            ? candidates[0].rgb
+            : this.deepenRgb(accentRgb, AURORA_SIBLING_LIGHTNESS, AURORA_SIBLING_CHROMA_BOOST);
+
+        return this.bandAuroraStops(accentRgb, second, 0.2, 0.52, 0.16, 0.48);
+    }
+
+    // Genuinely colourless artwork (Eagle NYC's black-and-white crest, The Urban
+    // Bear's white-on-black mark). A grey aurora is no aurora, so use the
+    // artwork's own lightness spread but tint it toward the card base: the card
+    // reads as deliberate slate/graphite rather than washed-out grey, and it
+    // still belongs to the brand instead of borrowing the site palette.
+    deriveAchromaticAurora(entries) {
+        if (entries.length === 0) return null;
+        const sorted = [...entries].sort((a, b) => this.rgbBrightness(b.rgb) - this.rgbBrightness(a.rgb));
+        const lightest = sorted[0].rgb;
+        const darkest = sorted[sorted.length - 1].rgb;
+        const tint = rgb => this.mixRgbColors(rgb, AURORA_BASE_RGB, 0.45);
+        // Wider bands than the coloured path uses: lightness is the only thing
+        // left to make the blobs visible at all.
+        return this.bandAuroraStops(tint(lightest), tint(darkest), 0.22, 0.4, 0.06, 0.14);
+    }
+
+    // Push two chosen stops into brightness bands that keep white text legible,
+    // then derive the third from their blend over the card base.
+    bandAuroraStops(first, second, firstMin, firstMax, secondMin, secondMax) {
+        const c1 = this.toneForAurora(first, firstMin, firstMax);
+        const c2 = this.toneForAurora(second, secondMin, secondMax);
+        const blended = this.mixRgbColors(c1, c2, 0.5);
+        return {
+            c1: this.rgbToHexColor(c1),
+            c2: this.rgbToHexColor(c2),
+            c3: this.rgbToHexColor(this.toneForAurora(this.mixRgbColors(blended, AURORA_BASE_RGB, 0.62), 0.05, 0.22))
+        };
+    }
+
+    // Three aurora stops for one colour record.
+    //
+    // Preferred path: the `palette`/`accent` written by
+    // tools/extract-favicon-colors.js, which sees the whole flyer (or the whole
+    // favicon composited over its white plate) instead of two k-means centroids.
+    //
+    // Fallback path (entries that only carry the older faviconBg/faviconFg
+    // pair): the original background/foreground stops, including the
+    // colourfulness veto that sent grey pairs to the site palette. Two grey
+    // centroids really do contain nothing to build an aurora from — the palette
+    // is what makes that veto unnecessary, so it only applies here.
+    deriveAuroraColors(record) {
+        if (!record) return null;
+
+        const entries = this.parsePaletteEntries(record.palette);
+        if (entries.length > 0) {
+            return this.deriveAuroraFromPalette(entries, this.parseHexColor(record.accent));
+        }
+
+        const backgroundRgb = this.parseHexColor(record.bg);
         if (!backgroundRgb) return null;
-        const foregroundRgb = this.parseHexColor(foreground) || backgroundRgb;
+        const foregroundRgb = this.parseHexColor(record.fg) || backgroundRgb;
         const colorfulness = Math.max(
             this.rgbColorfulness(backgroundRgb),
             this.rgbColorfulness(foregroundRgb)
         );
         if (colorfulness < 0.18) return null;
-        const cardBaseRgb = { r: 23, g: 26, b: 51 }; // #171a33
         const blended = this.mixRgbColors(backgroundRgb, foregroundRgb, 0.5);
         return {
             c1: this.rgbToHexColor(this.toneForAurora(backgroundRgb, 0.18, 0.5)),
             c2: this.rgbToHexColor(this.toneForAurora(foregroundRgb, 0.18, 0.5)),
-            c3: this.rgbToHexColor(this.toneForAurora(this.mixRgbColors(blended, cardBaseRgb, 0.6), 0.05, 0.22))
+            c3: this.rgbToHexColor(this.toneForAurora(this.mixRgbColors(blended, AURORA_BASE_RGB, 0.6), 0.05, 0.22))
         };
     }
 
-    // Per-event favicon colors live in data/event-colors/<city>.json as
-    // [{slug, url, faviconBg, faviconFg}]. Nothing loaded them in the browser
-    // before the aurora cards, so fetch once per city and cache the result.
+    // Per-event colors live in data/event-colors/<city>.json as
+    // [{slug, url, faviconBg, faviconFg, paletteSource, palette, accent}].
+    // Nothing loaded them in the browser before the aurora cards, so fetch once
+    // per city and cache the result.
     loadEventColors(city) {
         if (!city) return Promise.resolve(null);
         if (this.eventColorsByCity.has(city)) {
@@ -2189,12 +2328,22 @@ class DynamicCalendarLoader extends CalendarCore {
             .then(entries => {
                 const bySlug = new Map();
                 (Array.isArray(entries) ? entries : []).forEach(entry => {
-                    if (entry && entry.slug && entry.faviconBg) {
-                        bySlug.set(entry.slug, {
-                            bg: entry.faviconBg,
-                            fg: entry.faviconFg || entry.faviconBg
-                        });
-                    }
+                    if (!entry || !entry.slug) return;
+                    // A palette alone is enough: events whose only artwork is a
+                    // flyer (no usable favicon) now get colours too, and they
+                    // carry no faviconBg to gate on.
+                    if (!entry.faviconBg && typeof entry.palette !== 'string') return;
+                    bySlug.set(entry.slug, {
+                        bg: entry.faviconBg,
+                        fg: entry.faviconFg || entry.faviconBg,
+                        palette: entry.palette,
+                        accent: entry.accent,
+                        // The favicon's own background colour, painted behind
+                        // its tile. Dropping it here silently defeated the
+                        // whole plate feature: the data had it, the card asked
+                        // for it, and this normaliser threw it away.
+                        faviconPlate: entry.faviconPlate
+                    });
                 });
                 this.eventColorsByCity.set(city, bySlug);
                 logger.debug('CALENDAR', 'Loaded event colors', { city, count: bySlug.size });
@@ -2226,16 +2375,43 @@ class DynamicCalendarLoader extends CalendarCore {
                 this.loadEventColors(city).then(loaded => {
                     if (loaded && loaded.size > 0) {
                         this.applyEventColorsToRenderedCards();
+                        this.applyEventColorsToRenderedMarkers();
                     }
                 });
             }
             return null;
         }
-        const colors = bySlug.get(event.slug);
-        return colors ? this.deriveAuroraColors(colors.bg, colors.fg) : null;
+        return this.deriveAuroraColors(bySlug.get(event.slug));
     }
 
 
+
+    // The favicon's OWN background colour (faviconPlate — the highest-coverage
+    // colour of the favicon itself, recorded separately from `palette` because
+    // that may describe the flyer). Painting it behind and around the artwork
+    // is what lets the icon breathe without a white halo: a white-backed mark
+    // gets white, Urban Bear's white-on-black gets black, Bearracuda's "B"
+    // gets its own orange. Null when unknown — the tile then falls back to
+    // white in CSS.
+    getFaviconPlateForEvent(event) {
+        const bySlug = this.currentCity ? this.eventColorsByCity.get(this.currentCity) : null;
+        const colors = bySlug ? bySlug.get(event.slug) : null;
+        const plate = colors && colors.faviconPlate;
+        return plate && this.parseHexColor(plate) ? plate : null;
+    }
+
+    // Repaint map markers that were built before the colour file arrived.
+    applyEventColorsToRenderedMarkers() {
+        const bySlug = this.eventColorsByCity.get(this.currentCity);
+        if (!bySlug || bySlug.size === 0) return;
+        document.querySelectorAll('.favicon-marker[data-event-slug]').forEach(marker => {
+            const colors = bySlug.get(marker.getAttribute('data-event-slug'));
+            const plate = colors && colors.faviconPlate;
+            if (plate && this.parseHexColor(plate)) {
+                marker.style.setProperty('--fav-plate', plate);
+            }
+        });
+    }
 
     // Repaint aurora cards that rendered before the color file arrived.
     applyEventColorsToRenderedCards() {
@@ -2243,8 +2419,11 @@ class DynamicCalendarLoader extends CalendarCore {
         if (!bySlug || bySlug.size === 0) return;
         document.querySelectorAll('.event-card.detailed.aurora[data-event-slug]').forEach(card => {
             const colors = bySlug.get(card.getAttribute('data-event-slug'));
-            if (!colors) return;
-            const aurora = this.deriveAuroraColors(colors.bg, colors.fg);
+            const plate = colors && colors.faviconPlate;
+            if (plate && this.parseHexColor(plate)) {
+                card.style.setProperty('--fav-plate', plate);
+            }
+            const aurora = this.deriveAuroraColors(colors);
             if (!aurora) return;
             card.style.setProperty('--c1', aurora.c1);
             card.style.setProperty('--c2', aurora.c2);
@@ -2317,7 +2496,8 @@ class DynamicCalendarLoader extends CalendarCore {
             return `<a href="${href}" target="_blank" rel="noopener" class="event-link icon-only" aria-label="${aria}" title="${aria}"><i class="bi ${iconClass}"></i></a>`;
         }).join(' ') : '';
 
-        const teaHtml = event.tea ? `<div class="ec-tea">${this.escapeCardText(event.tea)}</div>` : '';
+        const teaText = this.sanitizeDisplayText(event.tea);
+        const teaHtml = teaText ? `<div class="ec-tea">${this.escapeCardText(teaText)}</div>` : '';
         const venueRow = this.generateAuroraVenueRow(event);
         const coverRow = this.generateAuroraCoverRow(event);
 
@@ -2370,8 +2550,11 @@ class DynamicCalendarLoader extends CalendarCore {
             `<div class="event-flyer" data-flyer-url="${flyerUrl}"><img src="${flyerUrl}" alt="" loading="lazy" decoding="async" onerror="this.parentNode.remove()"></div>` : '';
 
         const aurora = this.getAuroraColorsForEvent(event);
-        const auroraStyle = aurora ?
-            ` style="--c1:${aurora.c1};--c2:${aurora.c2};--c3:${aurora.c3}"` : '';
+        const plate = this.getFaviconPlateForEvent(event);
+        const styleParts = [];
+        if (aurora) styleParts.push(`--c1:${aurora.c1}`, `--c2:${aurora.c2}`, `--c3:${aurora.c3}`);
+        if (plate) styleParts.push(`--fav-plate:${plate}`);
+        const auroraStyle = styleParts.length ? ` style="${styleParts.join(';')}"` : '';
 
         const slug = this.escapeCardText(event.slug);
         const shareTime = `${event.day || ''}${event.time ? ' ' + event.time : ''}`;
@@ -2403,6 +2586,45 @@ class DynamicCalendarLoader extends CalendarCore {
                 </div>
             </div>
         `;
+    }
+
+    // Strip source-platform formatting from text that is about to be DISPLAYED.
+    // The scraper sanitizes descriptions when it writes them (#1575), but events
+    // already in the calendar keep whatever the source published — Sitges'
+    // Bear Cave events still carry literal "<p>…</p>\\n" from a Wix page, and
+    // dice.fm events carry markdown "**bold**". The site is the display layer,
+    // so it defends itself rather than waiting for every event to be re-scraped.
+    // Escaping happens afterwards via escapeCardText; this only REMOVES markup.
+    sanitizeDisplayText(text) {
+        if (typeof text !== 'string' || !text) return text;
+        let out = text;
+        // Literal two-character escapes ("\n" as backslash + n), then real tags.
+        out = out.replace(/\\r\\n|\\n/g, ' ').replace(/\\r/g, '');
+        out = out.replace(/<!--[\s\S]*?-->/g, '');
+        out = out.replace(/<\/?(?:p|div|br|li|ul|ol|h[1-6]|section|article|span|strong|b|em|i|u|a|img|figure|figcaption|blockquote|pre|code)\b[^<>]*\/?>/gi, ' ');
+        // Common entities, ampersand first so double-encoding resolves.
+        out = out.replace(/&amp;/gi, '&').replace(/&nbsp;/gi, ' ')
+                 .replace(/&lt;/gi, '<').replace(/&gt;/gi, '>')
+                 .replace(/&quot;/gi, '"').replace(/&(?:#39|#039|apos);/gi, "'");
+        // Markdown emphasis runs and backslash-escaped punctuation. Escaped
+        // characters are parked behind placeholders FIRST (same approach as the
+        // scraper's sanitizer): otherwise "\\*Now on Saturdays\\***" has its
+        // escaped asterisk counted as part of a run and leaves a stray
+        // backslash behind.
+        out = out.replace(/\[([^\[\]\n]*)\]\([^()\n]*\)/g, '$1');
+        out = out.split('\\*').join('\uE000').split('\\_').join('\uE001');
+        out = out.replace(/\*{2,}|_{2,}/g, '');
+        out = out.split('\uE000').join('*').split('\uE001').join('_');
+        out = out.replace(/\\([*_#\[\].])/g, '$1');
+        // Leftover ESCAPE RESIDUE. Stored descriptions can end in bare
+        // backslashes — Sitges' Bear Cave events carry "</p>\\\\" because a
+        // literal "\\n" from the source page went through ICS escaping and came
+        // back as backslashes with nothing to escape. Nothing in event copy
+        // legitimately ends on a backslash, so runs of them, and any backslash
+        // left dangling before whitespace or end-of-string, are dropped.
+        out = out.replace(/\\{2,}/g, '').replace(/\\+(?=\s|$)/g, '');
+        // Collapse the whitespace the removals leave behind.
+        return out.replace(/\s{2,}/g, ' ').trim();
     }
 
     // Clipboard write that works WITHOUT a secure context (plain-http

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -7956,6 +7956,22 @@ test('merge survival (enrich flow): the curated-upgraded address beats a same-pr
   assert.equal(merged.address, AQUA_EMPORIO_ADDRESS, 'the curated address wins in the enrich flow too');
 });
 
+// The generated bars twins are the curated source MINUS website-only
+// presentation fields: tools/generate-scraper-bars.js strips the extracted
+// colour palette (palette/accent/paletteSource) because the scraper never reads
+// it and scripts/scraper-bars.js is downloaded to the phone. Compare against
+// that contract rather than against the raw source.
+function barsWithoutPresentationFields(bars) {
+  return bars.map(bar => {
+    const trimmed = { ...bar };
+    delete trimmed.palette;
+    delete trimmed.accent;
+    delete trimmed.paletteSource;
+    delete trimmed.faviconPlate;
+    return trimmed;
+  });
+}
+
 test('curated bars: torremolinos.json carries Aqua Emporio and the generated scraper-bars twins are in sync', () => {
   const fs = require('fs');
   const path = require('path');
@@ -7970,11 +7986,11 @@ test('curated bars: torremolinos.json carries Aqua Emporio and the generated scr
 
   // Generated module twin (scripts/scraper-bars.js) is committed in sync.
   const scraperBars = require('./scraper-bars');
-  assert.deepEqual(scraperBars.torremolinos, torremolinosBars, 'scripts/scraper-bars.js regenerated after the torremolinos.json edit');
+  assert.deepEqual(scraperBars.torremolinos, barsWithoutPresentationFields(torremolinosBars), 'scripts/scraper-bars.js regenerated after the torremolinos.json edit');
 
   // Pure-JSON twin served by the site.
   const jsonTwin = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'scraper-bars.json'), 'utf8'));
-  assert.deepEqual(jsonTwin.torremolinos, torremolinosBars, 'data/scraper-bars.json regenerated after the torremolinos.json edit');
+  assert.deepEqual(jsonTwin.torremolinos, barsWithoutPresentationFields(torremolinosBars), 'data/scraper-bars.json regenerated after the torremolinos.json edit');
 
   // The event's ALL-CAPS bar resolves to the curated record (normalizeBarNameKey).
   const core = new SharedCore({}, { eventSchema: EventSchema, bars: scraperBars });
@@ -8089,11 +8105,11 @@ test('curated bars: boston.json carries Legacy and the generated scraper-bars tw
 
   // Generated module twin (scripts/scraper-bars.js) is committed in sync.
   const scraperBars = require('./scraper-bars');
-  assert.deepEqual(scraperBars.boston, bostonBars, 'scripts/scraper-bars.js regenerated after the boston.json edit');
+  assert.deepEqual(scraperBars.boston, barsWithoutPresentationFields(bostonBars), 'scripts/scraper-bars.js regenerated after the boston.json edit');
 
   // Pure-JSON twin served by the site.
   const jsonTwin = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'scraper-bars.json'), 'utf8'));
-  assert.deepEqual(jsonTwin.boston, bostonBars, 'data/scraper-bars.json regenerated after the boston.json edit');
+  assert.deepEqual(jsonTwin.boston, barsWithoutPresentationFields(bostonBars), 'data/scraper-bars.json regenerated after the boston.json edit');
 
   // The curated record is what findCuratedBarByName resolves for the rescue.
   const core = new SharedCore({}, { eventSchema: EventSchema, bars: scraperBars });

--- a/styles.css
+++ b/styles.css
@@ -2391,14 +2391,16 @@ body.index-page main {
 
 /* ═══════════════ Aurora event cards (city page list view) ═══════════════
    Self-contained dark card: three radial-gradient blobs in the event's own
-   favicon colors (--c1/--c2/--c3, set inline per event by
+   brand colours — picked from the palette its flyer or favicon was reduced to
+   (--c1/--c2/--c3, set inline per event by
    generateEventCard()) over a deep base, the whole flyer laid on top at its
    natural aspect ratio, and one frosted glass panel carrying every piece of
    information. Everything is scoped under `.aurora` so the older flat card
    styling above still applies anywhere the class isn't added, and the card is
    dark regardless of the surrounding site theme. */
 .event-card.detailed.aurora {
-    /* Fallback stops when an event has no color data: the site palette. */
+    /* Fallback stops when an event has no color data at all (no palette and no
+       favicon pair, or artwork we couldn't read): the site palette. */
     --c1: var(--primary-color, #667eea);
     --c2: var(--secondary-color, #ff6b6b);
     --c3: #2a2c4d;
@@ -2481,21 +2483,23 @@ body.index-page main {
     flex: 0 0 42px;
     border-radius: var(--favicon-plate-radius);
     overflow: hidden;
-    box-shadow: 0 2px 10px rgba(6, 8, 20, 0.35);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.22),
+                0 2px 10px rgba(6, 8, 20, 0.35);
     /* No border: box-sizing is border-box, so a 1.5px translucent border
        left a light ring around full-bleed dark artwork. The plate and shadow
        already define the tile. */
     /* Favicons are often a round mark on a flat plate; painting that plate
        colour keeps the tile reading as a rounded square instead of a circle.
        --fav-plate comes from the event's faviconBg (see the JS). */
-    background: var(--favicon-plate-bg);
+    background: var(--fav-plate, var(--favicon-plate-bg));
 }
 
 .event-card.detailed.aurora .ec-fav img {
     display: block;
     width: 100%;
     height: 100%;
-    object-fit: cover;
+    object-fit: contain;
+    padding: var(--favicon-plate-pad);
 }
 
 .event-card.detailed.aurora h3.ec-title {
@@ -6388,17 +6392,30 @@ body.loaded {
    transparent, which is exactly when it's wanted.
 --------------------------------------------------------------------------- */
 :root {
+    /* Fallback only — the real plate is each favicon's OWN background colour,
+       set per event as --fav-plate from the extracted faviconPlate. */
     --favicon-plate-bg: #ffffff;
     --favicon-plate-radius: 9px;
+    /* The plate extends OUTSIDE the artwork as a ring. Full-bleed icons
+       (Animal's red field, Bearracuda's orange "B") otherwise run straight
+       into the card gradient with nothing between them, which reads as
+       jarring — especially when icon and card share a hue. Done with an
+       outset ring rather than padding, because padding puts the plate INSIDE
+       the art and leaves a halo around dark full-bleed logos. Icons that are
+       already artwork-on-white simply blend into their own ring. */
+    --favicon-plate-pad: 2px;
 }
 /* Map markers adopt the same plate, radius and contain-fit as the cards. */
 .favicon-marker-container {
-    background: var(--favicon-plate-bg);
+    background: var(--fav-plate, var(--favicon-plate-bg));
     border-radius: var(--favicon-plate-radius);
+    border: none;
+    overflow: hidden;
+    box-shadow: 0 0 0 1px rgba(23, 26, 51, 0.25), 0 2px 6px rgba(6, 8, 20, 0.3);
 }
 .favicon-marker-icon {
-    object-fit: cover;
-    padding: 0;
+    object-fit: contain;
+    padding: var(--favicon-plate-pad);
     border-radius: calc(var(--favicon-plate-radius) - 2px);
 }
 /* The text fallback keeps its filled look — no plate behind letters. */

--- a/tools/extract-favicon-colors.js
+++ b/tools/extract-favicon-colors.js
@@ -1,13 +1,56 @@
 #!/usr/bin/env node
 
 /**
- * Extract two dominant colors (background + foreground/symbol) from already-downloaded
- * favicon images in img/favicons/.
+ * Extract brand colours from already-downloaded LOCAL artwork: favicons in
+ * img/favicons/ and event flyers in img/events/.  Makes no network requests.
  *
- * Favicons are downloaded by tools/download-images.js.  This script reads those
- * local files — it makes no network requests.  The same favicon-lookup logic used
- * by download-images.js is reused here so the two tools stay in sync:
+ * Two things come out of every image:
  *
+ *   1. `faviconBg` / `faviconFg` — the ORIGINAL two-colour pair, produced by the
+ *      unchanged k=2 RGB k-means over a 32×32 resize of the FAVICON with alpha
+ *      < 128 dropped, so existing consumers (tools/generate-og-images.js, the
+ *      aurora card's legacy path) keep working and the committed data doesn't
+ *      churn.  A handful of stored pairs do shift by ±1 per channel on
+ *      re-extraction — that predates this change (the same drift comes out of
+ *      the previous version of this file; the committed values were produced by
+ *      a different sharp/libvips build), it is not a change in behaviour.
+ *
+ *   2. `palette` / `accent` / `paletteSource` — the richer replacement.  A
+ *      weighted k-means in OKLab over a colour histogram of the best available
+ *      artwork, near-duplicate clusters merged, ordered by population:
+ *
+ *        "paletteSource": "flyer",
+ *        "palette": "#0d0c14:46:3 #d8342a:19:22 #e8c7a1:11:7",
+ *        "accent":  "#d8342a"
+ *
+ *      Each palette token is `hex:share:chroma` — `share` = percent of the image
+ *      the colour covers, `chroma` = OKLab chroma ×100 (0 = grey, ~32 = the most
+ *      saturated colour sRGB can hold).  One packed line per entity rather than
+ *      an array of objects because these files are committed and reviewed: the
+ *      object form cost ~6,000 lines of JSON across data/ for 800 numbers, and
+ *      it re-expanded every time another writer (tools/sync-bars.js) round-tripped
+ *      a bars file.  Packed, a palette change is one readable line in a diff.
+ *
+ *      `accent` is the most usable saturated colour and is OMITTED for genuinely
+ *      colourless artwork — its absence is how a consumer knows to fall back,
+ *      replacing the "is this pair grey?" guesswork consumers used to do.
+ *
+ * Why two colours were not enough: near-white brands (Eagle NYC #f0f0f0, CHUNK
+ * #f6f4f5) yielded grey pairs, and single-colour marks whose plate was dropped
+ * with the alpha (Animal #e51a1a/#f31c1c, Bearracuda #ff1901/#ff5000) yielded two
+ * nearly identical colours — a flat "gradient".  A five-entry palette carries the
+ * plate, the ink AND the brand colour, so the consumer picks stops instead of
+ * guessing.
+ *
+ * Artwork preference:
+ *   • Events — the FLYER (event.image, matched to img/events/ through the
+ *     .meta sidecars download-images.js writes) whenever one is on disk; it is
+ *     the event's own art and far richer than a 32px favicon.  The favicon is
+ *     the fallback and stays the brand-identity signal: if the flyer turns out
+ *     colourless but the favicon has an accent, the favicon wins.
+ *   • Bars — the favicon (bars have no flyer).
+ *
+ * Favicon lookup mirrors download-images.js so the two tools stay in sync:
  *   • Regular websites  → Google Favicon service filename, e.g. favicon-animal.nyc-64px.ico
  *   • Linktree pages    → profile-picture filename, e.g. favicon-linktr.ee-cubhouse-64px.png
  *   • Wikipedia pages   → infobox-logo filename, e.g. favicon-wikipedia-wiki-Eagle_NYC-64px.png
@@ -15,9 +58,9 @@
  * Generic social platforms (instagram, facebook, twitter, tiktok, youtube, googlemaps)
  * are skipped — they have no entity-specific locally-stored favicon.
  *
- * Bars:   results written to data/bars/<city>.json as `faviconBg` / `faviconFg`.
+ * Bars:   results written to data/bars/<city>.json.
  * Events: results written to data/event-colors/<city>.json as
- *         [{ slug, url, faviconBg, faviconFg }, …].
+ *         [{ slug, url, faviconBg, faviconFg, paletteSource, palette, accent }, …].
  *
  * Usage:
  *   node tools/extract-favicon-colors.js [options]
@@ -48,7 +91,10 @@ const {
   generateLinktreeFaviconFilename,
   generateWikipediaFaviconFilename,
   isPlatformFaviconUrl,
+  cleanImageUrl,
 } = require(path.join(ROOT, 'js', 'filename-utils.js'));
+
+const EVENTS_DIR = path.join(ROOT, 'img', 'events');
 
 // ---------------------------------------------------------------------------
 // CLI flags
@@ -141,6 +187,83 @@ function localFaviconPath(websiteUrl) {
   return null;
 }
 
+// ---------------------------------------------------------------------------
+// Event flyer lookup (img/events/)
+// ---------------------------------------------------------------------------
+
+/**
+ * download-images.js unwraps Eventbrite's img.evbuc.com proxy before hashing the
+ * filename, so the same unwrapping has to happen here or those flyers are never
+ * found.  Same logic, minus the logging (see adjustEventbriteImageUrl there).
+ */
+function unwrapEventbriteImageUrl(imageUrl) {
+  if (!imageUrl || typeof imageUrl !== 'string') return imageUrl;
+  if (!imageUrl.includes('img.evbuc.com')) return imageUrl;
+  try {
+    const inner = decodeURIComponent(new URL(imageUrl).pathname.substring(1));
+    if (!inner.includes('cdn.evbuc.com')) return imageUrl;
+    const innerUrl = new URL(inner);
+    return `${innerUrl.protocol}//${innerUrl.host}${innerUrl.pathname}`;
+  } catch {
+    return imageUrl;
+  }
+}
+
+/**
+ * Index of downloaded event flyers, keyed by the image URL they came from.
+ *
+ * The filename itself can NOT be recomputed reliably: generateEventFilename()
+ * puts the event's start date in it, and a date rendered in one timezone (the
+ * machine that ran download-images.js) doesn't always match the date this
+ * process computes — several Portland flyers are one day off.  The `.meta`
+ * sidecar records the exact `originalUrl` / `adjustedUrl`, so index by those
+ * instead and the match is exact regardless of naming drift.
+ *
+ * Built once, lazily; ~300 tiny JSON reads.
+ */
+let flyerIndex = null;
+
+function buildFlyerIndex() {
+  const index = new Map();
+  if (!fs.existsSync(EVENTS_DIR)) return index;
+
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) { walk(full); continue; }
+      if (!entry.name.endsWith('.meta')) continue;
+      const imagePath = full.slice(0, -'.meta'.length);
+      if (!fs.existsSync(imagePath)) continue; // failure-only metadata
+      let meta;
+      try { meta = JSON.parse(fs.readFileSync(full, 'utf8')); } catch { continue; }
+      for (const url of [meta.originalUrl, meta.adjustedUrl]) {
+        if (url && !index.has(url)) index.set(url, imagePath);
+      }
+    }
+  };
+  walk(EVENTS_DIR);
+  return index;
+}
+
+/**
+ * Absolute path to an event's already-downloaded flyer, or null.
+ * Tries the URL as it appears in the calendar plus the two normalisations
+ * download-images.js applies before saving (cleanImageUrl, Eventbrite unwrap).
+ */
+function localFlyerPath(event) {
+  if (!event || !event.image) return null;
+  if (!flyerIndex) flyerIndex = buildFlyerIndex();
+
+  const raw = event.image;
+  const cleaned = cleanImageUrl(raw);
+  const candidates = [raw, cleaned, unwrapEventbriteImageUrl(raw), unwrapEventbriteImageUrl(cleaned)];
+  for (const candidate of candidates) {
+    const hit = candidate && flyerIndex.get(candidate);
+    if (hit) return hit;
+  }
+  return null;
+}
+
 /**
  * Pick the best URL to represent a bar or event for color extraction.
  * Priority: own website → linktree.
@@ -212,7 +335,7 @@ function toHex(rgb) {
 }
 
 /**
- * Extract bg + fg colors from a local image file.
+ * LEGACY two-colour pair, unchanged on purpose.
  * Returns { bg, fg } or null on failure.
  */
 async function extractColorsFromFile(filePath, label) {
@@ -232,12 +355,438 @@ async function extractColorsFromFile(filePath, label) {
     if (pixels.length < 4) return null;
 
     const [bg, fg] = kMeans2(pixels);
-    console.log(`  ✅ ${label} — bg=${bg} fg=${fg} (${path.basename(filePath)})`);
     return { bg, fg };
   } catch (err) {
     console.log(`  ⚠️  ${label} — color extraction failed: ${err.message}`);
     return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Perceptual palette extraction (OKLab)
+// ---------------------------------------------------------------------------
+//
+// RGB euclidean distance is a poor stand-in for "looks different": #000080 and
+// #008000 are equidistant from black in RGB but nothing like equally far apart
+// to an eye.  OKLab is cheap (a matrix, a cube root, a matrix) and near-uniform,
+// so cluster distances, the near-duplicate merge threshold and the grey test all
+// become single fixed numbers that hold across every brand.
+//
+// No dependency for this — sharp decodes, the ~40 lines below do the rest.
+
+// Longest edge the analysed image is sampled down to.  `nearest` is deliberate:
+// a palette should contain colours that ARE in the artwork, and a smoothing
+// kernel invents blends along every high-contrast edge (a black logo on white
+// sprouts a family of greys that can outvote the brand colour).
+const SAMPLE_DIM = 128;
+
+// Low bits dropped per channel when bucketing (3 → 32 levels per channel).
+// Collapses JPEG noise into one weighted cluster candidate, so k-means runs over
+// a few thousand points instead of tens of thousands of pixels.
+const QUANT_BITS = 3;
+
+const CLUSTER_COUNT = 8;      // before merging; small vivid marks need the headroom
+const MERGE_DISTANCE = 0.075; // OKLab ΔE below which two clusters are "the same colour"
+const MAX_PALETTE = 5;        // entries written out
+const MIN_PALETTE_SHARE = 0.004; // 0.4% of the image — below this it's noise
+
+// Accent gates: what may represent a brand.
+const ACCENT_MIN_CHROMA = 0.045; // below this it's a grey/near-grey
+const ACCENT_MAX_L = 0.90;       // near-white plate — reported, never the accent
+const ACCENT_MIN_L = 0.10;       // near-black ink — same
+
+function srgbChannelToLinear(value) {
+  const c = value / 255;
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/** sRGB (0–255) → OKLab. https://bottosson.github.io/posts/oklab/ */
+function rgbToOklab(r, g, b) {
+  const R = srgbChannelToLinear(r);
+  const G = srgbChannelToLinear(g);
+  const B = srgbChannelToLinear(b);
+
+  const l = Math.cbrt(0.4122214708 * R + 0.5363325363 * G + 0.0514459929 * B);
+  const m = Math.cbrt(0.2119034982 * R + 0.6806995451 * G + 0.1073969566 * B);
+  const s = Math.cbrt(0.0883024619 * R + 0.2817188376 * G + 0.6299787005 * B);
+
+  return {
+    L: 0.2104542553 * l + 0.7936177850 * m - 0.0040720468 * s,
+    a: 1.9779984951 * l - 2.4285922050 * m + 0.4505937099 * s,
+    b: 0.0259040371 * l + 0.7827717662 * m - 0.8086757660 * s,
+  };
+}
+
+function oklabChroma(lab) {
+  return Math.sqrt(lab.a * lab.a + lab.b * lab.b);
+}
+
+function oklabDistance(a, b) {
+  return Math.sqrt((a.L - b.L) ** 2 + (a.a - b.a) ** 2 + (a.b - b.b) ** 2);
+}
+
+/**
+ * Sample an image into a weighted colour histogram.
+ *
+ * Alpha is COMPOSITED OVER WHITE rather than thresholded away.  The favicon
+ * plate is a fixed white now (--favicon-plate-* in styles.css), so white *is*
+ * what sits behind a transparent logo — dropping those pixels (what the legacy
+ * pair does) throws away the plate and with it any sense of contrast: Animal's
+ * transparent-background red "A" reduced to red-on-red.
+ *
+ * Returns [{ r, g, b, lab, weight }] ordered by weight, or null.
+ */
+async function sampleImageColors(filePath) {
+  const { data, info } = await sharp(filePath)
+    .resize(SAMPLE_DIM, SAMPLE_DIM, { fit: 'inside', kernel: 'nearest', withoutEnlargement: true })
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  if (info.channels !== 4) return null;
+
+  const buckets = new Map();
+  let pixels = 0;
+
+  for (let i = 0; i < data.length; i += 4) {
+    const alpha = data[i + 3] / 255;
+    // Composite over the white plate.
+    const r = data[i] * alpha + 255 * (1 - alpha);
+    const g = data[i + 1] * alpha + 255 * (1 - alpha);
+    const b = data[i + 2] * alpha + 255 * (1 - alpha);
+
+    const key = ((r >> QUANT_BITS) << 10) | ((g >> QUANT_BITS) << 5) | (b >> QUANT_BITS);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { r: 0, g: 0, b: 0, n: 0 };
+      buckets.set(key, bucket);
+    }
+    bucket.r += r; bucket.g += g; bucket.b += b; bucket.n++;
+    pixels++;
+  }
+
+  if (pixels === 0) return null;
+
+  // Deterministic order (weight desc, then colour) — the output is committed
+  // JSON, so nothing here may depend on Map iteration luck or a RNG.
+  return [...buckets.entries()]
+    .map(([key, bucket]) => {
+      const r = bucket.r / bucket.n;
+      const g = bucket.g / bucket.n;
+      const b = bucket.b / bucket.n;
+      return { key, r, g, b, lab: rgbToOklab(r, g, b), weight: bucket.n / pixels };
+    })
+    .sort((a, b) => (b.weight - a.weight) || (a.key - b.key));
+}
+
+/**
+ * Weighted k-means in OKLab with a deterministic farthest-point seeding
+ * (population × distance², no randomness), then a merge pass that collapses
+ * clusters closer than MERGE_DISTANCE.
+ *
+ * Each returned cluster reports its MEDOID — the histogram bin nearest the
+ * centroid — not the centroid itself, so every palette hex is a colour that
+ * actually occurs in the artwork instead of an invented blend of two.
+ */
+function clusterColors(bins, k) {
+  const count = Math.min(k, bins.length);
+  const centroids = [bins[0].lab];
+
+  while (centroids.length < count) {
+    let best = null;
+    let bestScore = -1;
+    for (const bin of bins) {
+      let nearest = Infinity;
+      for (const centroid of centroids) {
+        const d = oklabDistance(bin.lab, centroid);
+        if (d < nearest) nearest = d;
+      }
+      const score = bin.weight * nearest * nearest;
+      if (score > bestScore) { bestScore = score; best = bin; }
+    }
+    if (!best || bestScore <= 0) break;
+    centroids.push(best.lab);
+  }
+
+  let assignment = new Array(bins.length).fill(0);
+  for (let iter = 0; iter < 40; iter++) {
+    let moved = false;
+    for (let i = 0; i < bins.length; i++) {
+      let bestIndex = 0;
+      let bestDistance = Infinity;
+      for (let c = 0; c < centroids.length; c++) {
+        const d = oklabDistance(bins[i].lab, centroids[c]);
+        if (d < bestDistance) { bestDistance = d; bestIndex = c; }
+      }
+      if (assignment[i] !== bestIndex) { assignment[i] = bestIndex; moved = true; }
+    }
+
+    const sums = centroids.map(() => ({ L: 0, a: 0, b: 0, w: 0 }));
+    for (let i = 0; i < bins.length; i++) {
+      const sum = sums[assignment[i]];
+      const { lab, weight } = bins[i];
+      sum.L += lab.L * weight; sum.a += lab.a * weight; sum.b += lab.b * weight; sum.w += weight;
+    }
+    centroids.forEach((centroid, index) => {
+      const sum = sums[index];
+      if (sum.w > 0) centroids[index] = { L: sum.L / sum.w, a: sum.a / sum.w, b: sum.b / sum.w };
+    });
+
+    if (!moved) break;
+  }
+
+  // Collect members, drop empties.
+  let clusters = centroids.map(centroid => ({ centroid, weight: 0, members: [] }));
+  for (let i = 0; i < bins.length; i++) {
+    const cluster = clusters[assignment[i]];
+    cluster.members.push(bins[i]);
+    cluster.weight += bins[i].weight;
+  }
+  clusters = clusters.filter(cluster => cluster.members.length > 0);
+
+  // Merge near-duplicates (repeatedly join the closest pair under threshold).
+  for (;;) {
+    let pair = null;
+    let pairDistance = MERGE_DISTANCE;
+    for (let i = 0; i < clusters.length; i++) {
+      for (let j = i + 1; j < clusters.length; j++) {
+        const d = oklabDistance(clusters[i].centroid, clusters[j].centroid);
+        if (d < pairDistance) { pairDistance = d; pair = [i, j]; }
+      }
+    }
+    if (!pair) break;
+    const [i, j] = pair;
+    const a = clusters[i];
+    const b = clusters[j];
+    const weight = a.weight + b.weight;
+    clusters[i] = {
+      centroid: weight > 0 ? {
+        L: (a.centroid.L * a.weight + b.centroid.L * b.weight) / weight,
+        a: (a.centroid.a * a.weight + b.centroid.a * b.weight) / weight,
+        b: (a.centroid.b * a.weight + b.centroid.b * b.weight) / weight,
+      } : a.centroid,
+      weight,
+      members: a.members.concat(b.members),
+    };
+    clusters.splice(j, 1);
+  }
+
+  return clusters.map(cluster => {
+    let medoid = cluster.members[0];
+    let bestDistance = Infinity;
+    for (const member of cluster.members) {
+      const d = oklabDistance(member.lab, cluster.centroid);
+      if (d < bestDistance - 1e-9 || (Math.abs(d - bestDistance) <= 1e-9 && member.weight > medoid.weight)) {
+        bestDistance = Math.min(bestDistance, d);
+        medoid = member;
+      }
+    }
+    return { rgb: [medoid.r, medoid.g, medoid.b], lab: medoid.lab, weight: cluster.weight };
+  });
+}
+
+/**
+ * How well a colour would work as THE brand colour: chroma, damped by how much
+ * of the image it covers.  The damping is a fractional power rather than the
+ * raw share on purpose — a logo mark is often 1% of a favicon (Bear Happy
+ * Hour's orange bars) and still the only brand colour in the file, so it has to
+ * be able to out-score a large muted wash without a 40% skin tone losing to a
+ * stray 0.5% speck.
+ */
+function accentScore(chroma, weight) {
+  return chroma * Math.pow(Math.max(weight, 1e-6), 0.35);
+}
+
+/**
+ * Build the palette record for one local image.
+ * Returns { palette: 'hex:share:chroma …', accent?: string } or null.
+ */
+async function extractPaletteFromFile(filePath, label) {
+  try {
+    const bins = await sampleImageColors(filePath);
+    if (!bins || bins.length === 0) return null;
+
+    const clusters = clusterColors(bins, CLUSTER_COUNT)
+      .map(cluster => ({
+        hex: toHex(cluster.rgb),
+        weight: cluster.weight,
+        L: cluster.lab.L,
+        chroma: oklabChroma(cluster.lab),
+      }))
+      .filter(cluster => cluster.weight >= MIN_PALETTE_SHARE)
+      .sort((a, b) => b.weight - a.weight);
+
+    if (clusters.length === 0) return null;
+
+    // Keep the biggest few AND the most brand-usable few, so a tiny vivid mark
+    // is never truncated away by three shades of plate.
+    const kept = new Set(clusters.slice(0, 3));
+    [...clusters]
+      .filter(cluster => cluster.chroma >= ACCENT_MIN_CHROMA)
+      .sort((a, b) => accentScore(b.chroma, b.weight) - accentScore(a.chroma, a.weight))
+      .slice(0, MAX_PALETTE)
+      .forEach(cluster => { if (kept.size < MAX_PALETTE) kept.add(cluster); });
+
+    const accentCandidates = clusters.filter(cluster =>
+      cluster.chroma >= ACCENT_MIN_CHROMA && cluster.L <= ACCENT_MAX_L && cluster.L >= ACCENT_MIN_L);
+    accentCandidates.sort((a, b) => accentScore(b.chroma, b.weight) - accentScore(a.chroma, a.weight));
+    const accent = accentCandidates.length > 0 ? accentCandidates[0] : null;
+
+    // The accent must be in the palette or a consumer can't see how much of the
+    // artwork it covers.
+    if (accent && !kept.has(accent)) {
+      if (kept.size >= MAX_PALETTE) {
+        kept.delete([...kept].sort((a, b) => a.weight - b.weight)[0]);
+      }
+      kept.add(accent);
+    }
+
+    const palette = clusters
+      .filter(cluster => kept.has(cluster))
+      .slice(0, MAX_PALETTE)
+      .map(cluster => `${cluster.hex}:${Math.max(1, Math.round(cluster.weight * 100))}:${Math.round(cluster.chroma * 100)}`)
+      .join(' ');
+
+    return accent ? { palette, accent: accent.hex } : { palette };
+  } catch (err) {
+    console.log(`  ⚠️  ${label} — palette extraction failed: ${err.message}`);
+    return null;
+  }
+}
+
+
+/**
+ * The favicon's BACKGROUND colour, sampled from its outer edge.
+ *
+ * Not the most common colour overall: Bearracuda's mark fills ~72% of its
+ * icon on a fully transparent background, so "highest coverage" called its
+ * plate orange and the orange "B" then vanished into an orange tile. The
+ * background is whatever sits at the EDGES, and a transparent edge composites
+ * over white — which is exactly the white plate a transparent logo wants.
+ *
+ * Returns a hex string, or null when the file can't be read.
+ */
+async function extractPlateFromFile(filePath, label) {
+  try {
+    const size = 32;
+    const { data, info } = await sharp(filePath)
+      .resize(size, size, { fit: 'fill', kernel: 'nearest' })
+      .ensureAlpha()
+      .raw()
+      .toBuffer({ resolveWithObject: true });
+
+    const counts = new Map();
+    const consider = (x, y) => {
+      const o = (y * info.width + x) * 4;
+      const alpha = data[o + 3] / 255;
+      // Composite over white: a transparent edge IS a white plate.
+      const r = Math.round(data[o] * alpha + 255 * (1 - alpha));
+      const g = Math.round(data[o + 1] * alpha + 255 * (1 - alpha));
+      const b = Math.round(data[o + 2] * alpha + 255 * (1 - alpha));
+      // Quantise so antialiasing along the edge doesn't split the vote.
+      const key = `${r >> 3}:${g >> 3}:${b >> 3}`;
+      const prev = counts.get(key) || { n: 0, r: 0, g: 0, b: 0 };
+      counts.set(key, { n: prev.n + 1, r: prev.r + r, g: prev.g + g, b: prev.b + b });
+    };
+
+    const ring = 2; // outer band, in resized pixels
+    for (let y = 0; y < info.height; y++) {
+      for (let x = 0; x < info.width; x++) {
+        const onEdge = x < ring || y < ring || x >= info.width - ring || y >= info.height - ring;
+        if (onEdge) consider(x, y);
+      }
+    }
+
+    let best = null;
+    for (const bucket of counts.values()) {
+      if (!best || bucket.n > best.n) best = bucket;
+    }
+    if (!best) return null;
+    return toHex([best.r / best.n, best.g / best.n, best.b / best.n]);
+  } catch (err) {
+    console.log(`  ⚠️  ${label} — plate extraction failed: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Everything colour-related for one entity, from the best artwork available.
+ *
+ * The legacy pair always comes from the FAVICON (that's what it has always
+ * meant).  The palette prefers the flyer, because a poster carries the event's
+ * real colour story, and falls back to the favicon when there is no flyer — or
+ * when the flyer turns out to be colourless artwork and the favicon isn't,
+ * since the brand mark is the better identity signal in that case.
+ *
+ * Returns { bg, fg, palette, accent, paletteSource } with every field optional.
+ */
+async function extractColorRecord({ faviconPath, flyerPath, label }) {
+  const legacy = faviconPath ? await extractColorsFromFile(faviconPath, label) : null;
+
+  const flyer = flyerPath ? await extractPaletteFromFile(flyerPath, label) : null;
+  // The favicon palette is only needed when the flyer didn't give us a colour to
+  // build on — no point decoding a second image otherwise.
+  // Always read the favicon's palette when there is one: even when the flyer
+  // supplies the card colours, the TILE still needs the favicon's own plate
+  // colour (see faviconPlate below).
+  const favicon = faviconPath ? await extractPaletteFromFile(faviconPath, label) : null;
+
+  let chosen = null;
+  let source = null;
+  if (flyer && (flyer.accent || !favicon || !favicon.accent)) {
+    chosen = flyer; source = 'flyer';
+  } else if (favicon) {
+    chosen = favicon; source = 'favicon';
+  } else if (flyer) {
+    chosen = flyer; source = 'flyer';
+  }
+
+  if (!legacy && !chosen) return null;
+
+  // The favicon's own PLATE colour: the highest-coverage entry of the FAVICON's
+  // palette, kept separately because `palette` may describe the flyer instead.
+  // This is what the site paints behind and around a favicon tile, so a round
+  // mark on white sits on white and a white mark on black sits on black — the
+  // icon's own background, rather than a fixed white badge. It is a better
+  // answer than faviconBg, which is a 2-means winner and can pick the MARK:
+  // Animal's favicon reports faviconBg #e51a1a (its red "A") while its real
+  // background is white at 61% coverage.
+  const faviconPlate = faviconPath ? await extractPlateFromFile(faviconPath, label) : null;
+
+  return {
+    bg: legacy ? legacy.bg : null,
+    fg: legacy ? legacy.fg : null,
+    palette: chosen ? chosen.palette : null,
+    accent: chosen && chosen.accent ? chosen.accent : null,
+    paletteSource: source,
+    faviconPlate,
+  };
+}
+
+/** One-line summary of what came out, for the run log. */
+function describeRecord(record) {
+  const parts = [];
+  if (record.bg) parts.push(`bg=${record.bg} fg=${record.fg}`);
+  if (record.palette) {
+    parts.push(`${record.paletteSource}=[${record.palette}]`);
+    parts.push(record.accent ? `accent=${record.accent}` : 'accent=none');
+  }
+  return parts.join(' ');
+}
+
+/** Copy the colour fields onto a plain object, dropping the ones we don't have. */
+function assignColorFields(target, record) {
+  if (record.bg) target.faviconBg = record.bg;
+  if (record.fg) target.faviconFg = record.fg;
+  if (record.faviconPlate) target.faviconPlate = record.faviconPlate;
+  else delete target.faviconPlate;
+  if (record.palette) {
+    target.paletteSource = record.paletteSource;
+    target.palette = record.palette;
+    if (record.accent) target.accent = record.accent;
+    else delete target.accent;
+  }
+  return target;
 }
 
 // ---------------------------------------------------------------------------
@@ -260,7 +809,9 @@ async function processBars(cityKey) {
   let changed = false;
 
   for (const bar of bars) {
-    if (!FORCE && bar.faviconBg && bar.faviconFg) {
+    // "Already has colors" now means the palette too, or nothing would ever gain
+    // one without --force.  The skip/--force behaviour itself is unchanged.
+    if (!FORCE && bar.faviconBg && bar.faviconFg && bar.palette) {
       console.log(`  ⏭️  ${bar.name} — already has colors`);
       continue;
     }
@@ -274,11 +825,14 @@ async function processBars(cityKey) {
       console.log(`  ⏭️  ${bar.name} — local favicon not found for ${url} (run download-images first)`);
       continue;
     }
-    const colors = await extractColorsFromFile(localPath, bar.name);
-    if (colors) {
-      bar.faviconBg = colors.bg;
-      bar.faviconFg = colors.fg;
-      changed = true;
+    // Bars have no flyer — the favicon is the only artwork on disk.
+    const record = await extractColorRecord({ faviconPath: localPath, flyerPath: null, label: bar.name });
+    if (record) {
+      const before = JSON.stringify(bar);
+      assignColorFields(bar, record);
+      console.log(`  ✅ ${bar.name} — ${describeRecord(record)} (${path.basename(localPath)})`);
+      // Deterministic re-extraction: an unchanged bar must not rewrite the file.
+      if (JSON.stringify(bar) !== before) changed = true;
     }
   }
 
@@ -344,27 +898,47 @@ async function processEvents(cityKey) {
     seen.add(event.slug);
 
     const prev = existingBySlug.get(event.slug);
-    if (!FORCE && prev && prev.faviconBg && prev.faviconFg) {
+
+    const url = chooseBestUrl(event);
+    const faviconPath = url ? localFaviconPath(url) : null;
+    // The flyer is the event's own artwork, so an event with a flyer is worth
+    // processing even when its website is a ticketing platform we refuse to take
+    // a favicon from (those used to be skipped outright, colourless).
+    const flyerPath = localFlyerPath(event);
+
+    if (!faviconPath && !flyerPath) {
+      if (!url) console.log(`  ⏭️  ${event.name} — no usable URL and no local flyer`);
+      else console.log(`  ⏭️  ${event.name} — local favicon not found for ${url} and no local flyer (run download-images first)`);
+      continue;
+    }
+
+    // Same skip rule as bars — "already has colors" now includes the palette —
+    // except that the legacy pair is only expected when there is a favicon to
+    // derive it from, or flyer-only events would be re-extracted every run.
+    const complete = prev && prev.palette && ((prev.faviconBg && prev.faviconFg) || !faviconPath);
+    if (!FORCE && complete) {
       console.log(`  ⏭️  ${event.name} — already has colors`);
       continue;
     }
 
-    const url = chooseBestUrl(event);
-    if (!url) {
-      console.log(`  ⏭️  ${event.name} — no usable URL`);
-      continue;
-    }
-
-    const localPath = localFaviconPath(url);
-    if (!localPath) {
-      console.log(`  ⏭️  ${event.name} — local favicon not found for ${url} (run download-images first)`);
-      continue;
-    }
-
-    const colors = await extractColorsFromFile(localPath, event.name);
-    if (colors) {
-      existingBySlug.set(event.slug, { slug: event.slug, url, faviconBg: colors.bg, faviconFg: colors.fg });
-      changed = true;
+    const record = await extractColorRecord({ faviconPath, flyerPath, label: event.name });
+    if (record) {
+      const entry = { slug: event.slug };
+      const entryUrl = url || (prev && prev.url);
+      if (entryUrl) entry.url = entryUrl;
+      // Never lose an existing legacy pair just because this run found no
+      // favicon on disk — those two fields are a stable published contract.
+      if (!record.bg && prev && prev.faviconBg) {
+        entry.faviconBg = prev.faviconBg;
+        entry.faviconFg = prev.faviconFg;
+      }
+      assignColorFields(entry, record);
+      existingBySlug.set(event.slug, entry);
+      const artwork = record.paletteSource === 'flyer' ? path.relative(ROOT, flyerPath) : path.basename(faviconPath || '');
+      console.log(`  ✅ ${event.name} — ${describeRecord(record)} (${artwork})`);
+      // Re-extraction is deterministic, so an unchanged entry must not rewrite
+      // the file — a --force sweep should leave a clean git status.
+      if (JSON.stringify(prev) !== JSON.stringify(entry)) changed = true;
     }
   }
 
@@ -417,7 +991,7 @@ async function main() {
     if (DO_EVENTS) await processEvents(city);
   }
 
-  console.log('\n✅ Favicon color extraction complete.');
+  console.log('\n✅ Colour extraction complete.');
 }
 
 main().catch(err => {

--- a/tools/generate-scraper-bars.js
+++ b/tools/generate-scraper-bars.js
@@ -18,7 +18,19 @@ if (fs.existsSync(barsDir)) {
       try {
         const content = fs.readFileSync(filePath, 'utf8');
         const bars = JSON.parse(content);
-        scraperBars[cityKey] = bars;
+        // Website-only presentation data never ships to the phone: the scraper
+        // reads bar identity, location and socials, never the extracted colour
+        // palettes (those drive the city-page card gradients). Keeping them out
+        // of this generated file avoids growing a runtime download for data the
+        // Scriptable side has no use for.
+        scraperBars[cityKey] = bars.map(bar => {
+          const trimmed = { ...bar };
+          delete trimmed.palette;
+          delete trimmed.accent;
+          delete trimmed.paletteSource;
+          delete trimmed.faviconPlate;
+          return trimmed;
+        });
       } catch (e) {
         console.error(`Failed to parse ${file}:`, e.message);
       }

--- a/tools/sync-bars.js
+++ b/tools/sync-bars.js
@@ -357,6 +357,13 @@ function cleanBarObject(bar) {
         'favicon',
         'faviconBg',
         'faviconFg',
+        // Richer palette from tools/extract-favicon-colors.js. Local-only, like
+        // faviconBg/faviconFg — the sheet never carries these, so they have to be
+        // in the keep-list or a sync silently drops them.
+        'paletteSource',
+        'palette',
+        'accent',
+        'faviconPlate',
         'wikipediaExtractionFailureAt',
         'wikipediaExtractionFailureMessage',
         'gayCitiesExtractionFailureAt',


### PR DESCRIPTION
Stacked on #1580 (aurora cards) — merge that first.

## Colour extraction, rethought
Old: 2-means over a 32px favicon → a `{faviconBg, faviconFg}` pair. That's why grey brands needed a "is this pair grey?" hack in the card and why red-on-red brands rendered a flat gradient.

New, in `tools/extract-favicon-colors.js`:
- **OKLab, not raw RGB.** Alpha composited over white (the plate is white by convention now, so a transparent logo's plate gets *reported* rather than dropped), 5-bit weighted histogram, deterministic weighted k-means (k=8, no RNG since the output is committed), near-duplicate clusters merged, each cluster reported as a **medoid** so every hex actually occurs in the artwork.
- **Flyers, not just favicons.** Events prefer their downloaded flyer (matched via download-images' `.meta` sidecars) and fall back to the favicon. `paletteSource` records which.
- **Additive fields only**: `palette` — packed `hex:share:chroma` tokens ordered by coverage — and `accent`, the most usable saturated colour, **omitted when artwork is genuinely colourless**. `faviconBg`/`faviconFg` are untouched so `generate-og-images.js` and friends are unaffected.
- Packed string rather than an array of objects because `JSON.stringify(…, 2)` expands to ~6,000 committed lines for ~800 numbers; packed, a palette change is one reviewable line.

Card side: accent anchors stop 1, stop 2 is the palette entry reading most differently from it, single-colour artwork gets a hue-rotated sibling. **`accent` being absent is now the colourless signal**, which retires the `rgbColorfulness < 0.18` heuristic — colourless brands get a graphite aurora from their own lightness instead of borrowing the site palette.

| | before | after |
|---|---|---|
| Eagle NYC | grey pair → forced onto site indigo/coral | graphite aurora from its own artwork |
| CHUNK | grey pair from a photo favicon | flyer palette, purple accent |
| Animal | `#e51a1a`/`#f31c1c` → flat red | red → amber |
| Bearracuda Portland | one identical red across 12 events | each event echoes its own flyer |
| Bear Happy Hour | grey → site palette | orange from its 1% logo stripes |

**Regenerated every city** (36 files): 121 entities gain a palette (103 from flyers), 15 correctly have no accent, and **9 event entries appear that were previously skipped** because their only URL was a ticketing platform. 4 bars still fail on unreadable favicon files (pre-existing — they had no colours before either). 13 entries show a ±1-per-channel shift in the legacy pair; the *old* tool produces those same values today, so that's committed-data drift from a different libvips build, not a behaviour change.

## The phone stops receiving presentation data
`tools/generate-scraper-bars.js` now strips `palette`/`accent`/`paletteSource` from the generated twins — the scraper never reads them and `scripts/scraper-bars.js` is downloaded to your phone. The twin-sync tests assert that contract rather than byte-equality with the source.

## Bug found while reviewing: the site rendered raw source markup
#1575 sanitises descriptions when the **scraper writes** them — but events already in the calendar keep whatever the source published. Sitges' Bear Cave events were displaying `<p>…</p>` plus backslash escape residue (a literal `\n` that went through ICS escaping and came back as bare backslashes), and dice.fm events showed `**bold**`. The site is the display layer, so it now sanitises what it renders instead of waiting for every event to be re-scraped. Verified against the exact stored strings.

## Not done
- `generate-og-images.js` still paints from `faviconBg`/`faviconFg` (intact, unaffected). Switching it to `accent` changes published OG art — its own pass.
- No unit tests for the colour helpers: no package.json-enumerated suite covers `js/` front-end code, and I didn't add a new test file. The extractor is proven by the full regeneration plus screenshots.
- Recurring events have no flyer on disk (`img/events/recurring/` doesn't exist), so they stay favicon-only.
- Stale event-colour entries still aren't pruned (pre-existing).

Suite: **1054/1054**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP