### PR TITLE
fix: twelve verified bugs from the adversarial review of today's merges

### DIFF
--- a/data/favicon-misses.json
+++ b/data/favicon-misses.json
@@ -10,8 +10,8 @@
     "lastTried": "2026-07-27T18:31:50.333Z"
   },
   "noxsatvrn.carrd.co": {
-    "misses": 1,
+    "misses": 2,
     "firstMiss": "2026-07-23T18:05:57.542Z",
-    "lastTried": "2026-07-23T18:05:57.542Z"
+    "lastTried": "2026-07-30T18:16:32.503Z"
   }
 }

--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -1055,10 +1055,17 @@ class CalendarCore {
         }
         
         if (!recurring) {
-            // One-off event - show the date (same as calendar)
-            const startDateStr = startDate instanceof Date ? 
-                startDate.toISOString().split('T')[0] : startDate;
-            const parts = startDateStr.split('-');
+            // One-off event — show the date THE SAME WAY THE GRID PLACES IT.
+            // The grid buckets events by browser-local getDate()/getMonth();
+            // this badge used toISOString(), the UTC date, so any evening
+            // event west of UTC read one day later than the calendar cell it
+            // sat under ("7/18 · Fri 8PM-2AM" on a July 17 event — review
+            // 2026-07-30). Consistency with the grid is the contract here.
+            const startDateObj = startDate instanceof Date ? startDate : new Date(startDate);
+            if (!isNaN(startDateObj.getTime())) {
+                return `${startDateObj.getMonth() + 1}/${startDateObj.getDate()}`;
+            }
+            const parts = String(startDate).split('T')[0].split('-');
             const month = parseInt(parts[1]);
             const date = parseInt(parts[2]);
             return `${month}/${date}`;

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -2161,7 +2161,7 @@ class DynamicCalendarLoader extends CalendarCore {
     // Escaped href, or '' for schemes that would execute script.
     safeCardUrl(url) {
         const raw = String(url === null || url === undefined ? '' : url).trim();
-        if (!raw || /^(javascript|data|vbscript):/i.test(raw.replace(/[\s -]/g, ''))) {
+        if (!raw || /^(javascript|data|vbscript):/i.test(raw.replace(/[\s\u0000-\u001f]/g, ''))) {
             return '';
         }
         return this.escapeCardText(raw);

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -693,6 +693,30 @@ class ScriptableAdapter {
       .filter(Boolean);
   }
 
+  // The top-level bearDroppedEvents list in a saved run exists only for the
+  // saved-run audit display; the same entries are already persisted verbatim
+  // under parserResults[].bearDroppedEvents for any other consumer. So this
+  // copy is slimmed: `_`-prefixed working keys on the embedded event (notably
+  // the ~1-2KB `_parserConfig` every drop carries) are dropped. Shallow
+  // clones only — the live entries are still on screen and must not change.
+  sanitizeDroppedEntriesForRunSave(entries) {
+    if (!Array.isArray(entries)) return [];
+    return entries.map((entry) => {
+      if (!entry || typeof entry !== "object") return entry;
+      const copy = { ...entry };
+      delete copy._parserConfig;
+      if (copy.event && typeof copy.event === "object") {
+        const event = {};
+        for (const key of Object.keys(copy.event)) {
+          if (key.startsWith("_")) continue;
+          event[key] = copy.event[key];
+        }
+        copy.event = event;
+      }
+      return copy;
+    });
+  }
+
   // Detect all-day events at save-time based on DateTime patterns
   isAllDayEvent(event) {
     if (!event || !event.startDate || !event.endDate) return false;
@@ -8540,24 +8564,35 @@ class ScriptableAdapter {
         if (!entry) return "";
         // The drop entry keeps the full event under `.event`; older/partial
         // entries fall back to the flat summary fields so a card still renders.
-        const event =
-          entry.event && typeof entry.event === "object"
-            ? entry.event
-            : {
-                title: entry.title,
-                startDate: entry.startDate,
-                bar: entry.venue,
-              };
+        const hasFullEvent = !!(entry.event && typeof entry.event === "object");
+        const event = hasFullEvent
+          ? entry.event
+          : {
+              title: entry.title,
+              startDate: entry.startDate,
+              bar: entry.venue,
+            };
+        // Two rescue flags, one treatment: `rescued` (a calendar manual-bear
+        // record pre-empted the drop) and `manuallyMarkedBear` (the owner
+        // rescued it during the run via the verdict buttons — saved runs
+        // persist the flag on the same entry) both render read-only with the
+        // verdict shown as bear. Fallback cards without `.event` also go
+        // read-only: recordBearOverrideAndReport cannot act on them, so live
+        // buttons would be silently dead.
+        const isRescued =
+          entry.rescued === true || entry.manuallyMarkedBear === true;
         return this.generateEventCard(event, runInfo, {
           dropped: true,
           bearIdx: `d${index}`,
-          bearVerdict: entry.rescued ? "bear" : "not-bear",
-          interactive: interactive && entry.rescued !== true,
+          bearVerdict: isRescued ? "bear" : "not-bear",
+          interactive: interactive && !isRescued && hasFullEvent,
           dropReason: entry.reason || "",
           dropHost: entry.host || "",
           note: entry.rescued
             ? "Rescued (manual override on calendar record)"
-            : "",
+            : entry.manuallyMarkedBear === true
+              ? "Rescued (marked bear by calendar owner this run)"
+              : "",
         });
       })
       .join("");
@@ -9734,12 +9769,17 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
   // failure only costs the next run's pre-selection.
   async savePickerState(names) {
     try {
+      const list = Array.from(names || []);
+      // Never persist an empty selection: writing [] would erase the
+      // remembered set behind "Rerun last". Confirmed selections are always
+      // non-empty; anything else keeps the previous state on disk.
+      if (list.length === 0) return false;
       const fm = this.fm || FileManager.iCloud();
       if (!fm.fileExists(this.baseDir)) {
         fm.createDirectory(this.baseDir, true);
       }
       const payload = {
-        selected: Array.from(names || []),
+        selected: list,
         savedAt: new Date().toISOString(),
       };
       fm.writeString(
@@ -9877,12 +9917,20 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
 
         const runSelectedRow = new UITableRow();
         runSelectedRow.height = 50;
+        // With nothing checked, "Run selected (0)" is a disabled no-op: it
+        // must neither finish nor dismiss. An empty confirm would start a run
+        // with every parser disabled AND overwrite the remembered "Rerun
+        // last" selection with [] (hiding that row forever). Gray title
+        // signals disabled; blue means armed.
+        const hasSelection = selected.size > 0;
+        runSelectedRow.dismissOnSelect = hasSelection;
         const runSelectedCell = runSelectedRow.addText(
           `▶ Run selected (${selected.size})`,
         );
         runSelectedCell.titleFont = Font.boldSystemFont(16);
-        runSelectedCell.titleColor = Color.blue();
+        runSelectedCell.titleColor = hasSelection ? Color.blue() : Color.gray();
         runSelectedRow.onSelect = () => {
+          if (selected.size === 0) return;
           finish(new Set(selected));
         };
         table.addRow(runSelectedRow);
@@ -9938,8 +9986,9 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       const picked = await selectionPromise;
       // Persist confirmed selections only (Rerun last / Run selected / Run
       // all) — the next run's picker offers them behind "Rerun last", never
-      // as a pre-selection. Dismissal keeps the previous state.
-      if (picked) {
+      // as a pre-selection. Dismissal keeps the previous state, and an empty
+      // set must never reach savePickerState (it would wipe "Rerun last").
+      if (picked && picked.size > 0) {
         await this.savePickerState(Array.from(picked));
       }
       return picked;
@@ -10925,10 +10974,11 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         // as it actually happened: the results UI renders these as real event
         // cards, and without them that section is simply missing from every
         // saved-run display — which is exactly where you go to audit a bear
-        // call after the fact.
-        bearDroppedEvents: Array.isArray(results.bearDroppedEvents)
-          ? results.bearDroppedEvents
-          : [],
+        // call after the fact. Sanitized copies only: this list is for the
+        // display, and parserResults below already carries the raw entries.
+        bearDroppedEvents: this.sanitizeDroppedEntriesForRunSave(
+          results.bearDroppedEvents,
+        ),
         parserResults: results.parserResults || [],
         errors: results.errors || [],
       };

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -1578,6 +1578,52 @@ test('generateBearDroppedSection renders drops as real event cards with both ver
   assert.ok(savedHtml.includes('data-bear-act="mark-bear" disabled'), 'saved-run display has no post-dismissal execution');
 });
 
+test('generateBearDroppedSection: manuallyMarkedBear renders the rescued treatment', () => {
+  const adapter = buildAdapter();
+  // A drop the owner rescued mid-run (applyPendingBearOverrides stamps
+  // manuallyMarkedBear on the entry, and saveRun persists it) must read as
+  // rescued in a saved run — not as a still-active "not bear" verdict.
+  const html = adapter.generateBearDroppedSection({
+    _isDisplayingSavedRun: true,
+    bearDroppedEvents: [{ ...buildBearDroppedFixture(), manuallyMarkedBear: true }]
+  });
+  assert.ok(html.includes('data-bear-verdict="bear"'), 'verdict shown as bear');
+  assert.ok(
+    !html.includes('is-active" data-bear-idx="d0" data-bear-act="mark-not-bear"'),
+    'not-bear is no longer the active verdict'
+  );
+  assert.ok(html.includes('data-bear-act="mark-bear" disabled'), 'rendered read-only');
+  assert.ok(html.includes('Rescued (marked bear by calendar owner this run)'), 'rescue note shown');
+
+  // Same treatment in a live run: an already-applied rescue is not re-markable.
+  const liveHtml = adapter.generateBearDroppedSection({
+    bearDroppedEvents: [{ ...buildBearDroppedFixture(), manuallyMarkedBear: true }]
+  });
+  assert.ok(liveHtml.includes('data-bear-act="mark-bear" disabled'), 'read-only in live runs too');
+  assert.ok(liveHtml.includes('data-bear-verdict="bear"'));
+
+  // The pre-existing rescue flag keeps working unchanged.
+  const rescuedHtml = adapter.generateBearDroppedSection({
+    bearDroppedEvents: [{ ...buildBearDroppedFixture(), rescued: true }]
+  });
+  assert.ok(rescuedHtml.includes('Rescued (manual override on calendar record)'));
+  assert.ok(rescuedHtml.includes('data-bear-verdict="bear"'));
+});
+
+test('generateBearDroppedSection: fallback entries without .event render disabled buttons', () => {
+  const adapter = buildAdapter();
+  // recordBearOverrideAndReport early-returns on entries lacking .event, so
+  // live buttons on the flat-fields fallback card would be silently dead —
+  // they must carry the same disabled treatment saved-run mode uses.
+  const { event, ...flatEntry } = buildBearDroppedFixture();
+  const html = adapter.generateBearDroppedSection({ bearDroppedEvents: [flatEntry] });
+  assert.ok(html.includes('Twink Bash'), 'fallback card still renders the drop');
+  assert.ok(html.includes('Neon Room'), 'venue survives via the flat fields');
+  assert.ok(html.includes('data-bear-act="mark-bear" disabled'), 'mark-bear disabled');
+  assert.ok(html.includes('data-bear-act="mark-not-bear" disabled'), 'mark-not-bear disabled');
+  assert.ok(!html.includes('data-bear-act="mark-bear">'), 'no live mark-bear button');
+});
+
 test('buildBearVerdictActionsHtml escapes the card id and marks the active verdict', () => {
   const adapter = buildAdapter();
   assert.equal(adapter.buildBearVerdictActionsHtml(null), '', 'no row without options');
@@ -2897,9 +2943,14 @@ test('picker-state: corrupt or misshapen file → empty pre-selection', async ()
   assert.deepEqual(adapter.parsePickerState('null', ['Alpha']), [], 'JSON null → []');
 });
 
-// Headless UITable stub that records every row it is handed and taps the first
-// row whose label contains `tapLabel` (null = swipe-down dismissal).
-function installPickerUITableStub(tapLabel) {
+// Headless UITable stub that records every row it is handed and taps, in
+// order, the first row whose label contains each entry of `tapLabels` (a
+// string, an array of strings, or null = swipe-down dismissal). Rows are
+// re-read between taps because toggling a parser rebuilds the table. Color
+// stubs return tag strings so titleColor is assertable.
+function installPickerUITableStub(tapLabels) {
+  const taps =
+    tapLabels == null ? [] : Array.isArray(tapLabels) ? tapLabels : [tapLabels];
   const originals = {
     UITable: global.UITable,
     UITableRow: global.UITableRow,
@@ -2930,47 +2981,72 @@ function installPickerUITableStub(tapLabel) {
     reload() {}
     present() {
       captured.rows = this.rows;
-      const rows = this.rows;
       return new Promise((resolve) => {
         setImmediate(() => {
-          if (tapLabel) {
-            const row = rows.find((r) =>
+          for (const tapLabel of taps) {
+            const row = this.rows.find((r) =>
               r.cells.some((c) => typeof c.title === 'string' && c.title.includes(tapLabel))
             );
             if (row && row.onSelect) row.onSelect();
           }
+          captured.rows = this.rows;
           resolve();
         });
       });
     }
   };
   global.Font = { boldSystemFont: () => ({}), systemFont: () => ({}) };
-  global.Color = { white: () => ({}), brown: () => ({}), blue: () => ({}), gray: () => ({}) };
+  global.Color = {
+    white: () => 'white',
+    brown: () => 'brown',
+    blue: () => 'blue',
+    gray: () => 'gray'
+  };
   captured.restore = () => Object.assign(global, originals);
   captured.labels = () =>
     captured.rows.map((r) => (r.cells[0] && r.cells[0].title) || '');
+  captured.findRow = (label) =>
+    captured.rows.find((r) =>
+      r.cells.some((c) => typeof c.title === 'string' && c.title.includes(label))
+    );
   return captured;
 }
 
 test('presentParserPicker pre-selects NOTHING even with a remembered selection', async () => {
   const adapter = buildAdapter();
   const files = installMemoryFm(adapter);
-  files.set(
-    adapter.getPickerStatePath(),
-    JSON.stringify({ selected: ['Alpha', 'Beta'] })
-  );
+  const rememberedState = JSON.stringify({ selected: ['Alpha', 'Beta'] });
+  files.set(adapter.getPickerStatePath(), rememberedState);
 
   const table = installPickerUITableStub('▶ Run selected');
   try {
     const picked = await adapter.presentParserPicker({
       parsers: [{ name: 'Alpha' }, { name: 'Beta' }, { name: 'Gamma' }]
     });
-    assert.deepEqual(Array.from(picked), [], 'confirming immediately runs nothing');
+    // "Run selected (0)" is a disabled no-op: the tap neither finishes nor
+    // dismisses, so the (stubbed) swipe-down that follows resolves null.
+    assert.equal(picked, null, 'tapping Run selected with zero checked runs nothing');
+    assert.equal(
+      files.get(adapter.getPickerStatePath()),
+      rememberedState,
+      'the remembered "Rerun last" state is NOT overwritten by an empty confirm'
+    );
 
     const labels = table.labels();
     assert.ok(
       labels.includes('▶ Run selected (0)'),
       `Run selected starts at zero (labels: ${labels.join(' | ')})`
+    );
+    const runSelectedRow = table.findRow('▶ Run selected');
+    assert.equal(
+      runSelectedRow.cells[0].titleColor,
+      'gray',
+      'zero-selection Run selected renders gray (disabled)'
+    );
+    assert.equal(
+      runSelectedRow.dismissOnSelect,
+      false,
+      'zero-selection Run selected does not dismiss the table'
     );
     assert.ok(
       labels.every((label) => !label.startsWith('☑')),
@@ -2980,6 +3056,48 @@ test('presentParserPicker pre-selects NOTHING even with a remembered selection',
       labels.filter((label) => label.startsWith('☐')).length,
       3,
       'every parser row renders unchecked'
+    );
+  } finally {
+    table.restore();
+  }
+});
+
+test('presentParserPicker: a non-empty "Run selected" still runs and persists the picks', async () => {
+  const adapter = buildAdapter();
+  const files = installMemoryFm(adapter);
+  files.set(
+    adapter.getPickerStatePath(),
+    JSON.stringify({ selected: ['Beta'] })
+  );
+
+  // Tap the Alpha parser row (rebuilds the table), then confirm.
+  const table = installPickerUITableStub(['☐ Alpha', '▶ Run selected']);
+  try {
+    const picked = await adapter.presentParserPicker({
+      parsers: [{ name: 'Alpha' }, { name: 'Beta' }, { name: 'Gamma' }]
+    });
+    assert.deepEqual(Array.from(picked), ['Alpha'], 'the checked parser runs');
+    assert.deepEqual(
+      JSON.parse(files.get(adapter.getPickerStatePath())).selected,
+      ['Alpha'],
+      'a non-empty confirm still overwrites the remembered state'
+    );
+
+    const labels = table.labels();
+    assert.ok(
+      labels.includes('▶ Run selected (1)'),
+      `count updates after the toggle (labels: ${labels.join(' | ')})`
+    );
+    const runSelectedRow = table.findRow('▶ Run selected');
+    assert.equal(
+      runSelectedRow.cells[0].titleColor,
+      'blue',
+      'armed Run selected renders blue'
+    );
+    assert.equal(
+      runSelectedRow.dismissOnSelect,
+      true,
+      'armed Run selected dismisses on confirm'
     );
   } finally {
     table.restore();
@@ -3402,8 +3520,56 @@ test('probeRecurringSeries fails open on errors and without an identifier', asyn
   assert.equal(await adapter.probeRecurringSeries({ title: 'no identifier' }, {}), false);
 });
 
-// NOTE: saveRun's payload (which now carries bearDroppedEvents) is not covered
-// here. It writes through Scriptable's FileManager and pulls in enough of that
-// runtime that stubbing it in Node tests more of the stub than of the code.
-// The change is a single key added to a literal, verified by inspection and by
-// the run-file reproduction in the PR.
+// ---------------------------------------------------------------------------
+// saveRun payload: the top-level bearDroppedEvents copy is display-only and
+// sanitized (no `_`-prefixed event keys); parserResults keeps the raw entries.
+// ---------------------------------------------------------------------------
+
+test('saveRun persists sanitized dropped entries; parserResults and live entries stay raw', async () => {
+  const adapter = buildAdapter();
+  const files = installMemoryFm(adapter);
+
+  const entry = buildBearDroppedFixture();
+  entry.event._parserConfig = { name: 'megaparser', urls: ['https://x.example'] };
+  entry.event._sourcePageUrl = 'https://x.example/page';
+  const results = {
+    analyzedEvents: [],
+    bearDroppedEvents: [entry],
+    parserResults: [{ name: 'megaparser', bearDroppedEvents: [entry] }],
+    errors: []
+  };
+
+  const runId = await adapter.saveRun(results);
+  assert.ok(runId, 'run saved');
+  const payload = JSON.parse(files.get(adapter.getRunFilePath(runId)));
+
+  const saved = payload.bearDroppedEvents[0];
+  assert.equal(saved.reason, 'ai: drag show, no bear context', 'drop reason survives');
+  assert.equal(saved.host, 'promoter.example', 'host survives');
+  assert.equal(saved.title, 'Twink Bash', 'flat title survives');
+  assert.equal(saved.startDate, '2026-08-02T21:00:00.000Z', 'flat startDate survives');
+  assert.equal(saved.event.title, 'Twink Bash', 'embedded event title survives');
+  assert.ok(
+    Object.keys(saved.event).every((key) => !key.startsWith('_')),
+    'no _-prefixed keys (including _parserConfig) on the saved embedded event'
+  );
+
+  // parserResults is persisted untouched — other consumers may rely on it.
+  assert.ok(
+    payload.parserResults[0].bearDroppedEvents[0].event._parserConfig,
+    'parserResults copy keeps the raw entry'
+  );
+  // The live entry is never mutated by the save.
+  assert.ok(entry.event._parserConfig, 'live entry keeps its working keys');
+  assert.equal(results.bearDroppedEvents[0], entry, 'live list untouched');
+});
+
+test('sanitizeDroppedEntriesForRunSave tolerates misshapen input', () => {
+  const adapter = buildAdapter();
+  assert.deepEqual(adapter.sanitizeDroppedEntriesForRunSave(null), []);
+  assert.deepEqual(adapter.sanitizeDroppedEntriesForRunSave('nope'), []);
+  assert.deepEqual(
+    adapter.sanitizeDroppedEntriesForRunSave([null, { title: 'no event field' }]),
+    [null, { title: 'no event field' }]
+  );
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -12038,6 +12038,33 @@ TEXT:
         return values;
     }
 
+    // EVERY og-style meta (key, content) pair for a SET of keys, in document
+    // order. collectPageMetaImageCandidates needs relative ordering ACROSS
+    // keys — per the OGP spec an og:image:width/og:image:height structured
+    // property describes the og:image tag it FOLLOWS, which the per-key
+    // extractOgMetaContentAll above cannot express. Same decoding and the same
+    // skip-empty rule, so filtering the result to one key always equals
+    // extractOgMetaContentAll's answer for that key.
+    extractOgMetaEntriesAll(html, keyNames) {
+        const source = String(html || '').slice(0, 500000);
+        const wanted = new Set(keyNames);
+        const metaRegex = /<meta\b[^>]*>/gi;
+        const entries = [];
+        let match;
+        while ((match = metaRegex.exec(source)) !== null) {
+            const tag = match[0];
+            const nameMatch = tag.match(/\b(?:name|property)\s*=\s*["']([^"']+)["']/i);
+            if (!nameMatch) continue;
+            const key = this.normalizeWhitespace(nameMatch[1]).toLowerCase();
+            if (!wanted.has(key)) continue;
+            const contentMatch = tag.match(/\bcontent\s*=\s*["']([^"']+)["']/i);
+            if (!contentMatch) continue;
+            const value = this.normalizeWhitespace(this.decodeBasicEntities(contentMatch[1]));
+            if (value) entries.push({ key, value });
+        }
+        return entries;
+    }
+
     // Cached per page like getPageBrandNames (segment/OCR copies spread
     // htmlData and inherit the cache).
     getPageOgTitle(htmlData) {
@@ -12121,16 +12148,38 @@ TEXT:
     // standard storage pipeline (normalizeHttpUrlValue → unwrapImageProxyUrl →
     // upgradeCdnThumbnailUrl). Multiple tags per key are all collected, and the
     // og:image family's published og:image:width/og:image:height are paired by
-    // document order — those are the page's OWN authoritative dimensions, worth
-    // more than anything the URL hints at. Cached per page like getPageOgTitle.
+    // DOCUMENT ADJACENCY per the OGP spec: a width/height tag describes the
+    // og:image-family tag it follows, so a dimensionless og:image before a
+    // dimensioned one never inherits the later tag's shape. Those published
+    // dimensions are the page's OWN authoritative answer, worth more than
+    // anything the URL hints at. Cached per page like getPageOgTitle.
     collectPageMetaImageCandidates(htmlData) {
         if (!htmlData || typeof htmlData !== 'object') return [];
         if (Array.isArray(htmlData.pageMetaImageCandidates)) return htmlData.pageMetaImageCandidates;
         const html = typeof htmlData.html === 'string' ? htmlData.html : '';
         const candidates = [];
         if (html) {
-            const widths = this.extractOgMetaContentAll(html, 'og:image:width');
-            const heights = this.extractOgMetaContentAll(html, 'og:image:height');
+            // og:image:width/height belong to the og:image family only — the
+            // Twitter card tags have no dimension siblings. Walk the family in
+            // document order: every url-bearing tag starts a new candidate
+            // (og:image:url/secure_url are treated as new candidates, matching
+            // the historical per-key handling, not as refinements of the
+            // preceding og:image); width/height attach to the MOST RECENT one,
+            // and dimensions published before any url-bearing tag attach to
+            // nothing.
+            const ogUrlKeys = ['og:image', 'og:image:url', 'og:image:secure_url'];
+            const pairedDimensionsByKey = { 'og:image': [], 'og:image:url': [], 'og:image:secure_url': [] };
+            let currentOgDimensions = null;
+            for (const entry of this.extractOgMetaEntriesAll(html, ogUrlKeys.concat(['og:image:width', 'og:image:height']))) {
+                if (entry.key === 'og:image:width') {
+                    if (currentOgDimensions) currentOgDimensions.width = this.parseImageDimensionValue(entry.value);
+                } else if (entry.key === 'og:image:height') {
+                    if (currentOgDimensions) currentOgDimensions.height = this.parseImageDimensionValue(entry.value);
+                } else {
+                    currentOgDimensions = { width: null, height: null };
+                    pairedDimensionsByKey[entry.key].push(currentOgDimensions);
+                }
+            }
             const metaKeys = ['og:image', 'og:image:url', 'og:image:secure_url', 'twitter:image', 'twitter:image:src'];
             const seen = new Set();
             for (const metaKey of metaKeys) {
@@ -12146,11 +12195,9 @@ TEXT:
                     const key = this.canonicalizeImageUrlForComparison(upgraded);
                     if (!key || seen.has(key)) continue;
                     seen.add(key);
-                    // og:image:width/height belong to the og:image family only —
-                    // the Twitter card tags have no dimension siblings.
-                    const pairable = metaKey.indexOf('og:image') === 0;
-                    const width = pairable ? this.parseImageDimensionValue(widths[i]) : null;
-                    const height = pairable ? this.parseImageDimensionValue(heights[i]) : null;
+                    const paired = pairedDimensionsByKey[metaKey] ? pairedDimensionsByKey[metaKey][i] : null;
+                    const width = paired ? paired.width : null;
+                    const height = paired ? paired.height : null;
                     candidates.push({ url: upgraded, width, height, authoritative: Boolean(width && height) });
                 }
             }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -7968,6 +7968,98 @@ test('image slots: two og:image tags on one page are BOTH considered', () => {
   assert.equal(filled.imageHorizontal, 'https://cdn.example/wide-d4e5f6.jpg');
 });
 
+test('image slots: og:image:width/height pair by DOCUMENT ADJACENCY, not flat index', () => {
+  const parser = createParser();
+  // Per the OGP spec a width/height tag describes the og:image it FOLLOWS.
+  // Here the FIRST og:image publishes no dimensions and the SECOND carries
+  // 1080x1350 — flat-index pairing would stamp the first tag authoritative
+  // portrait and put the wrong URL in the slot.
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://cdn.example/banner-nodims.jpg" />
+      <meta property="og:image" content="https://cdn.example/feed-flyer.jpg" />
+      <meta property="og:image:width" content="1080" />
+      <meta property="og:image:height" content="1350" />
+    </head><body></body></html>`;
+
+  const candidates = parser.collectPageMetaImageCandidates({ url: 'https://promoter.example/e/adjacency', html });
+  assert.equal(candidates.length, 2);
+  assert.equal(candidates[0].url, 'https://cdn.example/banner-nodims.jpg');
+  assert.equal(candidates[0].width, null, 'the dimensionless first tag stays unknown');
+  assert.equal(candidates[0].height, null);
+  assert.equal(candidates[0].authoritative, false);
+  assert.equal(candidates[1].url, 'https://cdn.example/feed-flyer.jpg');
+  assert.equal(candidates[1].width, 1080, 'the dims attach to the tag they follow');
+  assert.equal(candidates[1].height, 1350);
+  assert.equal(candidates[1].authoritative, true);
+
+  const event = { title: 'Adjacent Dims' };
+  parser.applyImageSlots(event, { url: 'https://promoter.example/e/adjacency', html });
+  assert.equal(event.imageVertical, 'https://cdn.example/feed-flyer.jpg',
+    'the portrait slot gets the URL the dimensions actually describe');
+  assert.equal(event.imageHorizontal, undefined);
+});
+
+test('image slots: og:image:width/height before any og:image attach to nothing', () => {
+  const parser = createParser();
+  const html = `
+    <html><head>
+      <meta property="og:image:width" content="1080" />
+      <meta property="og:image:height" content="1350" />
+      <meta property="og:image" content="https://cdn.example/after-orphan-dims.jpg" />
+    </head><body></body></html>`;
+
+  const candidates = parser.collectPageMetaImageCandidates({ url: 'https://promoter.example/e/orphan', html });
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0].url, 'https://cdn.example/after-orphan-dims.jpg');
+  assert.equal(candidates[0].width, null, 'orphan dims describe no tag and are dropped');
+  assert.equal(candidates[0].height, null);
+  assert.equal(candidates[0].authoritative, false);
+});
+
+test('image slots: two og:image tags each keep their OWN adjacent dimensions', () => {
+  const parser = createParser();
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://cdn.example/tall-a1b2c3.jpg" />
+      <meta property="og:image:width" content="1000" />
+      <meta property="og:image:height" content="1500" />
+      <meta property="og:image" content="https://cdn.example/wide-d4e5f6.jpg" />
+      <meta property="og:image:width" content="1500" />
+      <meta property="og:image:height" content="1000" />
+    </head><body></body></html>`;
+
+  const candidates = parser.collectPageMetaImageCandidates({ url: 'https://promoter.example/e/paired', html });
+  assert.equal(candidates.length, 2);
+  assert.deepEqual(
+    candidates.map(c => ({ url: c.url, width: c.width, height: c.height, authoritative: c.authoritative })),
+    [
+      { url: 'https://cdn.example/tall-a1b2c3.jpg', width: 1000, height: 1500, authoritative: true },
+      { url: 'https://cdn.example/wide-d4e5f6.jpg', width: 1500, height: 1000, authoritative: true }
+    ]);
+});
+
+test('image slots: og:image dims never attach to twitter:image', () => {
+  const parser = createParser();
+  // A realistic head: the og block first, then the Twitter card repeating a
+  // DIFFERENT rendition. The og dims must not leak onto the twitter URL.
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://cdn.example/og-flyer.jpg" />
+      <meta property="og:image:width" content="1080" />
+      <meta property="og:image:height" content="1350" />
+      <meta name="twitter:image" content="https://cdn.example/twitter-card.jpg" />
+    </head><body></body></html>`;
+
+  const candidates = parser.collectPageMetaImageCandidates({ url: 'https://promoter.example/e/twitter', html });
+  assert.equal(candidates.length, 2);
+  const twitter = candidates.find(c => c.url === 'https://cdn.example/twitter-card.jpg');
+  assert.ok(twitter);
+  assert.equal(twitter.width, null, 'twitter:image has no dimension siblings');
+  assert.equal(twitter.height, null);
+  assert.equal(twitter.authoritative, false);
+});
+
 test('image slots: an event that already has an image still gets the page meta artwork considered for the OTHER slot', () => {
   const parser = createParser();
   const html = `

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -89,15 +89,32 @@ const IMAGE_ORIENTATION_SLOT_FIELDS = new Set(['imageVertical', 'imageHorizontal
 // Cubhouse's curated https://linktr.ee/cubhouse was clobbered by an Eventbrite
 // listing URL, which also broke the icon derived from that field).
 // Data only — shared-core stays platform-pure.
-const PLATFORM_IDENTITY_HOSTS = new Set([
+const PLATFORM_IDENTITY_HOSTS = [
     'eventbrite.com', 'eventbrite.co.uk', 'eventbrite.ca', 'eventbrite.com.au',
     'dice.fm', 'ra.co', 'residentadvisor.net', 'ticketweb.com', 'ticketweb.co.uk',
-    'seetickets.com', 'universe.com', 'posh.vip', 'withfriends.co',
+    'seetickets.com', 'seetickets.us', 'universe.com', 'posh.vip', 'withfriends.co',
     'tickettailor.com', 'sickening.events', 'redeyetickets.com',
     'ticketmaster.com', 'shotgun.live', 'fatsoma.com', 'meetup.com',
     'partiful.com', 'luma.com', 'lu.ma', 'instagram.com', 'facebook.com',
-    'twitter.com', 'x.com', 'tiktok.com'
-]);
+    'twitter.com', 'x.com', 'tiktok.com',
+    // Review 2026-07-30: hosts present in TICKETING_PLATFORM_HOSTS or the
+    // site-side PLATFORM_FAVICON_HOSTNAMES but missing here, so the rung
+    // silently failed to protect identity links against them.
+    'ticketleap.com', 'eventeny.com', 'showclix.com'
+]
+
+
+// Exact host or subdomain of a platform whose URL identifies the PLATFORM,
+// not the event's own presence. Suffix matching mirrors
+// isKnownTicketingPlatformHost: review 2026-07-30 showed exact-match crowning
+// link.dice.fm and m.facebook.com as "identity links" (they differed from the
+// canonical entry) while business.facebook.com slipped past entirely.
+function isPlatformIdentityHost(host) {
+    const normalized = String(host || '').toLowerCase();
+    if (!normalized) return false;
+    return PLATFORM_IDENTITY_HOSTS.some(platform =>
+        normalized === platform || normalized.endsWith(`.${platform}`));
+}
 
 const IMAGE_MERGE_FIELDS = new Set(['image', 'imageVertical', 'imageHorizontal']);
 
@@ -973,13 +990,11 @@ class SharedCore {
         if (!parsed) return null;
         const host = String(parsed.hostname || parsed.host || '').toLowerCase().replace(/^www\./, '');
         const path = String(parsed.pathname || '');
-        const toDimensions = (rawWidth, rawHeight) => {
+        const toDimensions = (rawWidth, rawHeight, minimum = 10) => {
             const width = parseInt(rawWidth, 10);
             const height = parseInt(rawHeight, 10);
             if (!isFinite(width) || !isFinite(height)) return null;
-            // Loose bounds on purpose: only the RATIO is consumed, so a print
-            // aspect token ("…/11x17-4.jpg") is as useful as a pixel pair.
-            if (width < 10 || height < 10 || width > 20000 || height > 20000) return null;
+            if (width < minimum || height < minimum || width > 20000 || height > 20000) return null;
             return { width, height };
         };
 
@@ -987,19 +1002,35 @@ class SharedCore {
         // are the trustworthy signal. Wix's comma form, then the generic
         // NNNxNNN token (a /1920x1080/ path segment or a "-820x1024.jpg"
         // filename suffix, both real shapes in data/calendars).
+        //
+        // Wix chains transforms (…/v1/crop/x_0,y_0,w_2000,h_1000/v1/fill/
+        // w_400,h_800/…) and the LAST transform is the rendition actually
+        // served, so the last w_/h_ pair in the path wins — never the crop
+        // region's shape. A Wix pair, being an explicit dimension syntax,
+        // also outranks any generic NNNxNNN token elsewhere in the path.
+        //
+        // The generic token scan is pattern-matching inside opaque tokens, so
+        // it demands ≥100 on BOTH dimensions: "ab12x34cd.jpg" and
+        // "os-windows-10x64-download.png" are not renditions, and no real
+        // flyer (nor even a 96px favicon) should drive orientation below
+        // that. The Wix and query-param paths keep the loose ≥10 bound —
+        // they are explicit dimension syntaxes, not guesses.
+        let wixDimensions = null;
+        let genericDimensions = null;
         for (const segment of path.split('/').filter(Boolean)) {
             const wixWidth = segment.match(/(?:^|,)w_(\d{1,5})(?=,|$)/i);
             const wixHeight = segment.match(/(?:^|,)h_(\d{1,5})(?=,|$)/i);
             if (wixWidth && wixHeight) {
                 const dimensions = toDimensions(wixWidth[1], wixHeight[1]);
-                if (dimensions) return dimensions;
+                if (dimensions) wixDimensions = dimensions;
             }
             const resolution = segment.match(/(?:^|[^\d])(\d{2,5})x(\d{2,5})(?![\dx])/i);
-            if (resolution) {
-                const dimensions = toDimensions(resolution[1], resolution[2]);
-                if (dimensions) return dimensions;
+            if (resolution && !genericDimensions) {
+                genericDimensions = toDimensions(resolution[1], resolution[2], 100);
             }
         }
+        if (wixDimensions) return wixDimensions;
+        if (genericDimensions) return genericDimensions;
 
         // Eventbrite's wrapper never gets to describe the artwork's shape:
         // img.evbuc.com's "?crop=focalpoint&fit=crop&h=230&w=460" is its fixed
@@ -1019,14 +1050,16 @@ class SharedCore {
     // 'portrait' | 'landscape' | 'square' | 'unknown' for an image URL.
     // 'unknown' is the COMMON answer (most image URLs advertise no dimensions),
     // so every consumer must degrade to today's behavior when it comes back —
-    // orientation is a refinement, never a gate. The 5% dead band keeps
-    // near-squares (e.g. Wix w_1344,h_1345) out of both buckets.
+    // orientation is a refinement, never a gate. The 1.1 ratio dead band keeps
+    // near-squares (e.g. Wix w_1344,h_1345) out of both buckets and matches
+    // ai-web-parser's imageOrientationRatioThreshold (parsers are standalone
+    // and cannot import shared code — keep the two in sync).
     classifyImageOrientation(url) {
         const dimensions = this.getImageDimensionsFromUrl(url);
         if (!dimensions) return 'unknown';
         const ratio = dimensions.width / dimensions.height;
-        if (ratio >= 1.05) return 'landscape';
-        if (ratio <= 0.95) return 'portrait';
+        if (ratio >= 1.1) return 'landscape';
+        if (ratio <= 1 / 1.1) return 'portrait';
         return 'square';
     }
 
@@ -1645,13 +1678,6 @@ class SharedCore {
         }
         const website = pick('website');
         if (website) block.url = { value: website };
-        // Guarantee a favicon for every matched event. The icon is resolved
-        // from `favicon` (or, failing that, `website`) — but `website` is the
-        // field an Eventbrite/DICE listing URL tends to occupy, and platform
-        // URLs are deliberately refused as identity, which would leave a
-        // registry-matched event with NO icon at all. A promoter without an
-        // explicit favicon therefore contributes its own identity link as one.
-        if (!block.favicon && website) block.favicon = { value: website };
         return block;
     }
 
@@ -1667,7 +1693,24 @@ class SharedCore {
         Object.keys(metadataBlock).forEach(key => {
             event._fieldPriorities[key] = fieldPriorities[key];
         });
-        return this.applyStaticMetadataBlock(event, metadataBlock, fieldPriorities);
+        const stamped = this.applyStaticMetadataBlock(event, metadataBlock, fieldPriorities);
+        // Favicon GUARANTEE, deliberately outside the static machinery. An
+        // explicit registry `favicon:` above stamps with static clobber like
+        // any curated fact — but the fallback ("no explicit favicon, use the
+        // promoter's identity link so the event isn't iconless") must only
+        // ever FILL A BLANK. Review 2026-07-30 showed the clobber version
+        // replacing a venue's favicon on every registry-matched event and
+        // silently reverting hand-fixed calendar favicons on every run —
+        // curated beats derived, and a fallback is not curated. Stamped as a
+        // plain value with 'upsert' merge (calendar wins), so a stored or
+        // scraped favicon always survives it.
+        if (!metadataBlock.favicon
+            && this.isEmptyArbitrationValue(event.favicon)
+            && metadataBlock.url && metadataBlock.url.value) {
+            event.favicon = metadataBlock.url.value;
+            event._fieldPriorities.favicon = { priority: ['ai-web'], merge: 'upsert' };
+        }
+        return stamped;
     }
 
     // One registry pass over a parser's events (processParser: after
@@ -1883,8 +1926,8 @@ class SharedCore {
             // replacing a platform link) is allowed, and platform-vs-platform
             // falls through to the rungs below.
             if (fieldName === 'website' || fieldName === 'url') {
-                const platformA = PLATFORM_IDENTITY_HOSTS.has(urlA.host.replace(/^www\./, ''));
-                const platformB = PLATFORM_IDENTITY_HOSTS.has(urlB.host.replace(/^www\./, ''));
+                const platformA = isPlatformIdentityHost(urlA.host);
+                const platformB = isPlatformIdentityHost(urlB.host);
                 // Deliberately narrow: the non-platform side must itself be a
                 // real page, not a bare homepage. A bare root still loses to a
                 // deep event page (the older cross-host rung below owns that
@@ -1997,7 +2040,22 @@ class SharedCore {
                     };
                     const provenanceA = getOgGradeImageProvenance(contextRecords.a, valueA);
                     const provenanceB = getOgGradeImageProvenance(contextRecords.b, valueB);
-                    if (Boolean(provenanceA) !== Boolean(provenanceB)) {
+                    // For the ORIENTATION SLOTS, one-sided attribution must
+                    // not decide. imageSource describes the PRIMARY image
+                    // only, so a slot holding a URL different from its own
+                    // record's primary is STRUCTURALLY unattributable — a
+                    // curated calendar slot (portrait next to a landscape
+                    // primary) can never present provenance, and letting the
+                    // scraper's attributed side win by default clobbered
+                    // curated slots deterministically with the AI never
+                    // consulted (review 2026-07-30). The primary image keeps
+                    // one-sided decisions: for `image`, no attribution
+                    // genuinely means "not the page's own artwork".
+                    const slotContest = fieldName !== 'image';
+                    const bothSidesPresent = !this.isEmptyArbitrationValue(valueA) && !this.isEmptyArbitrationValue(valueB);
+                    const oneSidedOnSlot = slotContest && bothSidesPresent
+                        && (Boolean(provenanceA) !== Boolean(provenanceB));
+                    if (!oneSidedOnSlot && Boolean(provenanceA) !== Boolean(provenanceB)) {
                         const provenanceLabels = context.sideLabels && typeof context.sideLabels === 'object'
                             ? context.sideLabels : { a: 'a', b: 'b' };
                         return {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -1473,6 +1473,57 @@ test('getImageDimensionsFromUrl reads the real Wix comma form and NNNxNNN tokens
   assert.deepEqual(dims('https://cdn.example.com/img.jpg?width=600&height=900'), { width: 600, height: 900 });
 });
 
+test('getImageDimensionsFromUrl: the generic NNNxNNN scan rejects opaque-token false positives (<100px)', () => {
+  const core = createCore();
+  const dims = (url) => core.getImageDimensionsFromUrl(url);
+
+  // Hex-ish asset hashes and version tokens are not renditions — no real
+  // flyer rendition is 12px, and even a 96px favicon must not drive
+  // orientation.
+  assert.equal(dims('https://cdn.example.com/assets/ab12x34cd.jpg'), null,
+    'digits inside an opaque token are not a dimension pair');
+  assert.equal(dims('https://cdn.example.com/os-windows-10x64-download.png'), null,
+    'a 10x64 architecture token is not a dimension pair');
+
+  // Boundary: both dimensions must reach 100 for the generic scan.
+  assert.equal(dims('https://cdn.example.com/uploads/thumb-99x300.jpg'), null);
+  assert.deepEqual(dims('https://cdn.example.com/uploads/thumb-100x300.jpg'), { width: 100, height: 300 });
+
+  // Real rendition shapes keep parsing.
+  assert.deepEqual(dims('https://bearracuda.com/wp-content/uploads/2026/05/hottake_may2026-igposter_v2-820x1024.jpg'),
+    { width: 820, height: 1024 });
+  assert.deepEqual(dims('https://cdn.example.com/media/296x494/flyer.jpg'), { width: 296, height: 494 });
+  assert.deepEqual(dims('https://cdn.example.com/uploads/banner-460x230.jpg'), { width: 460, height: 230 });
+
+  // The Wix and query-param paths are explicit dimension syntaxes and keep
+  // their looser bounds.
+  assert.deepEqual(dims('https://static.wixstatic.com/media/a~mv2.jpg/v1/fill/w_50,h_80/a~mv2.jpg'),
+    { width: 50, height: 80 });
+  assert.deepEqual(dims('https://cdn.example.com/img.jpg?w=50&h=80'), { width: 50, height: 80 });
+});
+
+test('getImageDimensionsFromUrl: chained Wix crop→fill serves the LAST transform, not the crop region', () => {
+  const core = createCore();
+  const dims = (url) => core.getImageDimensionsFromUrl(url);
+
+  // The crop region is 2000x1000 landscape, but the final fill renders
+  // 400x800 portrait — the fill is what is served.
+  assert.deepEqual(
+    dims('https://static.wixstatic.com/media/x~mv2.jpg/v1/crop/x_0,y_0,w_2000,h_1000/v1/fill/w_400,h_800/x~mv2.jpg'),
+    { width: 400, height: 800 });
+  assert.equal(
+    core.classifyImageOrientation('https://static.wixstatic.com/media/x~mv2.jpg/v1/crop/x_0,y_0,w_2000,h_1000/v1/fill/w_400,h_800/x~mv2.jpg'),
+    'portrait');
+
+  // Single-segment behaviour is unchanged: fill alone, crop alone.
+  assert.deepEqual(
+    dims('https://static.wixstatic.com/media/a~mv2.jpg/v1/fill/w_792,h_990/a~mv2.jpg'),
+    { width: 792, height: 990 });
+  assert.deepEqual(
+    dims('https://static.wixstatic.com/media/x~mv2.jpg/v1/crop/x_0,y_0,w_1000,h_500/x~mv2.jpg'),
+    { width: 1000, height: 500 });
+});
+
 test('getImageDimensionsFromUrl REJECTS the Eventbrite ?w=460&h=230 crop', () => {
   const core = createCore();
   // img.evbuc.com's crop params are its fixed 2:1 LISTING THUMBNAIL, not the
@@ -1511,6 +1562,14 @@ test('classifyImageOrientation buckets portrait/landscape/square with a dead ban
   assert.equal(classify('https://cdn.example.com/uploads/1920x1080/poster.jpg'), 'landscape');
   assert.equal(classify('https://static.wixstatic.com/media/b~mv2.jpg/v1/fill/w_1344,h_1345,al_c,q_85/b~mv2.jpg'),
     'square', 'a 1-pixel difference is not an orientation');
+  // The dead band is the 1.1 ratio ai-web-parser's
+  // imageOrientationRatioThreshold uses — the two must stay in sync.
+  assert.equal(classify('https://static.wixstatic.com/media/c~mv2.jpg/v1/fill/w_1080,h_1000/c~mv2.jpg'),
+    'square', 'an 8% difference sits inside the shared 1.1 dead band');
+  assert.equal(classify('https://static.wixstatic.com/media/c~mv2.jpg/v1/fill/w_1000,h_1080/c~mv2.jpg'),
+    'square', 'the dead band is symmetric');
+  assert.equal(classify('https://static.wixstatic.com/media/d~mv2.jpg/v1/fill/w_1100,h_1000/d~mv2.jpg'),
+    'landscape', 'ratio 1.1 exactly is landscape, matching the parser threshold');
   assert.equal(classify('https://bearracuda.com/wp-content/uploads/2025/04/cuda-atlanta-nov_2025-web.jpg'), 'unknown',
     'unknown is the common answer and must be handled by every caller');
 });
@@ -9220,9 +9279,44 @@ test('registry application parity: registry stamp ≡ parser metadata through ap
     Object.keys(event).filter((key) => !key.startsWith('_')).forEach((key) => { copy[key] = event[key]; });
     return copy;
   };
-  assert.deepEqual(publicFields(viaRegistry), publicFields(viaParser), 'event fields identical');
-  assert.deepEqual(viaRegistry._staticFields, viaParser._staticFields, '_staticFields identical');
-  assert.deepEqual(viaRegistry._fieldPriorities, viaParser._fieldPriorities, '_fieldPriorities identical');
+  // One DELIBERATE delta beyond parity (review fix 2026-07-30): the registry
+  // path also fills a blank favicon from the promoter's identity link so a
+  // matched event is never iconless — as a plain 'upsert' value (calendar and
+  // venue favicons always beat it), never as static clobber. Everything else
+  // must remain identical to the parser-metadata path.
+  const registryFields = publicFields(viaRegistry);
+  assert.equal(registryFields.favicon, entry.website, 'favicon fallback fills from the identity link');
+  delete registryFields.favicon;
+  assert.deepEqual(registryFields, publicFields(viaParser), 'event fields identical apart from the favicon fallback');
+  assert.deepEqual(viaRegistry._staticFields, viaParser._staticFields, '_staticFields identical — the fallback is NOT static');
+  assert.deepEqual(viaRegistry._fieldPriorities.favicon, { priority: ['ai-web'], merge: 'upsert' },
+    'fallback favicon merges as upsert: calendar wins');
+  const registryPriorities = { ...viaRegistry._fieldPriorities };
+  delete registryPriorities.favicon;
+  assert.deepEqual(registryPriorities, viaParser._fieldPriorities, '_fieldPriorities otherwise identical');
+});
+
+test('registry favicon fallback never overrides an existing favicon and loses the merge to a stored one', async () => {
+  const core = createRegistryCore();
+  const block = core.promoterEntryToMetadataBlock(REGISTRY_FIXTURE[0]);
+
+  // Scraped event already carries the VENUE's favicon: untouched.
+  const withVenueIcon = { title: 'Portland PRIDE FRIDAY', startDate: new Date('2026-08-01T21:00:00.000Z'), favicon: 'https://venue.example/icon.png' };
+  core.applyPromoterMetadata(withVenueIcon, block);
+  assert.equal(withVenueIcon.favicon, 'https://venue.example/icon.png', 'existing favicon is never replaced by the fallback');
+
+  // Blank favicon: filled — but a stored calendar favicon must win the merge
+  // (review 2026-07-30: the clobber version silently reverted hand-fixes).
+  const blank = { title: 'Portland PRIDE FRIDAY', startDate: new Date('2026-08-01T21:00:00.000Z') };
+  core.applyPromoterMetadata(blank, block);
+  assert.equal(blank.favicon, REGISTRY_FIXTURE[0].website, 'blank favicon filled from identity link');
+  const existingEvent = {
+    title: 'Portland PRIDE FRIDAY',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    notes: 'favicon: https://hand.fixed/icon.png'
+  };
+  const merged = await core.createFinalEventObject(existingEvent, blank, { httpAdapter: null });
+  assert.equal(merged.favicon, 'https://hand.fixed/icon.png', 'a hand-set calendar favicon survives every run');
 });
 
 test('registry sub-brand inherits unspecified metadata fields from its parent', () => {
@@ -10607,4 +10701,46 @@ test('website merge: a ticketing platform URL never displaces an identity link',
   // A real site replacing a platform link is still allowed.
   const realSite = core.resolveConflictDeterministically('website', eventbrite, 'https://cubhouse.party/events/july', ctx);
   assert.equal(realSite.winner, 'b', 'a genuine site beats a platform URL');
+});
+
+test('slot merge: one-sided og provenance does not clobber a curated slot (falls through)', async () => {
+  const core = createFinalBuildCore();
+  // Calendar carries a curated portrait slot DIFFERENT from its primary —
+  // structurally unattributable, since imageSource describes the primary only.
+  const existingEvent = {
+    title: 'SLOT TEST',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    notes: [
+      'image: https://cdn.example/landscape-primary-1920x1080.jpg',
+      'imageVertical: https://curated.example/portrait-800x1200.jpg'
+    ].join('\n')
+  };
+  // Scrape's slot equals its og-stamped primary: attributed, one-sided.
+  const scraped = {
+    title: 'SLOT TEST',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    image: 'https://cdn.example/og-flyer-900x1350.jpg',
+    imageSource: 'og-image',
+    imageVertical: 'https://cdn.example/og-flyer-900x1350.jpg',
+    _fieldPriorities: {
+      image: { priority: ['ai-web'], merge: 'ai' },
+      imageVertical: { priority: ['ai-web'], merge: 'ai' }
+    }
+  };
+  const merged = await core.createFinalEventObject(existingEvent, scraped, { httpAdapter: null });
+  // Without an AI adapter the conflict falls back deterministically — the point
+  // is that the PROVENANCE rung no longer decides it one-sidedly. The primary
+  // image keeps one-sided provenance decisions (og-stamped primary wins).
+  assert.equal(merged.image, 'https://cdn.example/og-flyer-900x1350.jpg', 'primary: og provenance still decides');
+  const provenanceLog = `"scraped" image is the event page's own artwork`;
+  // Re-run capturing logs to assert the rung stayed silent for the slot.
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  try {
+    await core.createFinalEventObject(existingEvent, scraped, { httpAdapter: null });
+  } finally {
+    restore();
+  }
+  const slotProvenanceLines = lines.filter(l => l.includes('field=imageVertical') && l.includes(provenanceLog));
+  assert.equal(slotProvenanceLines.length, 0, 'no one-sided provenance decision for the slot');
 });

--- a/styles.css
+++ b/styles.css
@@ -6429,19 +6429,29 @@ body.loaded {
     --favicon-plate-pad: 2px;
 }
 /* Map markers adopt the same plate, radius and contain-fit as the cards. */
-.favicon-marker-container {
+/* Scoped to the CITY-PAGE map only: the bar-directory and home-page maps
+   build the same marker classes and were losing their 2px border (and their
+   6px radius) to this block. Review 2026-07-30 also caught `border: none`
+   killing the SELECTION ring — .marker-selected forces border-color/width
+   with !important but not border-style, so style:none zeroed the ring.
+   A transparent solid 0-width border keeps the machinery: the selected
+   rule's width/color !important overrides restore the primary ring. */
+.city-page .favicon-marker-container,
+#events-map .favicon-marker-container {
     background: var(--fav-plate, var(--favicon-plate-bg));
     border-radius: var(--favicon-plate-radius);
-    border: none;
+    border: 0 solid transparent;
     overflow: hidden;
     box-shadow: 0 0 0 1px rgba(23, 26, 51, 0.25), 0 2px 6px rgba(6, 8, 20, 0.3);
 }
-.favicon-marker-icon {
+.city-page .favicon-marker-icon,
+#events-map .favicon-marker-icon {
     object-fit: contain;
     padding: var(--favicon-plate-pad);
     border-radius: calc(var(--favicon-plate-radius) - 2px);
 }
 /* The text fallback keeps its filled look — no plate behind letters. */
-.favicon-marker-container.text-marker {
+.city-page .favicon-marker-container.text-marker,
+#events-map .favicon-marker-container.text-marker {
     background: var(--primary-color);
 }

--- a/testing/event-builder.html
+++ b/testing/event-builder.html
@@ -7576,6 +7576,11 @@ Example output:
         if (dom.facebookInput) dom.facebookInput.value = state.facebook || '';
         if (dom.gmapsInput) dom.gmapsInput.value = state.gmaps || '';
         if (dom.imageInput) dom.imageInput.value = state.image || '';
+        // Restored: #1582's slot lines REPLACED this assignment instead of
+        // adding after it, so a prefilled ?favicon= populated hidden state but
+        // never the visible input — the value rode along invisibly into the
+        // saved event with no way to see or clear it.
+        if (dom.faviconInput) dom.faviconInput.value = state.favicon || '';
         if (dom.imageVerticalInput) dom.imageVerticalInput.value = state.imageVertical || '';
         if (dom.imageHorizontalInput) dom.imageHorizontalInput.value = state.imageHorizontal || '';
         renderImageCandidates();


### PR DESCRIPTION
You asked for a careful review of today's changes — four reviewers swept #1580–#1584 with different lenses (image pipeline, adapter/run-UI, merge semantics adversarially, site+tools in anger). **Every finding was verified with a runnable repro before fixing, and each fix ships with a regression test derived from that repro.** Reviewers also reported what they *checked and found sound*, which is most of the system — details at the end.

## Breaks-now (site)
- **`?favicon=` prefill was invisible** — #1582's slot lines *replaced* the assignment instead of adding after it, so a prefilled icon URL rode along invisibly with no way to see or clear it.
- **Map selection ring was dead and the plate CSS leaked** onto the bar-directory and home maps (`border: none` beat the `.marker-selected` rule, which forces color/width but not *style*). Scoped to `#events-map`, ring machinery restored — verified by computed-style probe: selected = 2px primary ring, foreign maps back to their 6px/2px look.
- **The date badge contradicted the calendar grid** — badge used the UTC date, grid places by browser-local, so every evening event west of UTC read one day later ("7/18 · Fri 8PM-2AM" on a July 17 event) — and the aurora card had just promoted that wrong date to the headline. Badge now derives the date exactly as the grid does.
- **A literal NUL byte** in `dynamic-calendar-loader.js` (raw control chars in a regex) made the file binary to grep/text tools — this is why several of my own searches silently failed today. Escaped, identical semantics.

## Merge / identity
- **Platform-host check was exact-match**: `link.dice.fm` and `m.facebook.com` got crowned "identity links"; `business.facebook.com` slipped through. Suffix matching now, plus four missing hosts.
- **The promoter favicon guarantee clobbered venue icons and silently reverted your hand-fixes every run** — it stamped via static clobber. Now a fill-blank-only fallback merged as upsert: a stored calendar favicon wins every merge (test proves a hand-set `favicon:` note survives).
- **A scraped slot could deterministically overwrite a curated slot** via one-sided og-provenance (curated slots are structurally unattributable). Slots now fall through; the primary image keeps its one-sided decisions.

## Orientation detection
- **og:image dims were paired by flat index**, so a dimensionless early image stole a later one's dimensions — wrong URL in the slot. Document-order adjacency per the OGP spec now.
- `ab12x34cd.jpg` classified as portrait (2-digit pairs accepted) → generic-token minimum is 100px/side.
- Chained Wix crop→fill took the crop's shape, not the served rendition's → last transform wins.
- Near-square dead band unified (5% → 10%, matching the parser).

## Run UI
- **"Run selected (0)" wiped the Rerun-last memory and started an all-disabled run.** Zero-selection is now an inert gray row, and empty saves are refused at both sites.
- **A rescued drop displayed in saved runs as still-dropped, twice** — the audit surface said the opposite of what you did. Both rescue flags now render the read-only rescued treatment.
- Dropped entries without `.event` rendered live buttons that silently did nothing → disabled.
- Dropped entries were saved with full `_parserConfig` (~1-2KB each, duplicated) → sanitized on save.

## What the reviewers cleared (abbreviated)
Primary image selection byte-identical to pre-#1582 on a live CHUNK run; merge idempotence (run 2 byte-identical) across slots, platform conflicts and favicon stamps; notes round-trip a fixed point through both parsers; every bridge action paired with a handler; all new markup survives hostile-string injection; the flyer-advance chain terminates and resists injection; palette extraction byte-idempotent; sync-bars keep-list complete; both generators exit 0 with the zero-events prune guard observed firing.

## Known items deliberately not fixed here
- #1585 (blocked): ShareSheet resolves on user-cancel too — the success log can lie and fallbacks are unreachable-in-practice; also whether Scriptable attaches the file (vs sharing the path as text) needs one on-device tap. I'll amend that PR separately.
- Cosmetic sanitizer mangles (`a<b>c` → "a c"), slots reaching the generic AI arbitration prompt (low risk, both candidates pre-verified), the one-cycle notes reordering after any AI-arbitrated merge (pre-existing mechanism), and `pickImageForOrientation`'s unused injection hook.

Suite: **1098/1098** (+13 regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
