### PR TITLE
fix(bear): manual-bear verdict sticks for FLAGGED events + no duplicate plan rows

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -9344,9 +9344,29 @@ class ScriptableAdapter {
         if (!Array.isArray(results.analyzedEvents)) {
           results.analyzedEvents = [];
         }
-        results.analyzedEvents.push(...prepped);
+        // Duplicate-row guard (same ordering defect as the prep-time rescue in
+        // SharedCore): these events join the plan after both dedup passes have
+        // run, so a twin already in the plan would leave two rows aimed at ONE
+        // calendar record. Fold into the existing row when there is one — the
+        // owner's verdict still counts either way, so the tally is unchanged.
+        const added = [];
+        for (const preppedEvent of prepped) {
+          const folded = core.foldBearOverrideIntoPlanEntry(
+            results.analyzedEvents,
+            preppedEvent,
+            {
+              existingIdentifier:
+                preppedEvent._existingEvent &&
+                preppedEvent._existingEvent.identifier,
+              manualBearSource: preppedEvent.bearSource,
+            },
+          );
+          if (folded) continue;
+          results.analyzedEvents.push(preppedEvent);
+          added.push(preppedEvent);
+        }
         counts.markedBear += prepped.length;
-        prepped.forEach((event) =>
+        added.forEach((event) =>
           console.log(
             `📱 Scriptable: Manual override — "${event.title || "Unknown"}" marked bear and prepped for calendar (${event._action || "new"})`,
           ),

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -4737,3 +4737,103 @@ test('the results page derives Copy JSON from the single card payload and still 
   assert.ok(html.includes('function prettyPrintCardPayloads('),
     'the page re-indents the compact payload in the DOM');
 });
+
+// ---------------------------------------------------------------------------
+// applyPendingBearOverrides: one calendar record, one plan row
+// ---------------------------------------------------------------------------
+
+// Events marked bear from the results UI are prepped and appended AFTER both
+// dedup passes have run (filterBearEvents runs before deduplicateEvents, so a
+// dropped twin never entered dedup). Without a guard, a twin already in the
+// plan leaves two `_action: "merge"` rows aimed at ONE calendar record.
+test('applyPendingBearOverrides folds a marked-bear twin into the existing plan row', async () => {
+  const adapter = buildAdapter();
+  const calendarRecord = {
+    identifier: 'CAL-TWIN-9',
+    title: 'Treasure Trail',
+    startDate: new Date('2026-08-08T21:00:00.000Z'),
+    endDate: new Date('2026-08-09T01:00:00.000Z'),
+    location: '',
+    notes: 'bar: The Eagle\nticketUrl: https://tixr.com/e/198706'
+  };
+  adapter.getExistingEvents = async () => [calendarRecord];
+
+  const existingRow = {
+    title: 'Treasure Trail',
+    startDate: new Date('2026-08-08T21:00:00.000Z'),
+    bar: 'The Eagle',
+    ticketUrl: 'https://tixr.com/e/198706',
+    isBearEvent: true,
+    bearReview: 'unsure — ai: no explicit bear signal',
+    _action: 'merge',
+    _existingEvent: { identifier: 'CAL-TWIN-9' }
+  };
+  const results = { analyzedEvents: [existingRow], config: { config: {} } };
+  const pending = {
+    markedBear: {
+      d0: {
+        title: 'TREASURE TRAIL — Bear Night',
+        reason: 'ai: drag show',
+        event: {
+          title: 'TREASURE TRAIL — Bear Night',
+          startDate: new Date('2026-08-08T22:00:00.000Z'),
+          bar: 'The Eagle',
+          ticketUrl: 'https://tixr.com/e/198706'
+        }
+      }
+    },
+    markedNotBear: {},
+    keptMarkedBear: {}
+  };
+
+  const counts = await adapter.applyPendingBearOverrides(results, pending);
+
+  assert.equal(results.analyzedEvents.length, 1, 'the marked twin folds into the row that already covers it');
+  assert.equal(counts.markedBear, 1, 'the owner\'s verdict still counts even when folded');
+  assert.equal(results.analyzedEvents[0].isBearEvent, true);
+  assert.equal(results.analyzedEvents[0].bearReview, undefined, 'the folded row loses its hide flag');
+  assert.ok(
+    String(results.analyzedEvents[0].bearSource || '').startsWith('manual-bear'),
+    'the manual verdict is stamped on the surviving row'
+  );
+
+  const identifiers = results.analyzedEvents
+    .map((entry) => entry._existingEvent && entry._existingEvent.identifier)
+    .filter(Boolean);
+  assert.equal(new Set(identifiers).size, identifiers.length,
+    'two plan rows must never share one _existingEvent.identifier');
+});
+
+test('applyPendingBearOverrides still appends a genuinely new marked-bear event', async () => {
+  const adapter = buildAdapter();
+  adapter.getExistingEvents = async () => [];
+
+  const existingRow = {
+    title: 'Unrelated Party',
+    startDate: new Date('2026-09-20T21:00:00.000Z'),
+    bar: 'Elsewhere',
+    _action: 'new'
+  };
+  const results = { analyzedEvents: [existingRow], config: { config: {} } };
+  const pending = {
+    markedBear: {
+      d0: {
+        title: 'Treasure Trail',
+        reason: 'ai: drag show',
+        event: {
+          title: 'Treasure Trail',
+          startDate: new Date('2026-08-08T22:00:00.000Z'),
+          bar: 'The Eagle'
+        }
+      }
+    },
+    markedNotBear: {},
+    keptMarkedBear: {}
+  };
+
+  const counts = await adapter.applyPendingBearOverrides(results, pending);
+
+  assert.equal(results.analyzedEvents.length, 2, 'an unrelated marked-bear event still gets its own row');
+  assert.equal(counts.markedBear, 1);
+  assert.equal(results.analyzedEvents[1].isBearEvent, true);
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -11131,9 +11131,11 @@ class SharedCore {
             // UI) is newer than the stored one and is never demoted by it.
             // Reuses the existing-event search prep just performed — no extra
             // calendar scans.
+            let preparedEvent = event;
             if (bearOverrideContext && !this.isManualBearSource(event.bearSource)) {
                 const matchedRecord = analysis.existingEvent || analysis.sourceEvent || null;
-                if (matchedRecord && this.getManualBearVerdictFromRecord(matchedRecord) === 'manual-not-bear') {
+                const storedVerdict = matchedRecord ? this.getManualBearVerdictFromRecord(matchedRecord) : null;
+                if (storedVerdict === 'manual-not-bear') {
                     console.log(`🐻 BEAR CHECK: "${event.title || 'Unknown'}" → not_bear (manual override on calendar record)`);
                     if (Array.isArray(bearOverrideContext.demoted)) {
                         bearOverrideContext.demoted.push({
@@ -11148,9 +11150,39 @@ class SharedCore {
                     }
                     continue;
                 }
+                // Manual override, promote direction: the bear check has THREE
+                // outcomes (keep / drop / flag) and only two were covered here.
+                // A FLAGGED event is pushed to `kept` with a `bearReview` stamp
+                // and never enters the drop collector, so it was invisible to
+                // both the demote branch above and the dropped-event rescue loop
+                // below — a stored `manual-bear` verdict could never clear the
+                // flag, and js/calendar-core.js `isHiddenForBearReview` re-hid
+                // the event on every run, silently undoing the owner's verdict
+                // (the record ended up carrying BOTH `bearReview: unsure — …`
+                // and `bearSource: manual-bear (…)`).
+                // The owner's stored verdict is authoritative regardless of this
+                // run's cascade result: adopting it unconditionally also clears a
+                // STALE flag already sitting on the calendar record (the merge
+                // rule's manual-bear branch drops the calendar's bearReview when
+                // the scraped side carries none), which a run whose cascade said
+                // "bear" would otherwise inherit and re-hide on forever.
+                // Mirrors the live-tap `keptMarkedBear` branch in the Scriptable
+                // adapter (isBearEvent set, stored bearSource adopted, review flag
+                // deleted) so a stored verdict and a live tap converge on one state.
+                if (storedVerdict === 'manual-bear') {
+                    const storedFields = this.parseNotesIntoFields(matchedRecord.notes || '');
+                    const storedBearSource = typeof storedFields.bearSource === 'string' ? storedFields.bearSource.trim() : '';
+                    preparedEvent = { ...event, isBearEvent: true };
+                    if (storedBearSource) preparedEvent.bearSource = storedBearSource;
+                    const clearedFlag = typeof preparedEvent.bearReview === 'string' && preparedEvent.bearReview
+                        ? preparedEvent.bearReview
+                        : '';
+                    delete preparedEvent.bearReview;
+                    console.log(`🐻 BEAR CHECK: "${event.title || 'Unknown'}" → bear (manual override on calendar record${clearedFlag ? `, cleared review flag: ${clearedFlag}` : ''})`);
+                }
             }
 
-            analyzedEvents.push(await this.buildAnalyzedCalendarEvent(event, analysis, calendarAdapter, config));
+            analyzedEvents.push(await this.buildAnalyzedCalendarEvent(preparedEvent, analysis, calendarAdapter, config));
         }
 
         // Manual override, rescue direction: an enforce-mode dropped event whose
@@ -11168,7 +11200,26 @@ class SharedCore {
                 if (!matchedRecord || this.getManualBearVerdictFromRecord(matchedRecord) !== 'manual-bear') continue;
                 console.log(`🐻 BEAR CHECK: "${droppedEvent.title || 'Unknown'}" → bear (manual override on calendar record)`);
                 const rescuedEvent = { ...droppedEvent, isBearEvent: true };
-                analyzedEvents.push(await this.buildAnalyzedCalendarEvent(rescuedEvent, analysis, calendarAdapter, config));
+                // Duplicate-row guard: filterBearEvents runs BEFORE
+                // deduplicateEvents, so a twin the bear check DROPped never
+                // entered dedup — it arrives here, after both dedup passes, and
+                // nothing re-dedups the plan. Pushing it blind produced two
+                // `_action: "merge"` rows carrying one `_existingEvent.identifier`
+                // (run evidence: two "Treasure Trail" rows, both matching the
+                // other on `ticket-url`, the strongest identity rung — the
+                // calendar layer even logged `Merge eligibility match
+                // (ticket-url)` twice). Fold the rescue into the row that already
+                // covers this event instead. The structural fix (dedup before the
+                // bear check) is deferred: it reorders an expensive AI stage and
+                // changes bear verdicts run-wide.
+                const storedFields = this.parseNotesIntoFields(matchedRecord.notes || '');
+                const folded = this.foldBearOverrideIntoPlanEntry(analyzedEvents, rescuedEvent, {
+                    existingIdentifier: analysis.existingEvent && analysis.existingEvent.identifier,
+                    manualBearSource: typeof storedFields.bearSource === 'string' ? storedFields.bearSource.trim() : ''
+                });
+                if (!folded) {
+                    analyzedEvents.push(await this.buildAnalyzedCalendarEvent(rescuedEvent, analysis, calendarAdapter, config));
+                }
                 dropped.rescued = true;
                 if (Array.isArray(bearOverrideContext.rescued)) {
                     bearOverrideContext.rescued.push(dropped);
@@ -11179,6 +11230,61 @@ class SharedCore {
         this.logCalendarStickinessSummary();
 
         return analyzedEvents;
+    }
+
+    // A late bear-override event (a drop rescued by a stored calendar verdict,
+    // or a live "Mark as bear" tap from the results UI) joins the write plan
+    // AFTER both dedup passes have run, because filterBearEvents runs before
+    // deduplicateEvents and a dropped twin therefore never entered dedup. When
+    // the plan already carries a row for the same event — same target calendar
+    // record, or a same-event identity signal — a second row would mean two
+    // writes aimed at ONE calendar record. Fold the override into the existing
+    // row instead and return it; return null when the override is genuinely new
+    // to the plan and the caller should push its own row.
+    //
+    // The fold is deterministic and additive (bear verdict fields + notes only):
+    // re-running the row's merge analysis would mean a second AI merge
+    // arbitration for one record. Same treatment the adapter's live-tap
+    // `keptMarkedBear` branch applies to a row already in the plan.
+    foldBearOverrideIntoPlanEntry(analyzedEvents, overrideEvent, options = {}) {
+        if (!Array.isArray(analyzedEvents) || analyzedEvents.length === 0) return null;
+        if (!overrideEvent || typeof overrideEvent !== 'object') return null;
+
+        const asIdentifier = (value) => (value === undefined || value === null ? '' : String(value));
+        const targetIdentifier = asIdentifier(options.existingIdentifier);
+        let match = null;
+        let matchReason = '';
+        if (targetIdentifier) {
+            match = analyzedEvents.find(entry => entry && entry !== overrideEvent && entry._existingEvent
+                && asIdentifier(entry._existingEvent.identifier) === targetIdentifier) || null;
+            if (match) matchReason = 'same calendar record';
+        }
+        if (!match) {
+            // Same relaxation deduplicateEvents uses for its identity scan: a
+            // degraded twin (missing start time → midnight default) must still
+            // match its properly-timed sibling.
+            let signal = null;
+            match = analyzedEvents.find(entry => {
+                if (!entry || entry === overrideEvent) return false;
+                signal = this.getSameEventIdentitySignal(overrideEvent, entry, { requireCloseStartTimes: false });
+                return Boolean(signal);
+            }) || null;
+            if (match) matchReason = signal;
+        }
+        if (!match) return null;
+
+        match.isBearEvent = true;
+        const manualSource = typeof options.manualBearSource === 'string' ? options.manualBearSource.trim() : '';
+        if (manualSource && this.isManualBearSource(manualSource) && !this.isManualBearSource(match.bearSource)) {
+            match.bearSource = manualSource;
+        }
+        // The website hides flagged events; an explicit bear verdict clears it.
+        if (typeof match.bearReview === 'string' && match.bearReview) {
+            delete match.bearReview;
+        }
+        match.notes = this.formatEventNotes(match);
+        console.log(`🐻 BEAR CHECK: "${overrideEvent.title || 'Unknown'}" bear override folded into the existing plan row (${matchReason}) — no duplicate write`);
+        return match;
     }
 
     // One event's calendar-prep analysis (extracted from prepareEventsForCalendar

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -5477,6 +5477,209 @@ test('prep-time override: a freshly tapped manual-bear event is never demoted by
   );
 });
 
+// The bear check has THREE outcomes: keep, DROP and FLAG. A FLAGGED event is
+// pushed to `kept` with a `bearReview` stamp and never reaches the drop
+// collector, so it is invisible to the rescue loop — and the kept-event branch
+// used to react only to `manual-not-bear`. A stored `manual-bear` verdict could
+// therefore never promote a flagged event, and js/calendar-core.js
+// `isHiddenForBearReview` re-hid it on chunky.dad every run.
+test('prep-time override: kept-but-FLAGGED event with a manual-bear calendar match is promoted and unflagged', async () => {
+  const core = createCore();
+  const calendarRecord = {
+    identifier: 'CAL-FLAGGED-1',
+    title: 'Treasure Trail',
+    startDate: new Date('2026-08-08T21:00:00.000Z'),
+    endDate: new Date('2026-08-09T01:00:00.000Z'),
+    location: '',
+    notes: 'bar: The Eagle\nbearSource: manual-bear (overrode ai: drag show)'
+  };
+  const adapter = buildPrepCalendarAdapter([calendarRecord]);
+  const flaggedEvent = {
+    title: 'Treasure Trail',
+    startDate: new Date('2026-08-08T21:00:00.000Z'),
+    bar: 'The Eagle',
+    bearSource: 'ai',
+    bearReview: 'unsure — ai: no explicit bear signal'
+  };
+  const context = buildOverrideContext();
+
+  const analyzed = await core.prepareEventsForCalendar([flaggedEvent], adapter, {}, context);
+
+  assert.equal(analyzed.length, 1, 'the flagged event stays in the write plan');
+  assert.equal(analyzed[0].isBearEvent, true, 'the stored verdict promotes it to a bear event');
+  assert.equal(analyzed[0].bearReview, undefined, 'the review flag is removed from the event');
+  const fields = core.parseNotesIntoFields(analyzed[0].notes);
+  assert.equal(fields.bearReview, undefined, 'the review flag never reaches the calendar notes');
+  assert.equal(
+    fields.bearSource,
+    'manual-bear (overrode ai: drag show)',
+    'the owner\'s stored verdict is adopted verbatim'
+  );
+  assert.equal(adapter.calls.length, 1, 'the promote check reuses prep\'s one existing-event search');
+});
+
+// Records already in the wild are self-contradictory: they carry BOTH
+// `bearReview: unsure — …` and `bearSource: manual-bear (…)`. Even when this
+// run's cascade says "bear" (no fresh flag), the bearReview merge rule is
+// calendar-wins, so the stale flag would be copied forward and keep the event
+// hidden forever. Adopting the stored verdict clears it.
+test('prep-time override: a stale bearReview on a manual-bear calendar record is cleared', async () => {
+  const core = createCore();
+  const calendarRecord = {
+    identifier: 'CAL-STALE-1',
+    title: 'Treasure Trail',
+    startDate: new Date('2026-08-08T21:00:00.000Z'),
+    endDate: new Date('2026-08-09T01:00:00.000Z'),
+    location: '',
+    notes: 'bar: The Eagle\nbearReview: unsure — ai\\: no explicit bear signal\nbearSource: manual-bear (overrode ai: drag show)'
+  };
+  const adapter = buildPrepCalendarAdapter([calendarRecord]);
+  const bearEvent = {
+    title: 'Treasure Trail',
+    startDate: new Date('2026-08-08T21:00:00.000Z'),
+    bar: 'The Eagle',
+    isBearEvent: true,
+    bearSource: 'keyword'
+  };
+
+  const analyzed = await core.prepareEventsForCalendar([bearEvent], adapter, {}, buildOverrideContext());
+
+  assert.equal(analyzed.length, 1);
+  assert.equal(
+    core.parseNotesIntoFields(analyzed[0].notes).bearReview,
+    undefined,
+    'the stale hide flag is not carried forward onto the owner\'s bear verdict'
+  );
+});
+
+// Regression guard for the other direction: making the check bidirectional must
+// not let a flagged event slip past the manual-not-bear tombstone.
+test('prep-time override: a flagged event with a manual-not-bear calendar match is still demoted', async () => {
+  const core = createCore();
+  const tombstoneNotes = 'bar: Neon Room\nbearSource: manual-not-bear (overrode ai: kept wrongly)';
+  const calendarRecord = {
+    identifier: 'CAL-TOMB-1',
+    title: 'Bronze Babez',
+    startDate: new Date('2026-08-05T21:00:00.000Z'),
+    endDate: new Date('2026-08-06T01:00:00.000Z'),
+    location: '',
+    notes: tombstoneNotes
+  };
+  const adapter = buildPrepCalendarAdapter([calendarRecord]);
+  const flaggedEvent = {
+    title: 'Bronze Babez',
+    startDate: new Date('2026-08-05T21:00:00.000Z'),
+    bar: 'Neon Room',
+    bearSource: 'ai',
+    bearReview: 'unlikely — ai: drag show'
+  };
+  const context = buildOverrideContext();
+
+  const analyzed = await core.prepareEventsForCalendar([flaggedEvent], adapter, {}, context);
+
+  assert.equal(analyzed.length, 0, 'demoted events never enter the write plan');
+  assert.equal(context.demoted.length, 1);
+  assert.equal(calendarRecord.notes, tombstoneNotes, 'the calendar tombstone stays exactly as-is');
+});
+
+// filterBearEvents runs BEFORE deduplicateEvents, so a twin the bear check
+// DROPped never entered dedup — it is rescued and appended after both dedup
+// passes, and nothing re-dedups the plan. Result in the wild: two `_action:
+// "merge"` rows carrying one `_existingEvent.identifier`, both matching on
+// `ticket-url` (the calendar layer logged `Merge eligibility match (ticket-url)`
+// twice).
+test('prep-time override: a rescued drop matching an analyzed event by ticket-url produces ONE plan row', async () => {
+  const core = createCore();
+  const calendarRecord = {
+    identifier: 'CAL-TWIN-1',
+    title: 'Treasure Trail',
+    startDate: new Date('2026-08-08T21:00:00.000Z'),
+    endDate: new Date('2026-08-09T01:00:00.000Z'),
+    location: '',
+    notes: 'bar: The Eagle\nbearSource: manual-bear (overrode ai: drag show)\nticketUrl: https://tixr.com/e/198706'
+  };
+  const adapter = buildPrepCalendarAdapter([calendarRecord]);
+  const keptTwin = {
+    title: 'Treasure Trail',
+    startDate: new Date('2026-08-08T21:00:00.000Z'),
+    bar: 'The Eagle',
+    ticketUrl: 'https://tixr.com/e/198706',
+    isBearEvent: true,
+    bearSource: 'keyword'
+  };
+  const droppedEntry = {
+    title: 'TREASURE TRAIL — Bear Night',
+    reason: 'ai: drag show',
+    event: {
+      title: 'TREASURE TRAIL — Bear Night',
+      startDate: new Date('2026-08-08T22:00:00.000Z'),
+      bar: 'The Eagle',
+      ticketUrl: 'https://tixr.com/e/198706'
+    }
+  };
+  const context = buildOverrideContext([droppedEntry]);
+
+  const analyzed = await core.prepareEventsForCalendar([keptTwin], adapter, {}, context);
+
+  assert.equal(analyzed.length, 1, 'the rescued twin folds into the row that already covers the event');
+  assert.equal(analyzed[0].isBearEvent, true);
+  assert.equal(droppedEntry.rescued, true, 'the drop is still reported as rescued');
+  assert.deepEqual(context.rescued, [droppedEntry]);
+
+  // No two plan rows may ever target the same calendar record.
+  const identifiers = analyzed
+    .map(entry => entry._existingEvent && entry._existingEvent.identifier)
+    .filter(Boolean);
+  assert.equal(
+    new Set(identifiers).size,
+    identifiers.length,
+    'two plan rows must never share one _existingEvent.identifier'
+  );
+});
+
+test('foldBearOverrideIntoPlanEntry: folds by calendar identifier, leaves genuinely new events alone', async () => {
+  const core = createCore();
+  const planRow = {
+    title: 'Treasure Trail',
+    startDate: new Date('2026-08-08T21:00:00.000Z'),
+    bar: 'The Eagle',
+    bearReview: 'unsure — ai: no explicit bear signal',
+    _action: 'merge',
+    _existingEvent: { identifier: 'CAL-TWIN-1' }
+  };
+  const plan = [planRow];
+
+  // Different day, different everything → genuinely new, nothing folded.
+  assert.equal(
+    core.foldBearOverrideIntoPlanEntry(plan, {
+      title: 'Some Other Party',
+      startDate: new Date('2026-09-20T21:00:00.000Z'),
+      bar: 'Elsewhere'
+    }, {}),
+    null,
+    'an unrelated override still gets its own row'
+  );
+  assert.equal(plan.length, 1);
+
+  // Same target calendar record → folded, verdict stamped, flag cleared.
+  const folded = core.foldBearOverrideIntoPlanEntry(plan, {
+    title: 'TREASURE TRAIL — Bear Night',
+    startDate: new Date('2026-08-08T22:00:00.000Z'),
+    bar: 'The Eagle'
+  }, {
+    existingIdentifier: 'CAL-TWIN-1',
+    manualBearSource: 'manual-bear (overrode ai: drag show)'
+  });
+  assert.equal(folded, planRow, 'the existing row is returned, not a new one');
+  assert.equal(planRow.isBearEvent, true);
+  assert.equal(planRow.bearReview, undefined, 'the review flag is cleared on the folded row');
+  assert.equal(planRow.bearSource, 'manual-bear (overrode ai: drag show)');
+  assert.equal(core.parseNotesIntoFields(planRow.notes).bearSource, 'manual-bear (overrode ai: drag show)');
+
+  // An empty plan has nothing to fold into.
+  assert.equal(core.foldBearOverrideIntoPlanEntry([], { title: 'x' }, { existingIdentifier: 'CAL-TWIN-1' }), null);
+});
+
 // ---------------------------------------------------------------------------
 // logDebug / logAiPayloadDebug (two-tier logging)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two confirmed, root-caused defects in how the owner's stored manual bear verdict is honored at calendar-prep time. Both were verified at the cited lines before anything changed.

## Defect A — a manual "this IS a bear event" verdict does not stick for FLAGGED events

The owner taps "Mark as bear". The verdict is persisted as `bearSource: manual-bear (…)` in the **calendar event's notes** (not a storage file). On the next run the event is still treated as non-bear, and it gets re-hidden on the public site.

**Mechanism.** The bear check has three outcomes — keep, DROP, and FLAG. At `scripts/shared-core.js:6290-6293` the FLAG branch pushes the event to `kept` with a `bearReview: 'unsure — …'` / `'unlikely — …'` stamp, but does **not** set `isBearEvent` and does **not** push to `dropCollector`:

```js
counts.flagged++;
const label = decision.result === 'not_bear' ? 'unlikely' : 'unsure';
kept.push({...event, bearReview: `${label} — ${decision.provenance}`});
```

The override read-back, `getManualBearVerdictFromRecord` (`shared-core.js:846`), had exactly two call sites:

- **`shared-core.js:11168`** — the rescue loop, which only reacts to `manual-bear` and only for events in `bearOverrideContext.droppedEvents`. A flagged event is not dropped, so it is invisible here.
- **`shared-core.js:11136`** — the kept-event branch, which was **one-directional**: it only reacted to `manual-not-bear`.

So the design covered `drop → bear` and `keep → not-bear`, but there was **no path for `flag → bear`**. A stored `manual-bear` could never promote a kept-but-flagged event.

**Real harm.** `js/calendar-core.js:352 isHiddenForBearReview` hides any event whose `bearReview` starts with `unlikely`/`unsure`. The flagged row therefore re-hid the event on chunky.dad on every run, silently undoing the owner's verdict. The resulting calendar record is self-contradictory, carrying BOTH `bearReview: unsure — …` AND `bearSource: manual-bear (…)`.

### Fix

The kept-event branch is now **bidirectional**. When the matched calendar record's verdict is `manual-bear`, the event is promoted before `buildAnalyzedCalendarEvent`: `isBearEvent = true`, the stored `bearSource` adopted verbatim, and `bearReview` deleted. This reuses the existing-event lookup already performed (no extra calendar scans — asserted in a test) and mirrors the `keptMarkedBear` branch in `scripts/adapters/scriptable-adapter.js:9295-9317`, which already performs exactly this deletion for a live tap, so a stored verdict and a live tap converge on identical state.

The promote fires whenever the record says `manual-bear`, not only when this run flagged the event. That deliberately also fixes the **records already polluted in the wild**: they carry both fields, and the `bearReview` merge rule is calendar-wins, so on a run whose cascade said plain "bear" the stale flag would be copied forward and keep the event hidden forever. Adopting the stored verdict routes the merge through the existing `manual-bear` branch at `shared-core.js:8555-8567`, whose documented job is to clear a stored hide flag.

### On the secondary merge-rule change (verified, deliberately NOT made)

The suggestion was to check whether a fresh `bearReview` can still be re-introduced onto a record whose calendar side says `manual-bear`, and to suppress it at `shared-core.js:8555` if so. Verified reachability instead of changing speculatively:

- **Main path** (`bear-event-scraper-unified.js:368`) always passes a non-null `bearOverrideContext`, so the new promote branch fires and deletes `bearReview` before the merge ever sees it.
- **Adapter path** (`scriptable-adapter.js:9339`) passes no context, but every event in `toPrep` already carries a `manual-bear` `bearSource` from `buildManualBearSource`, so the existing scraper-side `manual-bear` branch clears the flag.

Both reachable paths are covered, so `8555` is left untouched. The stale-flag case is covered by a test instead.

## Defect B — duplicate plan rows: two entries targeting ONE calendar record

Three "Treasure Trail" rows were observed. One is a legitimate read-only audit row for a rescued drop (by design, `scriptable-adapter.js:9023/9054/9063` — untouched). The other two were the SAME event twice, both `_action: "merge"`, both carrying the identical `_existingEvent.identifier`.

**Mechanism — ordering.** `shared-core.js:3789` runs `filterBearEvents(...)` BEFORE `:3793` `deduplicateEvents(...)`, so dedup only ever sees bear-kept events. One twin was DROPped by the bear check and never entered dedup. It is then rescued and **appended after both dedup passes** at `shared-core.js:11171`, called from `bear-event-scraper-unified.js:368`, which is after `deduplicateEvents(...)` at `:359`. Nothing re-dedups the plan.

The dedup logic itself is correct and would have collapsed them: both records share `ticketUrl: https://tixr.com/e/198706` on the same local day, the first and strongest rung of `getSameEventIdentitySignal` (`shared-core.js:12683-12686`, returns `'ticket-url'`). The calendar layer even logged `Merge eligibility match (ticket-url)` twice — `shouldMergeTimeConflict` at `scriptable-adapter.js:11072` delegates to the very same function.

### Fix — the local one

New `SharedCore.foldBearOverrideIntoPlanEntry(analyzedEvents, overrideEvent, options)`. A late bear-override event now checks the already-analyzed plan first; on a match it folds into that row (sets `isBearEvent`, stamps the manual `bearSource`, clears `bearReview`, reformats notes) and returns it, so the caller skips its push. Applied at **both** push sites:

- `shared-core.js` rescue loop, before the push at the old `:11171`
- `scripts/adapters/scriptable-adapter.js` `applyPendingBearOverrides`, at the old `:9340`

The match is deliberately checked before `buildAnalyzedCalendarEvent` runs in the rescue loop, so a folded rescue does not pay for a full `createFinalEventObject` (a second AI merge arbitration) on a row that would be thrown away. The fold itself is deterministic and additive — the existing row's merge analysis stands. Same treatment the adapter's live-tap `keptMarkedBear` branch already applies to a row already in the plan.

**The identifier backstop was added**, and it is the *first* rung: if a plan entry already targets the same `analysis.existingEvent.identifier`, fold. Rationale — it is the exact invariant being violated (two writes at one calendar record), it is free (the identifier is already in hand from the analysis just performed), and it catches pairs that identity signals would miss when a scrape is degraded on both sides. The `getSameEventIdentitySignal` scan is the second rung, using `requireCloseStartTimes: false` to mirror `deduplicateEvents`' own identity scan so a degraded twin (missing start time → midnight default) still matches. It also covers `_action: "new"` rows, which have no identifier to compare.

### Deferred: dedup before the bear check

Reordering `deduplicateEvents` to run before `filterBearEvents` is the structurally cleaner fix — it would make the whole class of defect impossible rather than patching two push sites. It is **deliberately deferred**: it reorders an expensive AI stage and changes bear verdicts run-wide (dedup merges fields, and merged fields feed the bear cascade's evidence), which is far too risky for this wave.

## Tests

`1439 passing, 0 failing` under `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test` — baseline 1432 plus 7 new tests. All new tests were confirmed failing on unfixed source first (the duplicate-row test failed with the exact reported symptom: `2 !== 1`).

`scripts/shared-core.test.js` (5):
- a kept-but-FLAGGED event whose matched record carries `bearSource: manual-bear` ends `isBearEvent: true` with `bearReview` removed from both the event and the notes, and still uses only one existing-event search
- a stale `bearReview` already on a `manual-bear` record is not carried forward
- a flagged event with a `manual-not-bear` record is still demoted, tombstone untouched (regression guard for the other direction)
- a rescued drop matching an analyzed event by `ticket-url` produces ONE plan row, and no two rows share one `_existingEvent.identifier`
- `foldBearOverrideIntoPlanEntry` unit coverage: folds by identifier, leaves genuinely new events alone, no-ops on an empty plan

`scripts/adapters/scriptable-adapter.test.js` (2): `applyPendingBearOverrides` folds a marked-bear twin into the existing row (verdict still counted), and still appends a genuinely new marked-bear event.

## Constraints

- No new runtime files — all four touched files already exist, so **no scriptable-script-updater entries are needed**.
- No `new URL(` / `URLSearchParams` added under `scripts/`.
- `shared-core.js` stays platform-pure: no `require`, injection only.
- No existing `console.log` text or AI prompt string was edited — additions only, so the AI response cache is not invalidated.
- Tests only in package.json-enumerated files.
- Nothing hardcoded per-venue, per-promoter, or per-city.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
