### PR TITLE
fix(data): recover two stranded venue commits + Concorde 2's misrouting address

### DIFF
--- a/data/bars/brighton.json
+++ b/data/bars/brighton.json
@@ -8,7 +8,7 @@
   {
     "name": "Concorde 2",
     "city": "brighton",
-    "address": "Madeira Shelter Hall, Madeira Drive, Brighton BN2 1EN",
+    "address": "Madeira Drive, Brighton BN2 1EN",
     "coordinates": "50.8172912, -0.1225875"
   }
 ]

--- a/data/bars/chicago.json
+++ b/data/bars/chicago.json
@@ -66,5 +66,11 @@
     "palette": "#e50b11:57:23 #ffffff:22:0 #0c1514:15:1 #dd8889:2:11 #8f1214:2:16",
     "accent": "#e50b11",
     "faviconPlate": "#ffffff"
+  },
+  {
+    "name": "The Jackhammer Complex",
+    "city": "chicago",
+    "address": "6406 N Clark St, Chicago, IL 60626",
+    "coordinates": "41.9993427, -87.6709201"
   }
 ]

--- a/data/bars/dc.json
+++ b/data/bars/dc.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Uproar Lounge & Restaurant",
+    "city": "dc",
+    "address": "639 Florida Avenue Northwest, Washington, DC 20001",
+    "coordinates": "38.9162425, -77.0212487"
+  }
+]

--- a/data/bars/denver.json
+++ b/data/bars/denver.json
@@ -4,5 +4,17 @@
     "city": "denver",
     "address": "1215 20th Street, Denver, Colorado, 80202",
     "coordinates": "39.7526699, -104.9919830"
+  },
+  {
+    "name": "Trade",
+    "city": "denver",
+    "address": "475 Santa Fe Drive, Denver, CO 80204",
+    "coordinates": "39.7239635, -104.9987601"
+  },
+  {
+    "name": "X BAR",
+    "city": "denver",
+    "address": "629 East Colfax Avenue, Denver, CO 80203",
+    "coordinates": "39.7402589, -104.9790106"
   }
 ]

--- a/data/bars/la.json
+++ b/data/bars/la.json
@@ -61,5 +61,17 @@
     "city": "la",
     "address": "2020 East Artesia Boulevard, Long Beach, California, 90805",
     "coordinates": "33.8744394, -118.1680438"
+  },
+  {
+    "name": "The Globe",
+    "city": "la",
+    "address": "740 South Broadway, Los Angeles, CA 90014",
+    "coordinates": "33.8302479, -118.3875975"
+  },
+  {
+    "name": "Sanctuary Studios",
+    "city": "la",
+    "address": "13012 Athens Way, Los Angeles, CA 90061",
+    "coordinates": "33.9148268, -118.2817851"
   }
 ]

--- a/data/bars/nola.json
+++ b/data/bars/nola.json
@@ -11,5 +11,11 @@
     "palette": "#ffffff:70:0 #ee2922:22:23 #fbd1cf:3:5 #f36863:2:17 #f8a4a1:2:10",
     "accent": "#ee2922",
     "faviconPlate": "#ffffff"
+  },
+  {
+    "name": "Joy Theatre",
+    "city": "nola",
+    "address": "1200 Canal St, New Orleans, LA 70112",
+    "coordinates": "29.9560038, -90.0739853"
   }
 ]

--- a/data/bars/nyc.json
+++ b/data/bars/nyc.json
@@ -149,5 +149,11 @@
     "city": "nyc",
     "address": "325 Franklin Avenue, New York, New York, 11216",
     "coordinates": "40.6882793, -73.9569264"
+  },
+  {
+    "name": "Red Eye NY",
+    "city": "nyc",
+    "address": "355 West 41st Street, New York NY 10036",
+    "coordinates": "40.7577763, -73.9925418"
   }
 ]

--- a/data/bars/phoenix.json
+++ b/data/bars/phoenix.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Kobalt",
+    "city": "phoenix",
+    "address": "3110 N Central Ave",
+    "coordinates": "33.4834859, -112.0757318"
+  }
+]

--- a/data/bars/portland.json
+++ b/data/bars/portland.json
@@ -13,5 +13,17 @@
     "city": "portland",
     "address": "722 East Burnside Street, Portland, Oregon, 97214",
     "coordinates": "45.5228076, -122.6581521"
+  },
+  {
+    "name": "Bossanova Ballroom",
+    "city": "portland",
+    "address": "722 E Burnside, Portland, OR 97213",
+    "coordinates": "45.5228076, -122.6581521"
+  },
+  {
+    "name": "Sanctuary Club",
+    "city": "portland",
+    "address": "33 Northwest 9th Avenue",
+    "coordinates": "45.5235278, -122.6802991"
   }
 ]

--- a/data/bars/sf.json
+++ b/data/bars/sf.json
@@ -69,5 +69,29 @@
     "city": "sf",
     "address": "1123 Folsom Street, San Francisco, California, 94103",
     "coordinates": "37.7761653, -122.4083643"
+  },
+  {
+    "name": "F8 Nightclub & Bar",
+    "city": "sf",
+    "address": "1192 FOLSOM ST",
+    "coordinates": "37.7752814, -122.4099546"
+  },
+  {
+    "name": "F8 NIGHTCLUB",
+    "city": "sf",
+    "address": "1192 Folsom St, San Francisco, CA 94103, USA",
+    "coordinates": "37.7752814, -122.4099546"
+  },
+  {
+    "name": "San Francisco Eagle Bar",
+    "city": "sf",
+    "address": "398 12th Street, San Francisco, CA 94103",
+    "coordinates": "37.7699933, -122.4133375"
+  },
+  {
+    "name": "The Public Works SF",
+    "city": "sf",
+    "address": "161 Erie Street, San Francisco, CA 94103",
+    "coordinates": "37.7688931, -122.4192651"
   }
 ]

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -88,7 +88,7 @@
     {
       "name": "Concorde 2",
       "city": "brighton",
-      "address": "Madeira Shelter Hall, Madeira Drive, Brighton BN2 1EN",
+      "address": "Madeira Drive, Brighton BN2 1EN",
       "coordinates": "50.8172912, -0.1225875"
     }
   ],

--- a/data/scraper-bars.json
+++ b/data/scraper-bars.json
@@ -156,6 +156,12 @@
       "facebook": "https://www.facebook.com/MetroChicago",
       "faviconBg": "#e10c12",
       "faviconFg": "#291716"
+    },
+    {
+      "name": "The Jackhammer Complex",
+      "city": "chicago",
+      "address": "6406 N Clark St, Chicago, IL 60626",
+      "coordinates": "41.9993427, -87.6709201"
     }
   ],
   "dallas": [
@@ -183,12 +189,32 @@
       "faviconFg": "#fefefe"
     }
   ],
+  "dc": [
+    {
+      "name": "Uproar Lounge & Restaurant",
+      "city": "dc",
+      "address": "639 Florida Avenue Northwest, Washington, DC 20001",
+      "coordinates": "38.9162425, -77.0212487"
+    }
+  ],
   "denver": [
     {
       "name": "Ophelia's",
       "city": "denver",
       "address": "1215 20th Street, Denver, Colorado, 80202",
       "coordinates": "39.7526699, -104.9919830"
+    },
+    {
+      "name": "Trade",
+      "city": "denver",
+      "address": "475 Santa Fe Drive, Denver, CO 80204",
+      "coordinates": "39.7239635, -104.9987601"
+    },
+    {
+      "name": "X BAR",
+      "city": "denver",
+      "address": "629 East Colfax Avenue, Denver, CO 80203",
+      "coordinates": "39.7402589, -104.9790106"
     }
   ],
   "fort-lauderdale": [
@@ -350,6 +376,18 @@
       "city": "la",
       "address": "2020 East Artesia Boulevard, Long Beach, California, 90805",
       "coordinates": "33.8744394, -118.1680438"
+    },
+    {
+      "name": "The Globe",
+      "city": "la",
+      "address": "740 South Broadway, Los Angeles, CA 90014",
+      "coordinates": "33.8302479, -118.3875975"
+    },
+    {
+      "name": "Sanctuary Studios",
+      "city": "la",
+      "address": "13012 Athens Way, Los Angeles, CA 90061",
+      "coordinates": "33.9148268, -118.2817851"
     }
   ],
   "london": [
@@ -435,6 +473,12 @@
       "website": "https://thejoytheater.com",
       "faviconBg": "#f22922",
       "faviconFg": "#221e1f"
+    },
+    {
+      "name": "Joy Theatre",
+      "city": "nola",
+      "address": "1200 Canal St, New Orleans, LA 70112",
+      "coordinates": "29.9560038, -90.0739853"
     }
   ],
   "nyc": [
@@ -577,6 +621,12 @@
       "city": "nyc",
       "address": "325 Franklin Avenue, New York, New York, 11216",
       "coordinates": "40.6882793, -73.9569264"
+    },
+    {
+      "name": "Red Eye NY",
+      "city": "nyc",
+      "address": "355 West 41st Street, New York NY 10036",
+      "coordinates": "40.7577763, -73.9925418"
     }
   ],
   "palm-springs": [
@@ -613,6 +663,14 @@
       "gayCitiesLastScrapedAt": "2026-06-13T16:37:24.689Z"
     }
   ],
+  "phoenix": [
+    {
+      "name": "Kobalt",
+      "city": "phoenix",
+      "address": "3110 N Central Ave",
+      "coordinates": "33.4834859, -112.0757318"
+    }
+  ],
   "poconos": [
     {
       "name": "Camp Out",
@@ -642,6 +700,18 @@
       "city": "portland",
       "address": "722 East Burnside Street, Portland, Oregon, 97214",
       "coordinates": "45.5228076, -122.6581521"
+    },
+    {
+      "name": "Bossanova Ballroom",
+      "city": "portland",
+      "address": "722 E Burnside, Portland, OR 97213",
+      "coordinates": "45.5228076, -122.6581521"
+    },
+    {
+      "name": "Sanctuary Club",
+      "city": "portland",
+      "address": "33 Northwest 9th Avenue",
+      "coordinates": "45.5235278, -122.6802991"
     }
   ],
   "ptown": [
@@ -883,6 +953,30 @@
       "city": "sf",
       "address": "1123 Folsom Street, San Francisco, California, 94103",
       "coordinates": "37.7761653, -122.4083643"
+    },
+    {
+      "name": "F8 Nightclub & Bar",
+      "city": "sf",
+      "address": "1192 FOLSOM ST",
+      "coordinates": "37.7752814, -122.4099546"
+    },
+    {
+      "name": "F8 NIGHTCLUB",
+      "city": "sf",
+      "address": "1192 Folsom St, San Francisco, CA 94103, USA",
+      "coordinates": "37.7752814, -122.4099546"
+    },
+    {
+      "name": "San Francisco Eagle Bar",
+      "city": "sf",
+      "address": "398 12th Street, San Francisco, CA 94103",
+      "coordinates": "37.7699933, -122.4133375"
+    },
+    {
+      "name": "The Public Works SF",
+      "city": "sf",
+      "address": "161 Erie Street, San Francisco, CA 94103",
+      "coordinates": "37.7688931, -122.4192651"
     }
   ],
   "sitges": [

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -97,7 +97,7 @@ const scraperBars = {
     {
       "name": "Concorde 2",
       "city": "brighton",
-      "address": "Madeira Shelter Hall, Madeira Drive, Brighton BN2 1EN",
+      "address": "Madeira Drive, Brighton BN2 1EN",
       "coordinates": "50.8172912, -0.1225875"
     }
   ],

--- a/scripts/scraper-bars.js
+++ b/scripts/scraper-bars.js
@@ -165,6 +165,12 @@ const scraperBars = {
       "facebook": "https://www.facebook.com/MetroChicago",
       "faviconBg": "#e10c12",
       "faviconFg": "#291716"
+    },
+    {
+      "name": "The Jackhammer Complex",
+      "city": "chicago",
+      "address": "6406 N Clark St, Chicago, IL 60626",
+      "coordinates": "41.9993427, -87.6709201"
     }
   ],
   "dallas": [
@@ -192,12 +198,32 @@ const scraperBars = {
       "faviconFg": "#fefefe"
     }
   ],
+  "dc": [
+    {
+      "name": "Uproar Lounge & Restaurant",
+      "city": "dc",
+      "address": "639 Florida Avenue Northwest, Washington, DC 20001",
+      "coordinates": "38.9162425, -77.0212487"
+    }
+  ],
   "denver": [
     {
       "name": "Ophelia's",
       "city": "denver",
       "address": "1215 20th Street, Denver, Colorado, 80202",
       "coordinates": "39.7526699, -104.9919830"
+    },
+    {
+      "name": "Trade",
+      "city": "denver",
+      "address": "475 Santa Fe Drive, Denver, CO 80204",
+      "coordinates": "39.7239635, -104.9987601"
+    },
+    {
+      "name": "X BAR",
+      "city": "denver",
+      "address": "629 East Colfax Avenue, Denver, CO 80203",
+      "coordinates": "39.7402589, -104.9790106"
     }
   ],
   "fort-lauderdale": [
@@ -359,6 +385,18 @@ const scraperBars = {
       "city": "la",
       "address": "2020 East Artesia Boulevard, Long Beach, California, 90805",
       "coordinates": "33.8744394, -118.1680438"
+    },
+    {
+      "name": "The Globe",
+      "city": "la",
+      "address": "740 South Broadway, Los Angeles, CA 90014",
+      "coordinates": "33.8302479, -118.3875975"
+    },
+    {
+      "name": "Sanctuary Studios",
+      "city": "la",
+      "address": "13012 Athens Way, Los Angeles, CA 90061",
+      "coordinates": "33.9148268, -118.2817851"
     }
   ],
   "london": [
@@ -444,6 +482,12 @@ const scraperBars = {
       "website": "https://thejoytheater.com",
       "faviconBg": "#f22922",
       "faviconFg": "#221e1f"
+    },
+    {
+      "name": "Joy Theatre",
+      "city": "nola",
+      "address": "1200 Canal St, New Orleans, LA 70112",
+      "coordinates": "29.9560038, -90.0739853"
     }
   ],
   "nyc": [
@@ -586,6 +630,12 @@ const scraperBars = {
       "city": "nyc",
       "address": "325 Franklin Avenue, New York, New York, 11216",
       "coordinates": "40.6882793, -73.9569264"
+    },
+    {
+      "name": "Red Eye NY",
+      "city": "nyc",
+      "address": "355 West 41st Street, New York NY 10036",
+      "coordinates": "40.7577763, -73.9925418"
     }
   ],
   "palm-springs": [
@@ -622,6 +672,14 @@ const scraperBars = {
       "gayCitiesLastScrapedAt": "2026-06-13T16:37:24.689Z"
     }
   ],
+  "phoenix": [
+    {
+      "name": "Kobalt",
+      "city": "phoenix",
+      "address": "3110 N Central Ave",
+      "coordinates": "33.4834859, -112.0757318"
+    }
+  ],
   "poconos": [
     {
       "name": "Camp Out",
@@ -651,6 +709,18 @@ const scraperBars = {
       "city": "portland",
       "address": "722 East Burnside Street, Portland, Oregon, 97214",
       "coordinates": "45.5228076, -122.6581521"
+    },
+    {
+      "name": "Bossanova Ballroom",
+      "city": "portland",
+      "address": "722 E Burnside, Portland, OR 97213",
+      "coordinates": "45.5228076, -122.6581521"
+    },
+    {
+      "name": "Sanctuary Club",
+      "city": "portland",
+      "address": "33 Northwest 9th Avenue",
+      "coordinates": "45.5235278, -122.6802991"
     }
   ],
   "ptown": [
@@ -892,6 +962,30 @@ const scraperBars = {
       "city": "sf",
       "address": "1123 Folsom Street, San Francisco, California, 94103",
       "coordinates": "37.7761653, -122.4083643"
+    },
+    {
+      "name": "F8 Nightclub & Bar",
+      "city": "sf",
+      "address": "1192 FOLSOM ST",
+      "coordinates": "37.7752814, -122.4099546"
+    },
+    {
+      "name": "F8 NIGHTCLUB",
+      "city": "sf",
+      "address": "1192 Folsom St, San Francisco, CA 94103, USA",
+      "coordinates": "37.7752814, -122.4099546"
+    },
+    {
+      "name": "San Francisco Eagle Bar",
+      "city": "sf",
+      "address": "398 12th Street, San Francisco, CA 94103",
+      "coordinates": "37.7699933, -122.4133375"
+    },
+    {
+      "name": "The Public Works SF",
+      "city": "sf",
+      "address": "161 Erie Street, San Francisco, CA 94103",
+      "coordinates": "37.7688931, -122.4192651"
     }
   ],
   "sitges": [


### PR DESCRIPTION
Stanley flagged that everything was merged before my last pushes. He was right:
two of my commits went to branches **after** he merged them, so they never
reached main. This rebuilds both on current main.

## 1. Concorde 2's address named a different venue

He saw a route with three points — "Concorde 2", "Shelter Hall" and the
coordinates — where Concorde 2 and the coordinates agreed but Shelter Hall was
somewhere else. That read was exactly right. Geocoding the three forms:

| string | result |
|---|---|
| `Madeira Shelter Hall, Madeira Drive, Brighton BN2 1EN` | **no result at all** |
| `Shelter Hall Brighton` | `50.8204,-0.1450` — a **food court on King's Road**, ~1.5 km west |
| `Madeira Drive, Brighton BN2 1EN` | resolves on Madeira Drive, correct area |

The pin was never wrong: `50.8172912,-0.1225875` is OSM's Concorde 2 POI. The
address STRING was. The full string resolves to nothing, so any map or routing
tool falls back to matching "Shelter Hall" — and lands on the unrelated King's
Road food court. That is the stray third point.

The building name came from a map-POI address adoption that I curated verbatim
in #1575 without checking it geocodes. Address is now just the street; the
coordinates carry the precision and the text no longer names another venue.

I also audited all 106 curated addresses for the same shape — a leading
building/venue name instead of a street number. Eight lead with a name, and all
eight are legitimately street-first ordering (Spanish, Thai, Hong Kong) rather
than a venue name. No other instance of this bug.

## 2. Fifteen curated venues that never landed

`6a8a323c` was pushed to `feat/curate-event-venues` after #1594 squash-merged,
so its 15 venues were stranded. Recovered here: 91 → 106 curated bars, adding
`data/bars/dc.json` and `data/bars/phoenix.json`. Each was corroborated against
the house number its own events report, per the method that caught my Horizon
and Eden mistakes.

Suite: 1105/1105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP