### PR TITLE
fix(builder): the Add button was refusing silently, and the revision was never picked up

### DIFF
--- a/testing/event-builder.html
+++ b/testing/event-builder.html
@@ -3834,6 +3834,21 @@
                 });
               }
             }
+            // Adopt the record's revision number. Resolving the result here is
+            // deliberately NOT a full load — applyExistingSelection would
+            // overwrite the fields the arriving link just prefilled — but the
+            // SEQUENCE is not a field the user edits, and without it the ICS
+            // export refuses to run (it will not guess a revision, because a
+            // wrong one is silently ignored by the calendar). Only fills a
+            // blank, so a real "Edit event" load always wins.
+            if (!normalizeText(state.editingExistingSequence)) {
+              const sequenceSource = selectedExistingResult.baseEvent || selectedExistingResult.event;
+              const resolvedSequence = parseIntegerValue(sequenceSource && sequenceSource.sequence);
+              if (resolvedSequence !== null) {
+                state.editingExistingSequence = String(resolvedSequence);
+                scheduleUrlUpdate();
+              }
+            }
           } else if (pendingExistingSelectionId || pendingExistingOccurrenceId) {
             const requestedMode = selectedExistingMode === 'series' ? 'series' : 'occurrence';
             if (requestedMode === 'series' && !selectedExistingResult.canEditSeries) {
@@ -10580,7 +10595,12 @@ Example output:
         // event carries a SEQUENCE, so a missing one means "not loaded yet",
         // never "genuinely zero".
         if (shouldIncrementSequence && existingSequence === null) {
-          updateCalendarStatus('Load this event with "Edit event" first — its revision number is needed or the calendar will ignore the update', 'warn');
+          const revisionMessage = 'Load this event with "Edit event" first — its revision number is needed or the calendar will ignore the update';
+          updateCalendarStatus(revisionMessage, 'warn');
+          // The status badge sits away from the button, so a refusal there
+          // reads as "the button does nothing". Toast it too, the way the
+          // Scriptable handoff already announces its own refusals.
+          showToast(revisionMessage, 'warn');
           return;
         }
         const nextSequence = shouldIncrementSequence


### PR DESCRIPTION
## What happened

Pressing **Add** on a matched-series link did nothing. Two bugs, stacked.

**1. The refusal was invisible.** #1601 made the ICS export refuse rather than guess a revision — correct, but it announced that only through `updateCalendarStatus`, a badge that sits away from the button. From the button's point of view it just... didn't work. It now also toasts, the way the Scriptable handoff already announces its own refusals.

**2. The revision was never picked up in the first place.** The link pre-selects the record in the picker, and `renderExistingResults` does resolve it — but resolving is deliberately *not* a full load, because `applyExistingSelection` would overwrite the fields the arriving link just prefilled. So `editingExistingSequence` stayed empty and the export refused every time, no matter what.

`SEQUENCE` is not a field anyone edits. It's now adopted during that resolve — and only into a blank, so a real "Edit event" load always wins.

## Verified against the real record

Stanley's series is published with what we need:

```
UID:cubscout-20260731T193113Z@chunky.dad
RRULE:FREQ=MONTHLY;BYDAY=1FR
SEQUENCE:0
```

So the export will now emit `SEQUENCE:1`, which beats it, and the update lands.

## Still wrong on that record, separately

```
DTSTART;TZID=America/New_York:20260807T210000
```

`America/New_York` for Eagle LA. That save predates the timezone fix in #1601, so it should not recur — but the stored record is still wrong and no scraper run will touch it.

## Caveat

The builder page has no automated coverage, so both changes are reasoned from the code path rather than executed. The suite (1163) only proves nothing else broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP