### PR TITLE
fix(scraper): a page is not its own canonical, and a terse card is still a card

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -2250,10 +2250,93 @@ class AiWebParser {
     buildStructuredMultiEventSegments(html) {
         const groups = this.extractRepeatedMultiEventStructureGroups(html);
         for (const group of groups) {
-            const segments = this.buildSegmentsFromStructureGroup(group);
-            if (segments.length >= 2) return segments;
+            const result = this.segmentStructureGroup(group);
+            if (result.segments.length >= 2) {
+                return this.coverRepeatedEventUnits(group, result);
+            }
         }
         return [];
+    }
+
+    // Coverage guard: a segmentation that produces far fewer windows than the
+    // page has SELF-IDENTIFYING EVENT UNITS is the wrong segmentation, even
+    // when it "succeeded".
+    //
+    // The page states its own event count structurally: a repeated card that
+    // carries its own navigable link — one no sibling card in the same group
+    // carries — plus its own date and its own title is a complete event unit.
+    // Nothing else on a listing page repeats with a per-copy identity like
+    // that. eaglela.com/events/ is the worked example: 12 such units, every
+    // one of them correctly bounded by the winning group, and 9 of the 12
+    // were then dropped by the generic minimum-character floor because their
+    // whole visible text is a short name and a day ("ONYX" / "09 Aug", 11
+    // chars). Segmentation reported success with 3 windows for 12 cards, so
+    // nine real events were never extracted and the run looked like a
+    // three-event week.
+    //
+    // A character count does not measure completeness — identity does. So
+    // when windows < identified units, this re-segments the SAME group with
+    // the character floor waived for units that identify themselves. Group
+    // selection is untouched (the winner is already chosen), entry
+    // boundaries are untouched (each entry still spans exactly what it
+    // spanned), and every other gate still applies: only windows that were
+    // being silently discarded come back. Pages whose segmentation already
+    // covers their units take the early return and are byte-identical.
+    coverRepeatedEventUnits(group, result) {
+        const segments = result && Array.isArray(result.segments) ? result.segments : [];
+        const identifiedUnitCount = Number(result && result.identifiedUnitCount) || 0;
+        if (identifiedUnitCount <= segments.length) return segments;
+        const covered = this.segmentStructureGroup(group, { allowTerseIdentifiedUnits: true });
+        if (covered.segments.length <= segments.length) return segments;
+        console.log(`🤖 AI Web: Segmentation covered ${segments.length} of ${identifiedUnitCount} repeated event unit(s) on this page — re-segmenting to ${covered.segments.length} window(s)`);
+        return covered.segments;
+    }
+
+    // The entry's own primary destination. Fragment-only, javascript:, mailto:
+    // and tel: hrefs are not destinations, so they never stand in for one.
+    // Query strings are KEPT: a listing that repeats one detail page per
+    // occurrence distinguishes its cards purely by query, and stripping it
+    // would make two real cards look like one. Regex only — no URL parsing
+    // (iOS JavaScriptCore has no URL/URLSearchParams).
+    extractMultiEventEntryIdentityLink(html) {
+        const pattern = /<a\b[^>]*\bhref\s*=\s*["']([^"']+)["']/gi;
+        let match;
+        while ((match = pattern.exec(String(html || ''))) !== null) {
+            const href = String(match[1] || '').split('#')[0].trim();
+            if (!href) continue;
+            if (/^(?:javascript|mailto|tel|sms|data):/i.test(href)) continue;
+            return href;
+        }
+        return '';
+    }
+
+    // Which entries of a repeated group identify THEMSELVES: each holds a
+    // primary destination that no sibling entry in the group holds. Cards in
+    // a listing point at their own detail pages; a repeated nav block, a
+    // pagination strip or a row of identical ticket buttons all point at the
+    // same place, so none of them qualifies.
+    mapMultiEventGroupIdentityLinks(entries) {
+        const links = (Array.isArray(entries) ? entries : [])
+            .map(entry => this.extractMultiEventEntryIdentityLink(entry && entry.html));
+        const counts = new Map();
+        links.forEach(link => {
+            if (!link) return;
+            counts.set(link, (counts.get(link) || 0) + 1);
+        });
+        return links.map(link => Boolean(link) && counts.get(link) === 1);
+    }
+
+    // The content gates every structural entry has to clear before it can be
+    // a window. Extracted verbatim from buildSegmentsFromStructureGroup so
+    // the coverage count and the segment build ask exactly the same question.
+    multiEventEntryClearsContentGates(normalizedLines) {
+        const lines = Array.isArray(normalizedLines) ? normalizedLines : [];
+        if (lines.length < this.extractionLimits.multiEventMinSegmentLines) return false;
+        if (this.hasMultiEventScriptLikeText(lines)) return false;
+        if (this.countMultiEventDateSignals(lines) > 2) return false;
+        if (!this.segmentHasDateSignal(lines)) return false;
+        if (!this.segmentHasTitleSignal(lines) && !this.segmentIsDateHeadedSchedule(lines)) return false;
+        return true;
     }
 
 
@@ -2311,8 +2394,19 @@ class AiWebParser {
     }
 
 
-    buildSegmentsFromStructureGroup(group) {
+    buildSegmentsFromStructureGroup(group, options = {}) {
+        return this.segmentStructureGroup(group, options).segments;
+    }
+
+    // Returns { segments, identifiedUnitCount } — the windows this group
+    // yields, and how many of its entries are self-identifying event units
+    // that cleared the content gates. The gap between the two IS the
+    // under-coverage signal coverRepeatedEventUnits acts on.
+    segmentStructureGroup(group, options = {}) {
         const entries = group && Array.isArray(group.entries) ? group.entries : [];
+        const identifiedUnits = this.mapMultiEventGroupIdentityLinks(entries);
+        const allowTerseIdentifiedUnits = Boolean(options && options.allowTerseIdentifiedUnits);
+        let identifiedUnitCount = 0;
         const uniqueSegments = [];
         const seen = new Set();
         // The repeated structural entries ARE the page's own item list — one
@@ -2328,17 +2422,24 @@ class AiWebParser {
         // entry count still sizes the per-run AI MISS budget downstream.
         this.recordMultiEventSegmentationStats(datedCandidateCount, 'structure group');
         const segmentBudget = this.resolveMultiEventSegmentationCeiling();
-        const addSegment = (segment) => {
+        const addSegment = (segment, isIdentifiedUnit = false) => {
             if (!segment || !Array.isArray(segment.lines)) return;
             const segmentText = segment.lines.join('\n');
-            if (segmentText.length < this.extractionLimits.multiEventMinSegmentChars) return;
+            if (!segmentText) return;
+            // The character floor rejects scraps of text that cannot be an
+            // event. A card that carries its own name, its own date and its
+            // own destination is not a scrap however few characters it
+            // spends, so identity replaces the floor for those.
+            const waiveMinChars = allowTerseIdentifiedUnits && isIdentifiedUnit;
+            if (!waiveMinChars && segmentText.length < this.extractionLimits.multiEventMinSegmentChars) return;
             const dedupeKey = segmentText.toLowerCase();
             if (seen.has(dedupeKey)) return;
             seen.add(dedupeKey);
             uniqueSegments.push(segment);
         };
 
-        for (const entry of entries) {
+        for (let entryIndex = 0; entryIndex < entries.length; entryIndex++) {
+            const entry = entries[entryIndex];
             if (uniqueSegments.length >= segmentBudget) {
                 // No silent caps. This break truncates the page: on
                 // thedallaseagle.com/events/ (a full month, ~27 listings) it
@@ -2353,25 +2454,25 @@ class AiWebParser {
             const normalizedLines = this.extractBodyParts(entry.html)
                 .map(line => this.normalizeWhitespace(line))
                 .filter(Boolean);
-            if (normalizedLines.length < this.extractionLimits.multiEventMinSegmentLines) continue;
-            if (this.hasMultiEventScriptLikeText(normalizedLines)) continue;
-            if (this.countMultiEventDateSignals(normalizedLines) > 2) continue;
-            if (!this.segmentHasDateSignal(normalizedLines)) continue;
-            if (!this.segmentHasTitleSignal(normalizedLines) && !this.segmentIsDateHeadedSchedule(normalizedLines)) continue;
+            if (!this.multiEventEntryClearsContentGates(normalizedLines)) continue;
+            const isIdentifiedUnit = identifiedUnits[entryIndex] === true;
+            if (isIdentifiedUnit) identifiedUnitCount++;
 
             const splitSegments = this.buildTextMultiEventSegmentsFromLines(normalizedLines, entry.html);
             if (splitSegments.length > 1) {
-                splitSegments.forEach(addSegment);
+                // Split windows are slices of one entry, not the entry's own
+                // identity — the floor still applies to each of them.
+                splitSegments.forEach(splitSegment => addSegment(splitSegment, false));
             } else {
                 const segmentLines = splitSegments.length === 1 ? splitSegments[0].lines : normalizedLines;
                 const trimmedLines = this.trimSegmentLinesToChars(
                     this.trimLinesAfterTerminalCallToAction(segmentLines),
                     this.extractionLimits.multiEventMaxSegmentChars
                 );
-                addSegment({ lines: trimmedLines, html: entry.html });
+                addSegment({ lines: trimmedLines, html: entry.html }, isIdentifiedUnit);
             }
         }
-        return uniqueSegments;
+        return { segments: uniqueSegments, identifiedUnitCount };
     }
 
     buildTextMultiEventSegmentsFromLines(lines, html = '') {
@@ -3954,6 +4055,18 @@ class AiWebParser {
             console.warn(`🤖 AI Web: Error extracting additional URLs: ${error}`);
         }
 
+        // A page's own rel="canonical" / og:url is a pointer AT THE DOCUMENT WE
+        // ALREADY HAVE — never a new page to crawl. It reaches this Map through
+        // several harvest routes at once (the generic href scan picks up
+        // <link rel="canonical" href>, the raw-HTML scan picks up
+        // <meta property="og:url" content>, and SEO plugins repeat the same URL
+        // as a JSON-LD WebPage @id), which is why the suppression lives here at
+        // the single funnel instead of on any one extractor.
+        // Run 20260806-124046: 9 of 24 AI extractions were the crawler
+        // re-fetching a detail page it had already extracted, purely because
+        // the page advertised its own canonical.
+        this.suppressSelfCanonicalUrls(urls, html, sourceUrl);
+
         const rankedUrls = this.rankAdditionalUrls(urls);
         const maxAdditionalUrls = this.resolveMaxAdditionalUrls(parserConfig);
         const hasFiniteLimit = Number.isFinite(maxAdditionalUrls) && maxAdditionalUrls >= 0;
@@ -4005,6 +4118,106 @@ class AiWebParser {
         }
 
         return limitedUrls;
+    }
+
+    /**
+     * The URLs a document declares as ITSELF: <link rel="canonical" href> and
+     * <meta property="og:url" content>. Attribute-order agnostic, raw values —
+     * resolution against the page URL is the caller's job.
+     * Strict on rel: only a lone `canonical` token counts, so rel lists like
+     * `rel="alternate canonical"` are left alone rather than guessed at.
+     */
+    extractSelfDeclaredCanonicalUrls(html) {
+        const declared = [];
+        if (!html || typeof html !== 'string') return declared;
+
+        const linkRegex = /<link\b[^>]*>/gi;
+        let match;
+        while ((match = linkRegex.exec(html)) !== null) {
+            const tag = match[0];
+            if (!/\brel\s*=\s*(?:"\s*canonical\s*"|'\s*canonical\s*'|canonical(?=[\s/>]))/i.test(tag)) continue;
+            const href = tag.match(/\bhref\s*=\s*["']([^"']+)["']/i);
+            if (href && href[1] && href[1].trim()) declared.push(href[1].trim());
+        }
+
+        const metaRegex = /<meta\b[^>]*>/gi;
+        while ((match = metaRegex.exec(html)) !== null) {
+            const tag = match[0];
+            if (!/\b(?:property|name)\s*=\s*["']og:url["']/i.test(tag)) continue;
+            const content = tag.match(/\bcontent\s*=\s*["']([^"']+)["']/i);
+            if (content && content[1] && content[1].trim()) declared.push(content[1].trim());
+        }
+
+        return declared;
+    }
+
+    /**
+     * host+path identity of a URL, ignoring query, fragment, trailing slash,
+     * `www.` and default ports. Two URLs with the same key address the same
+     * resource path — they are NOT necessarily the same rendered document, so
+     * this is only ever used to recognise a SELF-reference, never to dedupe
+     * crawl targets (parameterized variants of one path are real, distinct
+     * pages and must all still be crawled).
+     * Pure string work: iOS JavaScriptCore has no URL global.
+     */
+    getUrlPathIdentityKey(url) {
+        const text = String(url || '').trim();
+        if (!text) return '';
+        const match = text.match(/^https?:\/\/([^/?#]+)([^?#]*)/i);
+        if (!match) return '';
+        const host = match[1].toLowerCase().replace(/^www\./, '').replace(/:(?:80|443)$/, '');
+        if (!host) return '';
+        const path = String(match[2] || '').replace(/\/+$/, '').toLowerCase();
+        return `${host}${path}`;
+    }
+
+    /**
+     * Drop discovered links that are just this page's own canonical/og:url
+     * self-reference. Site-agnostic — nothing here knows about any CMS, query
+     * parameter or host.
+     *
+     * FAIL CLOSED: only a declared canonical that resolves to the SAME host+path
+     * as the page we actually fetched is suppressed. A canonical pointing at a
+     * different path or host may be a genuinely different resource (a slug
+     * alias, a section index), so it stays in the crawl queue and costs us at
+     * most one redundant fetch — never a lost page.
+     *
+     * Returns the suppressed URLs (for tests/callers); the crawl-visible effect
+     * is the mutation of `urls`.
+     */
+    suppressSelfCanonicalUrls(urls, html, sourceUrl) {
+        const suppressed = [];
+        if (!urls || typeof urls.get !== 'function' || urls.size === 0) return suppressed;
+        if (!html || !sourceUrl) return suppressed;
+
+        const sourceKey = this.getUrlPathIdentityKey(sourceUrl);
+        if (!sourceKey) return suppressed;
+
+        const seen = new Set();
+        for (const rawDeclared of this.extractSelfDeclaredCanonicalUrls(html)) {
+            let resolved = '';
+            try {
+                resolved = this.stripTrackingParams(this.normalizeUrl(rawDeclared, sourceUrl));
+            } catch (_) {
+                resolved = '';
+            }
+            if (!resolved) continue;
+            // Not the page we fetched → not a self-reference → leave it alone.
+            if (this.getUrlPathIdentityKey(resolved) !== sourceKey) continue;
+
+            const key = this.getUrlDedupeKey(resolved);
+            if (!key || seen.has(key)) continue;
+            seen.add(key);
+            const entry = urls.get(key);
+            if (!entry) continue;
+            urls.delete(key);
+            suppressed.push(entry.url);
+        }
+
+        if (suppressed.length > 0) {
+            console.log(`🤖 AI Web: Self-canonical link skipped for ${sourceUrl}: ${suppressed.join(', ')} — the page's own canonical/og:url is this same document, not a new page to crawl`);
+        }
+        return suppressed;
     }
 
     getDefaultMaxAdditionalUrls() {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -11802,3 +11802,267 @@ test('repeated anchors need their own listing identity before they can segment a
   assert.deepEqual(linesOf(NAKED_ANCHOR_PROGRAMME_HTML), linesOf(withoutAnchors),
     'repeated naked anchors leave a schedule page\'s segmentation exactly as it was');
 });
+
+// ── Self-canonical links are not new pages ────────────────────────────────
+// Run 20260806-124046 (Eagle LA): the listing links only parameterized
+// occurrence URLs (/events/b-bar/?occurrence=2026-08-06, …), and every one of
+// those pages advertises `<link rel="canonical" href=".../b-bar/">` plus a
+// matching `og:url`. The crawler harvested that self-reference as a discovered
+// link and re-fetched + AI-extracted the same document a second time — 9 of the
+// run's 24 extractions were exactly this.
+// The parameterized variants are NOT interchangeable (the bare URL renders
+// whichever occurrence is next), so nothing here may collapse them; only the
+// page's own self-declared canonical is suppressed.
+const SELF_CANONICAL_PAGE_HTML = `
+  <html><head>
+    <link rel="canonical" href="https://venue.example/events/beer-bust/" />
+    <meta property="og:url" content="https://venue.example/events/beer-bust/" />
+  </head><body>
+    <a href="https://venue.example/events/beer-bust/?occurrence=2026-09-10">Next week</a>
+    <a href="https://venue.example/events/hump-night/?occurrence=2026-09-09">Hump Night</a>
+  </body></html>
+`;
+
+test('a page\'s own rel=canonical / og:url self-reference is never offered as a crawlable link', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events/beer-bust/?occurrence=2026-09-03';
+  const links = parser.extractAdditionalUrls(SELF_CANONICAL_PAGE_HTML, sourceUrl, {});
+
+  assert.ok(!links.some(link => /^https:\/\/venue\.example\/events\/beer-bust\/?$/.test(link)),
+    `the page's own canonical must not be a discovered link, got: ${JSON.stringify(links)}`);
+  // …and the parameterized siblings, which ARE distinct documents, all survive.
+  assert.ok(links.includes('https://venue.example/events/beer-bust/?occurrence=2026-09-10'),
+    'a different occurrence of the same path is a real page and must still be crawled');
+  assert.ok(links.includes('https://venue.example/events/hump-night/?occurrence=2026-09-09'),
+    'unrelated event links are untouched');
+});
+
+test('og:url alone (no rel=canonical) is enough to recognise a self-reference', () => {
+  const parser = createParser();
+  const html = `
+    <html><head>
+      <meta property="og:url" content="https://venue.example/events/beer-bust/" />
+    </head><body>
+      <a href="https://venue.example/events/beer-bust/">Permalink</a>
+      <a href="https://venue.example/events/onyx/?occurrence=2026-09-12">Onyx</a>
+    </body></html>
+  `;
+  const links = parser.extractAdditionalUrls(html, 'https://venue.example/events/beer-bust/?occurrence=2026-09-03', {});
+  assert.ok(!links.includes('https://venue.example/events/beer-bust/'),
+    `og:url self-reference must be suppressed, got: ${JSON.stringify(links)}`);
+  assert.ok(links.includes('https://venue.example/events/onyx/?occurrence=2026-09-12'));
+});
+
+test('the self-canonical is suppressed no matter which harvest route re-offers it (JSON-LD @id)', () => {
+  const parser = createParser();
+  // SEO plugins publish the same self-URL as a JSON-LD WebPage @id/url, so the
+  // link reaches the candidate map through a second, independent extractor.
+  // Suppression sits at the shared funnel precisely so both routes are covered.
+  const html = `
+    <html><head>
+      <link rel="canonical" href="https://venue.example/events/beer-bust/" />
+      <script type="application/ld+json">
+        {"@context":"https://schema.org","@graph":[
+          {"@type":"WebPage","@id":"https://venue.example/events/beer-bust/","url":"https://venue.example/events/beer-bust/"}
+        ]}
+      </script>
+    </head><body>
+      <a href="https://venue.example/events/onyx/?occurrence=2026-09-12">Onyx</a>
+    </body></html>
+  `;
+  const links = parser.extractAdditionalUrls(html, 'https://venue.example/events/beer-bust/?occurrence=2026-09-03', {});
+  assert.ok(!links.includes('https://venue.example/events/beer-bust/'),
+    `the JSON-LD copy of the self-canonical must be suppressed too, got: ${JSON.stringify(links)}`);
+});
+
+test('skipping a self-canonical link is logged', () => {
+  const parser = createParser();
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  try {
+    parser.extractAdditionalUrls(SELF_CANONICAL_PAGE_HTML, 'https://venue.example/events/beer-bust/?occurrence=2026-09-03', {});
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(logs.some(line => line.includes('Self-canonical link skipped')
+    && line.includes('https://venue.example/events/beer-bust/')),
+    `a self-canonical skip log line is expected, got: ${JSON.stringify(logs)}`);
+});
+
+// GUARD (passes on origin/main too, by construction): the point is that the fix
+// must NOT start eating these. A canonical that names a different path or host
+// may be a genuinely different resource, so it stays in the crawl queue.
+test('a canonical pointing at a different resource is still crawled (fail closed)', () => {
+  const parser = createParser();
+  const html = `
+    <html><head>
+      <link rel="canonical" href="https://venue.example/events/" />
+      <meta property="og:url" content="https://other.example/mirror/beer-bust/" />
+    </head><body>
+      <a href="https://venue.example/events/">All events</a>
+      <a href="https://other.example/mirror/beer-bust/">Mirror</a>
+    </body></html>
+  `;
+  const links = parser.extractAdditionalUrls(html, 'https://venue.example/events/beer-bust/?occurrence=2026-09-03', {});
+  assert.ok(links.includes('https://venue.example/events/'),
+    'a cross-path canonical is not a self-reference and must survive');
+  assert.ok(links.includes('https://other.example/mirror/beer-bust/'),
+    'a cross-host og:url is not a self-reference and must survive');
+});
+
+test('getUrlPathIdentityKey folds only query/fragment/slash/www/port — never the path', () => {
+  const parser = createParser();
+  const key = 'venue.example/events/beer-bust';
+  assert.equal(parser.getUrlPathIdentityKey('https://venue.example/events/beer-bust/'), key);
+  assert.equal(parser.getUrlPathIdentityKey('https://www.venue.example/events/beer-bust?occurrence=2026-09-03#top'), key);
+  assert.equal(parser.getUrlPathIdentityKey('https://venue.example:443/EVENTS/Beer-Bust/'), key);
+  assert.notEqual(parser.getUrlPathIdentityKey('https://venue.example/events/beer-bust-2/'), key,
+    'a different path is a different resource');
+  assert.equal(parser.getUrlPathIdentityKey('mailto:x@y.example'), '', 'non-http input yields no key');
+  assert.equal(parser.getUrlPathIdentityKey(''), '');
+});
+
+test('self-canonical suppression needs no URL global (iOS JavaScriptCore)', () => {
+  const parser = createParser();
+  // Scriptable's JavaScriptCore has neither URL nor URLSearchParams; the
+  // path-identity comparison is pure string work and must survive without them.
+  const originalUrl = global.URL;
+  const originalUsp = global.URLSearchParams;
+  try {
+    delete global.URL;
+    delete global.URLSearchParams;
+    assert.equal(parser.getUrlPathIdentityKey('https://www.venue.example/events/beer-bust/?occurrence=2026-09-03'),
+      'venue.example/events/beer-bust');
+    const urls = new Map();
+    const key = parser.getUrlDedupeKey('https://venue.example/events/beer-bust/');
+    urls.set(key, { url: 'https://venue.example/events/beer-bust/', score: 1, index: 0 });
+    const suppressed = parser.suppressSelfCanonicalUrls(urls, SELF_CANONICAL_PAGE_HTML,
+      'https://venue.example/events/beer-bust/?occurrence=2026-09-03');
+    assert.deepEqual(suppressed, ['https://venue.example/events/beer-bust/']);
+    assert.equal(urls.size, 0);
+  } finally {
+    if (originalUrl === undefined) delete global.URL; else global.URL = originalUrl;
+    if (originalUsp === undefined) delete global.URLSearchParams; else global.URLSearchParams = originalUsp;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Segmentation must not silently UNDER-COVER a listing.
+//
+// Run 20260806 over eaglela.com/events/: the page shows 12 cards, the winning
+// structure group bounded all 12 correctly — and segmentation reported success
+// with 3 windows. The other 9 died on the generic minimum-character floor,
+// because a card whose whole visible text is a short name and a day ("ONYX" /
+// "09 Aug", 11 chars) does not spend 25 characters. Nine real events were
+// never segmented, never extracted and never reported.
+//
+// The page states its own event count structurally: a repeated card carrying
+// its own navigable destination — one no sibling card in the group carries —
+// plus its own date and its own title is a complete event unit. Characters do
+// not measure completeness; identity does.
+// ---------------------------------------------------------------------------
+
+const terseIdentifiedCard = (slug, name, day) => `
+  <article class="event-card">
+    <div class="event-image"><a href="/events/${slug}/?occurrence=2026-08-${day}"><img src="/img/${slug}.jpg" alt="${name}" /></a></div>
+    <h4 class="event-title"><a href="/events/${slug}/?occurrence=2026-08-${day}">${name}</a></h4>
+    <span class="event-date">${day} Aug</span>
+  </article>`;
+
+const verboseIdentifiedCard = (slug, name, day, blurb) => `
+  <article class="event-card">
+    <div class="event-image"><a href="/events/${slug}/?occurrence=2026-08-${day}"><img src="/img/${slug}.jpg" alt="${name}" /></a></div>
+    <h4 class="event-title"><a href="/events/${slug}/?occurrence=2026-08-${day}">${name}</a></h4>
+    <p class="event-excerpt">${blurb}</p>
+    <span class="event-date">${day} Aug</span>
+  </article>`;
+
+const TERSE_CARD_LISTING_HTML = `
+  <html><body><main class="event-list">
+    ${terseIdentifiedCard('onyx', 'ONYX', '09')}
+    ${terseIdentifiedCard('b-bar', 'B BAR', '10')}
+    ${terseIdentifiedCard('cub-scout', 'CUBSCOUT', '11')}
+    ${terseIdentifiedCard('meat-rack', 'MEAT RACK', '12')}
+    ${verboseIdentifiedCard('tightwad', 'Tightwad Tuesday', '13', 'Any 12oz beer only $3, all day, all night, no cover.')}
+    ${verboseIdentifiedCard('hump-night', 'Hump Night', '14', '$10 domestic pitchers and $6 well drinks from 9pm to 2am.')}
+  </main></body></html>`;
+
+test('segmentation covers every repeated card that identifies itself, however terse its text', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events';
+
+  const segments = parser.buildMultiEventSegments(TERSE_CARD_LISTING_HTML, sourceUrl);
+  assert.equal(segments.length, 6,
+    `one window per card — the two wordy cards must not stand in for all six, got ${JSON.stringify(segments.map(s => s.lines))}`);
+
+  const expected = [
+    ['ONYX', '09 Aug', 'https://venue.example/events/onyx/?occurrence=2026-08-09'],
+    ['B BAR', '10 Aug', 'https://venue.example/events/b-bar/?occurrence=2026-08-10'],
+    ['CUBSCOUT', '11 Aug', 'https://venue.example/events/cub-scout/?occurrence=2026-08-11'],
+    ['MEAT RACK', '12 Aug', 'https://venue.example/events/meat-rack/?occurrence=2026-08-12'],
+    ['Tightwad Tuesday', '13 Aug', 'https://venue.example/events/tightwad/?occurrence=2026-08-13'],
+    ['Hump Night', '14 Aug', 'https://venue.example/events/hump-night/?occurrence=2026-08-14']
+  ];
+  segments.forEach((segment, index) => {
+    const [title, date, link] = expected[index];
+    assert.equal(segment.lines[0], title, `window ${index + 1} opens on its own card title`);
+    assert.ok(segment.lines.includes(date),
+      `window ${index + 1} keeps its own date, got ${JSON.stringify(segment.lines)}`);
+    const resourceLines = parser.extractMultiEventSegmentResourceLines(segment.html, sourceUrl);
+    assert.ok(resourceLines.includes(`SEGMENT_LINK_URL: ${link}`),
+      `window ${index + 1} carries its OWN card link, got ${JSON.stringify(resourceLines)}`);
+  });
+
+  // The windows the old floor already let through are untouched — coverage
+  // ADDS the dropped cards, it never moves a boundary.
+  assert.deepEqual(segments[4].lines,
+    ['Tightwad Tuesday', 'Any 12oz beer only $3, all day, all night, no cover.', '13 Aug']);
+  assert.deepEqual(segments[5].lines,
+    ['Hump Night', '$10 domestic pitchers and $6 well drinks from 9pm to 2am.', '14 Aug']);
+});
+
+test('only a card with its OWN destination counts as a repeated event unit', () => {
+  const parser = createParser();
+
+  // Distinct per-card destinations → every card identifies itself.
+  const identifiedGroup = parser.extractRepeatedMultiEventStructureGroups(TERSE_CARD_LISTING_HTML)
+    .find(group => group.entries.length === 6);
+  assert.ok(identifiedGroup, 'the six cards form a repeated structure group');
+  assert.deepEqual(parser.mapMultiEventGroupIdentityLinks(identifiedGroup.entries),
+    [true, true, true, true, true, true]);
+
+  // One shared destination for every card (a row of identical ticket
+  // buttons, a repeated nav block): nothing identifies itself, so the
+  // character floor still stands and the terse rows stay out.
+  const sharedLinkHtml = TERSE_CARD_LISTING_HTML.replace(/href="\/events\/[^"]*"/g, 'href="/tickets"');
+  const sharedGroup = parser.extractRepeatedMultiEventStructureGroups(sharedLinkHtml)
+    .find(group => group.entries.length === 6);
+  assert.ok(sharedGroup, 'the shared-link cards still form a repeated structure group');
+  assert.deepEqual(parser.mapMultiEventGroupIdentityLinks(sharedGroup.entries),
+    [false, false, false, false, false, false]);
+  assert.equal(parser.buildMultiEventSegments(sharedLinkHtml, 'https://venue.example/events').length, 2,
+    'a group whose entries share one destination earns no coverage allowance');
+});
+
+test('an entry identity link is a real destination, query string included', () => {
+  const parser = createParser();
+
+  // Fragment-only, javascript: and mailto: targets are not destinations.
+  assert.equal(parser.extractMultiEventEntryIdentityLink('<a href="#">x</a><a href="/events/onyx/">ONYX</a>'),
+    '/events/onyx/');
+  assert.equal(parser.extractMultiEventEntryIdentityLink('<a href="javascript:void(0)">x</a><a href="/events/b-bar/">B BAR</a>'),
+    '/events/b-bar/');
+  assert.equal(parser.extractMultiEventEntryIdentityLink('<a href="mailto:a@b.c">mail</a>'), '');
+  assert.equal(parser.extractMultiEventEntryIdentityLink('<p>no links here</p>'), '');
+
+  // A fragment is not part of the destination; a query string IS — a listing
+  // that repeats one detail page per occurrence distinguishes its cards by
+  // query alone, and folding those together would erase real cards.
+  assert.equal(parser.extractMultiEventEntryIdentityLink('<a href="/events/b-bar/?occurrence=2026-08-06#top">B BAR</a>'),
+    '/events/b-bar/?occurrence=2026-08-06');
+  assert.deepEqual(parser.mapMultiEventGroupIdentityLinks([
+    { html: '<a href="/events/b-bar/?occurrence=2026-08-06">B BAR</a>' },
+    { html: '<a href="/events/b-bar/?occurrence=2026-08-13">B BAR</a>' }
+  ]), [true, true]);
+});


### PR DESCRIPTION
Both fixes here are generic mechanisms, not venue patches — that was the ask. Found via Eagle LA, but neither depends on the site, its CMS, or its markup.

## 1. A page's own canonical is not a page to crawl

Every occurrence page advertises its bare self:

```html
<link rel="canonical" href="https://eaglela.com/events/b-bar/" />
<meta property="og:url"  content="https://eaglela.com/events/b-bar/" />
```

**Nothing parses canonical anywhere in this codebase.** The self-URL arrives as collateral of three *generic* harvesters firing at once: the bare `href` regex (no tag filter, so a `<link>` is scraped exactly like an `<a>`), the `og:url` meta reader, and the JSON-LD `@id`. All three funnel into one candidate map — suppressing any single one leaves the other two to re-add it.

There is already a `same-as-source` rejection, which is why a *bare* page doesn't re-offer itself. A parameterized page's canonical differs by its query string, so it sailed through — **ranked first on the page**.

The listing links only parameterized occurrence URLs, so every page we crawled handed back the bare canonical, which we fetched and fully AI-extracted a second time. **9 of 22 page fetches in run `20260806-124046` were the same document twice.**

Suppression sits at the harvest funnel because `shared-core` never sees page HTML — `parseResult` carries only `events` and `additionalLinks`, so the crawl layer *cannot* know what a page declares as itself.

**Fails closed.** Only a canonical resolving to the same host+path as the page we actually fetched is dropped; one naming a different path or host may be a real resource and still gets crawled — at worst one redundant fetch, never a lost page. Parameterized siblings are never collapsed: I diffed them, and the bare page and `?occurrence=X` render **different occurrences**, so path-level dedup would delete real events.

### The honest corpus number

**41 of 2,477 saved page fetches (~1.7%)** — 39 Eagle LA, 2 Eventbrite. Not the broad win I first implied. Worth shipping on two specific grounds:

- **Eventbrite proves the mechanism is CMS-generic**, not a WordPress/MEC quirk — it will bite any future parser pointed at parameterized event URLs.
- **The Eagle LA cost is structural, not historical.** Every run since that parser was repointed on Aug 2 has burned 9–10 of ~22 fetches and extractions this way (10, 10, 10, 9) — ~43% of its per-run AI spend, recurring forever.

## 2. A terse card is still a card

Eagle LA's listing has **12 cards** and produced **3 segments**.

Not a ranking problem, and — correcting what I said earlier — **not fusion**. Every candidate group was already card-aligned at 12/12, and all 12 entries cleared every content gate with correct titles and dates. Nine were then thrown away by a single line: the `multiEventMinSegmentChars` floor of **25**. A real card here reads `B BAR | 06 Aug` — **12 characters**. Terse is not empty.

(My earlier "2 windows fused" reading was a probe artefact: I counted raw `href`s, and a window's tail includes the next card's anchor markup. Titles and dates never bleed — one each per window, always correct.)

**The generic signal: a self-identifying event unit** — a repeated entry carrying its own navigable destination (an `href` no sibling entry in the group carries) plus its own date and its own title. Nothing else on a listing page repeats with a per-copy identity. A character count measures verbosity; identity measures completeness.

### Risk containment

#1640's first attempt regressed bearssitges.org by changing group *selection*, so this deliberately does not:

- **Group selection is untouched.** The guard runs only on the already-selected group.
- **Boundaries never move.** Only entries that were silently discarded come back; the pre-existing windows keep byte-identical content hashes.
- A relaxed pass over groups yielding `<2` was **deliberately not added** — that *would* change selection. A corpus audit confirms no page would benefit.
- Groups whose entries share one destination (ticket buttons, nav, pagination) get no allowance.

### Corpus

48 pages compared by segment **content hash**, not counts: **47 identical**. `ela-live.html` **3 → 12**, purely additive — kept 3, lost 0, gained 9. **`sitges-live.html` unchanged at 16.** I re-verified this myself on the combined branch alongside de-live (19), furball (6), dore (1), sbo (5), dice-page (2) — all unchanged.

## Tests

10 added, **1543 → 1553 pass, 0 fail**. Nine fail on `origin/main`; one is a declared guard that passes both ways by design (a canonical pointing at a *different* resource is still crawled).

No new runtime files.

## Explicitly NOT fixed — and it is the dangerous one

In run `20260806-124046` a record titled **`Tightwad Tuesday` carries `/events/hump-night/`** and that event's date. Downstream dedup then merges Tightwad Tuesday into HUMP NIGHT on the shared URL — which would **delete a real event**.

**This is not a segmentation bug and this PR does not close it.** Segmentation gives that window the correct title, date and link both before and after. The mis-association happens somewhere downstream and remains unexplained. It should be treated as open, and it is a reason not to reorder dedup ahead of the bear check yet.
