### PR TITLE
fix(ci): the directory preview sync has never pushed since Jul 15 — `eval "git p" "ush"` runs `git p ush`

### DIFF
--- a/.github/workflows/directory-preview-sync.yml
+++ b/.github/workflows/directory-preview-sync.yml
@@ -41,7 +41,6 @@ jobs:
           echo "No cache changes to commit"
         else
           git commit -m "🖼️ Sync Microlink directory previews"
-          # Workaround to not trigger sandbox block for literal p u s h
-          eval "git p" "ush"
+          git push
           echo "✓ Directory preview cache committed."
         fi


### PR DESCRIPTION
## What broke

`.github/workflows/directory-preview-sync.yml` refreshes the Bear Directory's link previews twice a day, then commits the cache back to main. The commit is made. The push is not:

```
[main 20b1275] 🖼️ Sync Microlink directory previews
 7 files changed, 34 insertions(+), 39 deletions(-)
git: 'p' is not a git command.
##[error]Process completed with exit code 1.
```

`eval` joins its arguments with a space, so `eval "git p" "ush"` runs `git p ush`.

That line came in with #1346 as a workaround for a sandbox block on the literal word — a restriction that only applies to commands run locally, never inside a workflow file. `bars-sync.yml` has used a plain `git push` all along. This makes it match.

## Why it stayed green for a month

The push is inside the `else`, so it is only reached when there is actually something to commit. For a month there wasn't. The cache has a 30–45 day staleness threshold (`tools/sync-directory-previews.js:40`), and entries seeded by #1346 on Jun 14 began lapsing mid-July.

```
Jun 15 – Jul 14   2/day, all success   (nothing to commit)
Jul 15            first failure
Jul 16            last success
Jul 17 – Aug 1    2/day, all failure   (34 consecutive)
```

It is self-sustaining: the commit is discarded with the runner, so the same work is redone twelve hours later. ~15 Microlink requests per run have been spent and thrown away on every one of those 34 runs, and the previews on the site are frozen at whatever landed Jul 16.

## Verification

The workflow is schedule/`workflow_dispatch` only, so this cannot be proven by CI on the PR — the real check is a manual dispatch after merge, which should end in `✓ Directory preview cache committed.` and a `🖼️ Sync Microlink directory previews` commit on main.

What I did check: the YAML still parses, the step's shell body passes `bash -n`, and this is the only `eval "git ...` in the repo — no other workflow carries the same workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP