### PR TITLE
fix(scraper): vet segment images before offering them to the model

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -618,6 +618,24 @@ class AiWebParser {
         // (identity: a resized rendition IS its base image) so the two notions
         // of "resized derivative" can never drift apart.
         this.resizedImageFilenameSuffixPattern = /-(\d{2,5})x(\d{2,5})(\.(?:jpe?g|png|gif|webp|avif|bmp|tiff?))$/i;
+        // A "-WxH" rendition whose BOTH dimensions fit under this is an
+        // icon-scale derivative — WordPress' 150x150 "thumbnail" size class,
+        // social-icon sprites, favicons-as-uploads. Run 20260807-143442
+        // (thedallaseagle.com/events/): the site's 150x150 Mastodon social
+        // icon reached a segment prompt as SEGMENT_IMAGE_URL and shipped as
+        // GEAR NIGHT's `image`. 300x300 poster thumbs are deliberately ABOVE
+        // this bound — eaglela.com serves real flyers as -300x300 renditions.
+        this.iconScaleRenditionMaxDimension = 200;
+        // An image identity offered by at least this many DISTINCT segments'
+        // own HTML on ONE multi-event page is site furniture by definition
+        // (social icons, sponsor strips, footer chrome) — no single event's
+        // artwork repeats across three different listings on the same page.
+        this.segmentImageChromeMinSegments = 3;
+        // Per-PAGE record of those repeated-image identities, written by
+        // applyRepeatedSegmentImageChromeGate and keyed to the page URL so a
+        // stale page's verdicts can never leak into the next page's prompts.
+        // Never persisted: this is a per-parse determination, not an OCR fact.
+        this._repeatedSegmentChrome = null;
         // Non-image static-asset extensions (fonts/stylesheets/scripts + image
         // formats not in supportedImageExtensions). Together with that list
         // these mark a URL as a FILE, never an event page — see
@@ -1260,6 +1278,11 @@ class AiWebParser {
             return [];
         }
         console.log(`🤖 AI Web: multi-event-page split into ${segments.length} candidate segment${segments.length === 1 ? '' : 's'}`);
+
+        // Repeated-across-segments chrome first: an image identity offered by
+        // 3+ distinct segments' own HTML is site furniture — settle that
+        // BEFORE the OCR top-up/vet pass so no call is spent reading it.
+        this.applyRepeatedSegmentImageChromeGate(segments, sourceUrl);
 
         // OCR any segment images the capped page-level pass missed
         await this.ensureSegmentOcrCoverage(segments, ocrResults, parserConfig, sourceUrl, httpAdapter);
@@ -3794,10 +3817,84 @@ class AiWebParser {
         if (candidates.length === 0) return textStart;
 
         const candidateStart = start + Math.max(...candidates);
+        // Same-day-neighbor guard (run 20260807-142024, eaglela.com/calendar/):
+        // on a MEC day-cell grid the window for one event begins right after
+        // its SAME-DAY NEIGHBOR's tooltip, so the last <img> before the
+        // window's title is the neighbor's poster — sitting inside the
+        // neighbor's own event anchor, which the window boundary truncated.
+        // The page states the ownership itself: the captured image sits in an
+        // <a> that CLOSES before the window's title text, and the title sits
+        // in a DIFFERENT anchor (a different event link). Capturing through
+        // that boundary is how "MR BEAR LA MEET AND GREET" shipped with the
+        // B BAR Thursday-weekly poster. Both hrefs are required and compared
+        // verbatim, so a card whose linked thumbnail and linked title share
+        // one destination — or whose title is not inside any link — keeps its
+        // image exactly as before (fail open).
+        const imageAnchorHref = this.getOpenAnchorHrefAtPosition(source, candidateStart, start);
+        if (imageAnchorHref) {
+            const titleTextIndex = this.findFirstBodyTextIndex(source, textStart, Math.min(source.length, textStart + 600));
+            if (titleTextIndex >= 0) {
+                // Does the image's enclosing anchor close before the title text?
+                const between = source.slice(candidateStart, titleTextIndex);
+                const anchorTagPattern = /<\/?a\b[^>]*>/gi;
+                let anchorDepth = 1;
+                let imageAnchorClosesBeforeTitle = false;
+                let tagMatch;
+                while ((tagMatch = anchorTagPattern.exec(between)) !== null) {
+                    anchorDepth += tagMatch[0].charAt(1) === '/' ? -1 : 1;
+                    if (anchorDepth === 0) {
+                        imageAnchorClosesBeforeTitle = true;
+                        break;
+                    }
+                }
+                if (imageAnchorClosesBeforeTitle) {
+                    const titleAnchorHref = this.getOpenAnchorHrefAtPosition(source, titleTextIndex, candidateStart);
+                    if (titleAnchorHref && titleAnchorHref !== imageAnchorHref) {
+                        console.log(`🤖 AI Web: Segment image capture stopped — the preceding <img> belongs to a truncated neighboring card's anchor (${imageAnchorHref}), not this segment's (${titleAnchorHref})`);
+                        return textStart;
+                    }
+                }
+            }
+        }
         const interveningText = this.extractBodyParts(source.slice(candidateStart, textStart));
         const crossesPriorEvent = interveningText.some(line => this.isStrongMultiEventTitleLine(line)) &&
             interveningText.some(line => this.hasMultiEventDateSignal(line));
         return crossesPriorEvent ? textStart : candidateStart;
+    }
+
+    // First position at or after `fromIndex` (before `limit`) holding a
+    // non-whitespace character OUTSIDE any tag — where a segment's title TEXT
+    // actually begins, as opposed to where its record's element markup does.
+    findFirstBodyTextIndex(source, fromIndex, limit) {
+        const text = String(source || '');
+        const end = Math.min(text.length, Math.max(0, Number(limit) || 0));
+        let inTag = false;
+        for (let i = Math.max(0, Number(fromIndex) || 0); i < end; i++) {
+            const ch = text[i];
+            if (ch === '<') { inTag = true; continue; }
+            if (ch === '>') { inTag = false; continue; }
+            if (inTag) continue;
+            if (/\S/.test(ch)) return i;
+        }
+        return -1;
+    }
+
+    // The href of the <a …> tag still OPEN at `index`, scanning tags no
+    // earlier than `windowStart`; '' when no anchor is open there or the open
+    // tag carries no href. Pure string scanning — no URL parsing.
+    getOpenAnchorHrefAtPosition(source, index, windowStart = 0) {
+        const from = Math.max(0, Number(windowStart) || 0);
+        const to = Math.max(from, Number(index) || 0);
+        const slice = String(source || '').slice(from, to);
+        const anchorTagPattern = /<\/?a\b[^>]*>/gi;
+        let openTag = '';
+        let match;
+        while ((match = anchorTagPattern.exec(slice)) !== null) {
+            openTag = match[0].charAt(1) === '/' ? '' : match[0];
+        }
+        if (!openTag) return '';
+        const hrefMatch = openTag.match(/\bhref=["']([^"']*)["']/i);
+        return hrefMatch ? hrefMatch[1].trim() : '';
     }
 
     findMultiEventSegmentResourceEnd(html, lastTextEnd) {
@@ -3858,9 +3955,15 @@ class AiWebParser {
             // vectors — and the model dutifully returns one as `image`, with
             // real evidence, at confidence 100. Image lines only: a
             // SEGMENT_LINK_URL is not artwork and is never judged here.
-            if (/_IMAGE/i.test(label) && this.getNonEventImageOcrReason(finalUrl)) {
-                console.log(`🤖 AI Web: Segment image ${finalUrl} withheld from the prompt — ${this.getNonEventImageOcrReason(finalUrl)}`);
-                return;
+            // Three reasons can withhold an image line, checked in one place:
+            // page-chrome (repeated across 3+ segments), icon-scale "-WxH"
+            // renditions, and the vision pass' own furniture verdict.
+            if (/_IMAGE/i.test(label)) {
+                const withholdReason = this.getSegmentPromptImageWithholdReason(finalUrl, sourceUrl);
+                if (withholdReason) {
+                    console.log(`🤖 AI Web: Segment image ${finalUrl} withheld from the prompt — ${withholdReason}`);
+                    return;
+                }
             }
             // Check for duplicates using stripped URL to handle same image at different sizes
             const strippedUrl = this.stripSizeParams(finalUrl);
@@ -7113,6 +7216,13 @@ class AiWebParser {
         // URI) is never worth OCR'ing and never an orientation-slot candidate.
         // The shape rules live in shared-core so the merge rung agrees.
         if (this.getPlaceholderImageReason(lowerUrl)) return true;
+        // An icon-scale "-WxH" rendition (both dimensions ≤ 200 — WordPress'
+        // 150x150 thumbnail class, social icons) is never an event-image
+        // candidate. This judges only the CANDIDATE/offer layer — nothing
+        // here deletes an image an event already carries — and -300x300
+        // poster thumbs stay above the bound (eaglela.com uses them for real
+        // flyers).
+        if (this.isIconScaleImageRendition(url)) return true;
         // '404' only counts when it stands alone between non-alphanumerics
         // ("/404.png", "error-404.jpg") — as a bare substring it matches
         // random hex asset IDs (a Wix flyer named "238fae_c4047c55…" was
@@ -7164,6 +7274,26 @@ class AiWebParser {
         const match = base.match(this.resizedImageFilenameSuffixPattern);
         if (!match) return 0;
         return (parseInt(match[1], 10) || 0) * (parseInt(match[2], 10) || 0);
+    }
+
+    // Is this URL a "-WxH" filename rendition at icon scale — BOTH dimensions
+    // at or under iconScaleRenditionMaxDimension? Built on the same shared
+    // resizedImageFilenameSuffixPattern as identity/selection, so the notion
+    // of "rendition" can never drift. A URL with no such suffix is never
+    // icon-scale here, whatever its true pixels — this is a filename tell,
+    // not a measurement.
+    isIconScaleImageRendition(url) {
+        const text = typeof url === 'string' ? url.trim() : '';
+        if (!text) return false;
+        const tailIndex = text.search(/[?#]/);
+        const base = tailIndex >= 0 ? text.slice(0, tailIndex) : text;
+        const match = base.match(this.resizedImageFilenameSuffixPattern);
+        if (!match) return false;
+        const width = parseInt(match[1], 10) || 0;
+        const height = parseInt(match[2], 10) || 0;
+        return width > 0 && height > 0
+            && width <= this.iconScaleRenditionMaxDimension
+            && height <= this.iconScaleRenditionMaxDimension;
     }
 
     // Should `candidate` replace `incumbent` as the representative URL of ONE
@@ -7353,7 +7483,8 @@ class AiWebParser {
             const hasCoverage = normalizedUrls.some(url => coveredStrippedUrls.has(this.stripSizeParams(url)));
             if (hasCoverage) continue;
 
-            const candidate = normalizedUrls.find(url => !this.isLikelyUninterestingImageUrl(url));
+            const candidate = normalizedUrls.find(url => !this.isLikelyUninterestingImageUrl(url)
+                && !this.getRepeatedSegmentChromeReason(url, sourceUrl));
             if (!candidate) {
                 // A segment whose images ALL look uninteresting gets no OCR at
                 // all — say so instead of silently skipping (this hid the run
@@ -7367,6 +7498,42 @@ class AiWebParser {
             if (targetStrippedUrls.has(strippedCandidate)) continue;
             targetStrippedUrls.add(strippedCandidate);
             targets.push(candidate);
+        }
+
+        // ── Vet-before-offer ────────────────────────────────────────────
+        // Never offer the model an image URL the vision pass has not read.
+        // Runs 20260807-143442 (Dallas: a Mastodon social icon shipped as
+        // GEAR NIGHT's image) and 20260807-142024 (Eagle LA: same-day
+        // neighbors' posters) both trace to SEGMENT_IMAGE_URL /
+        // SEGMENT_IMAGE_HINT_URL lines whose URLs no OCR pass ever vetted —
+        // the furniture-verdict withhold and the consistency gate can only
+        // judge images that were actually read. So: every image URL a
+        // segment prompt could emit (its hint URLs, or the first-4-<img>
+        // fallback of a segment with no OCR text) gets an OCR read here
+        // first. Bounded by DISTINCT image identities on the page (the
+        // targetStrippedUrls dedupe) and by the same per-run miss budget as
+        // the top-up; a cached read is free and an identity is only ever
+        // read once, so a page's vet cost is paid on its first run only.
+        const vetTargets = [];
+        for (const segment of segments) {
+            for (const offeredUrl of this.collectOfferableSegmentImageUrls(segment, ocrResults, sourceUrl)) {
+                const strippedOffered = this.stripSizeParams(offeredUrl);
+                if (!strippedOffered || targetStrippedUrls.has(strippedOffered)) continue;
+                if (coveredStrippedUrls.has(strippedOffered)) continue;
+                // Already vetted (a verdict from this run's cache hits), or
+                // already withheld from every prompt (chrome / icon-scale /
+                // furniture) — no read needed to keep it away from the model.
+                if (this.getOcrImageVerdict(offeredUrl)) continue;
+                if (this.getSegmentPromptImageWithholdReason(offeredUrl, sourceUrl)) continue;
+                // Not a fetchable picture at all (1x1 spacers, data: URIs).
+                if (this.getPlaceholderImageReason(offeredUrl)) continue;
+                targetStrippedUrls.add(strippedOffered);
+                vetTargets.push(offeredUrl);
+            }
+        }
+        if (vetTargets.length > 0) {
+            console.log(`🤖 AI Web: OCR vet pass queued ${vetTargets.length} segment prompt image(s) offered without a prior OCR read`);
+            targets.push(...vetTargets);
         }
         if (targets.length === 0) return ocrResults;
 
@@ -7407,10 +7574,56 @@ class AiWebParser {
         );
         for (const rawResult of rawResults) {
             const normalized = this.normalizeOcrResult(rawResult);
-            if (!normalized || !normalized.text || normalized.text.trim().length === 0) continue;
+            if (!normalized) continue;
+            // Record the verdict at this seam too: getOcrTextForImage records
+            // it on real reads and cache hits, but the offer layer must see a
+            // verdict for every image read here even when a test/stubbed OCR
+            // path returned the result directly. Idempotent with the inner
+            // recording — same key, same verdict.
+            this.recordOcrImageVerdict(normalized.url, normalized);
+            if (!normalized.text || normalized.text.trim().length === 0) continue;
             ocrResults.push(normalized);
         }
         return ocrResults;
+    }
+
+    // Every image URL a segment's prompt could emit as a SEGMENT_IMAGE_HINT_URL
+    // or SEGMENT_IMAGE_URL line, mirroring extractMultiEventSegmentResourceLines:
+    // hint URLs are always offered (up to the 4-line cap); the first-4-<img>
+    // fallback fires only for a segment contributing no OCR text lines and no
+    // hints. A conservative superset is fine here — an extra vet read is one
+    // cached OCR call — but the mirror keeps the vet pass from reading images
+    // no prompt would ever mention.
+    collectOfferableSegmentImageUrls(segment, ocrResults, sourceUrl = '') {
+        if (!segment || typeof segment !== 'object') return [];
+        const offerable = [];
+        const seen = new Set();
+        const pushUrl = (rawUrl) => {
+            const normalized = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(rawUrl) || rawUrl);
+            if (!normalized || seen.has(normalized)) return;
+            seen.add(normalized);
+            offerable.push(normalized);
+        };
+        const hints = Array.isArray(segment.imageHintUrls) ? segment.imageHintUrls : [];
+        hints.slice(0, 4).forEach(pushUrl);
+        if (hints.length === 0) {
+            const { normalized: normalizedKeys, stripped: strippedKeys } =
+                this.getSegmentImageUrlKeys(segment, sourceUrl);
+            const hasOcrTextLine = (Array.isArray(ocrResults) ? ocrResults : []).some(ocr => {
+                if (!ocr || !String(ocr.text || '').trim()) return false;
+                const ocrUrl = this.normalizeHttpUrlValue(ocr.url);
+                const strippedOcrUrl = this.stripSizeParams(ocrUrl);
+                return normalizedKeys.has(ocrUrl) || (Boolean(strippedOcrUrl) && strippedKeys.has(strippedOcrUrl));
+            });
+            if (!hasOcrTextLine) {
+                this.extractOrderedImageUrlsFromHtml(
+                    typeof segment.html === 'string' ? segment.html : '',
+                    sourceUrl,
+                    4
+                ).forEach(pushUrl);
+            }
+        }
+        return offerable;
     }
 
     // The URL keys a segment claims OCR results with — normalized exact URLs
@@ -7476,6 +7689,12 @@ class AiWebParser {
             // or detached from this segment never matches, even via exact URL.
             if (excludedUrlKeys && strippedOcrUrl && excludedUrlKeys.has(strippedOcrUrl)) return false;
 
+            // Page-chrome exclusion: an identity offered by 3+ distinct
+            // segments on this page is site furniture and belongs to NO
+            // segment — its OCR text must not become any window's
+            // OCR_IMAGE_TEXT evidence.
+            if (this.getRepeatedSegmentChromeReason(ocrUrl, sourceUrl)) return false;
+
             const exactMatch = normalizedSegmentImageSet.has(ocrUrl);
             const strippedMatch = strippedOcrUrl && strippedSegmentImageSet.has(strippedOcrUrl);
 
@@ -7529,6 +7748,10 @@ class AiWebParser {
             const ocrUrl = this.normalizeHttpUrlValue(ocr.url);
             const strippedOcrUrl = this.stripSizeParams(ocrUrl);
             if (!strippedOcrUrl) continue;
+            // Page chrome belongs to nobody — it is already withheld from
+            // every segment on this page, so reassigning it to a "matching"
+            // sibling would smuggle it back in as a hint.
+            if (this.getRepeatedSegmentChromeReason(ocrUrl, sourceUrl)) continue;
             const ocrTokens = new Set(this.core.getCrossSourceTitleTokens(
                 `${String(ocr.text || '')} ${String(ocr.eventSummary || '')}`));
             const matchedCount = info => info.titleTokens.filter(token => ocrTokens.has(token)).length;
@@ -7575,6 +7798,74 @@ class AiWebParser {
             }
         }
         return sourceSegments;
+    }
+
+    // ── Repeated-across-segments = site chrome ─────────────────────────────
+    // An image identity (post-#1648 stripSizeParams key) that 3+ DISTINCT
+    // segments' own HTML all offer on ONE page is site furniture by
+    // definition — social icons, sponsor strips, footer chrome. No single
+    // event's artwork appears inside three different listings on the same
+    // page. Recorded per PAGE (keyed to sourceUrl, replaced on the next
+    // page's gate run) and NEVER written to the OCR cache: this is a layout
+    // fact about this parse, not a vision fact about the image. Withholding
+    // happens at the offer layer only — segment prompt lines, segment OCR
+    // matching, hint reassignment — an image an event ALREADY carries is
+    // never deleted by this rule.
+    applyRepeatedSegmentImageChromeGate(segments, sourceUrl = '') {
+        const store = { sourceUrl: String(sourceUrl || ''), reasonsByKey: new Map() };
+        this._repeatedSegmentChrome = store;
+        const sourceSegments = Array.isArray(segments) ? segments : [];
+        if (sourceSegments.length < this.segmentImageChromeMinSegments) return sourceSegments;
+
+        const segmentsByIdentity = new Map(); // stripped key → { count, url }
+        for (const segment of sourceSegments) {
+            const segmentHtml = segment && typeof segment.html === 'string' ? segment.html : '';
+            if (!segmentHtml) continue;
+            const seenInSegment = new Set();
+            for (const imageUrl of this.extractOrderedImageUrlsFromHtml(segmentHtml, sourceUrl)) {
+                const key = this.stripSizeParams(imageUrl);
+                if (!key || seenInSegment.has(key)) continue;
+                seenInSegment.add(key);
+                const entry = segmentsByIdentity.get(key) || { count: 0, url: imageUrl };
+                entry.count += 1;
+                segmentsByIdentity.set(key, entry);
+            }
+        }
+        for (const [key, entry] of segmentsByIdentity) {
+            if (entry.count < this.segmentImageChromeMinSegments) continue;
+            store.reasonsByKey.set(key, `it is offered by ${entry.count} distinct segments on this page — repeated across listings means site chrome, not one event's artwork`);
+            console.log(`🤖 AI Web: Page-chrome image ${entry.url} — offered by ${entry.count} distinct segments on one page; withholding it from every segment prompt`);
+        }
+        return sourceSegments;
+    }
+
+    // Why this page's chrome gate withholds a URL ('' when it doesn't, when
+    // no gate ran, or when the caller's page is not the page the verdicts
+    // were computed on — a stale page's chrome can never leak forward).
+    getRepeatedSegmentChromeReason(url, sourceUrl = '') {
+        const store = this._repeatedSegmentChrome;
+        if (!store || store.reasonsByKey.size === 0) return '';
+        if (String(sourceUrl || '') !== store.sourceUrl) return '';
+        const raw = String(url || '').trim();
+        if (!raw) return '';
+        const normalized = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(raw) || raw);
+        const key = this.stripSizeParams(normalized || raw);
+        if (!key) return '';
+        return store.reasonsByKey.get(key) || '';
+    }
+
+    // The one funnel every segment-prompt image line passes through before it
+    // may be offered to the model: page-chrome first (no OCR needed), then
+    // the icon-scale filename tell, then the vision pass' furniture verdict.
+    // '' means "offer it" — unknown always fails open, exactly like
+    // getNonEventImageOcrReason.
+    getSegmentPromptImageWithholdReason(url, sourceUrl = '') {
+        const chromeReason = this.getRepeatedSegmentChromeReason(url, sourceUrl);
+        if (chromeReason) return chromeReason;
+        if (this.isIconScaleImageRendition(url)) {
+            return `its "-WxH" filename suffix advertises an icon-scale rendition (both dimensions at or under ${this.iconScaleRenditionMaxDimension}px)`;
+        }
+        return this.getNonEventImageOcrReason(url);
     }
 
     // Report-only structured-data consistency tripwire, mirroring the spirit

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -12743,6 +12743,176 @@ test('a known non-event image is withheld from the segment prompt entirely', () 
     'the model is never offered an image the vision pass already called a logo');
 });
 
+// ---------------------------------------------------------------------------
+// VET BEFORE OFFER — runs 20260807-143442 (Dallas: the site's Mastodon social
+// icon shipped as GEAR NIGHT's image) and 20260807-142024 (Eagle LA calendar:
+// same-day neighbors' posters on the MR BEAR windows). A segment prompt must
+// never offer an image URL the OCR layer never read: the furniture-verdict
+// withhold and the consistency gate can only judge images that were vetted.
+// ---------------------------------------------------------------------------
+
+test('an unvetted segment image is OCR-vetted before the prompt is built, and its furniture verdict then withholds it', async () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events/';
+  const flyer = 'https://venue.example/uploads/gear-night-flyer.jpg';
+  const icon = 'https://venue.example/uploads/2025/04/fediverse-icon.png';
+
+  // The segment already has OCR coverage via its flyer, so the coverage
+  // top-up has nothing to do — but the icon hint would still be offered as a
+  // SEGMENT_IMAGE_HINT_URL line, and nothing has ever read it.
+  const segment = { lines: ['GEAR NIGHT', 'September 5, 2026'], html: '', imageHintUrls: [flyer, icon] };
+  const ocrResults = [{ url: flyer, text: 'GEAR NIGHT 10PM', imageClassification: 'event-flyer' }];
+
+  const ocrCalls = [];
+  parser.getOcrTextForImage = async (url) => {
+    ocrCalls.push(url);
+    return { url, text: '', imageClassification: 'logo' };
+  };
+
+  await parser.ensureSegmentOcrCoverage([segment], ocrResults, {}, sourceUrl, null);
+  assert.deepEqual(ocrCalls, [icon],
+    'the offered-but-unvetted icon gets an OCR read before any prompt is built; the covered flyer costs nothing');
+
+  const lines = parser.extractMultiEventSegmentResourceLines('', sourceUrl, segment.imageHintUrls, ocrResults);
+  assert.ok(lines.some(line => line === `SEGMENT_IMAGE_HINT_URL: ${flyer}`),
+    `the real flyer is still offered, got ${JSON.stringify(lines)}`);
+  assert.ok(!lines.some(line => line.includes(icon)),
+    `the vetted icon's furniture verdict withholds it from the prompt, got ${JSON.stringify(lines)}`);
+});
+
+test('a window never captures a truncated neighboring card\'s poster, so the wrong-title flyer is not offered to it', async () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/calendar/';
+  const poster = 'https://venue.example/uploads/b-bar-poster-generic.jpg';
+  // The MEC day-cell shape from run 20260807-142024: the neighbor's tooltip
+  // anchor holds its poster and is truncated by the window boundary — the
+  // window's own title lives inside a DIFFERENT event's anchor.
+  const html = `
+    <div class="grid">
+      <a href="https://venue.example/events/b-bar/?occurrence=2026-08-13">
+        <div class="tooltip-event-desc"><img src="${poster}" alt=""></div>
+      </a>
+      <a class="listing-tooltip" href="https://venue.example/events/mr-bear-meet/?occurrence=2026-08-13"><h4>MR BEAR MEET AND GREET</h4></a>
+    </div>`;
+
+  const segmentHtml = parser.extractRawHtmlForMultiEventSegment(html, ['MR BEAR MEET AND GREET']);
+  assert.ok(!segmentHtml.includes(poster),
+    `the neighbor's poster must not ride into the window html, got: ${JSON.stringify(segmentHtml)}`);
+
+  // End to end: even with the poster OCR'd (text naming B BAR, the neighbor),
+  // the MR BEAR window's prompt carries no line for it.
+  const segment = { lines: ['MR BEAR MEET AND GREET'], html: segmentHtml, imageHintUrls: [] };
+  const ocrResults = [{ url: poster, text: 'B BAR EVERY THURSDAY NO COVER', imageClassification: 'event-flyer' }];
+  parser.applySegmentOcrConsistencyGate([segment], ocrResults, sourceUrl);
+  const data = parser.buildMultiEventSegmentHtmlData({ url: sourceUrl, html }, segment, 0, 1, ocrResults);
+  assert.ok(!String(data.html).includes(poster),
+    `no OCR_IMAGE_URL/SEGMENT_IMAGE_URL line may offer the neighbor's poster, got: ${data.html}`);
+
+  // Guard: a card whose linked thumbnail and linked title share ONE
+  // destination keeps its image capture exactly as before.
+  const ownHtml = `
+    <div class="grid">
+      <a href="https://venue.example/events/leather-night/"><img src="https://venue.example/uploads/leather-night.jpg"></a>
+      <a href="https://venue.example/events/leather-night/"><h4>LEATHER NIGHT</h4></a>
+    </div>`;
+  const ownSegmentHtml = parser.extractRawHtmlForMultiEventSegment(ownHtml, ['LEATHER NIGHT']);
+  assert.ok(ownSegmentHtml.includes('leather-night.jpg'),
+    'a same-destination linked image is still this card\'s own artwork');
+});
+
+test('an image offered by 3+ distinct segments is page chrome — withheld from every segment prompt', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events/';
+  const icon = 'https://venue.example/uploads/2025/04/social-mastodon-badge.png';
+  const segments = [
+    { lines: ['GEAR NIGHT', 'September 5, 2026'], html: `<div><img src="https://venue.example/uploads/gear.jpg"><img src="${icon}"></div>`, imageHintUrls: [] },
+    { lines: ['LEATHER NIGHT', 'September 6, 2026'], html: `<div><img src="https://venue.example/uploads/leather.jpg"><img src="${icon}"></div>`, imageHintUrls: [] },
+    { lines: ['UNDIES NIGHT', 'September 7, 2026'], html: `<div><img src="https://venue.example/uploads/undies.jpg"><img src="${icon}"></div>`, imageHintUrls: [] }
+  ];
+
+  const logs = captureLogs(() => {
+    parser.applyRepeatedSegmentImageChromeGate(segments, sourceUrl);
+  });
+  assert.ok(logs.some(line => line.includes(`Page-chrome image ${icon}`) && line.includes('3 distinct segments')),
+    `chrome determination log expected, got ${JSON.stringify(logs)}`);
+
+  for (const segment of segments) {
+    const lines = parser.extractMultiEventSegmentResourceLines(segment.html, sourceUrl);
+    assert.ok(!lines.some(line => line.includes(icon)),
+      `chrome is withheld from every segment's prompt lines, got ${JSON.stringify(lines)}`);
+    assert.equal(lines.filter(line => line.startsWith('SEGMENT_IMAGE_URL:')).length, 1,
+      'each segment still offers its own flyer');
+  }
+
+  // Its OCR text (if any) reaches no segment either, and per-event flyers
+  // repeated across only two segments are untouched.
+  const iconOcr = [{ url: icon, text: 'JOIN US ON MASTODON', imageClassification: 'logo' }];
+  assert.deepEqual(parser.filterOcrResultsForSegment(iconOcr, segments[0], sourceUrl), []);
+  assert.equal(parser.getRepeatedSegmentChromeReason('https://venue.example/uploads/gear.jpg', sourceUrl), '');
+  // Page-scoped: the SAME url on a DIFFERENT page is not chrome there.
+  assert.equal(parser.getRepeatedSegmentChromeReason(icon, 'https://other.example/events/'), '');
+});
+
+test('an icon-scale -WxH rendition (both dims <= 200) is never offered or harvested; -300x300 posters are untouched', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events/';
+  const iconRendition = 'https://venue.example/uploads/2025/04/social-badge-150x150.png?lossy=2&strip=1&webp=1';
+  const posterThumb = 'https://venue.example/uploads/ig_b-bar-poster-2026-300x300.jpg';
+
+  // Candidate layer: the shared uninteresting-URL test now refuses the
+  // icon-scale rendition (so OCR slots, top-up and image slots all skip it)…
+  assert.equal(parser.isLikelyUninterestingImageUrl(iconRendition), true,
+    'a 150x150 filename rendition is icon-scale, never an event-image candidate');
+  // …while the 300x300 poster class eaglela.com serves real flyers at stays.
+  assert.equal(parser.isLikelyUninterestingImageUrl(posterThumb), false,
+    '-300x300 renditions are above the icon bound and must not regress');
+  assert.equal(parser.isIconScaleImageRendition('https://venue.example/uploads/wide-banner-600x150.jpg'), false,
+    'one large dimension is enough to clear the icon bound');
+  assert.equal(parser.isIconScaleImageRendition('https://venue.example/uploads/plain-flyer.jpg'), false,
+    'no -WxH suffix, no verdict — a filename tell only');
+
+  // Offer layer: the segment prompt withholds the icon-scale rendition even
+  // with no OCR verdict recorded for it, and still offers the poster thumb.
+  const segmentHtml = `<div><img src="${iconRendition}"><img src="${posterThumb}"></div>`;
+  const logs = captureLogs(() => {
+    const lines = parser.extractMultiEventSegmentResourceLines(segmentHtml, sourceUrl);
+    assert.ok(!lines.some(line => line.includes('social-badge-150x150')),
+      `icon-scale rendition must be withheld, got ${JSON.stringify(lines)}`);
+    assert.ok(lines.some(line => line === `SEGMENT_IMAGE_URL: ${posterThumb}`),
+      `the -300x300 poster is still offered, got ${JSON.stringify(lines)}`);
+  });
+  assert.ok(logs.some(line => line.includes('withheld from the prompt') && line.includes('icon-scale')),
+    `withhold log expected, got ${JSON.stringify(logs)}`);
+});
+
+// Behavior guard (passes before and after this change): a legitimately paired
+// -300x300 poster on a normal listing keeps its pairing end to end.
+test('guard: a -300x300 poster paired to its own listing keeps its OCR pairing and prompt lines', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events/';
+  const posterThumb = 'https://venue.example/uploads/ig_b-bar-poster-2026-300x300.jpg';
+  const segment = {
+    lines: ['B BAR', '13 Aug'],
+    html: `<a class="listing-tooltip" href="/events/b-bar/?occurrence=2026-08-13"><h4>B BAR</h4></a><div class="tooltip"><img src="${posterThumb}"></div>`,
+    imageHintUrls: []
+  };
+  const ocrResults = [{
+    url: 'https://venue.example/uploads/ig_b-bar-poster-2026.jpg',
+    text: 'B BAR EVERY THURSDAY NO COVER',
+    imageClassification: 'event-flyer'
+  }];
+
+  parser.applySegmentOcrConsistencyGate([segment, { lines: ['ONYX', '14 Aug'], html: '', imageHintUrls: [] }], ocrResults, sourceUrl);
+  assert.equal(segment.ocrExcludedUrlKeys, undefined, 'the gate leaves a matching pairing alone');
+
+  const matched = parser.filterOcrResultsForSegment(ocrResults, segment, sourceUrl);
+  assert.equal(matched.length, 1, 'the full-size OCR result still pairs with the -300x300-only segment');
+
+  const data = parser.buildMultiEventSegmentHtmlData({ url: sourceUrl, html: '<html></html>' }, segment, 0, 2, ocrResults);
+  assert.ok(String(data.html).includes('B BAR EVERY THURSDAY'),
+    'the poster\'s OCR text reaches its own listing\'s prompt');
+});
+
 test('the OCR cache carries an image classification across runs even when it has no text', async () => {
   const fs = require('fs');
   const os = require('os');


### PR DESCRIPTION
## The two real incidents (same root cause)

Multi-event segment prompts offered image URLs the OCR layer never vetted; the model dutifully copied them into `image`, and the evidence gate passed them because the URL is verbatim in the prompt:

1. **Dallas Eagle listing** (run 20260807-143442): the "Gear Night" segment carried `SEGMENT_IMAGE_URL: …/2025/04/mastodon-150x150.png…` — the site's Mastodon social icon — and GEAR NIGHT shipped with it as `image`. The icon was never OCR'd, so #1642's furniture-verdict machinery had no verdict, and "mastodon" matches nothing in `isLikelyUninterestingImageUrl`.
2. **Eagle LA /calendar/ grid** (run 20260807-142024): day-cell windows took their SAME-DAY NEIGHBOR's poster — "MR BEAR LA MEET AND GREET" (Thu Aug 13) got the B BAR Thursday-weekly poster, "MR BEAR LA 2027 VICTORY PARTY" (Sun Aug 16) got the Sunday Beer Bust poster.

## The fix — generic layers in `ai-web-parser.js`

1. **Vet-before-offer** (`ensureSegmentOcrCoverage`): every image URL a segment prompt could emit as `SEGMENT_IMAGE_URL`/`SEGMENT_IMAGE_HINT_URL` (hints + the first-4-`<img>` fallback) gets an OCR read before prompts are built, unless it already has a result/verdict or is already withheld. Bounded by DISTINCT image identities per page (post-#1648 `stripSizeParams` keys) and the existing per-run miss budget (Dallas: 8 distinct identities across 42 segments, budget 42; Eagle LA /calendar/: 20 identities across 6 segments, budget 16 — the identity dedupe binds long before the budget does). The existing machinery then judges them: furniture verdicts withhold, the consistency gate reassigns/detaches.
2. **Repeated-across-segments = site chrome**: an image identity offered by 3+ DISTINCT segments' own HTML on one page is withheld from every segment's prompt lines and OCR matching, per parse only (nothing written to the OCR cache). Additive `Page-chrome image …` log line.
3. **Icon-scale rendition tell**: a `-WxH` filename rendition (shared #1648 regex) with BOTH dimensions ≤ 200 is never offered/harvested as an event-image candidate. `-300x300` poster thumbs (Eagle LA's real flyers) are untouched, and nothing deletes an image an event already carries.
4. **Same-day-neighbor capture guard** (`findMultiEventSegmentResourceStart`): a window no longer captures a preceding `<img>` whose enclosing anchor closes before the window's title text while the title sits inside a DIFFERENT event's anchor — the page's own markup stating the poster belongs to the truncated neighboring card. This was required for incident 2: the OCR consistency gate cannot detach these pairings (the venue footer on every house flyer — "EAGLE LA" — token-corroborates any "…LA…" title, and the poster's true owner, B BAR, is not among the /calendar/ page's 6 segments). Both hrefs must exist and differ; same-destination linked thumbnails keep their capture (fail open).

No extraction is suppressed on grid/calendar pages (the Dallas /events/ page is also a MEC day-cell page and still produces its 42 segments). Prompt strings and all existing log text unchanged — additions only. **No new runtime files.**

## Real-page replays (deterministic: no network/AI; boundary pass stubbed with the device run's own verified boundaries; OCR stubbed from the device cache)

| Page | main | branch |
|---|---|---|
| Dallas /events/ (42 segments) | `mastodon-150x150` in 1 prompt image line (Gear Night, the shipped URL) | **0 lines** (icon-scale); only diff on the page is that one segment |
| Eagle LA /calendar/ (6 segments) | MR BEAR MEET AND GREET → `OCR_IMAGE_URL: B-Bar-poster…`; VICTORY PARTY → `OCR_IMAGE_URL: Sun-Beer-Bust-poster…` | **both posters gone**; each MR BEAR window now offers its own tooltip art (`MORE-INFO-Coming-Soon-1.jpg` / `CHECK-BACK-art.jpg-1.webp`, contest windows their own `Bear-la-cub-la-contest-*.jpeg`) |
| Eagle LA /events/ (12 segments) | 12 image-candidate lists | **byte-identical**, 0 diffs — every correctly paired `-300x300` poster kept |

## Tests

- Suite: main baseline 1622/1622 → branch **1627/1627** (quiet console, `npm test`).
- 5 new tests beside the existing OCR-verdict/gate tests (not EOF): 4 verified FAIL on clean origin/main / PASS on branch (vet-before-offer call-spy + withhold; neighbor-poster capture + wrong-window prompt; 3-segment chrome withhold with log line; -150x150 never a candidate while -300x300 survives), 1 declared behavior guard passing on both sides (a legitimately paired -300x300 poster keeps its pairing end to end).

## Wall-clock (first uncached run; OCR is local MLX, ~2s/call, cached forever after)

- Dallas /events/: ~+2–4 new OCR reads (footer logo + `mastodon_hover`; the 150x150 icon is now *never* read — icon-scale needs no call).
- Eagle LA /calendar/: 7 fresh reads vs main's 6 (**net +1**), and better spent: main burned 3 of its 6 on `-150x150` icon renditions and neighbor images; branch reads the real card art (contest posters, BLUF poster, coming-soon placeholders).
- Eagle LA /events/: 0 fresh reads on both sides (fully cached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP