### PR TITLE
fix(scraper+results): ticket URLs out of website, bear keyword tier, Lumberyard corpus leaks, and the 3 MB blank screen

### DIFF
--- a/data/promoters.json
+++ b/data/promoters.json
@@ -161,7 +161,8 @@
     "name": "Club Chub",
     "shortName": "CLUB CHUB",
     "instagram": "https://www.instagram.com/clubchubparty",
-    "bearAffinity": "always"
+    "bearAffinity": "always",
+    "website": "https://www.clubchubusa.com"
   },
   {
     "name": "Fat Dad",

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -5403,6 +5403,35 @@ class ScriptableAdapter {
     // recurring card registers its event natively and embeds only the id.
     this.resetIcsExportEvents();
     const allEvents = this.getAllEventsFromResults(results);
+    // Per-render payload budget: every card's debug JSON gets an equal share
+    // of one document-wide constant, so page size stops scaling with the
+    // number of events (see buildBudgetedEventJson).
+    const budgetedCardCount = Array.isArray(allEvents) ? allEvents.length : 0;
+    this._eventJsonBudgetReport = [];
+    this._eventJsonBudgetBytes =
+      this.computeEventJsonBudgetBytes(budgetedCardCount);
+    // Same construction for the two merge diff renderings, but shared out
+    // over the cards that actually RENDER a diff (only merges carry
+    // _original) and over both renderings each of those cards emits — so a
+    // run full of brand-new events never shrinks the allowance of the few
+    // merges the owner has to adjudicate.
+    const diffClaimCount =
+      2 *
+      Math.max(
+        1,
+        (Array.isArray(allEvents) ? allEvents : []).filter(
+          (event) => event && event._original,
+        ).length,
+      );
+    this._mergeDiffBudgetReport = [];
+    this._mergeDiffRemainingBytes =
+      ScriptableAdapter.MERGE_DIFF_TOTAL_BUDGET_BYTES;
+    this._mergeDiffPerCardBytes = Math.min(
+      Math.floor(
+        ScriptableAdapter.MERGE_DIFF_TOTAL_BUDGET_BYTES / diffClaimCount,
+      ),
+      ScriptableAdapter.MERGE_DIFF_MAX_PER_CARD_BYTES,
+    );
     const availableCalendars = await Calendar.forEvents();
 
     // Detect dark mode for better bar/low-light readability
@@ -6078,7 +6107,81 @@ class ScriptableAdapter {
             background: var(--background-primary);
             position: relative;
         }
-        
+
+        /* Shared chrome that used to be repeated as an inline style="" on
+           every copy button, every merge-table cell and every line-diff row.
+           At ~200 bytes a copy and ~2400 table cells per big run that
+           repetition alone was ~300 KB of the 3198 KB page. */
+        .copy-json-btn {
+            padding: 4px 8px;
+            font-size: 11px;
+            background: var(--primary-color);
+            color: var(--text-inverse);
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            font-family: 'Poppins', sans-serif;
+            font-weight: 500;
+            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
+        }
+
+        .raw-json {
+            font-size: 11px;
+            background: #333;
+            color: #fff;
+            padding: 10px;
+            border-radius: 5px;
+            overflow-x: auto;
+        }
+
+        .payload-cap-note {
+            font-size: 11px;
+            color: var(--warn-color);
+            margin-bottom: 6px;
+            line-height: 1.5;
+        }
+
+        .cmp-table {
+            width: 100%;
+            font-size: 12px;
+            border-collapse: collapse;
+            table-layout: auto;
+        }
+
+        .cmp-table th,
+        .cmp-table td {
+            padding: 5px;
+            border-bottom: 1px solid var(--border-color);
+            word-wrap: break-word;
+            overflow-wrap: break-word;
+            word-break: break-word;
+            color: var(--text-primary);
+            text-align: left;
+        }
+
+        .cmp-table th { vertical-align: bottom; }
+        .cmp-table td.cmp-field { vertical-align: top; }
+        .cmp-table td.cmp-field small { color: var(--text-secondary); }
+        .cmp-table th.cmp-flow,
+        .cmp-table td.cmp-flow {
+            text-align: center;
+            font-size: 16px;
+            color: var(--primary-color);
+            word-break: normal;
+        }
+        .cmp-table td.cmp-result { text-align: center; }
+
+        .notes-line { margin: 2px 0; }
+        .notes-line strong { color: #666; }
+
+        /* "…+N chars" affordance on a truncated diff value. */
+        .cmp-more {
+            color: var(--text-secondary);
+            font-size: 10px;
+            white-space: nowrap;
+        }
+
         .notes-preview strong {
             font-weight: 600;
             color: var(--text-primary);
@@ -7098,7 +7201,10 @@ class ScriptableAdapter {
         function toggleDisplayMode() {
             const toggle = document.getElementById('displayToggle');
             const eventCards = document.querySelectorAll('.event-card');
-            
+            // Raw mode is the first moment the debug dump is actually looked
+            // at, so that is when the compact payload gets re-indented.
+            if (toggle && toggle.checked) prettyPrintCardPayloads();
+
             eventCards.forEach(card => {
                 if (toggle.checked) {
                     card.classList.add('raw-mode');
@@ -7380,6 +7486,7 @@ class ScriptableAdapter {
 
         function copyRawOutput() {
             // Get all event cards
+            prettyPrintCardPayloads();
             const eventCards = document.querySelectorAll('.event-card');
             let rawOutput = '';
             
@@ -7535,9 +7642,46 @@ class ScriptableAdapter {
             }
         }
 
+        // Each card embeds its event JSON exactly ONCE, compact, in
+        // .raw-display pre.raw-json. Both the pretty debug dump and the two
+        // Copy JSON buttons are derived from that single payload in the DOM
+        // instead of being three escaped copies in the HTML string.
+        function prettyPrintCardPayloads() {
+            const payloads = document.querySelectorAll('pre.raw-json');
+            for (let i = 0; i < payloads.length; i++) {
+                const pre = payloads[i];
+                if (pre.getAttribute('data-pretty') === '1') continue;
+                try {
+                    pre.textContent = JSON.stringify(JSON.parse(pre.textContent), null, 2);
+                } catch (error) {
+                    // Leave the payload byte-for-byte as embedded.
+                }
+                pre.setAttribute('data-pretty', '1');
+            }
+        }
+
+        // Copy semantics are unchanged from the old data-event-json attribute:
+        // the same slimmed event, indented two spaces, minus _original at any
+        // depth (the Merge Comparison table is where provenance is read).
+        function readCardEventJSON(button) {
+            const card = button && button.closest ? button.closest('.event-card') : null;
+            const pre = card ? card.querySelector('pre.raw-json') : null;
+            const text = pre ? pre.textContent : '';
+            if (!text) return '';
+            try {
+                const parsed = JSON.parse(text, function (key, value) {
+                    return key === '_original' ? undefined : value;
+                });
+                return JSON.stringify(parsed, null, 2);
+            } catch (error) {
+                return text;
+            }
+        }
+
         function copyEventJSON(button) {
-            const eventJSON = button.getAttribute('data-event-json');
-            
+            prettyPrintCardPayloads();
+            const eventJSON = readCardEventJSON(button);
+
             // Try modern clipboard API first
             if (navigator.clipboard && navigator.clipboard.writeText) {
                 navigator.clipboard.writeText(eventJSON).then(() => {
@@ -7595,6 +7739,7 @@ class ScriptableAdapter {
         }
         
         function exportAsJSON() {
+            prettyPrintCardPayloads();
             const eventCards = document.querySelectorAll('.event-card');
             const exportData = {
                 timestamp: new Date().toISOString(),
@@ -7721,6 +7866,10 @@ class ScriptableAdapter {
 </body>
 </html>
         `;
+
+    this.logEventJsonBudgetReport();
+    this.logMergeDiffBudgetReport();
+    this.logResultsHtmlSizeGuard(html, budgetedCardCount);
 
     return html;
   }
@@ -9638,10 +9787,10 @@ class ScriptableAdapter {
                                   const value = line
                                     .substring(colonIndex + 1)
                                     .trim();
-                                  formattedHtml += `<div style="margin: 2px 0;"><strong style="color: #666;">${this.escapeHtml(key)}:</strong> ${this.escapeHtml(value)}</div>`;
+                                  formattedHtml += `<div class="notes-line"><strong>${this.escapeHtml(key)}:</strong> ${this.escapeHtml(value)}</div>`;
                                 } else {
                                   // Freeform description line
-                                  formattedHtml += `<div style="margin: 2px 0;">${this.escapeHtml(line)}</div>`;
+                                  formattedHtml += `<div class="notes-line">${this.escapeHtml(line)}</div>`;
                                 }
                               });
 
@@ -9714,25 +9863,24 @@ class ScriptableAdapter {
                                     Shows how each field will be merged between existing and new event data
                                 </div>
                             </div>
-                            <button onclick="copyEventJSON(this)" 
-                                    style="padding: 4px 8px; font-size: 11px; background: var(--primary-color); color: var(--text-inverse); border: none; border-radius: 8px; cursor: pointer; font-family: 'Poppins', sans-serif; font-weight: 500; transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);"
-                                    data-event-json='${this.escapeHtml(
-                                      this.buildEmbeddedEventJson(event, {
-                                        includeOriginal: false,
-                                      }),
-                                    )}'>
+                            <button onclick="copyEventJSON(this)" class="copy-json-btn">
                                 📋 Copy JSON
                             </button>
                         </div>
-                        <table style="width: 100%; font-size: 12px; border-collapse: collapse; table-layout: auto;">
+                        <table class="cmp-table">
                             <tr>
-                                <th style="text-align: left; padding: 5px; border-bottom: 1px solid var(--border-color); word-wrap: break-word; overflow-wrap: break-word; color: var(--text-primary);">Field</th>
-                                <th style="text-align: left; padding: 5px; border-bottom: 1px solid var(--border-color); word-wrap: break-word; overflow-wrap: break-word; color: var(--text-primary);">Existing Event</th>
-                                <th style="text-align: center; padding: 5px; border-bottom: 1px solid var(--border-color); word-wrap: break-word; overflow-wrap: break-word; color: var(--text-primary);">Flow</th>
-                                <th style="text-align: left; padding: 5px; border-bottom: 1px solid var(--border-color); word-wrap: break-word; overflow-wrap: break-word; color: var(--text-primary);">New Event</th>
-                                <th style="text-align: left; padding: 5px; border-bottom: 1px solid var(--border-color); word-wrap: break-word; overflow-wrap: break-word; color: var(--text-primary);">Result</th>
+                                <th>Field</th>
+                                <th>Existing Event</th>
+                                <th class="cmp-flow">Flow</th>
+                                <th>New Event</th>
+                                <th>Result</th>
                             </tr>
-                            ${this.generateComparisonRows(event)}
+                            ${this.claimMergeDiffBudget(
+                              "field-by-field comparison",
+                              this.generateComparisonRows(event),
+                              event,
+                              { asTableRow: true },
+                            )}
                         </table>
                     </div>
                     
@@ -9744,7 +9892,11 @@ class ScriptableAdapter {
                                 Git-style diff showing additions (+), deletions (-), and unchanged (=) fields
                             </div>
                         </div>
-                        ${this.generateLineDiffView(event)}
+                        ${this.claimMergeDiffBudget(
+                          "line-by-line diff",
+                          this.generateLineDiffView(event),
+                          event,
+                        )}
                     </div>
                     </div>
                 </div>
@@ -9814,21 +9966,35 @@ class ScriptableAdapter {
             }
             
             <div class="raw-display">
-                <pre style="font-size: 11px; background: #333; color: #fff; padding: 10px; border-radius: 5px; overflow-x: auto;">${this.escapeHtml(
-                  // Keeps _original (merge provenance) but drops the AI
-                  // prompt/validation blobs — see buildEmbeddedEventJson
-                  this.buildEmbeddedEventJson(event, {
-                    includeOriginal: true,
-                  }),
-                )}</pre>
+                ${(() => {
+                  // ONE payload per card. Keeps _original (merge provenance)
+                  // but drops the AI prompt/validation blobs — see
+                  // buildEmbeddedEventJson — and is budgeted so a big run
+                  // cannot grow the page without bound (buildBudgetedEventJson).
+                  const payload = this.buildBudgetedEventJson(event, runInfo);
+                  const what = [
+                    payload.dropped.length
+                      ? `dropped ${payload.dropped.join(", ")}`
+                      : "",
+                    payload.truncated && payload.truncated.length
+                      ? `shortened ${payload.truncated.slice(0, 6).join(", ")}`
+                      : "",
+                  ]
+                    .filter(Boolean)
+                    .join("; ");
+                  const notice = payload.capped
+                    ? `<div class="payload-cap-note">✂️ Debug JSON trimmed to fit the page (${this.escapeHtml(
+                        what,
+                      )}). Everything trimmed is still rendered above in this card; the untrimmed event is in the saved run file${
+                        payload.runFile
+                          ? ` <code>${this.escapeHtml(payload.runFile)}</code>`
+                          : ""
+                      }.</div>`
+                    : "";
+                  return `${notice}<pre class="raw-json">${this.escapeHtml(payload.json)}</pre>`;
+                })()}
                 <div style="margin-top: 8px; text-align: right;">
-                    <button onclick="copyEventJSON(this)" 
-                            style="padding: 4px 8px; font-size: 11px; background: var(--primary-color); color: var(--text-inverse); border: none; border-radius: 8px; cursor: pointer; font-family: 'Poppins', sans-serif; font-weight: 500; transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);"
-                            data-event-json='${this.escapeHtml(
-                              this.buildEmbeddedEventJson(event, {
-                                includeOriginal: false,
-                              }),
-                            )}'>
+                    <button onclick="copyEventJSON(this)" class="copy-json-btn">
                         📋 Copy JSON
                     </button>
                 </div>
@@ -9853,7 +10019,11 @@ class ScriptableAdapter {
   //     blobs) since that's where a human reads the merge provenance.
   //   - _parserConfig/_existingEvent/_conflicts/placeId/function slimming
   //     is unchanged from the previous inline replacers.
-  buildEmbeddedEventJson(event, { includeOriginal = true } = {}) {
+  //   - pretty:false emits the SAME object with no indentation. The card now
+  //     embeds the payload exactly once (compact, in the raw <pre>) and the
+  //     page re-indents it in the DOM on load, so the ~15% of the payload
+  //     that was pure indent whitespace never crosses into the HTML string.
+  buildEmbeddedEventJson(event, { includeOriginal = true, pretty = true } = {}) {
     return JSON.stringify(
       event,
       (key, value) => {
@@ -9887,7 +10057,316 @@ class ScriptableAdapter {
         }
         return value;
       },
-      2,
+      pretty ? 2 : 0,
+    );
+  }
+
+  // ---------------------------------------------------------------------
+  // Embedded-payload budget.
+  //
+  // The debug JSON is the single heaviest thing a card emits, and it grows
+  // with the event's own content (notes/description/_original), so "it fits
+  // today" was luck, not design: run 20260803-143036 (52 events) rendered a
+  // 3198 KB page and WebView.loadHTML white-screened.
+  //
+  // The budget is DOCUMENT-scoped, not per-card: every card gets
+  // TOTAL_BUDGET / eventCount, clamped to a per-card maximum so small runs
+  // (the common case) are never touched. That makes the payload contribution
+  // O(TOTAL_BUDGET) instead of O(events x content) — a 200-event run is
+  // bounded by the same constant a 5-event run is.
+  //
+  // Nothing here is deleted silently: whatever gets pruned is named in the
+  // in-card notice, stamped into the copied JSON under `_trimmed`, and
+  // logged once per run by logEventJsonBudgetReport().
+  // ---------------------------------------------------------------------
+  static get EVENT_JSON_TOTAL_BUDGET_BYTES() {
+    return 220 * 1024;
+  }
+
+  static get EVENT_JSON_MAX_PER_CARD_BYTES() {
+    return 24 * 1024;
+  }
+
+  // Same shape, one level up: a document-wide allowance for the two merge
+  // DIFF RENDERINGS (the 📊 Merge Comparison table and its line-by-line
+  // alternate view). Both are collapsed by default and both are derived
+  // views of _original, which the card's own payload still carries — so
+  // trimming them defers detail, it never destroys the only copy.
+  static get MERGE_DIFF_TOTAL_BUDGET_BYTES() {
+    return 400 * 1024;
+  }
+
+  static get MERGE_DIFF_MAX_PER_CARD_BYTES() {
+    return 40 * 1024;
+  }
+
+  // Evidence-derived safe ceiling for the whole page. Every run that the
+  // owner actually reviewed rendered at <= 1923 KB (20260801-192818, 15
+  // events, 30 s of review). The one silent white-screen was 3198 KB
+  // (20260803-143036, 52 events, "reviewed" in 3.3 s). Crossing this is not
+  // fatal, but it must never be silent — see logResultsHtmlSizeGuard.
+  static get RESULTS_HTML_WARN_BYTES() {
+    return 1923 * 1024;
+  }
+
+  // Pruned in this order, heaviest-and-most-redundant first. Every one of
+  // these is ALSO rendered as HTML elsewhere in the same card, so pruning it
+  // from the debug dump never removes the only copy:
+  //   _original        -> the "📊 Merge Comparison" table renders it
+  //                       field-by-field (existing / new / result)
+  //   _mergeDiff       -> same table's Result column
+  //   _mergeDecisions  -> same table's Result column + the AI merge insights
+  //   _fieldPriorities -> same table's per-field strategy label
+  //   _evidenceLines   -> the card's own evidence lines section
+  //   _analysis        -> the card's action badge + reason line
+  static get EVENT_JSON_PRUNE_ORDER() {
+    return [
+      "_original",
+      "_mergeDiff",
+      "_mergeDecisions",
+      "_fieldPriorities",
+      "_evidenceLines",
+      "_analysis",
+    ];
+  }
+
+  // Successively tighter per-string caps, tried in order once key-dropping
+  // has bottomed out. 320 chars still shows a whole notes line; 60 is the
+  // last resort on a run large enough that nothing else would fit.
+  static get EVENT_JSON_STRING_CAPS() {
+    return [1200, 480, 240, 120, 60];
+  }
+
+  // Depth-first copy with every long string shortened to `maxChars` and a
+  // marker appended naming the true length and where the full value lives.
+  // Never mutates the input — the calendar writer reads these same objects.
+  truncateLongStringsForBudget(value, maxChars, record, runFile) {
+    if (typeof value === "string") {
+      if (value.length <= maxChars) return value;
+      return `${value.substring(0, maxChars)}... [truncated ${
+        value.length - maxChars
+      } of ${value.length} chars to fit the results page — full value in ${
+        runFile || "the saved run JSON"
+      }]`;
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) =>
+        this.truncateLongStringsForBudget(item, maxChars, record, runFile),
+      );
+    }
+    if (value && typeof value === "object") {
+      const out = {};
+      for (const key of Object.keys(value)) {
+        const child = value[key];
+        if (typeof child === "string" && child.length > maxChars) {
+          record.push(key);
+        }
+        out[key] = this.truncateLongStringsForBudget(
+          child,
+          maxChars,
+          record,
+          runFile,
+        );
+      }
+      return out;
+    }
+    return value;
+  }
+
+  // Per-card payload budget for a run of `eventCount` cards.
+  computeEventJsonBudgetBytes(eventCount) {
+    const cards = Number.isFinite(eventCount) && eventCount > 0 ? eventCount : 1;
+    const share = Math.floor(
+      ScriptableAdapter.EVENT_JSON_TOTAL_BUDGET_BYTES / cards,
+    );
+    return Math.min(share, ScriptableAdapter.EVENT_JSON_MAX_PER_CARD_BYTES);
+  }
+
+  // Serialize one card's payload within the active budget.
+  // Returns { json, capped, dropped[], bytes, budget, runFile }.
+  buildBudgetedEventJson(event, runInfo = {}) {
+    const budget = Number.isFinite(this._eventJsonBudgetBytes)
+      ? this._eventJsonBudgetBytes
+      : ScriptableAdapter.EVENT_JSON_MAX_PER_CARD_BYTES;
+    const runFile = runInfo && runInfo.runId ? `data/runs/${runInfo.runId}.json` : "";
+
+    let working = event;
+    const dropped = [];
+    let json = this.buildEmbeddedEventJson(working, {
+      includeOriginal: true,
+      pretty: false,
+    });
+
+    for (const key of ScriptableAdapter.EVENT_JSON_PRUNE_ORDER) {
+      if (json.length <= budget) break;
+      if (!working || typeof working !== "object" || !(key in working)) continue;
+      // Shallow clone so the analyzed event itself is never mutated — the
+      // calendar writer reads these same keys after the HTML is built.
+      working = { ...working };
+      delete working[key];
+      dropped.push(key);
+      json = this.buildEmbeddedEventJson(working, {
+        includeOriginal: true,
+        pretty: false,
+      });
+    }
+
+    // Dropping whole keys bottoms out at the event's own content (title,
+    // notes, description). Past that the only way to stay inside the budget
+    // is to shorten the long VALUES — with a marker that says how much was
+    // cut and where the whole thing still is, so a truncated payload can
+    // never be misread as a complete one.
+    const truncatedFields = [];
+    if (json.length > budget) {
+      for (const cap of ScriptableAdapter.EVENT_JSON_STRING_CAPS) {
+        truncatedFields.length = 0;
+        const shortened = this.truncateLongStringsForBudget(
+          working,
+          cap,
+          truncatedFields,
+          runFile,
+        );
+        json = this.buildEmbeddedEventJson(shortened, {
+          includeOriginal: true,
+          pretty: false,
+        });
+        if (json.length <= budget) {
+          working = shortened;
+          break;
+        }
+        working = shortened;
+      }
+    }
+
+    if (!dropped.length && !truncatedFields.length) {
+      return { json, capped: false, dropped, bytes: json.length, budget, runFile };
+    }
+
+    // Stamp the provenance of the trim INTO the payload, so a copied JSON
+    // can never be mistaken for the complete object.
+    working = {
+      ...working,
+      _trimmed: {
+        reason: "results-html-budget",
+        droppedKeys: dropped,
+        truncatedFields: truncatedFields.slice(0, 20),
+        note: "Dropped keys are rendered field-by-field in this card's Merge Comparison table.",
+        fullEventAt: runFile || "the saved run JSON",
+      },
+    };
+    json = this.buildEmbeddedEventJson(working, {
+      includeOriginal: true,
+      pretty: false,
+    });
+
+    const title = (event && (event.title || event.name)) || "(untitled)";
+    const uniqueTruncated = [...new Set(truncatedFields)];
+    if (Array.isArray(this._eventJsonBudgetReport)) {
+      this._eventJsonBudgetReport.push({
+        title,
+        dropped,
+        truncated: uniqueTruncated,
+        bytes: json.length,
+        budget,
+      });
+    }
+    return {
+      json,
+      capped: true,
+      dropped,
+      truncated: uniqueTruncated,
+      bytes: json.length,
+      budget,
+      runFile,
+    };
+  }
+
+  // Per-card allowance for the merge diff renderings, drawn from a shared
+  // document-wide pool. A card that spends less leaves the rest for later
+  // cards, but no card may draw more than its equal share — so the total is
+  // <= MERGE_DIFF_TOTAL_BUDGET_BYTES no matter how many events a run has.
+  claimMergeDiffBudget(kind, html, event, { asTableRow = false } = {}) {
+    const text = typeof html === "string" ? html : "";
+    if (!text) return text;
+    if (!Number.isFinite(this._mergeDiffRemainingBytes)) return text;
+
+    const share = Number.isFinite(this._mergeDiffPerCardBytes)
+      ? this._mergeDiffPerCardBytes
+      : ScriptableAdapter.MERGE_DIFF_MAX_PER_CARD_BYTES;
+    const allowance = Math.min(share, this._mergeDiffRemainingBytes);
+
+    if (text.length <= allowance) {
+      this._mergeDiffRemainingBytes -= text.length;
+      return text;
+    }
+
+    const title = (event && (event.title || event.name)) || "(untitled)";
+    if (Array.isArray(this._mergeDiffBudgetReport)) {
+      this._mergeDiffBudgetReport.push({ title, kind, bytes: text.length, allowance });
+    }
+    const notice = `✂️ This card's ${this.escapeHtml(kind)} was too large to render inline (${Math.round(
+      text.length / 1024,
+    )} KB) and was deferred to keep the page renderable. The same before/after values are in this card's 📋 Copy JSON and in the saved run JSON.`;
+    // A <table> child has to stay a row or the WebView drops it entirely.
+    return asTableRow
+      ? `<tr><td colspan="5" class="payload-cap-note">${notice}</td></tr>`
+      : `<div class="payload-cap-note">${notice}</div>`;
+  }
+
+  // One line per run naming exactly which cards were trimmed and why. A cap
+  // nobody can see reads as "everything is here" when it is not.
+  logMergeDiffBudgetReport() {
+    const report = Array.isArray(this._mergeDiffBudgetReport)
+      ? this._mergeDiffBudgetReport
+      : [];
+    if (!report.length) return;
+    const detail = report
+      .slice(0, 12)
+      .map((entry) => `"${entry.title}" (${entry.kind}, ${Math.round(entry.bytes / 1024)} KB)`)
+      .join(", ");
+    const more = report.length > 12 ? `, +${report.length - 12} more` : "";
+    console.log(
+      `📱 Scriptable: Merge diff rendering deferred on ${report.length} card section(s) to stay inside the ${Math.round(
+        ScriptableAdapter.MERGE_DIFF_TOTAL_BUDGET_BYTES / 1024,
+      )} KB page diff budget — the same values remain in each card's Copy JSON and the saved run JSON: ${detail}${more}`,
+    );
+  }
+
+  // Last line of defence: the page can still be large for reasons no budget
+  // here controls (one fixed card per event). It must never be large
+  // SILENTLY, because a white-screened review looks exactly like an approved
+  // one from the log.
+  logResultsHtmlSizeGuard(html, eventCount) {
+    const bytes = typeof html === "string" ? html.length : 0;
+    if (bytes <= ScriptableAdapter.RESULTS_HTML_WARN_BYTES) return;
+    console.log(
+      `📱 Scriptable: ⚠️ Results HTML is ${Math.round(bytes / 1024)} KB for ${eventCount} event(s) — above the ${Math.round(
+        ScriptableAdapter.RESULTS_HTML_WARN_BYTES / 1024,
+      )} KB size that has actually rendered on device. If the results screen comes up blank, that is why: re-run with fewer parsers, or review from the saved run JSON.`,
+    );
+  }
+
+  logEventJsonBudgetReport() {
+    const report = Array.isArray(this._eventJsonBudgetReport)
+      ? this._eventJsonBudgetReport
+      : [];
+    if (!report.length) return;
+    const detail = report
+      .slice(0, 12)
+      .map((entry) => {
+        const parts = [];
+        if (entry.dropped.length) parts.push(`-${entry.dropped.join("/")}`);
+        if (entry.truncated && entry.truncated.length) {
+          parts.push(`shortened ${entry.truncated.slice(0, 4).join("/")}`);
+        }
+        return `"${entry.title}" (${parts.join("; ")})`;
+      })
+      .join(", ");
+    const more = report.length > 12 ? `, +${report.length - 12} more` : "";
+    console.log(
+      `📱 Scriptable: Debug JSON trimmed on ${report.length} card(s) to stay inside the ${Math.round(
+        ScriptableAdapter.EVENT_JSON_TOTAL_BUDGET_BYTES / 1024,
+      )} KB page payload budget — every trimmed key is still rendered in that card's Merge Comparison table: ${detail}${more}`,
     );
   }
 
@@ -10886,8 +11365,12 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         // This is important for showing "scraped value X, existing undefined, preserved undefined"
       }
 
-      // Format values for display - show exactly what the merge logic saw
-      const formatValue = (val, maxLength = 30) => {
+      // Format values for display - show exactly what the merge logic saw.
+      // `anchor` is the index of the first character at which the two sides
+      // of this row diverge; the visible window is centred there so a long
+      // description whose change is at character 900 does not render as two
+      // identical-looking 30-character stubs.
+      const formatValue = (val, anchor = 0, maxLength = 30) => {
         if (val === null) return '<em style="color: #999;">null</em>';
         if (val === undefined) return '<em style="color: #999;">undefined</em>';
         if (val === "") return '<em style="color: #999;">empty string</em>';
@@ -10921,10 +11404,45 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         }
         const str = stringValue;
         if (str.length > maxLength) {
-          return `<span title="${this.escapeHtml(str)}">${this.escapeHtml(str.substring(0, maxLength))}...</span>`;
+          // BOUNDED BY CONSTRUCTION. This used to emit the ENTIRE value into a
+          // title="" attribute on both the existing and the new cell, so a
+          // single long description cost ~2x its own length per row, per
+          // event, forever. Visible text is capped at maxLength and the
+          // tooltip at TOOLTIP_MAX_CHARS; the "+N chars" badge is the
+          // affordance that says how much is hidden and the complete value is
+          // one tap away via this card's 📋 Copy JSON / raw dump.
+          const TOOLTIP_MAX_CHARS = 240;
+          const start =
+            anchor > maxLength ? Math.max(0, anchor - Math.floor(maxLength / 3)) : 0;
+          const lead = start > 0 ? "..." : "";
+          const visible = str.substring(start, start + maxLength);
+          const tooltipSource = str.substring(start);
+          const tooltip =
+            tooltipSource.length > TOOLTIP_MAX_CHARS
+              ? `${tooltipSource.substring(0, TOOLTIP_MAX_CHARS)}... (+${
+                  tooltipSource.length - TOOLTIP_MAX_CHARS
+                } more chars - use Copy JSON for the full value)`
+              : tooltipSource;
+          return `<span title="${this.escapeHtml(tooltip)}">${lead}${this.escapeHtml(visible)}...</span><span class="cmp-more"> ${str.length} chars</span>`;
         }
         return this.escapeHtml(str);
       };
+
+      // Index of the first character at which the two sides differ, so a
+      // truncated diff always shows the part that actually changed.
+      const diffAnchor = (() => {
+        const asText = (v) => {
+          if (v === null || v === undefined || typeof v === "object") return "";
+          return String(v);
+        };
+        const a = asText(existingValue);
+        const b = asText(newValue);
+        if (!a || !b) return 0;
+        const max = Math.min(a.length, b.length);
+        let i = 0;
+        while (i < max && a[i] === b[i]) i++;
+        return i;
+      })();
 
       // Identity for DISPLAY only. Strict === was reporting startDate/endDate
       // as CLOBBERED on every merge even when nothing changed: those values are
@@ -11081,29 +11599,42 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         resultText = '<span style="color: #999;">NO CHANGE</span>';
       }
 
-      rows.push(`
-                <tr>
-                    <td style="padding: 5px; border-bottom: 1px solid var(--border-color); vertical-align: top; word-wrap: break-word; overflow-wrap: break-word; color: var(--text-primary);">
-                        <strong>${field}</strong>
-                        <br><small style="color: var(--text-secondary);">${strategy}</small>
-                    </td>
-                    <td style="padding: 5px; border-bottom: 1px solid var(--border-color); word-wrap: break-word; overflow-wrap: break-word; word-break: break-word; color: var(--text-primary);">
-                        ${formatValue(existingValue)}
-                    </td>
-                    <td style="padding: 5px; border-bottom: 1px solid var(--border-color); text-align: center; font-size: 16px; color: var(--primary-color); word-wrap: break-word; overflow-wrap: break-word;">
-                        ${flowIcon}
-                    </td>
-                    <td style="padding: 5px; border-bottom: 1px solid var(--border-color); word-wrap: break-word; overflow-wrap: break-word; word-break: break-word; color: var(--text-primary);">
-                        ${formatValue(newValue)}
-                    </td>
-                    <td style="padding: 5px; border-bottom: 1px solid var(--border-color); text-align: center; word-wrap: break-word; overflow-wrap: break-word; color: var(--text-primary);">
-                        ${resultText}
-                    </td>
-                </tr>
-            `);
+      rows.push(
+        `<tr><td class="cmp-field"><strong>${field}</strong><br><small>${strategy}</small></td>` +
+          `<td>${formatValue(existingValue, diffAnchor)}</td>` +
+          `<td class="cmp-flow">${flowIcon}</td>` +
+          `<td>${formatValue(newValue, diffAnchor)}</td>` +
+          `<td class="cmp-result">${resultText}</td></tr>`,
+      );
     });
 
     return rows.join("");
+  }
+
+  // Longest slice of any single value the line-by-line diff will render.
+  static get LINE_DIFF_MAX_CHARS() {
+    return 220;
+  }
+
+  // BOUNDED BY CONSTRUCTION.
+  //
+  // The line diff used to emit every value with escapeHtml() and no cap at
+  // all, and a REPLACED field emits both sides — so one 6 KB description
+  // cost ~12 KB of page, per event, forever. It is the one place in a card
+  // whose size was set purely by how chatty a venue's copywriter is.
+  //
+  // The slice is capped at LINE_DIFF_MAX_CHARS and anchored on the first
+  // diverging character, so the visible text always contains the change. The
+  // affordance is explicit: the badge states the true length and names where
+  // the complete value still lives (this card's 📋 Copy JSON / raw dump).
+  renderBoundedDiffValue(text, anchor = 0) {
+    const str = text === null || text === undefined ? "" : String(text);
+    const max = ScriptableAdapter.LINE_DIFF_MAX_CHARS;
+    if (str.length <= max) return this.escapeHtml(str);
+    const start = anchor > max ? Math.max(0, anchor - Math.floor(max / 4)) : 0;
+    const lead = start > 0 ? "..." : "";
+    const visible = str.substring(start, start + max);
+    return `${lead}${this.escapeHtml(visible)}...<span class="cmp-more"> [${str.length} chars total — 📋 Copy JSON for the full value]</span>`;
   }
 
   // Generate line-by-line diff view
@@ -11149,6 +11680,19 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         }
         return val.toString();
       };
+
+      // First character at which the two sides diverge — renderBoundedDiffValue
+      // centres its window there, so a replaced 4 KB description shows the
+      // part that actually changed instead of two identical opening lines.
+      const diffAnchor = (() => {
+        const a = formatValue(existingValue);
+        const b = formatValue(newValue);
+        if (!a || !b) return 0;
+        const max = Math.min(a.length, b.length);
+        let i = 0;
+        while (i < max && a[i] === b[i]) i++;
+        return i;
+      })();
 
       // Determine what happened with this field by comparing values
       let wasUsed = "unknown";
@@ -11200,44 +11744,44 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       if (isNew) {
         // Only new value exists - show as addition
         html += `<div class=\"diff-line diff-added\">`;
-        html += `<span>+</span> ${this.escapeHtml(formatValue(newValue))} <em class=\"diff-meta\">(new field)</em>`;
+        html += `<span>+</span> ${this.renderBoundedDiffValue(formatValue(newValue), diffAnchor)} <em class=\"diff-meta\">(new field)</em>`;
         html += `</div>`;
       } else if (isUnchanged) {
         // Only existing value exists - show as context (orange)
         html += `<div class=\"diff-line diff-context\">`;
-        html += `<span>═</span> ${this.escapeHtml(formatValue(existingValue))} <em class=\"diff-meta\">(existing, unchanged)</em>`;
+        html += `<span>═</span> ${this.renderBoundedDiffValue(formatValue(existingValue), diffAnchor)} <em class=\"diff-meta\">(existing, unchanged)</em>`;
         html += `</div>`;
       } else if (isSame) {
         // Existing and new are the same for display - avoid +/- noise
         html += `<div class=\"diff-line diff-same\">`;
-        html += `<span>═</span> ${this.escapeHtml(formatValue(existingValue))} <em class=\"diff-meta\">(same in both)</em>`;
+        html += `<span>═</span> ${this.renderBoundedDiffValue(formatValue(existingValue), diffAnchor)} <em class=\"diff-meta\">(same in both)</em>`;
         html += `</div>`;
       } else if (isReplaced) {
         // Value was replaced - show old as deletion, new as addition
         html += `<div class=\"diff-line diff-removed\">`;
-        html += `<span>-</span> ${this.escapeHtml(formatValue(existingValue))} <em class=\"diff-meta\">(removed)</em>`;
+        html += `<span>-</span> ${this.renderBoundedDiffValue(formatValue(existingValue), diffAnchor)} <em class=\"diff-meta\">(removed)</em>`;
         html += `</div>`;
         html += `<div class=\"diff-line diff-added\">`;
-        html += `<span>+</span> ${this.escapeHtml(formatValue(newValue))} <em class=\"diff-meta\">(added)</em>`;
+        html += `<span>+</span> ${this.renderBoundedDiffValue(formatValue(newValue), diffAnchor)} <em class=\"diff-meta\">(added)</em>`;
         html += `</div>`;
       } else if (isKept) {
         // New value exists but existing was kept - show both with context
         html += `<div class=\"diff-line diff-same\">`;
-        html += `<span>═</span> ${this.escapeHtml(formatValue(existingValue))} <em class=\"diff-meta\">(kept existing)</em>`;
+        html += `<span>═</span> ${this.renderBoundedDiffValue(formatValue(existingValue), diffAnchor)} <em class=\"diff-meta\">(kept existing)</em>`;
         html += `</div>`;
         html += `<div class=\"diff-line diff-ignored\" style=\"opacity:0.85;\">`;
-        html += `<span>~</span> ${this.escapeHtml(formatValue(newValue))} <em class=\"diff-meta\">(ignored new value)</em>`;
+        html += `<span>~</span> ${this.renderBoundedDiffValue(formatValue(newValue), diffAnchor)} <em class=\"diff-meta\">(ignored new value)</em>`;
         html += `</div>`;
       } else if (isMerged) {
         // Values were merged - show all three
         html += `<div class=\"diff-line diff-removed\">`;
-        html += `<span>-</span> ${this.escapeHtml(formatValue(existingValue))} <em class=\"diff-meta\">(original)</em>`;
+        html += `<span>-</span> ${this.renderBoundedDiffValue(formatValue(existingValue), diffAnchor)} <em class=\"diff-meta\">(original)</em>`;
         html += `</div>`;
         html += `<div class=\"diff-line diff-ignored\">`;
-        html += `<span>~</span> ${this.escapeHtml(formatValue(newValue))} <em class=\"diff-meta\">(proposed)</em>`;
+        html += `<span>~</span> ${this.renderBoundedDiffValue(formatValue(newValue), diffAnchor)} <em class=\"diff-meta\">(proposed)</em>`;
         html += `</div>`;
         html += `<div class=\"diff-line diff-merged\">`;
-        html += `<span>+</span> ${this.escapeHtml(formatValue(finalValue))} <em class=\"diff-meta\">(merged result)</em>`;
+        html += `<span>+</span> ${this.renderBoundedDiffValue(formatValue(finalValue), diffAnchor)} <em class=\"diff-meta\">(merged result)</em>`;
         html += `</div>`;
       }
 

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -7621,6 +7621,14 @@ class ScriptableAdapter {
                 } catch (decodeError) {
                     text = button.getAttribute('data-payload') || '';
                 }
+                // The attribute carries COMPACT json (percent-encoding charges
+                // 3 bytes per indent space). Re-indent for the textarea so what
+                // the owner copies is the same readable payload as before.
+                try {
+                    text = JSON.stringify(JSON.parse(text), null, 2);
+                } catch (reindentError) {
+                    // Not parseable (older payload, or the error stub) - show as-is.
+                }
 
                 area.style.display = 'block';
                 textarea.value = text;

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -2732,7 +2732,7 @@ test('generateEventCard embeds are all built by the shared serializer (no AI blo
   const html = adapter.generateEventCard(event, { runId: '20260725-210227' });
   assert.ok(!html.includes('PROMPT PROMPT'), 'no AI prompt text anywhere in the card HTML');
   assert.ok(!html.includes('VALIDATE VALIDATE'), 'no AI validation text anywhere in the card HTML');
-  assert.ok(html.includes('data-event-json'), 'copy buttons still carry event JSON');
+  assert.ok(html.includes('copyEventJSON(this)'), 'copy buttons are still wired up');
   assert.ok(html.includes('&quot;_original&quot;'), 'the raw <pre> dump still shows _original provenance');
 }
 );
@@ -4413,4 +4413,327 @@ test('run summary counts overrides and proposals, and stays silent when there ar
   assert.ok(
     !quiet.some(l => l.includes('verride') || l.includes('roposal')),
     `no authority lines when nothing is stamped, got: ${JSON.stringify(quiet)}`);
+});
+
+// ---------------------------------------------------------------------------
+// Results-HTML size (run 20260803-143036: 52 analyzed events rendered a
+// 3198 KB page, WebView.loadHTML white-screened, and the log shows the owner
+// "reviewing" 52 events in 3.3 seconds — i.e. he never saw them). Every run
+// he actually reviewed rendered at <= 1923 KB.
+//
+// The page was NOT big because of images, CSS or scripts. Measured on that
+// exact run it was: the same event JSON embedded THREE times per card
+// (2 x data-event-json + the raw <pre>) = 1290 KB / 43%; ~2400 merge-table
+// cells each carrying ~200 bytes of duplicated inline style = 300 KB; and a
+// line-by-line diff that emitted every value in full, both sides, uncapped.
+//
+// These guards are about construction, not one lucky number: the payload and
+// the diff renderings draw from DOCUMENT-WIDE budgets, so their contribution
+// is bounded by a constant instead of growing with the event count.
+// ---------------------------------------------------------------------------
+
+function buildSizedAnalyzedEvent(index) {
+  // Shaped like the real run's merge events: long notes + description, a
+  // full _original triple, per-field priorities and merge bookkeeping.
+  const blurb =
+    `Doors at 9. ${'Bears, cubs, otters and their admirers welcome. '.repeat(24)}`;
+  const notes = [
+    'website: https://example.com/party',
+    'instagram: https://instagram.com/example',
+    `description: ${blurb}`,
+    `shortName: Party ${index}`
+  ].join('\n');
+  const scraper = {
+    title: `MEGAWOOF ${index}`,
+    description: `${blurb}NEW LOCATION for ${index}.`,
+    startDate: '2026-09-01T02:00:00.000Z',
+    endDate: '2026-09-01T08:00:00.000Z',
+    bar: `Club ${index}`,
+    address: `${index} Main St, Los Angeles, CA`,
+    url: `https://example.com/e/${index}`,
+    image: `https://example.com/img/${index}.jpg`,
+    notes
+  };
+  const calendar = {
+    ...scraper,
+    description: `${blurb}OLD LOCATION for ${index}.`,
+    bar: `Club ${index} (old)`
+  };
+  return {
+    title: `MEGAWOOF ${index}`,
+    key: `megawoof-${index}`,
+    city: 'la',
+    _action: 'merge',
+    startDate: '2026-09-01T02:00:00.000Z',
+    endDate: '2026-09-01T08:00:00.000Z',
+    bar: `Club ${index}`,
+    address: `${index} Main St, Los Angeles, CA`,
+    description: `${blurb}NEW LOCATION for ${index}.`,
+    notes,
+    _fieldPriorities: {
+      title: { priority: ['ai-web'], merge: 'ai' },
+      description: { priority: ['ai-web'], merge: 'clobber' },
+      bar: { priority: ['ai-web'], merge: 'ai' },
+      address: { priority: ['ai-web'], merge: 'preserve' }
+    },
+    _mergeDecisions: { description: 'clobbered', bar: 'ai chose new' },
+    _mergeDiff: { description: [calendar.description, scraper.description] },
+    _original: { scraper, calendar, merged: { ...scraper }, aiArbitration: { arbitrated: ['bar'] } }
+  };
+}
+
+// Mirrors run 20260803-143036's composition: 52 analyzed events of which
+// roughly a third are merges carrying the full _original triple (that run had
+// 15). A page of nothing but merges is not what white-screened.
+function buildSizedResults(count) {
+  const analyzedEvents = [];
+  for (let i = 0; i < count; i++) {
+    const event = buildSizedAnalyzedEvent(i);
+    if (i % 3 !== 0) {
+      delete event._original;
+      delete event._mergeDiff;
+      delete event._mergeDecisions;
+      event._action = 'new';
+    }
+    analyzedEvents.push(event);
+  }
+  return { analyzedEvents };
+}
+
+function countPayloadEmbeds(html) {
+  return {
+    dataEventJson: (html.match(/data-event-json=/g) || []).length,
+    rawJsonPre: (html.match(/<pre class="raw-json">/g) || []).length
+  };
+}
+
+test('results HTML: a card embeds its event JSON exactly ONCE (three copies is what white-screened run 20260803-143036)', () => {
+  const adapter = buildAdapter();
+  const event = buildSizedAnalyzedEvent(1);
+  const html = adapter.generateEventCard(event, { runId: '20260803-143036' });
+
+  const embeds = countPayloadEmbeds(html);
+  assert.equal(embeds.dataEventJson, 0,
+    'no data-event-json attributes: the copy buttons derive from the card payload');
+  assert.equal(embeds.rawJsonPre, 1, 'exactly one embedded payload per card');
+
+  // The payload is compact — the ~15% of it that was pure indent whitespace
+  // never crosses into the HTML string; the page re-indents it in the DOM.
+  const payload = html.match(/<pre class="raw-json">([\s\S]*?)<\/pre>/)[1];
+  assert.ok(!payload.includes('\n  &quot;'),
+    'embedded payload is compact, not indented');
+
+  // ...and it is still the real, parseable event, still escaped.
+  const parsed = JSON.parse(payload
+    .replace(/&quot;/g, '"').replace(/&#039;/g, "'")
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&'));
+  assert.equal(parsed.title, 'MEGAWOOF 1');
+  assert.ok(parsed._original && parsed._original.calendar,
+    'merge provenance is still reachable from the card payload');
+});
+
+test('results HTML: page-derived text in the single payload is still escaped', () => {
+  const adapter = buildAdapter();
+  const event = buildSizedAnalyzedEvent(2);
+  event.title = 'Bear </pre><script>alert(1)</script> Night';
+  event._original.scraper.bar = 'Club "><img src=x onerror=alert(1)>';
+  const html = adapter.generateEventCard(event, { runId: 'r1' });
+  assert.ok(!html.includes('<script>alert(1)</script>'), 'no unescaped script tag');
+  assert.ok(!html.includes('onerror=alert(1)>'), 'no unescaped event handler');
+  assert.ok(html.includes('&lt;script&gt;'), 'the script tag is escaped, not stripped');
+  // The restructuring must not have left a second, differently-escaped copy
+  // of the same hostile text behind.
+  assert.equal(countPayloadEmbeds(html).dataEventJson, 0, 'no attribute-embedded copy');
+  assert.equal(countPayloadEmbeds(html).rawJsonPre, 1, 'exactly one escaped payload');
+});
+
+test('results HTML: the 52-event run that white-screened now renders well under the size that has actually rendered on device', async () => {
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML(buildSizedResults(52));
+  const kb = html.length / 1024;
+  assert.ok(kb < 1500,
+    `52-event page must be far below the 1923 KB that has rendered on device, got ${Math.round(kb)} KB`);
+});
+
+test('results HTML: small runs are not regressed — a 3-event page stays small and keeps its full detail', async () => {
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML(buildSizedResults(3));
+  const kb = html.length / 1024;
+  assert.ok(kb < 250, `3-event page stays small, got ${Math.round(kb)} KB`);
+  // Nothing is trimmed on a small run: the payloads keep their heavy keys.
+  assert.ok(html.includes('&quot;_original&quot;'), 'small-run payload keeps _original');
+  assert.ok(html.includes('&quot;_fieldPriorities&quot;'), 'small-run payload keeps _fieldPriorities');
+  assert.ok(!html.includes('&quot;_trimmed&quot;'), 'nothing was trimmed on a small run');
+  assert.equal(countPayloadEmbeds(html).rawJsonPre, 3, 'one payload per card');
+});
+
+test('results HTML is bounded BY CONSTRUCTION: 4x the events does not 4x the embedded payload', async () => {
+  const adapter = buildAdapter();
+  const totalPayloadBytes = async (count) => {
+    const html = await adapter.generateRichHTML(buildSizedResults(count));
+    let bytes = 0;
+    const re = /<pre class="raw-json">([\s\S]*?)<\/pre>/g;
+    let match;
+    while ((match = re.exec(html))) bytes += match[1].length;
+    return bytes;
+  };
+
+  const at50 = await totalPayloadBytes(50);
+  const at200 = await totalPayloadBytes(200);
+  const budget = ScriptableAdapter.EVENT_JSON_TOTAL_BUDGET_BYTES;
+
+  // Escaping inflates the embedded form, so compare against a generous
+  // multiple of the budget — the point is that it does NOT scale with N.
+  assert.ok(at200 < budget * 2,
+    `200-event payload total stays bounded by the ${Math.round(budget / 1024)} KB budget, got ${Math.round(at200 / 1024)} KB`);
+  assert.ok(at200 < at50 * 2,
+    `4x the events must not 4x the payload (50 events: ${Math.round(at50 / 1024)} KB, 200 events: ${Math.round(at200 / 1024)} KB)`);
+});
+
+test('results HTML: a trimmed payload is never silent — it is logged, stamped, and its keys are still rendered', async () => {
+  const adapter = buildAdapter();
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...args) => { lines.push(args.join(' ')); };
+  let html;
+  try {
+    html = await adapter.generateRichHTML(buildSizedResults(60));
+  } finally {
+    console.log = originalLog;
+  }
+
+  const trimLine = lines.find(l => l.includes('Debug JSON trimmed on'));
+  assert.ok(trimLine, `a trim must be logged, got: ${JSON.stringify(lines.slice(0, 5))}`);
+  assert.ok(trimLine.includes('MEGAWOOF'), 'the log names the affected event(s)');
+  assert.ok(trimLine.includes('_original') || trimLine.includes('_fieldPriorities'),
+    'the log names which keys were dropped');
+  assert.ok(trimLine.includes('Merge Comparison'),
+    'the log says where the dropped keys are still rendered');
+
+  // The copied JSON self-documents the trim, so it can never be mistaken
+  // for the complete object.
+  assert.ok(html.includes('&quot;_trimmed&quot;'), 'the payload stamps _trimmed');
+  assert.ok(html.includes('results-html-budget'), 'the stamp names the reason');
+  // And the page says so where the owner is looking.
+  assert.ok(html.includes('Debug JSON trimmed to fit the page'),
+    'the affected card carries a visible notice');
+  // The information itself is still on the page: the merge table renders it.
+  assert.ok(html.includes('Merge Comparison'), 'the merge comparison table is still rendered');
+});
+
+test('results HTML: an oversized page is never silent about its own size', async () => {
+  const adapter = buildAdapter();
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...args) => { lines.push(args.join(' ')); };
+  try {
+    // Far below the warn threshold: no noise on a normal run.
+    await adapter.generateRichHTML(buildSizedResults(3));
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(!lines.some(l => l.includes('above the')),
+    'no size warning on a page that is comfortably small');
+
+  // The guard itself fires on anything past what has actually rendered.
+  const oversized = 'x'.repeat(ScriptableAdapter.RESULTS_HTML_WARN_BYTES + 1);
+  const warned = [];
+  const restore = console.log;
+  console.log = (...args) => { warned.push(args.join(' ')); };
+  try {
+    adapter.logResultsHtmlSizeGuard(oversized, 200);
+  } finally {
+    console.log = restore;
+  }
+  assert.equal(warned.length, 1, 'exactly one warning line');
+  assert.ok(warned[0].includes('200 event(s)'), 'the warning names the event count');
+  assert.ok(warned[0].includes('blank'), 'the warning explains the blank screen it predicts');
+});
+
+test('line-by-line diff bounds each value with an affordance instead of emitting it in full, twice', () => {
+  const adapter = buildAdapter();
+  const event = buildSizedAnalyzedEvent(7);
+  const longOld = `OLD ${'a'.repeat(20000)}`;
+  const longNew = `NEW ${'a'.repeat(20000)}`;
+  event._original.calendar.description = longOld;
+  event._original.scraper.description = longNew;
+  event.description = longNew;
+
+  const html = adapter.generateLineDiffView(event);
+  assert.ok(!html.includes('a'.repeat(1000)),
+    'a 20 KB value is not emitted in full');
+  assert.ok(html.length < 20000,
+    `the whole line diff stays smaller than ONE of the values it shows, got ${html.length} bytes`);
+  // The affordance: the true length and where the full value still lives.
+  assert.ok(html.includes('chars total'), 'the badge states the real length');
+  assert.ok(html.includes('Copy JSON'), 'the badge names where the full value is');
+});
+
+test('a truncated diff still shows WHAT changed: the window follows the first divergence', () => {
+  const adapter = buildAdapter();
+  const shared = 'z'.repeat(4000);
+  const oldValue = `${shared}ANCIENT-VENUE-NAME${'z'.repeat(2000)}`;
+  const newValue = `${shared}BRAND-NEW-VENUE-NAME${'z'.repeat(2000)}`;
+
+  // Line view: both sides are rendered, and both must reveal the change.
+  const event = buildSizedAnalyzedEvent(8);
+  event._original.calendar.description = oldValue;
+  event._original.scraper.description = newValue;
+  event.description = newValue;
+  const lineHtml = adapter.generateLineDiffView(event);
+  assert.ok(lineHtml.includes('ANCIENT-VENUE-NAME'),
+    'the removed side shows the text that actually differs');
+  assert.ok(lineHtml.includes('BRAND-NEW-VENUE-NAME'),
+    'the added side shows the text that actually differs');
+  // Revealing the change is only half of it — showing it must not cost the
+  // whole 1300-character value twice, which is how it used to be done.
+  assert.ok(lineHtml.length < oldValue.length,
+    `the diff shows the change without emitting both values in full, got ${lineHtml.length} bytes`);
+
+  // Table view: the two cells must not truncate into identical stubs.
+  const rows = adapter.generateComparisonRows(event);
+  assert.ok(rows.includes('ANCIENT-VENUE-NAME') || rows.includes('BRAND-NEW-VENUE-NAME'),
+    `the table cells reveal the divergence, got: ${rows.slice(0, 400)}`);
+});
+
+test('merge-table cells carry no per-cell inline styles (2400 copies of one style string was 300 KB of the white-screened page)', () => {
+  const adapter = buildAdapter();
+  const rows = adapter.generateComparisonRows(buildSizedAnalyzedEvent(9));
+  assert.ok(rows.length > 0, 'the fixture actually produces comparison rows');
+  assert.ok(!/<td[^>]*style="/.test(rows),
+    'no <td style="..."> — the shared chrome lives in one CSS class');
+  assert.ok(/<td class="cmp-field">/.test(rows), 'cells are classed instead');
+});
+
+test('merge-table value cells no longer carry the ENTIRE value in a title attribute', () => {
+  const adapter = buildAdapter();
+  const event = buildSizedAnalyzedEvent(10);
+  const huge = `HUGE ${'q'.repeat(30000)}`;
+  event._original.calendar.address = huge;
+  event._original.scraper.address = `${huge} CHANGED`;
+  event.address = `${huge} CHANGED`;
+  const rows = adapter.generateComparisonRows(event);
+  const titles = rows.match(/title="[^"]*"/g) || [];
+  for (const title of titles) {
+    assert.ok(title.length < 1000,
+      `every tooltip is bounded, got a ${title.length}-byte title attribute`);
+  }
+  assert.ok(rows.includes('chars'), 'the cell states how long the real value is');
+});
+
+test('the results page derives Copy JSON from the single card payload and still drops _original', async () => {
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML(buildSizedResults(2));
+  assert.ok(html.includes('function readCardEventJSON('),
+    'the page derives the copy payload from the embedded card payload');
+  const fnStart = html.indexOf('function readCardEventJSON(');
+  const fnBody = html.slice(fnStart, fnStart + 900);
+  assert.ok(fnBody.includes("key === '_original'"),
+    'the copy path still strips _original, as the old button attribute did');
+  assert.ok(fnBody.includes('JSON.stringify(parsed, null, 2)'),
+    'the copied JSON keeps its two-space indentation');
+  assert.ok(!html.includes("getAttribute('data-event-json')"),
+    'nothing reads the removed attribute any more');
+  assert.ok(html.includes('function prettyPrintCardPayloads('),
+    'the page re-indents the compact payload in the DOM');
 });

--- a/scripts/event-provenance.js
+++ b/scripts/event-provenance.js
@@ -341,6 +341,21 @@ function buildExportIssueJson(event, options = {}) {
     }
 }
 
+// Same payload, no indentation — for embedding in the data-payload attribute
+// ONLY. That attribute is percent-encoded, and percent-encoding charges 3
+// bytes for every indent space (`%20`), so indent-2 was the single largest
+// item left on the results page after the 2026-08-03 size fix: 240 KB of a
+// 1462 KB page. The page-side handler re-indents before showing the textarea,
+// so what the owner copies is unchanged. buildExportIssueJson stays pretty —
+// it is the exported, tested serialization.
+function buildExportIssueCompactJson(event, options = {}) {
+    try {
+        return JSON.stringify(buildExportIssuePayload(event, options));
+    } catch (error) {
+        return JSON.stringify({ error: `Failed to build export payload: ${error.message}` });
+    }
+}
+
 // One value cell: truncated preview with the full value in title= for long
 // values, missing values as an em dash.
 function buildValueCellHtml(value) {
@@ -358,7 +373,7 @@ function buildValueCellHtml(value) {
 // exportProvenanceIssue() handler (defined by the display's script block)
 // reveals the textarea, selects it and attempts document.execCommand('copy').
 function buildExportControlsHtml(event, options = {}) {
-    const encoded = encodeURIComponent(buildExportIssueJson(event, options));
+    const encoded = encodeURIComponent(buildExportIssueCompactJson(event, options));
     return `
             <div class="provenance-export">
                 <button type="button" class="provenance-export-btn" onclick="exportProvenanceIssue(this)" data-payload="${escapeHtml(encoded)}">📤 Export issue</button>
@@ -434,6 +449,7 @@ const EventProvenance = {
     buildProvenanceModel,
     buildExportIssuePayload,
     buildExportIssueJson,
+    buildExportIssueCompactJson,
     buildEventProvenanceSectionHtml
 };
 
@@ -448,6 +464,7 @@ if (typeof module !== 'undefined' && module.exports) {
         buildProvenanceModel,
         buildExportIssuePayload,
         buildExportIssueJson,
+    buildExportIssueCompactJson,
         buildEventProvenanceSectionHtml
     };
 } else if (typeof window !== 'undefined') {

--- a/scripts/event-provenance.test.js
+++ b/scripts/event-provenance.test.js
@@ -6,6 +6,7 @@ const {
     buildProvenanceModel,
     buildExportIssuePayload,
     buildExportIssueJson,
+    buildExportIssueCompactJson,
     buildEventProvenanceSectionHtml
 } = require('./event-provenance');
 
@@ -310,4 +311,29 @@ test('the export control embeds a URI-encoded payload the page JS can decode', (
     assert.ok(html.includes(`onclick="exportProvenanceIssue(this)"`));
     assert.ok(html.includes('provenance-export-text'));
     assert.ok(html.includes('onfocus="this.select()"'));
+});
+
+// The data-payload attribute is percent-encoded, where every indent space
+// costs 3 bytes (`%20`). The embedded copy is therefore compact and the page
+// handler re-indents before showing the textarea — so the payload the owner
+// copies must be IDENTICAL in content to the pretty serialization.
+test('export payload: the compact embed round-trips to the same object as the pretty form', () => {
+  const event = buildMergedEventFixture();
+  const options = { action: 'merge', parser: 'Eagle LA', runId: '20260803-143036' };
+  const pretty = buildExportIssueJson(event, options);
+  const compact = buildExportIssueCompactJson(event, options);
+
+  assert.deepEqual(JSON.parse(compact), JSON.parse(pretty), 'same payload, different whitespace');
+  assert.ok(compact.length < pretty.length, 'the compact form is smaller');
+  assert.ok(!/\n/.test(compact), 'no newlines to percent-encode');
+  // What the page does before showing the textarea.
+  assert.equal(JSON.stringify(JSON.parse(compact), null, 2), pretty, 're-indenting reproduces the pretty form exactly');
+});
+
+test('export payload: the compact builder degrades like the pretty one', () => {
+  assert.equal(typeof JSON.parse(buildExportIssueCompactJson(null)), 'object');
+  const circular = { title: 'Loop' };
+  circular.self = circular;
+  const stub = JSON.parse(buildExportIssueCompactJson(circular));
+  assert.ok(typeof stub === 'object' && stub !== null, 'never throws, always parseable');
 });

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1265,6 +1265,24 @@ class AiWebParser {
             console.log(`🤖 AI Web: Skipped day-header echo "${event.title}" — weekday heading, not an event name`);
             return null;
         }
+        // Site-chrome guard (run 20260803-141425: thelumberyardbar.com's
+        // /upcoming-events produced an event titled "My Account", bar "The
+        // Lumber Yard Bar", rendered with the venue logo — a member-account
+        // nav link, not a night out). Same linguistic-generic contract as the
+        // guards above: the title must be NOTHING but site-chrome vocabulary
+        // AND the event must carry no schedule or price signal of its own, so
+        // a real party that happens to be called "Cruise Control" or "Menu
+        // Night" — anything with a non-chrome word — never qualifies, and a
+        // chrome-named listing that really does state a time or a cover is
+        // kept and left for a human.
+        if (this.isSiteChromeTitle(event.title)) {
+            if (this.hasScheduleOrPriceSignal(event)) {
+                console.log(`🤖 AI Web: Site-chrome title "${event.title}" carries a time/price signal — kept, verify manually`);
+            } else {
+                console.log(`🤖 AI Web: Skipped site chrome "${event.title}" — navigation/account link, not an event`);
+                return null;
+            }
+        }
         // Address plausibility gate: a venue name is not an address (run
         // 20260723-140457: extraction stored address "Legacy" — the bar's own
         // name — and it sailed through to geocoding). Runs BEFORE the bar
@@ -1358,6 +1376,82 @@ class AiWebParser {
     // "Dark Disco" are real event names), and a closed-word alone without a
     // weekday is not a notice either. Token classes only — no per-venue rules,
     // no position heuristics.
+    // Is this title nothing but site chrome? Shape, not a per-site list: a
+    // web page's furniture (account/session, commerce, navigation, legal)
+    // draws from a small closed vocabulary that no event name is built out
+    // of. EVERY token must be chrome and at least one must be an ANCHOR, so
+    // the modifier list alone ("my page", "the us") can never trigger it and
+    // one non-chrome word ("Bear Menu Night", "Home Cooking", "Info Night")
+    // makes the title a name again.
+    //
+    // WEAK anchors are the words a party could plausibly be named after on
+    // their own — a fetish night really could be called "CONTACT", a bar
+    // really could run "SIGN" — so they only count as chrome inside a
+    // multi-word title ("Contact Us", "Sign In", "About Us"). A bare weak
+    // anchor is always kept.
+    isSiteChromeTitle(title) {
+        const normalized = String(title || '')
+            .toLowerCase()
+            .replace(/&#?[0-9a-z]+;/gi, ' ')
+            .replace(/[^a-z0-9]+/g, ' ')
+            .trim();
+        if (!normalized) return false;
+        const strongAnchors = new Set([
+            'account', 'accounts', 'login', 'logins', 'logout', 'signin', 'signup', 'signout',
+            'register', 'registration', 'password', 'profile', 'wallet', 'membership',
+            'dashboard', 'settings', 'preferences', 'subscribe', 'newsletter', 'unsubscribe',
+            'cart', 'basket', 'checkout', 'wishlist', 'search', 'menu', 'navigation', 'nav',
+            'sitemap', 'homepage', 'faq', 'faqs', 'privacy', 'cookies', 'accessibility',
+            'disclaimer', 'copyright', 'careers'
+        ]);
+        const weakAnchors = new Set([
+            'log', 'sign', 'contact', 'home', 'about', 'help', 'support', 'info',
+            'information', 'directions', 'member', 'members', 'terms', 'policy',
+            'conditions', 'reservations', 'booking', 'bookings'
+        ]);
+        const modifiers = new Set([
+            'my', 'your', 'our', 'the', 'a', 'an', 'us', 'we', 'me', 'in', 'out', 'up', 'to',
+            'and', 'or', 'of', 'page', 'pages', 'site', 'link', 'links', 'here', 'view',
+            'main', 'skip', 'content', 'user', 'users', 'client', 'customer', 'go', 'back',
+            'top', 'bottom', 'more', 'new', 'create', 'edit', 'update', 'manage'
+        ]);
+        const tokens = normalized.split(/\s+/);
+        const weakCounts = tokens.length > 1;
+        let anchorCount = 0;
+        for (const token of tokens) {
+            if (strongAnchors.has(token)) {
+                anchorCount++;
+                continue;
+            }
+            if (weakAnchors.has(token)) {
+                if (weakCounts) anchorCount++;
+                continue;
+            }
+            if (modifiers.has(token)) continue;
+            return false;
+        }
+        return anchorCount > 0;
+    }
+
+    // Does the event state a schedule or a price in its OWN extracted text?
+    // startDate/endDate are excluded on purpose — normalization always
+    // synthesizes them, so they prove nothing about the source. Used only to
+    // spare a chrome-shaped title that nevertheless looks like a real
+    // listing (flag-don't-drop: it is kept and logged, never silently fixed).
+    hasScheduleOrPriceSignal(event) {
+        if (!event || typeof event !== 'object') return false;
+        for (const key of ['startTime', 'endTime', 'cover', 'ticketUrl']) {
+            if (typeof event[key] === 'string' && event[key].trim()) return true;
+        }
+        const text = ['title', 'description', 'shortName']
+            .map(key => (typeof event[key] === 'string' ? event[key] : ''))
+            .join(' ');
+        if (!text.trim()) return false;
+        return /\b\d{1,2}:\d{2}\b/.test(text)
+            || /\b\d{1,2}\s*(?:am|pm)\b/i.test(text)
+            || /[$€£]\s*\d/.test(text);
+    }
+
     isVenueHoursNoticeTitle(title) {
         const normalized = String(title || '')
             .toLowerCase()
@@ -1605,6 +1699,19 @@ class AiWebParser {
         return !this.isVenueHoursNoticeTitle(this.deriveSegmentListingTitle(segment));
     }
 
+    // A segment's page TEXT. Every segment constructor carries `lines` — the
+    // same extractBodyParts corpus the prompt and the verbatim-evidence gate
+    // read — so that is the authority. A segment that somehow arrives with no
+    // lines falls back to running the shared corpus builder over whatever
+    // content it has, which strips markup exactly the way cleanHtml does.
+    getSegmentPageText(segment, segmentContent) {
+        const lines = segment && Array.isArray(segment.lines) ? segment.lines.filter(Boolean) : [];
+        if (lines.length > 0) return lines.join('\n');
+        const content = String(segmentContent || '');
+        if (!/<[a-zA-Z!/]/.test(content)) return content;
+        return this.extractBodyParts(content).join('\n');
+    }
+
     buildMultiEventSegmentHtmlData(htmlData, segment, index, totalSegments, ocrResults = [], pageDateContext = null) {
         const sourceUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
         const segmentHtml = segment && typeof segment.html === 'string' ? segment.html : '';
@@ -1637,7 +1744,15 @@ class AiWebParser {
             // The segment's own page text WITHOUT the resource/OCR context
             // lines — the bar-convergence rescue's PAGE corpus, so OCR text
             // stays an independent signal instead of leaking into the page.
-            segmentText: segmentContent,
+            // TEXT, never markup: segmentContent prefers segment.html (the
+            // raw recovered HTML — that is what the prompt builder wants,
+            // because cleanHtml strips it), so this field used to hand the
+            // rescue 9 KB of Wix tag soup as "page lines". Run
+            // 20260803-141425 adopted the footer icon's own closing tag as
+            // the venue: bar "</svg>" on "Dolly and the DJ". The prompt the
+            // model saw was clean, so no verbatim-evidence gate could ever
+            // have caught it.
+            segmentText: this.getSegmentPageText(segment, segmentContent),
             aiEvent: null,
             aiExtraction: null,
             ocrResults: segmentOcrResults,
@@ -7370,8 +7485,52 @@ class AiWebParser {
         return `${section.label}\n${section.lines.join('\n')}`;
     }
 
+    // The 500,000-char corpus cap can slice through the middle of a <script>,
+    // <style> or comment block, orphaning its opening tag. Every corpus
+    // stripper matches open→close PAIRS, so an orphaned opener means the
+    // block body is not markup any more — it is "page text". On
+    // thelumberyardbar.com the cap lands inside a 228 KB
+    // <script type="application/json" id="wix-viewer-model"> and run
+    // 20260803-141425 extracted an event titled "My Account" straight out of
+    // that JSON's Wix member-router config ("title":"My Account"). Sealing
+    // the tail (never trimming it) keeps every byte of real content before
+    // the cut and lets the existing strippers remove the block as intended.
+    sealTruncatedHtmlBlocks(html) {
+        const source = String(html || '');
+        if (!source) return source;
+        const blockTypes = [
+            { open: /<script\b[^>]*>/gi, close: /<\/script[^>]*>/gi, seal: '</script>' },
+            { open: /<style\b[^>]*>/gi, close: /<\/style[^>]*>/gi, seal: '</style>' },
+            { open: /<!--/g, close: /-->/g, seal: '-->' }
+        ];
+        const lastMatchEnd = (pattern, from) => {
+            pattern.lastIndex = from;
+            let match;
+            let end = -1;
+            let start = -1;
+            while ((match = pattern.exec(source)) !== null) {
+                start = match.index;
+                end = match.index + match[0].length;
+            }
+            return { start, end };
+        };
+        const unsealed = [];
+        for (const type of blockTypes) {
+            const opener = lastMatchEnd(type.open, 0);
+            if (opener.start < 0) continue;
+            type.close.lastIndex = opener.end;
+            if (type.close.exec(source) !== null) continue;
+            unsealed.push({ start: opener.start, seal: type.seal });
+        }
+        if (unsealed.length === 0) return source;
+        // Innermost (latest opener) sealed first, so a comment opened inside
+        // a truncated script closes before the script does.
+        unsealed.sort((a, b) => b.start - a.start);
+        return source + unsealed.map(entry => entry.seal).join('');
+    }
+
     getPromptSectionBundle(html, aiConfig = {}) {
-        const source = String(html || '').slice(0, 500000);
+        const source = this.sealTruncatedHtmlBlocks(String(html || '').slice(0, 500000));
         const title = this.extractTitlePart(source);
         const metaParts = this.extractMetaParts(source);
         const jsonLdParts = this.extractJsonLdParts(source);
@@ -8871,7 +9030,7 @@ class AiWebParser {
     cleanHtml(html, aiConfig = {}) {
         if (!html) return '';
         const payloadMode = this.normalizePayloadMode(aiConfig.payloadMode);
-        const source = String(html).slice(0, 500000);
+        const source = this.sealTruncatedHtmlBlocks(String(html).slice(0, 500000));
         const title = this.extractTitlePart(source);
         const metaParts = this.extractMetaParts(source);
         const jsonLdParts = this.extractJsonLdParts(source);
@@ -15480,7 +15639,7 @@ TEXT:
     // them, but "the venue's address in the site footer" is exactly the
     // signal the single-recurring-address fact needs).
     getPageTextForSiteRole(html) {
-        let text = String(html || '').slice(0, 500000);
+        let text = this.sealTruncatedHtmlBlocks(String(html || '').slice(0, 500000));
         text = text.replace(/<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi, ' ');
         text = text.replace(/<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi, ' ');
         text = text.replace(/<!--[\s\S]*?-->/g, ' ');
@@ -15827,6 +15986,24 @@ TEXT:
         return this.getGenericInfrastructureDomainLabels().has(hostMatch[1].toLowerCase());
     }
 
+    // Raw markup is never a venue name — SHAPE only, no vocabulary. A value
+    // that is (or opens with, or is an attribute off) an HTML tag came from
+    // tag soup that leaked into a text corpus, and no venue on earth is
+    // called "</svg>" (run 20260803-141425 shipped exactly that as the bar
+    // for "Dolly and the DJ", rendering as "Dolly and the DJ - 📍</svg>").
+    // Deliberately narrow so real names survive: "<3" is not a tag (a tag
+    // name must start with a letter), and a value with no "<" at all can
+    // only qualify through the attribute shape (name="…"), which no venue
+    // name has.
+    looksLikeMarkupFragment(value) {
+        const text = String(value || '').trim();
+        if (!text) return false;
+        if (/<\/?[a-zA-Z][^<>]*>/.test(text)) return true;
+        if (/^<\/?[a-zA-Z][a-zA-Z0-9:-]*(?:\s|$)/.test(text)) return true;
+        if (/^[a-zA-Z][a-zA-Z0-9:-]*\s*=\s*["']/.test(text)) return true;
+        return false;
+    }
+
     // Post-extraction bar plausibility gate (mirror of
     // applyAddressPlausibilityGate: flag-and-drop, additive log): an
     // address-shaped bar VALUE is never a valid extraction. Run
@@ -15850,7 +16027,8 @@ TEXT:
         // never wired in here, so run 20260731 shipped SPOOKMINCE with bar
         // "Venue TBA" as if an unannounced venue were a real one.
         let reason = '';
-        if (this.isAddressShapedBarValue(bar)) reason = 'address-shaped';
+        if (this.looksLikeMarkupFragment(bar)) reason = 'markup fragment — not a venue name';
+        else if (this.isAddressShapedBarValue(bar)) reason = 'address-shaped';
         else if (this.isPlaceholderVenueName(bar)) reason = 'placeholder — venue not announced';
         else if (this.isDomainShapedBarValue(bar)) reason = 'website domain — not a venue name';
         else reason = this.getCityShapedBarRejection(bar, event, cityConfig);
@@ -16179,6 +16357,11 @@ TEXT:
             ? this.core.normalizeBarNameKey(text)
             : String(text).toLowerCase().replace(/^\s*the\s+/, '').replace(/[^a-z0-9]/g, '');
         if (identityKey.length < 3) return 'too short';
+        // Parity with applyBarPlausibilityGate: a value the gate would DELETE
+        // as markup must never be adoptable by the rescue either. Runs before
+        // every other shape test because a tag normalizes to an innocent key
+        // ("</svg>" → "svg"), which is what let it converge on page+url.
+        if (this.looksLikeMarkupFragment(text)) return 'markup';
         if (/(?:https?:\/\/|www\.)/i.test(text)) return 'url';
         // Parity with applyBarPlausibilityGate: a value the bar gate would
         // DELETE as a website domain must never be adoptable by the rescue

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -10693,3 +10693,188 @@ test('OCR prefers a full-size original over its own resized derivative, and neve
     parser.dropResizedImageUrlsWithOriginal([thumbnail, 'https://eaglela.com/wp-content/uploads/other-1-1.jpg']),
     [thumbnail, 'https://eaglela.com/wp-content/uploads/other-1-1.jpg']);
 });
+
+// ---------------------------------------------------------------------------
+// Run 20260803-141425, thelumberyardbar.com — two defects with one theme:
+// junk that never appeared in the model's own corpus, so no verbatim-evidence
+// gate could ever have caught it.
+//
+//   1. bar "</svg>" on "Dolly and the DJ". The bar-convergence rescue reads
+//      htmlData.segmentText as its PAGE corpus, but segmentText carried the
+//      segment's RAW recovered HTML (9 KB of Wix tag soup), so a footer icon's
+//      closing tag became a "page line", converged with the SEGMENT_LINK_URL
+//      slug of the SVG xmlns (http://www.w3.org/2000/svg → token "svg"), and
+//      was adopted as the venue. The prompt the model saw was clean.
+//   2. an event titled "My Account". The 500,000-char corpus cap slices
+//      through a 228 KB <script type="application/json" id="wix-viewer-model">,
+//      orphaning its opening tag, so the whole Wix router config — including
+//      {"title":"My Account"} — became "page text" for whole-page extraction.
+// ---------------------------------------------------------------------------
+
+// The real footer fragment: a social-icon SVG whose closing tag lands on its
+// own line, plus the xmlns that feeds the URL slug signal.
+const LUMBERYARD_SEGMENT_RAW_HTML = [
+  '<div id="comp-le3o2qlk" class="wixui-rich-text"><h3>Dolly and the DJ</h3></div>',
+  '<h4>Most Saturday Nights</h4>',
+  '<h4>Sunday afternoons</h4>',
+  '<h4>come hang with the friendly bears 2-6pm</h4>',
+  '<a data-testid="linkElement" href="mailto:thelumberyardbar@gmail.com" aria-label="Email Us"><span><svg data-bbox="13.05 2.55 33.878 54.8" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60">',
+  '<path d="M0 0h10v10H0z"/>',
+  '</svg>',
+  '</span></a>',
+  '<p>bottom of page</p>'
+].join('\n');
+
+const LUMBERYARD_SEGMENT_LINES = [
+  'Dolly and the DJ',
+  'Most Saturday Nights',
+  'Sunday afternoons',
+  'come hang with the friendly bears 2-6pm',
+  'bottom of page'
+];
+
+test('lumberyard: a multi-event segment hands the bar rescue TEXT, never the raw recovered HTML', () => {
+  const parser = createParser();
+  const htmlData = parser.buildMultiEventSegmentHtmlData(
+    { url: 'https://www.thelumberyardbar.com/events', html: '<html><body></body></html>' },
+    { lines: LUMBERYARD_SEGMENT_LINES, html: LUMBERYARD_SEGMENT_RAW_HTML },
+    2,
+    3,
+    [],
+    null
+  );
+  // The prompt payload keeps the raw HTML (cleanHtml strips it downstream and
+  // the resource extractors need the attributes) — only the PAGE corpus changes.
+  assert.ok(htmlData.html.includes('</svg>'), 'the prompt payload still carries the raw segment HTML');
+  // The exact URL signal from the run: the SVG's own xmlns is the segment's
+  // only link, and its slug token "svg" is what "</svg>" converged with.
+  assert.ok(htmlData.html.includes('SEGMENT_LINK_URL: http://www.w3.org/2000/svg'),
+    'the fixture must reproduce the run\'s xmlns link signal');
+  assert.equal(htmlData.segmentText, LUMBERYARD_SEGMENT_LINES.join('\n'));
+  assert.equal(/<[a-zA-Z!/]/.test(htmlData.segmentText), false, 'no markup reaches the rescue PAGE corpus');
+});
+
+test('lumberyard: the bar rescue no longer adopts the footer SVG closing tag as the venue', () => {
+  const parser = createParser();
+  const htmlData = parser.buildMultiEventSegmentHtmlData(
+    { url: 'https://www.thelumberyardbar.com/events', html: '<html><body></body></html>' },
+    { lines: LUMBERYARD_SEGMENT_LINES, html: LUMBERYARD_SEGMENT_RAW_HTML },
+    2,
+    3,
+    [],
+    null
+  );
+  const event = { title: 'Dolly and the DJ', city: 'seattle' };
+  const logs = captureLogs(() => {
+    parser.applyBarConvergenceRescue(event, htmlData, { name: 'The Lumber Yard Bar' }, null);
+  });
+  assert.equal('bar' in event, false, 'no bar is invented from markup');
+  assert.equal('_barRescue' in event, false);
+  assert.equal(
+    logs.some(line => line.includes('</svg>')), false,
+    `no markup candidate should even be considered, got: ${JSON.stringify(logs)}`);
+});
+
+test('lumberyard: markup is never a venue name — gate drops it, rescue never nominates it, real names untouched', () => {
+  const parser = createParser();
+
+  assert.equal(parser.looksLikeMarkupFragment('</svg>'), true);
+  assert.equal(parser.looksLikeMarkupFragment('<div class="wixui-rich-text">'), true);
+  assert.equal(parser.looksLikeMarkupFragment('<h3>Dolly and the DJ</h3>'), true);
+  assert.equal(parser.looksLikeMarkupFragment('<svg xmlns'), true, 'a truncated opening tag is still markup');
+  assert.equal(parser.looksLikeMarkupFragment('class="gRkIq0 sFiSiq"'), true, 'a bare attribute fragment is markup');
+  // Real venue names — including the awkward ones the curated corpus proves.
+  assert.equal(parser.looksLikeMarkupFragment('The Lumber Yard Bar'), false);
+  assert.equal(parser.looksLikeMarkupFragment('massive.club'), false);
+  assert.equal(parser.looksLikeMarkupFragment("Ty's"), false);
+  assert.equal(parser.looksLikeMarkupFragment('X BAR'), false);
+  assert.equal(parser.looksLikeMarkupFragment('<3 Lounge'), false, 'a heart is not a tag — a tag name starts with a letter');
+  assert.equal(parser.looksLikeMarkupFragment('R&B > Jazz'), false);
+  assert.equal(parser.looksLikeMarkupFragment(''), false);
+
+  // Gate layer: the exact value the run shipped.
+  const event = { title: 'Dolly and the DJ', bar: '</svg>', city: 'seattle' };
+  const logs = captureLogs(() => { parser.applyBarPlausibilityGate(event, null); });
+  assert.equal('bar' in event, false, 'the markup bar is cleared');
+  assert.ok(
+    logs.includes('🤖 AI Web: Dropped implausible bar "</svg>" (markup fragment — not a venue name)'),
+    `expected the markup drop line, got: ${JSON.stringify(logs)}`);
+
+  // Candidate layer: parity with the gate, so the rescue can never re-adopt it.
+  assert.equal(parser.getVenueLineCandidateRejection('</svg>', {}, {}, null, null), 'markup');
+  assert.equal(parser.getVenueLineCandidateRejection('Legacy', {}, {}, null, null), '');
+  assert.equal(parser.getVenueLineCandidateRejection('The Lumber Yard Bar', {}, {}, null, null), '');
+});
+
+test('lumberyard: a <script> straddling the corpus cap is sealed, not served as page text', () => {
+  const parser = createParser();
+  // The real shape: a huge inline application/json blob whose closing tag sits
+  // beyond the 500,000-char cap, followed by the page's actual copy.
+  const wixBlob = `{"dynamicPages":{"pageRoles":{"jfc17":{"title":"My Account","pageUriSEO":"my-account"}},"pad":"${'x'.repeat(520000)}"}}`;
+  const html = [
+    '<html><head><title>Upcoming Events | lumberyardbar</title></head><body>',
+    '<h1>QUEERAOKE</h1><p>Wednesday nights @ 8:30pm</p>',
+    `<script type="application/json" id="wix-viewer-model">${wixBlob}</script>`,
+    '<p>bottom of page</p>',
+    '</body></html>'
+  ].join('');
+  assert.ok(html.length > 500000, 'the fixture must actually exceed the corpus cap');
+
+  const cleaned = parser.cleanHtml(html, {});
+  assert.equal(cleaned.includes('My Account'), false, 'the orphaned script body never becomes page text');
+  assert.equal(cleaned.includes('dynamicPages'), false);
+  assert.ok(cleaned.includes('QUEERAOKE'), 'real copy before the cut survives');
+  assert.ok(cleaned.includes('Wednesday nights @ 8:30pm'));
+
+  const bundle = parser.getPromptSectionBundle(html, {});
+  const contentLines = bundle.content ? bundle.content.lines.join('\n') : '';
+  assert.equal(contentLines.includes('My Account'), false);
+  assert.ok(contentLines.includes('QUEERAOKE'));
+
+  // The seal is additive and idempotent: well-formed HTML is returned as-is.
+  const balanced = '<html><body><script>var a=1;</script><p>hi</p></body></html>';
+  assert.equal(parser.sealTruncatedHtmlBlocks(balanced), balanced);
+  assert.equal(parser.sealTruncatedHtmlBlocks('<body><p>hi</p><script>var a=1;'),
+    '<body><p>hi</p><script>var a=1;</script>');
+  assert.equal(parser.sealTruncatedHtmlBlocks('<p>hi</p><!-- cut here'), '<p>hi</p><!-- cut here-->');
+});
+
+test('lumberyard: a site-chrome title is not an event, and every real scraped title survives', () => {
+  const parser = createParser();
+  // The reported junk and its Wix siblings.
+  assert.equal(parser.isSiteChromeTitle('My Account'), true);
+  assert.equal(parser.isSiteChromeTitle('My Wallet'), true);
+  assert.equal(parser.isSiteChromeTitle('Log In'), true);
+  assert.equal(parser.isSiteChromeTitle('Sign Up'), true);
+  assert.equal(parser.isSiteChromeTitle('Cart'), true);
+  assert.equal(parser.isSiteChromeTitle('Search'), true);
+  assert.equal(parser.isSiteChromeTitle('Contact Us'), true);
+  assert.equal(parser.isSiteChromeTitle('About Us'), true);
+  assert.equal(parser.isSiteChromeTitle('Privacy Policy'), true);
+
+  // Real Lumberyard / Massive / BEEFMINCE titles from the same run history.
+  for (const title of [
+    'QUEERAOKE', 'Dolly and the DJ', 'Trivia Taco night', 'Drink and Draw',
+    'Taco Tuesday', 'Happy hour menu', 'BRUNCH 11-2pm', 'Brunch Menu',
+    'Bear Happy Hour', 'Massive Saturdays', 'Make Out Party', 'Bottom Forty',
+    'SABOR (Latin Night)', 'Discipline (Kink/Fetish)', 'BLOWPOP', 'THE BEAR CAVE',
+    'Member Appreciation Night', 'Menu Night', 'Home Cooking', 'Info Night'
+  ]) {
+    assert.equal(parser.isSiteChromeTitle(title), false, `real event title rejected as chrome: ${title}`);
+  }
+  // A bare weak anchor is a plausible party name and is always kept.
+  assert.equal(parser.isSiteChromeTitle('CONTACT'), false);
+  assert.equal(parser.isSiteChromeTitle('Home'), false);
+  assert.equal(parser.isSiteChromeTitle('Members'), false);
+  assert.equal(parser.isSiteChromeTitle(''), false);
+  assert.equal(parser.isSiteChromeTitle(null), false);
+
+  // Flag-don't-drop escape hatch: a chrome-shaped listing that states a real
+  // time or cover is kept for a human, never silently dropped.
+  assert.equal(parser.hasScheduleOrPriceSignal({ title: 'My Account' }), false);
+  assert.equal(parser.hasScheduleOrPriceSignal({ title: 'My Account', startDate: '2026-08-03' }), false,
+    'a synthesized startDate is not evidence of a schedule');
+  assert.equal(parser.hasScheduleOrPriceSignal({ title: 'Members Night', description: 'doors 10pm' }), true);
+  assert.equal(parser.hasScheduleOrPriceSignal({ title: 'Cart', cover: '$10' }), true);
+  assert.equal(parser.hasScheduleOrPriceSignal({ title: 'Cart', startTime: '22:00' }), true);
+});

--- a/scripts/scraper-promoters.js
+++ b/scripts/scraper-promoters.js
@@ -170,7 +170,8 @@ const scraperPromoters = [
     "name": "Club Chub",
     "shortName": "CLUB CHUB",
     "instagram": "https://www.instagram.com/clubchubparty",
-    "bearAffinity": "always"
+    "bearAffinity": "always",
+    "website": "https://www.clubchubusa.com"
   },
   {
     "name": "Fat Dad",

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2112,8 +2112,8 @@ class SharedCore {
         const platform = PLATFORM_IDENTITY_HOSTS.find(candidate =>
             host === candidate || host.endsWith(`.${candidate}`));
         if (!platform || host === platform) return false;
-        // No `new URL(` in scripts/ — take the path with the same regex shape
-        // used elsewhere in this file.
+        // The WHATWG URL parser is banned in scripts/ (platform purity), so
+        // take the path with the same regex shape used elsewhere in this file.
         const pathMatch = raw.match(/^https?:\/\/[^\/?#]+([^?#]*)/i);
         const path = pathMatch ? pathMatch[1] : '';
         return path === '' || path === '/';

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2089,6 +2089,36 @@ class SharedCore {
     // sickening.events/e/goldiloxx-chicago/tickets, which is exactly the
     // vendor link this must NOT protect. Fails closed — no matched entry, no
     // host-anchored token, no protection.
+    // A BRANDED SUBDOMAIN on a ticketing host with a bare path is that
+    // organizer's home page, not a ticket link — the same thing
+    // `eventbrite.com/o/<organizer-id>` already is, in a different shape.
+    // Measured on the corpus (2026-08-03), the two shapes never overlap:
+    //   organizer home  bbromp2026.eventbrite.com/          Big Bear ROMP 2026
+    //                   westernxposurefall2026.eventbrite.com/
+    //                   xxl2026.eventbrite.com/             Western Xposure XXL
+    //                   lazybearweek.eventbrite.com/        Lazy Bear Week 2026
+    //                   newduro.eventbrite.com              D>U>R>O
+    //   ticket link     eventbrite.com/e/quenchd-tickets-1993587626256
+    //                   eventbrite.com/e/club-chub-weekend-2026-…
+    // So this is decided by URL SHAPE and needs no curated data — which is why
+    // it is preferred over four hand-written registry entries. A path of any
+    // substance ('/e/…', '/o/…' handled elsewhere) is never an organizer home.
+    isPlatformOrganizerHomeUrl(url) {
+        const raw = String(url || '').trim();
+        if (!raw) return false;
+        const host = this.getHostFromUrl(raw).toLowerCase().replace(/^www\./, '');
+        if (!host || !isPlatformIdentityHost(host)) return false;
+        // The host must carry a brand label ABOVE the platform domain.
+        const platform = PLATFORM_IDENTITY_HOSTS.find(candidate =>
+            host === candidate || host.endsWith(`.${candidate}`));
+        if (!platform || host === platform) return false;
+        // No `new URL(` in scripts/ — take the path with the same regex shape
+        // used elsewhere in this file.
+        const pathMatch = raw.match(/^https?:\/\/[^\/?#]+([^?#]*)/i);
+        const path = pathMatch ? pathMatch[1] : '';
+        return path === '' || path === '/';
+    }
+
     isCuratedPlatformSelfIdentityUrl(event, url) {
         const lowered = String(url || '').toLowerCase();
         if (!lowered) return false;
@@ -11092,6 +11122,12 @@ class SharedCore {
                         }
                         notesNeedRebuild = true;
                         console.log(`🔗 LINKS: replaced platform website ${platformWebsite} with ${curatedWebsite}${existingTicketUrl ? '' : ' (platform link moved to ticketUrl)'} — curated identity of "${promoterEntry.name}" for "${analyzedEvent.title || 'event'}"`);
+                    } else if (!curatedWebsite && this.isPlatformOrganizerHomeUrl(platformWebsite)) {
+                        // A branded subdomain with a bare path is the
+                        // organizer's HOME on that platform, not a ticket
+                        // link — see isPlatformOrganizerHomeUrl. Decided by
+                        // URL shape, so it needs no registry entry.
+                        console.log(`🔗 LINKS: website ${platformWebsite} is a platform organizer home page, not a ticket link — left as-is for "${analyzedEvent.title || 'event'}"`);
                     } else if (!curatedWebsite && this.isCuratedPlatformSelfIdentityUrl(analyzedEvent, platformWebsite)) {
                         // The promoter's OWN presence on the platform (their
                         // instagram profile, their eventbrite organizer page).

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2080,6 +2080,25 @@ class SharedCore {
         return matches.length === 1 ? matches[0].entry : null;
     }
 
+    // True when a URL on a platform-identity host is the promoter's OWN
+    // curated presence on that platform — instagram.com/<handle>, or an
+    // eventbrite.com/o/<organizer-id> page named in the entry's urlPatterns —
+    // rather than a listing for one event. Only HOST-ANCHORED curated tokens
+    // (those carrying a path separator) can prove it: a bare brand token like
+    // Goldiloxx's "goldiloxx" also occurs inside the ticket URL
+    // sickening.events/e/goldiloxx-chicago/tickets, which is exactly the
+    // vendor link this must NOT protect. Fails closed — no matched entry, no
+    // host-anchored token, no protection.
+    isCuratedPlatformSelfIdentityUrl(event, url) {
+        const lowered = String(url || '').toLowerCase();
+        if (!lowered) return false;
+        const entry = this.getCuratedPromoterIdentityEntry(event);
+        if (!entry) return false;
+        const indexed = this.getPromoterRegistryIndex().entries.find(item => item.entry === entry);
+        const tokens = indexed && Array.isArray(indexed.urlTokens) ? indexed.urlTokens : [];
+        return tokens.some(token => token.includes('/') && lowered.includes(token));
+    }
+
     // Per-run match index over this.promoters (rebuilt when the registry
     // array is replaced, e.g. by the remote refresh). Precomputes:
     //   - nameKeys: identity keys of name + aliases (organizer equality)
@@ -6291,15 +6310,35 @@ class SharedCore {
             }
         }
 
+        // Keyword tier, split by WHERE the hit lives (owner ruling 2026-08-03:
+        // "Pet Night" and "Gear Night" are NOT bear events — both were keyword
+        // verdicts that short-circuited the AI on description prose, "unleash
+        // your inner pup" and a dress-code aside "you can always wear your
+        // regular leather or gear"). See classifyBearKeywordMatch: title and
+        // venue-name hits are identity and still short-circuit; a hit found
+        // ONLY in the free-text description short-circuits only when that
+        // description NAMES a registry brand.
         const matched = this.matchBearKeywords(searchText);
-        if (matched.length > 0) {
+        const keywordTier = this.classifyBearKeywordMatch(event, matched);
+        if (matched.length > 0 && keywordTier.shortCircuit) {
             return { result: 'bear', provenance: `keyword: ${matched.join(', ')}` };
+        }
+        if (matched.length > 0) {
+            console.log(`🐻 BEAR CHECK: keyword ${matched.join(', ')} appears only in the description of "${event.title || 'Unknown'}" and names no registry brand — deferring to the AI tier`);
         }
 
         const aiVerdict = await this.getAiBearVerdict(event, parserConfig, httpAdapter);
         if (aiVerdict) {
             const aiDecision = { result: aiVerdict.verdict, provenance: `ai: ${aiVerdict.reason || 'no reason given'}` };
             return this.applyBearEvidenceGate(aiDecision, event, parserConfig, aiVerdict.evidence);
+        }
+
+        // Fail closed: a deferred description-only match the AI tier could not
+        // judge keeps its legacy keyword verdict. The split RE-ROUTES the
+        // decision to a better judge — it never drops a bear event when that
+        // judge is unavailable.
+        if (matched.length > 0) {
+            return { result: 'bear', provenance: `keyword: ${matched.join(', ')} (ai unavailable)` };
         }
 
         if (trust.affinity === 'always') {
@@ -6344,6 +6383,87 @@ class SharedCore {
             if (new RegExp(`\\b${escaped}\\b`, 'i').test(source)) matched.push(keyword);
         }
         return matched;
+    }
+
+    // Registry-derived brand phrases that themselves carry bear vocabulary:
+    // "Bearracuda", "MEGA-WOOF", "Club Chub", "Bears Sitges Week". Derived
+    // from the curated promoter registry, never a hardcoded list — a brand
+    // whose own name contains no bear word (Goldiloxx, SPOOKMINCE) can never
+    // be the source of a keyword hit and is skipped. Cached against the
+    // registry array's identity, like getPromoterRegistryIndex.
+    getBearBrandPhraseIndex() {
+        if (this._bearBrandPhraseIndex && this._bearBrandPhraseIndex.source === this.promoters) {
+            return this._bearBrandPhraseIndex;
+        }
+        const list = Array.isArray(this.promoters) ? this.promoters : [];
+        const phrases = [];
+        const keys = [];
+        for (const entry of list) {
+            if (!entry) continue;
+            const names = [entry.name, entry.shortName, entry.shorterName,
+                ...(Array.isArray(entry.aliases) ? entry.aliases : [])];
+            for (const name of names) {
+                if (!name || this.matchBearKeywords(name).length === 0) continue;
+                const phrase = this.buildPromoterTokenPhrase(name);
+                if (phrase && !phrases.includes(phrase)) phrases.push(phrase);
+                // Compact key too: curated shortNames carry display hyphens
+                // ("MEGA-WOOF", "BEAR-RAC-UDA") that padded-token containment
+                // could never match against a description writing "MEGAWOOF".
+                const key = this.normalizePromoterNameKey(name);
+                if (key.length >= 5 && !keys.includes(key)) keys.push(key);
+            }
+        }
+        this._bearBrandPhraseIndex = { source: this.promoters, phrases, keys };
+        return this._bearBrandPhraseIndex;
+    }
+
+    // The registry brand this text NAMES ('' when none). Padded-token
+    // containment — the same idiom promoter title matching uses — plus
+    // compact-key containment for the hyphenated shortName variants.
+    textNamesBearBrand(text) {
+        const index = this.getBearBrandPhraseIndex();
+        const padded = this.buildPaddedPromoterTitleText(text);
+        if (padded) {
+            for (const phrase of index.phrases) {
+                if (padded.includes(` ${phrase} `)) return phrase;
+            }
+        }
+        const compact = this.normalizePromoterNameKey(text);
+        if (compact) {
+            for (const key of index.keys) {
+                if (compact.includes(key)) return key;
+            }
+        }
+        return '';
+    }
+
+    // Where a bear keyword hit lives, and whether that location may
+    // short-circuit the AI tier (owner ruling 2026-08-03).
+    //   title   → yes. A bear word in the event's own name is identity.
+    //   venue   → yes. `bar` is a NAME, not prose: BEARS DISCO, Bear-Village,
+    //             CHUNK-PARTY.COM are all correct keyword bears, and the venue
+    //             name is curated/extracted identity data (curated beats
+    //             derived).
+    //   description + a registry brand → yes. Bearracuda's Portland NYE / SF
+    //             FLSM / Treasure Trail family puts the BRAND in the
+    //             description and not the title; that is still identity.
+    //   description, generic vocabulary only → NO. "unleash your inner pup",
+    //             "wear your regular leather or gear" is prose about a
+    //             dress code, and the AI tier gets these right when it is
+    //             allowed to see them.
+    classifyBearKeywordMatch(event, matched) {
+        if (!Array.isArray(matched) || matched.length === 0) {
+            return { shortCircuit: false, source: 'none', brand: '' };
+        }
+        if (this.matchBearKeywords(event && event.title).length > 0) {
+            return { shortCircuit: true, source: 'title', brand: '' };
+        }
+        if (this.matchBearKeywords(event && event.bar).length > 0) {
+            return { shortCircuit: true, source: 'venue', brand: '' };
+        }
+        const brand = this.textNamesBearBrand(event && event.description);
+        if (brand) return { shortCircuit: true, source: 'description-brand', brand };
+        return { shortCircuit: false, source: 'description-generic', brand: '' };
     }
 
     // True when the event was actually extracted from a page on a DIFFERENT
@@ -10945,8 +11065,12 @@ class SharedCore {
             // platform value is simply replaced) and website/url adopt the
             // curated link. A curated linktree (Megawoof, Cubhouse) is fine
             // and intended — the site handles linktree favicons specially.
-            // Platform host but NO curated identity → flag-only log, nothing
-            // changes; a website on a non-platform host is never touched.
+            // Platform host but NO curated website → the platform link is
+            // CLEARED out of website/url and parked in ticketUrl (owner ruling
+            // 2026-08-03, see the branch below); the one exception is a URL
+            // that is the promoter's own curated presence ON that platform,
+            // which is a real identity link and is left alone. A website on a
+            // non-platform host is never touched.
             {
                 const platformWebsite = typeof analyzedEvent.website === 'string' ? analyzedEvent.website.trim() : '';
                 const websiteHost = platformWebsite
@@ -10968,8 +11092,51 @@ class SharedCore {
                         }
                         notesNeedRebuild = true;
                         console.log(`🔗 LINKS: replaced platform website ${platformWebsite} with ${curatedWebsite}${existingTicketUrl ? '' : ' (platform link moved to ticketUrl)'} — curated identity of "${promoterEntry.name}" for "${analyzedEvent.title || 'event'}"`);
-                    } else if (!curatedWebsite) {
+                    } else if (!curatedWebsite && this.isCuratedPlatformSelfIdentityUrl(analyzedEvent, platformWebsite)) {
+                        // The promoter's OWN presence on the platform (their
+                        // instagram profile, their eventbrite organizer page).
+                        // That IS an identity link — never stripped.
                         console.log(`🔗 LINKS: website ${platformWebsite} is on a platform host but no curated identity to fall back to — left as-is for "${analyzedEvent.title || 'event'}"`);
+                    } else if (!curatedWebsite) {
+                        // Owner ruling 2026-08-03, verbatim: "ticket URLs
+                        // shouldn't be website/url fields, they should always
+                        // go in the ticketUrl … filling it with the ticket
+                        // link again isn't helpful. It would be better to have
+                        // that field empty."  website/url are ONE canonical
+                        // field and drive the site favicon, so a vendor or
+                        // social LISTING url sitting there renders Eventbrite's
+                        // icon (or none) instead of the promoter's. With no
+                        // curated website to adopt, EMPTY is strictly better:
+                        // the site then falls back to the promoter's curated
+                        // favicon (Goldiloxx deliberately ships
+                        // `favicon: https://linktr.ee/goldiloxx` and NO
+                        // website). Observed 2026-08-03: Club Chub DTLA carried
+                        // website = facebook.com/events/1376781057883088 with
+                        // an empty ticketUrl, and GOLDILOXX Chicago carried the
+                        // same sickening.events ticket link in both fields
+                        // under two different paths.
+                        // Flag, don't drop: the link is never lost — it moves
+                        // into an EMPTY ticketUrl; when a real ticketUrl is
+                        // already there it wins and the platform duplicate goes.
+                        const existingTicketUrl = typeof analyzedEvent.ticketUrl === 'string' ? analyzedEvent.ticketUrl.trim() : '';
+                        if (!existingTicketUrl) {
+                            analyzedEvent.ticketUrl = platformWebsite;
+                        }
+                        delete analyzedEvent.website;
+                        // `url` is an ALIAS of website — ONE canonical field —
+                        // so it goes with it, exactly as the curated-adopt
+                        // branch above writes both. Deliberately NOT "promote a
+                        // differing url into website": in the corpus every such
+                        // url is a link-aggregator's own copy of the event page
+                        // (thebearcalendar.com/events/…), which
+                        // applyAggregatorWebsitePointers exists to move AWAY
+                        // from. Trust the pointer, not the copy.
+                        delete analyzedEvent.url;
+                        notesNeedRebuild = true;
+                        const parked = existingTicketUrl
+                            ? `existing ticketUrl ${existingTicketUrl} kept`
+                            : 'moved to ticketUrl';
+                        console.log(`🔗 LINKS: cleared platform website ${platformWebsite} — a ticketing/social link is never the identity link (${parked}, website/url left empty) for "${analyzedEvent.title || 'event'}"`);
                     }
                 }
             }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4764,6 +4764,129 @@ test('matchBearKeywords: boundary tier hits whole words, never substrings', () =
   assert.deepEqual(core.matchBearKeywords('fatal furniture update puppet'), []);
 });
 
+// ---------------------------------------------------------------------------
+// Keyword-tier split (owner ruling 2026-08-03: "Pet Night" and "Gear Night"
+// are NOT bear events). Every fixture is verbatim from the 20260803 runs.
+// WIRING: the split is registry-backed, so `promoters` MUST be injected — a
+// core without it can never find a brand and would fake a passing result.
+// ---------------------------------------------------------------------------
+const REAL_PROMOTERS = require('../data/promoters.json');
+function createBearTierCore() {
+  return new SharedCore(CITIES, { eventSchema: EventSchema, promoters: REAL_PROMOTERS });
+}
+
+test('bear keyword tier: title and venue-name hits still short-circuit; description-only generic vocabulary does not', () => {
+  const core = createBearTierCore();
+  const classify = (event) => core.classifyBearKeywordMatch(
+    event,
+    core.matchBearKeywords(`${event.title || ''} ${event.description || ''} ${event.bar || ''}`)
+  );
+
+  // Title — unchanged.
+  assert.deepEqual(classify({ title: 'CLUB CHUB: QUENCHD' }),
+    { shortCircuit: true, source: 'title', brand: '' });
+
+  // Venue name — a NAME, not prose. These are the corpus's correct
+  // bar-name-only keyword bears.
+  for (const bar of ['BEARS DISCO', 'Bear-Village', 'CHUNK-PARTY.COM']) {
+    assert.deepEqual(classify({ title: 'Osos en la Playa', bar }).shortCircuit, true, bar);
+  }
+
+  // Description-only GENERIC vocabulary — the two the owner ruled on.
+  assert.deepEqual(
+    classify({
+      title: 'Pet Night',
+      bar: 'Dallas Eagle',
+      description: 'It’s PET NIGHT at the Dallas Eagle! Get ready to unleash your inner pup and join us for a night of tail-wagging fun 🐶🦅 Spread the woof!'
+    }),
+    { shortCircuit: false, source: 'description-generic', brand: '' });
+  assert.deepEqual(
+    classify({
+      title: 'Wig Out Wig Night',
+      bar: 'Dallas Eagle',
+      description: 'From buzzcut to bombshell, it’s time to Wig Out! 🦅 It’s the Eagle, you can always wear your regular leather or gear and never feel out of place.'
+    }),
+    { shortCircuit: false, source: 'description-generic', brand: '' });
+  assert.deepEqual(
+    classify({
+      title: 'Gear Night',
+      bar: 'Dallas Eagle',
+      description: 'Grab your gear, it’s time for GEAR NIGHT! Leather, Harnesses, Rubber, Sports, any kind of gear is always welcome at the Dallas Eagle!'
+    }),
+    { shortCircuit: false, source: 'description-generic', brand: '' });
+});
+
+test('bear keyword tier: a description-only hit that NAMES a registry brand keeps its short-circuit', () => {
+  const core = createBearTierCore();
+  const classify = (event) => core.classifyBearKeywordMatch(
+    event,
+    core.matchBearKeywords(`${event.title || ''} ${event.description || ''} ${event.bar || ''}`)
+  );
+
+  // The Bearracuda family: the BRAND is in the description, never the title.
+  for (const title of ['Portland NYE', 'SF⛓️ FLSM', 'TREASURE TRAIL Portland PRIDE']) {
+    assert.deepEqual(
+      classify({ title, bar: 'Nova PDX', description: 'Bearracuda is the biggest, longest-running bear dance party in the world.' }),
+      { shortCircuit: true, source: 'description-brand', brand: 'bearracuda' },
+      title);
+  }
+  // The curated shortName's display hyphens ("MEGA-WOOF", "BEAR-RAC-UDA") must
+  // still match a description that writes the brand smooshed.
+  assert.equal(classify({ title: 'Saturday', description: 'MEGAWOOF presents an all-night takeover' }).source,
+    'description-brand');
+
+  // A registry brand whose own name carries NO bear vocabulary (SPOOKMINCE,
+  // Goldiloxx) is not a bear-brand phrase — it cannot rescue generic prose.
+  assert.equal(core.textNamesBearBrand('Goldiloxx is back in Chicago'), '');
+  // The brand set is DERIVED, never hardcoded: an empty registry finds none.
+  const bare = new SharedCore(CITIES, { eventSchema: EventSchema, promoters: [] });
+  assert.equal(bare.textNamesBearBrand('Bearracuda is the biggest bear dance party'), '');
+});
+
+test('bear keyword tier: a deferred description-only hit is judged by the AI, and never dropped when the AI is unavailable', async () => {
+  const petNight = {
+    title: 'Pet Night',
+    bar: 'Dallas Eagle',
+    city: 'dallas',
+    description: 'Get ready to unleash your inner pup and join us for a night of tail-wagging fun 🐶🦅 Spread the woof!'
+  };
+
+  // The AI tier now gets to see it — and its verdict is what ships.
+  const notBear = buildBearVerdictAdapter({
+    verdict: 'not_bear',
+    reason: 'a pup/gear night, not a bear event',
+    eventEvidence: ['unleash your inner pup']
+  });
+  const drops = [];
+  const kept = await createBearTierCore().filterBearEvents([petNight], bearCheckConfig('enforce'), notBear, drops);
+  assert.equal(notBear.calls.length, 1, 'the AI tier was consulted — the keyword tier no longer short-circuits it');
+  assert.equal(kept.length, 0, 'Pet Night is not a bear event');
+  assert.equal(drops.length, 1);
+  assert.match(drops[0].reason, /^ai: /);
+
+  // Fail closed: with no AI available the legacy keyword verdict stands, so
+  // the split can never silently lose a bear event.
+  const noAi = await createBearTierCore().filterBearEvents([petNight], bearCheckConfig('enforce'), null, []);
+  assert.equal(noAi.length, 1, 'kept when the AI tier cannot judge');
+  assert.equal(noAi[0].bearSource, 'keyword', 'still provenanced as a keyword verdict');
+
+  // A TITLE hit is unchanged: still short-circuits ahead of any AI request.
+  const titleAdapter = buildBearVerdictAdapter({ verdict: 'not_bear', reason: 'nope' });
+  const titleKept = await createBearTierCore().filterBearEvents(
+    [{ title: 'CLUB CHUB: QUENCHD', bar: 'The Godfrey Hotel Hollywood', city: 'dallas' }],
+    bearCheckConfig('enforce'), titleAdapter, []);
+  assert.equal(titleAdapter.calls.length, 0, 'no AI request for a title keyword hit');
+  assert.equal(titleKept[0].bearSource, 'keyword');
+
+  // Bearracuda's description-only BRAND hit likewise short-circuits.
+  const brandAdapter = buildBearVerdictAdapter({ verdict: 'not_bear', reason: 'nope' });
+  const brandKept = await createBearTierCore().filterBearEvents(
+    [{ title: 'Portland NYE', bar: 'Nova PDX', city: 'dallas', description: 'Bearracuda is the biggest bear dance party in the world.' }],
+    bearCheckConfig('enforce'), brandAdapter, []);
+  assert.equal(brandAdapter.calls.length, 0, 'no AI request when the description names the brand');
+  assert.equal(brandKept[0].bearSource, 'keyword');
+});
+
 test('bear check report mode returns exactly what legacy returns', async () => {
   const events = [
     { title: 'Bear Night' },
@@ -12463,7 +12586,7 @@ test('final build: an existing ticketUrl survives — the platform website is si
     ['🔗 LINKS: replaced platform website https://www.etix.com/ticket/p/54403374 with https://www.furball.nyc — curated identity of "Furball" for "FURBALL NYC"']);
 });
 
-test('final build: platform website with NO curated identity only logs; non-platform websites stay silent', async () => {
+test('final build: platform website with NO curated identity is CLEARED into ticketUrl; non-platform websites stay silent', async () => {
   const core = createFinalBuildCore({ promoters: require('../data/promoters.json') });
   const event = {
     title: 'MYSTERY TEA DANCE',
@@ -12479,11 +12602,16 @@ test('final build: platform website with NO curated identity only logs; non-plat
   } finally {
     restore();
   }
-  assert.equal(analyzed.website, 'https://www.eventbrite.com/e/mystery-tickets-1', 'left as-is');
-  assert.equal(analyzed.ticketUrl, undefined, 'nothing moved');
+  // Owner ruling 2026-08-03: an empty website beats a vendor's — the site
+  // falls back to the promoter's curated favicon.
+  assert.equal(analyzed.website, undefined, 'the vendor link never occupies website');
+  assert.equal(analyzed.url, undefined, 'url is an alias of website and goes with it');
+  assert.equal(analyzed.ticketUrl, 'https://www.eventbrite.com/e/mystery-tickets-1', 'the link is parked in ticketUrl, not lost');
+  assert.ok(!analyzed.notes.includes('website:'), 'notes carry no website line');
+  assert.ok(analyzed.notes.includes('ticketUrl: https://www.eventbrite.com/e/mystery-tickets-1'));
   assert.deepEqual(
     lines.filter(line => line.startsWith('🔗 LINKS:')),
-    ['🔗 LINKS: website https://www.eventbrite.com/e/mystery-tickets-1 is on a platform host but no curated identity to fall back to — left as-is for "MYSTERY TEA DANCE"']);
+    ['🔗 LINKS: cleared platform website https://www.eventbrite.com/e/mystery-tickets-1 — a ticketing/social link is never the identity link (moved to ticketUrl, website/url left empty) for "MYSTERY TEA DANCE"']);
 
   // A website whose host is NOT a platform host is never touched, even with
   // a matched promoter (Megawoof's curated linktree stays a linktree).
@@ -12504,6 +12632,185 @@ test('final build: platform website with NO curated identity only logs; non-plat
   }
   assert.equal(untouched.website, 'https://linktr.ee/megawoof_america');
   assert.equal(quiet.filter(line => line.startsWith('🔗 LINKS:')).length, 0, 'no LINKS line for a non-platform website');
+});
+
+// ---------------------------------------------------------------------------
+// Fix (owner, run 20260803): "Overall ticket URLs shouldn't be website/url
+// fields, they should always go in the ticketUrl … filling it with the ticket
+// link again isn't helpful. It would be better to have that field empty."
+// Every fixture below is a real event from the 20260803 runs.
+// ---------------------------------------------------------------------------
+
+test('final build: a facebook EVENT link never occupies website/url (real Club Chub DTLA)', async () => {
+  const core = createFinalBuildCore({ promoters: require('../data/promoters.json') });
+  const event = {
+    title: 'Club Chub DTLA - Latin Night',
+    startDate: new Date('2026-08-16T22:00:00.000Z'),
+    city: 'la',
+    website: 'https://www.facebook.com/events/1376781057883088/',
+    url: 'https://www.facebook.com/events/1376781057883088/',
+    instagram: 'https://www.instagram.com/clubchubparty',
+    _promoter: 'Club Chub'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+  // Club Chub is in the registry but carries NO website — so there is nothing
+  // to adopt, and empty is the right answer (the site falls back to the
+  // promoter's curated favicon).
+  assert.equal(analyzed.website, undefined, 'facebook.com/events/… is social, not identity');
+  assert.equal(analyzed.url, undefined, 'url is the same canonical field');
+  assert.equal(analyzed.ticketUrl, 'https://www.facebook.com/events/1376781057883088/', 'the link lands in ticketUrl');
+  assert.ok(!analyzed.notes.includes('website: https://www.facebook.com'), 'notes never serialize it as website');
+  assert.equal(analyzed.instagram, 'https://www.instagram.com/clubchubparty', 'the curated instagram is untouched');
+  assert.equal(lines.filter(line => line.startsWith('🔗 LINKS: cleared platform website')).length, 1);
+});
+
+test('final build: an eventbrite listing with tracking params never occupies website (real Club Chub Weekend 2026)', async () => {
+  const core = createFinalBuildCore({ promoters: require('../data/promoters.json') });
+  const listing = 'https://www.eventbrite.com/e/club-chub-weekend-2026-the-ultimate-celebration-tickets-1975884326209?utm-campaign=social&aff=ebdsshcopyurl';
+  const event = {
+    title: 'Club Chub Weekend 2026 — The Ultimate Celebration!',
+    startDate: new Date('2026-11-06T23:00:00.000Z'),
+    city: 'dallas',
+    website: listing,
+    url: listing,
+    _promoter: 'Club Chub'
+  };
+  const restore = captureFinalBuildLogs([]);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+  assert.equal(analyzed.website, undefined);
+  assert.equal(analyzed.url, undefined);
+  assert.equal(analyzed.ticketUrl, listing, 'query string and all — the value is moved verbatim, never rewritten');
+});
+
+test('final build: a duplicated ticket link is cleared out of website even when ticketUrl already holds one (real GOLDILOXX Chicago)', async () => {
+  const core = createFinalBuildCore({ promoters: require('../data/promoters.json') });
+  const event = {
+    title: 'GOLDILOXX Chicago | NYC\'s Interactive Nightlife Experience',
+    startDate: new Date('2026-09-05T02:00:00.000Z'),
+    city: 'chicago',
+    // The ticket link duplicated into website under a slightly different path.
+    website: 'https://www.sickening.events/e/goldiloxx-chicago-2/tickets',
+    ticketUrl: 'https://www.sickening.events/e/goldiloxx-chicago/tickets',
+    _promoter: 'Goldiloxx'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+  // Goldiloxx deliberately ships `favicon: https://linktr.ee/goldiloxx` and NO
+  // website — an empty website is exactly the owner's pattern here. The
+  // entry's bare "goldiloxx" urlPattern occurs inside the ticket URL and must
+  // NOT be read as the promoter's own presence on sickening.events.
+  assert.equal(core.isCuratedPlatformSelfIdentityUrl(event, event.website), false,
+    'a bare brand token inside a vendor path is not a self-identity link');
+  assert.equal(analyzed.website, undefined);
+  assert.equal(analyzed.ticketUrl, 'https://www.sickening.events/e/goldiloxx-chicago/tickets',
+    'the real ticketUrl is never overwritten by the website duplicate');
+  assert.deepEqual(
+    lines.filter(line => line.startsWith('🔗 LINKS: cleared platform website')),
+    ['🔗 LINKS: cleared platform website https://www.sickening.events/e/goldiloxx-chicago-2/tickets — a ticketing/social link is never the identity link (existing ticketUrl https://www.sickening.events/e/goldiloxx-chicago/tickets kept, website/url left empty) for "GOLDILOXX Chicago | NYC\'s Interactive Nightlife Experience"']);
+});
+
+test('final build: the CORRECT shape is untouched — a promoter homepage keeps website, vendor keeps ticketUrl (real CLUB CHUB: The Wig Out Party)', async () => {
+  const core = createFinalBuildCore({ promoters: require('../data/promoters.json') });
+  const event = {
+    title: 'CLUB CHUB: The Wig Out Party',
+    startDate: new Date('2026-11-01T20:00:00.000Z'),
+    city: 'dallas',
+    website: 'https://www.clubchubusa.com/',
+    url: 'https://www.clubchubusa.com/',
+    ticketUrl: 'https://www.eventbrite.com/e/wig-out-tickets-1',
+    _promoter: 'Club Chub'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+  assert.equal(analyzed.website, 'https://www.clubchubusa.com/', 'a legitimate promoter homepage is never stripped');
+  assert.equal(analyzed.ticketUrl, 'https://www.eventbrite.com/e/wig-out-tickets-1');
+  assert.equal(lines.filter(line => line.startsWith('🔗 LINKS:')).length, 0, 'nothing to say — this shape is already right');
+});
+
+test('final build: the promoter OWN presence on a platform host is an identity link and survives', async () => {
+  const core = createFinalBuildCore({
+    promoters: [
+      // Registry-shaped: a host-anchored urlPattern (the organizer page) and a
+      // curated instagram handle, and NO website to fall back to.
+      { name: 'Bearracuda', instagram: 'https://www.instagram.com/bearracuda',
+        urlPatterns: ['eventbrite.com/o/bearracuda-21867032189'], bearAffinity: 'usually' }
+    ]
+  });
+  const organizerPage = {
+    title: 'BEARRACUDA ATLANTA',
+    startDate: new Date('2026-09-12T23:00:00.000Z'),
+    city: 'dallas',
+    website: 'https://www.eventbrite.com/o/bearracuda-21867032189',
+    _promoter: 'Bearracuda'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(organizerPage, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+  assert.equal(analyzed.website, 'https://www.eventbrite.com/o/bearracuda-21867032189', 'the organizer page IS the identity link');
+  assert.equal(analyzed.ticketUrl, undefined, 'nothing moved');
+  assert.deepEqual(
+    lines.filter(line => line.startsWith('🔗 LINKS:')),
+    ['🔗 LINKS: website https://www.eventbrite.com/o/bearracuda-21867032189 is on a platform host but no curated identity to fall back to — left as-is for "BEARRACUDA ATLANTA"']);
+
+  // The instagram PROFILE is likewise self-identity; a facebook EVENT listing
+  // for the same promoter is not.
+  assert.equal(core.isCuratedPlatformSelfIdentityUrl(organizerPage, 'https://www.instagram.com/bearracuda'), true);
+  assert.equal(core.isCuratedPlatformSelfIdentityUrl(organizerPage, 'https://www.facebook.com/events/1376781057883088/'), false);
+});
+
+test('final build: url goes with website — a differing aggregator url is NOT promoted into it', async () => {
+  const core = createFinalBuildCore({ promoters: require('../data/promoters.json') });
+  // Real shape (Lazy Bear Week 2026, run 20260803): applyAggregatorWebsitePointers
+  // already moved website off the aggregator, leaving url on the aggregator's own
+  // copy of the event page. Trust the pointer, not the copy — that copy must not
+  // be promoted back into website when the vendor link is cleared.
+  const event = {
+    title: 'Lazy Bear Week 2026',
+    startDate: new Date('2026-08-20T23:00:00.000Z'),
+    city: 'dallas',
+    website: 'https://lazybearweek.eventbrite.com/',
+    url: 'https://thebearcalendar.com/events/lazy-bear-week-2026-2026/'
+  };
+  const restore = captureFinalBuildLogs([]);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+  assert.equal(analyzed.website, undefined, 'website/url are ONE field and clear together');
+  assert.equal(analyzed.url, undefined);
+  assert.equal(analyzed.ticketUrl, 'https://lazybearweek.eventbrite.com/',
+    'an organizer-branded eventbrite subdomain is still a ticketing link');
 });
 
 test('slot merge: one-sided og provenance does not clobber a curated slot (falls through)', async () => {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -12660,15 +12660,16 @@ test('final build: a facebook EVENT link never occupies website/url (real Club C
   } finally {
     restore();
   }
-  // Club Chub is in the registry but carries NO website — so there is nothing
-  // to adopt, and empty is the right answer (the site falls back to the
-  // promoter's curated favicon).
-  assert.equal(analyzed.website, undefined, 'facebook.com/events/… is social, not identity');
-  assert.equal(analyzed.url, undefined, 'url is the same canonical field');
+  // Club Chub now carries a curated website (owner-approved 2026-08-03), so
+  // the facebook EVENT link is REPLACED by the real site rather than merely
+  // cleared — strictly better: the card gets a real favicon instead of none.
+  assert.equal(analyzed.website, 'https://www.clubchubusa.com', 'the curated identity wins over the social link');
+  assert.equal(analyzed.url, 'https://www.clubchubusa.com', 'url is the same canonical field');
   assert.equal(analyzed.ticketUrl, 'https://www.facebook.com/events/1376781057883088/', 'the link lands in ticketUrl');
   assert.ok(!analyzed.notes.includes('website: https://www.facebook.com'), 'notes never serialize it as website');
   assert.equal(analyzed.instagram, 'https://www.instagram.com/clubchubparty', 'the curated instagram is untouched');
-  assert.equal(lines.filter(line => line.startsWith('🔗 LINKS: cleared platform website')).length, 1);
+  assert.equal(lines.filter(line => line.startsWith('🔗 LINKS: replaced platform website')).length, 1,
+    'the curated-identity branch fires, not the clear-to-empty one');
 });
 
 test('final build: an eventbrite listing with tracking params never occupies website (real Club Chub Weekend 2026)', async () => {
@@ -12689,8 +12690,8 @@ test('final build: an eventbrite listing with tracking params never occupies web
   } finally {
     restore();
   }
-  assert.equal(analyzed.website, undefined);
-  assert.equal(analyzed.url, undefined);
+  assert.equal(analyzed.website, 'https://www.clubchubusa.com', 'curated identity replaces the ticketing listing');
+  assert.equal(analyzed.url, 'https://www.clubchubusa.com');
   assert.equal(analyzed.ticketUrl, listing, 'query string and all — the value is moved verbatim, never rewritten');
 });
 
@@ -12807,10 +12808,12 @@ test('final build: url goes with website — a differing aggregator url is NOT p
   } finally {
     restore();
   }
-  assert.equal(analyzed.website, undefined, 'website/url are ONE field and clear together');
-  assert.equal(analyzed.url, undefined);
-  assert.equal(analyzed.ticketUrl, 'https://lazybearweek.eventbrite.com/',
-    'an organizer-branded eventbrite subdomain is still a ticketing link');
+  // An organizer-branded subdomain with a BARE path is that organizer's home
+  // page, not a ticket link (isPlatformOrganizerHomeUrl) — so it is kept, and
+  // the aggregator's own copy is still never promoted into website.
+  assert.equal(analyzed.website, 'https://lazybearweek.eventbrite.com/', 'the organizer home page survives');
+  assert.notEqual(analyzed.website, 'https://thebearcalendar.com/events/lazy-bear-week-2026-2026/',
+    'trust the pointer, not the aggregator copy');
 });
 
 test('slot merge: one-sided og provenance does not clobber a curated slot (falls through)', async () => {
@@ -14576,4 +14579,32 @@ test('getPromoterSelfUrlTokens: a sub-brand inherits its family home so authorit
   const tokens = core.getPromoterSelfUrlTokens(child);
   assert.ok(tokens.includes('spookybear'), 'its own pattern');
   assert.ok(tokens.includes('ursamen'), 'and its parent family home');
+});
+
+// A branded subdomain on a ticketing host with a BARE path is that organizer's
+// home page, not a ticket link — the same thing eventbrite.com/o/<id> already
+// is, in a different shape. Decided by URL shape, so it needs no registry
+// entry. Fixtures are the real corpus values from 2026-08-03.
+test('platform organizer home: branded subdomains keep website, event listings do not', () => {
+  const core = createCore();
+  for (const url of [
+    'https://lazybearweek.eventbrite.com/',
+    'https://bbromp2026.eventbrite.com/',
+    'https://xxl2026.eventbrite.com/',
+    'https://westernxposurefall2026.eventbrite.com/',
+    'https://newduro.eventbrite.com'
+  ]) {
+    assert.equal(core.isPlatformOrganizerHomeUrl(url), true, `organizer home: ${url}`);
+  }
+  for (const url of [
+    'https://www.eventbrite.com/e/quenchd-tickets-1993587626256',
+    'https://www.eventbrite.com/e/club-chub-weekend-2026-the-ultimate-celebration-tickets-1975884326209?utm-campaign=social',
+    'https://www.eventbrite.com/',
+    'https://www.facebook.com/events/1376781057883088/',
+    'https://www.sickening.events/e/goldiloxx-chicago-2/tickets',
+    'https://eaglela.com/events/hump-night/',
+    ''
+  ]) {
+    assert.equal(core.isPlatformOrganizerHomeUrl(url), false, `not an organizer home: ${url}`);
+  }
 });


### PR DESCRIPTION
The four things from today's runs. **Suite 1381 → 1409, 0 failures.** Every new test proven red against `origin/main` first.

## 1. Ticket URLs never occupy `website`/`url`

Your rule, applied at the single-candidate write path (#1614's rung only fired when two candidates competed):

| event | website before | after | ticketUrl after |
|---|---|---|---|
| Club Chub DTLA | `facebook.com/events/1376781057883088/` | **empty** | that URL |
| CLUB CHUB: QUENCHD | `eventbrite.com/e/quenchd-tickets-…` | **empty** | that URL |
| Club Chub Weekend 2026 | `eventbrite.com/e/…?utm-campaign=…` | **empty** | that URL |
| GOLDILOXX Chicago | `sickening.events/…-chicago-2/tickets` | **empty** | unchanged |
| *Wig Out Party (control)* | `clubchubusa.com` | unchanged | unchanged |

Across 198 runs: **75 of 152** platform-website events cleared (27 were exact duplicates of an existing ticketUrl). A promoter's *own* platform presence (instagram profile, `eventbrite.com/o/<organizer>`) is host-anchored and survives.

A "promote `url` into `website`" fallback was written and then dropped: in the corpus all 7 such values are `thebearcalendar.com/events/…`, the aggregator copy that existing code works to move *away* from.

## 2. Bear keyword tier — Pet Night and Gear Night ruled not-bear

Split by WHERE the keyword lives. Verified directly:

```
MUST short-circuit:
  bear in TITLE               matched=[bear]             → true   src=title
  venue BEARS DISCO           matched=[bear]             → true   src=venue
  Bearracuda brand in DESC    matched=[bear,bearracuda]  → true   src=description-brand
  Treasure Trail brand in DESC                           → true   src=description-brand

MUST defer to the AI:
  Pet Night                   matched=[woof,pup]         → false  src=description-generic
  Gear Night                  matched=[leather]          → false  src=description-generic
  Wig Out Wig Night           matched=[leather]          → false  src=description-generic
```

Of 668 keyword-bear events, **31 change tier**; **72 description-brand events — every Bearracuda Portland NYE / SF FLSM / Treasure Trail occurrence — are untouched**, as are all 8 venue-name hits. Brand set derived from the registry, not hardcoded. Fails closed: no AI verdict → the legacy keyword bear stands.

## 3. Lumberyard — two unrelated corpus leaks

**`bar: "</svg>"`** — `segmentText` was fed **raw HTML** instead of the text corpus, so the venue-rescue read Wix tag soup as page lines. It got a second corroborating signal because the same SVG's `xmlns="http://www.w3.org/2000/svg"` yields the URL token `svg`, matching `normalizeBarNameKey("</svg>")`. Two signals → adopted.

**`"My Account"`** — verified byte-for-byte:

```
page length                          543,057
<script id="wix-viewer-model"> opens 290,533
its </script> closes at              518,282   ← after the 500,000 cap
```

The cap lands *inside* the script. Strippers match open→close pairs, so the orphaned opener turned ~210 KB of Wix router JSON into body text — including `"pageRoles":{"jfc17":{"title":"My Account"…}`. Six of seven cached pages leaked it. The fix **seals** the truncated block rather than trimming back, so no real content is lost.

Both are the same class as the thumbnail-OCR hallucination and the apostrophe-truncated meta tags: **junk that never reaches the model still poisons the corpus the evidence gate validates against.**

Verified on the real page: `My Account`, `pageRoles`, `siteFeaturesConfigs`, `</svg>` all gone; `QUEERAOKE`, `Wednesday nights`, `Drink`, `Dolly`, `Bumper` all survive, with identical synthesized rrules. Flag-don't-drop checked across 336 distinct titles and 151 distinct bars — the guards reject exactly those two strings and nothing else.

## 4. The blank screen

Your diagnosis was right; mine was half right. The merge table is #2, not #1:

| | KB | % |
|---|---|---|
| same event JSON embedded **3× per card** | 1290 | 43% |
| merge comparison table (mostly ~2400 repeated inline `style` strings) | 541 | 18% |
| provenance section | 377 | 13% |
| line diff (no cap at all) | 129 | 4% |

**Measured: 2975 KB → 1428 KB**, 57.2 → 27.5 KB per event. Table chrome moved to CSS classes; one payload per card; diff values capped with the window **anchored on the first diverging character**, so a change at char 900 stays visible instead of two identical stubs.

Bounded by construction — budgets divided across cards, not per-card growth — with every trim logged, stamped `_trimmed` into the copied JSON, and shown on the card. A page-size guard warns above 1923 KB (set from evidence: every page you actually reviewed was ≤1923 KB; the only 3.3-second "review" was the 3198 KB one). Small runs trim nothing.

Nothing became unreachable: all 346 comparison rows, 15 merge tables, 52 provenance sections, bear-verdict rows and sanity flags render unchanged, zero diff deferrals. Only the redundant debug dump was trimmed, and its dropped keys are each rendered field-by-field elsewhere on the same card.

I also compacted the provenance export payload (percent-encoding charges 3 bytes per indent space); the page re-indents before showing the textarea, so what you copy is unchanged. Round-trip pinned by test.

## Still open for you

- **Club Chub `website: clubchubusa.com`** — curated data, yours. It's the difference between those events having a real favicon and none. Evidenced from your own run.
- **Organizer-branded Eventbrite subdomains** (`lazybearweek.eventbrite.com`, `bbromp2026`, `xxl2026`, `westernxposurefall2026` — 4 events) are cleared under your rule. A registry entry with that urlPattern would protect them, same mechanism as Goldiloxx.
- Seven other `.slice(0, 500000)` sites can orphan a script the same way. They feed parsers rather than text extraction so they're harmless today — same latent bug.
- `event-provenance.js` remains the largest single item at ~240 KB.

**No new runtime files** — no updater entries needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP