### PR TITLE
feat(data): curate 8 venues our events already reference, each corroborated

### DIFF
--- a/data/bars/denver.json
+++ b/data/bars/denver.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Ophelia's",
+    "city": "denver",
+    "address": "1215 20th Street, Denver, Colorado, 80202",
+    "coordinates": "39.7526699, -104.9919830"
+  }
+]

--- a/data/bars/la.json
+++ b/data/bars/la.json
@@ -49,5 +49,17 @@
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJXxXPUMi_woARE46Y7WO-Ww0",
     "gayCities": "https://losangeles.gaycities.com/bars/309258-gym-bar-weho",
     "gayCitiesLastScrapedAt": "2026-06-14T03:19:33.089Z"
+  },
+  {
+    "name": "Precinct DTLA",
+    "city": "la",
+    "address": "357 South Broadway, Los Angeles, California, 90013",
+    "coordinates": "34.0498331, -118.2493274"
+  },
+  {
+    "name": "Falcon North",
+    "city": "la",
+    "address": "2020 East Artesia Boulevard, Long Beach, California, 90805",
+    "coordinates": "33.8744394, -118.1680438"
   }
 ]

--- a/data/bars/nyc.json
+++ b/data/bars/nyc.json
@@ -143,5 +143,11 @@
     "palette": "#000021:69:8 #eef3fe:7:2 #1633fd:7:29 #eb1c25:5:23 #953f71:4:13",
     "accent": "#1633fd",
     "faviconPlate": "#000021"
+  },
+  {
+    "name": "C'mon Everybody",
+    "city": "nyc",
+    "address": "325 Franklin Avenue, New York, New York, 11216",
+    "coordinates": "40.6882793, -73.9569264"
   }
 ]

--- a/data/bars/portland.json
+++ b/data/bars/portland.json
@@ -7,5 +7,11 @@
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJnfNLuwAKlVQRXZrfhfLp_i4",
     "gayCities": "https://portland.gaycities.com/bars/893-cc-slaughters-nightclub-and-lounge",
     "gayCitiesLastScrapedAt": "2026-06-13T22:29:01.943Z"
+  },
+  {
+    "name": "Nova PDX",
+    "city": "portland",
+    "address": "722 East Burnside Street, Portland, Oregon, 97214",
+    "coordinates": "45.5228076, -122.6581521"
   }
 ]

--- a/data/bars/san-diego.json
+++ b/data/bars/san-diego.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "The Rail",
+    "city": "san-diego",
+    "address": "3796 5th Avenue, San Diego, California, 92103",
+    "coordinates": "32.7468104, -117.1606487"
+  }
+]

--- a/data/bars/sf.json
+++ b/data/bars/sf.json
@@ -63,5 +63,11 @@
     "palette": "#ffffff:74:0 #f15323:22:20 #f79a80:3:12 #f9b5a2:1:8",
     "accent": "#f15323",
     "faviconPlate": "#ffffff"
+  },
+  {
+    "name": "The Stud",
+    "city": "sf",
+    "address": "1123 Folsom Street, San Francisco, California, 94103",
+    "coordinates": "37.7761653, -122.4083643"
   }
 ]

--- a/data/bars/vegas.json
+++ b/data/bars/vegas.json
@@ -8,5 +8,11 @@
     "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJKfM4OVvEyIARKXe7Mp57Uv0",
     "gayCities": "https://lasvegas.gaycities.com/bars/1346-fun-hog-ranch",
     "gayCitiesLastScrapedAt": "2026-06-14T01:14:27.328Z"
+  },
+  {
+    "name": "Dust Las Vegas",
+    "city": "vegas",
+    "address": "855 East Twain Avenue, Winchester, Nevada, 89169",
+    "coordinates": "36.1213962, -115.1450910"
   }
 ]

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -185,6 +185,14 @@
       "faviconFg": "#fefefe"
     }
   ],
+  "denver": [
+    {
+      "name": "Ophelia's",
+      "city": "denver",
+      "address": "1215 20th Street, Denver, Colorado, 80202",
+      "coordinates": "39.7526699, -104.9919830"
+    }
+  ],
   "fort-lauderdale": [
     {
       "name": "Eagle",
@@ -332,6 +340,18 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJXxXPUMi_woARE46Y7WO-Ww0",
       "gayCities": "https://losangeles.gaycities.com/bars/309258-gym-bar-weho",
       "gayCitiesLastScrapedAt": "2026-06-14T03:19:33.089Z"
+    },
+    {
+      "name": "Precinct DTLA",
+      "city": "la",
+      "address": "357 South Broadway, Los Angeles, California, 90013",
+      "coordinates": "34.0498331, -118.2493274"
+    },
+    {
+      "name": "Falcon North",
+      "city": "la",
+      "address": "2020 East Artesia Boulevard, Long Beach, California, 90805",
+      "coordinates": "33.8744394, -118.1680438"
     }
   ],
   "london": [
@@ -547,6 +567,12 @@
       "website": "https://www.3dollarbillbk.com",
       "faviconBg": "#190832",
       "faviconFg": "#c5c5e9"
+    },
+    {
+      "name": "C'mon Everybody",
+      "city": "nyc",
+      "address": "325 Franklin Avenue, New York, New York, 11216",
+      "coordinates": "40.6882793, -73.9569264"
     }
   ],
   "palm-springs": [
@@ -606,6 +632,12 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJnfNLuwAKlVQRXZrfhfLp_i4",
       "gayCities": "https://portland.gaycities.com/bars/893-cc-slaughters-nightclub-and-lounge",
       "gayCitiesLastScrapedAt": "2026-06-13T22:29:01.943Z"
+    },
+    {
+      "name": "Nova PDX",
+      "city": "portland",
+      "address": "722 East Burnside Street, Portland, Oregon, 97214",
+      "coordinates": "45.5228076, -122.6581521"
     }
   ],
   "ptown": [
@@ -680,6 +712,14 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJZa2WW0xFIYQRrzpGYnmf8Og",
       "gayCities": "https://vallarta.gaycities.com/bars/302724-cc-slaughters",
       "gayCitiesLastScrapedAt": "2026-06-13T22:28:59.439Z"
+    }
+  ],
+  "san-diego": [
+    {
+      "name": "The Rail",
+      "city": "san-diego",
+      "address": "3796 5th Avenue, San Diego, California, 92103",
+      "coordinates": "32.7468104, -117.1606487"
     }
   ],
   "seattle": [
@@ -833,6 +873,12 @@
       "website": "https://publicsf.com",
       "faviconBg": "#f35425",
       "faviconFg": "#fd5825"
+    },
+    {
+      "name": "The Stud",
+      "city": "sf",
+      "address": "1123 Folsom Street, San Francisco, California, 94103",
+      "coordinates": "37.7761653, -122.4083643"
     }
   ],
   "sitges": [
@@ -887,6 +933,12 @@
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJKfM4OVvEyIARKXe7Mp57Uv0",
       "gayCities": "https://lasvegas.gaycities.com/bars/1346-fun-hog-ranch",
       "gayCitiesLastScrapedAt": "2026-06-14T01:14:27.328Z"
+    },
+    {
+      "name": "Dust Las Vegas",
+      "city": "vegas",
+      "address": "855 East Twain Avenue, Winchester, Nevada, 89169",
+      "coordinates": "36.1213962, -115.1450910"
     }
   ]
 }

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -194,6 +194,14 @@ const scraperBars = {
       "faviconFg": "#fefefe"
     }
   ],
+  "denver": [
+    {
+      "name": "Ophelia's",
+      "city": "denver",
+      "address": "1215 20th Street, Denver, Colorado, 80202",
+      "coordinates": "39.7526699, -104.9919830"
+    }
+  ],
   "fort-lauderdale": [
     {
       "name": "Eagle",
@@ -341,6 +349,18 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJXxXPUMi_woARE46Y7WO-Ww0",
       "gayCities": "https://losangeles.gaycities.com/bars/309258-gym-bar-weho",
       "gayCitiesLastScrapedAt": "2026-06-14T03:19:33.089Z"
+    },
+    {
+      "name": "Precinct DTLA",
+      "city": "la",
+      "address": "357 South Broadway, Los Angeles, California, 90013",
+      "coordinates": "34.0498331, -118.2493274"
+    },
+    {
+      "name": "Falcon North",
+      "city": "la",
+      "address": "2020 East Artesia Boulevard, Long Beach, California, 90805",
+      "coordinates": "33.8744394, -118.1680438"
     }
   ],
   "london": [
@@ -556,6 +576,12 @@ const scraperBars = {
       "website": "https://www.3dollarbillbk.com",
       "faviconBg": "#190832",
       "faviconFg": "#c5c5e9"
+    },
+    {
+      "name": "C'mon Everybody",
+      "city": "nyc",
+      "address": "325 Franklin Avenue, New York, New York, 11216",
+      "coordinates": "40.6882793, -73.9569264"
     }
   ],
   "palm-springs": [
@@ -615,6 +641,12 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJnfNLuwAKlVQRXZrfhfLp_i4",
       "gayCities": "https://portland.gaycities.com/bars/893-cc-slaughters-nightclub-and-lounge",
       "gayCitiesLastScrapedAt": "2026-06-13T22:29:01.943Z"
+    },
+    {
+      "name": "Nova PDX",
+      "city": "portland",
+      "address": "722 East Burnside Street, Portland, Oregon, 97214",
+      "coordinates": "45.5228076, -122.6581521"
     }
   ],
   "ptown": [
@@ -689,6 +721,14 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJZa2WW0xFIYQRrzpGYnmf8Og",
       "gayCities": "https://vallarta.gaycities.com/bars/302724-cc-slaughters",
       "gayCitiesLastScrapedAt": "2026-06-13T22:28:59.439Z"
+    }
+  ],
+  "san-diego": [
+    {
+      "name": "The Rail",
+      "city": "san-diego",
+      "address": "3796 5th Avenue, San Diego, California, 92103",
+      "coordinates": "32.7468104, -117.1606487"
     }
   ],
   "seattle": [
@@ -842,6 +882,12 @@ const scraperBars = {
       "website": "https://publicsf.com",
       "faviconBg": "#f35425",
       "faviconFg": "#fd5825"
+    },
+    {
+      "name": "The Stud",
+      "city": "sf",
+      "address": "1123 Folsom Street, San Francisco, California, 94103",
+      "coordinates": "37.7761653, -122.4083643"
     }
   ],
   "sitges": [
@@ -896,6 +942,12 @@ const scraperBars = {
       "googleMaps": "https://www.google.com/maps/place/?q=place_id:ChIJKfM4OVvEyIARKXe7Mp57Uv0",
       "gayCities": "https://lasvegas.gaycities.com/bars/1346-fun-hog-ranch",
       "gayCitiesLastScrapedAt": "2026-06-14T01:14:27.328Z"
+    },
+    {
+      "name": "Dust Las Vegas",
+      "city": "vegas",
+      "address": "855 East Twain Avenue, Winchester, Nevada, 89169",
+      "coordinates": "36.1213962, -115.1450910"
     }
   ]
 };


### PR DESCRIPTION
## First, the bad news on GayCities
It isn't scrapeable any more. **Every request 403s** — including the exact User-Agent `tools/sync-bars.js` uses, on a listing URL already in our data. It worked in June (the `gayCitiesLastScrapedAt` stamps prove it), so they've tightened the block. Same for Travel Gay. Nominatim and Wikipedia still respond, so automated enrichment stays there.

## So I filled the gap that actually exists
Existing bars barely need enrichment: of 82 curated bars, **1** was missing coordinates and **0** were missing an address. The real gap is **44 venues that appear in your event data with no curated entry at all** — the same gap Horizon, Eden, The Bear Cave and Westminster Pier were in.

**Method, built around the mistake I made this morning** (curating a guest house named "Horizon" as a nightclub):
1. geocode name + city, accept **only** when the OSM result's type is venue-ish (bar/pub/nightclub/restaurant) — never a hotel, never a street;
2. then **corroborate** against the address our own events independently extracted from the source pages, requiring a shared house number.

**Step 2 paid for itself immediately.** Phoenix's "Kobalt" matched an OSM entry on *West Earll Drive*, while every event says *3110 North Central Avenue*. Different place — rejected automatically. That's precisely the failure that produced the Horizon pin, caught by machine this time instead of by you noticing a wrong map pin.

**Committed (8), each with matching house numbers from two independent sources:**

| venue | city | address |
|---|---|---|
| Nova PDX | portland | 722 East Burnside Street |
| The Stud | sf | 1123 Folsom Street |
| Dust Las Vegas | vegas | 855 East Twain Avenue |
| Precinct DTLA | la | 357 South Broadway |
| Falcon North | la | 2020 East Artesia Blvd, Long Beach |
| C'mon Everybody | nyc | 325 Franklin Avenue |
| The Rail | san-diego | 3796 5th Avenue |
| Ophelia's | denver | 1215 20th Street |

Two new city files (`denver`, `san-diego`).

**Deliberately not committed:** Kobalt (contradicted), plus Bossanova Ballroom, Sanctuary Club, F8 Nightclub and Uproar Lounge — OSM returned no venue-type match, and I'm not guessing a pin again.

The remaining ~30 uncurated venues are mostly one-offs; I can work through them the same way if this approach looks right to you.

Suite: **1104/1104**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
