### PR TITLE
fix(scraper): stop phantom description conflicts from formatting markup

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2465,6 +2465,33 @@ class SharedCore {
         // information — keep it without burning an AI arbitration. Partial
         // overlap is a genuine conflict and still arbitrates; equal-after-
         // normalization pairs fall through to the case-only rule below.
+        // Formatting-only description difference — a PHANTOM conflict. The
+        // description sanitizer (normalizers.sanitizeDescriptionFormatting)
+        // runs at the final analyzed-event build, i.e. AFTER this arbitration,
+        // so a scraped description still carrying markdown was compared raw
+        // against an already-sanitized calendar value. Run 20260802 did this
+        // for every BEEFMINCE event, every run: dice.fm ships
+        // "**BEEFMINCE …** **\*Now on Saturdays\***", the calendar holds the
+        // sanitized "BEEFMINCE … *Now on Saturdays*", an AI call was spent, the
+        // model picked the markdown ("preserves the original bold formatting …
+        // more canonical"), and the sanitizer then stripped it straight back to
+        // the value already on the calendar. Net data change: zero — but it
+        // counted as a clobber and cost an arbitration every single run.
+        //
+        // Sanitizing is pure and idempotent, so equality after sanitizing PROVES
+        // the two carry the same text. Keep whichever side is already in
+        // sanitized form (that is what gets written anyway); if both or neither
+        // are, keep valueA for stability, matching the case-only rung below.
+        if (fieldName === 'description' && typeof valueA === 'string' && typeof valueB === 'string'
+            && this.normalizerPipeline
+            && typeof this.normalizerPipeline.sanitizeDescriptionFormatting === 'function') {
+            const cleanA = this.normalizerPipeline.sanitizeDescriptionFormatting(valueA);
+            const cleanB = this.normalizerPipeline.sanitizeDescriptionFormatting(valueB);
+            if (cleanA && cleanA === cleanB && valueA !== valueB) {
+                const winner = (valueB === cleanB && valueA !== cleanA) ? 'b' : 'a';
+                return { winner, reason: 'descriptions are identical once formatting markup is stripped' };
+            }
+        }
         if (fieldName === 'description' && typeof valueA === 'string' && typeof valueB === 'string') {
             const containA = this.normalizeDescriptionForContainment(valueA);
             const containB = this.normalizeDescriptionForContainment(valueB);

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -11683,3 +11683,54 @@ test('calendar stickiness enforcement is OFF by default and is a one-flag change
   // Never truthy-coerced: only an explicit true enforces.
   assert.equal(core.resolveAiConfig({ calendarStickinessEnforced: 'yes' }).calendarStickinessEnforced, false);
 });
+
+// ---------------------------------------------------------------------------
+// Phantom description conflicts. The formatting sanitizer runs at the FINAL
+// analyzed-event build — after merge arbitration — so a scraped description
+// still carrying markdown was arbitrated raw against an already-sanitized
+// calendar value. Run 20260802 did this for every BEEFMINCE event, every run:
+// an AI call, a "clobber", the model picking the markdown ("preserves the
+// original bold formatting"), and the sanitizer then stripping it back to the
+// exact value already on the calendar. Zero data change, real cost.
+// ---------------------------------------------------------------------------
+
+test('a description differing only in formatting markup never reaches the AI', () => {
+  // Wired exactly like production (real NormalizerPipeline injected) — an
+  // unwired core would make this rung silently unreachable and the test green
+  // for the wrong reason.
+  const core = createFinalBuildCore();
+  // Verbatim from logs/20260802-*.log (dice.fm vs the saved calendar value).
+  const scraped = "**BEEFMINCE | The UK's Tastiest Bear Club** **\\*Now on Saturdays\\***";
+  const calendar = "BEEFMINCE | The UK's Tastiest Bear Club *Now on Saturdays*";
+
+  // Calendar-side orientation: the already-clean value wins.
+  const calendarFirst = core.resolveConflictDeterministically('description', calendar, scraped, {});
+  assert.ok(calendarFirst, 'must resolve without the AI');
+  assert.equal(calendarFirst.winner, 'a');
+  assert.match(calendarFirst.reason, /formatting markup is stripped/);
+
+  // Swapped orientation: still the clean side, not the slot.
+  const scrapedFirst = core.resolveConflictDeterministically('description', scraped, calendar, {});
+  assert.ok(scrapedFirst, 'must resolve without the AI in both orientations');
+  assert.equal(scrapedFirst.winner, 'b', 'the sanitized value wins regardless of position');
+
+  // A genuinely different description still arbitrates.
+  assert.equal(
+    core.resolveConflictDeterministically('description', calendar, 'A totally different night at the RVT.', {}),
+    null);
+  // Identical values still resolve (via the pre-existing case-only rung, which
+  // keeps valueA) — but they must not be attributed to THIS rung, whose claim
+  // is specifically "the two differ only in markup".
+  const identical = core.resolveConflictDeterministically('description', calendar, calendar, {});
+  assert.ok(identical && identical.winner === 'a');
+  assert.doesNotMatch(identical.reason, /formatting markup is stripped/);
+});
+
+test('the formatting rung fails open when no normalizer pipeline is injected', () => {
+  // shared-core stays platform-pure: it never loads normalizers itself. With
+  // no pipeline the rung must simply not fire rather than throw.
+  const core = createCore();
+  const scraped = "**BEEFMINCE**";
+  const calendar = 'BEEFMINCE';
+  assert.doesNotThrow(() => core.resolveConflictDeterministically('description', calendar, scraped, {}));
+});


### PR DESCRIPTION
Split out of #1609 — this commit was pushed after that PR was merged, so it never landed. Rebased onto `main` (`55b00900`), suite re-verified there.

## The markdown churn is a **phantom conflict**

All 7 description entries in the run-20260802 stickiness report came from one parser (BEEFMINCE/dice.fm), and the sanitizer that fixes them **already exists and already fires** — `🧼 DESCRIPTION: stripped formatting markup` appears 11 times in the same run. It just runs at the final analyzed-event build, **after** merge arbitration.

So every run did this:

1. dice.fm ships `**BEEFMINCE | The UK's Tastiest Bear Club** **\\*Now on Saturdays\\***`
2. calendar holds the sanitized `BEEFMINCE | The UK's Tastiest Bear Club *Now on Saturdays*`
3. compared **raw vs sanitized** → declared a conflict → AI arbitration spent
4. the model picks the markdown — *"preserves the original bold formatting and asterisk emphasis used in official promotional material, making it more complete and canonical"*
5. the sanitizer strips it back to **exactly** the value already on the calendar

**Net data change: zero.** The calendar was never actually polluted. The cost was an AI call per event per run, an inflated `clobbered` count, and 7 of the 9 total stickiness observations.

Probe output, real strings from the log:
```
scraped  : "**BEEFMINCE | The UK's Tastiest Bear Club** **\\*Now on Saturdays\\***"
sanitized: "BEEFMINCE | The UK's Tastiest Bear Club *Now on Saturdays*"
calendar : "BEEFMINCE | The UK's Tastiest Bear Club *Now on Saturdays*"
EQUAL AFTER SANITIZE: true
idempotent: true
```

## The fix

A deterministic rung. Sanitizing is pure and idempotent, so equality after sanitizing **proves** the two carry the same text. Keeps whichever side is already sanitized (that is what gets written anyway), `valueA` on a tie — matching the case-only rung's stability convention. No AI call, no clobber, no stickiness line.

Fails open when no normalizer pipeline is injected, so `shared-core.js` stays platform-pure (it never loads `normalizers` itself).

## Tests

Wired with the **real** `NormalizerPipeline` exactly like production, via the existing `createFinalBuildCore` helper — an unwired core would make the rung unreachable and the test green for the wrong reason.

- both orientations pinned: the sanitized side wins by **content, not slot**
- genuinely different descriptions still arbitrate (returns `null`)
- identical values must **not** be attributed to this rung (they resolve via the pre-existing case-only rung)
- no-pipeline case does not throw

Suite: **1192 pass, 0 fail.** No console format strings changed, no new runtime files. **Unverified on device** — the tell in the next run is the disappearance of the BEEFMINCE `🧊 STICKY: … field=description` lines and their arbitration calls.