### PR TITLE
fix(scriptable): flush the run log to disk DURING the results UI — a hang was eating its own evidence

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -5602,12 +5602,30 @@ class ScriptableAdapter {
             } else if (params.a === "beacon") {
               this.recordResultsPageBeacon(params.id, params.d, pageBeacons);
             }
+            // Checkpoint the log while the sheet is still up. Every branch
+            // above has already logged its line by the time we reach here: the
+            // synchronous ones directly, and the fire-and-forget ones because
+            // the prologue of an un-awaited async call runs inline, up to its
+            // first await — which in each of them is after the console.log.
+            // This handler must still return a bool synchronously, and
+            // flushLogCheckpoint is sync and never throws.
+            this.flushLogCheckpoint(results, {
+              force: ScriptableAdapter.LOG_CHECKPOINT_FORCED_ACTIONS.has(
+                params.a,
+              ),
+            });
             return false; // cancel the fake navigation; the page stays put
           };
           // If the page could not be shed under the render ceiling, say so through
           // the ONE channel that survives a document WebKit refuses to run: a
           // native Alert, raised before the sheet, not a banner buried inside it.
           await this.warnResultsPageUnrenderable();
+          // LAST CHANCE BEFORE THE CLIFF. present() is where the run hangs: no
+          // sheet, no return, force-quit. Forced past the throttle so the page
+          // sizes, the paging lines and "Presenting results UI..." are on disk
+          // before control leaves for WebKit — after this, only the
+          // shouldAllowRequest handler above can write anything.
+          this.flushLogCheckpoint(results, { force: true });
           await webView.present(true);
           presentedPages += 1;
           // The page's own account of whether it ever rendered. Logged AFTER the
@@ -5618,6 +5636,9 @@ class ScriptableAdapter {
             );
           }
           this.reportResultsPageLiveness(pageBeacons);
+          // The verdict line is the whole point — put it on disk before the
+          // NEXT page gets its chance to hang. Forced: one write per page.
+          this.flushLogCheckpoint(results, { force: true });
 
           if (pendingPage === null || pendingPage === currentPage) break;
           currentPage = pendingPage;
@@ -5656,6 +5677,10 @@ class ScriptableAdapter {
         results,
         bearOverridePending,
       );
+      // Paging is over but appendLogSummary is still a calendar-execution
+      // prompt away — another native UI, another chance to stall. Forced, so
+      // what the overrides actually did survives that too.
+      this.flushLogCheckpoint(results, { force: true });
 
       // After displaying results, prompt for calendar execution if we have analyzed events
       // Don't prompt when displaying saved runs (they should use isDryRun override instead)
@@ -14092,6 +14117,111 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     return this.fm.joinPath(this.logsDir, `${runId}.log`);
   }
 
+  // ---------------------------------------------------------------------------
+  // UI-phase log checkpoints.
+  //
+  // FileLogger keeps every line in MEMORY (its `entries` array) and only ever
+  // touches disk when something asks it to — getLogText() → fm.writeString().
+  // In a run that finishes, that happens exactly once, in appendLogSummary,
+  // AFTER the results sheet has been dismissed. There is no incremental write.
+  //
+  // So when the sheet HANGS — the failure being chased here: no sheet appears,
+  // present() never returns, the script is force-quit — every line emitted from
+  // "Presenting results UI..." onwards dies in memory. That is:
+  //   • the liveness-beacon verdict ("rendered on device" / "never reported
+  //     liveness") — the single most diagnostic line in the whole run, because
+  //     it is the only evidence of whether WebKit ever ran the page at all
+  //   • the page-arming and "Results page N of M" lines
+  //   • every bear-override tap and venue-queue copy the owner made
+  //   • the calendar-execution prompt and its outcome
+  // A hang therefore destroyed precisely the evidence needed to explain the
+  // hang, and the saved log stopped on the same line the owner was already
+  // pasting in by hand. Persisting the run before the UI fixed the DATA loss;
+  // this fixes the EVIDENCE loss.
+  //
+  // THE MECHANISM THAT MAKES IT POSSIBLE: a WebView's shouldAllowRequest
+  // handler runs WHILE the sheet is presented — it fires on every tap, long
+  // before `await webView.present(true)` resolves. Anything flushed from
+  // inside one is already on disk when a later hang or force-quit arrives, so
+  // a killed run loses at most the handful of lines since the last checkpoint.
+  //
+  // This writes the SAME file appendLogSummary rewrites at the end (same run
+  // id, same path, whole buffer via writeString), so checkpointing never
+  // produces a second log — the final write simply supersedes the last
+  // checkpoint. Silent on success after the first announcement: every
+  // console.log here would itself land in the buffer being written.
+  getLogCheckpointPath(results) {
+    const runId = this.getRunIdForLogs(results);
+    if (runId) {
+      return this.getLogFilePath(runId);
+    }
+    // No run id yet — the run has not been saved, so there is nothing to name
+    // the file after. Checkpoints still have to land somewhere, so they go to
+    // one fixed file that each run overwrites. It is only ever read when a run
+    // died before it could be saved, which is exactly the case it exists for.
+    return this.fm.joinPath(this.logsDir, "ui-phase-checkpoint.log");
+  }
+
+  // Write the log buffer to disk mid-review. Throttled unless `force`.
+  // NEVER throws: a checkpoint failing is a lost diagnostic, while a throw out
+  // of shouldAllowRequest would break the sheet the owner is standing in front
+  // of. Returns whether a write actually happened (tests assert on it).
+  flushLogCheckpoint(results, options = {}) {
+    try {
+      // Redisplaying a saved run: getRunIdForLogs would resolve to that run's
+      // sourceRunId, and checkpointing would overwrite a historical log with
+      // this session's buffer. Never write during display mode — the same rule
+      // displayResults already applies to appendLogSummary.
+      if (!results || results._isDisplayingSavedRun) return false;
+      const force = options.force === true;
+      const now = Date.now();
+      if (
+        !force &&
+        Number.isFinite(this._lastLogCheckpointAt) &&
+        now - this._lastLogCheckpointAt <
+          ScriptableAdapter.LOG_CHECKPOINT_MIN_INTERVAL_MS
+      ) {
+        return false;
+      }
+      const fm = this.fm;
+      if (!fm) return false;
+      const logPath = this.getLogCheckpointPath(results);
+      if (!logPath) return false;
+      if (!this._logCheckpointAnnounced) {
+        // Announced BEFORE the buffer is read, so the first checkpoint file
+        // says where checkpoints are going. Once per run — this line is itself
+        // a log line, and one per flush would grow the file it is describing.
+        this._logCheckpointAnnounced = true;
+        console.log(
+          `📱 Scriptable: 🧷 Checkpointing the run log to ${logPath} while the results UI is open — a hang or force-quit now keeps everything up to the last tap.`,
+        );
+      }
+      // Always the full buffer: a checkpoint only ever gets read when the run
+      // died at the UI, and a trimmed one would drop the beacon verdicts. The
+      // buffer is byte-capped (FileLogger maxBytes), so this rewrite is bounded.
+      const content = logger.getLogText({ mode: "full" });
+      if (!content) return false;
+      if (!fm.fileExists(this.logsDir)) {
+        fm.createDirectory(this.logsDir, true);
+      }
+      fm.writeString(logPath, content);
+      this._lastLogCheckpointAt = now;
+      return true;
+    } catch (e) {
+      if (!this._logCheckpointFailed) {
+        this._logCheckpointFailed = true;
+        try {
+          console.log(
+            `📱 Scriptable: Log checkpoint failed (the review continues, the final log write is unaffected): ${e.message}`,
+          );
+        } catch (_) {
+          /* even the complaint is optional */
+        }
+      }
+      return false;
+    }
+  }
+
   async appendLogSummary(results) {
     try {
       const runId =
@@ -14141,6 +14271,30 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
 // Scriptable-specific CalendarEvent fields that must not be written to notes.
 // Passed to SharedCore via options.additionalExcludedFields so that shared-core.js
 // stays free of iOS-only API knowledge.
+// Throttle for UI-phase log checkpoints (see flushLogCheckpoint).
+// getLogText() + writeString() rewrite the WHOLE buffer, so an unthrottled
+// flush-per-line would be O(n^2) over a run. Measured at the 1 MB byte cap
+// (7,462 entries, 976 KB written): 0.16 ms to join + 0.14 ms to write, ~0.30 ms
+// per flush on a Mac; the phone's iCloud FileManager is slower but the same
+// shape. 250 ms therefore caps throttled traffic at ~4 writes/second — far
+// under any tap rate a human produces — while costing nothing that matters,
+// and every line the owner actually needs is forced past it anyway (below).
+ScriptableAdapter.LOG_CHECKPOINT_MIN_INTERVAL_MS = 250;
+
+// Bridge actions whose line must reach disk immediately, throttle or not.
+// Beacons are the reason this whole thing exists: the beacon verdict is the
+// only proof of whether WebKit ran the page, and it is worthless if the hang
+// that follows eats it. Bear overrides and venue copies are the owner's review
+// decisions — those go on disk as he makes them, not when the sheet closes.
+// Everything else (page arming, map/ICS/log/prompt taps) is repeatable noise
+// and rides the throttle.
+ScriptableAdapter.LOG_CHECKPOINT_FORCED_ACTIONS = new Set([
+  "beacon",
+  "mark-bear",
+  "mark-not-bear",
+  "copy-venue",
+]);
+
 ScriptableAdapter.NOTES_EXCLUDED_FIELDS = new Set([
   "identifier",
   "availability",

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -6267,3 +6267,334 @@ test('paging: a page that fails to render still applies the taps already made, a
   assert.ok(lines.some((l) => l.includes('Failed to present results page 2')),
     'and the failure is named in the log, not swallowed');
 });
+
+// ---------------------------------------------------------------------------
+// UI-phase log checkpoints (flushLogCheckpoint).
+//
+// The results sheet HANGS on device: it never appears, present() never
+// returns, the script is force-quit. FileLogger holds every line in memory and
+// only touches disk in appendLogSummary — AFTER the sheet is dismissed — so
+// every line from "Presenting results UI..." onwards died with the run. That
+// is the liveness-beacon verdict (the only proof of whether WebKit ran the
+// page), the paging lines, and every override tap: exactly the evidence needed
+// to explain the hang.
+//
+// shouldAllowRequest handlers run WHILE the sheet is presented, before
+// present() resolves — so a flush from inside one is on disk before the hang.
+// ---------------------------------------------------------------------------
+
+// Routes this module's console into the adapter's singleton FileLogger (the
+// same buffer captureConsole fills on device) so a checkpoint has real lines
+// to write, and collects them for assertions.
+function captureIntoRunLog() {
+  const tee = getConsoleTee();
+  const lines = [];
+  const originals = { log: console.log, warn: console.warn };
+  console.log = (...args) => { lines.push(args.join(' ')); tee('info', args); };
+  console.warn = (...args) => { lines.push(args.join(' ')); tee('warn', args); };
+  return {
+    lines,
+    restore: () => { console.log = originals.log; console.warn = originals.warn; }
+  };
+}
+
+// Memory FileManager that records the order of writes, so a test can ask what
+// was on disk at a given moment.
+function installCheckpointFm(adapter, { failWritesTo = null } = {}) {
+  const files = new Map();
+  const writes = [];
+  adapter.fm = {
+    joinPath: (a, b) => `${a}/${b}`,
+    fileExists: (p) => files.has(p) || p === adapter.baseDir || p === adapter.logsDir || p === adapter.runsDir,
+    isDirectory: () => false,
+    createDirectory: () => {},
+    fileName: (p) => String(p).split('/').pop(),
+    readString: (p) => (files.has(p) ? files.get(p) : null),
+    writeString: (p, text) => {
+      if (failWritesTo && failWritesTo(p)) throw new Error('simulated disk failure');
+      files.set(p, text);
+      writes.push(p);
+    },
+    downloadFileFromiCloud: async () => {}
+  };
+  return { files, writes };
+}
+
+// Like installFakeWebView, but present() runs a hook first — the device's
+// "the sheet is now up and native has not regained control" moment.
+function installFakeWebViewWithPresentHook(onPresent) {
+  let handler = null;
+  let resolvePresent = null;
+  const evals = [];
+  global.WebView = class {
+    async loadHTML() {}
+    set shouldAllowRequest(fn) { handler = fn; }
+    get shouldAllowRequest() { return handler; }
+    present() {
+      if (onPresent) onPresent();
+      return new Promise((resolve) => { resolvePresent = resolve; });
+    }
+    async evaluateJavaScript(js) { evals.push(js); return undefined; }
+  };
+  return {
+    tap: (url) => handler({ url }),
+    dismiss: () => resolvePresent(),
+    evals,
+    getHandler: () => handler
+  };
+}
+
+async function waitForHandler(wv) {
+  for (let i = 0; i < 300 && !wv.getHandler(); i++) {
+    await new Promise((r) => setImmediate(r));
+  }
+  assert.ok(wv.getHandler(), 'shouldAllowRequest assigned before present()');
+}
+
+test('log checkpoint: "Presenting results UI" is on disk BEFORE present() resolves', async () => {
+  const adapter = buildAdapter();
+  const { files } = installCheckpointFm(adapter);
+  const capture = captureIntoRunLog();
+  const results = { ...buildResultsStub(), calendarEvents: 1, config: { config: {} } };
+  const logPath = adapter.getLogCheckpointPath(results);
+
+  let onDiskWhilePresented = null;
+  const wv = installFakeWebViewWithPresentHook(() => {
+    // Read the filesystem stub from INSIDE present(), i.e. at the exact
+    // moment the device hangs: nothing after this point ever runs.
+    onDiskWhilePresented = files.get(logPath) || null;
+  });
+  try {
+    const done = adapter.presentRichResults(results);
+    await waitForHandler(wv);
+    wv.dismiss();
+    await done;
+  } finally {
+    delete global.WebView;
+    capture.restore();
+  }
+
+  assert.ok(onDiskWhilePresented, 'the run log exists on disk while the sheet is up');
+  assert.ok(
+    onDiskWhilePresented.includes('Presenting results UI'),
+    'the last line before the cliff is already persisted — a force-quit here keeps it'
+  );
+  assert.ok(
+    onDiskWhilePresented.includes('Results HTML size'),
+    'and so are the page-size lines that say how big the page that hung was'
+  );
+});
+
+test('log checkpoint: a beacon verdict reaches disk synchronously, so a hang after it keeps it', async () => {
+  const adapter = buildAdapter();
+  const { files } = installCheckpointFm(adapter);
+  const capture = captureIntoRunLog();
+  const results = { ...buildResultsStub(), calendarEvents: 1, config: { config: {} } };
+  const logPath = adapter.getLogCheckpointPath(results);
+
+  const wv = installFakeWebViewWithPresentHook();
+  let afterBeacon = null;
+  try {
+    const done = adapter.presentRichResults(results);
+    await waitForHandler(wv);
+
+    // The page reports it painted. No await between the tap and this read:
+    // whatever is on disk here is what survives a force-quit one line later.
+    assert.equal(wv.tap('chunkyscrape://act?a=beacon&id=painted&d=1px&n=1'), false);
+    afterBeacon = files.get(logPath) || null;
+
+    wv.dismiss();
+    await done;
+  } finally {
+    delete global.WebView;
+    capture.restore();
+  }
+
+  assert.ok(afterBeacon, 'the beacon flush wrote without awaiting anything');
+  assert.ok(
+    afterBeacon.includes('Results page beacon: painted'),
+    'the single most diagnostic line in the run is on disk before the sheet closes'
+  );
+});
+
+test('log checkpoint: a bear-override tap is on disk before the sheet closes', async () => {
+  const adapter = buildAdapter();
+  const { files } = installCheckpointFm(adapter);
+  const capture = captureIntoRunLog();
+  const results = {
+    ...buildResultsStub(),
+    calendarEvents: 1,
+    config: { config: {} },
+    bearDroppedEvents: [buildBearDroppedFixture()]
+  };
+  const logPath = adapter.getLogCheckpointPath(results);
+
+  const wv = installFakeWebViewWithPresentHook();
+  let afterTap = null;
+  try {
+    const done = adapter.presentRichResults(results);
+    await waitForHandler(wv);
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-not-bear&id=k0&n=1'), false);
+    afterTap = files.get(logPath) || null;
+    wv.dismiss();
+    await done;
+  } finally {
+    delete global.WebView;
+    capture.restore();
+  }
+
+  assert.ok(afterTap && afterTap.includes('Bear override tapped'),
+    'the owner\'s review decision is durable the moment he makes it');
+});
+
+test('log checkpoint: throttled actions coalesce, forced ones always write', async () => {
+  const adapter = buildAdapter();
+  const { writes } = installCheckpointFm(adapter);
+  const capture = captureIntoRunLog();
+  const results = { ...buildResultsStub(), calendarEvents: 1, config: { config: {} } };
+  const logPath = adapter.getLogCheckpointPath(results);
+  const countLogWrites = () => writes.filter((p) => p === logPath).length;
+
+  const wv = installFakeWebViewWithPresentHook();
+  let afterBurst = 0;
+  let afterForced = 0;
+  const TAPS = 12;
+  try {
+    const done = adapter.presentRichResults(results);
+    await waitForHandler(wv);
+    const beforeBurst = countLogWrites();
+
+    // Page-arming taps are repeatable noise and ride the throttle.
+    for (let i = 0; i < TAPS; i++) wv.tap(`chunkyscrape://act?a=page&id=1&n=${i}`);
+    afterBurst = countLogWrites() - beforeBurst;
+
+    // A forced action bypasses it, in the same millisecond window.
+    const beforeForced = countLogWrites();
+    wv.tap('chunkyscrape://act?a=beacon&id=dom-ready&n=99');
+    afterForced = countLogWrites() - beforeForced;
+
+    wv.dismiss();
+    await done;
+  } finally {
+    delete global.WebView;
+    capture.restore();
+  }
+
+  assert.ok(afterBurst < TAPS, `throttle coalesces rapid taps (${afterBurst} writes for ${TAPS} taps)`);
+  assert.equal(afterForced, 1, 'a forced flush always writes, throttle window or not');
+});
+
+test('log checkpoint: a flush that throws breaks neither the sheet nor the run', async () => {
+  const adapter = buildAdapter();
+  installCheckpointFm(adapter, { failWritesTo: (p) => String(p).includes('/logs/') });
+  const capture = captureIntoRunLog();
+  const results = {
+    ...buildResultsStub(),
+    calendarEvents: 1,
+    config: { config: {} },
+    bearDroppedEvents: [buildBearDroppedFixture()]
+  };
+  const keptEvent = results.analyzedEvents[0];
+
+  const wv = installFakeWebViewWithPresentHook();
+  try {
+    const done = adapter.presentRichResults(results);
+    await waitForHandler(wv);
+    assert.equal(wv.tap('chunkyscrape://act?a=beacon&id=painted&n=1'), false,
+      'the handler still returns its bool — a flush failure never escapes it');
+    assert.equal(wv.tap('chunkyscrape://act?a=mark-not-bear&id=k0&n=2'), false);
+    await new Promise((r) => setImmediate(r));
+    wv.dismiss();
+    await done; // must resolve, not reject
+  } finally {
+    delete global.WebView;
+    capture.restore();
+  }
+
+  // The review still happened: the verdict was applied after dismissal.
+  assert.ok(String(keptEvent.bearSource).startsWith('manual-not-bear'),
+    'the override survived a failing checkpoint');
+  const complaints = capture.lines.filter((l) => l.includes('Log checkpoint failed'));
+  assert.equal(complaints.length, 1, 'the failure is reported exactly once, not once per flush');
+});
+
+test('log checkpoint: checkpoints land on the SAME file the final log write uses', async () => {
+  // Protects the single-file invariant: once the run has an id (the run is
+  // saved before the sheet), checkpointing must reuse <runId>.log rather than
+  // leave a second log behind — and it must never touch the run JSON.
+  const adapter = buildAdapter();
+  const { files, writes } = installCheckpointFm(adapter);
+  const capture = captureIntoRunLog();
+  const results = {
+    ...buildResultsStub(),
+    calendarEvents: 1,
+    config: { config: {} },
+    savedRunId: '20260805-101112',
+    totalEvents: 2,
+    bearEvents: 2,
+    errors: [],
+    parserResults: []
+  };
+
+  const wv = installFakeWebViewWithPresentHook();
+  let duringSheet = null;
+  try {
+    const done = adapter.presentRichResults(results);
+    await waitForHandler(wv);
+    wv.tap('chunkyscrape://act?a=beacon&id=painted&n=1');
+    duringSheet = files.get(adapter.getLogFilePath('20260805-101112')) || null;
+    wv.dismiss();
+    await done;
+    await adapter.saveRun(results);
+    await adapter.appendLogSummary(results);
+  } finally {
+    delete global.WebView;
+    capture.restore();
+  }
+
+  assert.ok(duringSheet && duringSheet.includes('Results page beacon: painted'),
+    'checkpoints wrote the run\'s own log file while the sheet was up');
+  const logWrites = [...new Set(writes.filter((p) => p.includes('/logs/')))];
+  assert.deepEqual(logWrites, [adapter.getLogFilePath('20260805-101112')],
+    'one log file for the run — checkpoints and the final write share it');
+  assert.ok(!files.has(`${adapter.logsDir}/ui-phase-checkpoint.log`),
+    'no fallback file once the run has an id');
+
+  const runWrites = writes.filter((p) => p.includes('/runs/'));
+  assert.equal(runWrites.length, 1, 'exactly one run file written — checkpoints never save runs');
+  const savedRunLines = capture.lines.filter((l) => l.includes('Saved run'));
+  assert.equal(savedRunLines.length, 1, '"Saved run" still appears exactly once');
+  assert.ok(files.get(adapter.getLogFilePath('20260805-101112')).includes('Results page beacon: painted'),
+    'and the final log still carries everything the checkpoints captured');
+});
+
+test('log checkpoint: a saved-run redisplay never overwrites the historical log', async () => {
+  const adapter = buildAdapter();
+  const { files, writes } = installCheckpointFm(adapter);
+  const capture = captureIntoRunLog();
+  const results = {
+    ...buildResultsStub(),
+    calendarEvents: 1,
+    config: { config: {} },
+    _isDisplayingSavedRun: true,
+    sourceRunId: '20260804-125703'
+  };
+  adapter.loadRunLogsForDisplay = async () => savedRunLogInfo();
+  files.set(adapter.getLogFilePath('20260804-125703'), 'the original run log');
+
+  const wv = installFakeWebViewWithPresentHook();
+  try {
+    const done = adapter.presentRichResults(results);
+    await waitForHandler(wv);
+    wv.tap('chunkyscrape://act?a=beacon&id=painted&n=1');
+    wv.dismiss();
+    await done;
+  } finally {
+    delete global.WebView;
+    capture.restore();
+  }
+
+  assert.equal(writes.filter((p) => p.includes('/logs/')).length, 0, 'display mode writes no log at all');
+  assert.equal(files.get(adapter.getLogFilePath('20260804-125703')), 'the original run log',
+    'the run being reviewed keeps its own log');
+});


### PR DESCRIPTION
## The gap, in the owner's words

> "what about the logs from after the UI"

#1634 writes the run JSON + log **before** the sheet, so a UI hang no longer destroys the run's data. But he is right that it stops there.

**Verified against the code, not assumed:**

- `FileLogger` holds entries **in memory** (`this.entries`, `scriptable-adapter.js:108`) and appends with no disk touch (`append`, `:205`).
- The only write is `getLogText` (`:288`) → `fm.writeString(fullPath, content)`, reached via `appendLogSummary` (`:14095`, `fm.writeString(logPath, content)` at `:14133`).
- `appendLogSummary` runs from `displayResults` **after** `presentRichResults` returns (`:4682` vs `:4744`).

So the pre-UI snapshot ends at `Presenting results UI...` — **exactly the text he already pastes in by hand.** Every line emitted during the UI phase dies in memory on a force-quit:

- the liveness-beacon verdicts (`✅ Results page rendered on device` / `⚠️ … never reported liveness`, `:8759`–`:8778`) — **the single most diagnostic line in the run**, because it is the only evidence of whether WebKit ever ran the page
- `📄 Results page N of M` and the page-arming lines
- `Bear override tapped — …` (`:9745`)
- venue-queue copies and AI-prompt picker actions
- the calendar-execution prompt and its outcome

A hang destroyed precisely the evidence needed to explain the hang. #1634 made the run survive; this makes the hang **diagnosable**.

## The mechanism

`webView.shouldAllowRequest` handlers **execute while the sheet is presented** — they fire on every tap, long before `await webView.present(true)` resolves. Anything flushed from inside one is already on disk when the hang or force-quit arrives. That is the whole trick, and it is why this is possible at all.

## Flush points

Each one was read in `presentRichResults` before it was added:

1. **Immediately before `await webView.present(true)`** (after `warnResultsPageUnrenderable`) — forced. Captures both HTML-size lines, the paging/arming lines and `Presenting results UI...`. This is the last code that runs before the cliff.
2. **Inside the `shouldAllowRequest` handler, before `return false`** — one call covering every branch. **Forced** for `beacon`, `mark-bear`, `mark-not-bear`, `copy-venue`; throttled for the rest.
3. **After `reportResultsPageLiveness(pageBeacons)`** once `present()` returns — forced, one write per page, so page N's verdict is durable before page N+1 gets its chance to hang.
4. **After `applyPendingBearOverrides`**, before the calendar-execution prompt — forced. Paging is over but another native UI still stands between here and `appendLogSummary`.

Point 2 is a single call rather than one per branch because **every branch has already logged its line by then**: the synchronous branches directly, and the fire-and-forget ones because the prologue of an un-awaited async call runs inline up to its first `await` — which in `copyVenueEntryAndReport` (`:8785`) and `recordBearOverrideAndReport` (`:9711`) is *after* the `console.log`. Verified line by line.

## Throttle, with measured cost

`getLogText` + `writeString` rewrite the **whole** buffer, so a flush per line would be O(n²) over a run. Measured on the real `FileLogger` filled to its 1 MB byte cap — **the worst case, since `maxBytes` bounds it**:

```
entries: 7462   buffer: 999,908 bytes
getLogText({mode:'full'})  0.160 ms   (avg of 200)
writeString (976 KB)       0.143 ms   (avg of 200)
--------------------------------------------------
per flush                  ~0.30 ms
```

**250 ms**, which caps throttled traffic at ~4 writes/second — far under any tap rate a human produces — while costing nothing that matters. The phone's iCloud `FileManager` is slower than a Mac's `writeFileSync`, but the same shape, and the throttle is sized so that even a 50x slower write is invisible. Crucially, **nothing diagnostic rides the throttle**: the beacon verdicts, the override taps, the venue copies and all four positional flushes are forced past it. Only repeatable noise (page arming, map/ICS/log/prompt taps) coalesces.

## Constraints honoured

- **Handler stays synchronous.** `flushLogCheckpoint` is sync and returns a bool; the handler still `return false`s immediately. Same fire-and-forget shape as `copyVenueEntryAndReport` / `recordBearOverrideAndReport` — nothing was made `async`.
- **A flush failure never breaks the UI.** Whole body wrapped; all throws swallowed; complaint logged **at most once per run** (asserted in tests).
- **#1634's single-file invariant holds.** Checkpoints resolve their path through `getRunIdForLogs` → `getLogFilePath(runId)` — the *same* run id, the *same* path `appendLogSummary` writes, whole buffer via `writeString`, so the final write supersedes the last checkpoint instead of appending. Nothing here touches `runsDir` or calls `saveRun`. Test asserts: exactly one distinct `/logs/` path, exactly one run file, `✓ Saved run` exactly once.
- **#1632's paging invariants hold.** No change to `bearOverridePending`, `pendingPage`, the loop's try/catch, or the single execute prompt — the flush calls are leaves. Full paging suite still green.
- **Additions only.** 485 insertions, **0 deletions**. No existing `console.log` text and no AI prompt string was edited.
- No `new URL(` / `URLSearchParams` under `scripts/`; `shared-core.js` and `normalizers.js` untouched; tests only in the package.json-enumerated `scripts/adapters/scriptable-adapter.test.js`; iCloud Scriptable dir untouched; nothing hardcoded per-parser.

## ⚠️ New runtime file (flagging)

One new runtime **artifact** (not a script — no updater entry needed):

`chunky-dad-scraper/logs/ui-phase-checkpoint.log`

This is a **fallback only**. When the run already has an id, checkpoints go straight into `<runId>.log` and this file is never created. It exists because on `main` today the run id is minted inside `saveRun` *after* the sheet, so during the UI there is no id to name the file after — checkpoints still have to land somewhere. **Once #1634 merges, `results.savedRunId` is set before `presentRichResults` and this path stops being reachable for live runs.** Each run overwrites it, so it never accumulates, and it is only ever read when a run died before it could be saved — exactly the case it exists for.

## Also guarded

Saved-run **redisplay never checkpoints**. `getRunIdForLogs` would resolve to the viewed run's `sourceRunId`, and a checkpoint would have overwritten a historical log with the current session's buffer. `flushLogCheckpoint` bails on `_isDisplayingSavedRun`, mirroring the rule `displayResults` already applies to `appendLogSummary`. Covered by a test.

## Tests — 7 new, in the enumerated file

`generateRichHTML` is async and is awaited throughout (via `presentRichResults`).

- `Presenting results UI` is on disk **before `present()` resolves** — a `present()` stub reads the filesystem stub from *inside* the call, i.e. the exact moment the device hangs
- a beacon verdict reaches disk **synchronously** (no `await` between tap and read), so a throw/hang one line later still leaves it
- a bear-override tap is on disk **before the sheet closes**
- the throttle actually throttles (12 rapid taps ⇒ fewer than 12 writes) **and** a forced flush always writes, in the same millisecond window
- a flush that throws breaks neither the sheet nor the run — `presentRichResults` resolves, the override is still applied, and the complaint is logged exactly once
- checkpoints land on the **same file** the final log write uses: one distinct log path, no fallback file, one run file, one `✓ Saved run`
- a saved-run redisplay writes no log at all and leaves the historical one byte-identical

**Shown failing on unfixed code first:** 5 of the 7 fail with the source change stashed (the other two are regression guards that assert *absence* of writes, so they pass vacuously without the feature — noted rather than papered over).

## Verification

Full quiet suite, measured myself via `git stash` on both files:

| | tests | pass | fail |
|---|---|---|---|
| baseline (`origin/main`) | 1500 | 1500 | 0 |
| with this change | 1507 | 1507 | 0 |

+7, matching the 7 new tests.

The node test runner's intermittent `Unable to deserialize cloned data` IPC flake **did** appear — it truncated file reports and yielded bogus low counts (1397, 1383, 973). Those runs were discarded and re-run rather than reported; both numbers above are from clean runs, and the baseline was confirmed across three consecutive clean runs.

Based on `origin/main` — **#1634 is still open/unmerged**, so `persistRunSnapshot` is not in this diff. The two changes are orthogonal and converge by design: this reuses whatever run id is available at flush time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
