### PR TITLE
fix(scriptable): install the WebView handler before loadHTML, and stop serving the pre-fix JPEG logo from cache

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -612,8 +612,22 @@ class ScriptableAdapter {
         const mtime = this.fm.modificationDate(inlinePath);
         if (mtime && Date.now() - mtime.getTime() < HEADER_LOGO_CACHE_TTL_MS) {
           const cached = this.fm.readString(inlinePath);
-          if (typeof cached === "string" && cached.indexOf("data:image/") === 0) {
+          // PNG ONLY — the codec is a correctness property here, not a size
+          // choice, and this cache outlives the bug that wrote it. #1631
+          // encoded the logo as JPEG, which has no alpha, so the transparent
+          // mark came back with a white block behind it. #1632 switched the
+          // encoder to PNG and the white block STAYED, because this read hits
+          // first and hands back the JPEG string that is already on disk,
+          // under a 7-day TTL, before any of the fixed code runs. Accepting
+          // only the current codec makes every device carrying the bad cache
+          // heal itself on its next run.
+          if (typeof cached === "string" && cached.indexOf("data:image/png") === 0) {
             return cached;
+          }
+          if (typeof cached === "string" && cached.indexOf("data:image/") === 0) {
+            console.log(
+              `📱 Scriptable: Inline logo cache discarded — it holds ${cached.slice(11, cached.indexOf(";"))}, and only PNG keeps the logo's transparent background. Re-encoding.`,
+            );
           }
         }
       }
@@ -5552,7 +5566,22 @@ class ScriptableAdapter {
           // Per PAGE, so one bad page in a run is still visible as a bad page.
           const pageBeacons = [];
           const webView = new WebView();
-          await webView.loadHTML(html);
+          // THE HANDLER GOES ON BEFORE loadHTML, NOT AFTER.
+          //
+          // The page fires its first beacon from DOMContentLoaded — i.e. WHILE
+          // loadHTML is still running. With the handler installed afterwards,
+          // that beacon met a WebView with no shouldAllowRequest at all, so
+          // `return false` below never ran and the `chunkyscrape://` assignment
+          // went through as a REAL main-frame navigation to an unknown scheme,
+          // started on top of a main frame that had not finished loading.
+          //
+          // The proof is an absence: across every run ever logged the page sent
+          // a `dom-ready` beacon and the log recorded 11 `painted`, 11
+          // `interacted` and ZERO `dom-ready`. Not one arrived. Whether that
+          // stray navigation is survivable is a race with the rest of the load,
+          // which is why it cost a page only sometimes — BEEFMINCE page 3 hung
+          // with no sheet, no beacon and no further log lines while pages 1 and
+          // 2 of the same run rendered.
           webView.shouldAllowRequest = (request) => {
             const url = request && request.url ? String(request.url) : "";
             if (url.indexOf("chunkyscrape://") !== 0) {
@@ -5636,6 +5665,15 @@ class ScriptableAdapter {
             });
             return false; // cancel the fake navigation; the page stays put
           };
+          await webView.loadHTML(html);
+          // Splits the two places a page can hang. Until now the last line on
+          // disk was "Presenting results UI..." for BOTH "loadHTML never came
+          // back" and "present() never came back", because nothing was logged
+          // between them — so a force-quit left no way to tell which one ate
+          // the run. This line is that way.
+          console.log(
+            `📱 Scriptable: 📥 Page document handed to WebKit (loadHTML returned) — anything after this is present().`,
+          );
           // If the page could not be shed under the render ceiling, say so through
           // the ONE channel that survives a document WebKit refuses to run: a
           // native Alert, raised before the sheet, not a banner buried inside it.

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -6800,3 +6800,80 @@ test('log checkpoint: a saved-run redisplay never overwrites the historical log'
   assert.equal(files.get(adapter.getLogFilePath('20260804-125703')), 'the original run log',
     'the run being reviewed keeps its own log');
 });
+
+// ---------------------------------------------------------------------------
+// THE HANDLER MUST BE INSTALLED BEFORE loadHTML, NOT AFTER.
+//
+// The results page fires its first liveness beacon from DOMContentLoaded —
+// while loadHTML is still running. With shouldAllowRequest assigned after the
+// load, that beacon met a WebView with no handler, so the `return false` that
+// cancels the fake navigation never ran and a real main-frame navigation to
+// `chunkyscrape://` started on top of a main frame that had not finished
+// loading. The evidence was an absence: every run ever logged recorded
+// `painted` and `interacted` beacons and not one `dom-ready`.
+// ---------------------------------------------------------------------------
+test('shouldAllowRequest is installed before loadHTML, so the DOM-ready beacon is not a live navigation', async () => {
+  const adapter = buildAdapter();
+  const results = { ...buildResultsStub(), calendarEvents: 1 };
+
+  let handler = null;
+  let resolvePresent = null;
+  const handlerSetWhenLoadRan = [];
+  let beaconDuringLoad = null;
+  global.WebView = class {
+    async loadHTML() {
+      handlerSetWhenLoadRan.push(handler !== null);
+      // Exactly what the page does at DOMContentLoaded, at the moment it does
+      // it: navigate to the beacon URL while the document is still loading.
+      beaconDuringLoad = handler
+        ? handler({ url: 'chunkyscrape://act?a=beacon&id=dom-ready&d=2%20cards' })
+        : 'UNHANDLED';
+    }
+    set shouldAllowRequest(fn) { handler = fn; }
+    get shouldAllowRequest() { return handler; }
+    present() { return new Promise((resolve) => { resolvePresent = resolve; }); }
+    async evaluateJavaScript() { return undefined; }
+  };
+  try {
+    const done = adapter.presentRichResults(results);
+    for (let i = 0; i < 500 && !resolvePresent; i++) {
+      await new Promise((r) => setImmediate(r));
+    }
+    assert.deepEqual(handlerSetWhenLoadRan, [true],
+      'the handler was already on the WebView when loadHTML ran');
+    assert.equal(beaconDuringLoad, false,
+      'a beacon fired during the load is CANCELLED, not allowed to navigate');
+    resolvePresent();
+    await done;
+  } finally {
+    delete global.WebView;
+  }
+});
+
+// A cached logo from before the PNG fix must not be served forever: the codec
+// is what carries the alpha channel, so a JPEG data URI on disk is the white
+// background, not just a stale byte count.
+test('a JPEG inline-logo cache is discarded and re-encoded instead of reused', async () => {
+  const adapter = buildAdapter();
+  const written = [];
+  adapter.fm = {
+    joinPath: (a, b) => `${a}/${b}`,
+    fileExists: () => true,
+    modificationDate: () => new Date(),
+    readString: () => 'data:image/jpeg;base64,/9j/4AAQSkZJRg',
+    writeString: (p, value) => { written.push(value); },
+    createDirectory: () => {}
+  };
+  adapter.cacheDir = '/cache';
+  // No image available → the rebuild returns null. What matters is that the
+  // stale JPEG was NOT handed back as if it were fine.
+  adapter.loadHeaderLogoImage = async () => null;
+  const uri = await adapter.buildHeaderLogoDataUri();
+  assert.equal(uri, null, 'the JPEG cache is rejected, not returned');
+  assert.deepEqual(written, [], 'nothing re-cached when there is no image to encode');
+
+  // A PNG cache is still a cache hit — this must not re-encode on every run.
+  adapter.fm.readString = () => 'data:image/png;base64,iVBORw0KGgo';
+  assert.equal(await adapter.buildHeaderLogoDataUri(),
+    'data:image/png;base64,iVBORw0KGgo', 'a PNG cache is reused untouched');
+});


### PR DESCRIPTION
Two findings from the 2026-08-05 BEEFMINCE run (`20260805-125954`).

## 1. Page 3 of 3 hung — and it was never size, again

| page | cards | size | result |
|---|---|---|---|
| 1/3 | 7 | 484 KB | rendered (painted, interacted) |
| 2/3 | 8 | 507 KB | rendered (painted, interacted) |
| 3/3 | **1** | **136 KB** | **hang — no sheet, no beacon, no further log, force-quit** |

The failing page is the smallest one in the run. I re-rendered the saved run
locally through the real paged path and reproduced the device's plan exactly
(7/8/1 cards at 481/503/133 KB vs the device's 484/507/136 KB). That page 3
has **zero lone surrogates**, and real desktop WebKit renders it
(`OK bodyHTML,bodyChildren,cards,docHTML = 100941,9,1,135574`). So it is
neither #1632's surrogate nor a size cliff.

### Root cause

`shouldAllowRequest` was assigned **after** `await webView.loadHTML(html)`.
The page fires its first liveness beacon from `DOMContentLoaded` — while
`loadHTML` is still running. That beacon therefore met a WebView with no
handler at all: the `return false` that cancels the fake navigation never ran,
and `window.location.href = 'chunkyscrape://…'` proceeded as a **real
main-frame navigation to an unknown scheme, started on top of a main frame
that had not finished loading**.

The proof is an absence, in the logs on disk:

```
$ grep -rho "beacon: [a-z-]*" logs/*.log | sort | uniq -c
  11 beacon: interacted
  11 beacon: painted
```

Zero `dom-ready`. The page has sent one on every run ever recorded and not one
has ever arrived. Whether that stray navigation is survivable is a race with
the rest of the load, which is why it cost a page only sometimes.

The handler now goes on before `loadHTML`, which is what the file's own
comment already said the reliable pattern was.

**Honest status:** this is the best-supported explanation, not a proven one —
I cannot run Scriptable here, and desktop WebKit renders every page fine. What
makes the next run decisive either way is the second change below.

### The next run tells us which half hung

Added a log line the moment `loadHTML` returns. Until now `Presenting results
UI...` was the last line on disk for **both** "loadHTML never came back" and
"present() never came back", because nothing was logged between them.

Also: the page budget is deliberately left at 512 KB, so BEEFMINCE is **still
3 pages**. Page 3 is the test. Raising the budget to give single-page reviews
back is a one-line change once a 3-page run comes back clean.

## 2. The logo's white background survived its own fix

#1632 switched the encoder to PNG and set `opaque = false`. The background
stayed, because the inline data URI is cached to disk (`cache/logo-hero-inline.txt`)
under a 7-day TTL and the cache read runs **before** any of the fixed code. The
file on the device is `data:image/jpeg;base64,…`, 46,947 bytes, written Aug 4
20:09 — the buggy build's output, handed straight back on every run since.

JPEG has no alpha, so here the codec *is* the bug. Only a `data:image/png`
cache is accepted now, and a non-PNG one is discarded with a logged reason, so
every device carrying the bad cache heals on its next run.

## Tests

Both new tests fail on `origin/main` and pass here:

- `shouldAllowRequest is installed before loadHTML…` — the stub's `loadHTML`
  fires a `dom-ready` beacon at the moment the real page does and asserts it is
  **cancelled** rather than unhandled.
- `a JPEG inline-logo cache is discarded and re-encoded…` — and a PNG cache is
  still a cache hit, so this does not re-encode on every run.

Suite: **1515 pass, 0 fail** (1513 before).

## No new runtime files

Nothing to add to the script-updater.

## Deliberately not changed

- `presentReviewResults` (`:4484`) has the same load-before-handler ordering,
  but its page initiates no navigation during load, so it is not implicated.
  Left alone rather than widening the blast radius of a hang fix.
- The event on page 3 has `https://dice.fm/static/images/1px.png` saved as its
  flyer — a 1×1 tracking placeholder (and a 403). We are storing tracking
  pixels as event images; worth its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP