### PR TITLE
fix(scraper): resolve the venue from the event's own pin, and gate the structured-data path

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -683,6 +683,12 @@ class AiWebParser {
                 // Attribute the events to this page's site so the post-crawl
                 // venue-site address consensus can fill their blanks.
                 this.tagEventsWithVenueSitePage(keptStructuredEvents, effectiveHtmlData);
+                // Curated-coordinate venue resolution: an event whose bar is
+                // blank or city-shaped adopts the curated venue its own pin
+                // sits on. Runs here — after the Wix/JSON-LD enrichment above
+                // filled event.location — because the extraction-time bar gate
+                // cannot see a pin that arrives later.
+                this.resolveBarFromCuratedCoordinates(keptStructuredEvents, cityConfig);
                 // Report-only: what the page's Google Maps link pins, and
                 // whether the identity guard + curated precedence would let it
                 // fill a blank location. Writes nothing to event data.
@@ -818,6 +824,11 @@ class AiWebParser {
             // Attribute the events to this page's site so the post-crawl
             // venue-site address consensus can fill their blanks.
             this.tagEventsWithVenueSitePage(keptEvents, effectiveHtmlData);
+            // Curated-coordinate venue resolution: a bar the plausibility gate
+            // dropped (or extraction never found) is recovered from the
+            // curated bar the event's own pin sits on. Runs after the Wix /
+            // JSON-API enrichment above, which is where event.location arrives.
+            this.resolveBarFromCuratedCoordinates(keptEvents, cityConfig);
             // Report-only: what the page's Google Maps link pins, and whether
             // the identity guard + curated precedence would let it fill a
             // blank location. Writes nothing to event data.
@@ -12894,6 +12905,203 @@ TEXT:
         return null;
     }
 
+    // Radius, in METRES, for curated-coordinate venue resolution below.
+    // Derived from the curated corpus's own geometry — a sweep of every
+    // same-city curated coordinate pair in data/bars (2026-07-31) shows a
+    // clean gap:
+    //   DUPLICATE entries for ONE venue sit 0 m … 10.2 m apart
+    //     "Nova PDX"/"Bossanova Ballroom" 0 m (portland — old and new names of
+    //     722 E Burnside), "Public Works"/"The Public Works SF" 0 m,
+    //     "F8 Nightclub & Bar"/"F8 NIGHTCLUB" 0 m, "Precinct LA"/"Precinct
+    //     DTLA" 2 m, "SF Eagle"/"San Francisco Eagle Bar" 6 m,
+    //     "Joy Theater"/"Joy Theatre" 10 m;
+    //   genuinely DIFFERENT neighbouring venues start at 17.7 m
+    //     "Jackhammer"/"Touché" 18 m (chicago), "Gym Sports Bar"/"The Pub"
+    //     20 m (fort-lauderdale), "Powerhouse"/"Hole in the Wall Saloon" 22 m
+    //     (sf), everything else 40 m+.
+    // 12 m sits inside that gap: wide enough for the observed real pins (run
+    // 20260731-120505 pinned 1.4 m and 2.9 m from the curated coordinate) and
+    // for the duplicate spread, narrow enough that only an essentially
+    // identical pin qualifies. Two DIFFERENT venues can still both fall
+    // inside it (a pin between Jackhammer and Touché) — that case refuses
+    // outright rather than guessing.
+    getCuratedCoordinateVenueRadiusMeters() {
+        return 12;
+    }
+
+    // Whole-word, case-insensitive, flexible-whitespace presence pattern for a
+    // venue name — shared by the bar-convergence rescue's corpus votes and the
+    // curated-coordinate resolution's text corroboration so both agree on what
+    // "the page names this venue" means.
+    buildVenueNameWholeWordPattern(form) {
+        const escaped = String(form || '')
+            .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+            .replace(/\s+/g, '\\s+');
+        return new RegExp(`(?:^|[^A-Za-z0-9])${escaped}(?=$|[^A-Za-z0-9])`, 'i');
+    }
+
+    // Generic venue-type word ("club", "bar", "theatre" …) — a word that
+    // describes what a place IS rather than which place it is. Shared by
+    // isAddressShapedBarValue (a leading house number + venue-type word is a
+    // name, not a truncated street line) and the curated name-variant test
+    // (two venues sharing only "club" share nothing).
+    isGenericVenueTypeWord(word) {
+        return /^(?:club|bar|lounge|pub|tavern|saloon|cafe|café|grill|restaurant|studio|hall|house|room|theater|theatre|cabaret|hotel|inn|brewery|taproom|eatery|bistro|diner|kitchen)$/i
+            .test(String(word || '').trim());
+    }
+
+    // Are two curated bar names plausibly the SAME venue? The curated corpus
+    // carries duplicate rows for one venue (the owner's upstream sheet), so a
+    // blanket "more than one hit inside the radius = refuse" would refuse
+    // exactly the case this resolution exists for (722 E Burnside is curated
+    // twice, as "Nova PDX" and its former name "Bossanova Ballroom"). True on
+    // either:
+    //   - bar-name-key containment ("publicworks" ⊂ "publicworkssf",
+    //     "f8nightclub" ⊂ "f8nightclubbar"), minimum 4 chars so a short
+    //     fragment never unifies two venues;
+    //   - a shared significant word — 3+ chars, leading "the" dropped (the
+    //     same tolerance normalizeBarNameKey applies), generic venue-type
+    //     words excluded ("Joy Theater"/"Joy Theatre" share "joy";
+    //     "Precinct LA"/"Precinct DTLA" share "precinct"; "SF Eagle"/"San
+    //     Francisco Eagle Bar" share "eagle").
+    // False for every genuinely different neighbour in the corpus
+    // ("Jackhammer"/"Touché", "Gym Sports Bar"/"The Pub",
+    // "Powerhouse"/"Hole in the Wall Saloon").
+    curatedBarNamesAreVariants(nameA, nameB) {
+        const nameKey = value => (this.core && typeof this.core.normalizeBarNameKey === 'function'
+            ? this.core.normalizeBarNameKey(value)
+            : String(value || '').toLowerCase().replace(/^\s*the\s+/, '').replace(/[^a-z0-9]/g, ''));
+        const keyA = nameKey(nameA);
+        const keyB = nameKey(nameB);
+        if (!keyA || !keyB) return false;
+        if (keyA === keyB) return true;
+        if (keyA.length >= 4 && keyB.includes(keyA)) return true;
+        if (keyB.length >= 4 && keyA.includes(keyB)) return true;
+        const significantWords = value => new Set(
+            String(value || '')
+                .toLowerCase()
+                .replace(/^\s*the\s+/, '')
+                .split(/[^a-z0-9]+/)
+                .filter(word => word.length >= 3 && !this.isGenericVenueTypeWord(word))
+        );
+        const wordsA = significantWords(nameA);
+        for (const word of significantWords(nameB)) {
+            if (wordsA.has(word)) return true;
+        }
+        return false;
+    }
+
+    // Does the event's OWN text name this curated venue? Whole-word match
+    // against the title and description the page published — the same
+    // presence test the bar-convergence rescue votes with. Used only to
+    // choose BETWEEN curated bars the coordinate already selected; it never
+    // introduces a candidate of its own.
+    eventTextNamesCuratedBar(event, name) {
+        const form = String(name || '').trim();
+        if (!form || !event || typeof event !== 'object') return false;
+        const corpus = [event.title, event.description]
+            .filter(value => typeof value === 'string' && value.trim())
+            .join('\n');
+        if (!corpus) return false;
+        try {
+            return this.buildVenueNameWholeWordPattern(form).test(corpus);
+        } catch (_) {
+            return false; // an unbuildable pattern is no corroboration
+        }
+    }
+
+    // Curated-coordinate venue resolution (run 20260731-120505: "The RETURN"
+    // shipped bar "Portland" and "CHUNK BROOKLYN - The Return!" shipped bar
+    // "Brooklyn" — city-shaped values that are not venues at all — while both
+    // events carried a page-published pin within 3 m of a curated bar that
+    // names the real venue: Nova PDX at 722 E Burnside, C'mon Everybody at
+    // 325 Franklin Ave. The same run got both venues RIGHT on sibling events
+    // at the very same coordinates). Dropping a city-shaped bar
+    // (applyBarPlausibilityGate) is correct but leaves the event with no
+    // venue when the curated corpus plainly knows it.
+    //
+    // Runs per page on the finished events, AFTER structured-data enrichment
+    // has filled event.location — the extraction-time gate cannot see a pin
+    // that arrives later.
+    //
+    // Eligibility is deliberately narrow: a blank bar (including one the gate
+    // just dropped) or a bar the city gate rejects. A specific venue name is
+    // NEVER second-guessed. The lookup is city-scoped exactly like every
+    // other curated lookup here, and adoption is refused whenever the hits
+    // inside the radius are not all the same venue.
+    resolveBarFromCuratedCoordinates(events, cityConfig) {
+        const eventList = Array.isArray(events) ? events : [];
+        if (eventList.length === 0) return events;
+        if (!this.core || typeof this.core.getCuratedCityBars !== 'function'
+            || typeof this.core.coordinatePairDistanceKm !== 'function') return events;
+        const radiusMeters = this.getCuratedCoordinateVenueRadiusMeters();
+        const nameKey = value => (typeof this.core.normalizeBarNameKey === 'function'
+            ? this.core.normalizeBarNameKey(value)
+            : String(value || '').toLowerCase().replace(/^\s*the\s+/, '').replace(/[^a-z0-9]/g, ''));
+
+        for (const event of eventList) {
+            if (!event || typeof event !== 'object') continue;
+            const location = typeof event.location === 'string' ? event.location.trim() : '';
+            if (!location) continue;
+            const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
+            const rejection = bar ? this.getCityShapedBarRejection(bar, event, cityConfig) : '';
+            if (bar && !rejection) continue;
+            const cityKey = typeof event.city === 'string' ? event.city.trim() : '';
+            if (!cityKey || cityKey.toLowerCase() === 'unknown') continue;
+            let cityBars = null;
+            try {
+                cityBars = this.core.getCuratedCityBars(cityKey);
+            } catch (_) {
+                cityBars = null; // curated corpus is best-effort — fail closed
+            }
+            if (!Array.isArray(cityBars) || cityBars.length === 0) continue;
+
+            const hits = [];
+            for (const curatedBar of cityBars) {
+                if (!curatedBar || typeof curatedBar.name !== 'string' || !curatedBar.name.trim()) continue;
+                const km = this.core.coordinatePairDistanceKm(location, curatedBar.coordinates);
+                if (!Number.isFinite(km)) continue;
+                const meters = km * 1000;
+                if (meters <= radiusMeters) hits.push({ name: curatedBar.name.trim(), meters });
+            }
+            if (hits.length === 0) continue;
+            // Deterministic order: nearest, then the shorter identity key,
+            // then alphabetical — so the winner never depends on data order.
+            hits.sort((a, b) => (a.meters - b.meters)
+                || (nameKey(a.name).length - nameKey(b.name).length)
+                || (a.name < b.name ? -1 : (a.name > b.name ? 1 : 0)));
+
+            const title = typeof event.title === 'string' && event.title.trim() ? event.title.trim() : 'unknown';
+            let winner = hits[0];
+            let tieBreak = '';
+            if (hits.length > 1) {
+                // 1) The event's own page text names exactly one of them —
+                //    the coordinate narrowed the field, the page picks.
+                const named = hits.filter(hit => this.eventTextNamesCuratedBar(event, hit.name));
+                if (named.length === 1) {
+                    winner = named[0];
+                    tieBreak = `, the only one of ${hits.length} curated bars in range the event text names`;
+                } else if (hits.every(hit => this.curatedBarNamesAreVariants(hits[0].name, hit.name))) {
+                    // 2) Duplicate rows for ONE venue — adopt the nearest.
+                    winner = hits[0];
+                    tieBreak = `, nearest of ${hits.length} curated name variants for the same venue (${hits.map(hit => `"${hit.name}"`).join(', ')})`;
+                } else {
+                    // 3) Different places. Ambiguous means no answer.
+                    console.log(`🤖 AI Web: Curated coordinates for "${title}" are ambiguous — ${hits.map(hit => `"${hit.name}" (${Math.round(hit.meters)} m)`).join(', ')} within ${radiusMeters} m — no venue resolved`);
+                    continue;
+                }
+            }
+            if (bar && nameKey(bar) === nameKey(winner.name)) continue;
+            const replaced = bar
+                ? ` — replaces "${bar}" (${rejection})`
+                : '';
+            event.bar = winner.name;
+            event.barSource = 'curated';
+            console.log(`🤖 AI Web: Resolved bar "${winner.name}" for "${title}" from curated coordinates (${Math.round(winner.meters)} m from the event pin ${location}${tieBreak})${replaced}`);
+        }
+        return events;
+    }
+
     // Maps-link coordinate pass (run per page, right where the events are
     // attributed to their page). Judges the pin the page's maps link published
     // and, when it survives, stashes it for the pin ladder:
@@ -13656,8 +13864,7 @@ TEXT:
             && /(?:^|\s)(?:St|Street|Ave|Avenue|Blvd|Boulevard|Rd|Road|Dr|Drive|Ln|Lane|Way|Hwy|Pl|Place|Ct|Court)\.?(?:\s|$)/i.test(text)) return true;
         const truncatedStreetLine = text.match(/^\d{1,6}(?:-\d{1,6})?\s+([A-Za-z][A-Za-z'’.-]*)$/);
         if (truncatedStreetLine) {
-            const venueTypeWord = /^(?:club|bar|lounge|pub|tavern|saloon|cafe|café|grill|restaurant|studio|hall|house|room|theater|theatre|cabaret|hotel|inn|brewery|taproom|eatery|bistro|diner|kitchen)$/i;
-            return !venueTypeWord.test(truncatedStreetLine[1]);
+            return !this.isGenericVenueTypeWord(truncatedStreetLine[1]);
         }
         return false;
     }
@@ -13872,12 +14079,7 @@ TEXT:
         // Whole-word, case-insensitive, flexible-whitespace presence test —
         // every surface form of the candidate counts, so a curated "The
         // Eagle" still finds the page's plain "Eagle" line.
-        const buildWholeWordPattern = form => {
-            const escaped = form
-                .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-                .replace(/\s+/g, '\\s+');
-            return new RegExp(`(?:^|[^A-Za-z0-9])${escaped}(?=$|[^A-Za-z0-9])`, 'i');
-        };
+        const buildWholeWordPattern = form => this.buildVenueNameWholeWordPattern(form);
 
         // Proximity anchors for the tie-break: location-form or
         // address-shaped PAGE lines. Position's ONLY appearance.

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -689,6 +689,20 @@ class AiWebParser {
                 // filled event.location — because the extraction-time bar gate
                 // cannot see a pin that arrives later.
                 this.resolveBarFromCuratedCoordinates(keptStructuredEvents, cityConfig);
+                // Bar plausibility gate for the structured-data path. The AI
+                // path gates every event (see the call in
+                // extractSingleEventWithAi), but the JSON-LD/JSON-API fast
+                // path returns before ever reaching it — so a borough or
+                // district published as the venue name ("Brooklyn",
+                // "Portland": run 20260731-120505, whose CHUNK events take
+                // exactly this path) sailed through to the calendar.
+                // Deliberately runs AFTER the resolution above: resolution
+                // gets first refusal so a rescuable event gets its REAL venue,
+                // and only an unrescuable city-shaped value is dropped.
+                // Gating first would delete the bar before the resolution's
+                // text corroboration could use it — and drop events the
+                // curated pin could have answered.
+                keptStructuredEvents.forEach(event => this.applyBarPlausibilityGate(event, cityConfig));
                 // Report-only: what the page's Google Maps link pins, and
                 // whether the identity guard + curated precedence would let it
                 // fill a blank location. Writes nothing to event data.
@@ -12907,24 +12921,18 @@ TEXT:
 
     // Radius, in METRES, for curated-coordinate venue resolution below.
     // Derived from the curated corpus's own geometry — a sweep of every
-    // same-city curated coordinate pair in data/bars (2026-07-31) shows a
-    // clean gap:
-    //   DUPLICATE entries for ONE venue sit 0 m … 10.2 m apart
-    //     "Nova PDX"/"Bossanova Ballroom" 0 m (portland — old and new names of
-    //     722 E Burnside), "Public Works"/"The Public Works SF" 0 m,
-    //     "F8 Nightclub & Bar"/"F8 NIGHTCLUB" 0 m, "Precinct LA"/"Precinct
-    //     DTLA" 2 m, "SF Eagle"/"San Francisco Eagle Bar" 6 m,
-    //     "Joy Theater"/"Joy Theatre" 10 m;
-    //   genuinely DIFFERENT neighbouring venues start at 17.7 m
+    // same-city curated coordinate pair in data/bars (2026-07-31):
+    //   the closest genuinely DIFFERENT neighbouring venues are 17.7 m apart
     //     "Jackhammer"/"Touché" 18 m (chicago), "Gym Sports Bar"/"The Pub"
     //     20 m (fort-lauderdale), "Powerhouse"/"Hole in the Wall Saloon" 22 m
-    //     (sf), everything else 40 m+.
-    // 12 m sits inside that gap: wide enough for the observed real pins (run
-    // 20260731-120505 pinned 1.4 m and 2.9 m from the curated coordinate) and
-    // for the duplicate spread, narrow enough that only an essentially
-    // identical pin qualifies. Two DIFFERENT venues can still both fall
-    // inside it (a pin between Jackhammer and Touché) — that case refuses
-    // outright rather than guessing.
+    //     (sf), "FLEX"/"Atlas Social Club" 41 m, everything else further;
+    //   the real pins this resolution exists for sat 1.4 m and 2.9 m from
+    //     the curated coordinate (run 20260731-120505).
+    // 12 m sits between the two: wide enough for a page-published pin that
+    // disagrees with curated data by a few metres, comfortably below the
+    // distance at which two DIFFERENT venues could both qualify. Two venues
+    // can still both fall inside it (a pin midway between Jackhammer and
+    // Touché) — that case refuses outright rather than guessing.
     getCuratedCoordinateVenueRadiusMeters() {
         return 12;
     }
@@ -12950,12 +12958,15 @@ TEXT:
             .test(String(word || '').trim());
     }
 
-    // Are two curated bar names plausibly the SAME venue? The curated corpus
-    // carries duplicate rows for one venue (the owner's upstream sheet), so a
-    // blanket "more than one hit inside the radius = refuse" would refuse
-    // exactly the case this resolution exists for (722 E Burnside is curated
-    // twice, as "Nova PDX" and its former name "Bossanova Ballroom"). True on
-    // either:
+    // Are two curated bar names plausibly the SAME venue? DEFENSIVE DEPTH,
+    // not the primary path: as of the data cleanup in #1598 the curated
+    // corpus holds no same-venue duplicates at all, so a resolvable pin has
+    // exactly ONE curated bar in range and this test never runs. It exists
+    // because the corpus previously carried duplicate rows for one venue
+    // (722 E Burnside was curated as both "Nova PDX" and its former name
+    // "Bossanova Ballroom"), and the promote/venue-queue path that adds new
+    // bars can reintroduce one — a variant pair must not make the resolution
+    // give up. True on either:
     //   - bar-name-key containment ("publicworks" ⊂ "publicworkssf",
     //     "f8nightclub" ⊂ "f8nightclubbar"), minimum 4 chars so a short
     //     fragment never unifies two venues;
@@ -13027,8 +13038,14 @@ TEXT:
     // Eligibility is deliberately narrow: a blank bar (including one the gate
     // just dropped) or a bar the city gate rejects. A specific venue name is
     // NEVER second-guessed. The lookup is city-scoped exactly like every
-    // other curated lookup here, and adoption is refused whenever the hits
-    // inside the radius are not all the same venue.
+    // other curated lookup here.
+    //
+    // The primary path is ONE curated bar inside the radius — the only shape
+    // the cleaned corpus can produce (#1598 removed its same-venue duplicate
+    // rows, leaving no two curated bars in any city nearer than 17.7 m).
+    // More than one hit means genuinely different venues, so the answer is
+    // no answer. The one exception is defensive depth for a corpus that
+    // regains a duplicate row: see curatedBarNamesAreVariants.
     resolveBarFromCuratedCoordinates(events, cityConfig) {
         const eventList = Array.isArray(events) ? events : [];
         if (eventList.length === 0) return events;
@@ -13922,6 +13939,25 @@ TEXT:
             ? 'address-shaped'
             : this.getCityShapedBarRejection(bar, event, cityConfig);
         if (!reason) return event;
+        // Curated data outranks a derived shape heuristic. Both shape tests
+        // above read a NAME and guess what it is; the curated corpus KNOWS.
+        // A sweep of all 106 curated venue names (2026-07-31) found two the
+        // heuristics misread — "9th Avenue Saloon" (nyc) reads as a street
+        // address because it contains "Avenue", and "440 Castro" (sf) reads
+        // as a truncated street line — so a curated name for the event's own
+        // city is exempt. City-scoped on purpose: never the cross-city
+        // fallback, which could let some other city's curated venue excuse a
+        // value this event's city rejects. No curated bar is named after a
+        // city, so this cannot resurrect "Brooklyn"/"Portland".
+        const cityBars = typeof event.city === 'string' && event.city.trim()
+            && this.core && typeof this.core.getCuratedCityBars === 'function'
+            && typeof this.core.findCuratedBarByName === 'function'
+            ? this.core.getCuratedCityBars(event.city.trim())
+            : null;
+        if (cityBars && this.core.findCuratedBarByName(cityBars, bar)) {
+            console.log(`🤖 AI Web: Kept bar "${bar}" despite reading as ${reason} — curated venue for ${event.city}`);
+            return event;
+        }
         console.log(`🤖 AI Web: Dropped implausible bar "${bar}" (${reason})`);
         delete event.bar;
         return event;

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -8452,3 +8452,176 @@ test('maps-link coordinates: the parser only stashes the candidate — it never 
   assert.deepEqual(Object.keys(horizon).filter(key => !key.startsWith('_')).sort(),
     ['bar', 'city', 'title']);
 });
+
+// ---------------------------------------------------------------------------
+// Curated-coordinate venue resolution. Run 20260731-120505 shipped bar
+// "Portland" for "The RETURN" and bar "Brooklyn" for "CHUNK BROOKLYN - The
+// Return!" — city-shaped values that are not venues — while both events
+// carried a page-published pin within 3 m of the curated bar that names the
+// real venue, and the SAME run got both venues right on sibling events at the
+// very same coordinates. Coordinates (verbatim from that run and from
+// data/bars) are the fixture.
+// ---------------------------------------------------------------------------
+const VENUE_COORD_CURATED_BARS = {
+  portland: [
+    { name: 'Nova PDX', city: 'portland', address: '722 E Burnside, Portland', coordinates: '45.5228076, -122.6581521' },
+    // The owner's upstream sheet curates 722 E Burnside TWICE — the venue's
+    // former name is still a row. Duplicates must not defeat resolution.
+    { name: 'Bossanova Ballroom', city: 'portland', address: '722 E Burnside St, Portland', coordinates: '45.5228076, -122.6581521' },
+    { name: 'Stag PDX', city: 'portland', coordinates: '45.5232000, -122.6752000' }
+  ],
+  nyc: [
+    { name: "C'mon Everybody", city: 'nyc', address: '325 Franklin Avenue, New York', coordinates: '40.6882793, -73.9569264' }
+  ],
+  chicago: [
+    // 17.7 m apart — the closest genuinely DIFFERENT pair in the corpus.
+    { name: 'Jackhammer', city: 'chicago', coordinates: '41.9984139, -87.6710111' },
+    { name: 'Touché', city: 'chicago', coordinates: '41.9985708, -87.670974' }
+  ],
+  sf: [
+    { name: 'Public Works', city: 'sf', coordinates: '37.7688931, -122.4192651' },
+    { name: 'The Public Works SF', city: 'sf', coordinates: '37.7688931, -122.4192651' }
+  ]
+};
+
+function createVenueCoordinateParser() {
+  const parser = createParser();
+  parser.core = new SharedCore({}, { eventSchema: EventSchema, bars: VENUE_COORD_CURATED_BARS });
+  return parser;
+}
+
+test('curated-coordinate venue resolution: a city-shaped bar is replaced by the venue the pin sits on', () => {
+  const parser = createVenueCoordinateParser();
+
+  // Verbatim from run 20260731-120505.
+  const portland = {
+    title: 'The RETURN',
+    bar: 'Portland',
+    city: 'portland',
+    address: '722 E Burnside St, Portland, OR 97214, USA',
+    location: '45.52281000000001, -122.6581342',
+    description: "CHUNK PDX Presents E. FELD ... Saturday March 14th // NOVA PDX // 722 E Burnside St // 9pm - close"
+  };
+  const brooklyn = {
+    title: 'CHUNK BROOKLYN - The Return!',
+    bar: 'Brooklyn',
+    city: 'nyc',
+    address: '325 Franklin Ave, Brooklyn, NY 11238, USA',
+    location: '40.68830519999999, -73.9569221'
+  };
+
+  const logs = captureLogs(() => {
+    parser.resolveBarFromCuratedCoordinates([portland, brooklyn], CITY_GATE_CONFIG);
+  });
+
+  assert.equal(portland.bar, 'Nova PDX', 'the pin sits on Nova PDX, not on a city called Portland');
+  assert.equal(portland.barSource, 'curated');
+  assert.equal(brooklyn.bar, "C'mon Everybody", 'the pin sits on C\'mon Everybody');
+  assert.equal(brooklyn.barSource, 'curated');
+
+  assert.ok(
+    logs.some(line => line.includes('🤖 AI Web: Resolved bar "Nova PDX" for "The RETURN" from curated coordinates')
+      && line.includes('1 m from the event pin')
+      && line.includes('replaces "Portland"')),
+    `expected the additive resolution line naming venue + distance, got: ${JSON.stringify(logs)}`
+  );
+  assert.ok(
+    logs.some(line => line.includes('🤖 AI Web: Resolved bar "C\'mon Everybody"') && line.includes('3 m from the event pin')),
+    JSON.stringify(logs)
+  );
+});
+
+test('curated-coordinate venue resolution: fills a bar the gate dropped, and duplicates of one venue still resolve', () => {
+  const parser = createVenueCoordinateParser();
+
+  // The gate already dropped the bar — the event arrives with none at all.
+  const dropped = { title: 'The RETURN', city: 'portland', location: '45.52281000000001, -122.6581342',
+    description: 'doors 9pm // NOVA PDX // 722 E Burnside St' };
+  parser.resolveBarFromCuratedCoordinates([dropped], CITY_GATE_CONFIG);
+  assert.equal(dropped.bar, 'Nova PDX', 'a blank bar is filled from the pin');
+
+  // No text corroboration and two curated rows for ONE venue whose names are
+  // recognizable variants: the nearest wins rather than the pass refusing.
+  const sf = { title: 'Some SF party', city: 'sf', location: '37.7688931, -122.4192651' };
+  const sfLogs = captureLogs(() => parser.resolveBarFromCuratedCoordinates([sf], CITY_GATE_CONFIG));
+  assert.equal(sf.bar, 'Public Works');
+  assert.ok(sfLogs.some(line => line.includes('curated name variants for the same venue')), JSON.stringify(sfLogs));
+});
+
+test('curated-coordinate venue resolution: two DIFFERENT curated venues in range resolve nothing', () => {
+  const parser = createVenueCoordinateParser();
+
+  // Midpoint of Jackhammer and Touché — 9 m from each, both inside 12 m.
+  const event = { title: 'Some Chicago Party', city: 'chicago', location: '41.99849235, -87.67099255' };
+  const logs = captureLogs(() => parser.resolveBarFromCuratedCoordinates([event], CITY_GATE_CONFIG));
+
+  assert.equal('bar' in event, false, 'ambiguous means no answer — never a guess');
+  assert.ok(
+    logs.some(line => line.includes('are ambiguous') && line.includes('Jackhammer') && line.includes('Touché')
+      && line.includes('no venue resolved')),
+    `expected the refusal line naming both venues, got: ${JSON.stringify(logs)}`
+  );
+});
+
+test('curated-coordinate venue resolution: a real venue name is never overridden, and the pass fails closed', () => {
+  const parser = createVenueCoordinateParser();
+
+  const cases = [
+    // Already the right venue at the very same pin.
+    { title: 'Nova Box', bar: 'Nova PDX', city: 'portland', location: '45.52281000000001, -122.6581342' },
+    // The OTHER curated row for the same address — a specific venue name, so
+    // it is left exactly as extracted (the duplicate is data, not this pass').
+    { title: 'Bossanova night', bar: 'Bossanova Ballroom', city: 'portland', location: '45.52281000000001, -122.6581342' },
+    // An uncurated venue sitting on a curated pin still keeps its own name.
+    { title: 'Pop-up', bar: 'Some New Venue', city: 'nyc', location: '40.6882793, -73.9569264' },
+    // No pin, no city, unknown city, pin nowhere near a curated bar.
+    { title: 'No pin', bar: '', city: 'portland' },
+    { title: 'No city', bar: '', location: '45.5228076, -122.6581521' },
+    { title: 'Unknown city', bar: '', city: 'unknown', location: '45.5228076, -122.6581521' },
+    { title: 'Far away', bar: '', city: 'portland', location: '45.5300000, -122.6581521' }
+  ];
+  const before = cases.map(event => event.bar);
+  const logs = captureLogs(() => parser.resolveBarFromCuratedCoordinates(cases, CITY_GATE_CONFIG));
+
+  cases.forEach((event, index) => {
+    assert.equal(event.bar === undefined ? '' : event.bar, before[index] === undefined ? '' : before[index],
+      `"${event.title}" must be untouched`);
+    assert.equal(event.barSource, undefined, `"${event.title}" gains no provenance stamp`);
+  });
+  assert.equal(logs.length, 0, `nothing resolved → nothing logged, got: ${JSON.stringify(logs)}`);
+
+  // No curated corpus at all → the pass cannot judge and must not act.
+  const bare = createParser();
+  const orphan = { title: 'The RETURN', bar: 'Portland', city: 'portland', location: '45.52281000000001, -122.6581342' };
+  bare.resolveBarFromCuratedCoordinates([orphan], CITY_GATE_CONFIG);
+  assert.equal(orphan.bar, 'Portland', 'no bars data → fail closed, change nothing');
+});
+
+test('curated bar name variants: duplicate rows for one venue unify, different neighbours never do', () => {
+  const parser = createVenueCoordinateParser();
+  const same = [
+    ['Public Works', 'The Public Works SF'],
+    ['F8 Nightclub & Bar', 'F8 NIGHTCLUB'],
+    ['Precinct LA', 'Precinct DTLA'],
+    ['SF Eagle', 'San Francisco Eagle Bar'],
+    ['Joy Theater', 'Joy Theatre'],
+    ['EAGLE TOKYO', 'EAGLE TOKYO BLUE']
+  ];
+  for (const [a, b] of same) {
+    assert.equal(parser.curatedBarNamesAreVariants(a, b), true, `"${a}" / "${b}" are one venue`);
+  }
+  const different = [
+    ['Jackhammer', 'Touché'],
+    ['Gym Sports Bar', 'The Pub'],
+    ['Powerhouse', 'Hole in the Wall Saloon'],
+    ['FLEX', 'Atlas Social Club'],
+    ['Diesel', 'Madison Pub'],
+    // Generic venue-type words are never the shared word that unifies two names.
+    ['Atlas Social Club', 'Berlin Club'],
+    ['The Pub', 'The Tavern']
+  ];
+  for (const [a, b] of different) {
+    assert.equal(parser.curatedBarNamesAreVariants(a, b), false, `"${a}" / "${b}" are different places`);
+  }
+  assert.equal(parser.curatedBarNamesAreVariants('', 'Nova PDX'), false);
+});

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -8459,15 +8459,13 @@ test('maps-link coordinates: the parser only stashes the candidate — it never 
 // Return!" — city-shaped values that are not venues — while both events
 // carried a page-published pin within 3 m of the curated bar that names the
 // real venue, and the SAME run got both venues right on sibling events at the
-// very same coordinates. Coordinates (verbatim from that run and from
-// data/bars) are the fixture.
+// very same coordinates. Coordinates are verbatim from that run and from
+// data/bars. The fixture mirrors the CLEANED corpus (#1598): one row per
+// venue, so a resolvable pin has exactly one curated bar in range.
 // ---------------------------------------------------------------------------
 const VENUE_COORD_CURATED_BARS = {
   portland: [
     { name: 'Nova PDX', city: 'portland', address: '722 E Burnside, Portland', coordinates: '45.5228076, -122.6581521' },
-    // The owner's upstream sheet curates 722 E Burnside TWICE — the venue's
-    // former name is still a row. Duplicates must not defeat resolution.
-    { name: 'Bossanova Ballroom', city: 'portland', address: '722 E Burnside St, Portland', coordinates: '45.5228076, -122.6581521' },
     { name: 'Stag PDX', city: 'portland', coordinates: '45.5232000, -122.6752000' }
   ],
   nyc: [
@@ -8477,20 +8475,16 @@ const VENUE_COORD_CURATED_BARS = {
     // 17.7 m apart — the closest genuinely DIFFERENT pair in the corpus.
     { name: 'Jackhammer', city: 'chicago', coordinates: '41.9984139, -87.6710111' },
     { name: 'Touché', city: 'chicago', coordinates: '41.9985708, -87.670974' }
-  ],
-  sf: [
-    { name: 'Public Works', city: 'sf', coordinates: '37.7688931, -122.4192651' },
-    { name: 'The Public Works SF', city: 'sf', coordinates: '37.7688931, -122.4192651' }
   ]
 };
 
-function createVenueCoordinateParser() {
+function createVenueCoordinateParser(bars = VENUE_COORD_CURATED_BARS) {
   const parser = createParser();
-  parser.core = new SharedCore({}, { eventSchema: EventSchema, bars: VENUE_COORD_CURATED_BARS });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema, bars });
   return parser;
 }
 
-test('curated-coordinate venue resolution: a city-shaped bar is replaced by the venue the pin sits on', () => {
+test('curated-coordinate venue resolution: one curated bar in range replaces a city-shaped value', () => {
   const parser = createVenueCoordinateParser();
 
   // Verbatim from run 20260731-120505.
@@ -8499,8 +8493,7 @@ test('curated-coordinate venue resolution: a city-shaped bar is replaced by the 
     bar: 'Portland',
     city: 'portland',
     address: '722 E Burnside St, Portland, OR 97214, USA',
-    location: '45.52281000000001, -122.6581342',
-    description: "CHUNK PDX Presents E. FELD ... Saturday March 14th // NOVA PDX // 722 E Burnside St // 9pm - close"
+    location: '45.52281000000001, -122.6581342'
   };
   const brooklyn = {
     title: 'CHUNK BROOKLYN - The Return!',
@@ -8509,15 +8502,18 @@ test('curated-coordinate venue resolution: a city-shaped bar is replaced by the 
     address: '325 Franklin Ave, Brooklyn, NY 11238, USA',
     location: '40.68830519999999, -73.9569221'
   };
+  // A bar the plausibility gate already dropped arrives with none at all.
+  const dropped = { title: 'The RETURN', city: 'portland', location: '45.52281000000001, -122.6581342' };
 
   const logs = captureLogs(() => {
-    parser.resolveBarFromCuratedCoordinates([portland, brooklyn], CITY_GATE_CONFIG);
+    parser.resolveBarFromCuratedCoordinates([portland, brooklyn, dropped], CITY_GATE_CONFIG);
   });
 
   assert.equal(portland.bar, 'Nova PDX', 'the pin sits on Nova PDX, not on a city called Portland');
   assert.equal(portland.barSource, 'curated');
-  assert.equal(brooklyn.bar, "C'mon Everybody", 'the pin sits on C\'mon Everybody');
+  assert.equal(brooklyn.bar, "C'mon Everybody");
   assert.equal(brooklyn.barSource, 'curated');
+  assert.equal(dropped.bar, 'Nova PDX', 'a blank bar is filled from the pin');
 
   assert.ok(
     logs.some(line => line.includes('🤖 AI Web: Resolved bar "Nova PDX" for "The RETURN" from curated coordinates')
@@ -8529,23 +8525,6 @@ test('curated-coordinate venue resolution: a city-shaped bar is replaced by the 
     logs.some(line => line.includes('🤖 AI Web: Resolved bar "C\'mon Everybody"') && line.includes('3 m from the event pin')),
     JSON.stringify(logs)
   );
-});
-
-test('curated-coordinate venue resolution: fills a bar the gate dropped, and duplicates of one venue still resolve', () => {
-  const parser = createVenueCoordinateParser();
-
-  // The gate already dropped the bar — the event arrives with none at all.
-  const dropped = { title: 'The RETURN', city: 'portland', location: '45.52281000000001, -122.6581342',
-    description: 'doors 9pm // NOVA PDX // 722 E Burnside St' };
-  parser.resolveBarFromCuratedCoordinates([dropped], CITY_GATE_CONFIG);
-  assert.equal(dropped.bar, 'Nova PDX', 'a blank bar is filled from the pin');
-
-  // No text corroboration and two curated rows for ONE venue whose names are
-  // recognizable variants: the nearest wins rather than the pass refusing.
-  const sf = { title: 'Some SF party', city: 'sf', location: '37.7688931, -122.4192651' };
-  const sfLogs = captureLogs(() => parser.resolveBarFromCuratedCoordinates([sf], CITY_GATE_CONFIG));
-  assert.equal(sf.bar, 'Public Works');
-  assert.ok(sfLogs.some(line => line.includes('curated name variants for the same venue')), JSON.stringify(sfLogs));
 });
 
 test('curated-coordinate venue resolution: two DIFFERENT curated venues in range resolve nothing', () => {
@@ -8569,9 +8548,6 @@ test('curated-coordinate venue resolution: a real venue name is never overridden
   const cases = [
     // Already the right venue at the very same pin.
     { title: 'Nova Box', bar: 'Nova PDX', city: 'portland', location: '45.52281000000001, -122.6581342' },
-    // The OTHER curated row for the same address — a specific venue name, so
-    // it is left exactly as extracted (the duplicate is data, not this pass').
-    { title: 'Bossanova night', bar: 'Bossanova Ballroom', city: 'portland', location: '45.52281000000001, -122.6581342' },
     // An uncurated venue sitting on a curated pin still keeps its own name.
     { title: 'Pop-up', bar: 'Some New Venue', city: 'nyc', location: '40.6882793, -73.9569264' },
     // No pin, no city, unknown city, pin nowhere near a curated bar.
@@ -8595,6 +8571,50 @@ test('curated-coordinate venue resolution: a real venue name is never overridden
   const orphan = { title: 'The RETURN', bar: 'Portland', city: 'portland', location: '45.52281000000001, -122.6581342' };
   bare.resolveBarFromCuratedCoordinates([orphan], CITY_GATE_CONFIG);
   assert.equal(orphan.bar, 'Portland', 'no bars data → fail closed, change nothing');
+});
+
+// Defensive depth, not the primary path: the cleaned corpus (#1598) has no
+// same-venue duplicates, but the promote/venue-queue path that adds new bars
+// could reintroduce one, and a variant pair must not make resolution give up.
+// This is also exactly the corpus state on main before #1598 lands.
+const VENUE_COORD_DUPLICATED_BARS = {
+  portland: [
+    { name: 'Nova PDX', city: 'portland', coordinates: '45.5228076, -122.6581521' },
+    // The venue's former name — same address, a second curated row.
+    { name: 'Bossanova Ballroom', city: 'portland', coordinates: '45.5228076, -122.6581521' }
+  ],
+  sf: [
+    { name: 'Public Works', city: 'sf', coordinates: '37.7688931, -122.4192651' },
+    { name: 'The Public Works SF', city: 'sf', coordinates: '37.7688931, -122.4192651' }
+  ]
+};
+
+test('curated-coordinate venue resolution: a duplicated curated venue still resolves (defensive depth)', () => {
+  const parser = createVenueCoordinateParser(VENUE_COORD_DUPLICATED_BARS);
+
+  // Recognizable name variants of ONE venue: the nearest wins rather than the
+  // pass refusing.
+  const sf = { title: 'Some SF party', city: 'sf', location: '37.7688931, -122.4192651' };
+  const sfLogs = captureLogs(() => parser.resolveBarFromCuratedCoordinates([sf], CITY_GATE_CONFIG));
+  assert.equal(sf.bar, 'Public Works');
+  assert.ok(sfLogs.some(line => line.includes('curated name variants for the same venue')), JSON.stringify(sfLogs));
+
+  // Two rows whose names share nothing ("Nova PDX" / "Bossanova Ballroom"):
+  // the event's own text names exactly one of them, so that one wins.
+  const named = {
+    title: 'The RETURN', bar: 'Portland', city: 'portland',
+    location: '45.52281000000001, -122.6581342',
+    description: 'CHUNK PDX Presents ... Saturday March 14th // NOVA PDX // 722 E Burnside St // 9pm - close'
+  };
+  const namedLogs = captureLogs(() => parser.resolveBarFromCuratedCoordinates([named], CITY_GATE_CONFIG));
+  assert.equal(named.bar, 'Nova PDX');
+  assert.ok(namedLogs.some(line => line.includes('the only one of 2 curated bars in range the event text names')),
+    JSON.stringify(namedLogs));
+
+  // Same two rows, and the page text names NEITHER: fail closed.
+  const silent = { title: 'Untitled PDX party', city: 'portland', location: '45.52281000000001, -122.6581342' };
+  parser.resolveBarFromCuratedCoordinates([silent], CITY_GATE_CONFIG);
+  assert.equal('bar' in silent, false, 'unnameable duplicates resolve nothing rather than guess');
 });
 
 test('curated bar name variants: duplicate rows for one venue unify, different neighbours never do', () => {
@@ -8624,4 +8644,88 @@ test('curated bar name variants: duplicate rows for one venue unify, different n
     assert.equal(parser.curatedBarNamesAreVariants(a, b), false, `"${a}" / "${b}" are different places`);
   }
   assert.equal(parser.curatedBarNamesAreVariants('', 'Nova PDX'), false);
+});
+
+test('structured-data path: resolution gets first refusal, then the bar gate drops what it could not rescue', () => {
+  const parser = createVenueCoordinateParser();
+  // The exact ordering the structured-data fast path runs.
+  const pass = (events) => {
+    parser.resolveBarFromCuratedCoordinates(events, CITY_GATE_CONFIG);
+    events.forEach(event => parser.applyBarPlausibilityGate(event, CITY_GATE_CONFIG));
+    return events;
+  };
+
+  // 1. Resolvable city-shaped bar → replaced with the curated venue, and the
+  //    gate then has a real venue name to leave alone.
+  const resolvable = { title: 'The RETURN', bar: 'Portland', city: 'portland', location: '45.52281000000001, -122.6581342' };
+  // 2. Unresolvable city-shaped bar (pin nowhere near a curated venue) →
+  //    dropped by the gate rather than left as a borough.
+  const unresolvable = { title: 'CHUNK BROOKLYN', bar: 'Brooklyn', city: 'nyc', location: '40.75, -73.99' };
+  // 3. Unresolvable city-shaped bar with no pin at all → dropped.
+  const noPin = { title: 'CHUNK PDX', bar: 'Portland', city: 'portland' };
+  // 4. Ambiguous coordinates → refuse to resolve, then the gate drops the city.
+  const ambiguous = { title: 'Chicago thing', bar: 'Chicago', city: 'chicago', location: '41.99849235, -87.67099255' };
+  // 5. Legitimate venue names → untouched in every case.
+  const curatedVenue = { title: 'Nova Box', bar: 'Nova PDX', city: 'portland', location: '45.52281000000001, -122.6581342' };
+  const uncuratedVenue = { title: 'Pop-up', bar: 'Some New Venue', city: 'nyc', location: '40.6882793, -73.9569264' };
+  const placeNamed = { title: 'Bowl night', bar: 'Brooklyn Bowl', city: 'nyc', location: '40.75, -73.99' };
+
+  const logs = captureLogs(() => pass([resolvable, unresolvable, noPin, ambiguous, curatedVenue, uncuratedVenue, placeNamed]));
+
+  assert.equal(resolvable.bar, 'Nova PDX', 'resolution runs first and wins');
+  assert.equal('bar' in unresolvable, false, 'an unrescuable borough is dropped, not shipped');
+  assert.equal('bar' in noPin, false, 'no pin to rescue with → the gate still drops the city');
+  assert.equal('bar' in ambiguous, false, 'refuse to resolve, then drop');
+  assert.equal(curatedVenue.bar, 'Nova PDX');
+  assert.equal(uncuratedVenue.bar, 'Some New Venue');
+  assert.equal(placeNamed.bar, 'Brooklyn Bowl', 'whole-value equality only — a place-named venue survives');
+
+  // The gate's existing drop log is unchanged and still fires on this path.
+  assert.ok(logs.some(line => line === '🤖 AI Web: Dropped implausible bar "Brooklyn" (city name — resolves to city "nyc")'),
+    `expected the unchanged gate drop line, got: ${JSON.stringify(logs)}`);
+  assert.ok(logs.some(line => line.includes('Dropped implausible bar "Chicago"')), JSON.stringify(logs));
+  // The rescued event is never dropped — resolution ran before the gate.
+  assert.ok(!logs.some(line => line.includes('Dropped implausible bar "Portland"') && line.includes('The RETURN')),
+    JSON.stringify(logs));
+});
+
+test('bar plausibility gate: a curated venue name for the event city outranks the shape heuristics', () => {
+  // Both names are real curated venues that the shape tests misread: "9th
+  // Avenue Saloon" contains "Avenue", "440 Castro" is a number + one bare
+  // word. The gate now runs on the structured-data path too, so a false
+  // positive here would silently delete a correct venue.
+  const parser = createParser();
+  parser.core = new SharedCore({}, {
+    eventSchema: EventSchema,
+    bars: {
+      nyc: [{ name: '9th Avenue Saloon', city: 'nyc' }],
+      sf: [{ name: '440 Castro', city: 'sf' }]
+    }
+  });
+  assert.equal(parser.isAddressShapedBarValue('9th Avenue Saloon'), true, 'the heuristic does misread it');
+  assert.equal(parser.isAddressShapedBarValue('440 Castro'), true, 'the heuristic does misread it');
+
+  const saloon = { title: 'x', bar: '9th Avenue Saloon', city: 'nyc' };
+  const logs = captureLogs(() => parser.applyBarPlausibilityGate(saloon, CITY_GATE_CONFIG));
+  assert.equal(saloon.bar, '9th Avenue Saloon', 'curated data outranks the derived shape guess');
+  assert.ok(logs.some(line => line.includes('Kept bar "9th Avenue Saloon" despite reading as address-shaped')),
+    JSON.stringify(logs));
+
+  const castro = { title: 'x', bar: '440 Castro', city: 'sf' };
+  parser.applyBarPlausibilityGate(castro, CITY_GATE_CONFIG);
+  assert.equal(castro.bar, '440 Castro');
+
+  // The exemption is city-scoped and full-name only: it never rescues a value
+  // this city does not curate, and it cannot resurrect a city-shaped bar.
+  const wrongCity = { title: 'x', bar: '440 Castro', city: 'nyc' };
+  parser.applyBarPlausibilityGate(wrongCity, CITY_GATE_CONFIG);
+  assert.equal('bar' in wrongCity, false, 'another city curating the name is no excuse');
+
+  const uncurated = { title: 'x', bar: '79 WARRENTON', city: 'nyc' };
+  parser.applyBarPlausibilityGate(uncurated, CITY_GATE_CONFIG);
+  assert.equal('bar' in uncurated, false, 'an uncurated address-shaped bar still drops');
+
+  const borough = { title: 'x', bar: 'Brooklyn', city: 'nyc' };
+  parser.applyBarPlausibilityGate(borough, CITY_GATE_CONFIG);
+  assert.equal('bar' in borough, false, 'no curated bar is named after a city — the gate still fires');
 });


### PR DESCRIPTION
## The bug

Run `20260731-120505` (real CHUNK run) shipped events that named a **city** where a **venue** belongs:

| title | bar shipped | address | pin |
|---|---|---|---|
| `The RETURN` | **`Portland`** | 722 E Burnside St, Portland, OR 97214 | `45.52281000000001, -122.6581342` |
| `CHUNK BROOKLYN - The Return!` | **`Brooklyn`** | 325 Franklin Ave, Brooklyn, NY 11238 | `40.68830519999999, -73.9569221` |

The same run got both venues **right** on sibling events at the very same coordinates (`Nova Box` → `Nova PDX`, `CHUNK Brooklyn 7/4` → `C'mon Everybody`), and the curated corpus already held the answer keyed by a coordinate essentially identical to the event's own pin:

- `Nova PDX` — 722 E Burnside — **1 m** from the "Portland" event's pin
- `C'mon Everybody` — 325 Franklin Avenue — **3 m** from the "Brooklyn" event's pin

Two separate defects, both fixed here.

## Fix 1 — resolve the venue from the event's own pin

`applyBarPlausibilityGate`'s city-shape test correctly **drops** a value like `Portland`. Dropping is right but insufficient: it leaves the event with no venue when we can determine the real one.

`resolveBarFromCuratedCoordinates(events, cityConfig)` runs per page on the finished events — **after** structured-data (Wix/JSON-LD/JSON-API) enrichment fills `event.location`, which is where the pin actually arrives. The extraction-time gate cannot see a pin that lands later, which is why this is a separate pass rather than a branch inside the gate.

Eligibility is deliberately narrow:

- bar is **blank** (including one the gate just dropped), **or**
- bar is present but `getCityShapedBarRejection` rejects it.

**A specific venue name is never second-guessed**, and nothing else is ever touched. Reuses `coordinatePairDistanceKm`, `getCuratedCityBars`, `findCuratedBarByName`, `normalizeBarNameKey`, `getCityShapedBarRejection` — no new geo math, no new bar index. The lookup is city-scoped exactly like `findCuratedBarForEvent`; no city (or `unknown`) → no resolution.

Two helpers were **extracted rather than duplicated**: `buildVenueNameWholeWordPattern` (now shared with the bar-convergence rescue's corpus votes) and `isGenericVenueTypeWord` (now shared with `isAddressShapedBarValue`). Both are byte-identical to the code they replace.

### The radius: 12 m, and why

A sweep of every same-city curated coordinate pair in `data/bars` (33 city files) after the #1598 cleanup leaves **no same-venue duplicates at all**. The closest pairs are genuinely different neighbouring venues:

```
17.7 m  chicago          "Jackhammer"     <-> "Touché"
20.0 m  fort-lauderdale  "Gym Sports Bar" <-> "The Pub"
22.0 m  sf               "Powerhouse"     <-> "Hole in the Wall Saloon"
40.7 m  nyc              "FLEX"           <-> "Atlas Social Club"
42.1 m  tokyo            "EAGLE TOKYO"    <-> "EAGLE TOKYO BLUE"
45.9 m  seattle          "Diesel"         <-> "Madison Pub"
```

The real pins this exists for sat **1.4 m** and **2.9 m** from the curated coordinate. **12 m sits between the two**: wide enough for a page-published pin that disagrees with curated data by a few metres, comfortably below the distance at which two different venues could both qualify. Nothing in the corpus falls between 10.2 m and 17.7 m, so the number is not balanced on a knife edge.

### Multiple hits inside the radius

**Primary path: exactly one hit.** That is the only shape the cleaned corpus can produce. More than one hit means genuinely different venues, so the answer is no answer — log which venues were in range and resolve nothing. This is what the tests assert.

**Defensive depth, for a corpus that regains a duplicate.** The corpus *did* carry same-venue duplicate rows until #1598 (722 E Burnside was curated as both `Nova PDX` and its former name `Bossanova Ballroom`), and the promote/venue-queue path that adds new bars could reintroduce one. Rather than let that silently disable the resolution, two narrow exceptions run before the refusal:

1. the event's own page text names **exactly one** of the hits → that one;
2. else, every hit is a recognizable **name variant of one venue** (`curatedBarNamesAreVariants`: bar-name-key containment min 4 chars, or a shared significant word — 3+ chars, leading `the` dropped, generic venue-type words like `club`/`bar`/`theatre` excluded) → the nearest, then shortest identity key, then alphabetical, so the winner never depends on data order;
3. else refuse.

Verified against the whole corpus: the variant test unifies every historical duplicate pair and separates every different-venue pair.

## Fix 2 — the structured-data path was never gated at all

`applyBarPlausibilityGate` is called only from the AI path (`extractSingleEventWithAi`); the JSON-LD/JSON-API fast path returns before ever reaching it. So #1597's city-as-venue protection **did not cover the path CHUNK's events actually take** — a borough or district reached the calendar whenever coordinate resolution could not rescue it.

The gate now runs there too, **after** `resolveBarFromCuratedCoordinates`. Order is the point: resolution gets first refusal so a rescuable event gets its **real** venue, and only an unrescuable city-shaped value drops. Gating first would delete the bar before the resolution's text corroboration could use it, and would drop events the curated pin could have answered. The gate's existing drop log is unchanged.

### Fix 2a — curated names now outrank the shape heuristics

Running the gate on a path it never ran on made its false positives load-bearing. Sweeping **all 106 curated venue names** through it found two the shape tests misread, both of which would have been silently deleted:

- `9th Avenue Saloon` (nyc) — reads as a street address because it contains "Avenue"
- `440 Castro` (sf) — reads as a truncated street line (number + one bare word)

A curated name for the event's **own city** is now exempt: both shape tests *guess* what a name is, and the curated corpus *knows*. City-scoped and full-name only — never the cross-city fallback, which could let another city's venue excuse a value this city rejects. No curated bar is named after a city, so this cannot resurrect `Brooklyn`/`Portland` (verified against the corpus).

**Sweep after the fix: 106 names, ZERO drops.**

## Verification — real records, real curated data, dependencies wired

Driven through `resolveBarFromCuratedCoordinates` + `applyBarPlausibilityGate` in the structured path's exact order, with `parser.core = new SharedCore(scraper-cities, { eventSchema, bars })` and `cityConfig` passed explicitly.

### Structured-path matrix

| case | before | after |
|---|---|---|
| resolvable city-shaped (real: `The RETURN`) | `"Portland"` | **`"Nova PDX"`** |
| resolvable city-shaped (real: `CHUNK BROOKLYN - The Return!`) | `"Brooklyn"` | **`"C'mon Everybody"`** |
| unresolvable city-shaped (pin far from any venue) | `"Brooklyn"` | **DROPPED** |
| unresolvable city-shaped (no pin at all) | `"Portland"` | **DROPPED** |
| ambiguous coordinates (Jackhammer/Touché midpoint) | `"Chicago"` | **DROPPED** (refused, then gated) |
| legit venue, curated, on its own pin | `"Nova PDX"` | `"Nova PDX"` |
| legit venue, uncurated, on a curated pin | `"Some New Venue"` | `"Some New Venue"` |
| legit venue, place-named | `"Brooklyn Bowl"` | `"Brooklyn Bowl"` |
| legit venue (real: `Hot Gogo Bears`) | `"F8 NIGHTCLUB"` | `"F8 NIGHTCLUB"` |

```
🤖 AI Web: Resolved bar "Nova PDX" for "The RETURN" from curated coordinates (1 m from the event pin 45.52281000000001, -122.6581342) — replaces "Portland" (city name — resolves to city "portland")
🤖 AI Web: Resolved bar "C'mon Everybody" for "CHUNK BROOKLYN - The Return!" from curated coordinates (3 m from the event pin 40.68830519999999, -73.9569221) — replaces "Brooklyn" (city name — resolves to city "nyc")
🤖 AI Web: Curated coordinates for "Chicago thing" are ambiguous — "Touché" (9 m), "Jackhammer" (9 m) within 12 m — no venue resolved
🤖 AI Web: Dropped implausible bar "Brooklyn" (city name — resolves to city "nyc")
🤖 AI Web: Dropped implausible bar "Portland" (city name — resolves to city "portland")
🤖 AI Web: Dropped implausible bar "Chicago" (city name — resolves to city "chicago")
```

### Both corpus states, because #1598 may merge after this

This branch is based on a main that **still has the duplicates**, so both states were driven explicitly (state B by applying #1598's six deletions in-memory):

| | STATE A — duplicates present | STATE B — duplicates removed |
|---|---|---|
| `The RETURN` | `Nova PDX` (via text corroboration: 2 hits, page names one) | `Nova PDX` (single hit) |
| `CHUNK BROOKLYN - The Return!` | `C'mon Everybody` (single hit) | `C'mon Everybody` (single hit) |
| ambiguity refusal | refuses | refuses |
| good venue names | untouched | untouched |
| blank bar at 722 E Burnside, page names **no** venue | refuses (2 unnameable hits) | `Nova PDX` |

The full matrix above is **identical in both states**. The only behavioural difference is the last row, and it moves in the safe direction: state A fails closed where state B can answer.

## Suite

**1128 passing** (1121 baseline + 7 new tests), all in the already-enumerated `scripts/parsers/ai-web-parser.test.js`. No new test files. No `new URL(` / `URLSearchParams` added. `shared-core.js` and `normalizers.js` untouched. `data/bars/*.json` untouched.

## Not shipped: the title-fragment fix

`The RETURN` and `Hot Gogo Bears` arrived missing the brand, and their slugs carry it (`chunk-portland-the-return-…`, `chunk-san-francisco-…`). I could not build a slug-based restoration I trust, so I skipped it:

- **The SF case cannot be located in its slug at all.** `Hot Gogo Bears` shares no token with `chunk-san-francisco-saturday-january-17th`, so the slug cannot tell us whether the brand is *missing from* the title or whether the title is a *different* headline than the slug describes. Any rule that fires here is prefixing blind.
- **Casing and separators are unrecoverable.** The slug gives `portland`, not `Portland`/`PDX`; nothing tells us `CHUNK Portland - The RETURN` vs `CHUNK PORTLAND: The RETURN` vs `CHUNK: The RETURN`. The corpus itself is inconsistent (`CHUNK Brooklyn 7/4`, `CHUNK Portland - 5/23`, `CHUNK SF presents FATHER FIGURE`), so there is no house format to follow.
- **The blast radius is every parser.** "slug contains the organizer shortName and the title does not" is true for most event-detail URLs across every site, so this would mass-rewrite titles — and since `title` merges `ai-web`-first, it would reach existing calendar entries.

If you want it, the repo already has one precedent worth reusing: `buildOrganizerPrefixedTitle` emits `"<ORGANIZER>: <title>"` for bare-city titles, which would give `CHUNK: The RETURN` / `CHUNK: Hot Gogo Bears`. Say the word and I will gate it to that exact format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
