### PR TITLE
fix(scraper): CubScout LA parser becomes the Eagle LA venue parser

### DIFF
--- a/scripts/promoter-registry.test.js
+++ b/scripts/promoter-registry.test.js
@@ -193,8 +193,18 @@ test('repo scraper-input: registry-identity parsers carry no metadata or alwaysB
   }
   const { parsers } = require('./scraper-input');
   const promoterParsers = parsers.filter((parser) => registryKeys.has(nameKey(parser.name)));
-  assert.ok(promoterParsers.length >= 15,
-    `expected at least the 15 migrated promoter parsers, found ${promoterParsers.length}`);
+  // Floor guards against the filter silently matching nothing. It dropped from
+  // 15 to 14 when the "CubScout LA" PARSER became the "Eagle LA" venue parser
+  // (eaglela.com is a venue site hosting many parties, not one promoter's
+  // page). The CubScout LA promoter ENTRY is untouched and still claims the
+  // CUBSCOUT alias — see the alias tests above.
+  assert.ok(promoterParsers.length >= 14,
+    `expected at least the 14 migrated promoter parsers, found ${promoterParsers.length}`);
+  // A venue parser must never be treated as a promoter parser: "Eagle LA" is a
+  // curated BAR (data/bars/la.json), so it must not appear in this set — that
+  // is what makes the count 14 rather than a silently weakened floor.
+  assert.ok(!promoterParsers.some((parser) => nameKey(parser.name) === nameKey('Eagle LA')),
+    'the Eagle LA venue parser must not be classified as a promoter parser');
   for (const parser of promoterParsers) {
     assert.ok(!('metadata' in parser),
       `promoter parser "${parser.name}" must not carry metadata — promoter identity lives in data/promoters.json`);

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -140,9 +140,24 @@ const scraperConfig = {
       },
     },
     {
-      name: "CubScout LA",
-      // Eagle LA's recurring bear party page (The Events Calendar, JSON-LD).
-      urls: ["https://eaglela.com/events/cub-scout-3/"],
+      name: "Eagle LA",
+      // Venue parser, not a promoter one: eaglela.com is Eagle LA's own site
+      // (The Events Calendar, JSON-LD) and it hosts many bear parties, not
+      // just CubScout. This used to point at the single event page
+      // /events/cub-scout-3/, which meant (a) every other Eagle LA night was
+      // invisible — the archive lists BEAR HAPPY HOUR, SUNDAY BEER BUST, MEAT
+      // RACK, ONYX, CUBSCOUT and more in August 2026 alone — and (b) the slug
+      // was a hardcoded guess: a renamed series (cub-scout-4) would 404 and
+      // the parser would go quiet without failing. The listing archive is the
+      // stable entry point; the crawler reaches each occurrence from there.
+      //
+      // "Eagle LA" is a curated bar (data/bars/la.json), so the venue-site
+      // identity path resolves the site to the venue and events keep their own
+      // party names (CUBSCOUT, ONYX, …) with bar="Eagle LA" — the brand
+      // prefixer is a no-op on venue-role sites. The CubScout LA PROMOTER
+      // entry in scraper-promoters.js is unchanged and still claims the
+      // CUBSCOUT title alias.
+      urls: ["https://eaglela.com/events/"],
     },
     {
       name: "BEEFMINCE",


### PR DESCRIPTION
## The problem

`CubScout LA` pointed at a **single event page**: `https://eaglela.com/events/cub-scout-3/`.

That is a venue's site being scraped as if it were one promoter's party page, with the party's URL slug hardcoded. Two consequences:

1. **Every other Eagle LA night is invisible.** The events archive lists, in August 2026 alone: SUNDAY BEER BUST, SUNDAY SWAP MEAT, LUCKI BREAK, MOVIE MONDAYS, Tightwad Tuesday, HUMP NIGHT, **BEAR HAPPY HOUR**, B BAR, **CUBSCOUT**, **MEAT RACK**, **ONYX**. The scraper only ever saw one of them.
2. **The slug is a hardcoded guess.** Confirmed from the run logs — across every log on record the crawler has only ever reached `eaglela.com/events/cub-scout-3/`, its `?occurrence=` variants, and the site root. Event pages don't link to sibling events, so there was no path to the rest. If the venue reposts the series as `cub-scout-4`, this 404s and the parser goes **quiet without failing**.

## The change

Rename the parser to `Eagle LA` and point it at the listing archive `https://eaglela.com/events/`. Same shape as the existing venue parsers (`Dallas Eagle`, `massive.club`).

`Eagle LA` is already a **curated bar** (`data/bars/la.json`), so the venue-site identity path resolves the site to the venue: events keep their own party names (CUBSCOUT, ONYX, MEAT RACK) with `bar="Eagle LA"`, and the brand prefixer is a no-op on venue-role sites — no `EAGLE LA: CUBSCOUT` titles.

**The `CubScout LA` PROMOTER entry (`scripts/scraper-promoters.js`) is untouched.** CubScout is a real promoter and still claims the `CUBSCOUT` title alias; only the *parser* was misnamed and mis-pointed.

## One test assertion changed — worth your eye

`promoter-registry.test.js` asserted `promoterParsers.length >= 15`. Renaming the parser drops it to 14, because `Eagle LA` correctly no longer matches a promoter-registry name. Rather than just lowering the number, I added an assertion pinning **why** it is 14:

```js
assert.ok(!promoterParsers.some((parser) => nameKey(parser.name) === nameKey('Eagle LA')),
  'the Eagle LA venue parser must not be classified as a promoter parser');
```

The floor's purpose is to catch the filter silently matching nothing; that purpose is preserved and the venue/promoter distinction is now enforced instead of implied.

## Verification

- Quiet suite: **1190 pass, 0 fail**.
- Listing page confirmed live to be a real multi-event archive (11 distinct events in August 2026).
- Config-only change plus the one test — no runtime files added.
- **Unverified on device.** The first real run is the check: expect multiple Eagle LA events instead of one, all with `bar="Eagle LA"`, and non-bear nights (MOVIE MONDAYS, Tightwad Tuesday) filtered by the bear-check cascade rather than by a hardcoded URL.