### PR TITLE
fix(scraper): one transcribed glyph no longer immunizes a logo against the furniture gate

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -16422,6 +16422,21 @@ TEXT:
     // logo could still be published as an event's flyer. Recording the verdict
     // here makes that free answer available to image selection.
 
+    // Does an OCR transcription carry MEANINGFUL text — at least one token of
+    // three or more word characters (letters/digits)? Genuine event flyers
+    // always contain multi-character words (title, time, venue: "BEAR",
+    // "10PM", "NO COVER"), so within the already-suspicious furniture
+    // classifications (logo/thumbnail/hero-banner) a transcription with no
+    // such token is glyph noise, not readable text: run 20260807-155753
+    // shipped a social icon as an event image because the vision model
+    // transcribed the logo's single letter ("m") as text, and hasText alone
+    // immunized it against the furniture gate. Scoped to that gate only —
+    // event-flyer-classified images and the pairing-similarity path (where a
+    // 1-char text simply scores ~0 naturally) never consult this.
+    ocrTextHasMeaningfulContent(text) {
+        return /[\p{L}\p{N}]{3,}/u.test(String(text || ''));
+    }
+
     // Remember one OCR verdict under the image's canonical URL. Same key rules
     // as recordMeasuredImageDimensions: exact URL identity, both the raw and
     // normalized forms, so whichever spelling the event carries can find it.
@@ -16429,9 +16444,15 @@ TEXT:
         if (!result || typeof result !== 'object') return null;
         const classification = String(result.imageClassification || '').toLowerCase().trim();
         if (!classification) return null;
+        const rawText = String(result.text || '').trim();
         const verdict = {
             classification,
-            hasText: Boolean(String(result.text || '').trim())
+            // "Has text" means "has MEANINGFUL text" — see
+            // ocrTextHasMeaningfulContent. hasGlyphNoiseOnly remembers that the
+            // model DID transcribe something, so the withhold reason can say
+            // so instead of claiming "no readable text".
+            hasText: this.ocrTextHasMeaningfulContent(rawText),
+            hasGlyphNoiseOnly: Boolean(rawText) && !this.ocrTextHasMeaningfulContent(rawText)
         };
         let recorded = false;
         for (const url of [imageUrl, result.imageUrl, result.url, this.normalizeHttpUrlValue(imageUrl)]) {
@@ -16461,7 +16482,10 @@ TEXT:
      *   1. the model classified it as page furniture (logo/thumbnail/
      *      hero-banner — see nonEventOcrImageClassifications for why ad-banner
      *      is not in that set), AND
-     *   2. the model read NO text off it.
+     *   2. the model read NO text off it — where "text" means MEANINGFUL
+     *      text (ocrTextHasMeaningfulContent): a transcription with no token
+     *      of 3+ word characters ("m" off a social icon, stray punctuation)
+     *      is glyph noise and counts as no text.
      *
      * Condition 2 is what makes this safe. In the real OCR cache corpus two
      * images classified 'logo' carried 587 and 573 characters of text — those
@@ -16477,6 +16501,11 @@ TEXT:
         if (!verdict) return '';
         if (verdict.hasText) return '';
         if (!this.nonEventOcrImageClassifications.has(verdict.classification)) return '';
+        if (verdict.hasGlyphNoiseOnly) {
+            // New wording for the new case only — the model DID transcribe
+            // something, just nothing that clears the meaningful-text bar.
+            return `the vision pass classified it as ${verdict.classification} and transcribed only glyph noise (no token of 3+ word characters)`;
+        }
         return `the vision pass classified it as ${verdict.classification} with no readable text`;
     }
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -12743,6 +12743,123 @@ test('a known non-event image is withheld from the segment prompt entirely', () 
     'the model is never offered an image the vision pass already called a logo');
 });
 
+// ── MEANINGFUL text, not any text (run 20260807-155753) ────────────────────
+// The Dallas Eagle listing shipped the site's Mastodon icon as GEAR NIGHT's
+// image: the vision model classified it "logo" but transcribed the logo's
+// single stylized letter as text "m" (its own reason field said "which is a
+// logo, not text"), and that one glyph satisfied the furniture gate's
+// hasText condition — immunizing the icon against the verdict withhold. The
+// sibling mastodon-150x150.png fell to the icon-scale filename tell;
+// mastodon_hover.png has no -WxH suffix and appeared in only one segment, so
+// the furniture verdict was the only layer left. "Has text" now means "has
+// MEANINGFUL text": at least one token of 3+ word characters. Genuine event
+// flyers always contain multi-character words (titles, times, venue), so
+// within the already-suspicious classifications a ≤2-word-char transcription
+// is glyph noise.
+
+test('a logo whose entire transcription is one glyph is furniture — withheld from prompts and rejected as a value', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events/';
+  const icon = 'https://venue.example/uploads/2025/04/social_hover.png';
+  parser.recordOcrImageVerdict(icon, { imageClassification: 'logo', text: 'm' });
+
+  const lines = parser.extractMultiEventSegmentResourceLines(`<div><img src="${icon}"></div>`, sourceUrl);
+  assert.deepEqual(lines.filter(line => line.startsWith('SEGMENT_IMAGE_URL:')), [],
+    'a single-glyph transcription is not readable text — the logo verdict withholds the offer');
+
+  const event = { title: 'Gear Night', image: icon, imageSource: 'page', imageVertical: icon };
+  const logs = captureLogs(() => parser.rejectNonEventImageValues(event));
+  assert.equal(Object.prototype.hasOwnProperty.call(event, 'image'), false,
+    'one transcribed glyph must not immunize a logo against value rejection');
+  assert.equal(Object.prototype.hasOwnProperty.call(event, 'imageSource'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(event, 'imageVertical'), false);
+  assert.ok(logs.some(line => line.includes('glyph noise')),
+    `the withhold reason says the model transcribed glyph noise, got ${JSON.stringify(logs)}`);
+});
+
+test('a logo carrying a real word keeps today\'s behavior exactly — text vetoes the classification', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events/';
+  const misread = 'https://venue.example/uploads/misread-flyer.jpg';
+  parser.recordOcrImageVerdict(misread, { imageClassification: 'logo', text: 'BEAR NIGHT 10PM' });
+
+  const lines = parser.extractMultiEventSegmentResourceLines(`<div><img src="${misread}"></div>`, sourceUrl);
+  assert.deepEqual(lines.filter(line => line.startsWith('SEGMENT_IMAGE_URL:')), [`SEGMENT_IMAGE_URL: ${misread}`],
+    'a logo-classified image with real words is a misclassified flyer and is still offered');
+
+  const event = { title: 'Keep It', image: misread };
+  parser.rejectNonEventImageValues(event);
+  assert.equal(event.image, misread, 'real words still veto the logo classification');
+});
+
+test('an event-flyer with a one-glyph transcription is untouched by the meaningful-text gate', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events/';
+  const flyer = 'https://venue.example/uploads/minimal-flyer.jpg';
+  // The gate is scoped to the furniture classifications — an event-flyer
+  // verdict never consults it, however thin its transcription.
+  parser.recordOcrImageVerdict(flyer, { imageClassification: 'event-flyer', text: 'm' });
+
+  const lines = parser.extractMultiEventSegmentResourceLines(`<div><img src="${flyer}"></div>`, sourceUrl);
+  assert.deepEqual(lines.filter(line => line.startsWith('SEGMENT_IMAGE_URL:')), [`SEGMENT_IMAGE_URL: ${flyer}`]);
+
+  const event = { title: 'Minimal', image: flyer };
+  parser.rejectNonEventImageValues(event);
+  assert.equal(event.image, flyer, 'the meaningful-text rule must never touch event-flyer-classified images');
+});
+
+test('a thumbnail whose transcription is pure punctuation has no text — withheld', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://venue.example/events/';
+  const thumb = 'https://venue.example/uploads/preview-strip.png';
+  parser.recordOcrImageVerdict(thumb, { imageClassification: 'thumbnail', text: '•·—' });
+
+  const lines = parser.extractMultiEventSegmentResourceLines(`<div><img src="${thumb}"></div>`, sourceUrl);
+  assert.deepEqual(lines.filter(line => line.startsWith('SEGMENT_IMAGE_URL:')), [],
+    'punctuation-only OCR output is not text');
+
+  const event = { title: 'Strip', image: thumb };
+  parser.rejectNonEventImageValues(event);
+  assert.equal(Object.prototype.hasOwnProperty.call(event, 'image'), false);
+});
+
+test('replay 20260807-155753: the cached "m" verdict for mastodon_hover.png now withholds it, no cache change needed', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://www.thedallaseagle.com/events';
+  // The REAL device cache entry, verbatim (storage/ocr/b3335593.assetcdn.net/
+  // 3335593__wp-content__uploads__2025__04__mastodon_hover.png--…json).
+  const iconUrl = 'https://b3335593.assetcdn.net/3335593/wp-content/uploads/2025/04/mastodon_hover.png?lossy=2&strip=1&webp=1';
+  const cachedEntry = {
+    url: iconUrl,
+    text: 'm',
+    imageClassification: 'logo',
+    eventSummary: '',
+    confidence: 100,
+    reason: "The image contains only a stylized red 'm' logo, which is a logo, not text or event information."
+  };
+  // Segment html modeled on the Dallas listing markup around the icon: a
+  // lazyloaded <img> whose real URL lives in data-src.
+  const segmentHtml = `
+    <div class="event-card">
+      <h4>Gear Night</h4>
+      <span class="x-image x-graphic-child x-graphic-image x-graphic-secondary"><img data-src="${iconUrl}" width="78" height="78" alt="Image" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" class="lazyload"></span>
+    </div>`;
+
+  // Fixture validity: with no verdict recorded the gate fails open and the
+  // icon IS offered — exactly what shipped it as Gear Night's image.
+  const before = parser.extractMultiEventSegmentResourceLines(segmentHtml, sourceUrl);
+  assert.ok(before.some(line => line.includes('mastodon_hover.png')),
+    `without a verdict the fallback offers the icon, got ${JSON.stringify(before)}`);
+
+  // Reading the same cache entry (getOcrTextForImage records the verdict on
+  // every cache hit) must now withhold it: the gate is a read-time
+  // interpretation, the cached text stays "m" forever.
+  parser.recordOcrImageVerdict(iconUrl, cachedEntry);
+  const after = parser.extractMultiEventSegmentResourceLines(segmentHtml, sourceUrl);
+  assert.deepEqual(after.filter(line => line.includes('mastodon_hover.png')), [],
+    `mastodon_hover.png must appear in ZERO prompt image lines, got ${JSON.stringify(after)}`);
+});
+
 // ---------------------------------------------------------------------------
 // VET BEFORE OFFER — runs 20260807-143442 (Dallas: the site's Mastodon social
 // icon shipped as GEAR NIGHT's image) and 20260807-142024 (Eagle LA calendar:


### PR DESCRIPTION
## The "m" that beat three layers

Run 20260807-155753 shipped Dallas Eagle's **Mastodon social icon** (`…/2025/04/mastodon_hover.png?…`) as Gear Night's event image. The device OCR cache entry for that URL is classification `"logo"`, text `"m"` — the vision model transcribed the logo's single stylized letter as readable text, and its own reason field even says *"which is a logo, not text"*.

The furniture gate (#1642/#1652) withholds/deletes only when classification ∈ {logo, thumbnail, hero-banner} **and** there is NO text — so the single glyph immunized the icon. Its sibling `mastodon-150x150.png` fell to the icon-scale filename tell, but `mastodon_hover.png` has no `-WxH` suffix and appeared in only one segment (no chrome gate), so the OCR verdict was the only layer left — and `"m"` disarmed it.

## The meaningful-text rule

"Has readable text" now means "has **MEANINGFUL** text": at least one token of 3+ word characters (letters/digits). `"m"`, `"AB"`, punctuation, whitespace → no text; any real word (`"BEAR"`, `"10PM"`, `"NO COVER"`) → text. Genuine event flyers always carry multi-character words (titles, times, venue), so within the already-suspicious furniture classifications a ≤2-word-char transcription is glyph noise.

Implemented once (`ocrTextHasMeaningfulContent`) at the single place the verdict's `hasText` is computed (`recordOcrImageVerdict`), so every furniture-gate consumer — `getNonEventImageOcrReason`, `rejectNonEventImageValues`, `getSegmentPromptImageWithholdReason`, the #1652 vetting path — inherits it. A **new** reason string covers the glyph-noise case ("transcribed only glyph noise"); existing log and prompt strings are byte-for-byte untouched.

## Scope guarantees

- **Furniture gate only**: event-flyer-classified images never consult this — a flyer with a thin transcription is unaffected.
- **Logo-with-real-text behavior preserved exactly**: real words still veto the classification (the 587/573-char misclassified-flyer protection stands).
- **Pairing-similarity path untouched**: OCR-text-vs-segment comparison is unchanged (a 1-char text scores ~0 there naturally).
- **OCR cache untouched**: the gate is a read-time interpretation — cached entries with `text:"m"` start being withheld with no cache change (proven by a replay test using the real cache entry's verbatim values).
- **No new runtime files**, no `new URL`/`URLSearchParams`, nothing per-venue ("mastodon" appears only in fixtures/comments).

## Verification

- `node --check` clean on both files.
- Quiet full suite (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`): **1642 pass / 0 fail** on branch vs measured clean origin/main baseline **1637 pass / 0 fail** (+5, all new).
- 5 new tests beside the #1642/#1652 furniture-verdict tests; on clean origin/main source: **3 fail** (logo+"m" withheld+rejected; thumbnail+punctuation withheld; replay), **2 pass by design** (logo+"BEAR NIGHT 10PM" still offered — behavior guard; event-flyer+"m" unaffected — scope guard).
- Replay test uses the REAL device cache values (classification `logo`, text `"m"`, exact reason string) in a fixture modeled on the Dallas listing's lazyload markup: `mastodon_hover.png` is offered with no verdict (fixture validity — how it shipped) and appears in **zero** prompt image lines once the cached verdict is recorded.
- `git diff`: pure additions around the gate; no existing log/prompt string modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP