### PR TITLE
fix(scraper): never ask the AI for image orientation — it is measured, not guessed

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -8370,7 +8370,19 @@ class AiWebParser {
         });
 
         const aiPromptFields = selected;
-        const manuallyScrapedFields = new Set(['instagram', 'facebook', 'gmaps']);
+        // Fields the model is never asked for. instagram/facebook/gmaps are
+        // scraped deterministically; imageVertical/imageHorizontal are DERIVED
+        // from the actual dimensions of images we already found (published
+        // og:image:width/height, JSON-LD ImageObject, or the URL's own
+        // dimension tokens) — asking a model to classify a picture's shape
+        // from page text is nonsense, and it also silently changed every
+        // extraction prompt, invalidating the AI response cache
+        // (observed 2026-07-30: 18 prompt fields instead of 16, 58 sends /
+        // 9 hits on a CHUNK run). They still merge as normal event fields;
+        // only extraction is off-limits.
+        const manuallyScrapedFields = new Set([
+            'instagram', 'facebook', 'gmaps', 'imagevertical', 'imagehorizontal'
+        ]);
         const filteredPromptFields = aiPromptFields.filter(field => !manuallyScrapedFields.has(this.normalizePromptFieldName(field)));
         const removedManualFields = aiPromptFields.filter(field => manuallyScrapedFields.has(this.normalizePromptFieldName(field)));
         this.logDebug(`🤖 AI Web: Field priority filter selected ${selected.length} field(s) from ${Object.keys(priorities).length}`);


### PR DESCRIPTION
You were right on both counts.

## The AI was being asked for the slots
Your run: `Prompt fields selected (18): … imageVertical, imageHorizontal` — with the generic `- imageVertical: Event field` description, because they were never given prompt text.

**Cause:** #1582 registered the slots in `defaultPriorities` so they'd *merge* like other event fields. The extraction prompt's field list is derived from those same priorities, so they silently became *extractable* fields too.

That's wrong twice over. Orientation is a **measurement** — published `og:image:width/height`, JSON-LD ImageObject dimensions, or the URL's own dimension tokens. Asking a model to infer a picture's shape from page text is nonsense, and any answer it gave would bypass the deterministic path that actually works.

## And yes, it wrecked the cache
Prompt text is the cache key, so 16 → 18 fields changed **every** extraction prompt. Your run: **58 AI requests, 9 hits.**

**Fix:** the slots join instagram/facebook/gmaps as fields the model is never asked for. They still merge as normal event fields; only extraction is off-limits.

**Verified live on CHUNK:**
- prompts back to 14/16 fields (`skipped: … imageVertical, imageHorizontal`)
- slots still fill from real dimensions: `IMAGE SLOTS: vertical=…/w_792,h_990/…`
- a repeat run: **62 cache hits, 0 AI requests**

So the cache isn't just fixed going forward — the entries from before #1582 are valid again, because the prompts revert to their old text rather than having to be re-earned.

## Event builder: nothing to clean up
Its AI prompt is built from `EventSchema.AI_PROMPT_FIELDS`, which never contained the slots (verified: 21 fields, no slots). The builder *does* have portrait/landscape inputs and labels — that's the human editing surface, which is intended.

Suite: **1101/1101**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
