### PR TITLE
fix(scraper): the event's own page is the event's URL, not a ticket link

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1153,6 +1153,22 @@ class SharedCore {
             normalized === platform || normalized.endsWith(`.${platform}`));
     }
 
+    // True when `candidate` is a bare domain root and `incumbent` is an
+    // event-specific page on the SAME site. Used by the identity fields
+    // (website/url), where a venue's front door must never replace the page
+    // that describes THIS event — the same ruling the "same-host deeper URL
+    // beats domain root" rung already makes inside
+    // resolveConflictDeterministically. Fails closed: either side unparseable,
+    // different sites, or a candidate that is itself pathed all return false.
+    isBareRootBuryingSameSiteEventPage(candidate, incumbent) {
+        const candidateParts = this.getUrlRuleParts(candidate);
+        const incumbentParts = this.getUrlRuleParts(incumbent);
+        if (!candidateParts || !incumbentParts) return false;
+        if (!this.areUrlHostsSameSite(candidateParts.host, incumbentParts.host)) return false;
+        const candidateIsRoot = candidateParts.segments.length === 0 && !candidateParts.hasQuery;
+        return candidateIsRoot && incumbentParts.segments.length > 0;
+    }
+
     // Query-string parameter lookup built on plain string splitting —
     // URLSearchParams does not exist in iOS JavaScriptCore (Scriptable).
     extractSearchParamValue(search, key) {
@@ -5292,6 +5308,27 @@ class SharedCore {
                             event._sourcePageUrl = url;
                         }
                     });
+                    // A page that describes exactly ONE event IS that event's
+                    // page, so it can name itself. The structured-data routes
+                    // already do this (JSON-LD and the JSON-API reader both set
+                    // url from the page they read); the AI-extraction route had
+                    // no equivalent, so a crawled detail page left `url` on
+                    // whatever the parser's static metadata supplied — the
+                    // venue's bare homepage. That also killed the
+                    // `event-page-url` dedup rung, which returns nothing for a
+                    // domain root, leaving these events to match on name+time
+                    // alone. Only fills a blank or replaces a same-site bare
+                    // root: a listing page (many events) is skipped by the
+                    // count, and a URL the page actually named is never
+                    // displaced.
+                    if (parsedEvents.length === 1) {
+                        const soleEvent = parsedEvents[0];
+                        const existingUrl = typeof soleEvent.url === 'string' ? soleEvent.url.trim() : '';
+                        if (!existingUrl || this.isBareRootBuryingSameSiteEventPage(existingUrl, url)) {
+                            soleEvent.url = url;
+                            console.log(`🔗 LINKS: "${soleEvent.title || 'event'}" takes its own page ${url} as its url${existingUrl ? ` (was ${existingUrl})` : ''} — one event on the page`);
+                        }
+                    }
                     // Cross-org crawl guard: a DISCOVERED page whose site curated
                     // data attributes to another promoter/parser contributes no
                     // events to this parser — that org has its own entry. Only
@@ -11370,6 +11407,27 @@ class SharedCore {
                     }
                     const resolvedValue = this.applyMetadataTemplate(selectedValue, event);
 
+                    // A curated venue/organizer homepage identifies the VENUE.
+                    // It is the event's identity only when the page itself gave
+                    // us nothing more specific. Observed 2026-08-06 (Dallas
+                    // Eagle, run 20260806-102824): the parser extracted
+                    // .../events/womxns-night-5/ into `url`, this block then
+                    // stamped the bare homepage over the whole identity field,
+                    // and every event on that calendar shipped pointing at the
+                    // venue's front door. url/website are ONE canonical field,
+                    // so the incumbent is whichever of the two currently holds
+                    // the page-derived value. Identity fields only — every
+                    // other metadata key clobbers exactly as before.
+                    if (key === 'website' || key === 'url') {
+                        const pageDerived = (typeof event.website === 'string' && event.website.trim())
+                            ? event.website.trim()
+                            : (typeof event.url === 'string' ? event.url.trim() : '');
+                        if (this.isBareRootBuryingSameSiteEventPage(resolvedValue, pageDerived)) {
+                            console.log(`🔗 LINKS: kept the page's own ${pageDerived} over curated ${resolvedValue} for "${event.title || 'event'}" — same site, and the deeper URL is the one that describes THIS event`);
+                            return;
+                        }
+                    }
+
                     // Check if "static" has priority for this field
                     if (priorityConfig && priorityConfig.priority && priorityConfig.priority.includes('static')) {
                         // Apply static value since it's in the priority list
@@ -11935,6 +11993,60 @@ class SharedCore {
                             ? `existing ticketUrl ${existingTicketUrl} kept`
                             : 'moved to ticketUrl';
                         console.log(`🔗 LINKS: cleared platform website ${platformWebsite} — a ticketing/social link is never the identity link (${parked}, website/url left empty) for "${analyzedEvent.title || 'event'}"`);
+                    }
+                }
+            }
+
+            // A "ticket" link on the venue's OWN site that sells nothing is
+            // not a ticket — it is the event's page, filed under the wrong
+            // name. Observed 2026-08-06 (Dallas Eagle, run 20260806-102824):
+            // Bear and Twink Night shipped with
+            //   website:   https://www.thedallaseagle.com          (front door)
+            //   ticketUrl: https://www.thedallaseagle.com/events/bear-and-twink-night/
+            // The prompt offers the model only `web` and `tickets`, so a
+            // venue's own event link with a TICKETS button beside it lands in
+            // `tickets` and nothing downstream can notice: every URL rung
+            // arbitrates two candidates for the SAME field and none compares
+            // website against ticketUrl.
+            //
+            // Fails closed in both directions. A known ticketing/social
+            // platform host is never promoted (that is the vendor-stealing-
+            // the-favicon defect #1614 and #1622 fixed, and this must not
+            // reintroduce it). Promotion additionally requires the link to be
+            // on the same site we actually crawled, so a real vendor missing
+            // from both host lists still stays put.
+            {
+                const canonicalWebsite = typeof analyzedEvent.website === 'string' && analyzedEvent.website.trim()
+                    ? analyzedEvent.website.trim()
+                    : (typeof analyzedEvent.url === 'string' ? analyzedEvent.url.trim() : '');
+                const ticketUrl = typeof analyzedEvent.ticketUrl === 'string' ? analyzedEvent.ticketUrl.trim() : '';
+                const ticketParts = ticketUrl ? this.getUrlRuleParts(ticketUrl) : null;
+                const isVendorHost = ticketParts
+                    && (this.isKnownTicketingPlatformHost(ticketParts.host) || isPlatformIdentityHost(ticketParts.host));
+                if (ticketParts && !isVendorHost) {
+                    const sourcePageHost = this.getHostFromUrl(
+                        typeof analyzedEvent._sourcePageUrl === 'string' ? analyzedEvent._sourcePageUrl : ''
+                    );
+                    const websiteHost = this.getHostFromUrl(canonicalWebsite);
+                    const onCrawledSite =
+                        (websiteHost && this.areUrlHostsSameSite(ticketParts.host, websiteHost))
+                        || (sourcePageHost && this.areUrlHostsSameSite(ticketParts.host, sourcePageHost));
+                    const buriesEventPage = this.isBareRootBuryingSameSiteEventPage(canonicalWebsite, ticketUrl);
+                    if (onCrawledSite && (!canonicalWebsite || buriesEventPage)) {
+                        analyzedEvent.website = ticketUrl;
+                        analyzedEvent.url = ticketUrl;
+                        delete analyzedEvent.ticketUrl;
+                        notesNeedRebuild = true;
+                        console.log(`🔗 LINKS: "${analyzedEvent.title || 'event'}" ticketUrl ${ticketUrl} is a page on the venue's own site, not a ticket vendor — promoted to website/url${canonicalWebsite ? ` over ${canonicalWebsite}` : ''}`);
+                    } else if (canonicalWebsite && this.isBareRootBuryingSameSiteEventPage(ticketUrl, canonicalWebsite)) {
+                        // The mirror shape: the ticketUrl is the same site's
+                        // bare front door while website already names the
+                        // event. A homepage sells no tickets, so the field is
+                        // noise (corpus 2026-08-06: chunk-party.com ×3 and
+                        // bearracuda.com ×1 stored exactly this way).
+                        delete analyzedEvent.ticketUrl;
+                        notesNeedRebuild = true;
+                        console.log(`🔗 LINKS: dropped ticketUrl ${ticketUrl} for "${analyzedEvent.title || 'event'}" — it is the same site's homepage, not a ticket link`);
                     }
                 }
             }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -15494,3 +15494,176 @@ test('parser promoter: an ambiguous event stays ambiguous — the parser does no
   assert.deepEqual(JSON.parse(JSON.stringify(event)), before,
     'refusing to guess is a decision, and the weakest rung must not overrule it');
 });
+
+// ---------------------------------------------------------------------------
+// The event's own page is the event's identity link (2026-08-06, Dallas Eagle
+// run 20260806-102824). Three separate ways the pipeline lost it:
+//   1. a curated venue homepage in parser metadata clobbered the whole
+//      identity field, so every event shipped pointing at the front door;
+//   2. the model files a venue's own event link under `tickets` (the prompt
+//      offers only `web` and `tickets`), and no URL rung compares website
+//      against ticketUrl — they all arbitrate one field at a time;
+//   3. a crawled single-event page never named itself, leaving the static
+//      root behind and killing the event-page-url dedup rung, which returns
+//      nothing for a domain root.
+
+test('static metadata website does not bury the page\'s own event URL on the same site', () => {
+  const core = createCore();
+  const event = core.applyFieldPriorities(
+    {
+      title: "Womxn's Night",
+      startDate: new Date('2026-08-29T02:00:00.000Z'),
+      url: 'https://www.thedallaseagle.com/events/womxns-night-5/'
+    },
+    { name: 'Dallas Eagle', metadata: { website: { value: 'https://www.thedallaseagle.com' } } },
+    {}
+  );
+
+  assert.equal(event.url, 'https://www.thedallaseagle.com/events/womxns-night-5/', 'page-derived event URL survives');
+  assert.equal(event.website, undefined, 'the bare homepage is not stamped over it');
+  assert.equal((event._staticFields || {}).website, undefined, 'and it is not recorded as a static field');
+});
+
+test('static metadata website still applies with nothing better, and across sites', () => {
+  const core = createCore();
+  const config = { name: 'Dallas Eagle', metadata: { website: { value: 'https://www.thedallaseagle.com' } } };
+
+  // Nothing page-derived to protect → the curated homepage is the best identity there is.
+  const bare = core.applyFieldPriorities(
+    { title: 'Bear and Twink Night', startDate: new Date('2026-08-15T02:00:00.000Z') }, config, {});
+  assert.equal(bare.website, 'https://www.thedallaseagle.com', 'curated homepage still stamped');
+
+  // A DIFFERENT site's deep link is not this venue's identity — the guard is
+  // same-site only, so curated config still wins exactly as before.
+  const crossSite = core.applyFieldPriorities(
+    {
+      title: 'Bear and Twink Night',
+      startDate: new Date('2026-08-15T02:00:00.000Z'),
+      url: 'https://www.eventbrite.com/e/bear-and-twink-tickets-1'
+    }, config, {});
+  assert.equal(crossSite.website, 'https://www.thedallaseagle.com', 'cross-site link does not disarm the stamp');
+});
+
+test('final build promotes a same-site "ticketUrl" that is really the event\'s own page', async () => {
+  const core = createFinalBuildCore();
+  const event = {
+    title: 'Bear and Twink Night',
+    startDate: new Date('2026-08-15T02:00:00.000Z'),
+    city: 'dallas',
+    website: 'https://www.thedallaseagle.com',
+    url: 'https://www.thedallaseagle.com',
+    ticketUrl: 'https://www.thedallaseagle.com/events/bear-and-twink-night/'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.website, 'https://www.thedallaseagle.com/events/bear-and-twink-night/', 'event page becomes the identity link');
+  assert.equal(analyzed.url, 'https://www.thedallaseagle.com/events/bear-and-twink-night/', 'url follows website — one canonical field');
+  assert.equal(analyzed.ticketUrl, undefined, 'it was never a ticket link');
+  assert.ok(lines.some(line => line.startsWith('🔗 LINKS: "Bear and Twink Night" ticketUrl https://www.thedallaseagle.com/events/bear-and-twink-night/ is a page on the venue\'s own site')),
+    `got: ${JSON.stringify(lines.filter(l => l.startsWith('🔗 LINKS:')))}`);
+});
+
+test('final build never promotes a real ticket vendor into the identity field', async () => {
+  const core = createFinalBuildCore();
+  // Same bare-homepage website as the Dallas shape, but the ticket link is a
+  // genuine cross-host vendor — exactly what #1614/#1622 fought to keep OUT
+  // of website/url, because it steals the card's favicon.
+  const event = {
+    title: 'BEEFMINCE MEET MARKET',
+    startDate: new Date('2026-08-15T02:00:00.000Z'),
+    city: 'dallas',
+    website: 'https://www.thedallaseagle.com',
+    ticketUrl: 'https://dice.fm/event/xyz-beefmince'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.website, 'https://www.thedallaseagle.com', 'identity link untouched');
+  assert.equal(analyzed.ticketUrl, 'https://dice.fm/event/xyz-beefmince', 'the vendor link stays a ticket link');
+  assert.equal(lines.some(line => line.includes('is a page on the venue\'s own site')), false, 'no promotion');
+});
+
+test('final build drops a same-site homepage parked in ticketUrl', async () => {
+  const core = createFinalBuildCore();
+  // Mirror shape found in the published corpus (chunk-party.com ×3,
+  // bearracuda.com ×1): the ticketUrl is the site's own front door while
+  // website already names the event. A homepage sells no tickets.
+  const core2 = core;
+  const event = {
+    title: 'CHUNK LONDON',
+    startDate: new Date('2026-08-15T02:00:00.000Z'),
+    city: 'london',
+    website: 'https://www.chunk-party.com/events/chunk-london-august/',
+    ticketUrl: 'https://www.chunk-party.com'
+  };
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core2.buildAnalyzedCalendarEvent(event, NEW_ACTION_ANALYSIS, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.ticketUrl, undefined, 'the homepage is not a ticket link');
+  assert.equal(analyzed.website, 'https://www.chunk-party.com/events/chunk-london-august/', 'identity link untouched');
+  assert.ok(lines.some(line => line.includes('it is the same site\'s homepage, not a ticket link')),
+    `got: ${JSON.stringify(lines.filter(l => l.startsWith('🔗 LINKS:')))}`);
+});
+
+test('a crawled single-event page names itself; a listing page does not', async () => {
+  const core = new SharedCore(CITIES, {
+    eventSchema: EventSchema,
+    pageClassificationRules: [
+      { pattern: /venuehub\.example\/$/i, classification: 'multi-event-page' },
+      { pattern: /venuehub\.example\/events\//i, classification: 'event-page' }
+    ]
+  });
+  const display = createDisplayAdapterStub();
+  const day = new Date(Date.now() + 7 * 86400000);
+  const pages = {
+    // The listing: TWO events, so the page is not any one event's page.
+    'https://venuehub.example/': {
+      events: [
+        { title: 'Bear Tea Dance', bar: 'Hub Hall', startDate: day, url: 'https://venuehub.example' },
+        { title: 'Drag Brunch', bar: 'Hub Hall', startDate: new Date(day.getTime() + 86400000) }
+      ],
+      additionalLinks: ['https://venuehub.example/events/underwear-night']
+    },
+    // The detail page: ONE event, carrying only the venue's bare root.
+    'https://venuehub.example/events/underwear-night': {
+      events: [{
+        title: 'Underwear Night', bar: 'Hub Hall',
+        startDate: new Date(day.getTime() + 2 * 86400000),
+        url: 'https://venuehub.example'
+      }]
+    }
+  };
+  const { httpAdapter, parsers } = createCrawlHarness(pages);
+
+  const result = await core.processParser(
+    { name: 'Venue Hub', urls: ['https://venuehub.example/'], alwaysBear: true, ai: CRAWL_AI },
+    {}, httpAdapter, display, parsers
+  );
+
+  const byTitle = {};
+  for (const event of result.events) byTitle[event.title] = event;
+
+  assert.equal(byTitle['Underwear Night'].url, 'https://venuehub.example/events/underwear-night',
+    'the single-event page becomes that event\'s url');
+  assert.equal(byTitle['Bear Tea Dance'].url, 'https://venuehub.example',
+    'a listing page never overwrites its events\' urls');
+});


### PR DESCRIPTION
## What you reported

> URLs are weird (pointing to the shop?) … TicketUrls shouldn't go in the url field ever. URLs are for the event.

You were right, and it is in shipped data. `data/calendars/dallas.ics` today:

| event | `website` | `ticketUrl` |
|---|---|---|
| FURBALL | `furball.nyc` | `events.ticketleap.com/tickets/furballnyc/…` |
| Bear and Twink Night | `thedallaseagle.com` | `thedallaseagle.com/events/bear-and-twink-night/` |

FURBALL is exactly right. Dallas Eagle is wrong in both directions at once — that "ticketUrl" sells nothing, it is the event's own page on the venue's own host, while `url`/`website` holds the bare homepage.

**On the shop:** no defect. `shop.thedallaseagle.com` is linked twice on the listing page, but a scan of **235 saved runs** found it only ever as a key in the dead-end crawl store — **0 events** have ever captured a shop URL, in any field. The weirdness you spotted was real; the shop part of it wasn't.

## Three independent causes

**1. A curated venue homepage clobbered the whole identity field.** The parser extracted `.../events/womxns-night-5/` into `url`; `applyStaticMetadataBlock` then stamped the bare root over it. Proven against the real Dallas Eagle config — the event URL was destroyed *even when the model returned it correctly*. A homepage identifies the **venue**; it is the event's identity only when the page gave us nothing more specific. That is the same ruling the existing "same-host deeper URL beats domain root" merge rung already makes — static metadata was simply bypassing arbitration. Identity fields only; every other metadata key clobbers exactly as before.

**2. Nothing in the pipeline could notice a misfiled ticketUrl.** Every URL rung arbitrates two candidates for the *same* field, so none has ever compared `website` against `ticketUrl`. Now a same-site, non-vendor "ticket" link is promoted to `website`/`url`, and the mirror shape — the site's own bare homepage parked in `ticketUrl` — is dropped.

Fails closed both ways: a known ticketing/social platform host is **never** promoted (that is the vendor-stealing-the-favicon defect #1614 and #1622 fixed, and this must not reintroduce it), and promotion additionally requires the link to be on the site we actually crawled, so a genuine vendor missing from both host lists stays put.

**3. A crawled single-event page never named itself.** The JSON-LD and JSON-API routes already set `url` from the page they read; the AI-extraction route had no equivalent, so a detail page kept whatever static metadata supplied. That also silently killed the `event-page-url` dedup rung, which returns nothing for a domain root — leaving those events to match on name + time alone. A page describing exactly one event now names itself, filling a blank or replacing a same-site bare root only. Listing pages are excluded by the event count.

## Blast radius — measured, not estimated

Ran the real build pass over the published corpus (150 events carrying a `website` and/or `ticketUrl`) on `origin/main` and on this branch, then diffed.

**5 events change. Every one is correct.**

- `dallas.ics` **Bear and Twink Night** — gains its event page as `website`; the fake ticketUrl goes away.
- `chicago.ics`, `nyc.ics` ×2, `portland.ics` — four bare homepages parked in `ticketUrl` are dropped (`chunk-party.com` ×3, `bearracuda.com` ×1).

The 13 rewrites the existing platform pass already performs are **byte-identical** before and after.

Parser side, cause 1 reaches the three configs whose static `website` is a bare root: **Dallas Eagle, 3 Dollar Bill, The Lumberyard**.

**Favicons are unaffected** — I checked before touching this, since you flagged it: `convertWebsiteUrlToFaviconPath` derives from `hostname` only (Linktree is the one path-sensitive case), and every promotion here stays on the same host.

## Tests

6 added, **1534 → 1540 pass, 0 fail**.

Four fail on `origin/main`. The other two are deliberate guard tests that pass **both** ways — they pin behaviour that must *not* change: the curated stamp still applies when the page offered nothing better and across different sites, and a real ticket vendor is never promoted into the identity field.

No new runtime files, so nothing to add to the script updater.

## Not in this PR

- **The duplicates you saw are two different bugs, and neither is fixed here.** One pair (`Dirty Pop` / `Dirty Pop with DJ Drew G`) is one event scraped twice. The other pair is **two genuinely different events**, one of which acquired a fabricated date — deduping those would delete a real event. Both are being investigated separately.
- **The wrong times.** "Same night, slightly different times" turned out to be literally *wrong* times: 7 of 16 events on that page carry a neighbouring card's date/time. Separate investigation, and the more serious problem.
