### PR TITLE
fix(scraper): order-independent AI merge arbitration — canonical slots, neutral labels, boundary mapping

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -10959,6 +10959,12 @@ class SharedCore {
                 agreedKey = key;
             } else if (key !== agreedKey) {
                 return '';
+            } else if (organizer < firstOriginal) {
+                // Same organizer, different casing across records ("CLUB CHUB"
+                // vs "Club Chub"): "first-encountered" would depend on argument
+                // order and leak orientation back into the prompt — keep the
+                // lexicographically smaller casing instead.
+                firstOriginal = organizer;
             }
         }
         return firstOriginal;

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2506,26 +2506,79 @@ class SharedCore {
     // raw, <labelB>: raw } }]. Returns { [field]: { pick, reason } } containing only
     // fields whose answer survived the verbatim gate, or null when no usable response
     // was obtained at all (caller falls back for everything).
-    async arbitrateMergeConflicts({ conflicts, labels, aiConfig, httpAdapter, eventContext = '', organizer = '' }) {
+    //
+    // Order independence (2026-08-02, sanctioned prompt change): the prompt is a
+    // pure function of the UNORDERED pair of records. Run 20260801-172321 proved
+    // the model picks by slot, not content — the enrich path picked "incoming"
+    // 72% of the time, the calendar path picked "calendar" 66%, and the identical
+    // DURO title pair was arbitrated twice 11s apart in OPPOSITE orientations and
+    // picked "incoming" both times. So the two sides are re-oriented canonically
+    // (conflicts sorted by field name; each side keyed by its "field
+    // serializedValue" concatenation; the lexicographically smaller side becomes
+    // slot one; ties keep the caller's first label in slot one) and presented
+    // under NEUTRAL labels ("version-one"/"version-two") that carry no
+    // recency/savedness connotation. The model's neutral pick is mapped back to
+    // the caller's labels at the boundary, so callers, their logs, and
+    // decision.pick semantics are unchanged. Canonical prompts also let the AI
+    // response cache hit when the same pair recurs in the opposite orientation.
+    //
+    // `context` carries per-caller-label { title, startDate, source? } so the
+    // EVENT line is derived from slot order — identical for swapped inputs —
+    // instead of a caller-baked (order-dependent) string. The provenance
+    // segment renders only when a side declares `source`.
+    async arbitrateMergeConflicts({ conflicts, labels, aiConfig, httpAdapter, context = null, organizer = '' }) {
         const list = Array.isArray(conflicts) ? conflicts.filter(Boolean) : [];
         if (list.length === 0) return null;
         if (!aiConfig || aiConfig.enabled === false || aiConfig.arbitrateMerges === false) return null;
         if (!httpAdapter || typeof httpAdapter.postJson !== 'function') return null;
         const [labelA, labelB] = labels;
 
+        // Sort the batch by field name so the conflict list itself is order-stable.
+        const sortedConflicts = [...list].sort((a, b) => (a.field < b.field ? -1 : a.field > b.field ? 1 : 0));
         const serializedByField = {};
-        const conflictLines = [];
-        for (const conflict of list) {
-            const serializedA = this.serializeArbitrationValue(conflict.field, conflict.values[labelA]);
-            const serializedB = this.serializeArbitrationValue(conflict.field, conflict.values[labelB]);
-            serializedByField[conflict.field] = { [labelA]: serializedA, [labelB]: serializedB };
-            conflictLines.push(`- field: ${conflict.field}\n  ${labelA}: ${JSON.stringify(serializedA)}\n  ${labelB}: ${JSON.stringify(serializedB)}`);
+        for (const conflict of sortedConflicts) {
+            serializedByField[conflict.field] = {
+                [labelA]: this.serializeArbitrationValue(conflict.field, conflict.values[labelA]),
+                [labelB]: this.serializeArbitrationValue(conflict.field, conflict.values[labelB])
+            };
+        }
+
+        // Canonical orientation: the side whose sorted "field serializedValue"
+        // concatenation is lexicographically smaller takes slot one; on a tie
+        // (identical concatenations) the caller's first label stays slot one.
+        const orientationKey = (label) => sortedConflicts
+            .map(conflict => `${conflict.field} ${serializedByField[conflict.field][label]}`)
+            .join('\n');
+        const SLOT_ONE = 'version-one';
+        const SLOT_TWO = 'version-two';
+        const slotOneLabel = orientationKey(labelB) < orientationKey(labelA) ? labelB : labelA;
+        const slotTwoLabel = slotOneLabel === labelA ? labelB : labelA;
+        const callerLabelForSlot = { [SLOT_ONE]: slotOneLabel, [SLOT_TWO]: slotTwoLabel };
+
+        const conflictLines = sortedConflicts.map(conflict => {
+            const serialized = serializedByField[conflict.field];
+            return `- field: ${conflict.field}\n  ${SLOT_ONE}: ${JSON.stringify(serialized[slotOneLabel])}\n  ${SLOT_TWO}: ${JSON.stringify(serialized[slotTwoLabel])}`;
+        });
+
+        // EVENT line built from slot order so swapped inputs render identically:
+        // title/startDate come from slot one when both sides carry one (falling
+        // back to slot two), provenance lists the slots in slot order.
+        let eventContext = '';
+        if (context && typeof context === 'object') {
+            const slotOneInfo = context[slotOneLabel] && typeof context[slotOneLabel] === 'object' ? context[slotOneLabel] : {};
+            const slotTwoInfo = context[slotTwoLabel] && typeof context[slotTwoLabel] === 'object' ? context[slotTwoLabel] : {};
+            const title = String(slotOneInfo.title || '').trim() || String(slotTwoInfo.title || '').trim() || 'event';
+            const startDate = this.serializeArbitrationValue('startDate', slotOneInfo.startDate || slotTwoInfo.startDate) || 'unknown';
+            const provenance = ('source' in slotOneInfo) || ('source' in slotTwoInfo)
+                ? ` (${SLOT_ONE} from ${slotOneInfo.source || 'unknown'}, ${SLOT_TWO} from ${slotTwoInfo.source || 'unknown'})`
+                : '';
+            eventContext = `"${title}" starting ${startDate}${provenance}`;
         }
 
         const prompt = [
             'You are resolving merge conflicts between two records of the SAME event.',
             eventContext ? `EVENT: ${eventContext}` : '',
-            `Record "${labelA}" and record "${labelB}" each provide a value for the fields below.`,
+            `Record "${SLOT_ONE}" and record "${SLOT_TWO}" each provide a value for the fields below.`,
             '',
             'For each field, pick the value that is more correct, complete, and canonical',
             '(official names, full addresses, complete URLs, correctly formatted values).',
@@ -2544,9 +2597,9 @@ class SharedCore {
             '- For "title", a bare city name is not an event name — prefer the variant that names the event or its organizer.',
             '- For "title", the event\'s own date is NOT descriptive — never prefer a variant because it contains a date; prefer the dateless variant of an otherwise-equal name.',
             '- For "image", prefer event-specific promotional artwork over site or ticketing-service logos.',
-            `- "pick" must be "${labelA}" or "${labelB}".`,
+            `- "pick" must be "${SLOT_ONE}" or "${SLOT_TWO}".`,
             'Return JSON only:',
-            `{"choices": {"<field>": {"pick": "${labelA}" or "${labelB}", "value": "<exact copy of the chosen value>", "reason": "<one short sentence>"}}}`
+            `{"choices": {"<field>": {"pick": "${SLOT_ONE}" or "${SLOT_TWO}", "value": "<exact copy of the chosen value>", "reason": "<one short sentence>"}}}`
         ].filter(line => line !== '').join('\n');
 
         const arbitrationConfig = { ...aiConfig, numPredict: Math.min(Number(aiConfig.numPredict) || 800, 800) };
@@ -2563,7 +2616,7 @@ class SharedCore {
         const choices = parsed.choices && typeof parsed.choices === 'object' ? parsed.choices : parsed;
 
         const results = {};
-        for (const conflict of list) {
+        for (const conflict of sortedConflicts) {
             const field = conflict.field;
             const entry = choices[field];
             const serialized = serializedByField[field];
@@ -2577,8 +2630,12 @@ class SharedCore {
             const matchesA = this.arbitrationValuesEqual(field, answer, serialized[labelA]);
             const matchesB = this.arbitrationValuesEqual(field, answer, serialized[labelB]);
 
-            if (labels.includes(pick) && this.arbitrationValuesEqual(field, answer, serialized[pick])) {
-                results[field] = { pick, reason };
+            // The model answers in neutral slot labels; map the pick back to the
+            // caller's labels HERE, before results/logs ever see it — everything
+            // downstream keeps caller-label semantics byte-for-byte.
+            const pickedCallerLabel = callerLabelForSlot[pick] || '';
+            if (pickedCallerLabel && this.arbitrationValuesEqual(field, answer, serialized[pickedCallerLabel])) {
+                results[field] = { pick: pickedCallerLabel, reason };
             } else if (matchesA !== matchesB) {
                 // Wrong/missing pick label but the value is provably one of the options
                 const recoveredPick = matchesA ? labelA : labelB;
@@ -6465,7 +6522,13 @@ class SharedCore {
                     labels: ['existing', 'incoming'],
                     aiConfig,
                     httpAdapter: options.httpAdapter,
-                    eventContext: `"${eventTitle}" starting ${this.serializeArbitrationValue('startDate', newEvent.startDate || existingEvent.startDate) || 'unknown'} (record "existing" from ${existingEvent.source || 'unknown'}, record "incoming" from ${newEvent.source || 'unknown'})`,
+                    // Structured per-side provenance: arbitrateMergeConflicts
+                    // derives the EVENT line from canonical slot order so the
+                    // prompt is identical for swapped inputs.
+                    context: {
+                        existing: { title: existingEvent.title, startDate: existingEvent.startDate, source: existingEvent.source || 'unknown' },
+                        incoming: { title: newEvent.title, startDate: newEvent.startDate, source: newEvent.source || 'unknown' }
+                    },
                     organizer: this.getKnownOrganizer(newEvent, existingEvent)
                 });
             } catch (error) {
@@ -6916,7 +6979,6 @@ class SharedCore {
         if (pendingAiConflicts.length > 0) {
             const eventTitle = scraperObject.title || calendarObject.title || 'event';
             const aiConfig = this.getMergeArbitrationConfig(newEvent, options.globalConfig);
-            const eventContext = `"${eventTitle}" starting ${this.serializeArbitrationValue('startDate', scraperObject.startDate || calendarObject.startDate) || 'unknown'}`;
             let arbitration = null;
             try {
                 arbitration = await this.arbitrateMergeConflicts({
@@ -6924,7 +6986,13 @@ class SharedCore {
                     labels: ['calendar', 'scraped'],
                     aiConfig,
                     httpAdapter: options.httpAdapter,
-                    eventContext,
+                    // Structured per-side context (no `source` here — this path
+                    // never carried provenance): the EVENT line is derived from
+                    // canonical slot order, identical for swapped inputs.
+                    context: {
+                        calendar: { title: calendarObject.title, startDate: calendarObject.startDate },
+                        scraped: { title: scraperObject.title, startDate: scraperObject.startDate }
+                    },
                     organizer: this.getKnownOrganizer(scraperObject, calendarObject)
                 });
             } catch (error) {
@@ -10866,13 +10934,34 @@ class SharedCore {
 
     // The organizer brand a parser derived from page metadata and stamped as
     // internal metadata (_organizer, excluded from notes/merge field loops).
-    // First non-empty value across the given event records wins.
+    //
+    // BEHAVIOR CHANGE (2026-08-02): symmetric by design. The old "first
+    // non-empty value wins" rule made the arbitration prompt depend on argument
+    // order — the DURO run asserted KNOWN ORGANIZER "Eventbrite" in one
+    // orientation and "CLUB CHUB" in the other for the SAME event pair, steering
+    // the bar verdict differently each way. Now organizer candidates are
+    // collected from ALL passed events and compared under the promoter-name
+    // identity key: if every non-empty candidate agrees, the first-encountered
+    // original casing of that agreed name is returned; if they DISAGREE, return
+    // '' (fail closed — asserting either co-promoter in the prompt was exactly
+    // wrong in the DURO case); all-empty also returns ''.
     getKnownOrganizer(...events) {
+        let firstOriginal = '';
+        let agreedKey = '';
         for (const event of events) {
             const organizer = event && typeof event._organizer === 'string' ? event._organizer.trim() : '';
-            if (organizer) return organizer;
+            if (!organizer) continue;
+            const key = typeof this.normalizePromoterNameKey === 'function'
+                ? this.normalizePromoterNameKey(organizer)
+                : organizer.toLowerCase();
+            if (!firstOriginal) {
+                firstOriginal = organizer;
+                agreedKey = key;
+            } else if (key !== agreedKey) {
+                return '';
+            }
         }
-        return '';
+        return firstOriginal;
     }
 
     // === Calendar stickiness (REPORT-ONLY by default) ===

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -635,6 +635,24 @@ function buildArbitrationPair() {
   return { scraped, existing };
 }
 
+// Which neutral slot ("version-one"/"version-two") holds `value` for `field`
+// in the outgoing arbitration prompt? The prompt's slot assignment is canonical
+// (content-derived), not caller-ordered, so fixtures cannot hardcode it.
+function arbitrationSlotHolding(prompt, field, value) {
+  const match = String(prompt).match(
+    new RegExp(`- field: ${field}\\n  version-one: (.*)\\n  version-two: (.*)`)
+  );
+  if (!match) return '';
+  const target = String(value === null || value === undefined ? '' : value);
+  try {
+    if (JSON.parse(match[1]) === target) return 'version-one';
+    if (JSON.parse(match[2]) === target) return 'version-two';
+  } catch (_) {
+    return '';
+  }
+  return '';
+}
+
 function buildArbitrationAdapter(choices, options = {}) {
   const calls = [];
   return {
@@ -642,10 +660,29 @@ function buildArbitrationAdapter(choices, options = {}) {
     postJson: async (endpoint, payload) => {
       calls.push(payload);
       if (options.fail) throw new Error('AI endpoint down');
+      // The simulated model sees canonical neutral slot labels, so fixtures
+      // express their answer by VALUE: each choice's pick is translated to the
+      // neutral label of whichever slot holds that value in the actual outgoing
+      // prompt — exactly how a verbatim-copying model answers. Values matching
+      // neither slot (hallucination fixtures) keep their original pick and are
+      // rejected by the gate as before. keepPicks: true skips translation to
+      // exercise the wrong-label recovery path.
+      const prompt = String(payload.prompt || (Array.isArray(payload.messages)
+        ? payload.messages.map(m => m.content).join('\n')
+        : ''));
+      const translated = {};
+      for (const [field, choice] of Object.entries(choices || {})) {
+        const entry = { ...choice };
+        if (!options.keepPicks) {
+          const slot = arbitrationSlotHolding(prompt, field, entry.value);
+          if (slot) entry.pick = slot;
+        }
+        translated[field] = entry;
+      }
       return {
         ok: true,
         status: 200,
-        text: JSON.stringify({ response: JSON.stringify({ choices }) })
+        text: JSON.stringify({ response: JSON.stringify({ choices: translated }) })
       };
     }
   };
@@ -707,12 +744,13 @@ test('hallucinated or missing AI answers fall back to the scraped value (clobber
 test('a verbatim value with a wrong pick label is trusted via the value', async () => {
   const core = createCore();
   const { scraped, existing } = buildArbitrationPair();
-  // pick says scraped but the value verbatim-equals the CALENDAR candidate
+  // keepPicks sends labels the gate can't validate ("scraped" is not a neutral
+  // slot label) — the verbatim value alone must identify the winner
   const adapter = buildArbitrationAdapter({
     title: { pick: 'scraped', value: 'FURBALL DALLAS' },
     bar: { pick: 'scraped', value: 'STATION 4' },
     startDate: { pick: 'scraped', value: '2026-07-05T22:00:00.000Z' }
-  });
+  }, { keepPicks: true });
 
   const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
   assert.equal(finalEvent.bar, 'STATION 4', 'the verbatim-matched candidate wins despite the mislabeled pick');
@@ -762,6 +800,278 @@ test('non-conflicts never reach the AI and keep clobber semantics', async () => 
 
   assert.equal(adapter.calls.length, 0, 'no conflicts → no AI request');
   assert.equal(finalEvent.cover, '$10', 'one-sided fields are added via clobber semantics');
+});
+
+// ---------------------------------------------------------------------------
+// Order-independent arbitration: the prompt is a pure function of the
+// UNORDERED pair of records (canonical slot orientation + neutral labels),
+// and the neutral pick maps back to the caller's labels at the boundary.
+// ---------------------------------------------------------------------------
+
+const ARBITRATION_TEST_AI_CONFIG = { ai: { provider: 'ollama', endpoint: 'http://ai.example/api/generate', model: 'test-model' } };
+
+// Simulated model that always answers the given neutral slot, copying that
+// slot's value verbatim out of the actual outgoing prompt.
+function buildSlotPickingAdapter(slot, fields) {
+  const calls = [];
+  return {
+    calls,
+    postJson: async (endpoint, payload) => {
+      calls.push(payload);
+      const prompt = String(payload.prompt || '');
+      const choices = {};
+      for (const field of fields) {
+        const match = prompt.match(new RegExp(`- field: ${field}\\n  version-one: (.*)\\n  version-two: (.*)`));
+        assert.ok(match, `the ${field} conflict must reach the prompt`);
+        choices[field] = {
+          pick: slot,
+          value: JSON.parse(slot === 'version-one' ? match[1] : match[2]),
+          reason: 'slot picker'
+        };
+      }
+      return { ok: true, status: 200, text: JSON.stringify({ response: JSON.stringify({ choices }) }) };
+    }
+  };
+}
+
+function buildEnrichSide(fields) {
+  const core = createCore();
+  return {
+    source: 'ai-web',
+    startDate: new Date('2026-08-02T05:00:00.000Z'),
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: ARBITRATION_TEST_AI_CONFIG,
+    ...fields
+  };
+}
+
+test('enrich-path arbitration prompt is byte-identical for swapped inputs', async () => {
+  const core = createCore();
+  const sideA = () => buildEnrichSide({ title: 'CLUB CHUB: DURO', bar: 'DURO' });
+  const sideB = () => buildEnrichSide({ title: 'D>U>R>O is back NEW OUTDOOR LOCATION _ NIGHT FOAM PARTY', bar: 'DOWNTOWN LA' });
+
+  const adapterAB = buildArbitrationAdapter({});
+  await core.mergeParsedEvents(sideA(), sideB(), { httpAdapter: adapterAB });
+  const adapterBA = buildArbitrationAdapter({});
+  await core.mergeParsedEvents(sideB(), sideA(), { httpAdapter: adapterBA });
+
+  assert.equal(adapterAB.calls.length, 1);
+  assert.equal(adapterBA.calls.length, 1);
+  assert.equal(adapterAB.calls[0].prompt, adapterBA.calls[0].prompt,
+    'crawl order must not change a single byte of the arbitration prompt');
+  assert.match(adapterAB.calls[0].prompt, /version-one/, 'slots use neutral labels');
+  assert.ok(!/"existing"|"incoming"/.test(adapterAB.calls[0].prompt),
+    'caller labels never reach the model');
+});
+
+test('calendar-path arbitration prompt is byte-identical when the sides swap contents', async () => {
+  const buildCalendarPair = (swapped) => {
+    const core = createCore();
+    const titles = ['FURBALL', 'FURBALL DALLAS'];
+    const bars = ['STATION 4', 'S4'];
+    const [calTitle, scrTitle] = swapped ? [...titles].reverse() : titles;
+    const [calBar, scrBar] = swapped ? [...bars].reverse() : bars;
+    const scraped = {
+      title: scrTitle,
+      bar: scrBar,
+      startDate: new Date('2026-07-05T22:00:00.000Z'),
+      source: 'ai-web',
+      city: 'dallas',
+      _fieldPriorities: core.getResolvedFieldPriorities({}),
+      _parserConfig: ARBITRATION_TEST_AI_CONFIG
+    };
+    const existing = {
+      title: calTitle,
+      startDate: new Date('2026-07-05T22:00:00.000Z'),
+      notes: `bar: ${calBar}`
+    };
+    return { core, existing, scraped };
+  };
+
+  const straight = buildCalendarPair(false);
+  const adapterStraight = buildArbitrationAdapter({});
+  await straight.core.createFinalEventObject(straight.existing, straight.scraped, { httpAdapter: adapterStraight });
+
+  const swapped = buildCalendarPair(true);
+  const adapterSwapped = buildArbitrationAdapter({});
+  await swapped.core.createFinalEventObject(swapped.existing, swapped.scraped, { httpAdapter: adapterSwapped });
+
+  assert.equal(adapterStraight.calls.length, 1);
+  assert.equal(adapterSwapped.calls.length, 1);
+  assert.equal(adapterStraight.calls[0].prompt, adapterSwapped.calls[0].prompt,
+    'which side holds which value must not change a single byte of the prompt');
+});
+
+test('neutral-slot picks map back to the correct side under BOTH input orders (flip catcher)', async () => {
+  // Single bar conflict with sentinels whose canonical orientation is known a
+  // priori: "AAA SENTINEL ONE" sorts before "ZZZ SENTINEL TWO", so it is
+  // ALWAYS version-one no matter which input side carries it. A swapped
+  // boundary mapping would write the other side's value in all four runs.
+  const sentinelOne = 'AAA SENTINEL ONE';
+  const sentinelTwo = 'ZZZ SENTINEL TWO';
+  const sideOne = () => buildEnrichSide({ title: 'FURBALL', bar: sentinelOne });
+  const sideTwo = () => buildEnrichSide({ title: 'FURBALL', bar: sentinelTwo });
+
+  for (const [slot, expected] of [['version-one', sentinelOne], ['version-two', sentinelTwo]]) {
+    for (const [first, second] of [[sideOne, sideTwo], [sideTwo, sideOne]]) {
+      const core = createCore();
+      const adapter = buildSlotPickingAdapter(slot, ['bar']);
+      const merged = await core.mergeParsedEvents(first(), second(), { httpAdapter: adapter });
+      assert.equal(adapter.calls.length, 1, 'the bar conflict must be AI-arbitrated');
+      assert.equal(merged.bar, expected,
+        `picking ${slot} must land the ${expected} value regardless of input order`);
+    }
+  }
+});
+
+test('calendar-path neutral-slot picks map back correctly under both content orientations', async () => {
+  const sentinelOne = 'AAA SENTINEL ONE';
+  const sentinelTwo = 'ZZZ SENTINEL TWO';
+  const buildPair = (calendarHoldsOne) => {
+    const core = createCore();
+    const scraped = {
+      title: 'FURBALL',
+      bar: calendarHoldsOne ? sentinelTwo : sentinelOne,
+      startDate: new Date('2026-07-05T22:00:00.000Z'),
+      source: 'ai-web',
+      _fieldPriorities: core.getResolvedFieldPriorities({}),
+      _parserConfig: ARBITRATION_TEST_AI_CONFIG
+    };
+    const existing = {
+      title: 'FURBALL',
+      startDate: new Date('2026-07-05T22:00:00.000Z'),
+      notes: `bar: ${calendarHoldsOne ? sentinelOne : sentinelTwo}`
+    };
+    return { core, existing, scraped };
+  };
+
+  for (const [slot, expected] of [['version-one', sentinelOne], ['version-two', sentinelTwo]]) {
+    for (const calendarHoldsOne of [true, false]) {
+      const { core, existing, scraped } = buildPair(calendarHoldsOne);
+      const adapter = buildSlotPickingAdapter(slot, ['bar']);
+      const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+      assert.equal(adapter.calls.length, 1, 'the bar conflict must be AI-arbitrated');
+      assert.equal(finalEvent.bar, expected,
+        `picking ${slot} must land the ${expected} value whichever side holds it`);
+    }
+  }
+});
+
+test('getKnownOrganizer is symmetric: agreement returns the name, disagreement fails closed', () => {
+  const core = createCore();
+  // Agreement (both arg orders)
+  assert.equal(core.getKnownOrganizer({ _organizer: 'Bearracuda' }, { _organizer: 'Bearracuda' }), 'Bearracuda');
+  assert.equal(core.getKnownOrganizer({ _organizer: 'Bearracuda' }, {}), 'Bearracuda');
+  assert.equal(core.getKnownOrganizer({}, { _organizer: 'Bearracuda' }), 'Bearracuda');
+  // Agreement under the promoter identity key keeps first-encountered casing
+  assert.equal(core.getKnownOrganizer({ _organizer: 'BEARRACUDA' }, { _organizer: 'Bearracuda' }), 'BEARRACUDA');
+  // Disagreement → '' in BOTH orders (the DURO co-promoter case: asserting
+  // either "Eventbrite" or "CLUB CHUB" steered the bar verdict differently)
+  assert.equal(core.getKnownOrganizer({ _organizer: 'Eventbrite' }, { _organizer: 'CLUB CHUB' }), '');
+  assert.equal(core.getKnownOrganizer({ _organizer: 'CLUB CHUB' }, { _organizer: 'Eventbrite' }), '');
+  // All-empty → ''
+  assert.equal(core.getKnownOrganizer({}, { _organizer: '   ' }), '');
+  assert.equal(core.getKnownOrganizer(), '');
+});
+
+test('swapped-orientation re-arbitration is served from the AI response cache', async () => {
+  const store = new Map();
+  const attachCache = (core) => {
+    core.aiResponseCache = {
+      read: async (aiConfig, prompt) => store.get(prompt) || null,
+      write: async (aiConfig, prompt, passLabel, text) => { store.set(prompt, text); }
+    };
+  };
+  const sideA = () => buildEnrichSide({ title: 'CLUB CHUB: DURO' });
+  const sideB = () => buildEnrichSide({ title: 'D>U>R>O is back NEW OUTDOOR LOCATION _ NIGHT FOAM PARTY' });
+
+  const coreFirst = createCore();
+  attachCache(coreFirst);
+  const adapterFirst = buildSlotPickingAdapter('version-one', ['title']);
+  const mergedFirst = await coreFirst.mergeParsedEvents(sideA(), sideB(), { httpAdapter: adapterFirst });
+
+  const coreSecond = createCore();
+  attachCache(coreSecond);
+  const adapterSecond = buildSlotPickingAdapter('version-one', ['title']);
+  const mergedSecond = await coreSecond.mergeParsedEvents(sideB(), sideA(), { httpAdapter: adapterSecond });
+
+  assert.equal(adapterFirst.calls.length, 1, 'first orientation hits the transport');
+  assert.equal(adapterSecond.calls.length, 0, 'the swapped orientation must be a cache hit — no second AI call');
+  assert.equal(mergedFirst.title, mergedSecond.title, 'both orientations resolve to the same winning value');
+});
+
+test('DURO regression: the log 20260801-172321 pair arbitrates identically in both orientations', async () => {
+  // Reconstructed from logs/20260801-172321.log — the second arbitration
+  // (:2197-2226) carried these exact conflicts, and the first (:2096-2123) had
+  // already seen the same title pair in the OPPOSITE orientation 11s earlier;
+  // the model picked `incoming` both times. The two records also disagreed on
+  // the derived organizer ("Eventbrite" vs "CLUB CHUB" — :2102 vs :2218).
+  const duroSide = {
+    title: 'D>U>R>O is back NEW OUTDOOR LOCATION _ NIGHT FOAM PARTY',
+    address: 'DTLA, Los Angeles, CA 90013',
+    bar: 'DURO',
+    startDate: '2026-08-02T05:00:00.000Z',
+    source: 'ai-web',
+    _organizer: 'Eventbrite'
+  };
+  const chubSide = {
+    title: 'CLUB CHUB: DURO',
+    address: 'Downtown Los Angeles',
+    bar: 'DOWNTOWN LA',
+    startDate: '2026-08-02T05:00:00.000Z',
+    source: 'ai-web',
+    _organizer: 'CLUB CHUB'
+  };
+  // The real model's winning VALUES from :2218-2226
+  const modelAnswers = {
+    title: { value: 'CLUB CHUB: DURO', reason: 'canonical event name' },
+    address: { value: 'DTLA, Los Angeles, CA 90013', reason: 'more specific' },
+    bar: { value: 'DURO', reason: 'physical venue' }
+  };
+
+  const runOrientation = async (existingSide, incomingSide) => {
+    const core = createCore();
+    const adapter = buildArbitrationAdapter(modelAnswers);
+    const conflicts = ['title', 'address', 'bar'].map(field => ({
+      field,
+      values: { existing: existingSide[field], incoming: incomingSide[field] }
+    }));
+    const result = await core.arbitrateMergeConflicts({
+      conflicts,
+      labels: ['existing', 'incoming'],
+      aiConfig: { enabled: true, provider: 'ollama', endpoint: 'http://ai.example/api/generate', model: 'test-model' },
+      httpAdapter: adapter,
+      context: {
+        existing: { title: existingSide.title, startDate: existingSide.startDate, source: existingSide.source },
+        incoming: { title: incomingSide.title, startDate: incomingSide.startDate, source: incomingSide.source }
+      },
+      organizer: core.getKnownOrganizer(incomingSide, existingSide)
+    });
+    const winners = {};
+    for (const conflict of conflicts) {
+      winners[conflict.field] = result[conflict.field] ? conflict.values[result[conflict.field].pick] : null;
+    }
+    return { prompt: adapter.calls[0].prompt, winners };
+  };
+
+  const straight = await runOrientation(duroSide, chubSide); // as logged at :2197
+  const mirrored = await runOrientation(chubSide, duroSide); // as the pair sat at :2096
+
+  assert.equal(straight.prompt, mirrored.prompt, 'both orientations must render the SAME prompt');
+  assert.ok(!/KNOWN ORGANIZER/.test(straight.prompt),
+    'disagreeing organizers (Eventbrite vs CLUB CHUB) must fail closed — no organizer assertion');
+  const addressAt = straight.prompt.indexOf('- field: address');
+  const barAt = straight.prompt.indexOf('- field: bar');
+  const titleAt = straight.prompt.indexOf('- field: title');
+  assert.ok(addressAt !== -1 && addressAt < barAt && barAt < titleAt,
+    'conflict lines are sorted by field name');
+  assert.deepEqual(straight.winners, {
+    title: 'CLUB CHUB: DURO',
+    address: 'DTLA, Los Angeles, CA 90013',
+    bar: 'DURO'
+  });
+  assert.deepEqual(mirrored.winners, straight.winners,
+    'the same records must produce the same winning values from either orientation');
 });
 
 // ---------------------------------------------------------------------------
@@ -6815,8 +7125,11 @@ test('merge arbitration prompt: descriptive subtitles/editions win for title; st
       capturedPrompt = Array.isArray(payload.messages)
         ? payload.messages.map(m => m.content).join('\n')
         : String(payload.prompt || '');
+      // Canonical slots: "Treasure Trail Seattle" (scraped) sorts before
+      // "Treasure Trail Seattle: Summer Sausage" (calendar), so the calendar
+      // value sits in version-two — the model answers in neutral labels.
       const content = JSON.stringify({
-        choices: { title: { pick: 'calendar', value: 'Treasure Trail Seattle: Summer Sausage', reason: 'richer name' } }
+        choices: { title: { pick: 'version-two', value: 'Treasure Trail Seattle: Summer Sausage', reason: 'richer name' } }
       });
       return { ok: true, text: JSON.stringify({ choices: [{ message: { content } }] }) };
     }
@@ -6826,7 +7139,10 @@ test('merge arbitration prompt: descriptive subtitles/editions win for title; st
     labels: ['calendar', 'scraped'],
     aiConfig: { enabled: true, provider: 'openai', endpoint: 'http://test.local/v1/chat/completions', model: 'test-model' },
     httpAdapter,
-    eventContext: '"Treasure Trail Seattle" starting 2026-08-16T04:00:00.000Z'
+    context: {
+      calendar: { title: 'Treasure Trail Seattle: Summer Sausage', startDate: '2026-08-16T04:00:00.000Z' },
+      scraped: { title: 'Treasure Trail Seattle', startDate: '2026-08-16T04:00:00.000Z' }
+    }
   });
   // The rule set must say richer variants win (2026-07-21 run stripped
   // ": Summer Sausage" and "Horse Meat Disco" from calendar titles)...

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -963,8 +963,11 @@ test('getKnownOrganizer is symmetric: agreement returns the name, disagreement f
   assert.equal(core.getKnownOrganizer({ _organizer: 'Bearracuda' }, { _organizer: 'Bearracuda' }), 'Bearracuda');
   assert.equal(core.getKnownOrganizer({ _organizer: 'Bearracuda' }, {}), 'Bearracuda');
   assert.equal(core.getKnownOrganizer({}, { _organizer: 'Bearracuda' }), 'Bearracuda');
-  // Agreement under the promoter identity key keeps first-encountered casing
+  // Agreement under the promoter identity key with differing casings must be
+  // symmetric too — "first-encountered" would leak argument order back into
+  // the prompt. The lexicographically smaller casing wins in BOTH orders.
   assert.equal(core.getKnownOrganizer({ _organizer: 'BEARRACUDA' }, { _organizer: 'Bearracuda' }), 'BEARRACUDA');
+  assert.equal(core.getKnownOrganizer({ _organizer: 'Bearracuda' }, { _organizer: 'BEARRACUDA' }), 'BEARRACUDA');
   // Disagreement → '' in BOTH orders (the DURO co-promoter case: asserting
   // either "Eventbrite" or "CLUB CHUB" steered the bar verdict differently)
   assert.equal(core.getKnownOrganizer({ _organizer: 'Eventbrite' }, { _organizer: 'CLUB CHUB' }), '');


### PR DESCRIPTION
**Stacked on open PR #1606 (`fix/merge-churn-bar-rescue`) — GitHub will retarget this PR to `main` automatically when that merges.**

## Problem: the arbiter picks by slot, not content

Measured across all phone logs, `arbitrateMergeConflicts` is position-biased: the enrich path picked `incoming` **~72%** of the time and the calendar path picked `calendar` **~66%** — opposite leans from the same model on the same prompt shape. The smoking gun is in `logs/20260801-172321.log`: the identical pair `"CLUB CHUB: DURO"` vs `"D>U>R>O is back NEW OUTDOOR LOCATION _ NIGHT FOAM PARTY"` was arbitrated **twice, 11 seconds apart** (prompts at :2096-2123 and :2197-2226), in **opposite orientations** — and it picked `incoming` BOTH times.

The prompt was order-dependent in three places:
1. **Slot assignment** — `existing`/`incoming` (or `calendar`/`scraped`) was an accident of crawl order.
2. **The `EVENT:` context line** — title from `newEvent.title || existingEvent.title`, plus `(record "existing" from X, record "incoming" from Y)`.
3. **The `KNOWN ORGANIZER:` line** — `getKnownOrganizer` returned the *first* organizer found, so the DURO run asserted `"Eventbrite"` in one arbitration and `"CLUB CHUB"` in the other (log :2102 vs :2218).

Because the prompt differed by orientation, the prompt-keyed AI response cache always missed — the model was re-asked and free to contradict itself.

## Design

**Global canonical orientation with neutral labels, mapped back at the boundary. Caller API unchanged.**

- **Canonical orientation**: conflicts are sorted by field name; each side is keyed by the concatenation of `field + ' ' + serializedValue` over the sorted conflicts; the lexicographically smaller side becomes slot one (tie → caller's first label stays slot one). The batch's conflict lines are rendered in sorted-field order, so the whole prompt is order-stable.
- **Neutral labels**: slots render as `version-one`/`version-two` — no recency/savedness connotation for the model to latch onto.
- **Canonical context**: the two call sites now pass structured per-side `{ title, startDate, source? }`; the `EVENT:` line is derived from slot order (title/startDate from slot one, provenance `(version-one from X, version-two from Y)` in slot order), so it is byte-identical for swapped inputs. The calendar path never carried provenance and still doesn't.
- **Symmetric `getKnownOrganizer`**: candidates collected from ALL events, compared under the promoter-name identity key; all agree → first-encountered original casing; **disagree → `''` (fail closed)** — asserting either organizer was exactly wrong in the DURO co-promoter case; all-empty → `''`.
- **Boundary mapping**: the model answers `pick: "version-one"|"version-two"`; the pick is validated against the neutral labels and mapped back to the caller's labels (`existing`/`incoming` or `calendar`/`scraped`) before returning. Callers, their `🤝 AI MERGE:` logs, the #1606 stickiness observer, `decision.pick` semantics, and the verbatim value gate (wired through the mapping, including wrong-label recovery) behave byte-identically. `fallbackPick` and all deterministic rungs untouched.

**Cache consequence**: canonical prompts mean the same pair arbitrated again — in either orientation — is a cache hit instead of a fresh AI call. The logs show **274 no-op calendar arbitrations**; those repeated pairs stop costing model time and stop being an opportunity to flip.

> **Authorization**: Stanley authorized changing the merge-arbitration prompt structure on 2026-08-02 as a one-time exception to the frozen-prompt rule. It applies ONLY to this path — every other AI prompt (extraction, bear-check, field-trim, short-name, classify-page) is untouched, and all console format strings are unchanged (additions only).

## Tests (flip-proofing)

The dangerous failure mode is a swapped mapping silently writing the WRONG side's value while logs look plausible. New tests make that impossible:

- **Prompt purity**: both call paths (enrich via `mergeParsedEvents`, calendar via `createFinalEventObject`) run the same conflict set in both input orders — captured prompts asserted byte-identical, neutral labels asserted present, caller labels asserted absent.
- **Flip catcher**: a stubbed model picks a fixed neutral slot holding a known sentinel (`AAA SENTINEL ONE` / `ZZZ SENTINEL TWO`, canonical orientation known a priori); both picks × both input orders on both paths assert the merged event lands the sentinel value every way.
- **`getKnownOrganizer`**: symmetric agreement (both orders), casing-agreement, disagreement → `''`, all-empty → `''`.
- **Cache**: arbitrating the swapped pair second is asserted to make **zero** transport calls.
- **DURO regression**: the two real arbitrations from `logs/20260801-172321.log` (:2096-2123 / :2197-2226) reconstructed in both orientations — same prompt bytes, same winning values (`CLUB CHUB: DURO` / `DTLA, Los Angeles, CA 90013` / `DURO`), sorted conflict lines, and no organizer line (Eventbrite vs CLUB CHUB fails closed).

### Touched test fixtures (stub plumbing only — no outcome assertion weakened)

All in `scripts/shared-core.test.js`:
1. **`buildArbitrationAdapter`** (shared helper, used by ~30 arbitration tests): now translates each stubbed choice's `pick` to the neutral label of whichever slot holds that choice's *value* in the actual outgoing prompt — exactly how a verbatim-copying model answers. Values matching neither slot (hallucination fixtures) keep their pick and are rejected by the gate as before. New `arbitrationSlotHolding` helper backs it.
2. **`'a verbatim value with a wrong pick label is trusted via the value'`**: now passes `{ keepPicks: true }` so the fixture's wrong labels reach the gate untranslated and the recovery path stays exercised. Assertions unchanged.
3. **`'merge arbitration prompt: descriptive subtitles/editions win for title…'`** (direct `arbitrateMergeConflicts` call): stubbed pick `'calendar'` → `'version-two'` (the computed canonical slot for that value), and the pre-baked `eventContext` string → structured `context`. Result assertion unchanged (`{ title: { pick: 'calendar', reason: 'richer name' } }` — mapped back at the boundary).

No assertion about a merged-event outcome was changed anywhere.

## Verification

Quiet suite (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`): **before 1183 pass / 0 fail → after 1190 pass / 0 fail** (+7 new tests).

Probe outside the repo (`/Users/stanleyrya/.claude/jobs/49179ac5/tmp/probe-duro.js`, real DURO pair fed both ways, prompt-keyed response cache attached):

```
[orientation 1: existing=DURO-page record, incoming=CLUB CHUB record (log :2197)]
  prompt sha256: 5cc229f3e8f1fa0200f06798f10c2f9ce4ec29442586b6ea91dbc343ba6c8758
  organizer line present: false
  winner title: "CLUB CHUB: DURO"
  winner address: "DTLA, Los Angeles, CA 90013"
  winner bar: "DURO"
🤖 AI Web: AI response cache hit (merge-arbitration pass) — response: 236 chars

[orientation 2: swapped (as the pair sat at log :2096)]
  prompt sha256: 5cc229f3e8f1fa0200f06798f10c2f9ce4ec29442586b6ea91dbc343ba6c8758
  organizer line present: false
  winner title: "CLUB CHUB: DURO"
  winner address: "DTLA, Los Angeles, CA 90013"
  winner bar: "DURO"

=== verdict ===
prompts identical: true
winners identical: true
transport calls: 1 (second arbitration served from cache: true)
```

**Unverified on device** — no Scriptable run has exercised this change yet.

No new runtime files. Platform purity preserved (dependency injection only, no `new URL`/`URLSearchParams`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
