### PR TITLE
fix(scraper): cover price-shape gate + cross-org guard two-label fix and tightening

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -140,6 +140,32 @@ function urlPartsEndInAssetExtension(parts) {
 
 const IMAGE_MERGE_FIELDS = new Set(['image', 'imageVertical', 'imageHorizontal']);
 
+// classifyCoverShape data (2026-08-02, all shapes drawn from real run values).
+// A currency-marked amount: a symbol adjacent to digits ("$20", "$15-$30",
+// "From £10", "20$") — NFKC folding upstream already collapsed full-width and
+// mathematical-alphanumeric forms into these.
+const COVER_CURRENCY_SYMBOL_AMOUNT_PATTERN = /[$€£¥]\s?\d|\d\s?[$€£¥]/;
+// Amount + ISO 4217 code in either order ("20 EUR", "11.55-22.38 GBP",
+// "EUR 20"). A generic currency table is data, not per-venue hardcoding.
+const COVER_ISO_CURRENCY_CODES = 'USD|EUR|GBP|CAD|AUD|NZD|MXN|BRL|ARS|CLP|COP|JPY|CNY|KRW|CHF|SEK|NOK|DKK|PLN|CZK|HUF|ZAR|ILS|THB';
+const COVER_ISO_AMOUNT_PATTERN = new RegExp(
+    `\\d\\s?(?:${COVER_ISO_CURRENCY_CODES})(?![A-Za-z])|(?:^|[^A-Za-z])(?:${COVER_ISO_CURRENCY_CODES})\\s?\\d`,
+    'i'
+);
+// Whole-value free-admission phrases (2026-08-02, observed in real runs:
+// EN/ES/DE). Compared after trimming, case-folding, whitespace-collapsing and
+// stripping trailing !/. — so "NO COVER!" and "No cover." both match.
+const COVER_FREE_PHRASES = new Set([
+    'free',
+    'free admission',
+    'free entry',
+    'no cover',
+    'entrada libre',
+    'entrada gratuita',
+    'gratis',
+    'kostenlos'
+]);
+
 // The ONE calendar target an unrecognized city may produce. See
 // SharedCore.resolveCalendarTarget — the fallback must never be derived from
 // the city string itself, or a page's free text becomes a calendar name.
@@ -883,6 +909,32 @@ class SharedCore {
         const stripWhitespace = (value) => String(value === null || value === undefined ? '' : value).replace(/\s+/g, '');
         const strippedA = stripWhitespace(valueA);
         return strippedA !== '' && strippedA === stripWhitespace(valueB);
+    }
+
+    // Deterministic cover SHAPE classifier (2026-08-02): `cover` accumulates
+    // four incompatible value KINDS from different parsers — real prices
+    // ("$20", "20 EUR", "From £10"), free-admission claims ("No cover",
+    // "Entrada Libre"), and marketing prose ("ADV. TIX AT BEARRACUDA.COM",
+    // "SOLD OUT", a dress code) — and the merge layer needs to know WHICH kind
+    // each side is before it can decide anything. Returns 'empty' | 'price' |
+    // 'free' | 'prose'. Dumb and regex-based on purpose: a value containing
+    // any currency-marked amount is price ("$10, NO COVER" → price); a value
+    // that IS a free phrase in whole is free; everything else non-empty is
+    // prose. Input is NFKC-folded first so mathematical-bold Unicode
+    // (𝐑𝐞𝐝 𝐰𝐫𝐢𝐬𝐭𝐛𝐚𝐧𝐝… — U+1D400 block, observed in a real run) cannot dodge
+    // classification (String.prototype.normalize is available in iOS
+    // JavaScriptCore). Platform-pure — no URL parsing, no network, no config.
+    classifyCoverShape(value) {
+        const text = String(value === null || value === undefined ? '' : value)
+            .normalize('NFKC')
+            .trim();
+        if (text === '') return 'empty';
+        if (COVER_CURRENCY_SYMBOL_AMOUNT_PATTERN.test(text) || COVER_ISO_AMOUNT_PATTERN.test(text)) {
+            return 'price';
+        }
+        const folded = text.toLowerCase().replace(/\s+/g, ' ').replace(/[!.]+$/, '').trim();
+        if (COVER_FREE_PHRASES.has(folded)) return 'free';
+        return 'prose';
     }
 
     // A genuine conflict: both sides non-empty primitives whose serialized forms
@@ -2657,6 +2709,28 @@ class SharedCore {
                 if (containB.includes(containA)) {
                     return { winner: 'b', reason: 'description contains the other candidate\'s full text' };
                 }
+            }
+        }
+        // Cover shape rung (2026-08-02): different parsers write incompatible
+        // KINDS of cover for the same event — a currency-marked price ("$20",
+        // "20 EUR") vs marketing prose ("ADV. TIX AT BEARRACUDA.COM") — and AI
+        // arbitration flip-flopped between them run after run (observed:
+        // "BEARRACUDA: Seattle" went $20-$30 → $20 → ADV. TIX AT
+        // BEARRACUDA.COM → $20 across runs). A price is strictly more
+        // information than prose, so exactly that pair is decidable without
+        // AI: the price-shaped side wins. EVERY other combination falls
+        // through unchanged (fail open): price/price is a genuine price
+        // disagreement, free-vs-price is a genuine factual disagreement (two
+        // Sitges parsers really do claim "20 EUR" vs "Entrada Libre"), and
+        // free/prose + prose/prose carry no shape signal either way.
+        if (fieldName === 'cover') {
+            const shapeA = this.classifyCoverShape(valueA);
+            const shapeB = this.classifyCoverShape(valueB);
+            if ((shapeA === 'price' && shapeB === 'prose') || (shapeA === 'prose' && shapeB === 'price')) {
+                return {
+                    winner: shapeA === 'price' ? 'a' : 'b',
+                    reason: 'price-shaped cover beats marketing text'
+                };
             }
         }
         // Case-only variants are not a real conflict: production runs burned
@@ -5040,22 +5114,32 @@ class SharedCore {
 
     // The curated owner of a crawled page when that owner is demonstrably NOT
     // the parser currently running: { ownerName, ownerKind, host }. Returns
-    // null (→ caller no-ops, today's behavior) whenever the page is on one of
-    // the running parser's own configured domains, no claim covers it, the
-    // covering claims name more than one owner, or the single owner is this
-    // parser's own identity.
+    // null (→ caller no-ops, today's behavior) whenever no claim covers the
+    // page, the covering claims name more than one owner, the single owner is
+    // this parser's own identity, or the page sits on one of the running
+    // parser's own configured domains and the winning claim is domain-level.
     resolveForeignCrawlPageOwner(url, parserConfig, mainConfig) {
         const hostPathKey = this.getUrlHostPathKey(url);
         const pageDomain = this.getRegistrableDomainFromUrl(url);
         if (!hostPathKey || !pageDomain) return null;
 
-        // Same-site is never foreign: a parser's own configured domains stay
-        // fully crawlable (a promoter config pointed at a partner/host site
-        // still owns everything it configured).
+        // A parser's own configured domains stay crawlable — but on SHARED
+        // platforms (linktr.ee, eventbrite.com/o/…) "same domain" is not
+        // "same org", so the shield is scoped: it yields to a SUB-PATH claim
+        // naming a different owner, and holds against domain-level claims.
+        // Domain-level foreign claims must never pierce it: the ursamen
+        // family is the live counterexample — the Spooky Bear parser is
+        // configured at ursamen.org/spookybear while "Northeast Ursamen"
+        // (a separate registry entry, no alias link) claims ursamen.org
+        // whole-domain, and a domain-level pierce would lock the sub-brand
+        // out of its own family's site. Verified 2026-08-02 against the full
+        // registry: this scoping blocks Cubhouse → linktr.ee/megawoof_america
+        // and cross-parser eventbrite /o/ pages while leaving all 144
+        // own-domain parser×path probes untouched.
         const configuredUrls = Array.isArray(parserConfig && parserConfig.urls) ? parserConfig.urls : [];
-        for (const configuredUrl of configuredUrls) {
-            if (this.getRegistrableDomainFromUrl(configuredUrl) === pageDomain) return null;
-        }
+        const onOwnConfiguredDomain = configuredUrls.some(
+            configuredUrl => this.getRegistrableDomainFromUrl(configuredUrl) === pageDomain
+        );
 
         const matches = this.buildCrawlOwnershipClaims(mainConfig).filter(claim => {
             if (claim.domain !== pageDomain) return false;
@@ -5068,12 +5152,34 @@ class SharedCore {
         // whole-domain claim). Two DIFFERENT owners tied at that specificity is
         // ambiguous evidence — no-op.
         const maxSpecificity = Math.max(...matches.map(claim => claim.specificity));
-        const winners = matches.filter(claim => claim.specificity === maxSpecificity);
-        const ownerNames = [...new Set(winners.map(claim => claim.ownerName))];
-        if (ownerNames.length !== 1) return null;
+        let winners = matches.filter(claim => claim.specificity === maxSpecificity);
 
         const currentKey = this.normalizePromoterNameKey(parserConfig && parserConfig.name);
         if (currentKey && winners.some(claim => claim.selfKeys.includes(currentKey))) return null;
+
+        // A parser claim and a promoter claim on the IDENTICAL site URL are
+        // one owner wearing two labels, not two owners: the parser
+        // "Bearracuda Events" and the registry entry "Bearracuda" both claim
+        // bearracuda.com, and counting them as ambiguity silently disabled
+        // the guard for every parser whose name differs from its own promoter
+        // entry (found 2026-08-02 — the massive.club → bearracuda.com block
+        // never fired in production). Collapse across KINDS only, preferring
+        // the parser-kind label; two different owners of the SAME kind — or
+        // different site URLs tied at one specificity — remain genuine
+        // ambiguity and fail closed.
+        const distinctSites = new Set(winners.map(claim => claim.hostPathKey));
+        const parserOwners = new Set(winners.filter(c => c.ownerKind === 'parser').map(c => c.ownerName));
+        const promoterOwners = new Set(winners.filter(c => c.ownerKind !== 'parser').map(c => c.ownerName));
+        if (distinctSites.size === 1 && parserOwners.size <= 1 && promoterOwners.size <= 1
+            && parserOwners.size + promoterOwners.size === 2) {
+            const preferred = winners.find(claim => claim.ownerKind === 'parser') || winners[0];
+            winners = [preferred];
+        }
+        const ownerNames = [...new Set(winners.map(claim => claim.ownerName))];
+        if (ownerNames.length !== 1) return null;
+
+        // Own-domain shield: only a sub-path-scoped foreign claim pierces it.
+        if (onOwnConfiguredDomain && maxSpecificity === 0) return null;
 
         return {
             ownerName: winners[0].ownerName,
@@ -7053,6 +7159,26 @@ class SharedCore {
         delete mergedEvent.barSource;
         this.setProvenanceSource(mergedEvent, 'bar', 'barSource', newEvent, existingEvent);
 
+        // _coverFromJsonLdOffers must describe the merged event's COVER, not
+        // the base record: the `{ ...newEvent }` spread copies newEvent's
+        // stamp even when existing's cover won (underscore fields skip the
+        // field loop), and drops existing's stamp even when its offers-priced
+        // cover won. Recompute it from whichever record supplied the final
+        // value, with strict attribution like imageSource/barSource: a record
+        // only vouches for the stamp when its own cover IS the final value. A
+        // final cover no stamped side supplied carries no stamp (fail open —
+        // the calendar merge then treats it as an ordinary fresh price).
+        {
+            delete mergedEvent._coverFromJsonLdOffers;
+            const finalCover = this.serializeArbitrationValue('cover', mergedEvent.cover);
+            const suppliedOffersCover = (record) => Boolean(record && record._coverFromJsonLdOffers)
+                && finalCover !== ''
+                && this.serializeArbitrationValue('cover', record.cover) === finalCover;
+            if (suppliedOffersCover(newEvent) || suppliedOffersCover(existingEvent)) {
+                mergedEvent._coverFromJsonLdOffers = true;
+            }
+        }
+
         // _timezoneUnresolved must describe the merged event's DATES, not the base
         // record: the `{ ...newEvent }` spread above copies newEvent's flag even
         // when existing's anchored dates won, and drops existing's flag even when
@@ -7379,16 +7505,31 @@ class SharedCore {
                 continue;
             }
 
-            // Cover is priced by the LIVE ticket page: the calendar copy is just
-            // last run's snapshot, so AI arbitration (which has no freshness
-            // signal) is the wrong tool. Under the default "ai" strategy
-            // (explicit parser-config strategies still win):
+            // Cover is resolved deterministically under the default "ai"
+            // strategy (explicit parser-config strategies still win) — AI
+            // arbitration has no freshness signal and flip-flopped run after
+            // run. But "the calendar copy is just last run's snapshot" is only
+            // half true: a DIFFERENT parser may have written the calendar
+            // copy, and unconditional freshness-wins was the ping-pong engine
+            // (observed: "BEARRACUDA: Seattle" cycled $20-$30 → $20 → ADV. TIX
+            // AT BEARRACUDA.COM → $20 as two parsers alternated). Shape-aware
+            // rules (classifyCoverShape, 2026-08-02):
             // - formatting twins (whitespace-only difference, e.g.
             //   "$22.10 - $39.98" vs "$22.10-$39.98") are the SAME price — the
             //   calendar value is kept: no conflict, no AI call, no clobber entry;
-            // - genuinely different prices take the scraped (fresh) value
-            //   deterministically. An empty scraped cover never reaches here —
-            //   the empty-scrape rule above already kept the calendar value.
+            // - a price-shaped calendar value is never clobbered by a
+            //   non-price scrape (marketing prose / free-claim text): once a
+            //   real price lands on the calendar, prose can't undo it;
+            // - both price-shaped but the scraped cover is stamped
+            //   _coverFromJsonLdOffers (live ticket-vendor tier prices:
+            //   fee-inclusive, built from IN-STOCK tiers only, so they move
+            //   when a tier sells out) → the stored door price is kept;
+            // - everything else (scraped price vs non-price calendar, both
+            //   price unstamped, both non-price) takes the scraped (fresh)
+            //   value deterministically — a venue really updating its door
+            //   price must still propagate. An empty scraped cover never
+            //   reaches here — the empty-scrape rule above already kept the
+            //   calendar value.
             if (fieldName === 'cover' && mergeStrategy === 'ai'
                 && !this.isEmptyArbitrationValue(scraperValue)
                 && !this.isEmptyArbitrationValue(calendarValue)) {
@@ -7399,18 +7540,38 @@ class SharedCore {
                     continue;
                 }
                 if (serializedScraped !== serializedCalendar) {
+                    const recordCoverDecision = (chosenValue, reason) => {
+                        aiDecisionRecords.push({
+                            field: fieldName,
+                            existingValue: calendarValue,
+                            newValue: scraperValue,
+                            chosenValue: chosenValue,
+                            reason: reason,
+                            source: 'deterministic'
+                        });
+                    };
+                    const scrapedShape = this.classifyCoverShape(serializedScraped);
+                    const calendarShape = this.classifyCoverShape(serializedCalendar);
+                    if (calendarShape === 'price' && scrapedShape !== 'price') {
+                        const keptReason = `scraped "${serializedScraped}" is not price-shaped`;
+                        mergedObject[fieldName] = calendarValue;
+                        console.log(`🔒 MERGE: "${mergeTitle}" field=${fieldName} kept calendar value — ${keptReason}`);
+                        recordCoverDecision(calendarValue, keptReason);
+                        continue;
+                    }
+                    if (calendarShape === 'price' && scrapedShape === 'price'
+                        && Boolean(scraperObject._coverFromJsonLdOffers)) {
+                        const keptReason = `scraped "${serializedScraped}" is a live ticket-tier price (fee-inclusive, in-stock tiers only)`;
+                        mergedObject[fieldName] = calendarValue;
+                        console.log(`🔒 MERGE: "${mergeTitle}" field=${fieldName} kept calendar value — ${keptReason}`);
+                        recordCoverDecision(calendarValue, keptReason);
+                        continue;
+                    }
                     const freshnessReason = 'cover reflects the live ticket page — freshness wins';
                     mergedObject[fieldName] = scraperValue;
                     clobberedFields.push(fieldName);
                     console.log(`🔒 MERGE: "${mergeTitle}" field=${fieldName} resolved deterministically — ${freshnessReason}`);
-                    aiDecisionRecords.push({
-                        field: fieldName,
-                        existingValue: calendarValue,
-                        newValue: scraperValue,
-                        chosenValue: scraperValue,
-                        reason: freshnessReason,
-                        source: 'deterministic'
-                    });
+                    recordCoverDecision(scraperValue, freshnessReason);
                     continue;
                 }
                 // Identical values fall through to the configured strategy (no-op).

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -5692,6 +5692,330 @@ test('a genuinely differing scraped cover wins deterministically — freshness, 
     'the decision is recorded as deterministic for display/metrics');
 });
 
+// ---------------------------------------------------------------------------
+// Cover shape stability (2026-08-02). `cover` held four incompatible value
+// kinds and the SAME event flipped between them run after run ("BEARRACUDA:
+// Seattle" went $20-$30 → $20 → ADV. TIX AT BEARRACUDA.COM → $20). Every
+// value below is from a real run.
+// ---------------------------------------------------------------------------
+
+test('classifyCoverShape: every observed cover value classifies by shape', () => {
+  const core = createCore();
+  const expectations = {
+    price: [
+      '$20', '$15-$30', 'From £10', '20 EUR', '11.55-22.38 GBP',
+      '$14.92', '$9.27', '$20.24', '$22.10-$39.98',
+      '$10, NO COVER' // contains a currency-marked amount — price, not free
+    ],
+    prose: [
+      'ADV. TICKETS', 'ADV. TIX AT BEARRACUDA.COM', 'TIX AT THE DOOR',
+      'EARLY BEAR', 'SOLD OUT', 'TICKETS @ CHUNK-PARTY.COM',
+      'Included with Tag', 'white & silver', 'GAYMAFIABOSTON.COM FURBALL.NYC',
+      '3dollarbillbk.com',
+      // Mathematical-bold Unicode (U+1D400 block) from a real run — NFKC
+      // folding keeps it from dodging classification.
+      '𝐑𝐞𝐝 𝐰𝐫𝐢𝐬𝐭𝐛𝐚𝐧𝐝 𝐫𝐞𝐪𝐮𝐢𝐫𝐞𝐝 𝐟𝐨𝐫 𝐞𝐧𝐭𝐫𝐲'
+    ],
+    free: [
+      'Free admission', 'Free entry', 'free', 'No cover', 'NO COVER!',
+      'No cover.', 'Entrada Libre', 'Entrada Gratuita', 'gratis', 'kostenlos'
+    ],
+    empty: ['', '   ', null, undefined]
+  };
+  for (const [shape, values] of Object.entries(expectations)) {
+    for (const value of values) {
+      assert.equal(core.classifyCoverShape(value), shape,
+        `${JSON.stringify(value)} must classify as ${shape}`);
+    }
+  }
+});
+
+test('cover rung: price-shaped cover beats marketing prose in both directions', () => {
+  const core = createCore();
+  const proseVsPrice = core.resolveConflictDeterministically('cover', 'ADV. TIX AT BEARRACUDA.COM', '$20');
+  assert.deepEqual(proseVsPrice, { winner: 'b', reason: 'price-shaped cover beats marketing text' });
+  const priceVsProse = core.resolveConflictDeterministically('cover', '$20', 'ADV. TIX AT BEARRACUDA.COM');
+  assert.deepEqual(priceVsProse, { winner: 'a', reason: 'price-shaped cover beats marketing text' });
+});
+
+test('cover rung: price/free, price/price, free/prose and prose/prose all fall through to AI', () => {
+  const core = createCore();
+  // Two Sitges parsers genuinely claim "20 EUR" vs "Entrada Libre" — a real
+  // factual disagreement, never decidable by shape alone.
+  assert.equal(core.resolveConflictDeterministically('cover', '20 EUR', 'Entrada Libre'), null);
+  assert.equal(core.resolveConflictDeterministically('cover', '$15-$30', '$14.92'), null);
+  assert.equal(core.resolveConflictDeterministically('cover', 'No cover', 'SOLD OUT'), null);
+  assert.equal(core.resolveConflictDeterministically('cover', 'ADV. TICKETS', 'SOLD OUT'), null);
+});
+
+test('mergeParsedEvents: a price-shaped cover beats prose deterministically — no AI call', async () => {
+  const core = createCore();
+  const existing = {
+    title: 'BEARRACUDA: Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    cover: 'ADV. TIX AT BEARRACUDA.COM',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const incoming = {
+    title: 'BEARRACUDA: Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    cover: '$20',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const adapter = buildArbitrationAdapter({
+    cover: { pick: 'existing', value: 'ADV. TIX AT BEARRACUDA.COM', reason: 'should never be asked' }
+  });
+
+  const merged = await core.mergeParsedEvents(existing, incoming, { httpAdapter: adapter });
+
+  assert.equal(adapter.calls.length, 0, 'price-vs-prose covers must never reach arbitration');
+  assert.equal(merged.cover, '$20', 'the price-shaped side wins');
+});
+
+test('mergeParsedEvents: _coverFromJsonLdOffers follows the winning cover, never the base spread', async () => {
+  const core = createCore();
+  // Stamped incoming cover WINS (existing side empty) → the stamp survives.
+  const emptyExisting = {
+    title: 'Treasure Trail Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const stampedIncoming = {
+    title: 'Treasure Trail Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    cover: '$14.92',
+    source: 'ai-web',
+    _coverFromJsonLdOffers: true,
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const keptStamp = await core.mergeParsedEvents(emptyExisting, stampedIncoming, {
+    httpAdapter: buildArbitrationAdapter({})
+  });
+  assert.equal(keptStamp.cover, '$14.92');
+  assert.equal(keptStamp._coverFromJsonLdOffers, true,
+    'the stamp survives when the stamped record supplied the final cover');
+
+  // Stamped incoming cover LOSES (arbitration keeps the existing price) → the
+  // base { ...newEvent } spread must not leave a stamp describing a cover the
+  // offers record never produced.
+  const pricedExisting = {
+    title: 'Treasure Trail Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    cover: '$15-$30',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const adapter = buildArbitrationAdapter({
+    cover: { pick: 'existing', value: '$15-$30', reason: 'door price range' }
+  });
+  const droppedStamp = await core.mergeParsedEvents(pricedExisting, stampedIncoming, { httpAdapter: adapter });
+  assert.equal(adapter.calls.length, 1, 'price-vs-price covers still arbitrate');
+  assert.equal(droppedStamp.cover, '$15-$30');
+  assert.equal(droppedStamp._coverFromJsonLdOffers, undefined,
+    'a stamp for the losing cover must not shadow the winning one');
+});
+
+test('calendar merge: a non-price scrape never clobbers a price-shaped calendar cover', async () => {
+  const core = createCore();
+  const scraped = {
+    title: 'BEARRACUDA: Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    cover: 'ADV. TIX AT BEARRACUDA.COM',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  };
+  const existing = {
+    title: 'BEARRACUDA: Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    notes: 'cover: $20'
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let finalEvent;
+  try {
+    finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'the shape decision is deterministic — no AI');
+  assert.equal(finalEvent.cover, '$20', 'the stored price survives the prose scrape');
+  assert.equal(core.parseNotesIntoFields(finalEvent.notes).cover, '$20');
+  assert.ok(logLines.some(line => line === '🔒 MERGE: "BEARRACUDA: Seattle" field=cover kept calendar value — scraped "ADV. TIX AT BEARRACUDA.COM" is not price-shaped'),
+    `expected the kept-calendar log line, got: ${JSON.stringify(logLines)}`);
+  assert.ok(finalEvent._original.aiArbitration.deterministic.includes('cover'),
+    'the kept-calendar decision is recorded as deterministic');
+});
+
+test('calendar merge: an offers-stamped live tier price never clobbers the stored door price', async () => {
+  // "Treasure Trail Seattle": stored $15-$30 was clobbered by the live tixr
+  // tier price $14.92 — fee-inclusive and built from IN-STOCK tiers only, so
+  // it moves whenever a tier sells out.
+  const core = createCore();
+  const buildScrapedTixr = () => ({
+    title: 'Treasure Trail Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    cover: '$14.92',
+    source: 'ai-web',
+    _coverFromJsonLdOffers: true,
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  });
+  const existing = {
+    title: 'Treasure Trail Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    notes: 'cover: $15-$30'
+  };
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let runOne;
+  let runTwo;
+  try {
+    runOne = await core.createFinalEventObject(existing, buildScrapedTixr(), { httpAdapter: adapter });
+    // Convergence: the calendar record is unchanged, the next run scrapes the
+    // same live tier price — the stored range must survive EVERY run.
+    runTwo = await core.createFinalEventObject(
+      { ...existing, notes: runOne.notes },
+      buildScrapedTixr(),
+      { httpAdapter: adapter }
+    );
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'the stamp decision is deterministic — no AI');
+  assert.equal(runOne.cover, '$15-$30', 'the stored door price stays');
+  assert.equal(runTwo.cover, '$15-$30', 'the stored door price stays on every subsequent run');
+  assert.ok(logLines.some(line => line === '🔒 MERGE: "Treasure Trail Seattle" field=cover kept calendar value — scraped "$14.92" is a live ticket-tier price (fee-inclusive, in-stock tiers only)'),
+    `expected the kept-calendar log line, got: ${JSON.stringify(logLines)}`);
+  assert.ok(runOne._original.aiArbitration.deterministic.includes('cover'),
+    'the kept-calendar decision is recorded as deterministic');
+});
+
+test('calendar merge: an unstamped price update and a non-price-vs-non-price change still take freshness', async () => {
+  const core = createCore();
+  const buildScraped = (cover) => ({
+    title: 'BEARRACUDA: Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    cover,
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  });
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let priceUpdate;
+  let proseUpdate;
+  let freeToPrice;
+  try {
+    // Both price, no offers stamp: a venue really updating its door price
+    // must still propagate.
+    priceUpdate = await core.createFinalEventObject(
+      { title: 'BEARRACUDA: Seattle', startDate: new Date('2026-08-15T21:00:00.000Z'), notes: 'cover: $20-$30' },
+      buildScraped('$20'),
+      { httpAdapter: adapter }
+    );
+    // Both non-price: prose replacing prose is harmless — freshness is the
+    // best signal available (today's behavior, unchanged).
+    proseUpdate = await core.createFinalEventObject(
+      { title: 'BEARRACUDA: Seattle', startDate: new Date('2026-08-15T21:00:00.000Z'), notes: 'cover: TIX AT THE DOOR' },
+      buildScraped('SOLD OUT'),
+      { httpAdapter: adapter }
+    );
+    // Scraped price vs non-price calendar value: the price wins.
+    freeToPrice = await core.createFinalEventObject(
+      { title: 'BEARRACUDA: Seattle', startDate: new Date('2026-08-15T21:00:00.000Z'), notes: 'cover: Free admission' },
+      buildScraped('20 EUR'),
+      { httpAdapter: adapter }
+    );
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'every branch is deterministic — no AI');
+  assert.equal(priceUpdate.cover, '$20');
+  assert.equal(proseUpdate.cover, 'SOLD OUT');
+  assert.equal(freeToPrice.cover, '20 EUR');
+  const freshnessLines = logLines.filter(line => line.startsWith('🔒 MERGE:')
+    && line.includes('field=cover')
+    && line.includes('cover reflects the live ticket page — freshness wins'));
+  assert.equal(freshnessLines.length, 3,
+    `each branch must log the unchanged freshness line, got: ${JSON.stringify(logLines)}`);
+});
+
+test('calendar merge convergence: the BEARRACUDA prose/price ping-pong settles on the price', async () => {
+  // Real observed churn: two parsers write the same event — one extracts the
+  // flyer's "ADV. TIX AT BEARRACUDA.COM", the other the ticket page's "$20" —
+  // and the calendar flipped between them every run. Now: the price lands
+  // once and prose can never clobber it again.
+  const core = createCore();
+  const buildScraped = (cover) => ({
+    title: 'BEARRACUDA: Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    cover,
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: TEST_AI_PARSER_CONFIG
+  });
+  const calendarRecord = (notes) => ({
+    title: 'BEARRACUDA: Seattle',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    notes
+  });
+  const adapter = buildArbitrationAdapter({});
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (message) => { logLines.push(String(message)); };
+  let runB;
+  let runA;
+  try {
+    // Run 1 — parser B scrapes the price against parser A's stored prose:
+    // the price replaces prose (freshness clobber, unchanged log line).
+    runB = await core.createFinalEventObject(
+      calendarRecord('cover: ADV. TIX AT BEARRACUDA.COM'),
+      buildScraped('$20'),
+      { httpAdapter: adapter }
+    );
+    // Run 2 — parser A re-runs its prose against the now-stored price:
+    // prose no longer clobbers, the calendar keeps $20. Converged.
+    runA = await core.createFinalEventObject(
+      calendarRecord(runB.notes),
+      buildScraped('ADV. TIX AT BEARRACUDA.COM'),
+      { httpAdapter: adapter }
+    );
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(adapter.calls.length, 0, 'neither run consults the AI');
+  assert.equal(runB.cover, '$20', 'run 1: the scraped price replaces the stored prose');
+  assert.equal(core.parseNotesIntoFields(runB.notes).cover, '$20');
+  assert.equal(runA.cover, '$20', 'run 2: the prose re-scrape keeps the stored price — no ping-pong');
+  assert.equal(core.parseNotesIntoFields(runA.notes).cover, '$20');
+  assert.ok(logLines.some(line => line.startsWith('🔒 MERGE:')
+    && line.includes('field=cover')
+    && line.includes('cover reflects the live ticket page — freshness wins')),
+    'run 1 uses the unchanged freshness clobber line');
+  assert.ok(logLines.some(line => line === '🔒 MERGE: "BEARRACUDA: Seattle" field=cover kept calendar value — scraped "ADV. TIX AT BEARRACUDA.COM" is not price-shaped'),
+    `run 2 logs the kept-calendar line, got: ${JSON.stringify(logLines)}`);
+});
+
 test('PARSER MERGE summary lists only fields the merge actually changed on the outgoing record', async () => {
   const core = createCore();
   // bar: existing wins over the empty incoming side → the outgoing record changed.
@@ -7493,6 +7817,69 @@ test('resolveForeignCrawlPageOwner: parser configs claim too, and every ambiguit
   // Junk in → null out
   assert.equal(owner('not-a-url'), null);
   assert.equal(core.resolveForeignCrawlPageOwner('https://other.example/x', running, null), null);
+});
+
+test('resolveForeignCrawlPageOwner: a parser and its own promoter entry claiming the SAME site are one owner, not ambiguity', () => {
+  // The live shape that silently disabled the guard: parser "Bearracuda
+  // Events" and registry entry "Bearracuda" both claim bearracuda.com under
+  // different names, and the two-owner count read as ambiguous evidence.
+  const core = createCrossOrgCore([
+    { name: 'Cuda', website: 'https://cuda.example/' }
+  ]);
+  const mainConfig = { parsers: [
+    { name: 'Cuda Events', urls: ['https://cuda.example/'] },
+    { name: 'Venue Site', urls: ['https://venue.example'] }
+  ] };
+  const running = mainConfig.parsers[1];
+
+  const owner = core.resolveForeignCrawlPageOwner('https://cuda.example/events/x', running, mainConfig);
+  assert.ok(owner, 'two labels on one site must still resolve to a single owner');
+  assert.equal(owner.ownerName, 'Cuda Events', 'the parser-kind label is preferred for reporting');
+
+  // The owning parser itself is still self on its own site
+  assert.equal(core.resolveForeignCrawlPageOwner('https://cuda.example/events/x', mainConfig.parsers[0], mainConfig), null);
+
+  // Genuine ambiguity — two DIFFERENT sites tied at the same specificity —
+  // still fails closed
+  const ambiguousCore = createCrossOrgCore([
+    { name: 'Org A', website: 'https://shared.example/a' },
+    { name: 'Org B', website: 'https://shared.example/a' }
+  ]);
+  assert.equal(
+    ambiguousCore.resolveForeignCrawlPageOwner('https://shared.example/a/page', running, mainConfig),
+    null,
+    'two different owners on one path is ambiguous evidence — no-op');
+});
+
+test('resolveForeignCrawlPageOwner: own-domain shield yields only to a SUB-PATH foreign claim', () => {
+  const core = createCrossOrgCore([
+    // Family owner claims the whole domain; the running parser is a sub-brand
+    // configured at its own sub-path with NO alias link to the family entry
+    // (the live ursamen shape: Spooky Bear at ursamen.org/spookybear vs
+    // "Northeast Ursamen" claiming ursamen.org).
+    { name: 'Family Owner', website: 'https://family.example' },
+    // On a shared platform, each profile is a sub-path claim.
+    { name: 'Other Profile', website: 'https://profiles.example/other' }
+  ]);
+  const subBrand = { name: 'Sub Brand Night', urls: ['https://family.example/subbrand'] };
+  const profileParser = { name: 'My Profile', urls: ['https://profiles.example/mine'] };
+  const mainConfig = { parsers: [subBrand, profileParser] };
+
+  // Domain-level foreign claim does NOT pierce the sub-brand's own-domain
+  // footing — the family site stays fully crawlable.
+  assert.equal(core.resolveForeignCrawlPageOwner('https://family.example/about', subBrand, mainConfig), null);
+  assert.equal(core.resolveForeignCrawlPageOwner('https://family.example/subbrand/deeper', subBrand, mainConfig), null);
+
+  // A sub-path claim naming a different owner DOES pierce it: being
+  // configured somewhere on a shared platform is not a licence to ingest a
+  // sibling profile (the Cubhouse → linktr.ee/megawoof_america gap).
+  const pierced = core.resolveForeignCrawlPageOwner('https://profiles.example/other', profileParser, mainConfig);
+  assert.ok(pierced, 'a foreign sub-path claim on a shared platform must block');
+  assert.equal(pierced.ownerName, 'Other Profile');
+
+  // The parser's own profile and unclaimed profiles stay crawlable.
+  assert.equal(core.resolveForeignCrawlPageOwner('https://profiles.example/mine/links', profileParser, mainConfig), null);
+  assert.equal(core.resolveForeignCrawlPageOwner('https://profiles.example/unclaimed', profileParser, mainConfig), null);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two stability fixes, one PR (both live in `shared-core.js`).

## 1. `cover` gets a shape, and the ping-pong converges

The field held four incompatible value kinds and flipped between them run after run — "BEARRACUDA: Seattle" went `$20-$30` → `$20` → `ADV. TIX AT BEARRACUDA.COM` → `$20` as two parsers overwrote each other, and stored `$15-$30` was clobbered by tixr's live `$14.92` (fee-inclusive, built from **in-stock tiers only**, so it changes whenever a tier sells out).

- **`classifyCoverShape(value)`** → `price | free | prose | empty`. NFKC-folds first so the mathematical-bold wristband legend (𝐑𝐞𝐝 𝐰𝐫𝐢𝐬𝐭𝐛𝐚𝐧𝐝…, real run data) can't dodge it. 31 real observed values pin the classification.
- **New deterministic rung:** `price-shaped cover beats marketing text`. Only price-vs-prose decides. Price/free still arbitrates — `20 EUR` vs `Entrada Libre` is a genuine factual dispute between two Sitges parsers, not noise.
- **`freshness wins` no longer overwrites blindly.** Its premise ("the calendar copy is just last run's snapshot") is false when a *different parser* wrote the calendar copy. Now: prose never clobbers a stored price; an offers-stamped live tier price never clobbers the stored door price; a genuine unstamped price update still propagates. New log lines:
  - `🔒 MERGE: "…" field=cover kept calendar value — scraped "…" is not price-shaped`
  - `🔒 MERGE: "…" field=cover kept calendar value — scraped "…" is a live ticket-tier price (fee-inclusive, in-stock tiers only)`
- The `_coverFromJsonLdOffers` stamp is recomputed with strict attribution after dedup-merge, so a cover that *lost* the merge can't smuggle its stamp onto the winner.

Convergence (verified with the AI adapter armed to throw — never consulted): prose-writing parser + price-writing parser settle on the price and stay there; `$15-$30` vs offers `$14.92` keeps `$15-$30` every run; unstamped `$25` (a real door-price change) propagates.

No prose is dropped at extraction — classify-only, per flag-don't-drop. No prompt lines touched (AI cache unaffected).

## 2. Cross-org guard: a shipped bug fixed, plus the tightening

**Bug in #1612, found while probing with the full registry loaded:** a parser and its own promoter entry claiming the same site under different names — "Bearracuda Events" (parser) + "Bearracuda" (registry) on `bearracuda.com` — counted as **two owners → ambiguity → guard silently no-ops**. The massive→bearracuda block described in #1612's PR body never actually fired in production; my earlier probes had been run without the registry, which is also why the "zero regressions from tightening" measurement I quoted then was unsound. Fixed: claims of different *kinds* on the identical site URL collapse to one owner (parser label preferred); two same-kind owners remain genuine ambiguity and fail closed.

**Tightening:** the own-configured-domain exemption now yields to a **sub-path** claim naming a different owner, and holds against **domain-level** claims:

| Case | Now |
|---|---|
| massive.club → `bearracuda.com` | **blocked** (the bug fix) |
| Cubhouse → `linktr.ee/megawoof_america` | **blocked** (the known gap) |
| Megawoof → Bearracuda's eventbrite `/o/` page | **blocked** |
| Spooky Bear → rest of `ursamen.org` | allowed — "Northeast Ursamen" claims the domain but a domain-level claim can't lock a sub-brand out of its family's site |
| eventbrite `/e/` pages, spam hosts, own sites, ticket hops | unchanged |

**120-probe matrix** (every parser × configured URL × deep paths, full registry loaded): zero regressions.

## Verification

Suite: **1251 pass, 0 fail** (1240 baseline + 11 new). Combined-branch probe re-run after merging: all five key behaviors green. No `new URL`/`URLSearchParams` added; platform-purity intact; no new runtime files.

Expected visible effects: cover churn on contested events stops within a run or two; Bearracuda events stop being rewritten by the massive.club parser (they were one of the 32 contested slots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP