### PR TITLE
fix(scraper): same-event URL identity dedup + Dallas Eagle venue-site repoint

### DIFF
--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -94,7 +94,14 @@ const scraperConfig = {
     },
     {
       name: "Dallas Eagle",
-      urls: ["https://www.eventbrite.com/o/77139864473"],
+      // Venue-site repoint (2026-08-02, same shape as the Eagle LA fix in
+      // #1609): the Eventbrite org page /o/77139864473 is structurally dry —
+      // it lists nothing while the real events (dated "Start from:/End at:"
+      // listings plus "Every Wednesday" weeklies) live on the venue's own
+      // /events/ page, whose links the org-page crawl rejected as cross-host.
+      // The "End at:" start-time trap is covered by #1540's end-marker gate;
+      // dateless weeklies flow into the #1616 ICS-only recurrence path.
+      urls: ["https://www.thedallaseagle.com/events/"],
       metadata: {
         website: { value: "https://www.thedallaseagle.com" },
         facebook: { value: "https://www.facebook.com/lonestareagle" },

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1241,18 +1241,30 @@ class SharedCore {
         return 'square';
     }
 
-    // Normalized view of a description for the strict-superset merge rule:
-    // lowercased, basic HTML entities decoded, whitespace collapsed. BOTH
-    // candidates pass through this, so entity/whitespace differences never
-    // block a genuine containment.
-    normalizeDescriptionForContainment(value) {
+    // Basic HTML entity decoding shared by description containment, dedup
+    // title keys, and title similarity: the standard named/numeric entities
+    // that survive scraping (&amp;, quote/apostrophe forms, &nbsp;, dashes,
+    // ellipsis). Entities only — case folding, whitespace collapsing, and
+    // unicode-twin folding stay with the callers. Run 20260802-135030: the
+    // venue-site copy of "Club Nyc presents : R &amp; B Night Showcase"
+    // could never key-collide with its decoded eventim twin because the raw
+    // entity's letters ("amp") survived into the normalized title.
+    decodeBasicHtmlEntities(value) {
         return String(value || '')
             .replace(/&amp;/gi, '&')
             .replace(/&(?:rsquo|lsquo|apos|#8217|#8216|#39);/gi, "'")
             .replace(/&(?:rdquo|ldquo|quot|#8221|#8220|#34);/gi, '"')
             .replace(/&(?:nbsp|#160);/gi, ' ')
             .replace(/&(?:ndash|mdash|#8211|#8212);/gi, '-')
-            .replace(/&(?:hellip|#8230);/gi, '...')
+            .replace(/&(?:hellip|#8230);/gi, '...');
+    }
+
+    // Normalized view of a description for the strict-superset merge rule:
+    // lowercased, basic HTML entities decoded, whitespace collapsed. BOTH
+    // candidates pass through this, so entity/whitespace differences never
+    // block a genuine containment.
+    normalizeDescriptionForContainment(value) {
+        return this.decodeBasicHtmlEntities(value)
             // Fold the literal unicode twins of those entities too, so an
             // entity-encoded copy contains its decoded (curly-quote) twin.
             .replace(/[\u2018\u2019]/g, "'")
@@ -6667,12 +6679,37 @@ class SharedCore {
         return true;
     }
 
+    // Additive log for the URL-identity dedup signals: when a merge was
+    // decided by the event-page URL (not by key/place/name), name the shared
+    // page so run logs show WHY two differently-shaped records merged.
+    logUrlIdentityDedupSignal(signal, event, match) {
+        if (signal !== 'event-page-url' && signal !== 'event-url-id') return;
+        const page = this.getEventPageUrlIdentity(event) || this.getEventPageUrlIdentity(match);
+        const where = page ? page.hostPath : 'unknown-url';
+        console.log(`🔗 DEDUP: "${event.title || 'event'}" matched "${match.title || 'event'}" by event-page URL identity (${where})`);
+    }
+
     async deduplicateEvents(events, httpAdapter, globalConfig = null) {
         const seen = new Map();
         const deduplicated = [];
-        
+
         // Log progress for large batches
         const logProgress = events.length > 10;
+
+        // Fan-in guard for the URL-identity signals (the first-pass twin of
+        // the second pass's listing-page rule below): an event-page identity
+        // shared by 3+ records in one batch is a listing/hub page, not an
+        // event page, so it must never make two records "the same".
+        const pageIdentityCounts = new Map();
+        for (const event of events) {
+            const page = this.getEventPageUrlIdentity(event);
+            if (page) pageIdentityCounts.set(page.hostPath, (pageIdentityCounts.get(page.hostPath) || 0) + 1);
+        }
+        const excludedUrlIdentityHostPaths = new Set();
+        for (const [hostPath, count] of pageIdentityCounts) {
+            if (count >= 3) excludedUrlIdentityHostPaths.add(hostPath);
+        }
+        const identityScanOptions = { requireCloseStartTimes: false, excludedUrlIdentityHostPaths };
 
         for (const event of events) {
             const key = this.createEventKey(event);
@@ -6723,11 +6760,15 @@ class SharedCore {
                     // an existing event by ticketUrl/identity, so run the identity scan
                     // before pushing it as new. The vetoed base-key holder is excluded —
                     // its place mismatch already proved it is a different event.
-                    const identityMatch = deduplicated.find(existing =>
-                        existing !== keyMatch &&
-                        this.getSameEventIdentitySignal(event, existing, { requireCloseStartTimes: false }));
+                    let vetoScanSignal = null;
+                    const identityMatch = deduplicated.find(existing => {
+                        if (existing === keyMatch) return false;
+                        vetoScanSignal = this.getSameEventIdentitySignal(event, existing, identityScanOptions);
+                        return Boolean(vetoScanSignal);
+                    });
                     if (identityMatch) {
                         console.log(`🔄 SharedCore: Key collision variant match — merging "${event.title || 'event'}" into "${identityMatch.title || 'event'}" via identity scan`);
+                        this.logUrlIdentityDedupSignal(vetoScanSignal, event, identityMatch);
                         await mergeIntoExisting(identityMatch);
                         continue;
                     }
@@ -6748,10 +6789,14 @@ class SharedCore {
             // No key match — degraded fields (e.g. a missing start time defaulting to
             // midnight) make keys brittle, so scan for a same-event identity match
             // before accepting the event as new.
-            const identityMatch = deduplicated.find(existing =>
-                this.getSameEventIdentitySignal(event, existing, { requireCloseStartTimes: false }));
+            let identityScanSignal = null;
+            const identityMatch = deduplicated.find(existing => {
+                identityScanSignal = this.getSameEventIdentitySignal(event, existing, identityScanOptions);
+                return Boolean(identityScanSignal);
+            });
             if (identityMatch) {
                 console.log(`🔄 SharedCore: Identity match without key match — merging "${event.title || 'event'}" into "${identityMatch.title || 'event'}"`);
+                this.logUrlIdentityDedupSignal(identityScanSignal, event, identityMatch);
                 await mergeIntoExisting(identityMatch);
                 continue;
             }
@@ -6923,6 +6968,13 @@ class SharedCore {
         
         // Apply the original title normalization for ${normalizedTitle}
         if (format.includes('${normalizedTitle}')) {
+            // HTML entities fold BEFORE the special-char collapse: "R &amp; B"
+            // and "R & B" name the same event, but the raw entity's letters
+            // ("amp") would otherwise survive into the key as a real word
+            // (run 20260802-135030: "Club Nyc presents : R &amp; B Night
+            // Showcase" keyed as ...r-amp-b... while its decoded eventim twin
+            // keyed as ...r-b...).
+            normalizedTitle = this.decodeBasicHtmlEntities(normalizedTitle);
             // Generic text normalization for better deduplication
             normalizedTitle = normalizedTitle
                 // Replace sequences of special chars between letters with a single hyphen
@@ -11140,9 +11192,11 @@ class SharedCore {
     areTitlesSimilar(title1, title2) {
         if (!title1 || !title2) return false;
         
-        // Normalize titles for comparison
+        // Normalize titles for comparison. Entities decode first so "R &amp; B"
+        // and "R & B" compare equal — the raw entity's letters ("amp") would
+        // otherwise survive the special-char strip as if they were a word.
         const normalize = (str) => {
-            return str
+            return this.decodeBasicHtmlEntities(str)
                 .toLowerCase()
                 .replace(/[^a-z0-9]/g, '') // Remove special chars
                 .replace(/\s+/g, ''); // Remove spaces
@@ -11310,6 +11364,36 @@ class SharedCore {
             return 'ticket-url';
         }
 
+        // Two records pointing at the same event PAGE are the same event:
+        // same www-folded host and identical path with the query/fragment
+        // stripped (an ?afflky affiliate tag decorates the page, it doesn't
+        // distinguish events). Weaker sibling: same host and the same
+        // id-shaped trailing path segment — the platform's event id — which
+        // catches slug-only rewrites of one event page ("…POOL-PARTY/696752"
+        // vs "…DANCE-PARTY/696752", run 20260802-135030). Both signals
+        // inherit the same-local-day guard above, so a reused event page for
+        // a different night (or a record whose start drifted by days) never
+        // merges; bare-root urls never reach here (getEventPageUrlIdentity
+        // returns null for them). options.excludedUrlIdentityHostPaths lets
+        // deduplicateEvents suppress paths shared by 3+ records in one batch
+        // — that fan-in is a listing/hub page, not an event page (same rule
+        // as the second-pass same-URL merge).
+        const incomingPage = this.getEventPageUrlIdentity(newEvent);
+        const existingPage = this.getEventPageUrlIdentity(existingEvent);
+        const excludedHostPaths = options.excludedUrlIdentityHostPaths || null;
+        const pageExcluded = Boolean(excludedHostPaths &&
+            (excludedHostPaths.has(incomingPage && incomingPage.hostPath) ||
+             excludedHostPaths.has(existingPage && existingPage.hostPath)));
+        if (incomingPage && existingPage && !pageExcluded) {
+            if (incomingPage.hostPath === existingPage.hostPath) {
+                return 'event-page-url';
+            }
+            if (incomingPage.host === existingPage.host &&
+                incomingPage.trailingId && incomingPage.trailingId === existingPage.trailingId) {
+                return 'event-url-id';
+            }
+        }
+
         // Same place, roughly the same start time (tolerant of legacy wall-clock offsets),
         // and any pair of name-ish fields (title/name/shortName) similar.
         if ((!requireCloseStartTimes || this.areDatesEqual(incoming.startDate, existing.startDate, 120)) &&
@@ -11364,6 +11448,40 @@ class SharedCore {
             : {};
         if (Object.prototype.hasOwnProperty.call(staticFields, 'website')) return null;
         return this.getEventUrlIdentityKey(event && event.website);
+    }
+
+    // Event-page URL identity for getSameEventIdentitySignal. Built on
+    // getEventIdentityUrlKey, so everything that helper already excludes —
+    // missing/non-http urls, bare domain roots (a homepage is where events
+    // were FOUND, not what they ARE), and statically stamped websites — never
+    // yields an identity here. The query/fragment is stripped on top of that:
+    // affiliate tags (?afflky=3DollarBill, run 20260802-135030 LORAX XCX)
+    // decorate the SAME event page, they don't distinguish events. The host
+    // is www-folded (the existing host-comparison convention, e.g.
+    // applyAggregatorWebsitePointers); the path stays case-sensitive.
+    // trailingId is the final path segment when it is id-shaped: ALL digits,
+    // length >= 5. Ticketing platforms key the event by that trailing id
+    // while the slug before it is editorial and drifts ("…POOL-PARTY/696752"
+    // vs "…DANCE-PARTY/696752"). Five digits, not four: calendar years are
+    // real path segments in this corpus (wp-content/uploads/2026/…) and
+    // pagination numbers (/page/2) are shorter still, while every observed
+    // platform event id has at least five (tixr /e/199620, etix 54403374,
+    // ticketweb 14269444, eventim 696752/700051/699269).
+    getEventPageUrlIdentity(event) {
+        const key = this.getEventIdentityUrlKey(event);
+        if (!key) return null;
+        const withoutQuery = key.split('?')[0];
+        const match = withoutQuery.match(/^https?:\/\/([^/]+)(\/.+)$/);
+        if (!match) return null;
+        const host = match[1].replace(/^www\./, '');
+        const path = match[2];
+        const segments = path.split('/').filter(Boolean);
+        const lastSegment = segments.length > 0 ? segments[segments.length - 1] : '';
+        return {
+            host,
+            hostPath: `${host}${path}`,
+            trailingId: /^\d{5,}$/.test(lastSegment) ? lastSegment : null
+        };
     }
 
     // Sanity window for same-URL dedup: recurring events reuse their event page,

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -3864,6 +3864,330 @@ test('deduplicateEvents merges a vetoed event into a suffixed holder via the ide
   assert.equal(result.length, 2, 'shared ticketUrl on the same local day must merge the vetoed event');
 });
 
+// === Run 20260802-135030: 3dollarbillbk.com + its eventim ticketing pages ===
+// Six verbatim records were three real events and duplicatesRemoved was 1.
+// URL identity (same event page modulo query/fragment; same trailing platform
+// id) and HTML-entity folding close the gaps. All field values below are
+// verbatim from the run JSON.
+
+function buildLoraxEventim() {
+  return {
+    title: 'LORAX XCX',
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    bar: '3 Dollar Bill',
+    address: '260 Meserole St, Brooklyn, NY, 11206',
+    url: 'https://wl.eventim.us/event/LORAX-XCX/700051?afflky=3DollarBill',
+    ticketUrl: 'https://wl.eventim.us/event/LORAX-XCX/700051',
+    website: 'https://www.3dollarbillbk.com',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+}
+
+function buildLoraxDegraded() {
+  return {
+    title: 'LORAX XCX',
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    endDate: new Date('2026-08-08T02:00:00.000Z'), // zero duration
+    bar: '3 Dollar Bill',
+    address: '260 Meserole Dr, Brooklyn, NY', // Dr vs St, no zip
+    url: 'https://wl.eventim.us/event/LORAX-XCX/700051',
+    ticketUrl: 'https://3dollarbillbk.com',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+}
+
+function buildRainEventim(urlSlug) {
+  return {
+    title: 'RAIN ON ME - An Ariana X Gaga DANCE PARTY',
+    startDate: new Date('2026-08-02T20:00:00.000Z'),
+    endDate: new Date('2026-08-03T03:45:00.000Z'),
+    bar: '9 Bob Note',
+    address: '270 Meserole St, Brooklyn, NY, 11206',
+    url: `https://www.eventim.us/event/${urlSlug}/696752`,
+    ticketUrl: 'https://www.eventim.us/event/RAIN-ON-ME-An-Ariana-X-Gaga-DANCE-PARTY/696752',
+    website: 'https://www.3dollarbillbk.com',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+}
+
+// The venue-site copy whose scraped start is ~42h off the eventim pair —
+// bad data on a DIFFERENT calendar day, so it must never be swallowed.
+function buildRainVenueSiteCopy() {
+  return {
+    title: 'RAIN ON ME - An Ariana X Gaga DANCE PARTY',
+    startDate: new Date('2026-08-01T02:00:00.000Z'),
+    endDate: new Date('2026-08-02T20:00:00.000Z'),
+    bar: '9 Bob Note',
+    address: '270 Meserole St, Brooklyn, NY 11206',
+    url: '3DOLLARBILLBK.COM',
+    ticketUrl: 'https://3DOLLARBILLBK.COM',
+    website: 'https://www.3dollarbillbk.com',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+}
+
+function buildAquaticaDetail() {
+  return {
+    title: "Aquatica Erotica: Bushwick's Wettest Cabaret",
+    startDate: new Date('2026-08-07T23:00:00.000Z'),
+    endDate: new Date('2026-08-08T01:00:00.000Z'),
+    bar: '3 Dollar Bill',
+    address: '260 Meserole St, Brooklyn, NY, 11206',
+    url: 'https://wl.eventim.us/event/Aquatica-Erotica-Bushwicks-Wettest-Cabaret/699269?afflky=3DollarBill',
+    ticketUrl: 'https://wl.eventim.us/event/Aquatica-Erotica-Bushwicks-Wettest-Cabaret/699269',
+    website: 'https://www.3dollarbillbk.com',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+}
+
+function buildAquaticaTruncated() {
+  return {
+    title: 'Aquatica Erotica: Bushwick', // truncated
+    startDate: new Date('2026-08-07T23:30:00.000Z'),
+    endDate: new Date('2026-08-07T23:30:00.000Z'),
+    bar: '3 Dollar Bill',
+    address: '260 Meserole St, Brooklyn, NY 11206',
+    url: 'https://wl.eventim.us/event/Aquatica-Erotica-Bushwicks-Wettest-Cabaret/699269',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+}
+
+test('deduplicateEvents merges the LORAX XCX pair — event-page URL differs only by affiliate query', async () => {
+  const core = createCore();
+  const eventim = buildLoraxEventim();
+  const degraded = buildLoraxDegraded();
+  // The degraded copy's ticketUrl is a bare promoter root, so the ticket-url
+  // signal cannot fire — the query-stripped event-page URL is the identity.
+  assert.equal(
+    core.getSameEventIdentitySignal(eventim, degraded, { requireCloseStartTimes: false }),
+    'event-page-url'
+  );
+  const result = await core.deduplicateEvents([eventim, degraded], null);
+  assert.equal(result.length, 1, 'query-only URL difference is the same event page');
+});
+
+test('deduplicateEvents merges the Aquatica Erotica pair and logs the URL-identity signal', async () => {
+  const core = createCore();
+  const detail = buildAquaticaDetail();
+  const truncated = buildAquaticaTruncated();
+  assert.notEqual(core.createEventKey(detail), core.createEventKey(truncated), 'precondition: truncated title diverges the keys');
+  assert.equal(
+    core.getSameEventIdentitySignal(detail, truncated, { requireCloseStartTimes: false }),
+    'event-page-url'
+  );
+  const logged = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logged.push(args.join(' ')); originalLog(...args); };
+  let result;
+  try {
+    result = await core.deduplicateEvents([detail, truncated], null);
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(result.length, 1, 'same event page (with vs without ?afflky) must merge');
+  assert.ok(
+    logged.some(line => line.includes('🔗 DEDUP:') && line.includes('event-page URL identity')),
+    'the URL-identity merge must announce its signal in the log'
+  );
+});
+
+test('deduplicateEvents merges the RAIN ON ME eventim pair — slugs differ, trailing id identical', async () => {
+  const core = createCore();
+  const poolSlug = buildRainEventim('RAIN-ON-ME-An-Ariana-X-Gaga-POOL-PARTY');
+  const danceSlug = buildRainEventim('RAIN-ON-ME-An-Ariana-X-Gaga-DANCE-PARTY');
+  const result = await core.deduplicateEvents([poolSlug, danceSlug], null);
+  assert.equal(result.length, 1, 'same platform event id 696752 is the same event');
+});
+
+test('same trailing event-id signal fires on slug-rewritten URLs without a shared ticketUrl', () => {
+  const core = createCore();
+  const poolSlug = buildRainEventim('RAIN-ON-ME-An-Ariana-X-Gaga-POOL-PARTY');
+  const danceSlug = buildRainEventim('RAIN-ON-ME-An-Ariana-X-Gaga-DANCE-PARTY');
+  delete poolSlug.ticketUrl;
+  delete danceSlug.ticketUrl;
+  // Bars intact would let place-day-name catch this too — strip the place so
+  // the trailing-id signal is what fires.
+  delete poolSlug.bar;
+  delete poolSlug.address;
+  assert.equal(
+    core.getSameEventIdentitySignal(poolSlug, danceSlug, { requireCloseStartTimes: false }),
+    'event-url-id'
+  );
+});
+
+test('the 42h-off venue-site RAIN copy is never swallowed by the eventim pair', async () => {
+  const core = createCore();
+  const poolSlug = buildRainEventim('RAIN-ON-ME-An-Ariana-X-Gaga-POOL-PARTY');
+  const danceSlug = buildRainEventim('RAIN-ON-ME-An-Ariana-X-Gaga-DANCE-PARTY');
+  const venueCopy = buildRainVenueSiteCopy();
+  assert.equal(
+    core.getSameEventIdentitySignal(venueCopy, poolSlug, { requireCloseStartTimes: false }),
+    null,
+    'different local calendar days must yield no identity signal'
+  );
+  const result = await core.deduplicateEvents([poolSlug, danceSlug, venueCopy], null);
+  assert.equal(result.length, 2, 'the eventim pair merges; the 42h copy stays separate');
+});
+
+test('bare-host URLs never participate in URL identity', async () => {
+  const core = createCore();
+  const first = {
+    title: 'Latex Night',
+    startDate: new Date('2026-08-08T01:00:00.000Z'),
+    url: 'https://www.3dollarbillbk.com',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+  const second = {
+    title: 'Disco Inferno',
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    url: '3DOLLARBILLBK.COM',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+  assert.equal(core.getEventPageUrlIdentity(first), null, 'a homepage root is not an event page');
+  assert.equal(core.getEventPageUrlIdentity(second), null, 'a protocol-less bare host is not an event page');
+  assert.equal(core.getSameEventIdentitySignal(first, second, { requireCloseStartTimes: false }), null);
+  const result = await core.deduplicateEvents([first, second], null);
+  assert.equal(result.length, 2, 'two different events found on the same homepage stay separate');
+});
+
+test('short numeric path segments never trigger trailing-id identity', () => {
+  const core = createCore();
+  const base = {
+    startDate: new Date('2026-08-08T01:00:00.000Z'),
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+  const pageTwoEvents = { ...base, title: 'Neon Nights', url: 'https://venue.example/events/page/2' };
+  const pageTwoParties = { ...base, title: 'Garage Rave', url: 'https://venue.example/parties/page/2' };
+  assert.equal(
+    core.getSameEventIdentitySignal(pageTwoEvents, pageTwoParties, { requireCloseStartTimes: false }),
+    null,
+    'pagination numbers are not event ids'
+  );
+  // Four digits is a calendar year, a real path segment shape in this corpus
+  // (wp-content/uploads/2026/...) — still below the id threshold.
+  const galleryYear = { ...base, title: 'Neon Nights', url: 'https://venue.example/gallery/2026' };
+  const archiveYear = { ...base, title: 'Garage Rave', url: 'https://venue.example/archive/2026' };
+  assert.equal(
+    core.getSameEventIdentitySignal(galleryYear, archiveYear, { requireCloseStartTimes: false }),
+    null,
+    'a 4-digit year segment is not an event id'
+  );
+});
+
+test('the same trailing id on different hosts never merges', async () => {
+  const core = createCore();
+  const base = {
+    startDate: new Date('2026-08-08T01:00:00.000Z'),
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+  const hostA = { ...base, title: 'Neon Nights', url: 'https://tickets-a.example/event/Neon-Nights/696752' };
+  const hostB = { ...base, title: 'Garage Rave', url: 'https://tickets-b.example/event/Garage-Rave/696752' };
+  assert.equal(core.getSameEventIdentitySignal(hostA, hostB, { requireCloseStartTimes: false }), null);
+  const result = await core.deduplicateEvents([hostA, hostB], null);
+  assert.equal(result.length, 2, 'a coincidental id collision across hosts is not identity');
+});
+
+test('entity-encoded and decoded titles collide in event keys (Club Nyc verbatim)', () => {
+  const core = createCore();
+  const encoded = {
+    title: 'Club Nyc presents : R &amp; B Night Showcase',
+    bar: '3 Dollar Bill',
+    startDate: new Date('2026-08-06T23:00:00.000Z'),
+    city: 'nyc',
+    timezone: 'America/New_York'
+  };
+  const decoded = { ...encoded, title: 'Club Nyc presents : R & B Night Showcase' };
+  assert.equal(core.createEventKey(encoded), core.createEventKey(decoded), 'HTML entities must not defeat title keys');
+  assert.ok(core.areTitlesSimilar(encoded.title, decoded.title), 'HTML entities must not defeat title similarity');
+});
+
+test('an event-page URL shared by 3+ records in a batch is a listing page, not identity', async () => {
+  const core = createCore();
+  const base = {
+    startDate: new Date('2026-08-08T01:00:00.000Z'),
+    url: 'https://venue.example/events',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+  const stubs = [
+    { ...base, title: 'Neon Nights' },
+    { ...base, title: 'Garage Rave' },
+    { ...base, title: 'Latex Social' }
+  ];
+  const result = await core.deduplicateEvents(stubs, null);
+  assert.equal(result.length, 3, 'listing-page fan-in must suppress URL identity');
+});
+
+test('a genuine non-duplicate — two different parties at 3 Dollar Bill one night — stays separate', async () => {
+  const core = createCore();
+  const beef = {
+    title: 'BEEF: XL Bear Party',
+    startDate: new Date('2026-08-08T01:00:00.000Z'),
+    endDate: new Date('2026-08-08T05:00:00.000Z'),
+    bar: '3 Dollar Bill',
+    address: '260 Meserole St, Brooklyn, NY, 11206',
+    url: 'https://wl.eventim.us/event/BEEF-XL-Bear-Party/711111',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+  const twunk = {
+    title: 'TWUNK NATION',
+    startDate: new Date('2026-08-08T03:00:00.000Z'),
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    bar: '3 Dollar Bill',
+    address: '260 Meserole St, Brooklyn, NY, 11206',
+    url: 'https://wl.eventim.us/event/TWUNK-NATION/722222',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    source: 'ai-web'
+  };
+  assert.equal(core.getSameEventIdentitySignal(beef, twunk, { requireCloseStartTimes: false }), null);
+  const result = await core.deduplicateEvents([beef, twunk], null);
+  assert.equal(result.length, 2, 'same venue + same night + different titles/urls is two events');
+});
+
+test('e2e probe: the six verbatim run records collapse to three events, 42h copy stays separate', async () => {
+  const core = createCore();
+  const records = [
+    buildLoraxEventim(),
+    buildLoraxDegraded(),
+    buildRainEventim('RAIN-ON-ME-An-Ariana-X-Gaga-POOL-PARTY'),
+    buildRainEventim('RAIN-ON-ME-An-Ariana-X-Gaga-DANCE-PARTY'),
+    buildAquaticaDetail(),
+    buildAquaticaTruncated(),
+    buildRainVenueSiteCopy()
+  ];
+  const result = await core.deduplicateEvents(records, null);
+  assert.equal(result.length, 4, 'three real events plus the separate 42h-off copy');
+  const rainRecords = result.filter(event => /RAIN ON ME/.test(event.title));
+  assert.equal(rainRecords.length, 2, 'the merged eventim RAIN plus the unmerged 42h copy');
+  assert.equal(result.filter(event => /LORAX/.test(event.title)).length, 1);
+  assert.equal(result.filter(event => /Aquatica/.test(event.title)).length, 1);
+});
+
 test('deduplicateEvents still merges plain key-collision duplicates', async () => {
   const core = createCore();
   const first = {


### PR DESCRIPTION
## 1. Same-event URL identity dedup

Run `20260802-135030` (3 Dollar Bill + its eventim pages) produced **six records that were three real events** — `duplicatesRemoved: 1` — and LORAX XCX got **split bear verdicts**: one copy reached the write plan while its twin was bear-dropped.

The decisive signal was in plain sight: **the same platform event ID in both copies, every time** (`700051`, `696752`, `699269`), defeated by:
- query params (`?afflky=3DollarBill`)
- slug rewrites (`…POOL-PARTY/696752` vs `…DANCE-PARTY/696752` — same id!)
- truncated titles (`Aquatica Erotica: Bushwick` vs `…: Bushwick's Wettest Cabaret`)
- an HTML entity (`R &amp; B` vs `R & B`)

New identity signals, both under the existing same-local-day guard: **event-page-url** (same host+path, query stripped) and **event-url-id** (same host family + id-shaped trailing segment, all-digits, **length ≥5** — 4 would collide with year segments like `wp-content/uploads/2026`, and every observed platform id is ≥5: eventim, etix `54403374`, tixr, ticketweb). Entities now fold in title keys/similarity (the existing entity table extracted and shared, byte-identical output).

Safety, all pinned by tests: bare hosts/homepage roots never participate; an identity shared by 3+ records is a listing page and suppressed; cross-host same-id never merges; `/page/2` never triggers; **the venue-site RAIN ON ME copy with the bad 42h span is never swallowed** by the eventim pair; two genuinely different parties at one venue one night stay separate. Merging flows through the existing merge machinery — no new path.

**Known limit, deliberately not fixed here:** `filterBearEvents` runs *before* `deduplicateEvents` (`shared-core.js` ~3612), so duplicates each get their own AI bear verdict, and a pair whose copies split verdicts never co-exists in dedup's input — that's how the LORAX split happened. Reordering touches trim/metrics/summary semantics (a pipeline restructure), so it's flagged for a separate decision rather than smuggled into this fix. The new signals fully cover pairs that pass (or fail) the bear check together — which includes the both-bear duplicate-write case that matters for the calendar.

## 2. Dallas Eagle venue-site repoint

The parser's only URL was its Eventbrite org page, which lists nothing — while the real events live at `thedallaseagle.com/events/` (verified live today: HTTP 200, August dates, `Start from:/End at:` listings plus "Every Wednesday" weeklies). Same shape as the Eagle LA fix (#1609). The `End at:` start-time trap is already covered by #1540's gate, and the dateless weeklies flow into #1616's ICS-only recurrence path — this repoint is also the first real-world exercise of that new path outside the Lumberyard.

## Verification

- Suite: **1286 pass, 0 fail** (1274 baseline + 12 new).
- Independent probe of every signal with the verbatim run values: LORAX query-twin → `event-page-url`, RAIN slug-twin → `event-url-id`, 42h copy → null, cross-host same-id → null, pagination → null, entity titles collide in keys.
- No `new URL`/`URLSearchParams`, no prompt/log-text changes, nothing platform-specific beyond generic URL shapes, no new runtime files.

Note: `scraper-input.js` is touched (Dallas Eagle entry only) — your local uncommitted OCR-endpoint edit is in a different region and should pull cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP