### PR TITLE
fix(scraper): organizer brand belongs in the title — deterministic prefix, JSON-LD truncation repair, placeholder/domain bar gate

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -7626,6 +7626,71 @@ class AiWebParser {
     }
 
 
+    // Event `name` values from the page's own JSON-LD, cached per page like
+    // getPageBrandNames (segment/OCR htmlData copies are spreads and inherit
+    // the cache). Fails open to [] without a core: every consumer treats an
+    // empty list as "no structured data", which changes nothing.
+    getPageJsonLdEventNames(htmlData) {
+        if (!htmlData || typeof htmlData !== 'object') return [];
+        if (Array.isArray(htmlData.pageJsonLdEventNames)) return htmlData.pageJsonLdEventNames;
+        let names = [];
+        if (this.core && typeof this.core.extractJsonLdEventNodes === 'function') {
+            try {
+                names = this.core.extractJsonLdEventNodes(typeof htmlData.html === 'string' ? htmlData.html : '')
+                    .map(node => (node && typeof node.name === 'string'
+                        ? this.normalizeWhitespace(this.decodeBasicEntities(this.stripTags(node.name)).replace(/&amp;/gi, '&'))
+                        : ''))
+                    .filter(Boolean);
+            } catch (error) {
+                console.warn(`🤖 AI Web: JSON-LD event name lookup failed: ${error.message}`);
+                names = [];
+            }
+        }
+        if (Object.isExtensible(htmlData)) {
+            htmlData.pageJsonLdEventNames = names;
+        }
+        return names;
+    }
+
+
+    // Truncation repair: extraction dropped part of a headline the page itself
+    // publishes. When the page's JSON-LD names an Event whose `name` CONTAINS
+    // the extracted title (normalized, on token boundaries), the structured
+    // name is the same title's fuller authoritative form — adopt it verbatim.
+    //
+    // Containment is the entire licence, and it fails closed: a structured
+    // name that does not contain the extracted title belongs to a different
+    // event and is never swapped in, and a title contained in two or more
+    // structured names cannot be attributed to either. Nothing is composed or
+    // invented — the returned value is always one node's `name` exactly as
+    // published, and the caller runs it through the same title cleanups every
+    // other title gets. Structured data enriches here; it never bypasses
+    // extraction, which still ran and still decided.
+    repairTruncatedTitleFromJsonLd(title, htmlData) {
+        const original = String(title || '');
+        const names = this.getPageJsonLdEventNames(htmlData);
+        if (!original || names.length === 0) return original;
+        const normalize = (value) => String(value || '')
+            .toLowerCase()
+            .replace(/[^\p{L}\p{N}]+/gu, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        const normalizedTitle = normalize(original);
+        if (!normalizedTitle) return original;
+        const matches = names.filter(name => {
+            const normalizedName = normalize(name);
+            if (!normalizedName || normalizedName === normalizedTitle) return false;
+            return ` ${normalizedName} `.includes(` ${normalizedTitle} `);
+        });
+        if (matches.length === 0) return original;
+        if (matches.length > 1) {
+            console.log(`🤖 AI Web: Title "${original}" is contained in ${matches.length} JSON-LD event names — ambiguous, keeping the extracted title`);
+            return original;
+        }
+        return matches[0];
+    }
+
+
     // Padded-token containment of a candidate title in any '|'-separated
     // segment of the page's own og:title or <title> tag. Case-insensitive,
     // punctuation-collapsed; empty inputs never match.
@@ -8691,7 +8756,7 @@ ${String(snippet || '')}`;
             const aliasSuffix = pageBrandNames.length > 1
                 ? ` (also appears as ${pageBrandNames.slice(1).map(name => `"${name}"`).join(', ')})`
                 : '';
-            steeringContext += `KNOWN ORGANIZER (derived from page metadata): "${pageBrandNames[0]}"${aliasSuffix} — this is the event promoter/site brand, NOT the venue. Never return it as "bar", and do not treat its name in page titles as part of the event name.\n`;
+            steeringContext += `KNOWN ORGANIZER (derived from page metadata): "${pageBrandNames[0]}"${aliasSuffix} — this is the event promoter/site brand, NOT the venue. Never return it as "bar".\n`;
         }
         const extraContext = aiConfig && typeof aiConfig.extraContext === 'string' ? aiConfig.extraContext.trim() : '';
         if (extraContext) {
@@ -10738,6 +10803,19 @@ TEXT:
             aiEvent.summary,
             this.getResolvedParserMetadataFieldValue(parserConfig, ['title', 'name', 'summary'], aiEvent)
         );
+        // Restore a title extraction truncated, proven by containment in the
+        // page's own JSON-LD Event name (see repairTruncatedTitleFromJsonLd).
+        // Deliberately FIRST of the title cleanups: the adopted value is the
+        // published name verbatim, so it still has to face the leading-date
+        // strip and the brand-suffix strip below — the same two cleanups the
+        // structured-data path applies to JSON-LD titles.
+        if (title) {
+            const repairedTitle = this.repairTruncatedTitleFromJsonLd(title, htmlData);
+            if (repairedTitle !== title) {
+                console.log(`🤖 AI Web: Restored truncated title "${title}" → "${repairedTitle}" (contained in the page's own JSON-LD event name)`);
+                title = repairedTitle;
+            }
+        }
         // Strip a leading date phrase HERE rather than in the per-pass guard:
         // titles also arrive from segment headings and config metadata, which
         // never pass through that guard — a live BEEFMINCE run showed the

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -652,6 +652,13 @@ class AiWebParser {
                             console.log(`🤖 AI Web: Title "${event.title}" is just the event's city — prefixed known organizer → "${prefixedTitle}"`);
                             event.title = prefixedTitle;
                         }
+                        // …and the title-doctrine brand prefix, for the same
+                        // reason: structured-data events skip normalizeAiEvent.
+                        const brandTitle = this.buildBrandPrefixedTitle(event.title, pageBrandNames, effectiveHtmlData, parserConfig);
+                        if (brandTitle) {
+                            console.log(`🤖 AI Web: Title "${event.title}" does not name the page's organizer — prefixed brand → "${brandTitle}"`);
+                            event.title = brandTitle;
+                        }
                     });
                 }
                 // Enrichment only: fills empty fields from the Wix warmup blob,
@@ -8611,7 +8618,7 @@ class AiWebParser {
         // at the Dallas Eagle 🤼‍♂️🦅"). Appended to the schema line so the
         // schema text itself stays byte-identical.
         if (normalized === 'title') {
-            description += ` The title is the event's NAME — short and reusable, exactly as it appears in the source. When the source text is an announcement sentence or caption that contains the event name, extract just the name portion (it must still appear verbatim within the source). Never include venue, city, date, or marketing phrases in the title.`;
+            description += ` The title is the event's NAME — short and reusable, exactly as it appears in the source. When the source text is an announcement sentence or caption that contains the event name, extract just the name portion (it must still appear verbatim within the source). Never include venue, city, date, or marketing phrases in the title — but the organizer/promoter brand IS part of the name: when the source headline leads with it, keep it.`;
         }
         // Prompt-only steering (run 20260724-155934 findings): thedallaseagle.com
         // listings print "End at: August 1, 2026 - 2:00 am" and extraction kept
@@ -10121,6 +10128,15 @@ TEXT:
     // merely containing "com"/"org" never classifies as brand-citing; tokens
     // under 3 chars are skipped. Cached per page on htmlData like
     // getPageBrandNames.
+    // Labels that only ever mean "this is web infrastructure", never a place
+    // or a name. Shared by the brand/domain token corpus below and the
+    // domain-shaped bar rejection — deliberately NOT every TLD: ".club",
+    // ".bar" and ".bkk" are how real venues spell themselves ("massive.club",
+    // "BARBER.BAR", "BEEF.BKK" are all curated venue names).
+    getGenericInfrastructureDomainLabels() {
+        return new Set(['www', 'com', 'org', 'net', 'edu', 'gov', 'mil', 'info', 'biz', 'app', 'dev', 'web', 'site', 'online', 'html', 'htm']);
+    }
+
     getPageBrandDomainTokens(htmlData) {
         if (!htmlData || typeof htmlData !== 'object') return [];
         if (Array.isArray(htmlData.pageBrandDomainTokens)) return htmlData.pageBrandDomainTokens;
@@ -10139,7 +10155,7 @@ TEXT:
             : '';
         if (host) {
             add(host);
-            const genericLabels = new Set(['www', 'com', 'org', 'net', 'edu', 'gov', 'mil', 'info', 'biz', 'app', 'dev', 'web', 'site', 'online', 'html', 'htm']);
+            const genericLabels = this.getGenericInfrastructureDomainLabels();
             host.split('.').forEach(label => {
                 if (!genericLabels.has(label)) add(label);
             });
@@ -10906,6 +10922,16 @@ TEXT:
             if (prefixedTitle) {
                 console.log(`🤖 AI Web: Title "${title}" is just the event's city — prefixed known organizer → "${prefixedTitle}"`);
                 title = prefixedTitle;
+            }
+        }
+        // Title doctrine, promoter half: the brand belongs in the event's name.
+        // Runs AFTER the bare-city prefixer above, whose output already names
+        // the organizer — so this is a no-op there, never a second prefix.
+        if (pageBrandNames.length > 0) {
+            const brandTitle = this.buildBrandPrefixedTitle(title, pageBrandNames, htmlData, parserConfig);
+            if (brandTitle) {
+                console.log(`🤖 AI Web: Title "${title}" does not name the page's organizer — prefixed brand → "${brandTitle}"`);
+                title = brandTitle;
             }
         }
         const timezone = this.firstNonEmpty(
@@ -13996,6 +14022,25 @@ TEXT:
         return '';
     }
 
+    // A website is never a venue: run 20260731 shipped bar "CHUNK-PARTY.COM"
+    // (the promoter's own domain, swapped into the bar field while the real
+    // venue "C'mon Everybody" went to the title). Domain SHAPE, not mere
+    // punctuation — dots are legitimate in venue names, and the curated
+    // corpus proves it ("massive.club", "BARBER.BAR", "BEEF.BKK"):
+    //   - an explicit URL/host form ("https://…", "www.…") is always a domain;
+    //   - otherwise a bare single-token host qualifies ONLY when its last
+    //     label is a generic infrastructure label (.com/.net/.org/…), which no
+    //     venue uses as its name.
+    // Fails open on anything with whitespace — a real name, not a hostname.
+    isDomainShapedBarValue(value) {
+        const text = String(value || '').trim();
+        if (!text || /\s/.test(text)) return false;
+        if (/^(?:https?:\/\/|www\.)/i.test(text)) return true;
+        const hostMatch = text.match(/^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)*\.([a-z]{2,})$/i);
+        if (!hostMatch) return false;
+        return this.getGenericInfrastructureDomainLabels().has(hostMatch[1].toLowerCase());
+    }
+
     // Post-extraction bar plausibility gate (mirror of
     // applyAddressPlausibilityGate: flag-and-drop, additive log): an
     // address-shaped bar VALUE is never a valid extraction. Run
@@ -14013,9 +14058,16 @@ TEXT:
         if (!event || typeof event !== 'object') return event;
         const bar = typeof event.bar === 'string' ? event.bar.trim() : '';
         if (!bar) return event;
-        const reason = this.isAddressShapedBarValue(bar)
-            ? 'address-shaped'
-            : this.getCityShapedBarRejection(bar, event, cityConfig);
+        // Same flag-and-drop shape for every reason, so the curated exemption
+        // below applies uniformly. Placeholder reuses isPlaceholderVenueName,
+        // which the maps-link candidate path already trusts — it was simply
+        // never wired in here, so run 20260731 shipped SPOOKMINCE with bar
+        // "Venue TBA" as if an unannounced venue were a real one.
+        let reason = '';
+        if (this.isAddressShapedBarValue(bar)) reason = 'address-shaped';
+        else if (this.isPlaceholderVenueName(bar)) reason = 'placeholder — venue not announced';
+        else if (this.isDomainShapedBarValue(bar)) reason = 'website domain — not a venue name';
+        else reason = this.getCityShapedBarRejection(bar, event, cityConfig);
         if (!reason) return event;
         // Curated data outranks a derived shape heuristic. Both shape tests
         // above read a NAME and guess what it is; the curated corpus KNOWS.
@@ -14593,10 +14645,7 @@ TEXT:
         if (!Array.isArray(pageBrandNames) || pageBrandNames.length === 0) return '';
         if (!this.isCityOnlyTitle(title, cityValue, cityConfig)) return '';
         if (this.titleContainsPageBrandName(title, pageBrandNames)) return '';
-        const ogSiteName = this.getPageOgSiteName(htmlData);
-        const organizerDisplay = ogSiteName && this.matchesPageBrandName(ogSiteName, pageBrandNames)
-            ? ogSiteName
-            : pageBrandNames[0];
+        const organizerDisplay = this.getOrganizerDisplayName(pageBrandNames, htmlData);
         let baseTitle = title;
         const ogTitle = this.getPageOgTitle(htmlData);
         if (ogTitle) {
@@ -14608,6 +14657,92 @@ TEXT:
             }
         }
         return `${organizerDisplay}: ${baseTitle}`;
+    }
+
+    // How the page displays its own brand: og:site_name when it agrees with a
+    // derived brand name ("BEARRACUDA"), else the primary extracted name (the
+    // same value the _organizer stamp uses). Shared with the city-only
+    // prefixer above so both spell the organizer the same way.
+    getOrganizerDisplayName(pageBrandNames, htmlData) {
+        if (!Array.isArray(pageBrandNames) || pageBrandNames.length === 0) return '';
+        const ogSiteName = this.getPageOgSiteName(htmlData);
+        return ogSiteName && this.matchesPageBrandName(ogSiteName, pageBrandNames)
+            ? ogSiteName
+            : pageBrandNames[0];
+    }
+
+    // The page's derived brand is corroborated as THIS parser's promoter when
+    // the parser's own configured name says so ("CHUNK" ≡ brand "CHUNK";
+    // "Bearracuda Events" contains brand "Bearracuda"). Curated config beats a
+    // derived signal, and it is what keeps a crawled PLATFORM's brand out of
+    // event names: Cubhouse's linktr.ee pages derive "Linktree" and Goldiloxx's
+    // ticketing pages derive "DICE", neither of which any parser is named
+    // after. Whole-token matching only — no substrings.
+    pageBrandMatchesParserName(pageBrandNames, parserConfig) {
+        const configured = parserConfig && typeof parserConfig.name === 'string' ? parserConfig.name.trim() : '';
+        if (!configured) return false;
+        if (!Array.isArray(pageBrandNames) || pageBrandNames.length === 0) return false;
+        return this.matchesPageBrandName(configured, pageBrandNames)
+            || this.titleContainsPageBrandName(configured, pageBrandNames);
+    }
+
+    // …and the curated promoter registry (data/promoters.json) independently
+    // knows the brand as a promoter. Second curated signal, deliberately AND-ed
+    // with the parser-name check above: an AGGREGATOR is named after itself and
+    // passes the parser-name check on its own pages ("The Bear Calendar"), but
+    // it is not a promoter and its listings belong to Megawoof, Twisted Bear
+    // and friends — the registry is what knows the difference. Fails closed
+    // when the registry is unavailable (no core, empty list).
+    pageBrandIsCuratedPromoter(pageBrandNames) {
+        if (!this.core || typeof this.core.getPromoterEntryByName !== 'function') return false;
+        return (Array.isArray(pageBrandNames) ? pageBrandNames : [])
+            .some(name => Boolean(this.core.getPromoterEntryByName(name)));
+    }
+
+    // Title doctrine, promoter half: the event's NAME carries the organizer
+    // brand (venue, city and date have their own fields and stay out of it).
+    // The extraction prompt asks for the brand, but a prompt is a request —
+    // this is the deterministic backstop that makes the outcome the same
+    // whatever the model returned: "The RETURN" → "CHUNK: The RETURN".
+    //
+    // PREFIX ONLY. Nothing is ever removed from a title here: many promoters
+    // name events "<BRAND> <city> <date>" and nothing else, so stripping city
+    // and date would collapse "CHUNK Chicago - September 19th", "CHUNK
+    // Brooklyn 7/4" and "CHUNK Brooklyn - 5/9" to the identical string
+    // "CHUNK", destroying event identity and dedup.
+    //
+    // Fails closed in every direction:
+    // - no derived brand for the page → '' (a brand is never invented)
+    // - the brand is not corroborated by BOTH curated signals — the parser's
+    //   configured name and the promoter registry → '' (derived data alone
+    //   never licenses rewriting a title)
+    // - a page classified as the VENUE's own site → '' (there the brand IS the
+    //   venue, and the venue belongs in bar, not the title)
+    // - the title already names the brand in ANY casing or position → ''
+    //   (idempotent: "CHUNK Brooklyn 7/4" and "CHUNK CHICAGO presents SPRING
+    //   THAW!" are left exactly as they are, and a re-run never doubles up)
+    // - the title is nothing BUT the brand, so prefixing could only produce
+    //   "CHUNK: CHUNK" → '' (collapse guard)
+    // - an implausible brand — no alphanumerics, or long enough to swamp the
+    //   name it prefixes — → '' rather than an absurd title.
+    buildBrandPrefixedTitle(title, pageBrandNames, htmlData, parserConfig = null) {
+        const text = this.normalizeWhitespace(String(title || ''));
+        if (!text) return '';
+        if (!Array.isArray(pageBrandNames) || pageBrandNames.length === 0) return '';
+        if (!this.pageBrandMatchesParserName(pageBrandNames, parserConfig)) return '';
+        if (!this.pageBrandIsCuratedPromoter(pageBrandNames)) return '';
+        if (this.getPageSiteRole(htmlData) === 'venue') return '';
+        if (this.titleContainsPageBrandName(text, pageBrandNames)) return '';
+        // Collapse guard: a title that is ONLY brand tokens has no event name
+        // to carry, so there is nothing to prefix — leave the original alone.
+        const withoutBrandTokens = text.split(/\s+/)
+            .filter(token => token && !this.titleContainsPageBrandName(token, pageBrandNames))
+            .join(' ');
+        if (!/[a-z0-9]/i.test(withoutBrandTokens)) return '';
+        const organizerDisplay = this.normalizeWhitespace(this.getOrganizerDisplayName(pageBrandNames, htmlData));
+        if (!/[a-z0-9]/i.test(organizerDisplay)) return '';
+        if (organizerDisplay.length > 24 || organizerDisplay.split(/\s+/).length > 3) return '';
+        return `${organizerDisplay}: ${text}`;
     }
 
     // Split a combined OCR+page stream into ordered corpus chunks so the

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -8316,6 +8316,93 @@ test('strips a leading date phrase from an event title, and only then', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Truncated-title repair from the page's own JSON-LD Event name (run
+// 20260731-124200: CHUNK's page publishes "CHUNK Portland - The RETURN!
+// Saturday March 14th" in JSON-LD, <title>, og:title and <h1>, and extraction
+// shipped "The RETURN")
+// ---------------------------------------------------------------------------
+
+const jsonLdEventPage = (...nodes) => `<html><head>${nodes
+  .map(node => `<script type="application/ld+json">${JSON.stringify(node)}</script>`)
+  .join('')}</head><body></body></html>`;
+const jsonLdEventNode = (name) => ({
+  '@context': 'https://schema.org',
+  '@type': 'Event',
+  name,
+  startDate: '2026-03-14T21:00:00-07:00'
+});
+
+test('restores a truncated title from the page JSON-LD event name that contains it', () => {
+  const parser = createParser();
+  const html = jsonLdEventPage(jsonLdEventNode('CHUNK Portland - The RETURN! Saturday March 14th'));
+  const htmlData = { html, url: 'https://www.chunk-party.com/event-details/chunk-portland-the-return-saturday-march-14th' };
+  assert.equal(
+    parser.repairTruncatedTitleFromJsonLd('The RETURN', htmlData),
+    'CHUNK Portland - The RETURN! Saturday March 14th');
+  // Case, punctuation and whitespace differences never block the repair.
+  assert.equal(
+    parser.repairTruncatedTitleFromJsonLd('the  return!', htmlData),
+    'CHUNK Portland - The RETURN! Saturday March 14th');
+});
+
+test('never swaps in a JSON-LD event name that does not contain the extracted title', () => {
+  const parser = createParser();
+  const htmlData = { html: jsonLdEventPage(jsonLdEventNode('CHUNK Portland - SUMMER BLOW OUT!')), url: 'https://www.chunk-party.com/x' };
+  assert.equal(parser.repairTruncatedTitleFromJsonLd('The RETURN', htmlData), 'The RETURN');
+  // Word fragments are not containment: "RETURN" must not match "RETURNS".
+  const fragmentData = { html: jsonLdEventPage(jsonLdEventNode('CHUNK RETURNS to Portland')), url: 'https://www.chunk-party.com/x' };
+  assert.equal(parser.repairTruncatedTitleFromJsonLd('RETURN', fragmentData), 'RETURN');
+  // An equal name is not a truncation, and there is nothing to repair.
+  const equalData = { html: jsonLdEventPage(jsonLdEventNode('The RETURN')), url: 'https://www.chunk-party.com/x' };
+  assert.equal(parser.repairTruncatedTitleFromJsonLd('The RETURN', equalData), 'The RETURN');
+  // Ambiguity fails closed: two structured names contain the same title.
+  const ambiguousData = {
+    html: jsonLdEventPage(
+      jsonLdEventNode('CHUNK Brooklyn - The Return!'),
+      jsonLdEventNode('CHUNK Portland - The Return! Saturday March 14th')),
+    url: 'https://www.chunk-party.com/x'
+  };
+  assert.equal(parser.repairTruncatedTitleFromJsonLd('The Return', ambiguousData), 'The Return');
+  // No structured data, no title, no htmlData → unchanged.
+  assert.equal(parser.repairTruncatedTitleFromJsonLd('The RETURN', { html: '<html></html>', url: 'https://x.example/' }), 'The RETURN');
+  assert.equal(parser.repairTruncatedTitleFromJsonLd('', { html: jsonLdEventPage(jsonLdEventNode('CHUNK Portland - The RETURN!')) }), '');
+  assert.equal(parser.repairTruncatedTitleFromJsonLd('The RETURN', null), 'The RETURN');
+});
+
+test('the JSON-LD title repair fails open without a core and composes with the other title cleanups', () => {
+  // Fail open: the gate needs SharedCore's JSON-LD reader.
+  const coreless = new AiWebParser({ normalizeUrl });
+  const html = jsonLdEventPage(jsonLdEventNode('CHUNK Portland - The RETURN! Saturday March 14th'));
+  assert.deepEqual(coreless.getPageJsonLdEventNames({ html }), []);
+  assert.equal(coreless.repairTruncatedTitleFromJsonLd('The RETURN', { html }), 'The RETURN');
+
+  // Through the real normalization path, the repaired title still faces the
+  // leading-date strip and the pipe brand-suffix strip.
+  const parser = createParser();
+  const repaired = parser.normalizeAiEvent(
+    { title: 'The RETURN', startDate: '2026-03-14T21:00:00-07:00' },
+    {}, { html, url: 'https://www.chunk-party.com/x' }, null, null);
+  assert.equal(repaired.title, 'CHUNK Portland - The RETURN! Saturday March 14th');
+
+  const datedParser = createParser();
+  const dated = datedParser.normalizeAiEvent(
+    { title: 'BEEFMINCE MEET MARKET', startDate: '2026-09-09T21:00:00Z' },
+    {}, { html: jsonLdEventPage(jsonLdEventNode('Wednesday 9th September - BEEFMINCE MEET MARKET NIGHT')), url: 'https://bear.example/x' },
+    null, null);
+  assert.equal(dated.title, 'BEEFMINCE MEET MARKET NIGHT');
+
+  const brandedParser = createParser();
+  const brandedHtml = `<html><head><meta property="og:site_name" content="CHUNK"/>`
+    + `<script type="application/ld+json">${JSON.stringify({ '@context': 'https://schema.org', '@type': 'WebSite', name: 'CHUNK', url: 'https://www.chunk-party.com' })}</script>`
+    + `<script type="application/ld+json">${JSON.stringify(jsonLdEventNode('CHUNK Portland - The RETURN! Saturday March 14th | CHUNK'))}</script>`
+    + `</head><body></body></html>`;
+  const branded = brandedParser.normalizeAiEvent(
+    { title: 'The RETURN', startDate: '2026-03-14T21:00:00-07:00' },
+    {}, { html: brandedHtml, url: 'https://www.chunk-party.com/x' }, null, null);
+  assert.equal(branded.title, 'CHUNK Portland - The RETURN! Saturday March 14th');
+});
+
+// ---------------------------------------------------------------------------
 // Maps-link coordinate candidates (Dice.fm event pages publish the venue's
 // pin in the ll= param of their "Open in maps" link — high value, but Dice
 // geocoded Westminster Pier ~940 m off, onto a DIFFERENT pier, and pins

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -5330,7 +5330,7 @@ test('getFieldContext bar steering: the address-shape sentence is appended, exis
 
 test('getFieldContext title steering: the caption-vs-name sentences are appended, existing schema text unchanged, other fields unaffected', () => {
   const parser = createParser();
-  const steering = ` The title is the event's NAME — short and reusable, exactly as it appears in the source. When the source text is an announcement sentence or caption that contains the event name, extract just the name portion (it must still appear verbatim within the source). Never include venue, city, date, or marketing phrases in the title.`;
+  const steering = ` The title is the event's NAME — short and reusable, exactly as it appears in the source. When the source text is an announcement sentence or caption that contains the event name, extract just the name portion (it must still appear verbatim within the source). Never include venue, city, date, or marketing phrases in the title — but the organizer/promoter brand IS part of the name: when the source headline leads with it, keep it.`;
   const context = parser.getFieldContext('title', null);
   assert.ok(context.endsWith(steering),
     `the title steering is appended, got: ${JSON.stringify(context)}`);
@@ -8313,6 +8313,123 @@ test('strips a leading date phrase from an event title, and only then', () => {
   assert.equal(strip('Bearracuda Atlanta: Winter Beef Ball'), 'Bearracuda Atlanta: Winter Beef Ball');
   assert.equal(strip('Bear Week Sitges - Opening Party'), 'Bear Week Sitges - Opening Party');
   assert.equal(strip(''), '');
+});
+
+// ---------------------------------------------------------------------------
+// Title doctrine, promoter half: the organizer brand belongs in the event's
+// NAME (run 20260731-124200 shipped "The RETURN"). PREFIX ONLY — never strip.
+// ---------------------------------------------------------------------------
+
+const CHUNK_BRAND_HTML = '<html><head><meta property="og:site_name" content="CHUNK"/>'
+  + '<script type="application/ld+json">{"@context":"https://schema.org/","@type":"WebSite","name":"CHUNK","url":"https://www.chunk-party.com"}</script>'
+  + '</head><body></body></html>';
+function createChunkParser() {
+  const parser = createParser();
+  parser.core.promoters = [{ name: 'CHUNK' }];
+  return parser;
+}
+const CHUNK_PAGE = () => ({ html: CHUNK_BRAND_HTML, url: 'https://www.chunk-party.com/event-details/x' });
+const CHUNK_CONFIG = { name: 'CHUNK' };
+
+test('prefixes the organizer brand onto a title that lacks it, idempotently', () => {
+  const parser = createChunkParser();
+  const brands = parser.getPageBrandNames(CHUNK_PAGE());
+  const prefix = (title) => parser.buildBrandPrefixedTitle(title, brands, CHUNK_PAGE(), CHUNK_CONFIG);
+
+  assert.equal(prefix('The RETURN'), 'CHUNK: The RETURN');
+  assert.equal(prefix('NEW YEARS EVE'), 'CHUNK: NEW YEARS EVE');
+
+  // Idempotent in ANY casing or position — a re-run never doubles up. Every
+  // brand-bearing title from run 20260731-120505 is left exactly as it is.
+  for (const title of [
+    'CHUNK Portland - SUMMER BLOW OUT!',
+    'CHUNK Chicago - September 19th',
+    'CHUNK DORE ALLEY - Saturday July 25th',
+    'CHUNK Brooklyn 7/4',
+    'CHUNK Brooklyn - 5/9',
+    'CHUNK CHICAGO presents SPRING THAW!',
+    'CHUNK CHICAGO presents SAUSAGE PARTY!',
+    'CHUNK BROOKLYN - The Return!',
+    'chunk portland - the return!',
+    'Summer Blow Out — CHUNK'
+  ]) {
+    assert.equal(prefix(title), '', `already names the brand: ${title}`);
+  }
+  // And prefixing an already-prefixed title is a no-op.
+  assert.equal(prefix(prefix('The RETURN')), '');
+});
+
+test('the brand prefix never collapses a title to the bare brand', () => {
+  const parser = createChunkParser();
+  const brands = parser.getPageBrandNames(CHUNK_PAGE());
+  const prefix = (title) => parser.buildBrandPrefixedTitle(title, brands, CHUNK_PAGE(), CHUNK_CONFIG);
+  // "<BRAND> <city> <date>" is how this promoter names events: stripping the
+  // city and date would collapse four distinct events to the single string
+  // "CHUNK". Nothing is ever removed here — the title comes back untouched.
+  assert.equal(prefix('CHUNK Brooklyn 7/4'), '');
+  // A title that is nothing BUT brand tokens has no name to carry.
+  assert.equal(prefix('CHUNK'), '');
+  assert.equal(prefix('chunk'), '');
+  assert.equal(prefix(''), '');
+});
+
+test('the brand prefix demands BOTH curated signals and skips venue sites', () => {
+  const brands = createChunkParser().getPageBrandNames(CHUNK_PAGE());
+
+  // Registry knows CHUNK but the parser is named after something else — the
+  // aggregator/platform case (linktr.ee → "Linktree", dice.fm → "DICE").
+  const wrongParser = createChunkParser();
+  assert.equal(wrongParser.buildBrandPrefixedTitle('The RETURN', brands, CHUNK_PAGE(), { name: 'Cubhouse' }), '');
+  assert.equal(wrongParser.buildBrandPrefixedTitle('The RETURN', brands, CHUNK_PAGE(), null), '');
+
+  // Parser name matches but the promoter registry does not know the brand —
+  // an aggregator named after itself ("The Bear Calendar") lands here.
+  const noRegistry = createParser();
+  noRegistry.core.promoters = [];
+  assert.equal(noRegistry.buildBrandPrefixedTitle('The RETURN', brands, CHUNK_PAGE(), CHUNK_CONFIG), '');
+  const corelessParser = new AiWebParser({ normalizeUrl });
+  assert.equal(corelessParser.buildBrandPrefixedTitle('The RETURN', brands, CHUNK_PAGE(), CHUNK_CONFIG), '');
+
+  // A page that is the VENUE's own site: there the brand IS the venue.
+  const venueParser = createChunkParser();
+  const venuePage = { html: CHUNK_BRAND_HTML, url: 'https://www.chunk-party.com/x', pageSiteRole: 'venue' };
+  assert.equal(venueParser.buildBrandPrefixedTitle('The RETURN', brands, venuePage, CHUNK_CONFIG), '');
+
+  // No derived brand → nothing is invented.
+  assert.equal(createChunkParser().buildBrandPrefixedTitle('The RETURN', [], CHUNK_PAGE(), CHUNK_CONFIG), '');
+});
+
+// ---------------------------------------------------------------------------
+// Bar plausibility gate: placeholder and website-domain rejections
+// ---------------------------------------------------------------------------
+
+test('drops a placeholder or website-domain bar, and keeps dotted venue names', () => {
+  const parser = createParser();
+  const gate = (bar, city = 'nyc') => {
+    const event = { bar, city };
+    parser.applyBarPlausibilityGate(event, {});
+    return event.bar;
+  };
+  // Placeholder (run 20260731 shipped SPOOKMINCE with bar "Venue TBA").
+  assert.equal(gate('Venue TBA'), undefined);
+  assert.equal(gate('TBA'), undefined);
+  assert.equal(gate('Venue TBC'), undefined);
+  assert.equal(gate('To Be Announced'), undefined);
+  // Website domain (run 20260731 shipped bar "CHUNK-PARTY.COM").
+  assert.equal(gate('CHUNK-PARTY.COM'), undefined);
+  assert.equal(gate('www.chunk-party.com'), undefined);
+  assert.equal(gate('https://bearracuda.com'), undefined);
+  // Dotted venue names are NOT domains — all three are curated venues.
+  assert.equal(gate('massive.club', 'berlin'), 'massive.club');
+  assert.equal(gate('MASSIVE.CLUB', 'berlin'), 'MASSIVE.CLUB');
+  assert.equal(gate('BEEF.BKK', 'bangkok'), 'BEEF.BKK');
+  assert.equal(gate('BARBER.BAR', 'bangkok'), 'BARBER.BAR');
+  // Ordinary venue names are untouched.
+  assert.equal(gate("C'mon Everybody"), "C'mon Everybody");
+  assert.equal(gate('F8 Nightclub & Bar', 'sf'), 'F8 Nightclub & Bar');
+  assert.equal(gate('Nova PDX', 'portland'), 'Nova PDX');
+  // A name containing a domain-ish word is not a bare host.
+  assert.equal(gate('The Web Bar'), 'The Web Bar');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

A real CHUNK run shipped an event titled **"The RETURN"**. The page publishes the full name five times over: JSON-LD `Event.name`, `<title>`, `og:title`, `twitter:title`, `<h1>` — all `CHUNK Portland - The RETURN! Saturday March 14th`.

Forensics found **three** links in the chain, not one. All are addressed here except the merge rung, which current `main` already fixed (see below).

---

## Prompt edits (2, both owner-sanctioned)

Changing prompt text invalidates the AI response cache for extraction passes — the next run pays full AI time (~200-310s) instead of hitting cache. Accepted, and paid **once** for both edits.

### 1. KNOWN ORGANIZER steering line

**Before**
```
KNOWN ORGANIZER (derived from page metadata): "CHUNK" — this is the event promoter/site brand, NOT the venue. Never return it as "bar", and do not treat its name in page titles as part of the event name.
```
**After**
```
KNOWN ORGANIZER (derived from page metadata): "CHUNK" — this is the event promoter/site brand, NOT the venue. Never return it as "bar".
```
The removed clause asked for a judgement call — strip the brand as a site-name suffix, keep it as part of a headline. No new prompt text replaces it: `stripPageBrandFromTitle` already strips a pipe-delimited `" | <brand>"` suffix deterministically.

### 2. Per-field `title` rule

**Before**
```
… Never include venue, city, date, or marketing phrases in the title.
```
**After**
```
… Never include venue, city, date, or marketing phrases in the title — but the organizer/promoter brand IS part of the name: when the source headline leads with it, keep it.
```
This is the load-bearing instruction: in a live A/B the model's own evidence string was the full headline, and it dropped "Portland" (city) and "Saturday March 14th" (date) exactly as told. The city/date language is **unchanged** — only the brand is now permitted.

`git diff` against `main` removes exactly these two prompt lines and no others.

---

## Deterministic brand prefixing — PREFIX ONLY, never strip

A prompt is a request; the A/B proved the model follows the field rule literally. `buildBrandPrefixedTitle` makes the outcome deterministic: **"The RETURN" → "CHUNK: The RETURN"**.

**Separator `": "`** — matching the existing `buildOrganizerPrefixedTitle`, which already ships titles like `"CHUNK: San Francisco"`. Not the `" - "` from the brief, to avoid two formats for one idea.

**Nothing is ever removed.** Many promoters name events `<BRAND> <city> <date>` and nothing else, so post-hoc stripping of city and date would collapse `CHUNK Chicago - September 19th`, `CHUNK DORE ALLEY - Saturday July 25th`, `CHUNK Brooklyn 7/4` and `CHUNK Brooklyn - 5/9` to the identical string `"CHUNK"` — four distinct events, one title. A **collapse guard** additionally refuses any title made of nothing but brand tokens (test case: `CHUNK Brooklyn 7/4`, plus bare `CHUNK`).

Fails closed in every direction:
- no derived brand → nothing invented
- **BOTH curated signals required**: the parser's configured `name` AND the promoter registry (`data/promoters.json`) must know the brand. Derived data alone never licenses a title rewrite.
- venue sites (`siteRole 'venue'`) excluded — there the brand IS the venue
- idempotent: brand present in any casing or position → untouched; re-runs never double up

Why both signals: the parser-name check alone lets an **aggregator** brand other people's events (`The Bear Calendar` is named after itself and would have produced `"The Bear Calendar: MEGAWOOF"`); the registry alone would not stop a platform brand if a parser were ever named after one. Together they exclude `Linktree` (Cubhouse's linktr.ee), `DICE` (Goldiloxx's ticketing pages), `Google for Developers`, `The Bear Calendar`, and venue brands (`3 Dollar bill`, `Eagle LA`, `lumberyardbar`).

---

## Blast radius (quantified — title merges ai-web-first, so this can retitle live calendar entries)

### The 14 real events from run 20260731-120505

| # | before | after | why |
|---|--------|-------|-----|
| 1 | CHUNK Portland - SUMMER BLOW OUT! | *unchanged* | brand already in title (idempotent) |
| 2 | CHUNK Chicago - September 19th | *unchanged* | idempotent |
| 3 | CHUNK DORE ALLEY - Saturday July 25th | *unchanged* | idempotent |
| 4 | CHUNK Brooklyn 7/4 | *unchanged* | idempotent + collapse guard |
| 5 | Nova Box | **CHUNK: Nova Box** | brand absent → prefixed |
| 6 | CHUNK Brooklyn - 5/9 | *unchanged* | idempotent |
| 7 | FATHER FIGURE | *unchanged* | no brand derived on that page |
| 8 | CHUNK CHICAGO presents SPRING THAW! | *unchanged* | idempotent |
| 9 | The RETURN | **CHUNK: The RETURN** | brand absent → prefixed |
| 10 | Brooklyn | **CHUNK: Brooklyn** | brand absent → prefixed |
| 11 | Hot Gogo Bears | *unchanged* | no brand derived on that page |
| 12 | NEW YEARS EVE | **CHUNK: NEW YEARS EVE** | brand absent → prefixed |
| 13 | CHUNK CHICAGO presents SAUSAGE PARTY! | *unchanged* | idempotent |
| 14 | CHUNK BROOKLYN - The Return! | *unchanged* | idempotent |

**4 of 14 change; 10 are untouched.** End-to-end against the real cached homepage and the real model, segment 9 now produces `"CHUNK: The RETURN"` (was `"The RETURN"`).

**Calendar entries that would be rewritten on the next run:** the four above — `The RETURN`, `NEW YEARS EVE`, `Brooklyn`, `Nova Box` — each gaining a `CHUNK: ` prefix. #9 and #12 also merge against their detail pages, whose JSON-LD titles already carry the brand, so arbitration decides between two brand-bearing titles.

**Does anything get worse?** No title loses information — the transformation is strictly additive. The one to eyeball is #5 `Nova Box` → `CHUNK: Nova Box`: `Nova Box` is a bad title to begin with (a segment artifact naming the venue), and prefixing does not fix that, but it does not degrade it either. #10 `Brooklyn` → `CHUNK: Brooklyn` is the same outcome the pre-existing bare-city prefixer already aims for.

### Cross-parser: every configured parser × every cached host

Only these four would ever prefix, all promoters on their own sites:

```
Bearracuda Events: bearracuda.com    → "BEARRACUDA: <event>"
CHUNK:             www.chunk-party.com → "CHUNK: <event>"
BEEFMINCE:         beefmince.com     → "BEEFMINCE: <event>"
Club Chub:         www.clubchubusa.com → "CLUB CHUB: <event>"
```

Every other parser prefixes nothing on any cached host.

**Flagged, not shipped:** `Furball` derives brand `"furballnyc"` from its og:site_name. That is an odd spelling and would have produced `"furballnyc: FURBALL BLACKOUT"`; the registry name is `Furball`, which does not match `furballnyc`, so the gate excludes it and Furball titles are untouched. `Bears Sitges Week` is excluded the same way (brand `Bears Sitges` vs registry `Bears Sitges Club`). Both are no-change outcomes, not regressions — worth a registry alias if the owner wants them prefixed.

---

## Merge doctrine (shared-core ~2220) — verified, and left completely alone

The rule discarded the better title in the original run because Wix set `location.name = "Portland"`, making the correct title look venue-bearing. **PR #1599 fixed the input.** On current `main`, the same event's bar now resolves to `"Nova PDX"` (verified by driving the real cached detail page: `Resolved bar "Nova PDX" … from curated coordinates`), so:

```
resolveConflictDeterministically('title', 'CHUNK: The RETURN',
  'CHUNK Portland - The RETURN! Saturday March 14th', { barNames: ['Nova PDX'] })
→ null            (no longer misfires — falls through to arbitration)

resolveConflictDeterministically('title', 'Singlet Night at the Dallas Eagle',
  'Singlet Night with DJ Drew G', { barNames: ['Dallas Eagle'] })
→ { winner: 'b', reason: 'title doctrine: venue name belongs in bar, not title' }   (genuine protection intact)
```

**`shared-core.js` is not touched by this PR.**

---

## Truncated-title repair from JSON-LD (kept from the first round)

`repairTruncatedTitleFromJsonLd`: when the page's JSON-LD names an Event whose `name` **contains** the extracted title (normalized, on token boundaries), adopt the fuller structured name verbatim. Containment is the entire licence and it fails closed — a non-containing name is a different event's, and a title contained in two or more names is ambiguous and kept as-is. No `core` → fails open to `[]`. Placed first among the title cleanups so the adopted value still faces the leading-date strip and the brand-suffix strip.

Real cached Portland page, through `normalizeAiEvent`:
```
before: "The RETURN"
after:  "CHUNK Portland - The RETURN! Saturday March 14th"
```
Negative case: extracted `"The RETURN"` + JSON-LD `"CHUNK Portland - SUMMER BLOW OUT!"` → unchanged.

---

## Bar plausibility gate: two new rejection reasons

Both from real 20260731 output, both following the existing address-shaped/city-shaped pattern, both under the same curated-name exemption from #1599.

1. **Placeholder** — reuses the existing `isPlaceholderVenueName`, which was only ever wired into the maps-link candidate path. SPOOKMINCE shipped bar `"Venue TBA"` to the calendar as if it were a real venue.
2. **Website domain** — run 20260731 shipped `title "C'mon Everybody"` / `bar "CHUNK-PARTY.COM"` (title and bar swapped; this stops the domain reaching the bar field, it does not chase the swap). Domain **shape**, not punctuation: an explicit `https://`/`www.` form, or a bare single-token host whose last label is a generic infrastructure label (`.com/.net/.org/…`). `.club`, `.bar` and `.bkk` are deliberately not in that set.

### Curated sweep — all 100 venue names

```
shape-flagged before the curated exemption (2): 9th Avenue Saloon (nyc) → address-shaped ; 440 Castro (sf) → address-shaped
ACTUALLY DROPPED after the exemption (0): none
```

The two flagged are the pre-existing address-shape false positives #1599's exemption already covers. **Zero curated venues drop.** Targeted checks:

```
"Venue TBA"            DROPPED (placeholder — venue not announced)
"TBA"                  DROPPED (placeholder — venue not announced)
"Venue TBC"            DROPPED (placeholder — venue not announced)
"To Be Announced"      DROPPED (placeholder — venue not announced)
"CHUNK-PARTY.COM"      DROPPED (website domain — not a venue name)
"www.chunk-party.com"  DROPPED (website domain — not a venue name)
"https://bearracuda.com" DROPPED (website domain — not a venue name)
"massive.club"         KEPT      ← real venue, survives by SHAPE, not by exemption
"MASSIVE.CLUB"         KEPT
"BEEF.BKK"             KEPT      ← curated (bangkok)
"BARBER.BAR"           KEPT      ← curated (bangkok)
"Nova PDX"             KEPT
"C'mon Everybody"      KEPT
"F8 Nightclub & Bar"   KEPT
"3 Dollar Bill"        KEPT
"Portland"             DROPPED (city name — pre-existing rule)
"79 Warren"            DROPPED (address-shaped — pre-existing rule)
```

---

## Scope — what this does NOT fix

**"Hot Gogo Bears" does not improve, and brand prefixing does not touch it.** Its page has no JSON-LD at all (the cached copy is an empty Wix shell) and no brand is derived there, so every gate here fails closed on it. Its source is the OCR vision pass: the cached `eventSummary` for that flyer literally reads *"Hot Gogo Bears event at F8 Nightclub in San Francisco…"* — the vision model named the flyer's tagline as the event. That is a separate OCR-summary problem, not chased here. No slug reconstruction was added.

## Unverified

- The two prompt edits' effect on the model is **not** what produces the fix — the live A/B shows the model still returns `"The RETURN"`, and the deterministic prefixer is what supplies the brand. The prompt edits are correct on their own terms (one asked for judgement the model gets wrong; the other forbade what the owner now wants allowed), but do not rely on them alone.
- Blast radius was measured against the cached page corpus and `data/promoters.json` as they stand. A parser pointed at a site not in that corpus is unmeasured, though the two-curated-signal gate bounds it to promoters the owner has already curated.

## Tests

Suite **1135 passing / 0 failing** (main baseline 1128 + 7 new). One existing guardrail test was updated to the new title-steering string — it asserts the exact prompt text, and that text is the sanctioned edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
