### PR TITLE
fix(scraper): treat -WxH filename variants as the same image in the identity layer

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -610,6 +610,14 @@ class AiWebParser {
         this.maxRejectedSamplesPerReason = 3;
         this.maxRejectedSampleLength = 120;
         this.supportedImageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.avif', '.bmp', '.tif', '.tiff'];
+        // "-<width>x<height>" immediately before the image extension in a
+        // FILENAME (e.g. flyer-300x300.jpg for flyer.jpg — the WordPress-style
+        // resize convention). Single source of truth shared by
+        // getResizedImageOriginalUrl / getResizedImageFilenameArea (URL
+        // selection: prefer the full-size original) and stripSizeParams
+        // (identity: a resized rendition IS its base image) so the two notions
+        // of "resized derivative" can never drift apart.
+        this.resizedImageFilenameSuffixPattern = /-(\d{2,5})x(\d{2,5})(\.(?:jpe?g|png|gif|webp|avif|bmp|tiff?))$/i;
         // Non-image static-asset extensions (fonts/stylesheets/scripts + image
         // formats not in supportedImageExtensions). Together with that list
         // these mark a URL as a FILE, never an event page — see
@@ -3309,7 +3317,7 @@ class AiWebParser {
         if (limit === 0) return [];
 
         const results = [];
-        const seen = new Set();
+        const seen = new Map();
         const addImageRecord = (rawUrl, start, end) => {
             const normalized = this.normalizeUrl(String(rawUrl || '').trim(), sourceUrl);
             if (!normalized) return;
@@ -3318,14 +3326,27 @@ class AiWebParser {
             if (!finalUrl) return;
             // Use stripped URL for deduplication to handle same image at different sizes
             const strippedUrl = this.stripSizeParams(finalUrl);
-            if (seen.has(strippedUrl)) return;
+            if (seen.has(strippedUrl)) {
+                // Another rendition of an image already held. The first
+                // sighting keeps the record and its document position, but the
+                // representative URL is promoted when this rendition is the
+                // full-size original of a stored "-WxH" resized filename
+                // variant (or a strictly larger such variant) — the record's
+                // URL is what gets OCR'd and offered to the model.
+                const existing = seen.get(strippedUrl);
+                if (existing && this.isPreferredResizedRendition(finalUrl, existing.url)) {
+                    existing.url = finalUrl;
+                }
+                return;
+            }
             if (!this.hasSupportedImageFilenameAtEnd(finalUrl) && !this.hasLikelyImageUrl(finalUrl)) return;
-            seen.add(strippedUrl);
-            results.push({
+            const record = {
                 url: finalUrl,
                 start: Number.isFinite(Number(start)) ? Number(start) : -1,
                 end: Number.isFinite(Number(end)) ? Number(end) : (Number.isFinite(Number(start)) ? Number(start) : -1)
-            });
+            };
+            seen.set(strippedUrl, record);
+            results.push(record);
         };
 
         const attrPatterns = [
@@ -4649,6 +4670,15 @@ class AiWebParser {
         pathname = pathname.replace(/\/w_\d+(?:,h_\d+)?\/?/i, '/');  // w_296,h_370 patterns
         pathname = pathname.replace(/\/h_\d+(?:,w_\d+)?\/?/i, '/');  // h_370,w_296 patterns
         pathname = pathname.replace(/\/(?:w|h|width|height|wpx|hpx)=\d+\/?/gi, '/');  // /w=1920/ patterns
+        // A "-<width>x<height>" tail in the FILENAME right before the
+        // extension (flyer-300x300.jpg — the WordPress-style resize
+        // convention, resizedImageFilenameSuffixPattern) is a resized
+        // rendition of the same asset, not a different image: collapse it so
+        // every identity check built on this function (harvest dedup, segment
+        // OCR coverage, pairing maps, OCR-result dedup) sees ONE image.
+        // Choosing the representative URL still prefers the full-size
+        // original — see getResizedImageOriginalUrl and its callers.
+        pathname = pathname.replace(this.resizedImageFilenameSuffixPattern, '$3');
 
         // Remove size query parameters (both w=1920 and w_296,h_370 formats).
         const keptPairs = [];
@@ -6650,12 +6680,44 @@ class AiWebParser {
 
     // "…/flyer-1-1-300x300.jpg" → "…/flyer-1-1.jpg". The WordPress/webflow
     // resize convention: "-<width>x<height>" immediately before a known image
-    // extension. Returns '' when the URL carries no such suffix.
+    // extension (resizedImageFilenameSuffixPattern — the same pattern
+    // stripSizeParams collapses for identity). Returns '' when the URL
+    // carries no such suffix.
     getResizedImageOriginalUrl(url) {
         const text = typeof url === 'string' ? url.trim() : '';
         if (!text) return '';
-        const match = text.match(/^(.*)-\d{2,5}x\d{2,5}(\.(?:jpe?g|png|gif|webp|avif|bmp|tiff?))((?:[?#].*)?)$/i);
-        return match ? `${match[1]}${match[2]}${match[3]}` : '';
+        const tailIndex = text.search(/[?#]/);
+        const base = tailIndex >= 0 ? text.slice(0, tailIndex) : text;
+        const tail = tailIndex >= 0 ? text.slice(tailIndex) : '';
+        const match = base.match(this.resizedImageFilenameSuffixPattern);
+        return match ? `${base.slice(0, match.index)}${match[3]}${tail}` : '';
+    }
+
+    // Pixel area a "-WxH" resized filename variant advertises; 0 when the URL
+    // carries no such suffix. Companion to getResizedImageOriginalUrl, built
+    // on the same shared pattern.
+    getResizedImageFilenameArea(url) {
+        const text = typeof url === 'string' ? url.trim() : '';
+        if (!text) return 0;
+        const tailIndex = text.search(/[?#]/);
+        const base = tailIndex >= 0 ? text.slice(0, tailIndex) : text;
+        const match = base.match(this.resizedImageFilenameSuffixPattern);
+        if (!match) return 0;
+        return (parseInt(match[1], 10) || 0) * (parseInt(match[2], 10) || 0);
+    }
+
+    // Should `candidate` replace `incumbent` as the representative URL of ONE
+    // image identity (the caller has already proven them the same image via
+    // stripSizeParams)? Only the "-WxH" resized-filename convention votes
+    // here: the full-size base beats its resized variant, and a larger
+    // variant beats a smaller one. Renditions that differ any other way
+    // (query params, proxy wraps, transform tails) keep the incumbent —
+    // first sighting wins, exactly as before.
+    isPreferredResizedRendition(candidate, incumbent) {
+        const incumbentIsResized = Boolean(this.getResizedImageOriginalUrl(incumbent));
+        if (!incumbentIsResized) return false;
+        if (!this.getResizedImageOriginalUrl(candidate)) return true;
+        return this.getResizedImageFilenameArea(candidate) > this.getResizedImageFilenameArea(incumbent);
     }
 
     // Drop resized derivatives whose FULL-SIZE original is in the same URL
@@ -7164,6 +7226,20 @@ class AiWebParser {
         return url.length;
     }
 
+    // Order OCR results inside ONE dedup/consolidation group so index 0 is
+    // the best representative. A "-WxH" resized filename variant never
+    // outranks a base rendition: the URL size score reads "300x300" as a
+    // large ADVERTISED size while the full-size base (which advertises
+    // nothing) scores only the URL-length noise floor — sorted on score
+    // alone, the thumbnail would be crowned "largest". Within the same
+    // rendition kind the existing size-score order is unchanged.
+    compareOcrResultsForRepresentative(a, b) {
+        const aResized = this.getResizedImageOriginalUrl(a && a.url) ? 1 : 0;
+        const bResized = this.getResizedImageOriginalUrl(b && b.url) ? 1 : 0;
+        if (aResized !== bResized) return aResized - bResized;
+        return this.getImageSizeFromUrl(b && b.url) - this.getImageSizeFromUrl(a && a.url);
+    }
+
     /**
      * Why this URL is a placeholder rather than artwork ('' when it isn't).
      * The rules live in SharedCore.getPlaceholderImageUrlReason so extraction
@@ -7243,7 +7319,7 @@ class AiWebParser {
                 deduped.push(group[0]);
             } else {
                 // Sort by size score (descending) and pick the largest
-                group.sort((a, b) => this.getImageSizeFromUrl(b.url) - this.getImageSizeFromUrl(a.url));
+                group.sort((a, b) => this.compareOcrResultsForRepresentative(a, b));
                 // A Wix asset served as a portrait `fill` AND a landscape `fill`
                 // strips to ONE key here, so the group can hold two different
                 // SHAPES, not just two sizes. Keep the losers reachable for the
@@ -7296,7 +7372,7 @@ class AiWebParser {
                 consolidated.push(group[0]);
             } else {
                 // Sort by size score (descending) and pick the largest
-                group.sort((a, b) => this.getImageSizeFromUrl(b.url) - this.getImageSizeFromUrl(a.url));
+                group.sort((a, b) => this.compareOcrResultsForRepresentative(a, b));
                 // Identical OCR text means identical ARTWORK — which is exactly
                 // how a portrait flyer and its landscape banner twin look to
                 // this grouping. The twin survives on the winner instead of

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -12628,3 +12628,143 @@ test('a logo is still hard-refused even at perfect text similarity', () => {
     assert.equal(refused.score, -Infinity);
   }
 });
+
+// ---------------------------------------------------------------------------
+// "-WxH" resized-filename variants are the SAME image as their base
+// (identity), while URL selection keeps preferring the full-size original.
+// Run findings: the device OCR cache held BOTH renditions of ~12 Eagle LA
+// posters (~34 entries for ~12 images) because stripSizeParams collapsed
+// proxy wraps and transform tails but not the filename convention — so the
+// segment top-up judged thumbnail-only segments "uncovered" and OCR'd the
+// thumbnail even when the full-size original was already read.
+// ---------------------------------------------------------------------------
+
+test('stripSizeParams collapses a "-WxH" resized filename variant into its base image', () => {
+  const parser = createParser();
+  assert.equal(
+    parser.stripSizeParams('https://eaglela.com/wp-content/uploads/flyer-300x300.jpg'),
+    'https://eaglela.com/wp-content/uploads/flyer.jpg',
+    'the WordPress-style thumbnail strips to its base asset');
+  assert.equal(
+    parser.stripSizeParams('https://eaglela.com/wp-content/uploads/flyer-1024x683.png'),
+    'https://eaglela.com/wp-content/uploads/flyer.png',
+    'any -WxH rendition strips to its base asset');
+  assert.equal(
+    parser.stripSizeParams('https://eaglela.com/wp-content/uploads/flyer-300x300.jpg'),
+    parser.stripSizeParams('https://eaglela.com/wp-content/uploads/flyer.jpg'),
+    'variant and base share one identity key');
+
+  // Legitimate digits that are NOT a "-WxH immediately before the extension"
+  // token must never be mangled.
+  for (const url of [
+    'https://eaglela.com/wp-content/uploads/poster-8_8_26-square.jpg',
+    'https://eaglela.com/wp-content/uploads/foo-2026.jpg',
+    'https://eaglela.com/wp-content/uploads/foo-4x4-party.jpg'
+  ]) {
+    assert.equal(parser.stripSizeParams(url), url, `${url} must pass through unchanged`);
+  }
+});
+
+test('segment OCR top-up counts a "-WxH" variant as covered by its full-size OCR result', async () => {
+  const parser = createParser();
+  const original = 'https://eaglela.com/wp-content/uploads/hump-night-flyer.jpg';
+  const thumbnail = 'https://eaglela.com/wp-content/uploads/hump-night-flyer-300x300.jpg';
+
+  // The segment's HTML carries ONLY the thumbnail rendition; the page-level
+  // pass already OCR'd the full-size original.
+  const segments = [{ lines: [], html: '', imageHintUrls: [thumbnail] }];
+  const ocrResults = [{ url: original, text: 'HUMP NIGHT 9PM', imageClassification: 'event-flyer' }];
+
+  let ocrCalled = false;
+  parser.getOcrTextForImage = async () => {
+    ocrCalled = true;
+    return null;
+  };
+
+  await parser.ensureSegmentOcrCoverage(segments, ocrResults, {}, 'https://eaglela.com/events', null);
+  assert.equal(ocrCalled, false, 'the thumbnail is the same image — no second OCR call');
+  assert.equal(ocrResults.length, 1, 'no redundant OCR entry is appended');
+
+  // ...and the full-size OCR result pairs with the thumbnail-only segment.
+  const matched = parser.filterOcrResultsForSegment(ocrResults, segments[0], 'https://eaglela.com/events');
+  assert.equal(matched.length, 1);
+  assert.equal(matched[0].url, original);
+});
+
+test('harvest and pairing dedup treat a "-WxH" variant and its original as ONE image', () => {
+  const parser = createParser();
+  const original = 'https://eaglela.com/wp-content/uploads/meat-rack-poster.jpg';
+  const thumbnail = 'https://eaglela.com/wp-content/uploads/meat-rack-poster-300x300.jpg';
+
+  const html = `<img src="${thumbnail}"><img src="${original}">`;
+  const records = parser.extractOrderedImageRecordsFromHtml(html, 'https://eaglela.com/events');
+  assert.equal(records.length, 1, 'both renditions harvest to one record');
+  assert.equal(records[0].url, original, 'the full-size original is the representative URL');
+
+  // Pairing's URL dedup collapses OCR entries for both renditions to one
+  // image — and the full-size original wins the entry.
+  const deduped = parser.deduplicateOcrResultsByUrl([
+    { url: thumbnail, text: 'MEAT RACK' },
+    { url: original, text: 'MEAT RACK' }
+  ]);
+  assert.equal(deduped.length, 1, 'OCR results for both renditions collapse to one image');
+  assert.equal(deduped[0].url, original, 'the full-size original wins the OCR entry');
+});
+
+test('OCR consolidation never crowns a "-WxH" variant over the full-size original', () => {
+  const parser = createParser();
+  const original = 'https://eaglela.com/wp-content/uploads/b-bar-poster.jpg';
+  const thumbnail = 'https://eaglela.com/wp-content/uploads/b-bar-poster-1024x683.jpg';
+
+  // Same text + classification groups them; on size score alone the variant's
+  // advertised 1024x683 would beat the base's URL-length noise floor.
+  const consolidated = parser.consolidateDuplicateOcrResults([
+    { url: thumbnail, text: 'B BAR SATURDAY', imageClassification: 'event-flyer' },
+    { url: original, text: 'B BAR SATURDAY', imageClassification: 'event-flyer' }
+  ]);
+  assert.equal(consolidated.length, 1);
+  assert.equal(consolidated[0].url, original, 'the base rendition is the representative');
+});
+
+// Behavior guard (passes before and after this change): when both renditions
+// are harvested, exactly one OCR call is made and it targets the full-size
+// original — dropResizedImageUrlsWithOriginal and the harvest representative
+// agree on the same answer.
+test('extractOcrFromAllImages OCRs the full-size original exactly once, never the "-WxH" variant', async () => {
+  const parser = createParser();
+  const original = 'https://eaglela.com/wp-content/uploads/onyx-poster.jpg';
+  const thumbnail = 'https://eaglela.com/wp-content/uploads/onyx-poster-300x300.jpg';
+  const html = `<img src="${thumbnail}" srcset="${original} 1024w">`;
+
+  const ocrCalls = [];
+  parser.getOcrTextForImage = async (url) => {
+    ocrCalls.push(url);
+    return { url, text: 'ONYX NIGHT', imageClassification: 'event-flyer' };
+  };
+
+  const results = await parser.extractOcrFromAllImages({ url: 'https://eaglela.com/events', html }, { enabled: true }, null, 10);
+  assert.deepEqual(ocrCalls, [original], 'one OCR call, aimed at the full-size original');
+  assert.equal(results.length, 1);
+  assert.equal(results[0].url, original);
+});
+
+test('a lone "-WxH" thumbnail keeps its own identity and still gets OCR coverage', async () => {
+  const parser = createParser();
+  // Flag, don't drop: when the original is nowhere on the page, the variant
+  // is still harvested, still judged uncovered, and still OCR'd.
+  const thumbnail = 'https://eaglela.com/wp-content/uploads/lone-poster-300x300.jpg';
+  const records = parser.extractOrderedImageRecordsFromHtml(`<img src="${thumbnail}">`, 'https://eaglela.com/events');
+  assert.equal(records.length, 1);
+  assert.equal(records[0].url, thumbnail, 'a lone thumbnail is never rewritten to a URL the page does not carry');
+
+  const segments = [{ lines: [], html: '', imageHintUrls: [thumbnail] }];
+  const ocrResults = [];
+  const ocrCalls = [];
+  parser.getOcrTextForImage = async (url) => {
+    ocrCalls.push(url);
+    return { url, text: 'LONE POSTER 10PM', imageClassification: 'event-flyer' };
+  };
+  await parser.ensureSegmentOcrCoverage(segments, ocrResults, {}, 'https://eaglela.com/events', null);
+  assert.deepEqual(ocrCalls, [thumbnail], 'genuine coverage is not reduced');
+  assert.equal(ocrResults.length, 1);
+});


### PR DESCRIPTION
## The redundancy

`stripSizeParams` canonicalizes image URLs for identity (harvest dedup, segment OCR coverage, pairing dedup maps, OCR-result dedup) and collapses proxy wraps, Wix transform tails, `/NNNxNNN/` path segments, and w/h/size query params — but not the WordPress-style FILENAME convention `flyer-300x300.jpg` → `flyer.jpg`. Consequences, verified on the device:

- A segment whose HTML carries only the `-300x300` rendition was judged **"no OCR coverage"** even when the full-size original was already OCR'd — so the thumbnail got OCR'd too (phantom top-ups).
- The device OCR cache holds **both renditions of ~12 Eagle LA posters (~34 entries for ~12 images)**, and low-res reads feed the verbatim-evidence corpus (the documented `-300x300` misread turned a phone number into a Tulsa address at confidence 100).
- Harvest and pairing could carry both renditions as distinct records; the only guard (`dropResizedImageUrlsWithOriginal`) fires only when the original is literally in the same list, at two call sites.

## What changes

- **Identity collapses the variant**: `stripSizeParams` now also strips a trailing `-WxH` immediately before the file extension. The pattern is a single shared constant (`resizedImageFilenameSuffixPattern`) that `getResizedImageOriginalUrl` is rebuilt on, so the identity collapse and the selection preference can never drift apart. Generic pattern — nothing per venue/domain/CDN.
- **Representative still prefers the full-size original**: the harvest keeps one record per identity and promotes its URL to the base rendition when the page carries it (first sighting keeps the record and its document position; proxy/query renditions keep first-wins exactly as before). OCR dedup/"Consolidated … to largest" no longer crowns a `-WxH` variant just because its filename advertises `300x300` while the base scores only the URL-length noise floor.
- **`dropResizedImageUrlsWithOriginal` unchanged** (now mostly a no-op — harvest collapses the pair before it runs; it still protects lists built from other sources).
- **Lone thumbnails are safe**: a `-WxH` rendition whose original is absent from the page is still harvested, still judged uncovered, still OCR'd — no genuine coverage reduced (OCR calls are free; this is about redundancy/identity, not thrift).
- **OCR cache untouched**: no migration; entries for both renditions remain valid reads. The fix only stops creating redundant second-variant calls going forward. OCR request options/prompts unchanged (cache signature stable).
- Display URLs can improve: where a segment previously surfaced the `-300x300` rendition, the model now sees (and can return) the full-size original. The evidence gate is unaffected — `imageEvidenceUrls` is built from the same prompt text the model reads, so whichever rendition is offered is the one validated.

## Real-page replay (39 cached pages, deterministic — no network/AI)

`eaglela.com/*` + `www.thedallaseagle.com/*`:

- **0 image identities lost** on any page (base-collapsed set comparison, main vs branch).
- `-WxH` renditions inside the harvest windows drop **115 → 24**; all 24 survivors are lone thumbnails whose base isn't on that page (correctly kept).
- Final OCR-candidate lists contain **0 variant+base pairs on both sides** (main got there via `dropResizedImageUrlsWithOriginal`; branch collapses at harvest).
- Segment top-up on the Eagle LA listing page: **same 4 top-ups** (no coverage change), but branch OCRs the **full-size originals** (`IG_Lucky-Break-poster-2024.jpg`, `IG_MONDAY-MOVIES-poster-AUG-2026.jpg`, `IG_Tightwad-Tues-poster-2024.jpg`, `IG_Wed-HUMP-NIGHT-2024-web-1-1.jpg`) instead of their `-300x300` thumbnails — converging on the same cache keys the detail pages populate.
- Explained diffs on other pages: collapsing freed slots in the cap-10 harvest window, so a few below-cap URLs now enter it (`eaglela.com/?s={search_term_string}` — pre-existing junk-tolerance in `hasLikelyImageUrl`, admitted on main too whenever a page has <10 images; two `&amp;`-escaped `Vector.png` icon near-duplicates on thedallaseagle listing — pre-existing entity-escaping near-dup unrelated to `-WxH`). No poster lost anywhere.

## Verification

- `node --check` clean on both touched files.
- Full suite (serial, measured): clean origin/main **1598/1598** → branch **1604/1604**, 0 fail. (The parallel `npm test` runner intermittently drops this file's stream with a pre-existing "Unable to deserialize cloned data" IPC artifact on clean main too — reproduced on the untouched baseline.)
- 6 new tests, appended at EOF of `scripts/parsers/ai-web-parser.test.js` (no new test files): **4 fail on clean origin/main / pass on branch** (stripSizeParams variant collapse + digit-safety for `poster-8_8_26-square.jpg` / `foo-2026.jpg` / `foo-4x4-party.jpg`; top-up counts the variant as covered with a call spy asserting no second OCR; harvest+pairing dedup collapse to one record with the original as representative; consolidation never crowns the variant). **2 declared behavior guards pass on both** (extractOcrFromAllImages OCRs the original exactly once; a lone thumbnail keeps its identity and coverage).
- Diff scope: no existing console.log or prompt strings edited (additions only); no `new URL`/`URLSearchParams` added under `scripts/`.
- **No new runtime files.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP