### PR TITLE
fix(scriptable): persist the run BEFORE the results UI (a UI hang was destroying whole runs) + correct the page budget I anchored on a failure

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1401,14 +1401,19 @@ class ScriptableAdapter {
     return existing;
   }
 
-  // Stamp the just-saved run id into venue-queue entries tapped this session.
-  // Queue taps happen while the results sheet is up, BEFORE the run is saved,
-  // so results.savedRunId is null at queue-write time and entries were landing
-  // with runIds: []. The run id is generated from the save timestamp
-  // (saveRun → getRunId), so assigning it earlier would change what a run id
-  // means; instead queueVenueCandidateAndReport records which candidate keys
-  // it wrote and this backfill — called right after saveRun assigns
-  // results.savedRunId — stamps the now-known id into exactly those entries.
+  // Stamp the saved run id into venue-queue entries tapped this session.
+  // Queue taps happen while the results sheet is up. They used to run before
+  // the run was saved at all, so results.savedRunId was null at queue-write
+  // time and entries landed with runIds: []; the id is generated from the save
+  // timestamp (saveRun → getRunId), so it could not simply be assigned earlier
+  // without changing what a run id means. Now that the run is saved BEFORE the
+  // sheet (persistRunSnapshot, phase "pre-ui") the id usually exists at tap
+  // time and mergeBarAdditionEntry stamps it directly — but the id is still
+  // minted by saveRun, and a pre-UI save that failed leaves taps unstamped, so
+  // this backfill stays as the safety net: queueVenueCandidateAndReport records
+  // which candidate keys it wrote and this pass — called right after the
+  // post-review save confirms results.savedRunId — stamps the id into exactly
+  // those entries. Already-stamped entries are skipped, so it is idempotent.
   // Fail open: any failure leaves entries as the tap wrote them.
   async backfillQueuedVenueRunIds(results) {
     try {
@@ -4676,14 +4681,6 @@ class ScriptableAdapter {
 
       console.log("\n" + "=".repeat(60));
 
-      const shouldSkipUi = this.shouldSkipResultsUi(results);
-      if (!shouldSkipUi) {
-        // Present rich UI display (may update results.calendarEvents if user executes)
-        await this.presentRichResults(results);
-      } else {
-        console.log("📱 Scriptable: Skipping results UI (automation run)");
-      }
-
       // Persist this run for later display (skip when showing saved runs)
       const hasAnalyzedEvents = Array.isArray(results?.analyzedEvents);
       const parserConfigs = results?.config?.parsers || [];
@@ -4711,16 +4708,39 @@ class ScriptableAdapter {
         hasAnalyzedEvents &&
         hasActiveParsers;
       const retentionDays = 30;
+
+      // ------------------------------------------------------------------
+      // SAVE BEFORE SHOWING. The run JSON and its log are written HERE, above
+      // the results sheet, and rewritten below it.
+      //
+      // They used to be written only after the sheet came down, which meant
+      // any failure at the UI stage destroyed the entire run: every scraped
+      // event, every AI call's output, the whole log. That is not theory — a
+      // BEEFMINCE run ended with "Presenting results UI..." as its last line
+      // ever logged and had to be force-quit, and there was no run JSON left
+      // to diagnose it from. A UI failure must cost the REVIEW, never the
+      // DATA.
+      //
+      // The second write below lands on the SAME file (see
+      // persistRunSnapshot): the id minted here is reused, so post-review
+      // state — bear overrides, executed calendar actions, calendarEvents,
+      // errors raised during the review — updates this run instead of
+      // creating a second one.
+      // ------------------------------------------------------------------
       if (shouldSaveRun) {
-        await this.ensureRelativeStorageDirs();
-        const runId = await this.saveRun(results);
-        if (runId) {
-          results.savedRunId = runId;
-          results.savedRunPath = this.getRunFilePath(runId);
-          // Venue-queue taps happened before this id existed — stamp it into
-          // the entries queued during this session's results sheet.
-          await this.backfillQueuedVenueRunIds(results);
-        }
+        await this.persistRunSnapshot(results, { phase: "pre-ui" });
+      }
+
+      const shouldSkipUi = this.shouldSkipResultsUi(results);
+      if (!shouldSkipUi) {
+        // Present rich UI display (may update results.calendarEvents if user executes)
+        await this.presentRichResults(results);
+      } else {
+        console.log("📱 Scriptable: Skipping results UI (automation run)");
+      }
+
+      if (shouldSaveRun) {
+        await this.persistRunSnapshot(results, { phase: "post-ui" });
         // Cleanup old JSON runs
         await this.cleanupOldFiles("chunky-dad-scraper/runs", {
           maxAgeDays: retentionDays,
@@ -9437,9 +9457,10 @@ class ScriptableAdapter {
         await this.saveBarAdditions(queue);
         timesSeen = Number(entry.timesSeen) || 1;
         tapped[key] = timesSeen;
-        // Remember which entries this session wrote: the run id does not
-        // exist yet (the run is saved after the sheet is dismissed), so
-        // backfillQueuedVenueRunIds stamps it into these keys post-save.
+        // Remember which entries this session wrote. The run is now saved
+        // before the sheet opens, so the id above is normally already real —
+        // but if that pre-UI save failed there is still no id here, and
+        // backfillQueuedVenueRunIds stamps these keys after the final save.
         if (!Array.isArray(results._queuedVenueCandidateKeys)) {
           results._queuedVenueCandidateKeys = [];
         }
@@ -10706,8 +10727,25 @@ class ScriptableAdapter {
   // genuinely runaway future run. The lone-surrogate sweep in
   // finalizeRenderedHtml is what actually keeps a page from blanking now, and
   // the liveness beacons still report it per page if one ever does.
+  //
+  // ---- CORRECTION: 1 MB was an over-correction. ----
+  // With the surrogate fixed and deployed, the very next run put an 878 KB
+  // single page on the device and it did not blank — it HUNG. No sheet, no
+  // return, force-quit; the log ends on "Presenting results UI...". The same
+  // page renders fine in desktop WebKit, so this is iOS resource exhaustion,
+  // not a content defect, and it is a size-shaped failure after all: the
+  // surrogate bug was confounding the earlier reads, not standing in for them.
+  //
+  // Lowered to 768 KB. Note what this number is NOT anchored on: not 878 KB,
+  // the failure (that is the anchoring mistake made three times already —
+  // 1923 → 960 → 800 → 1024 KB, each picked off a page that failed). It is a
+  // BACKSTOP number now, and pagination is the primary defence, so it is set
+  // by its two jobs: 1.5x the 512 KB page budget, so it can never fire on a
+  // page the packer planned, and comfortably under the one size at which the
+  // device has actually failed. CHUNK's 864 KB success no longer argues for
+  // raising it — CHUNK is two ~430 KB pages now.
   static get RESULTS_HTML_MAX_BYTES() {
-    return 1024 * 1024;
+    return 768 * 1024;
   }
 
   // Per-PAGE budget for the Scriptable flow (the web flow never pages).
@@ -10757,8 +10795,36 @@ class ScriptableAdapter {
   // above every page ever produced on device, which makes pagination a rare
   // fallback rather than the default. Matches RESULTS_HTML_MAX_BYTES, so a
   // page built to this budget is never also shed.
+  //
+  // ---- CORRECTION: "size predicts nothing" was read off a poisoned sample
+  // in the other direction. ----
+  // The table above is every page from the surrogate era, where the bad card
+  // explained the blanks and left nothing for size to explain. With the
+  // surrogate fix DEPLOYED, the device evidence restarts, and it is:
+  //
+  //   BEEFMINCE  1/3   383 KB   ✅ rendered
+  //   BEEFMINCE  2/3   373 KB   ✅ rendered
+  //   Furball   single 490 KB   ✅ rendered      <- must not page (his ask)
+  //   CHUNK     single 864 KB   ✅ rendered      (once, pre-surrogate-fix)
+  //   BEEFMINCE single 878 KB   ❌ HANGS — sheet never appears, force-quit
+  //
+  // A hang is not a blank: WebKit is not refusing the document, iOS is
+  // running out of room to build it. Desktop WebKit renders that same 878 KB
+  // page fine, so it is environmental to the phone and there is no content
+  // fix for it — only a smaller page.
+  //
+  // 512 KB, and the anchor is 490 KB — the LARGEST PAGE PROVEN TO WORK at or
+  // under this ceiling — not 878 KB, the one that failed. Anchoring on the
+  // failure is the error that produced 1923 → 960 → 800 → 1024 KB, each of
+  // which was set just under something broken and was itself broken. 512 KB
+  // is the smallest round value that still keeps Furball's 490 KB history on
+  // ONE page, which was the owner's explicit complaint about pagination; the
+  // price is that BEEFMINCE (878 KB) and CHUNK (864 KB) become two pages
+  // each, one swipe, versus the three-to-four that he objected to. Sits at
+  // 2/3 of RESULTS_HTML_MAX_BYTES, so a page built to this budget is never
+  // also shed.
   static get RESULTS_PAGE_BUDGET_BYTES() {
-    return 1024 * 1024;
+    return 512 * 1024;
   }
 
   // The pager nav is emitted twice per page plus its style/script block.
@@ -12959,14 +13025,77 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     return this.fm.joinPath(this.runsDir, `${runId}.json`);
   }
 
-  async saveRun(results) {
+  // Writes (or rewrites) this run's JSON, and its log alongside it.
+  //
+  // Called TWICE per saved run, on purpose:
+  //   phase "pre-ui"  — before the results sheet is presented. Everything the
+  //                     scrape produced is already on disk by the time the UI
+  //                     can fail, so a hang/crash/force-quit at review costs
+  //                     the review only.
+  //   phase "post-ui" — after the sheet is dismissed. Rewrites the SAME file
+  //                     with what the review added (bear overrides, executed
+  //                     calendar actions, calendarEvents, errors).
+  //
+  // One run, one id, one file: the pre-ui pass stamps results.savedRunId (and
+  // the timestamp that id encodes), and the post-ui pass hands both back to
+  // saveRun, which reuses them instead of minting a second id from a second
+  // timestamp. If the pre-ui pass failed to write, the post-ui pass simply
+  // mints the id itself — exactly the old behaviour.
+  async persistRunSnapshot(results, { phase } = {}) {
+    // Saved-run redisplay never writes: displayResults gates on
+    // shouldSaveRun, and this second check keeps that true for any future
+    // caller (re-saving a redisplay would fork a viewed run into a new one).
+    if (!results || results._isDisplayingSavedRun) return null;
+    const preUi = phase === "pre-ui";
+    await this.ensureRelativeStorageDirs();
+    const runId = await this.saveRun(results, {
+      runId: results.savedRunId || null,
+      timestamp: results._savedRunTimestamp || null,
+      preUi,
+    });
+    if (runId) {
+      results.savedRunId = runId;
+      results.savedRunPath = this.getRunFilePath(runId);
+      if (!preUi) {
+        // Venue-queue taps that predate the id (or predate this fix) — stamp
+        // it into the entries queued during this session's results sheet.
+        await this.backfillQueuedVenueRunIds(results);
+      }
+    }
+    if (preUi) {
+      // The log is data too: it is the only record of what the AI passes did,
+      // and it died with the run JSON on a UI hang. Written here with the run
+      // so far, and rewritten in full (writeString, not append) once the
+      // review is done.
+      try {
+        await this.appendLogSummary(results, { preUi: true });
+      } catch (logErr) {
+        console.log(
+          `📱 Scriptable: Pre-UI log write failed: ${logErr.message}`,
+        );
+      }
+    }
+    return runId;
+  }
+
+  async saveRun(results, options = {}) {
     if (!this.fm) return;
     try {
       // Ensure directories exist first
       await this.ensureRelativeStorageDirs();
 
-      const ts = new Date();
-      const runId = this.getRunId(ts);
+      // A run is saved twice (see persistRunSnapshot). The second write must
+      // land on the FIRST write's file, so it passes back the id and the
+      // timestamp that id was minted from — reusing both is what keeps this
+      // one run instead of two.
+      const reusedRunId =
+        typeof options.runId === "string" && options.runId ? options.runId : "";
+      const reusedTs = options.timestamp ? new Date(options.timestamp) : null;
+      const ts =
+        reusedRunId && reusedTs && !Number.isNaN(reusedTs.getTime())
+          ? reusedTs
+          : new Date();
+      const runId = reusedRunId || this.getRunId(ts);
       const runFilePath = this.getRunFilePath(runId);
       const runContext = results.runContext || null;
       const analyzedEvents = this.sanitizeEventsForRunSave(
@@ -13029,7 +13158,21 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
 
       // Save run using absolute path
       this.fm.writeString(runFilePath, JSON.stringify(payload));
-      console.log(`📱 Scriptable: ✓ Saved run ${runId} to ${runFilePath}`);
+      // Remember which timestamp this id was minted from, so the post-review
+      // rewrite reuses it and summary.timestamp keeps agreeing with runId.
+      if (results && typeof results === "object") {
+        results._savedRunTimestamp = ts.toISOString();
+      }
+      if (options.preUi) {
+        // Distinct from the line below on purpose: same run, first of two
+        // writes. It is not a second run, and on a UI hang it is the only
+        // save line the log will ever show.
+        console.log(
+          `📱 Scriptable: 💾 Run ${runId} persisted to ${runFilePath} BEFORE the results UI — a hang, crash or force-quit at review can no longer lose this run's data.`,
+        );
+      } else {
+        console.log(`📱 Scriptable: ✓ Saved run ${runId} to ${runFilePath}`);
+      }
       return runId;
     } catch (e) {
       console.log(`📱 Scriptable: ✗ Failed to save run: ${e.message}`);
@@ -14092,7 +14235,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     return this.fm.joinPath(this.logsDir, `${runId}.log`);
   }
 
-  async appendLogSummary(results) {
+  async appendLogSummary(results, options = {}) {
     try {
       const runId =
         results?.savedRunId ||
@@ -14130,8 +14273,17 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         fm.createDirectory(this.logsDir, true);
       }
 
+      // writeString, not append: the pre-UI pass writes the run so far and the
+      // post-review pass overwrites it with the complete log, so calling this
+      // twice never duplicates a line.
       fm.writeString(logPath, content);
-      console.log(`📱 Scriptable: Successfully wrote log to ${logPath}`);
+      if (options.preUi) {
+        console.log(
+          `📱 Scriptable: 💾 Log for run ${runId} written to ${logPath} before the results UI (rewritten in full after review).`,
+        );
+      } else {
+        console.log(`📱 Scriptable: Successfully wrote log to ${logPath}`);
+      }
     } catch (e) {
       console.log(`📱 Scriptable: Failed to append log: ${e.message}`);
     }

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -2916,6 +2916,9 @@ function installMemoryFm(adapter) {
   adapter.fm = {
     joinPath: (a, b) => `${a}/${b}`,
     fileExists: (p) => files.has(p) || p === adapter.baseDir,
+    // Real FileManagers have this, and saveRun asks it of any path that
+    // already exists — which the second write of a run always does.
+    isDirectory: (p) => !files.has(p),
     createDirectory: () => {},
     readString: (p) => (files.has(p) ? files.get(p) : null),
     writeString: (p, text) => {
@@ -5074,20 +5077,23 @@ test('size cliff: an over-ceiling page is REDUCED under the ceiling, not merely 
     'all 40 cards are still on the page');
 });
 
-test('size cliff: the ceiling no longer sheds pages that are PROVEN to render', () => {
-  // The 955 KB blank that this ceiling was hedging against was never a size
-  // failure: that page carried two lone surrogates, and WebKit renders the
-  // empty shell for any document containing one (proven at 49 characters).
-  // Paginated, the SAME run blanked only on its smallest page — the one with
-  // the bad card. So a ceiling under 862 KB was shedding review detail off
-  // pages like CHUNK's, which WORKED.
+test('size cliff: the ceiling is a BACKSTOP behind pagination, under the size that hung the device', () => {
+  // The ceiling stopped being a cliff estimate when pagination started
+  // bounding the page by construction. Its two jobs now:
+  //   1. never fire on a page the packer planned (or the shed ladder would be
+  //      taking review detail off pages that are already in budget), and
+  //   2. cut in BEFORE 878 KB, the single page that hung the phone outright —
+  //      no sheet, no return, force-quit.
+  // It is deliberately not set just under 878 KB: anchoring on the failure is
+  // what produced 1923 -> 960 -> 800 -> 1024 KB, four wrong numbers in a row.
   const ceilingKb = ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024;
-  assert.ok(ceilingKb > 862,
-    `ceiling (${ceilingKb} KB) is above the 862 KB CHUNK page that rendered, so it is not shed`);
-  assert.ok(ceilingKb >= 959,
-    `ceiling (${ceilingKb} KB) is at or above every page ever produced on device (max 959 KB)`);
-  assert.ok(ceilingKb <= 2048,
-    'but still bounds a runaway run rather than being no ceiling at all');
+  const budgetKb = ScriptableAdapter.RESULTS_PAGE_BUDGET_BYTES / 1024;
+  assert.ok(ceilingKb >= budgetKb * 1.25,
+    `ceiling (${ceilingKb} KB) clears the ${budgetKb} KB page budget by enough that a planned page is never also shed`);
+  assert.ok(ceilingKb < 878,
+    `ceiling (${ceilingKb} KB) sheds before the 878 KB page that hung the device`);
+  assert.ok(ceilingKb > 490,
+    `ceiling (${ceilingKb} KB) is still above the largest page proven to render on device (490 KB)`);
 });
 
 test('size cliff: every shed is logged with what went and what it cost — no silent caps', async () => {
@@ -5809,41 +5815,52 @@ test('pagination: a run whose cards exceed one page budget is split, and EVERY p
   assert.ok(page1.includes('finishResultsPaging'), 'and offers a finish-early control');
 });
 
-test('pagination: is a RARE FALLBACK — every run ever observed stays one page', () => {
+test('pagination: the budget is anchored on the largest page PROVEN to render, never on one that failed', () => {
   const kb = ScriptableAdapter.RESULTS_PAGE_BUDGET_BYTES / 1024;
-  // Size predicted nothing: 248/486/489/862 KB rendered with zero lone
-  // surrogates, 959/713/371 KB blanked with two. The budget therefore exists
-  // to bound a runaway run, not to dodge a cliff — so it sits above every
-  // page ever produced on device, and Furball (490 KB) and CHUNK (864 KB)
-  // are both a single page again.
-  assert.ok(kb > 490, `Furball (490 KB) must not be split; budget is ${kb} KB`);
-  assert.ok(kb > 864, `CHUNK (864 KB, proven to render) must not be split; budget is ${kb} KB`);
-  assert.ok(kb >= 959, `budget (${kb} KB) covers the largest page ever produced on device`);
-  assert.ok(kb <= 2048, `budget (${kb} KB) still bounds a genuinely runaway run`);
+  // Post-surrogate-fix device evidence: 383/373/490 KB rendered, 878 KB HUNG
+  // (sheet never appeared, force-quit). The anchor is 490 KB — the largest
+  // page proven to work — because every previous value (1923, 960, 800, 1024)
+  // was picked from just under a page that had FAILED, and every one of them
+  // was wrong. Keeping Furball's 490 KB on one page is also the owner's
+  // stated requirement.
+  assert.ok(kb >= 490, `Furball (490 KB, device-proven) must not be split; budget is ${kb} KB`);
+  assert.ok(kb < 864, `budget (${kb} KB) splits the 864 KB and 878 KB pages instead of shipping them whole`);
+  assert.ok(kb < 878 / 1.5,
+    `budget (${kb} KB) leaves real headroom under the 878 KB hang rather than sitting just below it`);
   assert.ok(kb <= ScriptableAdapter.RESULTS_HTML_MAX_BYTES / 1024,
     'and a page built to this budget is never ALSO shed by the ceiling');
 });
 
 // A page's byte size is not what blanks it; a lone UTF-16 surrogate is. These
 // two guard the actual mechanism.
-test('page budget: a 490 KB run and an 864 KB run are each exactly ONE page', () => {
+// Builds a (fullHtml, cards) pair whose page total lands on a given KB size.
+// The planner only ever sees those two things, so feeding it them directly is
+// the honest way to assert on a specific page size.
+function buildSizedPageInputs(kb, cardCount = 16, chrome = 120 * 1024) {
+  const cardBytes = Math.floor((kb * 1024 - chrome) / cardCount);
+  const cards = Array.from({ length: cardCount }, (_, i) => ({
+    group: 'new', html: 'x'.repeat(cardBytes) + String(i).padStart(0, '0')
+  }));
+  return { cards, fullHtml: 'c'.repeat(chrome) + cards.map((c) => c.html).join('') };
+}
+
+test('page budget: the 490 KB run stays ONE page and the 878 KB run that hung becomes TWO', () => {
   const adapter = buildAdapter();
-  const budget = ScriptableAdapter.RESULTS_PAGE_BUDGET_BYTES;
-  // Cards sized so the whole page lands on the real observed totals. The
-  // planner only ever sees (fullHtml, cards), so feeding it those directly is
-  // the honest way to assert on a specific page size.
-  for (const kb of [490, 864]) {
-    const cardCount = 16;
-    const chrome = 120 * 1024;
-    const cardBytes = Math.floor((kb * 1024 - chrome) / cardCount);
-    const cards = Array.from({ length: cardCount }, (_, i) => ({
-      group: 'new', html: 'x'.repeat(cardBytes) + String(i).padStart(0, '0')
-    }));
-    const fullHtml = 'c'.repeat(chrome) + cards.map((c) => c.html).join('');
+  const budgetKb = Math.round(ScriptableAdapter.RESULTS_PAGE_BUDGET_BYTES / 1024);
+  // 490 KB is Furball's entire history and it rendered on device — splitting
+  // it was the owner's complaint, so it must not split. 878 KB is the
+  // BEEFMINCE page that hung the phone; it must.
+  const expected = [[490, 1], [864, 2], [878, 2]];
+  for (const [kb, wantPages] of expected) {
+    const { cards, fullHtml } = buildSizedPageInputs(kb);
     adapter._resultsPagePlan = null;
     const plan = adapter.planResultsPages(fullHtml, cards);
-    assert.equal(plan.pageCount, 1,
-      `a ${kb} KB run is ONE page (got ${plan.pageCount}); ${Math.round(budget / 1024)} KB budget`);
+    assert.equal(plan.pageCount, wantPages,
+      `a ${kb} KB run is ${wantPages} page(s), got ${plan.pageCount}; ${budgetKb} KB budget`);
+    plan.pages.forEach((page, i) => {
+      assert.ok(page.bytes <= ScriptableAdapter.RESULTS_PAGE_BUDGET_BYTES,
+        `${kb} KB run, page ${i + 1}: ${Math.round(page.bytes / 1024)} KB is within the ${budgetKb} KB budget`);
+    });
   }
 });
 
@@ -6266,4 +6283,189 @@ test('paging: a page that fails to render still applies the taps already made, a
   assert.equal(promptCalls, 1, 'the execute prompt still fires — a broken page 2 does not end the review');
   assert.ok(lines.some((l) => l.includes('Failed to present results page 2')),
     'and the failure is named in the log, not swallowed');
+});
+
+// ---------------------------------------------------------------------------
+// Data outlives review: the run JSON is on disk BEFORE the results UI opens.
+//
+// It used to be written only after the sheet came down, so a hang or a
+// force-quit at the review stage destroyed the whole run — every scraped
+// event, every AI call's output, the log. These tests pin the write ORDER
+// (a present stub that reads the filesystem stub back), and that the second
+// write lands on the SAME file rather than forking the run in two.
+// ---------------------------------------------------------------------------
+
+function buildRunSaveResults(overrides = {}) {
+  return {
+    analyzedEvents: [{ title: 'Bear Night', _action: 'new' }],
+    bearDroppedEvents: [],
+    parserResults: [{ name: 'megaparser', bearEvents: 1, totalEvents: 1 }],
+    errors: [],
+    totalEvents: 1,
+    bearEvents: 1,
+    calendarEvents: 0,
+    runContext: { type: 'manual', environment: 'app', trigger: 'run' },
+    config: { parsers: [{ name: 'megaparser', enabled: true }], runtime: {} },
+    ...overrides
+  };
+}
+
+// displayResults with everything but the save/present ordering stubbed out.
+// onPresent stands in for the review: it sees the filesystem exactly as the
+// results sheet would.
+function installRunSaveHarness(adapter, onPresent) {
+  const files = installMemoryFm(adapter);
+  const runFiles = () => [...files.keys()].filter((p) => p.startsWith(adapter.runsDir));
+  const seenAtPresent = [];
+  adapter.displayCalendarProperties = async () => {};
+  adapter.compareWithExistingCalendars = async () => {};
+  adapter.displayEnrichedEvents = async () => {};
+  adapter.cleanupOldFiles = async () => 0;
+  adapter.appendMetricsRecord = async () => {};
+  adapter.updateMetricsSummary = async () => {};
+  adapter.presentRichResults = async (results) => {
+    seenAtPresent.push(runFiles().map((p) => ({ path: p, json: JSON.parse(files.get(p)) })));
+    if (onPresent) await onPresent(results, files);
+  };
+  return { files, runFiles, seenAtPresent };
+}
+
+async function runDisplayResultsQuietly(adapter, results) {
+  const originalLog = console.log;
+  const lines = [];
+  console.log = (...args) => { lines.push(args.join(' ')); };
+  try {
+    await adapter.displayResults(results);
+  } finally {
+    console.log = originalLog;
+  }
+  return lines;
+}
+
+test('save-before-present: the complete run JSON is already on disk when the results UI opens', async () => {
+  const adapter = buildAdapter();
+  const { seenAtPresent, runFiles } = installRunSaveHarness(adapter);
+  const results = buildRunSaveResults();
+
+  const lines = await runDisplayResultsQuietly(adapter, results);
+
+  assert.equal(seenAtPresent.length, 1, 'the results UI was actually presented');
+  const atPresent = seenAtPresent[0];
+  assert.equal(atPresent.length, 1, 'exactly one run file existed BEFORE present() was called');
+  // Not a placeholder — the scrape's whole payload is in it.
+  const early = atPresent[0].json;
+  assert.equal(early.version, 2);
+  assert.equal(early.analyzedEvents.length, 1, 'the scraped events are in the pre-UI save');
+  assert.equal(early.analyzedEvents[0].title, 'Bear Night');
+  assert.equal(early.parserResults.length, 1, 'and so are the parser results');
+  assert.ok(early.summary.runId, 'the pre-UI save carries a real run id');
+
+  assert.equal(runFiles().length, 1, 'and the post-review write did not add a second file');
+  assert.ok(lines.some((l) => l.includes('BEFORE the results UI')),
+    'the pre-UI save says so in the log, distinctly from the final save line');
+  assert.equal(lines.filter((l) => l.includes('✓ Saved run')).length, 1,
+    'the existing saved-run line still appears exactly once — one run, not two');
+});
+
+test('save-before-present: a throw at the UI stage still leaves the whole run saved', async () => {
+  const adapter = buildAdapter();
+  const { files, runFiles } = installRunSaveHarness(adapter, () => {
+    // Stands in for the 878 KB page that hung the phone: whatever goes wrong
+    // at review, it must not take the data with it.
+    throw new Error('WebView.present never returned');
+  });
+  const results = buildRunSaveResults();
+
+  await runDisplayResultsQuietly(adapter, results);
+
+  const paths = runFiles();
+  assert.equal(paths.length, 1, 'the run survived the UI failure');
+  const payload = JSON.parse(files.get(paths[0]));
+  assert.equal(payload.analyzedEvents.length, 1, 'with its events intact');
+  assert.equal(payload.parserResults[0].name, 'megaparser', 'and its parser results intact');
+  assert.equal(payload.summary.totals.totalEvents, 1, 'and its totals intact');
+});
+
+test('save-before-present: post-review state updates the SAME run file, no duplicate run', async () => {
+  const adapter = buildAdapter();
+  const { files, runFiles, seenAtPresent } = installRunSaveHarness(adapter, (results) => {
+    // What a real review changes on its way out.
+    results.analyzedEvents[0].manuallyMarkedBear = true;
+    results.calendarEvents = 3;
+    results.errors.push('calendar write failed for one event');
+  });
+  const results = buildRunSaveResults();
+
+  await runDisplayResultsQuietly(adapter, results);
+
+  const paths = runFiles();
+  assert.equal(paths.length, 1, 'still exactly one run file');
+  assert.equal(paths[0], seenAtPresent[0][0].path, 'and it is the file the pre-UI save wrote');
+
+  const payload = JSON.parse(files.get(paths[0]));
+  assert.equal(payload.analyzedEvents[0].manuallyMarkedBear, true, 'the bear override landed');
+  assert.equal(payload.summary.totals.calendarEvents, 3, 'the executed calendar writes landed');
+  assert.equal(payload.errors.length, 1, 'and errors raised during review landed');
+
+  // Same id, both writes, and the timestamp the id encodes was not re-minted.
+  assert.equal(payload.summary.runId, seenAtPresent[0][0].json.summary.runId,
+    'the run id is unchanged by the second write');
+  assert.equal(payload.summary.timestamp, seenAtPresent[0][0].json.summary.timestamp,
+    'and so is the timestamp that id was minted from');
+  assert.equal(results.savedRunId, payload.summary.runId);
+  assert.equal(results.savedRunPath, paths[0]);
+});
+
+test('save-before-present: the run log is written pre-UI too, and rewritten in full afterwards', async () => {
+  const adapter = buildAdapter();
+  const { files } = installRunSaveHarness(adapter, () => {});
+  const logFiles = () => [...files.keys()].filter((p) => p.startsWith(adapter.logsDir));
+  let logsAtPresent = [];
+  const present = adapter.presentRichResults;
+  adapter.presentRichResults = async (r) => {
+    logsAtPresent = logFiles();
+    return present(r);
+  };
+
+  await runDisplayResultsQuietly(adapter, buildRunSaveResults());
+
+  assert.equal(logsAtPresent.length, 1, 'the log existed before the UI opened');
+  assert.equal(logFiles().length, 1, 'and the post-review write overwrote it rather than adding another');
+  assert.ok(logFiles()[0].endsWith('.log'));
+});
+
+test('save-before-present: a saved-run redisplay never re-saves', async () => {
+  const adapter = buildAdapter();
+  const { runFiles } = installRunSaveHarness(adapter);
+  const results = buildRunSaveResults({
+    _isDisplayingSavedRun: true,
+    sourceRunId: '20260804-125703'
+  });
+
+  const lines = await runDisplayResultsQuietly(adapter, results);
+
+  assert.equal(runFiles().length, 0, 'viewing a past run does not fork it into a new one');
+  assert.ok(lines.some((l) => l.includes('Skipping run save (display mode)')));
+  // And directly, so a future caller cannot route around displayResults' gate.
+  assert.equal(await adapter.persistRunSnapshot(results, { phase: 'pre-ui' }), null);
+  assert.equal(runFiles().length, 0, 'persistRunSnapshot refuses a redisplay on its own');
+});
+
+test('save-before-present: venue-queue backfill still stamps the run id', async () => {
+  const adapter = buildAdapter();
+  installRunSaveHarness(adapter, (results) => {
+    // A venue queued during the sheet, recorded the way a tap records it.
+    results._queuedVenueCandidateKeys = ['the-eagle|dallas'];
+  });
+  const queue = { 'the-eagle|dallas': { name: 'The Eagle', runIds: [] } };
+  adapter.loadBarAdditions = async () => queue;
+  let saved = null;
+  adapter.saveBarAdditions = async (q) => { saved = q; };
+
+  const results = buildRunSaveResults();
+  await runDisplayResultsQuietly(adapter, results);
+
+  assert.ok(saved, 'the queue was written back');
+  assert.deepEqual(saved['the-eagle|dallas'].runIds, [results.savedRunId],
+    'the tapped entry carries this run id, exactly once');
 });


### PR DESCRIPTION
## 1. The important one: the run JSON is now written BEFORE the results UI

Your BEEFMINCE run hung and you force-quit. This is where the log ends:

```
📱 Scriptable: Results HTML size: 874 KB
📱 Scriptable: Results HTML size (UTF-8 bytes): 878 KB
📱 Scriptable: Presenting results UI...
   <nothing further — force quit>
```

And this is the order every *successful* run logs, which is the actual bug:

```
Presenting results UI…  →  Prompting for calendar execution  →  ✓ Saved run <id> to <path>
```

`saveRun` ran **after** `presentRichResults` (`displayResults`, adapter
`:4679-4728` on main). So the sheet is the last gate before anything reaches
disk, and any hang, crash or force-quit at review destroys the whole run:
every scraped event, every AI call's result, the log. That is why there is no
run JSON from the hang to diagnose from. **A UI failure should cost the
review, never the data.**

### What changed

`displayResults` now saves twice, through one new method `persistRunSnapshot`:

| phase | when | what |
|---|---|---|
| `pre-ui` | before `presentRichResults` | full run JSON + the log so far |
| `post-ui` | after the sheet is dismissed | the **same file**, rewritten with bear overrides, executed calendar actions, `calendarEvents`, review-time errors |

- **One run, one id, one file.** The pre-UI pass stamps `results.savedRunId`
  *and* the timestamp that id was minted from; the post-UI pass hands both back
  to `saveRun`, which reuses them instead of minting a second id from a second
  `new Date()`. `summary.runId` and `summary.timestamp` are identical across
  both writes. `getRunId` remains the only place an id is minted, which is what
  the `:1408` comment asks for.
- **No double "✓ Saved run".** Existing console text is untouched; the pre-UI
  write logs a new, distinct line (`💾 Run <id> persisted to <path> BEFORE the
  results UI …`). On a hang, that line is now the only save line the log
  shows — which is exactly the signal that the data survived.
- **The log is data too.** `appendLogSummary` uses `writeString`, not append,
  so the pre-UI call writes the run so far and the post-review call overwrites
  it with the complete log. No duplicated lines, no second file.
- **Redisplay still never re-saves.** `persistRunSnapshot` returns `null` for
  `_isDisplayingSavedRun` on its own, in addition to `displayResults`' existing
  `shouldSaveRun` gate.
- **`backfillQueuedVenueRunIds` still works** and is still called right after
  the final save confirms the id. It is now usually a no-op in the good case —
  the id exists while the sheet is up, so `mergeBarAdditionEntry` stamps taps
  directly — but it remains the safety net for when the pre-UI save failed. Its
  comment (and the one at the tap site) were rewritten to describe the new
  order; both are covered by a test.
- Side benefit: the live results header now shows the real run id instead of
  nothing, because `results.savedRunId` exists while you are reviewing.

This fix stands on its own merits regardless of what causes the hang.

## 2. The budget correction — I over-raised it in #1632, by anchoring on a failure

In #1632 I raised the per-page budget 400 KB → 1 MB and `RESULTS_HTML_MAX_BYTES`
800 KB → 1 MB, arguing "no size-attributable blank exists". **That reasoning was
drawn while the lone-surrogate bug was confounding every observation.** With the
surrogate fixed and deployed, the device evidence restarts and it points back at
size:

| page | size | device result |
|---|---|---|
| BEEFMINCE 1/3 | 383 KB | rendered |
| BEEFMINCE 2/3 | 373 KB | rendered |
| Furball (single) | 490 KB | rendered |
| CHUNK (single) | 864 KB | rendered (once, pre-surrogate-fix) |
| BEEFMINCE (single) | **878 KB** | **HANGS** — sheet never appears, force-quit |

A hang is not a blank: WebKit is not refusing the document, iOS is running out
of room to build it. The same 878 KB page renders fine in real desktop WebKit
(`WKWebView.loadHTMLString`: `bodyHTML,bodyChildren,cards,docHTML =
800244,6,16,834877`, no process termination), so it is environmental to the
phone and there is no content fix for it — only a smaller page.

**`RESULTS_PAGE_BUDGET_BYTES`: 1 MB → 512 KB.** The anchor is **490 KB — the
largest page PROVEN to render** — not 878 KB, the one that failed. Naming the
mistake plainly: anchoring on the failure is what produced 1923 → 960 → 800 →
1024 KB, four wrong numbers in a row, each set just under something broken and
each itself broken. 512 KB is the smallest round value that still clears 490 KB
with the 6 KB pager reserve charged, so **Furball stays ONE page** — your
explicit complaint about #1631. BEEFMINCE and CHUNK become two pages each; the
three-to-four you objected to is gone.

**`RESULTS_HTML_MAX_BYTES`: 1 MB → 768 KB.** This is a backstop now, not a
cliff estimate, so it is set by its two jobs: 1.5× the page budget, so it can
never fire on a page the packer planned, and comfortably under the one size at
which the device has actually failed. CHUNK's 864 KB success no longer argues
for raising it — CHUNK is two ~430 KB pages now.

### Measured against every real run on the phone (221 run JSONs, read-only)

| | pages/run at 1 MB | pages/run at 512 KB |
|---|---|---|
| 1 page | 220 | **189** |
| 2 pages | 1 | 30 |
| 3 pages | 0 | 1 |
| 4 pages | 0 | 1 |

- Every Furball run: **1 page** (351 KB today).
- BEEFMINCE 825 KB → 2 pages `[489, 414]`. CHUNK 773 KB → 2 pages `[469, 382]`.
- The 52-event Bear Calendar run (1422 KB) was 2 pages at 1 MB — including a
  **1020 KB page** that on this evidence would have hung. It is now 4 pages,
  largest 506 KB.
- Largest page produced anywhere under the new budget: **508 KB** — inside the
  budget, and 260 KB under the shed ceiling, so nothing is shed.

Everything #1631/#1632 got right is preserved and still green: swipe-down
advances with no redundant next-page button, a throw mid-paging cannot unwind
past `applyPendingBearOverrides`, page boundaries pinned on the card-bytes
signature, overrides accumulate across pages, the execute prompt fires once,
surrogate-safe truncation and the `finalizeRenderedHtml` sweep.

## Tests

Six new tests in `scripts/adapters/scriptable-adapter.test.js` (enumerated file;
`generateRichHTML` awaited), plus three existing tests rewritten because they
encoded the 1 MB reasoning:

- the complete run JSON is on disk **before** `present()` is called (a present
  stub reads the filesystem stub back and asserts the write order)
- a throw at the UI stage still leaves the whole run saved
- post-review state lands in the **same** file — same id, same timestamp, no duplicate
- the log is written pre-UI and overwritten, not duplicated, afterwards
- a saved-run redisplay never re-saves
- venue-queue backfill still stamps the run id
- a 490 KB run is ONE page; 864 KB and 878 KB are TWO, every page in budget
- the ceiling is a backstop: ≥1.25× the budget, and below the 878 KB hang

**On unfixed code: 8 fail.** With the fix: **0**.

## Verification

- **Baseline, measured here on `origin/main`** (`git stash`, two runs, stable):
  `tests 1500, pass 1500, fail 0`.
- **With this PR:** `tests 1506, pass 1506, fail 0`.
- (The first baseline pass reported `1097/1096/1` — that was the node
  test-runner's `Unable to deserialize cloned data` IPC flake truncating two
  files' reports, not an assertion failure. It did not recur.)
- Page counts above re-measured against the real `runs/` directory in iCloud,
  read-only, with the adapter's FileManager stubbed to memory.

## New runtime files

**None.** Only `scripts/adapters/scriptable-adapter.js` changed at runtime, so
there is nothing to add to your scriptable-script-updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
