### PR TITLE
fix(scraper): collapse duplicate full-series exports of one recurring series in dedup

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -8165,6 +8165,81 @@ class SharedCore {
             crossSourceDeduplicated = kept;
         }
 
+        // Fourth pass: same-series export collapse (run 20260806-171735). When
+        // a run lands on a weekly series' own weekday, the site surfaces BOTH
+        // this week's and next week's occurrence stubs ("B BAR"
+        // ?occurrence=2026-08-06 AND ?occurrence=2026-08-13, each carrying
+        // FREQ=WEEKLY;BYDAY=TH) — and each record is a FULL series export whose
+        // rrule alone already covers every occurrence, so keeping both exports
+        // the same series twice. This is deliberately NOT the
+        // areStartDatesWithinDays territory: that exclusive window protects two
+        // DISTINCT single occurrences of a recurring event (SUNDAY BEER BUST's
+        // two Sundays, each a discrete upcoming night), and such records pass
+        // through this loop untouched because they are not series exports.
+        // Records collapse ONLY when the strict series identity of
+        // getSeriesExportIdentity matches on BOTH sides (full-series export,
+        // never slot-host; identical normalized rrule; same base event page
+        // with the ?occurrence= query stripped; parseable startDate — anything
+        // less fails closed) AND the existing same-event notion agrees
+        // (name-similar identity shapes, no positive different-place veto).
+        // The kept record is the EARLIEST occurrence — dedup runs on
+        // future-filtered events, so earliest IS the next upcoming one — and
+        // fields merge through the same mergeParsedEvents machinery as the
+        // passes above, with the kept occurrence's own date/url reasserted
+        // afterwards (the dropped record's ?occurrence= url and dates name the
+        // night being folded, not the night being kept).
+        const seriesCollapsed = [];
+        const seriesCollapseCounts = new Map();
+        for (const event of crossSourceDeduplicated) {
+            const eventSeries = this.getSeriesExportIdentity(event);
+            const match = eventSeries ? seriesCollapsed.find(existing => {
+                const existingSeries = this.getSeriesExportIdentity(existing);
+                if (!existingSeries) return false;
+                if (existingSeries.rrule !== eventSeries.rrule) return false;
+                if (existingSeries.hostPath !== eventSeries.hostPath) return false;
+                const shapeA = this.buildIdentityComparisonShape(event);
+                const shapeB = this.buildIdentityComparisonShape(existing);
+                if (!this.areIdentityNamesSimilar(shapeA, shapeB)) return false;
+                return !this.areEventsDistinctByPlace(event, existing);
+            }) : null;
+            if (!match) {
+                seriesCollapsed.push(event);
+                continue;
+            }
+            const matchSeries = this.getSeriesExportIdentity(match);
+            const keeper = matchSeries.startMs <= eventSeries.startMs ? match : event;
+            const dropped = keeper === match ? event : match;
+            const merged = await this.mergeParsedEvents(dropped, keeper, { httpAdapter, globalConfig });
+            merged.key = keeper.key;
+            // Reassert the kept occurrence's own instant and pointer: the merge
+            // may prefer the dropped side's values, but those name the folded
+            // night. A keeper without an endDate DELETES the dropped one — an
+            // end time seven days after the kept start is not a duration.
+            merged.startDate = keeper.startDate;
+            for (const occurrenceField of ['endDate', 'url', 'website']) {
+                const keeperValue = keeper[occurrenceField];
+                if (keeperValue === null || keeperValue === undefined || keeperValue === '') {
+                    delete merged[occurrenceField];
+                } else {
+                    merged[occurrenceField] = keeperValue;
+                }
+            }
+            // The owner's manual bear verdict lives on the event, whichever
+            // occurrence record he happened to tap it on.
+            if (event.manuallyMarkedBear === true || match.manuallyMarkedBear === true) {
+                merged.manuallyMarkedBear = true;
+            }
+            if (merged._timezoneUnresolved) {
+                this.resolveWallClockDates(merged);
+            }
+            const collapsedCount = (seriesCollapseCounts.get(match) || 1) + 1;
+            seriesCollapseCounts.set(merged, collapsedCount);
+            seriesCollapsed[seriesCollapsed.indexOf(match)] = merged;
+            const keptDay = new Date(Math.min(matchSeries.startMs, eventSeries.startMs)).toISOString().slice(0, 10);
+            console.log(`🔁 SERIES: collapsed ${collapsedCount} same-series exports of "${merged.title || 'event'}" (${eventSeries.rrule}) to the next occurrence ${keptDay} — the recurrence already covers the rest`);
+        }
+        crossSourceDeduplicated = seriesCollapsed;
+
         // Log results for large batches
         if (logProgress) {
             const duplicatesFound = events.length - crossSourceDeduplicated.length;
@@ -13503,6 +13578,40 @@ class SharedCore {
             }
         }
         return Math.abs(dateA.getTime() - dateB.getTime()) < days * 24 * 60 * 60 * 1000;
+    }
+
+    // Series-export identity for the series-collapse pass in deduplicateEvents.
+    // Returns { rrule, hostPath, startMs } ONLY when this record is a
+    // FULL-SERIES export whose series can be named — anything less returns null
+    // and the collapse fails closed, exactly the conservatism of
+    // areStartDatesWithinDays returning false on unparseable dates:
+    //   - it defines a recurring series (isRecurringSeriesEvent) and is not a
+    //     slot-host override — a slot host's record is a deliberate
+    //     single-occurrence override of someone else's series, never a series
+    //     export. Dedup runs before the analysis stage stamps
+    //     _seriesAuthority/_recurringExport, so pre-analysis records qualify on
+    //     the series claim alone; the stamps are honored when present (replayed
+    //     analyzed events);
+    //   - it states a non-empty recurrence rule (normalized: trimmed,
+    //     uppercased). A bare _recurring flag with no rule cannot prove two
+    //     records share ONE rule, so it never collapses;
+    //   - its url/website resolves to a real event page
+    //     (getEventPageUrlIdentity: query/fragment stripped so ?occurrence=
+    //     variants of one page match; domain roots and statically stamped
+    //     websites never yield an identity);
+    //   - its startDate parses (toEpochMillis — realm-safe for Scriptable's
+    //     cross-realm Dates).
+    getSeriesExportIdentity(event) {
+        if (!SharedCore.isRecurringSeriesEvent(event)) return null;
+        if (event._seriesAuthority === 'slot-host') return null;
+        if (event._recurringExport === false) return null;
+        const rrule = String(event.recurrenceRule || event.recurrence || '').trim().toUpperCase();
+        if (!rrule) return null;
+        const page = this.getEventPageUrlIdentity(event);
+        if (!page) return null;
+        const startMs = this.toEpochMillis(event.startDate);
+        if (startMs === null) return null;
+        return { rrule, hostPath: page.hostPath, startMs };
     }
 
     // When two records of the same event disagree on identity fields (city/key),

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -3952,6 +3952,122 @@ test('deduplicateEvents merges a vetoed event into a suffixed holder via the ide
   assert.equal(result.length, 2, 'shared ticketUrl on the same local day must merge the vetoed event');
 });
 
+// === Run 20260806-171735: eaglela.com "B BAR" exported one weekly series ===
+// twice. The run landed on the series' own weekday (a Thursday), so the site
+// surfaced this week's AND next week's occurrence stubs — same base event page
+// differing only in ?occurrence=, identical FREQ=WEEKLY;BYDAY=TH, both
+// full-series exports whose rrule already covers every Thursday. The series
+// collapse folds THAT pair only; distinct single occurrences of a recurring
+// event (SUNDAY BEER BUST's two Sundays, run 20260802-221204) must stay two
+// events. Dates are computed relative to now so "earliest = next upcoming"
+// holds whenever the suite runs.
+
+const SERIES_DAY_MS = 24 * 60 * 60 * 1000;
+
+function buildWeeklySeriesExport(startDate, overrides = {}) {
+  const occurrenceUrl = `https://eaglela.com/events/b-bar/?occurrence=${startDate.toISOString().slice(0, 10)}`;
+  return {
+    title: 'B BAR',
+    bar: 'Eagle LA',
+    startDate,
+    endDate: new Date(startDate.getTime() + 5 * 60 * 60 * 1000),
+    url: occurrenceUrl,
+    website: occurrenceUrl,
+    recurrenceRule: 'FREQ=WEEKLY;BYDAY=TH',
+    _recurring: true,
+    timezone: 'America/Los_Angeles',
+    source: 'ai-web',
+    ...overrides
+  };
+}
+
+test('deduplicateEvents collapses two full-series exports of one series to the next occurrence', async () => {
+  const core = createCore();
+  const thisWeek = new Date(Date.now() + 7 * SERIES_DAY_MS);
+  const nextWeek = new Date(thisWeek.getTime() + 7 * SERIES_DAY_MS);
+  const first = buildWeeklySeriesExport(thisWeek);
+  const second = buildWeeklySeriesExport(nextWeek);
+
+  const result = await core.deduplicateEvents([first, second], null);
+  assert.equal(result.length, 1, 'two exports of ONE series are redundant — the rrule covers every occurrence');
+  const kept = result[0];
+  assert.equal(kept.startDate.getTime(), thisWeek.getTime(), 'the earliest (next upcoming) occurrence is kept');
+  assert.equal(kept.url, first.url, 'the kept occurrence keeps its own ?occurrence= url');
+  assert.equal(kept.recurrenceRule, 'FREQ=WEEKLY;BYDAY=TH', 'the series rule survives the collapse');
+});
+
+test('deduplicateEvents keeps two distinct single occurrences of a recurring event separate', async () => {
+  // Behavior-preservation guard (passes on main and on the collapse branch):
+  // run 20260802-221204's SUNDAY BEER BUST extracted two genuinely distinct
+  // Sundays off the same event page — each a discrete upcoming night, NOT a
+  // full-series export (no recurrence claim). areStartDatesWithinDays'
+  // exclusive window keeps them apart and the series collapse must too.
+  const core = createCore();
+  const thisWeek = new Date(Date.now() + 7 * SERIES_DAY_MS);
+  const nextWeek = new Date(thisWeek.getTime() + 7 * SERIES_DAY_MS);
+  const buildOccurrence = (startDate) => ({
+    title: 'SUNDAY BEER BUST',
+    bar: 'Eagle LA',
+    startDate,
+    url: `https://eaglela.com/events/sunday-beer-bust-4/?occurrence=${startDate.toISOString().slice(0, 10)}`,
+    timezone: 'America/Los_Angeles',
+    source: 'ai-web'
+  });
+
+  const plainResult = await core.deduplicateEvents([buildOccurrence(thisWeek), buildOccurrence(nextWeek)], null);
+  assert.equal(plainResult.length, 2, 'two discrete upcoming nights stay two events');
+
+  // Slot-host overrides are deliberate single-occurrence overrides of someone
+  // else's series — even with a scraped rrule still attached they never
+  // qualify as full-series exports.
+  const slotHostResult = await core.deduplicateEvents([
+    buildWeeklySeriesExport(thisWeek, { _seriesAuthority: 'slot-host' }),
+    buildWeeklySeriesExport(nextWeek, { _seriesAuthority: 'slot-host' })
+  ], null);
+  assert.equal(slotHostResult.length, 2, 'slot-host overrides never collapse as a series');
+});
+
+test('deduplicateEvents does not collapse same-title series on different base pages', async () => {
+  // Lookalike pairs are not always twins: the same brand can hold two real
+  // weekly slots, each with its own event page. Same title + same rrule but a
+  // different base page must never fold.
+  const core = createCore();
+  const thisWeek = new Date(Date.now() + 7 * SERIES_DAY_MS);
+  const nextWeek = new Date(thisWeek.getTime() + 7 * SERIES_DAY_MS);
+  const first = buildWeeklySeriesExport(thisWeek);
+  const second = buildWeeklySeriesExport(nextWeek, {
+    url: 'https://eaglela.com/events/b-bar-patio/',
+    website: 'https://eaglela.com/events/b-bar-patio/'
+  });
+
+  const result = await core.deduplicateEvents([first, second], null);
+  assert.equal(result.length, 2, 'a different base event page is a different series record');
+});
+
+test('deduplicateEvents does not collapse same-page exports with different recurrence rules', async () => {
+  const core = createCore();
+  const thisWeek = new Date(Date.now() + 7 * SERIES_DAY_MS);
+  const nextWeek = new Date(thisWeek.getTime() + 7 * SERIES_DAY_MS);
+  const first = buildWeeklySeriesExport(thisWeek);
+  const second = buildWeeklySeriesExport(nextWeek, { recurrenceRule: 'FREQ=MONTHLY;BYDAY=1TH' });
+
+  const result = await core.deduplicateEvents([first, second], null);
+  assert.equal(result.length, 2, 'different rules are different series claims — never fold them');
+});
+
+test('deduplicateEvents series collapse preserves manuallyMarkedBear from the dropped occurrence', async () => {
+  const core = createCore();
+  const thisWeek = new Date(Date.now() + 7 * SERIES_DAY_MS);
+  const nextWeek = new Date(thisWeek.getTime() + 7 * SERIES_DAY_MS);
+  const first = buildWeeklySeriesExport(thisWeek);
+  const second = buildWeeklySeriesExport(nextWeek, { manuallyMarkedBear: true });
+
+  const result = await core.deduplicateEvents([first, second], null);
+  assert.equal(result.length, 1, 'the pair still collapses');
+  assert.equal(result[0].manuallyMarkedBear, true, "the owner's verdict survives whichever occurrence he tapped it on");
+  assert.equal(result[0].startDate.getTime(), thisWeek.getTime(), 'the earliest occurrence is still the one kept');
+});
+
 // === Run 20260802-135030: 3dollarbillbk.com + its eventim ticketing pages ===
 // Six verbatim records were three real events and duplicatesRemoved was 1.
 // URL identity (same event page modulo query/fragment; same trailing platform


### PR DESCRIPTION
## The bug

Run 20260806-171735 on `eaglela.com/events/` produced **two "B BAR" events** that both reached the results UI:

- startDate 2026-08-06, `https://eaglela.com/events/b-bar/?occurrence=2026-08-06`
- startDate 2026-08-13, `https://eaglela.com/events/b-bar/?occurrence=2026-08-13`

Both carry `recurrenceRule: FREQ=WEEKLY;BYDAY=TH`, identical title/description/image/venue, and both are full-series exports (`_recurring`/`_recurringExport`, series-owner). They differ only in the `?occurrence=` date. The run landed on a Thursday — B BAR's own weekday — so the site surfaced this week's *and* next week's instance stubs. Each record's rrule alone already covers every Thursday, so one weekly series was exported twice. Discovery/extraction is untouched; the fix is at dedup.

## Why collapsing is safe vs the deliberate SUNDAY BEER BUST guard

`areStartDatesWithinDays` deliberately keeps two occurrences of a recurring event ~7 days apart separate (SUNDAY BEER BUST's two distinct Sundays, run 20260802-221204 — each a discrete upcoming night). That behavior is **unchanged** — the diff is purely additive (225 insertions, 0 deletions) and no existing matcher was widened.

The new pass collapses a pair ONLY under a strict 4-condition series identity (`getSeriesExportIdentity`, fails closed on anything less):

1. **Both are full-series exports** — `isRecurringSeriesEvent` on both; slot-host overrides (`_seriesAuthority: 'slot-host'`) never qualify (they are deliberate single-occurrence overrides).
2. **Identical normalized recurrence rule** (trimmed, uppercased). A bare `_recurring` flag with no rule can't prove one shared rule → never collapses.
3. **Same base event page** — query/fragment stripped via the existing `getEventPageUrlIdentity` helper (no `new URL`; platform-pure), so `?occurrence=` variants of one page match while domain roots/stamped websites never yield an identity.
4. **The existing same-event title/venue notion agrees** — identity-shape name similarity + the different-place veto (no new/looser matcher).

Distinct single occurrences (no series claim, or slot-host) pass through untouched. Missing/unparseable startDate on either side → no collapse (same conservatism as `areStartDatesWithinDays`).

## What changed

- `scripts/shared-core.js`: new fourth pass in `deduplicateEvents` + `getSeriesExportIdentity` helper. The kept record is the earliest (= next upcoming; dedup runs on future-filtered events) occurrence; fields merge through the existing `mergeParsedEvents` machinery with the kept occurrence's own startDate/endDate/url/website reasserted; `manuallyMarkedBear` survives from either side; one additive `🔁 SERIES:` log line. No existing console.log/prompt text edited. Nothing per-venue/city/domain.
- `scripts/shared-core.test.js`: 5 tests adjacent to the existing `deduplicateEvents` blocks (no new test files).

## Verification

- `node --check` clean on both touched files.
- Quiet suite (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`): **1598 pass / 0 fail** on this branch vs **1593 pass / 0 fail** baseline on a clean origin/main worktree (+5 = exactly the new tests).
- New tests vs clean origin/main code: the regression test (two B BAR-shaped series exports collapse to one, keeping the earlier upcoming date) and the manuallyMarkedBear-survival test **fail on main, pass on branch**. The behavior-preservation guards pass on **both** main and branch, as designed: SUNDAY BEER BUST-shaped distinct occurrences + slot-host pairs stay separate; different base page + same title/rrule not collapsed; same page + different rrule not collapsed.
- **Real-run replay** (run 20260806-171735, `parserResults[0]` events + bearDroppedEvents, 25 records through `deduplicateEvents`):
  - main: 25 → 14 — B BAR ×2
  - branch: 25 → 13 — B BAR ×1, the 2026-08-06 occurrence with its own `?occurrence=2026-08-06` url
  - every other title's count identical on both (BEAR HAPPY HOUR 1, CUBSCOUT 1, SUNDAY BEER BUST 1, MEAT RACK 1, ONYX 1, SUNDAY SWAP MEAT 2, LUCKI BREAK 1, MOVIE MONDAYS 2, Tightwad Tuesday 1, HUMP NIGHT 1) — the collapse is surgical.
- `git diff origin/main`: purely additive; `areStartDatesWithinDays` byte-identical; no existing merge matcher touched.
- **No new runtime files.**

Note: GitHub Actions had an outage yesterday — if checks don't appear on this PR, that's why; the suite results above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP