### PR TITLE
fix(data): correct the Horizon and Eden pins I got wrong; curate Westminster Pier

### DIFF
--- a/data/bars/birmingham.json
+++ b/data/bars/birmingham.json
@@ -2,8 +2,7 @@
   {
     "name": "Eden",
     "city": "birmingham",
-    "address": "116 Sherlock Street, Birmingham B5 6NB",
-    "coordinates": "52.4714027, -1.8936278",
+    "address": "138 Gooch Street, Birmingham B5 7HF",
     "facebook": "https://www.facebook.com/eden.bar.birmingham/"
   }
 ]

--- a/data/bars/brighton.json
+++ b/data/bars/brighton.json
@@ -2,8 +2,7 @@
   {
     "name": "Horizon",
     "city": "brighton",
-    "address": "29-31 New Steine, Marine Parade, Brighton",
-    "coordinates": "50.8196107, -0.1315114",
+    "address": "211-214 Kings Road Arches, Brighton BN1 1NB",
     "instagram": "horizon.brighton"
   },
   {

--- a/data/bars/london.json
+++ b/data/bars/london.json
@@ -42,5 +42,11 @@
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ-crt4uwEdkgRt13r0ih1Lgk",
     "gayCities": "https://london.gaycities.com/bars/1685-eagle-london",
     "gayCitiesLastScrapedAt": "2026-06-13T16:37:31.585Z"
+  },
+  {
+    "name": "Westminster Pier",
+    "city": "london",
+    "address": "Victoria Embankment, London SW1A 2JH",
+    "coordinates": "51.5022544, -0.1231736"
   }
 ]

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -52,8 +52,7 @@
     {
       "name": "Eden",
       "city": "birmingham",
-      "address": "116 Sherlock Street, Birmingham B5 6NB",
-      "coordinates": "52.4714027, -1.8936278",
+      "address": "138 Gooch Street, Birmingham B5 7HF",
       "facebook": "https://www.facebook.com/eden.bar.birmingham/"
     }
   ],
@@ -83,8 +82,7 @@
     {
       "name": "Horizon",
       "city": "brighton",
-      "address": "29-31 New Steine, Marine Parade, Brighton",
-      "coordinates": "50.8196107, -0.1315114",
+      "address": "211-214 Kings Road Arches, Brighton BN1 1NB",
       "instagram": "horizon.brighton"
     },
     {
@@ -378,6 +376,12 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ-crt4uwEdkgRt13r0ih1Lgk",
       "gayCities": "https://london.gaycities.com/bars/1685-eagle-london",
       "gayCitiesLastScrapedAt": "2026-06-13T16:37:31.585Z"
+    },
+    {
+      "name": "Westminster Pier",
+      "city": "london",
+      "address": "Victoria Embankment, London SW1A 2JH",
+      "coordinates": "51.5022544, -0.1231736"
     }
   ],
   "montreal": [

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -61,8 +61,7 @@ const scraperBars = {
     {
       "name": "Eden",
       "city": "birmingham",
-      "address": "116 Sherlock Street, Birmingham B5 6NB",
-      "coordinates": "52.4714027, -1.8936278",
+      "address": "138 Gooch Street, Birmingham B5 7HF",
       "facebook": "https://www.facebook.com/eden.bar.birmingham/"
     }
   ],
@@ -92,8 +91,7 @@ const scraperBars = {
     {
       "name": "Horizon",
       "city": "brighton",
-      "address": "29-31 New Steine, Marine Parade, Brighton",
-      "coordinates": "50.8196107, -0.1315114",
+      "address": "211-214 Kings Road Arches, Brighton BN1 1NB",
       "instagram": "horizon.brighton"
     },
     {
@@ -387,6 +385,12 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJ-crt4uwEdkgRt13r0ih1Lgk",
       "gayCities": "https://london.gaycities.com/bars/1685-eagle-london",
       "gayCitiesLastScrapedAt": "2026-06-13T16:37:31.585Z"
+    },
+    {
+      "name": "Westminster Pier",
+      "city": "london",
+      "address": "Victoria Embankment, London SW1A 2JH",
+      "coordinates": "51.5022544, -0.1231736"
     }
   ],
   "montreal": [


### PR DESCRIPTION
You were right — and both bad pins were mine, added earlier today in #1575. That made them worse than useless: a curated pin **outranks** the geocoder, so my mistake actively suppressed a better answer.

## Horizon (Brighton)
I pinned **29-31 New Steine**. That OSM POI is a **guest house** that happens to be named "Horizon" (verified: `type=guest_house`, BN2 1PD). The nightclub is the former Shooshh site on the seafront — **211-214 Kings Road Arches, BN1 1NB** — about a kilometre away.

Address corrected. The **coordinate is removed, not replaced**: OSM has no entry for the club, and a guessed pin would keep overriding a geocoder that may do better. No pin beats a wrong pin.

## Eden (Birmingham)
This one stings: **the scraper had it right.** It extracted `138 Gooch Street, Birmingham, B5 7HF` and I overrode it with a Yelp-sourced "116 Sherlock Street" plus a pin from an OSM pub on *Bishop* Street. Eden is on the Gooch/Sherlock corner at B5 7HF. Address restored, bad pin removed.

## Westminster Pier
Added as a curated venue using the verified OSM pier POI, so BOATMINCE stops re-deriving it from "Victoria Embankment" each run.

## On your GayCities idea — yes, and the machinery already exists
`tools/sync-bars.js` already scrapes GayCities and Wikipedia for bar data, and it **only fills empty fields**. 63 bars already carry `gayCities:` links; these three UK venues don't yet. So the fix is just adding a `gayCities:` URL per venue and letting the existing sync fill address/coordinates — and that now works precisely *because* I removed the bad pins, since it won't overwrite a populated field.

I didn't invent those URLs here (guessing a listing URL is how the Horizon mistake happened). If you paste the GayCities links for Horizon, Eden and Concorde 2, the sync fills the rest automatically.

## Still open, not in this PR
- **Concorde 2**: its pin verifies cleanly (OSM `type=bar`, BN2 1EN, Madeira Drive). You said it's wrong "for other reasons" — what are you seeing? Wrong address text, wrong venue entirely, or the event not actually being there?

Suite: **1102/1102**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
