### PR TITLE
feat(scraper): name-led geocode ladder + maps-link ll= as the last pin rung

### DIFF
--- a/scripts/metrics-sections.js
+++ b/scripts/metrics-sections.js
@@ -54,7 +54,7 @@ const GUARD_LABELS = [
     { key: 'arbitrationDeterministic', label: 'Merge conflicts resolved deterministically' },
     { key: 'mapsLinkPin', label: "Pin taken from the page's maps link (no curated/geocoded pin)" },
     { key: 'mapsLinkConflict', label: "Maps-link pin disagrees with the accepted pin (verify venue)" },
-    { key: 'mapsLinkOverride', label: "Maps-link pin replaced a name-only geocoded pin" }
+    { key: 'mapsLinkDeclined', label: "Maps-link pin declined against a name-only geocoded pin (verify venue)" }
 ];
 
 const SIGNALS_PASS_ORDER = ['extraction', 'context-prep', 'repair', 'merge-arbitration', 'ocr'];

--- a/scripts/metrics-sections.js
+++ b/scripts/metrics-sections.js
@@ -51,7 +51,9 @@ const GUARD_LABELS = [
     { key: 'coordsPreserved', label: 'Calendar coordinates preserved' },
     { key: 'barPreserved', label: 'Calendar venue preserved' },
     { key: 'locationPreserved', label: 'Calendar location preserved' },
-    { key: 'arbitrationDeterministic', label: 'Merge conflicts resolved deterministically' }
+    { key: 'arbitrationDeterministic', label: 'Merge conflicts resolved deterministically' },
+    { key: 'mapsLinkPin', label: "Pin taken from the page's maps link (no curated/geocoded pin)" },
+    { key: 'mapsLinkConflict', label: "Maps-link pin disagrees with the accepted pin (verify venue)" }
 ];
 
 const SIGNALS_PASS_ORDER = ['extraction', 'context-prep', 'repair', 'merge-arbitration', 'ocr'];

--- a/scripts/metrics-sections.js
+++ b/scripts/metrics-sections.js
@@ -53,7 +53,8 @@ const GUARD_LABELS = [
     { key: 'locationPreserved', label: 'Calendar location preserved' },
     { key: 'arbitrationDeterministic', label: 'Merge conflicts resolved deterministically' },
     { key: 'mapsLinkPin', label: "Pin taken from the page's maps link (no curated/geocoded pin)" },
-    { key: 'mapsLinkConflict', label: "Maps-link pin disagrees with the accepted pin (verify venue)" }
+    { key: 'mapsLinkConflict', label: "Maps-link pin disagrees with the accepted pin (verify venue)" },
+    { key: 'mapsLinkOverride', label: "Maps-link pin replaced a name-only geocoded pin" }
 ];
 
 const SIGNALS_PASS_ORDER = ['extraction', 'context-prep', 'repair', 'merge-arbitration', 'ocr'];

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -95,6 +95,20 @@ class BaseNormalizer {
             .trim();
     }
 
+    // Coordinate-pair check kept local so the normalizers stay platform-pure
+    // (mirrors SharedCore.isCoordinatePair: two finite floats, lat within ±90,
+    // lng within ±180). On the base class because both the page-provenance
+    // stamp and the maps-link pin rung need it.
+    isCoordinatePairString(value) {
+        if (typeof value !== 'string') return false;
+        const match = value.trim().match(/^(-?\d{1,3}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)$/);
+        if (!match) return false;
+        const lat = Number(match[1]);
+        const lng = Number(match[2]);
+        return Number.isFinite(lat) && Number.isFinite(lng)
+            && Math.abs(lat) <= 90 && Math.abs(lng) <= 180;
+    }
+
     normalize(event) {
         return event;
     }
@@ -127,19 +141,6 @@ class BasicDataNormalizer extends BaseNormalizer {
 
         // Normalize basic text fields
         return this.core.normalizeEventTextFields(event);
-    }
-
-    // Coordinate-pair check kept local so this normalizer stays platform-pure
-    // (mirrors SharedCore.isCoordinatePair: two finite floats, lat within ±90,
-    // lng within ±180).
-    isCoordinatePairString(value) {
-        if (typeof value !== 'string') return false;
-        const match = value.trim().match(/^(-?\d{1,3}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)$/);
-        if (!match) return false;
-        const lat = Number(match[1]);
-        const lng = Number(match[2]);
-        return Number.isFinite(lat) && Number.isFinite(lng)
-            && Math.abs(lat) <= 90 && Math.abs(lng) <= 180;
     }
 
     stampPageProvenanceDefaults(event) {
@@ -943,6 +944,21 @@ const MAX_GEOCODE_QUERIES_PER_EVENT = 5;
 // drift without accepting a different block. Regular address-geocoded pins
 // keep the strict exact-house comparison.
 const POI_PIN_HOUSE_NUMBER_TOLERANCE = 20;
+
+// How far a page's maps-link pin (the ll= param a ticketing page publishes,
+// harvested by the AI web parser behind its venue-identity guard) may sit from
+// the pin the pipeline actually accepted before the disagreement is worth a
+// human's attention. The measured spread decides it:
+//   - Royal Vauxhall Tavern: ll= vs geocode  6 m — the same building;
+//   - Horizon:               ll= is 181 m from truth (the right venue, coarse
+//     platform geocode) — an imprecise pin, not a wrong one;
+//   - Westminster Pier:      ll= is 936 m from truth, on a DIFFERENT pier —
+//     the platform geocoded the street loosely and landed at Embankment Pier.
+// 300 m clears the worst observed BENIGN error (181 m) with room, and sits
+// well under the wrong-venue case (936 m), so the line fires for "these are
+// different places" and stays quiet for "same place, coarser pin". It only
+// governs a LOG: the accepted pin never changes because of it.
+const MAPS_LINK_CONFLICT_METERS = 300;
 
 // Street-type words a trailing directional can follow ("Cheshire Bridge Rd NE").
 const GEOCODE_STREET_TYPE_WORDS = 'Street|St|Road|Rd|Avenue|Ave|Boulevard|Blvd|Drive|Dr|Lane|Ln|Way|Place|Pl|Court|Ct|Parkway|Pkwy|Highway|Hwy';
@@ -2333,11 +2349,92 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             }
         }
 
+        // Last rung of the pin ladder: the page's own maps-link pin, used only
+        // when curated data and the geocoder above both came up empty. Also
+        // reports a disagreement when they didn't.
+        if (this.applyMapsLinkCoordinateFallback(event)) modified = true;
+
         if (modified && this.core && typeof this.core.formatEventNotes === 'function') {
             event.notes = this.core.formatEventNotes(event);
         }
 
         return event;
+    }
+
+    // MAPS-LINK PIN — the last rung of the location ladder.
+    //
+    // The AI web parser harvests the ll= coordinate a ticketing page publishes
+    // in its "Open in maps" link and stashes it on _mapsLinkCoordinate, but
+    // ONLY after its identity guard confirms the name the link leads with IS
+    // the event's venue (placeholders like "Venue TBA" never get stashed).
+    // This method is where that candidate meets the pipeline's own answers,
+    // and the precedence is:
+    //
+    //   1. curated coordinates from data/bars — BarDataNormalizer fills them
+    //      earlier in this same pipeline, so they are already on the event
+    //      when we get here, and they are never touched;
+    //   2. a successful forward geocode of the address — it runs above in
+    //      this same method, so its result is likewise already on the event;
+    //   3. THIS pin — written only when 1 and 2 left location blank.
+    //
+    // The measured reason for that order (5 venues, scored against verified
+    // truth): the address geocode is near-perfect when it resolves (0–1 m) but
+    // returned NOTHING for 3 of 5 venues, and in exactly those 3 the maps-link
+    // pin was right (0–181 m). Where the maps-link pin was badly wrong
+    // (Westminster Pier, 936 m) the geocode succeeded and wins here. The two
+    // sources are complementary, and a blank pin is the only thing this fills.
+    //
+    // Returns true when it wrote a location (so the caller refreshes notes).
+    applyMapsLinkCoordinateFallback(event) {
+        const candidate = event && typeof event === 'object' ? event._mapsLinkCoordinate : null;
+        if (!candidate || typeof candidate !== 'object') return false;
+        const candidateLocation = typeof candidate.location === 'string' ? candidate.location.trim() : '';
+        const claimed = this.parseCoordinatePairString(candidateLocation);
+        // Fails closed on its own input rather than trusting the stash: shape,
+        // range, and Null Island (the shape a failed geocode takes) are
+        // re-checked here even though the parser already refused them.
+        if (!claimed || (claimed.lat === 0 && claimed.lon === 0)) return false;
+
+        const title = event.title || 'unknown';
+        const venueName = typeof candidate.venueName === 'string' && candidate.venueName.trim()
+            ? candidate.venueName.trim()
+            : (typeof event.bar === 'string' ? event.bar.trim() : 'unknown venue');
+        const existingLocation = typeof event.location === 'string' ? event.location.trim() : '';
+
+        if (existingLocation) {
+            // A better-sourced pin already won. Report the disagreement anyway:
+            // this is the line that surfaces the next Westminster Pier, where a
+            // ticketing platform's own map points at a different place than the
+            // venue's address does.
+            const accepted = this.parseCoordinatePairString(existingLocation);
+            if (accepted) {
+                const distanceMeters = Math.round(this.haversineDistanceKm(
+                    accepted.lat, accepted.lon, claimed.lat, claimed.lon) * 1000);
+                if (distanceMeters >= MAPS_LINK_CONFLICT_METERS) {
+                    const acceptedSource = typeof event.pinSource === 'string' && event.pinSource.trim()
+                        ? event.pinSource.trim()
+                        : 'unknown source';
+                    console.warn(`🗺️ MAPS LINK CONFLICT: "${title}" accepted pin ${existingLocation} (${acceptedSource}) is ${distanceMeters} m from the page's maps link ${candidateLocation} for "${venueName}" — accepted pin kept; verify which is the real venue`);
+                }
+            }
+            return false;
+        }
+
+        event.location = candidateLocation;
+        event.pinSource = 'maps-link';
+        console.log(`🗺️ OpenStreetMapNormalizer: No curated or geocoded pin for "${title}" — using the page's maps link for "${venueName}" -> ${candidateLocation}`);
+        return true;
+    }
+
+    // "lat, lon" text → { lat, lon } numbers, or null. Local to the
+    // normalizers (this file stays platform-pure and dependency-free);
+    // isCoordinatePairString above already vets the shape.
+    parseCoordinatePairString(value) {
+        if (!this.isCoordinatePairString(value)) return null;
+        const parts = String(value).split(',');
+        const lat = Number(parts[0].trim());
+        const lon = Number(parts[1].trim());
+        return Number.isFinite(lat) && Number.isFinite(lon) ? { lat, lon } : null;
     }
 }
 

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -2408,23 +2408,25 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     //   1. curated coordinates from data/bars — BarDataNormalizer fills them
     //      earlier in this same pipeline, so they are already on the event
     //      when we get here, and they are never touched;
-    //   2. a STREET-GRADE forward geocode — the ladder above runs
-    //      "<venue>, <address>" then the address-only variants, so its result
-    //      is already on the event;
-    //   3. THIS pin — written when 1 and 2 left location blank, and preferred
-    //      over a geocoded pin whose QUERY carried no street line (see below).
+    //   2. a forward geocode — the ladder above runs "<venue>, <address>" then
+    //      the address-only variants then "<venue>, <city>", so its result is
+    //      already on the event;
+    //   3. THIS pin — written ONLY when 1 and 2 left location blank.
     //
-    // Why a geocoded pin can lose to this one: the ladder's last rungs query
-    // "<venue>, <city>" with no street line at all, and Nominatim answers those
-    // confidently and wrongly. Measured: with the address missing, "Horizon,
-    // brighton" resolved to a house called Horizon on Ainsworth Avenue — 5069 m
-    // from the venue — and came back EXACT grade with a POI name matching the
-    // bar, so no response-side signal caught it. The signal that does catch it
-    // is the query itself: no street line means the geocoder was guessing from
-    // a name, and an identity-guarded maps-link pin (the venue's own ticketing
-    // page, name-matched to the event's bar) is the better evidence. A query
-    // that DID carry a street line still wins — that is the case the
-    // name-led rung exists to make accurate.
+    // It fills a blank; it never replaces a pin. Filling a blank is a clear
+    // win (the alternative is no pin at all). Replacing one is a coin flip, and
+    // the coin was actually flipped: for a pin from the name-only
+    // "<venue>, <city>" rung — the weakest geocode we produce — the two
+    // measured cases point opposite ways. With the address missing, "Horizon,
+    // brighton" resolved to a house called Horizon on Ainsworth Avenue, 5069 m
+    // out, where the maps-link pin was right; "Westminster Pier, london"
+    // resolved EXACTLY right, where the maps-link pin is 936 m out at another
+    // pier. Nothing available at runtime separates them: both came back
+    // exact-grade, and the 5069 m hit even carried a POI name matching the bar.
+    // Swapping at even odds buys no accuracy and adds variance, so the
+    // disagreement is FLAGGED and the geocoded pin is kept (see
+    // isNameOnlyGeocodedPin). If the flagged cases accumulate and the maps link
+    // is usually the right one, that is the evidence for enabling a swap later.
     //
     // Returns true when it wrote a location (so the caller refreshes notes).
     applyMapsLinkCoordinateFallback(event) {
@@ -2457,19 +2459,19 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 ? event.pinSource.trim()
                 : 'unknown source';
             if (this.isNameOnlyGeocodedPin(event)) {
-                console.warn(`🗺️ MAPS LINK CONFLICT: "${title}" geocoded pin ${existingLocation} came from the name-only query "${event._geocodeQuery || 'unknown'}" (no address in it) and is ${distanceMeters} m from the page's maps link ${candidateLocation} for "${venueName}" — using the maps link`);
-                event.location = candidateLocation;
-                event.pinSource = 'maps-link';
-                // An address adopted from that same map hit is now evidence
-                // from a source this rung just declined to pin with. It is
-                // FLAGGED, not deleted: the two observed cases point opposite
-                // ways (the Horizon hit's "56 Ainsworth Avenue" is wrong; the
-                // Westminster Pier hit's "Victoria Embankment" is right), so
-                // dropping it would be a guess of its own.
+                // FLAG ONLY — the pin is NOT replaced. See the note above
+                // isNameOnlyGeocodedPin for why swapping here is a coin flip.
+                console.warn(`🗺️ MAPS LINK DECLINED: "${title}" geocoded pin ${existingLocation} came from the name-only query "${event._geocodeQuery || 'unknown'}" (no address in it) and is ${distanceMeters} m from the page's maps link ${candidateLocation} for "${venueName}" — geocoded pin kept, maps-link pin NOT applied; verify which is the real venue`);
+                // An address adopted from that same map hit is evidence from a
+                // source this line has just questioned. It is FLAGGED, not
+                // deleted: the two observed cases point opposite ways (the
+                // Horizon hit's "56 Ainsworth Avenue" is wrong; the Westminster
+                // Pier hit's "Victoria Embankment" is right), so dropping it
+                // would be a guess of its own.
                 if (event.addressSource === 'geo-poi' && event.address) {
-                    console.warn(`🗺️ MAPS LINK CONFLICT: "${title}" kept address "${event.address}" — it was adopted from that same declined map hit; verify it`);
+                    console.warn(`🗺️ MAPS LINK DECLINED: "${title}" address "${event.address}" was adopted from that same questioned map hit; verify it`);
                 }
-                return true;
+                return false;
             }
             console.warn(`🗺️ MAPS LINK CONFLICT: "${title}" accepted pin ${existingLocation} (${acceptedSource}) is ${distanceMeters} m from the page's maps link ${candidateLocation} for "${venueName}" — accepted pin kept; verify which is the real venue`);
             return false;
@@ -2484,7 +2486,12 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     // Is the event's accepted pin a GEOCODED pin that came from a NAME-ONLY
     // query — "<venue>, <city>" with no address text in it at all?
     //
-    // The rule is deliberately query-side, not response-side. Nominatim's
+    // This selects which WARNING to emit; it never changes a pin. A name-only
+    // pin is the weakest geocode the ladder produces, so its disagreement with
+    // an identity-guarded maps-link pin is reported as its own line (and its
+    // own run-summary counter) rather than folded in with ordinary conflicts.
+    //
+    // The test is deliberately query-side, not response-side. Nominatim's
     // response grade is the precision signal this file trusts everywhere else,
     // and it does not work here: the 5069 m "Horizon, brighton" hit came back
     // EXACT grade, with a POI name that matched the bar. Nothing in the
@@ -2492,17 +2499,15 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     //
     // "Name-only" is the narrowest possible reading — the query carried no
     // address, i.e. it was the venue+city rescue rung or the no-address venue
-    // lookup. A query built from the event's address stays street-grade for
-    // this purpose even when the street line has no house number or
-    // street-type word ("Victoria Embankment, London, UK"); those pins keep
-    // winning, which is exactly the case the name-led rung exists to make
-    // accurate.
+    // lookup. A query built from the event's address does not count even when
+    // the street line has no house number or street-type word ("Victoria
+    // Embankment, London, UK").
     //
     // Conservative on every axis:
-    //   - only geocoded pins qualify (curated and page pins are never second-
-    //     guessed here, and a maps-link pin cannot re-judge itself);
+    //   - only geocoded pins qualify (curated and page pins are never
+    //     second-guessed here, and a maps-link pin cannot re-judge itself);
     //   - the flag must be explicitly false — a pin carrying no flag at all
-    //     (an older record, another writer) keeps its pin (fail closed).
+    //     (an older record, another writer) takes the ordinary conflict line.
     isNameOnlyGeocodedPin(event) {
         const pinSource = typeof event.pinSource === 'string' ? event.pinSource.trim() : '';
         if (!pinSource.startsWith('geocoded-')) return false;

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -926,14 +926,19 @@ class LocationNormalizer extends BaseNormalizer {
 const CITY_CENTER_RADIUS_KM = 50;
 
 // Hard cap on Nominatim requests per event for the forward-geocode retry
-// ladder. 5 covers the full ladder (canonical address, unit/suite strip,
-// postal/country strip, directional strip, venue-name rescue); every request
+// ladder. 6 covers the full ladder (name+address, canonical address,
+// unit/suite strip, postal/country strip, directional strip, venue-name
+// rescue). It was 5 before the name-led rung was added in front; raising it by
+// exactly one keeps every rung that existed then reachable — capping at 5
+// would have silently dropped the venue+city rescue for address-bearing
+// events. The added request only exists when an event has BOTH a bar and an
+// address, and only fires when the name-led query returns nothing; every request
 // stays 1.1s-throttled and later rungs only fire after earlier ones return
 // nothing usable. A single US Census rescue request (US-looking addresses
 // only) and a single Photon rescue request may follow when every Nominatim
 // rung fails; both share the same rate limiter. Never raise this without
 // revisiting the rate-limit budget.
-const MAX_GEOCODE_QUERIES_PER_EVENT = 5;
+const MAX_GEOCODE_QUERIES_PER_EVENT = 6;
 
 // POI-adopted pins only: how far apart the reverse-geocoded house number and
 // the adopted address's house number may sit (same street) before the reverse
@@ -1812,15 +1817,24 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
 
     // Forward-geocode retry ladder: deduped, ordered query strings, hard-capped
     // at MAX_GEOCODE_QUERIES_PER_EVENT. Order:
-    //   1. The query exactly as built today (anchored to the city display name
+    //   1. "<bar>, <address>" — the venue name IN FRONT of its own address.
+    //      Measured against verified truth: "Victoria Embankment, London, UK"
+    //      (the address dice.fm publishes for Westminster Pier) resolves to a
+    //      point 1075 m away — the wrong pier — while "Westminster Pier,
+    //      Victoria Embankment, London, UK" resolves to 1 m. The name is the
+    //      disambiguator for a vague street line. It is FIRST, not universal:
+    //      the extra token over-constrains some queries (Horizon, Eden both
+    //      return NOTHING with the name attached and resolve fine without it),
+    //      which is exactly why the address-only rungs below still run.
+    //   2. The query exactly as built before (anchored to the city display name
     //      when the address doesn't already contain it).
-    //   2. The address with unit/suite tokens stripped (same anchoring) —
+    //   3. The address with unit/suite tokens stripped (same anchoring) —
     //      "Suite 200" / "#4" decoration returns 0 results.
-    //   3. The address with postal-code/country decoration stripped (same
+    //   4. The address with postal-code/country decoration stripped (same
     //      anchoring) — Nominatim chokes on "…, CA 94103, USA" endings.
-    //   4. The address with trailing directionals stripped (same anchoring) —
+    //   5. The address with trailing directionals stripped (same anchoring) —
     //      Nominatim's free-text parser chokes on "Rd NE" / "Road Northeast".
-    //   5. "<bar>, <city>" — venue-name lookup rescues venues OSM knows by name.
+    //   6. "<bar>, <city>" — venue-name lookup rescues venues OSM knows by name.
     buildGeocodeQueryVariants(address, eventCity, bar) {
         const city = this.geocodeCityAnchorName(typeof eventCity === 'string' ? eventCity.trim() : '');
         const anchorToCity = (text) => {
@@ -1842,7 +1856,14 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         // no-address event (venue-POI rescue) must not emit a junk ", <city>"
         // query; its ladder is the venue+city rescue rung alone.
         const baseAddress = String(address || '').trim();
+        const leadingBarName = typeof bar === 'string' ? bar.trim() : '';
         if (baseAddress) {
+            // Name-led rung first (only when the address doesn't already start
+            // with the venue name — ticketing pages sometimes publish it that
+            // way, and a doubled name is a query nothing matches).
+            if (leadingBarName && !baseAddress.toLowerCase().startsWith(leadingBarName.toLowerCase())) {
+                push(anchorToCity(`${leadingBarName}, ${baseAddress}`));
+            }
             push(anchorToCity(baseAddress));
             const unitStripped = this.stripUnitTokens(baseAddress);
             if (unitStripped && unitStripped !== baseAddress) push(anchorToCity(unitStripped));
@@ -2081,6 +2102,16 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 }
                 if (resolvedLocation) {
                     event.location = resolvedLocation;
+                    // The query string that actually produced the pin.
+                    // Underscore = metadata only (excluded from notes/merge
+                    // loops). The maps-link rung reads it: a pin from a query
+                    // carrying no street line is a name/city guess, however
+                    // confident the response looked.
+                    event._geocodeQuery = queryText;
+                    // Did this query carry the event's ADDRESS, or was it the
+                    // bare "<venue>, <city>" rescue? The maps-link rung below
+                    // only outranks the latter.
+                    event._geocodeQueryHadAddress = hasAddress && queryText !== venueRescueQuery;
                     modified = true;
                     console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
                     if (i > 0) {
@@ -2137,6 +2168,8 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                 }
                 if (resolvedLocation) {
                     event.location = resolvedLocation;
+                    event._geocodeQuery = address; // Census only ever queries the street address
+                    event._geocodeQueryHadAddress = true;
                     modified = true;
                     console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
                 }
@@ -2253,6 +2286,8 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                     }
                     if (resolvedLocation) {
                         event.location = resolvedLocation;
+                        event._geocodeQuery = photonQuery;
+                        event._geocodeQueryHadAddress = hasAddress && photonQuery !== venueRescueQuery;
                         modified = true;
                         console.log(`🗺️ OpenStreetMapNormalizer: Found coordinates for address "${event.address}" -> ${event.location}`);
                     }
@@ -2373,16 +2408,23 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     //   1. curated coordinates from data/bars — BarDataNormalizer fills them
     //      earlier in this same pipeline, so they are already on the event
     //      when we get here, and they are never touched;
-    //   2. a successful forward geocode of the address — it runs above in
-    //      this same method, so its result is likewise already on the event;
-    //   3. THIS pin — written only when 1 and 2 left location blank.
+    //   2. a STREET-GRADE forward geocode — the ladder above runs
+    //      "<venue>, <address>" then the address-only variants, so its result
+    //      is already on the event;
+    //   3. THIS pin — written when 1 and 2 left location blank, and preferred
+    //      over a geocoded pin whose QUERY carried no street line (see below).
     //
-    // The measured reason for that order (5 venues, scored against verified
-    // truth): the address geocode is near-perfect when it resolves (0–1 m) but
-    // returned NOTHING for 3 of 5 venues, and in exactly those 3 the maps-link
-    // pin was right (0–181 m). Where the maps-link pin was badly wrong
-    // (Westminster Pier, 936 m) the geocode succeeded and wins here. The two
-    // sources are complementary, and a blank pin is the only thing this fills.
+    // Why a geocoded pin can lose to this one: the ladder's last rungs query
+    // "<venue>, <city>" with no street line at all, and Nominatim answers those
+    // confidently and wrongly. Measured: with the address missing, "Horizon,
+    // brighton" resolved to a house called Horizon on Ainsworth Avenue — 5069 m
+    // from the venue — and came back EXACT grade with a POI name matching the
+    // bar, so no response-side signal caught it. The signal that does catch it
+    // is the query itself: no street line means the geocoder was guessing from
+    // a name, and an identity-guarded maps-link pin (the venue's own ticketing
+    // page, name-matched to the event's bar) is the better evidence. A query
+    // that DID carry a street line still wins — that is the case the
+    // name-led rung exists to make accurate.
     //
     // Returns true when it wrote a location (so the caller refreshes notes).
     applyMapsLinkCoordinateFallback(event) {
@@ -2407,16 +2449,29 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
             // ticketing platform's own map points at a different place than the
             // venue's address does.
             const accepted = this.parseCoordinatePairString(existingLocation);
-            if (accepted) {
-                const distanceMeters = Math.round(this.haversineDistanceKm(
-                    accepted.lat, accepted.lon, claimed.lat, claimed.lon) * 1000);
-                if (distanceMeters >= MAPS_LINK_CONFLICT_METERS) {
-                    const acceptedSource = typeof event.pinSource === 'string' && event.pinSource.trim()
-                        ? event.pinSource.trim()
-                        : 'unknown source';
-                    console.warn(`🗺️ MAPS LINK CONFLICT: "${title}" accepted pin ${existingLocation} (${acceptedSource}) is ${distanceMeters} m from the page's maps link ${candidateLocation} for "${venueName}" — accepted pin kept; verify which is the real venue`);
+            if (!accepted) return false;
+            const distanceMeters = Math.round(this.haversineDistanceKm(
+                accepted.lat, accepted.lon, claimed.lat, claimed.lon) * 1000);
+            if (distanceMeters < MAPS_LINK_CONFLICT_METERS) return false;
+            const acceptedSource = typeof event.pinSource === 'string' && event.pinSource.trim()
+                ? event.pinSource.trim()
+                : 'unknown source';
+            if (this.isNameOnlyGeocodedPin(event)) {
+                console.warn(`🗺️ MAPS LINK CONFLICT: "${title}" geocoded pin ${existingLocation} came from the name-only query "${event._geocodeQuery || 'unknown'}" (no address in it) and is ${distanceMeters} m from the page's maps link ${candidateLocation} for "${venueName}" — using the maps link`);
+                event.location = candidateLocation;
+                event.pinSource = 'maps-link';
+                // An address adopted from that same map hit is now evidence
+                // from a source this rung just declined to pin with. It is
+                // FLAGGED, not deleted: the two observed cases point opposite
+                // ways (the Horizon hit's "56 Ainsworth Avenue" is wrong; the
+                // Westminster Pier hit's "Victoria Embankment" is right), so
+                // dropping it would be a guess of its own.
+                if (event.addressSource === 'geo-poi' && event.address) {
+                    console.warn(`🗺️ MAPS LINK CONFLICT: "${title}" kept address "${event.address}" — it was adopted from that same declined map hit; verify it`);
                 }
+                return true;
             }
+            console.warn(`🗺️ MAPS LINK CONFLICT: "${title}" accepted pin ${existingLocation} (${acceptedSource}) is ${distanceMeters} m from the page's maps link ${candidateLocation} for "${venueName}" — accepted pin kept; verify which is the real venue`);
             return false;
         }
 
@@ -2424,6 +2479,34 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
         event.pinSource = 'maps-link';
         console.log(`🗺️ OpenStreetMapNormalizer: No curated or geocoded pin for "${title}" — using the page's maps link for "${venueName}" -> ${candidateLocation}`);
         return true;
+    }
+
+    // Is the event's accepted pin a GEOCODED pin that came from a NAME-ONLY
+    // query — "<venue>, <city>" with no address text in it at all?
+    //
+    // The rule is deliberately query-side, not response-side. Nominatim's
+    // response grade is the precision signal this file trusts everywhere else,
+    // and it does not work here: the 5069 m "Horizon, brighton" hit came back
+    // EXACT grade, with a POI name that matched the bar. Nothing in the
+    // response said "this is a guess". The query did.
+    //
+    // "Name-only" is the narrowest possible reading — the query carried no
+    // address, i.e. it was the venue+city rescue rung or the no-address venue
+    // lookup. A query built from the event's address stays street-grade for
+    // this purpose even when the street line has no house number or
+    // street-type word ("Victoria Embankment, London, UK"); those pins keep
+    // winning, which is exactly the case the name-led rung exists to make
+    // accurate.
+    //
+    // Conservative on every axis:
+    //   - only geocoded pins qualify (curated and page pins are never second-
+    //     guessed here, and a maps-link pin cannot re-judge itself);
+    //   - the flag must be explicitly false — a pin carrying no flag at all
+    //     (an older record, another writer) keeps its pin (fail closed).
+    isNameOnlyGeocodedPin(event) {
+        const pinSource = typeof event.pinSource === 'string' ? event.pinSource.trim() : '';
+        if (!pinSource.startsWith('geocoded-')) return false;
+        return event._geocodeQueryHadAddress === false;
     }
 
     // "lat, lon" text → { lat, lon } numbers, or null. Local to the

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { LocationNormalizer, OpenStreetMapNormalizer, BasicDataNormalizer, BarDataNormalizer } = require('./normalizers');
+const { NormalizerPipeline, LocationNormalizer, OpenStreetMapNormalizer, BasicDataNormalizer, BarDataNormalizer } = require('./normalizers');
 const { SharedCore } = require('./shared-core');
 const { EventSchema } = require('./event-schema');
 
@@ -2941,4 +2941,179 @@ test('sanitizeDescriptionFormatting handles block tags, entities, links, heading
 
   // Escaped-asterisk runs collapse over the fixed point: \*\*TBC\*\** → TBC
   assert.equal(sanitizeDescriptionFormatting('\\*\\*TBC\\*\\**'), 'TBC');
+});
+
+// ---------------------------------------------------------------------------
+// PIN LADDER: curated coordinates > address geocode > the page's maps-link
+// pin (the ll= param a ticketing page publishes, harvested by the AI web
+// parser behind its venue-identity guard and stashed on _mapsLinkCoordinate).
+//
+// Measured against verified truth on 5 real Dice venues:
+//   venue              maps-link err   address-geocode err
+//   Concorde 2               7 m       NO RESULT
+//   Royal Vauxhall Tavern    6 m             0 m
+//   Westminster Pier       936 m             1 m   <- ll= is a DIFFERENT pier
+//   Horizon                181 m       NO RESULT
+//   Eden                     0 m       NO RESULT
+// The geocode is near-perfect when it resolves but failed outright on 3 of 5;
+// the maps-link pin always resolves and was right in exactly those 3. So the
+// geocode outranks it, and it fills only what the geocode left blank.
+// ---------------------------------------------------------------------------
+
+const PIN_LADDER_CITIES = {
+  london: { timezone: 'Europe/London', patterns: ['london'] },
+  brighton: { timezone: 'Europe/London', patterns: ['brighton'] }
+};
+
+// Curated London bars — Westminster Pier's curated pin is the CORRECT one.
+const PIN_LADDER_BARS = {
+  london: [
+    { name: 'Westminster Pier', city: 'london', address: 'Victoria Embankment, London SW1A 2JH', coordinates: '51.5022544, -0.1231736' }
+  ]
+};
+
+// Verbatim ll= values from the cached Dice event pages.
+const DICE_PIER_PIN = '51.5099822,-0.117819';
+const DICE_CONCORDE_PIN = '50.8172448,-0.122510799999986';
+const DICE_RVT_PIN = '51.4863391,-0.1217784';
+
+// What Nominatim returns for Westminster Pier's address — 1 m from truth.
+const WESTMINSTER_PIER_GEOCODE = {
+  lat: '51.5022544',
+  lon: '-0.1231736',
+  class: 'amenity',
+  type: 'ferry_terminal',
+  addresstype: 'amenity',
+  name: 'Westminster Pier',
+  display_name: 'Westminster Pier, Victoria Embankment, London, SW1A 2JH, United Kingdom',
+  address: { road: 'Victoria Embankment', city: 'London', postcode: 'SW1A 2JH' }
+};
+
+function createPinLadderNormalizer() {
+  const core = new SharedCore(PIN_LADDER_CITIES, { eventSchema: EventSchema, bars: PIN_LADDER_BARS });
+  const normalizer = new OpenStreetMapNormalizer(core);
+  normalizer.delayForRateLimit = async () => {};
+  return normalizer;
+}
+
+test('pin ladder: a successful address geocode outranks the page maps-link pin, and the disagreement is logged', async () => {
+  const normalizer = createPinLadderNormalizer();
+  const httpAdapter = createStubHttpAdapter([WESTMINSTER_PIER_GEOCODE]);
+  const event = {
+    title: 'BOATMINCE',
+    bar: 'Westminster Pier',
+    city: 'london',
+    address: 'Victoria Embankment, London SW1A 2JH',
+    _mapsLinkCoordinate: { location: DICE_PIER_PIN, venueName: 'Westminster Pier' }
+  };
+
+  const capture = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    capture.restore();
+  }
+
+  // The geocode won; the maps-link pin (a different pier) never landed.
+  assert.equal(event.location, '51.5022544, -0.1231736');
+  assert.ok(String(event.pinSource).startsWith('geocoded-'), `geocode provenance expected, got ${event.pinSource}`);
+
+  // …and the ~940 m disagreement is reported so a human can check it.
+  const conflict = capture.lines.find(line => line.includes('MAPS LINK CONFLICT'));
+  assert.ok(conflict, `conflict line expected, got: ${JSON.stringify(capture.lines)}`);
+  assert.ok(conflict.includes('936 m'), conflict);
+  assert.ok(conflict.includes(DICE_PIER_PIN) && conflict.includes('51.5022544, -0.1231736'), conflict);
+  assert.ok(conflict.includes('accepted pin kept'), conflict);
+});
+
+test('pin ladder: the maps-link pin fills in when the address geocode finds nothing', async () => {
+  const normalizer = createPinLadderNormalizer();
+  const httpAdapter = createStubHttpAdapter([]); // Nominatim: no results, every rung
+  const event = {
+    title: 'BEEFMINCE x BRIGHTON',
+    bar: 'Concorde 2',
+    city: 'brighton',
+    address: 'Madeira Drive, Brighton BN2 1EN',
+    _mapsLinkCoordinate: { location: DICE_CONCORDE_PIN, venueName: 'Concorde 2' }
+  };
+
+  const capture = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(event, httpAdapter);
+  } finally {
+    capture.restore();
+  }
+
+  assert.equal(event.location, DICE_CONCORDE_PIN);
+  assert.equal(event.pinSource, 'maps-link');
+  assert.ok(capture.lines.some(line => line.includes('No curated or geocoded pin for "BEEFMINCE x BRIGHTON"')
+    && line.includes(DICE_CONCORDE_PIN)),
+    `fill line expected, got: ${JSON.stringify(capture.lines)}`);
+  // Nothing to disagree with — no conflict line.
+  assert.ok(!capture.lines.some(line => line.includes('MAPS LINK CONFLICT')), JSON.stringify(capture.lines));
+});
+
+test('pin ladder: curated coordinates win outright — the maps-link pin never displaces them', async () => {
+  const pipeline = new NormalizerPipeline();
+  pipeline.setCore(new SharedCore(PIN_LADDER_CITIES, { eventSchema: EventSchema, bars: PIN_LADDER_BARS }));
+  const osm = pipeline.normalizers[pipeline.normalizers.length - 1];
+  osm.delayForRateLimit = async () => {};
+  // A geocode result that would ALSO have been accepted, to prove the curated
+  // pin short-circuits the ladder rather than merely winning a tie.
+  const httpAdapter = createStubHttpAdapter([WESTMINSTER_PIER_GEOCODE]);
+
+  const capture = captureConsole(() => {});
+  let normalized;
+  try {
+    normalized = await pipeline.normalizeEventAsync({
+      title: 'BOATMINCE',
+      bar: 'Westminster Pier',
+      city: 'london',
+      startDate: new Date('2026-08-30T18:00:00.000Z'),
+      _mapsLinkCoordinate: { location: DICE_PIER_PIN, venueName: 'Westminster Pier' }
+    }, httpAdapter);
+  } finally {
+    capture.restore();
+  }
+
+  assert.equal(normalized.location, '51.5022544, -0.1231736', 'the curated pin is kept');
+  assert.equal(normalized.pinSource, 'curated');
+  assert.equal(httpAdapter.requests.length, 0, 'a curated pin means no geocode request at all');
+  const conflict = capture.lines.find(line => line.includes('MAPS LINK CONFLICT'));
+  assert.ok(conflict && conflict.includes('(curated)'), `curated-vs-maps-link conflict expected, got: ${JSON.stringify(capture.lines)}`);
+});
+
+test('pin ladder: a maps-link pin agreeing with the accepted pin logs no conflict, and junk is ignored', async () => {
+  const normalizer = createPinLadderNormalizer();
+
+  // RVT: the maps-link pin and the geocode are the same building (0 m).
+  const agreeing = {
+    title: 'BEEFMINCE x RVT',
+    location: DICE_RVT_PIN,
+    pinSource: 'geocoded-exact',
+    address: '372 Kennington Ln, London SE11 5HY',
+    _mapsLinkCoordinate: { location: '51.4863391,-0.1217784', venueName: 'The Royal Vauxhall Tavern' }
+  };
+  const agreeingCapture = captureConsole(() => {});
+  try {
+    await normalizer.normalizeAsync(agreeing, createStubHttpAdapter([]));
+  } finally {
+    agreeingCapture.restore();
+  }
+  assert.equal(agreeing.location, DICE_RVT_PIN);
+  assert.equal(agreeing.pinSource, 'geocoded-exact');
+  assert.ok(!agreeingCapture.lines.some(line => line.includes('MAPS LINK CONFLICT')), JSON.stringify(agreeingCapture.lines));
+
+  // An unusable stash is ignored (the parser never writes these, but the
+  // rung fails closed rather than trusting its input).
+  for (const stash of [null, {}, { location: '' }, { location: 'not,coords' }, { location: '0,0' }, { location: '91,0' }]) {
+    const event = { title: 'X', bar: 'Somewhere', city: 'london', _mapsLinkCoordinate: stash };
+    assert.equal(normalizer.applyMapsLinkCoordinateFallback(event), false, JSON.stringify(stash));
+    assert.equal(event.location, undefined, JSON.stringify(stash));
+  }
+
+  // No stash at all changes nothing.
+  const untouched = { title: 'X', bar: 'Somewhere', city: 'london' };
+  assert.equal(normalizer.applyMapsLinkCoordinateFallback(untouched), false);
+  assert.equal(untouched.location, undefined);
 });

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -3141,13 +3141,16 @@ test('pin ladder: a maps-link pin agreeing with the accepted pin logs no conflic
   assert.equal(untouched.location, undefined);
 });
 
-test('pin ladder: a NAME-ONLY geocoded pin loses to the identity-guarded maps-link pin', async () => {
+test('pin ladder: a NAME-ONLY geocoded pin is FLAGGED against the maps-link pin, never replaced', async () => {
   const normalizer = createPinLadderNormalizer();
 
   // Run evidence: with the address missing, the venue+city rescue query
   // "Horizon, brighton" resolved to a HOUSE called Horizon on Ainsworth
   // Avenue, 5 km away — and came back exact-grade with a POI name matching
-  // the bar, so no response-side signal could catch it.
+  // the bar, so no response-side signal could catch it. The maps-link pin is
+  // the better one HERE — but the same rung resolves Westminster Pier
+  // perfectly while ITS maps link is 936 m wrong, and nothing at runtime
+  // separates the two. So this logs loudly and changes nothing.
   const event = {
     title: 'BEEFMINCE Brighton Pride',
     bar: 'Horizon',
@@ -3163,26 +3166,29 @@ test('pin ladder: a NAME-ONLY geocoded pin loses to the identity-guarded maps-li
 
   const capture = captureConsole(() => {});
   try {
-    assert.equal(normalizer.applyMapsLinkCoordinateFallback(event), true);
+    assert.equal(normalizer.applyMapsLinkCoordinateFallback(event), false);
   } finally {
     capture.restore();
   }
 
-  assert.equal(event.location, '50.819936,-0.140382');
-  assert.equal(event.pinSource, 'maps-link');
+  // The geocoded pin is KEPT — nothing about the event's location changes.
+  assert.equal(event.location, '50.8130039, -0.0690619');
+  assert.equal(event.pinSource, 'geocoded-exact');
   // The address adopted from that same hit is FLAGGED, never deleted — the
   // evidence on whether such an address is wrong points both ways.
   assert.equal(event.address, '56 Ainsworth Avenue, Brighton, England');
   assert.equal(event.addressSource, 'geo-poi');
-  assert.ok(capture.lines.some(line => line.includes('MAPS LINK CONFLICT')
-    && line.includes('name-only query "Horizon, brighton"') && line.includes('using the maps link')),
+  assert.ok(capture.lines.some(line => line.includes('MAPS LINK DECLINED')
+    && line.includes('name-only query "Horizon, brighton"')
+    && line.includes('5069 m')
+    && line.includes('maps-link pin NOT applied')),
     JSON.stringify(capture.lines));
-  assert.ok(capture.lines.some(line => line.includes('kept address "56 Ainsworth Avenue, Brighton, England"')
-    && line.includes('verify it')),
+  assert.ok(capture.lines.some(line => line.includes('MAPS LINK DECLINED')
+    && line.includes('address "56 Ainsworth Avenue, Brighton, England" was adopted from that same questioned map hit')),
     JSON.stringify(capture.lines));
 });
 
-test('pin ladder: an ADDRESS-derived geocoded pin keeps winning, however vague its street line', async () => {
+test('pin ladder: an address-derived geocoded pin takes the ordinary conflict line and is kept', async () => {
   const normalizer = createPinLadderNormalizer();
 
   // Westminster Pier, the case the name-led rung fixed: the query carried the
@@ -3214,8 +3220,8 @@ test('pin ladder: an ADDRESS-derived geocoded pin keeps winning, however vague i
   assert.equal(event.address, 'Victoria Embankment, London, UK');
   assert.ok(capture.lines.some(line => line.includes('accepted pin kept')), JSON.stringify(capture.lines));
 
-  // Fail closed on every other shape: curated pins, page pins, and geocoded
-  // pins with no query flag at all are never second-guessed.
+  // Every other shape keeps its pin too, whatever the flag says: curated
+  // pins, page pins, and geocoded pins with no query flag at all.
   for (const overrides of [
     { pinSource: 'curated' },
     { pinSource: 'page' },

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -329,11 +329,13 @@ test('buildGeocodeQueryVariants orders, dedupes and caps the ladder', () => {
 
   const full = normalizer.buildGeocodeQueryVariants('2069 CHESHIRE BRIDGE RD NE', 'atlanta', 'The Heretic');
   assert.deepEqual(full, [
+    // Name-led rung first: the venue name disambiguates a vague street line.
+    'The Heretic, 2069 CHESHIRE BRIDGE RD NE, atlanta',
     '2069 CHESHIRE BRIDGE RD NE, atlanta',
     '2069 CHESHIRE BRIDGE RD, atlanta',
     'The Heretic, atlanta'
   ]);
-  assert.ok(full.length <= 3, 'hard cap: at most 3 queries per event');
+  assert.ok(full.length <= 6, 'hard cap: at most MAX_GEOCODE_QUERIES_PER_EVENT queries per event');
 
   // No strippable directional and no bar → the ladder collapses to one query
   assert.deepEqual(
@@ -349,8 +351,19 @@ test('buildGeocodeQueryVariants orders, dedupes and caps the ladder', () => {
   assert.deepEqual(
     normalizer.buildGeocodeQueryVariants('2069 Cheshire Bridge Road Northeast, Atlanta, GA, 30324', 'atlanta', 'The Heretic'),
     [
+      'The Heretic, 2069 Cheshire Bridge Road Northeast, Atlanta, GA, 30324',
       '2069 Cheshire Bridge Road Northeast, Atlanta, GA, 30324',
       '2069 Cheshire Bridge Road, Atlanta, GA, 30324',
+      'The Heretic, atlanta'
+    ]
+  );
+
+  // An address that ALREADY starts with the venue name is not doubled — a
+  // repeated name is a query nothing matches.
+  assert.deepEqual(
+    normalizer.buildGeocodeQueryVariants('The Heretic, 2069 Cheshire Bridge Road, Atlanta', 'atlanta', 'The Heretic'),
+    [
+      'The Heretic, 2069 Cheshire Bridge Road, Atlanta',
       'The Heretic, atlanta'
     ]
   );
@@ -360,53 +373,57 @@ test('retry ladder: 0 results retries with the directional stripped, rate-limite
   const normalizer = createOsmNormalizerWithAtlanta();
   let delays = 0;
   normalizer.delayForRateLimit = async () => { delays += 1; };
-  const httpAdapter = createSequencedStubAdapter([[], [HERETIC_RESULT]]);
-  const event = { title: 'ATL BEAR NIGHT', address: '2069 CHESHIRE BRIDGE RD NE', city: 'atlanta', bar: 'The Heretic' };
-
-  await normalizer.normalizeAsync(event, httpAdapter);
-
-  assert.equal(event.location, '33.8226, -84.3510');
-  assert.equal(httpAdapter.requests.length, 2, 'exactly one retry after the empty first response');
-  assert.equal(decodeQueryParam(httpAdapter.requests[0]), '2069 CHESHIRE BRIDGE RD NE, atlanta');
-  assert.equal(
-    decodeQueryParam(httpAdapter.requests[1]),
-    '2069 CHESHIRE BRIDGE RD, atlanta',
-    'the second query must have the trailing directional stripped'
-  );
-  assert.equal(delays, 2, 'every live request must pass through the rate limiter');
-});
-
-test('retry ladder: falls back to bar+city and stops at the hard cap of 3 requests', async () => {
-  const normalizer = createOsmNormalizerWithAtlanta();
-  normalizer.delayForRateLimit = async () => {};
   const httpAdapter = createSequencedStubAdapter([[], [], [HERETIC_RESULT]]);
   const event = { title: 'ATL BEAR NIGHT', address: '2069 CHESHIRE BRIDGE RD NE', city: 'atlanta', bar: 'The Heretic' };
 
   await normalizer.normalizeAsync(event, httpAdapter);
 
-  assert.equal(httpAdapter.requests.length, 3);
-  assert.equal(decodeQueryParam(httpAdapter.requests[2]), 'The Heretic, atlanta');
+  assert.equal(event.location, '33.8226, -84.3510');
+  assert.equal(httpAdapter.requests.length, 3, 'name-led rung, address rung, then the directional retry');
+  assert.equal(decodeQueryParam(httpAdapter.requests[0]), 'The Heretic, 2069 CHESHIRE BRIDGE RD NE, atlanta');
+  assert.equal(decodeQueryParam(httpAdapter.requests[1]), '2069 CHESHIRE BRIDGE RD NE, atlanta');
+  assert.equal(
+    decodeQueryParam(httpAdapter.requests[2]),
+    '2069 CHESHIRE BRIDGE RD, atlanta',
+    'the last query must have the trailing directional stripped'
+  );
+  assert.equal(delays, 3, 'every live request must pass through the rate limiter');
+});
+
+test('retry ladder: falls back to bar+city after every address rung', async () => {
+  const normalizer = createOsmNormalizerWithAtlanta();
+  normalizer.delayForRateLimit = async () => {};
+  const httpAdapter = createSequencedStubAdapter([[], [], [], [HERETIC_RESULT]]);
+  const event = { title: 'ATL BEAR NIGHT', address: '2069 CHESHIRE BRIDGE RD NE', city: 'atlanta', bar: 'The Heretic' };
+
+  await normalizer.normalizeAsync(event, httpAdapter);
+
+  assert.equal(httpAdapter.requests.length, 4);
+  assert.equal(decodeQueryParam(httpAdapter.requests[3]), 'The Heretic, atlanta');
   assert.equal(event.location, '33.8226, -84.3510', 'the venue-name lookup must rescue the event');
+  // The bar+city rung carries no address — the maps-link rung is allowed to
+  // outrank the pin it produces.
+  assert.equal(event._geocodeQueryHadAddress, false);
 });
 
 test('retry ladder: distance validation still applies to fallback variants', async () => {
   const normalizer = createOsmNormalizerWithAtlanta();
   normalizer.delayForRateLimit = async () => {};
   // Variant 2 returns a candidate ~1000 km from Atlanta — must be rejected, ladder continues
-  const httpAdapter = createSequencedStubAdapter([[], [PORTLAND_MICHIGAN_RESULT], []]);
+  const httpAdapter = createSequencedStubAdapter([[], [], [PORTLAND_MICHIGAN_RESULT], []]);
   const event = { title: 'ATL BEAR NIGHT', address: '2069 CHESHIRE BRIDGE RD NE', city: 'atlanta', bar: 'The Heretic' };
 
   await normalizer.normalizeAsync(event, httpAdapter);
 
   assert.equal(event.location, undefined, 'a far-away candidate from a simplified query must not win');
-  assert.equal(httpAdapter.requests.length, 5, 'rejection counts as failure and the ladder continues through the Photon rescue + venue follow-up');
+  assert.equal(httpAdapter.requests.length, 6, 'rejection counts as failure and the ladder continues through the Photon rescue + venue follow-up');
   assert.ok(
-    httpAdapter.requests[3].includes('photon.komoot.io/api/?q='),
-    `the fourth rung must be the Photon rescue: ${httpAdapter.requests[3]}`
+    httpAdapter.requests[4].includes('photon.komoot.io/api/?q='),
+    `the Photon rescue follows every Nominatim rung: ${httpAdapter.requests[4]}`
   );
   assert.ok(
-    httpAdapter.requests[4].includes('photon.komoot.io/api/?q=') && decodeQueryParam(httpAdapter.requests[4]) === 'The Heretic, atlanta',
-    `the final request is the Photon venue follow-up (empty Nominatim venue rescue): ${httpAdapter.requests[4]}`
+    httpAdapter.requests[5].includes('photon.komoot.io/api/?q=') && decodeQueryParam(httpAdapter.requests[5]) === 'The Heretic, atlanta',
+    `the final request is the Photon venue follow-up (empty Nominatim venue rescue): ${httpAdapter.requests[5]}`
   );
 });
 
@@ -500,17 +517,19 @@ test('buildGeocodeQueryVariants tries the postal/country-stripped core after the
   assert.deepEqual(
     normalizer.buildGeocodeQueryVariants('325 Franklin Ave, Brooklyn, NY 11238, USA', 'nyc', "C'mon Everybody"),
     [
+      "C'mon Everybody, 325 Franklin Ave, Brooklyn, NY 11238, USA, new york",
       '325 Franklin Ave, Brooklyn, NY 11238, USA, new york',
       '325 Franklin Ave, Brooklyn, new york',
       "C'mon Everybody, new york"
     ]
   );
-  // With a strippable directional too, the full 4-rung ladder fits the cap and
+  // With a strippable directional too, the full 5-rung ladder fits the cap and
   // the venue-name rescue is never evicted
   const atlanta = createOsmNormalizerWithAtlanta();
   assert.deepEqual(
     atlanta.buildGeocodeQueryVariants('2069 Cheshire Bridge Rd NE, Atlanta, GA 30324, USA', 'atlanta', 'The Heretic'),
     [
+      'The Heretic, 2069 Cheshire Bridge Rd NE, Atlanta, GA 30324, USA',
       '2069 Cheshire Bridge Rd NE, Atlanta, GA 30324, USA',
       '2069 Cheshire Bridge Rd NE, Atlanta',
       '2069 Cheshire Bridge Rd, Atlanta, GA 30324, USA',
@@ -522,8 +541,9 @@ test('buildGeocodeQueryVariants tries the postal/country-stripped core after the
 test('a simplified-query admin-area match is rejected instead of poisoning coordinates', async () => {
   const normalizer = createOsmNormalizerWithNyc();
   normalizer.delayForRateLimit = async () => {};
-  // Full address → 0 results; stripped variant → the borough itself; venue → 0
-  const httpAdapter = createSequencedStubAdapter([[], [BROOKLYN_BOROUGH_RESULT], []]);
+  // Name-led + full address → 0 results; stripped variant → the borough
+  // itself; venue → 0
+  const httpAdapter = createSequencedStubAdapter([[], [], [BROOKLYN_BOROUGH_RESULT], []]);
   const event = { title: 'BEAR NIGHT', address: '325 Franklin Ave, Brooklyn, NY 11238, USA', city: 'nyc', bar: "C'mon Everybody" };
   const warns = [];
   const realWarn = console.warn;
@@ -539,19 +559,19 @@ test('a simplified-query admin-area match is rejected instead of poisoning coord
     warns.some(w => w.includes('Rejected admin-area result') && w.includes('type=borough')),
     `the rejection must be logged: ${warns.join(' | ')}`
   );
-  assert.equal(httpAdapter.requests.length, 6, 'the ladder continues past the rejected result through the Census and Photon rescues + venue follow-up');
-  assert.ok(httpAdapter.requests[3].includes('geocoding.geo.census.gov'), 'the US-looking address gets a Census rescue before Photon');
-  assert.ok(httpAdapter.requests[4].includes('photon.komoot.io'), 'the next request is the Photon rescue');
+  assert.equal(httpAdapter.requests.length, 7, 'the ladder continues past the rejected result through the Census and Photon rescues + venue follow-up');
+  assert.ok(httpAdapter.requests[4].includes('geocoding.geo.census.gov'), 'the US-looking address gets a Census rescue before Photon');
+  assert.ok(httpAdapter.requests[5].includes('photon.komoot.io'), 'the next request is the Photon rescue');
   assert.ok(
-    httpAdapter.requests[5].includes('photon.komoot.io') && decodeQueryParam(httpAdapter.requests[5]) === "C'mon Everybody, new york",
-    `the final request is the Photon venue follow-up (empty Nominatim venue rescue): ${httpAdapter.requests[5]}`
+    httpAdapter.requests[6].includes('photon.komoot.io') && decodeQueryParam(httpAdapter.requests[6]) === "C'mon Everybody, new york",
+    `the final request is the Photon venue follow-up (empty Nominatim venue rescue): ${httpAdapter.requests[6]}`
   );
 });
 
 test('a venue-name simplified query still resolves through an amenity result', async () => {
   const normalizer = createOsmNormalizerWithNyc();
   normalizer.delayForRateLimit = async () => {};
-  const httpAdapter = createSequencedStubAdapter([[], [], [CMON_EVERYBODY_RESULT]]);
+  const httpAdapter = createSequencedStubAdapter([[], [], [], [CMON_EVERYBODY_RESULT]]);
   const event = { title: 'BEAR NIGHT', address: '325 Franklin Ave, Brooklyn, NY 11238, USA', city: 'nyc', bar: "C'mon Everybody" };
   const logs = [];
   const realLog = console.log;
@@ -904,7 +924,7 @@ test('geocode verification: cross-check mismatch rejects the pin in enforce mode
     `the rejected first pin must be flagged: ${lines.join(' | ')}`
   );
   assert.ok(
-    lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "CHUNK" accepted exact pin from nominatim (rung 2)')),
+    lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "CHUNK" accepted exact pin from nominatim (rung 3)')),
     `the verified accept must be logged: ${lines.join(' | ')}`
   );
 });
@@ -2339,7 +2359,9 @@ test('Mad.Bear ladder regression: generic refusals stay refused and the vague ad
       properties: { name: 'La Nogalera', osm_key: 'place', osm_value: 'hamlet' }
     }]
   };
-  const httpAdapter = createSequencedStubAdapter([[nogaleraLocality], [], photonHamlet]);
+  // Rung 1 is now the name-led query ("Aqua Emporio, LA NOGALERA,
+  // torremolinos") — the fused venue does not exist, so it returns nothing.
+  const httpAdapter = createSequencedStubAdapter([[], [nogaleraLocality], [], photonHamlet]);
   const event = { title: 'FURBALL MAD.BEAR', address: 'LA NOGALERA', city: 'torremolinos', bar: 'Aqua Emporio' };
 
   const captured = captureConsole(() => {});
@@ -2349,12 +2371,13 @@ test('Mad.Bear ladder regression: generic refusals stay refused and the vague ad
     captured.restore();
   }
 
-  assert.equal(httpAdapter.requests.length, 4, 'address rung, venue rescue rung, Photon rescue, Photon venue follow-up');
-  assert.equal(decodeQueryParam(httpAdapter.requests[0]), 'LA NOGALERA, torremolinos', 'city anchoring stays QUERY-only');
-  assert.equal(decodeQueryParam(httpAdapter.requests[1]), 'Aqua Emporio, torremolinos');
+  assert.equal(httpAdapter.requests.length, 5, 'name-led rung, address rung, venue rescue rung, Photon rescue, Photon venue follow-up');
+  assert.equal(decodeQueryParam(httpAdapter.requests[0]), 'Aqua Emporio, LA NOGALERA, torremolinos', 'the name-led rung leads');
+  assert.equal(decodeQueryParam(httpAdapter.requests[1]), 'LA NOGALERA, torremolinos', 'city anchoring stays QUERY-only');
+  assert.equal(decodeQueryParam(httpAdapter.requests[2]), 'Aqua Emporio, torremolinos');
   assert.ok(
-    httpAdapter.requests[3].includes('photon.komoot.io') && decodeQueryParam(httpAdapter.requests[3]) === 'Aqua Emporio, torremolinos',
-    `the empty Nominatim venue rescue triggers the Photon venue follow-up: ${httpAdapter.requests[3]}`
+    httpAdapter.requests[4].includes('photon.komoot.io') && decodeQueryParam(httpAdapter.requests[4]) === 'Aqua Emporio, torremolinos',
+    `the empty Nominatim venue rescue triggers the Photon venue follow-up: ${httpAdapter.requests[4]}`
   );
   assert.equal(event.address, 'LA NOGALERA', 'the persisted address is never mutated with the resolved city');
   assert.equal(event.location, undefined, 'generic locality/hamlet pins stay refused — no unstamped pin');
@@ -2537,7 +2560,7 @@ test('fusion via the Photon venue follow-up: empty Nominatim venue rescue + Phot
       properties: { name: 'Aqua Club', osm_key: 'amenity', osm_value: 'nightclub', street: 'Calle Casablanca', city: 'Torremolinos' }
     }]
   };
-  const httpAdapter = createSequencedStubAdapter([[nogaleraLocality], [], photonHamlet, aquaClubPhoton]);
+  const httpAdapter = createSequencedStubAdapter([[], [nogaleraLocality], [], photonHamlet, aquaClubPhoton]);
   const event = { title: 'FURBALL MAD.BEAR', address: 'LA NOGALERA', city: 'torremolinos', bar: 'AQUA EMPORIO' };
 
   const captured = captureConsole(() => {});
@@ -2547,10 +2570,10 @@ test('fusion via the Photon venue follow-up: empty Nominatim venue rescue + Phot
     captured.restore();
   }
 
-  assert.equal(httpAdapter.requests.length, 4, 'address rung, venue rescue, Photon address rescue, Photon venue follow-up');
+  assert.equal(httpAdapter.requests.length, 5, 'name-led rung, address rung, venue rescue, Photon address rescue, Photon venue follow-up');
   assert.ok(
-    httpAdapter.requests[3].includes('photon.komoot.io') && decodeQueryParam(httpAdapter.requests[3]) === 'AQUA EMPORIO, torremolinos',
-    `the follow-up must be the venue+city query: ${httpAdapter.requests[3]}`
+    httpAdapter.requests[4].includes('photon.komoot.io') && decodeQueryParam(httpAdapter.requests[4]) === 'AQUA EMPORIO, torremolinos',
+    `the follow-up must be the venue+city query: ${httpAdapter.requests[4]}`
   );
   assert.equal(event.location, undefined, 'a non-bar-matching venue hit never pins');
   assert.equal(event.address, 'LA NOGALERA', 'no address is adopted from a non-matching POI');
@@ -3116,4 +3139,120 @@ test('pin ladder: a maps-link pin agreeing with the accepted pin logs no conflic
   const untouched = { title: 'X', bar: 'Somewhere', city: 'london' };
   assert.equal(normalizer.applyMapsLinkCoordinateFallback(untouched), false);
   assert.equal(untouched.location, undefined);
+});
+
+test('pin ladder: a NAME-ONLY geocoded pin loses to the identity-guarded maps-link pin', async () => {
+  const normalizer = createPinLadderNormalizer();
+
+  // Run evidence: with the address missing, the venue+city rescue query
+  // "Horizon, brighton" resolved to a HOUSE called Horizon on Ainsworth
+  // Avenue, 5 km away — and came back exact-grade with a POI name matching
+  // the bar, so no response-side signal could catch it.
+  const event = {
+    title: 'BEEFMINCE Brighton Pride',
+    bar: 'Horizon',
+    city: 'brighton',
+    location: '50.8130039, -0.0690619',
+    pinSource: 'geocoded-exact',
+    address: '56 Ainsworth Avenue, Brighton, England',
+    addressSource: 'geo-poi',
+    _geocodeQuery: 'Horizon, brighton',
+    _geocodeQueryHadAddress: false,
+    _mapsLinkCoordinate: { location: '50.819936,-0.140382', venueName: 'Horizon' }
+  };
+
+  const capture = captureConsole(() => {});
+  try {
+    assert.equal(normalizer.applyMapsLinkCoordinateFallback(event), true);
+  } finally {
+    capture.restore();
+  }
+
+  assert.equal(event.location, '50.819936,-0.140382');
+  assert.equal(event.pinSource, 'maps-link');
+  // The address adopted from that same hit is FLAGGED, never deleted — the
+  // evidence on whether such an address is wrong points both ways.
+  assert.equal(event.address, '56 Ainsworth Avenue, Brighton, England');
+  assert.equal(event.addressSource, 'geo-poi');
+  assert.ok(capture.lines.some(line => line.includes('MAPS LINK CONFLICT')
+    && line.includes('name-only query "Horizon, brighton"') && line.includes('using the maps link')),
+    JSON.stringify(capture.lines));
+  assert.ok(capture.lines.some(line => line.includes('kept address "56 Ainsworth Avenue, Brighton, England"')
+    && line.includes('verify it')),
+    JSON.stringify(capture.lines));
+});
+
+test('pin ladder: an ADDRESS-derived geocoded pin keeps winning, however vague its street line', async () => {
+  const normalizer = createPinLadderNormalizer();
+
+  // Westminster Pier, the case the name-led rung fixed: the query carried the
+  // event's address ("Victoria Embankment") — no house number and no
+  // street-type word, but an address all the same — and the pin it produced
+  // is the correct pier. The maps link (a different pier, 936 m away) must
+  // NOT displace it; it only gets a conflict line.
+  const event = {
+    title: 'BOATMINCE',
+    bar: 'Westminster Pier',
+    city: 'london',
+    location: '51.5022544, -0.1231736',
+    pinSource: 'geocoded-approx',
+    address: 'Victoria Embankment, London, UK',
+    _geocodeQuery: 'Westminster Pier, Victoria Embankment, London, UK',
+    _geocodeQueryHadAddress: true,
+    _mapsLinkCoordinate: { location: DICE_PIER_PIN, venueName: 'Westminster Pier' }
+  };
+
+  const capture = captureConsole(() => {});
+  try {
+    assert.equal(normalizer.applyMapsLinkCoordinateFallback(event), false);
+  } finally {
+    capture.restore();
+  }
+
+  assert.equal(event.location, '51.5022544, -0.1231736', 'the address-derived pin is kept');
+  assert.equal(event.pinSource, 'geocoded-approx');
+  assert.equal(event.address, 'Victoria Embankment, London, UK');
+  assert.ok(capture.lines.some(line => line.includes('accepted pin kept')), JSON.stringify(capture.lines));
+
+  // Fail closed on every other shape: curated pins, page pins, and geocoded
+  // pins with no query flag at all are never second-guessed.
+  for (const overrides of [
+    { pinSource: 'curated' },
+    { pinSource: 'page' },
+    { pinSource: 'geocoded-exact', _geocodeQueryHadAddress: undefined },
+    { pinSource: undefined, _geocodeQueryHadAddress: false }
+  ]) {
+    const kept = {
+      title: 'X', bar: 'Westminster Pier', city: 'london',
+      location: '51.5022544, -0.1231736',
+      _geocodeQueryHadAddress: false,
+      ...overrides,
+      _mapsLinkCoordinate: { location: DICE_PIER_PIN, venueName: 'Westminster Pier' }
+    };
+    const keptCapture = captureConsole(() => {});
+    try {
+      assert.equal(normalizer.applyMapsLinkCoordinateFallback(kept), false, JSON.stringify(overrides));
+    } finally {
+      keptCapture.restore();
+    }
+    assert.equal(kept.location, '51.5022544, -0.1231736', JSON.stringify(overrides));
+  }
+
+  // Under the threshold, a name-only pin is left alone too.
+  const near = {
+    title: 'BEEFMINCE x BRIGHTON', bar: 'Concorde 2', city: 'brighton',
+    location: '50.8172912, -0.1225875',
+    pinSource: 'geocoded-exact',
+    _geocodeQuery: 'Concorde 2, brighton',
+    _geocodeQueryHadAddress: false,
+    _mapsLinkCoordinate: { location: DICE_CONCORDE_PIN, venueName: 'Concorde 2' }
+  };
+  const nearCapture = captureConsole(() => {});
+  try {
+    assert.equal(normalizer.applyMapsLinkCoordinateFallback(near), false);
+  } finally {
+    nearCapture.restore();
+  }
+  assert.equal(near.location, '50.8172912, -0.1225875');
+  assert.ok(!nearCapture.lines.some(line => line.includes('MAPS LINK CONFLICT')), JSON.stringify(nearCapture.lines));
 });

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -683,6 +683,10 @@ class AiWebParser {
                 // Attribute the events to this page's site so the post-crawl
                 // venue-site address consensus can fill their blanks.
                 this.tagEventsWithVenueSitePage(keptStructuredEvents, effectiveHtmlData);
+                // Report-only: what the page's Google Maps link pins, and
+                // whether the identity guard + curated precedence would let it
+                // fill a blank location. Writes nothing to event data.
+                this.logMapsLinkCoordinateCandidates(keptStructuredEvents, effectiveHtmlData);
                 return {
                     events: keptStructuredEvents,
                     additionalLinks: additionalLinks,
@@ -814,6 +818,10 @@ class AiWebParser {
             // Attribute the events to this page's site so the post-crawl
             // venue-site address consensus can fill their blanks.
             this.tagEventsWithVenueSitePage(keptEvents, effectiveHtmlData);
+            // Report-only: what the page's Google Maps link pins, and whether
+            // the identity guard + curated precedence would let it fill a
+            // blank location. Writes nothing to event data.
+            this.logMapsLinkCoordinateCandidates(keptEvents, effectiveHtmlData);
 
             return {
                 events: keptEvents,
@@ -12763,6 +12771,192 @@ TEXT:
             }
         }
         return addresses;
+    }
+
+    // "lat,lng" text (a maps link's ll= value) → canonical "lat,lng" string,
+    // or '' when it is not a usable pin. Same shape/range rules shared-core's
+    // isCoordinatePair applies (two finite numbers, |lat| <= 90,
+    // |lng| <= 180) plus a hard 0,0 reject — Null Island is the shape a
+    // failed geocode takes, never a venue.
+    parseMapsLinkCoordinateValue(value) {
+        const text = String(value || '').trim();
+        if (!text) return '';
+        const match = text.match(/^(-?\d{1,3}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)$/);
+        if (!match) return '';
+        const lat = Number(match[1]);
+        const lng = Number(match[2]);
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) return '';
+        if (Math.abs(lat) > 90 || Math.abs(lng) > 180) return '';
+        if (lat === 0 && lng === 0) return '';
+        return `${lat},${lng}`;
+    }
+
+    // Placeholder venue names a ticketing platform geocodes to the CITY
+    // CENTRE: Dice's "Venue TBA, London, London, UK" pins
+    // 51.5073509,-0.1277583 (Trafalgar Square) on every unannounced London
+    // party. The name is not a venue, so the coordinate is not a venue pin —
+    // rejected before the identity guard ever runs.
+    isPlaceholderVenueName(name) {
+        const text = String(name || '').trim();
+        if (!text) return true;
+        if (/(?:^|[^a-z])(?:tba|tbc|tbd)(?:[^a-z]|$)/i.test(text)) return true;
+        if (/\bto\s+be\s+(?:announced|confirmed|advised)\b/i.test(text)) return true;
+        if (/^(?:venue|location|address|secret\s+(?:venue|location))$/i.test(text)) return true;
+        return false;
+    }
+
+    // Coordinate candidates from the Google Maps links a ticketing page embeds
+    // beside its venue block (Dice.fm publishes exactly one per event page:
+    // https://maps.google.com/?q=<venue name>, <address>&ll=<lat>,<lng>).
+    // Same string/regex parsing and same &amp;-entity decode as
+    // extractMapsDirectionsAddresses above (no URL global on iOS
+    // JavaScriptCore); the q= text is entity-decoded too because the venue
+    // name it leads with carries typographic entities in raw HTML
+    // ("Horizon, 214 King&#x27;s Road, ...").
+    //
+    // Only ll= is read. The /@lat,lng and !3d/!4d forms are deliberately NOT
+    // parsed: they arrive without a q= name, so the identity guard below has
+    // nothing to check them against, and an unguarded pin is exactly what the
+    // Westminster Pier case (Dice's ll= lands ~940 m away, on a DIFFERENT
+    // pier) says we must never trust.
+    //
+    // Returns [{ location, venueName, url }] — deduped by location+name.
+    // Judging is the caller's job: this reports what the page published.
+    extractMapsLinkCoordinateCandidates(html) {
+        const source = String(html || '');
+        const candidates = [];
+        const seenKeys = new Set();
+        const urlMatches = source.match(/https?:\/\/[^\s"'<>]+/gi) || [];
+        for (const rawUrl of urlMatches) {
+            const url = rawUrl.replace(/&amp;/gi, '&').replace(/&#0*38;/g, '&');
+            if (!/^https?:\/\/(?:[a-z0-9-]+\.)*google\.[a-z.]{2,10}\/maps(?:[/?]|$)/i.test(url)
+                && !/^https?:\/\/maps\.google\.[a-z.]{2,10}\//i.test(url)) continue;
+            const queryIndex = url.indexOf('?');
+            if (queryIndex < 0) continue;
+            // Entities are decoded BEFORE the fragment is stripped: a numeric
+            // character reference inside the query ("...214 King&#x27;s
+            // Road...", Dice's Horizon page) carries a '#' that a naive
+            // fragment strip mistakes for the URL fragment, truncating the
+            // link — and the ll= that follows is lost with it.
+            // decodeBasicEntities leaves '&' encoded, so the pair split below
+            // is unaffected.
+            const search = this.decodeBasicEntities(url.slice(queryIndex)).replace(/#[\s\S]*$/, '');
+            const location = this.parseMapsLinkCoordinateValue(this.extractSearchParamValue(search, 'll'));
+            if (!location) continue;
+            // The q= text is "<venue name>, <street>, <city>, <country>" —
+            // the identity the pin claims is the leading comma segment.
+            const query = this.extractSearchParamValue(search, 'q')
+                .replace(/\s+/g, ' ')
+                .trim();
+            const venueName = query.split(',')[0].trim();
+            const key = `${location}|${venueName.toLowerCase()}`;
+            if (seenKeys.has(key)) continue;
+            seenKeys.add(key);
+            candidates.push({ location, venueName, url });
+        }
+        return candidates;
+    }
+
+    // Curated bar for an event's bar name, using the curated machinery's own
+    // strictness (findCuratedBarByName — full-name equality, "The " tolerant,
+    // never substring). The event's city scopes the lookup; with no city the
+    // cross-city lookup resolves only a UNIQUE hit (ambiguous names and
+    // generic franchise stems resolve nothing). Null on any miss.
+    findCuratedBarForEvent(event) {
+        if (!this.core || !event || typeof event !== 'object') return null;
+        const barName = typeof event.bar === 'string' ? event.bar.trim() : '';
+        if (!barName) return null;
+        const cityKey = typeof event.city === 'string' ? event.city.trim().toLowerCase() : '';
+        try {
+            if (cityKey && cityKey !== 'unknown' && typeof this.core.getCuratedCityBars === 'function'
+                && typeof this.core.findCuratedBarByName === 'function') {
+                const cityBars = this.core.getCuratedCityBars(cityKey);
+                const curatedBar = cityBars ? this.core.findCuratedBarByName(cityBars, barName) : null;
+                if (curatedBar) return curatedBar;
+            }
+            if (typeof this.core.findCuratedBarCityByName === 'function') {
+                const match = this.core.findCuratedBarCityByName(barName);
+                if (match && match.bar) return match.bar;
+            }
+        } catch (_) {
+            return null; // curated corpus is best-effort — fail closed to "no curated bar"
+        }
+        return null;
+    }
+
+    // REPORT-ONLY maps-link coordinate pass (run per page, right where the
+    // events are attributed to their page). Reports, for each event, the pin
+    // the page's maps link published and whether it would be usable:
+    //
+    //   1) placeholder names ("Venue TBA") are rejected outright — the pin is
+    //      a city centre, not a venue;
+    //   2) IDENTITY GUARD: the pin is only the EVENT's pin when the name the
+    //      link leads with IS the event's bar (normalizeBarNameKey equality —
+    //      the same full-name strictness curated matching uses). A page's
+    //      unrelated map widget can therefore never pin an event;
+    //   3) PRECEDENCE: curated bar coordinates always win. The candidate is
+    //      reported as fill-blank-eligible ONLY when the event has no location
+    //      AND no curated bar supplies one. It never clobbers and is never
+    //      used to "correct" a curated pin — Dice put Westminster Pier ~940 m
+    //      from the truth, and curated data is what is right in that fight.
+    //
+    // Nothing is written to event data: an accepted candidate is stashed on
+    // the internal _mapsLinkCoordinate field (underscore — excluded from
+    // notes/merge/output field loops) so a later enforcing pass has the
+    // evidence without this pass changing any event today.
+    logMapsLinkCoordinateCandidates(events, htmlData) {
+        const eventList = Array.isArray(events) ? events : [];
+        if (eventList.length === 0) return;
+        const html = htmlData && typeof htmlData.html === 'string' ? htmlData.html : '';
+        if (!html) return;
+        const candidates = this.extractMapsLinkCoordinateCandidates(html);
+        if (candidates.length === 0) return;
+        const nameKey = value => (this.core && typeof this.core.normalizeBarNameKey === 'function'
+            ? this.core.normalizeBarNameKey(value)
+            : String(value || '').toLowerCase().replace(/^\s*the\s+/, '').replace(/[^a-z0-9]/g, ''));
+
+        for (const event of eventList) {
+            if (!event || typeof event !== 'object') continue;
+            const title = typeof event.title === 'string' && event.title.trim() ? event.title.trim() : 'unknown';
+            const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+            const barKey = nameKey(bar);
+            for (const candidate of candidates) {
+                const placeholder = this.isPlaceholderVenueName(candidate.venueName);
+                const candidateKey = placeholder ? '' : nameKey(candidate.venueName);
+                const identityMatched = Boolean(barKey) && barKey === candidateKey;
+                const curatedBar = identityMatched ? this.findCuratedBarForEvent(event) : null;
+                const curatedLocation = curatedBar && typeof curatedBar.coordinates === 'string'
+                    ? curatedBar.coordinates.trim()
+                    : '';
+                const existingLocation = typeof event.location === 'string' ? event.location.trim() : '';
+                const guard = placeholder
+                    ? `REJECTED (placeholder venue name "${candidate.venueName}")`
+                    : (identityMatched
+                        ? 'PASSED'
+                        : `REJECTED (link venue "${candidate.venueName || 'none'}" is not the event bar "${bar || 'none'}")`);
+                // Distance to the curated pin is reported (never acted on):
+                // it is the evidence for how far a ticketing platform's
+                // geocode strays before anything is allowed to enforce.
+                const curatedDistanceKm = curatedLocation && this.core
+                    && typeof this.core.coordinatePairDistanceKm === 'function'
+                    ? this.core.coordinatePairDistanceKm(candidate.location, curatedLocation)
+                    : null;
+                const curatedNote = curatedLocation
+                    ? `curated coordinate ${curatedLocation} wins${Number.isFinite(curatedDistanceKm) ? ` (candidate is ${Math.round(curatedDistanceKm * 1000)} m away)` : ''}`
+                    : (curatedBar ? 'curated bar matched but carries no coordinate' : 'no curated coordinate');
+                const existingNote = existingLocation ? `event location already ${existingLocation}` : 'event location blank';
+                const eligible = identityMatched && !existingLocation && !curatedLocation;
+                console.log(`🤖 AI Web: Maps-link coordinate ${candidate.location} for "${title}" — identity guard ${guard}; ${curatedNote}; ${existingNote}; ${eligible ? 'would fill blank' : 'no fill'} (report-only)`);
+                if (!identityMatched) continue;
+                event._mapsLinkCoordinate = {
+                    location: candidate.location,
+                    venueName: candidate.venueName,
+                    curatedLocation,
+                    fillBlankEligible: eligible
+                };
+                break;
+            }
+        }
     }
 
     // Per-run harvest state: host → { addresses: {normKey → {display,

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -12894,26 +12894,28 @@ TEXT:
         return null;
     }
 
-    // REPORT-ONLY maps-link coordinate pass (run per page, right where the
-    // events are attributed to their page). Reports, for each event, the pin
-    // the page's maps link published and whether it would be usable:
+    // Maps-link coordinate pass (run per page, right where the events are
+    // attributed to their page). Judges the pin the page's maps link published
+    // and, when it survives, stashes it for the pin ladder:
     //
     //   1) placeholder names ("Venue TBA") are rejected outright — the pin is
     //      a city centre, not a venue;
     //   2) IDENTITY GUARD: the pin is only the EVENT's pin when the name the
     //      link leads with IS the event's bar (normalizeBarNameKey equality —
     //      the same full-name strictness curated matching uses). A page's
-    //      unrelated map widget can therefore never pin an event;
-    //   3) PRECEDENCE: curated bar coordinates always win. The candidate is
-    //      reported as fill-blank-eligible ONLY when the event has no location
-    //      AND no curated bar supplies one. It never clobbers and is never
-    //      used to "correct" a curated pin — Dice put Westminster Pier ~940 m
-    //      from the truth, and curated data is what is right in that fight.
+    //      unrelated map widget can therefore never pin an event.
     //
-    // Nothing is written to event data: an accepted candidate is stashed on
-    // the internal _mapsLinkCoordinate field (underscore — excluded from
-    // notes/merge/output field loops) so a later enforcing pass has the
-    // evidence without this pass changing any event today.
+    // A surviving candidate is stashed on the internal _mapsLinkCoordinate
+    // field (underscore — excluded from notes/merge/output field loops). This
+    // pass never writes location: the ladder's precedence is decided in
+    // OpenStreetMapNormalizer.applyMapsLinkCoordinateFallback, the one place
+    // that can see all three answers — curated coordinates (1st) and a
+    // successful address geocode (2nd) both outrank this pin, which fills only
+    // a blank. Dice put Westminster Pier ~940 m from the truth; its address
+    // geocodes to 1 m, so the geocode wins there.
+    //
+    // The curated coordinate is looked up here only to make this line say
+    // whether one already exists — the fill decision is not made here.
     logMapsLinkCoordinateCandidates(events, htmlData) {
         const eventList = Array.isArray(events) ? events : [];
         if (eventList.length === 0) return;
@@ -12946,7 +12948,7 @@ TEXT:
                         : `REJECTED (link venue "${candidate.venueName || 'none'}" is not the event bar "${bar || 'none'}")`);
                 // Distance to the curated pin is reported (never acted on):
                 // it is the evidence for how far a ticketing platform's
-                // geocode strays before anything is allowed to enforce.
+                // geocode strays, and curated data wins regardless.
                 const curatedDistanceKm = curatedLocation && this.core
                     && typeof this.core.coordinatePairDistanceKm === 'function'
                     ? this.core.coordinatePairDistanceKm(candidate.location, curatedLocation)
@@ -12955,14 +12957,17 @@ TEXT:
                     ? `curated coordinate ${curatedLocation} wins${Number.isFinite(curatedDistanceKm) ? ` (candidate is ${Math.round(curatedDistanceKm * 1000)} m away)` : ''}`
                     : (curatedBar ? 'curated bar matched but carries no coordinate' : 'no curated coordinate');
                 const existingNote = existingLocation ? `event location already ${existingLocation}` : 'event location blank';
-                const eligible = identityMatched && !existingLocation && !curatedLocation;
-                console.log(`🤖 AI Web: Maps-link coordinate ${candidate.location} for "${title}" — identity guard ${guard}; ${curatedNote}; ${existingNote}; ${eligible ? 'would fill blank' : 'no fill'} (report-only)`);
+                const outcome = identityMatched
+                    ? (existingLocation || curatedLocation
+                        ? 'held as evidence only'
+                        : 'held for the pin ladder — used only if the address geocode also finds nothing')
+                    : 'discarded';
+                console.log(`🤖 AI Web: Maps-link coordinate ${candidate.location} for "${title}" — identity guard ${guard}; ${curatedNote}; ${existingNote}; ${outcome}`);
                 if (!identityMatched) continue;
                 event._mapsLinkCoordinate = {
                     location: candidate.location,
                     venueName: candidate.venueName,
-                    curatedLocation,
-                    fillBlankEligible: eligible
+                    curatedLocation
                 };
                 break;
             }

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -12762,7 +12762,17 @@ TEXT:
             if (!paramKeys) continue;
             const queryIndex = url.indexOf('?');
             if (queryIndex < 0) continue;
-            const search = url.slice(queryIndex).replace(/#[\s\S]*$/, '');
+            // Entities are decoded BEFORE the fragment is stripped, for the
+            // same reason extractMapsLinkCoordinateCandidates below does it:
+            // a numeric character reference inside the query carries a '#'
+            // that a naive fragment strip mistakes for the URL fragment.
+            // Dice's Horizon link ("...214 King&#x27;s Road, Brighton, BN1
+            // 1NB") truncated to the harvested address "214 King" — a
+            // fragment that is still address-shaped, so the gate passed it
+            // and the venue-site consensus (#1545) could adopt it as a
+            // venue's address. decodeBasicEntities leaves '&' encoded, so
+            // the pair split is unaffected.
+            const search = this.decodeBasicEntities(url.slice(queryIndex)).replace(/#[\s\S]*$/, '');
             for (const key of paramKeys) {
                 const value = this.extractSearchParamValue(search, key).replace(/\s+/g, ' ').trim();
                 if (!value || !this.isAddressShapedBarValue(value)) continue;

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -8327,37 +8327,35 @@ test('maps-link coordinates: identity guard accepts the event bar, rejects place
   assert.equal(parser.isPlaceholderVenueName('Tabard Theatre'), false);
 });
 
-test('maps-link coordinates: curated data always wins and nothing is written to event data (report-only)', () => {
+test('maps-link coordinates: the parser only stashes the candidate — it never writes location', () => {
   const parser = createMapsLinkParser();
 
   // Westminster Pier — Dice's pin is ~940 m off, onto a different pier. The
-  // curated coordinate wins and the event is left untouched.
+  // curated coordinate is reported as the winner and the event is untouched.
   const pier = { title: 'BOATMINCE', bar: 'Westminster Pier', city: 'london' };
   const pierLogs = captureLogs(() => parser.logMapsLinkCoordinateCandidates([pier], { html: diceHtml(DICE_PIER_HREF) }));
   assert.ok(pierLogs.some(line => line.includes('curated coordinate 51.5022544, -0.1231736 wins (candidate is 936 m away)')),
     JSON.stringify(pierLogs));
-  assert.ok(pierLogs.some(line => line.includes('no fill (report-only)')), JSON.stringify(pierLogs));
+  assert.ok(pierLogs.some(line => line.includes('held as evidence only')), JSON.stringify(pierLogs));
   assert.equal(pier.location, undefined);
-  assert.equal(pier._mapsLinkCoordinate.fillBlankEligible, false);
 
   // An event that already carries a location is never clobbered.
   const located = { title: 'BEEFMINCE x RVT', bar: 'Royal Vauxhall Tavern', city: 'london', location: '51.1,-0.1' };
   const locatedLogs = captureLogs(() => parser.logMapsLinkCoordinateCandidates([located], { html: diceHtml(DICE_RVT_HREF) }));
   assert.ok(locatedLogs.some(line => line.includes('event location already 51.1,-0.1')), JSON.stringify(locatedLogs));
   assert.equal(located.location, '51.1,-0.1');
-  assert.equal(located._mapsLinkCoordinate.fillBlankEligible, false);
 
-  // The one shape a pin could fill: curated bar with NO coordinate, blank
-  // event location. Reported as eligible — still nothing written today.
+  // Curated bar with NO coordinate, blank event location: the candidate is
+  // held for the pin ladder, where the address geocode still outranks it.
   const horizon = { title: 'BEEFMINCE Brighton Pride', bar: 'Horizon', city: 'brighton' };
   const horizonLogs = captureLogs(() => parser.logMapsLinkCoordinateCandidates([horizon], { html: diceHtml(DICE_HORIZON_HREF) }));
   assert.ok(horizonLogs.some(line => line.includes('curated bar matched but carries no coordinate')
-    && line.includes('would fill blank (report-only)')), JSON.stringify(horizonLogs));
+    && line.includes('held for the pin ladder')), JSON.stringify(horizonLogs));
   assert.equal(horizon.location, undefined);
-  assert.equal(horizon._mapsLinkCoordinate.fillBlankEligible, true);
+  assert.equal(horizon._mapsLinkCoordinate.location, '50.819936,-0.140382');
 
-  // Only the internal underscore stash is ever added — no event field is
-  // touched by this pass.
+  // Only the internal underscore stash is ever added by THIS pass — the pin
+  // decision belongs to OpenStreetMapNormalizer.
   assert.deepEqual(Object.keys(horizon).filter(key => !key.startsWith('_')).sort(),
     ['bar', 'city', 'title']);
 });

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -5458,6 +5458,17 @@ test('extractMapsDirectionsAddresses harvests the literal massive.club direction
   // and non-map links contribute nothing.
   assert.deepEqual(parser.extractMapsDirectionsAddresses('<a href="https://maps.apple.com/?q=Massive+Seattle">x</a>'), []);
   assert.deepEqual(parser.extractMapsDirectionsAddresses('<a href="https://massive.club/events?destination=619+E+Pine+St">x</a>'), []);
+
+  // A numeric character reference in the query carries a '#' that must not be
+  // read as the URL fragment. Dice's real Horizon link truncated to the
+  // address "214 King" — still address-shaped, so the gate passed the
+  // fragment through to the venue-site consensus.
+  assert.deepEqual(
+    parser.extractMapsDirectionsAddresses(
+      '<a href="https://maps.google.com/?daddr=214%20King&#x27;s%20Road%2C%20Brighton%2C%20BN1%201NB">x</a>'
+    ),
+    ["214 King's Road, Brighton, BN1 1NB"]
+  );
 });
 
 test('venue-site consensus: the same footer address on 3 pages establishes consensus and fills blanks only', () => {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -8210,3 +8210,143 @@ test('strips a leading date phrase from an event title, and only then', () => {
   assert.equal(strip('Bear Week Sitges - Opening Party'), 'Bear Week Sitges - Opening Party');
   assert.equal(strip(''), '');
 });
+
+// ---------------------------------------------------------------------------
+// Maps-link coordinate candidates (Dice.fm event pages publish the venue's
+// pin in the ll= param of their "Open in maps" link — high value, but Dice
+// geocoded Westminster Pier ~940 m off, onto a DIFFERENT pier, and pins
+// "Venue TBA" at the centre of London)
+// ---------------------------------------------------------------------------
+
+// Verbatim hrefs from the cached Dice pages (raw HTML form: &amp;-encoded,
+// and the Horizon link carries a numeric entity INSIDE the query).
+const DICE_CONCORDE_HREF = 'https://maps.google.com/?q=Concorde%202%2C%20Madeira%20Shelter%20Hall%2C%20Madeira%20Dr%2C%20Brighton%20BN2%201EN&amp;ll=50.8172448,-0.122510799999986';
+const DICE_RVT_HREF = 'https://maps.google.com/?q=The%20Royal%20Vauxhall%20Tavern%2C%20372%20Kennington%20Ln%2C%20London%20SE11%205HY%2C%20UK&amp;ll=51.4863391,-0.1217784';
+const DICE_HORIZON_HREF = 'https://maps.google.com/?q=Horizon%2C%20214%20King&#x27;s%20Road%2C%20Brighton%2C%20BN1%201NB%2C%20United%20Kingdom&amp;ll=50.819936,-0.140382';
+const DICE_TBA_HREF = 'https://maps.google.com/?q=Venue%20TBA%2C%20London%2C%20London%2C%20UK&amp;ll=51.5073509,-0.1277583';
+const DICE_PIER_HREF = 'https://maps.google.com/?q=Westminster%20Pier%2C%20Victoria%20Embankment%2C%20London%2C%20UK&amp;ll=51.5099822,-0.117819';
+const diceHtml = (href) => `<div class="Venue"><a href="${href}" target="_blank" rel="noreferrer">Open in maps</a></div>`;
+
+const MAPS_LINK_CURATED_BARS = {
+  london: [
+    { name: 'Royal Vauxhall Tavern', city: 'london', coordinates: '51.4863391, -0.1217784' },
+    { name: 'Westminster Pier', city: 'london', coordinates: '51.5022544, -0.1231736' }
+  ],
+  brighton: [
+    { name: 'Concorde 2', city: 'brighton', coordinates: '50.8172912, -0.1225875' },
+    // Curated but coordinate-less — the only shape a maps-link pin could fill.
+    { name: 'Horizon', city: 'brighton', address: '211-214 Kings Road Arches, Brighton BN1 1NB' }
+  ]
+};
+
+function createMapsLinkParser() {
+  const parser = createParser();
+  parser.core = new SharedCore({}, { eventSchema: EventSchema, bars: MAPS_LINK_CURATED_BARS });
+  return parser;
+}
+
+test('extractMapsLinkCoordinateCandidates reads ll= and the leading venue name from real Dice hrefs', () => {
+  const parser = createMapsLinkParser();
+
+  assert.deepEqual(parser.extractMapsLinkCoordinateCandidates(diceHtml(DICE_CONCORDE_HREF)).map(
+    candidate => [candidate.venueName, candidate.location]),
+    [['Concorde 2', '50.8172448,-0.122510799999986']]);
+
+  assert.deepEqual(parser.extractMapsLinkCoordinateCandidates(diceHtml(DICE_RVT_HREF)).map(
+    candidate => [candidate.venueName, candidate.location]),
+    [['The Royal Vauxhall Tavern', '51.4863391,-0.1217784']]);
+
+  // The '#' of a numeric entity inside the query is NOT a URL fragment —
+  // stripping it as one truncated the link before the ll= (Horizon page).
+  assert.deepEqual(parser.extractMapsLinkCoordinateCandidates(diceHtml(DICE_HORIZON_HREF)).map(
+    candidate => [candidate.venueName, candidate.location]),
+    [['Horizon', '50.819936,-0.140382']]);
+
+  // One candidate per distinct pin+name, however many times the page links it.
+  assert.equal(parser.extractMapsLinkCoordinateCandidates(
+    diceHtml(DICE_RVT_HREF) + diceHtml(DICE_RVT_HREF)).length, 1);
+
+  // Non-map links, map links without ll=, and unusable pins yield nothing.
+  assert.deepEqual(parser.extractMapsLinkCoordinateCandidates(
+    '<a href="https://dice.fm/event?ll=51.4863391,-0.1217784">x</a>'), []);
+  assert.deepEqual(parser.extractMapsLinkCoordinateCandidates(
+    '<a href="https://maps.google.com/?q=The+Eagle">x</a>'), []);
+  assert.deepEqual(parser.extractMapsLinkCoordinateCandidates(
+    '<a href="https://maps.google.com/?q=Nowhere&amp;ll=0,0">x</a>'), []);
+  assert.deepEqual(parser.extractMapsLinkCoordinateCandidates(
+    '<a href="https://maps.google.com/?q=Nowhere&amp;ll=91.5,-0.12">x</a>'), []);
+  assert.deepEqual(parser.extractMapsLinkCoordinateCandidates(
+    '<a href="https://maps.google.com/?q=Nowhere&amp;ll=not,coords">x</a>'), []);
+});
+
+test('maps-link coordinates: identity guard accepts the event bar, rejects placeholders and unrelated venues', () => {
+  const parser = createMapsLinkParser();
+  const html = diceHtml(DICE_RVT_HREF);
+
+  // Same venue, casing/"The " tolerant (curated matching's own strictness).
+  const matched = { title: 'BEEFMINCE x RVT', bar: 'Royal Vauxhall Tavern', city: 'london' };
+  const matchedLogs = captureLogs(() => parser.logMapsLinkCoordinateCandidates([matched], { html }));
+  assert.ok(matchedLogs.some(line => line.includes('identity guard PASSED')), JSON.stringify(matchedLogs));
+  assert.equal(matched._mapsLinkCoordinate.location, '51.4863391,-0.1217784');
+
+  // A page's unrelated map widget never pins an event.
+  const unrelated = { title: 'Some other party', bar: 'Eagle London', city: 'london' };
+  const unrelatedLogs = captureLogs(() => parser.logMapsLinkCoordinateCandidates([unrelated], { html }));
+  assert.ok(unrelatedLogs.some(line => line.includes('identity guard REJECTED')), JSON.stringify(unrelatedLogs));
+  assert.equal(unrelated._mapsLinkCoordinate, undefined);
+
+  // An event with no bar has no identity to check against.
+  const barless = { title: 'Some other party', city: 'london' };
+  captureLogs(() => parser.logMapsLinkCoordinateCandidates([barless], { html }));
+  assert.equal(barless._mapsLinkCoordinate, undefined);
+
+  // "Venue TBA" is a city-centre placeholder, not a venue — rejected outright
+  // even when the event's own bar says the same words.
+  const tba = { title: 'SPOOKMINCE', bar: 'Venue TBA', city: 'london' };
+  const tbaLogs = captureLogs(() => parser.logMapsLinkCoordinateCandidates([tba], { html: diceHtml(DICE_TBA_HREF) }));
+  assert.ok(tbaLogs.some(line => line.includes('REJECTED (placeholder venue name "Venue TBA")')), JSON.stringify(tbaLogs));
+  assert.equal(tba._mapsLinkCoordinate, undefined);
+
+  assert.equal(parser.isPlaceholderVenueName('TBA'), true);
+  assert.equal(parser.isPlaceholderVenueName('Venue TBC'), true);
+  assert.equal(parser.isPlaceholderVenueName('Venue to be announced'), true);
+  assert.equal(parser.isPlaceholderVenueName('Venue'), true);
+  assert.equal(parser.isPlaceholderVenueName(''), true);
+  assert.equal(parser.isPlaceholderVenueName('The Royal Vauxhall Tavern'), false);
+  assert.equal(parser.isPlaceholderVenueName('Tabard Theatre'), false);
+});
+
+test('maps-link coordinates: curated data always wins and nothing is written to event data (report-only)', () => {
+  const parser = createMapsLinkParser();
+
+  // Westminster Pier — Dice's pin is ~940 m off, onto a different pier. The
+  // curated coordinate wins and the event is left untouched.
+  const pier = { title: 'BOATMINCE', bar: 'Westminster Pier', city: 'london' };
+  const pierLogs = captureLogs(() => parser.logMapsLinkCoordinateCandidates([pier], { html: diceHtml(DICE_PIER_HREF) }));
+  assert.ok(pierLogs.some(line => line.includes('curated coordinate 51.5022544, -0.1231736 wins (candidate is 936 m away)')),
+    JSON.stringify(pierLogs));
+  assert.ok(pierLogs.some(line => line.includes('no fill (report-only)')), JSON.stringify(pierLogs));
+  assert.equal(pier.location, undefined);
+  assert.equal(pier._mapsLinkCoordinate.fillBlankEligible, false);
+
+  // An event that already carries a location is never clobbered.
+  const located = { title: 'BEEFMINCE x RVT', bar: 'Royal Vauxhall Tavern', city: 'london', location: '51.1,-0.1' };
+  const locatedLogs = captureLogs(() => parser.logMapsLinkCoordinateCandidates([located], { html: diceHtml(DICE_RVT_HREF) }));
+  assert.ok(locatedLogs.some(line => line.includes('event location already 51.1,-0.1')), JSON.stringify(locatedLogs));
+  assert.equal(located.location, '51.1,-0.1');
+  assert.equal(located._mapsLinkCoordinate.fillBlankEligible, false);
+
+  // The one shape a pin could fill: curated bar with NO coordinate, blank
+  // event location. Reported as eligible — still nothing written today.
+  const horizon = { title: 'BEEFMINCE Brighton Pride', bar: 'Horizon', city: 'brighton' };
+  const horizonLogs = captureLogs(() => parser.logMapsLinkCoordinateCandidates([horizon], { html: diceHtml(DICE_HORIZON_HREF) }));
+  assert.ok(horizonLogs.some(line => line.includes('curated bar matched but carries no coordinate')
+    && line.includes('would fill blank (report-only)')), JSON.stringify(horizonLogs));
+  assert.equal(horizon.location, undefined);
+  assert.equal(horizon._mapsLinkCoordinate.fillBlankEligible, true);
+
+  // Only the internal underscore stash is ever added — no event field is
+  // touched by this pass.
+  assert.deepEqual(Object.keys(horizon).filter(key => !key.startsWith('_')).sort(),
+    ['bar', 'city', 'title']);
+});

--- a/scripts/run-log-summary.js
+++ b/scripts/run-log-summary.js
@@ -288,7 +288,8 @@ const GUARD_LINE_RES = {
     locationPreserved: /📍 MERGE: ".*?" location kept from (?:calendar|existing)/,
     arbitrationDeterministic: /🔒 MERGE: ".*?" field=\S+ resolved deterministically/,
     mapsLinkPin: /🗺️ \w*Normalizer: No curated or geocoded pin for ".*?" — using the page's maps link/,
-    mapsLinkConflict: /🗺️ MAPS LINK CONFLICT: ".*?" accepted pin .*? is \d+ m from the page's maps link/
+    mapsLinkConflict: /🗺️ MAPS LINK CONFLICT: ".*?" accepted pin .*? is \d+ m from the page's maps link/,
+    mapsLinkOverride: /🗺️ MAPS LINK CONFLICT: ".*?" geocoded pin .*? came from the name-only query/
 };
 
 function createGuardCounts() {

--- a/scripts/run-log-summary.js
+++ b/scripts/run-log-summary.js
@@ -286,7 +286,9 @@ const GUARD_LINE_RES = {
     coordsPreserved: /📍 MERGE: ".*?" location kept calendar coordinates/,
     barPreserved: /📍 MERGE: ".*?" bar kept from calendar/,
     locationPreserved: /📍 MERGE: ".*?" location kept from (?:calendar|existing)/,
-    arbitrationDeterministic: /🔒 MERGE: ".*?" field=\S+ resolved deterministically/
+    arbitrationDeterministic: /🔒 MERGE: ".*?" field=\S+ resolved deterministically/,
+    mapsLinkPin: /🗺️ \w*Normalizer: No curated or geocoded pin for ".*?" — using the page's maps link/,
+    mapsLinkConflict: /🗺️ MAPS LINK CONFLICT: ".*?" accepted pin .*? is \d+ m from the page's maps link/
 };
 
 function createGuardCounts() {

--- a/scripts/run-log-summary.js
+++ b/scripts/run-log-summary.js
@@ -289,7 +289,7 @@ const GUARD_LINE_RES = {
     arbitrationDeterministic: /🔒 MERGE: ".*?" field=\S+ resolved deterministically/,
     mapsLinkPin: /🗺️ \w*Normalizer: No curated or geocoded pin for ".*?" — using the page's maps link/,
     mapsLinkConflict: /🗺️ MAPS LINK CONFLICT: ".*?" accepted pin .*? is \d+ m from the page's maps link/,
-    mapsLinkOverride: /🗺️ MAPS LINK CONFLICT: ".*?" geocoded pin .*? came from the name-only query/
+    mapsLinkDeclined: /🗺️ MAPS LINK DECLINED: ".*?" geocoded pin .*? came from the name-only query/
 };
 
 function createGuardCounts() {

--- a/scripts/run-log-summary.test.js
+++ b/scripts/run-log-summary.test.js
@@ -218,7 +218,7 @@ const SIGNALS_FIXTURE = [
   // Maps-link pin rung (verbatim shapes from the dice.fm evidence run)
   '2026-07-13T09:00:18.600Z [INFO] 🗺️ OpenStreetMapNormalizer: No curated or geocoded pin for "BEEFMINCE x BRIGHTON" — using the page\'s maps link for "Concorde 2" -> 50.8172448,-0.122510799999986',
   '2026-07-13T09:00:18.700Z [WARN] 🗺️ MAPS LINK CONFLICT: "BOATMINCE" accepted pin 51.5022544, -0.1231736 (curated) is 936 m from the page\'s maps link 51.5099822,-0.117819 for "Westminster Pier" — accepted pin kept; verify which is the real venue',
-  '2026-07-13T09:00:18.800Z [WARN] 🗺️ MAPS LINK CONFLICT: "BEEFMINCE Brighton Pride" geocoded pin 50.8130039, -0.0690619 came from the name-only query "Horizon, brighton" (no address in it) and is 5069 m from the page\'s maps link 50.819936,-0.140382 for "Horizon" — using the maps link',
+  '2026-07-13T09:00:18.800Z [WARN] 🗺️ MAPS LINK DECLINED: "BEEFMINCE Brighton Pride" geocoded pin 50.8130039, -0.0690619 came from the name-only query "Horizon, brighton" (no address in it) and is 5069 m from the page\'s maps link 50.819936,-0.140382 for "Horizon" — geocoded pin kept, maps-link pin NOT applied; verify which is the real venue',
   // Merge-time guards: degenerate end, coordinate/bar/location preservation
   '2026-07-13T09:00:19.000Z [WARN] ⚠️ MERGE: "BEARRACUDA: Portland" scraped endDate <= startDate (zero duration) — treating as missing, keeping calendar end',
   '2026-07-13T09:00:20.000Z [INFO] 📍 MERGE: "BEARRACUDA: Portland" location kept calendar coordinates over scraped text/empty value',
@@ -255,7 +255,7 @@ test('buildSummary counts each guard line type', () => {
     arbitrationDeterministic: 2, // 🔒 website root-vs-deep + 🔒 emoji-twin title
     mapsLinkPin: 1,           // pin taken from the page's maps link
     mapsLinkConflict: 1,      // maps-link pin vs a kept pin, ≥ 300 m apart
-    mapsLinkOverride: 1        // the name-only geocoded pin that LOST to the maps link
+    mapsLinkDeclined: 1        // maps-link pin flagged against a name-only geocoded pin, not applied
   });
 
   // 🔒 lines are merge decisions too: they must show up in the merges list

--- a/scripts/run-log-summary.test.js
+++ b/scripts/run-log-summary.test.js
@@ -215,6 +215,9 @@ const SIGNALS_FIXTURE = [
   '2026-07-13T09:00:18.000Z [WARN] 🗺️ OpenStreetMapNormalizer: All 3 geocode candidates for "123 Main St" fall outside 15 km of atlanta center (nearest is 42.0 km away) — ignoring coordinates',
   // Geocode retry-ladder exhaustion (address unresolvable after all variants)
   '2026-07-13T09:00:18.500Z [WARN] 🗺️ OpenStreetMapNormalizer: No geocode results for "2069 CHESHIRE BRIDGE RD NE" (atlanta) after 3 queries — leaving location empty',
+  // Maps-link pin rung (verbatim shapes from the dice.fm evidence run)
+  '2026-07-13T09:00:18.600Z [INFO] 🗺️ OpenStreetMapNormalizer: No curated or geocoded pin for "BEEFMINCE x BRIGHTON" — using the page\'s maps link for "Concorde 2" -> 50.8172448,-0.122510799999986',
+  '2026-07-13T09:00:18.700Z [WARN] 🗺️ MAPS LINK CONFLICT: "BOATMINCE" accepted pin 51.5022544, -0.1231736 (curated) is 936 m from the page\'s maps link 51.5099822,-0.117819 for "Westminster Pier" — accepted pin kept; verify which is the real venue',
   // Merge-time guards: degenerate end, coordinate/bar/location preservation
   '2026-07-13T09:00:19.000Z [WARN] ⚠️ MERGE: "BEARRACUDA: Portland" scraped endDate <= startDate (zero duration) — treating as missing, keeping calendar end',
   '2026-07-13T09:00:20.000Z [INFO] 📍 MERGE: "BEARRACUDA: Portland" location kept calendar coordinates over scraped text/empty value',
@@ -248,7 +251,9 @@ test('buildSummary counts each guard line type', () => {
     coordsPreserved: 1,
     barPreserved: 1,
     locationPreserved: 2,     // "kept from calendar" + "kept from existing"
-    arbitrationDeterministic: 2 // 🔒 website root-vs-deep + 🔒 emoji-twin title
+    arbitrationDeterministic: 2, // 🔒 website root-vs-deep + 🔒 emoji-twin title
+    mapsLinkPin: 1,           // pin taken from the page's maps link
+    mapsLinkConflict: 1       // maps-link pin vs accepted pin, ≥ 300 m apart
   });
 
   // 🔒 lines are merge decisions too: they must show up in the merges list

--- a/scripts/run-log-summary.test.js
+++ b/scripts/run-log-summary.test.js
@@ -218,6 +218,7 @@ const SIGNALS_FIXTURE = [
   // Maps-link pin rung (verbatim shapes from the dice.fm evidence run)
   '2026-07-13T09:00:18.600Z [INFO] 🗺️ OpenStreetMapNormalizer: No curated or geocoded pin for "BEEFMINCE x BRIGHTON" — using the page\'s maps link for "Concorde 2" -> 50.8172448,-0.122510799999986',
   '2026-07-13T09:00:18.700Z [WARN] 🗺️ MAPS LINK CONFLICT: "BOATMINCE" accepted pin 51.5022544, -0.1231736 (curated) is 936 m from the page\'s maps link 51.5099822,-0.117819 for "Westminster Pier" — accepted pin kept; verify which is the real venue',
+  '2026-07-13T09:00:18.800Z [WARN] 🗺️ MAPS LINK CONFLICT: "BEEFMINCE Brighton Pride" geocoded pin 50.8130039, -0.0690619 came from the name-only query "Horizon, brighton" (no address in it) and is 5069 m from the page\'s maps link 50.819936,-0.140382 for "Horizon" — using the maps link',
   // Merge-time guards: degenerate end, coordinate/bar/location preservation
   '2026-07-13T09:00:19.000Z [WARN] ⚠️ MERGE: "BEARRACUDA: Portland" scraped endDate <= startDate (zero duration) — treating as missing, keeping calendar end',
   '2026-07-13T09:00:20.000Z [INFO] 📍 MERGE: "BEARRACUDA: Portland" location kept calendar coordinates over scraped text/empty value',
@@ -253,7 +254,8 @@ test('buildSummary counts each guard line type', () => {
     locationPreserved: 2,     // "kept from calendar" + "kept from existing"
     arbitrationDeterministic: 2, // 🔒 website root-vs-deep + 🔒 emoji-twin title
     mapsLinkPin: 1,           // pin taken from the page's maps link
-    mapsLinkConflict: 1       // maps-link pin vs accepted pin, ≥ 300 m apart
+    mapsLinkConflict: 1,      // maps-link pin vs a kept pin, ≥ 300 m apart
+    mapsLinkOverride: 1        // the name-only geocoded pin that LOST to the maps link
   });
 
   // 🔒 lines are merge decisions too: they must show up in the merges list


### PR DESCRIPTION
Ticketing pages embed a Google Maps link carrying the venue's coordinates in an `ll=` param. We ignored it. Harvesting it turned up a second, larger problem in how we geocode, so this PR ships both fixes.

## 1. The geocode query was dropping the venue name

Nominatim asked for `"Victoria Embankment, London, UK"` — the address dice.fm publishes for Westminster Pier — answers **1075 m away, at the wrong pier**. Asked for `"Westminster Pier, Victoria Embankment, London, UK"` it answers **0 m** (verified live; the result equals the curated pin exactly). The name was the disambiguator and the query dropped it.

"Always include the name" is not the fix either — measured live, the extra token returns **nothing** for Horizon, Eden and Concorde 2. So the ladder now tries both, in order:

1. `"<venue>, <address>"` — new, first
2. `"<address>"` — as before, plus the existing unit/postal/directional strip rungs
3. `"<venue>, <city>"` — as before, last

`MAX_GEOCODE_QUERIES_PER_EVENT` goes 5 → 6 so the added rung cannot evict the venue+city rescue. The extra request only exists for events with **both** a bar and an address, and only fires when the name-led query finds nothing.

## 2. The maps-link pin fills a blank — and only a blank

1. **Curated coordinates** (`data/bars/*.json`) — never touched, always win.
2. **Geocoded pin** from the ladder above.
3. **Maps-link `ll=` pin** — written only when 1 and 2 left `location` blank, stamped `pinSource: 'maps-link'`.

The parser harvests `ll=`, rejects placeholder venues (`Venue TBA`), applies the identity guard (`normalizeBarNameKey` equality between the name the link leads with and the event's bar), and stashes the survivor on `_mapsLinkCoordinate`. It never writes `location`.

**It never replaces an existing pin.** Filling a blank is a clear win — the alternative is no pin at all. Replacing one is a coin flip, and we flipped it: see below.

### Disagreements are logged, loudly, and counted

At ≥ 300 m apart, an additive line names both pins, the distance and the accepted pin's provenance — and fires even though the accepted pin is kept:

- `🗺️ MAPS LINK CONFLICT` — ordinary case (curated pin, or a geocode whose query carried the address).
- `🗺️ MAPS LINK DECLINED` — the weakest geocode we produce: a pin from the name-only `"<venue>, <city>"` rung. Gets its own line and its own counter so these stay distinguishable.

**Why 300 m:** it clears the worst benign disagreement observed (Horizon, 181 m — right venue, coarse platform geocode) and sits under the wrong-venue case (Westminster Pier, 936 m). Both counters (`mapsLinkConflict`, `mapsLinkDeclined`, plus `mapsLinkPin` for fills) are run-summary guards with labels in the metrics section, so they surface in the run UI.

### Why the name-only case is flagged and not overridden — deliberate, not an oversight

An earlier revision of this PR let the maps-link pin **replace** a name-only geocoded pin. That is removed. The evidence for it was 1 win, 1 loss, on a sample of two:

| case (address missing) | geocode | maps link | a swap would... |
|---|---|---|---|
| `"Horizon, brighton"` | 5069 m out (a *house* called Horizon) | right | help |
| `"Westminster Pier, london"` | **exactly right** | 936 m out (another pier) | hurt |

Same rung, same query shape, opposite answers — and nothing available at runtime separates them: both came back **exact grade**, and the 5069 m hit even carried a **POI name matching the bar**. Swapping at even odds buys no accuracy and adds variance. It also could not fire in the default configuration at all, because Dice publishes an address and those events resolve on the name-led rung — so the upside was near zero and the downside a silently wrong pin.

**This is a wait-for-evidence decision.** The flagged cases accumulate in the run summary. If the maps link turns out to be right most of the time, that is the data to enable the swap on.

An address adopted from a map hit whose pin got flagged is likewise **flagged, not deleted** — the same two cases point opposite ways (Horizon's adopted address is wrong; Westminster Pier's is right).

## Verification — real cached Dice pages, real JSON-LD extraction, live Nominatim

**Default run (curated data present):** Concorde 2 / RVT / Westminster Pier keep **curated**; Horizon → `50.8202925, -0.1428931` and Eden → `52.4696234, -1.8952392` from the geocode; Westminster Pier logs the 936 m conflict and keeps curated; `Venue TBA` unpinned.

**No curated data — the ladder alone, with the verbatim winning queries:**

| bar | winning query | final location | err vs curated truth |
|---|---|---|---|
| Westminster Pier | `Westminster Pier, Victoria Embankment, London, UK` | 51.5022544, -0.1231736 | **0 m** (was 1075 m) |
| Royal Vauxhall Tavern | `The Royal Vauxhall Tavern, 372 Kennington Ln, London SE11 5HY, UK` | 51.4863812, -0.1218439 | 7 m |
| Concorde 2 | `Concorde 2, brighton` | 50.8172912, -0.1225875 | **0 m** |
| Horizon | `214 King's Road, Brighton, BN1 1NB, United Kingdom` | 50.8202925, -0.1428931 | no curated truth |
| Eden | `138 Gooch Street, Birmingham, B5 7HF, United Kingdom` | 52.4696234, -1.8952392 | no curated truth |
| Venue TBA | — | unpinned | guard holds |

**Rung 3 (the fill) firing:** with no curated data and a geocoder that resolves nothing, all five venues take the maps-link pin with `pinSource: 'maps-link'`; `Venue TBA` still stays unpinned.

**The flag firing:** with the address missing, both name-only cases log `MAPS LINK DECLINED` and **keep their geocoded pins** — including Westminster Pier, which keeps its correct pin.

## Honest caveats

- **Five venues, one ticketing platform, UK-heavy, one geocoder, measured today.** The rung order and the 300 m threshold are calibrated on that small sample, and live geocoder results drift. Not settled; the conflict/declined logs are the instrument that will say when the ranking is wrong.
- Not exercised: a live scraper/phone run, and the AI extraction path (verification used the JSON-LD structured path, which is what Dice actually takes).

## What changed since the report-only version of this PR

Report-only became a real fill-a-blank precedence; the geocode ladder gained the name-led rung and one more request slot; disagreements are logged in two shapes with their own counters; `_geocodeQueryHadAddress` is a new pin-time flag that selects which one fires. Ten existing ladder tests were updated for the new rung order (query sequences and request counts only — no assertion was weakened).

## Constraints

No `new URL(` / `URLSearchParams` in `scripts/`; `shared-core.js` and `normalizers.js` stay platform-pure; existing `console.log` and prompt lines untouched (additions only); tests only in package.json-enumerated files. Suite: **1114 passing**, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP