### PR TITLE
fix(scraper): heal salvaged OCR cache entries, dedupe segmentation pass, rescue mislabeled flyers in pairing

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -674,6 +674,11 @@ class AiWebParser {
         // byte-identical context-prep prompt, so the HTTP round-trip can be reused.
         // In-memory only, scoped to this parser instance (one run).
         this.contextPrepResponseCache = new Map();
+        // Last buildMultiEventSegments computation, keyed on its arguments.
+        // parseEvents and extractEventsFromMultiEventPage both segment the
+        // same page in one invocation; the memo makes the second call free.
+        // In-memory only, single entry, scoped to this parser instance.
+        this._multiEventSegmentsMemo = null;
         this.aiResponseCacheStats = { hits: 0, misses: 0, writes: 0 };
         // Multi-event MISS-budget probe flag: while true, readCachedAiResponse
         // throws MULTI_EVENT_MISS_PROBE_ABORT instead of recording a miss (see
@@ -1936,7 +1941,32 @@ class AiWebParser {
         };
     }
 
+    // The full segmentation pass — structured-segment discovery plus the
+    // segments×images OCR-similarity cross-product inside
+    // attachSequentialImageHintsToSegments — runs once for diagnostics in
+    // parseEvents and again for extraction in extractEventsFromMultiEventPage,
+    // with identical inputs and an identical result. Memoize the last
+    // computation, keyed on the actual arguments, so the second call reuses
+    // the first result instead of re-running the matcher and re-printing
+    // every per-pair log line. Single entry: the next page's html naturally
+    // evicts the previous page's result; differing arguments (including an
+    // ocrResults array that changed identity or length) recompute as before.
     buildMultiEventSegments(html, sourceUrl = '', ocrResults = []) {
+        const ocrResultsLength = Array.isArray(ocrResults) ? ocrResults.length : 0;
+        const memo = this._multiEventSegmentsMemo;
+        if (memo
+            && memo.html === html
+            && memo.sourceUrl === sourceUrl
+            && memo.ocrResults === ocrResults
+            && memo.ocrResultsLength === ocrResultsLength) {
+            return memo.segments;
+        }
+        const segments = this.computeMultiEventSegments(html, sourceUrl, ocrResults);
+        this._multiEventSegmentsMemo = { html, sourceUrl, ocrResults, ocrResultsLength, segments };
+        return segments;
+    }
+
+    computeMultiEventSegments(html, sourceUrl = '', ocrResults = []) {
         const structuredSegments = this.buildStructuredMultiEventSegments(html);
         if (structuredSegments.length >= 2) {
             return this.attachSequentialImageHintsToSegments(html, structuredSegments, sourceUrl, ocrResults);
@@ -3115,7 +3145,22 @@ class AiWebParser {
         // <img> on the page — footer chrome. Unknown fails open; every
         // classification the model actually states behaves exactly as before.
         const pairingClassification = String(ocrResult?.imageClassification || '').toLowerCase().trim();
-        if (pairingClassification && pairingClassification !== 'event-flyer') {
+        // Similarity rescue for two specific labels the local vision model
+        // demonstrably gets wrong on genuine posters: 'ad-banner' (a real
+        // Lucki Break flyer saying "no cover") and 'multi-event-flyer' (a
+        // Movie Mondays poster listing several films). And a genuinely
+        // multi-event flyer IS the correct image for the multi-day umbrella
+        // event it advertises (festival/bear-week), whose card text overlaps
+        // the flyer heavily. For these two labels ONLY, let the pairing
+        // proceed when the OCR text clears an ELEVATED similarity bar (0.4 vs
+        // the normal 0.15) against this segment's text — a site-wide
+        // aggregate flyer or a real ad won't clear it against a single card.
+        // Every other stated label (logo, thumbnail, hero-banner, anything
+        // unrecognized) stays hard-refused exactly as before: site chrome
+        // must never earn a segment by accident, whatever its text says.
+        const similarityRescueClassifications = ['ad-banner', 'multi-event-flyer'];
+        const needsSimilarityRescue = similarityRescueClassifications.includes(pairingClassification);
+        if (pairingClassification && pairingClassification !== 'event-flyer' && !needsSimilarityRescue) {
             return { cost: Infinity, score: -Infinity };
         }
         if (!ocrResult) {
@@ -3150,6 +3195,17 @@ class AiWebParser {
                     cost = 20000; // Arbitrary high finite cost, but beatable by a good score
                 }
             }
+        }
+
+        // Rescue classifications ('ad-banner' / 'multi-event-flyer') pair only
+        // when their OCR text strongly matches this segment; below the
+        // elevated bar they are refused exactly as before this rescue existed.
+        if (needsSimilarityRescue) {
+            if (similarity < 0.4) {
+                return { cost: Infinity, score: -Infinity };
+            }
+            const rescueSegmentTitle = String(segmentText || '').split('\n').map(line => line.trim()).filter(Boolean)[0] || '';
+            console.log(`🖼️ PAIRING: allowing ${pairingClassification} image ${ocrResult.url || ''} for segment "${rescueSegmentTitle}" — flyer text strongly matches (similarity ${similarity.toFixed(2)} ≥ 0.40)`);
         }
 
         if (!Number.isFinite(cost)) {
@@ -5008,6 +5064,10 @@ class AiWebParser {
                 eventSummary: normalized.eventSummary,
                 confidence: normalized.confidence,
                 reason: normalized.reason,
+                // Additive: how many times a truncated-salvaged entry has been
+                // re-attempted (heal path in getOcrTextForImage). Absent on
+                // entries that were never salvaged or never retried.
+                ...(Number.isFinite(Number(parsed && parsed.salvageRetries)) ? { salvageRetries: Number(parsed.salvageRetries) } : {}),
                 cachePath,
                 cached: true
             };
@@ -7137,6 +7197,31 @@ class AiWebParser {
                 console.log(`🤖 AI Web: OCR negative cache hit (${cached.failureKind}) for ${cached.imageUrl || imageUrl} — skipping known-bad image`);
                 return null;
             }
+            // Heal truncated-salvaged cache entries: a salvage kept the OCR
+            // text but lost the classification, and the cache would replay
+            // that partial answer forever (64 of 442 device entries, 15%).
+            // Retry the SAME request (same prompt/options — cache key
+            // unchanged) and overwrite the entry with the fresh result. A
+            // fresh result that is itself salvaged still overwrites (fresher)
+            // but bumps salvageRetries so a stubbornly-truncating image stops
+            // costing a call once it has been retried twice. A FAILED heal
+            // call falls back to the salvaged entry and the run continues
+            // exactly as before this fix — the salvaged text is legitimate
+            // data and a heal must never make a run worse.
+            if (cached.reason === 'salvaged-from-truncated-response') {
+                const priorSalvageRetries = Number.isFinite(Number(cached.salvageRetries)) ? Number(cached.salvageRetries) : 0;
+                if (priorSalvageRetries < 2) {
+                    console.log(`🤖 AI Web: OCR cache entry for ${cached.imageUrl || imageUrl} was salvaged from a truncated response — retrying OCR to heal it (attempt ${priorSalvageRetries + 1}/2)`);
+                    let healed = null;
+                    try {
+                        healed = await this.requestAndCacheOcrResult(imageUrl, ocrConfig, passLabel, httpAdapter, { priorSalvageRetries });
+                    } catch (error) {
+                        console.log(`🤖 AI Web: OCR heal attempt failed for ${cached.imageUrl || imageUrl} (${error.message}) — keeping the salvaged cache entry`);
+                    }
+                    if (healed) return healed;
+                    console.log(`🤖 AI Web: OCR heal produced no fresh result for ${cached.imageUrl || imageUrl} — using the salvaged cache entry as before`);
+                }
+            }
             console.log(`🤖 AI Web: OCR cache hit for ${cached.imageUrl || imageUrl}`);
             // A cache hit is a verdict we already paid for — remember it here,
             // not downstream, because extractOcrFromAllImages drops textless
@@ -7146,6 +7231,18 @@ class AiWebParser {
             return cached;
         }
 
+        return this.requestAndCacheOcrResult(imageUrl, ocrConfig, passLabel, httpAdapter);
+    }
+
+    // The fresh-call half of getOcrTextForImage: download the image, run the
+    // vision model, write the per-image cache entry, return the result. Body
+    // unchanged from when it lived inline; extracted so the salvage-heal path
+    // above can reuse it verbatim. healContext ({ priorSalvageRetries }) is
+    // only passed by that heal path: it stamps the retry counter on a
+    // still-salvaged fresh result and suppresses the negative-cache write (a
+    // context-overflow verdict must not clobber a cache entry that already
+    // holds legitimate salvaged text).
+    async requestAndCacheOcrResult(imageUrl, ocrConfig = {}, passLabel = 'ocr', httpAdapter = null, healContext = null) {
         const rawUrl = String(imageUrl || '').trim();
         const normalizedUrl = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(rawUrl) || rawUrl);
         if (!normalizedUrl) {
@@ -7198,7 +7295,9 @@ class AiWebParser {
             // Context overflow is deterministic for a given image+model — cache the
             // failure so the same image is not re-downloaded and re-sent on every
             // page (and every run) that references it.
-            if (diagnostics.failureKind === 'context-overflow') {
+            // Never during a salvage heal, though: the existing cache entry
+            // holds legitimate OCR text and must survive a failed retry.
+            if (diagnostics.failureKind === 'context-overflow' && !healContext) {
                 const cachePath = await this.writeCachedOcrResult(imageUrl, ocrConfig, JSON.stringify({ failureKind: diagnostics.failureKind }));
                 if (cachePath) {
                     console.warn(`🤖 AI Web: Cached OCR failure (${diagnostics.failureKind}) for ${normalizedUrl} so it is not retried`);
@@ -7213,6 +7312,14 @@ class AiWebParser {
         }
         if (!parsed.text) {
             console.log(`🤖 AI Web: OCR response for ${imageUrl} has no text (imageClassification: ${parsed.imageClassification})`);
+        }
+        // Salvage-heal bookkeeping: the fresh call ALSO truncated. Overwrite
+        // the cache anyway (fresher salvage) but stamp the retry counter so
+        // the heal loop gives up after two attempts instead of spending ~2s
+        // on this image every future run forever.
+        if (healContext && parsed.reason === 'salvaged-from-truncated-response') {
+            parsed.salvageRetries = Number(healContext.priorSalvageRetries || 0) + 1;
+            console.log(`🤖 AI Web: OCR heal for ${normalizedUrl} still came back truncated — caching the fresher salvage (salvageRetries: ${parsed.salvageRetries})`);
         }
         const normalized = this.normalizeOcrResult(parsed);
         this.recordOcrImageVerdict(imageUrl, { ...normalized, imageUrl });

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -12209,3 +12209,260 @@ test('an OCR result with no classification is paired on its text, not refused', 
   const none = parser.getSegmentImagePairingCostWithOcr(bounds, imageRecord, null, '');
   assert.equal(none.cost, Infinity);
 });
+
+// ---------------------------------------------------------------------------
+// SALVAGED OCR CACHE HEAL — a truncated-salvaged cache entry is retried (same
+// prompt/options, same cache key) instead of replaying its partial answer
+// forever; a failed heal falls back to the salvage and never hurts the run.
+// ---------------------------------------------------------------------------
+
+// Fixture mirrors a real device entry (eaglela.com B-Bar poster): salvage kept
+// the OCR text but lost the classification.
+const SALVAGED_OCR_ENTRY = JSON.stringify({
+  text: 'NO COVER!\n\nB BAR\nEVERY THURSDAY\n\nBEARS CUBS OTTERS\nand OTHER\nFURRY\nCRITTERS!',
+  imageClassification: '',
+  eventSummary: null,
+  confidence: null,
+  reason: 'salvaged-from-truncated-response'
+});
+
+test('a truncated-salvaged OCR cache entry is healed by a fresh call that overwrites it', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-heal-test-'));
+
+  const parser = new AiWebParser({ normalizeUrl, ocrCacheDir: cacheDir });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+  const ocrConfig = { cacheEnabled: true, model: 'test-vision', prompt: 'ocr prompt', timeoutSeconds: 30 };
+  const imageUrl = 'https://eagle.example/wp-content/uploads/B-Bar-poster.jpg';
+  const cachePath = await parser.writeCachedOcrResult(imageUrl, ocrConfig, SALVAGED_OCR_ENTRY);
+  assert.ok(cachePath);
+
+  let aiCalls = 0;
+  parser.core.callAiGenerate = async () => {
+    aiCalls++;
+    return JSON.stringify({
+      text: 'NO COVER!\n\nB BAR\nEVERY THURSDAY',
+      imageClassification: 'event-flyer',
+      eventSummary: 'B Bar weekly bear night',
+      confidence: 95,
+      reason: 'clear poster'
+    });
+  };
+  const result = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', {
+    fetchImageAsBase64: async () => 'base64imagedata'
+  });
+
+  assert.equal(aiCalls, 1, 'a salvaged cache entry must trigger a fresh OCR call, not a plain hit');
+  assert.equal(result.imageClassification, 'event-flyer', 'the fresh classification replaces the salvage blank');
+  assert.equal(result.cached, false);
+
+  const stored = JSON.parse(JSON.parse(fs.readFileSync(cachePath, 'utf8')).response.text);
+  assert.equal(stored.imageClassification, 'event-flyer', 'the cache entry is overwritten with the fresh result');
+  assert.notEqual(stored.reason, 'salvaged-from-truncated-response');
+
+  // Next read is a plain hit — no further AI calls.
+  const second = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', {
+    fetchImageAsBase64: async () => { throw new Error('a healed entry must be a plain cache hit'); }
+  });
+  assert.equal(aiCalls, 1);
+  assert.equal(second.cached, true);
+  assert.equal(second.imageClassification, 'event-flyer');
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+test('a stubbornly-truncating image stops being retried after the salvageRetries cap', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-heal-cap-test-'));
+
+  const parser = new AiWebParser({ normalizeUrl, ocrCacheDir: cacheDir });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+  const ocrConfig = { cacheEnabled: true, model: 'test-vision', prompt: 'ocr prompt', timeoutSeconds: 30 };
+  const imageUrl = 'https://eagle.example/wp-content/uploads/cursed-poster.jpg';
+  const cachePath = await parser.writeCachedOcrResult(imageUrl, ocrConfig, SALVAGED_OCR_ENTRY);
+
+  // The model truncates every time: unbalanced JSON, text cut mid-string.
+  let aiCalls = 0;
+  parser.core.callAiGenerate = async () => {
+    aiCalls++;
+    return '{"text": "NO COVER!\\n\\nB BAR\\nEVERY THURSDAY';
+  };
+  const adapter = { fetchImageAsBase64: async () => 'base64imagedata' };
+
+  const first = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', adapter);
+  assert.equal(aiCalls, 1);
+  assert.ok(first.text.includes('B BAR'), 'the fresher salvage still carries the text');
+  let stored = JSON.parse(JSON.parse(fs.readFileSync(cachePath, 'utf8')).response.text);
+  assert.equal(stored.reason, 'salvaged-from-truncated-response');
+  assert.equal(stored.salvageRetries, 1, 'the first failed heal stamps the retry counter');
+
+  const second = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', adapter);
+  assert.equal(aiCalls, 2);
+  stored = JSON.parse(JSON.parse(fs.readFileSync(cachePath, 'utf8')).response.text);
+  assert.equal(stored.salvageRetries, 2);
+
+  const third = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', adapter);
+  assert.equal(aiCalls, 2, 'at salvageRetries >= 2 the entry is a plain hit — no more ~2s heal calls, ever');
+  assert.equal(third.cached, true);
+  assert.ok(third.text.includes('B BAR'), 'the salvaged text is still served');
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+test('a failed heal call falls back to the salvaged cache entry without failing the operation', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-heal-fallback-test-'));
+
+  const parser = new AiWebParser({ normalizeUrl, ocrCacheDir: cacheDir });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+  const ocrConfig = { cacheEnabled: true, model: 'test-vision', prompt: 'ocr prompt', timeoutSeconds: 30 };
+  const imageUrl = 'https://eagle.example/wp-content/uploads/B-Bar-poster.jpg';
+  const cachePath = await parser.writeCachedOcrResult(imageUrl, ocrConfig, SALVAGED_OCR_ENTRY);
+
+  // rybook is unreachable: the image download itself throws.
+  let downloadAttempts = 0;
+  parser.core.callAiGenerate = async () => { throw new Error('server unreachable'); };
+  const result = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', {
+    fetchImageAsBase64: async () => {
+      downloadAttempts++;
+      throw new Error('connection refused');
+    }
+  });
+  assert.equal(downloadAttempts, 1, 'the heal must actually be attempted before falling back');
+
+  assert.ok(result, 'the salvaged entry is legitimate data — a heal failure must not become an OCR failure');
+  assert.equal(result.cached, true);
+  assert.ok(result.text.includes('B BAR'));
+  assert.equal(result.reason, 'salvaged-from-truncated-response');
+
+  // The cache entry survives untouched — no negative-cache clobber either.
+  const stored = JSON.parse(JSON.parse(fs.readFileSync(cachePath, 'utf8')).response.text);
+  assert.equal(stored.reason, 'salvaged-from-truncated-response');
+  assert.equal(stored.failureKind, undefined);
+  assert.ok(stored.text.includes('B BAR'));
+
+  // A model-side context overflow during a heal must not clobber the salvage
+  // with a negative-cache entry (that WOULD lose legitimate text forever).
+  parser.core.callAiGenerate = async (config, prompt, label, adapter, recorder, image, diagnostics) => {
+    if (diagnostics) diagnostics.failureKind = 'context-overflow';
+    return null;
+  };
+  const afterOverflow = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', {
+    fetchImageAsBase64: async () => 'base64imagedata'
+  });
+  assert.equal(afterOverflow.cached, true, 'overflow during a heal still falls back to the salvage');
+  assert.ok(afterOverflow.text.includes('B BAR'));
+  const afterOverflowStored = JSON.parse(JSON.parse(fs.readFileSync(cachePath, 'utf8')).response.text);
+  assert.equal(afterOverflowStored.failureKind, undefined, 'no negative-cache write over a salvaged entry');
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// SEGMENTATION MEMOIZATION — parseEvents and extractEventsFromMultiEventPage
+// both segment the same page; the second call must reuse the first result
+// instead of re-running the full segments×images pairing pass.
+// ---------------------------------------------------------------------------
+
+test('buildMultiEventSegments memoizes: the second identical call does not recompute', () => {
+  const parser = createParser();
+  let computes = 0;
+  const original = parser.buildStructuredMultiEventSegments.bind(parser);
+  parser.buildStructuredMultiEventSegments = (...args) => {
+    computes++;
+    return original(...args);
+  };
+
+  const html = '<html><body><h3>FURBALL BLACKOUT</h3><p>July 10, 2026</p><h3>FURBALL POOL PARTY</h3><p>July 24, 2026</p></body></html>';
+  const sourceUrl = 'https://furball.example/events';
+  const ocrResults = [];
+
+  const first = parser.buildMultiEventSegments(html, sourceUrl, ocrResults);
+  const second = parser.buildMultiEventSegments(html, sourceUrl, ocrResults);
+  assert.equal(computes, 1, 'the duplicated diagnostics+extraction pass must run the pipeline once');
+  assert.equal(second, first, 'the identical result is reused, byte-identical outcomes');
+
+  // Different arguments are a different computation — never force-shared.
+  parser.buildMultiEventSegments(html + '<p>changed</p>', sourceUrl, ocrResults);
+  assert.equal(computes, 2);
+
+  // An ocrResults array that changed length is different input too.
+  parser.buildMultiEventSegments(html + '<p>changed</p>', sourceUrl, [{ url: 'https://cdn.example/f.jpg', text: 'X', imageClassification: 'event-flyer' }]);
+  assert.equal(computes, 3);
+});
+
+// ---------------------------------------------------------------------------
+// PAIRING SIMILARITY RESCUE — 'ad-banner' and 'multi-event-flyer' labels the
+// local vision model demonstrably misapplies to real posters may pair when
+// the flyer text strongly matches the segment (>= 0.4); everything else the
+// model states stays hard-refused.
+// ---------------------------------------------------------------------------
+
+test('an ad-banner-labeled poster whose text strongly matches the segment is rescued', () => {
+  const parser = createParser();
+  // Real corpus: the Lucki Break poster was labeled 'ad-banner' because it
+  // says "no cover" — its OCR text scored 0.75-1.0 against its own segment.
+  const bounds = { rawStart: 100, rawEnd: 400, matchedRecords: [{ text: 'LUCKI BREAK\nFriday August 14\nThe Eagle LA\nNo cover before 10pm' }] };
+  const imageRecord = { url: 'https://cdn.example/uploads/2026/08/lucki-break.jpg', start: 150, end: 200 };
+  const flyerText = 'LUCKI BREAK\nNO COVER\nFRIDAY AUGUST 14\nEAGLE LA';
+
+  const rescued = parser.getSegmentImagePairingCostWithOcr(
+    bounds, imageRecord, { url: imageRecord.url, imageClassification: 'ad-banner', text: flyerText }, ''
+  );
+  assert.ok(Number.isFinite(rescued.cost), 'a mislabeled real poster must be pairable when its text proves the match');
+  assert.ok(rescued.score > 100, 'the match is earned through text similarity');
+});
+
+test('an ad-banner below the elevated similarity bar is refused exactly as before', () => {
+  const parser = createParser();
+  const bounds = { rawStart: 100, rawEnd: 400, matchedRecords: [{ text: 'LUCKI BREAK\nFriday August 14\nThe Eagle LA\nNo cover before 10pm' }] };
+  const imageRecord = { url: 'https://cdn.example/uploads/happy-hour-banner.jpg', start: 150, end: 200 };
+  // Two of eight tokens overlap (~0.25): clears the normal 0.15 threshold but
+  // not the elevated 0.4 rescue bar — a real ad stays out.
+  const adText = 'HAPPY HOUR FRIDAY\nDOWNLOAD OUR APP\nfollow eagle';
+
+  const refused = parser.getSegmentImagePairingCostWithOcr(
+    bounds, imageRecord, { url: imageRecord.url, imageClassification: 'ad-banner', text: adText }, ''
+  );
+  assert.equal(refused.cost, Infinity, 'weakly-matching ad-banner text does not earn a segment');
+  assert.equal(refused.score, -Infinity);
+});
+
+test('a multi-event flyer is the correct image for its umbrella event segment', () => {
+  const parser = createParser();
+  // A festival/bear-week umbrella card overlaps its own multi-event flyer
+  // heavily — the user explicitly wants this match possible.
+  const bounds = { rawStart: 100, rawEnd: 400, matchedRecords: [{ text: 'BEAR WEEK PROVINCETOWN\nJuly 11-19 2026\nBearracuda Kickoff\nPool Party\nClosing Tea' }] };
+  const imageRecord = { url: 'https://cdn.example/uploads/bear-week-lineup.jpg', start: 150, end: 200 };
+  const flyerText = 'BEAR WEEK PROVINCETOWN\nBEARRACUDA KICKOFF\nPOOL PARTY\nCLOSING TEA';
+
+  const rescued = parser.getSegmentImagePairingCostWithOcr(
+    bounds, imageRecord, { url: imageRecord.url, imageClassification: 'multi-event-flyer', text: flyerText }, ''
+  );
+  assert.ok(Number.isFinite(rescued.cost), 'the umbrella event may claim its own lineup flyer');
+  assert.ok(rescued.score > 100);
+});
+
+test('a logo is still hard-refused even at perfect text similarity', () => {
+  const parser = createParser();
+  // Behavior guard (passes before and after the rescue existed): site chrome
+  // whose text happens to echo the card — a header logo with the venue name —
+  // must never earn a segment, whatever its similarity.
+  const segmentLine = 'THE EAGLE LA\nFriday August 14';
+  const bounds = { rawStart: 100, rawEnd: 400, matchedRecords: [{ text: segmentLine }] };
+  const imageRecord = { url: 'https://cdn.example/assets/site-logo.png', start: 150, end: 200 };
+
+  for (const chrome of ['logo', 'thumbnail', 'hero-banner', 'screenshot']) {
+    const refused = parser.getSegmentImagePairingCostWithOcr(
+      bounds, imageRecord, { url: imageRecord.url, imageClassification: chrome, text: segmentLine }, ''
+    );
+    assert.equal(refused.cost, Infinity, `${chrome} must stay refused at similarity 1.0`);
+    assert.equal(refused.score, -Infinity);
+  }
+});


### PR DESCRIPTION
## Three fixes in `scripts/parsers/ai-web-parser.js`

### 1. Heal truncated-salvaged OCR cache entries
`salvageTruncatedOcrResponse` rescues the `"text"` field when the vision model's JSON gets cut off, but the salvaged object (empty `imageClassification`, `reason: 'salvaged-from-truncated-response'`) was written to the per-image cache and replayed as a normal hit forever — 64 of 442 device entries (15%) were stuck missing classification. Now, at cache-read time in `getOcrTextForImage`, a salvaged entry triggers a fresh OCR call (same prompt/options — **cache key unchanged**, no cache invalidation) and the entry is overwritten with the fresh result.

Guards:
- Fresh call also truncated → still overwritten (fresher salvage) with an additive `salvageRetries` counter; healing stops at `salvageRetries >= 2`, so a stubbornly-truncating image costs at most 2 extra calls total, ever.
- Fresh call fails (network/server/download) → falls back to the cached salvaged entry and the run continues exactly as today; a heal failure can never become an OCR failure. A context-overflow during a heal is also barred from clobbering the salvage with a negative-cache entry.
- The fresh-call body was extracted verbatim into `requestAndCacheOcrResult`; all existing log lines unchanged, new lines are additions only.

### 2. Remove the duplicated segmentation+pairing pass
`buildMultiEventSegments` ran the full pipeline twice per multi-event page — once in `parseEvents` (result used only for `discoveredSegments` diagnostics and segment logging; verified nothing else consumes it) and again in `extractEventsFromMultiEventPage` — each chaining into the full segments×images OCR-similarity cross-product with per-pair log lines. Fixed by memoizing (not deleting): a single-entry memo keyed on the actual arguments (`html`, `sourceUrl`, `ocrResults` identity + length). Identical inputs reuse the identical result (byte-identical outcomes, same array reference); differing inputs recompute exactly as before.

### 3. Similarity rescue for `ad-banner` / `multi-event-flyer` in segment↔image pairing
The pairing gate hard-refused ANY stated classification ≠ `event-flyer`, but the local vision model demonstrably mislabels genuine posters (`ad-banner` for a poster saying "no cover", `multi-event-flyer` for a movie-night poster) whose OCR text scored 0.75–1.0 against their own segments — and a genuinely multi-event flyer IS the correct image for a multi-day umbrella event. For those two labels **only**, the pairing may proceed when OCR-text-vs-segment similarity clears an elevated **0.4** bar (normal threshold: 0.15); below 0.4 they are refused exactly as before, with an additive log line when the rescue fires. `logo`, `thumbnail`, `hero-banner`, and every other stated label stay hard-refused at any similarity — site chrome can never earn a segment by accident. The #1642 empty-classification fail-open and the `nonEventOcrImageClassifications` deletion asymmetry are untouched.

## Verification
- `node --check` clean on both touched files.
- Quiet suite (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`): **1587 pass / 0 fail, ~3.47s** on this branch vs **1579 pass / 0 fail, ~3.47s** baseline on origin/main @785bfb65 (8 new tests, appended at EOF only).
- New tests run against a clean origin/main worktree (785bfb65) with only the test file copied in: **6 of 8 FAIL on main, pass on branch** (heal overwrites cache; salvageRetries cap; heal-failure fallback with attempted-heal assertion; segmentation memoization via `buildStructuredMultiEventSegments` call-count spy; ad-banner rescued ≥0.4; multi-event-flyer rescued for umbrella segment). **2 of 8 are declared behavior-guards that pass on both**: ad-banner refused below 0.4, and logo/thumbnail/hero-banner/unknown still refused at similarity 1.0.
- Heal fixture text mirrors a real salvaged device entry (eaglela.com B-Bar poster, read-only inspection).

## Risks
- Heals cost ~2s (one local MLX call) per truncated entry on their first post-deploy run — 64 entries on the current device, bounded thereafter by the retry cap. OCR coverage is never reduced.
- Pairing rescue is scoped to two labels behind a 2.7× elevated similarity bar; logos and all other chrome classifications remain hard-refused.
- No OCR prompt/options changed — existing cache keys and entries stay valid.

No new runtime files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP