### PR TITLE
fix(scraper): dates stay in titles — the strip built for it never ran

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -640,6 +640,13 @@ class AiWebParser {
                         console.log(`🤖 AI Web: Stripped leading date from title "${event.title}" → "${strippedTitle}"`);
                         event.title = strippedTitle;
                     }
+                    // …and the redundant-date strip, for the same reason. Only
+                    // the leading-phrase strip was copied here originally, so
+                    // JSON-LD titles that print the date as a SUFFIX ("CHUNK
+                    // DORE ALLEY - Saturday July 25th") reached the calendar
+                    // dated on every run. Same verification as the AI route:
+                    // the printed date must match the event's own start.
+                    event.title = this.stripRedundantTitleDate(event.title, [event.startDate, event.start]);
                 });
                 if (pageBrandNames.length > 0) {
                     structuredEvents.forEach(event => {
@@ -7650,6 +7657,53 @@ class AiWebParser {
     }
 
 
+    // The redundant-date strip itself, factored out of normalizeAiEvent so the
+    // structured-data route can run it too. It could not before: JSON-LD
+    // events skip normalizeAiEvent entirely, and only the LEADING-phrase strip
+    // was ever copied across — so "Stripped redundant date from title" appears
+    // ZERO times in every run log on record, while chunk-party.com ships
+    // "CHUNK DORE ALLEY - Saturday July 25th" through JSON-LD on every run.
+    //
+    // dateCandidates are tried in order and may be ISO strings or Dates; the
+    // first that yields a local Y-M-D decides. Strips only when the printed
+    // date provably matches — a mismatch keeps the title and logs a review
+    // trail, and no usable date at all keeps the title untouched.
+    stripRedundantTitleDate(title, dateCandidates = []) {
+        if (typeof title !== 'string' || !title.trim()) return title;
+        const detectTitleDateSegment = this.core && typeof this.core.detectTitleDateSegment === 'function'
+            ? (value) => this.core.detectTitleDateSegment(value)
+            : ImportedDetectTitleDateSegment;
+        const titleDateSegment = typeof detectTitleDateSegment === 'function' ? detectTitleDateSegment(title) : null;
+        if (!titleDateSegment) return title;
+
+        const extractLocalDateParts = (value) => {
+            const text = value instanceof Date
+                ? (Number.isNaN(value.getTime()) ? null : value.toISOString())
+                : value;
+            if (typeof text !== 'string') return null;
+            const match = text.trim().match(/^(\d{4})-(\d{2})-(\d{2})(?:[T\s]|$)/);
+            if (!match) return null;
+            return { year: parseInt(match[1], 10), month: parseInt(match[2], 10), day: parseInt(match[3], 10) };
+        };
+
+        let expectedDate = null;
+        for (const candidate of (Array.isArray(dateCandidates) ? dateCandidates : [dateCandidates])) {
+            expectedDate = extractLocalDateParts(candidate);
+            if (expectedDate) break;
+        }
+        if (!expectedDate) return title;
+
+        const monthDayMatches = titleDateSegment.month === expectedDate.month && titleDateSegment.day === expectedDate.day;
+        const yearMatches = titleDateSegment.year === null || titleDateSegment.year === expectedDate.year;
+        if (monthDayMatches && yearMatches) {
+            console.log(`🤖 AI Web: Stripped redundant date from title ("${title}" → "${titleDateSegment.base}")`);
+            return titleDateSegment.base;
+        }
+        const expectedIso = `${expectedDate.year}-${String(expectedDate.month).padStart(2, '0')}-${String(expectedDate.day).padStart(2, '0')}`;
+        console.log(`🤖 AI Web: Title contains a date that does not match startDate ("${title}" vs ${expectedIso}) — kept, verify manually`);
+        return title;
+    }
+
     // Leading date phrase on an event TITLE, e.g. the Bear Cave's
     // "Wednesday 9th September – BEEFMINCE MEET MARKET". The day-header gate
     // above correctly KEEPS these (there is a real name after the date), so
@@ -11260,34 +11314,7 @@ TEXT:
         // (detectTitleDateSegment — one implementation, shared with the merge
         // rung); a mismatching printed date keeps the title and leaves a
         // manual-review trail. Any parse uncertainty fails open (title kept).
-        const detectTitleDateSegment = this.core && typeof this.core.detectTitleDateSegment === 'function'
-            ? (value) => this.core.detectTitleDateSegment(value)
-            : ImportedDetectTitleDateSegment;
-        const titleDateSegment = typeof detectTitleDateSegment === 'function' ? detectTitleDateSegment(title) : null;
-        if (titleDateSegment) {
-            const extractLocalDateParts = (value) => {
-                if (typeof value !== 'string') return null;
-                const match = value.trim().match(/^(\d{4})-(\d{2})-(\d{2})(?:[T\s]|$)/);
-                if (!match) return null;
-                return { year: parseInt(match[1], 10), month: parseInt(match[2], 10), day: parseInt(match[3], 10) };
-            };
-            const expectedDate = extractLocalDateParts(aiEvent.startDate)
-                || extractLocalDateParts(aiEvent.start)
-                || (startDateRaw instanceof Date && !Number.isNaN(startDateRaw.getTime())
-                    ? extractLocalDateParts(startDateRaw.toISOString())
-                    : null);
-            if (expectedDate) {
-                const monthDayMatches = titleDateSegment.month === expectedDate.month && titleDateSegment.day === expectedDate.day;
-                const yearMatches = titleDateSegment.year === null || titleDateSegment.year === expectedDate.year;
-                if (monthDayMatches && yearMatches) {
-                    console.log(`🤖 AI Web: Stripped redundant date from title ("${title}" → "${titleDateSegment.base}")`);
-                    title = titleDateSegment.base;
-                } else {
-                    const expectedIso = `${expectedDate.year}-${String(expectedDate.month).padStart(2, '0')}-${String(expectedDate.day).padStart(2, '0')}`;
-                    console.log(`🤖 AI Web: Title contains a date that does not match startDate ("${title}" vs ${expectedIso}) — kept, verify manually`);
-                }
-            }
-        }
+        title = this.stripRedundantTitleDate(title, [aiEvent.startDate, aiEvent.start, startDateRaw]);
 
         const event = {
             title,

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -8550,12 +8550,17 @@ test('the JSON-LD title repair fails open without a core and composes with the o
   assert.equal(coreless.repairTruncatedTitleFromJsonLd('The RETURN', { html }), 'The RETURN');
 
   // Through the real normalization path, the repaired title still faces the
-  // leading-date strip and the pipe brand-suffix strip.
+  // leading-date strip, the pipe brand-suffix strip, and the redundant-date
+  // strip. The trailing "Saturday March 14th" is attached by whitespace
+  // rather than a separator; it used to survive because detectTitleDateSegment
+  // required a separator, and the live AI arbiter then had to talk itself out
+  // of it case by case ("adds the event date, which is not part of the event's
+  // identity"). It matches startDate, so it is now removed deterministically.
   const parser = createParser();
   const repaired = parser.normalizeAiEvent(
     { title: 'The RETURN', startDate: '2026-03-14T21:00:00-07:00' },
     {}, { html, url: 'https://www.chunk-party.com/x' }, null, null);
-  assert.equal(repaired.title, 'CHUNK Portland - The RETURN! Saturday March 14th');
+  assert.equal(repaired.title, 'CHUNK Portland - The RETURN!');
 
   const datedParser = createParser();
   const dated = datedParser.normalizeAiEvent(
@@ -8572,7 +8577,9 @@ test('the JSON-LD title repair fails open without a core and composes with the o
   const branded = brandedParser.normalizeAiEvent(
     { title: 'The RETURN', startDate: '2026-03-14T21:00:00-07:00' },
     {}, { html: brandedHtml, url: 'https://www.chunk-party.com/x' }, null, null);
-  assert.equal(branded.title, 'CHUNK Portland - The RETURN! Saturday March 14th');
+  // Brand suffix stripped, then the redundant trailing date — both cleanups
+  // compose on the repaired title.
+  assert.equal(branded.title, 'CHUNK Portland - The RETURN!');
 });
 
 // ---------------------------------------------------------------------------
@@ -8988,4 +8995,56 @@ test('bar plausibility gate: a curated venue name for the event city outranks th
   const borough = { title: 'x', bar: 'Brooklyn', city: 'nyc' };
   parser.applyBarPlausibilityGate(borough, CITY_GATE_CONFIG);
   assert.equal('bar' in borough, false, 'no curated bar is named after a city — the gate still fires');
+});
+
+// ---------------------------------------------------------------------------
+// Redundant title dates. "Stripped redundant date from title" appears ZERO
+// times in every run log on record, because JSON-LD events skip
+// normalizeAiEvent and only the LEADING-phrase strip was copied to that route
+// — so chunk-party.com shipped "CHUNK DORE ALLEY - Saturday July 25th" to the
+// calendar on every run. Day-first dates ("Wednesday 9th September – …", the
+// Sitges listings) were invisible to the detector in BOTH routes.
+// ---------------------------------------------------------------------------
+test('stripRedundantTitleDate removes a printed date that matches the event start', () => {
+  const parser = createParser();
+  assert.equal(
+    parser.stripRedundantTitleDate('CHUNK DORE ALLEY - Saturday July 25th', ['2026-07-25T22:00:00-07:00']),
+    'CHUNK DORE ALLEY');
+  assert.equal(
+    parser.stripRedundantTitleDate('CHUNK Chicago - September 19th', ['2026-09-19T21:00:00-05:00']),
+    'CHUNK Chicago');
+  // Whitespace-attached trailing date — no separator at all.
+  assert.equal(
+    parser.stripRedundantTitleDate('CHUNK Brooklyn 7/4', ['2026-07-04T22:00:00-04:00']),
+    'CHUNK Brooklyn');
+  // Day-first, the Sitges shape.
+  assert.equal(
+    parser.stripRedundantTitleDate('Wednesday 9th September – BEEFMINCE MEET MARKET', ['2026-09-09T21:00:00Z']),
+    'BEEFMINCE MEET MARKET');
+});
+
+test('stripRedundantTitleDate keeps the title when the date is unverified or disagrees', () => {
+  const parser = createParser();
+  // Printed date contradicts startDate — a signal, not noise. Kept for review.
+  assert.equal(
+    parser.stripRedundantTitleDate('CHUNK DORE ALLEY - Saturday July 25th', ['2026-08-01T22:00:00-07:00']),
+    'CHUNK DORE ALLEY - Saturday July 25th');
+  // No usable date to verify against — never strip on a guess.
+  assert.equal(
+    parser.stripRedundantTitleDate('CHUNK DORE ALLEY - Saturday July 25th', [undefined, null, '']),
+    'CHUNK DORE ALLEY - Saturday July 25th');
+  assert.equal(parser.stripRedundantTitleDate('', ['2026-07-25T22:00:00-07:00']), '');
+});
+
+test('structured-data events get the redundant-date strip, not just the leading one', () => {
+  const parser = createParser();
+  // The JSON-LD route is the one that ships CHUNK's dated titles; before this
+  // it only ever ran stripLeadingDatePhraseFromTitle.
+  const html = jsonLdEventPage(jsonLdEventNode('CHUNK DORE ALLEY - Saturday July 25th'));
+  const events = parser.parseEvents({ html, url: 'https://www.chunk-party.com/event-details/chunk-dore-alley' }, {});
+  const titles = (Array.isArray(events) ? events : []).map(event => event && event.title);
+  assert.ok(
+    titles.includes('CHUNK DORE ALLEY') || titles.every(title => !/July 25th/.test(String(title))),
+    `no JSON-LD title should reach the calendar dated: ${JSON.stringify(titles)}`
+  );
 });

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1163,13 +1163,27 @@ class SharedCore {
         const dayPart = '(\\d{1,2})(?:st|nd|rd|th)?';
         const yearPart = '(?:,?\\s+(\\d{4}))?';
         const wordySegment = `${weekdayPart}${monthPart}\\s+${dayPart}${yearPart}`;
+        // Day-first ordering — the British/European form the Bear Cave's
+        // Sitges listings use ("Wednesday 9th September – BEEFMINCE MEET
+        // MARKET"). Month-first only meant every one of those titles read as
+        // dateless, so both the parser strip and the merge rung passed them
+        // straight through. Captures day, month, year in that order.
+        const dayFirstSegment = `${weekdayPart}${dayPart}\\s+${monthPart}${yearPart}`;
         const numericSegment = '(\\d{1,2})\\s*\\/\\s*(\\d{1,2})(?:\\s*\\/\\s*(\\d{4}))?';
         const separatorPart = '\\s*(?:[-–—|:•]|,)\\s*';
+        // TRAILING segments may also be attached by whitespace alone ("CHUNK
+        // Brooklyn 7/4", "CHUNK Portland - The RETURN! Saturday March 14th").
+        // Leading segments keep the strict separator on purpose: a bare space
+        // there would read "July 4th Party" as the date "July 4th" plus the
+        // name "Party", eating a real title.
+        const trailingSeparatorPart = `(?:${separatorPart}|\\s+)`;
         const attempts = [
-            { regex: new RegExp(`^(.*?)${separatorPart}${wordySegment}$`, 'i'), wordy: true, base: 1, month: 2, day: 3, year: 4 },
-            { regex: new RegExp(`^(.*?)${separatorPart}${numericSegment}$`, 'i'), wordy: false, base: 1, month: 2, day: 3, year: 4 },
+            { regex: new RegExp(`^(.*?)${trailingSeparatorPart}${wordySegment}$`, 'i'), wordy: true, base: 1, month: 2, day: 3, year: 4 },
+            { regex: new RegExp(`^(.*?)${trailingSeparatorPart}${numericSegment}$`, 'i'), wordy: false, base: 1, month: 2, day: 3, year: 4 },
             { regex: new RegExp(`^${wordySegment}${separatorPart}(.*)$`, 'i'), wordy: true, base: 4, month: 1, day: 2, year: 3 },
-            { regex: new RegExp(`^${numericSegment}${separatorPart}(.*)$`, 'i'), wordy: false, base: 4, month: 1, day: 2, year: 3 }
+            { regex: new RegExp(`^${numericSegment}${separatorPart}(.*)$`, 'i'), wordy: false, base: 4, month: 1, day: 2, year: 3 },
+            { regex: new RegExp(`^(.*?)${trailingSeparatorPart}${dayFirstSegment}$`, 'i'), wordy: true, base: 1, day: 2, month: 3, year: 4 },
+            { regex: new RegExp(`^${dayFirstSegment}${separatorPart}(.*)$`, 'i'), wordy: true, day: 1, month: 2, year: 3, base: 4 }
         ];
         for (const attempt of attempts) {
             const match = text.match(attempt.regex);

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -11198,3 +11198,55 @@ test('series edit: an occurrence override is still an override, not a series upd
     'and is still written'
   );
 });
+
+// ---------------------------------------------------------------------------
+// detectTitleDateSegment: day-first dates and whitespace-attached trailing
+// dates. Both were invisible, so the merge rung that drops a redundant dated
+// title never fired for the Sitges ("Wednesday 9th September – …") or CHUNK
+// ("CHUNK Brooklyn 7/4") titles, and the AI arbiter decided them case by case
+// — keeping the date in one event and dropping it in the next, same run.
+// ---------------------------------------------------------------------------
+test('detectTitleDateSegment reads day-first and whitespace-attached dates', () => {
+  const cases = [
+    ['Wednesday 9th September – BEEFMINCE MEET MARKET', 'BEEFMINCE MEET MARKET', 9, 9],
+    ['Saturday 12th September – BEEFMINCE: THE BIG BALL', 'BEEFMINCE: THE BIG BALL', 9, 12],
+    ['9 September - BEEFMINCE DISCO', 'BEEFMINCE DISCO', 9, 9],
+    ['CHUNK Brooklyn 7/4', 'CHUNK Brooklyn', 7, 4],
+    ['CHUNK Portland - The RETURN! Saturday March 14th', 'CHUNK Portland - The RETURN!', 3, 14]
+  ];
+  for (const [title, base, month, day] of cases) {
+    const segment = SharedCore.detectTitleDateSegment(title);
+    assert.ok(segment, `${title} must be detected`);
+    assert.equal(segment.base, base);
+    assert.equal(segment.month, month);
+    assert.equal(segment.day, day);
+  }
+});
+
+test('detectTitleDateSegment does not eat a name that merely starts with a date word', () => {
+  // A LEADING segment still needs a real separator, or "July 4th Party" would
+  // reduce to "Party". Edition years and weekday-only names stay untouched.
+  for (const title of ['July 4th Party', 'March 4 MADNESS', '4th of July Party',
+    'DECADENCE 2026', 'Pride 2027', 'Sunday Funday', 'May Day Party', 'BEEFMINCE x Bear Brum 2026']) {
+    assert.equal(SharedCore.detectTitleDateSegment(title), null, `${title} is not a dated title`);
+  }
+});
+
+test('a calendar title that only adds a date loses to the dateless one deterministically', () => {
+  const core = new SharedCore({}, { eventSchema: EventSchema });
+  const context = { sideLabels: { a: 'scraped', b: 'calendar' } };
+  // The already-saved BEEFMINCE titles: no AI arbitration, no coin flip.
+  for (const [clean, dated] of [
+    ['BEEFMINCE MEET MARKET', 'Wednesday 9th September – BEEFMINCE MEET MARKET'],
+    ['BEEFMINCE: THE BIG BALL', 'Saturday 12th September – BEEFMINCE: THE BIG BALL'],
+    ['CHUNK Brooklyn', 'CHUNK Brooklyn 7/4']
+  ]) {
+    const resolution = core.resolveConflictDeterministically('title', clean, dated, context);
+    assert.ok(resolution, `${dated} must resolve without the AI`);
+    assert.equal(resolution.winner, 'a', `the dateless title wins for ${dated}`);
+  }
+  // A calendar title that adds real information still arbitrates.
+  assert.equal(
+    core.resolveConflictDeterministically('title', 'FURBALL Chicago', 'FURBALL CHICAGO MARKET DAYS', context),
+    null);
+});


### PR DESCRIPTION
`Wednesday 9th September – BEEFMINCE MEET MARKET` and `CHUNK DORE ALLEY - Saturday July 25th` keep reaching the calendar. I went through the run history; there are three causes stacked on top of each other.

## 1. The deterministic strip has never executed — not once

`normalizeAiEvent` carries a purpose-built strip: detect the printed date, **verify it matches `startDate`**, remove it. Its log line is `Stripped redundant date from title`. That string appears **zero times across every log on record.**

Because JSON-LD events skip `normalizeAiEvent` entirely, and when the structured-data route was handed the title cleanups, only the *leading*-phrase strip was copied across. CHUNK ships every title through JSON-LD:

```
extraction summary: source=jsonld, aiPasses=1, ocrImages=0 → 1 event
```

So the strip written for `CHUNK DORE ALLEY - Saturday July 25th` has never once seen that title. Factored it into `stripRedundantTitleDate` and called from both routes, so a third extraction path can't silently skip it again.

## 2. The detector couldn't read the dates that actually appear

Run against the real titles on `origin/main`:

| title | detected |
|---|---|
| `Wednesday 9th September – BEEFMINCE MEET MARKET` | **null** — day-first |
| `Thursday 10th September – BEEFMINCE DISCO` | **null** — day-first |
| `CHUNK Brooklyn 7/4` | **null** — space separator |
| `CHUNK Portland - The RETURN! Saturday March 14th` | **null** — space separator |
| `CHUNK DORE ALLEY - Saturday July 25th` | ✓ (but see #1 — never reached) |

Day-first is the British form every Sitges listing uses; the detector only understood month-first. Added it, and allowed a whitespace-attached **trailing** segment.

Leading segments still require a real separator, deliberately — a bare space there would read `July 4th Party` as the date `July 4th` plus the name `Party`. Traps checked and still rejected: `July 4th Party`, `March 4 MADNESS`, `4th of July Party`, `DECADENCE 2026`, `Pride 2027`, `Sunday Funday`, `May Day Party`, `BEEFMINCE x Bear Brum 2026`.

## 3. So the AI arbiter decided it, and it is not consistent

From a single run:

> chose calendar `"Wednesday 9th September – BEEFMINCE MEET MARKET"` — *"includes the day and date, **which is part of the event's identity**"*

> chose existing `"CHUNK Portland - The RETURN!"` — *"adds the event date, **which is not part of the event's identity** per the rules"*

Same run, same field, opposite conclusions. The prompt has a rule about dates; the model overrides it whenever the dated variant reads as "more descriptive."

There is already a deterministic rung meant to pre-empt exactly this — `date-only suffix is redundant, kept the dateless title`. It was never reached, because the detector returned `null`. With the detector fixed it fires:

```
before: AI arbitrates      "Wednesday 9th September – BEEFMINCE MEET MARKET"
before: AI arbitrates      "CHUNK Brooklyn 7/4"
after:  DETERMINISTIC (a)  "Wednesday 9th September – BEEFMINCE MEET MARKET"
after:  DETERMINISTIC (a)  "CHUNK Brooklyn 7/4"

after:  AI arbitrates      "FURBALL CHICAGO MARKET DAYS"   ← still arbitrates, correctly
```

## Why this also fixes titles already saved

The scraper had in fact been producing the clean title for BEEFMINCE all along — `scraper: 'BEEFMINCE MEET MARKET'`, `calendar: 'Wednesday 9th September – BEEFMINCE MEET MARKET'` — and the merge handed it back to the dated one. Cleanups run in the parser, so anything saved before a cleanup shipped keeps its old title forever; there is no backfill path.

The merge rung runs on calendar merges, so once it resolves deterministically the **next run writes the clean title back**. No migration needed.

## Nothing strips on a guess

Two independent verifications, both kept:

- **Parser side**: strips only when the printed date matches the event's own start. A mismatch keeps the title and logs `Title contains a date that does not match startDate … verify manually`.
- **Merge side**: strips only when the two candidates are the same string apart from the date. A title that adds real information is never touched.

## Verification

- Quiet suite **1169 → 1175, 0 failures**.
- 6 new tests: day-first and whitespace-attached detection; the false-positive traps above; the merge rung resolving the real saved titles without AI; `stripRedundantTitleDate` stripping on match and keeping on mismatch/no-date; the structured-data route running it.
- **Two existing assertions updated** — they pinned the pre-fix behavior of `CHUNK Portland - The RETURN! Saturday March 14th` keeping its trailing date. Worth a look, since changing an existing expectation is the one place a "fix" can quietly become a regression. Note the live AI arbiter had independently reached the same verdict on that title.
- No new runtime files.
- Not verified on-device — a CHUNK/BEEFMINCE re-run is the real check. Expect `Stripped redundant date from title` to appear in a log for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP