### PR TITLE
fix(scraper): duplicate reports that weren't duplicates, and a tracking pixel saved as a flyer

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -4482,11 +4482,16 @@ class ScriptableAdapter {
     const list = Array.isArray(findings) ? findings : [];
     const html = this.generateReviewHTML(list, options);
     const webView = new WebView();
-    await webView.loadHTML(html);
 
     const appliedCounts = { applied: 0, failed: 0 };
     const inFlight = [];
 
+    // Handler first, THEN loadHTML — same ordering the results sheet needs.
+    // This page happens not to navigate during its own load today, so it was
+    // not implicated in the page-3 hang, but leaving the window open is how
+    // that bug got written in the first place: any future beacon, redirect or
+    // auto-submit fired from DOMContentLoaded would hit a WebView with no
+    // handler and become a live main-frame navigation mid-load.
     webView.shouldAllowRequest = (request) => {
       const url = request && request.url ? String(request.url) : "";
       if (url.indexOf("chunkyreview://") !== 0) {
@@ -4504,6 +4509,7 @@ class ScriptableAdapter {
       return false; // cancel the fake navigation; the page stays put
     };
 
+    await webView.loadHTML(html);
     await webView.present(true); // blocks until the user dismisses the sheet
     await Promise.allSettled(inFlight);
     console.log(
@@ -4995,8 +5001,34 @@ class ScriptableAdapter {
           [calendar],
         );
 
+        // AN EVENT IS NOT A DUPLICATE OF ITSELF.
+        //
+        // This check runs AFTER analysis, so an event that matched something
+        // in the calendar carries the record it matched in `_existingEvent`.
+        // That record is the merge target — the thing this run is about to
+        // UPDATE — and it is same-title, same-minute by construction, which is
+        // exactly the test below. Counting it made every successful merge
+        // report itself as a duplicate and as a time conflict with itself:
+        // BEEFMINCE on 2026-08-05 logged "15 events, 0 missing, 15 duplicates,
+        // 15 conflicts" for 15 events that each had exactly one calendar twin,
+        // while the write plan for the same run read "UPDATE: 15, CREATE: 0".
+        // Nothing was duplicated; the report was.
+        //
+        // A REAL second copy still shows up, because only the one matched
+        // record is excluded — two twins leave one behind.
+        const matchedIdentifier =
+          event._existingEvent && event._existingEvent.identifier
+            ? String(event._existingEvent.identifier)
+            : null;
+        const isMergeTarget = (existing) =>
+          matchedIdentifier !== null &&
+          existing &&
+          existing.identifier &&
+          String(existing.identifier) === matchedIdentifier;
+
         // Check for exact duplicates
         const duplicates = existingEvents.filter((existing) => {
+          if (isMergeTarget(existing)) return false;
           const titleMatch = existing.title === (event.title || event.name);
           const timeMatch =
             Math.abs(existing.startDate.getTime() - startDate.getTime()) <
@@ -5023,7 +5055,10 @@ class ScriptableAdapter {
         }
 
         // Check for time conflicts (overlapping events)
+        // Same exclusion: the record this event is merging INTO overlaps it
+        // completely, which is the whole point of a merge, not a clash.
         const conflicts = existingEvents.filter((existing) => {
+          if (isMergeTarget(existing)) return false;
           const existingStart = existing.startDate.getTime();
           const existingEnd = existing.endDate.getTime();
           const newStart = startDate.getTime();
@@ -9667,7 +9702,9 @@ class ScriptableAdapter {
             ? "Rescued (manual override on calendar record)"
             : entry.manuallyMarkedBear === true
               ? "Rescued (marked bear by calendar owner this run)"
-              : "",
+              : entry.duplicateOfPlanned
+                ? `Same event as "${entry.duplicateOfPlanned.title || "an event"}" in the write plan — one event scraped twice, already kept`
+                : "",
         });
       })
       .filter((card) => typeof card === "string" && card.length > 0);

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -6877,3 +6877,154 @@ test('a JPEG inline-logo cache is discarded and re-encoded instead of reused', a
   assert.equal(await adapter.buildHeaderLogoDataUri(),
     'data:image/png;base64,iVBORw0KGgo', 'a PNG cache is reused untouched');
 });
+
+// ---------------------------------------------------------------------------
+// THE MERGE TARGET IS NOT A DUPLICATE, AND IT IS NOT A CONFLICT.
+//
+// compareWithExistingCalendars runs after analysis, so an event that matched
+// something in the calendar carries that record in `_existingEvent`. It is
+// same-title/same-minute by construction — precisely the duplicate test — and
+// it overlaps in time completely, which is what a merge IS. Counting it made
+// BEEFMINCE report "15 events, 0 missing, 15 duplicates, 15 conflicts" for 15
+// events with exactly one calendar twin each, while the same run's write plan
+// read "UPDATE: 15, CREATE: 0".
+// ---------------------------------------------------------------------------
+function installCalendarCompareStubs(existingEvents) {
+  global.Calendar = { forEvents: async () => [{ title: 'chunky-dad-london' }] };
+  global.CalendarEvent = { between: async () => existingEvents };
+}
+
+function runCalendarCompare(adapter, results) {
+  const originalLog = console.log;
+  const lines = [];
+  console.log = (message) => { lines.push(String(message)); };
+  return adapter.compareWithExistingCalendars(results)
+    .then(() => { console.log = originalLog; return lines; })
+    .catch((error) => { console.log = originalLog; throw error; });
+}
+
+test('compareWithExistingCalendars does not report an event as a duplicate of its own merge target', async () => {
+  const adapter = buildAdapter();
+  adapter.getCalendarNameForDisplay = () => 'chunky-dad-london';
+  // Without this the timezone lookup throws, the method's catch swallows it,
+  // and the test would pass on an empty log for the wrong reason.
+  adapter.getTimezoneForCity = () => 'Europe/London';
+  const twin = {
+    identifier: 'CAL-1',
+    title: 'BEEFMINCE Trunk Den',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    endDate: new Date('2026-08-16T03:00:00.000Z')
+  };
+  const event = {
+    title: 'BEEFMINCE Trunk Den',
+    startDate: '2026-08-15T21:00:00.000Z',
+    endDate: '2026-08-16T03:00:00.000Z',
+    _action: 'merge',
+    _existingEvent: { identifier: 'CAL-1', title: 'BEEFMINCE Trunk Den' }
+  };
+  adapter.getAllEventsFromResults = () => [event];
+  installCalendarCompareStubs([twin]);
+  try {
+    const lines = await runCalendarCompare(adapter, {});
+    assert.ok(!lines.some((l) => l.includes('duplicate(s) in')),
+      'the record being merged into is not reported as a duplicate');
+    assert.ok(!lines.some((l) => l.includes('time conflict(s) in')),
+      'nor as a time conflict with itself');
+    assert.ok(lines.some((l) => l.includes('1 events, 0 missing, 0 duplicates, 0 conflicts')),
+      `summary counts nothing: ${lines.filter((l) => l.includes('Calendar check complete')).join(' | ')}`);
+  } finally {
+    delete global.Calendar;
+    delete global.CalendarEvent;
+  }
+});
+
+test('compareWithExistingCalendars still reports a REAL second copy alongside the merge target', async () => {
+  const adapter = buildAdapter();
+  adapter.getCalendarNameForDisplay = () => 'chunky-dad-london';
+  // Without this the timezone lookup throws, the method's catch swallows it,
+  // and the test would pass on an empty log for the wrong reason.
+  adapter.getTimezoneForCity = () => 'Europe/London';
+  const shape = {
+    title: 'BEEFMINCE Trunk Den',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    endDate: new Date('2026-08-16T03:00:00.000Z')
+  };
+  const event = {
+    title: 'BEEFMINCE Trunk Den',
+    startDate: '2026-08-15T21:00:00.000Z',
+    endDate: '2026-08-16T03:00:00.000Z',
+    _action: 'merge',
+    _existingEvent: { identifier: 'CAL-1' }
+  };
+  adapter.getAllEventsFromResults = () => [event];
+  installCalendarCompareStubs([
+    { identifier: 'CAL-1', ...shape },
+    { identifier: 'CAL-2', ...shape } // a genuine second copy
+  ]);
+  try {
+    const lines = await runCalendarCompare(adapter, {});
+    assert.ok(lines.some((l) => l.includes('1 duplicate(s) in chunky-dad-london')),
+      'the extra copy is still flagged — exactly one, not two');
+    assert.ok(lines.some((l) => l.includes('1 events, 0 missing, 1 duplicates, 1 conflicts')),
+      `summary counts the extra copy only: ${lines.filter((l) => l.includes('Calendar check complete')).join(' | ')}`);
+  } finally {
+    delete global.Calendar;
+    delete global.CalendarEvent;
+  }
+});
+
+test('an event with no calendar match still reports a same-title twin as a duplicate', async () => {
+  const adapter = buildAdapter();
+  adapter.getCalendarNameForDisplay = () => 'chunky-dad-london';
+  // Without this the timezone lookup throws, the method's catch swallows it,
+  // and the test would pass on an empty log for the wrong reason.
+  adapter.getTimezoneForCity = () => 'Europe/London';
+  const event = {
+    title: 'BEEFMINCE Trunk Den',
+    startDate: '2026-08-15T21:00:00.000Z',
+    endDate: '2026-08-16T03:00:00.000Z',
+    _action: 'new' // nothing matched, so nothing is excluded
+  };
+  adapter.getAllEventsFromResults = () => [event];
+  installCalendarCompareStubs([{
+    identifier: 'CAL-9',
+    title: 'BEEFMINCE Trunk Den',
+    startDate: new Date('2026-08-15T21:00:00.000Z'),
+    endDate: new Date('2026-08-16T03:00:00.000Z')
+  }]);
+  try {
+    const lines = await runCalendarCompare(adapter, {});
+    assert.ok(lines.some((l) => l.includes('1 duplicate(s) in chunky-dad-london')),
+      'a NEW event that collides with an existing one is still a real duplicate');
+  } finally {
+    delete global.Calendar;
+    delete global.CalendarEvent;
+  }
+});
+
+test('presentReviewResults installs shouldAllowRequest before loadHTML too', async () => {
+  const adapter = buildAdapter();
+  adapter.showReviewSummaryAlert = async () => {};
+  let handler = null;
+  let resolvePresent = null;
+  const handlerSetWhenLoadRan = [];
+  global.WebView = class {
+    async loadHTML() { handlerSetWhenLoadRan.push(handler !== null); }
+    set shouldAllowRequest(fn) { handler = fn; }
+    get shouldAllowRequest() { return handler; }
+    present() { return new Promise((resolve) => { resolvePresent = resolve; }); }
+    async evaluateJavaScript() { return undefined; }
+  };
+  try {
+    const done = adapter.presentReviewResults([buildBridgeFinding()], {});
+    for (let i = 0; i < 500 && !resolvePresent; i++) {
+      await new Promise((r) => setImmediate(r));
+    }
+    assert.deepEqual(handlerSetWhenLoadRan, [true],
+      'the handler was already on the WebView when loadHTML ran');
+    resolvePresent();
+    await done;
+  } finally {
+    delete global.WebView;
+  }
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -862,6 +862,11 @@ class AiWebParser {
                 // never skips or replaces an extraction step.
                 this.applyWixServerDataEnrichment(structuredEvents, effectiveHtmlData, cityConfig);
                 await this.applyJsonLdGapFill(structuredEvents, effectiveHtmlData, parserConfig, cityConfig, httpAdapter);
+                // Placeholder pixels are not artwork — drop them BEFORE the
+                // og:image fill below, so an event whose structured data
+                // published a 1x1 spacer can still adopt the page's real
+                // artwork instead of keeping the pixel.
+                structuredEvents.forEach(event => this.rejectPlaceholderImageValues(event));
                 // A single structured event whose node carried no image adopts
                 // the page's own og:image artwork (multi-event pages never do:
                 // one shared meta image cannot be attributed to one event).
@@ -6142,6 +6147,10 @@ class AiWebParser {
         for (const pattern of uninterestingPatterns) {
             if (lowerUrl.includes(pattern)) return true;
         }
+        // A self-declared placeholder (1x1 spacer, lazy-load pixel, tiny data:
+        // URI) is never worth OCR'ing and never an orientation-slot candidate.
+        // The shape rules live in shared-core so the merge rung agrees.
+        if (this.getPlaceholderImageReason(lowerUrl)) return true;
         // '404' only counts when it stands alone between non-alphanumerics
         // ("/404.png", "error-404.jpg") — as a bare substring it matches
         // random hex asset IDs (a Wix flyer named "238fae_c4047c55…" was
@@ -6607,6 +6616,48 @@ class AiWebParser {
             return this.core.getImageSizeScoreFromUrl(url);
         }
         return url.length;
+    }
+
+    /**
+     * Why this URL is a placeholder rather than artwork ('' when it isn't).
+     * The rules live in SharedCore.getPlaceholderImageUrlReason so extraction
+     * here and the merge's deterministic image rung judge a 1x1 spacer the same
+     * way. Same wiring contract as getImageSizeFromUrl above: core is always
+     * present in production, and a stubbed core simply fails open.
+     */
+    getPlaceholderImageReason(url) {
+        if (!url || typeof url !== 'string') return '';
+        if (this.core && typeof this.core.getPlaceholderImageUrlReason === 'function') {
+            return this.core.getPlaceholderImageUrlReason(url);
+        }
+        return '';
+    }
+
+    /**
+     * Drop `image` / `imageVertical` / `imageHorizontal` values that are
+     * self-declared placeholders (1x1 spacers, lazy-load pixels, tiny data:
+     * URIs). Run 20260805-125954 shipped "…/static/images/1px.png" as an
+     * event's flyer: a lazy-loading listing page gave the segment no other
+     * <img>, the URL reached the model as SEGMENT_IMAGE_URL, and it is
+     * genuinely on the page — so the verbatim evidence gate passed it. Nothing
+     * downstream of extraction was ever going to catch that, because every
+     * later check asks "is this URL real?", not "is this URL a picture?".
+     *
+     * Clearing `image` clears its imageSource stamp with it: provenance is a
+     * companion of the value, never an orphan.
+     */
+    rejectPlaceholderImageValues(event) {
+        if (!event || typeof event !== 'object') return event;
+        for (const field of ['image', 'imageVertical', 'imageHorizontal']) {
+            const value = typeof event[field] === 'string' ? event[field].trim() : '';
+            if (!value) continue;
+            const reason = this.getPlaceholderImageReason(value);
+            if (!reason) continue;
+            console.log(`🤖 AI Web: Rejected placeholder ${field} ${value} for "${event.title || ''}" — ${reason}`);
+            delete event[field];
+            if (field === 'image') delete event.imageSource;
+        }
+        return event;
     }
 
     /**
@@ -13098,6 +13149,12 @@ TEXT:
                 }
             });
         }
+
+        // Placeholder pixels are not artwork. Runs after the parser-config
+        // metadata override above (so a configured slot is judged too) and
+        // before the og:image fill below, so an event whose only extracted
+        // image was a 1x1 spacer can still adopt the page's real artwork.
+        this.rejectPlaceholderImageValues(event);
 
         // A single-event page (never a multi-event segment — one shared meta
         // image cannot be attributed to one segment) whose extraction found no

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1146,6 +1146,89 @@ test('embedded Google Maps URLs are uninteresting images', () => {
   assert.equal(parser.isLikelyUninterestingImageUrl('https://x.example/images/flyer.jpg'), false);
 });
 
+// ---------------------------------------------------------------------------
+// Placeholder-image guard (run 20260805-125954). A dice.fm listing page lazy-
+// loads its flyers, so the TURKEYMINCE segment's only <img> was
+// ".../static/images/1px.png". It reached the model as SEGMENT_IMAGE_URL, the
+// verbatim evidence gate passed it (it IS on the page), and it shipped as the
+// event's flyer stamped imageSource "page". The guard is about the SHAPE of the
+// URL — nothing here or in shared-core names dice.fm.
+// ---------------------------------------------------------------------------
+
+test('placeholder pixels are uninteresting images (never OCR targets or slot candidates)', () => {
+  const parser = createParser();
+  assert.equal(parser.isLikelyUninterestingImageUrl('https://dice.fm/static/images/1px.png'), true);
+  assert.equal(parser.isLikelyUninterestingImageUrl('https://x.example/i/1x1.png'), true);
+  assert.equal(parser.isLikelyUninterestingImageUrl('https://cdn.example.com/i.jpg?w=1&h=1'), true);
+  // Real artwork is untouched, including the Wix asset ID that already tripped
+  // the '404' rule once.
+  assert.equal(parser.isLikelyUninterestingImageUrl('https://x.example/images/flyer.jpg'), false);
+  assert.equal(
+    parser.isLikelyUninterestingImageUrl('https://static.wixstatic.com/media/238fae_c4047c55f4534a0990b2b7fdc19dab8f~mv2.png/v1/fill/w_577,h_1027,al_c,q_90,enc_avif/238fae.png'),
+    false
+  );
+});
+
+test('rejectPlaceholderImageValues clears every image slot it drops, with one named log line each', () => {
+  const parser = createParser();
+  const event = {
+    title: 'TURKEYMINCE',
+    image: 'https://dice.fm/static/images/1px.png',
+    imageSource: 'page',
+    imageVertical: 'https://x.example/i/spacer.gif',
+    imageHorizontal: 'https://bearracuda.com/wp-content/uploads/2026/06/sausageweb.jpg'
+  };
+  const logs = captureLogs(() => parser.rejectPlaceholderImageValues(event));
+
+  assert.equal('image' in event, false, 'the placeholder primary is dropped');
+  assert.equal('imageSource' in event, false, 'provenance never outlives the value it describes');
+  assert.equal('imageVertical' in event, false, 'orientation slots are guarded too');
+  assert.equal(event.imageHorizontal, 'https://bearracuda.com/wp-content/uploads/2026/06/sausageweb.jpg',
+    'a real flyer is left alone');
+
+  const rejections = logs.filter(line => line.includes('Rejected placeholder'));
+  assert.equal(rejections.length, 2);
+  assert.ok(rejections.some(line =>
+    line.includes('https://dice.fm/static/images/1px.png') && line.includes('names itself a placeholder')),
+    `the log names the URL and the reason: ${rejections.join(' | ')}`);
+
+  // Nothing to reject → nothing said.
+  const clean = { title: 'CLEAN', image: 'https://x.example/flyer.jpg', imageSource: 'og-image' };
+  assert.equal(captureLogs(() => parser.rejectPlaceholderImageValues(clean)).length, 0);
+  assert.equal(clean.image, 'https://x.example/flyer.jpg');
+  assert.equal(clean.imageSource, 'og-image');
+});
+
+test('normalizeAiEvent refuses a placeholder flyer and adopts the page\'s real artwork instead', () => {
+  const parser = createParser();
+  const htmlData = {
+    url: 'https://dice.fm/event/ww93qg-turkeymince-19th-dec-the-royal-vauxhall-tavern-london-tickets',
+    html: `<html><head>
+      <meta property="og:image" content="https://images.dice.fm/turkeymince-flyer.jpg" />
+    </head><body></body></html>`
+  };
+  const logs = captureLogs(() => {
+    const event = parser.normalizeAiEvent(
+      { title: 'TURKEYMINCE', startDate: '2026-12-19', img: 'https://dice.fm/static/images/1px.png' },
+      {}, htmlData, null, null);
+    assert.notEqual(event.image, 'https://dice.fm/static/images/1px.png',
+      'the 1x1 tracking pixel never becomes the flyer');
+    assert.equal(event.image, 'https://images.dice.fm/turkeymince-flyer.jpg');
+    assert.equal(event.imageSource, 'og-image', 'the stamp follows the artwork actually kept');
+  });
+  assert.ok(logs.some(line => line.includes('Rejected placeholder image')
+    && line.includes('https://dice.fm/static/images/1px.png')),
+    'the rejection is visible in the run log');
+
+  // With no page artwork to fall back on, the event simply has no image —
+  // better than a pixel, and no orphaned provenance stamp.
+  const bare = parser.normalizeAiEvent(
+    { title: 'TURKEYMINCE', startDate: '2026-12-19', img: 'https://dice.fm/static/images/1px.png' },
+    {}, { url: htmlData.url, html: '<html><head></head><body></body></html>' }, null, null);
+  assert.equal('image' in bare, false);
+  assert.equal('imageSource' in bare, false);
+});
+
 test("'404' flags standalone segments only, never hex asset IDs or pixel sizes", () => {
   const parser = createParser();
   // Regression (run 20260723-152928): the Boston flyer's Wix asset ID contains

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -11256,6 +11256,50 @@ class SharedCore {
             }
         }
 
+        // WHY A DROPPED EVENT CAN BE A TWIN OF A KEPT ONE.
+        //
+        // filterBearEvents runs BEFORE deduplicateEvents, so a thin second
+        // record of an event the run also scraped richly is bear-checked on
+        // its own — with none of its twin's description, host or evidence to
+        // judge by — and gets DROPped before dedup ever sees it. The owner
+        // then reads one event twice: kept in the write plan, and again in the
+        // dropped section with "no bear-specific wording".
+        //
+        // Run evidence (2026-08-05 BEEFMINCE): "TURKEYMINCE" merged into the
+        // London calendar for 19 Dec 22:00, while a second TURKEYMINCE record
+        // — same venue, same day, midnight placeholder start because the page
+        // stated no time — was dropped as "no bear-specific wording or
+        // evidence".
+        //
+        // Report only. The structural fix (dedup before the bear check) is
+        // still deferred for the reason recorded above: it reorders an
+        // expensive AI stage and changes bear verdicts run-wide. Saying so on
+        // the card costs nothing and stops the owner re-deciding an event he
+        // has already kept.
+        if (bearOverrideContext && Array.isArray(bearOverrideContext.droppedEvents)) {
+            for (const dropped of bearOverrideContext.droppedEvents) {
+                const droppedEvent = dropped && dropped.event;
+                if (!droppedEvent || dropped.rescued || dropped.duplicateOfPlanned) continue;
+                let signal = null;
+                const twin = analyzedEvents.find(entry => {
+                    if (!entry) return false;
+                    // Same relaxation the rescue fold uses: a twin whose start
+                    // time degraded to midnight must still match its sibling.
+                    signal = this.getSameEventIdentitySignal(droppedEvent, entry, { requireCloseStartTimes: false });
+                    return Boolean(signal);
+                }) || null;
+                if (!twin) continue;
+                // The signal is the identity rung that matched ('ticket-url',
+                // 'place-time-name', …) — the same vocabulary the calendar
+                // layer's "Merge eligibility match" lines use.
+                dropped.duplicateOfPlanned = {
+                    title: twin.title || '',
+                    signal: typeof signal === 'string' ? signal : ''
+                };
+                console.log(`🐻 BEAR CHECK: dropped "${droppedEvent.title || 'Unknown'}" is the same event as "${twin.title || 'Unknown'}" already in the write plan (${dropped.duplicateOfPlanned.signal || 'identity match'}) — one event scraped twice, not a second event`);
+            }
+        }
+
         this.logCalendarStickinessSummary();
 
         return analyzedEvents;

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -140,6 +140,47 @@ function urlPartsEndInAssetExtension(parts) {
 
 const IMAGE_MERGE_FIELDS = new Set(['image', 'imageVertical', 'imageHorizontal']);
 
+// Placeholder-image vocabulary for getPlaceholderImageUrlReason below. Words a
+// file can be NAMED that mean "there is no picture here" — the 1x1 spacer /
+// lazy-load / tracking pixel. Whole tokens only (see the caller), so a real
+// flyer that merely CONTAINS one of these words is untouched. Data only —
+// shared-core stays platform-pure, and nothing here names a host, venue,
+// promoter or city.
+//
+// Deliberately absent: "trans" (a gay/bear events site has real trans-pride
+// artwork), "loading"/"logo"/"icon" (already handled by the parser's
+// isLikelyUninterestingImageUrl, and "loading" would swallow "loading-dock").
+const PLACEHOLDER_IMAGE_NAME_TOKENS = new Set([
+    'px', 'pixel', 'pixels', 'spacer', 'spacers', 'blank', 'transparent',
+    'placeholder', 'placeholders', 'dot', 'clear', 'empty', 'shim', 'none',
+    'null', 'noimage', 'nopic', 'dummy'
+]);
+// Any advertised dimension at or below this is not a picture anybody looks at.
+// Kept tiny on purpose: an 8px favicon or a 10x64 sprite is a different problem
+// (isLikelyUninterestingImageUrl's job), and widening this would start eating
+// real path tokens like "10x64" or a "300x300" thumbnail.
+const PLACEHOLDER_MAX_TINY_DIMENSION = 4;
+// The canonical 1x1 transparent GIF is a 70-character base64 payload; the
+// smallest real flyer is orders of magnitude larger.
+const PLACEHOLDER_DATA_URI_MAX_PAYLOAD_CHARS = 512;
+
+// One token of an image filename's base name (lowercased, split on
+// non-alphanumerics) that means "placeholder": a vocabulary word, a
+// self-declared pixel size ("1px"), or a self-declared tiny box ("1x1").
+function isPlaceholderImageNameToken(token) {
+    const text = String(token || '');
+    if (!text) return false;
+    if (PLACEHOLDER_IMAGE_NAME_TOKENS.has(text)) return true;
+    const pixelSize = text.match(/^(\d{1,3})px$/);
+    if (pixelSize) return parseInt(pixelSize[1], 10) <= PLACEHOLDER_MAX_TINY_DIMENSION;
+    const box = text.match(/^(\d{1,3})x(\d{1,3})$/);
+    if (box) {
+        return parseInt(box[1], 10) <= PLACEHOLDER_MAX_TINY_DIMENSION
+            && parseInt(box[2], 10) <= PLACEHOLDER_MAX_TINY_DIMENSION;
+    }
+    return false;
+}
+
 // classifyCoverShape data (2026-08-02, all shapes drawn from real run values).
 // A currency-marked amount: a symbol adjacent to digits ("$20", "$15-$30",
 // "From £10", "20$") — NFKC folding upstream already collapsed full-width and
@@ -1212,6 +1253,104 @@ class SharedCore {
             score = url.length;
         }
         return score;
+    }
+
+    // The 1x1 spacer / lazy-load / tracking pixel every CDN and lazy-loader
+    // ships, and its relatives. Returns a human-readable REASON string when the
+    // URL's own shape says "this is not artwork", '' otherwise.
+    //
+    // Companion to getImageSizeScoreFromUrl / getImageDimensionsFromUrl above
+    // and bound by the same rules: no network, no `new URL` / URLSearchParams.
+    // Where the scorer answers "how big" and the dimension reader answers "what
+    // shape", this answers "is this an image at all" — and the size score
+    // cannot: a placeholder that advertises nothing scores on the URL-LENGTH
+    // noise floor, exactly like a real flyer with an opaque asset-ID filename
+    // (run 20260805-125954: an event shipped a 1px tracking pixel as its
+    // flyer, handed to the model as a segment's only SEGMENT_IMAGE_URL).
+    //
+    // SHAPE ONLY, never the host: which site serves the pixel is irrelevant,
+    // and pinning this to a domain would just move the bug to the next site.
+    // Deliberately conservative — every rule needs the URL to NAME itself a
+    // placeholder or ADVERTISE a sub-5px dimension, so an opaque asset ID
+    // ("238fae_c4047c55…jpg") and any real rendition fall through as ''.
+    getPlaceholderImageUrlReason(url) {
+        const text = typeof url === 'string' ? url.trim() : '';
+        if (!text) return '';
+
+        // data: URIs. A flyer is tens of kilobytes; the canonical 1x1
+        // transparent GIF is a 70-character base64 payload. Anything under the
+        // threshold can only be a solid-colour pixel or an empty SVG.
+        if (/^data:/i.test(text)) {
+            if (!/^data:image\//i.test(text)) return '';
+            const commaIndex = text.indexOf(',');
+            if (commaIndex < 0) return '';
+            const payload = text.slice(commaIndex + 1);
+            if (payload.length <= PLACEHOLDER_DATA_URI_MAX_PAYLOAD_CHARS) {
+                return `inline data: image with only ${payload.length} payload characters`;
+            }
+            return '';
+        }
+
+        const parsed = this.parseUrl(text);
+        const path = parsed ? String(parsed.pathname || '') : text.replace(/[?#].*$/, '');
+        const search = parsed ? String(parsed.search || '') : '';
+        const segments = path.split('/').filter(Boolean);
+
+        // 1. A filename that names itself: "1px.png", "spacer.gif",
+        //    "transparent-pixel.png", "blank_1x1.gif". EVERY token of the base
+        //    name must be a placeholder word — "pixel-party-flyer.jpg" and
+        //    "flyer-1px-border.png" carry real words and are left alone.
+        const lastSegment = segments.length > 0 ? segments[segments.length - 1] : '';
+        const baseName = lastSegment.toLowerCase().replace(/\.[a-z0-9]{1,5}$/, '');
+        if (baseName) {
+            const tokens = baseName.split(/[^a-z0-9]+/).filter(Boolean);
+            if (tokens.length > 0 && tokens.every(token => isPlaceholderImageNameToken(token))) {
+                return `filename "${lastSegment}" names itself a placeholder`;
+            }
+        }
+
+        // 2. Explicit sub-5px dimensions in the query string ("?w=1&h=1"). One
+        //    is enough: nothing anybody would look at is served 4 pixels wide.
+        for (const key of ['w', 'width', 'h', 'height']) {
+            const raw = String(this.extractSearchParamValue(search, key) || '').trim();
+            if (!/^\d{1,5}$/.test(raw)) continue;
+            if (parseInt(raw, 10) <= PLACEHOLDER_MAX_TINY_DIMENSION) {
+                return `URL advertises ${key}=${raw}`;
+            }
+        }
+
+        // 3. Explicit sub-5px dimensions in the path — the generic "/1x1/"
+        //    token and Wix's comma-joined "w_1,h_1" transform, the same two
+        //    syntaxes getImageDimensionsFromUrl reads. Both dimensions must be
+        //    tiny, so "10x64" and "w_577,h_1027" never match.
+        //
+        //    The NxN token must be delimited by NON-ALPHANUMERICS on both
+        //    sides — getImageDimensionsFromUrl's "ab12x34cd.jpg" lesson, which
+        //    bites here too: dice.fm's opaque event id "v3x3n7-spookmince-…"
+        //    reads as a 3x3 image if you let the token float inside a blob.
+        for (const segment of segments) {
+            const lower = segment.toLowerCase();
+            const box = lower.match(/(?:^|[^a-z0-9])(\d{1,3})x(\d{1,3})(?![a-z0-9])/);
+            if (box
+                && parseInt(box[1], 10) <= PLACEHOLDER_MAX_TINY_DIMENSION
+                && parseInt(box[2], 10) <= PLACEHOLDER_MAX_TINY_DIMENSION) {
+                return `URL path advertises a ${box[1]}x${box[2]} image`;
+            }
+            const wixWidth = lower.match(/(?:^|,)w_(\d{1,5})(?=,|$)/);
+            const wixHeight = lower.match(/(?:^|,)h_(\d{1,5})(?=,|$)/);
+            if (wixWidth && wixHeight
+                && parseInt(wixWidth[1], 10) <= PLACEHOLDER_MAX_TINY_DIMENSION
+                && parseInt(wixHeight[1], 10) <= PLACEHOLDER_MAX_TINY_DIMENSION) {
+                return `URL path advertises a ${wixWidth[1]}x${wixHeight[1]} image`;
+            }
+        }
+
+        return '';
+    }
+
+    // Boolean face of getPlaceholderImageUrlReason for callers that only gate.
+    isPlaceholderImageUrl(url) {
+        return this.getPlaceholderImageUrlReason(url) !== '';
     }
 
     // Width/height advertised BY the URL itself — { width, height } or null.
@@ -2643,6 +2782,20 @@ class SharedCore {
             // conservative behavior — imageSource stays a companion of `image`
             // alone, with no per-slot provenance.
             if (IMAGE_MERGE_FIELDS.has(fieldName)) {
+                // A self-declared placeholder pixel never beats a real image.
+                // Extraction now refuses these outright, but a value already
+                // stored on the calendar from an earlier run still arrives
+                // here, and the arbitration model has no reliable read on it
+                // (it once called a genuine og:image flyer "a generic
+                // placeholder"). Both-or-neither placeholder still arbitrates.
+                const placeholderReasonA = this.getPlaceholderImageUrlReason(String(valueA).trim());
+                const placeholderReasonB = this.getPlaceholderImageUrlReason(String(valueB).trim());
+                if (Boolean(placeholderReasonA) !== Boolean(placeholderReasonB)) {
+                    return {
+                        winner: placeholderReasonA ? 'b' : 'a',
+                        reason: `real image beats placeholder (${placeholderReasonA || placeholderReasonB})`
+                    };
+                }
                 const hasLogoSegment = (parts) => parts.segments.some(segment => /logo/i.test(segment));
                 const logoA = hasLogoSegment(urlA);
                 const logoB = hasLogoSegment(urlB);

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1328,7 +1328,16 @@ class SharedCore {
         //    sides — getImageDimensionsFromUrl's "ab12x34cd.jpg" lesson, which
         //    bites here too: dice.fm's opaque event id "v3x3n7-spookmince-…"
         //    reads as a 3x3 image if you let the token float inside a blob.
-        for (const segment of segments) {
+        //
+        //    DIRECTORY SEGMENTS ONLY — the FILENAME is rule 1's job. "1x1" in a
+        //    filename is far more often an ASPECT RATIO than a size: a CMS that
+        //    emits "flyer-1x1.jpg" for the square Instagram crop is naming a
+        //    real, full-size picture. A directory literally called "1x1/" is a
+        //    size bucket. Rule 1 still rejects a filename that is NOTHING but
+        //    the box ("1x1.png", "blank_1x1.gif"), so the spacer is caught
+        //    either way and the square flyer survives. Discarding a real flyer
+        //    is a worse failure here than keeping a pixel.
+        for (const segment of segments.slice(0, -1)) {
             const lower = segment.toLowerCase();
             const box = lower.match(/(?:^|[^a-z0-9])(\d{1,3})x(\d{1,3})(?![a-z0-9])/);
             if (box

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -15321,3 +15321,16 @@ test('prep-time twins: an unrelated dropped event is left unlabelled', async () 
   assert.equal(droppedEntry.duplicateOfPlanned, undefined,
     'a genuinely separate event is not labelled a twin');
 });
+
+test('placeholder images: a square-crop filename is artwork, a size-bucket directory is not', () => {
+  const core = createCore();
+  // "1x1" in a FILENAME is usually an aspect ratio — the square Instagram crop
+  // of a real flyer. Rejecting it would throw away artwork to catch a pixel.
+  assert.equal(core.isPlaceholderImageUrl('https://example.com/photos/1x1-crop-of-the-bear-party.jpg'), false);
+  assert.equal(core.isPlaceholderImageUrl('https://example.com/flyer-16x9.jpg'), false);
+  // A filename that is NOTHING but the box, or a directory named for the size,
+  // is still a placeholder.
+  assert.equal(core.isPlaceholderImageUrl('https://cdn.example.com/img/1x1.png'), true);
+  assert.equal(core.isPlaceholderImageUrl('https://example.com/i/blank_1x1.gif'), true);
+  assert.equal(core.isPlaceholderImageUrl('https://cdn.example.com/assets/1x1/bucket/real-flyer.jpg'), true);
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -2010,6 +2010,94 @@ test('guardrail: own-page artwork (og-image/jsonld) beats a page-sourced image; 
   assert.equal(core.resolveConflictDeterministically('image', og, page), null);
 });
 
+// ---------------------------------------------------------------------------
+// Placeholder-image guard. Run 20260805-125954 published a 1x1 lazy-load pixel
+// as an event's flyer (imageSource "page" — a listing page's segment offered no
+// other <img>, so the URL reached the model as SEGMENT_IMAGE_URL and passed the
+// verbatim evidence gate because it really is on the page). The rules are about
+// the SHAPE of the URL — never the host that served it.
+// ---------------------------------------------------------------------------
+
+test('getPlaceholderImageUrlReason names self-declared placeholder images and leaves real artwork alone', () => {
+  const core = createCore();
+  const reason = (url) => core.getPlaceholderImageUrlReason(url);
+
+  // The exact URL from the run that motivated the guard.
+  assert.match(reason('https://dice.fm/static/images/1px.png'), /names itself a placeholder/);
+  assert.equal(core.isPlaceholderImageUrl('https://dice.fm/static/images/1px.png'), true);
+
+  // Filenames that name themselves, including multi-token and mixed forms.
+  for (const url of [
+    'https://x.example/a/spacer.gif',
+    'https://x.example/assets/blank.png',
+    'https://x.example/i/px.gif',
+    'https://x.example/i/1x1.png',
+    'https://x.example/i/transparent-pixel.png',
+    'https://x.example/i/blank_1x1.gif',
+    'https://x.example/i/dot.gif',
+    'https://x.example/i/clear.gif',
+    'https://bearracuda.com/wp-content/uploads/2023/06/placeholder.png'
+  ]) {
+    assert.match(reason(url), /names itself a placeholder/, url);
+  }
+
+  // Dimensions the URL advertises about itself: query params, a generic path
+  // token, and Wix's comma-joined transform.
+  assert.match(reason('https://cdn.example.com/i.jpg?w=1&h=1'), /advertises w=1/);
+  assert.match(reason('https://cdn.example.com/i.jpg?height=1'), /advertises height=1/);
+  assert.match(reason('https://x.example/img/1x1/p.png'), /advertises a 1x1 image/);
+  assert.match(
+    reason('https://static.wixstatic.com/media/a~mv2.png/v1/fill/w_1,h_1,al_c/a.png'),
+    /advertises a 1x1 image/);
+
+  // A data: URI too small to be anything but a solid colour (the canonical 1x1
+  // transparent GIF), while a real inline image passes.
+  assert.match(
+    reason('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'),
+    /inline data: image with only \d+ payload characters/);
+  assert.equal(reason(`data:image/png;base64,${'A'.repeat(4000)}`), '');
+  assert.equal(reason(`data:text/html;base64,${'A'.repeat(4)}`), '', 'non-image data: URIs are not our business');
+
+  // Real artwork must survive — every one of these is a shape that exists in
+  // this repo's own calendars/fixtures or in a saved run.
+  for (const url of [
+    'https://static.wixstatic.com/media/238fae_c4047c55f4534a0990b2b7fdc19dab8f~mv2.png/v1/fill/w_577,h_1027,al_c,q_90,enc_avif/238fae.png',
+    'https://cdn.example.com/img/1920x1080/flyer.jpg',
+    'https://x.example/uploads/pixel-party-flyer.jpg',
+    'https://x.example/uploads/os-windows-10x64-download.png',
+    'https://img.evbuc.com/x.jpg?crop=focalpoint&fit=crop&h=230&w=460',
+    'https://x.example/uploads/flyer-1-1-300x300.jpg',
+    'https://bearracuda.com/wp-content/uploads/2026/06/sausageweb.jpg',
+    // dice.fm's opaque event id contains "3x3" — an id blob is not a dimension
+    'https://dice.fm/event/v3x3n7-spookmince-31st-oct-venue-tba-london-london-tickets',
+    ''
+  ]) {
+    assert.equal(reason(url), '', url);
+  }
+});
+
+test('merge rung: a placeholder pixel never beats a real image, in any image slot', () => {
+  const core = createCore();
+  const flyer = 'https://bearracuda.com/wp-content/uploads/2026/06/sausageweb.jpg';
+  const pixel = 'https://dice.fm/static/images/1px.png';
+
+  for (const field of ['image', 'imageVertical', 'imageHorizontal']) {
+    const a = core.resolveConflictDeterministically(field, flyer, pixel);
+    assert.equal(a && a.winner, 'a', `${field}: real image wins from the a side`);
+    assert.match(a.reason, /real image beats placeholder/);
+    const b = core.resolveConflictDeterministically(field, pixel, flyer);
+    assert.equal(b && b.winner, 'b', `${field}: real image wins from the b side`);
+  }
+
+  // Both placeholders is a genuine question, not a rung — fall through.
+  assert.equal(
+    core.resolveConflictDeterministically('image', pixel, 'https://x.example/a/spacer.gif'),
+    null, 'two placeholders decide nothing here');
+
+  // The rung is image-only: a ticketUrl that happens to look tiny is untouched.
+  assert.equal(core.resolveConflictDeterministically('ticketUrl', flyer, pixel), null);
+});
+
 test('imageSource is never arbitration-eligible and round-trips through notes like pinSource', () => {
   const core = createCore();
   assert.equal(core.isArbitrationEligibleField('imageSource'), false);

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -15158,3 +15158,78 @@ test('isDateLike and toEpochMillis are reachable statically for adapters and sta
   assert.equal(core.isDateLike(foreign), SharedCore.isDateLike(foreign));
   assert.equal(core.toEpochMillis(foreign), SharedCore.toEpochMillis(foreign));
 });
+
+// ---------------------------------------------------------------------------
+// A DROPPED EVENT THAT IS A TWIN OF A KEPT ONE SAYS SO.
+//
+// filterBearEvents runs before deduplicateEvents, so a thin second record of
+// an event the run also scraped richly is bear-checked alone — with none of
+// its twin's description or evidence — and dropped before dedup can fold it
+// in. The owner then reads one event twice. Report only: the structural fix
+// (dedup before the bear check) reorders an expensive AI stage.
+// ---------------------------------------------------------------------------
+test('prep-time twins: a dropped event that duplicates a planned one is labelled, not silently listed', async () => {
+  const core = createCore();
+  const ticketUrl = 'https://dice.fm/event/ww93qg-turkeymince-19th-dec';
+  const keptEvent = {
+    title: 'TURKEYMINCE',
+    startDate: new Date('2026-12-19T22:00:00.000Z'),
+    bar: 'Royal Vauxhall Tavern',
+    timezone: 'Europe/London',
+    ticketUrl
+  };
+  // The degraded twin: no stated time on the page, so it defaults to midnight.
+  const droppedEntry = {
+    title: 'TURKEYMINCE',
+    reason: 'ai: no bear-specific wording',
+    event: {
+      title: 'TURKEYMINCE',
+      startDate: new Date('2026-12-19T00:00:00.000Z'),
+      bar: 'Royal Vauxhall Tavern',
+      // Every identity signal is gated on the same LOCAL day, so the twin only
+      // matches once both records carry the timezone the real ones do.
+      timezone: 'Europe/London',
+      ticketUrl
+    }
+  };
+  const context = buildOverrideContext([droppedEntry]);
+
+  const analyzed = await core.prepareEventsForCalendar(
+    [keptEvent], buildPrepCalendarAdapter([]), {}, context);
+
+  assert.equal(analyzed.length, 1, 'the kept event is planned exactly once');
+  assert.ok(droppedEntry.duplicateOfPlanned,
+    'the drop is marked as a twin of something already in the plan');
+  assert.equal(droppedEntry.duplicateOfPlanned.title, 'TURKEYMINCE');
+  assert.equal(droppedEntry.duplicateOfPlanned.signal, 'ticket-url',
+    'and names the identity rung that matched');
+  assert.equal(droppedEntry.rescued, undefined,
+    'labelling is not rescuing — the bear verdict is untouched');
+});
+
+test('prep-time twins: an unrelated dropped event is left unlabelled', async () => {
+  const core = createCore();
+  const keptEvent = {
+    title: 'TURKEYMINCE',
+    startDate: new Date('2026-12-19T22:00:00.000Z'),
+    bar: 'Royal Vauxhall Tavern',
+    timezone: 'Europe/London',
+    ticketUrl: 'https://dice.fm/event/ww93qg-turkeymince-19th-dec'
+  };
+  const droppedEntry = {
+    title: 'Quiz Night',
+    reason: 'ai: no bear-specific wording',
+    event: {
+      title: 'Quiz Night',
+      startDate: new Date('2026-07-02T19:00:00.000Z'),
+      bar: 'Somewhere Else',
+      ticketUrl: 'https://example.com/quiz'
+    }
+  };
+  const context = buildOverrideContext([droppedEntry]);
+
+  await core.prepareEventsForCalendar([keptEvent], buildPrepCalendarAdapter([]), {}, context);
+
+  assert.equal(droppedEntry.duplicateOfPlanned, undefined,
+    'a genuinely separate event is not labelled a twin');
+});


### PR DESCRIPTION
Follow-up to #1636, from the same 2026-08-05 BEEFMINCE run. Answers "why are
there duplicates in BEEFMINCE": **the scraper never wrote an event twice** —
that run's own write plan read `UPDATE: 15, CREATE: 0`. Two separate things
made it look otherwise, and neither was the writer.

## 1. Every successful merge reported itself as a duplicate

```
✅ Calendar check complete: 15 events, 0 missing, 15 duplicates, 15 conflicts
```

`compareWithExistingCalendars` runs **after** analysis, so an event that matched
carries the record it matched in `_existingEvent`. That record is same-title,
same-minute and fully overlapping — precisely what the duplicate filter and the
conflict filter test for. So each event was flagged as a duplicate of, and in
conflict with, the record it was about to update. It only fires when matching
*succeeds*, which is why it looked like it got worse as merging got better.

Only the one matched record is excluded, so a **real** second copy is still
reported — pinned by its own test so a future "fix" can't quietly swallow
genuine duplicates.

## 2. A dropped event really was a twin of a kept one

TURKEYMINCE merged into `chunky-dad-london` for 19 Dec 22:00, and a second
TURKEYMINCE — same venue, same day, midnight-placeholder start because the page
stated no time — sat in the dropped section as "no bear-specific wording".

`filterBearEvents` runs **before** `deduplicateEvents`, so the thin record was
bear-checked alone, with none of its twin's description or evidence to judge
by, and dropped before dedup could fold it in. The code already knows this
ordering exists — it is why the manual-bear rescue path has a fold guard.

The drop now names the kept event and the identity rung that matched
(`ticket-url` here), on the card and in the log:

> Same event as "TURKEYMINCE" in the write plan — one event scraped twice, already kept

**Report only.** The structural fix (dedup before the bear check) stays
deferred: it reorders an expensive AI stage and would shift bear verdicts
run-wide. That deserves its own change, not a side effect of a reporting fix.

## 3. A 1×1 tracking pixel was saved as an event flyer

`event.image = https://dice.fm/static/images/1px.png` — dice.fm lazy-loads its
flyers, so the segment's only `<img src>` was the spacer. It reached the model
as `SEGMENT_IMAGE_URL`, came back as `img`, and passed the verbatim evidence
gate because the URL genuinely **is** on the page. Every downstream check asks
"is this URL real?", never "is this URL a picture?".

New `getPlaceholderImageUrlReason` in shared-core judges the **shape of the
URL** — no host, domain, venue, promoter or city appears in any rule:

- a filename whose every token is a placeholder word or self-declared box
  (`1px.png`, `spacer.gif`, `blank_1x1.gif`)
- an advertised sub-5px dimension (`?w=1`, a `/1x1/` directory, Wix `w_1,h_1`)
- a `data:image` URI under 512 payload chars

Applied in both extraction routes *before* the og:image fill, so an event whose
only image was a pixel still adopts the page's real artwork; a merge rung makes
a placeholder always lose to a real image, including one already on the
calendar from an earlier run.

**Verified against real data, not just fixtures:** the predicate was swept over
every image URL in 223 saved runs (1421 distinct) and all of `data/calendars`.
Two hits, both genuine placeholders; zero false positives.

Two false positives were caught and fixed before they shipped:
- `v3x3n7-spookmince-…` (a dice.fm event id) read as a "3x3 image" until the
  box token required non-alphanumeric delimiters — the same lesson
  `getImageDimensionsFromUrl` already carries about `ab12x34cd.jpg`.
- `flyer-1x1.jpg` read as a spacer, when in a **filename** `1x1` is far more
  often an aspect ratio: the square Instagram crop of a real flyer. The path
  rule now skips the filename and leaves it to the filename rule, which still
  rejects a name that is nothing but the box. Discarding a real flyer is a
  worse failure than keeping a pixel.

## 4. Same handler ordering as #1636, for the review sheet

`presentReviewResults` also assigned `shouldAllowRequest` after its `loadHTML`.
That page initiates no navigation during load, so it was not implicated in the
page-3 hang — but leaving the window open is how that bug got written.

## Tests

**1527 pass, 0 fail** (1515 on `origin/main` after #1636). Every new test was
checked to fail without its fix, except the deliberate guard that a real second
copy is still flagged, which must pass both ways.

## No new runtime files

Nothing to add to the script-updater.

## Correction to a rule I have been repeating

I have been asserting "no `new URL(` anywhere under `scripts/`". That is
overstated: `origin/main` already uses it in `shared-core.js` (once, inside a
try/catch with a string-parsing fallback right after), `ai-web-parser.js` (8),
both adapters and `event-schema.js`. The real rule is that it must never be the
*only* path, because Scriptable's JSC has no `URL`. Nothing here introduces a
new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP