### PR TITLE
fix(site): square flyers were showing as CDN crops of themselves

### DIFF
--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -840,6 +840,16 @@ class DynamicCalendarLoader extends CalendarCore {
                 const originalImageUrl = eventData[field];
                 if (!originalImageUrl) return;
                 if (this.dataSource === 'cached') {
+                    // Remember where this slot CAME FROM before the rewrite.
+                    // The local filename is a hash of the full URL, so two
+                    // delivery variants of one stored file (…/x.jpg?rect=A and
+                    // …/x.jpg?rect=B) land on two unrelated local paths and
+                    // nothing downstream can tell they are the same artwork.
+                    // getFlyerCandidates needs that fact to refuse a crop of
+                    // the image it already has. Underscore-prefixed, so
+                    // formatEventNotes can never write it to a calendar.
+                    if (!eventData._imageSourceUrls) eventData._imageSourceUrls = {};
+                    eventData._imageSourceUrls[field] = originalImageUrl;
                     eventData[field] = this.convertImageUrlToLocal(originalImageUrl, eventData);
 
                     logger.debug('CALENDAR', 'Converted image URL for cached data', {
@@ -2206,6 +2216,35 @@ class DynamicCalendarLoader extends CalendarCore {
         return '';
     }
 
+    // The identity of the STORED FILE a flyer URL points at: host + path, with
+    // the query string, the fragment and the scheme dropped. Two URLs sharing
+    // this key are one picture delivered with different parameters (imgix /
+    // Cloudinary / thumbor style crop + resize), not two pictures.
+    //
+    // EventSchema.imageAssetKey owns this rule (the scraper side shares it);
+    // the inline copy below is the fallback for a page that loaded the loader
+    // without the schema, and must stay identical to it.
+    //
+    // String parsing, not `new URL(` — the schema twin runs inside Scriptable,
+    // where neither URL nor URLSearchParams exists.
+    flyerAssetKey(url) {
+        const schema = typeof EventSchema !== 'undefined' ? EventSchema : null;
+        if (schema && typeof schema.imageAssetKey === 'function') {
+            return schema.imageAssetKey(url);
+        }
+        const raw = String(url === null || url === undefined ? '' : url).trim();
+        if (!raw) return '';
+        const withoutQuery = raw.split('#')[0].split('?')[0];
+        if (!withoutQuery) return '';
+        const authorityMatch = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.exec(withoutQuery);
+        if (!authorityMatch) return withoutQuery;   // root-relative: compare verbatim
+        const rest = withoutQuery.slice(authorityMatch[0].length);
+        const slash = rest.indexOf('/');
+        const host = (slash < 0 ? rest : rest.slice(0, slash)).toLowerCase();
+        const path = slash < 0 ? '' : rest.slice(slash);
+        return `${host}${path}`;                    // scheme ignored on purpose
+    }
+
     // Ordered flyer candidates for one event, best first, as
     // { u: url, o: 'portrait' | 'landscape' | '' } entries. `want` is the
     // orientation the layout prefers; `o` is only set when the orientation is
@@ -2245,6 +2284,36 @@ class DynamicCalendarLoader extends CalendarCore {
                 logger.debug('CALENDAR', 'pickImageForOrientation failed; using local flyer order', {
                     error: error && error.message
                 });
+            }
+        }
+
+        // A slot that is only a CROP of the primary (same host + path, different
+        // crop/resize query) is not a better-shaped picture — it is this picture
+        // with its edges cut off, so the uncropped primary leads instead. Applied
+        // after the schema pick so it also covers a schema that predates the rule.
+        // A separate wide image (different asset) keeps its preference untouched.
+        //
+        // Identity is read off the ORIGINAL url (parseEventData stamps
+        // _imageSourceUrls before rewriting cached slots to local img/events
+        // paths); on the live site the slot values are hashed filenames that
+        // hide the shared asset entirely.
+        const sources = event._imageSourceUrls || null;
+        const slotFieldOf = url => {
+            if (!url) return '';
+            if (url === primary) return 'image';
+            if (url === vertical) return 'imageVertical';
+            if (url === horizontal) return 'imageHorizontal';
+            return '';
+        };
+        const assetKeyOf = url => {
+            const field = slotFieldOf(url);
+            const source = sources && field && sources[field] ? sources[field] : url;
+            return this.flyerAssetKey(source);
+        };
+        if (primary && preferred && preferred !== primary) {
+            const preferredKey = assetKeyOf(preferred);
+            if (preferredKey && preferredKey === assetKeyOf(primary)) {
+                preferred = primary;
             }
         }
 

--- a/js/event-schema.js
+++ b/js/event-schema.js
@@ -368,10 +368,50 @@ function readImageSlotValue(event, fieldName) {
     return typeof value === 'string' ? value.trim() : '';
 }
 
+// The identity of the STORED FILE an image URL points at: host + path, with the
+// query string, the fragment and the scheme dropped. Two URLs that share this
+// key are the same picture served with different delivery parameters (imgix /
+// Cloudinary / thumbor style crop + resize), not two different pictures.
+//
+// String parsing on purpose: no `new URL(` / `URLSearchParams` — the Scriptable
+// runtime that runs scripts/event-schema.js — this file's twin — has neither.
+function imageAssetKey(url) {
+    const raw = typeof url === 'string' ? url.trim() : '';
+    if (!raw) return '';
+    const withoutQuery = raw.split('#')[0].split('?')[0];
+    if (!withoutQuery) return '';
+    // "https://host/path", "//host/path" — anything else (root-relative,
+    // downloaded flyers) has no host and compares verbatim.
+    const authorityMatch = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.exec(withoutQuery);
+    if (!authorityMatch) return withoutQuery;
+    const rest = withoutQuery.slice(authorityMatch[0].length);
+    const slash = rest.indexOf('/');
+    const host = (slash < 0 ? rest : rest.slice(0, slash)).toLowerCase();
+    const path = slash < 0 ? '' : rest.slice(slash);
+    // Scheme is deliberately ignored: http and https of one file are one file.
+    return `${host}${path}`;
+}
+
+// True when two image URLs resolve to the same stored asset and differ only in
+// their delivery query (crop/resize/format). See pickImageForOrientation.
+function isSameImageAsset(a, b) {
+    const keyA = imageAssetKey(a);
+    if (!keyA) return false;
+    return keyA === imageAssetKey(b);
+}
+
 // Pick the best image for a wanted orientation from the three slots.
 //   want: 'portrait' | 'vertical' | 'landscape' | 'horizontal' (anything else
 //         means "no preference" and returns the primary).
 // Fallback chain, in order:
+//   0. …unless the exact-orientation slot is the SAME STORED ASSET as the
+//      primary with a different crop query (isSameImageAsset). A "horizontal"
+//      variant of the picture we already have is not a wider picture — it is
+//      this picture with its top and bottom cut off (dice.fm ships a 768×768
+//      flyer as `image` and a rect=0,154,768,461 imgix crop of that same file
+//      as `imageHorizontal`, discarding 40% of the artwork). In that case the
+//      uncropped primary wins. A genuinely SEPARATE wide image — different
+//      host or path — still wins, which is the whole point of the slot.
 //   1. the exact-orientation slot (imageVertical / imageHorizontal)
 //   2. the primary `image` when it classifies as the wanted orientation
 //   3. the primary `image` when its orientation is UNKNOWN — by far the common
@@ -400,7 +440,10 @@ function pickImageForOrientation(event, want, options = {}) {
     }
 
     const exactSlot = wantsPortrait ? vertical : horizontal;
-    if (exactSlot) return exactSlot;
+    // Same file, different crop → the slot is a degraded copy of the primary,
+    // so the primary wins (isSameImageAsset is false whenever there is no
+    // primary to fall back to, which keeps the slot-only event answering).
+    if (exactSlot) return isSameImageAsset(exactSlot, primary) ? primary : exactSlot;
 
     const otherSlot = wantsPortrait ? horizontal : vertical;
     if (primary) {
@@ -415,7 +458,9 @@ function pickImageForOrientation(event, want, options = {}) {
         if (orientation === 'unknown') return primary;
         if (orientation === (wantsPortrait ? 'portrait' : 'landscape')) return primary;
     }
-    return otherSlot || primary || '';
+    // Same rule on the way out: a crop of the primary is never an upgrade.
+    if (otherSlot && !isSameImageAsset(otherSlot, primary)) return otherSlot;
+    return primary || otherSlot || '';
 }
 
 function getEventBuilderStateKey(paramKey) {
@@ -843,6 +888,8 @@ const EventSchema = {
     parseNotesIntoFields,
     formatEventNotes,
     pickImageForOrientation,
+    imageAssetKey,
+    isSameImageAsset,
     getEventBuilderStateKey,
     escapeIcsText,
     foldIcsLine,

--- a/scripts/event-schema.js
+++ b/scripts/event-schema.js
@@ -375,10 +375,50 @@ function readImageSlotValue(event, fieldName) {
     return typeof value === 'string' ? value.trim() : '';
 }
 
+// The identity of the STORED FILE an image URL points at: host + path, with the
+// query string, the fragment and the scheme dropped. Two URLs that share this
+// key are the same picture served with different delivery parameters (imgix /
+// Cloudinary / thumbor style crop + resize), not two different pictures.
+//
+// String parsing on purpose: no `new URL(` / `URLSearchParams` — the Scriptable
+// runtime that runs scripts/event-schema.js — this file's twin — has neither.
+function imageAssetKey(url) {
+    const raw = typeof url === 'string' ? url.trim() : '';
+    if (!raw) return '';
+    const withoutQuery = raw.split('#')[0].split('?')[0];
+    if (!withoutQuery) return '';
+    // "https://host/path", "//host/path" — anything else (root-relative,
+    // downloaded flyers) has no host and compares verbatim.
+    const authorityMatch = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.exec(withoutQuery);
+    if (!authorityMatch) return withoutQuery;
+    const rest = withoutQuery.slice(authorityMatch[0].length);
+    const slash = rest.indexOf('/');
+    const host = (slash < 0 ? rest : rest.slice(0, slash)).toLowerCase();
+    const path = slash < 0 ? '' : rest.slice(slash);
+    // Scheme is deliberately ignored: http and https of one file are one file.
+    return `${host}${path}`;
+}
+
+// True when two image URLs resolve to the same stored asset and differ only in
+// their delivery query (crop/resize/format). See pickImageForOrientation.
+function isSameImageAsset(a, b) {
+    const keyA = imageAssetKey(a);
+    if (!keyA) return false;
+    return keyA === imageAssetKey(b);
+}
+
 // Pick the best image for a wanted orientation from the three slots.
 //   want: 'portrait' | 'vertical' | 'landscape' | 'horizontal' (anything else
 //         means "no preference" and returns the primary).
 // Fallback chain, in order:
+//   0. …unless the exact-orientation slot is the SAME STORED ASSET as the
+//      primary with a different crop query (isSameImageAsset). A "horizontal"
+//      variant of the picture we already have is not a wider picture — it is
+//      this picture with its top and bottom cut off (dice.fm ships a 768×768
+//      flyer as `image` and a rect=0,154,768,461 imgix crop of that same file
+//      as `imageHorizontal`, discarding 40% of the artwork). In that case the
+//      uncropped primary wins. A genuinely SEPARATE wide image — different
+//      host or path — still wins, which is the whole point of the slot.
 //   1. the exact-orientation slot (imageVertical / imageHorizontal)
 //   2. the primary `image` when it classifies as the wanted orientation
 //   3. the primary `image` when its orientation is UNKNOWN — by far the common
@@ -407,7 +447,10 @@ function pickImageForOrientation(event, want, options = {}) {
     }
 
     const exactSlot = wantsPortrait ? vertical : horizontal;
-    if (exactSlot) return exactSlot;
+    // Same file, different crop → the slot is a degraded copy of the primary,
+    // so the primary wins (isSameImageAsset is false whenever there is no
+    // primary to fall back to, which keeps the slot-only event answering).
+    if (exactSlot) return isSameImageAsset(exactSlot, primary) ? primary : exactSlot;
 
     const otherSlot = wantsPortrait ? horizontal : vertical;
     if (primary) {
@@ -422,7 +465,9 @@ function pickImageForOrientation(event, want, options = {}) {
         if (orientation === 'unknown') return primary;
         if (orientation === (wantsPortrait ? 'portrait' : 'landscape')) return primary;
     }
-    return otherSlot || primary || '';
+    // Same rule on the way out: a crop of the primary is never an upgrade.
+    if (otherSlot && !isSameImageAsset(otherSlot, primary)) return otherSlot;
+    return primary || otherSlot || '';
 }
 
 function getEventBuilderStateKey(paramKey) {
@@ -850,6 +895,8 @@ const EventSchema = {
     parseNotesIntoFields,
     formatEventNotes,
     pickImageForOrientation,
+    imageAssetKey,
+    isSameImageAsset,
     getEventBuilderStateKey,
     escapeIcsText,
     foldIcsLine,

--- a/scripts/event-schema.test.js
+++ b/scripts/event-schema.test.js
@@ -169,6 +169,211 @@ test('pickImageForOrientation walks the fallback chain and never loses an image'
   }), 'P.jpg');
 });
 
+// ---------------------------------------------------------------------------
+// Same-asset crop detection — the "why are square images cropped?" bug.
+//
+// dice.fm publishes ONE flyer and two delivery URLs for it: `image` is the whole
+// 768×768 square, `imageHorizontal` is an imgix rect= crop of THAT SAME FILE
+// keeping rows 154–614 (461 of 768 rows → 307 rows, 40% of the artwork, sliced
+// off the top and bottom). Preferring the "horizontal" slot therefore showed the
+// flyer with its head and feet cut off. A genuinely separate wide image — a
+// different asset — must still win.
+// ---------------------------------------------------------------------------
+
+// Verbatim from data/calendars/london.json, event "BEEFMINCE x RVT".
+const DICE_SQUARE = 'https://dice-media.imgix.net/attachments/2024-12-17/5e10abb8-c358-44be-8461-889edd0f6e3f.jpg?rect=0%2C0%2C768%2C768';
+const DICE_CROP = 'https://dice-media.imgix.net/attachments/2024-12-17/5e10abb8-c358-44be-8461-889edd0f6e3f.jpg?rect=0%2C154%2C768%2C461&w=1300&h=630&auto=compress';
+
+test('imageAssetKey/isSameImageAsset: one stored file under different delivery queries', () => {
+  const key = EventSchema.imageAssetKey;
+  assert.equal(key(DICE_SQUARE), key(DICE_CROP), 'crop params are not part of the asset identity');
+  assert.ok(EventSchema.isSameImageAsset(DICE_SQUARE, DICE_CROP));
+
+  // Scheme and host case are irrelevant; the path is not.
+  assert.ok(EventSchema.isSameImageAsset('http://CDN.example/a/flyer.jpg', 'https://cdn.example/a/flyer.jpg'));
+  assert.ok(EventSchema.isSameImageAsset('//cdn.example/a/flyer.jpg', 'https://cdn.example/a/flyer.jpg?w=10'));
+  assert.equal(EventSchema.isSameImageAsset('https://cdn.example/a/flyer.jpg', 'https://cdn.example/a/wide.jpg'), false);
+  assert.equal(EventSchema.isSameImageAsset('https://cdn.example/a/flyer.jpg', 'https://other.example/a/flyer.jpg'), false);
+  assert.equal(EventSchema.isSameImageAsset('https://cdn.example/A/flyer.jpg', 'https://cdn.example/a/flyer.jpg'), false);
+  // Root-relative (downloaded flyers) compares verbatim; blanks are never a match.
+  assert.ok(EventSchema.isSameImageAsset('/images/events/x.jpg?v=2', '/images/events/x.jpg'));
+  assert.equal(EventSchema.isSameImageAsset('', ''), false);
+  assert.equal(EventSchema.isSameImageAsset(DICE_CROP, ''), false);
+  assert.equal(EventSchema.isSameImageAsset(null, undefined), false);
+});
+
+test('pickImageForOrientation: a crop of the primary loses, a separate wide image still wins', () => {
+  const pick = EventSchema.pickImageForOrientation;
+
+  // The real dice.fm event: landscape asked for, uncropped square handed back.
+  assert.equal(pick({ image: DICE_SQUARE, imageHorizontal: DICE_CROP }, 'landscape'), DICE_SQUARE);
+  assert.equal(pick({ image: DICE_SQUARE, imageHorizontal: DICE_CROP }, 'horizontal'), DICE_SQUARE);
+
+  // A genuinely different asset keeps the owner's orientation preference.
+  assert.equal(pick({ image: 'https://cdn.example/a/square.jpg', imageHorizontal: 'https://cdn.example/a/wide.jpg' }, 'landscape'),
+    'https://cdn.example/a/wide.jpg');
+
+  // Portrait obeys the same rule in both directions.
+  assert.equal(pick({ image: DICE_SQUARE, imageVertical: DICE_CROP }, 'portrait'), DICE_SQUARE);
+  assert.equal(pick({ image: 'https://cdn.example/a/square.jpg', imageVertical: 'https://cdn.example/a/tall.jpg' }, 'portrait'),
+    'https://cdn.example/a/tall.jpg');
+
+  // …and on the other-slot fallback (step 4): portrait wanted, no vertical slot,
+  // and a primary that classifies as the WRONG shape, so the horizontal slot is
+  // the last thing left to try.
+  const classifyLandscape = () => 'landscape';
+  assert.equal(pick({ image: DICE_SQUARE, imageHorizontal: DICE_CROP }, 'portrait',
+    { classifyOrientation: classifyLandscape }), DICE_SQUARE,
+  'a crop of the primary is not a fallback worth taking');
+  assert.equal(pick({ image: 'https://cdn.example/a/square.jpg', imageHorizontal: 'https://cdn.example/a/wide.jpg' }, 'portrait',
+    { classifyOrientation: classifyLandscape }), 'https://cdn.example/a/wide.jpg',
+  'a different asset is still better than nothing');
+  // With no classifier the unknown primary wins, exactly as before.
+  assert.equal(pick({ image: DICE_SQUARE, imageHorizontal: DICE_CROP }, 'portrait'), DICE_SQUARE);
+
+  // No primary to fall back to → the slot is still used (never blank).
+  assert.equal(pick({ imageHorizontal: DICE_CROP }, 'landscape'), DICE_CROP);
+  assert.equal(pick({ imageVertical: DICE_CROP }, 'portrait'), DICE_CROP);
+});
+
+// ---------------------------------------------------------------------------
+// The website side of the same rule: DynamicCalendarLoader.getFlyerCandidates
+// owns what the card actually renders. It is a browser script (no module
+// exports), so it is evaluated in a vm context with the same globals the page
+// gives it — the same "load the real file, don't reimplement it" approach the
+// adapter tests use.
+// ---------------------------------------------------------------------------
+
+let cachedLoaderClass = null;
+function loadCalendarLoaderClass() {
+  if (cachedLoaderClass) return cachedLoaderClass;
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const vm = require('node:vm');
+  const noop = () => {};
+  const context = {
+    console,
+    window: {},
+    document: { addEventListener: noop },
+    navigator: {},
+    logger: new Proxy({}, { get: () => noop }),
+    setTimeout,
+    clearTimeout,
+    module: { exports: {} }
+  };
+  context.globalThis = context;
+  vm.createContext(context);
+  ['calendar-core.js', 'event-schema.js', 'dynamic-calendar-loader.js'].forEach(file => {
+    const full = path.join(__dirname, '..', 'js', file);
+    context.module = { exports: {} };
+    vm.runInContext(fs.readFileSync(full, 'utf8'), context, { filename: file });
+  });
+  cachedLoaderClass = context.window.DynamicCalendarLoader;
+  assert.equal(typeof cachedLoaderClass, 'function', 'DynamicCalendarLoader loaded');
+  return cachedLoaderClass;
+}
+
+// Prototype-only instance: getFlyerCandidates touches no constructor state, and
+// constructing the real loader would go looking for the DOM.
+function flyerLoader() {
+  return Object.create(loadCalendarLoaderClass().prototype);
+}
+
+test('getFlyerCandidates: an imgix crop of the primary never leads the flyer chain', () => {
+  const loader = flyerLoader();
+
+  const real = loader.getFlyerCandidates({ image: DICE_SQUARE, imageHorizontal: DICE_CROP }, 'landscape');
+  assert.equal(real[0].u, DICE_SQUARE, 'the uncropped square is displayed');
+  assert.ok(real.some(candidate => candidate.u === DICE_CROP),
+    'the crop stays in the fallback chain rather than being thrown away');
+
+  // Portrait request, same asset in the vertical slot.
+  const portrait = loader.getFlyerCandidates({ image: DICE_SQUARE, imageVertical: DICE_CROP }, 'portrait');
+  assert.equal(portrait[0].u, DICE_SQUARE);
+});
+
+test('getFlyerCandidates: a separate wide image still wins, and a lone slot is still shown', () => {
+  const loader = flyerLoader();
+
+  const separate = loader.getFlyerCandidates(
+    { image: 'https://cdn.example/a/square.jpg', imageHorizontal: 'https://cdn.example/a/wide.jpg' }, 'landscape');
+  assert.equal(separate[0].u, 'https://cdn.example/a/wide.jpg', "the owner's landscape preference is intact");
+  assert.equal(separate[0].o, 'landscape');
+
+  const tall = loader.getFlyerCandidates(
+    { image: 'https://cdn.example/a/square.jpg', imageVertical: 'https://cdn.example/a/tall.jpg' }, 'portrait');
+  assert.equal(tall[0].u, 'https://cdn.example/a/tall.jpg');
+
+  // Only the horizontal slot exists → it is still used (no regression to blank).
+  const only = loader.getFlyerCandidates({ imageHorizontal: DICE_CROP }, 'landscape');
+  assert.equal(only.length, 1);
+  assert.equal(only[0].u, DICE_CROP);
+
+  // Only a primary → unchanged single-image behaviour. Field-by-field, not
+  // deepEqual: these objects are made inside the vm context, so they are
+  // cross-realm and never structurally equal to a plain object made here.
+  const single = loader.getFlyerCandidates({ image: DICE_SQUARE }, 'landscape');
+  assert.equal(single.length, 1);
+  assert.equal(single[0].u, DICE_SQUARE);
+  assert.equal(single[0].o, '');
+
+  // No images at all → no candidates.
+  assert.equal(loader.getFlyerCandidates({}, 'landscape').length, 0);
+});
+
+test('getFlyerCandidates: local img/events paths still resolve via the stamped source URLs', () => {
+  // parseEventData rewrites cached slots to img/events paths whose filename is a
+  // hash of the FULL url, so the two delivery variants of one file land on two
+  // unrelated names — 2026-10-17_beefmince-x-rvt_5929ec4.jpg (768×768) and
+  // …_683d1276.jpg (768×461), both committed under img/events. Without the
+  // stamped originals nothing downstream can tell they are one picture.
+  const { convertImageUrlToLocalPath } = require('../js/filename-utils.js');
+  const loader = flyerLoader();
+  const eventInfo = { name: 'BEEFMINCE x RVT', startDate: '2026-10-17T22:00:00.000Z', recurring: false };
+  const localPrimary = '/' + convertImageUrlToLocalPath(DICE_SQUARE, eventInfo, 'img/events');
+  const localCrop = '/' + convertImageUrlToLocalPath(DICE_CROP, eventInfo, 'img/events');
+  assert.notEqual(localPrimary, localCrop, 'the two crops hash to different local files');
+
+  const candidates = loader.getFlyerCandidates({
+    image: localPrimary,
+    imageHorizontal: localCrop,
+    _imageSourceUrls: { image: DICE_SQUARE, imageHorizontal: DICE_CROP }
+  }, 'landscape');
+  assert.equal(candidates[0].u, localPrimary, 'the uncropped local file leads');
+
+  // Without the stamp the paths are genuinely unrelated and the slot preference
+  // stands — the rule must not guess.
+  const unstamped = loader.getFlyerCandidates({ image: localPrimary, imageHorizontal: localCrop }, 'landscape');
+  assert.equal(unstamped[0].u, localCrop);
+});
+
+test('getFlyerCandidates: every published same-asset flyer pair resolves to the uncropped image', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const loader = flyerLoader();
+  const dir = path.join(__dirname, '..', 'data', 'calendars');
+  const pairs = [];
+  fs.readdirSync(dir).filter(name => name.endsWith('.json')).forEach(name => {
+    const parsed = JSON.parse(fs.readFileSync(path.join(dir, name), 'utf8'));
+    const events = Array.isArray(parsed) ? parsed : (parsed.events || []);
+    events.forEach(event => {
+      const fields = EventSchema.parseNotesIntoFields(event.unprocessedDescription || '');
+      const image = event.image || fields.image;
+      const horizontal = event.imageHorizontal || fields.imageHorizontal;
+      if (image && horizontal && EventSchema.isSameImageAsset(image, horizontal)) {
+        pairs.push({ image, horizontal });
+      }
+    });
+  });
+  // Guards the fixture itself: if the published data ever stops carrying these
+  // pairs this test must fail loudly rather than silently assert nothing.
+  assert.ok(pairs.length > 0, 'published calendars carry same-asset image/imageHorizontal pairs');
+  pairs.forEach(pair => {
+    const candidates = loader.getFlyerCandidates({ image: pair.image, imageHorizontal: pair.horizontal }, 'landscape');
+    assert.equal(candidates[0].u, pair.image, `uncropped flyer chosen for ${pair.image}`);
+  });
+});
+
 test('parseNotesIntoFields: a value line that looks like "key: value" stays part of the value', () => {
   // The multi-line description contains an escaped "Doors\: 9pm" line; it must not
   // be promoted to its own field.


### PR DESCRIPTION
> "why are square images now cropped?" — seen at `https://chunky.dad/london/?view=month&date=2026-08-04`. Square flyers render with their tops and bottoms sliced off.

## What is actually happening

Nothing crops at CSS time — `.event-flyer img` is `object-fit: contain` (`styles.css:2118`) and the aurora rules only cap height. The crop is baked into the URL the site picks.

The site prefers the `imageHorizontal` slot over `image` (as requested). But on the affected events that slot is not a different image. Straight out of `data/calendars/london.json`, event **BEEFMINCE x RVT**:

| slot | URL |
| --- | --- |
| `image` | `https://dice-media.imgix.net/attachments/2024-12-17/5e10abb8-c358-44be-8461-889edd0f6e3f.jpg?rect=0%2C0%2C768%2C768` |
| `imageHorizontal` | `https://dice-media.imgix.net/attachments/2024-12-17/5e10abb8-c358-44be-8461-889edd0f6e3f.jpg?rect=0%2C154%2C768%2C461&w=1300&h=630&auto=compress` |

Same host, same path, same asset id `5e10abb8-…`. Only the imgix `rect` differs.

**The arithmetic:** `rect=0,154,768,461` keeps rows 154–614 of a 768-row image. 768 − 461 = **307 rows discarded — 40.0% of the artwork**, taken off the top and the bottom. The 1080px events do exactly the same thing: `0,216,1080,648` keeps 648 of 1080 rows, again **40%** gone. The two local copies confirm it: `img/events/one-time/2026/10/2026-10-17_beefmince-x-rvt_5929ec4.jpg` is 768×768, `…_683d1276.jpg` is 768×461.

## The rule: same-asset detection, not a host check

When the horizontal candidate resolves to the **same underlying asset** as the primary (same origin + path, differing only in crop/resize query parameters), it is not a better image — it is a degraded one, so the uncropped original wins. A genuinely **separate** wide image (different path/asset) still wins for landscape, exactly as asked.

Why not just special-case dice.fm? Because the published data already carries these same-asset pairs from **three unrelated hosts** — `dice-media.imgix.net` (9), `static.wixstatic.com` (1), `bearracuda.com` (1). A host list would have been wrong the day the next promoter changed CDN. The rule is a property of the URLs (one stored file, two delivery queries), which is what imgix, Cloudinary, thumbor and Wix all do, so it generalizes without naming anyone. Nothing per-venue/promoter/city/host is hardcoded.

## Site-wide effect

Across all 25 `data/calendars/*.json` (140 events): 11 events carry both `image` and `imageHorizontal`, and **every one of them is the same asset** — zero events have a genuinely different wide image today. Of those 11, **9 are real crops that this un-crops**:

| city | events |
| --- | --- |
| london | 6 |
| brighton | 2 |
| birmingham | 1 |

(the other 2 — chicago, portland — have byte-identical URLs in both slots, so they already rendered fine and are unchanged.)

Verified against the real published data, not just fixtures: every one of those 9 now resolves to the full-square URL, with the crop kept in the fallback chain.

## Implementation

- `js/event-schema.js` + `scripts/event-schema.js` (sibling pair — kept in sync, hunks are byte-identical): new `imageAssetKey` / `isSameImageAsset`, and `pickImageForOrientation` applies the rule at both its exact-slot and other-slot steps. **String parsing only — no `new URL(` / `URLSearchParams`**, per the Scriptable-runtime rule.
- `js/dynamic-calendar-loader.js`: `getFlyerCandidates` demotes a same-asset crop *after* the schema pick (so it holds even against a schema that predates the rule), delegating identity to `EventSchema.imageAssetKey` with an identical inline fallback. `normalizeFlyerUrl` filtering and the `data-flyer-fallbacks` chain are untouched — the crop is still queued as a fallback, just no longer first.
- `parseEventData` stamps `_imageSourceUrls` before rewriting cached slots to `img/events` paths. That rewrite hashes the **full** URL, so two crops of one file become two unrelated filenames and the shared asset becomes invisible; the stamp is what keeps the rule working on that path. Underscore-prefixed, so `formatEventNotes` can never write it into a calendar.

Behaviour with only one slot present is unchanged, and a lone `imageHorizontal` is still displayed (no regression to a blank card).

## Not in scope, deliberately

`tools/generate-event-pages.js` writes `<meta name="chunky:flyer">` with the horizontal URL, consumed by `tools/generate-og-images.js`. That surface is a 1.91:1 social card, where a wide crop is the *right* choice — left alone.

## Tests

Added to `scripts/event-schema.test.js` (package.json-enumerated; already reaches into `../js/` for `calendar-core.js`). The browser loader has no module exports, so it is evaluated in a `vm` context with the globals the page gives it — the real file, not a reimplementation.

- same asset + different `rect` → the uncropped `image` is chosen over `imageHorizontal`
- different asset paths → `imageHorizontal` still wins for landscape
- only `imageHorizontal` present → still used
- portrait requests prefer `imageVertical`, same rule applied in both directions
- the local `img/events` shape, proving the stamped source URLs carry the identity through the hashed-filename rewrite
- a real fixture: every same-asset pair in `data/calendars/*.json` resolves to the uncropped image (guarded by an assertion that the pairs still exist, so it can never silently assert nothing)

**Baseline measured on a clean `origin/main` worktree: 1487 pass / 0 fail. With this branch: 1493 pass / 0 fail** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`). 5 of the 6 new tests fail on unfixed code; the 6th is the regression guard that must pass both ways.

## Notes

- Display-layer only: no scraped data, calendar JSON or ICS is touched. Takes effect without a re-scrape.
- No new runtime files.
- No existing `console.log` text or AI prompt string was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
