### PR TITLE
fix(scraper): a bad date in one calendar candidate must not kill the whole run

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -9915,9 +9915,32 @@ class SharedCore {
     }
     
     // Check if two dates are equal within a tolerance (pure logic)
+    // Tolerant date comparison. Accepts Dates, ISO strings and epoch numbers,
+    // and returns FALSE (not equal → no match, the conservative answer) when a
+    // side is missing or unparseable.
+    //
+    // It used to call .getTime() straight on both arguments, so one non-Date
+    // anywhere in the candidate set threw and killed the entire run
+    // ("TypeError: date2.getTime is not a function", 2026-07-30, surfaced once
+    // allowPastEvents opened up far more calendar candidates). A matching
+    // helper is the wrong place to end a run: the worst it should do is
+    // decline a match. The one-time warn names the offending value so the real
+    // source is findable in the next log instead of guessed at.
     areDatesEqual(date1, date2, toleranceMinutes) {
-        const diff = Math.abs(date1.getTime() - date2.getTime());
-        return diff <= (toleranceMinutes * 60 * 1000);
+        const ms1 = this.toEpochMillis(date1);
+        const ms2 = this.toEpochMillis(date2);
+        if (ms1 === null || ms2 === null) {
+            if (!this._warnedNonDateComparison) {
+                this._warnedNonDateComparison = true;
+                const describe = (value) => {
+                    if (value === null || value === undefined) return String(value);
+                    return `${typeof value}:${String(value).slice(0, 40)}`;
+                };
+                console.warn(`⚠️ SharedCore: areDatesEqual got a non-date — a=${describe(date1)} b=${describe(date2)} (treated as not equal)`);
+            }
+            return false;
+        }
+        return Math.abs(ms1 - ms2) <= (toleranceMinutes * 60 * 1000);
     }
     
     // Check if two date ranges overlap (pure logic)

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -10773,3 +10773,36 @@ test('recurring withhold: override identity is never stamped on a series the scr
   assert.ok(!String(analyzed.notes || '').includes('overrideUid'), 'and never serialized into notes');
   assert.ok(lines.some(l => l.includes('dropped override identity')), `log explains why: ${JSON.stringify(lines)}`);
 });
+
+test('areDatesEqual never throws on a non-date, and declines the match', () => {
+  const core = createCore();
+  const real = new Date('2026-02-14T05:00:00.000Z');
+
+  // The exact crash shape from the 2026-07-30 device run: one side is not a
+  // Date, and .getTime() was called on it unguarded, ending the whole run.
+  assert.equal(core.areDatesEqual(real, undefined, 1), false, 'undefined declines rather than throws');
+  assert.equal(core.areDatesEqual(undefined, real, 1), false);
+  assert.equal(core.areDatesEqual(real, null, 1), false);
+  assert.equal(core.areDatesEqual(real, 'not a date', 1), false);
+  assert.equal(core.areDatesEqual(real, {}, 1), false);
+
+  // Usable shapes still compare correctly, including ISO strings and epochs —
+  // a calendar record and a scraped record do not always carry the same type.
+  assert.equal(core.areDatesEqual(real, new Date(real.getTime()), 1), true);
+  assert.equal(core.areDatesEqual(real, real.toISOString(), 1), true, 'ISO string equals its Date');
+  assert.equal(core.areDatesEqual(real, real.getTime(), 1), true, 'epoch millis equal their Date');
+  assert.equal(core.areDatesEqual(real, new Date(real.getTime() + 30 * 60 * 1000), 60), true, 'within tolerance');
+  assert.equal(core.areDatesEqual(real, new Date(real.getTime() + 90 * 60 * 1000), 60), false, 'outside tolerance');
+});
+
+test('analyzeEventAction survives a calendar candidate with an unusable date', () => {
+  const core = createCore();
+  const event = { title: 'CHUNK CHICAGO presents SPRING THAW!', startDate: new Date('2026-03-15T04:00:00.000Z') };
+  const existing = [
+    { title: 'CHUNK CHICAGO presents SPRING THAW!', startDate: undefined },
+    { title: 'Unrelated', startDate: new Date('2026-03-15T04:00:00.000Z') }
+  ];
+  // Previously threw out of the .find() callback and aborted the run.
+  const analysis = core.analyzeEventAction(event, existing, 'smart');
+  assert.ok(analysis && typeof analysis.action === 'string', `got an analysis: ${JSON.stringify(analysis)}`);
+});


### PR DESCRIPTION
Your run aborted with:

```
TypeError: date2.getTime is not a function
areDatesEqual → find → analyzeEventAction → resolveCalendarAnalysisWithSeriesProbe
```

`areDatesEqual` called `.getTime()` directly on both arguments. One candidate with a missing or non-Date `startDate` threw out of the `.find()` callback and **ended the entire scrape** — after several events had already merged fine, which is why the log looks healthy right up to the crash.

**Why now:** `allowPastEvents` (#1587) opens the calendar search to far more candidates, including old records, so the chance of meeting one unusable date went up sharply. The change didn't create the fragility, it just found it.

**Fix:** both sides route through `toEpochMillis` (Date, ISO string, or epoch millis) and it returns **false** — no match, the conservative answer — when either side is unusable. A matching helper should never be able to end a run; the worst it should do is decline a match. A one-time warn names the offending value so the *real* source is findable in your next log instead of guessed at:

```
⚠️ SharedCore: areDatesEqual got a non-date — a=… b=undefined (treated as not equal)
```

**Checked the neighbours too:** `doDatesOverlap` degrades to "no overlap" on junk rather than throwing, and the other `getTime()` sites in this path already guard with `isNaN`.

**Test rigor:** the new tests reproduce the exact crash shape (undefined / null / string / object against a real Date) and also assert that ISO strings and epoch millis still compare equal to their Date. Verified they **fail** against the pre-fix function and pass after — not just green-by-construction.

Suite: **1104/1104**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
