### PR TITLE
fix(results): recompute the merge diff against the notes actually written

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -11183,6 +11183,44 @@ class SharedCore {
 
     // One event's calendar-prep analysis (extracted from prepareEventsForCalendar
     // so manually rescued events run the exact same merge/diff pipeline).
+    // Notes-level merge diff for the results card. Extracted so it can be
+    // recomputed after the late field cleanups; semantics are byte-for-byte
+    // the inline version it replaces, including the preserve-strategy rules
+    // (a field absent from BOTH sides, or newly present under 'preserve',
+    // counts as preserved rather than removed/added).
+    buildNotesMergeDiff(originalNotes, mergedNotes, fieldPriorities = {}) {
+        const originalFields = this.parseNotesIntoFields(originalNotes || '');
+        const mergedFields = this.parseNotesIntoFields(mergedNotes || '');
+        const diff = { preserved: [], added: [], updated: [], removed: [] };
+        const strategyFor = (key) => {
+            const priorityConfig = fieldPriorities && fieldPriorities[key];
+            return (priorityConfig && priorityConfig.merge) || 'preserve';
+        };
+        Object.keys(originalFields).forEach(key => {
+            if (mergedFields[key] === originalFields[key]) {
+                diff.preserved.push(key);
+            } else if (!mergedFields[key]) {
+                if (strategyFor(key) === 'preserve' && originalFields[key] === undefined) {
+                    diff.preserved.push(key);
+                } else {
+                    diff.removed.push({ key, value: originalFields[key] });
+                }
+            } else {
+                diff.updated.push({ key, from: originalFields[key], to: mergedFields[key] });
+            }
+        });
+        Object.keys(mergedFields).forEach(key => {
+            if (!originalFields[key]) {
+                if (strategyFor(key) === 'preserve') {
+                    diff.preserved.push(key);
+                } else {
+                    diff.added.push({ key, value: mergedFields[key] });
+                }
+            }
+        });
+        return diff;
+    }
+
     async buildAnalyzedCalendarEvent(event, analysis, calendarAdapter, config = {}) {
         // (Block wrapper keeps the extracted loop body byte-identical to its
         // original prepareEventsForCalendar form — minimal, reviewable diff.)
@@ -11205,6 +11243,7 @@ class SharedCore {
                 analyzedEvent = await this.createFinalEventObject(analysis.existingEvent, event, { httpAdapter: calendarAdapter, globalConfig: config });
                 
                 // Calculate merge diff for display purposes
+                analyzedEvent._mergeDiffBaselineNotes = analysis.existingEvent.notes || '';
                 const originalFields = this.parseNotesIntoFields(analysis.existingEvent.notes || '');
                 const mergedFields = this.parseNotesIntoFields(analyzedEvent.notes || '');
                 
@@ -11270,6 +11309,7 @@ class SharedCore {
 
                 // Compute a merge diff comparing the base recurring event to the new override
                 // being created. This enables diff display for intent:merge + action:new cases.
+                analyzedEvent._mergeDiffBaselineNotes = analysis.sourceEvent.notes || '';
                 const originalFields = this.parseNotesIntoFields(analysis.sourceEvent.notes || '');
                 const mergedFields = this.parseNotesIntoFields(analyzedEvent.notes || '');
                 analyzedEvent._mergeDiff = {
@@ -11553,6 +11593,30 @@ class SharedCore {
                 if (finalTrimRecords.some(record => record && record.status === 'trimmed' && record.field !== 'title')) {
                     analyzedEvent.notes = this.formatEventNotes(analyzedEvent);
                 }
+            }
+
+            // Recompute the merge diff against the FINAL notes. It is first
+            // built ~350 lines above, straight out of createFinalEventObject —
+            // before the URL cleanups, the promoter/static metadata stamps and
+            // the final trim pass have run. Every one of those can change a
+            // notes-carried value, so the card was describing a write that no
+            // longer happens. Observed 2026-08-04 (Goldiloxx, run
+            // 20260804-095251): the card reported
+            //   website: ".../goldiloxx-chicago-2/tickets" → ".../goldiloxx-chicago"
+            // while the notes that actually get written carry NO website line
+            // at all — the ticketing-host cleanup had removed it. The owner
+            // reasonably read that as "we keep saving the ticket url in
+            // website". Behaviour was already correct; the display was not.
+            //
+            // Same inputs as the original computation, so a diff that was
+            // already accurate is unchanged.
+            if (analyzedEvent._mergeDiff && analyzedEvent._mergeDiffBaselineNotes !== undefined) {
+                analyzedEvent._mergeDiff = this.buildNotesMergeDiff(
+                    analyzedEvent._mergeDiffBaselineNotes,
+                    analyzedEvent.notes || '',
+                    analyzedEvent._fieldPriorities || {}
+                );
+                delete analyzedEvent._mergeDiffBaselineNotes;
             }
 
             // Computed evidence panel for the results-UI event card (underscore

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -14765,3 +14765,81 @@ test('platform organizer home: branded subdomains keep website, event listings d
     assert.equal(core.isPlatformOrganizerHomeUrl(url), false, `not an organizer home: ${url}`);
   }
 });
+
+// ---------------------------------------------------------------------------
+// _mergeDiff must describe the write that ACTUALLY happens (2026-08-04).
+//
+// The diff was built straight out of createFinalEventObject, ~350 lines before
+// the URL cleanups / promoter metadata / final trim run — all of which can
+// change a notes-carried value. Real case, Goldiloxx run 20260804-095251: the
+// card reported
+//   website: ".../goldiloxx-chicago-2/tickets" → ".../goldiloxx-chicago"
+// while the notes actually written carried NO website line, because the
+// ticketing-host cleanup had removed it. The owner read the card and asked
+// "why do we keep saving ticket url in website field?" — the behaviour was
+// already right; the display was lying.
+// ---------------------------------------------------------------------------
+
+test('merge diff: a field removed by the late URL cleanup is reported removed, not updated', async () => {
+  const core = createFinalBuildCore({ promoters: require('../data/promoters.json') });
+  // Calendar side holds the OLD bad value: a ticketing URL sitting in website.
+  const existingEvent = {
+    title: 'GOLDILOXX Chicago',
+    startDate: new Date('2026-09-20T02:00:00.000Z'),
+    notes: [
+      'bar: Jackhammer',
+      'website: https://www.sickening.events/e/goldiloxx-chicago-2/tickets',
+      'ticketUrl: https://www.sickening.events/e/goldiloxx-chicago-2/tickets'
+    ].join('\n')
+  };
+  const scraped = {
+    title: 'GOLDILOXX Chicago',
+    startDate: new Date('2026-09-20T02:00:00.000Z'),
+    city: 'chicago',
+    bar: 'Jackhammer',
+    website: 'https://sickening.events/e/goldiloxx-chicago',
+    url: 'https://sickening.events/e/goldiloxx-chicago',
+    _promoter: 'Goldiloxx'
+  };
+  const restore = captureFinalBuildLogs([]);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(
+      scraped,
+      { action: 'merge', reason: 'matched', existingEvent, sourceEvent: null, overrideIdentity: null },
+      {},
+      {}
+    );
+  } finally {
+    restore();
+  }
+
+  // The behaviour that was already correct: no ticketing URL in website.
+  assert.equal(analyzed.website, undefined, 'a ticketing host never occupies website');
+  assert.ok(!String(analyzed.notes || '').includes('website:'), 'and no website line is written');
+
+  // The display must agree with it.
+  const updatedWebsite = (analyzed._mergeDiff.updated || []).find(entry => entry.key === 'website');
+  assert.equal(updatedWebsite, undefined, 'the card must not claim a website update that never happens');
+  const removedWebsite = (analyzed._mergeDiff.removed || []).find(entry => entry.key === 'website');
+  assert.ok(removedWebsite, 'the stale calendar website is reported as removed');
+  assert.equal(removedWebsite.value, 'https://www.sickening.events/e/goldiloxx-chicago-2/tickets');
+
+  // The scratch field never survives onto the event or into notes.
+  assert.equal(analyzed._mergeDiffBaselineNotes, undefined, 'baseline scratch field is cleaned up');
+  assert.ok(!String(analyzed.notes || '').includes('mergeDiffBaseline'));
+});
+
+test('buildNotesMergeDiff: preserve-strategy semantics are unchanged', () => {
+  const core = createCore();
+  const priorities = { cover: { merge: 'clobber' }, description: { merge: 'preserve' } };
+  const diff = core.buildNotesMergeDiff(
+    'bar: Eagle LA\ncover: $10\nold: gone',
+    'bar: Eagle LA\ncover: $15\ndescription: new text',
+    priorities
+  );
+  assert.deepEqual(diff.preserved, ['bar', 'description'], 'unchanged field, and a new preserve-strategy field');
+  assert.deepEqual(diff.updated, [{ key: 'cover', from: '$10', to: '$15' }]);
+  assert.deepEqual(diff.removed, [{ key: 'old', value: 'gone' }]);
+  assert.deepEqual(diff.added, [], 'a preserve-strategy arrival is preserved, not added');
+});


### PR DESCRIPTION
**Answers your question: we don't save the ticket URL in `website` anymore — the card was lying to you.**

Your latest Goldiloxx run (`20260804-095251`, action `merge`) writes this:

```
website    undefined
url        undefined
ticketUrl  "https://www.sickening.events/e/goldiloxx-chicago/tickets"

notes actually written:  ticketUrl: … / instagram: … / favicon: …   ← no website line at all
```

That is correct — #1622's ticketing-host cleanup did its job. But the **card** reported:

```
website:  ".../goldiloxx-chicago-2/tickets"  →  ".../goldiloxx-chicago"
```

…a write that never happens.

## Cause

`_mergeDiff` is built straight out of `createFinalEventObject`, ~350 lines **before** the ticketing-host URL cleanup (`shared-core.js:11423`), the promoter/static metadata stamps, and the final trim pass. Any of those can change a notes-carried value, so the diff described a stale plan.

It now recomputes after those cleanups, from the same baseline notes, via a new `buildNotesMergeDiff()` extracted **byte-for-byte** from the inline version — preserve-strategy rules included (a field absent from both sides, or newly present under `preserve`, still counts as preserved rather than removed/added). A diff that was already accurate is unchanged; there's a dedicated test pinning those semantics.

The `_mergeDiffBaselineNotes` scratch field is deleted after use, and I asserted it can't leak into notes.

## Your calendar heals itself

The stale `website: …/tickets` currently sitting on the saved record disappears on the next write — notes are replaced wholesale (`scriptable-adapter.js:3295`, `:3408`), and the new notes carry no `website:` line. Nothing to clean up by hand.

## Worth noting

This is the **third** display-lies-about-behaviour bug in this review:

1. `✂️ TRIM: … answer failed verbatim gate` — actually a length failure, 0 hallucinations in 28 calls
2. `Segment cap reached (16)` — reported the baseline constant, not the budget that fired
3. this one — a diff computed before the code that changes the values

Each cost real diagnosis time, and in this case sent you looking for a bug that had already been fixed. Might be worth a pass over the results UI specifically for "does this line describe what the code now does."

Suite **1430 → 1432**, both new tests proven red without the fix.

*(Housekeeping: this commit was pushed to `fix/segment-discovery-allowlist` shortly after you merged #1624, so it stranded on the auto-recreated branch. Cherry-picked here; stranded branch deleted. The `?q=goldiloxx` config change did make it into #1624 — I initially mis-read a squash-merge as having dropped it.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP