### PR TITLE
fix(scraper): venue became the event name — "Nova Box"

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -288,14 +288,19 @@ class BarDataNormalizer extends BaseNormalizer {
 
             // Set bar name if not already set (since we matched by address/location/description/title)
             if (matchedBar.name && (!event.bar || event.bar.trim() === '' || descriptionWasVenue || titleWasVenue)) {
-                if (titleWasVenue && event.bar && event.bar.trim() !== '') {
+                if (titleWasVenue && event.bar && event.bar.trim() !== ''
+                    && this.isPromotableTitleFromBarField(event.bar, matchedBar.name)) {
                     // Title was a venue, so swap bar name into title
+                    const previousTitle = event.title;
                     event.title = event.bar;
+                    console.log(`🏷️ BarDataNormalizer: title "${previousTitle}" was the venue → promoted bar "${event.bar}" into title (bar := "${matchedBar.name}")`);
 
                     // Since description is usually also the bar when this bug happens, let's clear it
                     if (event.description && event.bar && event.description.trim() === event.bar.trim()) {
                         delete event.description;
                     }
+                } else if (titleWasVenue && event.bar && event.bar.trim() !== '') {
+                    console.log(`🏷️ BarDataNormalizer: title "${event.title}" was the venue but bar "${event.bar}" is a variant of "${matchedBar.name}" — kept title, corrected bar only`);
                 }
                 event.bar = matchedBar.name;
                 modified = true;
@@ -425,6 +430,37 @@ class BarDataNormalizer extends BaseNormalizer {
         event.addressSource = 'curated';
         console.log(`🗺️ GEOCODE VERIFY: "${title}" upgraded district address "${address}" to curated bar address "${curatedBar.address}" (bar: ${curatedBar.name})`);
         return true;
+    }
+
+    // Guards the title<-bar promotion above. That rewrite assumes the two
+    // fields are transposed — the venue landed in `title`, so `bar` must be
+    // holding the real event name. When `bar` is instead ANOTHER SPELLING of
+    // the same venue, the assumption is false and the promotion destroys the
+    // title: run 20260801-170254 turned "CHUNK: Nova PDX" into "Nova Box"
+    // (flyer OCR of "NOVA PDX") because nothing checked what was being
+    // promoted.
+    //
+    // Positive verification required for the destructive path: promote only
+    // when `bar` does NOT read as a variant of the venue it matched. A variant
+    // shares a significant word with the curated name AND is no wordier than
+    // it ("Nova Box" vs "Nova PDX"). A real title smuggled into `bar` carries
+    // words the venue name does not ("Eagle Bear Night" vs "Eagle") and still
+    // promotes exactly as before.
+    isPromotableTitleFromBarField(barValue, curatedName) {
+        const significantTokens = (value) => String(value || '')
+            .toLowerCase()
+            .split(/[^a-z0-9]+/)
+            .filter(token => token.length >= 3);
+
+        const barTokens = significantTokens(barValue);
+        const curatedTokens = significantTokens(curatedName);
+        if (barTokens.length === 0 || curatedTokens.length === 0) return true;
+
+        const curatedSet = new Set(curatedTokens);
+        const sharesToken = barTokens.some(token => curatedSet.has(token));
+        if (!sharesToken) return true;
+
+        return barTokens.length > curatedTokens.length;
     }
 }
 

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -3262,3 +3262,67 @@ test('pin ladder: an address-derived geocoded pin takes the ordinary conflict li
   assert.equal(near.location, '50.8172912, -0.1225875');
   assert.ok(!nearCapture.lines.some(line => line.includes('MAPS LINK CONFLICT')), JSON.stringify(nearCapture.lines));
 });
+
+// ---------------------------------------------------------------------------
+// title <- bar promotion guard. Run 20260801-170254 shipped a Portland event
+// named "Nova Box" — flyer OCR of the venue "NOVA PDX". BarDataNormalizer saw
+// the venue in the title, assumed the fields were transposed, and promoted the
+// OCR garbage in `bar` into `title` with no verification and no log line.
+// ---------------------------------------------------------------------------
+function createNovaNormalizer() {
+  const core = new SharedCore(
+    { portland: { timezone: 'America/Los_Angeles', patterns: ['portland'] } },
+    {
+      eventSchema: EventSchema,
+      bars: {
+        portland: [{
+          name: 'Nova PDX',
+          address: '722 East Burnside Street, Portland, Oregon, 97214',
+          coordinates: '45.52281000000001, -122.6581342'
+        }]
+      }
+    }
+  );
+  return new BarDataNormalizer(core);
+}
+
+test('a bar value that is a variant of the matched venue never becomes the title', () => {
+  const normalizer = createNovaNormalizer();
+  const event = { title: 'CHUNK: Nova PDX', bar: 'Nova Box', city: 'portland' };
+
+  const lines = captureConsoleLog(() => normalizer.normalize(event));
+
+  assert.equal(event.title, 'CHUNK: Nova PDX', 'the OCR venue variant must not overwrite the title');
+  assert.equal(event.bar, 'Nova PDX', 'the bar is still corrected to the curated name');
+  assert.ok(
+    lines.some(line => line.includes('is a variant of "Nova PDX" — kept title, corrected bar only')),
+    `the withheld promotion is logged: ${JSON.stringify(lines)}`
+  );
+});
+
+test('a genuine title-in-bar transposition still promotes, and says so', () => {
+  const core = new SharedCore(
+    { nyc: { timezone: 'America/New_York', patterns: ['nyc'] } },
+    { eventSchema: EventSchema, bars: { nyc: [{ name: 'Eagle', address: '554 W 28th St', coordinates: '40.7506, -74.0035' }] } }
+  );
+  const normalizer = new BarDataNormalizer(core);
+  const event = { title: 'Eagle', bar: 'Bear Night Party', city: 'nyc' };
+
+  const lines = captureConsoleLog(() => normalizer.normalize(event));
+
+  assert.equal(event.title, 'Bear Night Party', 'an unrelated name in `bar` is the real title');
+  assert.equal(event.bar, 'Eagle');
+  assert.ok(
+    lines.some(line => line.includes('was the venue → promoted bar "Bear Night Party" into title')),
+    `the promotion is logged: ${JSON.stringify(lines)}`
+  );
+});
+
+test('isPromotableTitleFromBarField: shared-word variants blocked, distinct names allowed', () => {
+  const normalizer = createNovaNormalizer();
+  assert.equal(normalizer.isPromotableTitleFromBarField('Nova Box', 'Nova PDX'), false);
+  assert.equal(normalizer.isPromotableTitleFromBarField('NOVA-PDX', 'Nova PDX'), false);
+  assert.equal(normalizer.isPromotableTitleFromBarField('Eagle Bear Night', 'Eagle'), true,
+    'a name that adds words to the venue is a real title');
+  assert.equal(normalizer.isPromotableTitleFromBarField('UNDERBEAR', 'Eagle'), true);
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1296,7 +1296,16 @@ class AiWebParser {
             const line = this.normalizeWhitespace(rawLine);
             if (!line) continue;
             if (/^(SEGMENT_[A-Z_]+|OCR_IMAGE_TEXT)/i.test(line)) continue;
-            if (this.hasMultiEventDateSignal(line)) continue;
+            if (this.hasMultiEventDateSignal(line)) {
+                // Listing widgets that print the name and the date on ONE line
+                // ("CHUNK Portland - 5/23 Sat, May 23") used to lose the title
+                // here, promoting the NEXT line — the venue — to the page's
+                // "own" listing title. Recover the name span instead; a line
+                // with no name span still falls through to the skip.
+                const span = this.deriveListingTitleSpanFromDatedLine(line);
+                if (!span) continue;
+                return span.length <= this.extractionLimits.multiEventTitleMaxChars ? span : '';
+            }
             if (/^\d{1,2}(:\d{2})?\s*(am|pm)?(\s*[-–]\s*\d{1,2}(:\d{2})?\s*(am|pm)?)?$/i.test(line)) continue;
             // European time-only lines: "14:00h", "21h a 03h", "de 21 a 03h",
             // "16h a 20:30h" — never a listing title (additive skip; the
@@ -1308,6 +1317,62 @@ class AiWebParser {
             // line is prose/description, so no hint is derived at all.
             return line.length <= this.extractionLimits.multiEventTitleMaxChars ? line : '';
         }
+        return '';
+    }
+
+    // The name span of a listing line that carries BOTH the event name and its
+    // date ("CHUNK Portland - 5/23 Sat, May 23" → "CHUNK Portland"). Returns a
+    // CONTIGUOUS substring of the line, never a re-glued reconstruction: the
+    // extraction gate drops any field whose value is not verbatim in the
+    // source, so a stitched-together hint would trade a wrong title for no
+    // title at all.
+    //
+    // Prefix wins over suffix — multi-event listings put the name first and the
+    // venue after the date ("BOATMINCE Sun, Aug 30 Westminster Pier London"),
+    // so the text AFTER the date is usually the venue, not the name.
+    //
+    // Stricter than hasMultiEventDateSignal on purpose: this drives a rewrite,
+    // not a detection, so a month name only counts as strippable with an
+    // adjacent day/year number. A bare-month line ("Pride March") matches
+    // nothing here and falls through to the caller's existing skip.
+    deriveListingTitleSpanFromDatedLine(value) {
+        const line = this.normalizeWhitespace(value);
+        if (!line) return '';
+
+        const dateTokenPattern = new RegExp([
+            // Weekday name or abbreviation, with optional trailing "." / ","
+            '\\b(?:mon|tues?|wed(?:nes)?|thur?s?|fri|sat(?:ur)?|sun)(?:day)?\\b\\.?,?',
+            // Month name REQUIRING an adjacent day and/or year number
+            '\\b(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?'
+                + '|aug(?:ust)?|sept?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)'
+                + '\\.?\\s+\\d{1,2}(?:st|nd|rd|th)?(?:,?\\s+\\d{4})?\\b',
+            // Numeric date: 5/23, 07.04, 12-25-2026
+            '\\b(?:0?[1-9]|1[0-2])[\\/.-](?:0?[1-9]|[12]\\d|3[01])(?:[\\/.-](?:\\d{2}|\\d{4}))?\\b'
+        ].join('|'), 'gi');
+
+        const matches = [...line.matchAll(dateTokenPattern)];
+        if (matches.length === 0) return '';
+
+        const first = matches[0];
+        const last = matches[matches.length - 1];
+        const trimSpan = (span) => String(span || '').replace(/^[\s\-–—:|,.]+/, '')
+            .replace(/[\s\-–—:|,.]+$/, '').trim();
+
+        // A usable name span has real words in it — not a leftover time
+        // fragment ("10:00 PM") and not a stray separator.
+        const isUsable = (span) => {
+            if (!span || span.length < 3) return false;
+            if (!/[a-z]{3}/i.test(span)) return false;
+            if (/^\d{1,2}(:\d{2})?\s*(am|pm)?(\s*[-–]\s*\d{1,2}(:\d{2})?\s*(am|pm)?)?$/i.test(span)) return false;
+            return true;
+        };
+
+        const prefix = trimSpan(line.slice(0, first.index));
+        if (isUsable(prefix)) return prefix;
+
+        const suffix = trimSpan(line.slice(last.index + last[0].length));
+        if (isUsable(suffix)) return suffix;
+
         return '';
     }
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -3400,6 +3400,62 @@ test('deriveSegmentListingTitle skips marker, time-only, and date lines; long pr
 });
 
 // ---------------------------------------------------------------------------
+// Name+date on ONE listing line. Run 20260801-170254: chunk-party.com prints
+// "CHUNK Portland - 5/23 Sat, May 23" as a single line, so the whole line was
+// skipped as a date line and the NEXT line — the venue "Nova PDX" — became the
+// page's "own" listing title. The prompt hands that to the AI as the title to
+// prefer, which is how a Portland event ended up named after a bar.
+// ---------------------------------------------------------------------------
+test('deriveSegmentListingTitle recovers the name span from a name+date listing line', () => {
+  const parser = createParser();
+
+  // The regression: the venue on the following line must NOT win.
+  assert.equal(parser.deriveSegmentListingTitle({
+    lines: ['CHUNK Portland - 5/23 Sat, May 23', 'Nova PDX', 'Details']
+  }), 'CHUNK Portland', 'name span before the date, not the venue line below');
+
+  assert.equal(parser.deriveSegmentListingTitle({
+    lines: ['CHUNK Portland - SUMMER BLOW OUT! Sat, Aug 22', 'Nova PDX']
+  }), 'CHUNK Portland - SUMMER BLOW OUT!');
+
+  // Name first, venue AFTER the date — the prefix is the name, never the suffix.
+  assert.equal(parser.deriveSegmentListingTitle({
+    lines: ['BOATMINCE Sun, Aug 30 Westminster Pier London']
+  }), 'BOATMINCE', 'text after the date is the venue, not the name');
+
+  assert.equal(parser.deriveSegmentListingTitle({
+    lines: ['BEEFMINCE x Bear Brum 2026 Sat, Sep 26 Eden Birmingham']
+  }), 'BEEFMINCE x Bear Brum 2026');
+});
+
+test('a derived listing title is always a contiguous span of its source line', () => {
+  const parser = createParser();
+  // The extraction gate drops any field not verbatim in the source, so a
+  // re-glued hint ("CHUNK Portland Bear Night") would cost the title entirely.
+  const lines = [
+    'CHUNK Portland - 5/23 Sat, May 23',
+    'BOATMINCE Sun, Aug 30 Westminster Pier London',
+    'BEEFMINCE x Bear Brum 2026 Sat, Sep 26 Eden Birmingham',
+    'SPOOKMINCE Sat, Oct 31 Venue TBA, London London'
+  ];
+  for (const line of lines) {
+    const derived = parser.deriveSegmentListingTitle({ lines: [line] });
+    assert.ok(derived, `derives a title for ${JSON.stringify(line)}`);
+    assert.ok(line.includes(derived), `${JSON.stringify(derived)} must appear verbatim in its source line`);
+  }
+});
+
+test('a dated line with no name span derives nothing rather than a time fragment', () => {
+  const parser = createParser();
+  // Date-only first line: falls through to the next line exactly as before.
+  assert.equal(parser.deriveSegmentListingTitle({
+    lines: ['Aug 7, 2026 10:00 PM', 'PERVERT', 'DJs Villa Senor']
+  }), 'PERVERT', 'a bare date line still yields to the real title below it');
+  assert.equal(parser.deriveSegmentListingTitle({ lines: ['Aug 7, 2026 10:00 PM'] }), '');
+  assert.equal(parser.deriveSegmentListingTitle({ lines: ['July 25, 2026'] }), '');
+});
+
+// ---------------------------------------------------------------------------
 // Console-tee coverage: every log-producing module imported via importModule
 // must carry the __wireConsoleTee shim, or its output silently vanishes from
 // the saved Scriptable run log (each imported module has its own console).


### PR DESCRIPTION
Run `20260801-170254` saved a Portland event titled **"Nova Box"**. That string is flyer OCR of the venue **NOVA PDX** — the same flyer OCR'd "CHUNKLAND" as "CP HONK L AND". Two independent defects had to line up, and a third hid the evidence.

## 1. The segment's real title was thrown away

`chunk-party.com` prints the name and the date on **one** listing line:

```
CHUNK Portland - 5/23 Sat, May 23     ← the real title
Nova PDX                              ← the venue
Details
```

`deriveSegmentListingTitle` skips any line carrying a date signal, so line 1 was discarded and **the venue became "the page's own listing title"** — which the extraction prompt then tells the AI to prefer for `title`. Needing a venue and having just spent the real one on the title, the AI reached into the flyer and took `NOVA BOX`.

Verified against shipped code before the fix:

```
CHUNK segment 5 → "Nova PDX"        (should be the CHUNK Portland line)
CHUNK segment 4 → "C'mon Everybody" (should be the CHUNK Brooklyn line)
```

**This is not one page.** Across 148 segments in two days of run logs, **98 (66%)** put the date on the title line — CHUNK, BEEFMINCE, BOATMINCE, SPOOKMINCE. The existing unit test fixture has the date on its own line, which is why it never surfaced.

A dated line now yields its **name span** instead of being skipped:

| line | derived |
|---|---|
| `CHUNK Portland - 5/23 Sat, May 23` | `CHUNK Portland` |
| `CHUNK Portland - SUMMER BLOW OUT! Sat, Aug 22` | `CHUNK Portland - SUMMER BLOW OUT!` |
| `BOATMINCE Sun, Aug 30 Westminster Pier London` | `BOATMINCE` |
| `BEEFMINCE x Bear Brum 2026 Sat, Sep 26 Eden Birmingham` | `BEEFMINCE x Bear Brum 2026` |
| `Aug 7, 2026 10:00 PM` | `''` — falls through to the next line, as before |

Design constraints, all pinned by tests:

- **Contiguous span only, never a reconstruction.** The extraction gate drops any field not verbatim in the source, so a re-glued hint (`CHUNK Portland Bear Night`) would trade a wrong title for *no* title.
- **Prefix beats suffix.** Listings put the name first and the venue after the date, so text following the date is usually the venue.
- **Stricter than `hasMultiEventDateSignal`**, because this drives a rewrite rather than a detection: a month name only counts as strippable with an adjacent day/year. A bare-month line (`Pride March`) matches nothing and keeps today's behavior.

**No date information is lost.** Only the one-line hint changes — `segmentContent` is still `segment.lines.join('\n')`, so the full line reaches the AI, alongside `segmentDateContext` and the flyer OCR:

```
hint   : "CHUNK Portland"
corpus : "CHUNK Portland - 5/23 Sat, May 23\nNova PDX\nDetails"
```

## 2. `BarDataNormalizer` promoted the garbage into the title

Post-extraction the event was `title: "CHUNK: Nova PDX"`, `bar: "Nova Box"`. The venue-in-title guard fired correctly, then did this with zero verification:

```js
// Title was a venue, so swap bar name into title
event.title = event.bar;    // "Nova Box"
event.bar   = matchedBar.name;
```

Reproduced on shipped code:

```
in:  { title: 'CHUNK: Nova PDX', bar: 'Nova Box' }
out: { title: 'Nova Box',        bar: 'Nova PDX' }
```

The rewrite assumes the fields are transposed — the venue landed in `title`, so `bar` must hold the real name. Here `bar` held *another spelling of the same venue*, so the assumption was false and the title was destroyed.

The destructive path now requires positive verification: `bar` must not read as a **variant** of the venue it matched — sharing a significant word *and* being no wordier (`Nova Box` vs `Nova PDX`). A real title smuggled into `bar` adds words the venue name lacks (`Eagle Bear Night` vs `Eagle`) and promotes exactly as before.

Diffed against `origin/main` across four shapes — only the bug case changes:

| case | vs baseline | result |
|---|---|---|
| OCR venue variant (the bug) | **CHANGED** | `title="CHUNK: Nova PDX" bar="Nova PDX"` |
| bar holds a real title | same | `title="Bear Night Party" bar="Eagle"` |
| bar is a substring of the venue | same | untouched |
| no bar at all | same | untouched |

## 3. The rewrite was silent

There was no `console.log` in that block, so the title changed between two log lines with nothing in between; the entire diagnosis had to come out of the run JSON. Both branches now log. Additive lines only — no existing log text or prompt line was edited.

## Why only this event, out of thirteen

Every segment on that page lost its title the same way. Twelve were rescued because the crawler followed through to the detail page and got a clean title from JSON-LD. `chunk-portland-5-23` is a past event whose detail page has **no JSON-LD** (`scriptsFound=0`) and got classified as a multi-event page yielding 0 events — so nothing overwrote the bad title.

## Verification

- Quiet suite: **1163 → 1169, 0 failures** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`), baseline measured on `origin/main` in the same worktree.
- 6 new tests: name-span recovery for the real CHUNK/BEEFMINCE lines; a contiguity assertion that every derived title appears verbatim in its source line; no-name-span lines derive nothing; the variant-blocked and genuine-transposition normalizer paths with their log lines; direct `isPromotableTitleFromBarField` coverage.
- No new runtime files, so no scriptable-script-updater entry needed.
- Not verified on-device — worth a CHUNK re-run to confirm the titles land.

## One thing this does NOT fix

`Nova Box` is **already in the Portland calendar** (this run merged against it, key `nova-box|2026-05-24|nova pdx`). A corrected title changes the dedupe key, so it will likely arrive as a new event beside the old one rather than renaming it. That one needs a manual delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP