### PR TITLE
fix(scraper): ride out a subway tunnel, stop on a real outage

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1471,13 +1471,72 @@ class ScriptableAdapter {
     return Number.isFinite(statusCode) ? statusCode : null;
   }
 
+  // ---------------------------------------------------------------------
+  // NETWORK RESILIENCE — the run's one choke point
+  // ---------------------------------------------------------------------
+  // Every byte the scraper pulls goes through exactly three methods on this
+  // adapter (fetchData / postJson / fetchImageAsBase64), so all three delegate
+  // to withNetworkResilience and nothing else in the codebase grows a retry.
+  // The POLICY — what counts as transient, how long to wait, when to stop the
+  // run — lives in the platform-pure SharedCore.NetworkResilience; this method
+  // supplies only the two things iOS owns: a real clock and a real timer.
+  //
+  // Lazily built so an adapter constructed for HTML rendering or a URL-input
+  // preview pays nothing. The orchestrator hands the same instance to
+  // SharedCore so the crawl loop can see the give-up verdict.
+  getNetworkResilience() {
+    if (this.networkResilience === undefined || this.networkResilience === null) {
+      // isRetryableFailure is an instance method that touches no instance
+      // state; this bare core exists only to reuse it. There is deliberately
+      // no second classifier anywhere in this feature.
+      const classifierCore = new SharedCore(this.config?.cities || {}, {
+        eventSchema: SharedEventSchema,
+      });
+      this.networkResilience = new SharedCore.NetworkResilience({
+        classifyRetryable: (error) => classifierCore.isRetryableFailure(error),
+        sleep: (delayMs) => this.sleepForNetworkRetry(delayMs),
+        now: () => Date.now(),
+        log: (message) => console.log(message),
+      });
+    }
+    return this.networkResilience;
+  }
+
+  // Same ladder the reverse-geocode rate limiter uses: setTimeout where it
+  // exists, Scriptable's Timer otherwise, resolve immediately if neither does
+  // (which is what makes this harmless under test doubles).
+  sleepForNetworkRetry(delayMs) {
+    return new Promise((resolve) => {
+      if (typeof setTimeout !== "undefined") {
+        setTimeout(resolve, delayMs);
+      } else if (typeof Timer !== "undefined") {
+        const timer = new Timer();
+        timer.timeInterval = delayMs;
+        timer.schedule(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  async withNetworkResilience(label, url, operation) {
+    return this.getNetworkResilience().run(label, url, operation);
+  }
+
   // Default maxDimension of 1024 matches what the OCR overflow-retry path uses:
   // first attempts at ~1568px reliably overflowed the vision model's context
   // (0 tokens, finish_reason "length") and only succeeded after retrying ≤1024,
   // so every large image paid a wasted round trip.
   async fetchImageAsBase64(url, timeoutSeconds = 30, maxDimension = 1024) {
+    return this.withNetworkResilience("image download", url, () =>
+      this.fetchImageAsBase64Once(url, timeoutSeconds, maxDimension),
+    );
+  }
+
+  async fetchImageAsBase64Once(url, timeoutSeconds = 30, maxDimension = 1024) {
+    let request = null;
     try {
-      const request = new Request(url);
+      request = new Request(url);
       request.timeoutInterval = timeoutSeconds;
       let image = await request.loadImage();
       // Vision-model image tokens scale with pixel count, not file size. Oversized
@@ -1503,11 +1562,32 @@ class ScriptableAdapter {
       const jpegData = Data.fromJPEG(image);
       return jpegData.toBase64String();
     } catch (error) {
-      throw new Error(`Failed to fetch image as base64: ${error.message}`);
+      const wrapped = new Error(
+        `Failed to fetch image as base64: ${error.message}`,
+      );
+      // Ground truth about what actually happened, stamped where it is known.
+      // If the request carries a response the host ANSWERED, so this is not a
+      // connectivity failure — it is bytes that would not decode (94 of the 95
+      // image failures across 241 run logs are "Cannot parse response to an
+      // image" behind a perfectly healthy 200). The wrapper text above matches
+      // isRetryableFailure's /failed to fetch/ pattern, so without this stamp
+      // every one of them would buy minutes of pointless backoff.
+      const responseStatus =
+        request && request.response ? request.response.statusCode : null;
+      if (Number.isFinite(responseStatus)) {
+        wrapped.statusCode = responseStatus;
+      }
+      throw wrapped;
     }
   }
 
   async postJson(url, payload, options = {}) {
+    return this.withNetworkResilience("AI/POST request", url, () =>
+      this.postJsonOnce(url, payload, options),
+    );
+  }
+
+  async postJsonOnce(url, payload, options = {}) {
     try {
       const request = new Request(url);
       request.method = "POST";
@@ -1585,47 +1665,60 @@ class ScriptableAdapter {
         }
       }
 
-      const request = new Request(url);
-      request.method = options.method || "GET";
-      request.headers = {
-        "User-Agent": this.config.userAgent,
-        Accept:
-          "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        ...options.headers,
-      };
+      // Only the round trip is retried — the cache read above is not network
+      // and must never be re-run (nor counted as a network success) just
+      // because the fetch behind it needs another attempt.
+      const responseData = await this.withNetworkResilience(
+        "page fetch",
+        url,
+        async () => {
+          const request = new Request(url);
+          request.method = options.method || "GET";
+          request.headers = {
+            "User-Agent": this.config.userAgent,
+            Accept:
+              "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            ...options.headers,
+          };
 
-      if (options.body) {
-        request.body = options.body;
+          if (options.body) {
+            request.body = options.body;
+          }
+
+          const response = await request.loadString();
+
+          // Check response status
+          const statusCode = request.response
+            ? request.response.statusCode
+            : 200;
+
+          if (statusCode >= 400) {
+            throw new Error(`HTTP ${statusCode} error from ${url}`);
+          }
+
+          if (response && response.length > 0) {
+            return {
+              html: response,
+              url: url,
+              statusCode: statusCode,
+              headers: request.response ? request.response.headers : {},
+            };
+          }
+          console.error(`📱 Scriptable: ✗ Empty response from ${url}`);
+          throw new Error(`Empty response from ${url}`);
+        },
+      );
+
+      if (canUseCache && isCacheableResponse(responseData)) {
+        await this.writeCachedPage(url, responseData, pageCacheConfig);
       }
 
-      const response = await request.loadString();
-
-      // Check response status
-      const statusCode = request.response ? request.response.statusCode : 200;
-
-      if (statusCode >= 400) {
-        throw new Error(`HTTP ${statusCode} error from ${url}`);
-      }
-
-      if (response && response.length > 0) {
-        const responseData = {
-          html: response,
-          url: url,
-          statusCode: statusCode,
-          headers: request.response ? request.response.headers : {},
-        };
-
-        if (canUseCache && isCacheableResponse(responseData)) {
-          await this.writeCachedPage(url, responseData, pageCacheConfig);
-        }
-
-        return responseData;
-      } else {
-        console.error(`📱 Scriptable: ✗ Empty response from ${url}`);
-        throw new Error(`Empty response from ${url}`);
-      }
+      return responseData;
     } catch (error) {
-      if (error?.cachedFailure) {
+      // Both of these carry decisions on the error object itself, so rewrapping
+      // would erase them: cachedFailure carries `retryable: false`, and a
+      // give-up carries the marker the crawl loop reads to stop the run.
+      if (error?.cachedFailure || error?.networkGiveUp) {
         throw error;
       }
       const errorMessage = `📱 Scriptable: ✗ HTTP request failed for ${url}: ${error.message}`;
@@ -5793,8 +5886,13 @@ class ScriptableAdapter {
 
         const globalDryRun = results.config?.config?.dryRun;
         const hasActiveEvents = eventsFromActiveParsers.length > 0;
+        // The interactive path is where the phone actually writes the calendar
+        // (the orchestrator only writes headless), so the truncated-run refusal
+        // has to be repeated here or a half-scraped run could still be saved
+        // with one tap. The results sheet above has already been shown.
+        const networkTruncated = Boolean(results.networkTruncated);
 
-        if (!globalDryRun && hasActiveEvents) {
+        if (!globalDryRun && !networkTruncated && hasActiveEvents) {
           console.log(
             `📱 Scriptable: Prompting for calendar execution (${eventsFromActiveParsers.length} events)`,
           );
@@ -5807,6 +5905,10 @@ class ScriptableAdapter {
           // Writes that threw are run faults — surface them in the saved run
           // JSON instead of leaving `errors: []` next to `calendarEvents: 0`.
           this.recordCalendarWriteFailures(results);
+        } else if (networkTruncated) {
+          console.log(
+            `📱 Scriptable: 🛑 Skipping execution prompt — this run was TRUNCATED by network loss (${results.networkTruncated.idleSeconds}s unreachable). Nothing will be written to the calendar; rerun with service.`,
+          );
         } else {
           const reason = globalDryRun ? "global dry run" : "no active events";
           console.log(`📱 Scriptable: Skipping execution prompt (${reason})`);
@@ -5910,6 +6012,8 @@ class ScriptableAdapter {
       runInsights,
       results,
     );
+    const networkTruncationBannerHtml =
+      this.buildNetworkTruncationBannerHtml(results);
     const headerLogoData = await this.loadHeaderLogoData();
     const headerLogoSrc = headerLogoData || HEADER_LOGO_URL;
     // Async section (reads the gathering-only venue queue for badge state),
@@ -7217,6 +7321,7 @@ class ScriptableAdapter {
     </style>
 </head>
 <body>
+    ${networkTruncationBannerHtml}
     <div class="header">
         <div class="header-content">
             <img src="${headerLogoSrc}" 
@@ -8707,6 +8812,29 @@ class ScriptableAdapter {
         summary: null,
       };
     }
+  }
+
+  // Full-width, unmissable, above everything: a run the network cut short must
+  // never be mistaken for a complete one. It sits ABOVE the header rather than
+  // inside it because the header scrolls past and the stat tiles below read
+  // like a finished run. Empty string on a healthy run, so nothing changes.
+  buildNetworkTruncationBannerHtml(results) {
+    const truncation = results && results.networkTruncated;
+    if (!truncation) return "";
+    const hosts = Array.isArray(truncation.hosts) ? truncation.hosts : [];
+    const skipped = Array.isArray(truncation.skippedParsers)
+      ? truncation.skippedParsers
+      : [];
+    const skippedLine =
+      skipped.length > 0
+        ? `<div style="margin-top:6px; font-weight:400;">Never even started: ${this.escapeHtml(skipped.join(", "))}</div>`
+        : "";
+    return `<div style="background:#b3261e; color:#fff; padding:16px 18px; border-radius:12px; margin-bottom:16px; font-size:15px; font-weight:700; line-height:1.45; box-shadow:0 2px 10px rgba(0,0,0,0.25);">
+        🛑 INCOMPLETE RUN — stopped by network loss
+        <div style="margin-top:6px; font-weight:400;">Nothing reached the network for ${this.escapeHtml(String(truncation.idleSeconds))}s (${this.escapeHtml(String(truncation.failures))} failed calls across ${hosts.length} host${hosts.length === 1 ? "" : "s"}${hosts.length > 0 ? `: ${this.escapeHtml(hosts.join(", "))}` : ""}).</div>
+        <div style="margin-top:6px; font-weight:400;">These results are PARTIAL and <strong>nothing has been written to the calendar</strong>. Rerun with service — every page and OCR result already fetched is cached, so it picks up from here.</div>
+        ${skippedLine}
+    </div>`;
   }
 
   // One-line run-health badge for the results-UI header, derived from the same

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -7028,3 +7028,95 @@ test('presentReviewResults installs shouldAllowRequest before loadHTML too', asy
     delete global.WebView;
   }
 });
+
+// ---------------------------------------------------------------------------
+// Network resilience: the adapter is the one choke point (fetchData / postJson
+// / fetchImageAsBase64 all funnel through withNetworkResilience) and the one
+// place that knows what actually happened on the wire.
+// ---------------------------------------------------------------------------
+
+test('fetchImageAsBase64 stamps the status the host answered with, so a non-image 200 is not retried', async () => {
+  const adapter = buildAdapter();
+  let attempts = 0;
+  const slept = [];
+  adapter.sleepForNetworkRetry = async (ms) => { slept.push(ms); };
+  global.Request = class {
+    constructor() { this.response = null; }
+    async loadImage() {
+      attempts += 1;
+      // Exactly what the corpus shows 94 times: the fetch succeeded, the bytes
+      // just are not an image.
+      this.response = { statusCode: 200 };
+      throw new Error('Cannot parse response to an image.');
+    }
+  };
+  try {
+    await assert.rejects(
+      adapter.fetchImageAsBase64('https://cdn.example/not-an-image', 30, 1024),
+      (error) => error.statusCode === 200 &&
+        /Failed to fetch image as base64/.test(error.message)
+    );
+  } finally {
+    delete global.Request;
+  }
+  assert.equal(attempts, 1,
+    'the wrapper text matches /failed to fetch/, so without the stamped status this would buy minutes of backoff');
+  assert.deepEqual(slept, [], 'not one millisecond of waiting on a host that answered');
+});
+
+test('fetchImageAsBase64 still retries a real connectivity failure on the minutes-long ladder', async () => {
+  const adapter = buildAdapter();
+  let attempts = 0;
+  const slept = [];
+  adapter.sleepForNetworkRetry = async (ms) => { slept.push(ms); };
+  global.Request = class {
+    constructor() { this.response = null; }
+    async loadImage() {
+      attempts += 1;
+      // No response object at all: nothing came back from the host.
+      throw new Error('The network connection was lost.');
+    }
+  };
+  try {
+    await assert.rejects(adapter.fetchImageAsBase64('https://cdn.example/a.jpg', 30, 1024));
+  } finally {
+    delete global.Request;
+  }
+  assert.ok(attempts > 1, 'losing service mid-download is exactly what the retry exists for');
+  assert.ok(slept.length > 0 && slept[0] >= 5000,
+    'backoff starts in seconds, not milliseconds — an inter-station gap lasts minutes');
+});
+
+test('a network-truncated run gets an unmissable banner and never claims to be complete', () => {
+  const adapter = buildAdapter();
+  const html = adapter.buildNetworkTruncationBannerHtml({
+    networkTruncated: {
+      idleSeconds: 312,
+      failures: 6,
+      hosts: ['a.example', 'b.example'],
+      skippedParsers: ['Furball', 'CHUNK']
+    }
+  });
+  assert.match(html, /INCOMPLETE RUN/);
+  assert.match(html, /nothing has been written to the calendar/i);
+  assert.match(html, /312s/);
+  assert.match(html, /Furball, CHUNK/);
+  assert.equal(adapter.buildNetworkTruncationBannerHtml({}), '',
+    'a healthy run renders exactly as it did before');
+});
+
+test('generateRichHTML puts the truncation banner above everything else on the page', async () => {
+  const adapter = buildAdapter();
+  const results = { ...buildResultsStub(), totalEvents: 2, rawBearEvents: 2, bearEvents: 2, calendarEvents: 0 };
+  results.networkTruncated = { idleSeconds: 300, failures: 4, hosts: ['a.example', 'b.example'], skippedParsers: [] };
+  // Earlier tests in this file delete the Calendar stub the module-level setup
+  // installed; generateRichHTML reads it.
+  global.Calendar = { forEvents: async () => [] };
+  const html = await adapter.generateRichHTML(results, {});
+  const bannerIndex = html.indexOf('INCOMPLETE RUN');
+  const headerIndex = html.indexOf('<div class="header">');
+  assert.ok(bannerIndex > -1, 'the banner has to be in the rendered page, not just the log');
+  assert.ok(headerIndex > -1);
+  assert.ok(bannerIndex < headerIndex,
+    'above the header: the header scrolls away and the stat tiles below read like a finished run');
+});

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -253,6 +253,15 @@ class BearEventScraperOrchestrator {
                 });
             }
 
+            // Network resilience: the adapter owns the retry/give-up state
+            // because it owns the timers, but the crawl and parser loops in
+            // shared-core have to see the same verdict to stop a doomed run.
+            // One instance, shared. Adapters without it (web) leave core null
+            // and behave exactly as before.
+            if (typeof finalAdapter.getNetworkResilience === 'function') {
+                sharedCore.networkResilience = finalAdapter.getNetworkResilience();
+            }
+
             // Curated bar data: the website's merged copy is fresher than any
             // local scraper-bars.js the moment a bar edit lands. Refresh ALL
             // cities up front (null cityKeys — the scraper can't know its
@@ -352,6 +361,12 @@ class BearEventScraperOrchestrator {
 
                 // Check if we should add to calendar
                 const isDryRun = Boolean(config.config?.dryRun);
+                // A run the network truncated is NOT a run. "I don't want
+                // partial runs… I will rerun when I can" — so it is refused
+                // here exactly like a dry run, while everything below still
+                // renders so the owner can see what was found before the
+                // service dropped. The results UI gate mirrors this.
+                const networkTruncated = Boolean(results.networkTruncated);
 
                 // Always prepare events for analysis (even in dry run mode) to show action types
                 // Perform cross-parser deduplication to merge events from different parsers
@@ -392,7 +407,11 @@ class BearEventScraperOrchestrator {
                     console.log('🐻 Orchestrator: Automation run detected - executing without UI prompt');
                 }
 
-                if (!isDryRun && typeof finalAdapter.executeCalendarActions === 'function' && analyzedEvents) {
+                if (networkTruncated) {
+                    const truncation = results.networkTruncated;
+                    console.error(`🐻 Orchestrator: 🛑 NETWORK-TRUNCATED RUN — refusing the calendar write. The network was unreachable for ${truncation.idleSeconds}s (${truncation.failures} failures across ${truncation.hosts.length} hosts). Nothing was written; rerun when you have service and the cache will pick up where this stopped.`);
+                    results.errors.push(`Run truncated: network unreachable for ${truncation.idleSeconds}s — calendar write refused, nothing was saved`);
+                } else if (!isDryRun && typeof finalAdapter.executeCalendarActions === 'function' && analyzedEvents) {
                     if (hasDisplay && !isWidget) {
                         // If we have a display (not widget), show results first and let user decide
                         console.log('🐻 Orchestrator: Display mode - review results before execution');

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -346,6 +346,10 @@ class SharedCore {
         // the orchestrator from AiWebParser.getAiResponseCache() — persistence
         // stays out of shared-core. Null = no caching.
         this.aiResponseCache = null;
+        // Shared NetworkResilience instance (the adapter owns it; the
+        // orchestrator hands it over). Null = no retry/give-up awareness, which
+        // is exactly how every non-networked test and the web path behave.
+        this.networkResilience = options.networkResilience || null;
         this.trackingParamPattern = /^(aff|affix|affiliate|utm[-_](?:source|medium|campaign|content|term)|ref|referral|fbclid|gclid|msclkid|dclid|source|mc_cid|mc_eid)$/i;
         
         // URL-to-parser mapping for automatic parser detection (parser: "auto").
@@ -3751,10 +3755,19 @@ class SharedCore {
 
         // Global URL tracking across all parsers to prevent duplicate processing
         const globalProcessedUrls = new Set();
+        // Parsers never started because the network gave up part-way through.
+        const networkTruncatedParsers = [];
 
         for (let i = 0; i < config.parsers.length; i++) {
+            // Network gave up mid-run: stop starting new parsers. Whatever the
+            // earlier parsers already produced is kept and shown, but the run is
+            // stamped truncated below and the calendar write is refused.
+            if (this.networkResilience && this.networkResilience.isGivenUp()) {
+                networkTruncatedParsers.push(...config.parsers.slice(i).map(p => p?.name || 'unnamed'));
+                break;
+            }
             const parserConfig = config.parsers[i];
-            
+
             // "enabled" is for manual runs only; automation runs use automation.automationEnabled
             if (!automationContext.filterParsers && parserConfig.enabled === false) {
                 disabledParsers.push(parserConfig.name);
@@ -3883,6 +3896,26 @@ class SharedCore {
         }
 
         await this.finalizeDeadEndRun(displayAdapter, results);
+
+        // Truncated run: say so unmistakably. The owner must never mistake a run
+        // the subway ended for a complete one, so this is loud in the log, it is
+        // carried on `results` for the UI banner, and downstream it REFUSES the
+        // calendar write ("I don't want partial runs… I will rerun when I can").
+        const giveUpReport = this.networkResilience ? this.networkResilience.getGiveUpReport() : null;
+        if (giveUpReport) {
+            results.networkTruncated = {
+                idleSeconds: giveUpReport.idleSeconds,
+                failures: giveUpReport.failures,
+                hosts: giveUpReport.hosts.slice(),
+                skippedParsers: networkTruncatedParsers.slice()
+            };
+            const skippedSuffix = networkTruncatedParsers.length > 0
+                ? ` Parsers never started: ${networkTruncatedParsers.join(', ')}.`
+                : '';
+            await displayAdapter.logError(
+                `SYSTEM: 🛑 RUN TRUNCATED — the network was unreachable for ${giveUpReport.idleSeconds}s (${giveUpReport.failures} failures across ${giveUpReport.hosts.length} hosts). THIS RUN IS INCOMPLETE and will NOT be written to the calendar.${skippedSuffix}`
+            );
+        }
 
         const duplicateSummary = results.duplicatesRemoved > 0
             ? ` (removed ${results.duplicatesRemoved} dupes)`
@@ -5080,7 +5113,16 @@ class SharedCore {
             return error.retryable;
         }
 
-        const statusCode = this.extractHttpStatusCodeFromError(error);
+        // A numeric `statusCode` stamped by the adapter outranks message
+        // scraping: the adapter watched the response come back, the message is
+        // a reconstruction. This matters for image downloads, whose wrapper
+        // text ("Failed to fetch image as base64: …") matches the /failed to
+        // fetch/ pattern below and so used to look retryable even when the
+        // server had answered 200 with bytes that simply were not an image —
+        // 94 of the 95 image failures across 241 run logs are exactly that.
+        const statusCode = (error && Number.isFinite(error.statusCode))
+            ? error.statusCode
+            : this.extractHttpStatusCodeFromError(error);
         if (typeof statusCode === 'number') {
             return [408, 425, 429, 500, 502, 503, 504].includes(statusCode);
         }
@@ -5099,7 +5141,23 @@ class SharedCore {
             /unavailable/i,
             /econnreset/i,
             /enotfound/i,
-            /eai_again/i
+            /eai_again/i,
+            // ---- The wordings iOS actually produces --------------------
+            // The patterns above are Node/browser vocabulary. Checked against
+            // the 241-run log corpus, only /time(d)?\s*out/ ever fired on a
+            // real device error: iOS says "The network connection WAS lost"
+            // (the adjacent-word pattern above misses it), it never says the
+            // letters "DNS", and NSURLErrorNotConnectedToInternet — the exact
+            // subway/elevator case this whole feature exists for — reads
+            // "The Internet connection appears to be offline." Without these,
+            // losing service was classified PERMANENT, which not only skipped
+            // any retry but wrote the URL into the no-retry failure cache, so
+            // one tunnel could poison a page for future runs too.
+            /connection was lost/i,
+            /appears to be offline/i,
+            /hostname could not be found/i,
+            /could not connect to the server/i,
+            /data connection is not currently allowed/i
         ];
         return retryablePatterns.some(pattern => pattern.test(message));
     }
@@ -5163,6 +5221,13 @@ class SharedCore {
         }
 
         for (let i = 0; i < urlsToProcess.length; i++) {
+            // The run has already concluded the phone has no service. Stop
+            // walking the queue rather than failing every remaining URL one by
+            // one — see processEvents, which turns this into results.networkTruncated.
+            if (this.networkResilience && this.networkResilience.isGivenUp()) {
+                await displayAdapter.logWarn(`SYSTEM: Network gave up — abandoning ${urlsToProcess.length - i} remaining URL(s) at depth ${currentDepth}`);
+                break;
+            }
             const rawUrl = urlsToProcess[i];
             const url = this.normalizeUrl(rawUrl, rawUrl);
             if (!url) {
@@ -14726,9 +14791,282 @@ SharedCore.PROVENANCE_TRUST_TIERS = Object.freeze({
     bearSource: Object.freeze({ 'manual-bear': 2, 'manual-not-bear': 2, 'keyword': 1, 'ai': 1, 'config': 1 })
 });
 
+// ============================================================================
+// NETWORK RESILIENCE — transient-failure retry + time-based give-up
+// ============================================================================
+// The scraper runs from a phone in motion. The owner's words: "these happen all
+// the time when I need to temporarily leave the app, or when I'm in the subway
+// and i lose service in between stops" and "gaps between subway stations is a
+// few mins long". That single sentence decides the whole design:
+//
+//   * Backoff measured in SECONDS is useless — an outage lasts MINUTES. The
+//     default ladder sleeps 5s/15s/30s/60s/90s (200s = 3m20s of patience),
+//     which rides out an inter-station gap.
+//   * Giving up after N CONSECUTIVE FAILURES is the wrong shape — a tunnel
+//     produces N failures within seconds and would kill a run that was about
+//     to recover. Give-up is therefore measured as ELAPSED TIME WITH ZERO
+//     SUCCESSES. Any success anywhere resets the clock.
+//
+// Everything here is platform-pure: the clock, the sleep and the failure
+// classifier are all injected. That keeps shared-core free of timers AND lets
+// the tests exercise minutes of backoff in microseconds.
+//
+// Three things deliberately do NOT count as "the network is down":
+//   1. A failure carrying an HTTP status code. The server answered, so the
+//      phone has service; a 403 wall or a 500 origin is not an outage. Those
+//      reset the give-up clock exactly like a success does.
+//   2. A cached-failure replay (error.cachedFailure) — no packet was sent.
+//   3. Failures from a single host. Give-up needs failures from at least two
+//      distinct hosts, so one dead image CDN can never stop a run even when it
+//      is the only thing the run happens to be touching at that moment.
+// ============================================================================
+class NetworkResilience {
+    constructor(options = {}) {
+        if (typeof options.classifyRetryable !== 'function') {
+            throw new Error('NetworkResilience requires a classifyRetryable(error) function — pass SharedCore.isRetryableFailure, never a second classifier');
+        }
+        if (typeof options.sleep !== 'function') {
+            throw new Error('NetworkResilience requires a sleep(ms) function — shared-core never imports a platform timer');
+        }
+        this.classifyRetryable = options.classifyRetryable;
+        this.sleep = options.sleep;
+        this.now = typeof options.now === 'function' ? options.now : (() => Date.now());
+        this.log = typeof options.log === 'function' ? options.log : (() => {});
+
+        this.retryDelaysMs = Array.isArray(options.retryDelaysMs) && options.retryDelaysMs.length > 0
+            ? options.retryDelaysMs.slice()
+            : NetworkResilience.DEFAULT_RETRY_DELAYS_MS.slice();
+        this.maxOperationMs = Number.isFinite(options.maxOperationMs)
+            ? options.maxOperationMs
+            : NetworkResilience.DEFAULT_MAX_OPERATION_MS;
+        this.giveUpAfterMs = Number.isFinite(options.giveUpAfterMs)
+            ? options.giveUpAfterMs
+            : NetworkResilience.DEFAULT_GIVE_UP_AFTER_MS;
+        this.minFailuresBeforeGiveUp = Number.isFinite(options.minFailuresBeforeGiveUp)
+            ? options.minFailuresBeforeGiveUp
+            : NetworkResilience.DEFAULT_MIN_FAILURES_BEFORE_GIVE_UP;
+        this.minHostsBeforeGiveUp = Number.isFinite(options.minHostsBeforeGiveUp)
+            ? options.minHostsBeforeGiveUp
+            : NetworkResilience.DEFAULT_MIN_HOSTS_BEFORE_GIVE_UP;
+        this.suspensionSlackMs = Number.isFinite(options.suspensionSlackMs)
+            ? options.suspensionSlackMs
+            : NetworkResilience.DEFAULT_SUSPENSION_SLACK_MS;
+
+        this.lastSuccessAtMs = this.now();
+        this.failuresSinceSuccess = 0;
+        this.hostsFailedSinceSuccess = new Set();
+        // Hosts that already burned a full retry budget in this run. They get
+        // one attempt and no waiting until something, anywhere, succeeds again.
+        this.exhaustedHosts = new Set();
+        this.giveUpReport = null;
+        this.totalRetries = 0;
+        this.suspensionsDetected = 0;
+    }
+
+    // Host key without a URL global (iOS JavaScriptCore has neither `URL` nor
+    // `URLSearchParams`). Scheme+authority is all the give-up rule needs; a
+    // value that isn't an http(s) URL keys under itself so it still groups.
+    static hostKeyForUrl(url) {
+        if (typeof url !== 'string' || url.length === 0) return 'unknown-host';
+        const match = url.match(/^[a-z][a-z0-9+.-]*:\/\/([^/?#]+)/i);
+        return match ? match[1].toLowerCase() : url.toLowerCase();
+    }
+
+    static isGiveUpError(error) {
+        return Boolean(error && error.networkGiveUp === true);
+    }
+
+    isGivenUp() {
+        return this.giveUpReport !== null;
+    }
+
+    getGiveUpReport() {
+        return this.giveUpReport;
+    }
+
+    // A network round trip completed. The give-up clock only ever measures
+    // "time since something last worked", so this is the one reset point.
+    noteSuccess() {
+        this.lastSuccessAtMs = this.now();
+        this.failuresSinceSuccess = 0;
+        this.hostsFailedSinceSuccess.clear();
+        // Something got through, so every host deserves its full patience back.
+        this.exhaustedHosts.clear();
+    }
+
+    // Returns true when the failure is evidence that the PHONE has no network,
+    // as opposed to evidence that one URL is unhappy.
+    noteFailure(hostKey, error) {
+        if (error && error.cachedFailure === true) {
+            // Replayed from the negative cache — nothing left the device.
+            return false;
+        }
+        const statusCode = error && Number.isFinite(error.statusCode)
+            ? error.statusCode
+            : NetworkResilience.readStatusFromMessage(error);
+        if (Number.isFinite(statusCode)) {
+            // The server answered. Service exists. Treat it like a success for
+            // give-up purposes so a bot wall or a 500 origin can never be
+            // mistaken for a tunnel.
+            this.noteSuccess();
+            return false;
+        }
+        this.failuresSinceSuccess += 1;
+        this.hostsFailedSinceSuccess.add(hostKey);
+        return true;
+    }
+
+    static readStatusFromMessage(error) {
+        const message = error && typeof error.message === 'string' ? error.message : '';
+        const match = message.match(/HTTP\s+(\d{3})/i);
+        if (!match) return null;
+        const statusCode = Number(match[1]);
+        return Number.isFinite(statusCode) ? statusCode : null;
+    }
+
+    // Sticky: once the run has given up it stays given up, so every later call
+    // fails instantly instead of adding minutes of pointless waiting.
+    evaluateGiveUp() {
+        if (this.giveUpReport) return this.giveUpReport;
+        const idleMs = this.now() - this.lastSuccessAtMs;
+        if (idleMs < this.giveUpAfterMs) return null;
+        if (this.failuresSinceSuccess < this.minFailuresBeforeGiveUp) return null;
+        if (this.hostsFailedSinceSuccess.size < this.minHostsBeforeGiveUp) return null;
+        this.giveUpReport = {
+            atMs: this.now(),
+            idleMs,
+            idleSeconds: Math.round(idleMs / 1000),
+            failures: this.failuresSinceSuccess,
+            hosts: Array.from(this.hostsFailedSinceSuccess)
+        };
+        return this.giveUpReport;
+    }
+
+    buildGiveUpError() {
+        const report = this.giveUpReport || { idleSeconds: 0, failures: 0, hosts: [] };
+        const error = new Error(
+            `Network unreachable for ${report.idleSeconds}s (${report.failures} failed calls across ${report.hosts.length} hosts) — run stopped`
+        );
+        error.networkGiveUp = true;
+        // Transient by definition: the phone will have service again later, so
+        // this must never be written to the permanent no-retry failure cache.
+        error.retryable = true;
+        error.giveUpReport = report;
+        return error;
+    }
+
+    // Wall time asleep is measured, not assumed. iOS suspends Scriptable's
+    // JavaScript when the app is backgrounded, so an `await` on a 15s timer can
+    // return with 20 minutes of wall clock behind it. That is the owner walking
+    // away, not the network dying, so the give-up clock restarts.
+    async sleepAndDetectSuspension(delayMs) {
+        const startedAt = this.now();
+        await this.sleep(delayMs);
+        const elapsedMs = this.now() - startedAt;
+        if (elapsedMs - delayMs >= this.suspensionSlackMs) {
+            this.suspensionsDetected += 1;
+            this.log(
+                `🌐 Network: ${Math.round(elapsedMs / 1000)}s of wall time passed during a ${Math.round(delayMs / 1000)}s wait — the app was backgrounded, not the network. Restarting the give-up clock.`
+            );
+            this.lastSuccessAtMs = this.now();
+            this.failuresSinceSuccess = 0;
+            this.hostsFailedSinceSuccess.clear();
+            this.exhaustedHosts.clear();
+        }
+        return elapsedMs;
+    }
+
+    // The single choke point. `operation` is one network attempt; everything
+    // about when to try again, how long to wait, and when to stop the run lives
+    // here and nowhere else.
+    async run(label, url, operation) {
+        if (this.giveUpReport) {
+            throw this.buildGiveUpError();
+        }
+        const hostKey = NetworkResilience.hostKeyForUrl(url);
+        const budgetMs = this.exhaustedHosts.has(hostKey) ? 0 : this.maxOperationMs;
+        const startedAt = this.now();
+        let attempt = 0;
+
+        for (;;) {
+            attempt += 1;
+            try {
+                const value = await operation();
+                if (attempt > 1) {
+                    this.log(`🌐 Network: recovered — ${label} succeeded on attempt ${attempt} (${url})`);
+                }
+                this.noteSuccess();
+                return value;
+            } catch (error) {
+                if (NetworkResilience.isGiveUpError(error)) {
+                    throw error;
+                }
+                const looksOffline = this.noteFailure(hostKey, error);
+                if (looksOffline && this.evaluateGiveUp()) {
+                    const report = this.giveUpReport;
+                    this.log(
+                        `🌐 Network: 🛑 GIVING UP — nothing has reached the network for ${report.idleSeconds}s (${report.failures} consecutive failures across ${report.hosts.length} hosts: ${report.hosts.join(', ')}). Stopping the run; everything already fetched is cached, so a rerun with service resumes from there.`
+                    );
+                    throw this.buildGiveUpError();
+                }
+
+                if (this.classifyRetryable(error) !== true) {
+                    throw error;
+                }
+                const delayMs = this.retryDelaysMs[attempt - 1];
+                if (!Number.isFinite(delayMs)) {
+                    this.markExhausted(hostKey, label, url);
+                    throw error;
+                }
+                // Patience is a TIME budget, not an attempt count: a host whose
+                // requests hang for the full client timeout must not be able to
+                // hold the run for six of them.
+                const elapsedMs = this.now() - startedAt;
+                if (elapsedMs + delayMs > budgetMs) {
+                    // budgetMs === 0 means this host is already known-exhausted
+                    // (or retries are configured off), so there is nothing new
+                    // to learn or to say.
+                    if (budgetMs > 0) {
+                        this.markExhausted(hostKey, label, url);
+                    }
+                    throw error;
+                }
+                this.totalRetries += 1;
+                this.log(
+                    `🌐 Network: ${label} failed (${error && error.message ? error.message : 'unknown error'}) — waiting ${Math.round(delayMs / 1000)}s before attempt ${attempt + 1}/${this.retryDelaysMs.length + 1}: ${url}`
+                );
+                await this.sleepAndDetectSuspension(delayMs);
+                if (this.giveUpReport) {
+                    throw this.buildGiveUpError();
+                }
+            }
+        }
+    }
+
+    markExhausted(hostKey, label, url) {
+        if (this.exhaustedHosts.has(hostKey)) return;
+        this.exhaustedHosts.add(hostKey);
+        this.log(
+            `🌐 Network: ${hostKey} used its whole retry budget on ${label} (${url}) — further calls to it get one attempt and no waiting until something else succeeds.`
+        );
+    }
+}
+
+NetworkResilience.DEFAULT_RETRY_DELAYS_MS = [5000, 15000, 30000, 60000, 90000];
+NetworkResilience.DEFAULT_MAX_OPERATION_MS = 240000;
+NetworkResilience.DEFAULT_GIVE_UP_AFTER_MS = 300000;
+NetworkResilience.DEFAULT_MIN_FAILURES_BEFORE_GIVE_UP = 3;
+NetworkResilience.DEFAULT_MIN_HOSTS_BEFORE_GIVE_UP = 2;
+NetworkResilience.DEFAULT_SUSPENSION_SLACK_MS = 30000;
+
+// Hung off SharedCore so it travels through every environment's export shape
+// (module.exports / window / Scriptable `this`) without a second export line.
+SharedCore.NetworkResilience = NetworkResilience;
+
 // Export for both environments
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
+        NetworkResilience,
         SharedCore,
         PROVENANCE_COMPANION_FIELDS: SharedCore.PROVENANCE_COMPANION_FIELDS,
         // Pure title date-segment detector, shared with the ai-web parser's

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -15667,3 +15667,377 @@ test('a crawled single-event page names itself; a listing page does not', async 
   assert.equal(byTitle['Bear Tea Dance'].url, 'https://venuehub.example',
     'a listing page never overwrites its events\' urls');
 });
+
+// ---------------------------------------------------------------------------
+// NetworkResilience — transient-failure retry + time-based give-up
+//
+// Every number below comes from the 241-run log corpus plus the owner's one
+// hard constraint ("gaps between subway stations is a few mins long"):
+//   * healthy runs go at most ~15s (p99) / ~30s (p99.9) between successful
+//     network calls, so a 300s give-up window has a 10x margin;
+//   * the longest failure burst ever recorded was 134s, and it was one bad
+//     host, not an outage — hence the two-distinct-hosts requirement;
+//   * the AI client timeout is 120s, so any give-up window under ~250s could
+//     be tripped by one hung request.
+//
+// Not one of these tests sleeps: the clock and the timer are injected, so the
+// whole 5-minute ladder is exercised in microseconds.
+// ---------------------------------------------------------------------------
+
+const { NetworkResilience } = require('./shared-core');
+
+// A fake timeline. `sleep` advances the clock by exactly what was asked for,
+// which is the "no suspension" case; `suspendBy` simulates iOS freezing the
+// app mid-wait by adding extra wall time the sleeper never asked for.
+function createTimeline({ suspendBy = 0 } = {}) {
+  const timeline = {
+    nowMs: 1000000,
+    sleeps: [],
+    logs: [],
+    now: () => timeline.nowMs,
+    advance: (ms) => { timeline.nowMs += ms; },
+    sleep: async (ms) => {
+      timeline.sleeps.push(ms);
+      timeline.nowMs += ms + suspendBy;
+    },
+    log: (message) => { timeline.logs.push(message); }
+  };
+  return timeline;
+}
+
+function createResilience(timeline, overrides = {}) {
+  const classifierCore = createCore();
+  return new NetworkResilience({
+    classifyRetryable: (error) => classifierCore.isRetryableFailure(error),
+    sleep: timeline.sleep,
+    now: timeline.now,
+    log: timeline.log,
+    ...overrides
+  });
+}
+
+function timeoutError() {
+  return new Error('POST request failed: The request timed out.');
+}
+
+test('NetworkResilience rides out a minutes-long outage on the backoff ladder', async () => {
+  const timeline = createTimeline();
+  const net = createResilience(timeline);
+  let attempts = 0;
+
+  const value = await net.run('page fetch', 'https://example.com/a', async () => {
+    attempts += 1;
+    if (attempts < 4) throw timeoutError();
+    return 'ok';
+  });
+
+  assert.equal(value, 'ok');
+  assert.equal(attempts, 4);
+  assert.deepEqual(timeline.sleeps, [5000, 15000, 30000],
+    'the ladder is measured in tens of seconds, not milliseconds — a subway gap lasts minutes');
+  const totalPatience = NetworkResilience.DEFAULT_RETRY_DELAYS_MS.reduce((a, b) => a + b, 0);
+  assert.ok(totalPatience >= 180000 && totalPatience <= 300000,
+    `full patience is ${totalPatience}ms — it has to span an inter-station gap without outliving the give-up window`);
+  assert.ok(timeline.logs.some(line => line.includes('waiting 5s before attempt 2')),
+    'a silent 90-second pause reads as a hang and gets the run killed — every wait announces itself');
+});
+
+test('NetworkResilience never adds latency to a permanent failure', async () => {
+  const timeline = createTimeline();
+  const net = createResilience(timeline);
+  let attempts = 0;
+
+  await assert.rejects(
+    net.run('page fetch', 'https://example.com/gone', async () => {
+      attempts += 1;
+      throw new Error('HTTP request failed for x: HTTP 410 error from x');
+    }),
+    /410/
+  );
+
+  assert.equal(attempts, 1, '410 Gone must still fail fast');
+  assert.deepEqual(timeline.sleeps, [], 'not one millisecond of backoff is spent on a permanent failure');
+});
+
+test('NetworkResilience gives up on elapsed time, not on a failure count', async () => {
+  const timeline = createTimeline();
+  const net = createResilience(timeline, { retryDelaysMs: [1000] });
+
+  // A tunnel produces a burst of failures within seconds. A consecutive-failure
+  // counter would stop the run here; the time-based rule must not.
+  for (let i = 0; i < 12; i++) {
+    const host = i % 2 === 0 ? 'https://a.example/x' : 'https://b.example/x';
+    await assert.rejects(net.run('page fetch', host, async () => { throw timeoutError(); }));
+  }
+  assert.equal(net.isGivenUp(), false,
+    'twelve failures in seconds is a tunnel, not an outage — counting failures trips at exactly the wrong moment');
+
+  // Same failures, but now five minutes of wall clock have passed with nothing
+  // succeeding anywhere.
+  timeline.advance(NetworkResilience.DEFAULT_GIVE_UP_AFTER_MS);
+  await assert.rejects(
+    net.run('page fetch', 'https://a.example/x', async () => { throw timeoutError(); }),
+    (error) => NetworkResilience.isGiveUpError(error)
+  );
+  assert.equal(net.isGivenUp(), true);
+  assert.ok(net.getGiveUpReport().hosts.length >= 2);
+  assert.ok(timeline.logs.some(line => line.includes('GIVING UP')));
+});
+
+test('NetworkResilience: any success resets the give-up clock', async () => {
+  const timeline = createTimeline();
+  const net = createResilience(timeline, { maxOperationMs: 0 });
+
+  for (let i = 0; i < 3; i++) {
+    await assert.rejects(net.run('page fetch', `https://h${i}.example/x`, async () => { throw timeoutError(); }));
+  }
+  timeline.advance(NetworkResilience.DEFAULT_GIVE_UP_AFTER_MS - 1000);
+  assert.equal(await net.run('page fetch', 'https://ok.example/x', async () => 'fine'), 'fine');
+
+  timeline.advance(NetworkResilience.DEFAULT_GIVE_UP_AFTER_MS - 1000);
+  for (let i = 0; i < 3; i++) {
+    await assert.rejects(net.run('page fetch', `https://h${i}.example/x`, async () => { throw timeoutError(); }));
+  }
+  assert.equal(net.isGivenUp(), false,
+    'the clock measures time since the last SUCCESS — one success buys the full window again');
+});
+
+test('NetworkResilience: one dead host can never stop the run', async () => {
+  const timeline = createTimeline();
+  const net = createResilience(timeline, { maxOperationMs: 0 });
+
+  // An hour of nothing but this one host failing, with no other host attempted.
+  for (let i = 0; i < 30; i++) {
+    timeline.advance(120000);
+    await assert.rejects(net.run('image download', 'https://cdn.dead.example/a.jpg', async () => { throw timeoutError(); }));
+  }
+
+  assert.equal(net.isGivenUp(), false,
+    'a flaky image CDN is not an offline phone — give-up needs failures from at least two distinct hosts');
+});
+
+test('NetworkResilience: a failure the SERVER answered proves the network is up', async () => {
+  const timeline = createTimeline();
+  const net = createResilience(timeline, { maxOperationMs: 0 });
+
+  for (let i = 0; i < 10; i++) {
+    timeline.advance(120000);
+    const host = i % 2 === 0 ? 'https://a.example/x' : 'https://b.example/x';
+    await assert.rejects(net.run('page fetch', host, async () => {
+      throw new Error('HTTP request failed for x: HTTP 403 error from x');
+    }));
+  }
+
+  assert.equal(net.isGivenUp(), false,
+    'a 403 bot wall means packets are flowing — bot-hostile hosts must never look like a subway tunnel');
+});
+
+test('NetworkResilience reads an oversleeping wait as app suspension, not as an outage', async () => {
+  // iOS suspends Scriptable's JavaScript when the app is backgrounded, so an
+  // await on a 5s timer can return with 20 minutes of wall clock behind it.
+  // That is the owner walking away, not the network dying.
+  const timeline = createTimeline({ suspendBy: 20 * 60 * 1000 });
+  const net = createResilience(timeline, { retryDelaysMs: [5000, 5000, 5000] });
+
+  await assert.rejects(net.run('page fetch', 'https://a.example/x', async () => { throw timeoutError(); }));
+  await assert.rejects(net.run('page fetch', 'https://b.example/x', async () => { throw timeoutError(); }));
+
+  assert.equal(net.isGivenUp(), false,
+    'an hour of wall clock spent suspended must not be charged to the give-up window');
+  assert.ok(net.suspensionsDetected > 0);
+  assert.ok(timeline.logs.some(line => line.includes('backgrounded')));
+});
+
+test('NetworkResilience: retry patience is a time budget, so a hanging host cannot own the run', async () => {
+  // Corpus: one image download hung 120881ms before timing out. Six attempts of
+  // that plus the full ladder would be 12+ minutes on a single image.
+  const timeline = createTimeline();
+  const net = createResilience(timeline);
+  let attempts = 0;
+
+  await assert.rejects(net.run('image download', 'https://slow.example/a.jpg', async () => {
+    attempts += 1;
+    timeline.advance(120000);
+    throw timeoutError();
+  }));
+
+  assert.ok(attempts <= 3, `a host that hangs for the client timeout got ${attempts} attempts — the budget must cut it short`);
+  const spent = timeline.sleeps.reduce((a, b) => a + b, 0) + attempts * 120000;
+  assert.ok(spent <= NetworkResilience.DEFAULT_MAX_OPERATION_MS + 120000,
+    'one operation must not be able to spend more than its budget plus one in-flight attempt');
+});
+
+test('NetworkResilience: a host that burned its whole budget stops costing minutes', async () => {
+  const timeline = createTimeline();
+  const net = createResilience(timeline);
+
+  await assert.rejects(net.run('image download', 'https://cdn.example/1.jpg', async () => { throw timeoutError(); }));
+  const sleepsAfterFirst = timeline.sleeps.length;
+  assert.ok(sleepsAfterFirst > 0);
+
+  await assert.rejects(net.run('image download', 'https://cdn.example/2.jpg', async () => { throw timeoutError(); }));
+  assert.equal(timeline.sleeps.length, sleepsAfterFirst,
+    'the second image on the same dead host gets one attempt and no waiting');
+
+  // Anything succeeding anywhere means the network came back — full patience returns.
+  await net.run('page fetch', 'https://other.example/', async () => 'ok');
+  await assert.rejects(net.run('image download', 'https://cdn.example/3.jpg', async () => { throw timeoutError(); }));
+  assert.ok(timeline.sleeps.length > sleepsAfterFirst, 'a success anywhere restores every host\'s patience');
+});
+
+test('NetworkResilience: giving up is sticky and instant for every later call', async () => {
+  const timeline = createTimeline();
+  const net = createResilience(timeline, { maxOperationMs: 0 });
+
+  for (const host of ['https://a.example/x', 'https://b.example/x', 'https://c.example/x']) {
+    await assert.rejects(net.run('page fetch', host, async () => { throw timeoutError(); }));
+  }
+  timeline.advance(NetworkResilience.DEFAULT_GIVE_UP_AFTER_MS);
+  await assert.rejects(net.run('page fetch', 'https://d.example/x', async () => { throw timeoutError(); }));
+  assert.equal(net.isGivenUp(), true);
+
+  let called = false;
+  await assert.rejects(
+    net.run('page fetch', 'https://e.example/x', async () => { called = true; return 'ok'; }),
+    (error) => NetworkResilience.isGiveUpError(error) && error.retryable === true
+  );
+  assert.equal(called, false, 'once the run has given up, nothing else touches the network');
+});
+
+test('NetworkResilience give-up errors must never poison the permanent failure cache', async () => {
+  const timeline = createTimeline();
+  const net = createResilience(timeline);
+  net.giveUpReport = { idleSeconds: 300, failures: 5, hosts: ['a', 'b'] };
+  const core = createCore();
+  const saved = [];
+  const httpAdapter = { saveFailureNote: async (url) => { saved.push(url); } };
+
+  await core.saveNonRetryableFailureNote(httpAdapter, 'https://a.example/x', net.buildGiveUpError(), 'crawl-page');
+
+  assert.deepEqual(saved, [],
+    'losing service is transient by definition — a give-up must never be cached as a permanent no-retry failure');
+});
+
+test('isRetryableFailure trusts a status the adapter stamped over the message it wrote', () => {
+  const core = createCore();
+  // The real shape from 94 of the 95 image failures in the corpus: the host
+  // answered 200 with bytes that were not an image, but the adapter's wrapper
+  // text matches the /failed to fetch/ pattern.
+  const decodeFailure = new Error('Failed to fetch image as base64: Cannot parse response to an image.');
+  assert.equal(core.isRetryableFailure(decodeFailure), true,
+    'message alone cannot tell a decode failure from a dead network');
+  decodeFailure.statusCode = 200;
+  assert.equal(core.isRetryableFailure(decodeFailure), false,
+    'the server answered 200 — retrying gets the same bytes back, forever');
+
+  const serverError = new Error('Failed to fetch image as base64: whatever');
+  serverError.statusCode = 503;
+  assert.equal(core.isRetryableFailure(serverError), true, '5xx is still worth another try');
+
+  const explicit = new Error('anything');
+  explicit.retryable = false;
+  explicit.statusCode = 503;
+  assert.equal(core.isRetryableFailure(explicit), false, 'an explicit retryable flag still outranks everything');
+});
+
+test('processEvents stamps a truncated run and stops starting parsers', async () => {
+  const core = createCore();
+  const display = createDisplayAdapterStub();
+  core.networkResilience = {
+    isGivenUp: () => true,
+    getGiveUpReport: () => ({ idleSeconds: 312, failures: 6, hosts: ['a.example', 'b.example'] })
+  };
+  const config = { parsers: [{ name: 'First', urls: [] }, { name: 'Second', urls: [] }] };
+
+  const results = await core.processEvents(config, {}, display, STUB_PARSERS);
+
+  assert.deepEqual(results.parserResults, [], 'no parser starts once the run has given up on the network');
+  assert.ok(results.networkTruncated, 'the run must carry the truncation forward — the calendar write reads it');
+  assert.equal(results.networkTruncated.idleSeconds, 312);
+  assert.deepEqual(results.networkTruncated.skippedParsers, ['First', 'Second']);
+  assert.ok(display.logs.some(line => line.includes('RUN TRUNCATED') && line.includes('will NOT be written to the calendar')),
+    'the owner must never mistake a network-truncated run for a complete one');
+});
+
+test('processEvents leaves a healthy run completely untouched', async () => {
+  const core = createCore();
+  const display = createDisplayAdapterStub();
+  core.networkResilience = { isGivenUp: () => false, getGiveUpReport: () => null };
+  const config = { parsers: [{ name: 'First', urls: [] }] };
+
+  const results = await core.processEvents(config, {}, display, STUB_PARSERS);
+
+  assert.deepEqual(results.parserResults.map(r => r.name), ['First']);
+  assert.equal(results.networkTruncated, undefined, 'a healthy run carries no truncation marker at all');
+});
+
+test('end to end: losing service mid-crawl abandons the queue and truncates the run', async () => {
+  // Wires the real NetworkResilience behind a real crawl, the way the adapter
+  // does on the phone: every fetch goes through the one choke point.
+  const timeline = createTimeline();
+  const core = createCore();
+  const display = createDisplayAdapterStub();
+  const net = createResilience(timeline);
+  core.networkResilience = net;
+
+  const attemptedUrls = new Set();
+  const httpAdapter = {
+    fetchData: async (url) => net.run('page fetch', url, async () => {
+      attemptedUrls.add(url);
+      // The tunnel: nothing at all gets through, on any host.
+      throw new Error('HTTP request failed for x: The network connection was lost.');
+    })
+  };
+  const parsers = { 'ai-web': { parseEvents: () => ({ events: [], additionalLinks: [] }) } };
+  const config = {
+    parsers: [
+      { name: 'First', urls: ['https://a.example/1', 'https://a.example/2', 'https://b.example/1', 'https://b.example/2'], ai: CRAWL_AI },
+      { name: 'Second', urls: ['https://c.example/1'], ai: CRAWL_AI }
+    ]
+  };
+
+  const results = await core.processEvents(config, httpAdapter, display, parsers);
+
+  assert.ok(net.isGivenUp(), 'a tunnel that outlasts the give-up window has to stop the run');
+  assert.ok(results.networkTruncated, 'the truncation is what the calendar write reads to refuse itself');
+  assert.deepEqual(results.networkTruncated.skippedParsers, ['Second'],
+    'the parser that never got a chance is named, so a short run is obviously short');
+  assert.ok(attemptedUrls.size < 5,
+    `the crawl queue was abandoned rather than walked to the end (reached ${attemptedUrls.size} of 5 URLs)`);
+  assert.equal(attemptedUrls.has('https://c.example/1'), false,
+    'the second parser was never started, so its URL was never touched');
+  assert.ok(display.logs.some(line => line.includes('RUN TRUNCATED')));
+  assert.ok(display.logs.some(line => line.includes('Network gave up — abandoning')));
+});
+
+test('isRetryableFailure recognises the wordings iOS actually produces when service drops', () => {
+  const core = createCore();
+  // Verbatim from the 241-run corpus and from NSURLError. Before this, only
+  // "The request timed out." was recognised — the other three were classified
+  // PERMANENT, which skipped every retry AND wrote the URL into the no-retry
+  // failure cache, poisoning it for later runs.
+  const transient = [
+    'HTTP request failed for x: The network connection was lost.',
+    'HTTP request failed for x: A server with the specified hostname could not be found.',
+    'HTTP request failed for x: The Internet connection appears to be offline.',
+    'HTTP request failed for x: Could not connect to the server.',
+    'HTTP request failed for x: The request timed out.'
+  ];
+  for (const message of transient) {
+    assert.equal(core.isRetryableFailure(new Error(message)), true, message);
+  }
+
+  // The permanent shapes stay permanent — a looser classifier would start
+  // buying minutes of backoff for the 403/404/410 walls that fill the corpus.
+  const permanent = [
+    'HTTP request failed for x: Cannot parse response to a string.',
+    'HTTP request failed for x: Empty response from https://a',
+    'HTTP request failed for x: HTTP 404 error from https://a',
+    'HTTP request failed for x: HTTP 410 error from https://a',
+    'HTTP request failed for x: HTTP 403 error from https://a',
+    'HTTP request failed for x: unsupported URL'
+  ];
+  for (const message of permanent) {
+    assert.equal(core.isRetryableFailure(new Error(message)), false, message);
+  }
+});


### PR DESCRIPTION
> "these happen all the time when I need to temporarily leave the app, or when I'm in the subway and i lose service in between stops" … "gaps between subway stations is a few mins long"

## The live bug this turned up

`isRetryableFailure` already existed. It **missed 3 of the 4 connectivity errors iOS actually emits**:

| pattern in the code | what iOS actually says |
|---|---|
| `/connection\s+(lost\|reset\|refused)/` | "The network connection **was** lost." — no match |
| `/dns/` | "A server with the specified hostname could not be found." — never contains "dns" |
| *(nothing)* | **"The Internet connection appears to be offline."** — the literal subway case |

Across 241 runs, only `/timed out/` ever fired on a real device error.

**And this wasn't just a missing retry.** Those errors were classified *permanent*, so `saveNonRetryableFailureNote` wrote them into the no-retry failure cache — **one tunnel could poison a URL for future runs.** The classifier is extended (additions only) with the real NSURLError wordings.

Second correction, to something I asserted: of the 95 image-download failures in the corpus, **94 are not transient at all** — they're `Cannot parse response to an image` behind a healthy HTTP 200 (the host served HTML/SVG). And the adapter's own wrapper text `Failed to fetch image as base64:` matches `/failed to fetch/`, so a naive retry would have burned **minutes of backoff on each one**. Fixed at the source: the fetch now stamps `error.statusCode`, and a stamped status outranks message scraping.

## The design, and where the numbers came from

**Ladder: 5s / 15s / 30s / 60s / 90s** (200s over 6 attempts). Every failure in the corpus recovered within 10.5s, so rungs 1–2 cover everything that actually happens; the rest exist purely for your inter-station gap.

**Give up on time, not on a count — 300s with zero successes.** A consecutive-failure counter trips within seconds in a tunnel, which is exactly backwards. Healthy runs gap between successful calls at **p99 15s, p99.9 30s, worst real 40s**, so 300s is a 10× margin — and 2.5× the 120s AI client timeout, so one hung request can't trip it. Every gap over 120s in the corpus is local CPU (image downscale, merge loops), which produces no failures and so cannot trip a rule that requires them.

**Guards:** at least **3 failures** (a backgrounded app makes zero attempts) and at least **2 distinct hosts**. The host rule also removes the need for a separate "is it rybook or the internet" test — if only rybook is down, page fetches keep succeeding and reset the clock; if only the internet is down, rybook still answers.

**Per-operation budget of 240s**, because patience is time, not attempts: one corpus image download hung **120,881 ms** before timing out, and six attempts of that would be 12+ minutes on a single image.

Honest caveat: **the corpus contains no real outage** — no 5xx, no 429, no ECONNRESET, 2 timeouts in 241 runs. So the ladder is calibrated from your stated "few mins", with the corpus used only to set floors the design must not violate.

## One choke point

All three outbound paths (`fetchData`, `postJson`, `fetchImageAsBase64`) delegate to one wrapper — page fetch, AI/OCR, image download and the Nominatim geocode all funnel through them. Nothing else grew a retry. In `fetchData` only the round trip is wrapped, so a disk-cache hit isn't miscounted as proof of connectivity.

Policy lives in a platform-pure `SharedCore.NetworkResilience` with clock, timer, logger and classifier injected — which is also why testing a 5-minute ladder costs microseconds.

## Suspension — conservative, because I couldn't prove it

Scriptable's timer behaviour across backgrounding could not be determined empirically (the corpus shows suspension over 5 min **only** in the post-scrape UI phase, never mid-scrape). So: the sleeper **measures actual wall time**, and a wait overshooting its request by 30s+ is read as backgrounding, logged, and the give-up clock **rebased rather than charged**. With the ≥3-failures rule, a suspension can't manufacture a give-up in either direction.

## A truncated run never reaches the calendar

**There are two write paths**, so the refusal is repeated in both: the headless automation/widget write, and the interactive iOS write nested inside the results UI. Gating only the orchestrator would have left the phone **one tap** from saving a half-scraped run.

The UI still renders so you can see what was found — with a full-width red banner **above** the header, because the header scrolls away and the stat tiles below otherwise read like a finished run.

The give-up error carries `retryable: true` on purpose, so it can never be written into the permanent failure cache. There's a test for exactly that.

## Tests

20 added, **1559 → 1579 pass, 0 fail**. **19 fail on `origin/main`**; the 20th is a declared no-regression guard that passes both ways. Suite wall clock **3.674s → 3.655s** — no test sleeps.

**No new runtime files** — nothing to add to your script-updater.

## Not done

`postJson` non-2xx doesn't throw — it returns `{ok: false}` and `callAiGenerate` turns that into `null`, so an AI server answering **503 still isn't retried**. It's a value path, not an error path, and changing it would touch merge-arbitration semantics. Separate call.
