### PR TITLE
feat: multi-orientation event images everywhere + run-UI and merge-identity fixes

### DIFF
--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -402,6 +402,19 @@ class CalendarCore {
                     if (additionalData.image) {
                         eventData.image = additionalData.image;
                     }
+                    // Orientation slots. parseKeyValueDescription lower-cases
+                    // the notes key before canonicalizing, so an un-aliased
+                    // "imageVertical:" arrives here as "imagevertical" —
+                    // both spellings are read so this works whether or not the
+                    // schema has aliases for them yet.
+                    const imageVertical = additionalData.imageVertical || additionalData.imagevertical;
+                    if (imageVertical) {
+                        eventData.imageVertical = imageVertical;
+                    }
+                    const imageHorizontal = additionalData.imageHorizontal || additionalData.imagehorizontal;
+                    if (imageHorizontal) {
+                        eventData.imageHorizontal = imageHorizontal;
+                    }
                     if (additionalData.favicon) {
                         eventData.favicon = additionalData.favicon;
                     }
@@ -655,7 +668,11 @@ class CalendarCore {
                     
                     
                     // Additional validation for URLs
-                    if (['website', 'instagram', 'facebook', 'gmaps', 'image', 'favicon', 'ticketUrl'].includes(mappedKey)) {
+                    // Both casings of the orientation slots are listed: `key`
+                    // is already lower-cased above, so an un-aliased
+                    // "imageVertical" canonicalizes to "imagevertical".
+                    if (['website', 'instagram', 'facebook', 'gmaps', 'image', 'favicon', 'ticketUrl',
+                         'imageVertical', 'imagevertical', 'imageHorizontal', 'imagehorizontal'].includes(mappedKey)) {
                         // Ensure we have a valid URL
                         if (value.startsWith('http://') || value.startsWith('https://')) {
                             data[mappedKey] = value;

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -41,6 +41,53 @@ const AURORA_MIN_SEPARATION = 0.2;
 const AURORA_SIBLING_LIGHTNESS = 0.55;
 const AURORA_SIBLING_CHROMA_BOOST = 1.12;
 
+// Every event field that holds a flyer URL. `image` is the primary; the two
+// orientation slots are optional (orientation is only knowable for a minority
+// of URLs) and a portrait primary legitimately appears in both `image` and
+// `imageVertical`.
+const IMAGE_SLOT_FIELDS = ['image', 'imageVertical', 'imageHorizontal'];
+
+// Move a flyer <img> onto its next candidate after a load failure. Events can
+// carry up to three flyer URLs (image / imageVertical / imageHorizontal), so a
+// dead CDN link no longer makes the artwork vanish — the card walks the
+// remaining candidates (queued in data-flyer-fallbacks by the card renderer)
+// and only removes the container once every one of them has failed, which is
+// exactly the pre-existing behaviour for the single-URL case.
+function advanceFlyerImage(img) {
+    const flyer = img && img.parentNode;
+    if (!flyer || typeof flyer.getAttribute !== 'function') {
+        if (img && typeof img.remove === 'function') img.remove();
+        return;
+    }
+    let queue = [];
+    try {
+        const raw = flyer.getAttribute('data-flyer-fallbacks');
+        if (raw) queue = JSON.parse(raw);
+    } catch (error) {
+        queue = [];
+    }
+    const remaining = Array.isArray(queue)
+        ? queue.filter(candidate => candidate && typeof candidate.u === 'string' && candidate.u)
+        : [];
+    const next = remaining.shift();
+    if (!next) {
+        flyer.remove();
+        return;
+    }
+    if (remaining.length) {
+        flyer.setAttribute('data-flyer-fallbacks', JSON.stringify(remaining));
+    } else {
+        flyer.removeAttribute('data-flyer-fallbacks');
+    }
+    flyer.setAttribute('data-flyer-url', next.u);
+    if (next.o) {
+        flyer.setAttribute('data-flyer-orientation', next.o);
+    } else {
+        flyer.removeAttribute('data-flyer-orientation');
+    }
+    img.src = next.u;
+}
+
 // Dynamic Google Calendar Loader - Supports multiple cities and calendars
 class DynamicCalendarLoader extends CalendarCore {
     constructor() {
@@ -638,7 +685,8 @@ class DynamicCalendarLoader extends CalendarCore {
     }
 
     // Lazily create the flyer <img> the first time a card is selected.
-    // Deselection re-hides it via CSS; a load failure removes the container entirely.
+    // Deselection re-hides it via CSS; a load failure walks the remaining
+    // candidates (see advanceFlyerImage) before the container is removed.
     ensureFlyerLoaded(selectedCard) {
         const flyer = selectedCard.querySelector('.event-flyer[data-flyer-url]');
         if (!flyer || flyer.querySelector('img')) {
@@ -647,7 +695,7 @@ class DynamicCalendarLoader extends CalendarCore {
         const img = document.createElement('img');
         img.alt = 'event flyer';
         img.decoding = 'async';
-        img.onerror = () => flyer.remove();
+        img.onerror = () => advanceFlyerImage(img);
         img.src = flyer.getAttribute('data-flyer-url');
         flyer.appendChild(img);
     }
@@ -785,24 +833,31 @@ class DynamicCalendarLoader extends CalendarCore {
                 eventData.shortName = eventData.name || eventData.bar || '';
             }
             
-            // Convert image URLs based on data source
-            if (eventData.image && this.dataSource === 'cached') {
-                const originalImageUrl = eventData.image;
-                eventData.image = this.convertImageUrlToLocal(originalImageUrl, eventData);
-                
-                logger.debug('CALENDAR', 'Converted image URL for cached data', {
-                    eventName: eventData.name,
-                    originalUrl: originalImageUrl,
-                    localPath: eventData.image,
-                    dataSource: this.dataSource
-                });
-            } else if (eventData.image && (this.dataSource === 'proxy' || this.dataSource === 'fallback')) {
-                logger.debug('CALENDAR', 'Using external image URL for external data', {
-                    eventName: eventData.name,
-                    imageUrl: eventData.image,
-                    dataSource: this.dataSource
-                });
-            }
+            // Convert image URLs based on data source. Every flyer slot is
+            // rewritten, not just the primary — filenames are content-hash
+            // derived, so two candidates for one event never collide.
+            IMAGE_SLOT_FIELDS.forEach(field => {
+                const originalImageUrl = eventData[field];
+                if (!originalImageUrl) return;
+                if (this.dataSource === 'cached') {
+                    eventData[field] = this.convertImageUrlToLocal(originalImageUrl, eventData);
+
+                    logger.debug('CALENDAR', 'Converted image URL for cached data', {
+                        eventName: eventData.name,
+                        field,
+                        originalUrl: originalImageUrl,
+                        localPath: eventData[field],
+                        dataSource: this.dataSource
+                    });
+                } else if (this.dataSource === 'proxy' || this.dataSource === 'fallback') {
+                    logger.debug('CALENDAR', 'Using external image URL for external data', {
+                        eventName: eventData.name,
+                        field,
+                        imageUrl: originalImageUrl,
+                        dataSource: this.dataSource
+                    });
+                }
+            });
         }
         return eventData;
     }
@@ -2112,6 +2167,58 @@ class DynamicCalendarLoader extends CalendarCore {
         return this.escapeCardText(raw);
     }
 
+    // Ordered flyer candidates for one event, best first, as
+    // { u: rawUrl, o: 'portrait' | 'landscape' | '' } entries. `want` is the
+    // orientation the layout prefers; `o` is only set when the orientation is
+    // KNOWN (i.e. the URL came out of an orientation slot), which is the
+    // minority case — orientation is unknowable for most URLs, so an empty `o`
+    // has to keep behaving exactly like today's single-image card.
+    //
+    // EventSchema.pickImageForOrientation owns the preference order when it is
+    // available; the local fallback (wanted slot → primary → other slot) keeps
+    // this working on its own.
+    getFlyerCandidates(event, want = 'portrait') {
+        if (!event) return [];
+        const readSlot = value => (typeof value === 'string' ? value.trim() : '');
+        const vertical = readSlot(event.imageVertical);
+        const horizontal = readSlot(event.imageHorizontal);
+        const primary = readSlot(event.image);
+        const wantedSlot = want === 'landscape' ? horizontal : vertical;
+        const otherSlot = want === 'landscape' ? vertical : horizontal;
+
+        let preferred = wantedSlot;
+        const schema = typeof EventSchema !== 'undefined' ? EventSchema : null;
+        if (schema && typeof schema.pickImageForOrientation === 'function') {
+            try {
+                const picked = schema.pickImageForOrientation(event, want);
+                if (typeof picked === 'string' && picked.trim()) {
+                    preferred = picked.trim();
+                }
+            } catch (error) {
+                logger.debug('CALENDAR', 'pickImageForOrientation failed; using local flyer order', {
+                    error: error && error.message
+                });
+            }
+        }
+
+        const orientationOf = url => {
+            if (url && url === vertical) return 'portrait';
+            if (url && url === horizontal) return 'landscape';
+            return '';
+        };
+
+        const candidates = [];
+        const seen = new Set();
+        [preferred, wantedSlot, primary, otherSlot].forEach(url => {
+            if (!url || seen.has(url)) return;
+            seen.add(url);
+            // safeCardUrl doubles as the scheme guard: '' means javascript:/data:.
+            if (!this.safeCardUrl(url)) return;
+            candidates.push({ u: url, o: orientationOf(url) });
+        });
+        return candidates;
+    }
+
     // Inline SVG for one of the aurora card icons (see AURORA_CARD_ICONS).
     cardIconSvg(name, className = 'ec-ico') {
         const paths = AURORA_CARD_ICONS[name];
@@ -2545,9 +2652,22 @@ class DynamicCalendarLoader extends CalendarCore {
         // percent-encoded and encodeURI would double-encode them); getAttribute decodes
         // back to the exact original URL. data-flyer-url is kept so ensureFlyerLoaded()
         // still recognises the container.
-        const flyerUrl = event.image ? this.safeCardUrl(event.image) : '';
+        //
+        // The card shows the flyer at its natural aspect ratio in a fairly wide
+        // box, so it asks for the PORTRAIT candidate; the rest of the chain is
+        // queued in data-flyer-fallbacks for advanceFlyerImage(). The known
+        // orientation rides along on the container so CSS can cap portrait and
+        // landscape differently BEFORE the image loads (no layout shift).
+        const flyerCandidates = this.getFlyerCandidates(event, 'portrait');
+        const flyerPick = flyerCandidates[0] || null;
+        const flyerUrl = flyerPick ? this.safeCardUrl(flyerPick.u) : '';
+        const flyerOrientationAttr = flyerPick && flyerPick.o
+            ? ` data-flyer-orientation="${this.escapeCardText(flyerPick.o)}"` : '';
+        const flyerFallbacks = flyerCandidates.slice(1);
+        const flyerFallbackAttr = flyerFallbacks.length
+            ? ` data-flyer-fallbacks="${this.escapeCardText(JSON.stringify(flyerFallbacks))}"` : '';
         const flyerHtml = flyerUrl ?
-            `<div class="event-flyer" data-flyer-url="${flyerUrl}"><img src="${flyerUrl}" alt="" loading="lazy" decoding="async" onerror="this.parentNode.remove()"></div>` : '';
+            `<div class="event-flyer" data-flyer-url="${flyerUrl}"${flyerOrientationAttr}${flyerFallbackAttr}><img src="${flyerUrl}" alt="" loading="lazy" decoding="async" onerror="window.chunkyAdvanceFlyer ? window.chunkyAdvanceFlyer(this) : this.parentNode.remove()"></div>` : '';
 
         const aurora = this.getAuroraColorsForEvent(event);
         const plate = this.getFaviconPlateForEvent(event);
@@ -5164,4 +5284,7 @@ async function updateLocationStatus() {
 // Export class for use in app.js - no auto-initialization
 if (typeof window !== 'undefined') {
     window.DynamicCalendarLoader = DynamicCalendarLoader;
+    // Referenced from the flyer <img>'s inline onerror, which fires for cards
+    // that were never selected (so it cannot rely on ensureFlyerLoaded).
+    window.chunkyAdvanceFlyer = advanceFlyerImage;
 }

--- a/js/event-schema.js
+++ b/js/event-schema.js
@@ -89,6 +89,23 @@ const EVENT_KEY_ALIASES = {
     favicon: 'favicon',
     img: 'image',
     photo: 'image',
+    // Multi-orientation image slots. normalizeAliasKey lowercases and strips
+    // spaces/hyphens/underscores, so the single 'imagevertical' entry also
+    // resolves 'imageVertical', 'Image Vertical', 'image-vertical' and
+    // 'image_vertical' as INPUT spellings (URL params, foreign notes). Only
+    // the camelCase canonical form is ever WRITTEN to notes: isValidMetadataKey
+    // permits letters/digits/spaces only, so a hyphenated or underscored key
+    // silently vanishes from the notes with no error.
+    imagevertical: 'imageVertical',
+    verticalimage: 'imageVertical',
+    imageportrait: 'imageVertical',
+    portraitimage: 'imageVertical',
+    imgvertical: 'imageVertical',
+    imagehorizontal: 'imageHorizontal',
+    horizontalimage: 'imageHorizontal',
+    imagelandscape: 'imageHorizontal',
+    landscapeimage: 'imageHorizontal',
+    imghorizontal: 'imageHorizontal',
     cover: 'cover',
     bearreview: 'bearReview',
 
@@ -127,6 +144,8 @@ const URL_LIKE_FIELDS = new Set([
     'instagram',
     'twitter',
     'image',
+    'imageVertical',
+    'imageHorizontal',
     'favicon'
 ]);
 
@@ -165,6 +184,8 @@ const EVENT_BUILDER_STATE_KEY_BY_EVENT_KEY = Object.freeze({
     facebook: 'facebook',
     gmaps: 'gmaps',
     image: 'image',
+    imageVertical: 'imageVertical',
+    imageHorizontal: 'imageHorizontal',
     favicon: 'favicon'
 });
 
@@ -336,6 +357,62 @@ function formatEventNotes(event, options = {}) {
     });
 
     return notes.join('\n');
+}
+
+// Trimmed string value of one image slot, or '' when absent/blank.
+function readImageSlotValue(event, fieldName) {
+    const value = event ? event[fieldName] : null;
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+// Pick the best image for a wanted orientation from the three slots.
+//   want: 'portrait' | 'vertical' | 'landscape' | 'horizontal' (anything else
+//         means "no preference" and returns the primary).
+// Fallback chain, in order:
+//   1. the exact-orientation slot (imageVertical / imageHorizontal)
+//   2. the primary `image` when it classifies as the wanted orientation
+//   3. the primary `image` when its orientation is UNKNOWN — by far the common
+//      case, and the reason this degrades to today's single-image behavior
+//   4. the other slot
+//   5. the primary `image`
+// Never returns null/undefined when the event carries any image; returns ''
+// only when it carries none.
+//
+// Classification is INJECTED, not imported: this file is pure and standalone
+// (the website loads it without shared-core). Pass
+// options.classifyOrientation — on the scraper side that is
+// sharedCore.classifyImageOrientation bound to the core instance. Without it
+// every primary reads as 'unknown', which collapses steps 2/3 into "return the
+// primary" — a safe, slot-driven result, since the parsers populate the slots.
+function pickImageForOrientation(event, want, options = {}) {
+    if (!event || typeof event !== 'object') return '';
+    const primary = readImageSlotValue(event, 'image');
+    const vertical = readImageSlotValue(event, 'imageVertical');
+    const horizontal = readImageSlotValue(event, 'imageHorizontal');
+    const wanted = String(want || '').trim().toLowerCase();
+    const wantsPortrait = wanted === 'portrait' || wanted === 'vertical';
+    const wantsLandscape = wanted === 'landscape' || wanted === 'horizontal';
+    if (!wantsPortrait && !wantsLandscape) {
+        return primary || vertical || horizontal || '';
+    }
+
+    const exactSlot = wantsPortrait ? vertical : horizontal;
+    if (exactSlot) return exactSlot;
+
+    const otherSlot = wantsPortrait ? horizontal : vertical;
+    if (primary) {
+        let orientation = 'unknown';
+        if (typeof options.classifyOrientation === 'function') {
+            try {
+                orientation = String(options.classifyOrientation(primary) || 'unknown');
+            } catch (error) {
+                orientation = 'unknown';
+            }
+        }
+        if (orientation === 'unknown') return primary;
+        if (orientation === (wantsPortrait ? 'portrait' : 'landscape')) return primary;
+    }
+    return otherSlot || primary || '';
 }
 
 function getEventBuilderStateKey(paramKey) {
@@ -745,6 +822,7 @@ const EventSchema = {
     isUrlLikeField,
     parseNotesIntoFields,
     formatEventNotes,
+    pickImageForOrientation,
     getEventBuilderStateKey,
     escapeIcsText,
     foldIcsLine,

--- a/nyc/fat-dad-54af58a5/index.html
+++ b/nyc/fat-dad-54af58a5/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="Fat dad – New York – chunky.dad">
   <meta property="og:description" content="Saturday">
   <meta property="og:url" content="https://chunky.dad/nyc/fat-dad-54af58a5/">
-  <meta property="og:image" content="https://chunky.dad/img/og/nyc/fat-dad-54af58a5.png?v=a4ab8cf0">
+  <meta property="og:image" content="https://chunky.dad/img/og/nyc/fat-dad-54af58a5.png?v=bb58ade3">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Fat dad – New York – chunky.dad">
   <meta name="twitter:description" content="Saturday">
-  <meta name="twitter:image" content="https://chunky.dad/img/og/nyc/fat-dad-54af58a5.png?v=a4ab8cf0">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/nyc/fat-dad-54af58a5.png?v=bb58ade3">
   <meta http-equiv="refresh" content="0; url=../?event=fat-dad-54af58a5&date=2026-06-20&view=week">
 </head>
 <body>

--- a/nyc/pride-059058a4/index.html
+++ b/nyc/pride-059058a4/index.html
@@ -11,11 +11,11 @@
   <meta property="og:title" content="Pride – New York – chunky.dad">
   <meta property="og:description" content="Friday">
   <meta property="og:url" content="https://chunky.dad/nyc/pride-059058a4/">
-  <meta property="og:image" content="https://chunky.dad/img/og/nyc/pride-059058a4.png?v=962a0147">
+  <meta property="og:image" content="https://chunky.dad/img/og/nyc/pride-059058a4.png?v=0bf4b449">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Pride – New York – chunky.dad">
   <meta name="twitter:description" content="Friday">
-  <meta name="twitter:image" content="https://chunky.dad/img/og/nyc/pride-059058a4.png?v=962a0147">
+  <meta name="twitter:image" content="https://chunky.dad/img/og/nyc/pride-059058a4.png?v=0bf4b449">
   <meta http-equiv="refresh" content="0; url=../?event=pride-059058a4&date=2026-06-26&view=week">
 </head>
 <body>

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -5053,16 +5053,15 @@ class ScriptableAdapter {
       // webview→native pattern, see presentReviewResults). Currently used by
       // the discovered-venue "Copy parser entry" buttons (chunkyscrape://).
       const venueEntrySnippets = this.collectVenueEntrySnippets(results);
-      // Effective (redacted) config JSON for the Active-config copy button;
-      // "" when this run/saved run carries no config snapshot.
-      const activeConfigSummary = this.buildActiveConfigSummaryForResults(results);
-      const activeConfigJson =
-        activeConfigSummary && typeof activeConfigSummary.json === "string"
-          ? activeConfigSummary.json
-          : "";
       // Manual bear/not-bear override taps recorded during the WebView session,
-      // applied after dismissal. Keyed by row id so repeat taps stay idempotent.
-      const bearOverridePending = { markedBear: {}, markedNotBear: {} };
+      // applied after dismissal. Keyed by namespaced card id ("k<i>" kept /
+      // "d<i>" dropped) so repeat taps stay idempotent and the two directions
+      // on one card overwrite each other instead of stacking.
+      const bearOverridePending = {
+        markedBear: {},
+        markedNotBear: {},
+        keptMarkedBear: {},
+      };
       // Venue-queue taps this session: candidate index → timesSeen after the
       // write. Repeat taps re-flash feedback without re-writing the queue.
       const venueQueueTaps = {};
@@ -5079,11 +5078,6 @@ class ScriptableAdapter {
           if (typeof snippet === "string" && snippet.length > 0) {
             // Fire-and-forget: the handler must return a bool synchronously
             this.copyVenueEntryAndReport(snippet, params.id, webView);
-          }
-        } else if (params.a === "copy-config") {
-          if (activeConfigJson.length > 0) {
-            // Fire-and-forget: the handler must return a bool synchronously
-            this.copyActiveConfigAndReport(activeConfigJson, webView);
           }
         } else if (params.a === "mark-bear" || params.a === "mark-not-bear") {
           // Fire-and-forget: records the override natively; the page gets
@@ -5218,29 +5212,44 @@ class ScriptableAdapter {
     const newVenueSectionHtml =
       await this.generateNewVenueCandidateSection(results);
 
-    // Group events by intent actions (intent can differ from write action for overrides)
+    // Group events by intent actions (intent can differ from write action for overrides).
+    // Each entry keeps its index into allEvents — which IS the index into
+    // results.analyzedEvents (getAllEventsFromResults preserves order) — so a
+    // card's bear-verdict buttons address the right event over the bridge.
     const newEvents = [];
     const mergeEvents = [];
     const conflictEvents = [];
 
-    for (const event of allEvents) {
+    allEvents.forEach((event, index) => {
+      const entry = { event, index };
       switch (this.normalizeIntentAction(event)) {
         case "new":
-          newEvents.push(event);
+          newEvents.push(entry);
           break;
         case "merge":
-          mergeEvents.push(event);
+          mergeEvents.push(entry);
           break;
         case "conflict":
         case "missing_calendar":
-          conflictEvents.push(event);
+          conflictEvents.push(entry);
           break;
         default:
           // Fallback for events without analysis
-          newEvents.push(event);
+          newEvents.push(entry);
           break;
       }
-    }
+    });
+
+    // Kept events are, by definition, the cascade's "bear" verdicts: their
+    // cards show that verdict active with a one-tap "Mark as not bear" beside
+    // it. Saved-run display renders the verdict read-only (no execution).
+    const keptCardsInteractive = results?._isDisplayingSavedRun !== true;
+    const keptCard = (entry) =>
+      this.generateEventCard(entry.event, provenanceRunInfo, {
+        bearIdx: `k${entry.index}`,
+        bearVerdict: "bear",
+        interactive: keptCardsInteractive,
+      });
 
     const html = `
 <!DOCTYPE html>
@@ -5577,6 +5586,77 @@ class ScriptableAdapter {
             box-shadow: var(--card-hover-shadow);
             transform: translateY(-3px);
             border-color: var(--border-color);
+        }
+
+        /* Dropped-as-non-bear cards reuse the normal card so they read as real
+           events; the accent stripe is the only visual difference. */
+        .event-card.bear-dropped-card {
+            border-left: 4px solid var(--secondary-color);
+        }
+
+        /* Bear verdict row: both directions on every card, active one filled. */
+        .bear-verdict-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin: 0 0 12px 0;
+            padding: 8px 10px;
+            background: var(--background-light);
+            border: 1px solid var(--border-color);
+            border-radius: 10px;
+        }
+
+        .bear-verdict-label {
+            font-size: 10px;
+            font-weight: 600;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: var(--text-secondary);
+        }
+
+        .bear-verdict-btn {
+            font-family: 'Poppins', sans-serif;
+            font-size: 12px;
+            font-weight: 600;
+            padding: 6px 12px;
+            border-radius: 999px;
+            border: 1px solid var(--border-color);
+            background: var(--background-primary);
+            color: var(--text-secondary);
+            cursor: pointer;
+            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        .bear-verdict-btn:hover:not(:disabled) {
+            transform: translateY(-1px);
+            border-color: var(--primary-color);
+            color: var(--text-primary);
+        }
+
+        .bear-verdict-btn.is-active {
+            border-color: transparent;
+            color: var(--text-inverse);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+        }
+
+        .bear-verdict-btn[data-bear-act="mark-bear"].is-active {
+            background: #34c759;
+        }
+
+        .bear-verdict-btn[data-bear-act="mark-not-bear"].is-active {
+            background: var(--secondary-color);
+        }
+
+        .bear-verdict-btn:disabled {
+            cursor: default;
+            opacity: 0.75;
+        }
+
+        .bear-verdict-note {
+            font-size: 11px;
+            color: var(--text-secondary);
+            flex: 1 1 100%;
         }
         
         .event-title {
@@ -6544,7 +6624,7 @@ class ScriptableAdapter {
             <span class="section-title">New Events to Add</span>
             <span class="section-count">${newEvents.length}</span>
         </div>
-        ${newEvents.map((event) => this.generateEventCard(event, provenanceRunInfo)).join("")}
+        ${newEvents.map(keptCard).join("")}
     </div>
     `
         : ""
@@ -6559,7 +6639,7 @@ class ScriptableAdapter {
             <span class="section-title">Events to Merge (Adding Info)</span>
             <span class="section-count">${mergeEvents.length}</span>
         </div>
-        ${mergeEvents.map((event) => this.generateEventCard(event, provenanceRunInfo)).join("")}
+        ${mergeEvents.map(keptCard).join("")}
     </div>
     `
         : ""
@@ -6574,7 +6654,7 @@ class ScriptableAdapter {
                             <span class="section-title">Events Requiring Review</span>
             <span class="section-count">${conflictEvents.length}</span>
         </div>
-        ${conflictEvents.map((event) => this.generateEventCard(event, provenanceRunInfo)).join("")}
+        ${conflictEvents.map(keptCard).join("")}
     </div>
     `
         : ""
@@ -6617,15 +6697,11 @@ class ScriptableAdapter {
 
     ${this.generateBearDroppedSection(results)}
 
-    ${this.generateBearKeptOverrideSection(results)}
-
     ${this.generateDiscoveredVenueSection(results)}
 
     ${newVenueSectionHtml}
 
     ${this.generateDiscoverySection(results)}
-
-    ${this.generateActiveConfigSection(results)}
 
     ${insightSectionsHtml}
 
@@ -6653,22 +6729,6 @@ class ScriptableAdapter {
             } catch (ignore) {}
         }
 
-        // Active-config copy button rides the same chunkyscrape:// navigation
-        // bridge (shouldAllowRequest, set before present()) and reuses the
-        // venue-copy nonce counter; the JSON payload stays native-side.
-        function copyActiveConfig(btn) {
-            window.location.href = 'chunkyscrape://act?a=copy-config&n=' + (++window.__venueCopyNonce);
-        }
-        function markConfigCopied() {
-            try {
-                var btn = document.querySelector('.config-copy-btn');
-                if (btn) {
-                    btn.textContent = 'Copied ✓';
-                    setTimeout(function () { btn.textContent = '📋 Copy effective config JSON'; }, 2000);
-                }
-            } catch (ignore) {}
-        }
-
         // Manual bear/not-bear override buttons use the same chunkyscrape://
         // navigation bridge (shouldAllowRequest, set before present()); the
         // per-tap nonce keeps repeat taps firing as distinct navigations.
@@ -6680,12 +6740,29 @@ class ScriptableAdapter {
             window.location.href = 'chunkyscrape://act?a=' + encodeURIComponent(act) +
                 '&id=' + encodeURIComponent(idx) + '&n=' + (window.__bearOverrideNonce++);
         }
+        // Feedback flips which of the card's two verdict buttons reads as
+        // active, so the tile always shows the verdict that will be saved.
         function markBearOverrideDone(idx, act) {
             try {
-                var btn = document.querySelector('.bear-override-btn[data-bear-idx="' + idx + '"][data-bear-act="' + act + '"]');
-                if (btn) {
-                    btn.textContent = act === 'mark-bear' ? 'Marked bear ✓' : 'Marked not-bear ✓';
-                    btn.disabled = true;
+                var buttons = document.querySelectorAll('.bear-override-btn[data-bear-idx="' + idx + '"]');
+                for (var i = 0; i < buttons.length; i++) {
+                    var isTapped = buttons[i].getAttribute('data-bear-act') === act;
+                    if (isTapped) {
+                        buttons[i].classList.add('is-active');
+                    } else {
+                        buttons[i].classList.remove('is-active');
+                    }
+                }
+                var row = buttons.length > 0 ? buttons[0].closest('.bear-verdict-row') : null;
+                if (row) {
+                    row.setAttribute('data-bear-verdict', act === 'mark-bear' ? 'bear' : 'not-bear');
+                    var note = row.querySelector('.bear-verdict-note');
+                    if (!note) {
+                        note = document.createElement('span');
+                        note.className = 'bear-verdict-note';
+                        row.appendChild(note);
+                    }
+                    note.textContent = act === 'mark-bear' ? 'Marked as bear ✓ (applied when you close this view)' : 'Marked as not bear ✓ (applied when you close this view)';
                 }
             } catch (ignore) {}
         }
@@ -7842,134 +7919,6 @@ class ScriptableAdapter {
     }
   }
 
-  // Redacted active-config summary for the results UI, or null when this
-  // run carries no config snapshot (old saved runs may lack results.config)
-  // or the pure builder is unavailable. Null-guards every path so saved-run
-  // display never breaks.
-  buildActiveConfigSummaryForResults(results) {
-    if (!results || !results.config || typeof results.config !== "object") {
-      return null;
-    }
-    const core = this.getIdentityCore();
-    if (!core || typeof core.buildActiveConfigSummary !== "function") {
-      return null;
-    }
-    try {
-      return core.buildActiveConfigSummary(results.config);
-    } catch (error) {
-      console.warn(
-        `📱 Scriptable: Could not build active-config summary: ${error.message}`,
-      );
-      return null;
-    }
-  }
-
-  // Active config section: the effective run settings this run executed with
-  // (values-only, secret-redacted) plus each parser's explicit overrides
-  // diffed against the global effective values. The copy button signals
-  // native via the chunkyscrape:// scheme handled in presentRichResults
-  // (shouldAllowRequest → Pasteboard.copy) — WKWebView has no reliable
-  // navigator.clipboard.
-  generateActiveConfigSection(results) {
-    const summary = this.buildActiveConfigSummaryForResults(results);
-    if (!summary) return "";
-    const core = this.getIdentityCore();
-    if (!core || typeof core.flattenConfigForDiff !== "function") return "";
-
-    const globalFlat = core.flattenConfigForDiff(
-      summary.global && typeof summary.global === "object" ? summary.global : {},
-    );
-    const globalRows = Object.entries(globalFlat)
-      .map(
-        ([key, value]) =>
-          `<tr><td style="padding:2px 10px 2px 0; font-family:monospace; font-size:11px; color:var(--text-secondary); vertical-align:top; white-space:nowrap;">${this.escapeHtml(key)}</td><td style="padding:2px 0; font-family:monospace; font-size:11px; word-break:break-all;">${this.escapeHtml(String(value))}</td></tr>`,
-      )
-      .join("");
-
-    const parsers = Array.isArray(summary.parsers) ? summary.parsers : [];
-    const parserBlocks = parsers
-      .map((parser) => {
-        const entry = parser && typeof parser === "object" ? parser : {};
-        const overrideEntries = Object.entries(
-          entry.overrides && typeof entry.overrides === "object"
-            ? entry.overrides
-            : {},
-        );
-        const overridesHtml =
-          overrideEntries.length === 0
-            ? '<div style="font-size:12px; color:var(--text-secondary);">no overrides</div>'
-            : `<div style="font-size:12px;"><div style="font-weight:600; margin-bottom:2px;">Overrides (${overrideEntries.length})</div>${overrideEntries
-                .map(([key, diff]) => {
-                  const value =
-                    diff && diff.value !== undefined ? String(diff.value) : "unset";
-                  const globalValue =
-                    diff && diff.globalValue !== undefined
-                      ? String(diff.globalValue)
-                      : "unset";
-                  return `<div style="font-family:monospace; font-size:11px; word-break:break-all;">${this.escapeHtml(key)}: ${this.escapeHtml(value)} (global: ${this.escapeHtml(globalValue)})</div>`;
-                })
-                .join("")}</div>`;
-        const enabledBadge = entry.enabled
-          ? '<span style="font-size:11px; font-weight:600; color:#34c759;">enabled</span>'
-          : '<span style="font-size:11px; opacity:0.6;">disabled</span>';
-        const urls = Array.isArray(entry.urls) ? entry.urls : [];
-        const urlsHtml =
-          urls.length > 0
-            ? `<div style="font-size:11px; font-family:monospace; opacity:0.7; word-break:break-all; margin:2px 0 4px 0;">${urls.map((url) => this.escapeHtml(String(url))).join("<br>")}</div>`
-            : "";
-        const parserLabel = entry.parser
-          ? ` <span style="font-weight:400; opacity:0.7;">(${this.escapeHtml(entry.parser)} parser)</span>`
-          : "";
-        return `
-        <div style="margin-bottom:12px; padding:10px; background:var(--background-light); border-radius:8px;">
-            <div style="font-weight:600; margin-bottom:2px;">${this.escapeHtml(entry.name || "(unnamed)")}${parserLabel} ${enabledBadge}</div>
-            ${urlsHtml}
-            ${overridesHtml}
-        </div>`;
-      })
-      .join("");
-
-    return `
-    <div class="section">
-        <div class="section-header">
-            <span class="section-icon">⚙️</span>
-            <span class="section-title">Active config</span>
-            <span class="section-count">${parsers.length}</span>
-        </div>
-        <details style="margin-bottom:12px;">
-            <summary>Run settings</summary>
-            <div style="overflow-x:auto;"><table style="border-collapse:collapse;">${globalRows}</table></div>
-        </details>
-        ${parserBlocks}
-        <div style="display:flex; gap:6px; margin-bottom:6px; flex-wrap:wrap; align-items:center;">
-            <button onclick="copyActiveConfig(this)" class="log-copy-btn config-copy-btn">📋 Copy effective config JSON</button>
-            <span style="font-size:12px; color:var(--text-secondary);">Secrets are redacted in the copied JSON</span>
-        </div>
-    </div>
-    `;
-  }
-
-  // Copy the effective (redacted) config JSON natively and (best-effort)
-  // flash the button. Called fire-and-forget from shouldAllowRequest, which
-  // must synchronously return a bool — so the await lives here, not in the
-  // handler.
-  async copyActiveConfigAndReport(activeConfigJson, webView) {
-    try {
-      Pasteboard.copy(activeConfigJson);
-      console.log("📱 Scriptable: Copied active config JSON to clipboard");
-    } catch (error) {
-      console.warn(
-        `📱 Scriptable: Failed to copy active config JSON: ${error.message}`,
-      );
-      return;
-    }
-    try {
-      await webView.evaluateJavaScript("markConfigCopied()", false);
-    } catch (error) {
-      /* button feedback is optional polish; the copy already happened */
-    }
-  }
-
   // ---------------------------------------------------------------------------
   // Map verify links (results-UI ↔ chunkyscrape:// bridge, read-only).
   // The owner verifies a venue by comparing three independent Google Maps
@@ -8309,6 +8258,10 @@ class ScriptableAdapter {
     addParam("facebook", event.facebook);
     addParam("gmaps", event.gmaps);
     addParam("image", event.image);
+    // Orientation slots ride along so the builder can edit them; both are
+    // optional (orientation is only knowable for a minority of URLs).
+    addParam("imageVertical", event.imageVertical);
+    addParam("imageHorizontal", event.imageHorizontal);
     addParam("shortName", event.shortName);
     const query = params.length > 0 ? `?${params.join("&")}` : "";
     return `https://chunky.dad/testing/event-builder.html${query}`;
@@ -8534,40 +8487,78 @@ class ScriptableAdapter {
     return date.toDateString();
   }
 
-  // "Dropped as non-bear (N)" section: enforce-mode bear-check drops with the
-  // AI's one-line reason and a "Mark bear & save" button per row. Buttons are
-  // omitted for saved-run display (no post-dismissal execution there) and for
-  // rows already rescued by a calendar manual-bear record.
+  // Bear verdict controls stamped onto EVERY event card — kept and dropped
+  // alike — so the current verdict is visible and either direction is one tap
+  // away. `bearIdx` is namespaced because the two source lists share one
+  // bridge: "k<i>" = results.analyzedEvents[i], "d<i>" =
+  // results.bearDroppedEvents[i]. Returns "" without an index (a plain card).
+  buildBearVerdictActionsHtml(options) {
+    const opts = options && typeof options === "object" ? options : {};
+    const rawIdx = typeof opts.bearIdx === "string" ? opts.bearIdx : "";
+    if (!rawIdx) return "";
+    const idx = this.escapeHtml(rawIdx);
+    const isBear = opts.bearVerdict !== "not-bear";
+    // Saved-run display has no post-dismissal execution, and a drop already
+    // rescued by a calendar record must not be double-marked: both render the
+    // verdict read-only rather than hiding it.
+    const interactive = opts.interactive === true;
+    const disabledAttr = interactive ? "" : " disabled";
+    const button = (act, label) => {
+      const active = (act === "mark-bear") === isBear;
+      return `<button type="button" onclick="markBearOverride(this)" class="bear-verdict-btn bear-override-btn${active ? " is-active" : ""}" data-bear-idx="${idx}" data-bear-act="${act}"${disabledAttr}>${label}</button>`;
+    };
+    const note = opts.note
+      ? `<span class="bear-verdict-note">${this.escapeHtml(String(opts.note))}</span>`
+      : "";
+    return `
+            <div class="bear-verdict-row" data-bear-verdict="${isBear ? "bear" : "not-bear"}">
+                <span class="bear-verdict-label">Bear verdict</span>
+                ${button("mark-bear", "🐻 Mark as bear")}
+                ${button("mark-not-bear", "🚫 Mark as not bear")}
+                ${note}
+            </div>`;
+  }
+
+  // "Dropped as non-bear (N)" section: enforce-mode bear-check drops rendered
+  // with the SAME event-card markup the kept events use (they are real events
+  // the cascade rejected, not a debug list), each carrying both verdict
+  // buttons. Buttons go read-only for saved-run display (no post-dismissal
+  // execution there) and for rows already rescued by a calendar manual-bear
+  // record.
   generateBearDroppedSection(results) {
     const entries = Array.isArray(results && results.bearDroppedEvents)
       ? results.bearDroppedEvents
       : [];
     if (entries.length === 0) return "";
-    const interactive =
-      !results || results._isDisplayingSavedRun !== true;
+    const interactive = !results || results._isDisplayingSavedRun !== true;
+    const runInfo = {
+      runId: (results && (results.savedRunId || results.sourceRunId)) || null,
+    };
 
-    const rows = entries
+    const cards = entries
       .map((entry, index) => {
         if (!entry) return "";
-        const metaBits = [
-          this.formatBearOverrideDate(entry.startDate),
-          entry.venue || "",
-          entry.host ? `from ${entry.host}` : "",
-        ]
-          .filter(Boolean)
-          .join(" · ");
-        const control = entry.rescued
-          ? `<span style="font-size:12px; color:var(--text-secondary);">🐻 Rescued (manual override on calendar record)</span>`
-          : interactive
-            ? `<button onclick="markBearOverride(this)" class="log-copy-btn bear-override-btn" data-bear-idx="${index}" data-bear-act="mark-bear">🐻 Mark bear &amp; save</button>`
-            : "";
-        return `
-        <div class="bear-dropped-item" style="margin-bottom:12px; padding:10px; background:var(--background-light); border-radius:8px;">
-            <div style="font-weight:600;">${this.escapeHtml(entry.title || "Unknown")}</div>
-            ${metaBits ? `<div style="font-size:12px; color:var(--text-secondary);">${this.escapeHtml(metaBits)}</div>` : ""}
-            ${entry.reason ? `<div style="font-size:12px; margin:4px 0; color:var(--text-secondary);">${this.escapeHtml(entry.reason)}</div>` : ""}
-            ${control}
-        </div>`;
+        // The drop entry keeps the full event under `.event`; older/partial
+        // entries fall back to the flat summary fields so a card still renders.
+        const event =
+          entry.event && typeof entry.event === "object"
+            ? entry.event
+            : {
+                title: entry.title,
+                startDate: entry.startDate,
+                bar: entry.venue,
+              };
+        return this.generateEventCard(event, runInfo, {
+          dropped: true,
+          bearIdx: `d${index}`,
+          bearVerdict: entry.rescued ? "bear" : "not-bear",
+          interactive: interactive && entry.rescued !== true,
+          dropReason: entry.reason || "",
+          dropHost: entry.host || "",
+          note: entry.rescued
+            ? "Rescued (manual override on calendar record)"
+            : "",
+        });
       })
       .join("");
 
@@ -8578,81 +8569,66 @@ class ScriptableAdapter {
             <span class="section-title">Dropped as non-bear</span>
             <span class="section-count">${entries.length}</span>
         </div>
-        ${rows}
+        <div style="font-size:12px; color:var(--text-secondary); margin-bottom:12px;">These events were filtered out by the bear check and will NOT be written. Tap "Mark as bear" to pull one back into this run's write plan — the verdict sticks on the calendar record for future scrapes.</div>
+        ${cards}
     </div>
     `;
   }
 
-  // Compact symmetric section for kept/analyzed events: each row gets a
-  // "Mark not-bear" button (per-card buttons would tangle the event-card HTML;
-  // a dedicated list keeps the bridge indexes 1:1 with results.analyzedEvents).
-  // Live runs only — saved-run display has no post-dismissal execution.
-  generateBearKeptOverrideSection(results) {
-    if (results && results._isDisplayingSavedRun === true) return "";
-    const events = Array.isArray(results && results.analyzedEvents)
-      ? results.analyzedEvents
-      : [];
-    if (events.length === 0) return "";
-
-    const rows = events
-      .map((event, index) => {
-        if (!event) return "";
-        const meta = [
-          this.formatBearOverrideDate(event.startDate),
-          event.bar || event.venue || "",
-        ]
-          .filter(Boolean)
-          .join(" · ");
-        return `
-        <div class="bear-kept-item" style="display:flex; align-items:center; gap:8px; justify-content:space-between; margin-bottom:6px; padding:6px 10px; background:var(--background-light); border-radius:8px;">
-            <div style="min-width:0;">
-                <span style="font-weight:600;">${this.escapeHtml(event.title || "Unknown")}</span>
-                ${meta ? `<span style="font-size:12px; color:var(--text-secondary);"> — ${this.escapeHtml(meta)}</span>` : ""}
-            </div>
-            <button onclick="markBearOverride(this)" class="log-copy-btn bear-override-btn" data-bear-idx="${index}" data-bear-act="mark-not-bear">🚫 Mark not-bear</button>
-        </div>`;
-      })
-      .join("");
-
-    return `
-    <div class="section">
-        <div class="section-header">
-            <span class="section-icon">🐻</span>
-            <span class="section-title">Kept as bear — mark mistakes not-bear</span>
-            <span class="section-count">${events.length}</span>
-        </div>
-        <div style="font-size:12px; color:var(--text-secondary); margin-bottom:8px;">Marked events are still saved to the calendar but hidden on the website, and the override sticks on future scrapes.</div>
-        ${rows}
-    </div>
-    `;
+  // Split a namespaced card id into its source list and array index:
+  //   "k7" → { list: "kept",    index: 7 }  (results.analyzedEvents[7])
+  //   "d2" → { list: "dropped", index: 2 }  (results.bearDroppedEvents[2])
+  // Both lists are addressable in both directions now that every card carries
+  // both buttons, so the id — not the action — says which list to read.
+  parseBearCardId(id) {
+    const key = String(id == null ? "" : id);
+    const match = /^([kd])(\d+)$/.exec(key);
+    if (!match) return null;
+    const index = Number(match[2]);
+    if (!Number.isInteger(index) || index < 0) return null;
+    return { list: match[1] === "k" ? "kept" : "dropped", index, key };
   }
 
-  // Record one override tap natively and (best-effort) flash the row's button.
-  // Called fire-and-forget from shouldAllowRequest, which must synchronously
-  // return a bool — so the await lives here, not in the handler. Repeat taps
-  // (per-tap nonce keeps them firing) overwrite the same pending slot.
+  // Record one override tap natively and (best-effort) flip the card's verdict
+  // buttons. Called fire-and-forget from shouldAllowRequest, which must
+  // synchronously return a bool — so the await lives here, not in the handler.
+  // Repeat taps (per-tap nonce keeps them firing) overwrite the same pending
+  // slot, and tapping the opposite direction clears the other slot, so the
+  // last tap on a card always wins.
   async recordBearOverrideAndReport(action, id, results, pending, webView) {
     try {
-      const key = String(id || "");
-      const index = Number(key);
-      if (!Number.isInteger(index) || index < 0) return;
+      const parsed = this.parseBearCardId(id);
+      if (!parsed) return;
+      const { key, index } = parsed;
       let title = "";
-      if (action === "mark-bear") {
+      if (parsed.list === "dropped") {
         const entries = Array.isArray(results && results.bearDroppedEvents)
           ? results.bearDroppedEvents
           : [];
         const entry = entries[index];
         if (!entry || !entry.event || entry.rescued) return;
-        pending.markedBear[key] = entry;
         title = entry.title || "";
+        if (action === "mark-bear") {
+          pending.markedBear[key] = entry;
+        } else {
+          // "Mark as not bear" on a drop just confirms the drop — undo any
+          // pending rescue and leave the event out of the write plan.
+          delete pending.markedBear[key];
+        }
       } else {
         const events = Array.isArray(results && results.analyzedEvents)
           ? results.analyzedEvents
           : [];
         const event = events[index];
         if (!event) return;
-        pending.markedNotBear[key] = event;
         title = event.title || "";
+        if (action === "mark-bear") {
+          pending.keptMarkedBear[key] = event;
+          delete pending.markedNotBear[key];
+        } else {
+          pending.markedNotBear[key] = event;
+          delete pending.keptMarkedBear[key];
+        }
       }
       console.log(
         `📱 Scriptable: Bear override tapped — ${action} #${key} "${title}"`,
@@ -8680,7 +8656,14 @@ class ScriptableAdapter {
     const markedNotBearIds = Object.keys(
       pending && pending.markedNotBear ? pending.markedNotBear : {},
     );
-    if (markedBearIds.length === 0 && markedNotBearIds.length === 0) {
+    const keptMarkedBearIds = Object.keys(
+      pending && pending.keptMarkedBear ? pending.keptMarkedBear : {},
+    );
+    if (
+      markedBearIds.length === 0 &&
+      markedNotBearIds.length === 0 &&
+      keptMarkedBearIds.length === 0
+    ) {
       return counts;
     }
     const core = this.getIdentityCore();
@@ -8717,6 +8700,34 @@ class ScriptableAdapter {
       );
     }
 
+    // Kept event confirmed bear: it is already in the write plan, so the only
+    // change is stamping the owner's verdict in place (same notes path as the
+    // not-bear branch) — that locks the event against a future AI flip.
+    for (const id of keptMarkedBearIds) {
+      const event = pending.keptMarkedBear[id];
+      if (!event) continue;
+      const overriddenReason =
+        typeof event.bearReview === "string" && event.bearReview
+          ? event.bearReview
+          : typeof event.bearSource === "string" && event.bearSource
+            ? `${event.bearSource} verdict`
+            : "";
+      event.isBearEvent = true;
+      event.bearSource = SharedCore.buildManualBearSource(
+        "bear",
+        overriddenReason,
+      );
+      // The website hides flagged events; an explicit owner "bear" clears it.
+      if (typeof event.bearReview === "string" && event.bearReview) {
+        delete event.bearReview;
+      }
+      event.notes = core.formatEventNotes(event);
+      counts.markedBear += 1;
+      console.log(
+        `📱 Scriptable: Manual override — "${event.title || "Unknown"}" confirmed bear (manual verdict stamped on the existing write)`,
+      );
+    }
+
     // Marked bear: stamp the manual verdict, then run the SAME calendar prep
     // (calendar assignment + merge analysis) the normal flow uses so these
     // late-added events join the write plan as fully analyzed events.
@@ -8744,7 +8755,7 @@ class ScriptableAdapter {
           results.analyzedEvents = [];
         }
         results.analyzedEvents.push(...prepped);
-        counts.markedBear = prepped.length;
+        counts.markedBear += prepped.length;
         prepped.forEach((event) =>
           console.log(
             `📱 Scriptable: Manual override — "${event.title || "Unknown"}" marked bear and prepped for calendar (${event._action || "new"})`,
@@ -8866,24 +8877,45 @@ class ScriptableAdapter {
   }
 
   // Generate HTML for individual event card
-  generateEventCard(event, runInfo = {}) {
+  generateEventCard(event, runInfo = {}, bearOptions = null) {
+    // bearOptions carries this card's bear verdict + bridge index (see
+    // buildBearVerdictActionsHtml). Absent → a plain card with no verdict row,
+    // which is what the standalone-card unit tests and any future caller get.
+    const bearOpts =
+      bearOptions && typeof bearOptions === "object" ? bearOptions : {};
+    const isDroppedCard = bearOpts.dropped === true;
+    const bearVerdictRow = this.buildBearVerdictActionsHtml(bearOpts);
     const intentAction = this.normalizeIntentAction(event) || "other";
     const writeAction = this.getWriteActionFromEvent(event);
-    const actionBadge =
-      {
-        new: '<span class="action-badge badge-new">NEW</span>',
-        merge: '<span class="action-badge badge-merge">MERGE</span>',
-        conflict: '<span class="action-badge badge-warning">CONFLICT</span>',
-        missing_calendar:
-          '<span class="action-badge badge-error">MISSING CALENDAR</span>',
-      }[intentAction] ||
-      '<span class="action-badge badge-warning">OTHER</span>';
+    // Dropped-as-non-bear cards never reached calendar analysis, so their
+    // intent/write labels would read "OTHER / OTHER" — the drop badge and the
+    // bear-check reason say something true instead.
+    const actionBadge = isDroppedCard
+      ? '<span class="action-badge badge-error">🚫 DROPPED — NOT BEAR</span>'
+      : {
+          new: '<span class="action-badge badge-new">NEW</span>',
+          merge: '<span class="action-badge badge-merge">MERGE</span>',
+          conflict: '<span class="action-badge badge-warning">CONFLICT</span>',
+          missing_calendar:
+            '<span class="action-badge badge-error">MISSING CALENDAR</span>',
+        }[intentAction] ||
+        '<span class="action-badge badge-warning">OTHER</span>';
     // Recurring series are display+export only (never auto-written): badge
     // the card and offer the ICS export instead of a calendar write.
     const recurringBadge = SharedCore.isRecurringSeriesEvent(event)
       ? '<span class="action-badge badge-warning recurring-badge">🔁 recurring — save via ICS</span>'
       : "";
-    const actionNote = `<div class="write-action-note">Intent: ${this.formatIntentActionLabel(intentAction)} • Write: ${this.formatWriteActionLabel(writeAction)}</div>`;
+    const dropDetail = [
+      bearOpts.dropReason ? String(bearOpts.dropReason) : "",
+      bearOpts.dropHost ? `from ${bearOpts.dropHost}` : "",
+    ]
+      .filter(Boolean)
+      .join(" • ");
+    const actionNote = isDroppedCard
+      ? dropDetail
+        ? `<div class="write-action-note">Bear check: ${this.escapeHtml(dropDetail)}</div>`
+        : ""
+      : `<div class="write-action-note">Intent: ${this.formatIntentActionLabel(intentAction)} • Write: ${this.formatWriteActionLabel(writeAction)}</div>`;
 
     const eventDate = new Date(event.startDate);
     const endDate = event.endDate ? new Date(event.endDate) : null;
@@ -8946,10 +8978,11 @@ class ScriptableAdapter {
     const eventActionsRow = this.buildEventCardActionsHtml(event);
 
     let html = `
-        <div class="event-card">
+        <div class="event-card${isDroppedCard ? " bear-dropped-card" : ""}">
             ${actionBadge}${recurringBadge}
             ${actionNote}
             <div class="event-title">${this.escapeHtml(event.title || event.name)}</div>
+            ${bearVerdictRow}
             
             <!-- Main Event Info -->
             <div class="event-details">
@@ -9658,7 +9691,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     return this.applyParserPickerSelection(parsers, new Set());
   }
 
-  // ── Picker-state persistence (pre-selection = last run's selection) ───────
+  // ── Picker-state persistence (feeds the "Rerun last" row, NOT a default) ──
 
   getPickerStatePath() {
     return this.fm.joinPath(this.baseDir, "picker-state.json");
@@ -9719,6 +9752,17 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     }
   }
 
+  // One-line preview of what "Rerun last" would run ("" when nothing is
+  // remembered). Long lists are truncated so the row subtitle stays readable.
+  formatRerunLastSubtitle(names) {
+    const list = Array.isArray(names) ? names.filter(Boolean) : [];
+    if (list.length === 0) return "";
+    const shown = list.slice(0, 3).join(", ");
+    return list.length > 3
+      ? `${shown} +${list.length - 3} more`
+      : shown;
+  }
+
   // Stalest-first ordering (ports computeStaleStatus's sort semantics from
   // stale-parsers.js): never-written → Infinity → top, then descending
   // days-since-last-write, name as tiebreak.
@@ -9755,7 +9799,9 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
   }
 
   // Presents a UITable listing all configured parsers (stalest-first) with
-  // checkmark toggles. Resolves with a Set of picked parser names, or null on
+  // checkmark toggles, ALL unchecked (the previous run's set is offered as an
+  // explicit "Rerun last" action row instead of being pre-ticked).
+  // Resolves with a Set of picked parser names, or null on
   // swipe-down dismissal / any error — the caller treats null as CANCEL (no
   // parsers run), never as run-as-configured.
   async presentParserPicker(config) {
@@ -9766,11 +9812,15 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       const records = await this.readMetricsRecordsForPicker();
       const entries = this.buildParserPickerEntries(parsers, records);
 
-      // Pre-selection = the previous run's confirmed selection (persisted in
-      // picker-state.json; first run / missing / corrupt → none pre-selected)
-      const selected = new Set(
-        await this.loadPickerState(entries.map((entry) => entry.name)),
+      // NOTHING is pre-selected: a fresh picker always starts empty, so the
+      // common "run one different parser" case is one tap on that parser plus
+      // one on Run selected — no un-checking of last run's leftovers first.
+      // The previous run's confirmed selection is still remembered (written by
+      // savePickerState below) and offered as an explicit "Rerun last" row.
+      const lastSelection = await this.loadPickerState(
+        entries.map((entry) => entry.name),
       );
+      const selected = new Set();
 
       let resolved = false;
       let resolveSelection;
@@ -9802,6 +9852,29 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         table.addRow(headerRow);
 
         // Action rows (default dismissOnSelect: tapping dismisses the table)
+
+        // "Rerun last" replaces the old sticky pre-selection: the remembered
+        // set is one tap away instead of being forced on every run. Hidden on
+        // the first run (nothing remembered yet).
+        if (lastSelection.length > 0) {
+          const rerunRow = new UITableRow();
+          rerunRow.height = 50;
+          const rerunCell = rerunRow.addText(
+            `↻ Rerun last (${lastSelection.length})`,
+          );
+          rerunCell.titleFont = Font.boldSystemFont(16);
+          rerunCell.titleColor = Color.blue();
+          rerunCell.subtitleText = this.formatRerunLastSubtitle(lastSelection);
+          rerunCell.subtitleColor = Color.gray();
+          rerunRow.onSelect = () => {
+            console.log(
+              `📱 Scriptable: Parser picker: rerun last selection (${lastSelection.length} parsers)`,
+            );
+            finish(new Set(lastSelection));
+          };
+          table.addRow(rerunRow);
+        }
+
         const runSelectedRow = new UITableRow();
         runSelectedRow.height = 50;
         const runSelectedCell = runSelectedRow.addText(
@@ -9863,8 +9936,9 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       );
 
       const picked = await selectionPromise;
-      // Persist confirmed selections only (Run selected / Run all) — the next
-      // run's picker pre-selects them. Dismissal keeps the previous state.
+      // Persist confirmed selections only (Rerun last / Run selected / Run
+      // all) — the next run's picker offers them behind "Rerun last", never
+      // as a pre-selection. Dismissal keeps the previous state.
       if (picked) {
         await this.savePickerState(Array.from(picked));
       }
@@ -10347,6 +10421,30 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         return this.escapeHtml(str);
       };
 
+      // Identity for DISPLAY only. Strict === was reporting startDate/endDate
+      // as CLOBBERED on every merge even when nothing changed: those values are
+      // Date objects (or a Date on one side and an ISO string on the other),
+      // and two Dates naming the same instant are never ===. Mirrors
+      // SharedCore.mergeValuesEqualForTracking, which already fixed the same
+      // bug for the merge LOG line but was never applied to this table.
+      const mergeValuesLookIdentical = (a, b) => {
+        if (a === b) return true;
+        const toMs = (value) => {
+          if (value instanceof Date) return value.getTime();
+          if (typeof value === "string") {
+            const parsed = Date.parse(value);
+            return Number.isNaN(parsed) ? null : parsed;
+          }
+          return null;
+        };
+        if (a instanceof Date || b instanceof Date) {
+          const aMs = toMs(a);
+          const bMs = toMs(b);
+          return aMs !== null && aMs === bMs;
+        }
+        return false;
+      };
+
       // Determine flow direction and result
       let flowIcon = "";
       let resultText = "";
@@ -10355,7 +10453,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         // New field being added
         flowIcon = "→";
         resultText = '<span style="color: #34c759;">ADDED</span>';
-      } else if (existingValue && newValue && existingValue === newValue) {
+      } else if (existingValue && newValue && mergeValuesLookIdentical(existingValue, newValue)) {
         // Both values are identical - no change needed
         flowIcon = "—";
         resultText = '<span style="color: #999;">SAME VALUE</span>';

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1530,7 +1530,7 @@ test('parseReviewActionUrl decodes mark-bear/mark-not-bear actions with their no
   assert.equal(markNotBear.n, '12');
 });
 
-test('generateBearDroppedSection renders drops with reason and button only when drops exist', () => {
+test('generateBearDroppedSection renders drops as real event cards with both verdict buttons', () => {
   const adapter = buildAdapter();
 
   assert.equal(adapter.generateBearDroppedSection({}), '', 'no section without drops');
@@ -1538,46 +1538,84 @@ test('generateBearDroppedSection renders drops with reason and button only when 
 
   const html = adapter.generateBearDroppedSection({ bearDroppedEvents: [buildBearDroppedFixture()] });
   assert.ok(html.includes('Dropped as non-bear'), 'section title present');
-  assert.ok(html.includes('Twink Bash'), 'title shown');
+  // Same card markup the kept events use — not a debug list
+  assert.ok(html.includes('class="event-card bear-dropped-card"'), 'rendered through generateEventCard');
+  assert.ok(html.includes('class="event-title">Twink Bash<'), 'title in the card title slot');
   assert.ok(html.includes('Neon Room'), 'venue shown');
-  assert.ok(html.includes('ai: drag show, no bear context'), 'AI reason shown');
-  assert.ok(html.includes('from promoter.example'), 'source host shown');
-  assert.ok(html.includes('data-bear-idx="0"'), 'row index carried on the button');
-  assert.ok(html.includes('data-bear-act="mark-bear"'), 'mark-bear action wired');
-  assert.ok(html.includes('markBearOverride(this)'), 'button signals via the bridge');
+  assert.ok(html.includes('Bear check: ai: drag show, no bear context • from promoter.example'), 'drop reason + host shown');
+  assert.ok(html.includes('DROPPED — NOT BEAR'), 'drop badge replaces the intent/write badge');
 
-  // A rescued row shows its badge instead of a button
+  // BOTH actions on the tile, addressed by the dropped-list namespace
+  assert.ok(html.includes('data-bear-idx="d0"'), 'dropped-list index carried on the buttons');
+  assert.ok(html.includes('data-bear-act="mark-bear"'), 'mark-bear action wired');
+  assert.ok(html.includes('data-bear-act="mark-not-bear"'), 'mark-not-bear action wired');
+  assert.equal((html.match(/markBearOverride\(this\)/g) || []).length, 2, 'exactly two verdict buttons per card');
+  // The current (not-bear) verdict is the highlighted one
+  assert.ok(
+    html.includes('bear-verdict-btn bear-override-btn is-active" data-bear-idx="d0" data-bear-act="mark-not-bear"'),
+    'not-bear is the active verdict on a dropped card'
+  );
+  assert.ok(
+    html.includes('bear-verdict-btn bear-override-btn" data-bear-idx="d0" data-bear-act="mark-bear"'),
+    'mark-bear rendered inactive'
+  );
+  assert.ok(!html.includes('disabled>'), 'live-run buttons are tappable');
+
+  // A rescued row keeps its cards + note but goes read-only (already applied)
   const rescuedHtml = adapter.generateBearDroppedSection({
     bearDroppedEvents: [{ ...buildBearDroppedFixture(), rescued: true }]
   });
   assert.ok(rescuedHtml.includes('Rescued (manual override on calendar record)'));
-  assert.ok(!rescuedHtml.includes('data-bear-act="mark-bear"'), 'no button on rescued rows');
+  assert.ok(rescuedHtml.includes('data-bear-act="mark-bear" disabled'), 'rescued rows cannot be re-marked');
+  assert.ok(rescuedHtml.includes('data-bear-verdict="bear"'), 'a rescued drop reads as bear');
 
-  // Saved-run display lists the drops but offers no buttons
+  // Saved-run display lists the drops but the buttons are inert
   const savedHtml = adapter.generateBearDroppedSection({
     _isDisplayingSavedRun: true,
     bearDroppedEvents: [buildBearDroppedFixture()]
   });
   assert.ok(savedHtml.includes('Twink Bash'));
-  assert.ok(!savedHtml.includes('data-bear-act="mark-bear"'));
+  assert.ok(savedHtml.includes('data-bear-act="mark-bear" disabled'), 'saved-run display has no post-dismissal execution');
 });
 
-test('generateBearKeptOverrideSection lists kept events with mark-not-bear buttons on live runs only', () => {
+test('buildBearVerdictActionsHtml escapes the card id and marks the active verdict', () => {
   const adapter = buildAdapter();
-  const results = buildResultsStub();
+  assert.equal(adapter.buildBearVerdictActionsHtml(null), '', 'no row without options');
+  assert.equal(adapter.buildBearVerdictActionsHtml({ bearVerdict: 'bear' }), '', 'no row without a card id');
 
-  const html = adapter.generateBearKeptOverrideSection(results);
-  assert.ok(html.includes('mark mistakes not-bear'), 'section title present');
-  assert.ok(html.includes('data-bear-idx="0"'));
-  assert.ok(html.includes('data-bear-idx="1"'));
-  assert.ok(html.includes('data-bear-act="mark-not-bear"'));
+  const bear = adapter.buildBearVerdictActionsHtml({ bearIdx: 'k3', bearVerdict: 'bear', interactive: true });
+  assert.ok(bear.includes('🐻 Mark as bear'));
+  assert.ok(bear.includes('🚫 Mark as not bear'));
+  assert.ok(bear.includes('data-bear-act="mark-bear"') && bear.includes('is-active" data-bear-idx="k3" data-bear-act="mark-bear"'));
+  assert.ok(!bear.includes('is-active" data-bear-idx="k3" data-bear-act="mark-not-bear"'));
 
-  assert.equal(
-    adapter.generateBearKeptOverrideSection({ ...results, _isDisplayingSavedRun: true }),
-    '',
-    'saved-run display has no post-dismissal execution, so no buttons'
+  const escaped = adapter.buildBearVerdictActionsHtml({
+    bearIdx: 'k1"><script>x</script>',
+    bearVerdict: 'not-bear',
+    interactive: false,
+    note: '<b>note</b>'
+  });
+  assert.ok(!escaped.includes('<script>'), 'card id is escaped into the attribute');
+  assert.ok(escaped.includes('&lt;b&gt;note&lt;/b&gt;'), 'note is escaped');
+  assert.ok(escaped.includes(' disabled>'), 'non-interactive renders read-only buttons');
+});
+
+test('generateEventCard renders kept events with both verdict buttons and escaped content', () => {
+  const adapter = buildAdapter();
+  const card = adapter.generateEventCard(
+    { title: 'Bear <b>Night</b>', _action: 'new', startDate: '2026-08-01T02:00:00.000Z', bar: 'Ram & "Ranch"' },
+    {},
+    { bearIdx: 'k0', bearVerdict: 'bear', interactive: true }
   );
-  assert.equal(adapter.generateBearKeptOverrideSection({ analyzedEvents: [] }), '');
+  assert.ok(card.includes('data-bear-idx="k0"'), 'kept-list index on the tile');
+  assert.equal((card.match(/data-bear-idx="k0"/g) || []).length, 2, 'both directions present');
+  assert.ok(card.includes('data-bear-verdict="bear"'), 'current verdict exposed on the row');
+  assert.ok(card.includes('Bear &lt;b&gt;Night&lt;/b&gt;'), 'title escaped');
+  assert.ok(card.includes('Ram &amp; &quot;Ranch&quot;'), 'venue escaped');
+  assert.ok(!card.includes('<b>Night</b>'), 'no raw title markup');
+
+  const plain = adapter.generateEventCard({ title: 'Plain', _action: 'new', startDate: '2026-08-01T02:00:00.000Z' });
+  assert.ok(!plain.includes('bear-verdict-row'), 'no verdict row without bear options');
 });
 
 test('generateRichHTML embeds the dropped section only when bearDroppedEvents is non-empty', async () => {
@@ -1590,9 +1628,20 @@ test('generateRichHTML embeds the dropped section only when bearDroppedEvents is
   assert.ok(withDrops.includes('chunkyscrape://act?a='), 'override buttons signal via the custom scheme');
   assert.ok(withDrops.includes('__bearOverrideNonce'), 'per-tap nonce keeps repeat taps distinct navigations');
   assert.ok(withDrops.includes('markBearOverrideDone'), 'best-effort feedback handler defined');
+  assert.ok(withDrops.includes('class="event-card bear-dropped-card"'), 'drops reach the page as real event cards');
+  assert.ok(withDrops.includes('data-bear-idx="d0"'), 'dropped events are addressable over the bridge');
 
   const withoutDrops = await adapter.generateRichHTML(buildResultsStub());
   assert.ok(!withoutDrops.includes('Dropped as non-bear'), 'no dropped section without drops');
+  // Every kept card carries both verdict buttons, indexed into analyzedEvents
+  assert.ok(withoutDrops.includes('data-bear-idx="k0"'), 'first kept event addressable');
+  assert.ok(withoutDrops.includes('data-bear-idx="k1"'), 'second kept event addressable');
+  assert.equal(
+    (withoutDrops.match(/data-bear-idx="k\d+" data-bear-act="mark-not-bear"/g) || []).length,
+    2,
+    'one not-bear button per kept card (the separate kept-override list is gone)'
+  );
+  assert.ok(!withoutDrops.includes('mark mistakes not-bear'), 'the standalone kept-override list is gone');
 });
 
 test('presentRichResults records override taps and applies them after dismissal', async () => {
@@ -1615,17 +1664,25 @@ test('presentRichResults records override taps and applies them after dismissal'
     }
     assert.ok(wv.getHandler(), 'shouldAllowRequest assigned before present()');
 
-    // Taps: rescue the dropped event, bury a kept one. Navigation cancelled.
-    assert.equal(wv.tap('chunkyscrape://act?a=mark-bear&id=0&n=1'), false);
-    assert.equal(wv.tap('chunkyscrape://act?a=mark-not-bear&id=0&n=2'), false);
+    // Taps: rescue the dropped event (d0), bury a kept one (k0), and confirm
+    // the other kept one as bear (k1). Navigation always cancelled.
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-bear&id=d0&n=1'), false);
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-not-bear&id=k0&n=2'), false);
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-bear&id=k1&n=3'), false);
     await new Promise((r) => setImmediate(r));
     assert.ok(
-      wv.evals.some((js) => js.includes('markBearOverrideDone("0", "mark-bear")')),
+      wv.evals.some((js) => js.includes('markBearOverrideDone("d0", "mark-bear")')),
       'in-page "Marked" feedback pushed (best-effort)'
     );
 
-    // Out-of-range ids are ignored without crashing.
-    assert.equal(wv.tap('chunkyscrape://act?a=mark-bear&id=99&n=3'), false);
+    // Last tap on a card wins: flipping k1 back to not-bear then to bear
+    // leaves exactly one pending verdict for it.
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-not-bear&id=k1&n=4'), false);
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-bear&id=k1&n=5'), false);
+
+    // Out-of-range and unnamespaced ids are ignored without crashing.
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-bear&id=d99&n=6'), false);
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-not-bear&id=0&n=7'), false);
 
     wv.dismiss();
     await done;
@@ -1644,6 +1701,13 @@ test('presentRichResults records override taps and applies them after dismissal'
 
   // Marked bear: prepped through the normal calendar flow and appended to the
   // plan (the stubbed environment yields action "new").
+  // A kept event confirmed bear is stamped in place (no duplicate write)
+  const confirmed = results.analyzedEvents[1];
+  assert.ok(String(confirmed.bearSource).startsWith('manual-bear'), 'kept event carries the owner verdict');
+  assert.equal(confirmed.isBearEvent, true);
+  assert.equal(confirmed.bearReview, undefined, 'an explicit owner bear clears the hide flag');
+  assert.equal(TestEventSchema.parseNotesIntoFields(confirmed.notes).bearSource, confirmed.bearSource);
+
   assert.equal(results.analyzedEvents.length, 3, 'rescued event joined the plan');
   const rescued = results.analyzedEvents[2];
   assert.equal(rescued.title, 'Twink Bash');
@@ -2627,89 +2691,20 @@ test('generateEventCard embeds are all built by the shared serializer (no AI blo
 }
 );
 
-// ---------------------------------------------------------------------------
-// Active config section: effective run settings + per-parser override diffs
-// rendered from results.config (SharedCore.buildActiveConfigSummary), with a
-// native copy-config bridge for the redacted JSON payload.
+// The "Active config" section was removed from the results UI (owner
+// feedback); a regression guard keeps it from creeping back.
 // ---------------------------------------------------------------------------
 
-function buildActiveConfigResultsFixture() {
-  return {
-    config: {
-      config: {
-        daysToLookAhead: 30,
-        dryRun: true,
-        pageCache: { enabled: true, ttlDays: 3 },
-        geocodeVerification: { mode: 'enforce' },
-        ai: {
-          provider: 'openai',
-          endpoint: 'http://rybook.example:8000/v1/chat/completions',
-          model: 'global-model',
-          bearCheck: { mode: 'enforce' }
-        },
-        ocr: { enabled: true, endpoint: 'http://rybook.example:8001/v1/chat/completions', model: 'vision-model', maxImages: 2 }
-      },
-      parsers: [
-        {
-          name: 'Megawoof <b>America</b>',
-          enabled: true,
-          parser: 'ai-web',
-          urls: ['https://www.eventbrite.com/o/megawoof-america'],
-          alwaysBear: true,
-          ai: { model: 'parser-model' }
-        },
-        { name: 'Furball', enabled: false, urls: ['https://furball.nyc'] }
-      ]
-    }
-  };
-}
-
-test('generateActiveConfigSection renders run settings, override diffs, and the copy button only when config exists', () => {
+test('generateRichHTML no longer renders an Active config section', async () => {
   const adapter = buildAdapter();
-
-  assert.equal(adapter.generateActiveConfigSection({}), '', 'no section without results.config');
-  assert.equal(adapter.generateActiveConfigSection(null), '', 'no section for null results');
-  assert.equal(adapter.generateActiveConfigSection({ config: null }), '', 'no section for a null config snapshot');
-
-  const html = adapter.generateActiveConfigSection(buildActiveConfigResultsFixture());
-  assert.ok(html.includes('Active config'), 'section title present');
-  assert.ok(html.includes('<span class="section-count">2</span>'), 'count is the parser count');
-
-  // Run settings live in a collapsed <details> with flattened global rows
-  assert.ok(html.includes('<summary>Run settings</summary>'), 'run-settings details present');
-  assert.ok(!html.includes('<details open'), 'details collapsed by default');
-  assert.ok(html.includes('ai.model'), 'flattened global keys rendered');
-  assert.ok(html.includes('global-model'), 'global values rendered');
-  assert.ok(html.includes('geocodeVerification.mode'), 'run-level knobs rendered');
-
-  // Per-parser rows: escaped name, enabled badge, urls, override diffs
-  assert.ok(html.includes('Megawoof &lt;b&gt;America&lt;/b&gt;'), 'parser names are escaped');
-  assert.ok(!html.includes('<b>America</b>'), 'raw markup never reaches the page');
-  assert.ok(html.includes('>enabled</span>'), 'enabled badge rendered');
-  assert.ok(html.includes('>disabled</span>'), 'disabled badge rendered');
-  assert.ok(html.includes('https://www.eventbrite.com/o/megawoof-america'), 'parser urls surfaced');
-  assert.ok(html.includes('Overrides (2)'), 'override count rendered');
-  assert.ok(html.includes('ai.model: parser-model (global: global-model)'), 'diff rendered value (global: value)');
-  assert.ok(html.includes('alwaysBear: true (global: unset)'), 'explicit knob with no global value says unset');
-  assert.ok(html.includes('no overrides'), 'parser without explicit knobs says no overrides');
-
-  // Copy button signals native (Pasteboard) — never navigator.clipboard
-  assert.ok(html.includes('copyActiveConfig(this)'), 'copy button wired to the custom-scheme signal');
-  assert.ok(html.includes('📋 Copy effective config JSON'), 'copy button label present');
-});
-
-test('generateRichHTML embeds the active-config section and the copy-config handler once', async () => {
-  const adapter = buildAdapter();
-  const results = { ...buildResultsStub(), ...buildActiveConfigResultsFixture() };
-  const html = await adapter.generateRichHTML(results);
-
-  assert.ok(html.includes('Active config'), 'section present when config exists');
-  assert.equal((html.match(/a=copy-config/g) || []).length, 1, 'copy-config bridge navigation defined exactly once');
-  assert.equal((html.match(/function copyActiveConfig\(/g) || []).length, 1, 'page handler defined exactly once');
-  assert.equal((html.match(/function markConfigCopied\(/g) || []).length, 1, 'feedback handler defined exactly once');
-
-  const withoutConfig = await adapter.generateRichHTML(buildResultsStub());
-  assert.ok(!withoutConfig.includes('Active config'), 'no section without a config snapshot');
+  const html = await adapter.generateRichHTML({
+    ...buildResultsStub(),
+    config: { config: { dryRun: true }, parsers: [{ name: 'Furball', enabled: true }] }
+  });
+  assert.ok(!html.includes('Active config'), 'section gone even when a config snapshot exists');
+  assert.ok(!html.includes('a=copy-config'), 'copy-config bridge navigation gone');
+  assert.ok(!html.includes('copyActiveConfig'), 'page handler gone');
+  assert.equal(typeof adapter.generateActiveConfigSection, 'undefined', 'builder deleted');
 });
 
 // ---------------------------------------------------------------------------
@@ -2902,6 +2897,146 @@ test('picker-state: corrupt or misshapen file → empty pre-selection', async ()
   assert.deepEqual(adapter.parsePickerState('null', ['Alpha']), [], 'JSON null → []');
 });
 
+// Headless UITable stub that records every row it is handed and taps the first
+// row whose label contains `tapLabel` (null = swipe-down dismissal).
+function installPickerUITableStub(tapLabel) {
+  const originals = {
+    UITable: global.UITable,
+    UITableRow: global.UITableRow,
+    Font: global.Font,
+    Color: global.Color
+  };
+  const captured = { rows: [] };
+  global.UITableRow = class {
+    constructor() {
+      this.cells = [];
+    }
+    addText(title) {
+      const cell = { title };
+      this.cells.push(cell);
+      return cell;
+    }
+  };
+  global.UITable = class {
+    constructor() {
+      this.rows = [];
+    }
+    addRow(row) {
+      this.rows.push(row);
+    }
+    removeAllRows() {
+      this.rows = [];
+    }
+    reload() {}
+    present() {
+      captured.rows = this.rows;
+      const rows = this.rows;
+      return new Promise((resolve) => {
+        setImmediate(() => {
+          if (tapLabel) {
+            const row = rows.find((r) =>
+              r.cells.some((c) => typeof c.title === 'string' && c.title.includes(tapLabel))
+            );
+            if (row && row.onSelect) row.onSelect();
+          }
+          resolve();
+        });
+      });
+    }
+  };
+  global.Font = { boldSystemFont: () => ({}), systemFont: () => ({}) };
+  global.Color = { white: () => ({}), brown: () => ({}), blue: () => ({}), gray: () => ({}) };
+  captured.restore = () => Object.assign(global, originals);
+  captured.labels = () =>
+    captured.rows.map((r) => (r.cells[0] && r.cells[0].title) || '');
+  return captured;
+}
+
+test('presentParserPicker pre-selects NOTHING even with a remembered selection', async () => {
+  const adapter = buildAdapter();
+  const files = installMemoryFm(adapter);
+  files.set(
+    adapter.getPickerStatePath(),
+    JSON.stringify({ selected: ['Alpha', 'Beta'] })
+  );
+
+  const table = installPickerUITableStub('▶ Run selected');
+  try {
+    const picked = await adapter.presentParserPicker({
+      parsers: [{ name: 'Alpha' }, { name: 'Beta' }, { name: 'Gamma' }]
+    });
+    assert.deepEqual(Array.from(picked), [], 'confirming immediately runs nothing');
+
+    const labels = table.labels();
+    assert.ok(
+      labels.includes('▶ Run selected (0)'),
+      `Run selected starts at zero (labels: ${labels.join(' | ')})`
+    );
+    assert.ok(
+      labels.every((label) => !label.startsWith('☑')),
+      'no parser row is pre-ticked'
+    );
+    assert.equal(
+      labels.filter((label) => label.startsWith('☐')).length,
+      3,
+      'every parser row renders unchecked'
+    );
+  } finally {
+    table.restore();
+  }
+});
+
+test('presentParserPicker offers "Rerun last" which runs the remembered selection', async () => {
+  const adapter = buildAdapter();
+  const files = installMemoryFm(adapter);
+  files.set(
+    adapter.getPickerStatePath(),
+    JSON.stringify({ selected: ['Alpha', 'Ghost', 'Beta'] })
+  );
+
+  const table = installPickerUITableStub('↻ Rerun last');
+  try {
+    const picked = await adapter.presentParserPicker({
+      parsers: [{ name: 'Alpha' }, { name: 'Beta' }, { name: 'Gamma' }]
+    });
+    // "Ghost" is no longer configured, so it is filtered out of the remembered set
+    assert.deepEqual(Array.from(picked).sort(), ['Alpha', 'Beta']);
+    assert.ok(table.labels().includes('↻ Rerun last (2)'), 'row counts the known remembered parsers');
+    // The confirmed selection is re-persisted so the row keeps working
+    assert.deepEqual(
+      JSON.parse(files.get(adapter.getPickerStatePath())).selected.sort(),
+      ['Alpha', 'Beta']
+    );
+  } finally {
+    table.restore();
+  }
+});
+
+test('presentParserPicker hides "Rerun last" on the first run (nothing remembered)', async () => {
+  const adapter = buildAdapter();
+  installMemoryFm(adapter);
+
+  const table = installPickerUITableStub('▶ Run all');
+  try {
+    const picked = await adapter.presentParserPicker({ parsers: [{ name: 'Alpha' }] });
+    assert.deepEqual(Array.from(picked), ['Alpha']);
+    assert.ok(
+      table.labels().every((label) => !label.includes('Rerun last')),
+      'no rerun row without a remembered selection'
+    );
+  } finally {
+    table.restore();
+  }
+});
+
+test('formatRerunLastSubtitle previews the remembered set and truncates long lists', () => {
+  const adapter = buildAdapter();
+  assert.equal(adapter.formatRerunLastSubtitle([]), '');
+  assert.equal(adapter.formatRerunLastSubtitle(null), '');
+  assert.equal(adapter.formatRerunLastSubtitle(['A', 'B']), 'A, B');
+  assert.equal(adapter.formatRerunLastSubtitle(['A', 'B', 'C', 'D', 'E']), 'A, B, C +2 more');
+});
+
 test('presentParserPicker: swipe-down dismissal resolves null and persists nothing (headless UITable)', async () => {
   const adapter = buildAdapter();
   const files = installMemoryFm(adapter);
@@ -3068,6 +3203,46 @@ test('event card: every event gets an Event Builder prefill link', () => {
   assert.ok(builderUrl.includes('city=dallas'));
   assert.ok(builderUrl.includes('website=https%3A%2F%2Fexample.com%2Fone-off'));
   assert.ok(!builderUrl.includes('recurrence='), 'no recurrence param without an rrule');
+});
+
+test('event card: builder prefill carries every flyer slot, and omits the ones the event lacks', () => {
+  const adapter = buildAdapter();
+  adapter.resetMapVerifyUrls();
+  adapter.resetIcsExportEvents();
+  adapter.generateEventCard({
+    title: 'Three Flyers',
+    _action: 'new',
+    startDate: '2026-08-01T02:00:00.000Z',
+    city: 'dallas',
+    image: 'https://cdn.example.com/primary.jpg?w=1',
+    imageVertical: 'https://cdn.example.com/tall.jpg',
+    imageHorizontal: 'https://cdn.example.com/wide.jpg'
+  });
+
+  const builderUrl = Object.values(adapter._mapVerifyUrls).find((url) =>
+    url.startsWith('https://chunky.dad/testing/event-builder.html?'),
+  );
+  assert.ok(builderUrl.includes('image=https%3A%2F%2Fcdn.example.com%2Fprimary.jpg%3Fw%3D1'),
+    'primary image prefilled and percent-encoded');
+  assert.ok(builderUrl.includes('imageVertical=https%3A%2F%2Fcdn.example.com%2Ftall.jpg'),
+    'portrait slot prefilled');
+  assert.ok(builderUrl.includes('imageHorizontal=https%3A%2F%2Fcdn.example.com%2Fwide.jpg'),
+    'landscape slot prefilled');
+
+  adapter.resetMapVerifyUrls();
+  adapter.generateEventCard({
+    title: 'One Flyer',
+    _action: 'new',
+    startDate: '2026-08-01T02:00:00.000Z',
+    city: 'dallas',
+    image: 'https://cdn.example.com/primary.jpg'
+  });
+  const plainUrl = Object.values(adapter._mapVerifyUrls).find((url) =>
+    url.startsWith('https://chunky.dad/testing/event-builder.html?'),
+  );
+  assert.ok(plainUrl.includes('image=https%3A%2F%2Fcdn.example.com%2Fprimary.jpg'), 'primary still prefilled');
+  assert.ok(!plainUrl.includes('imageVertical='), 'no empty portrait param');
+  assert.ok(!plainUrl.includes('imageHorizontal='), 'no empty landscape param');
 });
 
 test('event card: recurring events get the badge, the builder link, and the ICS export button', () => {

--- a/scripts/event-schema.js
+++ b/scripts/event-schema.js
@@ -89,6 +89,23 @@ const EVENT_KEY_ALIASES = {
     favicon: 'favicon',
     img: 'image',
     photo: 'image',
+    // Multi-orientation image slots. normalizeAliasKey lowercases and strips
+    // spaces/hyphens/underscores, so the single 'imagevertical' entry also
+    // resolves 'imageVertical', 'Image Vertical', 'image-vertical' and
+    // 'image_vertical' as INPUT spellings (URL params, foreign notes). Only
+    // the camelCase canonical form is ever WRITTEN to notes: isValidMetadataKey
+    // permits letters/digits/spaces only, so a hyphenated or underscored key
+    // silently vanishes from the notes with no error.
+    imagevertical: 'imageVertical',
+    verticalimage: 'imageVertical',
+    imageportrait: 'imageVertical',
+    portraitimage: 'imageVertical',
+    imgvertical: 'imageVertical',
+    imagehorizontal: 'imageHorizontal',
+    horizontalimage: 'imageHorizontal',
+    imagelandscape: 'imageHorizontal',
+    landscapeimage: 'imageHorizontal',
+    imghorizontal: 'imageHorizontal',
     cover: 'cover',
     bearreview: 'bearReview',
 
@@ -127,6 +144,8 @@ const URL_LIKE_FIELDS = new Set([
     'instagram',
     'twitter',
     'image',
+    'imageVertical',
+    'imageHorizontal',
     'favicon'
 ]);
 
@@ -165,6 +184,8 @@ const EVENT_BUILDER_STATE_KEY_BY_EVENT_KEY = Object.freeze({
     facebook: 'facebook',
     gmaps: 'gmaps',
     image: 'image',
+    imageVertical: 'imageVertical',
+    imageHorizontal: 'imageHorizontal',
     favicon: 'favicon'
 });
 
@@ -336,6 +357,62 @@ function formatEventNotes(event, options = {}) {
     });
 
     return notes.join('\n');
+}
+
+// Trimmed string value of one image slot, or '' when absent/blank.
+function readImageSlotValue(event, fieldName) {
+    const value = event ? event[fieldName] : null;
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+// Pick the best image for a wanted orientation from the three slots.
+//   want: 'portrait' | 'vertical' | 'landscape' | 'horizontal' (anything else
+//         means "no preference" and returns the primary).
+// Fallback chain, in order:
+//   1. the exact-orientation slot (imageVertical / imageHorizontal)
+//   2. the primary `image` when it classifies as the wanted orientation
+//   3. the primary `image` when its orientation is UNKNOWN — by far the common
+//      case, and the reason this degrades to today's single-image behavior
+//   4. the other slot
+//   5. the primary `image`
+// Never returns null/undefined when the event carries any image; returns ''
+// only when it carries none.
+//
+// Classification is INJECTED, not imported: this file is pure and standalone
+// (the website loads it without shared-core). Pass
+// options.classifyOrientation — on the scraper side that is
+// sharedCore.classifyImageOrientation bound to the core instance. Without it
+// every primary reads as 'unknown', which collapses steps 2/3 into "return the
+// primary" — a safe, slot-driven result, since the parsers populate the slots.
+function pickImageForOrientation(event, want, options = {}) {
+    if (!event || typeof event !== 'object') return '';
+    const primary = readImageSlotValue(event, 'image');
+    const vertical = readImageSlotValue(event, 'imageVertical');
+    const horizontal = readImageSlotValue(event, 'imageHorizontal');
+    const wanted = String(want || '').trim().toLowerCase();
+    const wantsPortrait = wanted === 'portrait' || wanted === 'vertical';
+    const wantsLandscape = wanted === 'landscape' || wanted === 'horizontal';
+    if (!wantsPortrait && !wantsLandscape) {
+        return primary || vertical || horizontal || '';
+    }
+
+    const exactSlot = wantsPortrait ? vertical : horizontal;
+    if (exactSlot) return exactSlot;
+
+    const otherSlot = wantsPortrait ? horizontal : vertical;
+    if (primary) {
+        let orientation = 'unknown';
+        if (typeof options.classifyOrientation === 'function') {
+            try {
+                orientation = String(options.classifyOrientation(primary) || 'unknown');
+            } catch (error) {
+                orientation = 'unknown';
+            }
+        }
+        if (orientation === 'unknown') return primary;
+        if (orientation === (wantsPortrait ? 'portrait' : 'landscape')) return primary;
+    }
+    return otherSlot || primary || '';
 }
 
 function getEventBuilderStateKey(paramKey) {
@@ -745,6 +822,7 @@ const EventSchema = {
     isUrlLikeField,
     parseNotesIntoFields,
     formatEventNotes,
+    pickImageForOrientation,
     getEventBuilderStateKey,
     escapeIcsText,
     foldIcsLine,

--- a/scripts/event-schema.test.js
+++ b/scripts/event-schema.test.js
@@ -62,6 +62,113 @@ test('notes round-trip: URL-like values keep their unescaped colons', () => {
   assert.equal(parsed.website, 'https://x.example/party');
 });
 
+// ---------------------------------------------------------------------------
+// Multi-orientation image slots (image / imageVertical / imageHorizontal)
+// ---------------------------------------------------------------------------
+
+test('notes round-trip: all three image slots survive byte-identically with unescaped colons', () => {
+  // Real values: a Wix portrait rendition and a bearracuda landscape flyer.
+  const event = {
+    image: 'https://bearracuda.com/wp-content/uploads/2026/05/hottake_may2026-igposter_v2-820x1024.jpg',
+    imageVertical: 'https://static.wixstatic.com/media/238fae_16613~mv2.jpg/v1/fill/w_792,h_990,al_c,q_85,enc_avif/238fae_16613~mv2.jpg',
+    imageHorizontal: 'https://cdn.example.com/uploads/1920x1080/poster.jpg'
+  };
+
+  const notes = EventSchema.formatEventNotes(event);
+  assert.equal(notes, [
+    `image: ${event.image}`,
+    `imageVertical: ${event.imageVertical}`,
+    `imageHorizontal: ${event.imageHorizontal}`
+  ].join('\n'), 'slots are written as bare, single-line camelCase key/URL pairs');
+  assert.ok(!/\\:/.test(notes), 'URL_LIKE_FIELDS keeps slot colons unescaped');
+
+  const parsed = EventSchema.parseNotesIntoFields(notes);
+  assert.deepEqual(parsed, event, 'round-trip is byte-identical');
+});
+
+test('regression guard: a hyphenated image slot key SILENTLY VANISHES from notes', () => {
+  // isValidMetadataKey allows letters/digits/spaces only. A hyphenated or
+  // underscored key is not rejected loudly — the line is simply not metadata,
+  // so the field disappears with no error. This is why the canonical notes
+  // keys must stay camelCase.
+  const url = 'https://static.wixstatic.com/media/a~mv2.jpg/v1/fill/w_792,h_990/a~mv2.jpg';
+  assert.deepEqual(EventSchema.parseNotesIntoFields(`image-vertical: ${url}`), {},
+    'a hyphenated key produces NO field at all');
+  assert.deepEqual(EventSchema.parseNotesIntoFields(`image_vertical: ${url}`), {},
+    'an underscored key produces NO field at all');
+  assert.equal(EventSchema.isValidMetadataKey('image-vertical'), false);
+  assert.equal(EventSchema.isValidMetadataKey('imageVertical'), true);
+  // The camelCase twin of the same value does survive.
+  assert.deepEqual(EventSchema.parseNotesIntoFields(`imageVertical: ${url}`), { imageVertical: url });
+});
+
+test('backward compat: an event with only image: round-trips exactly as before', () => {
+  const notes = 'image: https://bearracuda.com/wp-content/uploads/2025/04/cuda-atlanta-nov_2025-web.jpg';
+  const parsed = EventSchema.parseNotesIntoFields(notes);
+  assert.deepEqual(parsed, {
+    image: 'https://bearracuda.com/wp-content/uploads/2025/04/cuda-atlanta-nov_2025-web.jpg'
+  }, 'no empty slots are invented');
+  assert.equal(EventSchema.formatEventNotes(parsed), notes, 're-serializes unchanged');
+});
+
+test('image slot aliases resolve from every legal input spelling', () => {
+  ['imagevertical', 'imageVertical', 'Image Vertical', 'image-vertical', 'image_vertical',
+    'verticalImage', 'image portrait'].forEach(spelling => {
+    assert.equal(EventSchema.canonicalizeEventKey(spelling), 'imageVertical', spelling);
+  });
+  ['imagehorizontal', 'imageHorizontal', 'Image Horizontal', 'image-horizontal',
+    'horizontalImage', 'image landscape'].forEach(spelling => {
+    assert.equal(EventSchema.canonicalizeEventKey(spelling), 'imageHorizontal', spelling);
+  });
+  // Builder URL params: the separator-stripping alias pass makes the illegal
+  // notes spellings legal as QUERY PARAMS.
+  assert.equal(EventSchema.getEventBuilderStateKey('image-vertical'), 'imageVertical');
+  assert.equal(EventSchema.getEventBuilderStateKey('imageHorizontal'), 'imageHorizontal');
+  assert.equal(EventSchema.getEventBuilderStateKey('image'), 'image', 'the primary is unchanged');
+});
+
+test('pickImageForOrientation walks the fallback chain and never loses an image', () => {
+  const pick = EventSchema.pickImageForOrientation;
+  const all = { image: 'P.jpg', imageVertical: 'V.jpg', imageHorizontal: 'H.jpg' };
+
+  // 1. exact-orientation slot wins
+  assert.equal(pick(all, 'portrait'), 'V.jpg');
+  assert.equal(pick(all, 'vertical'), 'V.jpg', 'vertical is a synonym for portrait');
+  assert.equal(pick(all, 'landscape'), 'H.jpg');
+  assert.equal(pick(all, 'horizontal'), 'H.jpg');
+  // No/unknown preference → the primary
+  assert.equal(pick(all, ''), 'P.jpg');
+  assert.equal(pick(all, 'square'), 'P.jpg');
+
+  // 2. no slot + a primary that classifies as the wanted shape → the primary
+  const classify = (url) => (url === 'P-portrait.jpg' ? 'portrait' : 'landscape');
+  assert.equal(pick({ image: 'P-portrait.jpg' }, 'portrait', { classifyOrientation: classify }), 'P-portrait.jpg');
+
+  // 3. ALL-UNKNOWN (the common case: ~18% of real URLs advertise dimensions)
+  //    degrades to exactly today's behavior — the primary, for any request.
+  assert.equal(pick({ image: 'P.jpg' }, 'portrait'), 'P.jpg');
+  assert.equal(pick({ image: 'P.jpg' }, 'landscape'), 'P.jpg');
+  assert.equal(pick({ image: 'P.jpg', imageVertical: 'V.jpg' }, 'landscape'), 'P.jpg',
+    'an unknown primary beats the wrong-orientation slot');
+
+  // 4. primary classifies as the OTHER shape → the other slot
+  assert.equal(pick({ image: 'P-portrait.jpg', imageVertical: 'V.jpg' }, 'landscape',
+    { classifyOrientation: classify }), 'V.jpg');
+
+  // 5. last resort: the primary, even when nothing matched
+  assert.equal(pick({ image: 'P-portrait.jpg' }, 'landscape', { classifyOrientation: classify }), 'P-portrait.jpg');
+
+  // Slot-only events still answer; an image-less event answers ''
+  assert.equal(pick({ imageVertical: 'V.jpg' }, 'landscape'), 'V.jpg');
+  assert.equal(pick({ imageHorizontal: 'H.jpg' }, ''), 'H.jpg');
+  assert.equal(pick({}, 'portrait'), '');
+  assert.equal(pick(null, 'portrait'), '');
+  // A throwing classifier must never break selection
+  assert.equal(pick({ image: 'P.jpg' }, 'portrait', {
+    classifyOrientation: () => { throw new Error('boom'); }
+  }), 'P.jpg');
+});
+
 test('parseNotesIntoFields: a value line that looks like "key: value" stays part of the value', () => {
   // The multi-line description contains an escaped "Doors\: 9pm" line; it must not
   // be promoted to its own field.

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -472,6 +472,14 @@ class AiWebParser {
         this.wixMediaTransformPattern = /^(https?:\/\/static\.wixstatic\.com\/media\/([^/?#]+))\/v1\/(?:fill|fit|crop)\/([^/?#]+)(?:[/?#]|$)/i;
         // URLs already logged by upgradeCdnThumbnailUrl — log each upgrade once per run.
         this.upgradedCdnThumbnailUrls = new Set();
+        // Extra image shapes an event's own structured data published (schema.org
+        // publishes `image` as an ARRAY of aspect ratios). Keyed by the event
+        // object so nothing is ever stamped onto the event itself — the slots
+        // filler reads this and the entry dies with the event.
+        this.imageSlotCandidatesByEvent = new WeakMap();
+        // Near-square artwork belongs in NEITHER orientation slot: a shape must
+        // beat this ratio (or its reciprocal) to count as landscape (portrait).
+        this.imageOrientationRatioThreshold = 1.1;
         this.aiPromptHistory = [];
         // Context-prep responses keyed by prompt hash: confidence retries rebuild a
         // byte-identical context-prep prompt, so the HTTP round-trip can be reused.
@@ -647,6 +655,12 @@ class AiWebParser {
                 // content gets its own og-image/page provenance here (no image
                 // → no stamp).
                 structuredEvents.forEach(event => this.stampImageProvenance(event, effectiveHtmlData));
+                // Orientation slots from every shape the structured data and the
+                // page's meta tags published (page-wide meta artwork only when a
+                // single event owns the page, same rule as the og:image fill).
+                structuredEvents.forEach(event => this.applyImageSlots(event, effectiveHtmlData, {
+                    allowPageMetaCandidates: structuredEvents.length === 1
+                }));
                 // Bar provenance for the structured-data path: curated/
                 // venue-site stamps only — there is no extraction evidence
                 // corpus here, so the adjacency check never runs (fail open).
@@ -4103,6 +4117,7 @@ class AiWebParser {
         const offerUrl = offer && typeof offer === 'object' ? this.normalizeHttpUrlValue(offer.url) : '';
         const ticketUrl = offerUrl || this.normalizeHttpUrlValue(node.url) || '';
         const cover = this.formatJsonLdOffersCover(node.offers);
+        const jsonLdImageCandidates = this.pickJsonLdImageCandidates(node.image);
 
         const event = {
             title,
@@ -4113,9 +4128,12 @@ class AiWebParser {
             address,
             url: sourceUrl,
             ticketUrl,
-            image: this.pickJsonLdImage(node.image),
+            image: jsonLdImageCandidates.length > 0 ? jsonLdImageCandidates[0].url : '',
             source: this.config.source
         };
+        // The other aspect ratios this node published stay reachable for the
+        // orientation slots (off-event WeakMap — the event object is untouched).
+        this.rememberImageSlotCandidates(event, jsonLdImageCandidates);
         // The page's own structured data named this venue and it survived the
         // address-shaped-name gate above — the venue-site identity pass never
         // overrides a structured-data bar (underscore field, internal only).
@@ -4266,19 +4284,41 @@ class AiWebParser {
         return normalizedName.length > 0 && normalizedName === normalizeStreetText(streetLine);
     }
 
-    pickJsonLdImage(image) {
-        const candidates = Array.isArray(image) ? image : [image];
-        for (const candidate of candidates) {
-            if (typeof candidate === 'string' && candidate.trim()) {
+    // EVERY image shape a schema.org node published, in document order.
+    // schema.org tells publishers to give `image` as an array of aspect ratios
+    // (1x1, 4x3, 16x9) — exactly the portrait/landscape pair the orientation
+    // slots want — so the array is read whole instead of collapsing to [0].
+    // ImageObject entries carry authoritative width/height; those beat anything
+    // guessed from the URL.
+    pickJsonLdImageCandidates(image) {
+        const raw = Array.isArray(image) ? image : [image];
+        const candidates = [];
+        const seen = new Set();
+        for (const entry of raw) {
+            let url = '';
+            let width = null;
+            let height = null;
+            if (typeof entry === 'string' && entry.trim()) {
                 // JSON-LD events skip normalizeAiEvent, so upgrade degraded CDN
                 // thumbnails here — the stored image must never be a blurred preview.
-                return this.upgradeCdnThumbnailUrl(this.normalizeHttpUrlValue(candidate) || '') || '';
+                url = this.upgradeCdnThumbnailUrl(this.normalizeHttpUrlValue(entry) || '') || '';
+            } else if (entry && typeof entry === 'object' && typeof entry.url === 'string') {
+                url = this.upgradeCdnThumbnailUrl(this.normalizeHttpUrlValue(entry.url) || '') || '';
+                width = this.parseImageDimensionValue(entry.width);
+                height = this.parseImageDimensionValue(entry.height);
             }
-            if (candidate && typeof candidate === 'object' && typeof candidate.url === 'string') {
-                return this.upgradeCdnThumbnailUrl(this.normalizeHttpUrlValue(candidate.url) || '') || '';
-            }
+            if (!url) continue;
+            const key = this.canonicalizeImageUrlForComparison(url);
+            if (!key || seen.has(key)) continue;
+            seen.add(key);
+            candidates.push({ url, width, height, authoritative: Boolean(width && height) });
         }
-        return '';
+        return candidates;
+    }
+
+    pickJsonLdImage(image) {
+        const candidates = this.pickJsonLdImageCandidates(image);
+        return candidates.length > 0 ? candidates[0].url : '';
     }
 
     // Cover (price) from schema.org offers: a single offer object, a plain offer
@@ -5640,6 +5680,11 @@ class AiWebParser {
             } else {
                 // Sort by size score (descending) and pick the largest
                 group.sort((a, b) => this.getImageSizeFromUrl(b.url) - this.getImageSizeFromUrl(a.url));
+                // A Wix asset served as a portrait `fill` AND a landscape `fill`
+                // strips to ONE key here, so the group can hold two different
+                // SHAPES, not just two sizes. Keep the losers reachable for the
+                // orientation slots (the returned winner is unchanged).
+                this.attachOcrImageShapeVariants(group[0], group);
                 deduped.push(group[0]);
                 console.log(`🤖 AI Web: Deduplicated ${group.length} size variant(s) to largest: ${group[0].url}`);
             }
@@ -5688,6 +5733,12 @@ class AiWebParser {
             } else {
                 // Sort by size score (descending) and pick the largest
                 group.sort((a, b) => this.getImageSizeFromUrl(b.url) - this.getImageSizeFromUrl(a.url));
+                // Identical OCR text means identical ARTWORK — which is exactly
+                // how a portrait flyer and its landscape banner twin look to
+                // this grouping. The twin survives on the winner instead of
+                // being deleted; the returned array is unchanged so segment
+                // pairing and the extraction prompt behave exactly as before.
+                this.attachOcrImageShapeVariants(group[0], group);
                 consolidated.push(group[0]);
                 console.log(`🤖 AI Web: Consolidated ${group.length} duplicate image(s) to largest: ${group[0].url}`);
             }
@@ -11060,6 +11111,11 @@ TEXT:
         // 'page' otherwise; no image → no stamp.
         this.stampImageProvenance(event, htmlData);
 
+        // Orientation slots last, so they see the final image value. Same
+        // segment rule as the og:image fill above: page-wide meta artwork is
+        // not attributable to one segment of a multi-event page.
+        this.applyImageSlots(event, htmlData, { allowPageMetaCandidates: !dataFlags.segment });
+
         return event;
     }
 
@@ -11960,6 +12016,28 @@ TEXT:
         return '';
     }
 
+    // EVERY og-style meta content for a key, in document order. Pages legitimately
+    // publish more than one <meta property="og:image"> (one per aspect ratio, each
+    // followed by its own og:image:width/og:image:height) — extractOgMetaContent
+    // above answers only the first, so the rest were invisible. Same decoding, so
+    // list[0] always equals extractOgMetaContent's answer.
+    extractOgMetaContentAll(html, keyName) {
+        const source = String(html || '').slice(0, 500000);
+        const metaRegex = /<meta\b[^>]*>/gi;
+        const values = [];
+        let match;
+        while ((match = metaRegex.exec(source)) !== null) {
+            const tag = match[0];
+            const nameMatch = tag.match(/\b(?:name|property)\s*=\s*["']([^"']+)["']/i);
+            if (!nameMatch || this.normalizeWhitespace(nameMatch[1]).toLowerCase() !== keyName) continue;
+            const contentMatch = tag.match(/\bcontent\s*=\s*["']([^"']+)["']/i);
+            if (!contentMatch) continue;
+            const value = this.normalizeWhitespace(this.decodeBasicEntities(contentMatch[1]));
+            if (value) values.push(value);
+        }
+        return values;
+    }
+
     // Cached per page like getPageBrandNames (segment/OCR copies spread
     // htmlData and inherit the cache).
     getPageOgTitle(htmlData) {
@@ -12038,21 +12116,57 @@ TEXT:
     // never the lowercased comparison form getPageMetaImageUrls builds.
     // Obvious non-artwork URLs (logos/icons per isLikelyUninterestingImageUrl)
     // are skipped; an event that already has an image is left untouched.
+    // Every social-artwork candidate the page's meta tags publish, in the same
+    // key order fillImageFromPageMetaArtwork has always used, run through the
+    // standard storage pipeline (normalizeHttpUrlValue → unwrapImageProxyUrl →
+    // upgradeCdnThumbnailUrl). Multiple tags per key are all collected, and the
+    // og:image family's published og:image:width/og:image:height are paired by
+    // document order — those are the page's OWN authoritative dimensions, worth
+    // more than anything the URL hints at. Cached per page like getPageOgTitle.
+    collectPageMetaImageCandidates(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object') return [];
+        if (Array.isArray(htmlData.pageMetaImageCandidates)) return htmlData.pageMetaImageCandidates;
+        const html = typeof htmlData.html === 'string' ? htmlData.html : '';
+        const candidates = [];
+        if (html) {
+            const widths = this.extractOgMetaContentAll(html, 'og:image:width');
+            const heights = this.extractOgMetaContentAll(html, 'og:image:height');
+            const metaKeys = ['og:image', 'og:image:url', 'og:image:secure_url', 'twitter:image', 'twitter:image:src'];
+            const seen = new Set();
+            for (const metaKey of metaKeys) {
+                const contents = this.extractOgMetaContentAll(html, metaKey);
+                for (let i = 0; i < contents.length; i++) {
+                    // Same explicit &amp; second decode as getPageMetaImageUrls.
+                    const content = contents[i].replace(/&amp;/gi, '&');
+                    const normalized = this.normalizeHttpUrlValue(content);
+                    if (!normalized) continue;
+                    const unwrapped = this.unwrapImageProxyUrl(normalized) || normalized;
+                    const upgraded = this.upgradeCdnThumbnailUrl(unwrapped);
+                    if (!upgraded) continue;
+                    const key = this.canonicalizeImageUrlForComparison(upgraded);
+                    if (!key || seen.has(key)) continue;
+                    seen.add(key);
+                    // og:image:width/height belong to the og:image family only —
+                    // the Twitter card tags have no dimension siblings.
+                    const pairable = metaKey.indexOf('og:image') === 0;
+                    const width = pairable ? this.parseImageDimensionValue(widths[i]) : null;
+                    const height = pairable ? this.parseImageDimensionValue(heights[i]) : null;
+                    candidates.push({ url: upgraded, width, height, authoritative: Boolean(width && height) });
+                }
+            }
+        }
+        if (Object.isExtensible(htmlData)) {
+            htmlData.pageMetaImageCandidates = candidates;
+        }
+        return candidates;
+    }
+
     fillImageFromPageMetaArtwork(event, htmlData) {
         if (!event || typeof event !== 'object') return event;
         const existingImage = typeof event.image === 'string' ? event.image.trim() : '';
         if (existingImage) return event;
-        const html = htmlData && typeof htmlData.html === 'string' ? htmlData.html : '';
-        if (!html) return event;
-        const metaKeys = ['og:image', 'og:image:url', 'og:image:secure_url', 'twitter:image', 'twitter:image:src'];
-        for (const metaKey of metaKeys) {
-            // Same explicit &amp; second decode as getPageMetaImageUrls.
-            const content = this.extractOgMetaContent(html, metaKey).replace(/&amp;/gi, '&');
-            if (!content) continue;
-            const normalized = this.normalizeHttpUrlValue(content);
-            if (!normalized) continue;
-            const unwrapped = this.unwrapImageProxyUrl(normalized) || normalized;
-            const upgraded = this.upgradeCdnThumbnailUrl(unwrapped);
+        for (const candidate of this.collectPageMetaImageCandidates(htmlData)) {
+            const upgraded = candidate.url;
             if (!upgraded || this.isLikelyUninterestingImageUrl(upgraded)) continue;
             event.image = upgraded;
             event.imageSource = 'og-image';
@@ -12071,6 +12185,227 @@ TEXT:
         const metaImageUrls = this.getPageMetaImageUrls(htmlData);
         event.imageSource = canonical && metaImageUrls.includes(canonical) ? 'og-image' : 'page';
         return event;
+    }
+
+    // ========================================================================
+    // ORIENTATION SLOTS (imageVertical / imageHorizontal)
+    // ========================================================================
+    // Pages routinely publish the SAME artwork in two shapes — a portrait flyer
+    // for the feed and a landscape banner for the header. Extraction has always
+    // kept exactly one and deleted the rest, so a site that hands us both could
+    // still only ever be shown in one aspect. These helpers gather the shapes
+    // that were being thrown away (JSON-LD image arrays, extra og:image tags,
+    // OCR twins) and fill the two slots.
+    //
+    // Everything fails open and nothing here touches `image`: an orientation
+    // that cannot be established from PUBLISHED or URL-encoded dimensions fills
+    // NO slot, which is the common case (real URL-dimension coverage is low).
+    // Guessing an orientation would be worse than leaving the slot empty.
+
+    // A schema.org / og width or height value as a positive pixel count.
+    // Accepts numbers, numeric strings ("1200", "1200 px") and schema.org
+    // QuantitativeValue objects; anything else is null (no dimension known).
+    parseImageDimensionValue(value) {
+        if (value === null || value === undefined) return null;
+        if (typeof value === 'object') {
+            if (Array.isArray(value)) return this.parseImageDimensionValue(value[0]);
+            return this.parseImageDimensionValue(value.value !== undefined ? value.value : value['@value']);
+        }
+        const match = String(value).trim().match(/^(\d+(?:\.\d+)?)/);
+        if (!match) return null;
+        const pixels = Math.round(Number(match[1]));
+        return Number.isFinite(pixels) && pixels > 0 ? pixels : null;
+    }
+
+    // 'portrait' | 'landscape' | 'square' | 'unknown' from a pixel pair.
+    orientationFromImageDimensions(width, height) {
+        const w = this.parseImageDimensionValue(width);
+        const h = this.parseImageDimensionValue(height);
+        if (!w || !h) return 'unknown';
+        const ratio = w / h;
+        if (ratio >= this.imageOrientationRatioThreshold) return 'landscape';
+        if (ratio <= 1 / this.imageOrientationRatioThreshold) return 'portrait';
+        return 'square';
+    }
+
+    // Orientation of one candidate. Dimensions the page PUBLISHED (JSON-LD
+    // ImageObject width/height, og:image:width/height) are authoritative and
+    // answer first; only then do we ask shared-core to read dimensions out of
+    // the URL. Both shared-core readers are optional — this degrades to
+    // 'unknown' (no slot) when they are absent.
+    resolveImageCandidateOrientation(candidate) {
+        if (!candidate || !candidate.url) return 'unknown';
+        const published = this.orientationFromImageDimensions(candidate.width, candidate.height);
+        if (published !== 'unknown') return published;
+        if (this.core && typeof this.core.getImageDimensionsFromUrl === 'function') {
+            const dimensions = this.core.getImageDimensionsFromUrl(candidate.url);
+            if (dimensions) {
+                const derived = this.orientationFromImageDimensions(dimensions.width, dimensions.height);
+                if (derived !== 'unknown') {
+                    candidate.derivedWidth = this.parseImageDimensionValue(dimensions.width);
+                    candidate.derivedHeight = this.parseImageDimensionValue(dimensions.height);
+                    return derived;
+                }
+            }
+        }
+        if (this.core && typeof this.core.classifyImageOrientation === 'function') {
+            const classified = this.core.classifyImageOrientation(candidate.url);
+            if (classified === 'portrait' || classified === 'landscape' || classified === 'square') {
+                return classified;
+            }
+        }
+        return 'unknown';
+    }
+
+    // Pixel area when known (published beats URL-derived), else 0.
+    getImageCandidateArea(candidate) {
+        const width = this.parseImageDimensionValue(candidate && candidate.width) || (candidate && candidate.derivedWidth) || 0;
+        const height = this.parseImageDimensionValue(candidate && candidate.height) || (candidate && candidate.derivedHeight) || 0;
+        return width > 0 && height > 0 ? width * height : 0;
+    }
+
+    // Stash the extra shapes a structured node published for `event`, off-event
+    // (WeakMap) so no internal field ever rides along on the event object.
+    rememberImageSlotCandidates(event, candidates) {
+        if (!event || typeof event !== 'object') return;
+        if (!Array.isArray(candidates) || candidates.length === 0) return;
+        const existing = this.imageSlotCandidatesByEvent.get(event) || [];
+        this.imageSlotCandidatesByEvent.set(event, existing.concat(candidates));
+    }
+
+    // Keep the OCR results a grouping pass is about to drop reachable on the
+    // survivor. The returned OCR array keeps its exact shape — segment pairing,
+    // the extraction prompt and the evidence corpus all read the same fields
+    // they always did — but the discarded twin's URL is no longer lost.
+    attachOcrImageShapeVariants(winner, group) {
+        if (!winner || !Array.isArray(group) || group.length <= 1) return winner;
+        const variants = Array.isArray(winner.imageShapeVariants) ? winner.imageShapeVariants.slice() : [];
+        const seen = new Set([this.canonicalizeImageUrlForComparison(winner.url)]);
+        variants.forEach(url => seen.add(this.canonicalizeImageUrlForComparison(url)));
+        for (const member of group) {
+            if (!member) continue;
+            const memberUrls = [member.url].concat(Array.isArray(member.imageShapeVariants) ? member.imageShapeVariants : []);
+            for (const rawUrl of memberUrls) {
+                const normalized = this.normalizeHttpUrlValue(rawUrl);
+                if (!normalized) continue;
+                const key = this.canonicalizeImageUrlForComparison(normalized);
+                if (!key || seen.has(key)) continue;
+                seen.add(key);
+                variants.push(normalized);
+            }
+        }
+        if (variants.length > 0) {
+            winner.imageShapeVariants = variants;
+        }
+        return winner;
+    }
+
+    // The other shapes of THIS event's image that OCR grouping set aside. Only
+    // variants of the event's own image count — an unrelated flyer's twin is
+    // never attributable to this event.
+    collectOcrImageShapeCandidates(event, htmlData) {
+        const image = event && typeof event.image === 'string' ? event.image.trim() : '';
+        if (!image) return [];
+        const ocrResults = htmlData && Array.isArray(htmlData.ocrResults) ? htmlData.ocrResults : [];
+        if (ocrResults.length === 0) return [];
+        const imageStripped = this.stripSizeParams(image);
+        const imageCanonical = this.canonicalizeImageUrlForComparison(image);
+        const candidates = [];
+        for (const result of ocrResults) {
+            if (!result || !Array.isArray(result.imageShapeVariants) || result.imageShapeVariants.length === 0) continue;
+            const groupUrls = [result.url].concat(result.imageShapeVariants);
+            const ownsImage = groupUrls.some(url => {
+                const normalized = this.normalizeHttpUrlValue(url);
+                if (!normalized) return false;
+                return this.canonicalizeImageUrlForComparison(normalized) === imageCanonical
+                    || (Boolean(imageStripped) && this.stripSizeParams(normalized) === imageStripped);
+            });
+            if (!ownsImage) continue;
+            for (const url of result.imageShapeVariants) {
+                const normalized = this.normalizeHttpUrlValue(url);
+                if (normalized) candidates.push({ url: normalized, width: null, height: null, authoritative: false });
+            }
+        }
+        return candidates;
+    }
+
+    // Fill event.imageVertical / event.imageHorizontal from every image shape
+    // this page offered for the event. `event.image` is never read for
+    // selection beyond being a candidate itself and is never modified.
+    // options.allowPageMetaCandidates gates the page's shared og:image artwork
+    // the same way fillImageFromPageMetaArtwork does: one page-wide meta image
+    // cannot be attributed to one segment of a multi-event page.
+    applyImageSlots(event, htmlData, options = {}) {
+        if (!event || typeof event !== 'object') return event;
+
+        // A slot a parser config already declared (parserConfig.metadata assigns
+        // unconditionally) is a curated answer — never overwritten, only joined
+        // by the other orientation.
+        const declaredVertical = typeof event.imageVertical === 'string' ? event.imageVertical.trim() : '';
+        const declaredHorizontal = typeof event.imageHorizontal === 'string' ? event.imageHorizontal.trim() : '';
+
+        const collected = [];
+        const image = typeof event.image === 'string' ? event.image.trim() : '';
+        if (image) collected.push({ url: image, width: null, height: null, authoritative: false });
+        collected.push(...(this.imageSlotCandidatesByEvent.get(event) || []));
+        collected.push(...this.collectOcrImageShapeCandidates(event, htmlData));
+        if (options.allowPageMetaCandidates !== false) {
+            collected.push(...this.collectPageMetaImageCandidates(htmlData));
+        }
+        this.imageSlotCandidatesByEvent.delete(event);
+        if (collected.length === 0) return event;
+
+        // One URL can arrive from several sources — as the bare `image` value
+        // AND as a meta/JSON-LD entry carrying published dimensions. Merge them
+        // instead of letting the first, dimensionless sighting win.
+        const byUrl = new Map();
+        for (const candidate of collected) {
+            if (!candidate || !candidate.url) continue;
+            const key = this.canonicalizeImageUrlForComparison(candidate.url);
+            if (!key) continue;
+            const existing = byUrl.get(key);
+            if (!existing) {
+                byUrl.set(key, { url: candidate.url, width: candidate.width, height: candidate.height, authoritative: Boolean(candidate.authoritative) });
+                continue;
+            }
+            if (!existing.width) existing.width = candidate.width;
+            if (!existing.height) existing.height = candidate.height;
+            existing.authoritative = existing.authoritative || Boolean(existing.width && existing.height);
+        }
+
+        // A logo or sprite is never artwork — the same test the OCR pass and the
+        // og:image fill already use keeps it out of both slots.
+        const bySlot = { portrait: null, landscape: null };
+        for (const candidate of byUrl.values()) {
+            if (this.isLikelyUninterestingImageUrl(candidate.url)) continue;
+            const orientation = this.resolveImageCandidateOrientation(candidate);
+            if (orientation !== 'portrait' && orientation !== 'landscape') continue;
+            const incumbent = bySlot[orientation];
+            if (!incumbent || this.isBetterImageSlotCandidate(candidate, incumbent)) {
+                bySlot[orientation] = candidate;
+            }
+        }
+
+        if (declaredVertical) bySlot.portrait = null;
+        if (declaredHorizontal) bySlot.landscape = null;
+        if (!bySlot.portrait && !bySlot.landscape) return event;
+        if (bySlot.portrait) event.imageVertical = bySlot.portrait.url;
+        if (bySlot.landscape) event.imageHorizontal = bySlot.landscape.url;
+        console.log(`🖼️ IMAGE SLOTS: vertical=${event.imageVertical || 'none'} horizontal=${event.imageHorizontal || 'none'} for "${event.title || ''}"`);
+        return event;
+    }
+
+    // Ranking inside ONE orientation: published dimensions outrank guessed ones,
+    // then larger pixel area, then the shared URL size score (the same scale OCR
+    // dedup ranks on).
+    isBetterImageSlotCandidate(candidate, incumbent) {
+        if (Boolean(candidate.authoritative) !== Boolean(incumbent.authoritative)) {
+            return Boolean(candidate.authoritative);
+        }
+        const candidateArea = this.getImageCandidateArea(candidate);
+        const incumbentArea = this.getImageCandidateArea(incumbent);
+        if (candidateArea !== incumbentArea) return candidateArea > incumbentArea;
+        return this.getImageSizeFromUrl(candidate.url) > this.getImageSizeFromUrl(incumbent.url);
     }
 
     // ========================================================================

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -7793,3 +7793,309 @@ test('curated-bar venue chain: BarDataNormalizer canonicalizes the kept bar and 
   assert.equal(event.address, '4219 Santa Monica Blvd, Los Angeles, CA 90029');
   assert.equal(event.addressSource, 'curated');
 });
+
+// ============================================================================
+// IMAGE ORIENTATION SLOTS (imageVertical / imageHorizontal)
+// ============================================================================
+// A page that publishes the SAME artwork as a portrait flyer AND a landscape
+// banner used to lose one of the two before anything could use it. These tests
+// pin the capture side: candidates survive the grouping passes, published
+// dimensions beat URL guesses, and an unknown orientation still fills NO slot.
+
+// Stand-in for the shared-core URL dimension readers the schema/merge side owns.
+// Reads Wix-style w_<n>,h_<n> transform segments; everything else is unknown.
+function stubUrlDimensionReaders(parser) {
+  parser.core.getImageDimensionsFromUrl = (url) => {
+    const match = String(url || '').match(/[/_]w_(\d+),h_(\d+)/);
+    return match ? { width: Number(match[1]), height: Number(match[2]) } : null;
+  };
+  parser.core.classifyImageOrientation = (url) => {
+    const dimensions = parser.core.getImageDimensionsFromUrl(url);
+    if (!dimensions) return 'unknown';
+    if (dimensions.width > dimensions.height) return 'landscape';
+    if (dimensions.width < dimensions.height) return 'portrait';
+    return 'square';
+  };
+  return parser;
+}
+
+const WIX_PORTRAIT_FLYER = 'https://static.wixstatic.com/media/aaa111~mv2.jpg/v1/fill/w_792,h_990,al_c,q_85/flyer.jpg';
+const WIX_LANDSCAPE_BANNER = 'https://static.wixstatic.com/media/bbb222~mv2.jpg/v1/fill/w_1600,h_900,al_c,q_85/banner.jpg';
+
+test('image slots: a portrait/landscape OCR twin survives consolidation and fills both slots', () => {
+  const parser = stubUrlDimensionReaders(createParser());
+  const ocrResults = [
+    { url: WIX_PORTRAIT_FLYER, text: 'FURBALL BLACKOUT\n3 Dollar Bill', imageClassification: 'event-flyer' },
+    { url: WIX_LANDSCAPE_BANNER, text: 'FURBALL BLACKOUT\n3 Dollar Bill', imageClassification: 'event-flyer' }
+  ];
+
+  const consolidated = parser.consolidateDuplicateOcrResults(ocrResults);
+
+  // The returned array keeps its exact shape — segment pairing and the
+  // extraction prompt see one entry per artwork, exactly as before.
+  assert.equal(consolidated.length, 1, 'consolidation still returns one result per artwork');
+  assert.equal(consolidated[0].url, WIX_LANDSCAPE_BANNER, 'largest still wins the OCR entry');
+  // ...but the twin is no longer deleted.
+  assert.deepEqual(consolidated[0].imageShapeVariants, [WIX_PORTRAIT_FLYER]);
+
+  const event = { title: 'Furball Blackout', image: WIX_LANDSCAPE_BANNER };
+  parser.applyImageSlots(event, { url: 'https://furball.example/events', html: '', ocrResults: consolidated });
+
+  assert.equal(event.imageVertical, WIX_PORTRAIT_FLYER);
+  assert.equal(event.imageHorizontal, WIX_LANDSCAPE_BANNER);
+  assert.equal(event.image, WIX_LANDSCAPE_BANNER, 'image keeps its existing meaning and value');
+});
+
+test('image slots: the size-variant dedup keeps a differently-shaped fill of the same asset', () => {
+  const parser = stubUrlDimensionReaders(createParser());
+  // One Wix asset served as a portrait fill AND a landscape fill — these strip
+  // to the SAME key, so the old dedup deleted one shape outright.
+  const portraitFill = 'https://static.wixstatic.com/media/ccc333~mv2.jpg/v1/fill/w_600,h_900,al_c/asset.jpg';
+  const landscapeFill = 'https://static.wixstatic.com/media/ccc333~mv2.jpg/v1/fill/w_1200,h_628,al_c/asset.jpg';
+
+  const deduped = parser.deduplicateOcrResultsByUrl([
+    { url: portraitFill, text: 'flyer text' },
+    { url: landscapeFill, text: 'flyer text' }
+  ]);
+
+  assert.equal(deduped.length, 1);
+  assert.deepEqual(deduped[0].imageShapeVariants, [portraitFill]);
+
+  const event = { title: 'Asset Party', image: landscapeFill };
+  parser.applyImageSlots(event, { html: '', ocrResults: deduped });
+  assert.equal(event.imageVertical, portraitFill);
+  assert.equal(event.imageHorizontal, landscapeFill);
+});
+
+test('image slots: a JSON-LD image ARRAY of three shapes fills both slots (schema.org 1x1/4x3/16x9)', () => {
+  const parser = stubUrlDimensionReaders(createParser());
+  const html = `
+    <html><head><script type="application/ld+json">${JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'Event',
+      name: 'Bearracuda Portland',
+      startDate: '2026-07-18T21:00:00-07:00',
+      location: { '@type': 'Place', name: 'Holocene', address: '1001 SE Morrison St, Portland, OR' },
+      image: [
+        'https://cdn.example/w_1000,h_1000/square.jpg',
+        'https://cdn.example/w_800,h_1200/portrait.jpg',
+        'https://cdn.example/w_1920,h_1080/landscape.jpg'
+      ]
+    })}</script></head><body></body></html>`;
+
+  const events = parser.extractEventsFromJsonLd(html, 'https://bearracuda.example/e/portland');
+  assert.equal(events.length, 1);
+  const event = events[0];
+  // image keeps its current meaning: the FIRST published shape.
+  assert.equal(event.image, 'https://cdn.example/w_1000,h_1000/square.jpg');
+
+  parser.applyImageSlots(event, { url: 'https://bearracuda.example/e/portland', html });
+  assert.equal(event.imageVertical, 'https://cdn.example/w_800,h_1200/portrait.jpg');
+  assert.equal(event.imageHorizontal, 'https://cdn.example/w_1920,h_1080/landscape.jpg');
+});
+
+test('image slots: ImageObject width/height outrank the shape the URL advertises', () => {
+  const parser = stubUrlDimensionReaders(createParser());
+  // The URL says portrait (w_800,h_1200); the publisher says landscape.
+  const candidates = parser.pickJsonLdImageCandidates([
+    { '@type': 'ImageObject', url: 'https://cdn.example/w_800,h_1200/lying-url.jpg', width: 1600, height: 900 }
+  ]);
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].width, 1600);
+  assert.equal(candidates[0].height, 900);
+  assert.equal(candidates[0].authoritative, true);
+  assert.equal(parser.resolveImageCandidateOrientation(candidates[0]), 'landscape');
+
+  const event = { title: 'Authoritative Dimensions' };
+  parser.rememberImageSlotCandidates(event, candidates);
+  parser.applyImageSlots(event, { html: '' });
+  assert.equal(event.imageHorizontal, 'https://cdn.example/w_800,h_1200/lying-url.jpg');
+  assert.equal(event.imageVertical, undefined, 'the URL guess never overrides published dimensions');
+});
+
+test('image slots: og:image:width / og:image:height are parsed and drive orientation', () => {
+  // No URL dimension readers at all — the published meta dimensions alone must
+  // be enough (they are also the path that works before shared-core lands).
+  const parser = createParser();
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://cdn.example/artwork-a1b2c3.jpg" />
+      <meta property="og:image:width" content="1080" />
+      <meta property="og:image:height" content="1920" />
+    </head><body></body></html>`;
+
+  const candidates = parser.collectPageMetaImageCandidates({ url: 'https://promoter.example/e/1', html });
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].width, 1080);
+  assert.equal(candidates[0].height, 1920);
+  assert.equal(candidates[0].authoritative, true);
+
+  const event = { title: 'Meta Dimensions' };
+  parser.applyImageSlots(event, { url: 'https://promoter.example/e/1', html });
+  assert.equal(event.imageVertical, 'https://cdn.example/artwork-a1b2c3.jpg');
+  assert.equal(event.imageHorizontal, undefined);
+});
+
+test('image slots: two og:image tags on one page are BOTH considered', () => {
+  const parser = createParser();
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://cdn.example/tall-a1b2c3.jpg" />
+      <meta property="og:image:width" content="1000" />
+      <meta property="og:image:height" content="1500" />
+      <meta property="og:image" content="https://cdn.example/wide-d4e5f6.jpg" />
+      <meta property="og:image:width" content="1500" />
+      <meta property="og:image:height" content="1000" />
+    </head><body></body></html>`;
+  const htmlData = { url: 'https://promoter.example/e/2', html };
+
+  // extractOgMetaContent (first tag only) is unchanged; the new all-tags reader
+  // agrees with it on entry 0 and keeps the rest.
+  assert.equal(parser.extractOgMetaContent(html, 'og:image'), 'https://cdn.example/tall-a1b2c3.jpg');
+  assert.deepEqual(parser.extractOgMetaContentAll(html, 'og:image'), [
+    'https://cdn.example/tall-a1b2c3.jpg',
+    'https://cdn.example/wide-d4e5f6.jpg'
+  ]);
+
+  // The og:image fill still adopts the first usable tag — unchanged behaviour.
+  const filled = parser.fillImageFromPageMetaArtwork({ title: 'Two Tags' }, htmlData);
+  assert.equal(filled.image, 'https://cdn.example/tall-a1b2c3.jpg');
+  assert.equal(filled.imageSource, 'og-image');
+
+  // ...and the SECOND tag, previously discarded, fills the other slot.
+  parser.applyImageSlots(filled, htmlData);
+  assert.equal(filled.imageVertical, 'https://cdn.example/tall-a1b2c3.jpg');
+  assert.equal(filled.imageHorizontal, 'https://cdn.example/wide-d4e5f6.jpg');
+});
+
+test('image slots: an event that already has an image still gets the page meta artwork considered for the OTHER slot', () => {
+  const parser = createParser();
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://cdn.example/wide-d4e5f6.jpg" />
+      <meta property="og:image:width" content="1600" />
+      <meta property="og:image:height" content="900" />
+    </head><body></body></html>`;
+  const htmlData = { url: 'https://promoter.example/e/3', html };
+
+  const event = { title: 'Already Has One', image: 'https://cdn.example/extracted-flyer.jpg' };
+  parser.fillImageFromPageMetaArtwork(event, htmlData);
+  assert.equal(event.image, 'https://cdn.example/extracted-flyer.jpg', 'an existing image is never replaced');
+
+  parser.applyImageSlots(event, htmlData);
+  assert.equal(event.imageHorizontal, 'https://cdn.example/wide-d4e5f6.jpg');
+  assert.equal(event.imageVertical, undefined, 'the extracted image advertises no shape — no guess');
+});
+
+test('image slots: unknown-orientation candidates fill NO slot and leave the event byte-identical', () => {
+  const parser = createParser();  // no shared-core dimension readers at all
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://cdn.example/mystery-a1b2c3.jpg" />
+    </head><body></body></html>`;
+  const event = {
+    title: 'Unknown Shape',
+    image: 'https://cdn.example/extracted-a1b2c3.jpg',
+    imageSource: 'page',
+    startDate: '2026-08-01T02:00:00.000Z'
+  };
+  const before = JSON.stringify(event);
+
+  const logs = captureLogs(() => parser.applyImageSlots(event, { url: 'https://promoter.example/e/4', html }));
+
+  assert.equal(JSON.stringify(event), before, 'no dimensions anywhere → the event is untouched');
+  assert.equal(Object.prototype.hasOwnProperty.call(event, 'imageVertical'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(event, 'imageHorizontal'), false);
+  assert.deepEqual(logs, [], 'no slots filled → no slot log line');
+});
+
+test('image slots: a logo-shaped URL never lands in a slot', () => {
+  const parser = createParser();
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://cdn.example/site-logo.png" />
+      <meta property="og:image:width" content="600" />
+      <meta property="og:image:height" content="900" />
+      <meta property="twitter:image" content="https://cdn.example/artwork-d4e5f6.jpg" />
+    </head><body></body></html>`;
+  const htmlData = { url: 'https://promoter.example/e/5', html };
+
+  const event = { title: 'Logo Guard' };
+  parser.rememberImageSlotCandidates(event, [
+    { url: 'https://cdn.example/sprite-sheet.png', width: 400, height: 1200, authoritative: true },
+    { url: 'https://cdn.example/real-flyer.jpg', width: 800, height: 1200, authoritative: true }
+  ]);
+  parser.applyImageSlots(event, htmlData);
+
+  assert.equal(event.imageVertical, 'https://cdn.example/real-flyer.jpg', 'the logo and sprite are skipped');
+  assert.equal(event.imageHorizontal, undefined);
+});
+
+test('image slots: the summary log line names both slots', () => {
+  const parser = createParser();
+  const event = { title: 'Slot Logging' };
+  parser.rememberImageSlotCandidates(event, [
+    { url: 'https://cdn.example/tall.jpg', width: 800, height: 1200, authoritative: true },
+    { url: 'https://cdn.example/wide.jpg', width: 1600, height: 900, authoritative: true }
+  ]);
+  const logs = captureLogs(() => parser.applyImageSlots(event, { html: '' }));
+  assert.deepEqual(logs, [
+    '🖼️ IMAGE SLOTS: vertical=https://cdn.example/tall.jpg horizontal=https://cdn.example/wide.jpg for "Slot Logging"'
+  ]);
+});
+
+test('image slots: near-square artwork belongs to neither slot', () => {
+  const parser = createParser();
+  assert.equal(parser.orientationFromImageDimensions(1000, 1000), 'square');
+  assert.equal(parser.orientationFromImageDimensions(1050, 1000), 'square', 'a 5% difference is not an orientation');
+  assert.equal(parser.orientationFromImageDimensions(1200, 1000), 'landscape');
+  assert.equal(parser.orientationFromImageDimensions(1000, 1200), 'portrait');
+  assert.equal(parser.orientationFromImageDimensions(0, 1200), 'unknown');
+  assert.equal(parser.orientationFromImageDimensions('1600 px', '900'), 'landscape');
+});
+
+test('image slots: the larger candidate wins inside one orientation', () => {
+  const parser = createParser();
+  const event = { title: 'Biggest Wins' };
+  parser.rememberImageSlotCandidates(event, [
+    { url: 'https://cdn.example/small-tall.jpg', width: 400, height: 600, authoritative: true },
+    { url: 'https://cdn.example/big-tall.jpg', width: 1200, height: 1800, authoritative: true }
+  ]);
+  parser.applyImageSlots(event, { html: '' });
+  assert.equal(event.imageVertical, 'https://cdn.example/big-tall.jpg');
+});
+
+test('image slots: a parser-config declared slot is never clobbered, only joined', () => {
+  const parser = createParser();
+  // parserConfig.metadata assigns unconditionally and runs BEFORE the slots
+  // pass, so a curated slot value must survive it.
+  const event = { title: 'Curated Slot', imageVertical: 'https://cdn.example/curated-tall.jpg' };
+  parser.rememberImageSlotCandidates(event, [
+    { url: 'https://cdn.example/derived-tall.jpg', width: 800, height: 1200, authoritative: true },
+    { url: 'https://cdn.example/derived-wide.jpg', width: 1600, height: 900, authoritative: true }
+  ]);
+  const logs = captureLogs(() => parser.applyImageSlots(event, { html: '' }));
+
+  assert.equal(event.imageVertical, 'https://cdn.example/curated-tall.jpg', 'the declared slot wins');
+  assert.equal(event.imageHorizontal, 'https://cdn.example/derived-wide.jpg', 'the empty slot is still filled');
+  assert.deepEqual(logs, [
+    '🖼️ IMAGE SLOTS: vertical=https://cdn.example/curated-tall.jpg horizontal=https://cdn.example/derived-wide.jpg for "Curated Slot"'
+  ]);
+});
+
+test('image slots: real bearracuda.com og:image dimensions resolve a portrait slot (live-run shape)', () => {
+  // Verbatim meta shape from https://bearracuda.com/events/treasure-trail-seattle/
+  // — the page publishes 620x958, which nothing in the repo used to read.
+  const parser = createParser();
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://bearracuda.com/wp-content/uploads/2026/07/sausageweb.jpg" />
+      <meta property="og:image:width" content="620" />
+      <meta property="og:image:height" content="958" />
+      <meta property="og:image:type" content="image/jpeg" />
+    </head><body></body></html>`;
+  const event = { title: 'Treasure Trail Seattle' };
+  parser.applyImageSlots(event, { url: 'https://bearracuda.com/events/treasure-trail-seattle/', html });
+  assert.equal(event.imageVertical, 'https://bearracuda.com/wp-content/uploads/2026/07/sausageweb.jpg');
+  assert.equal(event.imageHorizontal, undefined);
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -71,6 +71,36 @@ const TICKETING_PLATFORM_HOSTS = [
     'ticketleap.com', 'dice.fm', 'eventeny.com', 'showclix.com'
 ];
 
+// Multi-orientation image slots. `image` stays the primary (unchanged
+// semantics); imageVertical/imageHorizontal are the best PORTRAIT and
+// LANDSCAPE candidates so different surfaces can pick the right shape. The
+// slots are NOT exclusive of `image` — when the primary is portrait, an event
+// carries both `image: X` and `imageVertical: X`. An absent slot means "no
+// candidate is known to be that shape" (including "the primary's shape is
+// unknown"), never "there is no image".
+const IMAGE_ORIENTATION_SLOT_FIELDS = new Set(['imageVertical', 'imageHorizontal']);
+// Every field the deterministic image merge rung owns: the primary plus its
+// orientation slots. They are all bare image URLs, so the logo-path,
+// og-grade-provenance and resolution-margin rules apply to them identically.
+// Hosts whose URLs identify a PLATFORM, not the event's own presence:
+// ticketing/listing services and social networks. A link like
+// eventbrite.com/e/… tells you where to buy, never who is throwing the party,
+// so it must not displace a promoter's identity link (observed 2026-07-30:
+// Cubhouse's curated https://linktr.ee/cubhouse was clobbered by an Eventbrite
+// listing URL, which also broke the icon derived from that field).
+// Data only — shared-core stays platform-pure.
+const PLATFORM_IDENTITY_HOSTS = new Set([
+    'eventbrite.com', 'eventbrite.co.uk', 'eventbrite.ca', 'eventbrite.com.au',
+    'dice.fm', 'ra.co', 'residentadvisor.net', 'ticketweb.com', 'ticketweb.co.uk',
+    'seetickets.com', 'universe.com', 'posh.vip', 'withfriends.co',
+    'tickettailor.com', 'sickening.events', 'redeyetickets.com',
+    'ticketmaster.com', 'shotgun.live', 'fatsoma.com', 'meetup.com',
+    'partiful.com', 'luma.com', 'lu.ma', 'instagram.com', 'facebook.com',
+    'twitter.com', 'x.com', 'tiktok.com'
+]);
+
+const IMAGE_MERGE_FIELDS = new Set(['image', 'imageVertical', 'imageHorizontal']);
+
 class SharedCore {
     constructor(cities, options = {}) {
         if (!cities || typeof cities !== 'object') {
@@ -920,6 +950,86 @@ class SharedCore {
         return score;
     }
 
+    // Width/height advertised BY the URL itself — { width, height } or null.
+    // Companion to getImageSizeScoreFromUrl above and bound by the same rules:
+    // no network, and no `new URL` / URLSearchParams (neither exists in iOS
+    // JavaScriptCore) — parseUrl + extractSearchParamValue only.
+    //
+    // It answers SHAPE rather than size, so it is stricter than the scorer in
+    // three ways:
+    //   - both dimensions must be present (one alone says nothing about
+    //     orientation) and inside believable bounds;
+    //   - it reads Wix's comma-joined transform segment
+    //     (…/v1/fill/w_792,h_990,al_c,q_85,enc_avif/… and the …/v1/crop/
+    //     x_0,y_0,w_…,h_… twin), which the scorer cannot see at all — on real
+    //     chunky.dad data that is the dimension token that actually appears;
+    //   - it REJECTS img.evbuc.com's ?w=&h= (see below).
+    // Returns null far more often than not — only a minority of real event
+    // image URLs advertise anything — so callers must treat null as "unknown",
+    // never as "not an image".
+    getImageDimensionsFromUrl(url) {
+        if (!url || typeof url !== 'string') return null;
+        const parsed = this.parseUrl(url.trim());
+        if (!parsed) return null;
+        const host = String(parsed.hostname || parsed.host || '').toLowerCase().replace(/^www\./, '');
+        const path = String(parsed.pathname || '');
+        const toDimensions = (rawWidth, rawHeight) => {
+            const width = parseInt(rawWidth, 10);
+            const height = parseInt(rawHeight, 10);
+            if (!isFinite(width) || !isFinite(height)) return null;
+            // Loose bounds on purpose: only the RATIO is consumed, so a print
+            // aspect token ("…/11x17-4.jpg") is as useful as a pixel pair.
+            if (width < 10 || height < 10 || width > 20000 || height > 20000) return null;
+            return { width, height };
+        };
+
+        // Path forms first — they describe the rendition being served, so they
+        // are the trustworthy signal. Wix's comma form, then the generic
+        // NNNxNNN token (a /1920x1080/ path segment or a "-820x1024.jpg"
+        // filename suffix, both real shapes in data/calendars).
+        for (const segment of path.split('/').filter(Boolean)) {
+            const wixWidth = segment.match(/(?:^|,)w_(\d{1,5})(?=,|$)/i);
+            const wixHeight = segment.match(/(?:^|,)h_(\d{1,5})(?=,|$)/i);
+            if (wixWidth && wixHeight) {
+                const dimensions = toDimensions(wixWidth[1], wixHeight[1]);
+                if (dimensions) return dimensions;
+            }
+            const resolution = segment.match(/(?:^|[^\d])(\d{2,5})x(\d{2,5})(?![\dx])/i);
+            if (resolution) {
+                const dimensions = toDimensions(resolution[1], resolution[2]);
+                if (dimensions) return dimensions;
+            }
+        }
+
+        // Eventbrite's wrapper never gets to describe the artwork's shape:
+        // img.evbuc.com's "?crop=focalpoint&fit=crop&h=230&w=460" is its fixed
+        // 2:1 LISTING THUMBNAIL crop of an arbitrary flyer — tools/
+        // download-images.js (adjustEventbriteImageUrl) strips exactly these
+        // params to recover the original. Reading them would label every
+        // Eventbrite flyer landscape.
+        if (host === 'img.evbuc.com') return null;
+
+        const search = String(parsed.search || '');
+        const width = this.extractSearchParamValue(search, 'w') || this.extractSearchParamValue(search, 'width');
+        const height = this.extractSearchParamValue(search, 'h') || this.extractSearchParamValue(search, 'height');
+        if (width && height) return toDimensions(width, height);
+        return null;
+    }
+
+    // 'portrait' | 'landscape' | 'square' | 'unknown' for an image URL.
+    // 'unknown' is the COMMON answer (most image URLs advertise no dimensions),
+    // so every consumer must degrade to today's behavior when it comes back —
+    // orientation is a refinement, never a gate. The 5% dead band keeps
+    // near-squares (e.g. Wix w_1344,h_1345) out of both buckets.
+    classifyImageOrientation(url) {
+        const dimensions = this.getImageDimensionsFromUrl(url);
+        if (!dimensions) return 'unknown';
+        const ratio = dimensions.width / dimensions.height;
+        if (ratio >= 1.05) return 'landscape';
+        if (ratio <= 0.95) return 'portrait';
+        return 'square';
+    }
+
     // Normalized view of a description for the strict-superset merge rule:
     // lowercased, basic HTML entities decoded, whitespace collapsed. BOTH
     // candidates pass through this, so entity/whitespace differences never
@@ -1535,6 +1645,13 @@ class SharedCore {
         }
         const website = pick('website');
         if (website) block.url = { value: website };
+        // Guarantee a favicon for every matched event. The icon is resolved
+        // from `favicon` (or, failing that, `website`) — but `website` is the
+        // field an Eventbrite/DICE listing URL tends to occupy, and platform
+        // URLs are deliberately refused as identity, which would leave a
+        // registry-matched event with NO icon at all. A promoter without an
+        // explicit favicon therefore contributes its own identity link as one.
+        if (!block.favicon && website) block.favicon = { value: website };
         return block;
     }
 
@@ -1758,6 +1875,30 @@ class SharedCore {
             // candidate value (strict attribution, like the image/bar
             // provenance rungs). Both bare roots, both/neither crawled, or no
             // records context → fall through to AI arbitration (fail open).
+            // Rung 0: a TICKETING/social platform URL never displaces a
+            // non-platform one for the identity fields. Which platform sells
+            // the tickets is not who throws the party, and this field feeds
+            // the event's icon — so losing the promoter's own link visibly
+            // breaks the card and the map marker. The reverse (a real site
+            // replacing a platform link) is allowed, and platform-vs-platform
+            // falls through to the rungs below.
+            if (fieldName === 'website' || fieldName === 'url') {
+                const platformA = PLATFORM_IDENTITY_HOSTS.has(urlA.host.replace(/^www\./, ''));
+                const platformB = PLATFORM_IDENTITY_HOSTS.has(urlB.host.replace(/^www\./, ''));
+                // Deliberately narrow: the non-platform side must itself be a
+                // real page, not a bare homepage. A bare root still loses to a
+                // deep event page (the older cross-host rung below owns that
+                // case, and reversing it would send people to a front door
+                // instead of the event).
+                const nonPlatformIsPathed = platformB
+                    ? (urlA.segments.length > 0 || urlA.hasQuery)
+                    : (urlB.segments.length > 0 || urlB.hasQuery);
+                if (platformA !== platformB && nonPlatformIsPathed) {
+                    return platformB
+                        ? { winner: 'a', reason: 'identity link beats a ticketing/social platform URL' }
+                        : { winner: 'b', reason: 'identity link beats a ticketing/social platform URL' };
+                }
+            }
             if ((fieldName === 'website' || fieldName === 'url') && urlA.host !== urlB.host) {
                 const bareRootA = urlA.segments.length === 0 && !urlA.hasQuery;
                 const bareRootB = urlB.segments.length === 0 && !urlB.hasQuery;
@@ -1815,7 +1956,17 @@ class SharedCore {
             // model picked over the actual event poster. Matches path
             // components only (never hostname or query); both-or-neither
             // logo-ish still arbitrates (with a prompt rule as backstop).
-            if (fieldName === 'image') {
+            // Applies to the primary AND to the imageVertical/imageHorizontal
+            // orientation slots (IMAGE_MERGE_FIELDS): they hold the same kind
+            // of value — a bare image URL — so the logo-path, provenance and
+            // resolution rules below are correct for them unchanged. Note the
+            // provenance rung's strict attribution means a slot only picks up
+            // an og-grade stamp when it EQUALS the record's own image (the
+            // common "primary is portrait" case); a slot holding a different
+            // URL is unattributable and falls through, which is the intended
+            // conservative behavior — imageSource stays a companion of `image`
+            // alone, with no per-slot provenance.
+            if (IMAGE_MERGE_FIELDS.has(fieldName)) {
                 const hasLogoSegment = (parts) => parts.segments.some(segment => /logo/i.test(segment));
                 const logoA = hasLogoSegment(urlA);
                 const logoB = hasLogoSegment(urlB);
@@ -6468,6 +6619,22 @@ class SharedCore {
                 continue;
             }
 
+            // Orientation image slots are NEVER cleared by a run that found no
+            // candidate of that shape. URL-derived orientation is knowable for
+            // only a minority of image URLs, so an empty imageVertical/
+            // imageHorizontal means "nothing this run could prove is that
+            // shape" — never "delete the curated one". Stated explicitly at the
+            // slot level (the generic empty-scrape rule further down happens to
+            // cover it today, but that rule carries per-field exclusions and
+            // this invariant must not depend on staying off that list).
+            if (IMAGE_ORIENTATION_SLOT_FIELDS.has(fieldName)
+                && this.isEmptyArbitrationValue(scraperValue)
+                && !this.isEmptyArbitrationValue(calendarValue)) {
+                mergedObject[fieldName] = calendarValue;
+                calendarKeptFields.push(fieldName);
+                continue;
+            }
+
             if (fieldName === 'location') {
                 // location is ALWAYS coordinates (the calendar is the database; the
                 // normalization layer fills this field with coordinates). Resolve it
@@ -8528,6 +8695,16 @@ class SharedCore {
             location: { priority: ["ai-web"], merge: "ai" },
             gmaps: { priority: ["ai-web"], merge: "ai" },
             image: { priority: ["ai-web"], merge: "ai" },
+            // Orientation slots merge exactly like the primary image. Without
+            // an entry here they would inherit the "upsert" default
+            // (calendarValue || scraperValue) — write-once, stale forever: the
+            // first portrait ever stored could never be replaced by a better
+            // one. "ai" routes them through the deterministic image rung first
+            // (logo-path / og-grade provenance / resolution margin), and the
+            // never-clear guard in createFinalEventObject keeps a curated slot
+            // when a run finds no candidate of that shape.
+            imageVertical: { priority: ["ai-web"], merge: "ai" },
+            imageHorizontal: { priority: ["ai-web"], merge: "ai" },
             cover: { priority: ["ai-web"], merge: "ai" },
             ticketUrl: { priority: ["ai-web"], merge: "ai" }
         };

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1441,6 +1441,137 @@ test('guardrail: image URLs without a clear resolution margin still go to the AI
 });
 
 // ---------------------------------------------------------------------------
+// Multi-orientation image slots: URL-derived dimensions, and the merge
+// semantics that keep imageVertical/imageHorizontal alive and non-thrashing.
+// ---------------------------------------------------------------------------
+
+test('getImageDimensionsFromUrl reads the real Wix comma form and NNNxNNN tokens', () => {
+  const core = createCore();
+  const dims = (url) => core.getImageDimensionsFromUrl(url);
+
+  // The form that actually appears on real data: a Wix transform segment whose
+  // w_/h_ pairs are comma-joined. getImageSizeScoreFromUrl cannot see it.
+  assert.deepEqual(
+    dims('https://static.wixstatic.com/media/a~mv2.jpg/v1/fill/w_792,h_990/a~mv2.jpg'),
+    { width: 792, height: 990 });
+  assert.deepEqual(
+    dims('https://static.wixstatic.com/media/238fae_16613~mv2.jpg/v1/fill/w_296,h_494,al_c,q_80,usm_0.66_1.00_0.01,enc_avif,quality_auto/238fae_16613~mv2.jpg'),
+    { width: 296, height: 494 }, 'trailing transform tokens do not confuse the pair');
+  assert.deepEqual(
+    dims('https://static.wixstatic.com/media/x~mv2.jpg/v1/crop/x_0,y_0,w_1000,h_500/x~mv2.jpg'),
+    { width: 1000, height: 500 }, 'the /v1/crop/ twin works too');
+
+  // NNNxNNN: a resolution path segment and a real filename suffix
+  assert.deepEqual(dims('https://cdn.example.com/uploads/1920x1080/poster.jpg'),
+    { width: 1920, height: 1080 });
+  assert.deepEqual(
+    dims('https://bearracuda.com/wp-content/uploads/2026/05/hottake_may2026-igposter_v2-820x1024.jpg'),
+    { width: 820, height: 1024 });
+
+  // Plain query params on a non-Eventbrite host
+  assert.deepEqual(dims('https://cdn.example.com/img.jpg?w=1920&h=1080'), { width: 1920, height: 1080 });
+  assert.deepEqual(dims('https://cdn.example.com/img.jpg?width=600&height=900'), { width: 600, height: 900 });
+});
+
+test('getImageDimensionsFromUrl REJECTS the Eventbrite ?w=460&h=230 crop', () => {
+  const core = createCore();
+  // img.evbuc.com's crop params are its fixed 2:1 LISTING THUMBNAIL, not the
+  // flyer's shape — tools/download-images.js strips exactly these to recover
+  // the original. Reading them would label every Eventbrite flyer landscape.
+  const eventbrite = 'https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1030030273%2F301420936599%2F1%2Foriginal.20250513-190933?crop=focalpoint&fit=crop&h=230&w=460&auto=format%2Ccompress&q=75&sharp=10&fp-x=0.014&fp-y=0.478&s=3ecb099c';
+  assert.equal(core.getImageDimensionsFromUrl(eventbrite), null);
+  assert.equal(core.classifyImageOrientation(eventbrite), 'unknown',
+    'an Eventbrite flyer stays unclassified rather than wrongly landscape');
+  // The cdn.evbuc.com original (what download-images resolves to) is unaffected
+  // by the host rule — it simply advertises nothing.
+  assert.equal(core.getImageDimensionsFromUrl(
+    'https://cdn.evbuc.com/images/1030030273/301420936599/1/original.20250513-190933'), null);
+});
+
+test('getImageDimensionsFromUrl returns null for the many URLs advertising nothing', () => {
+  const core = createCore();
+  const dims = (url) => core.getImageDimensionsFromUrl(url);
+  // Real calendar values with no dimension token at all — the common case.
+  assert.equal(dims('https://bearracuda.com/wp-content/uploads/2025/04/cuda-atlanta-nov_2025-web.jpg'), null);
+  assert.equal(dims('https://static.wixstatic.com/media/238fae_c4047c55~mv2.png'), null);
+  assert.equal(dims('https://dice-media.imgix.net/attachments/2026-07-27/52a9b2c1.jpg?rect=0%2C0%2C1080%2C1080'), null,
+    'an imgix rect= is not a w/h pair');
+  assert.equal(dims('https://cdn.example.com/img.jpg?w=600'), null, 'one dimension says nothing about shape');
+  assert.equal(dims('not a url'), null);
+  assert.equal(dims(''), null);
+  assert.equal(dims(null), null);
+  assert.equal(dims(undefined), null);
+  assert.equal(dims(42), null);
+});
+
+test('classifyImageOrientation buckets portrait/landscape/square with a dead band', () => {
+  const core = createCore();
+  const classify = (url) => core.classifyImageOrientation(url);
+  assert.equal(classify('https://static.wixstatic.com/media/a~mv2.jpg/v1/fill/w_792,h_990/a~mv2.jpg'), 'portrait');
+  assert.equal(classify('https://cdn.example.com/uploads/1920x1080/poster.jpg'), 'landscape');
+  assert.equal(classify('https://static.wixstatic.com/media/b~mv2.jpg/v1/fill/w_1344,h_1345,al_c,q_85/b~mv2.jpg'),
+    'square', 'a 1-pixel difference is not an orientation');
+  assert.equal(classify('https://bearracuda.com/wp-content/uploads/2025/04/cuda-atlanta-nov_2025-web.jpg'), 'unknown',
+    'unknown is the common answer and must be handled by every caller');
+});
+
+test('image orientation slots merge like the primary image and are never cleared by an empty scrape', async () => {
+  const core = createCore();
+  const logo = 'https://res.cloudinary.com/eventservice/image/upload/w_600/saas/logos/image_abc.webp';
+  const poster = 'https://bearracuda.com/wp-content/uploads/2026/05/45-3.png';
+
+  // The deterministic rung now covers the slots, unchanged
+  assert.deepEqual(
+    core.resolveConflictDeterministically('imageVertical', logo, poster),
+    { winner: 'b', reason: 'event artwork beats logo-path image' });
+  assert.deepEqual(
+    core.resolveConflictDeterministically('imageHorizontal', poster, logo),
+    { winner: 'a', reason: 'event artwork beats logo-path image' });
+
+  // Registered priorities, not the 'upsert' default (which would be write-once)
+  const resolved = core.getResolvedFieldPriorities({});
+  assert.equal(resolved.imageVertical.merge, 'ai');
+  assert.equal(resolved.imageHorizontal.merge, 'ai');
+
+  // Never-clear: a run that finds no portrait candidate keeps the curated one
+  const vertical = 'https://static.wixstatic.com/media/a~mv2.jpg/v1/fill/w_792,h_990/a~mv2.jpg';
+  const { scraped, existing } = buildAlignedArbitrationPair();
+  scraped.image = poster;
+  existing.notes += `\nimage: ${poster}\nimageVertical: ${vertical}`;
+  const adapter = buildArbitrationAdapter({});
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 0, 'an absent slot is never a conflict');
+  assert.equal(finalEvent.imageVertical, vertical, 'the curated portrait survives a scrape that found none');
+  assert.match(finalEvent.notes, new RegExp(`imageVertical: ${vertical.replace(/[.*+?^$()|[\]\\]/g, '\\$&')}`),
+    'the kept slot is written back as a bare single-line camelCase URL');
+});
+
+test('image slot merges do not thrash: two consecutive merges pick the same winner', async () => {
+  const core = createCore();
+  const logo = 'https://cdn.tickets.example/saas/logos/brand.png';
+  const poster = 'https://bearracuda.com/wp-content/uploads/2026/05/newfolsomweb.jpg';
+
+  // Round 1: the calendar holds a logo, the scrape a real poster → poster wins.
+  const first = buildAlignedArbitrationPair();
+  first.scraped.imageHorizontal = poster;
+  first.existing.notes += `\nimageHorizontal: ${logo}`;
+  const adapterA = buildArbitrationAdapter({});
+  const merged = await core.createFinalEventObject(first.existing, first.scraped, { httpAdapter: adapterA });
+  assert.equal(merged.imageHorizontal, poster);
+  assert.equal(adapterA.calls.length, 0, 'resolved deterministically, no AI');
+
+  // Round 2: re-run the SAME scrape against the merged calendar record. A
+  // thrashing rung would flip back; a stable one is a no-op with no conflict.
+  const second = buildAlignedArbitrationPair();
+  second.scraped.imageHorizontal = poster;
+  second.existing.notes += `\nimageHorizontal: ${merged.imageHorizontal}`;
+  const adapterB = buildArbitrationAdapter({});
+  const remerged = await core.createFinalEventObject(second.existing, second.scraped, { httpAdapter: adapterB });
+  assert.equal(remerged.imageHorizontal, poster, 'the same winner, run after run');
+  assert.equal(adapterB.calls.length, 0, 'an already-settled slot never reaches the AI');
+});
+
+// ---------------------------------------------------------------------------
 // Image provenance rung: an image stamped as the event page's OWN artwork
 // (imageSource og-image / jsonld at extraction) beats a merely page-derived
 // candidate deterministically. Attribution is strict (the record's image must
@@ -10456,4 +10587,24 @@ test('shortName gate: mid-word cut is not a verbatim substring', () => {
   const core = createFinalBuildCore();
   assert.equal(core.evaluateDerivedShortName('BEEFMINCE MEET MARKET', 'BEEF', 16).ok, false, 'mid-word cut rejected');
   assert.equal(core.evaluateDerivedShortName('BEEFMINCE MEET MARKET', 'BEEFMINCE', 16).ok, true, 'word-aligned accepted');
+});
+
+test('website merge: a ticketing platform URL never displaces an identity link', () => {
+  const core = createCore();
+  const ctx = { records: {}, sideLabels: { a: 'calendar', b: 'scraped' } };
+
+  // Cubhouse, observed 2026-07-30: the curated linktree lost to an Eventbrite
+  // listing, which also broke the favicon derived from this field.
+  const linktree = 'https://linktr.ee/cubhouse';
+  const eventbrite = 'https://www.eventbrite.com/e/cubhouse-tickets-123456789';
+  const keepsIdentity = core.resolveConflictDeterministically('website', linktree, eventbrite, ctx);
+  assert.ok(keepsIdentity, 'resolved deterministically rather than deferred to AI');
+  assert.equal(keepsIdentity.winner, 'a', 'the identity link wins');
+
+  const reversed = core.resolveConflictDeterministically('website', eventbrite, linktree, ctx);
+  assert.equal(reversed.winner, 'b', 'direction does not matter');
+
+  // A real site replacing a platform link is still allowed.
+  const realSite = core.resolveConflictDeterministically('website', eventbrite, 'https://cubhouse.party/events/july', ctx);
+  assert.equal(realSite.winner, 'b', 'a genuine site beats a platform URL');
 });

--- a/scripts/tools-serve-results.test.js
+++ b/scripts/tools-serve-results.test.js
@@ -223,8 +223,7 @@ test('rewriteBridgeHtml on a full generateRichHTML render removes every chunkysc
 
   const registries = {
     mapVerifyUrls: adapter._mapVerifyUrls || {},
-    venueSnippets: adapter.collectVenueEntrySnippets(results),
-    activeConfigJson: (adapter.buildActiveConfigSummaryForResults(results) || {}).json || ''
+    venueSnippets: adapter.collectVenueEntrySnippets(results)
   };
   const rewritten = rewriteBridgeHtml(html, registries);
 
@@ -249,8 +248,7 @@ test('rewriteBridgeHtml on a full generateRichHTML render removes every chunkysc
 
 test('rewriteBridgeHtml escapes payloads that could break out of the inline script', () => {
   const rewritten = rewriteBridgeHtml('<html><body></body></html>', {
-    venueSnippets: { 0: 'evil </script><script>alert(1)</script>' },
-    activeConfigJson: '{"a":"</script>"}'
+    venueSnippets: { 0: 'evil </script><script>alert(1)</script>' }
   });
   assert.ok(!rewritten.includes('</script><script>alert(1)'), 'payload cannot terminate the shim script');
   assert.ok(rewritten.includes('\\u003c/script'), 'angle brackets JSON-escaped');

--- a/styles.css
+++ b/styles.css
@@ -2438,6 +2438,21 @@ body.index-page main {
     box-shadow: 0 6px 20px rgba(6, 8, 20, 0.45);
 }
 
+/* When the flyer's orientation is KNOWN (the URL came out of an
+   imageVertical/imageHorizontal slot) the cap is set from the attribute, which
+   is on the container before the image loads — so the card reserves the right
+   amount of room instead of resizing once the bytes arrive. Portrait artwork
+   earns more height; landscape artwork is already wide and only needs enough
+   height to fill the card's width. Unknown orientation keeps the 300px cap
+   above, i.e. exactly today's behaviour. */
+.event-card.detailed.aurora .event-flyer[data-flyer-orientation="portrait"] img {
+    max-height: 380px;
+}
+
+.event-card.detailed.aurora .event-flyer[data-flyer-orientation="landscape"] img {
+    max-height: 240px;
+}
+
 .event-card.detailed.aurora .ec-panel {
     position: relative;
     margin: 0;
@@ -2640,6 +2655,14 @@ body.index-page main {
 @media (max-width: 520px) {
     .event-card.detailed.aurora .event-flyer img {
         max-height: 250px;
+    }
+
+    .event-card.detailed.aurora .event-flyer[data-flyer-orientation="portrait"] img {
+        max-height: 320px;
+    }
+
+    .event-card.detailed.aurora .event-flyer[data-flyer-orientation="landscape"] img {
+        max-height: 200px;
     }
 
     .event-card.detailed.aurora h3.ec-title {

--- a/testing/event-builder.html
+++ b/testing/event-builder.html
@@ -1155,6 +1155,76 @@
       display: block;
     }
 
+    /* Image candidate strip: one thumbnail per known flyer URL. `contain`, not
+       `cover` — the whole point is seeing which candidate is portrait and which
+       is landscape, and a cover crop hides exactly that. */
+    /* The strip spans the whole field grid so the thumbnails sit in a row. */
+    .image-candidates-group {
+      grid-column: 1 / -1;
+    }
+
+    .image-candidates-label {
+      display: block;
+      font-size: 0.85rem;
+      color: var(--muted, #9aa4b2);
+      margin-bottom: 0.35rem;
+    }
+
+    .image-candidates {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+    }
+
+    .image-candidates[data-empty="1"] {
+      display: none;
+    }
+
+    .image-candidate {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.35rem;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 8px;
+      background: rgba(255, 255, 255, 0.04);
+      cursor: pointer;
+      font: inherit;
+      color: inherit;
+      max-width: 140px;
+    }
+
+    .image-candidate:hover,
+    .image-candidate:focus-visible {
+      border-color: var(--accent);
+    }
+
+    .image-candidate[data-primary="1"] {
+      border-color: var(--accent);
+      box-shadow: inset 0 0 0 1px var(--accent);
+      cursor: default;
+    }
+
+    .image-candidate img {
+      width: 120px;
+      height: 120px;
+      object-fit: contain;
+      border-radius: 4px;
+      background: rgba(0, 0, 0, 0.3);
+      display: block;
+    }
+
+    .image-candidate-badge {
+      font-size: 0.7rem;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      color: var(--muted, #9aa4b2);
+      text-align: center;
+      line-height: 1.3;
+      overflow-wrap: anywhere;
+    }
+
     .diff-coords-link {
       display: inline-flex;
       align-items: center;
@@ -2343,6 +2413,33 @@
                   <small>Image uploads aren’t allowed at this time, but you can add a public image link here.</small>
                 </div>
                 <div class="field-group">
+                  <label for="event-image-vertical">Portrait Image URL</label>
+                  <div class="input-with-action">
+                    <input type="url" id="event-image-vertical" placeholder="https://chunky.dad/img/events/sample-portrait.jpg">
+                    <button type="button" class="field-action field-action-inline" data-paste-target="event-image-vertical" aria-label="Paste portrait image link">
+                      <i class="bi bi-clipboard-plus" aria-hidden="true"></i>
+                      <span>Paste</span>
+                    </button>
+                  </div>
+                  <small>Tall/portrait version of the flyer. Used by the event cards, which show artwork at its natural aspect ratio.</small>
+                </div>
+                <div class="field-group">
+                  <label for="event-image-horizontal">Landscape Image URL</label>
+                  <div class="input-with-action">
+                    <input type="url" id="event-image-horizontal" placeholder="https://chunky.dad/img/events/sample-landscape.jpg">
+                    <button type="button" class="field-action field-action-inline" data-paste-target="event-image-horizontal" aria-label="Paste landscape image link">
+                      <i class="bi bi-clipboard-plus" aria-hidden="true"></i>
+                      <span>Paste</span>
+                    </button>
+                  </div>
+                  <small>Wide/landscape version of the flyer. Used for share cards (1200×630) and anywhere a wide crop reads better.</small>
+                </div>
+                <div class="field-group image-candidates-group">
+                  <span class="image-candidates-label">Image candidates</span>
+                  <div class="image-candidates" id="image-candidates" data-empty="1"></div>
+                  <small>Loaded previews show their real pixel size. Click one to promote it to the Promo Image (the current promo image takes its place).</small>
+                </div>
+                <div class="field-group">
                   <label for="event-favicon">Custom Icon URL</label>
                   <div class="input-with-action">
                     <input type="url" id="event-favicon" placeholder="https://example.com/favicon.ico">
@@ -3102,6 +3199,9 @@
         dom.facebookInput = document.getElementById('event-facebook');
         dom.gmapsInput = document.getElementById('event-gmaps');
         dom.imageInput = document.getElementById('event-image');
+        dom.imageVerticalInput = document.getElementById('event-image-vertical');
+        dom.imageHorizontalInput = document.getElementById('event-image-horizontal');
+        dom.imageCandidates = document.getElementById('image-candidates');
         dom.faviconInput = document.getElementById('event-favicon');
         dom.resetButton = document.getElementById('reset-form');
         dom.addToCalendarButton = document.getElementById('add-to-calendar');
@@ -5742,6 +5842,8 @@
           useVenueInstagram: false,
           useVenueFacebook: false,
           image: normalizeText(eventData.image || ''),
+          imageVertical: normalizeText(eventData.imageVertical || ''),
+          imageHorizontal: normalizeText(eventData.imageHorizontal || ''),
           editingExistingOverrideType: '',
           editingExistingSourceUid: '',
           editingExistingOverrideRecurrenceId: '',
@@ -6395,6 +6497,8 @@
         facebook: 'Facebook',
         gmaps: 'Google Maps',
         image: 'Image',
+        imageVertical: 'Portrait image',
+        imageHorizontal: 'Landscape image',
         favicon: 'Icon URL'
       });
 
@@ -6659,7 +6763,7 @@ Example output:
 
       function richDiffHtml(field, rawValue) {
         if (!rawValue) return '';
-        if (field === 'image') {
+        if (field === 'image' || field === 'imageVertical' || field === 'imageHorizontal') {
           // Only render preview for https:// URLs to avoid security risks
           if (!rawValue.startsWith('https://')) return '';
           return `<div class="diff-rich-block"><img src="${escapeDiffHtml(rawValue)}" class="diff-img-preview" alt="Event image preview" loading="lazy" onerror="this.style.display='none'"></div>`;
@@ -7210,6 +7314,8 @@ Example output:
           useVenueInstagram: false,
           useVenueFacebook: false,
           image: '',
+          imageVertical: '',
+          imageHorizontal: '',
           favicon: '',
           isEditingExisting: false,
           editingExistingId: '',
@@ -7378,6 +7484,28 @@ Example output:
         return EventSchema;
       }
 
+      // The orientation slots resolved locally, so the builder round-trips them
+      // whether or not EventSchema's builder-state map knows them yet.
+      const IMAGE_SLOT_PARAM_TO_STATE_KEY = Object.freeze({
+        imagevertical: 'imageVertical',
+        imgvertical: 'imageVertical',
+        imgv: 'imageVertical',
+        verticalimage: 'imageVertical',
+        portraitimage: 'imageVertical',
+        imagehorizontal: 'imageHorizontal',
+        imghorizontal: 'imageHorizontal',
+        imgh: 'imageHorizontal',
+        horizontalimage: 'imageHorizontal',
+        landscapeimage: 'imageHorizontal'
+      });
+
+      function getImageSlotStateKey(paramKey) {
+        const normalized = String(paramKey || '').toLowerCase().replace(/[\s\-_]/g, '');
+        return Object.prototype.hasOwnProperty.call(IMAGE_SLOT_PARAM_TO_STATE_KEY, normalized)
+          ? IMAGE_SLOT_PARAM_TO_STATE_KEY[normalized]
+          : null;
+      }
+
       function loadStateFromUrl(baseState) {
         const schema = getRequiredEventSchema();
         const params = new URLSearchParams(window.location.search);
@@ -7385,7 +7513,7 @@ Example output:
         const parseContext = { sawEditFlag: false, sawEventParam: false };
         params.forEach((value, key) => {
           if (value == null) return;
-          const stateKey = schema.getEventBuilderStateKey(key);
+          const stateKey = schema.getEventBuilderStateKey(key) || getImageSlotStateKey(key);
           if (stateKey) {
             parseContext.sawEventParam = true;
             if (stateKey === 'start' || stateKey === 'end') {
@@ -7448,12 +7576,102 @@ Example output:
         if (dom.facebookInput) dom.facebookInput.value = state.facebook || '';
         if (dom.gmapsInput) dom.gmapsInput.value = state.gmaps || '';
         if (dom.imageInput) dom.imageInput.value = state.image || '';
-        if (dom.faviconInput) dom.faviconInput.value = state.favicon || '';
+        if (dom.imageVerticalInput) dom.imageVerticalInput.value = state.imageVertical || '';
+        if (dom.imageHorizontalInput) dom.imageHorizontalInput.value = state.imageHorizontal || '';
+        renderImageCandidates();
         updateTimeNotes();
         applyRecurrenceStateToForm();
         syncLinkFieldStates();
         updateCoordinatesFieldState();
         updateVenueLinkToggles({ applyValues: false, preserveState: true });
+      }
+
+      // Slots that can hold a flyer URL, in the order the strip shows them.
+      const IMAGE_CANDIDATE_SLOTS = Object.freeze([
+        { field: 'image', label: 'Promo' },
+        { field: 'imageVertical', label: 'Portrait' },
+        { field: 'imageHorizontal', label: 'Landscape' }
+      ]);
+
+      // One thumbnail per distinct flyer URL. The builder is the only place in
+      // the pipeline that gets ground-truth dimensions for free (the browser
+      // decodes the image anyway), so each loaded preview reports its real
+      // naturalWidth×naturalHeight — that is how you tell whether a URL parked
+      // in the "portrait" slot really is portrait.
+      function renderImageCandidates() {
+        if (!dom.imageCandidates) return;
+        dom.imageCandidates.textContent = '';
+        const byUrl = new Map();
+        IMAGE_CANDIDATE_SLOTS.forEach(slot => {
+          const url = String((state && state[slot.field]) || '').trim();
+          // http(s) only: keeps javascript:/data: URLs out of an <img src>.
+          if (!url || !/^https?:\/\//i.test(url)) return;
+          const existing = byUrl.get(url);
+          if (existing) {
+            existing.labels.push(slot.label);
+            return;
+          }
+          byUrl.set(url, { url, field: slot.field, labels: [slot.label] });
+        });
+        dom.imageCandidates.dataset.empty = byUrl.size ? '0' : '1';
+        byUrl.forEach(candidate => {
+          const isPrimary = candidate.field === 'image';
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'image-candidate';
+          button.dataset.candidateField = candidate.field;
+          if (isPrimary) button.dataset.primary = '1';
+          button.title = isPrimary
+            ? `${candidate.url}\n(already the promo image)`
+            : `${candidate.url}\nClick to make this the promo image`;
+
+          const img = document.createElement('img');
+          img.alt = `${candidate.labels.join(' / ')} image preview`;
+          img.loading = 'lazy';
+          img.decoding = 'async';
+
+          const badge = document.createElement('span');
+          badge.className = 'image-candidate-badge';
+          badge.textContent = candidate.labels.join(' · ');
+
+          img.onerror = () => {
+            img.style.display = 'none';
+            badge.textContent = `${candidate.labels.join(' · ')} · unavailable`;
+          };
+          img.onload = () => {
+            const width = img.naturalWidth;
+            const height = img.naturalHeight;
+            if (!width || !height) return;
+            const measured = width === height ? 'square' : (height > width ? 'portrait' : 'landscape');
+            badge.textContent = `${candidate.labels.join(' · ')} · ${width}×${height} ${measured}`;
+          };
+          img.src = candidate.url;
+
+          button.appendChild(img);
+          button.appendChild(badge);
+          dom.imageCandidates.appendChild(button);
+        });
+      }
+
+      // Promote an orientation slot's URL to the primary image. Swap semantics:
+      // the demoted primary takes the slot's place so no URL is lost. When
+      // there was no primary, the promoted URL stays in its slot as well — a
+      // portrait primary legitimately lives in both `image` and `imageVertical`.
+      function promoteImageCandidate(field) {
+        if (!field || field === 'image') return;
+        if (!state || !Object.prototype.hasOwnProperty.call(state, field)) return;
+        const promoted = String(state[field] || '').trim();
+        if (!promoted) return;
+        const demoted = String(state.image || '').trim();
+        state.image = promoted;
+        if (demoted && demoted !== promoted) {
+          state[field] = demoted;
+        }
+        if (dom.imageInput) dom.imageInput.value = state.image;
+        if (dom.imageVerticalInput) dom.imageVerticalInput.value = state.imageVertical || '';
+        if (dom.imageHorizontalInput) dom.imageHorizontalInput.value = state.imageHorizontal || '';
+        renderImageCandidates();
+        refreshUi();
       }
 
       function bindEvents() {
@@ -7674,7 +7892,29 @@ Example output:
         if (dom.imageInput) {
           dom.imageInput.addEventListener('input', event => {
             state.image = event.target.value;
+            renderImageCandidates();
             refreshUi();
+          });
+        }
+        if (dom.imageVerticalInput) {
+          dom.imageVerticalInput.addEventListener('input', event => {
+            state.imageVertical = event.target.value;
+            renderImageCandidates();
+            refreshUi();
+          });
+        }
+        if (dom.imageHorizontalInput) {
+          dom.imageHorizontalInput.addEventListener('input', event => {
+            state.imageHorizontal = event.target.value;
+            renderImageCandidates();
+            refreshUi();
+          });
+        }
+        if (dom.imageCandidates) {
+          dom.imageCandidates.addEventListener('click', event => {
+            const button = event.target.closest('.image-candidate');
+            if (!button || !dom.imageCandidates.contains(button)) return;
+            promoteImageCandidate(button.dataset.candidateField || '');
           });
         }
         if (dom.faviconInput) {
@@ -8455,6 +8695,8 @@ Example output:
           dom.shortNameInput,
           dom.coverInput,
           dom.imageInput,
+          dom.imageVerticalInput,
+          dom.imageHorizontalInput,
           dom.faviconInput,
           dom.descriptionInput,
           dom.citySelect,
@@ -9330,6 +9572,13 @@ Example output:
           setTextParam('searchEndDate', state.editingExistingSearchEndDate);
         }
         setTextParam('img', state.image);
+        // buildShareUrl re-emits the WHOLE address bar from a fresh
+        // URLSearchParams, and init() runs updateUrl() on DOMContentLoaded — a
+        // param missing from this list is stripped from the URL before the user
+        // types anything, so the orientation slots have to be emitted here or
+        // prefill dies on load.
+        setTextParam('imageVertical', state.imageVertical);
+        setTextParam('imageHorizontal', state.imageHorizontal);
         setTextParam('favicon', state.favicon);
         const coordsValue = (state.location || '').trim();
         setTextParam('coords', coordsValue);
@@ -9417,6 +9666,8 @@ Example output:
         setParam('facebook', state.facebook);
         setParam('gmaps', state.gmaps);
         setParam('image', state.image);
+        setParam('imageVertical', state.imageVertical);
+        setParam('imageHorizontal', state.imageHorizontal);
         setParam('favicon', state.favicon);
         const coordinates = parseCoordinates(state.location);
         setParam('lat', coordinates ? coordinates.lat : '');
@@ -9862,6 +10113,8 @@ Example output:
             : null,
           isDeletingOverride: deletingCustomOverride,
           image: (state.image || '').trim() || null,
+          imageVertical: (state.imageVertical || '').trim() || null,
+          imageHorizontal: (state.imageHorizontal || '').trim() || null,
           favicon: (state.favicon || '').trim() || null,
           website: (state.website || '').trim() || null,
           instagram: (state.instagram || '').trim() || null,

--- a/testing/test-unified-scraper.html
+++ b/testing/test-unified-scraper.html
@@ -658,6 +658,10 @@
             add('fb', event.facebook);
             add('gmaps', event.gmaps);
             add('img', event.image);
+            // Orientation slots use their full names — event-builder resolves
+            // them via its own IMAGE_SLOT_PARAM_TO_STATE_KEY map.
+            add('imageVertical', event.imageVertical);
+            add('imageHorizontal', event.imageHorizontal);
             add('cover', event.cover);
 
             const qs = params.toString();

--- a/tools/download-images.js
+++ b/tools/download-images.js
@@ -1254,9 +1254,14 @@ async function extractImageUrls() {
     console.log(`   Found ${events.length} events`);
     
     for (const event of events) {
-      // Extract event images from parsed data with event information
-      if (event.image) {
-        const cleanUrl = cleanImageUrl(event.image);
+      // Extract event images from parsed data with event information. Every
+      // flyer slot is downloaded, not just the primary: the site rewrites all
+      // three to local paths for cached data, so a slot that was never
+      // downloaded would 404 on the card. Filenames are content-hash derived,
+      // so a URL that appears in two slots resolves to one file.
+      for (const imageField of ['image', 'imageVertical', 'imageHorizontal']) {
+        if (!event[imageField]) continue;
+        const cleanUrl = cleanImageUrl(event[imageField]);
         if (cleanUrl.startsWith('http') && cleanUrl.includes('.')) {
           // Adjust Eventbrite image URLs to get uncropped versions
           const adjustedUrl = adjustEventbriteImageUrl(cleanUrl);
@@ -1267,7 +1272,7 @@ async function extractImageUrls() {
             startDate: event.startDate,
             recurring: event.recurring || false
           });
-          console.log(`📸 Found event image: ${event.name} (${event.recurring ? 'recurring' : 'one-time'})`);
+          console.log(`📸 Found event image (${imageField}): ${event.name} (${event.recurring ? 'recurring' : 'one-time'})`);
           if (adjustedUrl !== cleanUrl) {
             console.log(`🎫 Eventbrite: Adjusted image URL for ${event.name}: ${cleanUrl} -> ${adjustedUrl}`);
           }

--- a/tools/generate-event-pages.js
+++ b/tools/generate-event-pages.js
@@ -91,6 +91,14 @@ function buildEventHtml(cityKey, cityName, event) {
   if (event.bar) descriptionParts.push(`@ ${event.bar}`);
   const description = sanitize(descriptionParts.join(' · ')) || `${cityName} bear event`;
   const url = `${SITE_BASE}/${cityKey}/${encodeURIComponent(event.slug)}/`;
+  // The flyer the OG card should paint. The artboard is 1200×630, so the
+  // LANDSCAPE candidate wins when the event has one; otherwise the primary
+  // image (orientation unknown for most URLs) and finally nothing, which
+  // leaves the text-only card that has always been generated.
+  const flyerUrl = String(event.imageHorizontal || event.image || '').trim();
+  const flyerMeta = /^https?:\/\//i.test(flyerUrl)
+    ? `\n  <meta name="chunky:flyer" content="${sanitize(flyerUrl).replace(/"/g, '&quot;')}">`
+    : '';
   // Prefer generated per-event OG image and add a content-hash version for cache busting
   const generatedPng = `/img/og/${cityKey}/${encodeURIComponent(event.slug)}.png`;
   let version = '';
@@ -101,7 +109,11 @@ function buildEventHtml(cityKey, cityName, event) {
       time: event.time || '',
       bar: event.bar || '',
       cover: event.cover || '',
-      description: event.tea || event.unprocessedDescription || ''
+      description: event.tea || event.unprocessedDescription || '',
+      // The generated OG card paints the flyer when there is one, so a flyer
+      // change has to bust the cache too — before this, swapping an event's
+      // image left every share preview showing the old artwork.
+      flyer: flyerUrl
     });
     version = crypto.createHash('md5').update(seed).digest('hex').slice(0, 8);
   } catch (e) {
@@ -145,7 +157,7 @@ ${MARKER}
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="${title}">
   <meta name="twitter:description" content="${description}">
-  <meta name="twitter:image" content="${ogImage}">
+  <meta name="twitter:image" content="${ogImage}">${flyerMeta}
   <meta http-equiv="refresh" content="0; url=${redirectTarget}">
 </head>
 <body>

--- a/tools/generate-og-images.js
+++ b/tools/generate-og-images.js
@@ -101,12 +101,28 @@ function darken(hex, ratio = 0.6) {
   return `#${[dr, dg, db].map(v => v.toString(16).padStart(2, '0')).join('')}`;
 }
 
+// Undo the entity escaping generate-event-pages.js applies to meta content.
+function unescapeMeta(text) {
+  return String(text || '')
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
 // Build a minimal HTML snippet (no external CSS/fonts) for deterministic render.
 // When faviconColors is provided the OG card uses the event's extracted favicon palette.
-function buildTemplate({ cityName, eventName, day, time, bar, faviconColors }) {
+// When flyerUrl is provided the event's own artwork is painted (dimmed and
+// blurred behind, whole and uncropped beside the text). Every flyer path is
+// opt-in and self-healing: if the image fails to load the page drops back to
+// the text-only card that has always been generated, via the body class.
+function buildTemplate({ cityName, eventName, day, time, bar, faviconColors, flyerUrl }) {
   const title = sanitize(eventName);
   const subtitle = [sanitize(cityName), sanitize(day), sanitize(time)].filter(Boolean).join(' • ');
   const venue = bar ? `@ ${sanitize(bar)}` : '';
+  const flyer = /^https?:\/\//i.test(String(flyerUrl || '').trim())
+    ? sanitize(String(flyerUrl).trim()).replace(/"/g, '&quot;')
+    : '';
 
   // Derive background and accent from favicon colors when available
   const bgGrad = faviconColors
@@ -138,15 +154,29 @@ function buildTemplate({ cityName, eventName, day, time, bar, faviconColors }) {
     .title { font-size: 64px; line-height: 1.05; font-weight: 800; margin: 0 0 18px; }
     .subtitle { font-size: 28px; color: #d0d7de; margin: 0 0 8px; }
     .venue { font-size: 28px; color: #e6edf3; margin: 0; }
+    /* Flyer layers: inert unless body.has-flyer, which the images themselves
+       clear when they fail to load. */
+    .flyer-bg, .flyer-art { display: none; }
+    body.has-flyer .flyer-bg { display: block; position: absolute; inset: 0; overflow: hidden; }
+    body.has-flyer .flyer-bg img { width: 100%; height: 100%; object-fit: cover; filter: blur(26px) brightness(0.42) saturate(1.1); transform: scale(1.1); }
+    body.has-flyer .stage { position: relative; display: flex; align-items: center; gap: 40px; }
+    body.has-flyer .card { width: 620px; height: 470px; }
+    body.has-flyer .title { font-size: 52px; }
+    body.has-flyer .flyer-art { display: flex; align-items: center; justify-content: center; width: 400px; height: 510px; }
+    body.has-flyer .flyer-art img { max-width: 400px; max-height: 510px; object-fit: contain; border-radius: 16px; box-shadow: 0 18px 50px rgba(0,0,0,0.55); }
   </style>
   <title>${title}</title>
   </head>
-  <body>
+  <body class="${flyer ? 'has-flyer' : ''}">
+    ${flyer ? `<div class="flyer-bg"><img src="${flyer}" onerror="document.body.className=''"></div>` : ''}
+    <div class="stage">
     <div class="card">
       <div class="brand">chunky.dad</div>
       <div class="title">${title}</div>
       <div class="subtitle">${subtitle}</div>
       ${venue ? `<div class="venue">${venue}</div>` : ''}
+    </div>
+    ${flyer ? `<div class="flyer-art"><img src="${flyer}" onerror="document.body.className=''"></div>` : ''}
     </div>
   </body>
 </html>`;
@@ -202,7 +232,12 @@ async function main() {
         || (bar ? barColors.get(bar.toLowerCase()) : null)
         || null;
 
-      targets.push({ cityKey: cityFromCanonical, slug: evDir.name, title, day, time, bar, faviconColors });
+      // The event's flyer, written into the stub by generate-event-pages.js
+      // (landscape candidate preferred — this artboard is 1200×630).
+      const flyerMatch = html.match(/<meta name="chunky:flyer" content="([^"]+)"/);
+      const flyerUrl = flyerMatch ? unescapeMeta(flyerMatch[1]) : '';
+
+      targets.push({ cityKey: cityFromCanonical, slug: evDir.name, title, day, time, bar, faviconColors, flyerUrl });
     }
   }
 
@@ -218,8 +253,15 @@ async function main() {
     for (const t of targets) {
       const page = await browser.newPage();
       await page.setViewport({ width: 1200, height: 630, deviceScaleFactor: 1 });
-      const html = buildTemplate({ cityName: t.cityKey, eventName: t.title, day: t.day, time: t.time, bar: t.bar, faviconColors: t.faviconColors });
-      await page.setContent(html, { waitUntil: 'networkidle0' });
+      const baseArgs = { cityName: t.cityKey, eventName: t.title, day: t.day, time: t.time, bar: t.bar, faviconColors: t.faviconColors };
+      try {
+        await page.setContent(buildTemplate({ ...baseArgs, flyerUrl: t.flyerUrl }), { waitUntil: 'networkidle0', timeout: 20000 });
+      } catch (err) {
+        // A slow or unreachable flyer host must never fail the build: fall back
+        // to the text-only card, which needs no network at all.
+        console.warn(`⚠️  Flyer render timed out for ${t.cityKey}/${t.slug}; using text-only card`);
+        await page.setContent(buildTemplate(baseArgs), { waitUntil: 'load' });
+      }
       const buffer = await page.screenshot({ type: 'png' });
       const outPath = path.join(OUTPUT_DIR, t.cityKey, `${t.slug}.png`);
       if (writeIfChanged(outPath, buffer)) {

--- a/tools/serve-results.js
+++ b/tools/serve-results.js
@@ -130,7 +130,6 @@ const BRIDGE_SHIM_MARKER = 'chunky-server-bridge-shim';
 //   registries = {
 //     mapVerifyUrls:   { id → real https URL }   (open-url bridge)
 //     venueSnippets:   { index → parser entry }  (copy-venue bridge)
-//     activeConfigJson: string                   (copy-config bridge)
 //   }
 // ---------------------------------------------------------------------------
 function rewriteBridgeHtml(html, registries = {}) {
@@ -144,9 +143,6 @@ function rewriteBridgeHtml(html, registries = {}) {
     const venueSnippets = registries.venueSnippets && typeof registries.venueSnippets === 'object'
         ? registries.venueSnippets
         : {};
-    const activeConfigJson = typeof registries.activeConfigJson === 'string'
-        ? registries.activeConfigJson
-        : '';
 
     // 1) open-url → plain anchors: swap the bridge onclick for the real URL
     //    from the per-render registry, opening in a new tab.
@@ -173,8 +169,7 @@ function rewriteBridgeHtml(html, registries = {}) {
 <script>
 (function () {
     window.__serverBridgeData = {
-        venueSnippets: ${jsonForInlineScript(venueSnippets)},
-        activeConfigJson: ${jsonForInlineScript(activeConfigJson)}
+        venueSnippets: ${jsonForInlineScript(venueSnippets)}
     };
 })();
 // Clipboard with non-secure-context fallback: navigator.clipboard only exists
@@ -213,15 +208,6 @@ function copyVenueEntry(btn) {
     serverCopyText(snippet, function (ok) {
         if (ok && typeof markVenueEntryCopied === 'function') markVenueEntryCopied(idx);
         if (!ok) window.prompt('Copy manually (clipboard needs HTTPS — try tailscale serve):', snippet);
-    });
-}
-// copy-config: same story with the redacted effective-config JSON.
-function copyActiveConfig(btn) {
-    var json = window.__serverBridgeData.activeConfigJson;
-    if (typeof json !== 'string' || !json) return;
-    serverCopyText(json, function (ok) {
-        if (ok && typeof markConfigCopied === 'function') markConfigCopied();
-        if (!ok) window.prompt('Copy manually (clipboard needs HTTPS — try tailscale serve):', json);
     });
 }
 // export-ics: native built the ICS and opened DocumentPicker; the browser
@@ -473,13 +459,7 @@ async function renderLatestResults(state, saved) {
         mapVerifyUrls: adapter._mapVerifyUrls || {},
         venueSnippets: typeof adapter.collectVenueEntrySnippets === 'function'
             ? adapter.collectVenueEntrySnippets(results)
-            : {},
-        activeConfigJson: (() => {
-            const summary = typeof adapter.buildActiveConfigSummaryForResults === 'function'
-                ? adapter.buildActiveConfigSummaryForResults(results)
-                : null;
-            return summary && typeof summary.json === 'string' ? summary.json : '';
-        })()
+            : {}
     };
     state.icsRegistry = adapter._icsExportEvents || {};
     state.lastRenderResults = results;


### PR DESCRIPTION
## Images: portrait AND landscape
`imageVertical` / `imageHorizontal` alongside `image`, each a bare URL on its own notes line. Not exclusive of the primary; an absent slot means "nothing is known to be that shape", never "delete" (never-clear merge guard).

The format was chosen against **measured** behaviour of your parsers, not assumed: a hyphenated notes key silently vanishes, a multi-line value fragments into a bogus second field, and anything but a bare URL in `image:` makes `calendar-core` reject the entire event's metadata. Each trap now has a regression test.

**Orientation detection** — new `getImageDimensionsFromUrl` reads Wix's comma form (`w_792,h_990`) which the existing size scorer literally cannot see, and **rejects** Eventbrite's `?w=460&h=230` (their fixed 2:1 listing thumb — trusting it would label every Eventbrite flyer landscape).

**Capture** stops throwing candidates away: JSON-LD `image` arrays (often literally 1×1/4×3/16×9), *every* `og:image` tag, and `og:image:width`/`height` which nothing in the repo parsed before. Live proof — Bearracuda from published dimensions, CHUNK from Wix URLs, with their NYE event correctly landing horizontal:
```
🖼️ IMAGE SLOTS: vertical=…/w_792,h_990/… horizontal=none for "CHUNK Chicago - September 19th"
🖼️ IMAGE SLOTS: vertical=none horizontal=…/w_4112,h_3300/… for "CHUNK CHICAGO presents NEW YEARS EVE"
```

**Consumers**: card prefers portrait; a dead flyer URL now advances to the next candidate instead of vanishing; OG art prefers landscape; the builder gets both fields plus a thumbnail strip showing real pixel dimensions. Prefill carries them through every drop point — including `buildShareUrl`, which rebuilds the query string from a whitelist *on page load*.

Only ~18% of real URLs advertise dimensions, so "unknown" is the common path and everything degrades to exactly today's behaviour.

## Run UI (your feedback)
- Picker starts with **nothing selected**; the remembered set is an explicit `↻ Rerun last (N)` row instead of a pre-selection you have to undo.
- **Active-config section deleted.**
- **Bear verdicts on the tiles**: dropped events render as real event cards in their own section, and every card — kept or dropped — carries both "Mark as bear" and "Mark as not bear" with the current verdict indicated. Taps use the existing override bridge; no new persistence path.

## Merge / identity fixes
- **Identical times no longer report CLOBBERED.** They're `Date` objects, and two Dates for one instant are never `===`. This exact bug was fixed for the merge *log* line already; the comparison table never got it.
- **A ticketing URL can't displace an identity link** for website/url — Cubhouse's curated linktree was being clobbered by an Eventbrite listing, which broke its icon. Narrow by design: a bare homepage still loses to a deep event page, so the earlier cross-host rung stands (two tests caught my first, broader attempt).
- **Promoters now guarantee a favicon**: a matched promoter contributes its identity link as `favicon` when it has no explicit one, so registry-matched events always have an icon even when a platform URL wins `website`.

## Known gaps (not fixed here)
- `scripts/display-saved-run.js` never passes `bearDroppedEvents` through, so the dropped section stays empty for saved-run display — pre-existing.
- `tools/generate-event-pages.js` parses 0 events unless `js/event-schema.js` is preloaded; run plainly it deletes every event stub. Pre-existing, reproduced at HEAD, worth its own fix.

Suite: **1085/1085**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP