### PR TITLE
fix(scraper): segment window integrity — stop fence-post slices swallowing the neighbor's JSON-LD

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1245,6 +1245,11 @@ class AiWebParser {
         // BEFORE any per-segment prompt content is built below.
         this.applySegmentOcrConsistencyGate(segments, ocrResults, sourceUrl);
 
+        // Report-only tripwire: a window carrying a NEIGHBORING card's
+        // JSON-LD would have its url/date/image hijacked by the structured
+        // pass of per-segment extraction — announce it (nothing is dropped).
+        this.applySegmentStructuredDataConsistencyGate(segments, sourceUrl);
+
         // Segment-derived site-role facts (multiple distinct addresses →
         // organizer; one recurring address that also appears outside the
         // listings → venue) can settle what the JSON-LD types alone could not.
@@ -2382,13 +2387,32 @@ class AiWebParser {
 
         for (const pattern of containerPatterns) {
             pattern.lastIndex = 0;
+            // Oversized containers are discarded as candidates, but the regex
+            // has already advanced past their ENTIRE body — so a page-level
+            // wrapper <section> would hide every per-card <article> inside it
+            // (MEC-style listings wrap all cards in one 80KB+ section, and the
+            // cards were never scanned: the winning group fell through to
+            // image-anchor fence-post slices that leak each neighbor's
+            // JSON-LD). Resume the scan just past the oversized container's
+            // opening tag instead, so its children get their own turn.
+            // lastIndex only ever moves forward, and the resume count is
+            // capped so pathologically nested markup stays linear.
+            let oversizedResumes = 0;
+            const maxOversizedResumes = 200;
             let match;
             while ((match = pattern.exec(source)) !== null) {
                 const tagName = String(match[1] || '').toLowerCase();
                 const attrs = match[2] || '';
                 if (tagName === 'div' && !this.hasMultiEventStructureHint(attrs)) continue;
                 const containerHtml = match[0];
-                if (containerHtml.length > this.extractionLimits.multiEventMaxSegmentChars * 4) continue;
+                if (containerHtml.length > this.extractionLimits.multiEventMaxSegmentChars * 4) {
+                    const openTagEnd = containerHtml.indexOf('>');
+                    if (openTagEnd >= 0 && oversizedResumes < maxOversizedResumes) {
+                        oversizedResumes++;
+                        pattern.lastIndex = match.index + openTagEnd + 1;
+                    }
+                    continue;
+                }
                 const signature = this.getMultiEventStructureSignature(tagName, attrs);
                 addCandidate(`container:${signature}`, {
                     html: containerHtml,
@@ -2688,6 +2712,42 @@ class AiWebParser {
         return Array.from(new Set(tokens)).sort();
     }
 
+    // A fence-post slice runs from one card's anchor to the NEXT card's
+    // anchor, so structured data emitted BETWEEN two cards (MEC-style
+    // plugins print each card's <script type="application/ld+json">
+    // immediately BEFORE its markup) lands at the TAIL of the PREVIOUS
+    // card's slice — and the per-segment jsonld extraction pass then reads
+    // the neighbor's url/date/image as this card's own (eaglela.com run
+    // 20260806: all 12 listings title-shifted by one). The rule here is
+    // purely positional: a trailing JSON-LD block, followed by nothing but
+    // markup (no visible text) whose first tag is not a closing tag,
+    // belongs to the next card — truncate the slice at the block's start.
+    // A block genuinely inside the entry's own container is untouched:
+    // either visible entry text follows it, or its container's closing tag
+    // does, and both keep it.
+    trimTrailingJsonLdFromFencePostSlice(entryHtml) {
+        let html = String(entryHtml || '');
+        const blockPattern = /<script[^>]*type\s*=\s*["']application\/ld\+json["'][^>]*>[\s\S]*?<\/script>/gi;
+        for (let pass = 0; pass < 8; pass++) {
+            blockPattern.lastIndex = 0;
+            let lastBlockStart = -1;
+            let lastBlockEnd = -1;
+            let match;
+            while ((match = blockPattern.exec(html)) !== null) {
+                lastBlockStart = match.index;
+                lastBlockEnd = blockPattern.lastIndex;
+            }
+            if (lastBlockStart <= 0) break;
+            const tail = html.slice(lastBlockEnd);
+            const tailText = tail.replace(/<[^>]*>?/g, ' ').replace(/\s+/g, ' ').trim();
+            if (tailText) break;
+            const firstTag = (tail.match(/<\s*\/?[a-z]/i) || [''])[0];
+            if (/<\s*\//.test(firstTag)) break;
+            html = html.slice(0, lastBlockStart);
+        }
+        return html;
+    }
+
     extractRepeatedMultiEventResourceGroups(html) {
         const source = String(html || '');
         const anchors = [];
@@ -2726,10 +2786,11 @@ class AiWebParser {
                 const end = nextAnchor
                     ? nextAnchor.start
                     : Math.min(source.length, anchor.start + this.extractionLimits.multiEventMaxSegmentChars * 4);
+                const entryHtml = this.trimTrailingJsonLdFromFencePostSlice(source.slice(anchor.start, end));
                 return {
-                    html: source.slice(anchor.start, end),
+                    html: entryHtml,
                     start: anchor.start,
-                    end,
+                    end: anchor.start + entryHtml.length,
                     kind: 'resource'
                 };
             });
@@ -2810,10 +2871,11 @@ class AiWebParser {
                 const end = nextAnchor
                     ? nextAnchor.start
                     : Math.min(text.length, anchor.start + this.extractionLimits.multiEventMaxSegmentChars * 4);
+                const entryHtml = this.trimTrailingJsonLdFromFencePostSlice(text.slice(anchor.start, end));
                 return {
-                    html: text.slice(anchor.start, end),
+                    html: entryHtml,
                     start: anchor.start,
-                    end,
+                    end: anchor.start + entryHtml.length,
                     kind: 'resource-link'
                 };
             });
@@ -6928,6 +6990,80 @@ class AiWebParser {
                 } else {
                     console.log(`🤖 AI Web: Detached OCR image ${ocr.url} from segment ${i + 1} ("${owner.title}") — flyer text matches multiple sibling titles`);
                 }
+            }
+        }
+        return sourceSegments;
+    }
+
+    // Report-only structured-data consistency tripwire, mirroring the spirit
+    // of applySegmentOcrConsistencyGate: a multi-event window whose html
+    // carries an Event-typed JSON-LD node pointing at a DIFFERENT same-site
+    // event page than the window's own identity link is very likely holding a
+    // neighboring card's structured data — the per-segment extraction reads
+    // that block FIRST, so the neighbor's url/date/image would win over the
+    // card's own text (eaglela.com run 20260806: 12 chimera events, each
+    // titled by card k with card k+1's url/date/poster). The segmentation
+    // fixes upstream should make this impossible on known layouts; this line
+    // is the tripwire for layouts they don't cover. LOG ONLY — nothing is
+    // dropped or rewritten here (report-only before enforce).
+    applySegmentStructuredDataConsistencyGate(segments, sourceUrl = '') {
+        const sourceSegments = Array.isArray(segments) ? segments : [];
+        if (sourceSegments.length < 2) return sourceSegments;
+        if (!this.core || typeof this.core.extractJsonLdEventNodes !== 'function') return sourceSegments;
+
+        // String splitting only — no URL parsing (iOS JavaScriptCore has no
+        // URL/URLSearchParams). Fragment dropped; query kept (listing pages
+        // can distinguish occurrences purely by query).
+        const splitUrlParts = (value) => {
+            const raw = String(value || '').split('#')[0].trim();
+            if (!raw) return null;
+            const schemeMatch = raw.match(/^(?:[a-z][a-z0-9+.-]*:)?\/\//i);
+            if (!schemeMatch) return { host: '', path: raw };
+            const rest = raw.slice(schemeMatch[0].length);
+            const pathStart = rest.search(/[/?]/);
+            if (pathStart === -1) return { host: rest.toLowerCase(), path: '/' };
+            return { host: rest.slice(0, pathStart).toLowerCase(), path: rest.slice(pathStart) };
+        };
+        const toPathKey = (path) => String(path || '').replace(/\/+(\?|$)/, '$1').toLowerCase() || '/';
+        const stripWww = (host) => String(host || '').replace(/^www\./, '');
+        const pageParts = splitUrlParts(sourceUrl);
+        const pageHost = pageParts ? pageParts.host : '';
+        const isSameSiteHost = (host) => {
+            if (!host) return true; // relative url — same site by construction
+            if (!pageHost) return false;
+            if (this.core && typeof this.core.areUrlHostsSameSite === 'function') {
+                return this.core.areUrlHostsSameSite(host, pageHost);
+            }
+            return stripWww(host) === stripWww(pageHost);
+        };
+
+        for (const segment of sourceSegments) {
+            const segmentHtml = segment && typeof segment.html === 'string' ? segment.html : '';
+            if (!segmentHtml || !segmentHtml.includes('ld+json')) continue;
+            const identityLink = this.extractMultiEventEntryIdentityLink(segmentHtml);
+            const identityParts = splitUrlParts(identityLink);
+            if (!identityParts) continue;
+            const identityKey = toPathKey(identityParts.path);
+            let nodes = [];
+            try {
+                nodes = this.core.extractJsonLdEventNodes(segmentHtml);
+            } catch (_) {
+                continue;
+            }
+            const reported = new Set();
+            for (const node of nodes) {
+                const nodeUrl = typeof node.url === 'string' && node.url.trim()
+                    ? node.url.trim()
+                    : (typeof node['@id'] === 'string' ? node['@id'].trim() : '');
+                if (!nodeUrl || reported.has(nodeUrl)) continue;
+                const nodeParts = splitUrlParts(nodeUrl);
+                if (!nodeParts) continue;
+                if (!isSameSiteHost(nodeParts.host)) continue; // off-site (ticketing etc.) — not a neighbor card
+                if (toPathKey(nodeParts.path) === identityKey) continue; // the window's own event
+                reported.add(nodeUrl);
+                const title = this.deriveSegmentListingTitle(segment) ||
+                    ((segment.lines && segment.lines[0]) ? String(segment.lines[0]) : '');
+                console.log(`🧬 SEGMENT: window for "${title}" carries foreign JSON-LD for ${nodeUrl} — structured data likely belongs to a neighboring card`);
             }
         }
         return sourceSegments;

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -6521,6 +6521,168 @@ test('OCR consistency gate: an excluded flyer\'s OCR text and image lines never 
 });
 
 // ---------------------------------------------------------------------------
+// Segment window integrity (MEC-shaped listings): each card's JSON-LD script
+// sits BETWEEN the previous card and its own <article>, and all cards live in
+// one oversized wrapper <section>. The container scan must not let the
+// oversized wrapper hide the per-card articles, fence-post slices must not
+// carry the NEXT card's JSON-LD, and a window that still holds foreign
+// JSON-LD trips the report-only 🧬 SEGMENT line.
+// ---------------------------------------------------------------------------
+
+function buildJsonLdBeforeCardListingHtml(cardCount = 4) {
+  const cards = [];
+  for (let i = 1; i <= cardCount; i++) {
+    const url = `https://venue.example/events/night-${i}/?occurrence=2026-09-0${i}`;
+    cards.push(
+      `<script type="application/ld+json">${JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Event',
+        name: `NIGHT ${i} SPECTACULAR`,
+        startDate: `2026-09-0${i}T21:00:00-07:00`,
+        url,
+        image: `https://venue.example/media/night-${i}.jpg`
+      })}</script>\n` +
+      '<article class="event-article" itemscope>' +
+      '<div class="topsec">' +
+      `<h3 class="card-title"><a class="event-link" href="${url}">NIGHT ${i} SPECTACULAR</a></h3>` +
+      `<p>Saturday, September ${i}, 2026</p>` +
+      '<p>A big night with music and dancing at the main bar downtown.</p>' +
+      '</div></article>'
+    );
+  }
+  // The wrapper must exceed multiEventMaxSegmentChars * 4 so the container
+  // scan discards it as a candidate — the bug was that the discard also
+  // skipped everything inside it.
+  const filler = `<div class="chrome">${'lorem ipsum wrapper chrome padding '.repeat(400)}</div>`;
+  return `<html><body><section class="events-wrap">${filler}\n${cards.join('\n')}</section></body></html>`;
+}
+
+test('an oversized wrapper section does not hide its per-card articles, and no window carries a neighboring card\'s JSON-LD', () => {
+  const parser = createParser();
+  const html = buildJsonLdBeforeCardListingHtml(4);
+  assert.ok(html.indexOf('</section>') - html.indexOf('<section') >
+    parser.extractionLimits.multiEventMaxSegmentChars * 4,
+    'fixture wrapper must exceed the container size cap');
+
+  const groups = parser.extractRepeatedMultiEventStructureGroups(html);
+  const articleGroup = groups.find(group => group.signature === 'container:article:event');
+  assert.ok(articleGroup, `container:article:event group must be found inside the oversized wrapper, got ${JSON.stringify(groups.map(g => g.signature))}`);
+  assert.equal(articleGroup.entries.length, 4, 'all four cards must be scanned');
+  assert.equal(groups[0].signature, 'container:article:event',
+    'the per-card container group must outrank the fence-post resource groups');
+
+  const segments = parser.buildMultiEventSegments(html, 'https://venue.example/events/');
+  assert.equal(segments.length, 4, 'one window per card');
+  segments.forEach((segment, index) => {
+    const identity = parser.extractMultiEventEntryIdentityLink(segment.html);
+    assert.ok(identity.includes(`night-${index + 1}`), `window ${index + 1} keeps its own identity link, got ${identity}`);
+    const nodes = parser.core.extractJsonLdEventNodes(segment.html || '');
+    for (const node of nodes) {
+      assert.equal(String(node.url || ''), identity,
+        `window ${index + 1} ("${segment.lines[0]}") must not carry a neighbor's JSON-LD, found ${node.url}`);
+    }
+  });
+});
+
+test('fence-post slices: trailing JSON-LD between cards is trimmed; a block inside the entry\'s own markup is kept', () => {
+  const parser = createParser();
+
+  // Between-cards: the block trails the entry's content and is followed only
+  // by the NEXT card's opening markup — strip it and everything after.
+  const betweenCards =
+    '<div class="event-image"><img src="/night-1.jpg" /></div>' +
+    '<h3>NIGHT ONE</h3><p>Saturday, September 5, 2026</p></article>\n' +
+    '<script type="application/ld+json">{"@type":"Event","name":"NIGHT TWO","startDate":"2026-09-06","url":"https://venue.example/events/night-2/"}</script>\n' +
+    '<article class="event-article"><div class="topsec">';
+  const trimmed = parser.trimTrailingJsonLdFromFencePostSlice(betweenCards);
+  assert.ok(!trimmed.includes('ld+json'), 'the neighbor JSON-LD block must be trimmed');
+  assert.ok(!trimmed.includes('night-2'), 'nothing after the block rides along');
+  assert.ok(trimmed.includes('NIGHT ONE'), 'the entry\'s own content survives');
+
+  // Stacked neighbor blocks at the tail all go.
+  const stacked = betweenCards.replace('<article class="event-article">',
+    '<script type="application/ld+json">{"@type":"Event","name":"X","startDate":"2026-09-07"}</script><article class="event-article">');
+  assert.ok(!parser.trimTrailingJsonLdFromFencePostSlice(stacked).includes('ld+json'));
+
+  // Inside the entry's own container (closing tag follows): keep.
+  const insideOwnContainer =
+    '<div><h3>NIGHT ONE</h3><script type="application/ld+json">{"@type":"Event","name":"NIGHT ONE","startDate":"2026-09-05"}</script></div>';
+  assert.equal(parser.trimTrailingJsonLdFromFencePostSlice(insideOwnContainer), insideOwnContainer);
+
+  // Followed by visible entry text: keep.
+  const followedByText =
+    '<h3>NIGHT ONE</h3><script type="application/ld+json">{"@type":"Event","name":"NIGHT ONE","startDate":"2026-09-05"}</script><p>Doors at 9pm</p>';
+  assert.equal(parser.trimTrailingJsonLdFromFencePostSlice(followedByText), followedByText);
+
+  // End to end: image-anchored fence-post entries come back without the
+  // neighbor's block.
+  const cards = [];
+  for (let i = 1; i <= 3; i++) {
+    cards.push(
+      `<script type="application/ld+json">{"@type":"Event","name":"NIGHT ${i}","startDate":"2026-09-0${i}","url":"https://venue.example/events/night-${i}/"}</script>` +
+      `<div class="listing-row"><div class="event-image"><a href="https://venue.example/events/night-${i}/"><img src="/night-${i}.jpg" /></a></div>` +
+      `<h3>NIGHT ${i}</h3><p>Saturday, September ${i}, 2026</p></div>`
+    );
+  }
+  const groups = parser.extractRepeatedMultiEventResourceGroups(`<html><body>${cards.join('\n')}</body></html>`);
+  const imageGroup = groups.find(group => group.signature === 'resource:div:event.image');
+  assert.ok(imageGroup, `image fence-post group expected, got ${JSON.stringify(groups.map(g => g.signature))}`);
+  imageGroup.entries.forEach((entry, index) => {
+    assert.ok(!entry.html.includes('ld+json'),
+      `fence-post entry ${index + 1} must not carry the next card's JSON-LD`);
+  });
+});
+
+test('structured-data consistency gate: foreign same-site JSON-LD logs the 🧬 tripwire and drops nothing', () => {
+  const parser = createParser();
+  const foreignJsonLd =
+    '<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Event","name":"NIGHT TWO","startDate":"2026-09-06T21:00:00-07:00","url":"https://venue.example/events/night-2/"}]}</script>';
+  const ownJsonLd =
+    '<script type="application/ld+json">{"@type":"Event","name":"NIGHT TWO","startDate":"2026-09-06T21:00:00-07:00","url":"https://venue.example/events/night-2/"}</script>';
+  const segments = [
+    {
+      lines: ['NIGHT ONE', 'Saturday, September 5, 2026'],
+      html: `<a href="https://venue.example/events/night-1/">NIGHT ONE</a><p>Saturday, September 5, 2026</p>${foreignJsonLd}`
+    },
+    {
+      lines: ['NIGHT TWO', 'Sunday, September 6, 2026'],
+      html: `<a href="https://venue.example/events/night-2/">NIGHT TWO</a><p>Sunday, September 6, 2026</p>${ownJsonLd}`
+    }
+  ];
+  const htmlBefore = segments.map(segment => segment.html);
+
+  let returned;
+  const logs = captureLogs(() => {
+    returned = parser.applySegmentStructuredDataConsistencyGate(segments, 'https://venue.example/events/');
+  });
+
+  const tripwires = logs.filter(line => line.includes('🧬 SEGMENT:'));
+  assert.equal(tripwires.length, 1, `exactly one tripwire expected, got ${JSON.stringify(logs)}`);
+  assert.ok(tripwires[0].includes('carries foreign JSON-LD for https://venue.example/events/night-2/'), tripwires[0]);
+  assert.ok(tripwires[0].includes('structured data likely belongs to a neighboring card'), tripwires[0]);
+
+  // Report-only: nothing dropped, nothing rewritten.
+  assert.equal(returned, segments);
+  assert.equal(segments.length, 2);
+  segments.forEach((segment, index) => assert.equal(segment.html, htmlBefore[index]));
+
+  // Off-site JSON-LD (ticketing platforms) is not a neighboring card.
+  const offsite = [
+    {
+      lines: ['NIGHT ONE', 'Saturday, September 5, 2026'],
+      html: '<a href="https://venue.example/events/night-1/">NIGHT ONE</a>' +
+        '<script type="application/ld+json">{"@type":"Event","name":"NIGHT ONE","startDate":"2026-09-05","url":"https://tickets.example/e/12345"}</script>'
+    },
+    { lines: ['NIGHT TWO', 'Sunday, September 6, 2026'], html: '<a href="https://venue.example/events/night-2/">NIGHT TWO</a>' }
+  ];
+  const offsiteLogs = captureLogs(() => {
+    parser.applySegmentStructuredDataConsistencyGate(offsite, 'https://venue.example/events/');
+  });
+  assert.equal(offsiteLogs.filter(line => line.includes('🧬 SEGMENT:')).length, 0,
+    `off-site JSON-LD must not trip the gate, got ${JSON.stringify(offsiteLogs)}`);
+});
+
+// ---------------------------------------------------------------------------
 // og:image fill for imageless single-event pages (2c): a page that produced
 // exactly one event adopts its own og:image; multi-event segments never do.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

On MEC (Modern Events Calendar) style listings — eaglela.com/events/ is the diagnosed case — each card's `<script type="application/ld+json">` sits BEFORE its `<article>`, and all 12 cards live inside one 84,552-char wrapper `<section>`. `extractRepeatedMultiEventStructureGroups` discarded the oversized wrapper for size, but the alternation regex had already advanced past its entire body, so the 12 clean per-card `article:event` containers were never scanned. Segmentation fell through to image-anchor fence-post slices (`end = nextAnchor.start`), making window k = card k's content + card k+1's complete JSON-LD; the per-segment `jsonld` extraction pass reads that block first, so all 12 listing extractions came out title-shifted by one (chimera events — the verbatim evidence gate cannot catch it because the neighbor's values genuinely are in the window).

## The fix (three parts, all generic — no per-site/plugin/CDN rules)

1. **Recurse into size-capped containers**: when a matched container exceeds the size cap, resume the scan just past its opening tag instead of skipping its body. `lastIndex` only moves forward and resumes are capped at 200 per pattern, so pathological nesting stays bounded. On the Eagle LA page this yields the 12-entry `container:article:event` group, which outranks the fence-post resource groups under the existing (unchanged) ordering.
2. **Fence-post slices trim trailing JSON-LD**: a trailing `ld+json` block followed only by markup (no visible text) whose first tag is an opening tag belongs to the NEXT card — the slice is truncated at the block's start (stacked blocks too, bounded loop). A block genuinely inside the entry's own container is kept: either visible entry text or its container's closing tag follows it. Applied to both the image-anchor and repeated-link fence-post slicers.
3. **Report-only tripwire** (`applySegmentStructuredDataConsistencyGate`, mirroring the OCR consistency gate's spirit): a window whose html carries an Event-typed JSON-LD node pointing at a DIFFERENT same-site page than the window's own identity link logs `🧬 SEGMENT: window for "<title>" carries foreign JSON-LD for <url> — structured data likely belongs to a neighboring card`. LOG ONLY — nothing dropped (report-only before enforce). JSON parsing via the existing `extractJsonLdEventNodes` (try/catch, arrays/@graph tolerated); string-split URL comparison, no `new URL(`.

## Verification

- `node --check` on both touched files: clean.
- Quiet suite `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`: **1582 tests, 1582 pass, 0 fail** (was 1579 before the 3 new tests).
- New tests (inserted adjacent to the OCR-consistency-gate tests, not at EOF): oversized-wrapper fixture, fence-post trim fixture (trim + both keep-cases + end-to-end image-anchor group), and the report-only gate (logs on foreign same-site JSON-LD incl. @graph, silent on off-site, drops/rewrites nothing). Verified against a scratch worktree of origin/main @785bfb65: **all 3 fail on main, all 3 pass on this branch** (441/441 in the file on branch; 438 pass / 3 fail on main).
- **Real-page replay** of the exact device-run HTML (`devstorage/pages/eaglela.com/events.json`, 180,943 chars), deterministic, no AI/network:
  - main: 4 groups (winner `resource:div:event.image`), 12 windows, **11 of 12 windows carry the NEXT event's JSON-LD** (e.g. window "BEAR HAPPY HOUR" carries B BAR's `/events/b-bar/?occurrence=2026-08-06` block) — the device bug reproduced byte-for-byte.
  - branch: 5 groups (winner `container:article:event`, 12 entries), 12 windows with the SAME 12 identity links in the same order, **0 foreign JSON-LD in any window**, no tripwire logs.
  - The other 21 cached pages (all single-event detail pages — no other multi-event listings in the cache) replay **byte-identically** on main vs branch.

## Risks

- Part 1 surfaces container groups on any page with an oversized wrapper; group ranking is untouched, and per-entry date/title/content gates still judge every new candidate, but pages whose wrapper previously hid a *worse* container group could in principle pick a different winner than before. The tripwire log will surface any page where windows still carry foreign structured data.
- Part 2's keep-rule is conservative (any visible text after the block keeps it), so a layout that puts the next card's title before its anchor is left untrimmed — that's exactly what the Part 3 tripwire reports.

No new runtime files. No AI prompt strings or existing log lines were edited (additions only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP