### PR TITLE
fix(scraper): cross-realm Date handling + meta content-attribute truncation

### DIFF
--- a/js/event-schema.js
+++ b/js/event-schema.js
@@ -754,7 +754,24 @@ function buildRecurringEventIcs(event, options = {}) {
 // YYYY-MM-DD string, never a time.
 function computeNextRruleOccurrence(rrule, fromDate) {
     const text = String(rrule || '').replace(/^RRULE\s*:/i, '').trim().toUpperCase();
-    if (!text || !(fromDate instanceof Date) || Number.isNaN(fromDate.getTime())) return null;
+    if (!text) return null;
+    // Cross-realm coercion, NOT defensive padding. Scriptable loads every file
+    // through its own importModule, so `event-schema` and the parsers hold
+    // different Date constructors: a Date built in ai-web-parser fails
+    // `instanceof Date` here even though it is a perfectly good Date. This was
+    // the ONLY date-taking function in this file lacking the coercion its
+    // siblings already do (formatIcsDate:632, parseIcsDate:641,
+    // buildRecurringEventIcs:696) — so it returned null for every real caller,
+    // silently disabling BOTH the dateless-weekly synthesis (#1616) and the
+    // older derived-occurrence path (#1563). Measured 2026-08-03: the success
+    // log line `🔁 RECURRING: derived next occurrence` appears ZERO times
+    // across every run ever recorded on device.
+    // Reject the absent cases BEFORE coercing: `new Date(null)` is epoch 0, a
+    // perfectly valid Date, which would turn "no anchor supplied" into a 1969
+    // occurrence. Same order of checks as SharedCore.toEpochMillis.
+    if (fromDate === null || fromDate === undefined || fromDate === '') return null;
+    const from = fromDate instanceof Date ? fromDate : new Date(fromDate);
+    if (Number.isNaN(from.getTime())) return null;
     const parts = {};
     for (const segment of text.split(';')) {
         const eq = segment.indexOf('=');
@@ -765,7 +782,7 @@ function computeNextRruleOccurrence(rrule, fromDate) {
     const WEEKDAY_INDEX = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
     const pad2 = (value) => String(value).padStart(2, '0');
     const formatLocalDate = (date) => `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
-    const today = new Date(fromDate.getFullYear(), fromDate.getMonth(), fromDate.getDate());
+    const today = new Date(from.getFullYear(), from.getMonth(), from.getDate());
     if (parts.FREQ === 'DAILY') {
         return parts.BYDAY === undefined ? formatLocalDate(today) : null;
     }

--- a/scripts/event-schema.js
+++ b/scripts/event-schema.js
@@ -761,7 +761,24 @@ function buildRecurringEventIcs(event, options = {}) {
 // YYYY-MM-DD string, never a time.
 function computeNextRruleOccurrence(rrule, fromDate) {
     const text = String(rrule || '').replace(/^RRULE\s*:/i, '').trim().toUpperCase();
-    if (!text || !(fromDate instanceof Date) || Number.isNaN(fromDate.getTime())) return null;
+    if (!text) return null;
+    // Cross-realm coercion, NOT defensive padding. Scriptable loads every file
+    // through its own importModule, so `event-schema` and the parsers hold
+    // different Date constructors: a Date built in ai-web-parser fails
+    // `instanceof Date` here even though it is a perfectly good Date. This was
+    // the ONLY date-taking function in this file lacking the coercion its
+    // siblings already do (formatIcsDate:632, parseIcsDate:641,
+    // buildRecurringEventIcs:696) — so it returned null for every real caller,
+    // silently disabling BOTH the dateless-weekly synthesis (#1616) and the
+    // older derived-occurrence path (#1563). Measured 2026-08-03: the success
+    // log line `🔁 RECURRING: derived next occurrence` appears ZERO times
+    // across every run ever recorded on device.
+    // Reject the absent cases BEFORE coercing: `new Date(null)` is epoch 0, a
+    // perfectly valid Date, which would turn "no anchor supplied" into a 1969
+    // occurrence. Same order of checks as SharedCore.toEpochMillis.
+    if (fromDate === null || fromDate === undefined || fromDate === '') return null;
+    const from = fromDate instanceof Date ? fromDate : new Date(fromDate);
+    if (Number.isNaN(from.getTime())) return null;
     const parts = {};
     for (const segment of text.split(';')) {
         const eq = segment.indexOf('=');
@@ -772,7 +789,7 @@ function computeNextRruleOccurrence(rrule, fromDate) {
     const WEEKDAY_INDEX = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
     const pad2 = (value) => String(value).padStart(2, '0');
     const formatLocalDate = (date) => `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
-    const today = new Date(fromDate.getFullYear(), fromDate.getMonth(), fromDate.getDate());
+    const today = new Date(from.getFullYear(), from.getMonth(), from.getDate());
     if (parts.FREQ === 'DAILY') {
         return parts.BYDAY === undefined ? formatLocalDate(today) : null;
     }

--- a/scripts/event-schema.test.js
+++ b/scripts/event-schema.test.js
@@ -479,3 +479,50 @@ test('computeNextRruleOccurrence: unsupported forms return null (event stays dis
   assert.equal(f('FREQ=WEEKLY;BYDAY=XX', now), null, 'unknown weekday code');
   assert.equal(f('FREQ=DAILY;BYDAY=FR', now), null, 'filtered daily rules are out of subset');
 });
+
+// ---------------------------------------------------------------------------
+// Cross-realm Date coercion (2026-08-03 run review).
+//
+// Scriptable loads every file through its own importModule, so `event-schema`
+// and the parsers hold DIFFERENT Date constructors. A perfectly good Date built
+// in ai-web-parser is `typeof 'object'` here and fails `instanceof Date`.
+// computeNextRruleOccurrence was the ONLY date-taking function in this file
+// without the coercion its siblings do, so it returned null for every real
+// caller — silently disabling both the dateless-weekly synthesis (#1616) and
+// the derived-occurrence path (#1563). Evidence: the success log line
+// `🔁 RECURRING: derived next occurrence` appears ZERO times across every run
+// ever recorded on device.
+//
+// `vm.runInNewContext` reproduces the realm split exactly; a plain `new Date()`
+// here CANNOT catch this regression.
+// ---------------------------------------------------------------------------
+
+const vm = require('node:vm');
+
+function foreignDate(iso) {
+  const made = vm.runInNewContext('new Date(iso)', { iso });
+  assert.equal(made instanceof Date, false, 'guard: the fixture must be cross-realm');
+  assert.equal(Object.prototype.toString.call(made), '[object Date]', 'guard: still a real Date');
+  return made;
+}
+
+test('computeNextRruleOccurrence: a cross-realm Date resolves like a native one', () => {
+  const f = EventSchema.computeNextRruleOccurrence;
+  // 2026-08-03 is a Monday.
+  const native = new Date(2026, 7, 3, 12, 0, 0);
+  const foreign = foreignDate('2026-08-03T12:00:00');
+
+  assert.equal(f('FREQ=WEEKLY;BYDAY=WE', foreign), f('FREQ=WEEKLY;BYDAY=WE', native));
+  assert.equal(f('FREQ=WEEKLY;BYDAY=WE', foreign), '2026-08-05', 'the real Lumberyard QUEERAOKE case');
+  assert.equal(f('FREQ=MONTHLY;BYDAY=2SU', foreign), f('FREQ=MONTHLY;BYDAY=2SU', native));
+  assert.equal(f('FREQ=DAILY', foreign), '2026-08-03');
+});
+
+test('computeNextRruleOccurrence: coercion accepts an ISO string but still rejects junk', () => {
+  const f = EventSchema.computeNextRruleOccurrence;
+  assert.equal(f('FREQ=WEEKLY;BYDAY=WE', '2026-08-03T12:00:00'), '2026-08-05');
+  assert.equal(f('FREQ=WEEKLY;BYDAY=WE', 'not a date'), null);
+  assert.equal(f('FREQ=WEEKLY;BYDAY=WE', null), null);
+  assert.equal(f('FREQ=WEEKLY;BYDAY=WE', undefined), null);
+  assert.equal(f('FREQ=WEEKLY;BYDAY=WE', {}), null);
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -12044,7 +12044,17 @@ TEXT:
                     if (dayPhraseSynthesis) {
                         console.log(`🔁 RECURRING: "${title}" synthesized from day phrase "${dayPhraseSynthesis.phrase}" → ${recurrenceRule}, next ${nextOccurrence} — will be withheld from calendar write (ICS only)`);
                     }
+                } else {
+                    // Additive diagnostics. Both guards on this path used to
+                    // fall through with NO logging, so a dead recurrence path
+                    // was invisible in every run log — the schema-side
+                    // cross-realm null (fixed in computeNextRruleOccurrence)
+                    // cost a multi-day investigation purely because nothing
+                    // said which guard bit. Never changes behavior.
+                    console.log(`🔁 RECURRING: rrule "${recurrenceRule}" for "${title}" produced an invalid derived start from occurrence ${nextOccurrence} — event will fail the required-startDate guard`);
                 }
+            } else {
+                console.log(`🔁 RECURRING: rrule "${recurrenceRule}" for "${title}" yielded no next occurrence — event will fail the required-startDate guard`);
             }
         }
 
@@ -12842,6 +12852,24 @@ TEXT:
         return this.normalizeWhitespace(this.stripTags(match[1]));
     }
 
+    // A double-quoted HTML attribute may legitimately contain apostrophes
+    // ("Bushwick's Wettest Cabaret"), and a single-quoted one may contain
+    // double quotes. The previous `["']([^"']+)["']` shape used ONE character
+    // class for BOTH delimiters, so it stopped at whichever quote came first
+    // and silently truncated the value. Measured 2026-08-02 on
+    // 3dollarbillbk.com: og:title "Buy Tickets to Aquatica Erotica: Bushwick's
+    // Wettest Cabaret in Brooklyn on Aug 07, 2026" reached the model as "Buy
+    // Tickets to Aquatica Erotica: Bushwick". That truncated string then BECAME
+    // the page corpus, so the verbatim-evidence gate structurally could not
+    // catch it — it was validating against already-broken input. Matching the
+    // closing delimiter to the opening one with a backreference is the fix.
+    // Returns '' when the attribute is absent or empty, so callers keep their
+    // existing falsy skip.
+    readMetaContentAttribute(tag) {
+        const match = String(tag || '').match(/\bcontent\s*=\s*(["'])([\s\S]*?)\1/i);
+        return match ? match[2] : '';
+    }
+
     extractMetaParts(html) {
         const results = [];
         const seen = new Set();
@@ -12850,8 +12878,8 @@ TEXT:
         while ((match = regex.exec(html)) !== null) {
             const tag = match[0];
             const nameMatch = tag.match(/\b(?:name|property)\s*=\s*["']([^"']+)["']/i);
-            const contentMatch = tag.match(/\bcontent\s*=\s*["']([^"']+)["']/i);
-            if (!nameMatch || !contentMatch) continue;
+            const contentValue = this.readMetaContentAttribute(tag);
+            if (!nameMatch || !contentValue) continue;
             const key = this.normalizeWhitespace(nameMatch[1]).toLowerCase();
             if (this.excludedMetaKeyRegexes.some(regexPattern => regexPattern.test(key))) continue;
             const allowedMetaKeys = new Set([
@@ -12865,7 +12893,7 @@ TEXT:
             ]);
             const hasAllowedPrefix = key.startsWith('og:') || key.startsWith('twitter:') || key.startsWith('event:');
             if (!hasAllowedPrefix && !allowedMetaKeys.has(key)) continue;
-            const value = this.sanitizeMetaContent(key, contentMatch[1]);
+            const value = this.sanitizeMetaContent(key, contentValue);
             if (!value) continue;
             const line = `${key}: ${value}`;
             const dedupeKey = line.toLowerCase();
@@ -12962,8 +12990,8 @@ TEXT:
             const tag = match[0];
             const nameMatch = tag.match(/\b(?:name|property)\s*=\s*["']([^"']+)["']/i);
             if (!nameMatch || this.normalizeWhitespace(nameMatch[1]).toLowerCase() !== 'og:site_name') continue;
-            const contentMatch = tag.match(/\bcontent\s*=\s*["']([^"']+)["']/i);
-            if (contentMatch) addName(this.sanitizeMetaContent('og:site_name', contentMatch[1]));
+            const contentValue = this.readMetaContentAttribute(tag);
+            if (contentValue) addName(this.sanitizeMetaContent('og:site_name', contentValue));
         }
         return Array.from(names);
     }
@@ -13098,9 +13126,9 @@ TEXT:
             const tag = match[0];
             const nameMatch = tag.match(/\b(?:name|property)\s*=\s*["']([^"']+)["']/i);
             if (!nameMatch || this.normalizeWhitespace(nameMatch[1]).toLowerCase() !== keyName) continue;
-            const contentMatch = tag.match(/\bcontent\s*=\s*["']([^"']+)["']/i);
-            if (!contentMatch) continue;
-            const value = this.normalizeWhitespace(this.decodeBasicEntities(contentMatch[1]));
+            const contentValue = this.readMetaContentAttribute(tag);
+            if (!contentValue) continue;
+            const value = this.normalizeWhitespace(this.decodeBasicEntities(contentValue));
             if (value) return value;
         }
         return '';
@@ -13120,9 +13148,9 @@ TEXT:
             const tag = match[0];
             const nameMatch = tag.match(/\b(?:name|property)\s*=\s*["']([^"']+)["']/i);
             if (!nameMatch || this.normalizeWhitespace(nameMatch[1]).toLowerCase() !== keyName) continue;
-            const contentMatch = tag.match(/\bcontent\s*=\s*["']([^"']+)["']/i);
-            if (!contentMatch) continue;
-            const value = this.normalizeWhitespace(this.decodeBasicEntities(contentMatch[1]));
+            const contentValue = this.readMetaContentAttribute(tag);
+            if (!contentValue) continue;
+            const value = this.normalizeWhitespace(this.decodeBasicEntities(contentValue));
             if (value) values.push(value);
         }
         return values;
@@ -13147,9 +13175,9 @@ TEXT:
             if (!nameMatch) continue;
             const key = this.normalizeWhitespace(nameMatch[1]).toLowerCase();
             if (!wanted.has(key)) continue;
-            const contentMatch = tag.match(/\bcontent\s*=\s*["']([^"']+)["']/i);
-            if (!contentMatch) continue;
-            const value = this.normalizeWhitespace(this.decodeBasicEntities(contentMatch[1]));
+            const contentValue = this.readMetaContentAttribute(tag);
+            if (!contentValue) continue;
+            const value = this.normalizeWhitespace(this.decodeBasicEntities(contentValue));
             if (value) entries.push({ key, value });
         }
         return entries;

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -10092,3 +10092,68 @@ test('extractUrlsFromNextData harvests the JSON body even with following script 
   // No __NEXT_DATA__ tag → clean empty result.
   assert.deepEqual(parser.extractUrlsFromNextData('<html><script>1</script></html>', 'https://dice.fm/x'), []);
 });
+
+// ---------------------------------------------------------------------------
+// Meta `content` attributes must not truncate at an apostrophe
+// (2026-08-03 run review).
+//
+// The previous `["']([^"']+)["']` shape used ONE character class for BOTH
+// delimiters, so a double-quoted value stopped at its first apostrophe. On
+// 3dollarbillbk.com that turned og:title "…Aquatica Erotica: Bushwick's Wettest
+// Cabaret…" into "…Aquatica Erotica: Bushwick" — and because the truncated
+// string then BECAME the page corpus, the verbatim-evidence gate could not
+// catch it. Any event title or description with an apostrophe was affected.
+// ---------------------------------------------------------------------------
+
+test('meta content: an apostrophe inside a double-quoted value is not a delimiter', () => {
+  const parser = createParser();
+  const realTag = `<meta property="og:title" content="Buy Tickets to Aquatica Erotica: Bushwick's Wettest Cabaret in Brooklyn on Aug 07, 2026" />`;
+  assert.equal(
+    parser.readMetaContentAttribute(realTag),
+    `Buy Tickets to Aquatica Erotica: Bushwick's Wettest Cabaret in Brooklyn on Aug 07, 2026`
+  );
+});
+
+test('meta content: single-quoted values, embedded double quotes, and absent/empty attributes', () => {
+  const parser = createParser();
+  assert.equal(
+    parser.readMetaContentAttribute(`<meta name="description" content='Bear Happy Hour — it is "first Thursdays"' />`),
+    'Bear Happy Hour — it is "first Thursdays"',
+    'single-quoted value keeps embedded double quotes'
+  );
+  assert.equal(parser.readMetaContentAttribute(`<meta name="viewport" />`), '', 'absent attribute');
+  assert.equal(parser.readMetaContentAttribute(`<meta name="x" content="" />`), '', 'empty attribute stays falsy');
+  assert.equal(parser.readMetaContentAttribute(`<meta name="x" CONTENT="Cased">`), 'Cased', 'attribute name is case-insensitive');
+  assert.equal(parser.readMetaContentAttribute(null), '', 'null tag');
+  assert.equal(
+    parser.readMetaContentAttribute(`<meta property="og:title" content="LORAX XCX in Brooklyn on Aug 07, 2026" />`),
+    'LORAX XCX in Brooklyn on Aug 07, 2026',
+    'the apostrophe-free sibling is unchanged'
+  );
+});
+
+test('meta content: og extraction end-to-end keeps the apostrophe title intact', () => {
+  const parser = createParser();
+  const html = `<html><head>
+    <meta property="og:site_name" content="3 Dollar Bill" />
+    <meta property="og:title" content="Buy Tickets to Aquatica Erotica: Bushwick's Wettest Cabaret in Brooklyn on Aug 07, 2026" />
+    <meta name="description" content="Bushwick's wettest cabaret returns" />
+  </head><body></body></html>`;
+
+  assert.equal(
+    parser.extractOgMetaContent(html, 'og:title'),
+    `Buy Tickets to Aquatica Erotica: Bushwick's Wettest Cabaret in Brooklyn on Aug 07, 2026`
+  );
+  assert.deepEqual(
+    parser.extractOgMetaContentAll(html, 'og:title'),
+    [`Buy Tickets to Aquatica Erotica: Bushwick's Wettest Cabaret in Brooklyn on Aug 07, 2026`]
+  );
+  const entries = parser.extractOgMetaEntriesAll(html, ['og:title', 'og:site_name']);
+  assert.equal(entries.length, 2);
+  assert.equal(entries.find(entry => entry.key === 'og:site_name').value, '3 Dollar Bill');
+
+  const metaParts = parser.extractMetaParts(html);
+  const description = metaParts.find(part => String(part).includes('wettest cabaret'));
+  assert.ok(description, 'the description meta survives');
+  assert.ok(String(description).includes(`Bushwick's`), 'and keeps its apostrophe');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -902,6 +902,22 @@ class SharedCore {
         return 2 * earthRadiusKm * Math.asin(Math.min(1, Math.sqrt(h)));
     }
 
+    // Realm-independent "is this a Date". Scriptable loads every file through
+    // its own importModule, so shared-core and the parsers/normalizers hold
+    // DIFFERENT Date constructors: a Date built in ai-web-parser is
+    // `typeof 'object'` here and fails `instanceof Date`, silently taking the
+    // wrong branch with no throw. Proven in production 2026-08-02 by
+    // resolveWallClockDates' own log formatter, which printed
+    // `Date.prototype.toString()` output (the `instanceof` false branch) for
+    // 85 genuine Date objects. `Object.prototype.toString` reads the internal
+    // [[Class]] slot, which is realm-agnostic, so it is the correct test
+    // wherever a value CROSSES a module boundary. Prefer coercion
+    // (toEpochMillis) when you want the number; prefer this when you need to
+    // know the type without turning unrelated strings into dates.
+    isDateLike(value) {
+        return Object.prototype.toString.call(value) === '[object Date]';
+    }
+
     // Date-or-ISO-string → epoch milliseconds, or null when absent/unparseable.
     toEpochMillis(value) {
         if (value === null || value === undefined || value === '') return null;
@@ -918,7 +934,7 @@ class SharedCore {
     // fresh Date objects that fail the `!==` identity check.
     mergeValuesEqualForTracking(a, b) {
         if (a === b) return true;
-        if (a instanceof Date || b instanceof Date) {
+        if (this.isDateLike(a) || this.isDateLike(b)) {
             const aMs = this.toEpochMillis(a);
             const bMs = this.toEpochMillis(b);
             return aMs !== null && aMs === bMs;
@@ -940,7 +956,7 @@ class SharedCore {
     }
 
     serializeArbitrationValue(fieldName, value) {
-        if (value instanceof Date) return value.toISOString();
+        if (this.isDateLike(value)) return value.toISOString();
         if ((fieldName === 'startDate' || fieldName === 'endDate') && value) {
             const date = new Date(value);
             if (!Number.isNaN(date.getTime())) return date.toISOString();
@@ -989,7 +1005,7 @@ class SharedCore {
     // whitespace-only cover formatting twins.
     isGenuineFieldConflict(fieldName, valueA, valueB) {
         if (this.isEmptyArbitrationValue(valueA) || this.isEmptyArbitrationValue(valueB)) return false;
-        const isPrimitive = (v) => v instanceof Date || typeof v !== 'object';
+        const isPrimitive = (v) => this.isDateLike(v) || typeof v !== 'object';
         if (!isPrimitive(valueA) || !isPrimitive(valueB)) return false;
         const serializedA = this.serializeArbitrationValue(fieldName, valueA);
         const serializedB = this.serializeArbitrationValue(fieldName, valueB);
@@ -1445,10 +1461,14 @@ class SharedCore {
         if (!event || typeof event !== 'object') return flags;
         const nowMs = context && Number.isFinite(context.nowMs) ? context.nowMs : Date.now();
         const title = typeof event.title === 'string' ? event.title.replace(/\s+/g, ' ').trim() : '';
+        // Was a private re-implementation gated on `instanceof Date` with no
+        // coercion fallback — so on device (cross-realm Dates, see isDateLike)
+        // it returned NaN for every real event and rules 4/5 below could NEVER
+        // fire. Measured 2026-08-02: zero `⚠️ SANITY` lines across 178 runs.
+        // toEpochMillis is the shared helper every other date site here uses.
         const toMs = (value) => {
-            if (value instanceof Date) return value.getTime();
-            if (typeof value === 'string' && value.trim()) return new Date(value).getTime();
-            return NaN;
+            const ms = this.toEpochMillis(value);
+            return ms === null ? NaN : ms;
         };
 
         // 1. title-is-date-phrase — the whole title is a date/time expression

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -13202,3 +13202,112 @@ test('no enforcement: a flagged event\'s action and write fields are byte-identi
   });
   assert.equal(writeShape(flagged[0]), writeShape(twin[0]));
 });
+
+// ---------------------------------------------------------------------------
+// Cross-realm Date handling (2026-08-03 run review).
+//
+// Scriptable loads every file through its own importModule, so shared-core and
+// the parsers/normalizers hold DIFFERENT Date constructors. A genuine Date
+// built in ai-web-parser is `typeof 'object'` inside shared-core and fails
+// `instanceof Date` — no throw, just the wrong branch. Proven in production
+// 2026-08-02 by resolveWallClockDates' own log formatter, which printed
+// Date.prototype.toString() output (the `instanceof` false branch) for 85 real
+// Date objects.
+//
+// Every test below MUST build its fixture with vm.runInNewContext. A plain
+// `new Date()` is same-realm and passes against the buggy code too.
+// ---------------------------------------------------------------------------
+
+const nodeVm = require('node:vm');
+
+function crossRealmDate(iso) {
+  const made = nodeVm.runInNewContext('new Date(iso)', { iso });
+  assert.equal(made instanceof Date, false, 'guard: fixture must be cross-realm');
+  assert.equal(Object.prototype.toString.call(made), '[object Date]', 'guard: still a real Date');
+  return made;
+}
+
+test('cross-realm: isDateLike identifies a foreign Date that instanceof rejects', () => {
+  const core = createCore();
+  const foreign = crossRealmDate('2026-08-03T02:09:18.000Z');
+  assert.equal(core.isDateLike(foreign), true);
+  assert.equal(core.isDateLike(new Date()), true, 'native Dates still qualify');
+  assert.equal(core.isDateLike('2026-08-03T02:09:18.000Z'), false, 'a string is not a Date');
+  assert.equal(core.isDateLike(null), false);
+  assert.equal(core.isDateLike({}), false);
+  assert.equal(core.isDateLike(1754186958000), false, 'a number is not a Date');
+});
+
+test('cross-realm: same-instant foreign Dates stay OUT of the merge clobber log', () => {
+  const core = createCore();
+  const iso = '2026-08-16T04:00:00.000Z';
+  // Production 2026-08-02: 44 of 44 distinct `🔄 MERGE: … clobbered N fields`
+  // lines listed startDate, including pairs naming the identical instant.
+  assert.equal(core.mergeValuesEqualForTracking(crossRealmDate(iso), crossRealmDate(iso)), true);
+  assert.equal(core.mergeValuesEqualForTracking(crossRealmDate(iso), iso), true, 'foreign Date vs ISO string');
+  assert.equal(core.mergeValuesEqualForTracking(crossRealmDate(iso), new Date(iso)), true, 'foreign vs native');
+  assert.equal(
+    core.mergeValuesEqualForTracking(crossRealmDate(iso), crossRealmDate('2026-08-16T05:00:00.000Z')),
+    false,
+    'a genuinely different instant is still a change'
+  );
+  assert.equal(core.mergeValuesEqualForTracking('S4', 'Rockbar'), false, 'non-dates still compare strictly');
+});
+
+test('cross-realm: a real date disagreement is still a genuine field conflict', () => {
+  const core = createCore();
+  assert.equal(
+    core.isGenuineFieldConflict('startDate', crossRealmDate('2026-08-06T17:00:00.000Z'), crossRealmDate('2026-08-07T04:00:00.000Z')),
+    true,
+    'the real BEAR HAPPY HOUR 5pm-vs-9pm divergence must be arbitrable'
+  );
+  assert.equal(
+    core.isGenuineFieldConflict('startDate', crossRealmDate('2026-08-06T17:00:00.000Z'), '2026-08-06T17:00:00.000Z'),
+    false,
+    'same instant across realms is not a conflict'
+  );
+  assert.equal(
+    core.isGenuineFieldConflict('coordinates', { lat: 1 }, { lat: 2 }),
+    false,
+    'genuine non-primitives stay ineligible'
+  );
+});
+
+test('cross-realm: sanity flags fire on foreign Dates (start-long-past, duration-implausible)', () => {
+  const core = createCore();
+  const nowMs = Date.parse('2026-08-03T02:09:18.000Z');
+
+  // The real massive.club record: a CREATE dated 784 days in the past that
+  // stamped `_sanityFlags: []` in run 20260802-220918.
+  const nark = {
+    title: 'Nark is Massive - Mix 001',
+    _action: 'new',
+    startDate: crossRealmDate('2024-06-10T02:00:00.000Z'),
+    endDate: crossRealmDate('2024-06-10T09:00:00.000Z')
+  };
+  assert.deepEqual(
+    core.getEventSanityFlags(nark, { nowMs }).map(flag => flag.code),
+    ['start-long-past']
+  );
+
+  // The real Lumberyard record: 2025-03-22 → 2026-10-17 from JSON-LD.
+  const queerArtMarket = {
+    title: 'Queer Art Market',
+    _action: 'new',
+    startDate: crossRealmDate('2025-03-22T21:00:00.000Z'),
+    endDate: crossRealmDate('2026-10-17T01:00:00.000Z')
+  };
+  assert.deepEqual(
+    core.getEventSanityFlags(queerArtMarket, { nowMs }).map(flag => flag.code).sort(),
+    ['duration-implausible', 'start-long-past']
+  );
+
+  // A healthy near-term event stays clean whichever realm built its dates.
+  const healthy = {
+    title: 'PACK PARTY',
+    _action: 'new',
+    startDate: crossRealmDate('2026-08-14T05:00:00.000Z'),
+    endDate: crossRealmDate('2026-08-14T09:00:00.000Z')
+  };
+  assert.deepEqual(core.getEventSanityFlags(healthy, { nowMs }), []);
+});


### PR DESCRIPTION
Three root causes from the 2026-08-02 run review. All three failed **silently** — wrong branch, no throw — which is why they survived.

## 1. `instanceof Date` is false across Scriptable module boundaries

Scriptable loads every file through its own `importModule`, so `shared-core`, `event-schema` and the parsers hold **different `Date` constructors**. A genuine `Date` built in `ai-web-parser` is `typeof 'object'` inside `shared-core` and fails `instanceof Date`.

Proof needs no device access — `resolveWallClockDates`' own log formatter is `value instanceof Date ? value.toISOString() : String(value)`, and production printed `Date.prototype.toString()` output (the false branch) for **85 real Date objects** on 2026-08-02.

| Site | Was |
|---|---|
| `computeNextRruleOccurrence` | returned `null` for every real caller — silently disabled **both** #1616's dateless-weekly synthesis and #1563's derived-occurrence path. `🔁 RECURRING: derived next occurrence` appears **zero** times across every run ever recorded. It was the only date-taking function in that file lacking the coercion its siblings at `:632`/`:641`/`:696` already do. |
| `getEventSanityFlags`'s private `toMs` | `NaN` → `start-long-past` and `duration-implausible` could never fire (zero `⚠️ SANITY` lines across 178 runs) |
| `isGenuineFieldConflict` | dates counted as non-primitives → `startDate`/`endDate` **never** arbitrated |
| `mergeValuesEqualForTracking` | fell through to `false` → **44 of 44** distinct `🔄 MERGE: … clobbered N fields` lines listed `startDate`, including same-instant pairs |

New `SharedCore.isDateLike` uses `Object.prototype.toString`, which reads the realm-agnostic internal slot. Used where we need the **type**; `toEpochMillis` remains the tool when we want the number. Deliberately **not** blanket coercion — that would make unrelated strings compare equal as dates.

## 2. Meta `content` truncated at the first apostrophe

`["']([^"']+)["']` used one character class for **both** delimiters. On 3dollarbillbk.com:

```
og:title  "Buy Tickets to Aquatica Erotica: Bushwick's Wettest Cabaret in Brooklyn on Aug 07, 2026"
reached the model as
          "Buy Tickets to Aquatica Erotica: Bushwick"
```

That truncated string then **became the page corpus**, so the verbatim-evidence gate structurally could not catch it — it was validating against already-broken input. Affected any title or description with an apostrophe. Five call sites now share one helper that backreferences the opening delimiter.

## 3. Silent recurrence guards

The two guards around the derived-start assignment had no `else` and no logging, so a dead recurrence path was invisible in every run log. **Additive diagnostics only** — no behaviour change.

## Verification

- Suite **1286 → 1295**, 0 failures.
- **All 9 new tests fail against `origin/main`** and pass here. They build fixtures with `vm.runInNewContext`; a plain `new Date()` is same-realm and passes against the buggy code, so this class is only catchable that way.
- Driven against **real on-device production data**:
  - the real `Nark is Massive` record now flags `start-long-past` (production stamped `[]`)
  - the real cached Lumberyard QUEERAOKE corpus now yields `FREQ=WEEKLY;BYDAY=WE` → next occurrence `2026-08-05` (**was `null`**)
  - the real 3DB `og:title` comes through whole
- An edge case my own test caught: `new Date(null)` is epoch 0 — a valid Date — which would have turned "no anchor supplied" into a **1969** occurrence. Absent values are now rejected before coercion.

`js/event-schema.js` kept byte-identical to `scripts/event-schema.js` per that file's own sync requirement.

**No new runtime files** — all changes are new methods inside existing files, so no `scriptable-script-updater` entries are needed.

## Not in this PR

Still open from the review, in priority order: don't segment on bare schedule labels (the Dallas Eagle `"Start from"` ghosts), never geocode a city-less address, the `!identity` gate that costs 3DB its venue + coordinates, a known-city fail-closed gate, thumbnail OCR, the `areStartDatesWithinDays` `<=` boundary, and a "not an event" classification category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP