### PR TITLE
feat(scraper): report-only event sanity flags + dateless-weekly recurrence synthesis (ICS-only)

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -4933,6 +4933,15 @@ class ScriptableAdapter {
     if (eventsByAction.other.length > 0) {
       console.log(`   ❓ Other: ${eventsByAction.other.length} events`);
     }
+    // REPORT-ONLY sanity flags (SharedCore.getEventSanityFlags): count line
+    // only when something is flagged — flags never change any action above.
+    const sanityFlaggedCount = allEvents.filter(
+      (event) =>
+        Array.isArray(event?._sanityFlags) && event._sanityFlags.length > 0,
+    ).length;
+    if (sanityFlaggedCount > 0) {
+      console.log(`   ⚠️ Sanity flags: ${sanityFlaggedCount} event(s)`);
+    }
 
     const detailedActions = ["merge", "conflict"];
     const actionsToShow = detailedActions.filter(
@@ -4976,6 +4985,13 @@ class ScriptableAdapter {
         );
       } else if (action === "conflict" && event._analysis?.reason) {
         console.log(`  ⚠️  Reason: ${event._analysis.reason}`);
+      }
+      // Additive adjacent line — report-only sanity flags never alter the
+      // Intent/Write line above.
+      if (Array.isArray(event._sanityFlags) && event._sanityFlags.length > 0) {
+        console.log(
+          `  ⚠️ Sanity: ${event._sanityFlags.map((flag) => flag.code).join(", ")}`,
+        );
       }
     });
 
@@ -9166,6 +9182,19 @@ class ScriptableAdapter {
       event && event._seriesMatch
         ? '<span class="action-badge badge-merge series-match-badge">🔁 already saved — matches this series</span>'
         : "";
+    // Additive third badge, same pattern as seriesMatchBadge: report-only
+    // sanity flags (SharedCore.getEventSanityFlags) — compact codes only,
+    // details live in the run log's ⚠️ SANITY line. Never changes the
+    // action badge or the write plan.
+    const sanityFlags = Array.isArray(event && event._sanityFlags)
+      ? event._sanityFlags
+      : [];
+    const sanityBadge =
+      sanityFlags.length > 0
+        ? `<span class="action-badge badge-warning sanity-flag-badge">⚠️ sanity: ${this.escapeHtml(
+            sanityFlags.map((flag) => flag.code).join(", "),
+          )}</span>`
+        : "";
     const dropDetail = [
       bearOpts.dropReason ? String(bearOpts.dropReason) : "",
       bearOpts.dropHost ? `from ${bearOpts.dropHost}` : "",
@@ -9240,7 +9269,7 @@ class ScriptableAdapter {
 
     let html = `
         <div class="event-card${isDroppedCard ? " bear-dropped-card" : ""}">
-            ${actionBadge}${recurringBadge}${seriesMatchBadge}
+            ${actionBadge}${recurringBadge}${seriesMatchBadge}${sanityBadge}
             ${actionNote}
             <div class="event-title">${this.escapeHtml(event.title || event.name)}</div>
             ${bearVerdictRow}

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -4012,3 +4012,92 @@ test('builder link: a matched series pre-selects the record without flipping int
   });
   assert.ok(!plain.includes('occid='), 'no picker pre-selection for a standalone edit');
 });
+
+// ---------------------------------------------------------------------------
+// REPORT-ONLY sanity flags in the results UI: compact badge on the event
+// card, adjacent line in the enriched-events sample, and an Event Actions
+// Summary count line that appears ONLY when something is flagged. Flags are
+// stamped upstream (SharedCore.getEventSanityFlags) — the adapter only
+// renders them, never alters an action.
+// ---------------------------------------------------------------------------
+
+test('generateEventCard shows the sanity badge only on flagged events', () => {
+  const adapter = buildAdapter();
+  const flagged = adapter.generateEventCard({
+    title: '6:30 PM',
+    _action: 'new',
+    startDate: '2026-08-01T02:00:00.000Z',
+    _sanityFlags: [
+      { code: 'title-is-date-phrase', detail: 'title is entirely a date/time expression' },
+      { code: 'duration-implausible', detail: 'spans 575.4 days (longest curated festival is 10)' }
+    ]
+  });
+  assert.ok(flagged.includes('sanity-flag-badge'));
+  assert.ok(flagged.includes('⚠️ sanity: title-is-date-phrase, duration-implausible'));
+
+  const plain = adapter.generateEventCard({
+    title: 'Plain',
+    _action: 'new',
+    startDate: '2026-08-01T02:00:00.000Z',
+    _sanityFlags: []
+  });
+  assert.ok(!plain.includes('sanity-flag-badge'));
+  // Absent field (saved runs from before the stamp) renders like empty.
+  const legacy = adapter.generateEventCard({
+    title: 'Legacy',
+    _action: 'new',
+    startDate: '2026-08-01T02:00:00.000Z'
+  });
+  assert.ok(!legacy.includes('sanity-flag-badge'));
+});
+
+test('Event Actions Summary carries the sanity count line only when events are flagged', async () => {
+  const adapter = buildAdapter();
+  const capture = async (results) => {
+    const lines = [];
+    const originalLog = console.log;
+    console.log = (...args) => { lines.push(args.join(' ')); };
+    try {
+      await adapter.displayEnrichedEvents(results);
+    } finally {
+      console.log = originalLog;
+    }
+    return lines;
+  };
+
+  const flaggedLines = await capture({
+    analyzedEvents: [
+      {
+        title: '6:30 PM',
+        _action: 'new',
+        startDate: '2026-08-01T02:00:00.000Z',
+        _sanityFlags: [{ code: 'title-is-date-phrase', detail: 'title is entirely a date/time expression' }]
+      },
+      {
+        title: 'Plain',
+        _action: 'new',
+        startDate: '2026-08-01T02:00:00.000Z',
+        _sanityFlags: []
+      }
+    ]
+  });
+  assert.ok(
+    flaggedLines.includes('   ⚠️ Sanity flags: 1 event(s)'),
+    `expected the count line, got: ${JSON.stringify(flaggedLines.filter(line => line.includes('Sanity')))}`);
+  // The sample event block gets the adjacent per-event line too.
+  assert.ok(flaggedLines.includes('  ⚠️ Sanity: title-is-date-phrase'));
+
+  const cleanLines = await capture({
+    analyzedEvents: [
+      {
+        title: 'Plain',
+        _action: 'new',
+        startDate: '2026-08-01T02:00:00.000Z',
+        _sanityFlags: []
+      }
+    ]
+  });
+  assert.ok(
+    !cleanLines.some(line => line.includes('Sanity')),
+    `no sanity lines when nothing is flagged, got: ${JSON.stringify(cleanLines.filter(line => line.includes('Sanity')))}`);
+});

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -672,6 +672,11 @@ async saveFailureNote(url, error, metadata = {}) {
                 console.log(`   Date: ${event.startDate}`);
                 console.log(`   Venue: ${event.venue || 'N/A'}`);
                 console.log(`   URL: ${event.url || 'N/A'}`);
+                // Additive line: report-only sanity flags stamped by
+                // SharedCore.getEventSanityFlags (absent → nothing printed).
+                if (Array.isArray(event._sanityFlags) && event._sanityFlags.length > 0) {
+                    console.log(`   ⚠️ Sanity: ${event._sanityFlags.map(flag => flag.code).join(', ')}`);
+                }
                 console.log('   ---');
             });
         }

--- a/scripts/adapters/web-adapter.test.js
+++ b/scripts/adapters/web-adapter.test.js
@@ -284,3 +284,30 @@ test('getCalendarName fails closed for an unrecognized city and logs it once', (
   assert.equal(wiltonLines.length, 1, 'logged once per distinct unrecognized city, not once per event');
   assert.ok(wiltonLines[0].includes('Unrecognized city'), `expected the visible drop line, got: ${wiltonLines[0]}`);
 });
+
+// ---------------------------------------------------------------------------
+// REPORT-ONLY sanity flags: the small-batch event detail block prints an
+// additive line for flagged events (stamped upstream by
+// SharedCore.getEventSanityFlags) and stays silent otherwise.
+// ---------------------------------------------------------------------------
+
+test('displayCalendarEvents prints the sanity line only for flagged events', () => {
+  const adapter = makeAdapter();
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...args) => { lines.push(args.join(' ')); };
+  try {
+    adapter.displayCalendarEvents([
+      {
+        title: '6:30 PM',
+        startDate: '2026-08-01T02:00:00.000Z',
+        _sanityFlags: [{ code: 'title-is-date-phrase', detail: 'title is entirely a date/time expression' }]
+      },
+      { title: 'Plain', startDate: '2026-08-01T02:00:00.000Z' }
+    ], { name: 'test-parser' });
+  } finally {
+    console.log = originalLog;
+  }
+  const sanityLines = lines.filter(line => line.includes('⚠️ Sanity:'));
+  assert.deepEqual(sanityLines, ['   ⚠️ Sanity: title-is-date-phrase']);
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -115,6 +115,53 @@ const RRULE_BYDAY_EVIDENCE_REGEXES = {
 // signal in schedule prose.
 const RRULE_ORDINAL_WORD_REGEX = /\b(?:1st|first|2nd|second|3rd|third|4th|fourth|5th|fifth|last)\b/i;
 
+// ── Dateless-weekly day-phrase synthesis (run 20260802-140413) ──────────────
+// thelumberyardbar.com states every event as a weekday pattern and never a
+// date ("QUEERAOKE Wednesday nights @ 8:30pm"), so every extraction died on
+// the required-startDate guard. The deterministic day-phrase extractor
+// (extractRecurrenceFromDayPhrases) turns exactly one unambiguous weekday
+// pattern in the event's OWN source text into an RRULE, which then rides the
+// existing derived-next-occurrence path — and the existing recurring-withhold
+// machinery (the scraper never writes series; ICS export only).
+// These tables are generic English vocabulary — data, not per-venue rules.
+// Full day names only: abbreviated forms ("Tues", "Sat") stay the
+// model-rrule evidence path's job (RRULE_BYDAY_EVIDENCE_REGEXES); a
+// whole-corpus deterministic scan over abbreviations would false-positive on
+// ordinary words ("we sat down"), so synthesis fails closed on them.
+const DAY_PHRASE_WEEKDAY_WORDS = [
+    { code: 'MO', word: 'monday' },
+    { code: 'TU', word: 'tuesday' },
+    { code: 'WE', word: 'wednesday' },
+    { code: 'TH', word: 'thursday' },
+    { code: 'FR', word: 'friday' },
+    { code: 'SA', word: 'saturday' },
+    { code: 'SU', word: 'sunday' }
+];
+
+// Ordinal-position vocabulary → BYDAY ordinal ("last Tuesday" → -1TU,
+// "2nd Saturday" → 2SA).
+const DAY_PHRASE_ORDINAL_WORDS = [
+    { value: 1, words: ['first', '1st'] },
+    { value: 2, words: ['second', '2nd'] },
+    { value: 3, words: ['third', '3rd'] },
+    { value: 4, words: ['fourth', '4th'] },
+    { value: 5, words: ['fifth', '5th'] },
+    { value: -1, words: ['last'] }
+];
+
+const DAY_PHRASE_DAY_ALTERNATION = DAY_PHRASE_WEEKDAY_WORDS.map(entry => entry.word).join('|');
+const DAY_PHRASE_ORDINAL_ALTERNATION = DAY_PHRASE_ORDINAL_WORDS
+    .map(entry => entry.words.join('|'))
+    .join('|');
+
+// Max folded-character gap between an event's title span and a day-phrase
+// span for the phrase to count as THAT event's schedule when a page names
+// several patterns. Derived from the real Lumberyard events page (run
+// 20260802-140413): correct title→phrase pairs measured at gaps 1, 3 and 6;
+// the closest WRONG pair (a neighbouring listing's phrase) at 30. 25 splits
+// them with margin on both sides.
+const DAY_PHRASE_TITLE_GAP_MAX = 25;
+
 // ── Multilingual date-vocabulary locales ─────────────────────────────────────
 // The languages of the configured cities (sitges/madrid/pv/mexico-city →
 // es/ca; paris → fr; berlin → de; milan → it; sao-paulo → pt), plus en for
@@ -10664,23 +10711,310 @@ TEXT:
     }
 
     /**
+     * NFKC-fold (compatibility/fullwidth forms), then the same diacritic
+     * fold the evidence layer already uses (lowercase, accents stripped),
+     * then whitespace collapse — the one normalization every day-phrase and
+     * corpus day-word match runs on.
+     */
+    foldDayPhraseText(value) {
+        return this.foldDiacritics(String(value || '').normalize('NFKC')).replace(/\s+/g, ' ');
+    }
+
+    /**
+     * Deterministic day-phrase recurrence extraction for dateless events
+     * (run 20260802-140413, The Lumberyard): scan the event's OWN source
+     * text for weekday-pattern phrases and translate exactly ONE unambiguous
+     * pattern into an RRULE. Regex over generic English vocabulary only —
+     * no AI calls, no per-venue rules.
+     *   - weekly shapes: "every Wednesday", "Wednesdays", "Wednesday
+     *     night(s)" → FREQ=WEEKLY;BYDAY=WE
+     *   - monthly ordinal shapes: "last Tuesday", "first Friday",
+     *     "2nd Saturday" → FREQ=MONTHLY;BYDAY=-1TU / 1FR / 2SA
+     * Bare singular weekdays ("Friday, August 7") are NOT a pattern — they
+     * are how one-off dates are written.
+     * Returns:
+     *   { rrule, phrase, startTime, endTime } — exactly one distinct rule
+     *   { conflict: [rrules...] } — multiple distinct rules with no clear
+     *     association; the caller fails closed
+     *   null — no pattern found
+     */
+    extractRecurrenceFromDayPhrases(sourceText, eventTitle = '') {
+        const corpus = this.foldDayPhraseText(this.stripTags(String(sourceText || '')));
+        if (!corpus) return null;
+        const matches = [];
+        // Monthly ordinal phrases first — their spans mask the weekly scan so
+        // "every 2nd Friday" / "2nd Fridays" never double-read as weekly.
+        const ordinalRegex = new RegExp(
+            `\\b(${DAY_PHRASE_ORDINAL_ALTERNATION})\\s+(${DAY_PHRASE_DAY_ALTERNATION})s?\\b`, 'g');
+        let match;
+        while ((match = ordinalRegex.exec(corpus)) !== null) {
+            const ordinal = DAY_PHRASE_ORDINAL_WORDS.find(entry => entry.words.includes(match[1]));
+            const day = DAY_PHRASE_WEEKDAY_WORDS.find(entry => entry.word === match[2]);
+            if (!ordinal || !day) continue;
+            matches.push({
+                rrule: `FREQ=MONTHLY;BYDAY=${ordinal.value}${day.code}`,
+                phrase: match[0],
+                start: match.index,
+                end: match.index + match[0].length
+            });
+        }
+        const ordinalSpans = matches.map(entry => ({ start: entry.start, end: entry.end }));
+        const weeklyRegex = new RegExp(
+            `\\bevery\\s+(${DAY_PHRASE_DAY_ALTERNATION})s?\\b`
+            + `|\\b(${DAY_PHRASE_DAY_ALTERNATION})s\\b`
+            + `|\\b(${DAY_PHRASE_DAY_ALTERNATION})\\s+nights?\\b`, 'g');
+        while ((match = weeklyRegex.exec(corpus)) !== null) {
+            const day = DAY_PHRASE_WEEKDAY_WORDS.find(entry => entry.word === (match[1] || match[2] || match[3]));
+            if (!day) continue;
+            const start = match.index;
+            const end = match.index + match[0].length;
+            if (ordinalSpans.some(span => start < span.end && end > span.start)) continue;
+            matches.push({ rrule: `FREQ=WEEKLY;BYDAY=${day.code}`, phrase: match[0], start, end });
+        }
+        if (matches.length === 0) return null;
+        const distinctRules = Array.from(new Set(matches.map(entry => entry.rrule)));
+        if (distinctRules.length > 1) {
+            // Title-adjacency disambiguation. A venue's weekly-lineup page
+            // legitimately names several day patterns ("Trivia … (except the
+            // last Tuesday - Drink and Draw) QUEERAOKE Wednesday nights @
+            // 8:30pm … Dolly and the DJ Most Saturday Nights" — the real
+            // Lumberyard events page, where segmentation finds no valid
+            // segments and the corpus is the whole page). The phrase that
+            // belongs to THIS event is the one adjacent to its own title:
+            // nearest phrase by span gap, within DAY_PHRASE_TITLE_GAP_MAX
+            // folded characters. Measured on the real page: correct pairs
+            // sit at gaps 1 (QUEERAOKE→Wednesday), 3 (Drink and Draw→last
+            // Tuesday) and 6 (Dolly→Saturday Nights), while the closest
+            // WRONG pair (Trivia→last Tuesday, which belongs to Drink and
+            // Draw) is at 30 — the 25 bound splits them with margin. Title
+            // absent from the corpus, or no phrase within the bound → fail
+            // closed exactly as before.
+            const adjacent = this.pickTitleAdjacentDayPhrase(corpus, matches, eventTitle);
+            if (!adjacent) return { conflict: distinctRules };
+            const adjacentTime = this.captureDayPhraseAdjacentTime(corpus, adjacent);
+            return {
+                rrule: adjacent.rrule,
+                phrase: adjacent.phrase,
+                startTime: adjacentTime.startTime,
+                endTime: adjacentTime.endTime,
+                titleAdjacent: true
+            };
+        }
+        const first = matches.slice().sort((a, b) => a.start - b.start)[0];
+        const time = this.captureDayPhraseAdjacentTime(corpus, first);
+        return { rrule: first.rrule, phrase: first.phrase, startTime: time.startTime, endTime: time.endTime };
+    }
+
+    // Nearest day-phrase to the event's own title, by span gap in the folded
+    // corpus, within DAY_PHRASE_TITLE_GAP_MAX. Ampersands fold to "and" for
+    // the title lookup ("Drink & Draw" ↔ page text "Drink and Draw"). Every
+    // occurrence of the title counts; the phrase minimizing the gap over all
+    // occurrences wins. Returns the winning match or null.
+    pickTitleAdjacentDayPhrase(corpus, matches, eventTitle) {
+        const foldedTitle = this.foldDayPhraseText(String(eventTitle || '').replace(/\s*&\s*/g, ' and '))
+            .trim();
+        if (!foldedTitle || foldedTitle.length < 3) return null;
+        const titleSpans = [];
+        let index = -1;
+        while ((index = corpus.indexOf(foldedTitle, index + 1)) >= 0) {
+            titleSpans.push({ start: index, end: index + foldedTitle.length });
+        }
+        if (titleSpans.length === 0) return null;
+        const gapToTitle = (candidate) => Math.min(...titleSpans.map(span =>
+            candidate.start >= span.end
+                ? candidate.start - span.end
+                : (candidate.end <= span.start ? span.start - candidate.end : 0)));
+        const inWindow = matches
+            .map(candidate => ({ candidate, gap: gapToTitle(candidate) }))
+            .filter(entry => entry.gap <= DAY_PHRASE_TITLE_GAP_MAX)
+            .sort((a, b) => a.gap - b.gap);
+        if (inWindow.length === 0) return null;
+        // Two in-window phrases DIRECTLY conjoined ("Mondays and Thursdays",
+        // "Tuesday & Friday nights") are one multi-day listing, not a nearest-
+        // wins situation — a single-BYDAY rrule would silently drop half the
+        // schedule, so that stays ambiguous. A second-nearest phrase with real
+        // words between (a NEIGHBOURING listing's day, the QUEERAOKE page
+        // shape) does not block the adjacent one.
+        const best = inWindow[0].candidate;
+        for (const { candidate } of inWindow.slice(1)) {
+            if (candidate.rrule === best.rrule) continue;
+            const betweenStart = Math.min(best.end, candidate.end);
+            const betweenEnd = Math.max(best.start, candidate.start);
+            const between = corpus.slice(betweenStart, betweenEnd);
+            if (between.length <= 7 && /^\s*(?:and|&|,|or|\+)?\s*$/.test(between)) return null;
+        }
+        return best;
+    }
+
+    /**
+     * Adjacent-time capture for a matched day phrase: a time token in a
+     * short window after the phrase ("Wednesday nights @ 8:30pm",
+     * "Tuesdays at 7"), else a short window before it ("Karaoke 9pm every
+     * Friday"). No token → empty strings; the caller then follows the
+     * existing no-stated-time convention (_recurringNoStartTime).
+     */
+    captureDayPhraseAdjacentTime(corpus, phraseMatch) {
+        // Windows stop at the nearest OTHER weekday word: a day word starts
+        // the next listing, and reading past it steals a neighbour's time
+        // ("… Wednesday nights @ 8:30pm" bled into the previous listing's
+        // window; "Saturday Nights Sunday afternoons … 2-6pm" handed the
+        // Sunday hang's hours to the Saturday event on the real Lumberyard
+        // page).
+        const dayWordRegex = new RegExp(`\\b(?:${DAY_PHRASE_DAY_ALTERNATION})s?\\b`, 'g');
+        let after = corpus.slice(phraseMatch.end, phraseMatch.end + 60);
+        const nextDay = dayWordRegex.exec(after);
+        if (nextDay) after = after.slice(0, nextDay.index);
+        let before = corpus.slice(Math.max(0, phraseMatch.start - 40), phraseMatch.start);
+        let lastDayEnd = -1;
+        dayWordRegex.lastIndex = 0;
+        let dayHit;
+        while ((dayHit = dayWordRegex.exec(before)) !== null) {
+            lastDayEnd = dayHit.index + dayHit[0].length;
+        }
+        if (lastDayEnd >= 0) before = before.slice(lastDayEnd);
+        return this.parseDayPhraseTimeWindow(after)
+            || this.parseDayPhraseTimeWindow(before)
+            || { startTime: '', endTime: '' };
+    }
+
+    /**
+     * Parse the first time token in a day-phrase window. Recognized:
+     *   - meridiem tokens: "8:30pm", "9 pm", "9:00 p.m."
+     *   - bare @/at hours: "@ 8", "at 7", "at 7:30" — read as EVENING
+     *     (hour 1–11 → +12): bar-event convention, and only ever reachable
+     *     behind an explicit @/at marker; ambiguous bare 12 is skipped
+     * An end time is captured only from an explicit range tail with its own
+     * meridiem token ("8pm-12am", "8pm to 1am"); "-close"/"til late" carry
+     * no clock value and leave the end to existing defaulting.
+     * Returns { startTime: 'HH:MM', endTime: 'HH:MM'|'' } or null.
+     */
+    parseDayPhraseTimeWindow(windowText) {
+        const text = String(windowText || '');
+        const meridiemRegex = /\b(\d{1,2})(?::(\d{2}))?\s*(am|pm|a\.m\.|p\.m\.)/;
+        const bareRegex = /(?:@|\bat)\s*(\d{1,2})(?::(\d{2}))?\b/;
+        const toMeridiemTime = (token) => this.normalizeTimeString(
+            `${token[1]}:${token[2] || '00'}${token[3].replace(/\./g, '')}`
+        );
+        const meridiem = meridiemRegex.exec(text);
+        const bare = bareRegex.exec(text);
+        // "@ 8:30pm" produces overlapping bare ("@ 8") and meridiem
+        // ("8:30pm") hits — the meridiem token is the whole truth there. The
+        // bare token only wins when it is genuinely earlier and disjoint
+        // ("@ 8 til 2am").
+        const bareWins = bare && (!meridiem || (bare.index < meridiem.index
+            && meridiem.index >= bare.index + bare[0].length));
+        let startTime = '';
+        let matchEnd = -1;
+        if (bareWins) {
+            const hour = parseInt(bare[1], 10);
+            const minute = bare[2] ? parseInt(bare[2], 10) : 0;
+            if (hour >= 13 && hour <= 23 && minute >= 0 && minute <= 59) {
+                startTime = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+            } else if (hour >= 1 && hour <= 11 && minute >= 0 && minute <= 59) {
+                startTime = `${String(hour + 12).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+            }
+            matchEnd = bare.index + bare[0].length;
+        } else if (meridiem) {
+            startTime = toMeridiemTime(meridiem);
+            matchEnd = meridiem.index + meridiem[0].length;
+        }
+        if (!startTime) return null;
+        let endTime = '';
+        const tail = text.slice(matchEnd);
+        const rangeMatch = /^\s*(?:-|–|—|to|til|till|until|'til)\s*(\d{1,2})(?::(\d{2}))?\s*(am|pm|a\.m\.|p\.m\.)/.exec(tail);
+        if (rangeMatch) {
+            endTime = toMeridiemTime(rangeMatch);
+        }
+        return { startTime, endTime };
+    }
+
+    // Shared HH:MM normalization for day-phrase time tokens (delegates to
+    // the module-level start-time normalizer used everywhere else).
+    normalizeTimeString(value) {
+        return normalizeStartTimeValue(String(value || ''));
+    }
+
+    /**
+     * Corpus day-word evidence for a MODEL-provided rrule (the
+     * 'schedule-evidence' fallback): a WEEKLY/MONTHLY+BYDAY-only rule counts
+     * as evidenced when each BYDAY day has a weekly-shaped day phrase (and,
+     * for MONTHLY, its ordinal word adjacent to the day word) in the event's
+     * own corpus — the literal "FREQ=WEEKLY;BYDAY=WE" string is never on the
+     * page, and on dateless pages the model often cites paraphrased evidence
+     * that fails the verbatim check. Same fold rules as the deterministic
+     * extractor; bare singular weekday names do NOT count (they are how
+     * one-off dates are written); ordinal-adjacent prose contradicts WEEKLY
+     * ("EVERY 2ND FRIDAY" is monthly — the Lumberyard model error) and fails
+     * closed. Any rrule part beyond FREQ/BYDAY stays gated exactly as today.
+     */
+    rruleDayWordsEvidencedByCorpus(normalizedRrule, evidenceContext) {
+        const corpus = this.foldDayPhraseText(
+            evidenceContext && typeof evidenceContext.normalized === 'string' ? evidenceContext.normalized : ''
+        );
+        if (!corpus) return false;
+        const parts = {};
+        String(normalizedRrule || '').split(';').forEach(segment => {
+            const eq = segment.indexOf('=');
+            if (eq > 0) parts[segment.slice(0, eq)] = segment.slice(eq + 1);
+        });
+        if (Object.keys(parts).some(key => key !== 'FREQ' && key !== 'BYDAY')) return false;
+        const bydayTokens = parts.BYDAY ? parts.BYDAY.split(',').map(token => token.trim()).filter(Boolean) : [];
+        if (bydayTokens.length === 0) return false;
+        if (parts.FREQ === 'WEEKLY') {
+            return bydayTokens.every(token => {
+                const match = token.match(/^(MO|TU|WE|TH|FR|SA|SU)$/);
+                if (!match) return false;
+                const day = DAY_PHRASE_WEEKDAY_WORDS.find(entry => entry.code === match[1]);
+                const weeklyShaped = new RegExp(
+                    `\\bevery\\s+${day.word}s?\\b|\\b${day.word}s\\b|\\b${day.word}\\s+nights?\\b`);
+                const ordinalShaped = new RegExp(
+                    `\\b(?:${DAY_PHRASE_ORDINAL_ALTERNATION})\\s+${day.word}s?\\b`);
+                return weeklyShaped.test(corpus) && !ordinalShaped.test(corpus);
+            });
+        }
+        if (parts.FREQ === 'MONTHLY') {
+            if (bydayTokens.length !== 1) return false;
+            const match = bydayTokens[0].match(/^([+-]?\d)(MO|TU|WE|TH|FR|SA|SU)$/);
+            if (!match) return false;
+            const ordinal = DAY_PHRASE_ORDINAL_WORDS.find(entry => entry.value === Number(match[1]));
+            const day = DAY_PHRASE_WEEKDAY_WORDS.find(entry => entry.code === match[2]);
+            if (!ordinal || !day) return false;
+            return new RegExp(`\\b(?:${ordinal.words.join('|')})\\s+${day.word}s?\\b`).test(corpus);
+        }
+        return false;
+    }
+
+    /**
      * The rrule/recurrence validation class ('schedule-evidence' mode): the
      * VALUE is a derived translation, never verbatim, so the gate checks the
      * model's EVIDENCE phrase instead — it must be a verbatim corpus quote
      * (the same check other fields apply to values), contain schedule
      * vocabulary, the value must parse as an RRULE, and the schedule words
-     * must corroborate the rule. Returns { valid, reason }.
+     * must corroborate the rule. When the cited phrase is missing, not
+     * verbatim, or vocabulary-free, a WEEKLY/MONTHLY+BYDAY rule gets one
+     * deterministic second chance against the event's own corpus
+     * (rruleDayWordsEvidencedByCorpus) — a verbatim phrase that CONTRADICTS
+     * the rule ('schedule-mismatch') never does. Returns { valid, reason }.
      */
     validateRruleScheduleEvidence(value, modelEvidence, evidenceContext) {
         const normalizedRrule = this.normalizeRruleValue(value);
         if (!normalizedRrule) return { valid: false, reason: 'not-an-rrule' };
         const evidence = String(modelEvidence || '').trim();
+        if (evidence) {
+            if (this.evidenceAdmitsInference(evidence)) return { valid: false, reason: 'inference-evidence' };
+            if (this.hasExactEvidence(evidenceContext, evidence)
+                && this.evidenceContainsScheduleVocabulary(evidence)) {
+                return this.rruleMatchesScheduleEvidence(normalizedRrule, evidence)
+                    ? { valid: true, reason: '' }
+                    : { valid: false, reason: 'schedule-mismatch' };
+            }
+        }
+        if (this.rruleDayWordsEvidencedByCorpus(normalizedRrule, evidenceContext)) {
+            return { valid: true, reason: '' };
+        }
         if (!evidence) return { valid: false, reason: 'no-evidence' };
-        if (this.evidenceAdmitsInference(evidence)) return { valid: false, reason: 'inference-evidence' };
         if (!this.hasExactEvidence(evidenceContext, evidence)) return { valid: false, reason: 'evidence-not-verbatim' };
-        if (!this.evidenceContainsScheduleVocabulary(evidence)) return { valid: false, reason: 'no-schedule-vocabulary' };
-        if (!this.rruleMatchesScheduleEvidence(normalizedRrule, evidence)) return { valid: false, reason: 'schedule-mismatch' };
-        return { valid: true, reason: '' };
+        return { valid: false, reason: 'no-schedule-vocabulary' };
     }
 
     /**
@@ -11500,7 +11834,7 @@ TEXT:
         // recurrence), so the pickup must read that name too — battery run
         // 20260728: CubScout's validated FREQ=MONTHLY;BYDAY=1FR sat on
         // aiEvent.recurrence and never reached event.recurrenceRule.
-        const recurrenceRule = this.isPromptFieldRequested('rrule', parserConfig, promptFields, dataFlags)
+        let recurrenceRule = this.isPromptFieldRequested('rrule', parserConfig, promptFields, dataFlags)
             ? this.normalizeRruleValue(this.firstNonEmpty(
                 aiEvent.recurrenceRule,
                 aiEvent.recurrence,
@@ -11646,21 +11980,70 @@ TEXT:
         // these events stay withheld from calendar writes (display + ICS/
         // Builder export only). Unsupported rrule forms return null and the
         // event is discarded exactly as before.
+        // Dateless day-phrase synthesis (run 20260802-140413, The
+        // Lumberyard): a titled event with NO usable startDate and NO
+        // model rrule gets one deterministic scan of its OWN source text
+        // (the segment's text for multi-event segments, the prompt corpus
+        // otherwise) for an unambiguous weekday pattern. Exactly one
+        // distinct pattern → the derived RRULE joins the existing
+        // next-occurrence path below and the event flows into the existing
+        // recurring-withhold machinery (never a calendar write; ICS export
+        // only). Multiple distinct patterns with no clear association →
+        // fail closed, event dies on the required-startDate guard as today.
+        let dayPhraseSynthesis = null;
+        if (!startDate && title && !recurrenceRule) {
+            const dayPhraseSource = htmlData && typeof htmlData.segmentText === 'string' && htmlData.segmentText.trim()
+                ? htmlData.segmentText
+                : (htmlData && typeof htmlData.html === 'string' ? htmlData.html : '');
+            const derivedRecurrence = this.extractRecurrenceFromDayPhrases(dayPhraseSource, title);
+            if (derivedRecurrence && Array.isArray(derivedRecurrence.conflict)) {
+                console.log(`🔁 RECURRING: skipped day-phrase synthesis for "${title}" — multiple distinct day patterns in source (${derivedRecurrence.conflict.join(', ')}) with no clear association`);
+            } else if (derivedRecurrence) {
+                dayPhraseSynthesis = derivedRecurrence;
+                recurrenceRule = derivedRecurrence.rrule;
+            }
+        }
+
         let recurringDerivedNoStartTime = false;
+        let recurringDerivedWallClock = false;
         if (!startDate && title && recurrenceRule) {
             const schema = this.getEventSchema();
             const nextOccurrence = schema && typeof schema.computeNextRruleOccurrence === 'function'
                 ? schema.computeNextRruleOccurrence(recurrenceRule, this.now())
                 : null;
             if (nextOccurrence) {
-                const derivedStart = this.convertLocalDateTimeToUtc(`${nextOccurrence} ${startTimeRaw || '00:00:00'}`, timezone)
-                    || combineDateAndTime(nextOccurrence, startTimeRaw || '00:00')
+                const derivedStartTime = startTimeRaw || (dayPhraseSynthesis && dayPhraseSynthesis.startTime) || '';
+                const derivedStart = this.convertLocalDateTimeToUtc(`${nextOccurrence} ${derivedStartTime || '00:00:00'}`, timezone)
+                    || combineDateAndTime(nextOccurrence, derivedStartTime || '00:00')
                     || null;
                 if (derivedStart instanceof Date && !Number.isNaN(derivedStart.getTime())) {
                     startDate = derivedStart;
+                    // A day-phrase range ("8pm-12am") carries its own end
+                    // time; anchor it to the same occurrence date, rolling
+                    // past-midnight ends to the next day like the main
+                    // combination path does.
+                    const derivedEndTime = endTimeRaw || (dayPhraseSynthesis && dayPhraseSynthesis.endTime) || '';
+                    if (!endDate && derivedEndTime) {
+                        let derivedEnd = this.convertLocalDateTimeToUtc(`${nextOccurrence} ${derivedEndTime}`, timezone)
+                            || combineDateAndTime(nextOccurrence, derivedEndTime)
+                            || null;
+                        if (derivedEnd instanceof Date && !Number.isNaN(derivedEnd.getTime())) {
+                            if (derivedEnd.getTime() < derivedStart.getTime()) {
+                                derivedEnd = new Date(derivedEnd.getTime() + 24 * 60 * 60 * 1000);
+                            }
+                            endDate = derivedEnd;
+                        }
+                    }
                     if (!endDate) endDate = new Date(derivedStart);
-                    recurringDerivedNoStartTime = !startTimeRaw;
+                    recurringDerivedNoStartTime = !derivedStartTime;
+                    // No resolved timezone → the derived instant is wall-clock
+                    // components labeled UTC (the existing _timezoneUnresolved
+                    // convention); flag it for downstream re-anchoring.
+                    recurringDerivedWallClock = !timezone;
                     console.log(`🔁 RECURRING: derived next occurrence ${nextOccurrence} from rrule for "${title}"`);
+                    if (dayPhraseSynthesis) {
+                        console.log(`🔁 RECURRING: "${title}" synthesized from day phrase "${dayPhraseSynthesis.phrase}" → ${recurrenceRule}, next ${nextOccurrence} — will be withheld from calendar write (ICS only)`);
+                    }
                 }
             }
         }
@@ -11718,6 +12101,13 @@ TEXT:
             event._recurringNoStartTime = true;
         }
 
+        // Provenance for a deterministically synthesized recurrence: the
+        // matched day phrase that produced the rrule. Internal underscore
+        // field — excluded from calendar notes and merge field loops.
+        if (dayPhraseSynthesis) {
+            event._recurrenceFromDayPhrase = dayPhraseSynthesis.phrase;
+        }
+
         // AI free-text hygiene: the model copies JSON-LD/HTML descriptions
         // verbatim, markup included (CubScout shipped a raw <img …> tag as its
         // whole description). Apply the SAME stripTags + decodeBasicEntities +
@@ -11764,7 +12154,7 @@ TEXT:
             }
         }
 
-        if (usedWallClockFallback) {
+        if (usedWallClockFallback || recurringDerivedWallClock) {
             event._timezoneUnresolved = true;
         }
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -7395,9 +7395,13 @@ test('rrule validation rejects non-RRULE values, unverbatim evidence, and schedu
   assert.equal(prose.event.rrule, undefined, 'prose is not an RRULE');
   assert.equal(prose.report.dropped[0].reason, 'rrule-schedule-evidence');
 
-  // Evidence absent from the corpus → rejected.
+  // Evidence absent from the corpus AND no corpus day-word support for the
+  // rule → rejected. (BYDAY=1SA: the corpus names no Saturday, so the
+  // day-word fallback cannot rescue it — a 1FR rule with a fabricated
+  // pointer IS rescued now because "1ST FRIDAY OF THE MONTH" is literally
+  // in the corpus; see the corpus day-word fallback tests.)
   const absent = runRruleValidation(parser, {
-    rrule: 'FREQ=MONTHLY;BYDAY=1FR',
+    rrule: 'FREQ=MONTHLY;BYDAY=1SA',
     __fieldEvidence: { rrule: 'FIRST SATURDAY MONTHLY MEETUP' }
   });
   assert.equal(absent.event.rrule, undefined, 'evidence must be a verbatim corpus quote');
@@ -7514,6 +7518,260 @@ test('normalizeAiEvent still discards dateless events with unsupported or missin
     'unsupported rrule form → discarded exactly as before');
   assert.equal(parser.normalizeAiEvent({ title: 'Y' }, {}, null, null, null), null,
     'no rrule, no date → discarded exactly as before');
+});
+
+// ---------------------------------------------------------------------------
+// Dateless-weekly day-phrase synthesis (run 20260802-140413, The Lumberyard):
+// pages that state a weekday pattern but never a date — deterministic regex
+// turns the phrase into an rrule + next occurrence so the event reaches the
+// existing recurring-withhold machinery instead of dying on the
+// required-startDate guard
+// ---------------------------------------------------------------------------
+
+const LUMBERYARD_CITY_CONFIG = { seattle: { timezone: 'America/Los_Angeles', patterns: ['seattle'] } };
+const LUMBERYARD_QUEERAOKE_TEXT = 'QUEERAOKE Wednesday nights @ 8:30pm Come Join Bumper and Sing your heart out.';
+const LUMBERYARD_DRINK_DRAW_TEXT = 'Hosted by Nathan (except the last Tuesday - Drink and Draw)';
+
+function normalizeDayPhraseEvent(parser, aiEvent, sourceText, cityConfig = LUMBERYARD_CITY_CONFIG) {
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let event;
+  try {
+    event = parser.normalizeAiEvent(aiEvent, {}, { html: sourceText, url: 'https://www.thelumberyardbar.com/' }, cityConfig, null);
+  } finally {
+    console.log = originalLog;
+  }
+  return { event, logs };
+}
+
+test('day-phrase synthesis: the real QUEERAOKE string becomes a weekly Wednesday 8:30pm series', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 7, 3, 12, 0, 0); // Mon 2026-08-03 local
+
+  const { event, logs } = normalizeDayPhraseEvent(parser,
+    { title: 'QUEERAOKE', city: 'seattle' }, LUMBERYARD_QUEERAOKE_TEXT);
+  assert.ok(event, 'the dateless event survives normalization');
+  assert.equal(event.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE');
+  // Next Wednesday from Mon Aug 3 is Aug 5; 8:30pm PDT = Aug 6 03:30 UTC.
+  assert.equal(event.startDate.toISOString(), '2026-08-06T03:30:00.000Z');
+  assert.ok(event.startDate.getTime() > parser.now().getTime(), 'next occurrence is in the future');
+  assert.equal(event._recurringNoStartTime, undefined, 'captured @ 8:30pm keeps the ICS export');
+  assert.equal(event._recurrenceFromDayPhrase, 'wednesday nights', 'provenance stamps the matched phrase');
+  assert.equal(event._timezoneUnresolved, undefined, 'resolved timezone → real instant');
+  assert.ok(logs.includes('🔁 RECURRING: "QUEERAOKE" synthesized from day phrase "wednesday nights" → FREQ=WEEKLY;BYDAY=WE, next 2026-08-05 — will be withheld from calendar write (ICS only)'),
+    `synthesis log expected, got: ${JSON.stringify(logs.filter(line => line.includes('RECURRING')))}`);
+});
+
+test('day-phrase synthesis: the real Drink & Draw string becomes a last-Tuesday monthly series (no stated time → existing no-start-time convention)', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 7, 3, 12, 0, 0);
+
+  const { event, logs } = normalizeDayPhraseEvent(parser,
+    { title: 'Drink & Draw', city: 'seattle' }, LUMBERYARD_DRINK_DRAW_TEXT);
+  assert.ok(event, 'the dateless event survives normalization');
+  assert.equal(event.recurrenceRule, 'FREQ=MONTHLY;BYDAY=-1TU');
+  // Last Tuesday of Aug 2026 is Aug 25; no stated time → the existing
+  // derived-occurrence convention (local-midnight placeholder +
+  // _recurringNoStartTime, so the card offers the Event Builder link).
+  assert.equal(event.startDate.toISOString(), '2026-08-25T07:00:00.000Z');
+  assert.ok(event.startDate.getTime() > parser.now().getTime(), 'next occurrence is in the future');
+  assert.equal(event._recurringNoStartTime, true, 'no stated time rides the existing no-start-time flag');
+  assert.equal(event._recurrenceFromDayPhrase, 'last tuesday');
+  assert.ok(logs.includes('🔁 RECURRING: "Drink & Draw" synthesized from day phrase "last tuesday" → FREQ=MONTHLY;BYDAY=-1TU, next 2026-08-25 — will be withheld from calendar write (ICS only)'),
+    `synthesis log expected, got: ${JSON.stringify(logs.filter(line => line.includes('RECURRING')))}`);
+});
+
+test('day-phrase synthesis: "every Friday" and "2nd Saturday" variants, including a time range', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 7, 3, 12, 0, 0);
+
+  const friday = normalizeDayPhraseEvent(parser,
+    { title: 'BEAR NIGHT', city: 'seattle' }, 'BEAR NIGHT every Friday at 9pm with DJ Cub').event;
+  assert.ok(friday);
+  assert.equal(friday.recurrenceRule, 'FREQ=WEEKLY;BYDAY=FR');
+  assert.equal(friday.startDate.toISOString(), '2026-08-08T04:00:00.000Z', 'next Friday Aug 7, 9pm PDT');
+  assert.equal(friday._recurrenceFromDayPhrase, 'every friday');
+
+  const saturday = normalizeDayPhraseEvent(parser,
+    { title: 'UNDERWEAR PARTY', city: 'seattle' }, 'UNDERWEAR PARTY 2nd Saturday @ 10pm').event;
+  assert.ok(saturday);
+  assert.equal(saturday.recurrenceRule, 'FREQ=MONTHLY;BYDAY=2SA');
+  assert.equal(saturday.startDate.toISOString(), '2026-08-09T05:00:00.000Z', '2nd Saturday Aug 8, 10pm PDT');
+
+  // Range with an explicit end time: end anchors to the same occurrence.
+  const range = normalizeDayPhraseEvent(parser,
+    { title: 'BEER BUST', city: 'seattle' }, 'BEER BUST Sundays 4pm-9pm all are welcome').event;
+  assert.ok(range);
+  assert.equal(range.recurrenceRule, 'FREQ=WEEKLY;BYDAY=SU');
+  assert.equal(range.startDate.toISOString(), '2026-08-09T23:00:00.000Z', 'next Sunday Aug 9, 4pm PDT');
+  assert.equal(range.endDate.toISOString(), '2026-08-10T04:00:00.000Z', '9pm PDT end from the range tail');
+
+  // "-close" has no clock value: start captured, end left to defaulting.
+  const close = normalizeDayPhraseEvent(parser,
+    { title: 'EXPOSED', city: 'seattle' }, 'EXPOSED UNDERWEAR OR LESS Fridays 8pm-close').event;
+  assert.ok(close);
+  assert.equal(close.recurrenceRule, 'FREQ=WEEKLY;BYDAY=FR');
+  assert.equal(close.startDate.toISOString(), '2026-08-08T03:00:00.000Z', 'next Friday Aug 7, 8pm PDT');
+  assert.equal(close.endDate.toISOString(), close.startDate.toISOString(), 'no end claim → existing defaulting');
+});
+
+test('day-phrase synthesis fails closed on multiple distinct day patterns in one segment', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 7, 3, 12, 0, 0);
+
+  // A multi-pattern segment where the event's OWN day is stated right next
+  // to its title resolves by title adjacency: "Trivia Tuesday nights @ 7"
+  // is Trivia's schedule; the "last Tuesday" carve-out 40+ chars away
+  // belongs to the neighbouring Drink and Draw listing. (The rrule cannot
+  // express the "except" — the series is offered ICS-only and withheld from
+  // calendar writes, so the operator sees it before importing.)
+  const trivia = normalizeDayPhraseEvent(parser,
+    { title: 'Trivia', city: 'seattle' },
+    'Trivia Tuesday nights @ 7 Hosted by Nathan (except the last Tuesday - Drink and Draw)');
+  assert.ok(trivia.event, 'title-adjacent day phrase resolves the multi-pattern segment');
+  assert.equal(trivia.event.recurrenceRule, 'FREQ=WEEKLY;BYDAY=TU');
+  assert.equal(trivia.event._recurrenceFromDayPhrase, 'tuesday nights');
+  assert.equal(trivia.event.startDate.toISOString(), '2026-08-05T02:00:00.000Z', 'next Tuesday Aug 4, 7pm PDT from "@ 7"');
+
+  // The REAL Lumberyard trivia wording states no day for Trivia itself —
+  // "last Tuesday" (gap 30) belongs to Drink and Draw, outside the
+  // adjacency bound — so it still fails closed and dies as today.
+  const realTrivia = normalizeDayPhraseEvent(parser,
+    { title: 'Trivia Taco night', city: 'seattle' },
+    'Trivia Taco night Hosted by Nathan (except the last Tuesday - Drink and Draw) QUEERAOKE Wednesday nights @ 8:30pm');
+  assert.equal(realTrivia.event, null, 'no title-adjacent phrase → no synthesis, event dies as before');
+  assert.ok(realTrivia.logs.some(line => line.startsWith('🔁 RECURRING: skipped day-phrase synthesis for "Trivia Taco night" — multiple distinct day patterns in source (')),
+    `fail-closed log expected, got: ${JSON.stringify(realTrivia.logs.filter(line => line.includes('RECURRING')))}`);
+
+  // Directly conjoined day phrases are ONE multi-day listing — nearest-wins
+  // would silently drop half the schedule, so adjacency refuses.
+  const conjoined = normalizeDayPhraseEvent(parser,
+    { title: 'HAPPY HOUR', city: 'seattle' }, 'HAPPY HOUR Mondays and Thursdays 4pm');
+  assert.equal(conjoined.event, null, 'conjoined days stay ambiguous even when title-adjacent');
+
+  // Two different weekdays → same fail-closed path.
+  const twoDays = normalizeDayPhraseEvent(parser,
+    { title: 'HAPPY HOUR', city: 'seattle' }, 'HAPPY HOUR Mondays and Thursdays 4pm');
+  assert.equal(twoDays.event, null);
+
+  // A bare singular weekday is how one-off dates are written — never a pattern.
+  const bare = normalizeDayPhraseEvent(parser,
+    { title: 'ONE OFF', city: 'seattle' }, 'Join us Friday for a special show');
+  assert.equal(bare.event, null, 'bare singular weekday → no synthesis');
+});
+
+test('day-phrase synthesis without a resolved timezone follows the _timezoneUnresolved wall-clock convention', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 7, 3, 12, 0, 0);
+
+  const { event } = normalizeDayPhraseEvent(parser, { title: 'QUEERAOKE' }, LUMBERYARD_QUEERAOKE_TEXT, null);
+  assert.ok(event);
+  assert.equal(event.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE');
+  assert.equal(event.startDate.toISOString(), '2026-08-05T20:30:00.000Z', 'wall-clock components labeled UTC');
+  assert.equal(event._timezoneUnresolved, true, 'flagged for downstream re-anchoring');
+});
+
+test('day-phrase synthesis never fires when a real date is present (regression pin)', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 7, 3, 12, 0, 0);
+
+  const { event, logs } = normalizeDayPhraseEvent(parser,
+    { title: 'ONE-OFF PARTY', startDate: '2026-08-15', startTime: '21:00', city: 'seattle' },
+    'ONE-OFF PARTY Saturday August 15 — and come by every Friday for happy hour');
+  assert.ok(event);
+  assert.equal(event.startDate.toISOString(), '2026-08-16T04:00:00.000Z', 'the extracted real date stands');
+  assert.equal(event.recurrenceRule, '', 'no rrule synthesized over a dated event');
+  assert.equal(event._recurrenceFromDayPhrase, undefined);
+  assert.ok(!logs.some(line => line.includes('synthesized from day phrase')), 'no synthesis log');
+});
+
+test('model rrule with day-word corpus evidence passes the schedule-evidence gate without a verbatim pointer', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  const runWithCorpus = (aiEvent, corpus) => parser.validateAiEventEvidence(aiEvent, { html: corpus }, {}, null, {
+    evidenceContext: parser.buildAiEvidenceContextFromText(corpus),
+    validationContext: { imageEvidenceUrls: new Set() }
+  });
+
+  // No cited evidence at all → the corpus day-words carry the rule.
+  const noEvidence = runWithCorpus({ rrule: 'FREQ=WEEKLY;BYDAY=WE' }, LUMBERYARD_QUEERAOKE_TEXT);
+  assert.equal(noEvidence.event.rrule, 'FREQ=WEEKLY;BYDAY=WE', 'day-word corpus evidence accepted');
+  assert.deepEqual(noEvidence.report.dropped, []);
+
+  // Paraphrased (non-verbatim) pointer → rescued by corpus day-words.
+  const paraphrased = runWithCorpus({
+    rrule: 'FREQ=WEEKLY;BYDAY=WE',
+    __fieldEvidence: { rrule: 'happens weekly on Wednesday evenings' }
+  }, LUMBERYARD_QUEERAOKE_TEXT);
+  assert.equal(paraphrased.event.rrule, 'FREQ=WEEKLY;BYDAY=WE');
+
+  // Monthly ordinal: fabricated pointer, but the corpus states the ordinal
+  // day phrase verbatim ("1ST FRIDAY OF THE MONTH" in RRULE_TEST_CORPUS).
+  const monthly = runRruleValidation(parser, {
+    rrule: 'FREQ=MONTHLY;BYDAY=1FR',
+    __fieldEvidence: { rrule: 'FIRST FRIDAY MONTHLY MEETUP' }
+  });
+  assert.equal(monthly.event.rrule, 'FREQ=MONTHLY;BYDAY=1FR');
+
+  // A day the corpus never names → still dropped.
+  const wrongDay = runWithCorpus({ rrule: 'FREQ=WEEKLY;BYDAY=FR' }, LUMBERYARD_QUEERAOKE_TEXT);
+  assert.equal(wrongDay.event.rrule, undefined, 'no day-word support → gated as before');
+
+  // Bare singular weekday prose is a one-off date, not weekly evidence.
+  const bareSingular = runWithCorpus({ rrule: 'FREQ=WEEKLY;BYDAY=FR' }, 'Doors at 8, Friday, August 7');
+  assert.equal(bareSingular.event.rrule, undefined);
+});
+
+test('non-BYDAY-only rrules never use the corpus day-word fallback', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  const runWithCorpus = (aiEvent) => parser.validateAiEventEvidence(aiEvent, { html: LUMBERYARD_QUEERAOKE_TEXT }, {}, null, {
+    evidenceContext: parser.buildAiEvidenceContextFromText(LUMBERYARD_QUEERAOKE_TEXT),
+    validationContext: { imageEvidenceUrls: new Set() }
+  });
+
+  const interval = runWithCorpus({ rrule: 'FREQ=WEEKLY;BYDAY=WE;INTERVAL=2' });
+  assert.equal(interval.event.rrule, undefined, 'INTERVAL stays gated exactly as today');
+  const daily = runWithCorpus({ rrule: 'FREQ=DAILY' });
+  assert.equal(daily.event.rrule, undefined, 'no BYDAY → no fallback');
+});
+
+test('e2e: a day-phrase synthesized event is withheld from calendar writes (ICS export path)', async () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 7, 3, 12, 0, 0);
+  const { event } = normalizeDayPhraseEvent(parser,
+    { title: 'QUEERAOKE', city: 'seattle' }, LUMBERYARD_QUEERAOKE_TEXT);
+  assert.ok(event);
+  assert.equal(SharedCore.isRecurringSeriesEvent(event), true,
+    'the synthesized rrule lands on recurrenceRule — the key the series detection reads');
+
+  const core = new SharedCore({}, { eventSchema: EventSchema });
+  const adapter = { getExistingEvents: async () => [] };
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let analyzed;
+  try {
+    analyzed = await core.prepareEventsForCalendar([event], adapter, {});
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(analyzed.length, 1, "flag-don't-drop: the synthesized series stays in the results");
+  assert.equal(analyzed[0]._recurring, true);
+  assert.equal(analyzed[0]._recurringExport, true, 'stamped for the results-UI ICS export');
+  assert.equal(analyzed[0].recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'rrule survives for the ICS export');
+  assert.ok(logs.some(line => line.includes('🔁 RECURRING: "QUEERAOKE" withheld from calendar write — save via ICS export')),
+    `withhold log expected, got: ${JSON.stringify(logs.filter(line => line.includes('RECURRING')))}`);
+  assert.deepEqual(SharedCore.filterEventsForExecution(analyzed), [],
+    'NO calendar write action results from the synthesized series');
 });
 
 // ── Multilingual segment date signals (es/ca/fr/de/it/pt) ──────────────────

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -171,6 +171,53 @@ const COVER_FREE_PHRASES = new Set([
 // the city string itself, or a page's free text becomes a calendar name.
 const UNKNOWN_CALENDAR_NAME = 'chunky-dad-unknown';
 
+// ---------------------------------------------------------------------------
+// Title date/time vocabulary — ONE set of pattern fragments shared by
+// detectTitleDateSegment (the #1605 dates-stay-in-titles strip) and the
+// sanity classifier's date-phrase residue check (getEventSanityFlags), so a
+// date shape the strip learns the sanity check learns for free. These are the
+// EXACT fragments detectTitleDateSegment always used, hoisted unchanged.
+// ---------------------------------------------------------------------------
+const TITLE_DATE_MONTH_NUMBERS = {
+    jan: 1, january: 1, feb: 2, february: 2, mar: 3, march: 3,
+    apr: 4, april: 4, may: 5, jun: 6, june: 6, jul: 7, july: 7,
+    aug: 8, august: 8, sep: 9, sept: 9, september: 9,
+    oct: 10, october: 10, nov: 11, november: 11, dec: 12, december: 12
+};
+const TITLE_DATE_WEEKDAY_NAMES = '(?:mon(?:day)?|tue(?:s(?:day)?)?|wed(?:nesday)?|thu(?:r(?:s(?:day)?)?)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?)';
+const TITLE_DATE_WEEKDAY_PART = `(?:${TITLE_DATE_WEEKDAY_NAMES}\\.?,?\\s+)?`;
+const TITLE_DATE_MONTH_PART = '(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|june?|july?|aug(?:ust)?|sept?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\\.?';
+const TITLE_DATE_DAY_PART = '(\\d{1,2})(?:st|nd|rd|th)?';
+const TITLE_DATE_YEAR_PART = '(?:,?\\s+(\\d{4}))?';
+
+// Legalese phrase shapes for the title-looks-like-boilerplate sanity flag.
+// A generic legalese phrase table is DATA (like ADDRESS_STREET_TYPE_TOKENS
+// above), not per-page hardcoding: these are ticketing-terms markers that no
+// real event NAME contains. Matched case-insensitively on diacritic-folded,
+// punctuation-collapsed text ("NON-REFUNDABLE" ≡ "non refundable"). Observed
+// live: run 20260802-142231 (beefdip) proposed "DOG TAGS ARE NON REFUNDABLE ·
+// TAGS ARE NON TRANSFERABLE" — a liability waiver — as a CREATE.
+const TITLE_LEGALESE_PHRASES = Object.freeze([
+    'non refundable',
+    'non transferable',
+    'terms and conditions',
+    'all sales final'
+]);
+
+// start-long-past: a CREATE-shaped write whose start is further back than
+// this is almost certainly a stale page artifact (ONBEAR FEST proposed as
+// NEW at 2021-01-31, five years past). 370 keeps annual events that just
+// passed (365 + slack) out of the flag.
+const SANITY_START_LONG_PAST_DAYS = 370;
+// duration-implausible: longest span a single real event reaches. Verified
+// against data/festivals.json nextDates: the longest curated festival is
+// Bear Carnival at 10 days (2027-04-08 → 2027-04-18; Bears Sitges Week is 9,
+// BeefDip Bear Week 8), so 10 is the smallest bound that clears every
+// curated festival. The 19-month "Queer Art Market" (2025-03-22 →
+// 2026-10-18) flags; note the 9-day WHITE PARTY club night sits UNDER this
+// bound — a deterministic span rule cannot tell it from Bears Sitges Week.
+const SANITY_MAX_EVENT_DURATION_DAYS = 10;
+
 class SharedCore {
     constructor(cities, options = {}) {
         if (!cities || typeof cities !== 'object') {
@@ -1278,16 +1325,13 @@ class SharedCore {
         if (typeof title !== 'string') return null;
         const text = title.replace(/\s+/g, ' ').trim();
         if (!text) return null;
-        const MONTH_NUMBERS = {
-            jan: 1, january: 1, feb: 2, february: 2, mar: 3, march: 3,
-            apr: 4, april: 4, may: 5, jun: 6, june: 6, jul: 7, july: 7,
-            aug: 8, august: 8, sep: 9, sept: 9, september: 9,
-            oct: 10, october: 10, nov: 11, november: 11, dec: 12, december: 12
-        };
-        const weekdayPart = '(?:(?:mon(?:day)?|tue(?:s(?:day)?)?|wed(?:nesday)?|thu(?:r(?:s(?:day)?)?)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?)\\.?,?\\s+)?';
-        const monthPart = '(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|june?|july?|aug(?:ust)?|sept?(?:ember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\\.?';
-        const dayPart = '(\\d{1,2})(?:st|nd|rd|th)?';
-        const yearPart = '(?:,?\\s+(\\d{4}))?';
+        // Vocabulary hoisted to module scope (TITLE_DATE_*) so the sanity
+        // classifier's residue check shares these exact fragments.
+        const MONTH_NUMBERS = TITLE_DATE_MONTH_NUMBERS;
+        const weekdayPart = TITLE_DATE_WEEKDAY_PART;
+        const monthPart = TITLE_DATE_MONTH_PART;
+        const dayPart = TITLE_DATE_DAY_PART;
+        const yearPart = TITLE_DATE_YEAR_PART;
         const wordySegment = `${weekdayPart}${monthPart}\\s+${dayPart}${yearPart}`;
         // Day-first ordering — the British/European form the Bear Cave's
         // Sitges listings use ("Wednesday 9th September – BEEFMINCE MEET
@@ -1336,6 +1380,181 @@ class SharedCore {
     // callers hold a SharedCore instance.
     detectTitleDateSegment(title) {
         return SharedCore.detectTitleDateSegment(title);
+    }
+
+    // Residue of a title once date/time phrases are removed — the sanity
+    // classifier's view of "what is left that could be a NAME". Built from
+    // the SAME TITLE_DATE_* vocabulary as detectTitleDateSegment (which
+    // cannot serve here directly: it fails open when no base name remains,
+    // and a title that IS entirely a date is exactly the broken case).
+    // Removes, in order: clock times ("6:30 PM", "18.30"), hour+meridiem
+    // ("12 PM"), European hour marks ("01h", "06h30"), wordy month+day
+    // phrases with optional weekday/year ("Saturday Jan 23"), day-first
+    // phrases ("9th September"), numeric M/D(/Y) ("7/25/2026"), standalone
+    // weekday names, and standalone years. Bare month names are deliberately
+    // NOT removed ("May" is a word before it is a month). Returns the
+    // collapsed residue string, or null when nothing date/time-shaped was
+    // found (so a short but dateless title can never read as a date phrase).
+    static stripTitleDateTimePhrases(title) {
+        if (typeof title !== 'string') return null;
+        const text = title.replace(/\s+/g, ' ').trim();
+        if (!text) return null;
+        const patterns = [
+            /\b\d{1,2}[:.]\d{2}\s*(?:a\.?m\.?|p\.?m\.?|h)?(?![a-z0-9])/gi,
+            /\b\d{1,2}\s*(?:a\.?m\.?|p\.?m\.?)(?![a-z0-9])/gi,
+            /\b\d{1,2}\s*h(?:\d{2})?\b/gi,
+            new RegExp(`\\b${TITLE_DATE_WEEKDAY_PART}${TITLE_DATE_MONTH_PART}\\s+${TITLE_DATE_DAY_PART}${TITLE_DATE_YEAR_PART}\\b`, 'gi'),
+            new RegExp(`\\b${TITLE_DATE_WEEKDAY_PART}${TITLE_DATE_DAY_PART}\\s+${TITLE_DATE_MONTH_PART}${TITLE_DATE_YEAR_PART}\\b`, 'gi'),
+            /\b\d{1,2}\s*\/\s*\d{1,2}(?:\s*\/\s*\d{2,4})?\b/g,
+            new RegExp(`\\b${TITLE_DATE_WEEKDAY_NAMES}\\b\\.?`, 'gi'),
+            /\b(?:19|20)\d{2}\b/g
+        ];
+        let residue = text;
+        for (const pattern of patterns) {
+            residue = residue.replace(pattern, ' ');
+        }
+        residue = residue.replace(/\s+/g, ' ').trim();
+        return residue === text ? null : residue;
+    }
+
+    // ------------------------------------------------------------------
+    // REPORT-ONLY event sanity classifier (flag, don't drop). Deterministic
+    // shape rules + curated data only — no AI, no per-page/per-venue/
+    // per-language cases. Returns [{ code, detail }, ...]; empty = sane.
+    // Callers stamp the result on the underscore channel (_sanityFlags) for
+    // the results UI; NOTHING here changes _action, withholds a write, or
+    // reorders events. Real events that motivated each code are cited
+    // inline (all reached the 2026-08-02 write plans in preview mode).
+    // context.nowMs injects "now" (test determinism), defaulting to
+    // Date.now() — the same convention as the dead-end store's nowMs params.
+    // ------------------------------------------------------------------
+    getEventSanityFlags(event, context = {}) {
+        const flags = [];
+        if (!event || typeof event !== 'object') return flags;
+        const nowMs = context && Number.isFinite(context.nowMs) ? context.nowMs : Date.now();
+        const title = typeof event.title === 'string' ? event.title.replace(/\s+/g, ' ').trim() : '';
+        const toMs = (value) => {
+            if (value instanceof Date) return value.getTime();
+            if (typeof value === 'string' && value.trim()) return new Date(value).getTime();
+            return NaN;
+        };
+
+        // 1. title-is-date-phrase — the whole title is a date/time expression
+        //    ("Saturday Jan 23 12 PM – 5 PM", an event literally titled
+        //    "6:30 PM"), or near-nothing remains once date/time phrases are
+        //    stripped. Titles with real words beyond the date phrase ("NYE
+        //    2027 Party", "Friday Night Bears") keep ≥3 word characters of
+        //    residue and never flag.
+        if (title) {
+            const residue = SharedCore.stripTitleDateTimePhrases(title);
+            if (residue !== null) {
+                const residueWordChars = this.foldDiacritics(residue).replace(/[^a-z0-9]/g, '');
+                if (residueWordChars.length < 3) {
+                    flags.push({
+                        code: 'title-is-date-phrase',
+                        detail: `title is entirely a date/time expression`
+                    });
+                }
+            }
+        }
+
+        // 2. title-is-curated-bar — the title IS a curated bar name ("CC
+        //    Slaughters" as the title of a party). Identity-key EQUALITY only
+        //    (normalizeBarNameKey, the same strictness as curated matching
+        //    everywhere): "Bearracuda at CC Slaughters" contains the key but
+        //    does not equal it, so it never flags. The event's own city's
+        //    bars are checked when curated; with no curated city, ANY city's
+        //    bars can claim the title (a venue name is not an event name in
+        //    any city).
+        if (title && this.normalizeBarNameKey(title)) {
+            let curatedMatch = null;
+            const cityBars = this.getCuratedCityBars(event.city);
+            if (cityBars) {
+                const bar = this.findCuratedBarByName(cityBars, title);
+                if (bar) curatedMatch = { bar, city: String(event.city) };
+            } else if (this.bars && typeof this.bars === 'object') {
+                for (const cityKey of Object.keys(this.bars)) {
+                    const bars = this.bars[cityKey];
+                    if (!Array.isArray(bars)) continue;
+                    const bar = this.findCuratedBarByName(bars, title);
+                    if (bar) {
+                        curatedMatch = { bar, city: cityKey };
+                        break;
+                    }
+                }
+            }
+            if (curatedMatch) {
+                flags.push({
+                    code: 'title-is-curated-bar',
+                    detail: `title is the curated bar "${curatedMatch.bar.name}" (${curatedMatch.city})`
+                });
+            }
+        }
+
+        // 3. title-looks-like-boilerplate — conservative on purpose:
+        //    (a) no letters at all (Unicode-aware, so non-Latin event names
+        //        are safe), or
+        //    (b) a legalese marker from TITLE_LEGALESE_PHRASES ("DOG TAGS
+        //        ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE" — a
+        //        liability waiver proposed as a CREATE).
+        //    Sentence fragments ("The weekend kicks off on") and filler
+        //    announcements ("En breve anunciaremos mas vendors") are
+        //    deliberately NOT detected here: telling a truncated sentence
+        //    from a legitimate name-length phrase deterministically means
+        //    grammar heuristics, and those false-positive on real event
+        //    names ("The Party Never Ends", "Where the Bears Are") — too
+        //    risky for a rule that must stay report-only credible. The AI
+        //    junk-title idea is deliberately out of scope this wave.
+        if (title) {
+            if (!/\p{L}/u.test(title)) {
+                flags.push({
+                    code: 'title-looks-like-boilerplate',
+                    detail: 'title contains no letters'
+                });
+            } else {
+                const paddedTitle = ` ${this.foldDiacritics(title).replace(/[^a-z0-9]+/g, ' ').replace(/\s+/g, ' ').trim()} `;
+                const legalese = TITLE_LEGALESE_PHRASES.find(phrase => paddedTitle.includes(` ${phrase} `));
+                if (legalese) {
+                    flags.push({
+                        code: 'title-looks-like-boilerplate',
+                        detail: `title carries legalese ("${legalese}")`
+                    });
+                }
+            }
+        }
+
+        // 4. start-long-past — a CREATE-shaped write more than
+        //    SANITY_START_LONG_PAST_DAYS in the past (ONBEAR FEST proposed
+        //    as NEW at 2021-01-31, five years past). CREATE-shaped only: a
+        //    normal UPDATE of a past calendar record is routine maintenance.
+        const action = typeof event._action === 'string' && event._action
+            ? event._action
+            : (event._analysis && typeof event._analysis.action === 'string' ? event._analysis.action : '');
+        const startMs = toMs(event.startDate);
+        if (action === 'new' && Number.isFinite(startMs)
+            && (nowMs - startMs) > SANITY_START_LONG_PAST_DAYS * 24 * 60 * 60 * 1000) {
+            const daysPast = Math.round((nowMs - startMs) / (24 * 60 * 60 * 1000));
+            flags.push({
+                code: 'start-long-past',
+                detail: `CREATE with startDate ${daysPast} days in the past (limit ${SANITY_START_LONG_PAST_DAYS})`
+            });
+        }
+
+        // 5. duration-implausible — endDate − startDate longer than any
+        //    curated festival (SANITY_MAX_EVENT_DURATION_DAYS; see the
+        //    constant for the festivals.json verification). Catches the
+        //    19-month "Queer Art Market" (2025-03-22 → 2026-10-18).
+        const endMs = toMs(event.endDate);
+        if (Number.isFinite(startMs) && Number.isFinite(endMs)
+            && (endMs - startMs) > SANITY_MAX_EVENT_DURATION_DAYS * 24 * 60 * 60 * 1000) {
+            const spanDays = Math.round(((endMs - startMs) / (24 * 60 * 60 * 1000)) * 10) / 10;
+            flags.push({
+                code: 'duration-implausible',
+                detail: `spans ${spanDays} days (longest curated festival is ${SANITY_MAX_EVENT_DURATION_DAYS})`
+            });
+        }
+
+        return flags;
     }
 
     // A value shaped like a street address is NEVER a venue name. Anchored on
@@ -10122,6 +10341,21 @@ class SharedCore {
                     if (recordedTrimFields.has(overlong.field)) continue;
                     analyzedEvent._evidenceLines.push(`⚠️ ${overlong.field} overlong (${overlong.value.length} > ${overlong.maxChars} chars) — calendar-sourced, not trimmed`);
                 }
+            }
+
+            // REPORT-ONLY sanity flags (flag, don't drop): deterministic
+            // shape checks for obviously-broken events that have reached
+            // write plans before — legal boilerplate as a title, a bare
+            // date/time as a title, a curated bar name as a title, a
+            // years-past CREATE, a multi-month "event". Stamped on the
+            // underscore channel (display-only, excluded from notes/merge
+            // serialization like _evidenceLines) and surfaced by the
+            // adapters. Flags NEVER change _action, withhold a write, or
+            // reorder anything — enforcement, if ever, is a separately
+            // approved change.
+            analyzedEvent._sanityFlags = this.getEventSanityFlags(analyzedEvent);
+            if (analyzedEvent._sanityFlags.length > 0) {
+                console.log(`⚠️ SANITY: "${analyzedEvent.title || 'Unknown'}" flagged ${analyzedEvent._sanityFlags.map(flag => flag.code).join(', ')} — ${analyzedEvent._sanityFlags[0].detail}`);
             }
 
             // Recurring series are display+export only: keep the card in the

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -12670,3 +12670,211 @@ test('classifyPageWithAi records cache hits and invalidation clears them via the
   // No provider invalidate → false, never throws.
   assert.equal(await core.invalidateAiClassificationCacheEntry(url, html, aiConfig, { read: async () => null }), false);
 });
+
+// ---------------------------------------------------------------------------
+// REPORT-ONLY sanity flags (getEventSanityFlags): deterministic shape rules
+// for obviously-broken events that reached the 2026-08-02 write plans in
+// preview mode — legal boilerplate as a title (beefdip run 20260802-142231),
+// a bare date/time as a title, a curated bar name as a title, a 5-years-past
+// CREATE (ONBEAR FEST at 2021-01-31), a 19-month "event". Flags never change
+// _action, withhold, or reorder — see the no-enforcement twin test below.
+// ---------------------------------------------------------------------------
+
+const SANITY_NOW_MS = Date.parse('2026-08-02T12:00:00Z');
+const SANITY_CITIES = { portland: { timezone: 'America/Los_Angeles', patterns: ['portland'] } };
+const SANITY_BARS = { portland: [{ name: 'CC Slaughters' }] };
+
+function createSanityCore(bars = SANITY_BARS) {
+  return new SharedCore(SANITY_CITIES, { eventSchema: EventSchema, ...(bars ? { bars } : {}) });
+}
+
+function sanityCodes(core, event) {
+  return core.getEventSanityFlags(event, { nowMs: SANITY_NOW_MS }).map(flag => flag.code);
+}
+
+test('sanity: a title that is entirely a date/time expression flags title-is-date-phrase', () => {
+  const core = createSanityCore();
+  // Real write-plan titles: the whole title is a date+time range; an event
+  // literally titled "6:30 PM" (earlier run).
+  assert.deepEqual(sanityCodes(core, { title: 'Saturday Jan 23 12 PM – 5 PM' }), ['title-is-date-phrase']);
+  assert.deepEqual(sanityCodes(core, { title: '6:30 PM' }), ['title-is-date-phrase']);
+});
+
+test('sanity: titles with real words beyond the date phrase never flag as date phrases', () => {
+  const core = createSanityCore();
+  assert.deepEqual(sanityCodes(core, { title: 'NYE 2027 Party' }), []);
+  assert.deepEqual(sanityCodes(core, { title: 'Friday Night Bears' }), []);
+  // Time-range PREFIX with a real name after it — the name survives the
+  // strip, so the title flag stays off (its 9-day span is a separate rule,
+  // and sits under the festival bound — see the duration test).
+  assert.deepEqual(sanityCodes(core, { title: '01h a 06h WHITE PARTY en «BEARS DISCO» by Scandal' }), []);
+});
+
+test('sanity: a curated bar name as the whole title flags; containment never does', () => {
+  const core = createSanityCore();
+  // Real case: "CC Slaughters" (a curated bar) as the title of a party.
+  assert.deepEqual(sanityCodes(core, { title: 'CC Slaughters', city: 'portland' }), ['title-is-curated-bar']);
+  // Identity-key equality only — an event AT the bar keeps its name.
+  assert.deepEqual(sanityCodes(core, { title: 'Bearracuda at CC Slaughters', city: 'portland' }), []);
+  // Key normalization: "The CC-Slaughters!" collapses to the same key.
+  assert.deepEqual(sanityCodes(core, { title: 'The CC-Slaughters!', city: 'portland' }), ['title-is-curated-bar']);
+});
+
+test('sanity: with no resolved city, any city\'s curated bars can claim the title', () => {
+  const core = createSanityCore();
+  assert.deepEqual(sanityCodes(core, { title: 'CC Slaughters' }), ['title-is-curated-bar']);
+  // No bars data at all → fail open, no flag.
+  assert.deepEqual(sanityCodes(createSanityCore(null), { title: 'CC Slaughters' }), []);
+});
+
+test('sanity: legalese markers and letterless titles flag title-looks-like-boilerplate', () => {
+  const core = createSanityCore();
+  // Real case: a liability waiver proposed as a CREATE (beefdip,
+  // run 20260802-142231).
+  assert.deepEqual(
+    sanityCodes(core, { title: 'DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE' }),
+    ['title-looks-like-boilerplate']);
+  // Diacritic-folded + punctuation-collapsed matching.
+  assert.deepEqual(sanityCodes(core, { title: 'Entradas NON-REFUNDÁBLE' }), ['title-looks-like-boilerplate']);
+  // No letters at all.
+  assert.deepEqual(sanityCodes(core, { title: '*** !!! ***' }), ['title-looks-like-boilerplate']);
+});
+
+test('sanity: sentence fragments and filler announcements are DELIBERATELY not flagged', () => {
+  const core = createSanityCore();
+  // Real junk that stays unflagged on purpose: detecting truncated sentences
+  // ("The weekend kicks off on") or filler ("En breve anunciaremos mas
+  // vendors") deterministically means grammar heuristics that false-positive
+  // on legitimate names ("Where the Bears Are"). Out of scope this wave —
+  // the AI junk-title idea is a separate, later decision.
+  assert.deepEqual(sanityCodes(core, { title: 'The weekend kicks off on' }), []);
+  assert.deepEqual(sanityCodes(core, { title: 'En breve anunciaremos mas vendors' }), []);
+});
+
+test('sanity: a CREATE more than 370 days past flags start-long-past; updates and recent creates never do', () => {
+  const core = createSanityCore();
+  // Real case: ONBEAR FEST proposed as NEW at 2021-01-31 — five years past.
+  assert.deepEqual(
+    sanityCodes(core, { title: 'ONBEAR FEST', _action: 'new', startDate: '2021-01-31T20:00:00Z' }),
+    ['start-long-past']);
+  // A normal past-event UPDATE is routine calendar maintenance.
+  assert.deepEqual(
+    sanityCodes(core, { title: 'ONBEAR FEST', _action: 'merge', startDate: '2021-01-31T20:00:00Z' }),
+    []);
+  // Real case under the bound: ursamen's "Out of Hibernation" carried a date
+  // ~5 months past — inside 370 days, so this rule stays silent (the bound
+  // exists to keep just-passed annual events out of the flag).
+  assert.deepEqual(
+    sanityCodes(core, { title: 'Out of Hibernation', _action: 'new', startDate: '2026-03-01T20:00:00Z' }),
+    []);
+  // _analysis.action counts as CREATE-shaped too.
+  assert.deepEqual(
+    sanityCodes(core, { title: 'ONBEAR FEST', _analysis: { action: 'new' }, startDate: '2021-01-31T20:00:00Z' }),
+    ['start-long-past']);
+});
+
+test('sanity: spans longer than any curated festival flag duration-implausible; festival-length spans never do', () => {
+  const core = createSanityCore();
+  // Real case: "Queer Art Market" spanning 2025-03-22 → 2026-10-18 (19
+  // months), proposed for writing.
+  const market = { title: 'Queer Art Market', _action: 'new', startDate: '2025-03-22T10:00:00Z', endDate: '2026-10-18T20:00:00Z' };
+  assert.ok(sanityCodes(core, market).includes('duration-implausible'));
+  // Bound verified against data/festivals.json: the longest curated festival
+  // is Bear Carnival at 10 days; Bears Sitges Week is 9. Both must stay
+  // clean, so >10 days is the smallest safe bound — which also means the
+  // 9-day WHITE PARTY club night sits UNDER it (indistinguishable from
+  // Bears Sitges Week by span alone; its flags must come from other rules).
+  assert.deepEqual(
+    sanityCodes(core, { title: 'Bear Week Provincetown', startDate: '2027-07-10T00:00:00Z', endDate: '2027-07-17T00:00:00Z' }),
+    [], 'a 7-day festival is clean');
+  assert.deepEqual(
+    sanityCodes(core, { title: 'Bears Sitges Week', startDate: '2026-09-04T00:00:00Z', endDate: '2026-09-13T00:00:00Z' }),
+    [], 'the 9-day curated festival is clean');
+  assert.deepEqual(
+    sanityCodes(core, { title: 'Bear Carnival', startDate: '2027-04-08T00:00:00Z', endDate: '2027-04-18T00:00:00Z' }),
+    [], 'the 10-day longest curated festival is clean');
+  assert.deepEqual(
+    sanityCodes(core, { title: 'Some Party', startDate: '2026-08-01T00:00:00Z', endDate: '2026-08-12T06:00:00Z' }),
+    ['duration-implausible'], 'past the longest curated festival → flagged');
+});
+
+test('sanity: getEventSanityFlags never mutates the event and stacks multiple flags', () => {
+  const core = createSanityCore();
+  const event = {
+    title: 'Queer Art Market',
+    _action: 'new',
+    startDate: '2025-03-22T10:00:00Z',
+    endDate: '2026-10-18T20:00:00Z'
+  };
+  const snapshot = JSON.parse(JSON.stringify(event));
+  const flags = core.getEventSanityFlags(event, { nowMs: SANITY_NOW_MS });
+  assert.deepEqual(flags.map(flag => flag.code), ['start-long-past', 'duration-implausible']);
+  assert.ok(flags.every(flag => typeof flag.detail === 'string' && flag.detail.length > 0));
+  assert.deepEqual(JSON.parse(JSON.stringify(event)), snapshot, 'classifier is read-only');
+});
+
+test('sanity flags are stamped on the analyzed event with the ⚠️ SANITY log line', async () => {
+  const core = createCore();
+  const adapter = buildPrepCalendarAdapter([]); // no existing events → CREATE
+  const scraped = {
+    title: 'DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE',
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    bar: 'STATION 4',
+    city: 'dallas',
+    shortName: 'TAGS' // keeps the shortName derivation pass inert
+  };
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logLines.push(args.join(' ')); };
+  let analyzed;
+  try {
+    analyzed = await core.prepareEventsForCalendar([scraped], adapter, {});
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(analyzed.length, 1);
+  assert.deepEqual(analyzed[0]._sanityFlags.map(flag => flag.code), ['title-looks-like-boilerplate']);
+  const sanityLines = logLines.filter(line => line.startsWith('⚠️ SANITY: '));
+  assert.equal(sanityLines.length, 1);
+  assert.equal(
+    sanityLines[0],
+    '⚠️ SANITY: "DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE" flagged title-looks-like-boilerplate — title carries legalese ("non refundable")');
+});
+
+test('no enforcement: a flagged event\'s action and write fields are byte-identical to an unflagged twin\'s', async () => {
+  const core = createCore();
+  const buildTwin = (title) => ({
+    title,
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    bar: 'STATION 4',
+    city: 'dallas',
+    shortName: 'TAGS'
+  });
+  const flagged = await core.prepareEventsForCalendar(
+    [buildTwin('DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE')],
+    buildPrepCalendarAdapter([]), {});
+  const twin = await core.prepareEventsForCalendar(
+    [buildTwin('DOG TAGS BEAR PARTY')],
+    buildPrepCalendarAdapter([]), {});
+
+  assert.equal(flagged.length, 1, 'the flagged event is never withheld');
+  assert.equal(twin.length, 1);
+  assert.ok(flagged[0]._sanityFlags.length > 0, 'the boilerplate twin is flagged');
+  assert.deepEqual(twin[0]._sanityFlags, [], 'the clean twin is not');
+
+  // Every action/write field the calendar write path reads is byte-identical
+  // (title differs by construction; _sanityFlags is display-only).
+  const writeShape = (event) => JSON.stringify({
+    action: event._action,
+    analysisAction: event._analysis.action,
+    startDate: event.startDate,
+    endDate: event.endDate,
+    bar: event.bar,
+    city: event.city,
+    shortName: event.shortName,
+    notes: event.notes
+  });
+  assert.equal(writeShape(flagged[0]), writeShape(twin[0]));
+});


### PR DESCRIPTION
Two additions from the run review, one PR. Both ride existing machinery and neither changes what gets written to a calendar.

## 1. Event sanity flags — report-only

Deterministic `getEventSanityFlags` classifier for the junk that reached the write plan on 2026-08-02 (preview mode caught it):

| Real value | Flag |
|---|---|
| `DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE` (BeefDip's liability waiver, proposed as CREATE in sf) | `title-looks-like-boilerplate` |
| `Saturday Jan 23 12 PM – 5 PM`, `6:30 PM` | `title-is-date-phrase` (reuses the #1605 date-strip vocabulary) |
| `CC Slaughters` as a party title | `title-is-curated-bar` (identity-key equality; `Bearracuda at CC Slaughters` doesn't flag) |
| ONBEAR FEST at 2021-01-31 proposed as new | `start-long-past` (>370 days, sparing just-passed annuals) |
| Queer Art Market spanning 19 months | `duration-implausible` |

Surfaced as: one `⚠️ SANITY:` log line, a card badge, a summary count (only when >0), and a web-adapter detail line. **Flag-don't-drop, pinned by test**: a flagged event's `_action`, dates, and notes are byte-identical to an unflagged twin's.

Two honest limits, documented in code + tests rather than papered over: the duration bound is **>10 days because Bear Carnival is legitimately 10 days** in curated festivals (so the 9-day WHITE PARTY span stays unflagged — indistinguishable from Bears Sitges Week); and sentence fragments (`En breve anunciaremos mas vendors`) are deliberately not detected — grammar heuristics would false-positive on real names like "Where the Bears Are".

## 2. Dateless weeklies → recurring, ICS-only (Stanley-approved design)

The Lumberyard's own site produced **0 events** — not a parse bug: the page states schedules without dates (*"QUEERAOKE Wednesday nights @ 8:30pm"*). Now: deterministic day-phrase extraction (weekly + monthly-ordinal shapes, generic English tables, no AI calls, no prompt changes) synthesizes an rrule + next occurrence, and the event flows into the **existing recurring-withhold path** — never a calendar write, offered as ICS export, exactly like the Eagle LA weeklies already do. A model-provided `BYDAY` rrule whose day-words appear in the corpus also passes the verbatim evidence gate now.

The part that made it actually work on the real page (where segmentation finds no segments, so the corpus is the whole page with four day patterns): **title-adjacency disambiguation** — the phrase nearest the event's own title, within 25 folded chars. The bound is measured, not guessed: correct pairs on the real cached page sit at gaps 1/3/6; the closest wrong pair at 30. Two refinements caught during verification against the real page:
- Directly conjoined days (`Mondays and Thursdays`) stay ambiguous — nearest-wins would silently drop half a schedule.
- Time-capture windows stop at the next weekday word — previously Drink & Draw inherited QUEERAOKE's 8:30pm and Dolly captured the Sunday hang's 2-6pm.

End state on the real cached Lumberyard page:

```
QUEERAOKE          → FREQ=WEEKLY;BYDAY=WE, 8:30pm   (withheld, ICS-only)
Drink & Draw       → FREQ=MONTHLY;BYDAY=-1TU, no time (correctly)
Dolly and the DJ   → FREQ=WEEKLY;BYDAY=SA, no time  (correctly)
Trivia Taco night  → dies (correct — its day is genuinely not stated on the page)
```

## Verification

- Suite: **1274 pass, 0 fail** (1251 baseline + 23 new).
- Sanity classifier probed against all 11 real values + near-misses with the full curated corpus.
- Weekly synthesis verified end-to-end against the **real cached page** from the phone, not synthetic fixtures — which is exactly how the segmentless multi-pattern gap and both time-bleed bugs were found.
- No prompt lines touched (AI cache unaffected), no existing log text changed, no `new URL`, nothing per-venue, no new runtime files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP