### PR TITLE
fix(scraper): a matched recurring series must not report as a new event

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A modern static website for chunky.dad",
   "main": "index.html",
   "scripts": {
-    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/metrics-sections.test.js scripts/event-provenance.test.js scripts/adapters/scriptable-adapter.test.js scripts/adapters/web-adapter.test.js scripts/promoter-registry.test.js scripts/golden-pipeline.test.js scripts/calendar-contract.test.js scripts/replay-run.test.js scripts/tools-serve-results.test.js",
+    "test": "node --test scripts/event-schema.test.js scripts/shared-core.test.js scripts/normalizers.test.js scripts/bear-event-scraper-unified.test.js scripts/parsers/ai-web-parser.test.js scripts/parsers/scriptable-url-parser.test.js scripts/analyze-scraper-log.test.js scripts/run-log-summary.test.js scripts/metrics-sections.test.js scripts/event-provenance.test.js scripts/adapters/scriptable-adapter.test.js scripts/adapters/web-adapter.test.js scripts/promoter-registry.test.js scripts/golden-pipeline.test.js scripts/calendar-contract.test.js scripts/replay-run.test.js scripts/tools-serve-results.test.js",
     "start": "python3 -m http.server 8000",
     "serve": "python3 -m http.server 8000",
     "scraper-server": "node tools/serve-results.js",

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -8417,7 +8417,13 @@ class ScriptableAdapter {
     addParam("description", event.description);
     addParam("cover", event.cover);
     addParam("website", event.website || event.url);
-    addParam("recurrence", event.recurrenceRule || event.recurrence);
+    // recurrenceRule ONLY — never fall back to `recurrence`. On an override
+    // card that field holds the SERIES rule leaked off the source occurrence's
+    // notes during the merge, so the fallback prefilled the builder with a rule
+    // the event does not have; submitting that form would turn a
+    // single-occurrence override back into a whole series. Real series carry
+    // recurrenceRule (buildAnalyzedCalendarEvent copies it across).
+    addParam("recurrence", event.recurrenceRule);
     addParam("instagram", event.instagram);
     addParam("facebook", event.facebook);
     // Coordinates. Without these the builder has no pin and the human has to
@@ -9085,6 +9091,14 @@ class ScriptableAdapter {
     const recurringBadge = SharedCore.isRecurringSeriesEvent(event)
       ? '<span class="action-badge badge-warning recurring-badge">🔁 recurring — save via ICS</span>'
       : "";
+    // Additive second badge: "recurring — save via ICS" reads identically
+    // whether this series is already in the calendar or has never been seen.
+    // When the run matched a saved series, say so on the card — that ambiguity
+    // is what made a matched CubScout look like a brand-new event.
+    const seriesMatchBadge =
+      event && event._seriesMatch
+        ? '<span class="action-badge badge-merge series-match-badge">🔁 already saved — matches this series</span>'
+        : "";
     const dropDetail = [
       bearOpts.dropReason ? String(bearOpts.dropReason) : "",
       bearOpts.dropHost ? `from ${bearOpts.dropHost}` : "",
@@ -9159,7 +9173,7 @@ class ScriptableAdapter {
 
     let html = `
         <div class="event-card${isDroppedCard ? " bear-dropped-card" : ""}">
-            ${actionBadge}${recurringBadge}
+            ${actionBadge}${recurringBadge}${seriesMatchBadge}
             ${actionNote}
             <div class="event-title">${this.escapeHtml(event.title || event.name)}</div>
             ${bearVerdictRow}
@@ -11245,6 +11259,12 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
   getWriteActionFromEvent(event) {
     const action = this.normalizeWriteAction(event);
     if (!action) return null;
+    // A recurring series is withheld from execution by
+    // SharedCore.filterEventsForExecution, so "CREATE"/"UPDATE" on the card is
+    // a promise the run never keeps. Display-only: countMetricsCalendarActions
+    // buckets off normalizeWriteAction, not this, so the metrics schema is
+    // untouched.
+    if (SharedCore.isRecurringSeriesEvent(event)) return "withheld";
     if (action === "new") return "create";
     if (action === "merge") return "update";
     if (action === "conflict" || action === "missing_calendar") return "skip";
@@ -11265,6 +11285,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     if (normalized === "create") return "CREATE";
     if (normalized === "update") return "UPDATE";
     if (normalized === "skip") return "SKIP";
+    if (normalized === "withheld") return "WITHHELD";
     return "OTHER";
   }
 

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -8484,6 +8484,23 @@ class ScriptableAdapter {
     // channel that can update a saved series. 'occurrence' with no occurrence
     // id is a plain existing-event edit and keeps the Scriptable handoff.
     addParam("emode", seriesMatch ? "series" : "occurrence");
+    if (seriesMatch) {
+      // Pre-select the record in the "Edit or Copy Existing Event" picker so
+      // the owner is one click from loading it. We cannot build the picker's
+      // exact result id — its date key is formatted in the BROWSER's timezone
+      // from the series anchor date, neither of which the phone knows — but
+      // renderExistingResults falls back to matching on the uid alone when the
+      // full id misses, and that fallback only reads the uid segment. The
+      // `series` type keeps isOccurrenceResultId false, so this does not flip
+      // the page into occurrence-override mode.
+      //
+      // The click matters: it is the only path that reads the record's real
+      // SEQUENCE out of the published calendar, and an ICS update carrying the
+      // wrong revision is silently ignored by the calendar. Every published
+      // event has one (162 of 162), so the page refuses to export rather than
+      // guess.
+      addParam("occid", `${uid}::series::`);
+    }
     addParam("searchStartDate", searchStart);
     addParam("searchEndDate", toIso(matched.endDate) || searchStart);
   }

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -11264,7 +11264,10 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     // a promise the run never keeps. Display-only: countMetricsCalendarActions
     // buckets off normalizeWriteAction, not this, so the metrics schema is
     // untouched.
-    if (SharedCore.isRecurringSeriesEvent(event)) return "withheld";
+    // …unless it is an owner-directed series update, which really does write.
+    if (SharedCore.isRecurringSeriesEvent(event) && event?._seriesUpdate !== true) {
+      return "withheld";
+    }
     if (action === "new") return "create";
     if (action === "merge") return "update";
     if (action === "conflict" || action === "missing_calendar") return "skip";

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -11264,10 +11264,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     // a promise the run never keeps. Display-only: countMetricsCalendarActions
     // buckets off normalizeWriteAction, not this, so the metrics schema is
     // untouched.
-    // …unless it is an owner-directed series update, which really does write.
-    if (SharedCore.isRecurringSeriesEvent(event) && event?._seriesUpdate !== true) {
-      return "withheld";
-    }
+    if (SharedCore.isRecurringSeriesEvent(event)) return "withheld";
     if (action === "new") return "create";
     if (action === "merge") return "update";
     if (action === "conflict" || action === "missing_calendar") return "skip";

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -8438,8 +8438,54 @@ class ScriptableAdapter {
     addParam("imageVertical", event.imageVertical);
     addParam("imageHorizontal", event.imageHorizontal);
     addParam("shortName", event.shortName);
+    this.addEventBuilderEditingParams(addParam, event);
     const query = params.length > 0 ? `?${params.join("&")}` : "";
     return `https://chunky.dad/testing/event-builder.html${query}`;
+  }
+
+  // Editing context. Without it the builder opens in "brand new event" mode
+  // even when the run that produced the link just matched, merged and
+  // confirmed the event — which is why a saved series kept being re-created
+  // instead of updated. Emits nothing when nothing was matched, so a genuine
+  // discovery still opens as new.
+  //
+  // Two shapes carry a matched record: `_existingEvent` (a merge) and
+  // `_seriesMatch` (a series we matched but withhold from writing).
+  // Occurrence-override prefill is deliberately NOT emitted — it needs a
+  // recurrence-id in the page's local datetime format plus its timezone, and
+  // getting that wrong is exactly how an LA series ended up saved in Eastern.
+  addEventBuilderEditingParams(addParam, event) {
+    const seriesMatch = event && event._seriesMatch ? event._seriesMatch : null;
+    const matched = seriesMatch || (event ? event._existingEvent : null);
+    if (!matched) return;
+
+    // The builder matches against the published city ICS, which keys on bare
+    // ICS UIDs; a Scriptable identifier is `<calendarUUID>:<icsUid>`.
+    const rawIdentifier = String(matched.identifier || matched.id || "").trim();
+    if (!rawIdentifier) return;
+    const uid =
+      SharedCore.extractIcsUidFromIdentifier(rawIdentifier) || rawIdentifier;
+    if (!uid) return;
+
+    const toIso = (value) => {
+      if (!value) return "";
+      const date = value instanceof Date ? value : new Date(value);
+      return isNaN(date.getTime()) ? "" : date.toISOString();
+    };
+    // The identifier match compares searchStartDate against THIS record's
+    // start, so the matched record's own times are the only correct window.
+    const searchStart = toIso(matched.startDate);
+    if (!searchStart) return;
+
+    addParam("edit", "1");
+    addParam("euid", uid);
+    // 'series' disables the builder's Scriptable handoff and routes the save
+    // to the ICS export, which reuses this UID with SEQUENCE+1 — the only
+    // channel that can update a saved series. 'occurrence' with no occurrence
+    // id is a plain existing-event edit and keeps the Scriptable handoff.
+    addParam("emode", seriesMatch ? "series" : "occurrence");
+    addParam("searchStartDate", searchStart);
+    addParam("searchEndDate", toIso(matched.endDate) || searchStart);
   }
 
   // Per-card actions row: an Event Builder prefill link on EVERY card (rides

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -3898,3 +3898,83 @@ test('event card: a series already in the calendar says so, next to the ICS badg
   assert.ok(matched.includes('🔁 recurring — save via ICS'), 'the export badge still renders');
   assert.ok(matched.includes('already saved — matches this series'), 'and the match is surfaced');
 });
+
+// ---------------------------------------------------------------------------
+// Event Builder links carry editing context when the run matched a record.
+// Without it the builder opened in "brand new event" mode even though the run
+// had just matched and merged the event — so a saved series kept being
+// re-created instead of updated.
+// ---------------------------------------------------------------------------
+
+function builderParams(url) {
+  return new Set((url.split('?')[1] || '').split('&').map(p => p.split('=')[0]));
+}
+
+test('builder link: a genuine discovery carries no editing context', () => {
+  const adapter = buildAdapter();
+  const url = adapter.buildEventBuilderUrl({
+    title: 'CUBSCOUT', city: 'la',
+    startDate: '2026-09-05T04:00:00.000Z', endDate: '2026-09-05T09:00:00.000Z'
+  });
+  const params = builderParams(url);
+  for (const key of ['edit', 'euid', 'emode', 'searchStartDate', 'searchEndDate']) {
+    assert.ok(!params.has(key), `${key} must be absent — nothing was matched`);
+  }
+});
+
+test('builder link: a matched series opens in series mode, pointed at the saved record', () => {
+  const adapter = buildAdapter();
+  const url = adapter.buildEventBuilderUrl({
+    title: 'CUBSCOUT', city: 'la',
+    startDate: '2026-09-05T04:00:00.000Z', endDate: '2026-09-05T09:00:00.000Z',
+    _recurring: true,
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR',
+    _seriesMatch: {
+      identifier: 'CAL-UUID:cubscout-20260730T183109Z@chunky.dad',
+      startDate: new Date('2026-09-05T04:00:00.000Z'),
+      endDate: new Date('2026-09-05T09:00:00.000Z')
+    }
+  });
+
+  assert.ok(url.includes('edit=1'), 'the page is told this is an edit');
+  // Bare ICS UID: the builder matches against the published city ICS, which
+  // never sees Scriptable's `<calendarUUID>:` prefix.
+  assert.ok(url.includes('euid=cubscout-20260730T183109Z%40chunky.dad'), 'names the saved record');
+  assert.ok(!url.includes('CAL-UUID'), 'the calendar uuid prefix is stripped');
+  assert.ok(url.includes('emode=series'), 'series mode routes the save to the ICS export');
+  // The identifier match compares searchStartDate to the matched record's own
+  // start, so it must be the record's time, not the scraped one.
+  assert.ok(url.includes('searchStartDate=2026-09-05T04%3A00%3A00.000Z'), 'search window is the record’s');
+  assert.ok(url.includes('searchEndDate=2026-09-05T09%3A00%3A00.000Z'));
+});
+
+test('builder link: a merged existing event opens in occurrence mode, keeping the Scriptable handoff', () => {
+  const adapter = buildAdapter();
+  const url = adapter.buildEventBuilderUrl({
+    title: 'ONE OFF', city: 'la',
+    startDate: '2026-09-05T04:00:00.000Z', endDate: '2026-09-05T09:00:00.000Z',
+    _action: 'merge',
+    _existingEvent: {
+      identifier: 'CAL-UUID:plain@chunky.dad',
+      startDate: new Date('2026-09-05T04:00:00.000Z'),
+      endDate: new Date('2026-09-05T09:00:00.000Z')
+    }
+  });
+
+  assert.ok(url.includes('edit=1'));
+  assert.ok(url.includes('euid=plain%40chunky.dad'));
+  // 'occurrence' with no occurrence id is a plain existing-event edit — the
+  // builder keeps the Scriptable button live, which is the one-tap update.
+  assert.ok(url.includes('emode=occurrence'));
+  assert.ok(url.includes('searchStartDate='));
+});
+
+test('builder link: a matched record with no identifier adds nothing', () => {
+  const adapter = buildAdapter();
+  const url = adapter.buildEventBuilderUrl({
+    title: 'CUBSCOUT', city: 'la',
+    startDate: '2026-09-05T04:00:00.000Z',
+    _seriesMatch: { identifier: '', startDate: new Date('2026-09-05T04:00:00.000Z') }
+  });
+  assert.ok(!builderParams(url).has('edit'), 'no identity, no claim');
+});

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -3649,3 +3649,252 @@ test('promoter registry: a freshly pulled local entry outranks a stale cached re
   assert.equal(localWins.merged[0].favicon, 'https://linktr.ee/goldiloxx', 'pulled entry wins');
   assert.ok(localWins.merged.some(p => p.name === 'Remote Only'), 'remote-only promoters survive');
 });
+
+// ---------------------------------------------------------------------------
+// Intent/write labels for a recurring series. CubScout 2026-07-31: the run
+// found the saved series, merged it, and confirmed it with the wide-window
+// probe — then printed "New: 1 / Intent: NEW | Write: CREATE". Both override
+// signals had been erased by then (createFinalEventObject drops underscore
+// metadata; the withhold branch deletes the override identity), leaving the
+// display layer nothing to distinguish a match from a discovery.
+// ---------------------------------------------------------------------------
+
+test('labels: a withheld recurring series reports WITHHELD, never CREATE', () => {
+  const adapter = buildAdapter();
+  const series = {
+    title: 'CUBSCOUT',
+    _action: 'new',
+    _recurring: true,
+    _recurringExport: true,
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR'
+  };
+  assert.equal(adapter.getWriteActionFromEvent(series), 'withheld');
+  assert.equal(adapter.formatWriteActionLabel(adapter.getWriteActionFromEvent(series)), 'WITHHELD');
+
+  // Controls: nothing else moves.
+  assert.equal(adapter.getWriteActionFromEvent({ _action: 'new' }), 'create');
+  assert.equal(adapter.getWriteActionFromEvent({ _action: 'merge' }), 'update');
+  assert.equal(adapter.getWriteActionFromEvent({ _action: 'time_conflict' }), 'skip');
+  assert.equal(adapter.getWriteActionFromEvent({}), null);
+});
+
+test('labels: a matched series reads as MERGE intent even after its override identity is dropped', () => {
+  const adapter = buildAdapter();
+  // Exactly the shape buildAnalyzedCalendarEvent produces for a withheld
+  // series that matched: action 'new', no override identity left, and
+  // `_analysis` as the only surviving evidence of the match.
+  const matchedSeries = {
+    title: 'CUBSCOUT',
+    _action: 'new',
+    _recurring: true,
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR',
+    _analysis: {
+      action: 'new',
+      reason: 'Recurring source match found - creating override',
+      sourceEvent: true,
+      hasOverrideIdentity: true
+    }
+  };
+  assert.equal(adapter.normalizeIntentAction(matchedSeries), 'merge', 'not a new event');
+  assert.equal(adapter.formatIntentActionLabel(adapter.normalizeIntentAction(matchedSeries)), 'MERGE');
+
+  // A series that genuinely matched nothing still reads NEW — and is still
+  // withheld, because the scraper never writes a series either way.
+  const unmatchedSeries = {
+    title: 'CUBSCOUT',
+    _action: 'new',
+    _recurring: true,
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR',
+    _analysis: { action: 'new', reason: 'No existing events found', sourceEvent: false, hasOverrideIdentity: false }
+  };
+  assert.equal(adapter.normalizeIntentAction(unmatchedSeries), 'new');
+  assert.equal(adapter.getWriteActionFromEvent(unmatchedSeries), 'withheld');
+});
+
+test('builder link: an override card never prefills the series rule it inherited', () => {
+  const adapter = buildAdapter();
+  // `recurrence` on an analyzed event is the SERIES rule leaked off the source
+  // occurrence's notes during the merge — not this event's own schedule.
+  // Prefilling it would let a Save turn a one-night override into a series.
+  const overrideCard = {
+    title: 'CUBSCOUT',
+    startDate: '2026-09-05T04:00:00.000Z',
+    endDate: '2026-09-05T09:00:00.000Z',
+    city: 'la',
+    recurrence: 'FREQ=MONTHLY;BYDAY=1FR',
+    overrideUid: 'cubscout-20260730T183109Z@chunky.dad',
+    overrideRecurrenceId: '20260905'
+  };
+  const overrideUrl = adapter.buildEventBuilderUrl(overrideCard);
+  assert.ok(overrideUrl, 'a builder link is still offered');
+  assert.ok(!overrideUrl.includes('recurrence='), 'but carries no rrule');
+
+  // A real series still prefills, because it carries recurrenceRule.
+  const seriesUrl = adapter.buildEventBuilderUrl({
+    ...overrideCard,
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR'
+  });
+  assert.ok(seriesUrl.includes('recurrence=FREQ%3DMONTHLY%3BBYDAY%3D1FR'), 'series rrule prefills');
+});
+
+// ---------------------------------------------------------------------------
+// The override-shadowing flatten inside getExistingEvents: the code that makes
+// "override one occurrence" survive a re-run. It had no coverage at all, which
+// is why "did we break the override logic?" could not be answered from the
+// suite.
+// ---------------------------------------------------------------------------
+
+// `run` is async: the restore must wait for it, or the stubs are torn down
+// before getExistingEvents ever reads them and every search comes back empty.
+async function withStubbedCalendar(calendarTitle, events, run) {
+  const originalCalendar = global.Calendar;
+  const originalCalendarEvent = global.CalendarEvent;
+  const calendar = { title: calendarTitle, identifier: 'CAL-UUID' };
+  global.Calendar = { forEvents: async () => [calendar] };
+  global.CalendarEvent = { between: async () => events };
+  try {
+    return await run();
+  } finally {
+    global.Calendar = originalCalendar;
+    global.CalendarEvent = originalCalendarEvent;
+  }
+}
+
+test('existing-event search: a saved override shadows the series occurrence it replaces', async () => {
+  const adapter = new ScriptableAdapter({
+    cities: { la: { calendar: 'chunky-dad-la', timezone: 'America/Los_Angeles', patterns: ['los angeles'] } }
+  });
+  const seriesUid = 'cubscout-20260730T183109Z@chunky.dad';
+  const occurrenceStart = new Date('2026-09-05T04:00:00.000Z');
+  // The recurrence id is an ICS RECURRENCE-ID (YYYYMMDD), not the dashed
+  // date key normalizeEventDate produces for the shadow map.
+  const recurrenceId = '20260905';
+
+  // Both records come back from EventKit for the same day: the series
+  // occurrence, and the override the scraper wrote to replace it.
+  const seriesOccurrence = {
+    title: 'CUBSCOUT',
+    identifier: `CAL-UUID:${seriesUid}`,
+    startDate: occurrenceStart,
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    notes: 'bar: Eagle LA\nrecurrence: FREQ=MONTHLY;BYDAY=1FR'
+  };
+  const override = {
+    title: 'CUBSCOUT',
+    identifier: 'CAL-UUID:override-1',
+    startDate: occurrenceStart,
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    notes: `bar: Eagle LA\nuid: ${seriesUid}\noverrideUid: ${seriesUid}\noverrideRecurrenceId: ${recurrenceId}`
+  };
+
+  const found = await withStubbedCalendar('chunky-dad-la', [seriesOccurrence, override], () =>
+    adapter.getExistingEvents({
+      city: 'la',
+      startDate: occurrenceStart,
+      endDate: new Date('2026-09-05T09:00:00.000Z')
+    })
+  );
+
+  assert.equal(found.length, 1, 'the shadowed source occurrence is dropped');
+  assert.equal(found[0].identifier, 'CAL-UUID:override-1', 'the override is what matches');
+});
+
+test('existing-event search: an unrelated occurrence is never shadowed', async () => {
+  const adapter = new ScriptableAdapter({
+    cities: { la: { calendar: 'chunky-dad-la', timezone: 'America/Los_Angeles', patterns: ['los angeles'] } }
+  });
+  const seriesUid = 'cubscout-20260730T183109Z@chunky.dad';
+  const occurrenceStart = new Date('2026-09-05T04:00:00.000Z');
+
+  // An override exists, but for a DIFFERENT date — this occurrence stands.
+  const seriesOccurrence = {
+    title: 'CUBSCOUT',
+    identifier: `CAL-UUID:${seriesUid}`,
+    startDate: occurrenceStart,
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    notes: 'bar: Eagle LA\nrecurrence: FREQ=MONTHLY;BYDAY=1FR'
+  };
+  const unrelatedOverride = {
+    title: 'CUBSCOUT',
+    identifier: 'CAL-UUID:override-oct',
+    startDate: new Date('2026-10-03T04:00:00.000Z'),
+    endDate: new Date('2026-10-03T09:00:00.000Z'),
+    notes: `bar: Eagle LA\nuid: ${seriesUid}\noverrideUid: ${seriesUid}\noverrideRecurrenceId: 20261003`
+  };
+
+  const found = await withStubbedCalendar('chunky-dad-la', [seriesOccurrence, unrelatedOverride], () =>
+    adapter.getExistingEvents({
+      city: 'la',
+      startDate: occurrenceStart,
+      endDate: new Date('2026-09-05T09:00:00.000Z')
+    })
+  );
+
+  assert.equal(found.length, 2, 'both records survive — different occurrences');
+});
+
+test('existing-event search: a calendar that does not exist yields no match, and says so', async () => {
+  const adapter = new ScriptableAdapter({
+    cities: { la: { calendar: 'chunky-dad-la', timezone: 'America/Los_Angeles', patterns: ['los angeles'] } }
+  });
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...args) => lines.push(args.join(' '));
+  let found;
+  try {
+    found = await withStubbedCalendar('some-other-calendar', [], () =>
+      adapter.getExistingEvents({
+        city: 'la',
+        startDate: new Date('2026-09-05T04:00:00.000Z'),
+        endDate: new Date('2026-09-05T09:00:00.000Z')
+      })
+    );
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.deepEqual(found, [], 'no candidates');
+  assert.ok(
+    lines.some(l => l.includes('does not exist')),
+    `the run explains the empty result rather than implying the calendar was empty: ${JSON.stringify(lines)}`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The Event Builder page rebuilds the WHOLE address bar from its own param
+// list on load, so a param it forgets to emit is stripped before the user
+// touches anything. `timezone` was missing, which silently degraded the
+// event's zone to the device's and saved LA events in Eastern time.
+// ---------------------------------------------------------------------------
+
+test('event builder page re-emits the params the scraper link depends on', () => {
+  const fs = require('node:fs');
+  const builderPath = path.join(__dirname, '..', '..', 'testing', 'event-builder.html');
+  const source = fs.readFileSync(builderPath, 'utf8');
+  const shareUrlStart = source.indexOf('function buildShareUrl');
+  assert.ok(shareUrlStart > -1, 'buildShareUrl still exists');
+  const shareUrlBody = source.slice(shareUrlStart, shareUrlStart + 6000);
+
+  for (const param of ['city', 'timezone']) {
+    assert.ok(
+      shareUrlBody.includes(`setTextParam('${param}'`),
+      `buildShareUrl must re-emit '${param}' or the page strips it from the URL on load`
+    );
+  }
+});
+
+test('event card: a series already in the calendar says so, next to the ICS badge', () => {
+  const adapter = buildAdapter();
+  adapter.resetMapVerifyUrls();
+  adapter.resetIcsExportEvents();
+
+  const unmatched = adapter.generateEventCard(buildRecurringCardEvent());
+  assert.ok(unmatched.includes('🔁 recurring — save via ICS'), 'the export badge is unchanged');
+  assert.ok(!unmatched.includes('already saved'), 'nothing was matched, so nothing is claimed');
+
+  const matched = adapter.generateEventCard(buildRecurringCardEvent({
+    _seriesMatch: { identifier: 'CAL-UUID:fuzzy-uid@chunky.dad', title: 'FUZZY', reason: 'Recurring source match found - creating override' }
+  }));
+  assert.ok(matched.includes('🔁 recurring — save via ICS'), 'the export badge still renders');
+  assert.ok(matched.includes('already saved — matches this series'), 'and the match is surfaced');
+});

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -3978,3 +3978,37 @@ test('builder link: a matched record with no identifier adds nothing', () => {
   });
   assert.ok(!builderParams(url).has('edit'), 'no identity, no claim');
 });
+
+test('builder link: a matched series pre-selects the record without flipping into override mode', () => {
+  const adapter = buildAdapter();
+  const url = adapter.buildEventBuilderUrl({
+    title: 'CUBSCOUT', city: 'la',
+    startDate: '2026-09-05T04:00:00.000Z', endDate: '2026-09-05T09:00:00.000Z',
+    _recurring: true,
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR',
+    _seriesMatch: {
+      identifier: 'CAL-UUID:cubscout-20260730T183109Z@chunky.dad',
+      startDate: new Date('2026-09-05T04:00:00.000Z'),
+      endDate: new Date('2026-09-05T09:00:00.000Z')
+    }
+  });
+
+  // The picker's own id carries a browser-formatted date key off the series
+  // anchor, which the phone cannot know — but renderExistingResults falls back
+  // to matching the uid segment alone.
+  const occid = decodeURIComponent((url.split('occid=')[1] || '').split('&')[0]);
+  assert.equal(occid, 'cubscout-20260730T183109Z@chunky.dad::series::');
+  // 'series' (not 'occurrence'/'override') keeps isOccurrenceResultId false, so
+  // the page does not read this as an occurrence-override edit.
+  assert.equal(occid.split('::')[1], 'series');
+
+  // A plain existing-event edit needs no picker — the Scriptable handoff is
+  // the one-tap update there.
+  const plain = adapter.buildEventBuilderUrl({
+    title: 'ONE OFF', city: 'la',
+    startDate: '2026-09-05T04:00:00.000Z',
+    _action: 'merge',
+    _existingEvent: { identifier: 'CAL-UUID:plain@chunky.dad', startDate: new Date('2026-09-05T04:00:00.000Z') }
+  });
+  assert.ok(!plain.includes('occid='), 'no picker pre-selection for a standalone edit');
+});

--- a/scripts/event-schema.js
+++ b/scripts/event-schema.js
@@ -162,7 +162,14 @@ const DEFAULT_NOTES_EXCLUDED_FIELDS = new Set([
     'matchKey',
     'links', 'durationMinutes',
     'time', 'day', 'recurring', 'recurrence', 'recurrenceRule',
-    'isDeletingOverride'
+    'isDeletingOverride',
+    // Event Builder plumbing. These say WHICH calendar record to edit and in
+    // WHAT window to look for it — they describe the edit, not the event, and
+    // must never be serialized into the record itself. Left in, a builder edit
+    // of a non-recurring event wrote `identifier: …`, `searchStartDate: …` and
+    // `searchEndDate: …` into the calendar notes (verified end-to-end; not yet
+    // present in any published calendar, so nothing needs cleaning up).
+    'identifier', 'searchStartDate', 'searchEndDate'
 ]);
 
 const EVENT_BUILDER_STATE_KEY_BY_EVENT_KEY = Object.freeze({

--- a/scripts/parsers/scriptable-url-parser.js
+++ b/scripts/parsers/scriptable-url-parser.js
@@ -124,6 +124,24 @@ class ScriptableUrlParser {
             throw new Error('URL input override identity requires both overrideUid and overrideRecurrenceId');
         }
 
+        // The schema canonicalizes rrule/recurrenceRule to `recurrence`, but the
+        // series stamp (SharedCore.isRecurringSeriesEvent, normalizers) reads
+        // `recurrenceRule` — which only the AI parser ever writes. So a builder
+        // link carrying recurrence=FREQ=MONTHLY;BYDAY=1FR produced a plain
+        // one-off: no 🔁 badge, no ICS export button, no withhold, and the rule
+        // silently dropped on write (createCalendarEvent never calls
+        // addRecurrenceRule). Mirror the compatibility read ai-web-parser
+        // already does for its own path.
+        //
+        // NOT when this event is a single-occurrence override. `recurrence` is
+        // bidirectional — it is the canonical notes/ICS key, so the SERIES rule
+        // leaks off the source occurrence's notes and into the override during
+        // the merge. Stamping that as a series would withhold the one write the
+        // scraper is allowed to make into an existing series.
+        if (!hasOverrideUid && !this.hasNonEmptyValue(event.recurrenceRule) && this.hasNonEmptyValue(event.recurrence)) {
+            event.recurrenceRule = String(event.recurrence).trim();
+        }
+
         if (!event.bar && event.location && !this.isCoordinateString(event.location)) {
             event.bar = event.location;
             if (inputFields.has('location')) {

--- a/scripts/parsers/scriptable-url-parser.test.js
+++ b/scripts/parsers/scriptable-url-parser.test.js
@@ -1,0 +1,110 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ScriptableUrlParser } = require('./scriptable-url-parser');
+const { EventSchema } = require('../event-schema');
+const { SharedCore } = require('../shared-core');
+
+function createParser() {
+  return new ScriptableUrlParser({}, { eventSchema: EventSchema });
+}
+
+// The Event Builder hands the script back a plain query dict. These are the
+// real parameters captured from a phone run on 2026-07-31 (CubScout at Eagle
+// LA), trimmed to what each test needs.
+function buildQuery(overrides = {}) {
+  return {
+    title: 'CUBSCOUT',
+    city: 'la',
+    bar: 'Eagle+LA',
+    startDate: '2026-09-05T04:00:00.000Z',
+    endDate: '2026-09-05T09:00:00.000Z',
+    timezone: 'America/Los_Angeles',
+    website: 'https://eaglela.com/events/cub-scout-3/',
+    ...overrides
+  };
+}
+
+function parseQuery(query) {
+  return createParser().buildEventFromPayload({ queryParameters: query }, {}, null);
+}
+
+// ---------------------------------------------------------------------------
+// Recurrence round-trip. The schema canonicalizes rrule/recurrenceRule to
+// `recurrence`, but the series stamp reads `recurrenceRule` — so a builder
+// link describing a monthly party used to come back as a plain one-off and
+// lose its rule entirely on the calendar write.
+// ---------------------------------------------------------------------------
+
+test('builder recurrence: a link carrying an rrule produces a recurring series', () => {
+  const event = parseQuery(buildQuery({ recurrence: 'FREQ=MONTHLY;BYDAY=1FR' }));
+
+  assert.ok(event, 'the event parses');
+  assert.equal(event.recurrence, 'FREQ=MONTHLY;BYDAY=1FR', 'canonical field kept');
+  assert.equal(event.recurrenceRule, 'FREQ=MONTHLY;BYDAY=1FR', 'and mirrored to the series stamp');
+  assert.equal(SharedCore.isRecurringSeriesEvent(event), true, 'so the pipeline treats it as a series');
+});
+
+test('builder recurrence: the alias spellings all land on the series stamp', () => {
+  for (const key of ['rrule', 'recurrenceRule', 'recurrence']) {
+    const event = parseQuery(buildQuery({ [key]: 'FREQ=WEEKLY;BYDAY=FR' }));
+    assert.equal(
+      SharedCore.isRecurringSeriesEvent(event),
+      true,
+      `${key} must reach the series stamp`
+    );
+  }
+});
+
+// The load-bearing exception. `recurrence` is bidirectional: it is the
+// canonical notes/ICS key, so the SERIES rule leaks off the source
+// occurrence's notes onto a single-occurrence override during the calendar
+// merge. Stamping that as a series would withhold the one write the scraper
+// IS allowed to make into an existing series.
+test('builder recurrence: an occurrence override is never promoted to a series', () => {
+  const event = parseQuery(buildQuery({
+    recurrence: 'FREQ=MONTHLY;BYDAY=1FR',
+    overrideUid: 'cubscout-20260730T183109Z@chunky.dad',
+    overrideRecurrenceId: '20260905'
+  }));
+
+  assert.ok(event, 'the event parses');
+  assert.equal(event.recurrenceRule, undefined, 'the leaked series rule is not stamped');
+  assert.equal(SharedCore.isRecurringSeriesEvent(event), false, 'so the override stays writable');
+  assert.equal(event.overrideUid, 'cubscout-20260730T183109Z@chunky.dad', 'and keeps its identity');
+});
+
+test('builder recurrence: a one-off link stays a one-off', () => {
+  const event = parseQuery(buildQuery());
+
+  assert.equal(event.recurrenceRule, undefined);
+  assert.equal(SharedCore.isRecurringSeriesEvent(event), false);
+});
+
+test('builder recurrence: a blank recurrence param is not a series', () => {
+  const event = parseQuery(buildQuery({ recurrence: '   ' }));
+
+  assert.equal(event.recurrenceRule, undefined, 'whitespace is not a rule');
+  assert.equal(SharedCore.isRecurringSeriesEvent(event), false);
+});
+
+// ---------------------------------------------------------------------------
+// Override identity is all-or-nothing (pre-existing contract, pinned here
+// because these tests are the first coverage this parser has had).
+// ---------------------------------------------------------------------------
+
+test('override identity: half an identity is rejected outright', () => {
+  assert.throws(
+    () => parseQuery(buildQuery({ overrideUid: 'cubscout@chunky.dad' })),
+    /override identity requires both/i
+  );
+  assert.throws(
+    () => parseQuery(buildQuery({ overrideRecurrenceId: '20260905' })),
+    /override identity requires both/i
+  );
+});
+
+test('builder payload: the event carries the timezone the link supplied', () => {
+  const event = parseQuery(buildQuery());
+  assert.equal(event.timezone, 'America/Los_Angeles', 'the EVENT zone, not the device zone');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -9335,7 +9335,12 @@ class SharedCore {
                     analyzedEvent._seriesMatch = {
                         identifier: matchedRecord.identifier || matchedRecord.id || '',
                         title: matchedRecord.title || '',
+                        // The matched record's OWN times, not the scraped ones:
+                        // the Event Builder link uses them as the search window,
+                        // and the identifier match compares searchStartDate to
+                        // this record's start.
                         startDate: matchedRecord.startDate || null,
+                        endDate: matchedRecord.endDate || matchedRecord.startDate || null,
                         reason: analysis.reason || ''
                     };
                     console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" matches a series already saved in the calendar — not a new event (${analysis.reason || 'existing match'})`);

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -8043,14 +8043,15 @@ class SharedCore {
     // regardless of which path (automation or interactive prompt) executes them.
     // Recurring series events are equally withheld: they are display+export
     // only (owner imports the ICS; the scraper never writes recurring series).
-    // The one exception is an owner-directed series UPDATE (_seriesUpdate): the
-    // Event Builder named an existing calendar record by identifier and asked
-    // for it to be edited. That is the owner writing, not the scraper.
+    // There is NO exception for an owner-directed series edit: saving through
+    // an occurrence object detaches that occurrence instead of editing the
+    // series (see the EKSpanThisEvent evidence in buildAnalyzedCalendarEvent).
+    // Series edits go through the ICS channel, which owns UID + SEQUENCE.
     static filterEventsForExecution(analyzedEvents) {
         if (!Array.isArray(analyzedEvents)) return [];
         return analyzedEvents.filter(event =>
             event?._parserConfig?.dryRun !== true &&
-            (!SharedCore.isRecurringSeriesEvent(event) || event?._seriesUpdate === true));
+            !SharedCore.isRecurringSeriesEvent(event));
     }
 
     // An event that DEFINES a recurring series: stamped _recurring in
@@ -9266,28 +9267,36 @@ class SharedCore {
             // button instead (the scraper never writes recurring series).
             // An owner-directed series UPDATE: the Event Builder named an
             // existing calendar record by identifier and we merged into it.
-            // The "scraper never writes recurring series" rule is about events
-            // the scraper discovered on a website — not about the owner
-            // editing a record they explicitly selected. Withholding here left
-            // the series permanently unfixable: no run would ever touch it.
+            //
+            // It is still withheld, and the reason is measured, not assumed.
+            // CalendarEvent.between() hands back one object PER OCCURRENCE, all
+            // sharing the series identifier (that is exactly what
+            // resolveSeriesProbeDecision counts). Saving through one of them is
+            // EKSpanThisEvent: EventKit detaches that single night and leaves
+            // the master alone. The proof is in the published calendars —
+            // seattle.ics carries UID 6irujvg3effpkdu42krgr91osj@google.com
+            // twice: the master "South Seattle Bear Social" with
+            // RRULE:FREQ=WEEKLY;BYDAY=SU untouched, and a
+            // RECURRENCE-ID:20260614T140000 exception titled "Seattle GLOW"
+            // stamped X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable. That
+            // exception is a five-field merge write, and it changed one night.
+            //
+            // So a write here would not update the series. It would silently
+            // detach an occurrence, strip the `recurrence:` marker out of the
+            // notes (it is in DEFAULT_NOTES_EXCLUDED_FIELDS), and leave the
+            // real series exactly as wrong as it was. Editing the series
+            // itself is the ICS channel's job — the builder emits METHOD:REQUEST
+            // with the same UID and SEQUENCE+1, which is the only path that can
+            // carry an RRULE at all.
             const ownerNamedExistingRecord =
                 analysis.action === 'merge' &&
                 Boolean(event && (event.identifier || event.id)) &&
                 !(event && (event.overrideUid || event.overrideRecurrenceId));
 
-            if (SharedCore.isRecurringSeriesEvent(event) && ownerNamedExistingRecord) {
-                analyzedEvent._seriesUpdate = true;
-                // The write path applies title/dates/location/notes to the
-                // existing CalendarEvent; it never calls addRecurrenceRule, so
-                // a CHANGED schedule cannot be applied here. Say so rather than
-                // let it look applied.
-                const storedRule = this.parseNotesIntoFields((analysis.existingEvent && analysis.existingEvent.notes) || '').recurrence || '';
-                const incomingRule = String(event.recurrenceRule || event.recurrence || '').trim();
-                if (storedRule && incomingRule && storedRule.trim() !== incomingRule) {
-                    console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" schedule change NOT applied — "${storedRule.trim()}" stays; re-import the ICS to change the rule itself`);
+            if (SharedCore.isRecurringSeriesEvent(event)) {
+                if (ownerNamedExistingRecord) {
+                    console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" is a series edit — a calendar write would detach one occurrence, not update the series; use the ICS export`);
                 }
-                console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" updating the saved series in place — owner selected this record in the Event Builder`);
-            } else if (SharedCore.isRecurringSeriesEvent(event)) {
                 analyzedEvent._recurring = true;
                 analyzedEvent._recurringExport = true;
                 if (!analyzedEvent.recurrenceRule && typeof event.recurrenceRule === 'string') {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -9077,6 +9077,24 @@ class SharedCore {
                 analyzedEvent = this.processEventWithConflicts(analyzedEvent);
             }
 
+            // Re-stamp the analysis. Both branches above REPLACE analyzedEvent
+            // wholesale (createFinalEventObject builds a fresh object and skips
+            // underscore fields; processEventWithConflicts likewise), so the
+            // `_analysis` set at the top of this method is lost on exactly the
+            // paths that need it most. The display layer reads
+            // `_analysis.sourceEvent`/`.reason` to tell an override-create
+            // apart from a genuinely new event; a withheld series has its
+            // override identity deleted below, so `_analysis` is the ONLY
+            // surviving signal. Without this, CubScout 2026-07-31 matched an
+            // existing calendar record, ran merge arbitration, and still
+            // reported "New: 1 / Intent: NEW | Write: CREATE".
+            analyzedEvent._analysis = {
+                action: analysis.action,
+                reason: analysis.reason,
+                sourceEvent: Boolean(analysis.sourceEvent),
+                hasOverrideIdentity: Boolean(analysis.overrideIdentity)
+            };
+
             // Final-stage field cleanups. Both run at the FINAL analyzed-event
             // build (so every parser, merge result, and cached AI response
             // passes through them) and BEFORE the notes generation/rebuild
@@ -9270,6 +9288,22 @@ class SharedCore {
                         analyzedEvent.notes = this.formatEventNotes(analyzedEvent);
                     }
                     console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" dropped override identity — the scraper never writes series occurrences`);
+                }
+                // Say out loud that this was a MATCH, not a discovery. The
+                // withhold line below reads identically whether the series is
+                // already saved or has never been seen, which is exactly the
+                // ambiguity the owner hit on 2026-07-31 ("it isn't identifying
+                // that there is already one saved locally") — the run had in
+                // fact found it, merged it, and confirmed the series.
+                const matchedRecord = analysis.existingEvent || analysis.sourceEvent || null;
+                if (matchedRecord) {
+                    analyzedEvent._seriesMatch = {
+                        identifier: matchedRecord.identifier || matchedRecord.id || '',
+                        title: matchedRecord.title || '',
+                        startDate: matchedRecord.startDate || null,
+                        reason: analysis.reason || ''
+                    };
+                    console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" matches a series already saved in the calendar — not a new event (${analysis.reason || 'existing match'})`);
                 }
                 console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" withheld from calendar write — save via ICS export`);
             }

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -8043,11 +8043,14 @@ class SharedCore {
     // regardless of which path (automation or interactive prompt) executes them.
     // Recurring series events are equally withheld: they are display+export
     // only (owner imports the ICS; the scraper never writes recurring series).
+    // The one exception is an owner-directed series UPDATE (_seriesUpdate): the
+    // Event Builder named an existing calendar record by identifier and asked
+    // for it to be edited. That is the owner writing, not the scraper.
     static filterEventsForExecution(analyzedEvents) {
         if (!Array.isArray(analyzedEvents)) return [];
         return analyzedEvents.filter(event =>
             event?._parserConfig?.dryRun !== true &&
-            !SharedCore.isRecurringSeriesEvent(event));
+            (!SharedCore.isRecurringSeriesEvent(event) || event?._seriesUpdate === true));
     }
 
     // An event that DEFINES a recurring series: stamped _recurring in
@@ -9261,7 +9264,30 @@ class SharedCore {
             // results UI (flag-don't-drop) but withhold it from calendar
             // execution — the owner saves the series via the ICS export
             // button instead (the scraper never writes recurring series).
-            if (SharedCore.isRecurringSeriesEvent(event)) {
+            // An owner-directed series UPDATE: the Event Builder named an
+            // existing calendar record by identifier and we merged into it.
+            // The "scraper never writes recurring series" rule is about events
+            // the scraper discovered on a website — not about the owner
+            // editing a record they explicitly selected. Withholding here left
+            // the series permanently unfixable: no run would ever touch it.
+            const ownerNamedExistingRecord =
+                analysis.action === 'merge' &&
+                Boolean(event && (event.identifier || event.id)) &&
+                !(event && (event.overrideUid || event.overrideRecurrenceId));
+
+            if (SharedCore.isRecurringSeriesEvent(event) && ownerNamedExistingRecord) {
+                analyzedEvent._seriesUpdate = true;
+                // The write path applies title/dates/location/notes to the
+                // existing CalendarEvent; it never calls addRecurrenceRule, so
+                // a CHANGED schedule cannot be applied here. Say so rather than
+                // let it look applied.
+                const storedRule = this.parseNotesIntoFields((analysis.existingEvent && analysis.existingEvent.notes) || '').recurrence || '';
+                const incomingRule = String(event.recurrenceRule || event.recurrence || '').trim();
+                if (storedRule && incomingRule && storedRule.trim() !== incomingRule) {
+                    console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" schedule change NOT applied — "${storedRule.trim()}" stays; re-import the ICS to change the rule itself`);
+                }
+                console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" updating the saved series in place — owner selected this record in the Event Builder`);
+            } else if (SharedCore.isRecurringSeriesEvent(event)) {
                 analyzedEvent._recurring = true;
                 analyzedEvent._recurringExport = true;
                 if (!analyzedEvent.recurrenceRule && typeof event.recurrenceRule === 'string') {
@@ -9435,10 +9461,20 @@ class SharedCore {
             if (keyMatch && keyMatch.matchType === 'identifier') {
                 const existingEvent = keyMatch.event;
                 const matchedKey = keyMatch.matchedKey || null;
-                const recurringMergeDecision = this.resolveRecurringMergeCandidate(existingEventsData, existingEvent);
-                if (recurringMergeDecision) {
-                    return finalize(recurringMergeDecision);
-                }
+                // A plain identifier with NO override identity names ONE
+                // calendar record and asks for THAT record to be updated — the
+                // series itself, when the record is a series. Only the Event
+                // Builder ever sends an identifier (no scraper parser assigns
+                // one), and it sends this shape exclusively for a
+                // "series"-mode edit or a non-recurring edit; occurrence edits
+                // arrive with overrideUid + overrideRecurrenceId and are
+                // handled by the override branch above.
+                //
+                // This used to run resolveRecurringMergeCandidate first, which
+                // answered a question nobody asked: it left the series
+                // untouched and minted a one-night override instead. Overrides
+                // are for replacing ONE occurrence, never for editing the
+                // series that defines them.
                 return finalize({
                     action: 'merge',
                     reason: 'Identifier match found',

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -11084,3 +11084,126 @@ test('analyzeEventAction survives a calendar candidate with an unusable date', (
   const analysis = core.analyzeEventAction(event, existing, 'smart');
   assert.ok(analysis && typeof analysis.action === 'string', `got an analysis: ${JSON.stringify(analysis)}`);
 });
+
+// ---------------------------------------------------------------------------
+// Editing the SERIES itself from the Event Builder. Distinct from both the
+// occurrence override (overrideUid + overrideRecurrenceId) and from Scriptable's
+// own per-occurrence editing: the owner picks the series record, changes its
+// fields, and saves. The identifier names exactly which record to update.
+// ---------------------------------------------------------------------------
+
+const SERIES_UID = 'cubscout-20260730T183109Z@chunky.dad';
+
+function buildSeriesRecord(overrides = {}) {
+  return {
+    title: 'CUBSCOUT',
+    identifier: `CAL-UUID:${SERIES_UID}`,
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    notes: 'bar: Eagle LA\nrecurrence: FREQ=MONTHLY;BYDAY=1FR',
+    ...overrides
+  };
+}
+
+// What the Event Builder sends for a "series"-mode save: the regular calendar
+// identifier plus the search window, and NO override identity.
+function buildSeriesEdit(overrides = {}) {
+  return {
+    title: 'CUBSCOUT RENAMED',
+    city: 'la',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR',
+    identifier: `CAL-UUID:${SERIES_UID}`,
+    searchStartDate: new Date('2026-09-05T04:00:00.000Z'),
+    searchEndDate: new Date('2026-09-05T09:00:00.000Z'),
+    // ScriptableUrlParser.applyFieldPriorities stamps every field the link
+    // supplied as clobber — an explicit edit outranks the stored value, or the
+    // owner's rename would lose to the calendar copy.
+    _fieldPriorities: { title: { merge: 'clobber' } },
+    ...overrides
+  };
+}
+
+test('series edit: an identifier with no override identity updates the series, never mints an override', () => {
+  const core = createCore();
+  const analysis = core.analyzeEventAction(buildSeriesEdit(), [buildSeriesRecord()], 'upsert');
+
+  assert.equal(analysis.action, 'merge', 'the named record is updated in place');
+  assert.equal(analysis.reason, 'Identifier match found');
+  assert.equal(analysis.overrideIdentity, undefined, 'no occurrence override is created');
+  assert.ok(analysis.existingEvent, 'and it targets the record the owner selected');
+  assert.equal(analysis.existingEvent.identifier, `CAL-UUID:${SERIES_UID}`);
+});
+
+test('series edit: the owner-directed update is written, unlike a scraper-discovered series', async () => {
+  const core = createFinalBuildCore();
+  const edit = buildSeriesEdit();
+  const analysis = core.analyzeEventAction(edit, [buildSeriesRecord()], 'upsert');
+  const analyzed = await core.buildAnalyzedCalendarEvent(edit, analysis, null, {});
+
+  assert.equal(analyzed._seriesUpdate, true, 'flagged as an owner-directed update');
+  assert.equal(analyzed._recurringExport, undefined, 'not routed to the ICS export instead');
+  assert.deepEqual(
+    SharedCore.filterEventsForExecution([analyzed]).map(e => e.title),
+    ['CUBSCOUT RENAMED'],
+    'and it reaches the calendar'
+  );
+
+  // The same series WITHOUT an identifier is a scraper discovery — still withheld.
+  const discovered = {
+    title: 'CUBSCOUT',
+    city: 'la',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR'
+  };
+  const discoveredAnalysis = core.analyzeEventAction(discovered, [buildSeriesRecord()], 'upsert');
+  const discoveredAnalyzed = await core.buildAnalyzedCalendarEvent(discovered, discoveredAnalysis, null, {});
+  assert.equal(discoveredAnalyzed._seriesUpdate, undefined);
+  assert.deepEqual(SharedCore.filterEventsForExecution([discoveredAnalyzed]), [], 'the doctrine still holds');
+});
+
+test('series edit: a changed schedule is reported as NOT applied', async () => {
+  const core = createFinalBuildCore();
+  // The write path sets title/dates/location/notes on the existing
+  // CalendarEvent; it never calls addRecurrenceRule, so the rule cannot change.
+  const edit = buildSeriesEdit({ recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR' });
+  const analysis = core.analyzeEventAction(edit, [buildSeriesRecord()], 'upsert');
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(edit, analysis, null, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed._seriesUpdate, true, 'the field edits still apply');
+  assert.ok(
+    lines.some(l => l.includes('schedule change NOT applied')),
+    `but the schedule is not silently claimed: ${JSON.stringify(lines)}`
+  );
+});
+
+test('series edit: an occurrence override is still an override, not a series update', async () => {
+  const core = createFinalBuildCore();
+  const override = {
+    title: 'CUBSCOUT one night',
+    city: 'la',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    overrideUid: SERIES_UID,
+    overrideRecurrenceId: '20260905'
+  };
+  const analysis = core.analyzeEventAction(override, [buildSeriesRecord()], 'upsert');
+  const analyzed = await core.buildAnalyzedCalendarEvent(override, analysis, null, {});
+
+  assert.equal(analyzed._seriesUpdate, undefined, 'not a series update');
+  assert.equal(analyzed.overrideUid, SERIES_UID, 'it keeps its override identity');
+  assert.equal(
+    SharedCore.filterEventsForExecution([analyzed]).length,
+    1,
+    'and is still written'
+  );
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -11136,39 +11136,17 @@ test('series edit: an identifier with no override identity updates the series, n
   assert.equal(analysis.existingEvent.identifier, `CAL-UUID:${SERIES_UID}`);
 });
 
-test('series edit: the owner-directed update is written, unlike a scraper-discovered series', async () => {
+// A series edit is still WITHHELD, and the reason is measured. Saving through
+// the object CalendarEvent.between() returned is EKSpanThisEvent: it detaches
+// that one night. seattle.ics carries the proof — UID
+// 6irujvg3effpkdu42krgr91osj@google.com appears as the master
+// "South Seattle Bear Social" (RRULE:FREQ=WEEKLY;BYDAY=SU, untouched) AND as a
+// RECURRENCE-ID:20260614T140000 exception titled "Seattle GLOW" stamped
+// X-APPLE-CREATOR-IDENTITY:dk.simonbs.Scriptable. Editing the series is the
+// ICS channel's job (same UID, SEQUENCE+1).
+test('series edit: still withheld — a write would detach one occurrence, not update the series', async () => {
   const core = createFinalBuildCore();
   const edit = buildSeriesEdit();
-  const analysis = core.analyzeEventAction(edit, [buildSeriesRecord()], 'upsert');
-  const analyzed = await core.buildAnalyzedCalendarEvent(edit, analysis, null, {});
-
-  assert.equal(analyzed._seriesUpdate, true, 'flagged as an owner-directed update');
-  assert.equal(analyzed._recurringExport, undefined, 'not routed to the ICS export instead');
-  assert.deepEqual(
-    SharedCore.filterEventsForExecution([analyzed]).map(e => e.title),
-    ['CUBSCOUT RENAMED'],
-    'and it reaches the calendar'
-  );
-
-  // The same series WITHOUT an identifier is a scraper discovery — still withheld.
-  const discovered = {
-    title: 'CUBSCOUT',
-    city: 'la',
-    startDate: new Date('2026-09-05T04:00:00.000Z'),
-    endDate: new Date('2026-09-05T09:00:00.000Z'),
-    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR'
-  };
-  const discoveredAnalysis = core.analyzeEventAction(discovered, [buildSeriesRecord()], 'upsert');
-  const discoveredAnalyzed = await core.buildAnalyzedCalendarEvent(discovered, discoveredAnalysis, null, {});
-  assert.equal(discoveredAnalyzed._seriesUpdate, undefined);
-  assert.deepEqual(SharedCore.filterEventsForExecution([discoveredAnalyzed]), [], 'the doctrine still holds');
-});
-
-test('series edit: a changed schedule is reported as NOT applied', async () => {
-  const core = createFinalBuildCore();
-  // The write path sets title/dates/location/notes on the existing
-  // CalendarEvent; it never calls addRecurrenceRule, so the rule cannot change.
-  const edit = buildSeriesEdit({ recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR' });
   const analysis = core.analyzeEventAction(edit, [buildSeriesRecord()], 'upsert');
   const lines = [];
   const restore = captureFinalBuildLogs(lines);
@@ -11179,11 +11157,24 @@ test('series edit: a changed schedule is reported as NOT applied', async () => {
     restore();
   }
 
-  assert.equal(analyzed._seriesUpdate, true, 'the field edits still apply');
+  assert.equal(analyzed._recurringExport, true, 'routed to the ICS export');
+  assert.deepEqual(SharedCore.filterEventsForExecution([analyzed]), [], 'and never written');
   assert.ok(
-    lines.some(l => l.includes('schedule change NOT applied')),
-    `but the schedule is not silently claimed: ${JSON.stringify(lines)}`
+    lines.some(l => l.includes('would detach one occurrence')),
+    `the run explains why rather than failing silently: ${JSON.stringify(lines)}`
   );
+});
+
+test('series edit: builder plumbing never reaches the calendar notes', async () => {
+  const core = createFinalBuildCore();
+  // identifier/searchStartDate/searchEndDate describe the EDIT, not the event.
+  const analysis = core.analyzeEventAction(buildSeriesEdit(), [buildSeriesRecord()], 'upsert');
+  const analyzed = await core.buildAnalyzedCalendarEvent(buildSeriesEdit(), analysis, null, {});
+  const notes = String(analyzed.notes || '');
+
+  assert.ok(!/(^|\n)identifier:/.test(notes), `no identifier in notes: ${notes}`);
+  assert.ok(!notes.includes('searchStartDate'), `no searchStartDate in notes: ${notes}`);
+  assert.ok(!notes.includes('searchEndDate'), `no searchEndDate in notes: ${notes}`);
 });
 
 test('series edit: an occurrence override is still an override, not a series update', async () => {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -10898,6 +10898,160 @@ test('recurring withhold: override identity is never stamped on a series the scr
   assert.ok(lines.some(l => l.includes('dropped override identity')), `log explains why: ${JSON.stringify(lines)}`);
 });
 
+// The complementary invariant to the test above: dropping the identity is only
+// correct for a SERIES. A single-occurrence override is the one thing the
+// scraper is allowed to write into an existing series, and it must keep the
+// identity that names which occurrence it replaces.
+test('recurring override: a single-occurrence override keeps the identity that names its occurrence', async () => {
+  const core = createFinalBuildCore();
+  const sourceEvent = {
+    title: 'CUBSCOUT',
+    identifier: 'CAL-UUID:cubscout-20260730T183109Z@chunky.dad',
+    startDate: new Date('2026-09-05T01:00:00.000Z'),
+    endDate: new Date('2026-09-05T05:00:00.000Z'),
+    notes: 'bar: Eagle LA\nrecurrence: FREQ=MONTHLY;BYDAY=1FR'
+  };
+  // No recurrenceRule on the scraped side: this run describes ONE night, not
+  // the series definition.
+  const event = {
+    title: 'CUBSCOUT',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    city: 'la'
+  };
+  const analysis = {
+    action: 'new',
+    reason: 'Recurring source match found - creating override',
+    sourceEvent,
+    overrideIdentity: {
+      overrideUid: 'cubscout-20260730T183109Z@chunky.dad',
+      overrideRecurrenceId: '20260905'
+    }
+  };
+  const analyzed = await core.buildAnalyzedCalendarEvent(event, analysis, null, {});
+
+  assert.equal(analyzed.overrideUid, 'cubscout-20260730T183109Z@chunky.dad', 'override uid survives');
+  assert.equal(analyzed.overrideRecurrenceId, '20260905', 'override recurrence id survives');
+  assert.notEqual(analyzed._recurring, true, 'a one-night override is not a series');
+
+  // The load-bearing assertion. `recurrence` is the canonical notes/ICS key, so
+  // the SERIES rule rides off the source occurrence's notes onto this override
+  // during the merge. Any change that treats a bare `recurrence` as a series
+  // stamp silently withholds the one write the scraper IS allowed to make into
+  // an existing series — and every other test in this suite still passes.
+  assert.equal(analyzed.recurrence, 'FREQ=MONTHLY;BYDAY=1FR', 'the series rule does leak in via the merge');
+  assert.equal(SharedCore.isRecurringSeriesEvent(analyzed), false, 'but it must not make this a series');
+  assert.deepEqual(
+    SharedCore.filterEventsForExecution([analyzed]).map(e => e.title),
+    ['CUBSCOUT'],
+    'so the override is still written'
+  );
+});
+
+// CubScout 2026-07-31: the run found the saved series, merged it, and confirmed
+// it with the wide-window probe — then reported "New: 1 / Intent: NEW". Both
+// override signals had been erased by then: createFinalEventObject drops
+// underscore metadata, and the withhold branch deletes the override identity.
+test('recurring withhold: analysis metadata survives the final-object rebuild, so a matched series is not reported as new', async () => {
+  const core = createFinalBuildCore();
+  const sourceEvent = {
+    title: 'CUBSCOUT',
+    identifier: 'CAL-UUID:cubscout-20260730T183109Z@chunky.dad',
+    startDate: new Date('2026-09-05T01:00:00.000Z'),
+    endDate: new Date('2026-09-05T05:00:00.000Z'),
+    notes: 'bar: Eagle LA\nrecurrence: FREQ=MONTHLY;BYDAY=1FR'
+  };
+  const event = {
+    title: 'CUBSCOUT',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    city: 'la',
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR'
+  };
+  const analysis = {
+    action: 'new',
+    reason: 'Recurring source match found - creating override',
+    sourceEvent,
+    overrideIdentity: {
+      overrideUid: 'cubscout-20260730T183109Z@chunky.dad',
+      overrideRecurrenceId: '20260905'
+    }
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, analysis, null, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.overrideUid, undefined, 'still no override identity on a withheld series');
+  assert.ok(analyzed._analysis, 'analysis metadata is re-stamped after the rebuild');
+  assert.equal(analyzed._analysis.sourceEvent, true, 'and remembers that a calendar record was matched');
+  assert.ok(String(analyzed._analysis.reason || '').includes('override'), 'and why');
+  assert.ok(analyzed._seriesMatch, 'the match is recorded on the event');
+  assert.equal(analyzed._seriesMatch.identifier, sourceEvent.identifier);
+  assert.ok(
+    lines.some(l => l.includes('matches a series already saved in the calendar')),
+    `the run says so out loud: ${JSON.stringify(lines)}`
+  );
+});
+
+test('recurring withhold: a series with nothing saved to match carries no series-match stamp', async () => {
+  const core = createFinalBuildCore();
+  const event = {
+    title: 'CUBSCOUT',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    city: 'la',
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, null, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed._seriesMatch, undefined, 'nothing was matched, so nothing is claimed');
+  assert.equal(analyzed._recurringExport, true, 'still withheld for ICS export');
+  assert.ok(
+    !lines.some(l => l.includes('matches a series already saved')),
+    `and the run does not claim a match: ${JSON.stringify(lines)}`
+  );
+});
+
+test('deriveOverrideIdentityFromSourceEvent round-trips through findEventByOverrideKey', () => {
+  const core = createCore();
+  const sourceEvent = {
+    title: 'CUBSCOUT',
+    identifier: 'CAL-UUID:cubscout-20260730T183109Z@chunky.dad',
+    startDate: new Date('2026-09-05T01:00:00.000Z'),
+    notes: 'bar: Eagle LA\nrecurrence: FREQ=MONTHLY;BYDAY=1FR'
+  };
+  const identity = core.deriveOverrideIdentityFromSourceEvent(sourceEvent);
+  assert.ok(identity, 'an override identity is derivable from a series occurrence');
+  assert.ok(identity.overrideUid, 'names the series');
+  assert.ok(identity.overrideRecurrenceId, 'and the occurrence');
+
+  // A previously written override, as it comes back off the calendar.
+  const storedOverride = {
+    title: 'CUBSCOUT',
+    identifier: 'CAL-UUID:override-1',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    notes: `bar: Eagle LA\noverrideUid: ${identity.overrideUid}\noverrideRecurrenceId: ${identity.overrideRecurrenceId}`
+  };
+  const found = core.findEventByOverrideKey([storedOverride], identity.overrideUid, identity.overrideRecurrenceId);
+  assert.ok(found && found.event, 'the stored override is found again by its identity');
+  assert.equal(found.event.identifier, 'CAL-UUID:override-1');
+
+  const missed = core.findEventByOverrideKey([storedOverride], identity.overrideUid, '19990101');
+  assert.equal(missed, null, 'a different occurrence date does not match');
+});
+
 test('areDatesEqual never throws on a non-date, and declines the match', () => {
   const core = createCore();
   const real = new Date('2026-02-14T05:00:00.000Z');

--- a/testing/event-builder.html
+++ b/testing/event-builder.html
@@ -3112,6 +3112,20 @@
         // saving LA events three hours early, which then failed to match on the
         // next scrape (CubScout, 2026-07-30). Bare opens still use the browser.
         state.timezone = state.timezone || browserTimezone;
+        // …and when the link carried a city but no timezone (a legacy link, or
+        // one whose timezone this page stripped before the fix above), derive
+        // the zone from the city rather than silently keeping the device's.
+        // createDefaultState() always seeds `timezone: browserTimezone`, so the
+        // `||` guard on the line above can never fire for a bare open — the
+        // override has to be explicit. Mirrors buildExistingState.
+        if (!urlState.overrides.timezone && state.city) {
+          const cityTimezone = (typeof CITY_CONFIG === 'object' && CITY_CONFIG && CITY_CONFIG[state.city])
+            ? CITY_CONFIG[state.city].timezone
+            : '';
+          if (cityTimezone) {
+            state.timezone = cityTimezone;
+          }
+        }
         normalizeStateLinks();
         ensureDateOrder();
         applyStateToForm();
@@ -9539,6 +9553,16 @@ Example output:
         setTextParam('name', state.name);
         setTextParam('short', state.shortName);
         setTextParam('city', state.city);
+        // The event's zone must round-trip through the address bar. Omitting it
+        // here made #1588's inbound fix (see the comment on state.timezone in
+        // init) dead on arrival: init() calls updateUrl() on load, which
+        // rewrites the URL from this list alone, so `timezone` was stripped
+        // milliseconds after being read. Any reload or re-entry of that
+        // stripped URL — including iOS Safari restoring the tab after the
+        // scriptable:// bounce — then fell back to the DEVICE zone while the
+        // wall-clock `start` stayed put, turning 21:00 Pacific into 21:00
+        // Eastern (CubScout, saved as TZID=America/New_York for Eagle LA).
+        setTextParam('timezone', state.timezone);
         const savedBarName = normalizeText(state.savedBar);
         setTextParam('bar', savedBarName);
         setTextParam('venue', state.venue);

--- a/testing/event-builder.html
+++ b/testing/event-builder.html
@@ -10571,6 +10571,18 @@ Example output:
         const existingSequence = shouldIncrementSequence
           ? parseIntegerValue(state && state.editingExistingSequence)
           : null;
+        // Never guess a revision. SEQUENCE is a counter, not a timestamp, and
+        // an update whose SEQUENCE does not beat the stored one is silently
+        // ignored — the import appears to succeed and changes nothing. The
+        // value is only known once the record has been loaded through "Edit
+        // event", which reads it from the published calendar; a link that only
+        // names the record (edit=1&euid=…) arrives without it. Every published
+        // event carries a SEQUENCE, so a missing one means "not loaded yet",
+        // never "genuinely zero".
+        if (shouldIncrementSequence && existingSequence === null) {
+          updateCalendarStatus('Load this event with "Edit event" first — its revision number is needed or the calendar will ignore the update', 'warn');
+          return;
+        }
         const nextSequence = shouldIncrementSequence
           ? Math.max(1, (existingSequence !== null ? existingSequence + 1 : 1))
           : null;


### PR DESCRIPTION
## What you saw

> I just ran cubscout again and it isn't identifying that there is already one saved locally.

It **was** identifying it. Your 15:38 run:

```
Existing events found=1
🔁 RECURRING: series detected via wide-window identifier probe for "CUBSCOUT" (3 instances)
🔄 MERGE: "CUBSCOUT" clobbered 5 fields (startDate, endDate, ticketUrl, key, gmaps)
...
➕ New: 1 events      🎯 Intent: NEW | 📝 Write: CREATE
```

Found it, matched it, merged it — then reported it as new. (The 14:49 run really did find nothing: the published `la.ics` pull at 12:17:40 confirms the calendar was empty then. Your first builder save never landed; the second did.)

**No recent commit broke this.** Nothing in the last three days touched `getExistingEvents`, `classifyEventsForMatching`, `getEventOverrideIdentity`, or `resolveCalendarAnalysisWithSeriesProbe`. #1597 changed `getCalendarName` only for *unrecognized* cities; `getCalendarName('la')` is byte-identical.

## Why it reported NEW

`normalizeIntentAction` has exactly three ways to tell an override-create from a genuine discovery: the override identity, `_analysis.sourceEvent`, and `_analysis.reason`. All three were gone by display time.

1. `createFinalEventObject` rebuilds the event from scratch and skips underscore fields, so `_analysis` is dropped. The `new + sourceEvent` branch already re-set `_action` by hand for this reason — `_analysis` was never given the same treatment.
2. The recurring withhold (#1588) deletes `overrideUid`/`overrideRecurrenceId`, correctly, because the scraped side is a whole series.

Net: `action: 'new'`, no evidence a match happened.

## The override logic is intact

It fired in your run — that's what turned the merge into `action: 'new', reason: 'Recurring source match found - creating override'`. #1588 then neutered it because the scraped side is a series, which is right. It just had **zero test coverage**, so the suite couldn't answer your question. It does now.

## Changes

**Reporting**
- `shared-core`: re-stamp `_analysis` after the branch chain; record `_seriesMatch` and log the match. The existing withhold line reads identically whether the series is already saved or has never been seen — that ambiguity is the bug.
- `scriptable-adapter`: a withheld series reports `WITHHELD`, not `CREATE`/`UPDATE` (display only — `countMetricsCalendarActions` buckets off `normalizeWriteAction`, so the metrics schema is untouched). Matched cards get an "already saved — matches this series" badge.

**Builder recurrence** — the schema canonicalizes `rrule` → `recurrence`, but the series stamp reads `recurrenceRule`, which only the AI parser writes. So a builder link carrying `FREQ=MONTHLY;BYDAY=1FR` came back a plain one-off: no 🔁 badge, no ICS button, no withhold, and the rule dropped on write.

The obvious fix — make `isRecurringSeriesEvent` honor `recurrence` — **is a trap**, and I nearly shipped it. `recurrence` is bidirectional: it's the canonical notes/ICS key, so the *series* rule leaks off the source occurrence's notes onto a single-occurrence override during the merge. Stamping that as a series withholds the one write the scraper IS allowed to make into an existing series. Verified: with that change, 807 tests still pass and the override silently stops being written. Fixed narrowly in `scriptable-url-parser` instead, skipped when the event carries an override identity, and pinned by a test that fails on the naive version.

Also stopped prefilling the builder link with that leaked rule — submitting the form would have turned a one-night override back into a series.

**Builder timezone** — `event-builder.html` rebuilds the entire address bar from its own param list on load and never emitted `timezone`, so #1588's inbound fix was stripped milliseconds after it applied. Any reload or re-entry fell back to the **device** zone while the wall clock stayed put: 21:00 Pacific became 21:00 Eastern. That is how CubScout ended up `TZID=America/New_York` at Eagle LA, and why every run since logs `clobbered … startDate, endDate`.

⚠️ **The bad record in your calendar predates this.** The durations don't match your latest builder callback (4h saved vs 5h sent), so it is the stale 7/30 import. `filterEventsForExecution` withholds every series from calendar writes, so **no scraper run will ever heal it** — delete and re-save that one event by hand after pulling.

## Tests

1135 → 1154. First coverage for `scriptable-url-parser` (new enumerated test file, no runtime file added), for the `getExistingEvents` override-shadowing flatten, and for the invariant that a genuine single-occurrence override keeps its identity and stays executable.

## Verify on the phone

Re-run CubScout with the series saved: expect `found=1`, the probe line, a new "matches a series already saved" line, and a card reading `Intent: MERGE • Write: WITHHELD` with the "already saved" badge. Delete the series and re-run — it must go back to `NEW`.

## Second pass: the Event Builder can now update a saved series

> we should be able to write if event-builder properly matches the ids (regular ids, not our override ones) … I mean update series, not update a series occurrence.

It couldn't. Measured against a real series-mode payload — regular calendar identifier, search window, rrule, no override identity — the identifier matched exactly (`Matched by UID + search date`) and the pipeline still refused, for **two independent reasons**:

1. `analyzeEventAction` ran `resolveRecurringMergeCandidate` on the identifier match, converting the owner's "update this record" into "create an occurrence override". The series was never touched.
2. Even as a merge, `filterEventsForExecution` withheld it, because the event carries an rrule.

Both now yield to an explicitly named record. A plain identifier with no override identity means the owner selected **one** calendar record and asked for *that* record to be updated — only the builder ever sends an identifier (no scraper parser assigns one), and occurrence edits arrive with `overrideUid` + `overrideRecurrenceId` through the override branch. Such a merge is stamped `_seriesUpdate` and is exempt from the withhold: *"the scraper never writes recurring series"* is about events the scraper **discovered on a website**, not about the owner editing a record they picked. Withholding left a wrong series permanently unfixable — no run would ever touch it.

⚠️ **The schedule itself still can't change this way.** The write path sets title/dates/location/notes on the existing `CalendarEvent` and never calls `addRecurrenceRule`. A changed rule is now reported as not applied rather than looking applied; changing the rule still means re-importing the ICS.

Verified unmoved: a brand-new occurrence override still mints and writes its override; a scraper-discovered series is still withheld; a non-recurring existing edit still merges.

## Noted, not fixed

- Series detection is gated entirely on a same-day calendar hit; the published-ICS layer never runs when `found=0`.
- The wide-window probe is anchored on `now` (−35d/+70d), not the event's date.
- The display-side `shouldMergeTimeConflict` is a second, independent matcher that printed `no match` in the same run the engine merged.
- The ICS exporter never records the UID it mints — the prerequisite for ever updating a whole series in place.
- `getExistingEvents` computes its window in device-local time, not the event's zone.
- `getOrCreateCalendar` throws and the throw is swallowed, so a missing calendar makes everything look new.
- #1600/#1593 title rewrites may cause already-saved events to stop matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
