### PR TITLE
fix(scraper): one window per card, and a padded day is still a date

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -2610,6 +2610,90 @@ class AiWebParser {
             });
             groups.push({ signature, entries });
         }
+        for (const linkGroup of this.extractRepeatedMultiEventLinkGroups(source)) {
+            groups.push(linkGroup);
+        }
+        return groups;
+    }
+
+    // Card-aligned windows anchored on a page's REPEATED HYPERLINKS.
+    //
+    // The container scan above assumes each card is one element. Plenty of
+    // listing markup breaks that assumption: the card's link/title and its
+    // date/description are SIBLINGS under a shared cell, with no element
+    // enclosing exactly one card. thedallaseagle.com/events/ is the worked
+    // example — 42 cards, and the container scan produced 170 fragment
+    // entries of which ZERO cleared the per-entry date+title gates, so
+    // segmentation fell through to the flat text splitter, which knows
+    // nothing about card boundaries and fused 7 of 16 windows onto a
+    // neighbouring card's date/time.
+    //
+    // The structural invariant that still holds on such a page is the
+    // repeated hyperlink: one anchor per card, all sharing an attribute
+    // signature, in document order. Slicing between consecutive
+    // same-signature anchors reconstructs the card — its own link, its own
+    // title, its own date text — with no knowledge of the site, its CMS, or
+    // its class names.
+    //
+    // Nav bars, footers and pagination repeat anchors too. Nothing here
+    // trusts an anchor group on its own: the caller still requires >= 2
+    // event-like entries, and every entry still has to clear the same
+    // line-count/date/title gates in buildSegmentsFromStructureGroup that
+    // container entries clear.
+    extractRepeatedMultiEventLinkGroups(source) {
+        const text = String(source || '');
+        if (!text) return [];
+
+        const anchors = [];
+        const pattern = /<a\b[^>]*\bhref\s*=\s*["'][^"']+["'][^>]*>/gi;
+        let match;
+        while ((match = pattern.exec(text)) !== null) {
+            const attrs = (match[0].match(/^<a\b([^>]*)>/i) || [])[1] || '';
+            // The anchor must carry its own listing identity, exactly as the
+            // container scan demands of a <div>. Without this, every bare
+            // <a href> on a page joins one giant "a:plain" group; on
+            // bearssitges.org that group (69 anchors, 16 event-like) outranked
+            // the correct festival day-programme segmentation and replaced 16
+            // day sections with 11 windows headed "www.bearsevents.com )".
+            // A repeated link that identifies itself as an event/card/item
+            // link is a listing; a naked <a> is just a link.
+            if (!this.hasMultiEventStructureHint(attrs)) continue;
+            const start = match.index;
+            // Same proximity rule the image anchors use: a card that links
+            // its poster AND its title must open ONE window, not two.
+            // Anchors arrive in ascending order here, so comparing against
+            // the previous kept anchor is equivalent to the image path's
+            // scan of every anchor — and stays linear on link-heavy pages.
+            if (anchors.length > 0 && start - anchors[anchors.length - 1].start < 200) continue;
+            anchors.push({
+                start,
+                signature: `resource-link:${this.getMultiEventStructureSignature('a', attrs)}`
+            });
+        }
+
+        const bySignature = new Map();
+        anchors.forEach(anchor => {
+            if (!bySignature.has(anchor.signature)) bySignature.set(anchor.signature, []);
+            bySignature.get(anchor.signature).push(anchor);
+        });
+
+        const groups = [];
+        for (const [signature, groupAnchors] of bySignature.entries()) {
+            if (groupAnchors.length < 2) continue;
+            const entries = groupAnchors.map((anchor, index) => {
+                const nextAnchor = groupAnchors[index + 1];
+                const end = nextAnchor
+                    ? nextAnchor.start
+                    : Math.min(text.length, anchor.start + this.extractionLimits.multiEventMaxSegmentChars * 4);
+                return {
+                    html: text.slice(anchor.start, end),
+                    start: anchor.start,
+                    end,
+                    kind: 'resource-link'
+                };
+            });
+            groups.push({ signature, entries });
+        }
         return groups;
     }
 
@@ -10820,6 +10904,22 @@ TEXT:
             `${month}-${day}`,
             `${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
         ]);
+        // Zero-padded day beside a month name ("Aug 05 2026") — the numeric
+        // slash/dash forms above already carry both paddings, but the
+        // month-name forms only ever emitted the UNPADDED day, so any page
+        // whose date formatter pads single-digit days ("M d Y") corroborated
+        // nothing and the gate dropped a real, verbatim-on-the-page date.
+        // Run 20260806-102824: startDate "2026-08-05" cited "Aug 05 2026",
+        // which IS in the corpus; no variant matched, the date became null
+        // and an rrule fallback invented 2026-08-12 for a real event.
+        // "aug 05" is exactly as specific as "aug 5" — one calendar day, no
+        // fuzziness — and because matching is substring-based it also covers
+        // "August 05", "Aug 05, 2026" and "Aug 05 2026".
+        const paddedDay = String(day).padStart(2, '0');
+        if (paddedDay !== String(day)) {
+            variants.add(`${monthNames[monthIndex]} ${paddedDay}`);
+            variants.add(`${monthShortNames[monthIndex]} ${paddedDay}`);
+        }
         if (Number.isFinite(year) && year > 0) {
             variants.add(`${monthNames[monthIndex]} ${day}, ${year}`);
             variants.add(`${monthShortNames[monthIndex]} ${day}, ${year}`);

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -3807,6 +3807,66 @@ test('date-mode values with a time component need that time in the source (T00:0
 });
 
 // ---------------------------------------------------------------------------
+// Run 20260806-102824: a single-event page rendered its date as "Aug 05 2026"
+// (zero-padded day — a very common date-format setting). The model returned
+// startdate 2026-08-05 citing that exact string, but buildDateEvidenceVariants
+// only ever emitted the UNPADDED month-name form ("aug 5"), so nothing matched,
+// the gate dropped a REAL date, and an rrule fallback then invented the next
+// occurrence — shipping a fabricated date that collided with a different real
+// event. The padded day is exactly as specific as the unpadded one.
+// ---------------------------------------------------------------------------
+
+test('a zero-padded day beside a month name corroborates the date (Aug 05 2026)', () => {
+  const parser = createParser();
+  const validationContext = { imageEvidenceUrls: new Set() };
+  const source = 'BEAR NIGHT\nDate\nAug 05 2026\nTime\n7:00 pm - 9:00 pm';
+  const evidenceContext = parser.buildAiEvidenceContextFromText(source);
+
+  assert.ok(
+    parser.buildDateEvidenceVariants(parser.extractDateEvidenceParts('2026-08-05')).includes('aug 05'),
+    'the padded short-month form must be among the generated variants'
+  );
+
+  const result = parser.validateAiEventEvidence(
+    {
+      startDate: '2026-08-05',
+      endDate: '2026-08-05',
+      __fieldEvidence: { startDate: 'Aug 05 2026', endDate: 'Aug 05 2026' }
+    },
+    { html: source }, {}, null,
+    { evidenceContext, validationContext }
+  );
+  assert.equal(result.event.startDate, '2026-08-05', 'the page states this date verbatim — it must survive the gate');
+  assert.equal(result.event.endDate, '2026-08-05', 'the same holds for the end date');
+  assert.equal(result.report.dropped.length, 0, 'nothing is dropped when the date is on the page');
+
+  // Padded long-month spelling and a comma-separated rendering work too.
+  const longMonth = parser.buildAiEvidenceContextFromText('Date: August 05, 2026');
+  assert.equal(
+    parser.validateAiEventEvidence(
+      { startDate: '2026-08-05' }, { html: 'x' }, {}, null,
+      { evidenceContext: longMonth, validationContext }
+    ).event.startDate,
+    '2026-08-05',
+    '"August 05, 2026" is the same day'
+  );
+
+  // ...and the gate is not one notch looser: every date the page does NOT
+  // state is still dropped, including the exact fabrication this bug shipped
+  // (the rrule's "next occurrence", 2026-08-12).
+  const check = (value) => parser.validateAiEventEvidence(
+    { startDate: value }, { html: source }, {}, null,
+    { evidenceContext, validationContext }
+  ).event.startDate;
+  assert.equal(check('2026-08-12'), undefined, 'a date the page never states is still dropped');
+  assert.equal(check('2026-08-15'), undefined, 'a padded variant must not match by prefix ("aug 05" vs "aug 15")');
+  assert.equal(check('2026-09-05'), undefined, 'the month still has to match');
+  const twoDigit = parser.buildDateEvidenceVariants(parser.extractDateEvidenceParts('2026-08-15'));
+  assert.ok(twoDigit.includes('aug 15'), 'two-digit days keep their existing variant');
+  assert.ok(!twoDigit.includes('aug 015'), 'two-digit days are never double-padded');
+});
+
+// ---------------------------------------------------------------------------
 // NYE year-jump: a Dec 31 event ending 2am must land on Jan 1 of the NEXT
 // year — never the same year's Jan 1 eleven months in the past (which used to
 // collapse the end onto the start).
@@ -11611,4 +11671,134 @@ test('discovery allowlist: segment filter is a no-op on own pages and without pa
   );
   // null/absent parserConfig → no-op, never a throw
   assert.equal(parser.filterSegmentsByDiscoveryAllowlist(segments, 'https://x.com/', null).length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Card-aligned segmentation when NO element encloses a whole card.
+//
+// Run 20260806 over thedallaseagle.com/events/ (42 cards): the container scan
+// found the right group (170 entries) but every entry was a FRAGMENT — the
+// card's link/title and its date/description are SIBLINGS under a shared day
+// cell, so no container holds one card. Zero entries cleared the per-entry
+// date+title gates, buildStructuredMultiEventSegments returned 0, and
+// segmentation fell through to the flat text splitter: 16 windows, 7 of them
+// carrying a DIFFERENT card's date/time (80s Retro dated Aug 19 when its card
+// says Aug 16; Drink Draw and Dine given Gear Night's 10pm-2am).
+//
+// The generic invariant that survives this markup is the repeated HYPERLINK:
+// one identified anchor per card, in document order. Windows sliced between
+// consecutive same-signature anchors reconstruct the card.
+// ---------------------------------------------------------------------------
+
+const SIBLING_CARD_LISTING_HTML = `
+  <html><body><dl class="calendar-row">
+    <dt class="calendar-day"><div class="daynum">5</div>
+      <div class="past-relative"><a class="listing-tooltip event-single-link" href="https://eagle.example/events/leather-night/"><h4 class="event-title">Leather Night</h4></a></div>
+      <div class="tooltip_templates event-single-content"><div id="tip-1">
+        <div class="tooltip-event-title">Leather Night</div>
+        <div class="event-detailed-time"><div class="detailed-time-start">Start from: August 5, 2026 - 9:00 pm</div><div class="detailed-time-end">End at: August 6, 2026 - 2:00 am</div></div>
+        <div class="tooltip-event-content"><div class="tooltip-event-desc">Gear up and join us for the monthly leather social.</div></div>
+      </div></div></dt>
+    <dt class="calendar-day"><div class="daynum">12</div>
+      <div class="past-relative"><a class="listing-tooltip event-single-link" href="https://eagle.example/events/otter-night/"><h4 class="event-title">Otter Night</h4></a></div>
+      <div class="tooltip_templates event-single-content"><div id="tip-2">
+        <div class="tooltip-event-title">Otter Night</div>
+        <div class="event-detailed-time"><div class="detailed-time-start">Start from: August 12, 2026 - 10:00 pm</div><div class="detailed-time-end">End at: August 13, 2026 - 1:00 am</div></div>
+        <div class="tooltip-event-content"><div class="tooltip-event-desc">Sleek and playful, the monthly otter meetup takes the back bar.</div></div>
+      </div></div></dt>
+    <dt class="calendar-day"><div class="daynum">19</div>
+      <div class="past-relative"><a class="listing-tooltip event-single-link" href="https://eagle.example/events/cub-social/"><h4 class="event-title">Cub Social</h4></a></div>
+      <div class="tooltip_templates event-single-content"><div id="tip-3">
+        <div class="tooltip-event-title">Cub Social</div>
+        <div class="event-detailed-time"><div class="detailed-time-start">Start from: August 19, 2026 - 8:00 pm</div><div class="detailed-time-end">End at: August 20, 2026 - 12:00 am</div></div>
+        <div class="tooltip-event-content"><div class="tooltip-event-desc">Cheap drafts and a patio takeover for the cubs and their admirers.</div></div>
+      </div></div></dt>
+  </dl></body></html>`;
+
+test('card-aligned segments survive when a card link and its date are sibling elements', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://eagle.example/events/';
+
+  // The failure this fixes: the container scan cannot see a whole card here.
+  const containerGroups = parser.extractRepeatedMultiEventStructureGroups(SIBLING_CARD_LISTING_HTML)
+    .filter(group => String(group.signature || '').startsWith('container:'));
+  const containerSegments = containerGroups
+    .map(group => parser.buildSegmentsFromStructureGroup(group))
+    .find(segments => segments.length >= 2);
+  assert.equal(containerSegments, undefined,
+    'no single container encloses one card on this shape — the repeated-anchor path is what has to carry it');
+
+  const segments = parser.buildStructuredMultiEventSegments(SIBLING_CARD_LISTING_HTML);
+  assert.equal(segments.length, 3,
+    `one segment per card, got ${segments.length}: ${JSON.stringify(segments.map(s => s.lines[0]))}`);
+
+  const expected = [
+    ['Leather Night', 'Start from: August 5, 2026 - 9:00 pm', 'End at: August 6, 2026 - 2:00 am', 'https://eagle.example/events/leather-night/'],
+    ['Otter Night', 'Start from: August 12, 2026 - 10:00 pm', 'End at: August 13, 2026 - 1:00 am', 'https://eagle.example/events/otter-night/'],
+    ['Cub Social', 'Start from: August 19, 2026 - 8:00 pm', 'End at: August 20, 2026 - 12:00 am', 'https://eagle.example/events/cub-social/']
+  ];
+  segments.forEach((segment, index) => {
+    const [title, start, end, link] = expected[index];
+    assert.equal(segment.lines[0], title, `segment ${index + 1} opens on its own card title`);
+    assert.ok(segment.lines.includes(start), `segment ${index + 1} keeps its own start, got ${JSON.stringify(segment.lines)}`);
+    assert.ok(segment.lines.includes(end), `segment ${index + 1} keeps its own end, got ${JSON.stringify(segment.lines)}`);
+    const resourceLines = parser.extractMultiEventSegmentResourceLines(segment.html, sourceUrl);
+    assert.ok(resourceLines.includes(`SEGMENT_LINK_URL: ${link}`),
+      `segment ${index + 1} recovers its OWN card link, got ${JSON.stringify(resourceLines)}`);
+  });
+
+  // No fusion in either direction: a card never carries a neighbour's clock.
+  expected.forEach(([, start, end], index) => {
+    segments.forEach((segment, other) => {
+      if (other === index) return;
+      assert.ok(!segment.lines.includes(start), `segment ${other + 1} must not carry card ${index + 1}'s start`);
+      assert.ok(!segment.lines.includes(end), `segment ${other + 1} must not carry card ${index + 1}'s end`);
+    });
+  });
+});
+
+// A repeated anchor only counts as a listing when it carries its own listing
+// identity — the same structure-hint vocabulary the container scan already
+// demands of a <div>. Without that requirement every bare <a href> on a page
+// joins one giant group: on bearssitges.org that group (69 anchors) outranked
+// the correct festival day-programme segmentation and replaced 16 day sections
+// with 11 windows headed "www.bearsevents.com )".
+const NAKED_ANCHOR_PROGRAMME_HTML = `
+  <html><body>
+    <div class="programme">
+      <p>JUEVES - 03</p>
+      <p>21:00 Opening dinner at the port <a href="https://bears.example/a">info</a></p>
+      <p>01h a 06h Opening Party at the disco <a href="https://bears.example/b">tickets</a></p>
+      <p>VIERNES - 04</p>
+      <p>14:00 Pool party at the beach club <a href="https://bears.example/c">info</a></p>
+      <p>01h a 06h White Party at the disco <a href="https://bears.example/d">tickets</a></p>
+      <p>SABADO - 05</p>
+      <p>12:00 Bear market on the promenade <a href="https://bears.example/e">info</a></p>
+      <p>01h a 06h Sailor Party at the disco <a href="https://bears.example/f">tickets</a></p>
+    </div>
+  </body></html>`;
+
+test('repeated anchors need their own listing identity before they can segment a page', () => {
+  const parser = createParser();
+
+  // Positive: identified anchors DO form a listing group.
+  const identified = parser.extractRepeatedMultiEventLinkGroups(SIBLING_CARD_LISTING_HTML);
+  assert.equal(identified.length, 1, 'the identified card anchors form exactly one group');
+  assert.equal(identified[0].entries.length, 3);
+  assert.ok(String(identified[0].signature).startsWith('resource-link:'));
+
+  // Guard: naked <a href> links carry no listing identity, so they never
+  // group — the day-programme keeps its own segmentation.
+  assert.deepEqual(parser.extractRepeatedMultiEventLinkGroups(NAKED_ANCHOR_PROGRAMME_HTML), [],
+    'bare anchors must never form a listing group and hijack a schedule page');
+
+  // Inertness, stated as invariance: whatever this page segments into, the
+  // naked anchors must not have influenced it. Segmenting the page with the
+  // anchors stripped out has to produce exactly the same windows.
+  const withoutAnchors = NAKED_ANCHOR_PROGRAMME_HTML.replace(/<a\b[^>]*>|<\/a>/gi, '');
+  const linesOf = (html) => parser
+    .buildMultiEventSegments(html, 'https://bears.example/programa/')
+    .map(segment => segment.lines.map(line => line.replace(/\s*(?:info|tickets)$/, '').trim()));
+  assert.deepEqual(linesOf(NAKED_ANCHOR_PROGRAMME_HTML), linesOf(withoutAnchors),
+    'repeated naked anchors leave a schedule page\'s segmentation exactly as it was');
 });


### PR DESCRIPTION
## What you actually saw

> similar duplicate events (same events on the same night with slightly different times)

The times weren't slightly different. **They were wrong.** Two separate defects, both on that page.

## 1. One window per card

That listing page publishes **42 event cards**. The container scan meant to find them assumes each card is one element, and matches with a nesting-blind non-greedy regex — so every "card" it produced was a truncated fragment (`htmlLen=224, lines=["Underwear Happy Hour"]`). **All 170 entries failed the per-entry gates — zero passed.** Segmentation then fell through to a flat text splitter that knows nothing about card boundaries.

Measured on the real page: **16 windows for 42 cards**, two of them fusing three separate events, seven recovering no link at all. Six windows were clean; **ten carried a neighbouring card's title, description, date or time.**

| event | shipped as | the card actually says |
|---|---|---|
| 80s Retro with DJ Blaine | Aug 19, 9pm–2am | **Aug 16, 5–9pm** |
| Sweet Tea with DJ Apthout | Sep 2, 9pm–2am | **Aug 30, 5–10pm** |
| Drink Draw and Dine | Aug 22, 10pm–2am | **Aug 21, 7–9pm** |
| Lost Souls Bingham Cup Send Off | Aug 8, 9pm–2am | **Aug 8, 1–4pm** |

`Free pool and free Switch all night` isn't even a title — it's a bullet from Karaoke's description, fused with Discipline Corps' times and link.

**The fix:** the invariant that survives this markup is the repeated hyperlink — one anchor per card, sharing an attribute signature, in document order. Slicing between consecutive same-signature anchors reconstructs the card with no knowledge of the site or its CMS.

An anchor must carry its own listing identity to qualify — the **same** `hasMultiEventStructureHint` check the container scan already demands of a `<div>`. That guard isn't decorative: without it, every bare `<a href>` joins one group, and on bearssitges.org that group (69 anchors) outranked the correct day-programme segmentation and replaced 16 festival day sections with 11 junk windows.

**Result on the real page: 19 windows, every one covering exactly one event, zero fused.** I verified this independently of the change author.

**Corpus check across all 44 saved pages, comparing segment *content* hashes rather than counts: 42 identical, 2 changed — both Dallas Eagle snapshots.**

### The honest limitation

This does **not** correct those 7 wrong dates — it **suppresses** them. Those cards carry no month-name date in their markup at all (just a clock range; the day lives in an ancestor cell attribute we don't read), so they now fail the date gate and are **dropped rather than mis-dated**.

Net: **6 clean events → 19 clean events, and 7 wrong dates → 0 wrong dates**, but coverage stays at 19 of 42 rather than rising to 42. Reading the day from an ancestor cell is a separate, larger change.

## 2. A padded day is still a date

This is the one that made two different events look like duplicates.

The evidence gate checks the extracted **value** against the page corpus (not, as I first assumed, the model's evidence string). It generated both paddings for numeric forms — `08/05`, `8/5` — but only the **unpadded** day for month-name forms. The page renders `Aug 05 2026`. Nothing matched, the date became `null`, and an rrule fallback invented "next occurrence" instead.

That is how `UNDERWEAR HAPPY HOUR` — really **Aug 5** — shipped onto **2026-08-12**, where a different real event already sits. **Those two records are not duplicates, and deduplicating them would delete a real event.**

`aug 05` denotes exactly one calendar day — identical specificity to the `aug 5` already generated — and matching is substring-based, so the two added forms also cover `August 05`, `Aug 05, 2026` and `Aug 05 2026`. Verified against the same corpus: `2026-08-05` now passes while `2026-08-12` (the exact fabrication this shipped), `2026-08-15` and `2026-09-05` are still rejected. Days 10–31 untouched.

**Scale, across 235 saved runs:** 2158 evidence drops, 647 naming `startdate`/`enddate`, and 46 rrule-derived dates — of which **35 (76%) directly follow a dropped date**. This closes one input to that funnel, not the funnel.

## Tests

3 added, **1534 → 1537 pass, 0 fail**. All three fail on `origin/main`. No new runtime files.

## Deliberately not in this PR

- **The rrule fallback itself.** It can't distinguish "this page never stated a date" (the Lumberyard case it was built for) from "this page stated a date and we lost it" — in the second case it fabricates. The signal to tell them apart already exists and already reaches that code (`__droppedFieldValues`). Failing closed there would kill events that today ship with an approximately-right date, so it wants a report-only pass first. Your call, separate PR.
- **Latent looseness in the date variants:** `-5`, `-05`, `05,` are genuinely fuzzy. On a full-page evidence context, `2026-08-05` passes on main *by coincidence*, matching `-05` inside a JSON-LD `"dateModified":"2026-08-05t…"`. A page's last-modified timestamp is not event-date corroboration. Pre-existing; flagged, not touched.
- **Dedup before the bear check.** Still deferred, and this PR is a reason to keep deferring: one of the two "duplicate" pairs is two distinct events.
