### PR TITLE
fix(scraper): deduplicate the FULL parsed set before the bear check

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -4701,9 +4701,23 @@ class ScriptableAdapter {
       );
       if (results.duplicatesRemoved > 0) {
         console.log(`🔄 Duplicates Removed: ${results.duplicatesRemoved}`);
-        console.log(
-          `🐻 Final Bear Events: ${results.bearEvents} (${results.rawBearEvents} - ${results.duplicatesRemoved} dupes)`,
-        );
+        // Since the 2026-08-06 reorder dedup runs BEFORE the bear filter, so
+        // rawBearEvents === bearEvents and the legacy "raw - dupes" subtraction
+        // no longer describes the pipeline. Keep printing the legacy sentence
+        // for old saved runs (where its arithmetic holds) and print the
+        // new-order sentence otherwise.
+        if (
+          results.rawBearEvents - results.duplicatesRemoved ===
+          results.bearEvents
+        ) {
+          console.log(
+            `🐻 Final Bear Events: ${results.bearEvents} (${results.rawBearEvents} - ${results.duplicatesRemoved} dupes)`,
+          );
+        } else {
+          console.log(
+            `🐻 Final Bear Events: ${results.bearEvents} (${results.duplicatesRemoved} dupes removed before bear filtering)`,
+          );
+        }
       } else {
         console.log(
           `🐻 Final Bear Events: ${results.bearEvents} (no duplicates found)`,
@@ -12261,9 +12275,21 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     );
     if (results.duplicatesRemoved > 0) {
       lines.push(`🔄 Duplicates Removed: ${results.duplicatesRemoved}`);
-      lines.push(
-        `🐻 Final Bear Events: ${results.bearEvents} (${results.rawBearEvents} - ${results.duplicatesRemoved} dupes)`,
-      );
+      // Same consistency guard as the console summary: the legacy
+      // "raw - dupes" sentence only prints when its arithmetic holds
+      // (old saved runs from before the dedup-before-bear-filter reorder).
+      if (
+        results.rawBearEvents - results.duplicatesRemoved ===
+        results.bearEvents
+      ) {
+        lines.push(
+          `🐻 Final Bear Events: ${results.bearEvents} (${results.rawBearEvents} - ${results.duplicatesRemoved} dupes)`,
+        );
+      } else {
+        lines.push(
+          `🐻 Final Bear Events: ${results.bearEvents} (${results.duplicatesRemoved} dupes removed before bear filtering)`,
+        );
+      }
     } else {
       lines.push(
         `🐻 Final Bear Events: ${results.bearEvents} (no duplicates found)`,

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -4079,27 +4079,44 @@ class SharedCore {
         // event's own evidence to data/promoters.json and — in enforce mode —
         // stamp the curated identity + metadata.
         this.applyPromoterRegistryMatches(futureEvents, effectiveParserConfig, mainConfig);
-        const bearEvents = await this.filterBearEvents(futureEvents, effectiveParserConfig, httpAdapter, bearDropCollector);
         // Overlong-field trims run before dedup so trimmed values feed the
         // dedup keys/merges (report mode by default; see getTrimConfig).
-        await this.applyOverlongFieldTrims(bearEvents, effectiveParserConfig, httpAdapter);
-        const deduplicatedEvents = await this.deduplicateEvents(bearEvents, httpAdapter, mainConfig?.config || mainConfig || null);
-        
+        await this.applyOverlongFieldTrims(futureEvents, effectiveParserConfig, httpAdapter);
+        // Dedup BEFORE the bear check (reordered 2026-08-06): one real event is
+        // scraped up to three times (listing stub + bare event page +
+        // ?occurrence= page), and judging each record separately meant split
+        // verdicts on partial evidence plus triplicate cards in the
+        // dropped-events UI (Eagle LA run: 20 dropped records for 9 real
+        // events, three "mark as bear" taps for one MEAT RACK). Fold the
+        // records first so the bear check judges each real event ONCE, with
+        // its merged evidence. Safe now that segmentation no longer produces
+        // neighbor-URL chimera events (#1644) — dedup's same-URL rung can no
+        // longer weld two different real events together.
+        const deduplicatedEvents = await this.deduplicateEvents(futureEvents, httpAdapter, mainConfig?.config || mainConfig || null);
+
         // Calculate deduplication stats
-        const duplicatesRemoved = bearEvents.length - deduplicatedEvents.length;
-        
-        await displayAdapter.logInfo(`SYSTEM: Event filtering complete: ${allEvents.length} → ${futureEvents.length} future → ${bearEvents.length} bear → ${deduplicatedEvents.length} final`);
+        const duplicatesRemoved = futureEvents.length - deduplicatedEvents.length;
+        if (duplicatesRemoved > 0) {
+            await displayAdapter.logInfo(`SYSTEM: Deduplicated ${futureEvents.length} → ${deduplicatedEvents.length} before bear filtering (${duplicatesRemoved} duplicate record(s) folded)`);
+        }
+        const bearEvents = await this.filterBearEvents(deduplicatedEvents, effectiveParserConfig, httpAdapter, bearDropCollector);
+
+        await displayAdapter.logInfo(`SYSTEM: Event filtering complete: ${allEvents.length} → ${futureEvents.length} future → ${bearEvents.length} bear → ${bearEvents.length} final`);
 
         const result = {
             name: effectiveParserConfig.name,
             parserType: parserName,
             urlCount,
             totalEvents: allEvents.length,
+            // Since the 2026-08-06 reorder (dedup before the bear check) there
+            // is no post-filter dedup step: rawBearEvents and bearEvents are
+            // the same count, and duplicatesRemoved covers the FULL parsed set
+            // (bear and non-bear records alike), not just bear duplicates.
             rawBearEvents: bearEvents.length,
-            bearEvents: deduplicatedEvents.length,
+            bearEvents: bearEvents.length,
             duplicatesRemoved: duplicatesRemoved,
             durationMs: Date.now() - parserStartedAt,
-            events: deduplicatedEvents,
+            events: bearEvents,
             urlClassifications,
             config: effectiveParserConfig // Include config for orchestrator to use
         };
@@ -6648,10 +6665,14 @@ class SharedCore {
         //
         // A listing page yields a stub per event (title + date, no time, no
         // description) and the crawler then follows the stub's own link and
-        // yields the full record. Both enter this filter as separate records,
-        // and this filter runs BEFORE deduplicateEvents — so the stub is
-        // bear-judged ALONE, with none of its twin's description or evidence
-        // to judge by, and is gone before dedup can fold it in.
+        // yields the full record. Historically both entered this filter as
+        // separate records because it ran BEFORE deduplicateEvents — the stub
+        // was bear-judged ALONE, with none of its twin's description or
+        // evidence to judge by, and was gone before dedup could fold it in.
+        // Since 2026-08-06 dedup runs FIRST, so folded twins never reach this
+        // sweep; it stays as a safety net for same-event pairs dedup could not
+        // fold (e.g. records it kept apart on a place veto, or whose identity
+        // only this scan's laxer options match).
         //
         // 2026-08-05 BEEFMINCE, 26 records for 15 events: dedup folded 10 of
         // the 11 twin pairs, and the 11th never reached it. "TURKEYMINCE" the
@@ -7597,8 +7618,10 @@ class SharedCore {
         return records;
     }
 
-    // Trim pass over one parser's bear events (processParser: after the bear
-    // filter, before dedup — so trimmed values feed dedup keys and merges).
+    // Trim pass over one parser's future events (processParser: after the
+    // future filter, before dedup — so trimmed values feed dedup keys and
+    // merges; since 2026-08-06 dedup runs before the bear check, so this
+    // pass sees the full pre-dedup set rather than only bear events).
     // Zero AI calls when mode is 'off', AI is unavailable, or nothing is
     // overlong. NOTE: report mode still fires AI calls for overlong values —
     // a future golden-fixture text exceeding a limit would fire AI calls
@@ -11633,18 +11656,18 @@ class SharedCore {
                 if (!matchedRecord || this.getManualBearVerdictFromRecord(matchedRecord) !== 'manual-bear') continue;
                 console.log(`🐻 BEAR CHECK: "${droppedEvent.title || 'Unknown'}" → bear (manual override on calendar record)`);
                 const rescuedEvent = { ...droppedEvent, isBearEvent: true };
-                // Duplicate-row guard: filterBearEvents runs BEFORE
-                // deduplicateEvents, so a twin the bear check DROPped never
-                // entered dedup — it arrives here, after both dedup passes, and
-                // nothing re-dedups the plan. Pushing it blind produced two
-                // `_action: "merge"` rows carrying one `_existingEvent.identifier`
-                // (run evidence: two "Treasure Trail" rows, both matching the
-                // other on `ticket-url`, the strongest identity rung — the
-                // calendar layer even logged `Merge eligibility match
-                // (ticket-url)` twice). Fold the rescue into the row that already
-                // covers this event instead. The structural fix (dedup before the
-                // bear check) is deferred: it reorders an expensive AI stage and
-                // changes bear verdicts run-wide.
+                // Duplicate-row guard: this rescue joins the plan AFTER every
+                // dedup pass has run, and nothing re-dedups the plan. Pushing
+                // it blind produced two `_action: "merge"` rows carrying one
+                // `_existingEvent.identifier` (run evidence: two "Treasure
+                // Trail" rows, both matching the other on `ticket-url`, the
+                // strongest identity rung — the calendar layer even logged
+                // `Merge eligibility match (ticket-url)` twice). Fold the
+                // rescue into the row that already covers this event instead.
+                // Dropped records are deduplicated since the 2026-08-06
+                // reorder (dedup before the bear check), but a rescued drop
+                // can still coincide with a plan row from another parser or an
+                // earlier rescue, so the guard stays.
                 const storedFields = this.parseNotesIntoFields(matchedRecord.notes || '');
                 const folded = this.foldBearOverrideIntoPlanEntry(analyzedEvents, rescuedEvent, {
                     existingIdentifier: analysis.existingEvent && analysis.existingEvent.identifier,
@@ -11662,12 +11685,12 @@ class SharedCore {
 
         // WHY A DROPPED EVENT CAN BE A TWIN OF A KEPT ONE.
         //
-        // filterBearEvents runs BEFORE deduplicateEvents, so a thin second
-        // record of an event the run also scraped richly is bear-checked on
-        // its own — with none of its twin's description, host or evidence to
-        // judge by — and gets DROPped before dedup ever sees it. The owner
-        // then reads one event twice: kept in the write plan, and again in the
-        // dropped section with "no bear-specific wording".
+        // Historically filterBearEvents ran BEFORE deduplicateEvents, so a
+        // thin second record of an event the run also scraped richly was
+        // bear-checked on its own — with none of its twin's description, host
+        // or evidence to judge by — and got DROPped before dedup ever saw it.
+        // The owner then read one event twice: kept in the write plan, and
+        // again in the dropped section with "no bear-specific wording".
         //
         // Run evidence (2026-08-05 BEEFMINCE): "TURKEYMINCE" merged into the
         // London calendar for 19 Dec 22:00, while a second TURKEYMINCE record
@@ -11675,9 +11698,10 @@ class SharedCore {
         // stated no time — was dropped as "no bear-specific wording or
         // evidence".
         //
-        // Report only. The structural fix (dedup before the bear check) is
-        // still deferred for the reason recorded above: it reorders an
-        // expensive AI stage and changes bear verdicts run-wide. Saying so on
+        // Report only. The structural fix (dedup before the bear check)
+        // shipped 2026-08-06, so dropped records are now deduplicated — but a
+        // dropped event can still coincide with a kept row from another
+        // parser, or with a pair dedup deliberately kept apart. Saying so on
         // the card costs nothing and stops the owner re-deciding an event he
         // has already kept.
         if (bearOverrideContext && Array.isArray(bearOverrideContext.droppedEvents)) {
@@ -11711,8 +11735,7 @@ class SharedCore {
 
     // A late bear-override event (a drop rescued by a stored calendar verdict,
     // or a live "Mark as bear" tap from the results UI) joins the write plan
-    // AFTER both dedup passes have run, because filterBearEvents runs before
-    // deduplicateEvents and a dropped twin therefore never entered dedup. When
+    // AFTER every dedup pass has run, and nothing re-dedups the plan. When
     // the plan already carries a row for the same event — same target calendar
     // record, or a same-event identity signal — a second row would mean two
     // writes aimed at ONE calendar record. Fold the override into the existing

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -16041,3 +16041,178 @@ test('isRetryableFailure recognises the wordings iOS actually produces when serv
     assert.equal(core.isRetryableFailure(new Error(message)), false, message);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Pipeline order: deduplicateEvents runs BEFORE filterBearEvents (2026-08-06
+// reorder). One real event is scraped up to three times (listing stub + bare
+// event page + ?occurrence= page); dedup must fold the records FIRST so the
+// bear check judges each real event once, on merged evidence, and the
+// dropped-events UI shows one card (one "mark as bear" tap) per real event.
+// Wiring mirrors the processParser test above: stub parser, stub fetchData,
+// bear-verdict AI on postJson, arbitrateMerges off so merges stay
+// deterministic and `calls` counts bear-check requests only.
+// ---------------------------------------------------------------------------
+
+function futureIsoAt(daysFromNow, utcHour) {
+  const d = new Date(Date.now() + daysFromNow * 86400000);
+  d.setUTCHours(utcHour, 0, 0, 0);
+  return d.toISOString();
+}
+
+async function runDedupFirstPipeline(rawEvents, verdict) {
+  const core = createCore();
+  const display = createDisplayAdapterStub();
+  const calls = [];
+  const httpAdapter = {
+    fetchData: async (url) => ({ html: '<html><body>venue calendar</body></html>', url, statusCode: 200, headers: {} }),
+    postJson: async (endpoint, payload) => {
+      calls.push(payload);
+      return { ok: true, status: 200, text: JSON.stringify({ response: JSON.stringify(verdict) }) };
+    }
+  };
+  let served = false;
+  const parsers = {
+    'ai-web': {
+      parseEvents: () => {
+        if (served) return { events: [], additionalLinks: [] };
+        served = true;
+        return { events: rawEvents.map(e => ({ ...e })), additionalLinks: [] };
+      }
+    }
+  };
+  const parserConfig = {
+    name: 'Venue Calendar',
+    urls: ['https://venue.example/events'],
+    ai: {
+      provider: 'ollama',
+      endpoint: 'http://ai.example/api/generate',
+      model: 'test-model',
+      classifyPages: false,
+      arbitrateMerges: false,
+      bearCheck: { mode: 'enforce' }
+    }
+  };
+  const result = await core.processParser(parserConfig, {}, httpAdapter, display, parsers, new Set());
+  return { core, result, calls };
+}
+
+function venueRecord(overrides = {}) {
+  return {
+    title: 'Trivia Night',
+    startDate: futureIsoAt(14, 22),
+    bar: 'Dallas Eagle',
+    city: 'dallas',
+    timezone: 'America/Chicago',
+    source: 'ai-web',
+    url: 'https://venue.example/events/trivia-night',
+    ...overrides
+  };
+}
+
+test('pipeline order: a non-bear triple is folded BEFORE the bear check — one dropped card, one AI verdict, one mark-bear target with merged evidence', async () => {
+  // The Eagle LA shape: listing stub (no description), crawled event page,
+  // and the ?occurrence= crawl of the same page (extra image).
+  const stub = venueRecord({});
+  const page = venueRecord({ description: 'Weekly trivia and karaoke with prizes.' });
+  const occurrence = venueRecord({
+    description: 'Weekly trivia and karaoke with prizes.',
+    url: 'https://venue.example/events/trivia-night?occurrence=2026-08-19',
+    image: 'https://venue.example/img/trivia.jpg'
+  });
+
+  const { core, result, calls } = await runDedupFirstPipeline([stub, page, occurrence], {
+    verdict: 'not_bear',
+    reason: 'venue trivia night, no bear-specific wording'
+  });
+
+  assert.equal(result.totalEvents, 3);
+  assert.equal(result.duplicatesRemoved, 2, 'dedup must fold the full parsed set, not just bear-approved records');
+  assert.equal(result.rawBearEvents, 0);
+  assert.equal(result.bearEvents, 0);
+  assert.deepEqual(result.events, []);
+  assert.equal(calls.length, 1, 'ONE real event = ONE bear verdict, judged on the merged record');
+
+  const dropped = result.bearDroppedEvents || [];
+  assert.equal(dropped.length, 1, 'the dropped-events UI must show one card per real event, not one per scraped record');
+  const entry = dropped[0];
+  assert.equal(entry.title, 'Trivia Night');
+  // The single card carries the MERGED record, so one "mark as bear" tap
+  // (adapter flow: entry.event → prepareEventsForCalendar) rescues every
+  // field the duplicates contributed — no second card left unmarked.
+  assert.equal(entry.event.description, 'Weekly trivia and karaoke with prizes.', 'merged evidence from the crawled page');
+  assert.equal(entry.event.image, 'https://venue.example/img/trivia.jpg', 'merged evidence from the ?occurrence= record');
+  const manualSource = SharedCore.buildManualBearSource('bear', entry.reason);
+  assert.equal(core.isManualBearSource(manualSource), true, 'the tap-produced verdict stamps onto the one merged record');
+});
+
+test('pipeline order: a bear event and its thin duplicate merge FIRST and get one verdict — no split verdicts on partial evidence', async () => {
+  // Bear-ness lives only in the crawled page description (description-only
+  // generic keywords defer to the AI tier). Judged alone, the thin stub has
+  // no evidence at all — the old order gave the twins different verdicts.
+  const page = venueRecord({
+    title: 'Rack Night',
+    url: 'https://venue.example/events/rack-night',
+    description: 'A party for bears and cubs all night.'
+  });
+  const stub = venueRecord({ title: 'Rack Night', url: 'https://venue.example/events/rack-night' });
+
+  const { result, calls } = await runDedupFirstPipeline([page, stub], {
+    verdict: 'bear',
+    reason: 'explicit bear party wording',
+    eventEvidence: ['A party for bears and cubs all night.']
+  });
+
+  assert.equal(calls.length, 1, 'one merged record, one AI verdict — never one per scraped record');
+  assert.equal(result.duplicatesRemoved, 1);
+  assert.equal(result.rawBearEvents, 1, 'the verdict count is per real event now');
+  assert.equal(result.bearEvents, 1);
+  assert.equal(result.events.length, 1);
+  const merged = result.events[0];
+  assert.equal(merged.title, 'Rack Night');
+  assert.equal(merged.isBearEvent, true);
+  assert.equal(merged.bearSource, 'ai');
+  assert.equal(merged.bearReview, undefined, 'no stray review flag from a partial-evidence twin verdict');
+  assert.equal(merged.description, 'A party for bears and cubs all night.');
+  assert.equal(result.bearDroppedEvents, undefined, 'nothing to drop — the thin record is a fragment, not a second event');
+});
+
+test('pipeline order: counters stay truthful — duplicatesRemoved covers the FULL set and rawBearEvents equals the final bear count', async () => {
+  const day = 14;
+  const triviaStub = venueRecord({});
+  const triviaPage = venueRecord({ description: 'Weekly trivia and karaoke with prizes.' });
+  const bearNight = venueRecord({
+    title: 'BEAR NIGHT',
+    startDate: futureIsoAt(day + 1, 23),
+    url: 'https://venue.example/events/bear-night',
+    description: 'Bears take over the patio.'
+  });
+  const bashStub = venueRecord({
+    title: 'BEAR BASH',
+    startDate: futureIsoAt(day + 2, 23),
+    url: 'https://venue.example/events/bear-bash'
+  });
+  const bashPage = venueRecord({
+    title: 'BEAR BASH',
+    startDate: futureIsoAt(day + 2, 23),
+    url: 'https://venue.example/events/bear-bash',
+    description: 'The bash returns.'
+  });
+
+  const { result, calls } = await runDedupFirstPipeline(
+    [triviaStub, triviaPage, bearNight, bashStub, bashPage],
+    { verdict: 'not_bear', reason: 'venue trivia night, no bear-specific wording' }
+  );
+
+  assert.equal(result.totalEvents, 5, 'totalEvents = every parsed record');
+  assert.equal(result.duplicatesRemoved, 2, 'duplicates removed across the FULL set (one trivia twin + one bash twin)');
+  assert.equal(result.rawBearEvents, 2, 'bear events after filtering the deduplicated set');
+  assert.equal(result.bearEvents, 2, 'no post-filter dedup: final == rawBearEvents');
+  assert.equal(result.events.length, result.bearEvents);
+  assert.equal((result.bearDroppedEvents || []).length, 1);
+  assert.equal(calls.length, 1, 'keyword bears short-circuit; only the merged trivia record reaches the AI');
+  // The printed sentence must add up: parsed − dupes = kept + dropped.
+  assert.equal(
+    result.totalEvents - result.duplicatesRemoved,
+    result.events.length + (result.bearDroppedEvents || []).length
+  );
+});


### PR DESCRIPTION
## Problem (diagnosed on the 2026-08-06 Eagle LA device run)

`processParser` ran `filterBearEvents` BEFORE `deduplicateEvents`, so dedup only folded bear-approved records. One real event is scraped up to three times (listing entry + bare crawled event page + `?occurrence=` crawled page), which meant:

- **Triplicate cards**: the run's 20 bear-DROPPED records rendered as 20 cards for only 9 real events (MEAT RACK ×3, ONYX ×3, LUCKI BREAK ×3, Tightwad Tuesday ×3, HUMP NIGHT ×3, …).
- **Triple mark-bear taps**: the owner had to tap "mark as bear" on three separate MEAT RACK cards, and the `manuallyMarkedBear` override landed on one record while its twins stayed unmarked.
- **Split verdicts**: each raw record was bear-judged ALONE, so a thin stub and its evidence-rich twin could get different verdicts from partial evidence.

## Why it's safe now

This reorder was deferred because segmentation used to produce chimera events carrying a NEIGHBOR's URL — dedup's same-URL rung would have welded two different real events. #1644 fixed that; today's post-fix run has zero chimeras.

Replay evidence (saved run `20260806-171735`, 25 surviving records = 5 kept + 20 dropped, `deduplicateEvents(events, null)` with dates revived):

- 25 → **13** real events, **zero cross-title merges** (input/output per-title counts match exactly: every fold is same-title).
- MOVIE MONDAYS 8/03 vs 8/10 (two real occurrences) correctly kept separate.
- The SUNDAY SWAP MEAT trio folds to one — the merge log shows why it's correct: the "8-09" record is a midnight-placeholder occurrence stub of the SAME local Sunday as the two 21:00 records, same event page URL ("kept explicit start time over midnight-placeholder startDate").
- `manuallyMarkedBear` carried on a duplicate survives the merge (MEAT RACK, ONYX both retained it post-fold).

## What changed

`scripts/shared-core.js` `processParser`: overlong-field trims → **`deduplicateEvents` over ALL future events** → `filterBearEvents` over the deduplicated set. The bear check now judges each real event once, on merged evidence; `bearDroppedEvents` carries one merged record per real event, so a single mark-bear tap (adapter flow: `entry.event` → `prepareEventsForCalendar`) rescues the whole event. **Zero changes to dedup's matching/merging logic** — the diff touches call-site order, counters, stale comments, the adapter's summary-line branching, and tests only. `filterBearEvents`' twin sweep and `foldBearOverrideIntoPlanEntry` stay as defense-in-depth (late rescues still join the plan post-dedup).

## Counter semantics

- `duplicatesRemoved` = removed across the FULL parsed set (bear and non-bear records alike).
- `rawBearEvents` = bear events after filtering the deduplicated set = `bearEvents` (no post-filter dedup step exists anymore).
- All existing console.log text is frozen and untouched. The legacy `Final Bear Events: N (X - Y dupes)` sentence now only prints when its arithmetic actually holds (old saved runs); new-order runs print an additive `(N dupes removed before bear filtering)` line, plus a new `SYSTEM: Deduplicated X → Y before bear filtering` line.

## Verification

1. `node --check` clean on all three touched files.
2. Quiet suite `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`: **1593 pass, 0 fail** (origin/main baseline at d40ffb04: 1590; +3 new tests).
3. New tests (scripts/shared-core.test.js, driving the real `processParser` with stub parser + bear-verdict AI adapter): (a) a non-bear triple folds BEFORE the bear check → ONE dropped card carrying merged description+image, ONE AI verdict; (b) a bear event + its thin duplicate → one merged record, one verdict, no stray `bearReview` from a partial-evidence twin; (c/d) counters truthful (`totalEvents` 5, `duplicatesRemoved` 2 full-set, `rawBearEvents == bearEvents == events.length`, parsed − dupes = kept + dropped). **All 3 FAIL on a clean origin/main worktree** (e.g. `duplicatesRemoved 0 !== 2`) **and PASS on this branch**.
4. Real-run replay through the reordered `processParser` (verdict stub replicating the run: 5 final titles bear, rest dropped): totalEvents 25, duplicatesRemoved 12, rawBearEvents = bearEvents = 5, dropped cards 8, **13 verdicts instead of 25**, zero cross-title merges. **UI card count becomes 13 (5 bear + 8 dropped) vs the 25 the user saw.**
5. `git diff` confirms zero hunks inside `deduplicateEvents` / merge logic.

No new runtime files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP