### PR TITLE
fix(scriptable): a lone surrogate blanks the results page, not its size — plus the logo's alpha and swipe-to-page

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -589,9 +589,19 @@ class ScriptableAdapter {
 
   // Build (or read back) the small inlined logo. Order:
   //   1. the cached data URI string — nothing is decoded or re-encoded.
-  //   2. the cached/downloaded PNG, downscaled and JPEG-encoded, then cached.
+  //   2. the cached/downloaded PNG, downscaled and re-encoded as PNG, cached.
   //   3. the full-size PNG data URI (old behaviour) if this device has no
-  //      DrawContext/Data.fromJPEG — degrade heavier, never blank.
+  //      DrawContext — degrade heavier, never blank.
+  //
+  // PNG, not JPEG. Shrinking to 160 px is where essentially all of the byte
+  // win comes from; switching the CODEC to JPEG on top of it saved another
+  // ~28 KB of base64 and cost the logo its ALPHA CHANNEL, which JPEG does not
+  // have — the transparent mark came back with a solid block behind it.
+  // Measured on the real 320x320 cache/logo-hero.png:
+  //   320px PNG  96,923 B -> ~129,231 B base64   transparent   (before #1631)
+  //   160px JPEG 11,633 B ->  ~15,512 B base64   OPAQUE        (#1631's bug)
+  //   160px PNG  33,105 B ->  ~44,140 B base64   transparent   (this)
+  // ~3x smaller than the original and the background stays gone.
   async buildHeaderLogoDataUri() {
     const inlinePath = this.fm.joinPath(
       this.cacheDir,
@@ -616,8 +626,7 @@ class ScriptableAdapter {
     const logoImage = await this.loadHeaderLogoImage();
     if (!logoImage) return null;
     const scaled = this.downscaleImage(logoImage, HEADER_LOGO_INLINE_PX);
-    const dataUri =
-      this.imageToJpegDataUri(scaled) || this.imageToDataUri(scaled);
+    const dataUri = this.imageToDataUri(scaled);
     if (!dataUri) return null;
     console.log(
       `📱 Scriptable: Header logo inlined at ${Math.round(ScriptableAdapter.utf8ByteLength(dataUri) / 1024)} KB (${HEADER_LOGO_INLINE_PX}px ${dataUri.indexOf("data:image/jpeg") === 0 ? "JPEG" : "PNG"})`,
@@ -660,13 +669,11 @@ class ScriptableAdapter {
       // Points, not pixels: without this a 3x screen would redraw at 480 px
       // and the byte win would evaporate on exactly the devices that matter.
       ctx.respectScreenScale = false;
-      // JPEG has no alpha; an opaque canvas keeps a transparent source from
-      // matting to black against the header gradient.
-      ctx.opaque = true;
-      if (typeof Color !== "undefined" && typeof Color.white === "function") {
-        ctx.setFillColor(Color.white());
-        ctx.fillRect(new Rect(0, 0, targetW, targetH));
-      }
+      // TRANSPARENT canvas. This was `opaque = true` plus a white fill, which
+      // is what JPEG output required — and it is exactly what put a solid
+      // background behind the logo. The output is PNG now, so the alpha
+      // channel is kept and the header gradient shows through the mark.
+      ctx.opaque = false;
       ctx.drawImageInRect(image, new Rect(0, 0, targetW, targetH));
       return ctx.getImage() || image;
     } catch (error) {
@@ -675,22 +682,10 @@ class ScriptableAdapter {
     }
   }
 
-  imageToJpegDataUri(image) {
-    if (!image) return null;
-    try {
-      if (typeof Data === "undefined" || typeof Data.fromJPEG !== "function") {
-        return null;
-      }
-      const data = Data.fromJPEG(image);
-      const base64 = data && data.toBase64String();
-      return base64 ? `data:image/jpeg;base64,${base64}` : null;
-    } catch (error) {
-      console.log(
-        `📱 Scriptable: Logo JPEG conversion failed: ${error.message}`,
-      );
-      return null;
-    }
-  }
+  // (imageToJpegDataUri lived here. Deleted rather than left unwired: its only
+  // purpose was to encode the header logo as JPEG, and JPEG is what stripped
+  // the logo's alpha channel. Leaving it around is an invitation to re-wire
+  // the regression.)
 
   async loadHeaderLogoImage() {
     try {
@@ -5473,10 +5468,16 @@ class ScriptableAdapter {
       // write. Repeat taps re-flash feedback without re-writing the queue.
       const venueQueueTaps = {};
 
-      // Paging state. `pendingPage` is set by a pager tap on the current page
-      // and consumed after that page's sheet is dismissed; null means "done",
-      // which is also what a plain swipe-down with no tap means. That is the
-      // finish-early path: review page 1, dismiss, execute.
+      // Paging state. `pendingPage` is what happens after this page's sheet is
+      // dismissed: a page number to open next, or null for "done".
+      //
+      // THE DEFAULT IS ADVANCE, NOT FINISH. It used to be the other way round:
+      // a plain swipe-down meant "done", so getting to page 2 cost a tap, and
+      // so did stopping at the end — two taps per page for the one behaviour
+      // everybody actually wants. Now dismissing the sheet just moves on, the
+      // last page's dismissal finishes on its own, and the only tap left is
+      // the explicit one: "✅ Done reviewing" to stop early, or "← Page N-1"
+      // to go back (a swipe can only go forward).
       let currentPage = 1;
       let pendingPage = null;
       let pageCount = 1;
@@ -5511,6 +5512,15 @@ class ScriptableAdapter {
           if (pageCount > 1) {
             console.log(
               `📱 Scriptable: 📄 Presenting results page ${currentPage} of ${pageCount} — taps on every page are kept and applied once, after the last one.`,
+            );
+            // Armed BEFORE present(), so a sheet dismissed with no tap at all
+            // advances instead of ending the review. shouldAllowRequest only
+            // ever overrides this (a jump-back, or an explicit finish).
+            pendingPage = currentPage < pageCount ? currentPage + 1 : null;
+            console.log(
+              pendingPage
+                ? `📱 Scriptable: 📄 Swiping this sheet down opens page ${pendingPage} — no tap needed. Tap "Done reviewing" instead to stop here.`
+                : "📱 Scriptable: 📄 Last page — swiping this sheet down finishes the review and applies every tap.",
             );
           }
           console.log("📱 Scriptable: Presenting results UI...");
@@ -8056,7 +8066,7 @@ class ScriptableAdapter {
     if (this.resolveRenderTarget(options) === "web") {
       this._resultsPagePlan = null;
       this._resultsSizeReduction = null;
-      return fullHtml;
+      return this.finalizeRenderedHtml(fullHtml);
     }
 
     const plan = this.planResultsPages(fullHtml, pageableCards);
@@ -8064,7 +8074,9 @@ class ScriptableAdapter {
     if (plan.pageCount <= 1) {
       // Unchanged single-page render: same string the pre-pagination code
       // produced, shed ladder and all.
-      return this.applyResultsHtmlSizeGuard(fullHtml, budgetedCardCount);
+      return this.finalizeRenderedHtml(
+        this.applyResultsHtmlSizeGuard(fullHtml, budgetedCardCount),
+      );
     }
 
     const requestedPage = Math.min(
@@ -8108,7 +8120,24 @@ class ScriptableAdapter {
     // The shed ladder still runs, but as a BACKSTOP only: pagination bounds
     // the page by construction, so the ladder can now only fire for a single
     // card that is itself bigger than a whole page budget.
-    return this.applyResultsHtmlSizeGuard(pageHtml, slice.cards.length);
+    return this.finalizeRenderedHtml(
+      this.applyResultsHtmlSizeGuard(pageHtml, slice.cards.length),
+    );
+  }
+
+  // LAST THING every render passes through. One unpaired surrogate anywhere in
+  // this string makes WKWebView draw an empty document, so the page is swept
+  // for them after every shed, banner and pager has had its say — nothing
+  // downstream can reintroduce one. Fires almost never; when it does it says
+  // so, because a silently repaired page is a bug that hides itself.
+  finalizeRenderedHtml(html) {
+    const swept = ScriptableAdapter.stripLoneSurrogates(html);
+    if (swept.count > 0) {
+      console.log(
+        `📱 Scriptable: 🧹 Replaced ${swept.count} unpaired UTF-16 surrogate(s) in the results HTML with U+FFFD — WebKit renders an EMPTY document for a page containing one, at any size. Something upstream cut a string through the middle of an emoji.`,
+      );
+    }
+    return swept.html;
   }
 
   // "scriptable" unless the caller explicitly asks for the web flow. Default
@@ -8236,11 +8265,17 @@ class ScriptableAdapter {
 
   // Page navigation rides the SAME chunkyscrape:// bridge every other button
   // uses (shouldAllowRequest, assigned before present()). There is no API to
-  // dismiss a presented WebView from native, so a tap only ARMS the next page
+  // dismiss a presented WebView from native, so a tap only ARMS a page
   // natively and the page itself says so; the swipe-down that closes the
   // sheet is what hands control back, and presentRichResults re-presents.
-  // Dismissing without tapping anything means "done" — that is the finish-
-  // early path, and it is the default.
+  //
+  // SWIPING DOWN IS "NEXT". Native arms page+1 before present(), so the plain
+  // dismissal — the gesture that closes the sheet anyway — is the whole
+  // forward path, and the last page's dismissal ends the review by itself.
+  // That is why there is no "Page N+1 →" button any more: it did exactly what
+  // the swipe already does, and having to press it and THEN swipe was the
+  // complaint. The two buttons left are the two things a swipe cannot express:
+  // go BACK, and STOP EARLY.
   buildResultsPagerHtml(plan, page, withScript) {
     const pageCount = plan.pageCount;
     const slice = plan.pages[page - 1] || { cards: [] };
@@ -8250,22 +8285,26 @@ class ScriptableAdapter {
     const totalCards = plan.pages.reduce((sum, p) => sum + p.cards.length, 0);
     const first = totalCards === 0 ? 0 : before + 1;
     const last = before + slice.cards.length;
+    const remaining = pageCount - page;
     const prevBtn =
       page > 1
         ? `<button type="button" class="results-pager-btn" onclick="gotoResultsPage(${page - 1})">← Page ${page - 1}</button>`
         : "";
-    const nextBtn =
-      page < pageCount
-        ? `<button type="button" class="results-pager-btn is-primary" onclick="gotoResultsPage(${page + 1})">Page ${page + 1} →</button>`
+    const doneBtn =
+      remaining > 0
+        ? `<button type="button" class="results-pager-btn is-done" onclick="finishResultsPaging()">✅ Done reviewing — skip the last ${remaining} page${remaining === 1 ? "" : "s"}</button>`
         : "";
+    const hint =
+      remaining > 0
+        ? `Swipe this sheet down for page ${page + 1} — no button needed. Your 🐻 / 🚫 taps are kept across every page and applied once, at the end.`
+        : "Last page. Swipe this sheet down to apply your 🐻 / 🚫 taps from every page and continue.";
     const nav = `
     <div class="results-pager">
         <div class="results-pager-label">Page ${page} of ${pageCount} · cards ${first}–${last} of ${totalCards}</div>
         <div class="results-pager-buttons">
-            ${prevBtn}${nextBtn}
-            <button type="button" class="results-pager-btn is-done" onclick="finishResultsPaging()">✅ Done reviewing</button>
+            ${prevBtn}${doneBtn}
         </div>
-        <div class="results-pager-hint">Your 🐻 / 🚫 taps are kept across every page and applied once, when you finish. Swipe the sheet down to move on.</div>
+        <div class="results-pager-hint">${hint}</div>
     </div>`;
     if (!withScript) return nav;
     return `${nav}
@@ -10650,8 +10689,25 @@ class ScriptableAdapter {
   // Crossing it is not a warning — see applyResultsHtmlSizeGuard, which sheds
   // page content until the page is back under this number. A banner cannot do
   // that job: a banner lives INSIDE the document WebKit refuses to run.
+  //
+  // ---- CORRECTION: the 955 KB failure above was never a size failure. ----
+  // That BEEFMINCE page carried two LONE SURROGATES (a provenance preview cut
+  // through the middle of 🏳), and WebKit renders the empty shell for ANY
+  // document containing one — reproduced against real WebKit at 49 CHARACTERS.
+  // Paginated, the same run blanked only on page 3 (371 KB, its SMALLEST
+  // page), the one holding the bad card, while 383 KB and 376 KB rendered.
+  // So "the cliff is in (862, 955]" was an inference from a poisoned sample:
+  // there is no size-attributable blank anywhere in the record.
+  //
+  // 800 KB was therefore shedding real review detail off pages that would
+  // have rendered — CHUNK at 862 KB is a page that WORKED. Raised to 1 MB:
+  // above every page ever observed on device (largest: 959 KB), so no run in
+  // the recorded history is shed or split at all, while still bounding a
+  // genuinely runaway future run. The lone-surrogate sweep in
+  // finalizeRenderedHtml is what actually keeps a page from blanking now, and
+  // the liveness beacons still report it per page if one ever does.
   static get RESULTS_HTML_MAX_BYTES() {
-    return 800 * 1024;
+    return 1024 * 1024;
   }
 
   // Per-PAGE budget for the Scriptable flow (the web flow never pages).
@@ -10674,8 +10730,35 @@ class ScriptableAdapter {
   // this order renders. 400 KB leaves better than 2x headroom to the nearest
   // failure, and pagination means the cost of the margin is one extra swipe
   // per ~400 KB, not lost review detail.
+  //
+  // ---- CORRECTION: 400 KB was paying a margin against a phantom. ----
+  // The only failure that budget was hedging against turned out to be a lone
+  // surrogate, not bytes (see RESULTS_HTML_MAX_BYTES). The margin was not
+  // free either: it split Furball — 490 KB, a single page for its entire
+  // history — into pages for no reason, and the extra swipes were the first
+  // thing the owner complained about.
+  //
+  // The evidence, re-read with the real cause known:
+  //
+  //   PARSER      PAGE   SIZE     RESULT   lone surrogates on the page
+  //   Goldiloxx  single  248 KB     ✅ 0
+  //   Furball    single  489 KB     ✅ 0     <- must not page
+  //   CHUNK      single  862 KB     ✅ 0     <- must not page
+  //   BEEFMINCE  single  959 KB     ❌ 2     blank at 959…
+  //   BEEFMINCE  single  713 KB     ❌ 2     …and still blank 246 KB smaller
+  //   BEEFMINCE   1/3    383 KB     ✅ 0
+  //   BEEFMINCE   2/3    376 KB     ✅ 0
+  //   BEEFMINCE   3/3    371 KB     ❌ 2     the SMALLEST page is the one
+  //                                          that fails — because it is the
+  //                                          one holding the bad card
+  //
+  // Every ✅ has zero, every ❌ has two, and size predicts nothing. So the
+  // budget is set to bound a runaway run, not to dodge a cliff: 1 MB sits
+  // above every page ever produced on device, which makes pagination a rare
+  // fallback rather than the default. Matches RESULTS_HTML_MAX_BYTES, so a
+  // page built to this budget is never also shed.
   static get RESULTS_PAGE_BUDGET_BYTES() {
-    return 400 * 1024;
+    return 1024 * 1024;
   }
 
   // The pager nav is emitted twice per page plus its style/script block.
@@ -10724,6 +10807,68 @@ class ScriptableAdapter {
     return bytes;
   }
 
+  // ---------------------------------------------------------------------
+  // LONE SURROGATES: the one thing that blanks a results page at ANY size.
+  //
+  // WKWebView.loadHTMLString (which Scriptable's WebView.loadHTML wraps) hands
+  // the document to its content process as UTF-8. A lone surrogate — half of
+  // an astral character's UTF-16 pair — has no UTF-8 encoding, so the whole
+  // document is dropped and WebKit renders the empty shell
+  // `<html><head></head><body></body></html>`: no DOM, no scripts, no beacons.
+  // Verified against real WebKit: a 49-CHARACTER page carrying one lone
+  // \uD83C blanks exactly like a 371 KB one, while 383 KB and 864 KB pages
+  // with none render fine. Size was never the mechanism.
+  //
+  // Lone surrogates are not in the scraped data; they are MANUFACTURED at
+  // render time by every preview/tooltip/diff truncation that cuts a string at
+  // a code-unit index, because one emoji is two units. The truncators below
+  // use safeSubstring so they stop making them; this sweep is the backstop
+  // that guarantees no future truncation anywhere can blank the sheet again.
+  // ---------------------------------------------------------------------
+
+  // Matches a well-formed pair FIRST, so only genuinely unpaired surrogates
+  // fall through to the single-unit alternative.
+  static stripLoneSurrogates(html) {
+    const text = typeof html === "string" ? html : String(html || "");
+    let count = 0;
+    const cleaned = text.replace(
+      /[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDFFF]/g,
+      (match) => {
+        if (match.length === 2) return match;
+        count += 1;
+        return "�";
+      },
+    );
+    return { html: count > 0 ? cleaned : text, count };
+  }
+
+  // Substring that never cuts a surrogate pair in half: a start index sitting
+  // on a low surrogate steps forward past it, and an end index sitting between
+  // the halves steps back. Both ends can land mid-pair when the slice is
+  // anchored on a diff position rather than on 0.
+  static safeSubstring(text, start, end) {
+    const str = typeof text === "string" ? text : String(text || "");
+    let from = Math.max(0, Math.min(str.length, Math.floor(start || 0)));
+    if (from > 0 && from < str.length) {
+      const code = str.charCodeAt(from);
+      // Landed on the LOW half of a pair whose HIGH half is being cut away.
+      if (code >= 0xdc00 && code <= 0xdfff) from += 1;
+    }
+    let to =
+      end === undefined
+        ? str.length
+        : Math.max(0, Math.min(str.length, Math.floor(end)));
+    if (to > from && to < str.length) {
+      const code = str.charCodeAt(to - 1);
+      // Last kept unit is a HIGH half whose LOW half is being cut away.
+      if (code >= 0xd800 && code <= 0xdbff) to -= 1;
+    }
+    // Clamped LAST: both adjustments above can cross the other end, and
+    // String.prototype.substring SWAPS reversed arguments — which would hand
+    // back exactly the orphaned half this function exists to remove.
+    return to <= from ? "" : str.substring(from, to);
+  }
+
   // Pruned in this order, heaviest-and-most-redundant first. Every one of
   // these is ALSO rendered as HTML elsewhere in the same card, so pruning it
   // from the debug dump never removes the only copy:
@@ -10758,7 +10903,9 @@ class ScriptableAdapter {
   truncateLongStringsForBudget(value, maxChars, record, runFile) {
     if (typeof value === "string") {
       if (value.length <= maxChars) return value;
-      return `${value.substring(0, maxChars)}... [truncated ${
+      // safeSubstring: this string is JSON-embedded into the page, and a lone
+      // surrogate left by a mid-emoji cut blanks the whole document.
+      return `${ScriptableAdapter.safeSubstring(value, 0, maxChars)}... [truncated ${
         value.length - maxChars
       } of ${value.length} chars to fit the results page — full value in ${
         runFile || "the saved run JSON"
@@ -12286,11 +12433,18 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
           const start =
             anchor > maxLength ? Math.max(0, anchor - Math.floor(maxLength / 3)) : 0;
           const lead = start > 0 ? "..." : "";
-          const visible = str.substring(start, start + maxLength);
-          const tooltipSource = str.substring(start);
+          // safeSubstring, not substring: a cut through an emoji's surrogate
+          // pair leaves a lone surrogate, which makes WebKit render an EMPTY
+          // document (see stripLoneSurrogates).
+          const visible = ScriptableAdapter.safeSubstring(
+            str,
+            start,
+            start + maxLength,
+          );
+          const tooltipSource = ScriptableAdapter.safeSubstring(str, start);
           const tooltip =
             tooltipSource.length > TOOLTIP_MAX_CHARS
-              ? `${tooltipSource.substring(0, TOOLTIP_MAX_CHARS)}... (+${
+              ? `${ScriptableAdapter.safeSubstring(tooltipSource, 0, TOOLTIP_MAX_CHARS)}... (+${
                   tooltipSource.length - TOOLTIP_MAX_CHARS
                 } more chars - use Copy JSON for the full value)`
               : tooltipSource;
@@ -12504,7 +12658,8 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     if (str.length <= max) return this.escapeHtml(str);
     const start = anchor > max ? Math.max(0, anchor - Math.floor(max / 4)) : 0;
     const lead = start > 0 ? "..." : "";
-    const visible = str.substring(start, start + max);
+    // safeSubstring: cutting an emoji's surrogate pair in half blanks the page.
+    const visible = ScriptableAdapter.safeSubstring(str, start, start + max);
     return `${lead}${this.escapeHtml(visible)}...<span class="cmp-more"> [${str.length} chars total — 📋 Copy JSON for the full value]</span>`;
   }
 

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -5074,15 +5074,20 @@ test('size cliff: an over-ceiling page is REDUCED under the ceiling, not merely 
     'all 40 cards are still on the page');
 });
 
-test('size cliff: the ceiling is set from a size PROVEN to render, not from a size observed blank', () => {
-  // 862 KB rendered; 955 KB did not. A ceiling at or above the largest
-  // observed success is a ceiling with no margin against a cliff whose exact
-  // position is unknown — and 960 KB was above the BLANK page, which is how
-  // BEEFMINCE (959 KB UTF-8) slipped under it.
+test('size cliff: the ceiling no longer sheds pages that are PROVEN to render', () => {
+  // The 955 KB blank that this ceiling was hedging against was never a size
+  // failure: that page carried two lone surrogates, and WebKit renders the
+  // empty shell for any document containing one (proven at 49 characters).
+  // Paginated, the SAME run blanked only on its smallest page — the one with
+  // the bad card. So a ceiling under 862 KB was shedding review detail off
+  // pages like CHUNK's, which WORKED.
   const ceilingKb = ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024;
-  assert.ok(ceilingKb < 862, `ceiling (${ceilingKb} KB) is below the 862 KB that rendered`);
-  assert.ok(ceilingKb < 955, `ceiling (${ceilingKb} KB) is below the 955 KB that white-screened`);
-  assert.ok(ceilingKb >= 512, 'but not so low that ordinary runs get gutted');
+  assert.ok(ceilingKb > 862,
+    `ceiling (${ceilingKb} KB) is above the 862 KB CHUNK page that rendered, so it is not shed`);
+  assert.ok(ceilingKb >= 959,
+    `ceiling (${ceilingKb} KB) is at or above every page ever produced on device (max 959 KB)`);
+  assert.ok(ceilingKb <= 2048,
+    'but still bounds a runaway run rather than being no ceiling at all');
 });
 
 test('size cliff: every shed is logged with what went and what it cost — no silent caps', async () => {
@@ -5107,7 +5112,7 @@ test('size cliff: the shed ladder runs heaviest-first and stops as soon as the p
   const adapter = buildAdapter();
   // A modest overshoot: the logo alone should cover it, so nothing else is
   // touched. A page must never lose more than it had to.
-  await captureLogAsync(() => renderOversizedResultsPage(adapter, { events: 8, logoBytes: 700 * 1024 }));
+  await captureLogAsync(() => renderOversizedResultsPage(adapter, { events: 8, logoBytes: 980 * 1024 }));
 
   const ids = adapter._resultsSizeReduction.sheds.map(s => s.id);
   assert.deepEqual(ids, ['header-logo'],
@@ -5556,10 +5561,14 @@ test('recordCalendarWriteFailures creates errors[] when absent and is a no-op on
 // cliff — shows everything with nothing shed.
 // ---------------------------------------------------------------------------
 
-// Image globals modelled on the real cached logo: PNG bytes ≈ px², JPEG ≈ px²/2
-// (the 320px source is 96,923 B as PNG and ~12 KB as a 160px JPEG). Modelling
-// the size as a function of the pixel dimension is what makes the assertion
-// below cover the DOWNSCALE as well as the re-encode.
+// Image globals modelled on the real cached logo, measured with `sips` on the
+// actual cache/logo-hero.png (320x320, 96,923 B, alpha):
+//   320px PNG  96,923 B   ~ px²      transparent
+//   160px PNG  33,105 B   ~ px²*1.3  transparent
+//   160px JPEG 11,633 B   ~ px²/2    OPAQUE  <- #1631's regression
+// Modelling size as a function of the pixel dimension is what makes the
+// assertions cover the DOWNSCALE as well as the encode; modelling ALPHA is
+// what catches a codec that silently drops it.
 function installFakeImageGlobals() {
   const saved = {
     Size: global.Size, Rect: global.Rect, Color: global.Color,
@@ -5574,18 +5583,29 @@ function installFakeImageGlobals() {
     setFillColor() { this.__fill = true; }
     fillRect() { this.filled = true; }
     drawImageInRect(image) { this.__drew = image; }
-    getImage() { return { size: this.size, __drawn: true }; }
+    // An opaque canvas (or one painted with a background fill) yields an image
+    // with no usable alpha — exactly what put a block behind the logo.
+    getImage() {
+      return { size: this.size, __drawn: true, hasAlpha: !this.opaque && !this.filled };
+    }
   };
   global.Data = {
-    fromPNG: (img) => ({ toBase64String: () => 'P'.repeat(b64len(img.size.width * img.size.width)) }),
-    fromJPEG: (img) => ({ toBase64String: () => 'J'.repeat(b64len((img.size.width * img.size.width) / 2)) })
+    // PNG keeps whatever alpha the image had; JPEG cannot carry any.
+    fromPNG: (img) => ({
+      __hasAlpha: img.hasAlpha !== false,
+      toBase64String: () => 'P'.repeat(b64len(img.size.width * img.size.width))
+    }),
+    fromJPEG: (img) => ({
+      __hasAlpha: false,
+      toBase64String: () => 'J'.repeat(b64len((img.size.width * img.size.width) / 2))
+    })
   };
-  global.Image = { fromFile: () => ({ size: new global.Size(320, 320) }) };
+  global.Image = { fromFile: () => ({ size: new global.Size(320, 320), hasAlpha: true }) };
   return () => { Object.assign(global, saved); };
 }
 
 function withInlinedLogo(adapter) {
-  adapter.loadHeaderLogoImage = async () => ({ size: new global.Size(320, 320) });
+  adapter.loadHeaderLogoImage = async () => ({ size: new global.Size(320, 320), hasAlpha: true });
   return adapter;
 }
 
@@ -5593,6 +5613,12 @@ function inlinedLogoPayload(html) {
   const match = /src="data:image\/([a-z]+);base64,([^"]*)"/i.exec(html);
   return match ? { format: match[1], bytes: match[2].length } : null;
 }
+
+// How many heavy events it now takes to actually PAGE. The budget is 1 MB
+// (pagination is a rare fallback, not the default), and 40 of these events
+// render as ~899 KB — one page, as they should. 80 is ~1.6 MB and really
+// splits, which is what the paging-behaviour tests below need to exercise.
+const PAGING_EVENTS = 80;
 
 // A WebView that can be presented more than once, the way the paging loop
 // does: every present() cycle gets its own promise and its own handler.
@@ -5624,12 +5650,131 @@ function installPagingWebView() {
   };
 }
 
+// ---------------------------------------------------------------------------
+// LONE SURROGATES — the thing that actually blanked the results sheet.
+//
+// WKWebView (which Scriptable's WebView.loadHTML wraps) hands the document to
+// its content process as UTF-8. A lone surrogate has no UTF-8 encoding, so the
+// document is dropped and WebKit renders `<html><head></head><body></body>
+// </html>` — no DOM, no scripts, no beacons. Verified against real WebKit
+// (a Swift WKWebView driven with loadHTMLString) at 49 CHARACTERS.
+//
+// They are not in the scraped data. They are MANUFACTURED by render-time
+// truncation: one emoji is two UTF-16 code units, and a preview that cuts at a
+// code-unit index can cut between them. Real case: run 20260804-201054's
+// "BEEFMINCE Brighton Pride" description, whose provenance preview cut through
+// the 🏳 of 🏳️‍🌈 and left \uD83C. That one card blanked the whole 959 KB page,
+// and after pagination blanked page 3 — the run's SMALLEST page — while its
+// larger pages 1 and 2 rendered fine.
+// ---------------------------------------------------------------------------
+
+function findLoneSurrogates(text) {
+  const hits = [];
+  for (let i = 0; i < text.length; i++) {
+    const c = text.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const n = text.charCodeAt(i + 1);
+      if (n >= 0xdc00 && n <= 0xdfff) { i++; continue; }
+      hits.push({ index: i, code: c });
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      hits.push({ index: i, code: c });
+    }
+  }
+  return hits;
+}
+
+test('blank page: the exact BEEFMINCE description that blanked the sheet renders with ZERO lone surrogates', async () => {
+  const adapter = buildAdapter();
+  // Verbatim shape of the card that did it: a long description with 🏳️‍🌈
+  // sitting where the 80-char provenance preview cuts. The scraped string is
+  // perfectly well-formed — the damage was entirely ours.
+  const description =
+    'Now it’s happening — BEEFMINCE Brighton Pride on Saturday 1 August at Horizon 🏳️‍🌈🔥 For the first time ever, BEEFMINCE has a Saturday night party for Pride.';
+  assert.equal(findLoneSurrogates(description).length, 0,
+    'the SOURCE data is clean — this is a render bug, not a data bug');
+
+  const event = {
+    ...buildSizedAnalyzedEvent(0),
+    title: 'BEEFMINCE Brighton Pride',
+    description,
+    _original: {
+      scraper: { description, title: 'BEEFMINCE Brighton Pride' },
+      calendar: { title: 'BEEFMINCE Brighton Pride' },
+      merged: { description, title: 'BEEFMINCE Brighton Pride' }
+    }
+  };
+  const html = await adapter.generateRichHTML({ analyzedEvents: [event] }, { target: 'scriptable', page: 1 });
+
+  const hits = findLoneSurrogates(html);
+  assert.deepEqual(hits, [],
+    `the rendered page must contain no unpaired surrogate; found ${hits.length}` +
+    (hits.length ? ` (first: U+${hits[0].code.toString(16).toUpperCase()} at ${hits[0].index})` : ''));
+  // And the truncation still truncated — the fix is a safe cut, not no cut.
+  assert.ok(html.includes('…'), 'the preview is still elided');
+});
+
+test('blank page: truncation cuts a surrogate pair whole or not at all, at BOTH ends', () => {
+  const flag = '🏳'; // one character, two code units
+  const s = `abc${flag}def`;
+
+  // End cut landing between the halves backs up past the whole pair.
+  assert.equal(ScriptableAdapter.safeSubstring(s, 0, 4), 'abc',
+    'a cut between the high and low half drops the whole character');
+  assert.equal(ScriptableAdapter.safeSubstring(s, 0, 5), `abc${flag}`,
+    'a cut after the pair keeps it intact');
+  // Start cut landing on the low half steps forward past it.
+  assert.equal(ScriptableAdapter.safeSubstring(s, 4), 'def',
+    'a start index on the low half skips the orphaned half');
+  assert.equal(ScriptableAdapter.safeSubstring(s, 3), `${flag}def`,
+    'a start index on the high half keeps the pair');
+  for (let start = 0; start <= s.length; start++) {
+    for (let end = start; end <= s.length; end++) {
+      assert.equal(findLoneSurrogates(ScriptableAdapter.safeSubstring(s, start, end)).length, 0,
+        `safeSubstring(${start}, ${end}) produced a lone surrogate`);
+    }
+  }
+
+  // The provenance value preview is where the real one came from: its cut is
+  // at 79 units, so sweep an emoji across every position that straddles it.
+  const { buildEventProvenanceSectionHtml } = require('../event-provenance');
+  for (let pad = 70; pad <= 88; pad++) {
+    const description = `${'x'.repeat(pad)}🏳${'y'.repeat(40)}`;
+    const section = buildEventProvenanceSectionHtml(
+      { description, title: 'T', _original: { scraper: { description }, calendar: {}, merged: { description } } },
+      {}
+    );
+    assert.equal(findLoneSurrogates(section).length, 0,
+      `provenance preview left half an emoji behind with the pair at offset ${pad}`);
+  }
+});
+
+test('blank page: the render sweep is the backstop, and it SAYS SO — no silent repair', async () => {
+  const adapter = buildAdapter();
+  // A truncation nobody has thought of yet, simulated: something upstream puts
+  // an unpaired surrogate into a card. The page must still be renderable.
+  const poisoned = '<html><body><h1>hel\uD83Clo</h1></body></html>';
+  assert.equal(findLoneSurrogates(poisoned).length, 1, 'the fixture really is poisoned');
+
+  const { lines, value } = captureLog(() => adapter.finalizeRenderedHtml(poisoned));
+  assert.deepEqual(findLoneSurrogates(value), [], 'the swept page carries none');
+  assert.ok(value.includes('�'), 'the damage is marked with U+FFFD rather than hidden');
+  assert.equal(lines.filter((l) => l.includes('unpaired UTF-16 surrogate')).length, 1,
+    'exactly one log line names what was repaired and why it matters');
+
+  // A clean page is returned untouched and says nothing.
+  const clean = '<html><body><h1>hel🏳lo</h1></body></html>';
+  const quiet = captureLog(() => adapter.finalizeRenderedHtml(clean));
+  assert.equal(quiet.value, clean, 'a clean page is the same string, not a rebuilt one');
+  assert.equal(quiet.lines.filter((l) => l.includes('unpaired UTF-16 surrogate')).length, 0,
+    'and nothing is logged when nothing fired');
+});
+
 test('pagination: a run whose cards exceed one page budget is split, and EVERY page is under budget', async () => {
   const adapter = buildAdapter();
-  const results = buildSizedResults(40);
+  const results = buildSizedResults(PAGING_EVENTS);
   const page1 = await adapter.generateRichHTML(results, { target: 'scriptable', page: 1 });
   const pageCount = adapter.getResultsPageCount();
-  assert.ok(pageCount > 1, `40 heavy cards must not fit on one page, got ${pageCount} page(s)`);
+  assert.ok(pageCount > 1, `${PAGING_EVENTS} heavy cards must not fit on one page, got ${pageCount} page(s)`);
 
   const budget = ScriptableAdapter.RESULTS_PAGE_BUDGET_BYTES;
   const htmls = [page1];
@@ -5648,8 +5793,8 @@ test('pagination: a run whose cards exceed one page budget is split, and EVERY p
 
   // Splitting is not dropping: every card is on exactly one page.
   const cardsPerPage = htmls.map((html) => (html.match(/class="event-card"/g) || []).length);
-  assert.equal(cardsPerPage.reduce((a, b) => a + b, 0), 40,
-    `all 40 cards are spread across the pages, got ${cardsPerPage.join('+')}`);
+  assert.equal(cardsPerPage.reduce((a, b) => a + b, 0), PAGING_EVENTS,
+    `all ${PAGING_EVENTS} cards are spread across the pages, got ${cardsPerPage.join('+')}`);
   assert.ok(cardsPerPage.every((n) => n > 0), 'no page is empty');
 
   // Size-driven, not count-driven: heavy merge cards and light new-event cards
@@ -5664,22 +5809,42 @@ test('pagination: a run whose cards exceed one page budget is split, and EVERY p
   assert.ok(page1.includes('finishResultsPaging'), 'and offers a finish-early control');
 });
 
-test('pagination: the per-page budget is anchored under every size PROVEN to render', () => {
+test('pagination: is a RARE FALLBACK — every run ever observed stays one page', () => {
   const kb = ScriptableAdapter.RESULTS_PAGE_BUDGET_BYTES / 1024;
-  // 248/486/489/862 KB all rendered on device; 955 KB was blank 3 times out
-  // of 3. Anchor on the successes, with a factor-of-two margin, not on the
-  // failure — every previous threshold was set just under a page observed to
-  // FAIL, and every one of them was wrong.
-  assert.ok(kb <= 862 / 2,
-    `per-page budget (${kb} KB) keeps 2x headroom under the 862 KB proven to render`);
-  assert.ok(kb < 955 / 2,
-    `per-page budget (${kb} KB) is less than half the 955 KB that white-screened 3/3`);
-  assert.ok(kb <= 489,
-    `per-page budget (${kb} KB) is at or under the 486/489 KB pages that rendered`);
-  assert.ok(kb >= 128,
-    `per-page budget (${kb} KB) is not so small that ordinary runs fragment`);
-  assert.ok(kb < ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024,
-    'and it is strictly tighter than the shed ceiling it makes redundant');
+  // Size predicted nothing: 248/486/489/862 KB rendered with zero lone
+  // surrogates, 959/713/371 KB blanked with two. The budget therefore exists
+  // to bound a runaway run, not to dodge a cliff — so it sits above every
+  // page ever produced on device, and Furball (490 KB) and CHUNK (864 KB)
+  // are both a single page again.
+  assert.ok(kb > 490, `Furball (490 KB) must not be split; budget is ${kb} KB`);
+  assert.ok(kb > 864, `CHUNK (864 KB, proven to render) must not be split; budget is ${kb} KB`);
+  assert.ok(kb >= 959, `budget (${kb} KB) covers the largest page ever produced on device`);
+  assert.ok(kb <= 2048, `budget (${kb} KB) still bounds a genuinely runaway run`);
+  assert.ok(kb <= ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024,
+    'and a page built to this budget is never ALSO shed by the ceiling');
+});
+
+// A page's byte size is not what blanks it; a lone UTF-16 surrogate is. These
+// two guard the actual mechanism.
+test('page budget: a 490 KB run and an 864 KB run are each exactly ONE page', () => {
+  const adapter = buildAdapter();
+  const budget = ScriptableAdapter.RESULTS_PAGE_BUDGET_BYTES;
+  // Cards sized so the whole page lands on the real observed totals. The
+  // planner only ever sees (fullHtml, cards), so feeding it those directly is
+  // the honest way to assert on a specific page size.
+  for (const kb of [490, 864]) {
+    const cardCount = 16;
+    const chrome = 120 * 1024;
+    const cardBytes = Math.floor((kb * 1024 - chrome) / cardCount);
+    const cards = Array.from({ length: cardCount }, (_, i) => ({
+      group: 'new', html: 'x'.repeat(cardBytes) + String(i).padStart(0, '0')
+    }));
+    const fullHtml = 'c'.repeat(chrome) + cards.map((c) => c.html).join('');
+    adapter._resultsPagePlan = null;
+    const plan = adapter.planResultsPages(fullHtml, cards);
+    assert.equal(plan.pageCount, 1,
+      `a ${kb} KB run is ONE page (got ${plan.pageCount}); ${Math.round(budget / 1024)} KB budget`);
+  }
 });
 
 test('pagination: a small run is ONE page and is byte-identical to showing everything', async () => {
@@ -5738,7 +5903,7 @@ test('web flow: every event on ONE page, nothing shed, no pager', async () => {
   }
 });
 
-test('logo: inlined on BOTH flows, downscaled and JPEG-encoded to well under 20 KB', async () => {
+test('logo: inlined on BOTH flows as a downscaled PNG that KEEPS ITS ALPHA, well under 50 KB', async () => {
   const restore = installFakeImageGlobals();
   try {
     const scriptableAdapter = withInlinedLogo(buildAdapter());
@@ -5750,13 +5915,36 @@ test('logo: inlined on BOTH flows, downscaled and JPEG-encoded to well under 20 
     for (const [name, html] of [['scriptable', scriptable], ['web', web]]) {
       const logo = inlinedLogoPayload(html);
       assert.ok(logo, `${name} flow inlines the header logo (the cute icon is on both)`);
-      assert.equal(logo.format, 'jpeg', `${name} flow re-encodes the photo-like logo as JPEG`);
-      assert.ok(logo.bytes < 20 * 1024,
-        `${name} flow inlines ${Math.round(logo.bytes / 1024)} KB, must be under 20 KB (was ~129 KB)`);
+      // THE REGRESSION: #1631 encoded this as JPEG for the extra ~28 KB, and
+      // JPEG has no alpha channel — the transparent mark came back with a
+      // solid block behind it ("The icon has a background now?"). PNG or the
+      // background is back.
+      assert.equal(logo.format, 'png',
+        `${name} flow keeps the logo as PNG — JPEG has no alpha channel and put a background behind it`);
+      assert.ok(logo.bytes < 50 * 1024,
+        `${name} flow inlines ${Math.round(logo.bytes / 1024)} KB, must be under 50 KB (was ~129 KB)`);
     }
 
-    // The win is downscale AND re-encode: at the source 320 px even a JPEG
-    // would be ~68 KB, so passing the 20 KB bar above proves both happened.
+    // The win is the DOWNSCALE, and it is the only thing the byte budget ever
+    // needed: at the source 320 px the PNG alone is ~129 KB of base64, so
+    // passing the 50 KB bar above proves the redraw happened.
+  } finally {
+    restore();
+  }
+});
+
+test('logo: the redraw canvas is transparent, so the inlined PNG really carries alpha', () => {
+  const restore = installFakeImageGlobals();
+  try {
+    const adapter = buildAdapter();
+    const scaled = adapter.downscaleImage({ size: new global.Size(320, 320), hasAlpha: true }, 160);
+    assert.equal(scaled.size.width, 160, 'the logo is redrawn at 160 px');
+    assert.equal(scaled.hasAlpha, true,
+      'the redraw canvas is NOT opaque and is NOT background-filled — an opaque canvas plus a white fill is what JPEG needed and what erased the transparency');
+
+    // And the encode preserves it: PNG carries the alpha through, JPEG cannot.
+    assert.equal(global.Data.fromPNG(scaled).__hasAlpha, true, 'PNG keeps the alpha channel');
+    assert.equal(global.Data.fromJPEG(scaled).__hasAlpha, false, 'JPEG would drop it — which is why it is not used');
   } finally {
     restore();
   }
@@ -5768,7 +5956,7 @@ test('logo: the re-encoded data URI is built once and cached, not rebuilt per pa
     const adapter = buildAdapter();
     let builds = 0;
     adapter.loadHeaderLogoImage = async () => { builds += 1; return { size: new global.Size(320, 320) }; };
-    const results = buildSizedResults(40);
+    const results = buildSizedResults(PAGING_EVENTS);
     await adapter.generateRichHTML(results, { target: 'scriptable', page: 1 });
     const pageCount = adapter.getResultsPageCount();
     assert.ok(pageCount > 1, 'this run really does page');
@@ -5783,7 +5971,7 @@ test('logo: the re-encoded data URI is built once and cached, not rebuilt per pa
 
 test('paging: bear overrides tapped on page 1 SURVIVE to page 2 and are all applied, once', async () => {
   const adapter = buildAdapter();
-  const results = buildSizedResults(40);
+  const results = buildSizedResults(PAGING_EVENTS);
   results.config = { config: { dryRun: false } };
   results.calendarEvents = 0;
   results.bearDroppedEvents = [];
@@ -5845,30 +6033,123 @@ test('paging: bear overrides tapped on page 1 SURVIVE to page 2 and are all appl
   assert.equal(promptCalls, 1, 'the execute prompt fired exactly once across two page views');
 });
 
-test('paging: dismissing page 1 without tapping anything finishes the review (finish-early default)', async () => {
+test('paging: a plain swipe-down ADVANCES — every page, no button, and the last one ends the review', async () => {
+  // "Kinda weird that I have to hit buttons to proceed to the next page and
+  // close at the end." Dismissing the sheet is now the whole forward path:
+  // native arms page+1 BEFORE present(), so a review of N pages costs N swipes
+  // and zero taps.
   const adapter = buildAdapter();
-  const results = buildSizedResults(40);
+  const results = buildSizedResults(PAGING_EVENTS);
   results.config = { config: { dryRun: false } };
   results.calendarEvents = 0;
   let promptCalls = 0;
   adapter.promptForCalendarExecution = async () => { promptCalls += 1; return 0; };
 
   const wv = installPagingWebView();
+  let pageCount = 0;
   try {
     const done = adapter.presentRichResults(results);
     await wv.waitForPage(1);
+    pageCount = adapter.getResultsPageCount();
+    assert.ok(pageCount > 1, 'this run really does page');
+    // Swipe, and only swipe, all the way through.
+    for (let p = 1; p <= pageCount; p++) {
+      wv.dismiss();
+      if (p < pageCount) await wv.waitForPage(p + 1);
+    }
+    await done;
+  } finally {
+    delete global.WebView;
+  }
+
+  assert.equal(wv.loads.length, pageCount,
+    `every page was reached by swiping alone (${wv.loads.length} of ${pageCount} built, no taps)`);
+  wv.loads.forEach((html, i) => {
+    assert.ok(html.includes(`Page ${i + 1} of ${pageCount}`), `load ${i + 1} really is page ${i + 1}`);
+  });
+  // The last page's dismissal ends it — nothing had to be pressed to "close at the end".
+  assert.equal(promptCalls, 1, 'the execute prompt fired exactly once, after the last swipe');
+
+  // And the page says so instead of offering a redundant Next button.
+  assert.ok(!wv.loads[0].includes('Page 2 →'),
+    'no "next page" button — it did exactly what the swipe already does');
+  assert.ok(wv.loads[0].includes('Swipe this sheet down for page 2'),
+    'page 1 tells the owner the swipe is the way forward');
+  assert.ok(wv.loads[pageCount - 1].includes('Last page.'),
+    'the final page says it is the last one');
+  assert.ok(!wv.loads[pageCount - 1].includes('class="results-pager-btn is-done"'),
+    'and offers no finish-early BUTTON, because dismissing it IS finishing');
+});
+
+test('paging: "Done reviewing" is the explicit way to stop early, and it still applies every tap', async () => {
+  const adapter = buildAdapter();
+  const results = buildSizedResults(PAGING_EVENTS);
+  results.config = { config: { dryRun: false } };
+  results.calendarEvents = 0;
+  results.bearDroppedEvents = [];
+  const appliedWith = [];
+  const realApply = adapter.applyPendingBearOverrides.bind(adapter);
+  adapter.applyPendingBearOverrides = async (res, pending) => {
+    appliedWith.push(Object.keys(pending.markedNotBear).slice().sort());
+    return realApply(res, pending);
+  };
+  let promptCalls = 0;
+  adapter.promptForCalendarExecution = async () => { promptCalls += 1; return 0; };
+
+  const wv = installPagingWebView();
+  let pageCount = 0;
+  try {
+    const done = adapter.presentRichResults(results);
+    await wv.waitForPage(1);
+    pageCount = adapter.getResultsPageCount();
+    assert.ok(wv.loads[0].includes('finishResultsPaging()'),
+      'a page with pages after it carries the finish-early control');
+    assert.ok(wv.loads[0].includes(`skip the last ${pageCount - 1} page`),
+      'and the button says exactly what it skips');
+    wv.tap('chunkyscrape://act?a=mark-not-bear&id=k0&n=1');
+    await wv.settle();
+    assert.equal(wv.tap('chunkyscrape://act?a=page-done&n=2'), false,
+      'the finish tap cancels the fake navigation');
     wv.dismiss();
     await done;
   } finally {
     delete global.WebView;
   }
-  assert.equal(wv.loads.length, 1, 'a plain swipe-down ends the review — no page 2 was ever built');
+
+  assert.equal(wv.loads.length, 1, 'stopping early really stopped — page 2 was never built');
+  assert.deepEqual(appliedWith, [['k0']], 'the tap made before stopping is still applied, once');
   assert.equal(promptCalls, 1, 'and the execute prompt still fired, exactly once');
+});
+
+test('paging: "← Page N-1" still jumps BACK, which a swipe cannot express', async () => {
+  const adapter = buildAdapter();
+  const results = buildSizedResults(PAGING_EVENTS);
+  results.calendarEvents = 1; // skip the execution prompt
+
+  const wv = installPagingWebView();
+  try {
+    const done = adapter.presentRichResults(results);
+    await wv.waitForPage(1);
+    assert.ok(!wv.loads[0].includes('← Page'), 'page 1 has nothing to go back to');
+    wv.dismiss();
+    await wv.waitForPage(2);
+    assert.ok(wv.loads[1].includes('← Page 1'), 'page 2 offers the way back');
+    wv.tap('chunkyscrape://act?a=page&id=1&n=1');
+    wv.dismiss();
+    await wv.waitForPage(3);
+    assert.ok(wv.loads[2].includes('Page 1 of'), 'the back tap really re-opened page 1');
+    wv.tap('chunkyscrape://act?a=page-done&n=2');
+    wv.dismiss();
+    await done;
+  } finally {
+    delete global.WebView;
+  }
+  assert.equal(wv.loads.length, 3, 'three presentations: page 1, page 2, page 1 again');
 });
 
 test('paging: each page fires its own liveness beacons, so one bad page is still detectable', async () => {
   const adapter = buildAdapter();
-  const results = buildSizedResults(40);
+  const results = buildSizedResults(PAGING_EVENTS);
   results.calendarEvents = 1; // skip the execution prompt
 
   const wv = installPagingWebView();
@@ -5903,7 +6184,7 @@ test('paging: each page fires its own liveness beacons, so one bad page is still
 
 test('paging: page boundaries are PINNED — chrome that shrinks mid-review cannot slide a card out of view', async () => {
   const adapter = buildAdapter();
-  const results = buildSizedResults(40);
+  const results = buildSizedResults(PAGING_EVENTS);
   // Chrome is not constant across a review: queueing a venue on page 1
   // replaces a button with a shorter label. If the boundaries were recomputed
   // from each render's chrome, the freed bytes would enlarge page 1 and page 2
@@ -5938,12 +6219,12 @@ test('paging: page boundaries are PINNED — chrome that shrinks mid-review cann
   // And still nothing is lost: the union is the whole run.
   const seen = after.flat();
   assert.equal(new Set(seen).size, seen.length, 'no card appears on two pages');
-  assert.equal(seen.length, 40, 'no card fell between two pages');
+  assert.equal(seen.length, PAGING_EVENTS, 'no card fell between two pages');
 });
 
 test('paging: a page that fails to render still applies the taps already made, and still asks about execution', async () => {
   const adapter = buildAdapter();
-  const results = buildSizedResults(40);
+  const results = buildSizedResults(PAGING_EVENTS);
   results.config = { config: { dryRun: false } };
   results.calendarEvents = 0;
 

--- a/scripts/event-provenance.js
+++ b/scripts/event-provenance.js
@@ -77,10 +77,26 @@ function formatValueText(value) {
     return String(value);
 }
 
+// Cut length is in UTF-16 code UNITS, and an astral character (emoji, and every
+// flag/skin-tone sequence) is two of them. Cutting between the two halves
+// leaves a LONE SURROGATE in the string, which is not representable in UTF-8 —
+// and WKWebView, handed a document containing one, renders NOTHING AT ALL:
+// `<html><head></head><body></body></html>`, no DOM, no scripts, no matter how
+// small the page is. One truncated description therefore used to blank the
+// entire results sheet. Back the cut up by one unit when it would land inside
+// a surrogate pair, so the pair is either wholly kept or wholly dropped.
+function safeSliceEnd(str, end) {
+    if (end <= 0) return 0;
+    if (end >= str.length) return str.length;
+    const code = str.charCodeAt(end - 1);
+    // Last kept unit is a HIGH surrogate whose LOW half would be cut away.
+    return code >= 0xd800 && code <= 0xdbff ? end - 1 : end;
+}
+
 function truncateText(text, maxLength = VALUE_PREVIEW_MAX) {
     const str = String(text || '');
     if (str.length <= maxLength) return str;
-    return `${str.slice(0, maxLength - 1)}…`;
+    return `${str.slice(0, safeSliceEnd(str, maxLength - 1))}…`;
 }
 
 // Field-aware equality: date fields compare by instant so a saved run's ISO


### PR DESCRIPTION
## ITEM 1 — the exact breaking bytes

**`U+D83C` — an unpaired UTF-16 high surrogate. Two of them, on one card.**

```
…BEEFMINCE Brighton Pride on Saturday 1 August at Horizon \uD83C…
                                                          ^^^^^^
                          half of 🏳 (U+1F3F3 = \uD83C \uDFF3), the low half cut away
```

`WKWebView.loadHTMLString` — which Scriptable's `WebView.loadHTML` wraps — hands the document to its content process as UTF-8. A lone surrogate has no UTF-8 encoding, so the whole document is dropped and WebKit renders the empty shell:

```
<html><head></head><body></body></html>
```

No DOM, no script execution, no beacons. Exactly what the owner saw.

### How it was found — the engine matters

Previous passes cleared this page with **jsdom and Chrome**, which both accept lone surrogates silently. This one used **real WebKit**: a Swift `WKWebView` driven with `loadHTMLString`, the same API Scriptable wraps. The page was fed as **UTF-16LE** so the bad code unit survived to `NSString` instead of being flattened to `U+FFFD` by any UTF-8 round-trip (which is what hid it from every previous check — read the run JSON through Node and the evidence destroys itself).

```
min-clean.u16  utf16len=48      lone=0  ->  docHTML=61   bodyHTML=22      cards=0   ✅
min-lone.u16   utf16len=49      lone=1  ->  docHTML=39   bodyHTML=0       cards=0   ❌  <html><head></head><body></body></html>
p1.u16         utf16len=389871  lone=0  ->  docHTML=375956  bodyHTML=341323  cards=5   ✅
p2.u16         utf16len=383415  lone=0  ->  docHTML=363118  bodyHTML=328485  cards=5   ✅
p3.u16         utf16len=367721  lone=2  ->  docHTML=39   bodyHTML=0       cards=0   ❌  <html><head></head><body></body></html>
```

**A 49-character document blanks.** Size is not a variable in this.

### The card, and where the surrogate came from

Not the dropped card, not `sitgesbearcave.com`, not the ZWJ. It was **idx 10, `BEEFMINCE Brighton Pride`**, and the source data is *perfectly well-formed* — the lone surrogate is **manufactured at render time**:

`scripts/event-provenance.js:83` cut the provenance value preview at a UTF-16 code-unit index:

```js
return `${str.slice(0, maxLength - 1)}…`;   // one emoji is TWO code units
```

The 80-char cut landed between `\uD83C` and `\uDFF3`.

## Size is not the cause — the corrected table

Re-measured every cited run through the shipped renderer, counting lone surrogates per page:

| Run | Parser | Page | Size | lone surrogates | Result |
|---|---|---|---|---|---|
| 144859 | CHUNK | 1/3 | 369 KB | **0** | ✅ |
| 144859 | CHUNK | 2/3 | 366 KB | **0** | ✅ |
| 144859 | CHUNK | 3/3 | 268 KB | **0** | ✅ |
| 144859 | CHUNK | single | **864 KB** | **0** | ✅ rendered |
| 145058 | BEEFMINCE | single | 959 KB | **2** | ❌ blank |
| 153742 | BEEFMINCE | single | 959 KB | **2** | ❌ blank |
| 181636 | BEEFMINCE | single | **713 KB** | **2** | ❌ blank |
| 201054 | BEEFMINCE | 1/3 | 383 KB | **0** | ✅ |
| 201054 | BEEFMINCE | 2/3 | 376 KB | **0** | ✅ |
| 201054 | BEEFMINCE | **3/3** | **371 KB** | **2** | ❌ **blank** |

Every ✅ has zero. Every ❌ has two. **Size predicts nothing**; the surrogate count predicts everything, including why the *smallest* page of run 201054 is the only one that fails and why the same run blanked 246 KB smaller.

### The fix — rendering layer only, no event dropped, no scraped data touched

1. `event-provenance.js` `safeSliceEnd` — the preview cut backs up past a surrogate pair.
2. `ScriptableAdapter.safeSubstring` — same for the merge-diff previews, the tooltip cut and the JSON budget truncation, at **both** ends of the slice (an anchored slice can land mid-pair at the start too). A brute-force test over every `(start, end)` pair caught a real bug here: `substring` **swaps reversed arguments**, so a naive clamp handed back exactly the orphaned half.
3. `ScriptableAdapter.stripLoneSurrogates` + `finalizeRenderedHtml` — every render is swept as the last thing before it is returned, after every shed/banner/pager. Unpaired surrogates become `U+FFFD`. **No future truncation anywhere can blank the sheet again.** It logs one line when it fires; nothing is repaired silently.

### Verified against the real run

```
BEFORE  20260804-201054: pages=3 [382KB/0lone 376KB/0lone 360KB/2lone]
AFTER   20260804-201054: pageCount=1  871.1 KB  loneSurrogates=0
real WebKit:  docHTML=834877  bodyHTML=800244  cards=16   ✅ renders
```

All 16 cards, one page, in the engine that used to refuse it.

## ITEM 2 — the icon lost its transparency

Correct: **JPEG has no alpha channel**. #1631 converted the header logo to 160px JPEG for the last ~28 KB and the transparent mark came back with a solid block behind it.

Switched to **160px PNG**, and made the redraw canvas transparent again — `downscaleImage` was setting `ctx.opaque = true` plus a white `fillRect`, which is what JPEG output required and is literally what painted the background.

Measured on the real `cache/logo-hero.png` (320×320, 96,923 B, RGBA):

| | bytes | base64 | alpha |
|---|---|---|---|
| current inline, 320px PNG | 96,923 | ~129,231 | ✅ transparent (huge) |
| #1631 shipped, 160px JPEG | 11,633 | ~15,512 | ❌ **OPAQUE — the bug** |
| **this PR, 160px PNG** | **33,105** | **~44,140** | ✅ **transparent, ~3× smaller** |

Alpha verified on the produced bytes, not just asserted: `PNG 160x160 colorType=6 (rgba) bitDepth=8`, `sips hasAlpha: yes`. `Data.fromPNG` is used (no quality argument reintroduced anywhere). The `typeof` guards and the PNG-passthrough fallback are unchanged, so node/desktop still legitimately gets the full-res icon. `imageToJpegDataUri` is **deleted** rather than left unwired — its only purpose was to produce the regression.

## ITEM 3 — pagination trigger, and the taps

### Trigger: 400 KB → **1 MB**

The 400 KB budget was hedging against a cliff that does not exist. With the real cause known, there is **no size-attributable blank anywhere in the record** — so the budget now exists to bound a runaway run, not to dodge a cliff, and sits above every page ever produced on device (largest: 959 KB).

- Furball, **490 KB** — one page. ✅
- CHUNK, **864 KB** (proven to render) — one page. ✅
- Every run in `runs/` re-measured: **`pageCount=1`, all of them.**

`RESULTS_HTML_MAX_BYTES` raised 800 KB → 1 MB to match. It was anchored on the same phantom ("the cliff is in (862, 955]"), and at 800 KB it was **shedding review detail off pages like CHUNK's, which worked**. A page built to the budget is now never also shed.

### Taps: swiping down is "next"

*"Kinda weird that I have to hit buttons to proceed to the next page and close at the end."*

Native now arms `currentPage + 1` **before `present()`**, so the plain dismissal — the gesture that closes the sheet anyway — is the whole forward path, and the last page's dismissal ends the review by itself. An N-page review costs **N swipes and zero taps**.

- The redundant `Page N+1 →` button is **gone** — it did exactly what the swipe already does.
- `← Page N-1` stays: going back is something a swipe cannot express.
- `✅ Done reviewing — skip the last N pages` stays as the explicit finish-early control, and disappears on the last page where dismissing *is* finishing.

Still `shouldAllowRequest`, still assigned before `present()`, still no `evaluateJavaScript` on a presented web view — the page updates its own hint.

### #1631's two fixes, re-verified

- A throw mid-paging still does not unwind past `applyPendingBearOverrides` — the owner's verdicts survive a failed page (`paging: a page that fails to render still applies the taps already made…`).
- Page boundaries are still pinned on the card-bytes signature (`paging: page boundaries are PINNED…`).
- Bear overrides still accumulate across all pages and are applied **once**; the execute prompt still fires **exactly once**.

## Tests

Only `scripts/adapters/scriptable-adapter.test.js` (package.json-enumerated). `generateRichHTML` awaited throughout.

New: the verbatim Brighton Pride description renders with zero lone surrogates · truncation never splits a pair at either end (exhaustive over all start/end) · the provenance preview is swept across every offset that straddles its cut · the sweep is a logged backstop and leaves clean pages byte-identical · a 490 KB and an 864 KB run are each exactly ONE page · the logo is PNG with alpha under 50 KB · the redraw canvas is transparent · swiping alone reaches every page and finishes · "Done reviewing" stops early and still applies every tap · "← Page N-1" still jumps back.

All new tests were confirmed **failing on unfixed code** first (8/8 fail with the source stashed).

### Suite

Baseline measured on this branch's merge-base with `git stash`, not quoted:

```
BEFORE (origin/main f2bc8a4b):  tests 1487   pass 1487   fail 0
AFTER  (this branch):           tests 1494   pass 1494   fail 0
```

## Notes

- **No new runtime files.** The Swift `WKWebView` probe used to find this lives outside the repo, in the job scratch dir — nothing to add to the updater.
- One `console.log` disappears from the diff: it belonged to the deleted dead `imageToJpegDataUri`. No existing log text or prompt string was edited.
- No `new URL(` / `URLSearchParams` added under `scripts/`. `shared-core.js` / `normalizers.js` untouched. Nothing hardcoded per parser/venue/city. iCloud Scriptable dir read only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
