### PR TITLE
feat(scraper): enforce derived occurrence cadence — stamp rrules + fold renumbered-slug series into one withheld ICS export

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4759,11 +4759,15 @@ class AiWebParser {
     }
 
     /**
-     * Report-only occurrence-cadence evidence from calendar grids: when one
-     * event page shows up on 2+ dates across the page and its month feeds,
-     * log the observed dates and the cadence they imply. LOG ONLY — no event
-     * gains a recurrence field from this path (doctrine: report-only before
-     * enforce; the scraper never writes series).
+     * Occurrence-cadence evidence from calendar grids: when one event page
+     * shows up on 2+ dates across the page and its month feeds, log the
+     * observed dates and the cadence they imply. The per-page-identity dates
+     * ALSO accumulate into a per-run stash (occurrenceCadenceObservations,
+     * union across every page of the crawl — same lifecycle as
+     * venueSiteHarvest) which applyDerivedCadenceStamps consumes after the
+     * whole crawl. Logging here stays report-shaped; enforcement happens only
+     * in the post-crawl stamp pass, and stamped series still flow through the
+     * existing withhold+ICS machinery (the scraper never writes series).
      */
     reportOccurrenceCadence(htmlSources, sourceUrl = '') {
         const datesByPage = new Map();
@@ -4778,6 +4782,17 @@ class AiWebParser {
                 if (!datesByPage.has(pathKey)) datesByPage.set(pathKey, new Set());
                 datesByPage.get(pathKey).add(occurrenceMatch[1]);
             }
+        }
+        // Accumulate EVERY observation (even single dates — another page of
+        // the crawl may add more) into the per-run stash for the post-crawl
+        // stamp pass.
+        if (!this.occurrenceCadenceObservations) this.occurrenceCadenceObservations = new Map();
+        for (const [pathKey, dateSet] of datesByPage) {
+            if (!this.occurrenceCadenceObservations.has(pathKey)) {
+                this.occurrenceCadenceObservations.set(pathKey, new Set());
+            }
+            const accumulated = this.occurrenceCadenceObservations.get(pathKey);
+            for (const date of dateSet) accumulated.add(date);
         }
         for (const [pathKey, dateSet] of datesByPage) {
             if (dateSet.size < 2) continue;
@@ -4821,6 +4836,192 @@ class AiWebParser {
             };
         }
         return { summary: dates.join(', '), verdict: 'no clear cadence' };
+    }
+
+    /**
+     * Conservative cadence → RRULE derivation from sorted unique YYYY-MM-DD
+     * dates. Only two shapes ever derive a rule; everything else returns null
+     * and stays report-only:
+     *   - WEEKLY: every observed date falls on the SAME weekday AND the
+     *     sorted dates contain a run of >= 3 consecutive 7-day gaps (four
+     *     back-to-back weeks). Skipped weeks elsewhere are tolerated — a
+     *     holiday gap does not un-weekly a residency — but a biweekly
+     *     pattern (all 14-day gaps) can never produce the required run.
+     *   - MONTHLY: >= 2 observations, every date in a DIFFERENT month, all
+     *     on the same ordinal weekday (all "1st Thursday" etc.).
+     * Same digit-only date math as describeOccurrenceCadence — no Date
+     * string parsing, no timezone involvement.
+     */
+    deriveCadenceRrule(dates) {
+        if (!Array.isArray(dates) || dates.length < 2) return null;
+        const parts = [];
+        for (const date of dates) {
+            const match = String(date || '').match(/^(\d{4})-(\d{2})-(\d{2})$/);
+            if (!match) return null;
+            const year = parseInt(match[1], 10);
+            const month = parseInt(match[2], 10);
+            const day = parseInt(match[3], 10);
+            parts.push({ year, month, day, epochMs: Date.UTC(year, month - 1, day) });
+        }
+        parts.sort((a, b) => a.epochMs - b.epochMs);
+        const BYDAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+        const weekdays = parts.map(part => new Date(part.epochMs).getUTCDay());
+        if (!weekdays.every(weekday => weekday === weekdays[0])) return null;
+        let consecutiveWeeklyGaps = 0;
+        let bestWeeklyRun = 0;
+        for (let i = 1; i < parts.length; i++) {
+            const gapDays = Math.round((parts[i].epochMs - parts[i - 1].epochMs) / 86400000);
+            if (gapDays === 7) {
+                consecutiveWeeklyGaps++;
+                if (consecutiveWeeklyGaps > bestWeeklyRun) bestWeeklyRun = consecutiveWeeklyGaps;
+            } else {
+                consecutiveWeeklyGaps = 0;
+            }
+        }
+        if (bestWeeklyRun >= 3) {
+            return { rrule: `FREQ=WEEKLY;BYDAY=${BYDAY_CODES[weekdays[0]]}` };
+        }
+        const ordinals = parts.map(part => Math.floor((part.day - 1) / 7) + 1);
+        const monthKeys = new Set(parts.map(part => `${part.year}-${part.month}`));
+        if (monthKeys.size >= 2 && monthKeys.size === parts.length
+            && ordinals.every(ordinal => ordinal === ordinals[0])
+            && ordinals[0] >= 1 && ordinals[0] <= 5) {
+            return { rrule: `FREQ=MONTHLY;BYDAY=${ordinals[0]}${BYDAY_CODES[weekdays[0]]}` };
+        }
+        return null;
+    }
+
+    /**
+     * Post-crawl derived-cadence enforcement (called by shared-core's
+     * processParser once every page of the run has been crawled, BEFORE
+     * dedup — the same seam as applyVenueSiteAddressConsensus, and for the
+     * same reason: cadence can only be judged with the whole run's records
+     * and observations in view).
+     *
+     * Two observation sources feed one decision per record group:
+     *   1. ?occurrence= link observations stashed by reportOccurrenceCadence
+     *      (per event-page identity, union across listing + month feeds);
+     *   2. the run's own extracted records grouped by the dedup's existing
+     *      title/venue identity (areIdentityNamesSimilar + positive
+     *      getCrossSourceVenueIdentity + no distinct-place veto — the exact
+     *      helpers the dedup passes already trust, nothing looser). This is
+     *      what catches MEC installs that renumber slugs per occurrence
+     *      (karaoke-19, karaoke-20 …), where URL-keyed observation never
+     *      accumulates.
+     *
+     * A qualifying group (deriveCadenceRrule) gets recurrenceRule stamped on
+     * every member that lacks one, so the EXISTING series machinery folds the
+     * occurrence-singles into one withheld series export (ICS button — the
+     * scraper never writes series to the calendar). Members also get a
+     * per-run _cadenceGroup marker: the series collapse in deduplicateEvents
+     * only folds records on DIFFERENT base pages when both carry the same
+     * marker (renumbered-slug case), so nothing outside this pass ever
+     * loosens the #1647 same-page identity.
+     *
+     * Stated beats derived (curated data beats derived, fail closed): a
+     * record that already carries a recurrence rule is NEVER overridden. If
+     * any stated rule in the group disagrees with the derived one, the whole
+     * group is left untouched and one conflict line is logged; agreement
+     * makes the stamp a no-op for that record. Records without a parseable
+     * start date never join a group (getEventNightKey fails closed), so the
+     * rrule-fallback date-fabrication path in normalizeAiEvent — which only
+     * runs for records WITHOUT a startDate, and runs before this pass — can
+     * never newly fire because of a stamp.
+     */
+    applyDerivedCadenceStamps(events) {
+        const observations = this.occurrenceCadenceObservations || null;
+        this.occurrenceCadenceObservations = null;
+        const eventList = Array.isArray(events) ? events : [];
+        if (eventList.length === 0) return;
+        const core = this.core;
+        if (!core
+            || typeof core.getEventNightKey !== 'function'
+            || typeof core.buildIdentityComparisonShape !== 'function'
+            || typeof core.areIdentityNamesSimilar !== 'function'
+            || typeof core.getCrossSourceVenueIdentity !== 'function'
+            || typeof core.areEventsDistinctByPlace !== 'function') {
+            return; // fail closed: without the dedup's own identity helpers, stamp nothing
+        }
+
+        const groups = [];
+        for (const event of eventList) {
+            if (!event || typeof event !== 'object') continue;
+            if (typeof event.title !== 'string' || !event.title.trim()) continue;
+            const nightKey = core.getEventNightKey(event);
+            if (!nightKey) continue; // fail closed: undated records observe nothing
+            const shape = core.buildIdentityComparisonShape(event);
+            const group = groups.find(candidate => candidate.members.some(member =>
+                core.areIdentityNamesSimilar(member.shape, shape)
+                && core.getCrossSourceVenueIdentity(member.event, event) !== null
+                && !core.areEventsDistinctByPlace(member.event, event)));
+            if (group) {
+                group.members.push({ event, shape, nightKey });
+            } else {
+                groups.push({ members: [{ event, shape, nightKey }] });
+            }
+        }
+
+        let groupIndex = 0;
+        for (const group of groups) {
+            const dates = new Set(group.members.map(member => member.nightKey));
+            // Fold in the ?occurrence= observations whose page identity
+            // matches one of this group's records (the record IS the page's
+            // event — its identity ties the link observations to the group).
+            const memberPathKeys = new Set();
+            for (const member of group.members) {
+                for (const value of [member.event.url, member.event.website]) {
+                    const pathKey = this.getUrlPathIdentityKey(value);
+                    if (pathKey) memberPathKeys.add(pathKey);
+                }
+            }
+            if (observations) {
+                for (const [pathKey, dateSet] of observations) {
+                    if (!memberPathKeys.has(pathKey)) continue;
+                    for (const date of dateSet) dates.add(date);
+                }
+            }
+            const sortedDates = Array.from(dates).sort();
+            const derived = this.deriveCadenceRrule(sortedDates);
+            if (!derived) continue; // existing report-only line already covered it
+
+            const title = group.members[0].event.title;
+            const statedRules = new Set();
+            for (const member of group.members) {
+                const stated = String(member.event.recurrenceRule || member.event.recurrence || '').trim().toUpperCase();
+                if (stated) statedRules.add(stated);
+            }
+            const disagreeing = Array.from(statedRules).filter(rule => rule !== derived.rrule);
+            if (disagreeing.length > 0) {
+                console.log(`🔁 CADENCE: derived ${derived.rrule} for "${title}" disagrees with stated rule(s) ${disagreeing.join(', ')} — stated cadence kept, nothing stamped (curated data beats derived)`);
+                continue;
+            }
+            const unstamped = group.members.filter(member =>
+                !String(member.event.recurrenceRule || member.event.recurrence || '').trim());
+            // The same-series marker goes on EVERY member of a derived group,
+            // including groups whose members all already state the (agreeing)
+            // rule: a renumbered-slug install mints a new page per occurrence
+            // (run 20260807-143442: 5 "Underwear Happy Hour" records, each
+            // stating FREQ=WEEKLY;BYDAY=WE on its own slug), and without the
+            // marker the series collapse can never fold them. The marker
+            // asserts nothing beyond what this pass just proved — the rules
+            // stay exactly as stated.
+            groupIndex++;
+            const groupMarker = `cadence-${groupIndex}:${derived.rrule}`;
+            for (const member of group.members) {
+                member.event._cadenceGroup = groupMarker;
+            }
+            const basis = this.describeOccurrenceCadence(sortedDates);
+            if (unstamped.length === 0) {
+                if (group.members.length > 1) {
+                    console.log(`🔁 CADENCE: derived ${derived.rrule} agrees with the stated rule on ${group.members.length} "${title}" record(s) — same-series marker only, nothing stamped (report basis: ${basis.summary})`);
+                }
+                continue;
+            }
+            for (const member of unstamped) {
+                member.event.recurrenceRule = derived.rrule;
+            }
+            console.log(`🔁 CADENCE: stamped ${derived.rrule} on ${unstamped.length} "${title}" record(s) — derived from ${sortedDates.length} observed dates (report basis: ${basis.summary})`);
+        }
     }
 
     /**

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -13200,3 +13200,217 @@ test('a lone "-WxH" thumbnail keeps its own identity and still gets OCR coverage
   assert.deepEqual(ocrCalls, [thumbnail], 'genuine coverage is not reduced');
   assert.equal(ocrResults.length, 1);
 });
+
+// ===========================================================================
+// Derived-cadence enforcement (occurrence links + same-title record groups →
+// conservative recurrenceRule stamps; stated rules always win). Venue names
+// below are fixtures only.
+// ===========================================================================
+
+function buildCadenceStampRecord(overrides = {}) {
+  return {
+    title: 'KARAOKE',
+    bar: 'Fixture Eagle',
+    startDate: new Date('2026-08-05T20:00:00.000Z'), // Wednesday
+    endDate: new Date('2026-08-05T23:00:00.000Z'),
+    url: 'https://fixture-eagle.example/events/karaoke-19/',
+    source: 'ai-web',
+    ...overrides
+  };
+}
+
+function withCapturedLogs(run) {
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logs.push(args.join(' ')); };
+  try {
+    run();
+  } finally {
+    console.log = originalLog;
+  }
+  return logs;
+}
+
+test('deriveCadenceRrule: weekly needs same weekday + a run of 3 consecutive 7-day gaps, tolerating skipped weeks', () => {
+  const parser = createParser();
+  // lucki-break shape (run 20260807-142024): Mondays with Labor-Day Sep 7
+  // skipped — four consecutive 7-day gaps in August still prove weekly.
+  const skippedWeek = ['2026-08-03', '2026-08-10', '2026-08-17', '2026-08-24', '2026-08-31', '2026-09-14', '2026-09-21', '2026-09-28'];
+  assert.deepEqual(parser.deriveCadenceRrule(skippedWeek), { rrule: 'FREQ=WEEKLY;BYDAY=MO' });
+  // Exactly at the threshold: 4 dates = 3 consecutive gaps.
+  assert.deepEqual(parser.deriveCadenceRrule(['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26']),
+    { rrule: 'FREQ=WEEKLY;BYDAY=WE' });
+  // Below the threshold: 3 dates = only 2 consecutive gaps.
+  assert.equal(parser.deriveCadenceRrule(['2026-08-05', '2026-08-12', '2026-08-19']), null);
+  // Biweekly-looking (same weekday, all 14-day gaps) never derives.
+  assert.equal(parser.deriveCadenceRrule(['2026-08-05', '2026-08-19', '2026-09-02', '2026-09-16']), null);
+  // Mixed weekdays never derive.
+  assert.equal(parser.deriveCadenceRrule(['2026-08-05', '2026-08-13', '2026-08-21', '2026-08-29']), null);
+  // Monthly: >=2 observations, all different months, same ordinal weekday.
+  assert.deepEqual(parser.deriveCadenceRrule(['2026-08-07', '2026-09-04']), { rrule: 'FREQ=MONTHLY;BYDAY=1FR' });
+  // Same ordinal but a repeated month fails closed.
+  assert.equal(parser.deriveCadenceRrule(['2026-08-08', '2026-08-22', '2026-09-12']), null);
+  // Single observation derives nothing.
+  assert.equal(parser.deriveCadenceRrule(['2026-08-05']), null);
+});
+
+test('applyDerivedCadenceStamps: weekly stamp from ?occurrence= link observations', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://fixture-eagle.example/calendar/';
+  const html = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26']
+    .map(date => `<a href="https://fixture-eagle.example/events/hump-night/?occurrence=${date}">HUMP NIGHT</a>`)
+    .join('\n');
+  parser.reportOccurrenceCadence([html], sourceUrl);
+  const record = buildCadenceStampRecord({
+    title: 'HUMP NIGHT',
+    url: 'https://fixture-eagle.example/events/hump-night/?occurrence=2026-08-05'
+  });
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps([record]));
+  assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'link observations alone carry the weekly proof');
+  assert.ok(typeof record._cadenceGroup === 'string' && record._cadenceGroup, 'group marker stamped');
+  assert.ok(logs.some(line => line.includes('🔁 CADENCE: stamped FREQ=WEEKLY;BYDAY=WE on 1 "HUMP NIGHT" record(s)')),
+    `enforce line expected, got: ${JSON.stringify(logs)}`);
+});
+
+test('applyDerivedCadenceStamps: weekly stamp from same-title records on renumbered slugs (no occurrence links)', () => {
+  const parser = createParser();
+  // MEC renumbering (run 20260807-143442): one weekly night, a NEW slug per
+  // occurrence — URL-keyed observation can never accumulate these.
+  const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      endDate: new Date(`${date}T23:00:00.000Z`),
+      url: `https://fixture-eagle.example/events/karaoke-${19 + index}/`
+    }));
+  parser.applyDerivedCadenceStamps(records);
+  for (const record of records) {
+    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE');
+  }
+  const markers = new Set(records.map(record => record._cadenceGroup));
+  assert.equal(markers.size, 1, 'all four records share ONE same-series marker');
+  assert.ok([...markers][0], 'the shared marker is non-empty');
+});
+
+test('applyDerivedCadenceStamps: monthly stamp from two same-ordinal observations in different months', () => {
+  const parser = createParser();
+  const records = [
+    buildCadenceStampRecord({
+      title: 'CUB SCOUT',
+      startDate: new Date('2026-08-07T21:00:00.000Z'), // 1st Friday
+      endDate: new Date('2026-08-07T23:00:00.000Z'),
+      url: 'https://fixture-eagle.example/events/cub-scout-3/'
+    }),
+    buildCadenceStampRecord({
+      title: 'CUB SCOUT',
+      startDate: new Date('2026-09-04T21:00:00.000Z'), // 1st Friday
+      endDate: new Date('2026-09-04T23:00:00.000Z'),
+      url: 'https://fixture-eagle.example/events/cub-scout-4/'
+    })
+  ];
+  parser.applyDerivedCadenceStamps(records);
+  assert.equal(records[0].recurrenceRule, 'FREQ=MONTHLY;BYDAY=1FR');
+  assert.equal(records[1].recurrenceRule, 'FREQ=MONTHLY;BYDAY=1FR');
+});
+
+test('applyDerivedCadenceStamps: mixed weekdays stamp nothing', () => {
+  const parser = createParser();
+  const records = [
+    buildCadenceStampRecord({ startDate: new Date('2026-08-05T20:00:00.000Z') }), // Wednesday
+    buildCadenceStampRecord({ startDate: new Date('2026-08-13T20:00:00.000Z'), url: 'https://fixture-eagle.example/events/karaoke-20/' }), // Thursday
+    buildCadenceStampRecord({ startDate: new Date('2026-08-21T20:00:00.000Z'), url: 'https://fixture-eagle.example/events/karaoke-21/' }), // Friday
+    buildCadenceStampRecord({ startDate: new Date('2026-08-29T20:00:00.000Z'), url: 'https://fixture-eagle.example/events/karaoke-22/' }) // Saturday
+  ];
+  parser.applyDerivedCadenceStamps(records);
+  for (const record of records) {
+    assert.equal(record.recurrenceRule, undefined, 'no clear cadence → no stamp');
+    assert.equal(record._cadenceGroup, undefined, 'no derivation → no marker');
+  }
+});
+
+test('applyDerivedCadenceStamps: stated rule beats derived — conflict logs, nothing stamped, stated kept', () => {
+  const parser = createParser();
+  // The model extracted an explicit stated cadence on one record; the derived
+  // weekday disagrees. Curated/stated data beats derived — fail closed for
+  // the WHOLE group.
+  const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      endDate: new Date(`${date}T23:00:00.000Z`),
+      url: `https://fixture-eagle.example/events/karaoke-${19 + index}/`
+    }));
+  records[0].recurrenceRule = 'FREQ=WEEKLY;BYDAY=FR';
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  assert.equal(records[0].recurrenceRule, 'FREQ=WEEKLY;BYDAY=FR', 'the stated rule is NEVER overridden');
+  for (const record of records.slice(1)) {
+    assert.equal(record.recurrenceRule, undefined, 'siblings of a conflicting stated rule stay unstamped');
+    assert.equal(record._cadenceGroup, undefined, 'no marker on a conflicted group');
+  }
+  assert.ok(logs.some(line => line.includes('disagrees with stated rule(s) FREQ=WEEKLY;BYDAY=FR') && line.includes('stated cadence kept')),
+    `conflict line expected, got: ${JSON.stringify(logs)}`);
+});
+
+test('applyDerivedCadenceStamps: derived agreeing with stated is a no-op stamp but still marks the same-series group', () => {
+  const parser = createParser();
+  // Run 20260807-143442: all five "Underwear Happy Hour" records already
+  // state FREQ=WEEKLY;BYDAY=WE, each on its own renumbered slug. The rules
+  // stay untouched; the marker is what lets the series collapse fold them.
+  const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      endDate: new Date(`${date}T23:00:00.000Z`),
+      url: `https://fixture-eagle.example/events/underwear-${11 + index}/`,
+      title: 'UNDERWEAR HAPPY HOUR',
+      recurrenceRule: 'FREQ=WEEKLY;BYDAY=WE'
+    }));
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  const markers = new Set(records.map(record => record._cadenceGroup));
+  assert.equal(markers.size, 1, 'one shared marker across the stated-rule group');
+  assert.ok([...markers][0]);
+  for (const record of records) {
+    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'stated rules untouched');
+  }
+  assert.ok(logs.some(line => line.includes('same-series marker only, nothing stamped')),
+    `marker-only line expected, got: ${JSON.stringify(logs)}`);
+});
+
+test('applyDerivedCadenceStamps: different venues never share a group, and undated records are never stamped', () => {
+  const parser = createParser();
+  // Same title + same weekday cadence at TWO different venues: positive
+  // venue identity fails → two separate groups → each below the weekly
+  // threshold on its own → nothing stamped anywhere.
+  const atFixtureEagle = ['2026-08-05', '2026-08-12'].map((date, index) =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      url: `https://fixture-eagle.example/events/karaoke-${19 + index}/`
+    }));
+  const atOtherBar = ['2026-08-19', '2026-08-26'].map((date, index) =>
+    buildCadenceStampRecord({
+      bar: 'Fixture Tavern',
+      address: '999 Other St, Dallas, TX 75201',
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      url: `https://fixture-tavern.example/events/karaoke-${3 + index}/`
+    }));
+  parser.applyDerivedCadenceStamps([...atFixtureEagle, ...atOtherBar]);
+  for (const record of [...atFixtureEagle, ...atOtherBar]) {
+    assert.equal(record.recurrenceRule, undefined, 'cross-venue dates never combine into one cadence');
+  }
+
+  // The rrule-fallback guard: the date-fabrication path in normalizeAiEvent
+  // only serves records WITHOUT a startDate, and such records never join a
+  // group here (getEventNightKey fails closed) — so a stamp can never hand
+  // the fallback a new rrule to fabricate a date from.
+  const undated = buildCadenceStampRecord({ startDate: null, endDate: null });
+  const dated = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      url: `https://fixture-eagle.example/events/karaoke-${19 + index}/`
+    }));
+  const before = dated.map(record => record.startDate.getTime());
+  parser.applyDerivedCadenceStamps([undated, ...dated]);
+  assert.equal(undated.recurrenceRule, undefined, 'an undated record is never stamped');
+  assert.equal(undated.startDate, null, 'an undated record gains no fabricated date');
+  assert.deepEqual(dated.map(record => record.startDate.getTime()), before, 'stamping never mutates startDate');
+  for (const record of dated) {
+    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'the dated group still stamps normally');
+  }
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -4053,6 +4053,17 @@ class SharedCore {
         if (aiWebParser && typeof aiWebParser.applyVenueSiteIdentityCorrections === 'function') {
             aiWebParser.applyVenueSiteIdentityCorrections(allEvents, mainConfig?.cities || null);
         }
+        // Derived-cadence enforcement (deterministic, parser-derived): with
+        // every page of the run seen, the ai-web parser's occurrence-link
+        // observations plus the run's own same-title record groups derive a
+        // conservative recurrenceRule (weekly/monthly only; stated rules are
+        // never overridden). Judged only here — before dedup — so the
+        // EXISTING series machinery folds the stamped occurrence-singles
+        // into one withheld series export (ICS only; never a calendar
+        // write). Platform-pure: the parser hook receives injected data.
+        if (aiWebParser && typeof aiWebParser.applyDerivedCadenceStamps === 'function') {
+            aiWebParser.applyDerivedCadenceStamps(allEvents);
+        }
 
         // Aggregator website pointer (trust the pointer, not the copy —
         // battery run 20260728: all 42 The Bear Calendar events carried
@@ -8196,7 +8207,24 @@ class SharedCore {
                 const existingSeries = this.getSeriesExportIdentity(existing);
                 if (!existingSeries) return false;
                 if (existingSeries.rrule !== eventSeries.rrule) return false;
-                if (existingSeries.hostPath !== eventSeries.hostPath) return false;
+                if (existingSeries.hostPath !== eventSeries.hostPath) {
+                    // Renumbered-slug extension (run 20260807-143442: a MEC
+                    // install mints a NEW slug per occurrence — karaoke-19,
+                    // karaoke-20 — so one weekly series shows N different
+                    // base pages and the same-page identity above can never
+                    // fold it). Equally fail-closed as the original: records
+                    // on different base pages collapse ONLY when BOTH carry
+                    // the SAME per-run _cadenceGroup marker, stamped by the
+                    // parser's derived-cadence pass exclusively on groups it
+                    // proved title-similar + positively same-venue with a
+                    // jointly-derived rule. Same title + same rrule WITHOUT
+                    // that shared marker (two real weekly slots of one brand,
+                    // stated rules, different venues) still never folds —
+                    // lookalike pairs are not always twins.
+                    const eventGroup = typeof event._cadenceGroup === 'string' ? event._cadenceGroup : '';
+                    const existingGroup = typeof existing._cadenceGroup === 'string' ? existing._cadenceGroup : '';
+                    if (!eventGroup || eventGroup !== existingGroup) return false;
+                }
                 const shapeA = this.buildIdentityComparisonShape(event);
                 const shapeB = this.buildIdentityComparisonShape(existing);
                 if (!this.areIdentityNamesSimilar(shapeA, shapeB)) return false;

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4068,6 +4068,95 @@ test('deduplicateEvents series collapse preserves manuallyMarkedBear from the dr
   assert.equal(result[0].startDate.getTime(), thisWeek.getTime(), 'the earliest occurrence is still the one kept');
 });
 
+// === Run 20260807-143442: renumbered-slug series collapse (cadence marker) ===
+// The Dallas Eagle's MEC install mints a NEW slug per occurrence (karaoke-19,
+// karaoke-20 …), so one weekly series shows N different base pages and the
+// same-page identity above can never fold it. The derived-cadence pass in the
+// ai-web parser stamps a per-run _cadenceGroup marker on groups it proved
+// title-similar + positively same-venue with a jointly derived rule; ONLY a
+// shared marker lets records on different base pages collapse. Venue names
+// below are fixtures.
+
+function buildRenumberedSlugSeriesExport(startDate, slugNumber, overrides = {}) {
+  return {
+    title: 'KARAOKE',
+    bar: 'Fixture Eagle',
+    startDate,
+    endDate: new Date(startDate.getTime() + 3 * 60 * 60 * 1000),
+    url: `https://fixture-eagle.example/events/karaoke-${slugNumber}/`,
+    recurrenceRule: 'FREQ=WEEKLY;BYDAY=TH',
+    _cadenceGroup: 'cadence-1:FREQ=WEEKLY;BYDAY=TH',
+    timezone: 'America/Chicago',
+    source: 'ai-web',
+    ...overrides
+  };
+}
+
+test('deduplicateEvents collapses a cadence-marked group across renumbered slug pages to one withheld series export', async () => {
+  const core = createCore();
+  const first = new Date(Date.now() + 7 * SERIES_DAY_MS);
+  const records = [0, 1, 2].map(week =>
+    buildRenumberedSlugSeriesExport(new Date(first.getTime() + week * 7 * SERIES_DAY_MS), 19 + week));
+
+  const result = await core.deduplicateEvents(records, null);
+  assert.equal(result.length, 1, 'three occurrence-singles of one marked series fold to one record');
+  const kept = result[0];
+  assert.equal(kept.startDate.getTime(), first.getTime(), 'the earliest (next upcoming) occurrence is kept');
+  assert.equal(kept.recurrenceRule, 'FREQ=WEEKLY;BYDAY=TH');
+  assert.equal(kept.url, records[0].url, 'the kept occurrence keeps its own slug page');
+
+  // Recurring-events doctrine: the survivor flows into the EXISTING
+  // withhold+ICS path — display + export only, never a calendar write.
+  const adapter = buildPrepCalendarAdapter([]);
+  const analyzed = await core.prepareEventsForCalendar([{ ...kept, city: 'dallas' }], adapter, {});
+  assert.equal(analyzed.length, 1);
+  assert.equal(analyzed[0]._recurringExport, true, 'stamped display+export only');
+  assert.deepEqual(SharedCore.filterEventsForExecution(analyzed), [],
+    'a cadence-derived series never reaches a calendar write');
+});
+
+test('deduplicateEvents never folds different base pages without a shared cadence marker, nor different venues with one', async () => {
+  const core = createCore();
+  const thisWeek = new Date(Date.now() + 7 * SERIES_DAY_MS);
+  const nextWeek = new Date(thisWeek.getTime() + 7 * SERIES_DAY_MS);
+
+  // Same title + same rrule on different base pages, NO marker on either
+  // side (stated rules, not cadence-derived): the #1647 fail-closed identity
+  // stands — lookalike pairs are not always twins.
+  const unmarked = await core.deduplicateEvents([
+    buildRenumberedSlugSeriesExport(thisWeek, 19, { _cadenceGroup: undefined }),
+    buildRenumberedSlugSeriesExport(nextWeek, 20, { _cadenceGroup: undefined })
+  ], null);
+  assert.equal(unmarked.length, 2, 'no shared marker → different base pages never fold');
+
+  // Marker on ONE side only never folds either.
+  const halfMarked = await core.deduplicateEvents([
+    buildRenumberedSlugSeriesExport(thisWeek, 19),
+    buildRenumberedSlugSeriesExport(nextWeek, 20, { _cadenceGroup: undefined })
+  ], null);
+  assert.equal(halfMarked.length, 2, 'a one-sided marker proves nothing');
+
+  // Two genuinely different events with the same rrule, similar titles and
+  // even the same marker string, at DIFFERENT venues: the positive
+  // different-place veto still blocks the fold.
+  const differentVenues = await core.deduplicateEvents([
+    buildRenumberedSlugSeriesExport(thisWeek, 19, { address: '100 Fixture St, Dallas, TX 75201' }),
+    buildRenumberedSlugSeriesExport(nextWeek, 3, {
+      bar: 'Fixture Tavern',
+      address: '999 Other Ave, Dallas, TX 75226',
+      url: 'https://fixture-tavern.example/events/karaoke-3/'
+    })
+  ], null);
+  assert.equal(differentVenues.length, 2, 'different venues never fold, marker or not');
+
+  // Different rules with the same marker never fold (rule check runs first).
+  const differentRules = await core.deduplicateEvents([
+    buildRenumberedSlugSeriesExport(thisWeek, 19),
+    buildRenumberedSlugSeriesExport(nextWeek, 20, { recurrenceRule: 'FREQ=MONTHLY;BYDAY=1TH' })
+  ], null);
+  assert.equal(differentRules.length, 2, 'different rules are different series claims — never fold them');
+});
+
 // === Run 20260802-135030: 3dollarbillbk.com + its eventim ticketing pages ===
 // Six verbatim records were three real events and duplicatesRemoved was 1.
 // URL identity (same event page modulo query/fragment; same trailing platform


### PR DESCRIPTION
## What

#1650's report-only cadence observation (validated against ground truth with zero wrong candidates) graduates to **enforcement**: a derived cadence becomes a real `recurrenceRule` stamped BEFORE dedup, so the existing series machinery folds N occurrence-singles into ONE series export — withheld from calendar writes, ICS button only. No new runtime files.

## Two observation sources

1. **Occurrence links** (existing since #1650): `?occurrence=YYYY-MM-DD` links per event-page identity, now accumulated per-run across listing + month feeds (`occurrenceCadenceObservations`, same lifecycle as `venueSiteHarvest`).
2. **Same-title record groups** (new — required for Dallas): the run's own extracted records grouped by the dedup's existing identity helpers (`areIdentityNamesSimilar` + positive `getCrossSourceVenueIdentity` + no `areEventsDistinctByPlace` veto — nothing looser). Catches MEC installs that renumber slugs per occurrence (karaoke-19, karaoke-20 …), where URL-keyed observation never accumulates — run 20260807-143442 had ZERO cadence lines despite "Karaoke" ×5 at 7-day gaps.

## Enforcement rules (conservative; anything else stays report-only)

- **Weekly** `FREQ=WEEKLY;BYDAY=<XX>`: all observed dates on the SAME weekday AND ≥3 consecutive 7-day gaps. Skipped weeks tolerated (LUCKI BREAK skips Labor-Day Sep 7 and still qualifies on its 4-gap August run); biweekly/mixed-weekday can never qualify.
- **Monthly** `FREQ=MONTHLY;BYDAY=<n><XX>`: ≥2 observations, every date in a DIFFERENT month, all the same ordinal weekday.
- **Stated beats derived** (guaranteed): a record already carrying a rule is NEVER overridden. Derived ≠ stated → one additive conflict line, stated kept, whole group untouched. Derived = stated → rules untouched (marker only). Undated records never join a group (`getEventNightKey` fails closed), so the rrule-fallback date-fabrication path — which only serves records WITHOUT a startDate and runs earlier — can never newly fire because of a stamp (pinned by test).

## Collapse extension (fail-closed, additive)

`getSeriesExportIdentity` and the #1647 same-page collapse identity are byte-for-byte unchanged. One additive gate: records on DIFFERENT base pages fold only when BOTH carry the same per-run `_cadenceGroup` marker, which the cadence pass stamps exclusively on groups it proved title-similar + positively same-venue with a jointly derived rule. Different venues (place veto), different rrules, one-sided/absent markers, and the original "same title + same rrule on different base pages" lookalike case all still refuse to fold — each pinned by test.

## Real-run replay (deterministic — saved run records + cached grids, no AI/network)

**Dallas Eagle 20260807-143442**: 54 records → **34** (10 withheld series among survivors):
- Karaoke ×5 → 1 — stamped `FREQ=WEEKLY;BYDAY=TH`
- Underwear Happy Hour ×5 → 1 — stated `FREQ=WEEKLY;BYDAY=WE` agreed, marker-only fold
- UNDERWEAR NIGHT ×3 + Underwear Night and Contest ×3 + …with DJ Drew G ×2 → 1 — stated `WE` agreed (8-record group)
- Motley Clue Trivia ×4 → 1 — stated `FREQ=WEEKLY;BYDAY=TU` agreed
- Womxn's Night ×2 → 1, Pet Night ×2 → 1 — stamped `FREQ=MONTHLY;BYDAY=4FR`
- NOT collapsed: Discipline Corps ×2 (Aug 7 = 1st Fri vs Sep 11 = 2nd Fri — no consistent ordinal, one record states bare `FREQ=MONTHLY`); GEAR NIGHT ×3 (Saturdays at 7/14-day mixed gaps — genuinely not simple weekly/monthly)

**Eagle LA 20260807-142024**: 32 records → **27** (15 withheld series):
- SUNDAY BEER BUST ×2 → 1, SUNDAY SWAP MEAT ×2 → 1 — stamped `FREQ=WEEKLY;BYDAY=SU` from 9 observed dates
- CUBSCOUT ×2 → 1 — stated `FREQ=MONTHLY;BYDAY=1FR` agreed, folded ACROSS renumbered slugs (cubscout-51 vs cub-scout-3)
- OUTLAW ×2 → 1 (`FREQ=MONTHLY;BYDAY=1SA`), BLUF LA ×2 → 1 (`3FR`)
- Stamped singles: LUCKI BREAK `WEEKLY;MO` (skipped-week case), Tightwad Tuesday `WEEKLY;TU`, ONYX `MONTHLY;2SU`
- b-bar / movie-mondays / bear-happy-hour already carried stated rules the derived cadence agrees with (no-op, as designed)
- NOT stamped: HUMP NIGHT ×1 — its record's url is the domain root, so no page identity ties it to the hump-night observations (conservative miss); MEAT RACK — stated `2SA,4SA` multi-day rule is not derivable under these rules

Zero conflict lines, zero `🔁 RECURRING: derived next occurrence` fallback firings in both replays.

## Verification

- `node --check` clean on all four files; full suite **1632/1632** on branch vs **1622/1622** measured on clean origin/main @1b9d38c4 (+10 new tests, 0 regressions); quiet-console suite also 1632/1632.
- 9/10 new tests verified FAIL on clean origin/main; the 10th ("never folds different base pages without a shared marker / different venues with one") is a declared fail-closed guard that must also hold on main and survive the extension.
- Existing console.log text and AI prompts untouched (additions only); no `new URL`/`URLSearchParams`; nothing hardcoded per venue (venue names in fixtures/comments only); tests appended at ai-web-parser.test.js EOF and next to the #1647 series-collapse tests in shared-core.test.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP