### PR TITLE
feat(scraper): calendar-hub ranking, MEC month-feed discovery, report-only cadence evidence

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1611,6 +1611,79 @@ class ScriptableAdapter {
     }
   }
 
+  // Form-encoded POST (application/x-www-form-urlencoded) — the shape
+  // WordPress admin-ajax endpoints expect; postJson sends a JSON body, which
+  // admin-ajax ignores. Same resilience choke point as its siblings
+  // (fetchData / postJson / fetchImageAsBase64): the round trip runs under
+  // withNetworkResilience and nothing else grows a retry.
+  //
+  // options.cacheUrl (optional) keys the response into the page cache under a
+  // stable synthetic URL: POST responses can never ride fetchData's GET-only
+  // cache, so callers that replay a page's own AJAX call (calendar month
+  // feeds) pass the synthetic URL they want the response remembered as —
+  // same storage, same TTL as every cached page.
+  async postForm(url, body, options = {}) {
+    const pageCacheConfig = this.getPageCacheConfig();
+    const cacheUrl =
+      typeof options.cacheUrl === "string" && options.cacheUrl
+        ? options.cacheUrl
+        : null;
+    const canUseCache = pageCacheConfig.enabled && cacheUrl !== null;
+    if (canUseCache) {
+      const cachedPage = await this.readCachedPage(cacheUrl, pageCacheConfig);
+      if (cachedPage) {
+        this.logPageCacheHit(cacheUrl, cachedPage, pageCacheConfig);
+        return {
+          ok: true,
+          status: cachedPage.statusCode || 200,
+          text: cachedPage.html,
+        };
+      }
+    }
+    const response = await this.withNetworkResilience("form POST", url, () =>
+      this.postFormOnce(url, body, options),
+    );
+    if (
+      canUseCache &&
+      response &&
+      response.ok &&
+      typeof response.text === "string" &&
+      response.text.length > 0
+    ) {
+      await this.writeCachedPage(
+        cacheUrl,
+        { html: response.text, url: cacheUrl, statusCode: response.status, headers: {} },
+        pageCacheConfig,
+      );
+    }
+    return response;
+  }
+
+  async postFormOnce(url, body, options = {}) {
+    try {
+      const request = new Request(url);
+      request.method = "POST";
+      request.headers = {
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "User-Agent": this.config.userAgent,
+        ...options.headers,
+      };
+      request.body = String(body == null ? "" : body);
+      if (options.timeoutSeconds) {
+        request.timeoutInterval = options.timeoutSeconds;
+      }
+      const responseText = await request.loadString();
+      const statusCode = request.response ? request.response.statusCode : 200;
+      return {
+        ok: statusCode >= 200 && statusCode < 300,
+        status: statusCode,
+        text: responseText,
+      };
+    } catch (error) {
+      throw new Error(`Form POST request failed: ${error.message}`);
+    }
+  }
+
   async saveFailureNote(url, error, metadata = {}) {
     if (metadata && metadata.retryable === true) {
       return false;

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -7087,6 +7087,104 @@ test('fetchImageAsBase64 still retries a real connectivity failure on the minute
     'backoff starts in seconds, not milliseconds — an inter-station gap lasts minutes');
 });
 
+// postForm (form-encoded POST for admin-ajax month feeds) is a sibling of
+// fetchData/postJson and must sit behind the SAME resilience choke point.
+test('postForm retries a real connectivity failure on the same minutes-long ladder as its siblings', async () => {
+  const adapter = buildAdapter();
+  let attempts = 0;
+  const slept = [];
+  adapter.sleepForNetworkRetry = async (ms) => { slept.push(ms); };
+  global.Request = class {
+    constructor() { this.response = null; }
+    async loadString() {
+      attempts += 1;
+      throw new Error('The network connection was lost.');
+    }
+  };
+  try {
+    await assert.rejects(
+      adapter.postForm('https://venue.example/wp-admin/admin-ajax.php', 'action=mec_monthly_view_load_month&mec_year=2026&mec_month=09')
+    );
+  } finally {
+    delete global.Request;
+  }
+  assert.ok(attempts > 1, 'a month feed on a train ride deserves the same patience as a page fetch');
+  assert.ok(slept.length > 0 && slept[0] >= 5000,
+    'same ladder as fetchData/postJson — nothing else in the codebase grows a retry');
+});
+
+test('postForm sends a form-encoded body and caches the response under the synthetic cacheUrl — the second run never touches the network', async () => {
+  const adapter = new ScriptableAdapter({ cities: {}, pageCache: { enabled: true, ttlDays: 3 } });
+  const store = new Map();
+  adapter.readCachedPage = async (url, config) => {
+    assert.equal(config.ttlDays, 3, 'month feeds ride the global page-cache TTL, not a private one');
+    return store.get(url) || null;
+  };
+  adapter.writeCachedPage = async (url, responseData, config) => {
+    store.set(url, { html: responseData.html, url, statusCode: responseData.statusCode, headers: {} });
+  };
+  let attempts = 0;
+  let seenHeaders = null;
+  let seenBody = null;
+  global.Request = class {
+    constructor(url) { this.url = url; this.response = null; }
+    async loadString() {
+      attempts += 1;
+      seenHeaders = this.headers;
+      seenBody = this.body;
+      this.response = { statusCode: 200 };
+      return '{"month":"<a href=\\"https://venue.example/events/x/?occurrence=2026-09-05\\">X</a>"}';
+    }
+  };
+  const cacheUrl = 'https://venue.example/wp-admin/admin-ajax.php?mec_month_feed=2026-09';
+  try {
+    const first = await adapter.postForm(
+      'https://venue.example/wp-admin/admin-ajax.php',
+      'action=mec_monthly_view_load_month&mec_year=2026&mec_month=09&navigator_click=true&atts%5Bid%5D=1224',
+      { headers: { 'X-Requested-With': 'XMLHttpRequest' }, cacheUrl }
+    );
+    assert.equal(first.ok, true);
+    assert.match(seenHeaders['Content-Type'], /application\/x-www-form-urlencoded/,
+      'admin-ajax reads form fields, not JSON');
+    assert.equal(seenHeaders['X-Requested-With'], 'XMLHttpRequest');
+    assert.equal(seenBody, 'action=mec_monthly_view_load_month&mec_year=2026&mec_month=09&navigator_click=true&atts%5Bid%5D=1224',
+      'the body is sent exactly as handed over — nothing re-encodes the atts blob');
+
+    const second = await adapter.postForm(
+      'https://venue.example/wp-admin/admin-ajax.php',
+      'action=mec_monthly_view_load_month&mec_year=2026&mec_month=09&navigator_click=true&atts%5Bid%5D=1224',
+      { headers: { 'X-Requested-With': 'XMLHttpRequest' }, cacheUrl }
+    );
+    assert.equal(second.text, first.text, 'the cached grid is byte-identical');
+  } finally {
+    delete global.Request;
+  }
+  assert.equal(attempts, 1, 'the second run must be a page-cache hit, not a network call');
+});
+
+test('postForm without a cacheUrl neither reads nor writes the page cache', async () => {
+  const adapter = new ScriptableAdapter({ cities: {}, pageCache: { enabled: true, ttlDays: 3 } });
+  let cacheReads = 0;
+  let cacheWrites = 0;
+  adapter.readCachedPage = async () => { cacheReads += 1; return null; };
+  adapter.writeCachedPage = async () => { cacheWrites += 1; };
+  global.Request = class {
+    constructor() { this.response = null; }
+    async loadString() {
+      this.response = { statusCode: 200 };
+      return 'ok';
+    }
+  };
+  try {
+    const response = await adapter.postForm('https://venue.example/wp-admin/admin-ajax.php', 'action=x');
+    assert.equal(response.ok, true);
+  } finally {
+    delete global.Request;
+  }
+  assert.equal(cacheReads, 0, 'an uncached POST must not consult the page cache');
+  assert.equal(cacheWrites, 0, 'an uncached POST must not write the page cache');
+});
+
 test('a network-truncated run gets an unmissable banner and never claims to be complete', () => {
   const adapter = buildAdapter();
   const html = adapter.buildNetworkTruncationBannerHtml({

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -460,6 +460,56 @@ class WebAdapter {
         }
     }
 
+    // Node-side mirror of ScriptableAdapter.postForm: form-encoded POST (the
+    // shape WordPress admin-ajax endpoints expect) with the same optional
+    // cacheUrl contract — a stable synthetic URL the response is remembered
+    // as in the page cache (POSTs can never ride fetchData's GET-only cache).
+    async postForm(url, body, options = {}) {
+        const pageCacheConfig = this.getPageCacheConfig();
+        const cacheUrl = typeof options.cacheUrl === 'string' && options.cacheUrl ? options.cacheUrl : null;
+        const canUseCache = pageCacheConfig.enabled && cacheUrl !== null;
+        if (canUseCache) {
+            const cachedPage = await this.readCachedPage(cacheUrl, pageCacheConfig);
+            if (cachedPage) {
+                this.logPageCacheHit(cacheUrl, cachedPage, pageCacheConfig);
+                return {
+                    ok: true,
+                    status: cachedPage.statusCode || 200,
+                    text: cachedPage.html
+                };
+            }
+        }
+        const timeout = options.timeoutSeconds ? options.timeoutSeconds * 1000 : this.config.timeout;
+        let result;
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+                    'User-Agent': this.config.userAgent,
+                    ...options.headers
+                },
+                body: String(body == null ? '' : body),
+                signal: AbortSignal.timeout(timeout)
+            });
+            result = {
+                ok: response.ok,
+                status: response.status,
+                text: await response.text()
+            };
+        } catch (error) {
+            throw new Error(`Form POST request failed: ${error.message}`);
+        }
+        if (canUseCache && result.ok && typeof result.text === 'string' && result.text.length > 0) {
+            await this.writeCachedPage(
+                cacheUrl,
+                { html: result.text, url: cacheUrl, statusCode: result.status, headers: {} },
+                pageCacheConfig
+            );
+        }
+        return result;
+    }
+
 async saveFailureNote(url, error, metadata = {}) {
         if (metadata && metadata.retryable === true) {
             return false;

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -783,7 +783,18 @@ class AiWebParser {
                 ? { ...htmlData, html: this.linearizeJsonForPrompt(jsonApiPayload) }
                 : htmlData;
             const html = effectiveHtmlData && effectiveHtmlData.html ? effectiveHtmlData.html : '';
-            const additionalLinks = this.extractAdditionalUrls(html, sourceUrl, parserConfig);
+            // Calendar month feeds: a MEC month-grid page gets its NEXT
+            // month(s) fetched by replaying the page's own AJAX call, and the
+            // returned grids join URL discovery as additional sources (links
+            // only — the grid HTML never segments). Non-MEC pages, adapters
+            // without postForm and lookahead 0 all no-op here.
+            const monthFeedSources = await this.collectMecMonthFeeds(effectiveHtmlData, parserConfig, httpAdapter);
+            const additionalLinks = this.extractAdditionalUrls(html, sourceUrl, parserConfig, monthFeedSources);
+            if (monthFeedSources.length > 0) {
+                // Report-only cadence evidence from the page grid + month
+                // feeds (never sets recurrence on anything).
+                this.reportOccurrenceCadence([html, ...monthFeedSources.map(feed => feed.html)], sourceUrl);
+            }
 
             // Derive the page's organizer/site brand ONCE per page (from JSON-LD
             // Organization/WebSite and og:site_name). Extraction prompts, the
@@ -4361,7 +4372,12 @@ class AiWebParser {
         return !/^[^a-z0-9]+$/i.test(line);
     }
 
-    extractAdditionalUrls(html, sourceUrl, parserConfig) {
+    // `monthFeedSources` (optional): calendar month grids fetched via the
+    // page's own AJAX month feed (see collectMecMonthFeeds) — each entry is
+    // { label: 'YYYY-MM', html } and contributes candidates to the SAME map,
+    // before ranking, so month-feed links compete under the one budget instead
+    // of being bolted on past the cut.
+    extractAdditionalUrls(html, sourceUrl, parserConfig, monthFeedSources = null) {
         const urls = new Map();
         const discoveryStats = {
             hrefCandidates: 0,
@@ -4436,6 +4452,14 @@ class AiWebParser {
             }
         } catch (error) {
             console.warn(`🤖 AI Web: Error extracting additional URLs: ${error}`);
+        }
+
+        // Calendar month feeds fetched from the page's own AJAX endpoint: their
+        // grids are URL-discovery sources ONLY (the grid HTML itself does not
+        // segment), and only for event pages the page's own links don't already
+        // reach — see addMonthFeedUrlCandidates for the collapse rule.
+        if (Array.isArray(monthFeedSources) && monthFeedSources.length > 0) {
+            this.addMonthFeedUrlCandidates(urls, monthFeedSources, sourceUrl, parserConfig, discoveryStats);
         }
 
         // A page's own rel="canonical" / og:url is a pointer AT THE DOCUMENT WE
@@ -4538,9 +4562,11 @@ class AiWebParser {
      * host+path identity of a URL, ignoring query, fragment, trailing slash,
      * `www.` and default ports. Two URLs with the same key address the same
      * resource path — they are NOT necessarily the same rendered document, so
-     * this is only ever used to recognise a SELF-reference, never to dedupe
-     * crawl targets (parameterized variants of one path are real, distinct
-     * pages and must all still be crawled).
+     * this is only used (a) to recognise a SELF-reference and (b) to pick
+     * which month-feed grid links are NET-NEW event pages
+     * (addMonthFeedUrlCandidates) — never to dedupe the page's own crawl
+     * targets (parameterized variants of one path are real, distinct pages
+     * and must all still be crawled).
      * Pure string work: iOS JavaScriptCore has no URL global.
      */
     getUrlPathIdentityKey(url) {
@@ -4552,6 +4578,249 @@ class AiWebParser {
         if (!host) return '';
         const path = String(match[2] || '').replace(/\/+$/, '').toLowerCase();
         return `${host}${path}`;
+    }
+
+    // ------------------------------------------------------------------
+    // Calendar month feeds (Modern Events Calendar / "MEC" WordPress
+    // plugin). A MEC month-grid page drives its own "next month" button
+    // with an admin-ajax POST; replaying the page's OWN call (its ajax URL,
+    // its verbatim atts blob) returns the next month's grid as JSON without
+    // a browser — verified live against eaglela.com 2026-08-07. Plugin-
+    // protocol markers only, like the ticketing-platform integrations: no
+    // domain, venue or city is named here.
+    // ------------------------------------------------------------------
+
+    /**
+     * Detect a MEC month-grid page and harvest everything the month-feed
+     * replay needs FROM THE PAGE ITSELF: the plugin's ajax endpoint, the
+     * URL-encoded `atts%5B...%5D` shortcode-attributes blob (taken verbatim —
+     * never constructed), and the grid's active month. Returns
+     * { ajaxUrl, attsQuery, year, month } or null when any piece is missing
+     * (fail open: no feed, page behaves exactly as before).
+     * Pure string/regex work — no URL global (iOS JavaScriptCore).
+     */
+    detectMecMonthlyView(html) {
+        const text = String(html || '');
+        if (!/data-mec-cell=|mec-load-month/.test(text)) return null;
+        const ajaxMatch = text.match(/["']ajax_url["']\s*:\s*["'](https?:[^"']*admin-ajax\.php[^"']*)["']/i);
+        const ajaxUrl = ajaxMatch ? ajaxMatch[1].replace(/\\\//g, '/') : '';
+        if (!ajaxUrl) return null;
+        const attsMatch = text.match(/atts:\s*["']((?:atts%5B|atts\[)[^"']+)["']/);
+        const attsQuery = attsMatch ? attsMatch[1] : '';
+        if (!attsQuery) return null;
+        let year = NaN;
+        let month = NaN;
+        const activeMatch = text.match(/active_month:\s*\{\s*year:\s*["'](\d{4})["']\s*,\s*month:\s*["'](\d{1,2})["']/);
+        if (activeMatch) {
+            year = parseInt(activeMatch[1], 10);
+            month = parseInt(activeMatch[2], 10);
+        } else {
+            const currentMatch = text.match(/["']current_year["']\s*:\s*["'](\d{4})["']\s*,\s*["']current_month["']\s*:\s*["'](\d{1,2})["']/);
+            if (currentMatch) {
+                year = parseInt(currentMatch[1], 10);
+                month = parseInt(currentMatch[2], 10);
+            }
+        }
+        if (!Number.isFinite(year) || !Number.isFinite(month) || month < 1 || month > 12) return null;
+        return { ajaxUrl, attsQuery, year, month };
+    }
+
+    // How many FUTURE months of a detected calendar month grid to fetch.
+    // Default 1 (current + next): phone wall-clock is the budget that
+    // matters, and one month ahead is what turns "the event appeared when
+    // the venue's grid rolled over" into "we saw it a month early". Clamped
+    // 0..3; per-parser `calendarLookaheadMonths` wins over the global knob.
+    resolveCalendarLookaheadMonths(parserConfig) {
+        const configured = parserConfig && parserConfig.calendarLookaheadMonths !== undefined
+            ? parserConfig.calendarLookaheadMonths
+            : (this.config ? this.config.calendarLookaheadMonths : undefined);
+        const value = Number(configured);
+        if (!Number.isFinite(value)) return 1;
+        return Math.max(0, Math.min(3, Math.floor(value)));
+    }
+
+    /**
+     * Replay the page's own MEC month-feed AJAX call for the next month(s).
+     * Returns [{ label: 'YYYY-MM', html: '<grid html>' }, ...] — [] whenever
+     * the page is not a MEC month grid, the adapter cannot form-POST, or the
+     * lookahead is 0. A failed month POST degrades exactly like any failed
+     * crawled page: log and continue — never abort the run.
+     *
+     * All HTTP goes through the injected httpAdapter (postForm), so the
+     * NetworkResilience wrapper and the page cache apply. Each month is
+     * cached under a stable synthetic URL (ajax URL + mec_month_feed=YYYY-MM
+     * query suffix — query, not fragment: the cache normalizer strips
+     * fragments) so repeat runs inside the TTL replay the same grid without
+     * touching the network.
+     */
+    async collectMecMonthFeeds(htmlData, parserConfig, httpAdapter) {
+        const html = htmlData && htmlData.html ? htmlData.html : '';
+        const sourceUrl = htmlData && htmlData.url ? htmlData.url : '';
+        if (!html || !sourceUrl || !httpAdapter || typeof httpAdapter.postForm !== 'function') return [];
+        const mec = this.detectMecMonthlyView(html);
+        if (!mec) return [];
+        // Never POST cross-host: the ajax endpoint must live on the page's own
+        // registrable domain (it always does for a real WordPress install —
+        // anything else is an injected or mangled URL).
+        const pageDomain = this.getRegistrableDomainFromUrl(sourceUrl);
+        if (!pageDomain || this.getRegistrableDomainFromUrl(mec.ajaxUrl) !== pageDomain) {
+            console.log(`🤖 AI Web: MEC month feed skipped for ${sourceUrl} — ajax endpoint ${mec.ajaxUrl} is not on the page's own site`);
+            return [];
+        }
+        const lookahead = this.resolveCalendarLookaheadMonths(parserConfig);
+        if (lookahead <= 0) return [];
+        const activeLabel = `${mec.year}-${String(mec.month).padStart(2, '0')}`;
+        console.log(`🤖 AI Web: MEC month grid detected on ${sourceUrl} (active month ${activeLabel}) — fetching ${lookahead} future month(s) via ${mec.ajaxUrl}`);
+        const feeds = [];
+        let year = mec.year;
+        let month = mec.month;
+        for (let step = 0; step < lookahead; step++) {
+            month += 1;
+            if (month > 12) {
+                month = 1;
+                year += 1;
+            }
+            const monthNumber = String(month).padStart(2, '0');
+            const monthLabel = `${year}-${monthNumber}`;
+            // The page's own protocol, replayed: fixed action/navigator fields
+            // plus the atts blob EXACTLY as the page embedded it.
+            const body = `action=mec_monthly_view_load_month&mec_year=${year}&mec_month=${monthNumber}&navigator_click=true&${mec.attsQuery}`;
+            const cacheUrl = `${mec.ajaxUrl}${mec.ajaxUrl.includes('?') ? '&' : '?'}mec_month_feed=${monthLabel}`;
+            try {
+                const response = await httpAdapter.postForm(mec.ajaxUrl, body, {
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                    cacheUrl
+                });
+                if (!response || response.ok === false) {
+                    throw new Error(`HTTP ${response && response.status !== undefined ? response.status : 'error'} from month feed`);
+                }
+                const payload = JSON.parse(String(response.text || ''));
+                const monthHtml = typeof payload.month === 'string' ? payload.month : '';
+                const sideHtml = typeof payload.events_side === 'string' ? payload.events_side : '';
+                const gridHtml = `${monthHtml}\n${sideHtml}`;
+                if (!gridHtml.trim()) throw new Error('month feed response carried no grid HTML');
+                feeds.push({ label: monthLabel, html: gridHtml });
+                console.log(`🤖 AI Web: MEC month feed ${monthLabel} loaded (${gridHtml.length} chars of grid HTML)`);
+            } catch (error) {
+                // Same degradation as any failed crawled page: this month's
+                // grid is a bonus discovery source, not a required subsystem.
+                console.log(`🤖 AI Web: MEC month feed ${monthLabel} failed for ${sourceUrl}: ${error && error.message ? error.message : error} — continuing without it`);
+            }
+        }
+        return feeds;
+    }
+
+    /**
+     * Feed month-grid links into the shared candidate map. Collapse rule
+     * (what the crawl actually NEEDS from a future month): each distinct
+     * event page once — a grid lists one `?occurrence=` link per day it
+     * repeats on, and the page behind them is the same document, so only the
+     * FIRST (earliest) occurrence of a path the page's own links don't
+     * already reach is added. The page's own candidates are never collapsed
+     * (parameterized variants the page itself links are real, distinct
+     * cards — see getUrlPathIdentityKey).
+     */
+    addMonthFeedUrlCandidates(urls, monthFeedSources, sourceUrl, parserConfig, discoveryStats) {
+        const knownPageKeys = new Set();
+        for (const entry of urls.values()) {
+            const pathKey = this.getUrlPathIdentityKey(entry.url);
+            if (pathKey) knownPageKeys.add(pathKey);
+        }
+        for (const feed of monthFeedSources) {
+            if (!feed || !feed.html) continue;
+            let addedCount = 0;
+            for (const candidate of this.extractHrefCandidates(feed.html)) {
+                const url = this.stripTrackingParams(this.normalizeUrl(candidate.url, sourceUrl));
+                const validation = this.validateEventUrl(url, sourceUrl, parserConfig);
+                if (!validation.valid) {
+                    if (discoveryStats && typeof discoveryStats === 'object') {
+                        this.recordRejectedCandidate(discoveryStats, validation.reason, candidate.url, url);
+                    }
+                    continue;
+                }
+                const pathKey = this.getUrlPathIdentityKey(url);
+                if (pathKey && knownPageKeys.has(pathKey)) continue;
+                if (pathKey) knownPageKeys.add(pathKey);
+                const dedupeKey = this.getUrlDedupeKey(url);
+                if (urls.has(dedupeKey)) continue;
+                // Net-new event page seen a month early: a bump over the
+                // scoring rules sized to clear the band the current grid's
+                // occurrence repeats occupy — they score identically in shape
+                // AND can carry a +30 anchor-keyword bonus ("night", "party"),
+                // and rank ties break on insertion order, which the page's own
+                // links always win. Net-new information outranks one more
+                // repeat of a page the crawl can already reach.
+                const score = this.scoreAdditionalUrl(url, sourceUrl, candidate.context) + 40;
+                urls.set(dedupeKey, { url, score, index: urls.size });
+                addedCount++;
+            }
+            console.log(`🤖 AI Web: MEC month feed ${feed.label} contributed ${addedCount} net-new event page link(s) to URL discovery`);
+        }
+    }
+
+    /**
+     * Report-only occurrence-cadence evidence from calendar grids: when one
+     * event page shows up on 2+ dates across the page and its month feeds,
+     * log the observed dates and the cadence they imply. LOG ONLY — no event
+     * gains a recurrence field from this path (doctrine: report-only before
+     * enforce; the scraper never writes series).
+     */
+    reportOccurrenceCadence(htmlSources, sourceUrl = '') {
+        const datesByPage = new Map();
+        for (const source of Array.isArray(htmlSources) ? htmlSources : []) {
+            if (!source) continue;
+            for (const candidate of this.extractHrefCandidates(source)) {
+                const url = this.normalizeUrl(candidate.url, sourceUrl);
+                const occurrenceMatch = String(url || '').match(/[?&]occurrence=(\d{4}-\d{2}-\d{2})(?!\d)/);
+                if (!occurrenceMatch) continue;
+                const pathKey = this.getUrlPathIdentityKey(url);
+                if (!pathKey) continue;
+                if (!datesByPage.has(pathKey)) datesByPage.set(pathKey, new Set());
+                datesByPage.get(pathKey).add(occurrenceMatch[1]);
+            }
+        }
+        for (const [pathKey, dateSet] of datesByPage) {
+            if (dateSet.size < 2) continue;
+            const dates = Array.from(dateSet).sort();
+            const slug = pathKey.split('/').filter(Boolean).pop() || pathKey;
+            const cadence = this.describeOccurrenceCadence(dates);
+            console.log(`🔁 CADENCE: "${slug}" observed on ${dates.length} dates (${cadence.summary}) — ${cadence.verdict} (report-only)`);
+        }
+    }
+
+    /**
+     * Cadence math for sorted unique YYYY-MM-DD dates (2+): uniform 7-day
+     * gaps → weekly candidate; same ordinal weekday across 2+ months (e.g.
+     * every 2nd Saturday) → monthly candidate; anything else is reported
+     * as-is with no candidate verdict. Date.UTC on split digits only — no
+     * Date parsing of strings, no timezone involvement.
+     */
+    describeOccurrenceCadence(dates) {
+        const parts = dates.map(date => {
+            const [year, month, day] = date.split('-').map(piece => parseInt(piece, 10));
+            return { date, year, month, day, epochMs: Date.UTC(year, month - 1, day) };
+        });
+        const gapsDays = [];
+        for (let i = 1; i < parts.length; i++) {
+            gapsDays.push(Math.round((parts[i].epochMs - parts[i - 1].epochMs) / 86400000));
+        }
+        if (gapsDays.length > 0 && gapsDays.every(gap => gap === 7)) {
+            return { summary: `${parts[0].date} +7d ×${gapsDays.length}`, verdict: 'weekly candidate' };
+        }
+        const weekdayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+        const weekdays = parts.map(part => new Date(part.epochMs).getUTCDay());
+        const ordinals = parts.map(part => Math.floor((part.day - 1) / 7) + 1);
+        const monthKeys = new Set(parts.map(part => `${part.year}-${part.month}`));
+        if (monthKeys.size >= 2 && monthKeys.size === parts.length
+            && weekdays.every(weekday => weekday === weekdays[0])
+            && ordinals.every(ordinal => ordinal === ordinals[0])) {
+            const ordinalNames = ['1st', '2nd', '3rd', '4th', '5th'];
+            return {
+                summary: `${parts.length}× ${ordinalNames[ordinals[0] - 1]} ${weekdayNames[weekdays[0]]}`,
+                verdict: 'monthly candidate'
+            };
+        }
+        return { summary: dates.join(', '), verdict: 'no clear cadence' };
     }
 
     /**
@@ -7762,6 +8031,39 @@ class AiWebParser {
         if (/\/(?:about|contact|privacy|terms|login|signin|signup|search|tag|category|blog)(?:\/|$)/i.test(path)) score -= 35;
         // Eventbrite /l/ paths are marketing/landing pages, not event detail or listing pages
         if (/eventbrite\./i.test(parsedUrl.hostname) && /^\/l\//i.test(path)) score -= 100;
+        // Same-site events-calendar HUB links (a /calendar/ or /schedule/ path
+        // segment, or anchor text naming a calendar). A venue's /events/
+        // listing often links its month-grid view, which can carry more of the
+        // venue's programme than the listing itself (Eagle LA: 25 events on
+        // /calendar/ vs 12 on /events/) — but the hub URL names no event, so
+        // every event-like link outranks it (they score ~160 here, the bare
+        // hub nets -35 after the bare-listing demotion above) and the hub
+        // never survives the maxAdditionalUrls cut. The bonus is sized to
+        // clear the event-link band INCLUDING its +30 anchor-keyword case
+        // (85+40+25+10+30 = 190) without competing with rich ticketing links
+        // (~240). Guard rails: SAME registrable domain only (a
+        // cross-host calendar link gets nothing), and detail-shaped paths
+        // (/events/<slug>, /e/<id>) are excluded so ordinary event links whose
+        // anchor text mentions a calendar cannot ride it. Links the reject
+        // filters drop (.ics / ?ical=1 calendar exports, blocked hosts) never
+        // reach scoring at all, so this cannot resurrect them.
+        const isDetailShapedPath = /\/e\/[^/?#]+/i.test(path) || /\/events?\/[^/?#]+/i.test(path);
+        if (parsedSource && !isDetailShapedPath) {
+            const linkDomain = this.getRegistrableDomainFromUrl(url);
+            const sameRegistrableDomain = linkDomain && linkDomain === this.getRegistrableDomainFromUrl(sourceUrl);
+            // Hub-shaped = the path ENDS at the hub word (/calendar/,
+            // /events/schedule/). A hub word mid-path (/calendar/<junk>) is
+            // some sub-resource, not the hub. Slash-variant self-references
+            // (//calendar// on the /calendar/ page) are excluded by comparing
+            // slash-normalized path segments against the source page's own.
+            const linkSegments = path.split('/').filter(Boolean);
+            const hasCalendarHubSegment = linkSegments.length > 0
+                && /^(?:calendar|calendars|schedule|events?-calendar)$/.test(linkSegments[linkSegments.length - 1]);
+            const contextNamesCalendar = /\bcalendar\b/.test(contextText);
+            const sourceSegmentsKey = String(parsedSource.pathname || '').toLowerCase().split('/').filter(Boolean).join('/');
+            const isSourcePathVariant = linkSegments.join('/') === sourceSegmentsKey;
+            if (sameRegistrableDomain && !isSourcePathVariant && (hasCalendarHubSegment || contextNamesCalendar)) score += 240;
+        }
         return score;
     }
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -12280,6 +12280,268 @@ test('self-canonical suppression needs no URL global (iOS JavaScriptCore)', () =
 });
 
 // ---------------------------------------------------------------------------
+// Calendar-hub awareness in URL discovery + MEC month feeds.
+//
+// A venue's /events/ listing links its month-grid calendar view, but the hub
+// URL names no event, so every event-like link outranks it and it never
+// survived the ranking cut (Eagle LA: /calendar/ shows 25 events in Aug 2026,
+// /events/ shows 12 — and the hub link scored -35). The month-grid pages
+// (Modern Events Calendar plugin) additionally publish their "next month"
+// button as an admin-ajax POST the parser can replay — plugin-protocol
+// markers only, nothing here names a real venue outside fixture text.
+// ---------------------------------------------------------------------------
+
+function buildEventListingLinks(count) {
+  // Anchor text carries a scoring keyword ("party") so these links sit at the
+  // TOP of the event-link band (score 190) — the hub must clear even that.
+  return Array.from({ length: count }, (_, i) =>
+    `<a href="https://venue.example/events/night-${i + 1}/?occurrence=2026-08-${String((i % 28) + 1).padStart(2, '0')}">Party Night ${i + 1}</a>`
+  ).join('\n');
+}
+
+test('a same-site /calendar/ hub link survives a ranking cut that event links would otherwise fill', () => {
+  const parser = createParser();
+  const html = `
+    <html><body>
+      ${buildEventListingLinks(16)}
+      <a href="https://venue.example/calendar/">Events Calendar</a>
+    </body></html>
+  `;
+  const links = parser.extractAdditionalUrls(html, 'https://venue.example/events/', {});
+  const hubRank = links.indexOf('https://venue.example/calendar/');
+  assert.ok(hubRank !== -1,
+    `the calendar hub must survive the maxAdditionalUrls cut, got: ${JSON.stringify(links)}`);
+  // The crawl loop re-slices to its own default budget of 12 at the next
+  // depth (SharedCore.limitAdditionalUrls) — surviving the parser's cut but
+  // not that one would still lose the hub.
+  assert.ok(hubRank < 12, `the hub must sit inside the crawl budget of 12, got rank ${hubRank}`);
+});
+
+// GUARD (passes on origin/main too, by construction): the point is that the
+// hub bonus must NOT start resurrecting what the reject filters drop or
+// boosting links off the page's own site.
+test('a cross-host calendar link and an .ics export link get no hub boost', () => {
+  const parser = createParser();
+  const html = `
+    <html><body>
+      ${buildEventListingLinks(16)}
+      <a href="https://othersite.example/calendar/">Calendar</a>
+      <a href="https://venue.example/events/?ical=1">Subscribe (.ics)</a>
+      <a href="https://venue.example/feed/events.ics">Export calendar</a>
+    </body></html>
+  `;
+  const links = parser.extractAdditionalUrls(html, 'https://venue.example/events/', {});
+  assert.ok(!links.some(link => link.startsWith('https://othersite.example/')),
+    `a cross-host calendar link must never be boosted into the cut, got: ${JSON.stringify(links)}`);
+  assert.ok(!links.some(link => /ical=1|\.ics/.test(link)),
+    `the #1559 calendar-export reject must keep winning, got: ${JSON.stringify(links)}`);
+  // Belt and braces at the scoring level: cross-host means no bonus at all.
+  const crossHostScore = parser.scoreAdditionalUrl('https://othersite.example/calendar/', 'https://venue.example/events/', '<a>Calendar</a>');
+  assert.ok(crossHostScore < 0, `cross-host calendar hub must keep its bare-listing demotion, got ${crossHostScore}`);
+});
+
+// Trimmed from the real eaglela.com capture (2026-08-07): the atts blob is the
+// page's own URL-encoded shortcode-attributes querystring — the protocol
+// replays it VERBATIM, never constructs it.
+const MEC_FIXTURE_ATTS = 'atts%5B_edit_lock%5D=1626389781%3A1&atts%5Bsf_status%5D=1&atts%5Bshow_past_events%5D=1&atts%5Bid%5D=1224';
+
+const MEC_MONTH_GRID_PAGE_HTML = `
+  <html><head><title>Calendar - Venue</title></head><body>
+    <div class="mec-wrap">
+      <dt class="mec-calendar-day mec-has-event" data-mec-cell="20260802">
+        <a href="https://venue.example/events/beer-bust/?occurrence=2026-08-02">SUNDAY BEER BUST</a>
+      </dt>
+      <dt class="mec-calendar-day mec-has-event" data-mec-cell="20260805">
+        <a href="https://venue.example/events/hump-night/?occurrence=2026-08-05">HUMP NIGHT</a>
+      </dt>
+      <div class="mec-next-month mec-load-month" data-mec-year="2026" data-mec-month="09"><a href="#" class="mec-load-month-link">September</a></div>
+    </div>
+    <script id="mec-frontend-script-js-extra">
+    var mecdata = {"elementor_edit_mode":"no","ajax_url":"https://venue.example/wp-admin/admin-ajax.php","current_year":"2026","current_month":"08"};
+    </script>
+    <script>
+    jQuery("#mec_monthly_view_month_101_202608").mecMonthlyView(
+    {
+        id: "101",
+        today: "20260807",
+        month_id: "202608",
+        active_month: {year: "2026", month: "08"},
+        next_month: {year: "2026", month: "09"},
+        month_navigator: 1,
+        atts: "${MEC_FIXTURE_ATTS}",
+    });
+    </script>
+  </body></html>
+`;
+
+// Trimmed from the real September response: JSON whose "month" (grid) and
+// "events_side" HTML carry the /events/<slug>/?occurrence= links. hump-night
+// repeats from the page's own August grid; jockstrapped appears twice.
+const MEC_SEPTEMBER_RESPONSE_JSON = JSON.stringify({
+  month: `
+    <dt class="mec-calendar-day" data-mec-cell="20260902">
+      <a class="mec-monthly-tooltip" href="https://venue.example/events/hump-night/?occurrence=2026-09-02">HUMP NIGHT</a>
+    </dt>
+    <dt class="mec-calendar-day" data-mec-cell="20260911">
+      <a class="mec-monthly-tooltip" href="https://venue.example/events/jockstrapped/?occurrence=2026-09-11">JOCKSTRAPPED</a>
+    </dt>
+    <dt class="mec-calendar-day" data-mec-cell="20260925">
+      <a class="mec-monthly-tooltip" href="https://venue.example/events/jockstrapped/?occurrence=2026-09-25">JOCKSTRAPPED</a>
+    </dt>
+  `,
+  events_side: '<a href="https://venue.example/events/stynk/?occurrence=2026-09-05">STYNK</a>',
+  navigator: '<div class="mec-next-month mec-load-month" data-mec-year="2026" data-mec-month="10"></div>',
+  previous_month: { label: '2026 August', id: '202608', year: '2026', month: '08' },
+  current_month: { label: '2026 September', id: '202609', year: '2026', month: '09' },
+  next_month: { label: '2026 October', id: '202610', year: '2026', month: '10' }
+});
+
+test('a MEC month-grid page replays its own admin-ajax month feed and harvests next month\'s links', async () => {
+  const parser = createParser();
+  const postCalls = [];
+  const stubAdapter = {
+    postForm: async (url, body, options) => {
+      postCalls.push({ url, body, options });
+      return { ok: true, status: 200, text: MEC_SEPTEMBER_RESPONSE_JSON };
+    }
+  };
+  const result = await parser.parseEvents(
+    { url: 'https://venue.example/calendar/', html: MEC_MONTH_GRID_PAGE_HTML },
+    { discoveryOnly: true }, null, 'link-aggregator', stubAdapter);
+
+  assert.equal(postCalls.length, 1, 'default lookahead is exactly ONE future month');
+  assert.equal(postCalls[0].url, 'https://venue.example/wp-admin/admin-ajax.php');
+  assert.equal(postCalls[0].options.headers['X-Requested-With'], 'XMLHttpRequest');
+  assert.ok(postCalls[0].body.startsWith('action=mec_monthly_view_load_month&mec_year=2026&mec_month=09&navigator_click=true&'),
+    `the replay uses the plugin's own action/month fields, got: ${postCalls[0].body.slice(0, 120)}`);
+
+  const links = result.additionalLinks;
+  assert.ok(links.includes('https://venue.example/events/jockstrapped/?occurrence=2026-09-11'),
+    `net-new September pages must join discovery, got: ${JSON.stringify(links)}`);
+  assert.ok(links.includes('https://venue.example/events/stynk/?occurrence=2026-09-05'),
+    'events_side links are harvested too');
+  assert.ok(!links.includes('https://venue.example/events/jockstrapped/?occurrence=2026-09-25'),
+    'one distinct event page once: only the earliest occurrence of a net-new page is enqueued');
+  assert.ok(!links.includes('https://venue.example/events/hump-night/?occurrence=2026-09-02'),
+    'a page the listing already links (any occurrence) is already reachable — its September repeat adds no new page');
+  assert.ok(links.includes('https://venue.example/events/hump-night/?occurrence=2026-08-05'),
+    'the page\'s own links are never collapsed');
+
+  // Report-only doctrine: nothing on this path may set recurrence on anything.
+  assert.equal(result.events.length, 0, 'discoveryOnly returns no events');
+  assert.ok(!JSON.stringify(result).includes('"recurrence"'),
+    'no recurrence field may appear anywhere in the parse result from month feeds');
+});
+
+test('the month-feed POST body carries the page\'s atts blob verbatim and a stable synthetic cache URL', async () => {
+  const parser = createParser();
+  const postCalls = [];
+  const stubAdapter = {
+    postForm: async (url, body, options) => {
+      postCalls.push({ url, body, options });
+      return { ok: true, status: 200, text: MEC_SEPTEMBER_RESPONSE_JSON };
+    }
+  };
+  await parser.parseEvents(
+    { url: 'https://venue.example/calendar/', html: MEC_MONTH_GRID_PAGE_HTML },
+    { discoveryOnly: true }, null, 'link-aggregator', stubAdapter);
+  assert.equal(postCalls.length, 1);
+  assert.ok(postCalls[0].body.endsWith(`&${MEC_FIXTURE_ATTS}`),
+    `the atts blob is harvested from the page and replayed VERBATIM, got: ${postCalls[0].body}`);
+  assert.equal(postCalls[0].options.cacheUrl,
+    'https://venue.example/wp-admin/admin-ajax.php?mec_month_feed=2026-09',
+    'the synthetic cache key must be stable across runs so the page cache can answer the next one');
+});
+
+test('a failed month-feed POST degrades like any failed crawled page: logged, run continues', async () => {
+  const parser = createParser();
+  const stubAdapter = {
+    postForm: async () => { throw new Error('HTTP 500 error from https://venue.example/wp-admin/admin-ajax.php'); }
+  };
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  let result;
+  try {
+    result = await parser.parseEvents(
+      { url: 'https://venue.example/calendar/', html: MEC_MONTH_GRID_PAGE_HTML },
+      { discoveryOnly: true }, null, 'link-aggregator', stubAdapter);
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(logs.some(line => line.includes('MEC month feed 2026-09 failed') && line.includes('continuing without it')),
+    `the failure must be visible in the log, got: ${JSON.stringify(logs.filter(l => l.includes('MEC')))}`);
+  assert.ok(result.additionalLinks.includes('https://venue.example/events/hump-night/?occurrence=2026-08-05'),
+    'the page\'s own discovery must be untouched by the month-feed failure');
+});
+
+test('calendarLookaheadMonths is clamped 0..3 and 0 disables the feed', async () => {
+  const parser = createParser();
+  assert.equal(parser.resolveCalendarLookaheadMonths({}), 1, 'default: current + 1 month');
+  assert.equal(parser.resolveCalendarLookaheadMonths({ calendarLookaheadMonths: 9 }), 3);
+  assert.equal(parser.resolveCalendarLookaheadMonths({ calendarLookaheadMonths: -2 }), 0);
+  let posts = 0;
+  const stubAdapter = { postForm: async () => { posts++; return { ok: true, status: 200, text: MEC_SEPTEMBER_RESPONSE_JSON }; } };
+  await parser.parseEvents(
+    { url: 'https://venue.example/calendar/', html: MEC_MONTH_GRID_PAGE_HTML },
+    { discoveryOnly: true, calendarLookaheadMonths: 0 }, null, 'link-aggregator', stubAdapter);
+  assert.equal(posts, 0, 'lookahead 0 must never touch the network');
+});
+
+// GUARD (passes on origin/main too, by construction): the month feed must
+// never gain the ability to POST off the page's own site.
+test('the month feed never POSTs to an ajax endpoint off the page\'s own site', async () => {
+  const parser = createParser();
+  const crossHostPage = MEC_MONTH_GRID_PAGE_HTML.replace(
+    'https://venue.example/wp-admin/admin-ajax.php',
+    'https://evil.example/wp-admin/admin-ajax.php');
+  let posts = 0;
+  const stubAdapter = { postForm: async () => { posts++; return { ok: true, status: 200, text: MEC_SEPTEMBER_RESPONSE_JSON }; } };
+  await parser.parseEvents(
+    { url: 'https://venue.example/calendar/', html: crossHostPage },
+    { discoveryOnly: true }, null, 'link-aggregator', stubAdapter);
+  assert.equal(posts, 0, 'a cross-host ajax_url is an injected or mangled URL — never replay it');
+});
+
+test('cadence report: 7-day gaps log a weekly candidate, a single date logs nothing (report-only)', () => {
+  const parser = createParser();
+  const weeklyHtml = ['2026-09-01', '2026-09-08', '2026-09-15', '2026-09-22', '2026-09-29']
+    .map(date => `<a href="https://venue.example/events/hump-night/?occurrence=${date}">HUMP NIGHT</a>`)
+    .join('\n');
+  const singleHtml = '<a href="https://venue.example/events/one-off/?occurrence=2026-09-19">ONE OFF</a>';
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  try {
+    parser.reportOccurrenceCadence([weeklyHtml, singleHtml], 'https://venue.example/calendar/');
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(logs.includes('🔁 CADENCE: "hump-night" observed on 5 dates (2026-09-01 +7d ×4) — weekly candidate (report-only)'),
+    `expected the weekly-candidate line, got: ${JSON.stringify(logs)}`);
+  assert.ok(!logs.some(line => line.includes('"one-off"')),
+    'a single observed date is no cadence evidence — log nothing');
+});
+
+test('cadence report: same ordinal weekday across months logs a monthly candidate', () => {
+  const parser = createParser();
+  // 2nd Sunday of August and September 2026.
+  const html = ['2026-08-09', '2026-09-13']
+    .map(date => `<a href="https://venue.example/events/onyx/?occurrence=${date}">ONYX</a>`)
+    .join('\n');
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  try {
+    parser.reportOccurrenceCadence([html], 'https://venue.example/calendar/');
+  } finally {
+    console.log = originalLog;
+  }
+  assert.ok(logs.includes('🔁 CADENCE: "onyx" observed on 2 dates (2× 2nd Sunday) — monthly candidate (report-only)'),
+    `expected the monthly-candidate line, got: ${JSON.stringify(logs)}`);
+});
+
+// ---------------------------------------------------------------------------
 // Segmentation must not silently UNDER-COVER a listing.
 //
 // Run 20260806 over eaglela.com/events/: the page shows 12 cards, the winning

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -176,7 +176,11 @@ const scraperConfig = {
       // prefixer is a no-op on venue-role sites. The CubScout LA PROMOTER
       // entry in scraper-promoters.js is unchanged and still claims the
       // CUBSCOUT title alias.
-      urls: ["https://eaglela.com/events/"],
+      //
+      // /calendar/ is the MEC month grid — it lists MORE of the month than
+      // the /events/ archive (25 vs 12 in Aug 2026) and is where the
+      // month-feed lookahead fetches next month's grid from.
+      urls: ["https://eaglela.com/events/", "https://eaglela.com/calendar/"],
     },
     {
       name: "BEEFMINCE",


### PR DESCRIPTION
## What this does

Venue sites running the **Modern Events Calendar** WordPress plugin (Eagle LA, Dallas Eagle) publish a monthly grid whose "next month" button is an admin-ajax POST. Replaying that POST works without a browser (verified live 2026-08-07). Three generic features — plugin-protocol markers only; "eaglela" appears solely in `scraper-input.js` config and test fixtures:

### 1. Calendar-hub awareness in URL discovery (`scoreAdditionalUrl`)
A SAME-SITE link whose path ends in a `calendar`/`schedule` segment (or whose anchor text names a calendar) gets a ranking bonus (+240) sized to survive both the parser's top-15 cut and the crawl loop's 12-link depth budget — previously the hub scored **-35** and always lost to `/events/<slug>?occurrence=` links (160–190). Guards: same registrable domain only (cross-host calendar links get nothing), detail-shaped paths excluded, slash-variant self-references excluded, and the #1559 calendar-export reject (`.ics` / `?ical=1` / `tribe-bar-date`) still answers before scoring ever runs.

### 2. MEC month-feed discovery
When a fetched page carries the month-grid markers (`data-mec-cell=` / `mec-load-month`) plus a discoverable same-site `admin-ajax.php` URL and the page's embedded `atts%5B…%5D` blob, the parser replays the page's own AJAX call for the next month(s):
- `POST <site>/wp-admin/admin-ajax.php` with `X-Requested-With: XMLHttpRequest`, body `action=mec_monthly_view_load_month&mec_year=YYYY&mec_month=MM&navigator_click=true&` + the page's atts blob **verbatim** (harvested, never constructed).
- The JSON response's `month` + `events_side` grids feed URL discovery ONLY (the grid HTML never segments — verified 0 windows), collapsed to **one link per net-new event page** (earliest occurrence; pages the listing already links are skipped — existing `getUrlPathIdentityKey` machinery).
- Lookahead: `calendarLookaheadMonths`, clamped 0..3, **default 1**.
- Transport: new `postForm` on the Scriptable adapter (form-encoded — `postJson` sends JSON, which admin-ajax ignores), wrapped in `withNetworkResilience` like its siblings, mirrored on the Node-side `WebAdapter`. Month responses ride the page cache (3-day TTL) under a stable synthetic URL `…admin-ajax.php?mec_month_feed=YYYY-MM` (query suffix, not fragment — the cache normalizer strips fragments).
- Failure semantics: a failed month POST logs `MEC month feed YYYY-MM failed … — continuing without it` and the run continues, exactly like any failed crawled page.

### 3. Report-only occurrence-cadence evidence
When one event page slug shows 2+ occurrence dates across the grid + month feeds:
`🔁 CADENCE: "hump-night" observed on 9 dates (2026-08-05 +7d ×8) — weekly candidate (report-only)`
Uniform 7-day gaps → weekly candidate; same ordinal weekday across months → monthly candidate; otherwise the dates are listed with "no clear cadence". **LOG ONLY** — no event gains a recurrence field from this path (report-only before enforce; the scraper never writes series).

### 4. Config
Eagle LA gains `https://eaglela.com/calendar/` alongside `/events/`.
⚠️ **Note:** you have uncommitted local edits to `scripts/scraper-input.js` in your primary checkout — reconcile on pull.

## Live proof (real eaglela.com data)
- `/calendar/` current month: **25 events** vs **12** on `/events/`.
- September month feed (captured response): **20 distinct event pages, 40 occurrence links — 9 net-new a month early**; end-to-end replay against the captured page + response harvests exactly those 9 into the final top-15 (all 9 inside the crawl budget of 12).
- Fresh live October POST (one request, 2026-08-07): `https://eaglela.com/wp-admin/admin-ajax.php` → HTTP 200, 170,146 bytes, 40 October occurrence links across 20 distinct event pages — the protocol generalizes beyond the captured month.

## Expected crawl-volume delta (Eagle LA, default budgets)
≈ **+13 page fetches + 1 admin-ajax POST per run** (POST cached 3 days): +1 `/calendar/` page, +12 grid-discovered detail pages at the calendar's crawl depth (9 of them September event pages reachable nowhere on `/events/` today), −1 August occurrence link displaced at the `/events/` depth-1 cut by the hub link.

## Verification
- `node --check` clean on all 6 touched files.
- Quiet suite: **1622/1622 pass, 0 fail** (measured clean origin/main baseline: 1610/1610).
- 12 new tests (9 in `ai-web-parser.test.js`, 3 in `scriptable-adapter.test.js`): **10 fail on clean origin/main / pass on branch**; 2 are declared behavior-guards that pass on main by construction (cross-host/.ics no-boost; never-POST-off-site).
- AI-cache invalidation: **N/A** — no prompt strings touched (additive log lines only; all existing log text unchanged).
- **No new runtime files** — new methods live in existing files (`ai-web-parser.js`, `scriptable-adapter.js`, `web-adapter.js`).
- No `URL`/`URLSearchParams` in any new code path (string/regex only); `shared-core.js`/`normalizers.js` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP