### PR TITLE
fix(scraper): stop bear-judging half an event, and let a promoter's own site name its events

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -6419,6 +6419,9 @@ class SharedCore {
         const tag = mode === 'report' ? ' [report]' : '';
         const counts = { bear: 0, keyword: 0, ai: 0, flagged: 0, dropped: 0 };
         const kept = [];
+        // Drops are decided per record here but FINALISED after the loop, once
+        // every record's verdict exists — see the twin sweep below.
+        const pendingDrops = [];
         for (const event of events) {
             // Trust is per-event: a registry-matched promoter's bearAffinity
             // wins over parserConfig.alwaysBear in both directions; unmatched
@@ -6453,16 +6456,18 @@ class SharedCore {
                 // Flag, don't drop silently: enforce-mode drops are surfaced to
                 // the results UI (and prep-time manual-override rescue) via the
                 // caller's collector. Report mode changes nothing.
-                if (dropCollector && mode === 'enforce') {
-                    dropCollector.push({
+                pendingDrops.push({
+                    event,
+                    title,
+                    entry: {
                         title,
                         startDate: event.startDate || event.date || null,
                         venue: event.bar || event.venue || '',
                         reason: decision.provenance,
                         host: this.getHostFromUrl(event._sourcePageUrl || event.url || event.website || '') || '',
                         event: { ...event }
-                    });
-                }
+                    }
+                });
             } else {
                 // alwaysBear sources never lose events: not_bear/unsure is kept
                 // with a review flag; untrusted unsure is likewise kept+flagged.
@@ -6472,6 +6477,55 @@ class SharedCore {
                 kept.push({...event, bearReview: `${label} — ${decision.provenance}`});
             }
         }
+        // ONE EVENT SCRAPED TWICE IS ONE EVENT.
+        //
+        // A listing page yields a stub per event (title + date, no time, no
+        // description) and the crawler then follows the stub's own link and
+        // yields the full record. Both enter this filter as separate records,
+        // and this filter runs BEFORE deduplicateEvents — so the stub is
+        // bear-judged ALONE, with none of its twin's description or evidence
+        // to judge by, and is gone before dedup can fold it in.
+        //
+        // 2026-08-05 BEEFMINCE, 26 records for 15 events: dedup folded 10 of
+        // the 11 twin pairs, and the 11th never reached it. "TURKEYMINCE" the
+        // stub (19 Dec 00:00, description EMPTY) was dropped for "lack of
+        // description", while "TURKEYMINCE" the event page (19 Dec 22:00,
+        // "TIS' THE SEASON TO BE BEARY!") was kept on those very words. Same
+        // ticket URL. Same event. The owner then reviewed it twice.
+        //
+        // So a drop only stands if NO other record of the same event survived.
+        // If one did, this record is a fragment of a kept event, not a second
+        // event to judge — dedup folds it moments later. Nothing new reaches
+        // the calendar: the event was already going there via its twin.
+        //
+        // requireCloseStartTimes: false is the same relaxation dedup itself
+        // uses, because a stub's missing start time degrades to midnight and
+        // must still match its properly-timed sibling.
+        for (const pending of pendingDrops) {
+            let signal = null;
+            const twin = kept.find(candidate => {
+                signal = this.getSameEventIdentitySignal(pending.event, candidate, { requireCloseStartTimes: false });
+                return Boolean(signal);
+            }) || null;
+            if (!twin) {
+                if (dropCollector && mode === 'enforce') dropCollector.push(pending.entry);
+                continue;
+            }
+            counts.dropped--;
+            counts.bear++;
+            console.log(`🐻 BEAR CHECK${tag}: "${pending.title}" DROP reversed — same event as kept "${twin.title || 'Unknown'}" (${signal}); it is one event scraped twice, and the record that carried the evidence was kept`);
+            // Inherit the twin's provenance rather than minting a new
+            // bearSource value: the verdict genuinely came from that record's
+            // evidence, and FIELD_SOURCE_PRIORITY.bearSource ranks a fixed
+            // vocabulary (manual-bear/manual-not-bear/keyword/ai/config) — an
+            // unranked token would fail open in every merge that consults it.
+            const rescued = { ...pending.event, isBearEvent: true };
+            if (typeof twin.bearSource === 'string' && twin.bearSource) {
+                rescued.bearSource = twin.bearSource;
+            }
+            kept.push(rescued);
+        }
+
         const flagLabel = mode === 'report' ? 'would-flag' : 'flagged';
         const dropLabel = mode === 'report' ? 'would-drop' : 'dropped';
         console.log(`🐻 BEAR CHECK${tag}: ${counts.bear} bear (${counts.keyword} keyword, ${counts.ai} ai), ${counts.flagged} ${flagLabel}, ${counts.dropped} ${dropLabel}`);

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2484,25 +2484,87 @@ class SharedCore {
     // would-stamp decisions and changes NOTHING; enforce stamps _promoter,
     // curated metadata, and (when the organizer was empty and the match came
     // from title/url evidence) _organizer.
+    // The promoter a PARSER is, derived from the site it is configured to
+    // scrape: the one registry entry whose curated website is the same site as
+    // one of `parserConfig.urls`. Null unless exactly one entry matches.
+    //
+    // This is the weakest evidence rung and the last one tried, because it
+    // says nothing about the individual event — only "this parser reads this
+    // promoter's own site". That is enough, and until now it was thrown away:
+    // the BEEFMINCE parser is configured with `urls: ["https://beefmince.com/
+    // events"]` and the registry's BEEFMINCE entry has
+    // `website: "https://beefmince.com"`, yet 2026-08-05 matched 24 of 26
+    // events and left BOTH TURKEYMINCE records with no promoter at all —
+    // because that page's events link out to dice.fm, so no per-event field
+    // ever mentions beefmince.com.
+    //
+    // Not circular, unlike the static-metadata exclusion in
+    // evaluatePromoterEntryMatch: that rejects matching on a value the
+    // pipeline itself stamped onto the event. This joins two independently
+    // curated sources — scraper-input.js's parser URLs and the registry — and
+    // neither is derived from the other.
+    //
+    // Fail closed, the same way matchEventToPromoter does: zero matching
+    // entries or more than one and this returns null rather than guessing. An
+    // aggregator parser (Eventbrite, a ticketing platform, a city listings
+    // site) matches no registry website, so it inherits nothing.
+    resolveParserPromoterEntry(parserConfig) {
+        if (!parserConfig || !Array.isArray(this.promoters)) return null;
+        const parserUrls = Array.isArray(parserConfig.urls) ? parserConfig.urls : [];
+        if (parserUrls.length === 0) return null;
+        const parserHosts = parserUrls
+            .map(url => this.getHostFromUrl(url))
+            .filter(Boolean);
+        if (parserHosts.length === 0) return null;
+
+        const matches = [];
+        for (const entry of this.promoters) {
+            const entryHost = entry && entry.website ? this.getHostFromUrl(entry.website) : '';
+            if (!entryHost) continue;
+            if (parserHosts.some(host => this.areUrlHostsSameSite(host, entryHost))) {
+                matches.push(entry);
+            }
+        }
+        return matches.length === 1 ? matches[0] : null;
+    }
+
     applyPromoterRegistryMatches(events, parserConfig, mainConfig) {
         const mode = this.getPromoterRegistryMode(mainConfig);
         if (mode === 'off') return;
         if (!Array.isArray(this.promoters) || this.promoters.length === 0) return;
         if (!Array.isArray(events) || events.length === 0) return;
         const tag = mode === 'report' ? '[report]' : '';
-        const counts = { matched: 0, organizer: 0, title: 0, url: 0 };
+        const counts = { matched: 0, organizer: 0, title: 0, url: 0, parser: 0 };
+        // Last resort only — computed once, applied per event below when the
+        // event's OWN fields matched nothing.
+        const parserEntry = this.resolveParserPromoterEntry(parserConfig);
         for (const event of events) {
-            const match = this.matchEventToPromoter(event);
+            const ownMatch = this.matchEventToPromoter(event);
+            // A sub-brand the title named (BOATMINCE, SPOOKMINCE) must keep
+            // winning over the parent site the parser reads, so this only fills
+            // the gap where nothing at all matched. Ambiguity still fails
+            // closed: `ownMatch.ambiguous` is a decision not to guess, and the
+            // parser must not overrule it.
+            const fromParser = !ownMatch && Boolean(parserEntry);
+            const match = fromParser ? { entry: parserEntry, evidence: 'parser-site' } : ownMatch;
             if (!match) continue;
             const title = event.title || 'Unknown';
             if (match.ambiguous) {
                 console.log(`🪪 PROMOTER REGISTRY${tag}: "${title}" -> no match (ambiguous: ${match.ambiguous.join(', ')})`);
                 continue;
             }
-            counts.matched++;
-            if (match.evidence === 'organizer') counts.organizer++;
-            else if (match.evidence === 'title') counts.title++;
-            else counts.url++;
+            if (fromParser) {
+                // Counted separately, and NOT into `counts.matched`: the
+                // "N of M event(s) matched (…organizer, …title, …url)" line
+                // below is the per-event-evidence tally and its breakdown has
+                // to keep adding up. The parser rung gets its own line.
+                counts.parser++;
+            } else {
+                counts.matched++;
+                if (match.evidence === 'organizer') counts.organizer++;
+                else if (match.evidence === 'title') counts.title++;
+                else counts.url++;
+            }
             const metadataBlock = this.promoterEntryToMetadataBlock(match.entry);
             const stampKeys = Object.keys(metadataBlock);
             if (mode === 'enforce') {
@@ -2519,6 +2581,9 @@ class SharedCore {
         }
         if (counts.matched > 0 || mode === 'report') {
             console.log(`🪪 PROMOTER REGISTRY${tag}: ${counts.matched} of ${events.length} event(s) matched (${counts.organizer} organizer, ${counts.title} title, ${counts.url} url)`);
+        }
+        if (counts.parser > 0) {
+            console.log(`🪪 PROMOTER REGISTRY${tag}: ${counts.parser} more event(s) inherited ${parserEntry.name} from the parser's own site (${this.getHostFromUrl(parserEntry.website)}) — nothing in the event itself named a promoter`);
         }
     }
 

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -15432,3 +15432,65 @@ test('bear check: a drop with no surviving twin still drops', async () => {
   assert.equal(drops.length, 1, 'and is still surfaced to the owner');
   assert.equal(drops[0].title, 'Quiz Night');
 });
+
+// ---------------------------------------------------------------------------
+// THE PARSER IS EVIDENCE TOO.
+//
+// A parser configured to read a promoter's own site tells you whose events
+// these are, regardless of what any individual event says. 2026-08-05: the
+// BEEFMINCE parser reads beefmince.com and the registry's BEEFMINCE entry IS
+// beefmince.com, yet the pass matched 24 of 26 events and left both
+// TURKEYMINCE records promoter-less — that page's events link out to dice.fm,
+// so no per-event field ever mentions beefmince.com.
+// ---------------------------------------------------------------------------
+test('parser promoter: a parser reading a promoter\'s own site resolves to that promoter', () => {
+  const core = createRegistryCore();
+  // Host equality, not name equality — the parser is "Bearracuda Events" and
+  // the entry is "Bearracuda", and the trailing slash on the entry's website
+  // and the parser's deep path must not matter.
+  assert.equal(
+    core.resolveParserPromoterEntry({ name: 'Bearracuda Events', urls: ['https://www.bearracuda.com/events/'] }).name,
+    'Bearracuda');
+});
+
+test('parser promoter: fails closed on an aggregator, no urls, or an ambiguous site', () => {
+  const core = createRegistryCore();
+  assert.equal(core.resolveParserPromoterEntry({ name: 'x', urls: ['https://www.eventbrite.com/o/someone-1'] }), null,
+    'an aggregator matches no registry website');
+  assert.equal(core.resolveParserPromoterEntry({ name: 'x' }), null, 'no urls, no inference');
+  assert.equal(core.resolveParserPromoterEntry(null), null);
+
+  const shared = createRegistryCore([
+    { name: 'A', website: 'https://shared.example', bearAffinity: 'always' },
+    { name: 'B', website: 'https://shared.example', bearAffinity: 'always' }
+  ]);
+  assert.equal(shared.resolveParserPromoterEntry({ name: 'x', urls: ['https://shared.example/events'] }), null,
+    'two entries on one site is a tie, and a tie is not an answer');
+});
+
+test('parser promoter: fills the gap where the event named nobody, and never overrules the event', () => {
+  const core = createRegistryCore();
+  const parserConfig = { name: 'Bearracuda Events', urls: ['https://bearracuda.com/'] };
+
+  // Nothing in this event mentions Bearracuda — tickets link out, as they do
+  // on the real page that caused this.
+  const anonymous = { title: 'TURKEY TAKEOVER', startDate: new Date('2026-08-01T21:00:00.000Z'),
+    ticketUrl: 'https://dice.fm/event/abc123-turkey-takeover' };
+  // A title that names a DIFFERENT promoter must still win.
+  const named = { title: 'Goldiloxx presents', startDate: new Date('2026-08-01T21:00:00.000Z') };
+
+  core.applyPromoterRegistryMatches([anonymous, named], parserConfig, ENFORCE_REGISTRY_CONFIG);
+
+  assert.equal(anonymous._promoter, 'Bearracuda', 'the parser fills a gap the event left');
+  assert.equal(named._promoter, 'Goldiloxx', 'per-event evidence still beats the parser');
+});
+
+test('parser promoter: an ambiguous event stays ambiguous — the parser does not break the tie', () => {
+  const core = createRegistryCore();
+  const event = { title: 'Bearracuda x Goldiloxx Takeover', startDate: new Date('2026-08-01T21:00:00.000Z') };
+  const before = JSON.parse(JSON.stringify(event));
+  core.applyPromoterRegistryMatches([event], { name: 'Bearracuda Events', urls: ['https://bearracuda.com/'] },
+    ENFORCE_REGISTRY_CONFIG);
+  assert.deepEqual(JSON.parse(JSON.stringify(event)), before,
+    'refusing to guess is a decision, and the weakest rung must not overrule it');
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -15334,3 +15334,101 @@ test('placeholder images: a square-crop filename is artwork, a size-bucket direc
   assert.equal(core.isPlaceholderImageUrl('https://example.com/i/blank_1x1.gif'), true);
   assert.equal(core.isPlaceholderImageUrl('https://cdn.example.com/assets/1x1/bucket/real-flyer.jpg'), true);
 });
+
+// ---------------------------------------------------------------------------
+// ONE EVENT SCRAPED TWICE IS ONE EVENT.
+//
+// A listing page yields a stub (title + date, no time, no description); the
+// crawler follows the stub's own link and yields the full record. Both reach
+// filterBearEvents, which runs BEFORE deduplicateEvents — so the stub is
+// bear-judged alone and can be dropped before dedup folds it in. 2026-08-05
+// BEEFMINCE: the TURKEYMINCE stub was dropped for "lack of description" while
+// the TURKEYMINCE event page was kept on "TIS' THE SEASON TO BE BEARY!".
+// ---------------------------------------------------------------------------
+// The twin sweep is what these pin, not the AI cascade that produced the
+// verdicts — so the decision seam is stubbed and the AI plumbing stays out of
+// it. `not_bear` on an untrusted parser is what DROPs a record.
+function buildTwinBearCore(verdicts) {
+  const core = createCore();
+  core.computeBearCheckDecision = async (event) => verdicts[event.description] || verdicts.default;
+  return core;
+}
+
+function buildTwinBearParserConfig() {
+  return { name: 'BEEFMINCE', ai: { bearCheck: { mode: 'enforce' } } };
+}
+
+test('bear check: a drop is reversed when another record of the SAME event was kept', async () => {
+  const ticketUrl = 'https://dice.fm/event/ww93qg-turkeymince-19th-dec';
+  const stub = {
+    title: 'TURKEYMINCE',
+    startDate: new Date('2026-12-19T00:00:00.000Z'), // no time stated on the listing
+    bar: 'Royal Vauxhall Tavern',
+    timezone: 'Europe/London',
+    description: '',
+    ticketUrl
+  };
+  const full = {
+    title: 'TURKEYMINCE',
+    startDate: new Date('2026-12-19T22:00:00.000Z'),
+    bar: 'Royal Vauxhall Tavern',
+    timezone: 'Europe/London',
+    description: "TIS' THE SEASON TO BE BEARY!",
+    ticketUrl
+  };
+  const core = buildTwinBearCore({
+    '': { result: 'not_bear', provenance: 'ai: no bear-specific wording' },
+    "TIS' THE SEASON TO BE BEARY!": { result: 'bear', provenance: 'keyword: bear' }
+  });
+  const drops = [];
+  const kept = await core.filterBearEvents([stub, full], buildTwinBearParserConfig(), null, drops);
+
+  assert.equal(kept.length, 2, 'both records survive — dedup folds them moments later');
+  assert.deepEqual(drops, [], 'nothing is surfaced to the owner as a dropped event');
+  const rescued = kept.find((e) => e.startDate.getTime() === stub.startDate.getTime());
+  assert.ok(rescued, 'the stub is the record that came back');
+  assert.equal(rescued.isBearEvent, true);
+  assert.equal(rescued.bearSource, 'keyword',
+    "it inherits the twin's provenance instead of minting an unranked bearSource");
+});
+
+test('bear check: the twin must have been KEPT — two dropped records of one event both drop', async () => {
+  const ticketUrl = 'https://dice.fm/event/ww93qg-turkeymince-19th-dec';
+  const base = {
+    title: 'TURKEYMINCE', bar: 'Royal Vauxhall Tavern', timezone: 'Europe/London', ticketUrl
+  };
+  const core = buildTwinBearCore({
+    default: { result: 'not_bear', provenance: 'ai: no bear-specific wording' }
+  });
+  const drops = [];
+  const kept = await core.filterBearEvents([
+    { ...base, description: 'a', startDate: new Date('2026-12-19T00:00:00.000Z') },
+    { ...base, description: 'b', startDate: new Date('2026-12-19T22:00:00.000Z') }
+  ], buildTwinBearParserConfig(), null, drops);
+
+  assert.equal(kept.length, 0, 'a twin that was itself dropped rescues nothing');
+  assert.equal(drops.length, 2);
+});
+
+test('bear check: a drop with no surviving twin still drops', async () => {
+  const core = buildTwinBearCore({
+    'Pub quiz, teams of four.': { result: 'not_bear', provenance: 'ai: not a bear event' },
+    'Bears, cubs and chubs.': { result: 'bear', provenance: 'keyword: bear' }
+  });
+  const drops = [];
+  const kept = await core.filterBearEvents([
+    {
+      title: 'Quiz Night', startDate: new Date('2026-12-19T19:00:00.000Z'), bar: 'Somewhere Else',
+      timezone: 'Europe/London', description: 'Pub quiz, teams of four.', ticketUrl: 'https://example.com/quiz'
+    },
+    {
+      title: 'BEEFMINCE x RVT', startDate: new Date('2026-12-19T22:00:00.000Z'), bar: 'Royal Vauxhall Tavern',
+      timezone: 'Europe/London', description: 'Bears, cubs and chubs.', ticketUrl: 'https://dice.fm/event/other'
+    }
+  ], buildTwinBearParserConfig(), null, drops);
+
+  assert.equal(kept.length, 1, 'a genuinely separate event is still dropped');
+  assert.equal(kept[0].title, 'BEEFMINCE x RVT');
+  assert.equal(drops.length, 1, 'and is still surfaced to the owner');
+  assert.equal(drops[0].title, 'Quiz Night');
+});


### PR DESCRIPTION
"Why are there two TURKEYMINCE in the logs?"

Because there are two **records** of one event, and the bear check judges
records, not events. Two commits: the rescue, and the reason it was needed.

## They are the same event. They are not the same information.

| field | listing stub | crawled event page |
|---|---|---|
| title | TURKEYMINCE | TURKEYMINCE |
| startDate | 2026-12-19T**00:00**:00Z | 2026-12-19T**22:00**:00Z |
| endDate | 2026-12-19T00:00:00Z | 2026-12-20T04:00:00Z |
| description | **(EMPTY)** | `TIS' THE SEASON TO BE BEARY! Get your stocki…` |
| bar | Royal Vauxhall Tavern | Royal Vauxhall Tavern |
| ticketUrl | `…ww93qg-turkeymince…` | `…ww93qg-turkeymince…` |

`dice.fm/promoters/beefmince-3oorg` lists each event as a stub — title and
date, no time, no description. The crawler then follows the stub's own link,
parses `dice.fm/event/ww93qg-turkeymince-…`, and produces the full record.
**That part is normal**: the run scraped 26 records for 15 events, and dedup
folded 10 of the 11 twin pairs without anyone noticing.

## 1. The 11th pair never reached dedup

`filterBearEvents` runs **before** `deduplicateEvents` (shared-core.js
~3806/3810). So the stub was bear-judged alone, and the AI said exactly what
was wrong with that, in its own words:

```
🐻 BEAR CHECK: "TURKEYMINCE" → DROP (ai: The title 'TURKEYMINCE' and lack of
   description provide no bear-specific wording or evidence…)
🐻 BEAR CHECK: "TURKEYMINCE" → bear (keyword: bear, beef)
```

It was dropped for missing the sentence its twin was kept on.

**Fix:** a drop only stands if no other record of the same event survived.
Verdicts are unchanged; only their finalisation moves after the loop, so every
record's verdict exists before any drop is committed. The rescued fragment
inherits its twin's `bearSource` rather than minting a new token —
`FIELD_SOURCE_PRIORITY.bearSource` ranks a fixed vocabulary and an unranked
value would fail open in every merge that consults it.

**No new write risk.** The event was already going to the calendar via its
twin; this stops it being reviewed twice, once as a dropped non-bear.

Replaying `20260805-184024`: the dropped record matches **exactly one** kept
record, via `ticket-url`. One twin, not zero and not several.

## 2. Why it was judged blind in the first place

Every other stub survives its solo judgement for one of two reasons, and
TURKEYMINCE has neither:

- `BEEFMINCE …` titles hit `keyword: beef` on the title alone.
- `BOATMINCE` and `SPOOKMINCE` are curated registry entries
  (`parent: BEEFMINCE`), so the AI is handed promoter context and trusts them.

`TURKEYMINCE` is in neither, so `🪪 PROMOTER REGISTRY` matched 24 of 26 events
and left **both** TURKEYMINCE records with no promoter at all.

The registry only ever looked at an event's OWN fields. So the BEEFMINCE
parser reading `beefmince.com` and the registry's BEEFMINCE entry *being*
`beefmince.com` never met — that page's events link out to dice.fm, so no
per-event field ever mentions beefmince.com. And BEEFMINCE carries
`bearAffinity: "always"`: the promoter it never got is precisely the trust
context the AI was missing.

**Fix:** a new weakest rung, tried last — the one registry entry whose curated
website is the same site as one of `parserConfig.urls`.

- **Fails closed** like every other rung: zero matching entries or more than
  one and it stamps nothing. Aggregator parsers (Eventbrite, ticketing
  platforms, city listings) inherit nothing.
- **Never overrules the event.** A sub-brand named in the title still wins, and
  an ambiguous event stays ambiguous — refusing to guess is a decision the
  weakest rung must not overrule.
- **Not circular.** `evaluatePromoterEntryMatch` excludes event fields the
  pipeline itself stamped; this joins two independently curated sources —
  scraper-input's parser URLs and the registry — and neither derives from the
  other. Stamped values land in `_staticFields`, so they can't become evidence
  next run either.

Blast radius, measured against the real 25-entry registry and all 21 configured
parsers — **8 resolve**:

| parser | inherits |
|---|---|
| Bearracuda Events | Bearracuda |
| Bears Sitges Week | Bears Sitges Club |
| CHUNK, Furball, BEEFMINCE, BeefDip, Bear it MTL, Club Chub | themselves |

The two name mismatches are the point: the join key is the **website host**,
not the name.

## Logs

Existing lines are untouched. Parser-rung matches are counted separately so the
`N of M event(s) matched (…organizer, …title, …url)` breakdown keeps adding up,
and both new behaviours get their own additive lines.

## Tests

**1534 pass, 0 fail** (1527 on `origin/main` after #1637). Each new test was
checked to fail without its fix, except two deliberate over-reach guards that
must pass both ways: a twin that was itself dropped rescues nothing, and an
ambiguous event stays ambiguous.

## Still deliberately NOT here

**Reordering dedup before the bear check.** Its main harm — a fragment judged
without its twin's evidence — is what commit 1 fixes, so the remaining value is
cost (AI calls spent on records that dedup away) and verdict quality on flagged
events. The risk is unchanged: dedup would then run over non-bear events too
and could fold junk into a real event. That needs a real before/after run, not
a side effect of this one.

## No new runtime files

Nothing to add to the script-updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP