### PR TITLE
fix(scriptable): shed page content under a proven-render ceiling instead of warning inside a page WebKit will not draw

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -5417,6 +5417,10 @@ class ScriptableAdapter {
         }
         return false; // cancel the fake navigation; the page stays put
       };
+      // If the page could not be shed under the render ceiling, say so through
+      // the ONE channel that survives a document WebKit refuses to run: a
+      // native Alert, raised before the sheet, not a banner buried inside it.
+      await this.warnResultsPageUnrenderable();
       await webView.present(true);
       // The page's own account of whether it ever rendered. Logged AFTER the
       // sheet closes so a blank review leaves a different trace than a real one.
@@ -10064,11 +10068,41 @@ class ScriptableAdapter {
   // renders at after the Run Logs cut, so it warns approaching the danger
   // zone instead of after it.
   //
-  // Crossing it is not fatal, but it must never be silent — see
-  // applyResultsHtmlSizeGuard, which both logs it and puts a banner on the
-  // page, because the owner is looking at a WebView, not at the log.
-  static get RESULTS_HTML_WARN_BYTES() {
-    return 960 * 1024;
+  // 960 KB was still too high, and for the same reason as 1923 KB before it:
+  // it was picked from a blank page's own size instead of from a size that had
+  // been PROVEN to render. The liveness beacons added in #1629 finally made
+  // that provable per run. One deployed build, 2026-08-04:
+  //
+  //     Dallas Eagle  486 KB  ✅ painted, interacted
+  //     Goldiloxx     248 KB  ✅ rendered
+  //     CHUNK         862 KB  ✅ painted, interacted
+  //     Furball       489 KB  ✅ painted, interacted
+  //     BEEFMINCE     955 KB  ❌ no beacon at all (3 runs out of 3)
+  //
+  // "No beacon at all" means WebKit never ran the page: no DOM, no scripts,
+  // literally <html><head></head><body></body></html>. So the cliff is
+  // somewhere in (862, 955] and 960 KB sat ABOVE it — BEEFMINCE measured
+  // 959 KB UTF-8, slipped under the guard, and white-screened anyway.
+  //
+  // 800 KB is the largest round number that keeps a ~7% margin under the
+  // 862 KB that is actually proven to render. It is deliberately NOT set to
+  // the largest observed success: the cliff's true position is unknown, only
+  // bounded, and the cost of being over it is a blank screen with no
+  // diagnostics on it.
+  //
+  // Crossing it is not a warning — see applyResultsHtmlSizeGuard, which sheds
+  // page content until the page is back under this number. A banner cannot do
+  // that job: a banner lives INSIDE the document WebKit refuses to run.
+  static get RESULTS_HTML_MAX_BYTES() {
+    return 800 * 1024;
+  }
+
+  // The "what got shed" banner is written into the page AFTER the shed loop
+  // has measured it, so the loop has to stop short of the ceiling by at least
+  // the banner's own size or the finished document lands back over it. Four
+  // rungs' worth of banner text is under 1 KB; 2 KB is the margin.
+  static get RESULTS_HTML_BANNER_RESERVE_BYTES() {
+    return 2 * 1024;
   }
 
   // UTF-8 byte length without Buffer/TextEncoder (neither exists in
@@ -10323,32 +10357,268 @@ class ScriptableAdapter {
   // one from the log.
   logResultsHtmlSizeGuard(html, eventCount) {
     const bytes = ScriptableAdapter.utf8ByteLength(html);
-    if (bytes <= ScriptableAdapter.RESULTS_HTML_WARN_BYTES) return;
+    if (bytes <= ScriptableAdapter.RESULTS_HTML_MAX_BYTES) return;
     console.log(
       `📱 Scriptable: ⚠️ Results HTML is ${Math.round(bytes / 1024)} KB for ${eventCount} event(s) — above the ${Math.round(
-        ScriptableAdapter.RESULTS_HTML_WARN_BYTES / 1024,
+        ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024,
       )} KB size that has actually rendered on device. If the results screen comes up blank, that is why: re-run with fewer parsers, or review from the saved run JSON.`,
     );
   }
 
-  // The log line above is invisible to someone staring at a WebView, which is
-  // exactly the situation the guard exists to describe. So the same warning
-  // also goes ON the page, at the very top, where it is the first thing that
-  // renders — and if the page never renders, its absence and the missing
-  // liveness beacons say the same thing from two directions.
+  // Removes every balanced `<tag …>…</tag>` element whose opening tag starts
+  // with `startMarker`. Depth-counted rather than regex-matched because these
+  // sections nest the same tag inside themselves (a <div> full of <div>s), and
+  // a lazy regex would cut at the first inner close and leave a broken page.
+  static stripBalancedElements(html, startMarker, tagName) {
+    const source = typeof html === "string" ? html : "";
+    const scanner = new RegExp(`<${tagName}[\\s>]|</${tagName}>`, "g");
+    let out = "";
+    let cursor = 0;
+    let removed = 0;
+    for (;;) {
+      const start = source.indexOf(startMarker, cursor);
+      if (start === -1) break;
+      scanner.lastIndex = start;
+      let depth = 0;
+      let end = -1;
+      let match;
+      while ((match = scanner.exec(source)) !== null) {
+        depth += match[0].charAt(1) === "/" ? -1 : 1;
+        if (depth === 0) {
+          end = match.index + match[0].length;
+          break;
+        }
+      }
+      if (end === -1) break; // Unbalanced — leave the rest of the page alone.
+      out += source.slice(cursor, start);
+      cursor = end;
+      removed += 1;
+    }
+    return { html: removed ? out + source.slice(cursor) : source, removed };
+  }
+
+  // Shed ladder, heaviest-and-least-valuable first. Each rung returns the
+  // reduced page plus a count of what it touched; applyResultsHtmlSizeGuard
+  // stops at the first rung that gets the page under the ceiling, so a run
+  // only ever loses what it actually had to lose.
+  //
+  // Nothing here is the ONLY copy of anything:
+  //   header-logo   decoration, zero information; falls back to the same
+  //                 remote URL the page already uses when the cache is cold.
+  //   line-diff     the "Line-by-Line Diff" pane is display:none by default
+  //                 AND renders the same fields as the Field-by-Field table
+  //                 sitting directly above it. toggleDiffView already
+  //                 no-ops when the pane is absent.
+  //   debug-json    the same event is rendered field-by-field across the
+  //                 whole card, and verbatim in the saved run JSON file.
+  //   provenance    collapsed by default; field origins are in the run JSON.
+  static get RESULTS_HTML_SHED_LADDER() {
+    return [
+      {
+        id: "header-logo",
+        describe: (n) =>
+          `${n} inlined base64 image(s) (the header logo) swapped for their remote URL`,
+        apply: (html) => {
+          let removed = 0;
+          const next = html.replace(
+            /src="data:image\/[a-z0-9+.-]+;base64,[^"]*"/gi,
+            () => {
+              removed += 1;
+              return `src="${HEADER_LOGO_URL}"`;
+            },
+          );
+          return { html: next, removed };
+        },
+      },
+      {
+        id: "line-diff-views",
+        describe: (n) =>
+          `${n} hidden "Line-by-Line Diff" pane(s) (same fields as the Field-by-Field table above them)`,
+        apply: (html) => {
+          const stripped = ScriptableAdapter.stripBalancedElements(
+            html,
+            '<div id="line-view-',
+            "div",
+          );
+          if (!stripped.removed) return stripped;
+          // toggleDiffView already no-ops when the pane is gone, but a button
+          // that silently does nothing is a display that lies. Relabel it —
+          // scoped to the toggle's own id so the page's inline script, which
+          // contains the same words, is never touched.
+          stripped.html = stripped.html.replace(
+            /(id="diff-toggle-[^"]*"\s*>)\s*Switch to Line View\s*(<\/button>)/g,
+            "$1Line view trimmed for page size$2",
+          );
+          return stripped;
+        },
+      },
+      {
+        id: "debug-json",
+        describe: (n) =>
+          `${n} embedded debug JSON payload(s) (still verbatim in the saved run file)`,
+        apply: (html) => {
+          let removed = 0;
+          const next = html.replace(
+            /(<pre class="raw-json">)[\s\S]*?(<\/pre>)/g,
+            (_all, open, close) => {
+              removed += 1;
+              return `${open}${ScriptableAdapter.SHED_DEBUG_JSON_PLACEHOLDER}${close}`;
+            },
+          );
+          return { html: next, removed };
+        },
+      },
+      {
+        id: "provenance",
+        describe: (n) =>
+          `${n} collapsed "🔍 Provenance" section(s) (field origins are in the saved run file)`,
+        apply: (html) =>
+          ScriptableAdapter.stripBalancedElements(
+            html,
+            '<details class="provenance-details"',
+            "details",
+          ),
+      },
+    ];
+  }
+
+  // Valid JSON on purpose: readCardEventJSON parses whatever is in the <pre>,
+  // so "Copy JSON" on a shed card copies this sentence instead of copying
+  // silence. A button that copies an empty string is a display that lies.
+  static get SHED_DEBUG_JSON_PLACEHOLDER() {
+    return '{"_shed":"Debug JSON was removed so this page would render at all — see the saved run file for the untrimmed event."}';
+  }
+
+  // The old guard put a banner on the page and stopped there. That banner is
+  // useless in the exact case it was written for: past WebView.loadHTML's
+  // silent size cliff WebKit never runs the document, so nothing inside it —
+  // banner included — is ever drawn. Over-budget therefore has to REDUCE the
+  // page, not annotate it.
+  //
+  // Order of operations:
+  //   1. under the ceiling  -> return untouched, no noise.
+  //   2. over it            -> shed rungs in order until under, log each drop
+  //                            with its byte cost, banner what was lost (that
+  //                            banner is now on a page that WILL render).
+  //   3. still over         -> record it so presentRichResults can raise a
+  //                            native Alert, which does not live inside the
+  //                            document that cannot be drawn.
   applyResultsHtmlSizeGuard(html, eventCount) {
-    const page = typeof html === "string" ? html : "";
+    let page = typeof html === "string" ? html : "";
     this.logResultsHtmlSizeGuard(page, eventCount);
-    const bytes = ScriptableAdapter.utf8ByteLength(page);
-    if (bytes <= ScriptableAdapter.RESULTS_HTML_WARN_BYTES) return page;
-    const banner = `
-    <div class="results-size-warning">⚠️ This page is ${Math.round(bytes / 1024)} KB for ${eventCount} event(s), above the ${Math.round(
-      ScriptableAdapter.RESULTS_HTML_WARN_BYTES / 1024,
-    )} KB that has reliably rendered on device. If it looks blank or stops scrolling, that is why — re-run with fewer parsers, or review the saved run JSON.</div>`;
+    const bytesBefore = ScriptableAdapter.utf8ByteLength(page);
+    this._resultsSizeReduction = null;
+    if (bytesBefore <= ScriptableAdapter.RESULTS_HTML_MAX_BYTES) return page;
+
+    const sheds = [];
+    const shedTarget =
+      ScriptableAdapter.RESULTS_HTML_MAX_BYTES -
+      ScriptableAdapter.RESULTS_HTML_BANNER_RESERVE_BYTES;
+    let bytes = bytesBefore;
+    for (const rung of ScriptableAdapter.RESULTS_HTML_SHED_LADDER) {
+      if (bytes <= shedTarget) break;
+      const result = rung.apply(page);
+      if (!result || !result.removed) continue;
+      const after = ScriptableAdapter.utf8ByteLength(result.html);
+      const saved = bytes - after;
+      page = result.html;
+      bytes = after;
+      const shed = {
+        id: rung.id,
+        count: result.removed,
+        bytes: saved,
+        detail: rung.describe(result.removed),
+      };
+      sheds.push(shed);
+      // NO SILENT CAPS: one line per drop, naming what went and what it cost.
+      console.log(
+        `📱 Scriptable: ✂️ Results page shed "${shed.id}" to fit the ${Math.round(
+          ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024,
+        )} KB render ceiling — dropped ${shed.detail}, recovering ${Math.round(
+          saved / 1024,
+        )} KB (page now ${Math.round(bytes / 1024)} KB).`,
+      );
+    }
+
+    const overBudget = bytes > shedTarget;
+    this._resultsSizeReduction = {
+      eventCount,
+      bytesBefore,
+      bytesAfter: bytes,
+      sheds,
+      overBudget,
+    };
+
+    if (overBudget) {
+      console.log(
+        `📱 Scriptable: ⚠️ Results page is still ${Math.round(bytes / 1024)} KB after shedding everything sheddable (ceiling ${Math.round(
+          ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024,
+        )} KB) — WebKit may refuse to run it. Raising a native alert, since a message printed inside an undrawn page cannot be read.`,
+      );
+    } else if (sheds.length) {
+      console.log(
+        `📱 Scriptable: ✅ Results page reduced ${Math.round(bytesBefore / 1024)} KB → ${Math.round(
+          bytes / 1024,
+        )} KB for ${eventCount} event(s), back under the ${Math.round(
+          ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024,
+        )} KB ceiling.`,
+      );
+    }
+
+    const summary = sheds.length
+      ? sheds
+          .map((s) => `${s.detail} (−${Math.round(s.bytes / 1024)} KB)`)
+          .join("; ")
+      : "nothing on this page was sheddable";
+    const banner = overBudget
+      ? `
+    <div class="results-size-warning">⚠️ This page is ${Math.round(bytes / 1024)} KB for ${eventCount} event(s), still above the ${Math.round(
+      ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024,
+    )} KB that has reliably rendered on device — if you can read this, it rendered anyway. Trimmed: ${summary}. Re-run with fewer parsers, or review the saved run JSON.</div>`
+      : `
+    <div class="results-size-warning">✂️ This page was ${Math.round(bytesBefore / 1024)} KB for ${eventCount} event(s), above the ${Math.round(
+      ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024,
+    )} KB that reliably renders on device, so it was trimmed to ${Math.round(
+      bytes / 1024,
+    )} KB. Dropped: ${summary}. Everything dropped is still in the saved run JSON.</div>`;
     const bodyIndex = page.indexOf("<body>");
     if (bodyIndex === -1) return page;
     const insertAt = bodyIndex + "<body>".length;
     return page.slice(0, insertAt) + banner + page.slice(insertAt);
+  }
+
+  // The only channel that survives a page WebKit will not run. Called from
+  // presentRichResults BEFORE present(), so the owner reads it and then sees
+  // whatever the sheet turns out to be — instead of staring at white and
+  // guessing.
+  async warnResultsPageUnrenderable(reduction) {
+    const info = reduction || this._resultsSizeReduction;
+    if (!info || !info.overBudget) return false;
+    if (typeof Alert === "undefined") return false;
+    const dropped = (info.sheds || [])
+      .map((s) => `• ${s.detail} (−${Math.round(s.bytes / 1024)} KB)`)
+      .join("\n");
+    try {
+      const alert = new Alert();
+      alert.title = "Results page may not render";
+      alert.message = [
+        `The results page is ${Math.round(info.bytesAfter / 1024)} KB for ${info.eventCount} event(s), above the ${Math.round(
+          ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024,
+        )} KB that WebKit has been proven to draw. If the next screen is blank, that is why — do not treat it as a reviewed run.`,
+        dropped ? `Already trimmed:\n${dropped}` : "Nothing was sheddable.",
+        "Re-run with fewer parsers, or review the saved run JSON.",
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+      alert.addAction("Show it anyway");
+      await alert.presentAlert();
+      return true;
+    } catch (error) {
+      console.log(
+        `📱 Scriptable: Results size alert failed: ${error.message}`,
+      );
+      return false;
+    }
   }
 
   logEventJsonBudgetReport() {

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -4596,6 +4596,12 @@ test('results HTML: small runs are not regressed — a 3-event page stays small 
 
 test('results HTML is bounded BY CONSTRUCTION: 4x the events does not 4x the embedded payload', async () => {
   const adapter = buildAdapter();
+  // The per-card payload budget is what is under test here. The page-level
+  // shed ladder (applyResultsHtmlSizeGuard) is a SEPARATE, later mechanism —
+  // at these event counts it would strip the payloads outright and the
+  // measurement below would prove nothing about the budget. It has its own
+  // tests further down.
+  adapter.applyResultsHtmlSizeGuard = (html) => html;
   const totalPayloadBytes = async (count) => {
     const html = await adapter.generateRichHTML(buildSizedResults(count));
     let bytes = 0;
@@ -4619,6 +4625,9 @@ test('results HTML is bounded BY CONSTRUCTION: 4x the events does not 4x the emb
 
 test('results HTML: a trimmed payload is never silent — it is logged, stamped, and its keys are still rendered', async () => {
   const adapter = buildAdapter();
+  // Same separation as above: this pins the per-card budget's stamp, not the
+  // page-level shed ladder that would replace the whole payload at 60 events.
+  adapter.applyResultsHtmlSizeGuard = (html) => html;
   const lines = [];
   const originalLog = console.log;
   console.log = (...args) => { lines.push(args.join(' ')); };
@@ -4663,7 +4672,7 @@ test('results HTML: an oversized page is never silent about its own size', async
     'no size warning on a page that is comfortably small');
 
   // The guard itself fires on anything past what has actually rendered.
-  const oversized = 'x'.repeat(ScriptableAdapter.RESULTS_HTML_WARN_BYTES + 1);
+  const oversized = 'x'.repeat(ScriptableAdapter.RESULTS_HTML_MAX_BYTES + 1);
   const warned = [];
   const restore = console.log;
   console.log = (...args) => { warned.push(args.join(' ')); };
@@ -4941,11 +4950,11 @@ test('size guard counts UTF-8 bytes, not UTF-16 code units', () => {
   // A page whose UTF-16 length is comfortably UNDER the threshold but whose
   // real UTF-8 size is over it. The old guard measured html.length and would
   // have stayed silent on exactly this page.
-  const units = Math.floor(ScriptableAdapter.RESULTS_HTML_WARN_BYTES * 0.7);
+  const units = Math.floor(ScriptableAdapter.RESULTS_HTML_MAX_BYTES * 0.7);
   const page = '→'.repeat(units);
-  assert.ok(page.length < ScriptableAdapter.RESULTS_HTML_WARN_BYTES,
+  assert.ok(page.length < ScriptableAdapter.RESULTS_HTML_MAX_BYTES,
     'UTF-16 length is under the threshold');
-  assert.ok(ScriptableAdapter.utf8ByteLength(page) > ScriptableAdapter.RESULTS_HTML_WARN_BYTES,
+  assert.ok(ScriptableAdapter.utf8ByteLength(page) > ScriptableAdapter.RESULTS_HTML_MAX_BYTES,
     'UTF-8 size is over it');
 
   const adapter = buildAdapter();
@@ -4970,7 +4979,7 @@ test('an over-budget page says so ON the page, not only in a log the owner canno
   let loud;
   try {
     quiet = adapter.applyResultsHtmlSizeGuard(small, 3);
-    const oversized = `<html><body>${'x'.repeat(ScriptableAdapter.RESULTS_HTML_WARN_BYTES + 1)}</body></html>`;
+    const oversized = `<html><body>${'x'.repeat(ScriptableAdapter.RESULTS_HTML_MAX_BYTES + 1)}</body></html>`;
     loud = adapter.applyResultsHtmlSizeGuard(oversized, 80);
   } finally {
     console.log = originalLog;
@@ -4981,6 +4990,237 @@ test('an over-budget page says so ON the page, not only in a log the owner canno
   assert.ok(loud.indexOf('results-size-warning') < loud.indexOf('xxxx'),
     'the banner is the first thing in the body, so it renders first');
   assert.ok(loud.includes('80 event(s)'), 'the banner names the run it is describing');
+});
+
+// ---------------------------------------------------------------------------
+// WebView.loadHTML's silent size cliff: over it WebKit never runs the page.
+//
+// Empirical bounds, one deployed build, 2026-08-04, verdicts from the #1629
+// liveness beacons: 862 KB rendered ("painted, interacted"); 955 KB produced
+// NO beacon at all, three runs out of three — no DOM, no scripts, literally
+// <html><head></head><body></body></html>. The old 960 KB threshold sat ABOVE
+// that cliff, so BEEFMINCE at 959 KB UTF-8 slipped under the guard and
+// white-screened anyway; and the guard's only response was a banner INSIDE
+// the document WebKit refuses to draw.
+// ---------------------------------------------------------------------------
+
+// A page big enough to trip the ceiling on its own, with real sheddable
+// structure in it: an inlined base64 header logo (the single heaviest
+// non-card item on the device page) plus real merge cards.
+async function renderOversizedResultsPage(adapter, { events = 40, logoBytes = 300 * 1024 } = {}) {
+  adapter.loadHeaderLogoData = async () => `data:image/png;base64,${'A'.repeat(logoBytes)}`;
+  return adapter.generateRichHTML(buildSizedResults(events));
+}
+
+function captureLog(fn) {
+  const lines = [];
+  const original = console.log;
+  console.log = (...args) => { lines.push(args.join(' ')); };
+  try {
+    return { value: fn(), lines };
+  } finally {
+    console.log = original;
+  }
+}
+
+async function captureLogAsync(fn) {
+  const lines = [];
+  const original = console.log;
+  console.log = (...args) => { lines.push(args.join(' ')); };
+  try {
+    const value = await fn();
+    return { value, lines };
+  } finally {
+    console.log = original;
+  }
+}
+
+test('size cliff: an over-ceiling page is REDUCED under the ceiling, not merely annotated', async () => {
+  const adapter = buildAdapter();
+  const { value: html } = await captureLogAsync(() => renderOversizedResultsPage(adapter));
+
+  const reduction = adapter._resultsSizeReduction;
+  assert.ok(reduction, 'the render records what it had to do to fit');
+  assert.ok(reduction.bytesBefore > ScriptableAdapter.RESULTS_HTML_MAX_BYTES,
+    `the unreduced page really was over the ceiling (${reduction.bytesBefore} bytes)`);
+  assert.ok(reduction.sheds.length > 0, 'something was actually shed');
+  assert.equal(reduction.overBudget, false, 'and it got under the ceiling');
+
+  // The point of the whole change: the STRING HANDED TO loadHTML is smaller.
+  // A banner cannot do this, which is why a banner was never the fix.
+  const finalBytes = ScriptableAdapter.utf8ByteLength(html);
+  assert.ok(finalBytes < reduction.bytesBefore,
+    'the returned page is smaller than the page that was built');
+  assert.ok(finalBytes <= ScriptableAdapter.RESULTS_HTML_MAX_BYTES,
+    `the returned page — banner included — is under the ceiling (${finalBytes} bytes)`);
+
+  // The heaviest rung is the inlined logo, and it degrades to the same remote
+  // URL the page already falls back to when the logo cache is cold.
+  assert.ok(!html.includes('data:image/png;base64,AAAA'),
+    'the inlined base64 logo is gone');
+  assert.ok(html.includes('https://chunky.dad/favicons/logo-hero.png'),
+    'the logo falls back to its remote URL rather than vanishing');
+
+  // Reduction is not mutilation: every card survives.
+  assert.equal((html.match(/class="event-card"/g) || []).length, 40,
+    'all 40 cards are still on the page');
+});
+
+test('size cliff: the ceiling is set from a size PROVEN to render, not from a size observed blank', () => {
+  // 862 KB rendered; 955 KB did not. A ceiling at or above the largest
+  // observed success is a ceiling with no margin against a cliff whose exact
+  // position is unknown — and 960 KB was above the BLANK page, which is how
+  // BEEFMINCE (959 KB UTF-8) slipped under it.
+  const ceilingKb = ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024;
+  assert.ok(ceilingKb < 862, `ceiling (${ceilingKb} KB) is below the 862 KB that rendered`);
+  assert.ok(ceilingKb < 955, `ceiling (${ceilingKb} KB) is below the 955 KB that white-screened`);
+  assert.ok(ceilingKb >= 512, 'but not so low that ordinary runs get gutted');
+});
+
+test('size cliff: every shed is logged with what went and what it cost — no silent caps', async () => {
+  const adapter = buildAdapter();
+  const { lines } = await captureLogAsync(() => renderOversizedResultsPage(adapter));
+
+  const shedLines = lines.filter(l => l.includes('Results page shed'));
+  assert.equal(shedLines.length, adapter._resultsSizeReduction.sheds.length,
+    'exactly one log line per shed');
+  for (const shed of adapter._resultsSizeReduction.sheds) {
+    const line = shedLines.find(l => l.includes(`"${shed.id}"`));
+    assert.ok(line, `shed "${shed.id}" is named in the log`);
+    assert.ok(/recovering \d+ KB/.test(line), `shed "${shed.id}" reports its byte cost`);
+    assert.ok(/page now \d+ KB/.test(line), `shed "${shed.id}" reports the running size`);
+    assert.ok(shed.bytes > 0, `shed "${shed.id}" actually removed bytes`);
+  }
+  assert.ok(lines.some(l => l.includes('back under the')),
+    'and the run says, in one line, that the page ended up renderable');
+});
+
+test('size cliff: the shed ladder runs heaviest-first and stops as soon as the page fits', async () => {
+  const adapter = buildAdapter();
+  // A modest overshoot: the logo alone should cover it, so nothing else is
+  // touched. A page must never lose more than it had to.
+  await captureLogAsync(() => renderOversizedResultsPage(adapter, { events: 8, logoBytes: 700 * 1024 }));
+
+  const ids = adapter._resultsSizeReduction.sheds.map(s => s.id);
+  assert.deepEqual(ids, ['header-logo'],
+    'only the first rung fired; the debug JSON and provenance sections are untouched');
+  assert.equal(adapter._resultsSizeReduction.overBudget, false);
+});
+
+test('size cliff: shedding a section leaves the page structurally intact and its controls honest', () => {
+  const adapter = buildAdapter();
+  // Nested same-tag elements: a lazy regex would cut at the first inner
+  // </div> and shred the page. The strip is depth-counted for this reason.
+  const nested = '<div id="line-view-a" class="diff-view"><div><div>x</div></div></div>';
+  const stripped = ScriptableAdapter.stripBalancedElements(
+    `<body><div class="card">before${nested}after</div></body>`,
+    '<div id="line-view-',
+    'div'
+  );
+  assert.equal(stripped.removed, 1);
+  assert.equal(stripped.html, '<body><div class="card">beforeafter</div></body>');
+
+  // An unbalanced fragment is left alone rather than half-cut.
+  const unbalanced = ScriptableAdapter.stripBalancedElements(
+    '<div id="line-view-a">oops',
+    '<div id="line-view-',
+    'div'
+  );
+  assert.equal(unbalanced.removed, 0, 'nothing is cut when the element never closes');
+
+  // The button that used to open the shed pane says why it no longer does —
+  // and the page's inline script, which contains the same words, is untouched.
+  const rung = ScriptableAdapter.RESULTS_HTML_SHED_LADDER.find(r => r.id === 'line-diff-views');
+  const page = '<button id="diff-toggle-a">\n  Switch to Line View\n</button>'
+    + '<div id="line-view-a"><div>diff</div></div>'
+    + "<script>button.textContent = 'Switch to Line View';</script>";
+  const out = rung.apply(page).html;
+  assert.ok(out.includes('Line view trimmed for page size'), 'the dead button is relabelled');
+  assert.ok(out.includes("button.textContent = 'Switch to Line View';"),
+    "the page's own script is not rewritten");
+
+  // A shed debug payload still parses, so "Copy JSON" copies an explanation
+  // instead of copying silence.
+  const jsonRung = ScriptableAdapter.RESULTS_HTML_SHED_LADDER.find(r => r.id === 'debug-json');
+  const shedJson = jsonRung.apply('<pre class="raw-json">{"title":"x"}</pre>').html;
+  const payload = shedJson.match(/<pre class="raw-json">([\s\S]*?)<\/pre>/)[1];
+  assert.ok(JSON.parse(payload)._shed, 'the placeholder is valid JSON that names itself');
+});
+
+test('size cliff: an un-shrinkable page surfaces via a NATIVE alert, not an in-page banner', async () => {
+  const adapter = buildAdapter();
+  // Nothing on this page is sheddable, so it stays over the ceiling — the
+  // exact case where an in-page banner is invisible by construction.
+  const unshrinkable = `<html><body>${'x'.repeat(ScriptableAdapter.RESULTS_HTML_MAX_BYTES + 1)}</body></html>`;
+  const { lines } = captureLog(() => adapter.applyResultsHtmlSizeGuard(unshrinkable, 90));
+
+  assert.equal(adapter._resultsSizeReduction.overBudget, true);
+  assert.ok(lines.some(l => l.includes('Raising a native alert')),
+    'the run says it is falling back to the one channel that survives a blank page');
+
+  const presented = [];
+  const originalAlert = global.Alert;
+  global.Alert = class {
+    constructor() { this.actions = []; }
+    addAction(title) { this.actions.push(title); }
+    async presentAlert() { presented.push({ title: this.title, message: this.message }); }
+  };
+  let raised;
+  try {
+    raised = await adapter.warnResultsPageUnrenderable();
+  } finally {
+    if (originalAlert === undefined) delete global.Alert; else global.Alert = originalAlert;
+  }
+
+  assert.equal(raised, true, 'the alert was raised');
+  assert.equal(presented.length, 1, 'exactly one alert');
+  assert.ok(presented[0].message.includes('90 event(s)'), 'it names the run');
+  assert.ok(presented[0].message.includes('blank'),
+    'it warns that the next screen may be blank, which the page itself could not');
+  assert.ok(presented[0].message.includes('not'), 'and that a blank sheet is not a reviewed run');
+});
+
+test('size cliff: no alert when the page came back under the ceiling', async () => {
+  const adapter = buildAdapter();
+  const presented = [];
+  const originalAlert = global.Alert;
+  global.Alert = class {
+    addAction() {}
+    async presentAlert() { presented.push(this.message); }
+  };
+  try {
+    await captureLogAsync(() => renderOversizedResultsPage(adapter));
+    const raised = await adapter.warnResultsPageUnrenderable();
+    assert.equal(raised, false, 'a page that was successfully reduced raises nothing');
+  } finally {
+    if (originalAlert === undefined) delete global.Alert; else global.Alert = originalAlert;
+  }
+  assert.equal(presented.length, 0);
+
+  // A small page leaves no reduction record at all.
+  const clean = buildAdapter();
+  captureLog(() => clean.applyResultsHtmlSizeGuard('<html><body>ok</body></html>', 1));
+  assert.equal(clean._resultsSizeReduction, null);
+  assert.equal(await clean.warnResultsPageUnrenderable(), false);
+});
+
+test('size cliff: the ceiling is measured in UTF-8 BYTES, not UTF-16 code units (regression pin)', () => {
+  const adapter = buildAdapter();
+  // A page whose String.length is comfortably under the ceiling but whose
+  // real UTF-8 size — what WebKit holds — is over it. Measuring html.length
+  // here is how a 959 KB page reads as "fine".
+  const filler = '→'.repeat(Math.floor(ScriptableAdapter.RESULTS_HTML_MAX_BYTES * 0.7));
+  const page = `<html><body><div id="line-view-a" class="diff-view">${filler}</div></body></html>`;
+  assert.ok(page.length < ScriptableAdapter.RESULTS_HTML_MAX_BYTES,
+    'UTF-16 length is under the ceiling');
+  assert.ok(ScriptableAdapter.utf8ByteLength(page) > ScriptableAdapter.RESULTS_HTML_MAX_BYTES,
+    'UTF-8 size is over it');
+
+  const { value: reduced } = captureLog(() => adapter.applyResultsHtmlSizeGuard(page, 12));
+  assert.ok(adapter._resultsSizeReduction, 'the guard fired on the real byte size');
+  assert.equal(adapter._resultsSizeReduction.sheds.length, 1);
+  assert.equal(adapter._resultsSizeReduction.overBudget, false);
+  assert.ok(!reduced.includes('→'), 'the multi-byte payload was actually removed');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

BEEFMINCE's results page white-screens in the Scriptable WebView. `WebView.loadHTML` has a **silent size cliff**: over it WebKit never runs the page at all — no DOM, no scripts, literally `<html><head></head><body></body></html>`.

The liveness beacons added in #1629 finally make that verdict unambiguous per run. One deployed build, 2026-08-04:

| Run | Parser | HTML size | Beacon verdict |
|---|---|---|---|
| 20260804-144759 | Dallas Eagle | 486 KB | ✅ `painted, interacted` |
| 20260804-144941 | Goldiloxx | 248 KB | ✅ rendered |
| 20260804-144859 | CHUNK | **862 KB** | ✅ `painted, interacted` |
| 20260804-145006 | Furball | 489 KB | ✅ `painted, interacted` |
| 20260804-145058 | BEEFMINCE | **955 KB** | ❌ **no beacon at all** |
| 20260804-151935 | BEEFMINCE | **955 KB** | ❌ **no beacon at all** |
| 20260804-153742 | BEEFMINCE | **955 KB** | ❌ **no beacon at all** |

**862 KB renders. 955 KB does not. Reproducible 3/3.** The cliff is somewhere in (862, 955].

```
Results HTML size: 955 KB
Results HTML size (UTF-8 bytes): 959 KB
Presenting results UI...
⚠️ Results page never reported liveness — no beacon arrived at all, so WebKit did not run the page.
```

## Why 960 KB was the wrong threshold

`RESULTS_HTML_WARN_BYTES` was `960 * 1024` — and it was picked from an observed **blank** page (986 KB), not from an observed **rendered** one. That is the same circular mistake as the 1923 KB value before it ("the largest page the owner had ever reviewed"), just one size down: a threshold set from the failure side can only ever fire *after* the failure. BEEFMINCE measured 959 KB UTF-8, slipped under 960 by 1 KB, and white-screened.

Renamed to **`RESULTS_HTML_MAX_BYTES` = 800 KB**, set from the *success* side with margin: ~7% under the 862 KB that is actually proven to draw. Deliberately not set at the largest observed success — the cliff's exact position is unknown, only bounded, and the cost of being over it is a blank screen with no diagnostics on it. A regression test pins `ceiling < 862` and `ceiling < 955`.

## Why a banner inside an unloadable page is useless

`applyResultsHtmlSizeGuard` injected a `.results-size-warning` div into the document and stopped there. Past the cliff WebKit never runs that document, so the banner is **invisible by construction — in exactly the case it exists for**. Same "displays that lie" class this project keeps hitting.

Over-budget now **reduces the page**:

- Shed rungs run in order, stopping at the first one that gets the page under the ceiling, so a run only loses what it had to lose.
- **Every drop is logged with what went and what it cost** — no silent caps.
- The banner is kept, but only ever lands on a page that *will* render, and it now names what was dropped.
- If the page still cannot fit, `presentRichResults` raises a **native `Alert` before `present()`** — the one channel that survives a document WebKit will not draw.

## The shed ladder (measured on run 20260804-145058)

Nothing on the ladder is the only copy of anything.

| # | Rung | What it is | Bytes recovered |
|---|---|---|---|
| 1 | `header-logo` | `cache/logo-hero.png` inlined as a base64 data URI; swapped for the same remote URL the page already falls back to when the cache is cold. Zero information content. | **−126 KB** (129,254 B) |
| 2 | `line-diff-views` | The "Line-by-Line Diff" pane — `display:none` by default **and** a second rendering of the same fields as the Field-by-Field table directly above it. | **−119 KB** (121,595 B) |
| 3 | `debug-json` | The embedded `<pre class="raw-json">` payload; the same event is rendered field-by-field across the card and verbatim in the saved run JSON. | −188 KB (not needed here) |
| 4 | `provenance` | The collapsed "🔍 Provenance" section; field origins are in the saved run JSON. | −147 KB (not needed here) |

Forced through all four rungs (ceiling dropped to 391 KB as a probe): 951 → 825 → 706 → 518 → **371 KB**, page structurally intact (`<div>`/`<details>`/`<pre>` all balanced, 15/15 cards present).

Honesty details, so no shed leaves a control lying:
- Rung 2 also relabels the now-dead "Switch to Line View" button to "Line view trimmed for page size" — scoped to the toggle's own `id` so the page's inline script, which contains the same words, is never rewritten.
- Rung 3's placeholder is **valid JSON** (`{"_shed":"…"}`), so "Copy JSON" copies an explanation instead of copying silence.
- `stripBalancedElements` is depth-counted, not regex-matched: these sections nest the same tag inside themselves, and a lazy regex would cut at the first inner close and shred the page.

## Before / after — the required proof

BEEFMINCE run **20260804-145058** regenerated offline with a device-faithful harness (real saved run JSON, real `cache/logo-hero.png` inlined so the offline size matches the device log):

| | UTF-8 bytes | KB |
|---|---|---|
| Before | 974,310 | **951.5 KB** |
| After (2 sheds) | 723,290 | **706.3 KB** |

Device logged 959 KB UTF-8 for this run; the harness measures 951.5 KB — 0.8% apart, so the offline number is trustworthy. **706.3 KB is 94 KB under the new 800 KB ceiling and 156 KB under the 862 KB proven to render.** All 15 event cards survive.

Log from the reduced run:
```
⚠️ Results HTML is 951 KB for 15 event(s) — above the 800 KB size that has actually rendered on device. …
✂️ Results page shed "header-logo" … recovering 126 KB (page now 825 KB).
✂️ Results page shed "line-diff-views" … recovering 119 KB (page now 706 KB).
✅ Results page reduced 951 KB → 706 KB for 15 event(s), back under the 800 KB ceiling.
```

Every other run in the table re-measured under the new code: Dallas Eagle 434.9 KB, Goldiloxx 244.9 KB, Furball 477.0 KB — all untouched, no sheds, no log noise. CHUNK (836.9 KB offline) sheds the logo only and lands at 711.1 KB.

## Existing budgets: re-measured, left alone

`EVENT_JSON_TOTAL_BUDGET_BYTES` (220 KB) and `MERGE_DIFF_TOTAL_BUDGET_BYTES` (400 KB) were re-measured on this run — the debug-JSON budget fired on 7 of 15 cards and stayed inside 220 KB. They are unchanged: the shed ladder is a strictly better instrument for this problem because it only fires when a page is actually too big, instead of taxing every run that isn't.

## Tests

8 new tests in `scripts/adapters/scriptable-adapter.test.js` (the package.json-enumerated file). **All 8 fail against unfixed `origin/main`** (verified in a clean worktree with a compat shim aliasing the renamed constant, so they exercise the old *behaviour* rather than just blowing up on a missing symbol):

- an over-ceiling page is **REDUCED** under the ceiling, not merely annotated (asserts the string handed to `loadHTML` is smaller, banner included, and that all 40 cards survive)
- the ceiling is set from a size **proven to render**, not from a size observed blank
- **every shed is logged with its byte cost** — one line per shed, each naming what went, what it recovered, and the running size
- the ladder runs heaviest-first and **stops as soon as the page fits** (a modest overshoot sheds the logo only)
- shedding leaves the page structurally intact and its controls honest (nested-tag strip, unbalanced-fragment safety, button relabel scoped away from the inline script, placeholder is parseable JSON)
- the un-renderable case surfaces via a **native Alert**, not only an in-page banner
- no alert when the page came back under the ceiling
- the ceiling is measured in **UTF-8 bytes, not UTF-16 code units** (regression pin: a page whose `String.length` is under the ceiling but whose real byte size is over it still triggers reduction)

Two pre-existing tests needed one line each: they pin the *per-card payload budget* at 60 and 200 events, where the *page-level* ladder would now strip the payloads outright and the measurement would prove nothing. Both now stub `applyResultsHtmlSizeGuard` with a comment naming the separation. Their assertions are unchanged and they still pass on old code.

## Verification

- `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test` → **1475 passing, 0 failing**.
- Baseline on `origin/main` measured in a clean stash: **1467 passing, 0 failing**. 1467 + 8 = 1475. ✔

## Notes

- **No new runtime files** — the change is confined to `scripts/adapters/scriptable-adapter.js`, so there is nothing to add to the script updater.
- `tools/serve-results.js` shares `generateRichHTML`, so pages over 800 KB get shed on the Mac tailnet server too. Desktop Safari has no such cliff, but the shed content there is the same redundant/decorative material and the full data is in the run JSON, so this is left as-is rather than adding an unrequested mode flag.
- No `new URL(` / `URLSearchParams` added under `scripts/`; `shared-core.js` / `normalizers.js` untouched; no existing `console.log` text or AI prompt string edited (only the constant identifier inside one existing template, and additions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
