### PR TITLE
feat(scraper): two-month calendar lookahead by default

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4729,16 +4729,24 @@ class AiWebParser {
     }
 
     // How many FUTURE months of a detected calendar month grid to fetch.
-    // Default 1 (current + next): phone wall-clock is the budget that
+    // Default 2 (current + two ahead): phone wall-clock is the budget that
     // matters, and one month ahead is what turns "the event appeared when
     // the venue's grid rolled over" into "we saw it a month early". Clamped
     // 0..3; per-parser `calendarLookaheadMonths` wins over the global knob.
+    // Why 2, not 1: cadence derivation needs enough observations to commit,
+    // and one month is provably one short — Dallas GEAR NIGHT looked like
+    // "mixed 7/14-day Saturday gaps" on the August grid alone, while the
+    // September grid (4 consecutive Saturdays) settles it as weekly; the
+    // Discipline Corps ordinal (2nd Friday) likewise only repeats once a
+    // second future month is visible. The marginal cost is one cached
+    // admin-ajax POST per site per page-cache TTL plus that month's net-new
+    // detail crawls.
     resolveCalendarLookaheadMonths(parserConfig) {
         const configured = parserConfig && parserConfig.calendarLookaheadMonths !== undefined
             ? parserConfig.calendarLookaheadMonths
             : (this.config ? this.config.calendarLookaheadMonths : undefined);
         const value = Number(configured);
-        if (!Number.isFinite(value)) return 1;
+        if (!Number.isFinite(value)) return 2;
         return Math.max(0, Math.min(3, Math.floor(value)));
     }
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -12409,7 +12409,7 @@ test('a MEC month-grid page replays its own admin-ajax month feed and harvests n
     { url: 'https://venue.example/calendar/', html: MEC_MONTH_GRID_PAGE_HTML },
     { discoveryOnly: true }, null, 'link-aggregator', stubAdapter);
 
-  assert.equal(postCalls.length, 1, 'default lookahead is exactly ONE future month');
+  assert.equal(postCalls.length, 2, 'default lookahead is exactly TWO future months');
   assert.equal(postCalls[0].url, 'https://venue.example/wp-admin/admin-ajax.php');
   assert.equal(postCalls[0].options.headers['X-Requested-With'], 'XMLHttpRequest');
   assert.ok(postCalls[0].body.startsWith('action=mec_monthly_view_load_month&mec_year=2026&mec_month=09&navigator_click=true&'),
@@ -12445,7 +12445,7 @@ test('the month-feed POST body carries the page\'s atts blob verbatim and a stab
   await parser.parseEvents(
     { url: 'https://venue.example/calendar/', html: MEC_MONTH_GRID_PAGE_HTML },
     { discoveryOnly: true }, null, 'link-aggregator', stubAdapter);
-  assert.equal(postCalls.length, 1);
+  assert.equal(postCalls.length, 2);
   assert.ok(postCalls[0].body.endsWith(`&${MEC_FIXTURE_ATTS}`),
     `the atts blob is harvested from the page and replayed VERBATIM, got: ${postCalls[0].body}`);
   assert.equal(postCalls[0].options.cacheUrl,
@@ -12477,7 +12477,7 @@ test('a failed month-feed POST degrades like any failed crawled page: logged, ru
 
 test('calendarLookaheadMonths is clamped 0..3 and 0 disables the feed', async () => {
   const parser = createParser();
-  assert.equal(parser.resolveCalendarLookaheadMonths({}), 1, 'default: current + 1 month');
+  assert.equal(parser.resolveCalendarLookaheadMonths({}), 2, 'default: current + 2 months — one month of observations is provably one short for cadence derivation (Dallas GEAR NIGHT)');
   assert.equal(parser.resolveCalendarLookaheadMonths({ calendarLookaheadMonths: 9 }), 3);
   assert.equal(parser.resolveCalendarLookaheadMonths({ calendarLookaheadMonths: -2 }), 0);
   let posts = 0;


### PR DESCRIPTION
## Why

Cadence derivation (#1651) needs enough observations to commit, and one month is provably one short:

- **GEAR NIGHT (Dallas)** looked like "mixed 7/14-day Saturday gaps" on the August grid alone and refused to fold. The live **September grid shows it on 4 consecutive Saturdays** (Sep 5/12/19/26, plus Oct 3) — weekly, settled. (Slug renumbering across occurrences — gear-night-11/12/17/19/20/22 — is handled by #1651's title-group derivation.)
- **Discipline Corps** is 2nd-Friday monthly: Sep 11 and Oct 9 are both 2nd Fridays, but that ordinal only repeats once a *second* future month is visible.

Both were verified against live month-feed responses from thedallaseagle.com today (the same admin-ajax protocol shipped in #1650).

## Change

`resolveCalendarLookaheadMonths` default 1 → 2. Clamp (0..3) and the per-parser `calendarLookaheadMonths` override are unchanged. Two existing tests updated to pin the new default (they fail on main with the old default); no new runtime files.

## Cost

One additional **cached** admin-ajax POST per MEC site per page-cache TTL (3 days), plus the extra month's net-new detail-page crawls (net-new only — the candidate dedupe from #1650 applies).

## Verification

- `node --check` clean; quiet suite **1642 pass / 0 fail** (same total as baseline — two assertions updated in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP