### PR TITLE
fix(scraper): use the image classification we already pay for, in both directions

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -638,6 +638,24 @@ class AiWebParser {
         // are already in hand) and by OCR cache hits that carry a stored
         // measurement. In-memory only, scoped to this parser instance (one run).
         this.measuredImageDimensionsByUrl = new Map();
+        // What the OCR vision pass actually SAW in an image — { classification,
+        // hasText } keyed by canonical image URL. Populated by every OCR read,
+        // fresh call AND disk-cache hit, so a verdict we already paid for
+        // survives extractOcrFromAllImages' textless filter (which drops the
+        // whole result, classification included) and outlives the run that
+        // produced it — the OCR cache is on disk and stores imageClassification,
+        // so a site's chrome stays known across runs and across parsers.
+        // In-memory only, scoped to this parser instance, exactly like the
+        // measured dimensions above.
+        this.ocrImageVerdictsByUrl = new Map();
+        // OCR classifications that mean "page furniture, not this event's
+        // artwork". Derived from the real cache corpus (441 OCR'd images):
+        // 'thumbnail' is 57/61 textless, 'logo' 16/83, 'hero-banner' 1/6.
+        // 'ad-banner' is DELIBERATELY ABSENT — every ad-banner in that corpus
+        // carried readable text and several were genuine weekly venue posters
+        // ("Tightwad Tuesday", "Lucky Break"), so rejecting it would throw away
+        // real flyers. 'multi-event-flyer' is absent for the same reason.
+        this.nonEventOcrImageClassifications = new Set(['logo', 'thumbnail', 'hero-banner']);
         // How far into an image the header scan reads. PNG/GIF/WebP answer in
         // the first 30 bytes; a JPEG's frame header sits after its EXIF/ICC
         // blocks, which on real camera-sourced flyers routinely run past 32KB.
@@ -867,6 +885,12 @@ class AiWebParser {
                 // published a 1x1 spacer can still adopt the page's real
                 // artwork instead of keeping the pixel.
                 structuredEvents.forEach(event => this.rejectPlaceholderImageValues(event));
+                // …and neither is a logo the vision pass already read as page
+                // furniture. Same position and same reasoning as the
+                // placeholder rejection above: reject BEFORE the og:image fill,
+                // so the event trades site chrome for the page's real artwork
+                // instead of simply losing its picture.
+                structuredEvents.forEach(event => this.rejectNonEventImageValues(event));
                 // A single structured event whose node carried no image adopts
                 // the page's own og:image artwork (multi-event pages never do:
                 // one shared meta image cannot be attributed to one event).
@@ -3079,8 +3103,26 @@ class AiWebParser {
         const proximityCost = this.getSegmentImagePairingCost(segmentBounds, imageRecord);
 
         // Only allow event-flyer classification - other image types don't contain event details
-        if (ocrResult?.imageClassification !== 'event-flyer') {
+        //
+        // …but "no classification at all" is not an image TYPE, it is a missing
+        // answer, and answering it with a rejection fails CLOSED. In the real
+        // OCR cache corpus 64 of 441 stored results (15%) came back with an
+        // empty imageClassification — and they are genuine flyers: "BEAR WEEK
+        // KICK OFF / BEARRACUDA / PROVINCETOWN", "JUNGLE LUST / NEON BEACH
+        // PARTY", a full burlesque line-up. Every one of them was refused a
+        // segment here, which is precisely how a segment ends up with no
+        // matched flyer and falls back to offering the model the first four
+        // <img> on the page — footer chrome. Unknown fails open; every
+        // classification the model actually states behaves exactly as before.
+        const pairingClassification = String(ocrResult?.imageClassification || '').toLowerCase().trim();
+        if (pairingClassification && pairingClassification !== 'event-flyer') {
             return { cost: Infinity, score: -Infinity };
+        }
+        if (!ocrResult) {
+            return { cost: Infinity, score: -Infinity };
+        }
+        if (!pairingClassification) {
+            console.log(`🤖 AI Web: OCR result for ${ocrResult.url || 'an image'} carries no imageClassification — pairing on its text instead of refusing it`);
         }
 
         // Start with proximity-based cost and base score for valid event-flyer
@@ -3468,6 +3510,17 @@ class AiWebParser {
             if (!normalized || !/^https?:\/\//i.test(normalized)) return;
             const finalUrl = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(normalized) || normalized);
             if (!finalUrl) return;
+            // Never OFFER the model an image the vision pass already read as
+            // page furniture. The image loops below fall back to "the first
+            // four <img> in this segment's HTML" when nothing was OCR-matched,
+            // which on a footer-heavy page is social icons and decorative
+            // vectors — and the model dutifully returns one as `image`, with
+            // real evidence, at confidence 100. Image lines only: a
+            // SEGMENT_LINK_URL is not artwork and is never judged here.
+            if (/_IMAGE/i.test(label) && this.getNonEventImageOcrReason(finalUrl)) {
+                console.log(`🤖 AI Web: Segment image ${finalUrl} withheld from the prompt — ${this.getNonEventImageOcrReason(finalUrl)}`);
+                return;
+            }
             // Check for duplicates using stripped URL to handle same image at different sizes
             const strippedUrl = this.stripSizeParams(finalUrl);
             // Consistency-gate exclusions: an image reassigned/detached from
@@ -7085,6 +7138,11 @@ class AiWebParser {
                 return null;
             }
             console.log(`🤖 AI Web: OCR cache hit for ${cached.imageUrl || imageUrl}`);
+            // A cache hit is a verdict we already paid for — remember it here,
+            // not downstream, because extractOcrFromAllImages drops textless
+            // results entirely and a 'logo with no text' is exactly the verdict
+            // image selection needs most.
+            this.recordOcrImageVerdict(imageUrl, cached);
             return cached;
         }
 
@@ -7157,6 +7215,7 @@ class AiWebParser {
             console.log(`🤖 AI Web: OCR response for ${imageUrl} has no text (imageClassification: ${parsed.imageClassification})`);
         }
         const normalized = this.normalizeOcrResult(parsed);
+        this.recordOcrImageVerdict(imageUrl, { ...normalized, imageUrl });
         const cachePath = await this.writeCachedOcrResult(imageUrl, ocrConfig, JSON.stringify(parsed), measuredPixels);
         return {
             imageUrl,
@@ -13469,6 +13528,13 @@ TEXT:
         // image was a 1x1 spacer can still adopt the page's real artwork.
         this.rejectPlaceholderImageValues(event);
 
+        // A picture that IS a picture can still be the wrong one. The vision
+        // pass already classified every image it read; a logo/thumbnail/
+        // hero-banner it found no text on is site chrome, never this event's
+        // flyer. Also before the og:image fill, so the slot can be refilled
+        // with real artwork rather than left empty.
+        this.rejectNonEventImageValues(event);
+
         // A single-event page (never a multi-event segment — one shared meta
         // image cannot be attributed to one segment) whose extraction found no
         // image adopts the page's own og:image artwork.
@@ -14667,6 +14733,9 @@ TEXT:
         for (const candidate of this.collectPageMetaImageCandidates(htmlData)) {
             const upgraded = candidate.url;
             if (!upgraded || this.isLikelyUninterestingImageUrl(upgraded)) continue;
+            // A page whose og:image is its own brand logo must not hand that
+            // logo to the event the URL-shape test just let through.
+            if (this.getNonEventImageOcrReason(upgraded)) continue;
             event.image = upgraded;
             event.imageSource = 'og-image';
             console.log(`🤖 AI Web: Filled image from page og:image for "${event.title}"`);
@@ -15000,6 +15069,107 @@ TEXT:
         return this.measuredImageDimensionsByUrl.get(key) || null;
     }
 
+    // ------------------------------------------------------------------
+    // OCR IMAGE VERDICTS (the classification we already paid for)
+    // ------------------------------------------------------------------
+    // The OCR prompt has always returned an `imageClassification`, but the only
+    // consumer was segment↔image pairing (getSegmentImagePairingCostWithOcr)
+    // and the OCR dedup key. Nothing asked it before letting a URL become
+    // event.image, so a decorative site asset the model had ALREADY called a
+    // logo could still be published as an event's flyer. Recording the verdict
+    // here makes that free answer available to image selection.
+
+    // Remember one OCR verdict under the image's canonical URL. Same key rules
+    // as recordMeasuredImageDimensions: exact URL identity, both the raw and
+    // normalized forms, so whichever spelling the event carries can find it.
+    recordOcrImageVerdict(imageUrl, result) {
+        if (!result || typeof result !== 'object') return null;
+        const classification = String(result.imageClassification || '').toLowerCase().trim();
+        if (!classification) return null;
+        const verdict = {
+            classification,
+            hasText: Boolean(String(result.text || '').trim())
+        };
+        let recorded = false;
+        for (const url of [imageUrl, result.imageUrl, result.url, this.normalizeHttpUrlValue(imageUrl)]) {
+            const key = this.canonicalizeImageUrlForComparison(url);
+            if (!key) continue;
+            this.ocrImageVerdictsByUrl.set(key, verdict);
+            recorded = true;
+        }
+        return recorded ? verdict : null;
+    }
+
+    // The OCR verdict for an image URL, or null when nothing OCR'd it. Null is
+    // "unknown", never "not artwork" — most images on most pages are never
+    // OCR'd at all, so every caller must fail open on null.
+    getOcrImageVerdict(imageUrl) {
+        if (!this.ocrImageVerdictsByUrl || this.ocrImageVerdictsByUrl.size === 0) return null;
+        const key = this.canonicalizeImageUrlForComparison(imageUrl);
+        if (!key) return null;
+        return this.ocrImageVerdictsByUrl.get(key) || null;
+    }
+
+    /**
+     * Why the vision pass says this URL is not an event's artwork ('' when it
+     * doesn't say so). TWO conditions, both required, because either alone
+     * loses real flyers:
+     *
+     *   1. the model classified it as page furniture (logo/thumbnail/
+     *      hero-banner — see nonEventOcrImageClassifications for why ad-banner
+     *      is not in that set), AND
+     *   2. the model read NO text off it.
+     *
+     * Condition 2 is what makes this safe. In the real OCR cache corpus two
+     * images classified 'logo' carried 587 and 573 characters of text — those
+     * are misclassified flyers, and a classification-only rule would have
+     * deleted them. Every event-flyer in that same corpus has text (median 179
+     * chars, minimum non-zero), so requiring "no text" can never reject one.
+     *
+     * Unknown is always keep: an image nobody OCR'd, an OCR result with no
+     * classification, or a classification outside the set all return ''.
+     */
+    getNonEventImageOcrReason(url) {
+        const verdict = this.getOcrImageVerdict(url);
+        if (!verdict) return '';
+        if (verdict.hasText) return '';
+        if (!this.nonEventOcrImageClassifications.has(verdict.classification)) return '';
+        return `the vision pass classified it as ${verdict.classification} with no readable text`;
+    }
+
+    /**
+     * Drop `image` / `imageVertical` / `imageHorizontal` values the vision pass
+     * already told us are site chrome. Companion to
+     * rejectPlaceholderImageValues: that one asks "is this URL a picture at
+     * all?" from the URL's own shape, this one asks "is this picture this
+     * event's artwork?" using the classification OCR returns for free.
+     *
+     * Run 20260806-125121 shipped a decorative butterfly ("…/2024/04/Vector.png",
+     * a design-tool default export) as the Dallas Eagle "Gear Night" image: the
+     * page's segment had no OCR-matched flyer, so the segment prompt fell back
+     * to the first four <img> on the page — footer chrome — and the model
+     * returned the butterfly with confidence 100 and perfectly valid evidence.
+     * The very same asset had ALREADY been OCR'd and classified `logo`; the
+     * pairing gate used that verdict to refuse it as a segment flyer and then
+     * nothing carried the verdict forward to image selection.
+     *
+     * Clearing `image` clears its imageSource stamp with it, exactly like the
+     * placeholder rejection — provenance is a companion of the value.
+     */
+    rejectNonEventImageValues(event) {
+        if (!event || typeof event !== 'object') return event;
+        for (const field of ['image', 'imageVertical', 'imageHorizontal']) {
+            const value = typeof event[field] === 'string' ? event[field].trim() : '';
+            if (!value) continue;
+            const reason = this.getNonEventImageOcrReason(value);
+            if (!reason) continue;
+            console.log(`🤖 AI Web: Rejected non-event ${field} ${value} for "${event.title || ''}" — ${reason}`);
+            delete event[field];
+            if (field === 'image') delete event.imageSource;
+        }
+        return event;
+    }
+
     // Orientation of one candidate. Dimensions the page PUBLISHED (JSON-LD
     // ImageObject width/height, og:image:width/height) are authoritative and
     // answer first; only then do we ask shared-core to read dimensions out of
@@ -15165,6 +15335,10 @@ TEXT:
         const bySlot = { portrait: null, landscape: null };
         for (const candidate of byUrl.values()) {
             if (this.isLikelyUninterestingImageUrl(candidate.url)) continue;
+            // …and neither is an image the vision pass read as page furniture.
+            // Without this a rejected `image` could walk straight back in as an
+            // orientation slot, because `image` is a slot candidate itself.
+            if (this.getNonEventImageOcrReason(candidate.url)) continue;
             const orientation = this.resolveImageCandidateOrientation(candidate);
             if (orientation !== 'portrait' && orientation !== 'landscape') continue;
             const incumbent = bySlot[orientation];

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -12066,3 +12066,146 @@ test('an entry identity link is a real destination, query string included', () =
     { html: '<a href="/events/b-bar/?occurrence=2026-08-13">B BAR</a>' }
   ]), [true, true]);
 });
+
+// ---------------------------------------------------------------------------
+// OCR IMAGE VERDICTS — the classification we already pay for, used to keep a
+// decorative site asset from becoming an event's flyer.
+// ---------------------------------------------------------------------------
+
+test('a logo the vision pass found no text on never becomes an event image', () => {
+  const parser = createParser();
+  const butterfly = 'https://cdn.example/3335593/wp-content/uploads/2024/04/Vector.png?lossy=2&strip=1&webp=1';
+  parser.recordOcrImageVerdict(butterfly, { imageClassification: 'logo', text: '' });
+
+  const event = { title: 'Gear Night', image: butterfly, imageSource: 'page', imageVertical: butterfly };
+  parser.rejectNonEventImageValues(event);
+
+  assert.equal(Object.prototype.hasOwnProperty.call(event, 'image'), false,
+    'a decorative vector the model called a logo is not this event\'s artwork');
+  assert.equal(Object.prototype.hasOwnProperty.call(event, 'imageSource'), false,
+    'provenance dies with the value it described');
+  assert.equal(Object.prototype.hasOwnProperty.call(event, 'imageVertical'), false);
+});
+
+test('an image the vision pass read words off survives, whatever it called it', () => {
+  const parser = createParser();
+  // Real corpus: two images classified "logo" carried 587 and 573 characters
+  // of OCR text — misclassified flyers. Text is the veto on the classification.
+  const misread = 'https://static.example/media/f45f1a_36ccf2f3fc5c48f0b4adbf2d4c339048~mv2.jpeg';
+  parser.recordOcrImageVerdict(misread, {
+    imageClassification: 'logo',
+    text: 'BEAR NIGHT\nSaturday July 18\n10PM - 4AM\nThe Eagle'
+  });
+  // ad-banner is not in the rejection set at all: every ad-banner in the corpus
+  // carried text and several were genuine weekly venue posters.
+  const poster = 'https://venue.example/wp-content/uploads/Tightwad-Tues-poster-2024.jpg';
+  parser.recordOcrImageVerdict(poster, { imageClassification: 'ad-banner', text: 'TIGHTWAD TUESDAY $3 WELL' });
+  // Never OCR'd at all → unknown → keep. This is the common case.
+  const unseen = 'https://venue.example/wp-content/uploads/2026/07/some-flyer.jpg';
+
+  for (const url of [misread, poster, unseen]) {
+    const event = { title: 'Keep It', image: url, imageVertical: url };
+    parser.rejectNonEventImageValues(event);
+    assert.equal(event.image, url, `${url} must survive — losing a real flyer is worse than keeping chrome`);
+    assert.equal(event.imageVertical, url);
+  }
+});
+
+test('a rejected non-event image cannot walk back in as an orientation slot or an og:image', () => {
+  const parser = createParser();
+  const chrome = 'https://cdn.example/assets/hero-header-2024.png';
+  parser.recordOcrImageVerdict(chrome, { imageClassification: 'hero-banner', text: '' });
+  parser.recordMeasuredImageDimensions(chrome, { width: 1600, height: 600 });
+
+  const slotEvent = { title: 'Slotted', image: chrome };
+  parser.applyImageSlots(slotEvent, { url: 'https://venue.example/events', html: '' });
+  assert.equal(Object.prototype.hasOwnProperty.call(slotEvent, 'imageHorizontal'), false,
+    'a landscape shape is still not artwork when the model called it page chrome');
+
+  const metaEvent = { title: 'Meta' };
+  parser.fillImageFromPageMetaArtwork(metaEvent, {
+    url: 'https://venue.example/events',
+    html: `<meta property="og:image" content="${chrome}">`
+  });
+  assert.equal(Object.prototype.hasOwnProperty.call(metaEvent, 'image'), false,
+    'a page whose og:image is its own banner must not hand it to an event');
+});
+
+test('a known non-event image is withheld from the segment prompt entirely', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events/';
+  const butterfly = 'https://cdn.example/uploads/2024/04/Vector.png';
+  const socialIcon = 'https://cdn.example/uploads/2025/04/mastodon_hover.png';
+  const segmentHtml = `<div><img src="${butterfly}"><img src="${socialIcon}"></div>`;
+
+  const before = parser.extractMultiEventSegmentResourceLines(segmentHtml, sourceUrl);
+  assert.equal(before.filter(line => line.startsWith('SEGMENT_IMAGE_URL:')).length, 2,
+    'with no verdicts the fallback still offers every image it finds (fail open)');
+
+  parser.recordOcrImageVerdict(butterfly, { imageClassification: 'logo', text: '' });
+  parser.recordOcrImageVerdict(socialIcon, { imageClassification: 'logo', text: '' });
+  const after = parser.extractMultiEventSegmentResourceLines(segmentHtml, sourceUrl);
+  assert.deepEqual(after.filter(line => line.startsWith('SEGMENT_IMAGE_URL:')), [],
+    'the model is never offered an image the vision pass already called a logo');
+});
+
+test('the OCR cache carries an image classification across runs even when it has no text', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-verdict-test-'));
+
+  const imageUrl = 'https://cdn.example/uploads/2024/04/Vector.png';
+  const ocrConfig = { cacheEnabled: true, model: 'test-vision', prompt: 'ocr prompt', timeoutSeconds: 30 };
+
+  const first = new AiWebParser({ normalizeUrl, ocrCacheDir: cacheDir });
+  first.core = new SharedCore({}, { eventSchema: EventSchema });
+  first.core.callAiGenerate = async () => JSON.stringify({ text: '', imageClassification: 'logo', confidence: 95 });
+  await first.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', {
+    fetchImageAsBase64: async () => toBase64Fixture(webpLossyBytes(200, 200))
+  });
+  assert.equal(first.getOcrImageVerdict(imageUrl).classification, 'logo');
+
+  // The textless filter in extractOcrFromAllImages throws this result away, so
+  // the verdict has to live somewhere the filter cannot reach.
+  const nextRun = new AiWebParser({ normalizeUrl, ocrCacheDir: cacheDir });
+  nextRun.core = new SharedCore({}, { eventSchema: EventSchema });
+  nextRun.core.callAiGenerate = async () => { throw new Error('AI must not run on a cache hit'); };
+  await nextRun.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', {
+    fetchImageAsBase64: async () => { throw new Error('a cache hit must not re-download the image'); }
+  });
+
+  const event = { title: 'Gear Night', image: imageUrl };
+  nextRun.rejectNonEventImageValues(event);
+  assert.equal(Object.prototype.hasOwnProperty.call(event, 'image'), false,
+    'a site\'s chrome stays known across runs and across parsers, for free');
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+test('an OCR result with no classification is paired on its text, not refused', () => {
+  const parser = createParser();
+  const bounds = { rawStart: 100, rawEnd: 400, matchedRecords: [{ text: 'BEAR WEEK KICK OFF\nBearracuda Provincetown' }] };
+  const imageRecord = { url: 'https://cdn.example/uploads/2026/05/web.jpg', start: 150, end: 200 };
+  const flyerText = 'BEAR WEEK KICK OFF\nBEARRACUDA\nPROVINCETOWN\n\nBEATS BY\nKELLY';
+
+  // 15% of the real OCR cache came back with an empty imageClassification and
+  // was refused a segment — these are genuine flyers, not page furniture.
+  const unclassified = parser.getSegmentImagePairingCostWithOcr(
+    bounds, imageRecord, { url: imageRecord.url, imageClassification: '', text: flyerText }, ''
+  );
+  assert.ok(Number.isFinite(unclassified.cost), 'a missing classification must not veto a real flyer');
+  assert.ok(unclassified.score > 100, 'and its text still has to earn the match');
+
+  // A classification the model actually STATES is unchanged: a logo is still
+  // refused, exactly as before.
+  const logo = parser.getSegmentImagePairingCostWithOcr(
+    bounds, imageRecord, { url: imageRecord.url, imageClassification: 'logo', text: '' }, ''
+  );
+  assert.equal(logo.cost, Infinity);
+  assert.equal(logo.score, -Infinity);
+
+  // No OCR result at all is still no pairing.
+  const none = parser.getSegmentImagePairingCostWithOcr(bounds, imageRecord, null, '');
+  assert.equal(none.cost, Infinity);
+});


### PR DESCRIPTION
## Your butterfly, and the answer to "can matching be smarter"

**Yes — and the classification was already there.** The vision pass had *already* looked at `Vector.png`, classified it `logo`, and found zero text. That verdict was used to refuse it as a segment flyer, and then **thrown away**.

The chain — and the two halves are the same bug from opposite ends:

1. Only OCR results **with text** are kept, so a textless `logo` is dropped whole, classification included. The verdict now exists nowhere.
2. The pairing gate refuses anything `!== 'event-flyer'`, so that segment got no matched flyer.
3. With no flyer and no image hint, the segment prompt falls back to **"the first four `<img>` in this segment's HTML"** — on a footer-heavy page that's the butterfly, a duplicate, and two mastodon icons.
4. The model returned it at confidence 100 with perfectly valid verbatim evidence. It *is* on the page. Nothing downstream tests `event.image` against anything but the placeholder rule.

Every existing guard passed it **correctly**: the placeholder rule asks *"is this a picture?"*, not *"is it this event's picture?"*; #1637's pixel guard catches 1px-shaped URLs and a butterfly is a real 47 KB image; `isLikelyUninterestingImageUrl` is never applied to `event.image` at all.

## Half one: carry the verdict forward

A run-scoped verdict registry, populated on **both** the cache-hit and fresh-call paths — so it survives the textless filter and comes back free on later runs *and other parsers*. The disk cache already stored the classification; nothing ever read it back for selection.

An image is refused as artwork only when the model both classified it `logo`/`thumbnail`/`hero-banner` **and** read no text off it. Applied to `image`/`imageVertical`/`imageHorizontal`, the og:image fill, and slot candidates — and, closing the root cause, **withheld from the segment prompt entirely** so the model is never offered it. Rejection runs *before* the og:image fill, so an event trades chrome for the page's real artwork rather than losing its picture.

## Half two: stop refusing real flyers

`!== 'event-flyer'` also rejected every result whose classification came back **empty** — **64 of 441 stored results (15%)**, and they're genuine flyers: `BEAR WEEK KICK OFF / BEARRACUDA / PROVINCETOWN`, `JUNGLE LUST / NEON BEACH PARTY`, a full burlesque line-up, median 224 characters of text.

Refusing those is *what starves a segment of its flyer* and triggers the first-four-`<img>` fallback that then serves site chrome. No classification is a **missing answer**, not an image type — unknown now pairs on its text. Every classification the model actually states behaves exactly as before.

Worth knowing: OCR text is already carrying the matching, not proximity — **165 of 172 successful pairings (96%) were decided by text similarity**, only 7 by proximity alone. The weakness was never the signal, it was refusing to use it.

## Numbers — real corpus, zero flyers lost, verified not assumed

- Of 441 stored results the gate flags **74** (57 thumbnail, 16 logo, 1 hero-banner). **Flyers flagged: 0.** `event-flyer` results with no text: **0**.
- Of the AI's **858** actual image picks: **68 occurrences / 9 distinct URLs** rejected — dice 1px ×58, the butterfly, a dice-fan GIF, an RA news photo, a webflow `faq.webp`. **Untouched: all 598 event-flyer picks, 3 multi-event-flyer, 9 ad-banner.**
- Up to **64 genuine flyers become pairable** that never could be before.
- Published calendars: 147 image values, 33 with a verdict, **0 flagged** — no decorative image has shipped. (The butterfly reached the event object but its event was bear-dropped, so "published" was never proven — I'd claimed it was.)

## Deliberately not changed

- **`ad-banner` and `multi-event-flyer` are not rejected** — all 17 ad-banners in the corpus carry text and several are real weekly venue posters (`Tightwad-Tues-poster-2024.jpg`).
- **No text-length threshold.** The shortest real `event-flyer` has **7 characters** of text. Any threshold above zero eats real flyers, so 13 known-bad picks are knowingly left in.
- **`isLikelyUninterestingImageUrl` still not applied to `event.image`** — its bare-substring matching fires `'tag'` inside "vintage", and it would catch **0** of the bad picks this gate misses. Zero upside, non-zero tail risk.
- **The caps stay.** Even with a local model, raising them isn't free in wall clock: **280 real vision calls at a median 2,001 ms each**, so lifting the single-event cap from 2 to 10 costs up to **~16 s per page**. The classification gate gets the correctness win without spending any of it. Flagged as an open question, not settled.

## Tests

6 added, **1543 → 1549 pass, 0 fail**. All 6 fail on `origin/main`; two carry explicit fail-open assertions that hold both ways by design. `this.defaultOcrPrompt` untouched — the diff removes exactly **one** line, the pairing condition itself.

## Not here: the OCR-unreachable abort

You said no partial runs. **Today the run is fully fail-open at four layers**, and a connection-refused is indistinguishable from an empty model response to every caller — `ocrResults` becomes `[]` and the run proceeds with no log line saying so. Exactly the partial run you're rejecting.

That needs a distinguished transport failure threaded through two `.catch` layers, orchestrator plumbing to stop the crawl, and a results-UI surface. **It's its own PR.** Recommendation: a preflight check before the crawl, with abort-on-first-transport-failure as the backstop — failing after 20 pages is much worse than failing before page 1.

One live distinction it must not blur: there were **96 `OCR image download failed`** events in the logs, and those are *third-party image hosts*, not your OCR server. They must never abort a run.

## For your eye, not a defect

7 events (chicago, phoenix, portland ×2, seattle, sf ×2) carry images under `res.cloudinary.com/eventservice/…/saas/logos/…`. That's a ticketing platform's generic upload bucket — possibly real artwork, possibly chrome. None were ever OCR'd so the gate can't judge them, and a path rule would be exactly the hardcoded-CDN heuristic we've been avoiding.
