### PR TITLE
fix(scraper): rrule-fallback report-only rescue census + generic calendar-grid ancestor-date inheritance

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1909,9 +1909,19 @@ class AiWebParser {
         // no unambiguous date context or the segment states its own month,
         // so existing segments stay byte-identical (additive line only).
         const segmentDateContextLine = this.buildSegmentDateContextLine(segment, pageDateContext);
+        // Ancestor-inherited date (calendar-grid layouts, see
+        // findAncestorDateForMultiEventEntry): rendered as an ADDITIVE
+        // context line quoting the ancestor's own attribute markup, so the
+        // stated date is present verbatim in what the model sees and the
+        // evidence gate can corroborate it. '' for every segment without a
+        // hint — those prompts stay byte-identical.
+        const ancestorDateLine = segment && segment.ancestorDateContext && segment.ancestorDateContext.dateText
+            ? `SEGMENT_ANCESTOR_DATE: ${segment.ancestorDateContext.dateText} (this segment's card sits inside an enclosing dated container: ${segment.ancestorDateContext.attrName}="${segment.ancestorDateContext.attrValue}")`
+            : '';
         const contextLines = [
             `SEGMENT_INDEX: ${index + 1}/${totalSegments}`,
             segmentDateContextLine,
+            ancestorDateLine,
             ...resourceLines
         ].filter(Boolean);
         const segmentContent = segmentHtml || (segment && Array.isArray(segment.lines) ? segment.lines.join('\n') : '');
@@ -2311,7 +2321,19 @@ class AiWebParser {
         for (const group of groups) {
             const result = this.segmentStructureGroup(group);
             if (result.segments.length >= 2) {
-                return this.coverRepeatedEventUnits(group, result);
+                // The winning group is chosen on the PRE-EXISTING gates only;
+                // ancestor-date inheritance then re-runs the SAME group so it
+                // can only add cards within the winning segmentation. Letting
+                // inheritance vote during group selection would crown junk:
+                // a page's fragment-cut container group (whose dateless
+                // fragments all sit under some dated ancestor) would clear
+                // the two-segment bar and outrank the real card-aligned
+                // group.
+                const withAncestorDates = this.segmentStructureGroup(group, { pageHtml: html });
+                const finalResult = withAncestorDates.segments.length > result.segments.length
+                    ? withAncestorDates
+                    : result;
+                return this.coverRepeatedEventUnits(group, finalResult, html);
             }
         }
         return [];
@@ -2341,11 +2363,11 @@ class AiWebParser {
     // spanned), and every other gate still applies: only windows that were
     // being silently discarded come back. Pages whose segmentation already
     // covers their units take the early return and are byte-identical.
-    coverRepeatedEventUnits(group, result) {
+    coverRepeatedEventUnits(group, result, pageHtml = '') {
         const segments = result && Array.isArray(result.segments) ? result.segments : [];
         const identifiedUnitCount = Number(result && result.identifiedUnitCount) || 0;
         if (identifiedUnitCount <= segments.length) return segments;
-        const covered = this.segmentStructureGroup(group, { allowTerseIdentifiedUnits: true });
+        const covered = this.segmentStructureGroup(group, { allowTerseIdentifiedUnits: true, pageHtml });
         if (covered.segments.length <= segments.length) return segments;
         console.log(`🤖 AI Web: Segmentation covered ${segments.length} of ${identifiedUnitCount} repeated event unit(s) on this page — re-segmenting to ${covered.segments.length} window(s)`);
         return covered.segments;
@@ -2388,14 +2410,147 @@ class AiWebParser {
     // The content gates every structural entry has to clear before it can be
     // a window. Extracted verbatim from buildSegmentsFromStructureGroup so
     // the coverage count and the segment build ask exactly the same question.
-    multiEventEntryClearsContentGates(normalizedLines) {
+    multiEventEntryClearsContentGates(normalizedLines, options = null) {
         const lines = Array.isArray(normalizedLines) ? normalizedLines : [];
         if (lines.length < this.extractionLimits.multiEventMinSegmentLines) return false;
         if (this.hasMultiEventScriptLikeText(lines)) return false;
         if (this.countMultiEventDateSignals(lines) > 2) return false;
-        if (!this.segmentHasDateSignal(lines)) return false;
+        // Ancestor-date inheritance (calendar-grid layouts): a structural
+        // ancestor's own dated markup can satisfy the date gate for an entry
+        // whose text states no date — every other gate still applies, and
+        // callers only set this after resolving a real enclosing date (see
+        // findAncestorDateForMultiEventEntry).
+        const assumeAncestorDate = Boolean(options && options.assumeAncestorDate);
+        if (!assumeAncestorDate && !this.segmentHasDateSignal(lines)) return false;
         if (!this.segmentHasTitleSignal(lines) && !this.segmentIsDateHeadedSchedule(lines)) return false;
         return true;
+    }
+
+    // Nearest structural ANCESTOR of a group entry that carries a resolvable
+    // full calendar date in its own attributes (datetime / data-* /
+    // aria-label — the generic attribute families calendar grids and day
+    // cells use, never a per-site or per-plugin name). Regex only, no DOM,
+    // no URL parsing. An ancestor is an opening tag BEFORE the entry whose
+    // element is still open when the entry starts: any tag that closed
+    // earlier — a sibling card, a previous day cell — fails the check, so a
+    // date can never be inherited sideways. The backward scan is bounded to
+    // the same oversized-container window segmentation itself uses, which
+    // keeps the lookup inside the entry's own segmentation container.
+    // Returns { dateText, attrName, attrValue } or null.
+    findAncestorDateForMultiEventEntry(pageHtml, entry) {
+        const source = String(pageHtml || '');
+        const entryStart = entry && Number.isFinite(entry.start) ? entry.start : -1;
+        if (!source || entryStart <= 0 || entryStart > source.length) return null;
+        const windowStart = Math.max(0, entryStart - this.extractionLimits.multiEventMaxSegmentChars * 4);
+        const windowHtml = source.slice(windowStart, entryStart);
+        // Elements that can never contain the entry (HTML void elements) are
+        // skipped up front: they have no close tag, so the still-open check
+        // below would mistake them for ancestors.
+        const voidTags = new Set(['area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr']);
+        const tagPattern = /<([a-z][a-z0-9]*)\b([^>]*)>/gi;
+        const candidates = [];
+        let match;
+        while ((match = tagPattern.exec(windowHtml)) !== null) {
+            const tagName = String(match[1] || '').toLowerCase();
+            const attrsText = match[2] || '';
+            if (voidTags.has(tagName)) continue;
+            if (/\/\s*$/.test(attrsText)) continue; // self-closing: encloses nothing
+            const dated = this.resolveDateFromTagAttributes(attrsText);
+            if (!dated) continue;
+            candidates.push({
+                tagName,
+                afterOpenIndex: windowStart + match.index + match[0].length,
+                dated
+            });
+        }
+        // Nearest ancestor first.
+        for (let i = candidates.length - 1; i >= 0; i--) {
+            const candidate = candidates[i];
+            if (this.multiEventTagRemainsOpenBefore(source, candidate.tagName, candidate.afterOpenIndex, entryStart)) {
+                return candidate.dated;
+            }
+        }
+        return null;
+    }
+
+    // Whether the element whose opening tag ends at afterOpenIndex is still
+    // open at limitIndex: count same-name opens/closes between the two.
+    // Stray unmatched close tags only ever close the element EARLIER, which
+    // is the safe direction (no false ancestors).
+    multiEventTagRemainsOpenBefore(source, tagName, afterOpenIndex, limitIndex) {
+        const scanText = String(source || '').slice(afterOpenIndex, limitIndex);
+        const pairPattern = new RegExp(`<(/?)${tagName}\\b`, 'gi');
+        let depth = 1;
+        let match;
+        while ((match = pairPattern.exec(scanText)) !== null) {
+            depth += match[1] ? -1 : 1;
+            if (depth <= 0) return false;
+        }
+        return depth >= 1;
+    }
+
+    // First attribute on an opening tag whose value resolves to a full
+    // calendar date. Only the generic date-bearing attribute families are
+    // read: datetime, data-*, aria-label.
+    resolveDateFromTagAttributes(attrsText) {
+        const attrPattern = /\b(datetime|aria-label|data-[a-z0-9_-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/gi;
+        const text = String(attrsText || '');
+        let match;
+        while ((match = attrPattern.exec(text)) !== null) {
+            const attrName = String(match[1] || '').toLowerCase();
+            const attrValue = match[2] !== undefined ? match[2] : (match[3] || '');
+            const parts = this.resolveFullDatePartsFromText(attrValue);
+            if (!parts) continue;
+            const monthNamesEn = ['January', 'February', 'March', 'April', 'May', 'June',
+                'July', 'August', 'September', 'October', 'November', 'December'];
+            return {
+                dateText: `${monthNamesEn[parts.month - 1]} ${parts.day}, ${parts.year}`,
+                attrName,
+                attrValue
+            };
+        }
+        return null;
+    }
+
+    // Full year+month+day from a short attribute-style text: ISO
+    // ("2026-08-06", with or without a time suffix), compact 8-digit
+    // ("20260806"), or an English month-name form ("August 6, 2026" /
+    // "6 August 2026" — aria-label style). Yearless or partial forms never
+    // resolve: inheriting a date is only safe when the ancestor states one
+    // completely. Returns { year, month, day } or null.
+    resolveFullDatePartsFromText(text) {
+        const value = String(text || '').trim();
+        if (!value || value.length > 120) return null;
+        const validated = (year, month, day) => {
+            if (!Number.isFinite(year) || year < 1970 || year > 2100) return null;
+            if (!Number.isFinite(month) || month < 1 || month > 12) return null;
+            if (!Number.isFinite(day) || day < 1 || day > 31) return null;
+            return { year, month, day };
+        };
+        const isoMatch = value.match(/(?:^|[^0-9])(\d{4})-(\d{1,2})-(\d{1,2})(?![0-9])/);
+        if (isoMatch) {
+            const parts = validated(parseInt(isoMatch[1], 10), parseInt(isoMatch[2], 10), parseInt(isoMatch[3], 10));
+            if (parts) return parts;
+        }
+        const compactMatch = value.match(/(?:^|[^0-9])(20\d{2})(\d{2})(\d{2})(?![0-9])/);
+        if (compactMatch) {
+            const parts = validated(parseInt(compactMatch[1], 10), parseInt(compactMatch[2], 10), parseInt(compactMatch[3], 10));
+            if (parts) return parts;
+        }
+        const monthNamePattern = '(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)';
+        const monthIndexOf = (name) => ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
+            .indexOf(String(name || '').slice(0, 3).toLowerCase()) + 1;
+        const monthFirst = value.match(new RegExp(`\\b${monthNamePattern}\\s+(\\d{1,2})(?:st|nd|rd|th)?,?\\s+(\\d{4})\\b`, 'i'));
+        if (monthFirst) {
+            const parts = validated(parseInt(monthFirst[3], 10), monthIndexOf(monthFirst[1]), parseInt(monthFirst[2], 10));
+            if (parts) return parts;
+        }
+        const dayFirst = value.match(new RegExp(`\\b(\\d{1,2})(?:st|nd|rd|th)?\\s+${monthNamePattern}\\s+(\\d{4})\\b`, 'i'));
+        if (dayFirst) {
+            const parts = validated(parseInt(dayFirst[3], 10), monthIndexOf(dayFirst[2]), parseInt(dayFirst[1], 10));
+            if (parts) return parts;
+        }
+        return null;
     }
 
 
@@ -2484,6 +2639,7 @@ class AiWebParser {
         const entries = group && Array.isArray(group.entries) ? group.entries : [];
         const identifiedUnits = this.mapMultiEventGroupIdentityLinks(entries);
         const allowTerseIdentifiedUnits = Boolean(options && options.allowTerseIdentifiedUnits);
+        const pageHtml = options && typeof options.pageHtml === 'string' ? options.pageHtml : '';
         let identifiedUnitCount = 0;
         const uniqueSegments = [];
         const seen = new Set();
@@ -2510,7 +2666,15 @@ class AiWebParser {
             // spends, so identity replaces the floor for those.
             const waiveMinChars = allowTerseIdentifiedUnits && isIdentifiedUnit;
             if (!waiveMinChars && segmentText.length < this.extractionLimits.multiEventMinSegmentChars) return;
-            const dedupeKey = segmentText.toLowerCase();
+            // A recurring card repeated under several day cells has IDENTICAL
+            // text — only the inherited ancestor date tells the occurrences
+            // apart ("lookalike pairs are not always twins"). Salt the dedupe
+            // key with that date so each dated occurrence keeps its window;
+            // segments without a hint keep the exact key they had.
+            const ancestorDateSalt = segment.ancestorDateContext && segment.ancestorDateContext.dateText
+                ? `${segment.ancestorDateContext.dateText}\n`
+                : '';
+            const dedupeKey = ancestorDateSalt + segmentText.toLowerCase();
             if (seen.has(dedupeKey)) return;
             seen.add(dedupeKey);
             uniqueSegments.push(segment);
@@ -2532,7 +2696,32 @@ class AiWebParser {
             const normalizedLines = this.extractBodyParts(entry.html)
                 .map(line => this.normalizeWhitespace(line))
                 .filter(Boolean);
-            if (!this.multiEventEntryClearsContentGates(normalizedLines)) continue;
+            // Ancestor-date inheritance (generic, no per-site rules): on
+            // calendar-grid layouts each card's DAY lives on a structural
+            // ANCESTOR element (the enclosing day cell's datetime / data-* /
+            // aria-label markup), so the entry's own text carries a title and
+            // a time but no date, and the date gate discards a real card
+            // (thedallaseagle.com/events/: 23 of 42 cards). When — and only
+            // when — the entry states no date of its own yet clears every
+            // OTHER gate, resolve the nearest still-open ancestor tag that
+            // carries a full calendar date and attach it as a segment-level
+            // hint; the prompt builder renders it as an additive context line
+            // so extraction can state the date WITH gate-verifiable evidence.
+            // Deterministic and bounded: nearest ancestor first, bounded scan
+            // window, and sibling cards can never leak a date sideways (their
+            // tags close before this entry starts, failing the ancestor
+            // check). An entry with its own date signal never looks up.
+            let ancestorDateContext = null;
+            if (!this.multiEventEntryClearsContentGates(normalizedLines)) {
+                const dateGateIsOnlyFailure = pageHtml
+                    && !this.segmentHasDateSignal(normalizedLines)
+                    && this.multiEventEntryClearsContentGates(normalizedLines, { assumeAncestorDate: true });
+                ancestorDateContext = dateGateIsOnlyFailure
+                    ? this.findAncestorDateForMultiEventEntry(pageHtml, entry)
+                    : null;
+                if (!ancestorDateContext) continue;
+                console.log(`🤖 AI Web: Segment inherits date ${ancestorDateContext.dateText} from an enclosing container's ${ancestorDateContext.attrName}="${ancestorDateContext.attrValue}" — the card's own text states no date`);
+            }
             const isIdentifiedUnit = identifiedUnits[entryIndex] === true;
             if (isIdentifiedUnit) identifiedUnitCount++;
 
@@ -2547,7 +2736,9 @@ class AiWebParser {
                     this.trimLinesAfterTerminalCallToAction(segmentLines),
                     this.extractionLimits.multiEventMaxSegmentChars
                 );
-                addSegment({ lines: trimmedLines, html: entry.html }, isIdentifiedUnit);
+                const segment = { lines: trimmedLines, html: entry.html };
+                if (ancestorDateContext) segment.ancestorDateContext = ancestorDateContext;
+                addSegment(segment, isIdentifiedUnit);
             }
         }
         return { segments: uniqueSegments, identifiedUnitCount };
@@ -13157,6 +13348,25 @@ TEXT:
         return text;
     }
 
+    // The evidence-gate-dropped STATED start-date value retained on the event
+    // (the __droppedFieldValues memo the per-snippet validation accumulates,
+    // keyed by normalized field name), if any. Read-only observation input
+    // for the rrule-fallback's report-only rescue census — the value is never
+    // fed back into the dates actually used.
+    getDroppedStatedStartDateValue(aiEvent) {
+        const values = aiEvent && aiEvent.__droppedFieldValues && typeof aiEvent.__droppedFieldValues === 'object'
+            ? aiEvent.__droppedFieldValues
+            : null;
+        if (!values) return '';
+        const startDateFields = new Set(['startdate', 'start', 'date']);
+        for (const key of Object.keys(values)) {
+            if (!startDateFields.has(this.normalizePromptFieldName(key))) continue;
+            const value = values[key];
+            if (typeof value === 'string' && value.trim()) return value.trim();
+        }
+        return '';
+    }
+
     normalizeAiEvent(aiEvent, parserConfig, htmlData = null, cityConfig = null, promptFields = null) {
         const scrapedLinks = this.extractLinksFromPage(
             htmlData && typeof htmlData.html === 'string' ? htmlData.html : '',
@@ -13609,6 +13819,26 @@ TEXT:
                     console.log(`🔁 RECURRING: derived next occurrence ${nextOccurrence} from rrule for "${title}"`);
                     if (dayPhraseSynthesis) {
                         console.log(`🔁 RECURRING: "${title}" synthesized from day phrase "${dayPhraseSynthesis.phrase}" → ${recurrenceRule}, next ${nextOccurrence} — will be withheld from calendar write (ICS only)`);
+                    }
+                    // Report-only rescue census ("trust the pointer, not the
+                    // copy": rescuing gate-dropped fields is LOG-ONLY before
+                    // any enforce step). A 241-log device corpus showed 46
+                    // rrule-derived dates, and 35 of them fired immediately
+                    // after the evidence gate dropped a REAL stated date
+                    // (usually a rendering-variant mismatch) — the fallback
+                    // then invented a DIFFERENT day than the page's own. Log
+                    // which population this firing belongs to so future logs
+                    // can count both; the derived date stays in use either
+                    // way (zero behavior change).
+                    const droppedStatedStart = this.getDroppedStatedStartDateValue(aiEvent);
+                    if (droppedStatedStart) {
+                        const droppedParsed = this.parseDateValue(droppedStatedStart, timezone);
+                        const droppedParsedLabel = droppedParsed instanceof Date && !Number.isNaN(droppedParsed.getTime())
+                            ? ` (parses to ${droppedParsed.toISOString().slice(0, 10)})`
+                            : '';
+                        console.log(`🔁 RECURRING: fallback derived ${nextOccurrence} for "${title}" but the evidence gate dropped a stated date "${droppedStatedStart}"${droppedParsedLabel} — a rescue would keep the page's own date (report-only)`);
+                    } else {
+                        console.log(`🔁 RECURRING: fallback derived ${nextOccurrence} for "${title}" with no gate-dropped stated date available (report-only)`);
                     }
                 } else {
                     // Additive diagnostics. Both guards on this path used to

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -7932,6 +7932,82 @@ test('normalizeAiEvent still discards dateless events with unsupported or missin
 });
 
 // ---------------------------------------------------------------------------
+// rrule-fallback report-only rescue census ("trust the pointer, not the
+// copy"): when the fallback fabricates a next occurrence, log whether the
+// evidence gate had just dropped a REAL stated date for the same event
+// (35 of 46 fallback firings in a 241-log device corpus). LOG-ONLY — the
+// derived date stays in use either way; this builds the evidence base for a
+// later enforce step.
+// ---------------------------------------------------------------------------
+
+test('rrule fallback census: a gate-dropped stated date is reported and the derived date stays in use (report-only)', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 6, 22, 15, 0, 0); // Wed 2026-07-22 local
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let event;
+  try {
+    event = parser.normalizeAiEvent(
+      {
+        title: 'DRINK AND DRAW',
+        rrule: 'FREQ=WEEKLY;BYDAY=TU',
+        // The dropped-value memo exactly as the per-snippet evidence gate
+        // retains it (field names are normalized lowercase canonical keys).
+        __droppedFieldValues: { startdate: 'July 21, 2026' }
+      },
+      {}, null, null, null
+    );
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(event, 'the recurring event survives normalization exactly as before');
+  assert.equal(event.startDate.toISOString().slice(0, 10), '2026-07-28',
+    'REPORT-ONLY: the derived occurrence is still the date in use — the dropped stated date changes nothing');
+  assert.ok(logs.includes('🔁 RECURRING: derived next occurrence 2026-07-28 from rrule for "DRINK AND DRAW"'),
+    'the pre-existing derivation line is untouched');
+  assert.ok(logs.includes('🔁 RECURRING: fallback derived 2026-07-28 for "DRINK AND DRAW" but the evidence gate dropped a stated date "July 21, 2026" (parses to 2026-07-21) — a rescue would keep the page\'s own date (report-only)'),
+    `dropped-date census line expected, got: ${JSON.stringify(logs.filter(l => l.includes('report-only')))}`);
+});
+
+test('rrule fallback census: firing with NO dropped stated date logs the counting line (report-only)', () => {
+  global.EventSchema = EventSchema;
+  const parser = createParser();
+  parser.now = () => new Date(2026, 6, 22, 15, 0, 0);
+
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let event;
+  try {
+    event = parser.normalizeAiEvent(
+      { title: 'DRINK AND DRAW', rrule: 'FREQ=WEEKLY;BYDAY=TU' },
+      {}, null, null, null
+    );
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(event, 'survives normalization');
+  assert.equal(event.startDate.toISOString().slice(0, 10), '2026-07-28', 'derived date unchanged');
+  assert.ok(logs.includes('🔁 RECURRING: fallback derived 2026-07-28 for "DRINK AND DRAW" with no gate-dropped stated date available (report-only)'),
+    `no-drop counting line expected, got: ${JSON.stringify(logs.filter(l => l.includes('report-only')))}`);
+  assert.ok(!logs.some(l => l.includes('a rescue would keep')),
+    'the dropped-date line never fires without a dropped value — the two populations stay countable');
+});
+
+test('getDroppedStatedStartDateValue reads only start-date-shaped memo fields', () => {
+  const parser = createParser();
+  assert.equal(parser.getDroppedStatedStartDateValue({ __droppedFieldValues: { startdate: 'Aug 5 2026' } }), 'Aug 5 2026');
+  assert.equal(parser.getDroppedStatedStartDateValue({ __droppedFieldValues: { date: '8/5/2026' } }), '8/5/2026');
+  assert.equal(parser.getDroppedStatedStartDateValue({ __droppedFieldValues: { start: '2026-08-05 21:00' } }), '2026-08-05 21:00');
+  assert.equal(parser.getDroppedStatedStartDateValue({ __droppedFieldValues: { city: 'Dallas', starttime: '21:00' } }), '',
+    'city and time-only drops are not stated dates');
+  assert.equal(parser.getDroppedStatedStartDateValue({}), '', 'no memo → empty');
+});
+
+// ---------------------------------------------------------------------------
 // Dateless-weekly day-phrase synthesis (run 20260802-140413, The Lumberyard):
 // pages that state a weekday pattern but never a date — deterministic regex
 // turns the phrase into an rrule + next occurrence so the event reaches the
@@ -8271,6 +8347,100 @@ test('Sitges-shaped multi-event page splits into per-day segments with September
   if (intro) {
     assert.equal(parser.buildSegmentDateContextLine(intro, ctx), '', 'segments stating their own month are never anchored');
   }
+});
+
+// ---------------------------------------------------------------------------
+// Calendar-grid ancestor dates: on monthly-calendar layouts each card's DAY
+// lives on a structural ANCESTOR (the enclosing day cell's dated attribute),
+// so the card's own slice has a title and a time but no date and the date
+// gate used to discard the real card (thedallaseagle.com/events/: 23 of 42).
+// Generic inheritance: the nearest STILL-OPEN ancestor tag carrying a full
+// date in datetime/data-*/aria-label markup dates the segment via an
+// additive SEGMENT_ANCESTOR_DATE context line. No per-site rules.
+// ---------------------------------------------------------------------------
+
+function buildCalendarGridCellHtml(dateAttr, dayNumber, slug, title, detailsLine, descSentence) {
+  return `<dt class="calendar-day"${dateAttr ? ` data-date="${dateAttr}"` : ''}>
+      <div>${dayNumber}</div>
+      <a class="day-event-link" href="https://grid.example/events/${slug}/"><h4>${title}</h4></a>
+      <div class="details">${detailsLine}</div>
+      <div class="desc">${descSentence.repeat(4)}</div>
+    </dt>`;
+}
+
+const CALENDAR_GRID_HTML = `<html><body><dl class="calendar">
+  ${buildCalendarGridCellHtml('2026-08-05', 5, 'disco-night', 'Disco Night', 'August 5, 2026 - 9:00 pm', 'Dance floor classics with our resident DJ spinning all night long. ')}
+  ${buildCalendarGridCellHtml('2026-08-06', 6, 'karaoke-1', 'Karaoke', '7:00 pm - 10:00 pm', 'Hit the stage and sing your heart out with all of your friends. ')}
+  ${buildCalendarGridCellHtml('2026-08-07', 7, 'gear-night', 'Gear Night', 'August 7, 2026 - 10:00 pm', 'Grab your gear and join the whole crew for the biggest night. ')}
+  ${buildCalendarGridCellHtml('2026-08-08', 8, 'trivia-1', 'Trivia', '8:00 pm - 10:00 pm', 'Solos and squads compete for prizes each week with our host. ')}
+</dl></body></html>`;
+
+test('calendar-grid ancestor dates: dateless cards inherit the enclosing cell date as a segment hint; own dates are never overridden', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://grid.example/events/';
+  const segments = parser.buildMultiEventSegments(CALENDAR_GRID_HTML, sourceUrl);
+  assert.equal(segments.length, 4,
+    `all four cards get windows (two dated, two rescued via ancestor cells), got ${segments.length}: ${JSON.stringify(segments.map(s => s.lines[0]))}`);
+
+  const karaoke = segments.find(s => s.lines[0] === 'Karaoke');
+  assert.ok(karaoke, 'the dateless Karaoke card gains a window');
+  assert.deepEqual(karaoke.ancestorDateContext,
+    { dateText: 'August 6, 2026', attrName: 'data-date', attrValue: '2026-08-06' },
+    'the hint carries the enclosing cell\'s OWN date and its verbatim attribute markup');
+  const trivia = segments.find(s => s.lines[0] === 'Trivia');
+  assert.ok(trivia, 'the second dateless card gains a window too');
+  assert.equal(trivia.ancestorDateContext.dateText, 'August 8, 2026',
+    'each card inherits from ITS OWN cell — never a neighbouring one');
+
+  const disco = segments.find(s => s.lines[0] === 'Disco Night');
+  assert.ok(disco, 'dated cards keep their windows');
+  assert.equal(disco.ancestorDateContext, undefined,
+    'a segment that states its own date is never overridden by an ancestor date');
+
+  // The hint rides into the segment prompt/evidence corpus as an ADDITIVE
+  // context line quoting the ancestor's actual attribute text, so a stated
+  // startDate of 2026-08-06 is corroborable by the evidence gate.
+  const htmlData = parser.buildMultiEventSegmentHtmlData({ html: CALENDAR_GRID_HTML, url: sourceUrl }, karaoke, 1, segments.length, []);
+  assert.ok(htmlData.html.includes('SEGMENT_ANCESTOR_DATE: August 6, 2026 (this segment\'s card sits inside an enclosing dated container: data-date="2026-08-06")'),
+    `ancestor date line rides into the segment prompt html, got context: ${htmlData.html.split('\n').slice(0, 4).join(' | ')}`);
+  const evidence = parser.buildAiEvidenceContextFromText(htmlData.html);
+  assert.equal(parser.hasDateEvidence(evidence, '2026-08-06'), true, 'the inherited date is gate-verifiable evidence');
+  assert.equal(parser.hasDateEvidence(evidence, '2026-08-13'), false, 'a different day still fails the gate');
+
+  const discoHtmlData = parser.buildMultiEventSegmentHtmlData({ html: CALENDAR_GRID_HTML, url: sourceUrl }, disco, 0, segments.length, []);
+  assert.ok(!discoHtmlData.html.includes('SEGMENT_ANCESTOR_DATE'),
+    'segments without a hint keep byte-identical prompt content');
+});
+
+test('calendar-grid ancestor dates: a sibling card\'s own dated markup is never inherited sideways', () => {
+  const parser = createParser();
+  // The dated cards carry their date INSIDE the card (a closed <time> tag);
+  // the cells themselves are undated. The dateless card therefore has no
+  // dated ANCESTOR — only closed sibling markup — and must stay dropped.
+  const html = `<html><body><dl class="calendar">
+    ${buildCalendarGridCellHtml('', 5, 'disco-night', 'Disco Night', '<time datetime="2026-08-05">August 5, 2026 - 9:00 pm</time>', 'Dance floor classics with our resident DJ spinning all night long. ')}
+    ${buildCalendarGridCellHtml('', 6, 'karaoke-1', 'Karaoke', '7:00 pm - 10:00 pm', 'Hit the stage and sing your heart out with all of your friends. ')}
+    ${buildCalendarGridCellHtml('', 7, 'gear-night', 'Gear Night', '<time datetime="2026-08-07">August 7, 2026 - 10:00 pm</time>', 'Grab your gear and join the whole crew for the biggest night. ')}
+  </dl></body></html>`;
+  const segments = parser.buildMultiEventSegments(html, 'https://grid.example/events/');
+  assert.equal(segments.length, 2,
+    `only the self-dated cards get windows, got ${segments.length}: ${JSON.stringify(segments.map(s => s.lines[0]))}`);
+  assert.ok(!segments.some(s => s.lines[0] === 'Karaoke'),
+    'the dateless card is NOT rescued by a sibling\'s closed <time> markup');
+  assert.ok(segments.every(s => s.ancestorDateContext === undefined),
+    'no segment carries a fabricated ancestor hint');
+});
+
+test('resolveFullDatePartsFromText: only complete, plausible dates resolve', () => {
+  const parser = createParser();
+  assert.deepEqual(parser.resolveFullDatePartsFromText('2026-08-06'), { year: 2026, month: 8, day: 6 }, 'ISO');
+  assert.deepEqual(parser.resolveFullDatePartsFromText('20260806'), { year: 2026, month: 8, day: 6 }, 'compact calendar-cell form');
+  assert.deepEqual(parser.resolveFullDatePartsFromText('Friday, August 7, 2026'), { year: 2026, month: 8, day: 7 }, 'aria-label month-name form');
+  assert.deepEqual(parser.resolveFullDatePartsFromText('7 August 2026'), { year: 2026, month: 8, day: 7 }, 'day-first form');
+  assert.equal(parser.resolveFullDatePartsFromText('202608'), null, 'month-only compact never resolves');
+  assert.equal(parser.resolveFullDatePartsFromText('6'), null, 'bare day number never resolves');
+  assert.equal(parser.resolveFullDatePartsFromText('20269999'), null, 'implausible month/day rejected');
+  assert.equal(parser.resolveFullDatePartsFromText('id-1234567890'), null, 'long ids never resolve');
 });
 
 test('derivePageDateContext: year capture, ambiguity, and majority fallback', () => {


### PR DESCRIPTION
Two related date-integrity items, one PR. Only `scripts/parsers/ai-web-parser.js` (+ its test file) is touched. **No new runtime files.**

## Item 1 — rrule fallback fabricates dates: REPORT-ONLY rescue census

The fallback in `normalizeAiEvent` (`!startDate && title && recurrenceRule` → derive next occurrence from the rrule) invents a date the page never stated. Corpus analysis of 241 real device logs: **46 fabricated dates, 35 of which fired immediately after the evidence gate dropped a REAL stated date** (usually a rendering-variant mismatch) — the page's own date was discarded and the fallback then invented a different day.

Per the "trust the pointer, not the copy" doctrine this is **log-only before enforce — explicitly ZERO behavior change**. When the fallback fires it now checks the `__droppedFieldValues` memo (the gate-dropped values already retained on the event) for a stated start date and logs one of two ADDITIVE lines:

- `🔁 RECURRING: fallback derived <date> for "<title>" but the evidence gate dropped a stated date "<value>" (parses to <iso>) — a rescue would keep the page's own date (report-only)`
- `🔁 RECURRING: fallback derived <date> for "<title>" with no gate-dropped stated date available (report-only)`

Both populations are countable in future device logs; the derived date stays in use either way. This builds the evidence base for a later enforce step.

## Item 2 — calendar-grid dates living on an ancestor element (Dallas Eagle)

**Re-measured on origin/main @be8bfd77 (post-#1644)** against the exact cached device page (`www.thedallaseagle.com/events/`, fetched 2026-08-06, 42 distinct event cards):

- #1644's link-anchor grouping already fixed the *fragmentation* half: the winning `resource-link:a:event` group cleanly bounds all 42 cards (the old run's "16 fused windows" is gone), and 19 cards that state their own `Start from: <date>` text pass.
- **The ancestor-date gap remains: 23 of 42 cards still fail ONLY the date gate** — their day lives on the enclosing calendar cell (`<dt data-mec-cell="20260806" data-day="6" ...>`), outside the card's own slice, which has just a title + time-of-day.

Fix (generic, nothing per venue/city/domain/plugin): when a structural-group entry clears every gate EXCEPT the date gate, resolve the nearest **still-open ancestor tag** (regex-only, bounded backward window) whose `datetime` / `data-*` / `aria-label` attribute carries a **full** calendar date (ISO, 8-digit compact, or English month-name form). The date attaches to the segment as a hint and rides into the segment prompt as an ADDITIVE context line quoting the ancestor's verbatim markup:

`SEGMENT_ANCESTOR_DATE: August 6, 2026 (this segment's card sits inside an enclosing dated container: data-mec-cell="20260806")`

so extraction can state the date WITH evidence the gate verifies (confirmed: `hasDateEvidence('2026-08-06')` passes against the hint line; a wrong day still fails). Safety properties, each tested:

- **Winner selection unchanged**: the winning group is chosen on the pre-existing gates; inheritance only re-runs the winning group (letting it vote would crown the 170-entry fragment container group on this very page).
- **Nearest ancestor first, bounded scan** (same oversized-container window segmentation uses), still-open check = stop at anything that closed before the entry.
- **Never overrides a date the segment already has** (lookup only runs for dateless entries).
- **No sideways inheritance**: a sibling card's own dated markup (e.g. a closed `<time>`) can never qualify — its tags close before the next entry starts.
- Identical recurring cards under different day cells (5× Karaoke etc.) get the inherited date salted into the dedupe key so each occurrence keeps its window.

### Replay numbers (deterministic; segmentation/gates only, no network, no AI)

| page | before (main @be8bfd77) | after |
|---|---|---|
| www.thedallaseagle.com/events/ | 19 windows / 42 cards (23 dropped, all date-gate-only) | **42 windows** (19 own-date + 23 ancestor-hinted) |
| eaglela.com/events/ | 12 windows | 12 windows (byte-identical, 0 hints) |
| all 37 other cached device pages (per-event pages, both hosts) | — | **byte-identical** (full DETAIL diff: the only changed section is the Dallas listing) |

## Cache note

Prompt content grew ONLY via the new additive `SEGMENT_ANCESTOR_DATE` line on affected segments — those segments' AI response cache entries will re-miss once (expected/acceptable). No existing prompt line or console.log text was reworded (verified: zero removed log/prompt lines in the diff). All other pages' prompts are byte-identical, so their caches keep hitting.

## Verification

- `node --check` clean on both touched files.
- Quiet suite (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`): **branch 1604 pass / 0 fail** vs measured clean origin/main baseline **1598 pass / 0 fail** (+6 new tests).
- New tests verified against clean origin/main: **5 of 6 FAIL on main / all 6 PASS on branch**. The sixth (`sibling card's own dated markup is never inherited sideways`) is a declared behavior-guard — on main the dateless card is dropped outright, so the no-sideways invariant holds trivially there.
  - (a) fallback + dropped stated date → report-only line, derived date unchanged ✅ (fails on main)
  - (b) fallback with no dropped date → counting line ✅ (fails on main)
  - (c) calendar-grid fixture: dateless cards gain the ancestor hint, hint line reaches prompt html, gate corroborates the date ✅ (fails on main)
  - (d) a segment with its own date is never overridden ✅ (same test as c; fails on main via c's assertions)
  - (e) no cross-card inheritance from a sibling's markup ✅ (declared guard)
  - plus a memo-reader unit test and a date-resolver unit test (both fail on main).
- No `new URL(`/`URLSearchParams` under `scripts/`; `shared-core.js`/`normalizers.js` untouched.
- Tests inserted adjacent to the existing rrule-fallback and Sitges segmentation blocks (hunks at lines 7931 and 8349 of 12800 — not at EOF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP