### PR TITLE
feat(scraper): saved-series lookup beyond the same-day hit — matched series report SERIES MATCH, not NEW

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2730,6 +2730,22 @@ class ScriptableAdapter {
       ) {
         return this._publishedRecurringUidsByCity[key];
       }
+      const body = await this.fetchPublishedCalendarIcsBody(key);
+      const uids = body ? SharedCore.extractRecurringUidsFromIcs(body) : null;
+      this._publishedRecurringUidsByCity[key] = uids;
+      return uids;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  // One published-calendar ICS body fetch, shared by the UID scan and the
+  // full-record parse (page-cached, so both consumers cost one request per
+  // TTL). Null on any failure.
+  async fetchPublishedCalendarIcsBody(cityKey) {
+    try {
+      const key = String(cityKey || "").trim();
+      if (!key) return null;
       const url = `https://chunky.dad/data/calendars/${encodeURIComponent(key)}.ics`;
       const icsCacheConfig = {
         enabled: this.getPageCacheConfig().enabled,
@@ -2749,9 +2765,7 @@ class ScriptableAdapter {
           await this.writeCachedPage(url, responseData, icsCacheConfig);
         }
       }
-      const uids = body ? SharedCore.extractRecurringUidsFromIcs(body) : null;
-      this._publishedRecurringUidsByCity[key] = uids;
-      return uids;
+      return body;
     } catch (error) {
       return null;
     }
@@ -2774,6 +2788,11 @@ class ScriptableAdapter {
         instances,
         identifier,
       );
+      // Cache the full decision (not just the boolean) so the honest-state
+      // report can say HOW MANY instances the confirmed series has without a
+      // second calendar read.
+      if (!this._seriesProbeDecisions) this._seriesProbeDecisions = {};
+      this._seriesProbeDecisions[String(identifier).trim()] = decision;
       if (decision.isSeries) {
         console.log(
           `🔁 RECURRING: series detected via wide-window identifier probe for "${title}" (${decision.instanceCount} instances)`,
@@ -2783,6 +2802,98 @@ class ScriptableAdapter {
     } catch (error) {
       // Fail open — probe errors never change merge behavior.
       return false;
+    }
+  }
+
+  // Cached wide-window probe decision ({ instanceCount, isSeries }) for an
+  // identifier this run, or null. Reporting-only consumer: SharedCore's
+  // series-match stamp reads the instance count off it.
+  getSeriesProbeDecision(identifier) {
+    const key =
+      identifier === null || identifier === undefined
+        ? ""
+        : String(identifier).trim();
+    if (!key || !this._seriesProbeDecisions) return null;
+    return Object.prototype.hasOwnProperty.call(this._seriesProbeDecisions, key)
+      ? this._seriesProbeDecisions[key]
+      : null;
+  }
+
+  // Wide-window candidate fetch for the saved-series lookup (SharedCore
+  // .findSavedSeriesMatch): every calendar event in the same now-anchored
+  // window the identifier probe uses. The day-window getExistingEvents
+  // search can legitimately return found=0 for a series the owner ALREADY
+  // saved — a monthly series whose next instance is on a different day, a
+  // weekly series saved last week — so the lookup needs the whole window,
+  // cached per calendar per run. Read-only; fails open to null.
+  async getWideWindowCalendarEvents(event) {
+    try {
+      const city = (event && event.city) || "default";
+      const calendarName = this.getCalendarName(city);
+      if (!this._wideWindowEventsByCalendar) {
+        this._wideWindowEventsByCalendar = {};
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(
+          this._wideWindowEventsByCalendar,
+          calendarName,
+        )
+      ) {
+        return this._wideWindowEventsByCalendar[calendarName];
+      }
+      let entry = null;
+      try {
+        const calendar = await this.getOrCreateCalendar(calendarName);
+        const now = new Date();
+        const windowStart = new Date(now.getTime() - 35 * 24 * 60 * 60 * 1000);
+        const windowEnd = new Date(now.getTime() + 70 * 24 * 60 * 60 * 1000);
+        const instances = await CalendarEvent.between(windowStart, windowEnd, [
+          calendar,
+        ]);
+        entry = {
+          calendarName,
+          events: Array.isArray(instances) ? instances : [],
+        };
+        console.log(
+          `📱 Scriptable: Wide-window series lookup calendar="${calendarName}" window=${windowStart.toISOString()} → ${windowEnd.toISOString()} found=${entry.events.length}`,
+        );
+      } catch (error) {
+        // Fail open (missing calendar, EventKit error): the lookup layer
+        // simply has no candidates and the published-ICS fallback runs.
+        entry = null;
+      }
+      this._wideWindowEventsByCalendar[calendarName] = entry;
+      return entry;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  // Parsed published-calendar VEVENT records for one city (fallback layer of
+  // the saved-series lookup). Same fetch/cache machinery as
+  // getPublishedRecurringUids — the body is page-cached, so the two helpers
+  // share one network fetch per run. Null on any failure (callers fail open).
+  async getPublishedCalendarRecords(cityKey) {
+    try {
+      const key = String(cityKey || "").trim();
+      if (!key) return null;
+      if (!this._publishedCalendarRecordsByCity) {
+        this._publishedCalendarRecordsByCity = {};
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(
+          this._publishedCalendarRecordsByCity,
+          key,
+        )
+      ) {
+        return this._publishedCalendarRecordsByCity[key];
+      }
+      const body = await this.fetchPublishedCalendarIcsBody(key);
+      const records = body ? SharedCore.parsePublishedCalendarIcs(body) : null;
+      this._publishedCalendarRecordsByCity[key] = records;
+      return records;
+    } catch (error) {
+      return null;
     }
   }
 
@@ -5376,6 +5487,7 @@ class ScriptableAdapter {
       merge: [],
       conflict: [],
       missing_calendar: [],
+      series_match: [],
       other: [],
     };
 
@@ -5396,6 +5508,15 @@ class ScriptableAdapter {
     console.log(
       `   ❌ Missing Calendar: ${eventsByAction.missing_calendar.length} events`,
     );
+    // Additive bucket (line only when non-zero, same rule as Other): series
+    // the run matched to an already-saved series and withheld — these are
+    // deliberately NOT counted toward ➕ New, which is exactly the claim
+    // that kept re-offering already-saved series for import.
+    if (eventsByAction.series_match.length > 0) {
+      console.log(
+        `   🔁 Series match: ${eventsByAction.series_match.length} events (already saved — withheld)`,
+      );
+    }
     if (eventsByAction.other.length > 0) {
       console.log(`   ❓ Other: ${eventsByAction.other.length} events`);
     }
@@ -5548,6 +5669,7 @@ class ScriptableAdapter {
       merge: 0,
       conflict: 0,
       missing_calendar: 0,
+      series_match: 0,
       other: 0,
     };
 
@@ -5573,6 +5695,7 @@ class ScriptableAdapter {
               merge: "🔄",
               conflict: "⚠️",
               missing_calendar: "❌",
+              series_match: "🔁",
               other: "❓",
             }[action] || "❓";
 
@@ -6123,6 +6246,12 @@ class ScriptableAdapter {
           newEvents.push(entry);
           break;
         case "merge":
+          mergeEvents.push(entry);
+          break;
+        // A series-matched (already saved, withheld) event matched an
+        // existing record — its card belongs with the matches, never in the
+        // New section whose framing is what re-offered saved series.
+        case "series_match":
           mergeEvents.push(entry);
           break;
         case "conflict":
@@ -10368,6 +10497,8 @@ class ScriptableAdapter {
           conflict: '<span class="action-badge badge-warning">CONFLICT</span>',
           missing_calendar:
             '<span class="action-badge badge-error">MISSING CALENDAR</span>',
+          series_match:
+            '<span class="action-badge badge-merge">SERIES MATCH</span>',
         }[intentAction] ||
         '<span class="action-badge badge-warning">OTHER</span>';
     // Recurring series are display+export only (never auto-written): badge
@@ -13765,6 +13896,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     if (normalized === "new") return "NEW";
     if (normalized === "conflict") return "CONFLICT";
     if (normalized === "missing_calendar") return "MISSING_CALENDAR";
+    if (normalized === "series_match") return "SERIES MATCH";
     return "OTHER";
   }
 
@@ -13779,6 +13911,16 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
   }
 
   normalizeIntentAction(event) {
+    const action = this.normalizeIntentActionBase(event);
+    // Honest terminal state: a withheld series that MATCHED a saved series
+    // is not NEW (and not a plain merge either — nothing will be written).
+    // Display/summary intent only; normalizeMetricsIntentAction keeps the
+    // base derivation so the metrics schema and its buckets are untouched.
+    if (action && event && event._seriesMatch) return "series_match";
+    return action;
+  }
+
+  normalizeIntentActionBase(event) {
     const action = this.normalizeWriteAction(event);
     if (!action) return null;
     if (action !== "new") return action;
@@ -13802,7 +13944,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
   }
 
   normalizeMetricsIntentAction(event) {
-    return this.normalizeIntentAction(event);
+    return this.normalizeIntentActionBase(event);
   }
 
   countMetricsActions(events) {

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -3930,6 +3930,203 @@ test('event card: a series already in the calendar says so, next to the ICS badg
 });
 
 // ---------------------------------------------------------------------------
+// Honest terminal state for a matched-but-withheld series: SERIES MATCH /
+// WITHHELD with its own summary bucket, never counted toward ➕ New (runs
+// 20260807-161034 / 20260807-114625: B BAR, CUBSCOUT, ONYX came back "NEW"
+// the day after the owner saved exactly those series).
+// ---------------------------------------------------------------------------
+
+test('intent action: a series-matched withheld event reports SERIES MATCH / WITHHELD, metrics keep the base bucket', () => {
+  const adapter = buildAdapter();
+  const event = buildRecurringCardEvent({
+    _seriesMatch: {
+      identifier: 'CAL-UUID:fuzzy-uid@chunky.dad',
+      instances: 2,
+      calendarName: 'chunky-dad-dallas'
+    }
+  });
+
+  assert.equal(adapter.normalizeIntentAction(event), 'series_match');
+  assert.equal(adapter.formatIntentActionLabel('series_match'), 'SERIES MATCH');
+  assert.equal(adapter.getWriteActionFromEvent(event), 'withheld');
+  assert.equal(adapter.formatWriteActionLabel('withheld'), 'WITHHELD');
+  // Metrics are untouched: the base derivation still buckets this as new,
+  // so the metrics schema and historical comparisons keep their meaning.
+  assert.equal(adapter.normalizeMetricsIntentAction(event), 'new');
+  const counts = adapter.countMetricsActions([event]);
+  assert.equal(counts.new, 1, 'metrics bucket unchanged');
+  assert.equal(counts.other, 0, 'and nothing leaks into other');
+});
+
+test('event actions summary: series matches get their own bucket instead of counting toward New', async () => {
+  const adapter = buildAdapter();
+  const matchedSeries = buildRecurringCardEvent({
+    _seriesMatch: { identifier: 'CAL-UUID:fuzzy-uid@chunky.dad', instances: 2, calendarName: 'chunky-dad-dallas' }
+  });
+  const genuinelyNewSeries = buildRecurringCardEvent({ title: 'BRAND NEW SERIES' });
+  const plainNew = {
+    title: 'ONE OFF',
+    _action: 'new',
+    startDate: '2026-08-09T02:00:00.000Z',
+    city: 'dallas'
+  };
+
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...args) => lines.push(args.join(' '));
+  try {
+    await adapter.displayEnrichedEvents({
+      analyzedEvents: [matchedSeries, genuinelyNewSeries, plainNew],
+      errors: []
+    });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.ok(lines.some(l => l.includes('➕ New: 2 events')),
+    `the matched series is NOT new — only the genuine discoveries are: ${JSON.stringify(lines.filter(l => l.includes('events')))}`);
+  assert.ok(lines.some(l => l.includes('🔁 Series match: 1 events (already saved — withheld)')),
+    'the matched series gets its own bucket');
+});
+
+test('getSeriesProbeDecision: the wide-window probe caches its instance count for the honest-state report', async () => {
+  const adapter = new ScriptableAdapter({
+    cities: { la: { calendar: 'chunky-dad-la', timezone: 'America/Los_Angeles', patterns: ['los angeles'] } }
+  });
+  const identifier = 'CAL-UUID:cubscout-1@chunky.dad';
+  const instances = [{ identifier }, { identifier }, { identifier: 'CAL-UUID:other' }];
+  const isSeries = await withStubbedCalendar('chunky-dad-la', instances, () =>
+    adapter.probeSeriesByWideWindow(identifier, 'la', 'CUBSCOUT'));
+
+  assert.equal(isSeries, true);
+  assert.deepEqual(adapter.getSeriesProbeDecision(identifier), { instanceCount: 2, isSeries: true });
+  assert.equal(adapter.getSeriesProbeDecision('CAL-UUID:never-probed'), null);
+  assert.equal(adapter.getSeriesProbeDecision(''), null);
+});
+
+test('getWideWindowCalendarEvents: fetches the probe window once per calendar and fails open', async () => {
+  const adapter = new ScriptableAdapter({
+    cities: { la: { calendar: 'chunky-dad-la', timezone: 'America/Los_Angeles', patterns: ['los angeles'] } }
+  });
+  const saved = [{
+    identifier: 'CAL-UUID:cubscout-1@chunky.dad',
+    title: 'CUBSCOUT',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    notes: 'bar: Eagle LA'
+  }];
+
+  let betweenCalls = 0;
+  const originalCalendar = global.Calendar;
+  const originalCalendarEvent = global.CalendarEvent;
+  global.Calendar = { forEvents: async () => [{ title: 'chunky-dad-la', identifier: 'CAL-UUID' }] };
+  global.CalendarEvent = { between: async () => { betweenCalls += 1; return saved; } };
+  try {
+    const first = await adapter.getWideWindowCalendarEvents({ city: 'la', title: 'CUBSCOUT' });
+    assert.ok(first, 'lookup succeeds');
+    assert.equal(first.calendarName, 'chunky-dad-la');
+    assert.equal(first.events.length, 1);
+    const second = await adapter.getWideWindowCalendarEvents({ city: 'la', title: 'B BAR' });
+    assert.equal(second, first, 'cached per calendar per run');
+    assert.equal(betweenCalls, 1, 'one calendar read for the whole run');
+  } finally {
+    global.Calendar = originalCalendar;
+    global.CalendarEvent = originalCalendarEvent;
+  }
+
+  // Missing calendar → fail open to null (the published-ICS fallback runs).
+  const failing = new ScriptableAdapter({
+    cities: { la: { calendar: 'chunky-dad-la', timezone: 'America/Los_Angeles', patterns: ['los angeles'] } }
+  });
+  const result = await withStubbedCalendar('some-other-calendar', [], () =>
+    failing.getWideWindowCalendarEvents({ city: 'la' }));
+  assert.equal(result, null, 'no calendar, no candidates — never a throw');
+});
+
+test('getPublishedCalendarRecords: parses the published city ICS through the shared body fetch', async () => {
+  const adapter = buildAdapter();
+  const ics = [
+    'BEGIN:VCALENDAR',
+    'BEGIN:VEVENT',
+    'DTSTART;TZID=America/Los_Angeles:20260904T210000',
+    'RRULE:FREQ=MONTHLY;BYDAY=1FR',
+    'UID:cubscout-20260731T193113Z@chunky.dad',
+    'SUMMARY:CUBSCOUT',
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ].join('\r\n');
+  const fetched = [];
+  adapter.fetchPublishedCalendarIcsBody = async (cityKey) => {
+    fetched.push(cityKey);
+    return ics;
+  };
+
+  const records = await adapter.getPublishedCalendarRecords('la');
+  assert.ok(Array.isArray(records));
+  assert.equal(records.length, 1);
+  assert.equal(records[0].uid, 'cubscout-20260731T193113Z@chunky.dad');
+  assert.equal(records[0].summary, 'CUBSCOUT');
+  assert.equal(records[0].rrule, 'FREQ=MONTHLY;BYDAY=1FR');
+
+  await adapter.getPublishedCalendarRecords('la');
+  assert.deepEqual(fetched, ['la'], 'memoized per city per run');
+  assert.equal(await adapter.getPublishedCalendarRecords(''), null, 'no city, no fetch');
+});
+
+test('event card actions: a recurrence-only builder event now gets the ICS export button', () => {
+  const adapter = buildAdapter();
+  adapter.resetMapVerifyUrls();
+  adapter.resetIcsExportEvents();
+  const builderEvent = {
+    title: 'CUBSCOUT',
+    startDate: '2026-09-05T04:00:00.000Z',
+    endDate: '2026-09-05T09:00:00.000Z',
+    city: 'la',
+    // The canonical schema field only — no recurrenceRule, no _recurring.
+    recurrence: 'FREQ=MONTHLY;BYDAY=1FR'
+  };
+  const html = adapter.buildEventCardActionsHtml(builderEvent);
+  assert.ok(html.includes('Save recurring (.ics)'),
+    'the RRULE is routed to the ICS channel instead of silently dropping');
+});
+
+test('getEventOverrideIdentity: notes-carried override identity, source uid, and date key', () => {
+  const adapter = buildAdapter();
+  const uid = 'cubscout-20260731T193113Z@chunky.dad';
+  const override = {
+    identifier: 'CAL-UUID:override-1',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    notes: `bar: Eagle LA\nuid: ${uid}\noverrideUid: ${uid}\noverrideRecurrenceId: 20260905`
+  };
+  const identity = adapter.getEventOverrideIdentity(override);
+  assert.equal(identity.overrideUid, uid);
+  assert.equal(identity.overrideRecurrenceId, '20260905');
+  assert.equal(identity.overrideKey, `${uid.toLowerCase()}::20260905`);
+  assert.equal(identity.sourceUid, uid);
+  assert.ok(identity.recurrenceDateKey, 'the occurrence date key is derived from the start date');
+
+  // A plain series occurrence has NO override identity, only a source uid.
+  const occurrence = {
+    identifier: `CAL-UUID:${uid}`,
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    notes: 'bar: Eagle LA'
+  };
+  const plain = adapter.getEventOverrideIdentity(occurrence);
+  assert.equal(plain.overrideKey, '', 'no override claim');
+  assert.equal(plain.sourceUid, uid, 'the identifier suffix IS the ICS UID');
+
+  const empty = adapter.getEventOverrideIdentity(null);
+  assert.equal(empty.overrideKey, '');
+  assert.equal(empty.sourceUid, '');
+});
+
+test('normalizeOverrideUid delegates to the shared normalization (trim, keep case)', () => {
+  const adapter = buildAdapter();
+  assert.equal(adapter.normalizeOverrideUid('  MixedCase@Chunky.dad '), 'MixedCase@Chunky.dad');
+  assert.equal(adapter.normalizeOverrideUid(null), '');
+});
+
+// ---------------------------------------------------------------------------
 // Event Builder links carry editing context when the run matched a record.
 // Without it the builder opened in "brand new event" mode even though the run
 // had just matched and merged the event — so a saved series kept being

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -971,6 +971,41 @@ async saveFailureNote(url, error, metadata = {}) {
         }
     }
 
+    // Node-side mirror of ScriptableAdapter.getWideWindowCalendarEvents (the
+    // saved-series lookup's candidate source): expand the published city
+    // calendar over the same now-anchored -35d..+70d window the identifier
+    // probe uses. Expanded series occurrences carry `recurrence`, which the
+    // lookup reads as the candidate's series evidence. Fails open to null.
+    async getWideWindowCalendarEvents(event) {
+        try {
+            const city = (event && event.city) || 'default';
+            const published = await this.getPublishedCalendarEvents(city);
+            const core = this.getSharedCoreRef();
+            if (!published || !core) return null;
+            const now = new Date();
+            const windowStart = new Date(now.getTime() - 35 * 24 * 60 * 60 * 1000);
+            const windowEnd = new Date(now.getTime() + 70 * 24 * 60 * 60 * 1000);
+            const expansion = core.expandPublishedCalendarEventsInWindow(
+                published.records, windowStart, windowEnd
+            );
+            return { calendarName: city, events: expansion.events };
+        } catch (error) {
+            return null;
+        }
+    }
+
+    // Node-side mirror of ScriptableAdapter.getPublishedCalendarRecords: the
+    // parsed VEVENT records already fetched for getExistingEvents. Null on
+    // any failure (callers fail open).
+    async getPublishedCalendarRecords(cityKey) {
+        try {
+            const published = await this.getPublishedCalendarEvents(cityKey || '');
+            return published && Array.isArray(published.records) ? published.records : null;
+        } catch (error) {
+            return null;
+        }
+    }
+
     // Display/Logging Adapter Implementation
     async logInfo(message) {
         console.log(`%cℹ️ ${message}`, 'color: #2196F3');

--- a/scripts/adapters/web-adapter.test.js
+++ b/scripts/adapters/web-adapter.test.js
@@ -123,6 +123,38 @@ test('getExistingEvents returns window-filtered events from the published calend
   });
 });
 
+// Node-side mirrors of the Scriptable saved-series lookup hooks: the wide
+// window is the published calendar expanded over the probe window, and the
+// record fallback is the parsed VEVENT list itself.
+test('getWideWindowCalendarEvents mirrors the probe window off the published calendar', async () => {
+  await withFetchStub(LA_ICS_FIXTURE, async (fetchCalls) => {
+    const adapter = makeAdapter();
+    const lookup = await adapter.getWideWindowCalendarEvents({ city: 'la', title: 'Club Chub' });
+
+    assert.ok(lookup, 'lookup available on Node');
+    assert.equal(lookup.calendarName, 'la');
+    const chubOccurrences = lookup.events.filter((e) => e.identifier === 'chub-la@test');
+    assert.ok(chubOccurrences.length >= 1, 'the monthly series expands into the now-anchored window');
+    assert.equal(chubOccurrences[0].recurrence, 'FREQ=MONTHLY;BYDAY=3SU',
+      'expanded occurrences carry the series evidence the lookup reads');
+    assert.equal(fetchCalls(), 1, 'shares the per-run published-calendar memo');
+  });
+});
+
+test('getPublishedCalendarRecords exposes the parsed VEVENTs and fails open', async () => {
+  await withFetchStub(LA_ICS_FIXTURE, async () => {
+    const adapter = makeAdapter();
+    const records = await adapter.getPublishedCalendarRecords('la');
+    assert.ok(Array.isArray(records));
+    assert.deepEqual(records.map((r) => r.uid).sort(), ['chub-la@test', 'duro-la@test', 'gala-la@test']);
+    assert.equal(records.find((r) => r.uid === 'chub-la@test').rrule, 'FREQ=MONTHLY;BYDAY=3SU');
+  });
+  await withFetchStub(new Error('network down'), async () => {
+    const adapter = makeAdapter();
+    assert.equal(await adapter.getPublishedCalendarRecords('la'), null, 'fetch failure fails open to null');
+  });
+});
+
 test('disk cache honors the 0.25-day TTL across adapter instances', async () => {
   const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chunky-ics-cache-'));
   const pageCache = { enabled: true, ttlDays: 3 };

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -10428,23 +10428,153 @@ class SharedCore {
     // absence or errors leave today's behavior untouched.
     async resolveCalendarAnalysisWithSeriesProbe(event, existingEventsData, mergeMode, calendarAdapter) {
         let analysis = this.analyzeEventAction(event, existingEventsData, mergeMode);
-        if (analysis.action !== 'merge' || !analysis.existingEvent) {
-            return analysis;
-        }
-        if (!calendarAdapter || typeof calendarAdapter.probeRecurringSeries !== 'function') {
-            return analysis;
-        }
-        try {
-            const isSeries = await calendarAdapter.probeRecurringSeries(analysis.existingEvent, event);
-            if (isSeries === true) {
-                const identifier = analysis.existingEvent.identifier || analysis.existingEvent.id || '';
-                this.noteConfirmedRecurringSeries(identifier);
-                analysis = this.analyzeEventAction(event, existingEventsData, mergeMode);
+        if (analysis.action === 'merge' && analysis.existingEvent) {
+            if (!calendarAdapter || typeof calendarAdapter.probeRecurringSeries !== 'function') {
+                return analysis;
             }
-        } catch (error) {
-            // Fail open — probe errors never change merge behavior.
+            try {
+                const isSeries = await calendarAdapter.probeRecurringSeries(analysis.existingEvent, event);
+                if (isSeries === true) {
+                    const identifier = analysis.existingEvent.identifier || analysis.existingEvent.id || '';
+                    this.noteConfirmedRecurringSeries(identifier);
+                    analysis = this.analyzeEventAction(event, existingEventsData, mergeMode);
+                }
+            } catch (error) {
+                // Fail open — probe errors never change merge behavior.
+            }
+            return analysis;
+        }
+        // The day-window search matched nothing this event maps to, but the
+        // scraped event itself EXPORTS a series. A saved series' visible
+        // instances legitimately live on OTHER days than the scraped
+        // occurrence (a monthly series whose next saved instance is a
+        // different day; a weekly series saved last week), so `found=0` here
+        // proves nothing — run the saved-series lookup before letting the
+        // run claim NEW and re-offer the same ICS (run 20260807-161034:
+        // B BAR/CUBSCOUT/ONYX all "new" the day after their series were
+        // saved). Reporting-only: the analysis action stays 'new' and the
+        // write stays withheld — a match only changes what the run SAYS.
+        if (analysis.action === 'new' && !analysis.existingEvent && !analysis.sourceEvent &&
+            SharedCore.isRecurringSeriesEvent(event)) {
+            try {
+                const seriesMatch = await this.findSavedSeriesMatch(event, calendarAdapter);
+                if (seriesMatch) {
+                    analysis.seriesMatch = seriesMatch;
+                }
+            } catch (error) {
+                // Fail open — lookup errors leave today's NEW verdict untouched.
+            }
         }
         return analysis;
+    }
+
+    // Identity gate for the saved-series lookup: the dedup's own name and
+    // place helpers (areIdentityNamesSimilar / areIdentityPlacesSimilar —
+    // nothing looser), minus getSameEventIdentitySignal's same-local-day
+    // gate. Relaxing the day is the entire point — the saved series' visible
+    // instances are on other days — and it is compensated by the caller
+    // requiring the candidate to be a POSITIVELY CONFIRMED saved series
+    // before anything is claimed.
+    matchesSavedSeriesIdentity(event, candidate) {
+        const incoming = this.buildIdentityComparisonShape(event);
+        const existing = this.buildIdentityComparisonShape(candidate);
+        return this.areIdentityNamesSimilar(incoming, existing) &&
+            this.areIdentityPlacesSimilar(incoming, existing);
+    }
+
+    // Saved-series lookup for a series-export event whose own day window
+    // found nothing. Two layers, both adapter-provided and both fail-open:
+    //   1. Wide-window calendar candidates (calendarAdapter
+    //      .getWideWindowCalendarEvents): match by dedup identity, then
+    //      require the candidate to be a saved series via the doctrine's
+    //      detection order — notes `recurrence:` key (or the expanded
+    //      record's own recurrence field) → local multi-instance identifier
+    //      count → adapter probe (published calendar ICS, then wide-window
+    //      identifier probe).
+    //   2. Published calendar ICS records (calendarAdapter
+    //      .getPublishedCalendarRecords): a series VEVENT with matching
+    //      identity in the city's published calendar also proves "already
+    //      saved".
+    // Returns { identifier, title, startDate, endDate, instances,
+    // calendarName, reason } or null. Never changes any analysis action.
+    async findSavedSeriesMatch(event, calendarAdapter) {
+        if (!calendarAdapter) return null;
+        const calendarNameFor = () => {
+            try {
+                return typeof calendarAdapter.getCalendarName === 'function'
+                    ? String(calendarAdapter.getCalendarName(event.city || 'default') || '')
+                    : String(event.city || '');
+            } catch (error) {
+                return String(event.city || '');
+            }
+        };
+        // Layer 1: wide-window calendar candidates.
+        if (typeof calendarAdapter.getWideWindowCalendarEvents === 'function') {
+            const lookup = await calendarAdapter.getWideWindowCalendarEvents(event);
+            const candidates = lookup && Array.isArray(lookup.events) ? lookup.events : [];
+            const lookupCalendarName = lookup && lookup.calendarName
+                ? String(lookup.calendarName)
+                : calendarNameFor();
+            for (const candidate of candidates) {
+                if (!candidate) continue;
+                if (!this.matchesSavedSeriesIdentity(event, candidate)) continue;
+                const fields = this.parseNotesIntoFields(candidate.notes || '');
+                const statedRule = (typeof fields.recurrence === 'string' && fields.recurrence.trim())
+                    || (typeof candidate.recurrence === 'string' && candidate.recurrence.trim())
+                    || '';
+                const identifier = candidate.identifier || candidate.id || '';
+                const probeDecision = SharedCore.resolveSeriesProbeDecision(candidates, identifier);
+                let confirmed = Boolean(statedRule) || probeDecision.isSeries;
+                if (!confirmed && typeof calendarAdapter.probeRecurringSeries === 'function') {
+                    confirmed = (await calendarAdapter.probeRecurringSeries(candidate, event)) === true;
+                }
+                if (!confirmed) continue;
+                this.noteConfirmedRecurringSeries(identifier);
+                return {
+                    identifier,
+                    title: candidate.title || '',
+                    startDate: candidate.startDate || null,
+                    endDate: candidate.endDate || candidate.startDate || null,
+                    instances: Math.max(probeDecision.instanceCount, 1),
+                    calendarName: lookupCalendarName,
+                    reason: 'Saved series match (wide-window)'
+                };
+            }
+        }
+        // Layer 2 (fallback): published calendar ICS records.
+        if (typeof calendarAdapter.getPublishedCalendarRecords === 'function') {
+            const records = await calendarAdapter.getPublishedCalendarRecords(event.city || '');
+            if (Array.isArray(records)) {
+                for (const record of records) {
+                    // Only series-defining VEVENTs count: an RRULE and no
+                    // RECURRENCE-ID (override instances are not the series).
+                    if (!record || !record.rrule || record.recurrenceId) continue;
+                    const candidate = {
+                        identifier: record.uid || '',
+                        title: record.summary || '',
+                        startDate: record.start && record.start.date ? record.start.date : null,
+                        endDate: record.end && record.end.date
+                            ? record.end.date
+                            : (record.start && record.start.date) || null,
+                        location: record.location || '',
+                        notes: record.description || ''
+                    };
+                    if (!candidate.identifier || !candidate.startDate) continue;
+                    if (!this.matchesSavedSeriesIdentity(event, candidate)) continue;
+                    this.noteConfirmedRecurringSeries(candidate.identifier);
+                    return {
+                        identifier: candidate.identifier,
+                        title: candidate.title,
+                        startDate: candidate.startDate,
+                        endDate: candidate.endDate,
+                        instances: 1,
+                        calendarName: calendarNameFor(),
+                        reason: 'Saved series match (published calendar ICS)'
+                    };
+                }
+            }
+        }
+        return null;
     }
 
     resolveRecurringMergeCandidate(existingEventsData, existingEvent) {
@@ -10816,7 +10946,20 @@ class SharedCore {
     static isRecurringSeriesEvent(event) {
         if (!event || typeof event !== 'object') return false;
         if (event._recurring === true) return true;
-        return typeof event.recurrenceRule === 'string' && event.recurrenceRule.trim() !== '';
+        if (typeof event.recurrenceRule === 'string' && event.recurrenceRule.trim() !== '') return true;
+        // The canonical schema field: event-schema canonicalizes
+        // rrule/recurrenceRule → `recurrence`, so a builder-made event may
+        // carry ONLY `recurrence` — without this it was invisible as a
+        // series (no 🔁 badge, no ICS export, no withhold, and the RRULE
+        // silently dropped on write because createCalendarEvent never sets
+        // one). BUT: `recurrence` also leaks off an EXISTING record's notes
+        // onto a single-occurrence override during the merge
+        // (createFinalEventObject), and an override-identified event is by
+        // definition ONE occurrence — treating that leak as a series claim
+        // would withhold the one write the scraper IS allowed to make into
+        // an existing series (see the pinned override-survival test).
+        if (event.overrideUid || event.overrideRecurrenceId) return false;
+        return typeof event.recurrence === 'string' && event.recurrence.trim() !== '';
     }
 
     // Scriptable identifiers look like `<calendarUUID>:<icsUid>` — the suffix
@@ -12564,6 +12707,28 @@ class SharedCore {
                 // fact found it, merged it, and confirmed the series.
                 const matchedRecord = analysis.existingEvent || analysis.sourceEvent || null;
                 if (matchedRecord) {
+                    // Same-day match: instance count comes from the probe's
+                    // cached wide-window decision (when the adapter exposes
+                    // it), calendar name from the adapter's city mapping.
+                    let probedInstances = 0;
+                    try {
+                        if (calendarAdapter && typeof calendarAdapter.getSeriesProbeDecision === 'function') {
+                            const probeDecision = calendarAdapter.getSeriesProbeDecision(matchedRecord.identifier || matchedRecord.id || '');
+                            if (probeDecision && Number.isFinite(probeDecision.instanceCount)) {
+                                probedInstances = probeDecision.instanceCount;
+                            }
+                        }
+                    } catch (probeCacheError) {
+                        // Reporting-only — never let display data block the plan.
+                    }
+                    let matchedCalendarName = '';
+                    try {
+                        if (calendarAdapter && typeof calendarAdapter.getCalendarName === 'function') {
+                            matchedCalendarName = String(calendarAdapter.getCalendarName(analyzedEvent.city || event.city || 'default') || '');
+                        }
+                    } catch (calendarNameError) {
+                        matchedCalendarName = '';
+                    }
                     analyzedEvent._seriesMatch = {
                         identifier: matchedRecord.identifier || matchedRecord.id || '',
                         title: matchedRecord.title || '',
@@ -12573,9 +12738,30 @@ class SharedCore {
                         // this record's start.
                         startDate: matchedRecord.startDate || null,
                         endDate: matchedRecord.endDate || matchedRecord.startDate || null,
-                        reason: analysis.reason || ''
+                        reason: analysis.reason || '',
+                        instances: probedInstances,
+                        calendarName: matchedCalendarName
                     };
                     console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" matches a series already saved in the calendar — not a new event (${analysis.reason || 'existing match'})`);
+                } else if (analysis.seriesMatch) {
+                    // Saved-series lookup match (the day window held nothing,
+                    // but the wide window / published calendar does): the
+                    // event is NOT new — it matched a saved series. Scalars
+                    // only; the run JSON persists this stamp.
+                    analyzedEvent._seriesMatch = {
+                        identifier: analysis.seriesMatch.identifier || '',
+                        title: analysis.seriesMatch.title || '',
+                        startDate: analysis.seriesMatch.startDate || null,
+                        endDate: analysis.seriesMatch.endDate || null,
+                        reason: analysis.seriesMatch.reason || 'Saved series match',
+                        instances: Number.isFinite(analysis.seriesMatch.instances) ? analysis.seriesMatch.instances : 0,
+                        calendarName: analysis.seriesMatch.calendarName || ''
+                    };
+                }
+                if (analyzedEvent._seriesMatch &&
+                    analyzedEvent._seriesMatch.calendarName &&
+                    analyzedEvent._seriesMatch.instances > 0) {
+                    console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" matches the saved series already in ${analyzedEvent._seriesMatch.calendarName} (${analyzedEvent._seriesMatch.instances} instances) — not a new event`);
                 }
                 console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" withheld from calendar write — save via ICS export`);
             }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -12288,6 +12288,266 @@ test('noteConfirmedRecurringSeries feeds shouldCreateOverrideFromRecurringMatch'
 });
 
 // ---------------------------------------------------------------------------
+// Saved-series lookup beyond the same-day hit (runs 20260807-161034 /
+// 20260807-114625): the day-window search legitimately returns found=0 for a
+// series the owner ALREADY saved — a monthly series whose next saved instance
+// is on a different day, a weekly series saved last week — so a series-export
+// event must get a wide-window / published-calendar lookup before the run
+// claims NEW and re-offers the same ICS.
+// ---------------------------------------------------------------------------
+
+// The owner's real saved shape (data/calendars/la.ics CUBSCOUT): notes carry
+// uid:/timezone: keys but NO recurrence: key — series-ness is proven by the
+// multi-instance identifier count or the published calendar, never assumed.
+const CUBSCOUT_SAVED_NOTES = [
+  'shortName: CUB-SCOUT',
+  'bar: Eagle LA',
+  'address: 4219 Santa Monica Blvd, Los Angeles, CA 90029',
+  'timezone: America/Los_Angeles',
+  'uid: cubscout-20260731T193113Z@chunky.dad'
+].join('\n');
+
+function buildSavedCubscoutOccurrence(startIso) {
+  const startDate = new Date(startIso);
+  return {
+    identifier: 'CAL-UUID:cubscout-20260731T193113Z@chunky.dad',
+    title: 'CUBSCOUT',
+    startDate,
+    endDate: new Date(startDate.getTime() + 5 * 3600 * 1000),
+    location: '34.0912127, -118.2840632',
+    notes: CUBSCOUT_SAVED_NOTES
+  };
+}
+
+// Scraped series export whose own day window will hold nothing: the saved
+// series' instances are Sep-anchored while the scraped occurrence is Aug 7.
+function buildScrapedCubscoutSeriesExport() {
+  return {
+    title: 'CUBSCOUT',
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    endDate: new Date('2026-08-08T09:00:00.000Z'),
+    bar: 'Eagle LA',
+    city: 'la',
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=1FR',
+    _recurring: true
+  };
+}
+
+const LA_CITIES = { la: { timezone: 'America/Los_Angeles', patterns: ['la'] } };
+
+function createLaCore() {
+  return new SharedCore(LA_CITIES, { eventSchema: EventSchema });
+}
+
+function buildSeriesLookupAdapter(wideWindowEvents, overrides = {}) {
+  return {
+    getExistingEvents: async () => [],
+    getCalendarName: (city) => `chunky-dad-${city || 'default'}`,
+    getWideWindowCalendarEvents: async () => ({
+      calendarName: 'chunky-dad-la',
+      events: wideWindowEvents
+    }),
+    getPublishedCalendarRecords: async () => null,
+    ...overrides
+  };
+}
+
+test('saved-series lookup: found=0 + series export matches the saved series in the wide window and stamps the honest state', async () => {
+  const core = createLaCore();
+  const saved = [
+    buildSavedCubscoutOccurrence('2026-09-05T04:00:00.000Z'),
+    buildSavedCubscoutOccurrence('2026-10-03T04:00:00.000Z')
+  ];
+  const adapter = buildSeriesLookupAdapter(saved);
+  const event = buildScrapedCubscoutSeriesExport();
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(event, [], 'upsert', adapter);
+  assert.equal(analysis.action, 'new', 'the analysis ACTION is untouched — matching and reporting only');
+  assert.ok(analysis.seriesMatch, 'the lookup found the saved series');
+  assert.equal(analysis.seriesMatch.identifier, 'CAL-UUID:cubscout-20260731T193113Z@chunky.dad');
+  assert.equal(analysis.seriesMatch.instances, 2, 'both wide-window instances counted');
+  assert.equal(analysis.seriesMatch.calendarName, 'chunky-dad-la');
+
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (message) => { lines.push(String(message)); };
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(event, analysis, adapter, {});
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(analyzed._action, 'new', 'still not a write — the scraper never writes series');
+  assert.ok(analyzed._seriesMatch, 'the match survives onto the analyzed event');
+  assert.equal(analyzed._seriesMatch.instances, 2);
+  assert.equal(analyzed._seriesMatch.calendarName, 'chunky-dad-la');
+  assert.equal(analyzed._seriesMatch.reason, 'Saved series match (wide-window)');
+  assert.equal(analyzed._recurringExport, true, 'the ICS export is still offered');
+  assert.ok(
+    lines.some(l => l.includes('matches the saved series already in chunky-dad-la (2 instances) — not a new event')),
+    `the run says so out loud: ${JSON.stringify(lines)}`
+  );
+  assert.ok(
+    lines.some(l => l.includes('withheld from calendar write')),
+    'the withhold line is unchanged'
+  );
+  assert.deepEqual(SharedCore.filterEventsForExecution([analyzed]), [], 'and nothing is written');
+});
+
+test('saved-series lookup: a notes recurrence key confirms a series with a single visible instance', async () => {
+  const core = createLaCore();
+  const single = buildSavedCubscoutOccurrence('2026-09-05T04:00:00.000Z');
+  single.notes = `${CUBSCOUT_SAVED_NOTES}\nrecurrence: FREQ=MONTHLY;BYDAY=1FR`;
+  const adapter = buildSeriesLookupAdapter([single], {
+    probeRecurringSeries: async () => {
+      throw new Error('the notes key already fired — the probe must not run');
+    }
+  });
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(
+    buildScrapedCubscoutSeriesExport(), [], 'upsert', adapter);
+  assert.ok(analysis.seriesMatch, 'notes recurrence key alone confirms the candidate');
+  assert.equal(analysis.seriesMatch.instances, 1);
+});
+
+test('saved-series lookup: an identity match WITHOUT series evidence is never claimed', async () => {
+  const core = createLaCore();
+  // One saved one-off titled like the series, probe says not-a-series.
+  const oneOff = buildSavedCubscoutOccurrence('2026-09-05T04:00:00.000Z');
+  const adapter = buildSeriesLookupAdapter([oneOff], {
+    probeRecurringSeries: async () => false
+  });
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(
+    buildScrapedCubscoutSeriesExport(), [], 'upsert', adapter);
+  assert.equal(analysis.seriesMatch, undefined, 'a lone one-off is not a saved series');
+  assert.equal(analysis.action, 'new');
+});
+
+test('saved-series lookup: a genuinely-new series matches nothing and still reports NEW with the ICS offer', async () => {
+  const core = createLaCore();
+  // The calendar holds an unrelated series — identity must not match.
+  const unrelated = {
+    identifier: 'CAL-UUID:onyx-1@chunky.dad',
+    title: 'ONYX',
+    startDate: new Date('2026-09-14T04:00:00.000Z'),
+    endDate: new Date('2026-09-14T08:00:00.000Z'),
+    location: '',
+    notes: 'bar: Eagle LA\nrecurrence: FREQ=MONTHLY;BYDAY=2SU'
+  };
+  const adapter = buildSeriesLookupAdapter([unrelated]);
+  const event = buildScrapedCubscoutSeriesExport();
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(event, [], 'upsert', adapter);
+  assert.equal(analysis.seriesMatch, undefined, 'nothing matched, nothing claimed');
+
+  const analyzed = await core.buildAnalyzedCalendarEvent(event, analysis, adapter, {});
+  assert.equal(analyzed._action, 'new');
+  assert.equal(analyzed._seriesMatch, undefined);
+  assert.equal(analyzed._recurringExport, true, 'a genuinely-new series still offers the ICS');
+});
+
+test('saved-series lookup: the published calendar ICS is the fallback proof of "already saved"', async () => {
+  const core = createLaCore();
+  const publishedIcs = [
+    'BEGIN:VCALENDAR',
+    'BEGIN:VEVENT',
+    'DTSTART;TZID=America/Los_Angeles:20260904T210000',
+    'DTEND;TZID=America/Los_Angeles:20260905T020000',
+    'RRULE:FREQ=MONTHLY;BYDAY=1FR',
+    'UID:cubscout-20260731T193113Z@chunky.dad',
+    'DESCRIPTION:bar: Eagle LA\\naddress: 4219 Santa Monica Blvd\\, Los Angeles\\,',
+    '  CA 90029\\ntimezone: America/Los_Angeles\\nuid: cubscout-20260731T193113Z@c',
+    ' hunky.dad',
+    'LOCATION:34.0912127\\, -118.2840632',
+    'SUMMARY:CUBSCOUT',
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ].join('\r\n');
+  const adapter = buildSeriesLookupAdapter([], {
+    // Wide window unavailable (missing calendar fails open to null).
+    getWideWindowCalendarEvents: async () => null,
+    getPublishedCalendarRecords: async () => SharedCore.parsePublishedCalendarIcs(publishedIcs)
+  });
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(
+    buildScrapedCubscoutSeriesExport(), [], 'upsert', adapter);
+  assert.ok(analysis.seriesMatch, 'the published series proves already-saved');
+  assert.equal(analysis.seriesMatch.identifier, 'cubscout-20260731T193113Z@chunky.dad');
+  assert.equal(analysis.seriesMatch.reason, 'Saved series match (published calendar ICS)');
+});
+
+test('saved-series lookup: fails open on adapter errors and never runs for non-series events', async () => {
+  const core = createLaCore();
+  const throwing = buildSeriesLookupAdapter([], {
+    getWideWindowCalendarEvents: async () => { throw new Error('calendar unavailable'); },
+    getPublishedCalendarRecords: async () => { throw new Error('network unavailable'); }
+  });
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(
+    buildScrapedCubscoutSeriesExport(), [], 'upsert', throwing);
+  assert.equal(analysis.action, 'new', 'errors leave the NEW verdict untouched');
+  assert.equal(analysis.seriesMatch, undefined);
+
+  let lookupCalls = 0;
+  const counting = buildSeriesLookupAdapter([], {
+    getWideWindowCalendarEvents: async () => { lookupCalls += 1; return null; }
+  });
+  const plain = {
+    title: 'ONE OFF',
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    bar: 'Eagle LA',
+    city: 'la'
+  };
+  const plainAnalysis = await core.resolveCalendarAnalysisWithSeriesProbe(plain, [], 'upsert', counting);
+  assert.equal(plainAnalysis.action, 'new');
+  assert.equal(lookupCalls, 0, 'a non-series event never triggers the lookup');
+});
+
+test('isRecurringSeriesEvent: the canonical `recurrence` field counts as a series stamp — except on an override', () => {
+  // Builder-made events carry ONLY the canonical field (event-schema
+  // canonicalizes rrule/recurrenceRule → recurrence); they must be a series
+  // (🔁 badge, ICS export, withhold) instead of silently dropping the RRULE.
+  assert.equal(SharedCore.isRecurringSeriesEvent({ recurrence: 'FREQ=MONTHLY;BYDAY=1FR' }), true);
+  assert.equal(SharedCore.isRecurringSeriesEvent({ recurrence: '   ' }), false);
+  // The pinned leak case: `recurrence` rides off the EXISTING record's notes
+  // onto a single-occurrence override during the merge — an override is ONE
+  // occurrence, and treating the leak as a series claim would withhold the
+  // one write the scraper IS allowed to make into an existing series.
+  assert.equal(SharedCore.isRecurringSeriesEvent({
+    recurrence: 'FREQ=MONTHLY;BYDAY=1FR',
+    overrideUid: 'cubscout-20260731T193113Z@chunky.dad',
+    overrideRecurrenceId: '20260905'
+  }), false);
+});
+
+test('recurrence-only builder event: withheld from writes, offered as ICS export', async () => {
+  const core = createLaCore();
+  const builderEvent = {
+    title: 'CUBSCOUT',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T09:00:00.000Z'),
+    bar: 'Eagle LA',
+    city: 'la',
+    recurrence: 'FREQ=MONTHLY;BYDAY=1FR'
+  };
+  const analysis = { action: 'new', reason: 'No existing events found', sourceEvent: null, overrideIdentity: null };
+  const analyzed = await core.buildAnalyzedCalendarEvent(builderEvent, analysis, null, {});
+  assert.equal(analyzed._recurringExport, true, 'the series is routed to the ICS export');
+  assert.deepEqual(SharedCore.filterEventsForExecution([analyzed]), [],
+    'and withheld from the calendar write instead of dropping the RRULE');
+});
+
+test('normalizeOverrideUid: trims, preserves case, and blanks null/undefined', () => {
+  assert.equal(SharedCore.normalizeOverrideUid('  cubscout-1@chunky.dad  '), 'cubscout-1@chunky.dad');
+  assert.equal(SharedCore.normalizeOverrideUid('MixedCase@Chunky.dad'), 'MixedCase@Chunky.dad');
+  assert.equal(SharedCore.normalizeOverrideUid(''), '');
+  assert.equal(SharedCore.normalizeOverrideUid('   '), '');
+  assert.equal(SharedCore.normalizeOverrideUid(null), '');
+  assert.equal(SharedCore.normalizeOverrideUid(undefined), '');
+});
+
+// ---------------------------------------------------------------------------
 // Published-calendar ICS parsing + RRULE expansion (Mac/Node merge fidelity)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The problem: saved series come back as ➕ NEW every run

You save a recurring series via the ICS-export button; the next run re-offers the exact same ICS as `➕ NEW`. Run **20260807-161034**: B BAR, CUBSCOUT, ONYX all `action: new` the day after you saved exactly those three series.

Root cause: `getExistingEvents` searches only the scraped occurrence's **own day window**, and the series probe (`resolveCalendarAnalysisWithSeriesProbe`) returned early unless that same-day search produced a merge hit. A monthly series whose next saved instance is on a **different day** (CUBSCOUT: saved Sep-anchored `1FR`, scraped occurrence Aug 7) or a weekly series saved for next week (B BAR) yields `found=0` → `new` → the series-aware layer never runs.

## The lookup design (matching + reporting only — the scraper still NEVER writes a series)

When the day-window analysis lands on `new` with no match **and** the scraped event is a series export, `SharedCore.findSavedSeriesMatch` runs two fail-open layers:

1. **Wide-window calendar candidates** (`getWideWindowCalendarEvents`, the identifier probe's own now−35d..+70d window, one cached fetch per calendar per run). A candidate counts only if **both**:
   - it matches by the dedup's own identity helpers — `areIdentityNamesSimilar` **and** `areIdentityPlacesSimilar`, nothing looser; the relaxed same-day gate is compensated by the series requirement below;
   - it is a **positively confirmed saved series**, in the doctrine's detection order: notes `recurrence:` key (or the expanded record's own recurrence field) → local multi-instance identifier count → `probeRecurringSeries` (published-ICS, then wide-window probe). Your real saved shape (la.ics CUBSCOUT: `uid:`/`timezone:` in notes, **no** `recurrence:` key) is confirmed by its 2 wide-window instances.
2. **Published calendar ICS fallback** (`getPublishedCalendarRecords` → existing `parsePublishedCalendarIcs`): a series VEVENT with matching identity in `data/calendars/<city>.ics` also proves "already saved". This reused the existing ICS parser — no new ICS subsystem was built.

The analysis **action stays `new`**, `filterEventsForExecution` still withholds, no calendar-write path was added, and every error path leaves today's NEW verdict untouched. The Node WebAdapter mirrors both hooks off the published calendar.

## Honest terminal state (before → after)

Same replayed events, same summary shape — only substituted values plus one added bucket:

**Before (origin/main):**
```
📊 Event Actions Summary:
   ➕ New: 6 events
   🔀 Merge: 0 events
   ⚠️  Conflict: 0 events
   ❌ Missing Calendar: 0 events
```
**After (this branch):**
```
📊 Event Actions Summary:
   ➕ New: 3 events
   🔀 Merge: 0 events
   ⚠️  Conflict: 0 events
   ❌ Missing Calendar: 0 events
   🔁 Series match: 3 events (already saved — withheld)
```

- `_seriesMatch` now carries `instances` (sourced from the probe's cached wide-window decision) and `calendarName`; additive line: `🔁 RECURRING: "B BAR" matches the saved series already in chunky-dad-la (3 instances) — not a new event`. All existing 🔁 lines are byte-identical.
- Intent/write labels read `SERIES MATCH` / `WITHHELD`; the card badge (`SERIES MATCH` + existing "already saved — matches this series") says it plainly, and the 💾 ICS button **still renders** for deliberate re-import.
- Metrics are untouched: `normalizeMetricsIntentAction` keeps the base derivation, so metric buckets and history keep their meaning.

## Builder `recurrence` field

`event-schema` canonicalizes `rrule`/`recurrenceRule` → `recurrence`, but `isRecurringSeriesEvent` read `recurrenceRule` only — a builder event carrying only `recurrence` was invisible as a series (no 🔁 badge, no ICS button, RRULE silently dropped on write). `recurrence` now counts as a series stamp **except** on an override-identified event: the pinned test proves `recurrence` leaks off the existing record's notes onto single-occurrence overrides in `createFinalEventObject`, and that one allowed write must survive (it does — the pinned test is unchanged and still passes). `shouldCreateOverrideFromRecurringMatch` reads the existing event's notes — different object, untouched. Replay guard: zero analyzed events across all 13 saved runs carry a bare `recurrence`, so scraper withhold rates are unchanged.

## Verification

- `node --check` clean on all 6 touched files; **quiet suite 1661 pass / 0 fail** (measured origin/main baseline: **1642 / 0**; +19 new tests).
- **13 of 19 new tests FAIL on clean origin/main** and pass here; the other 6 are declared guards (false-positive protection: identity-match-without-series-evidence never claimed; genuinely-new series still NEW with ICS; fail-open; `normalizeOverrideUid` / `getEventOverrideIdentity` coverage fills). `classifyEventsForMatching` shadowing, `findEventByOverrideKey` round-trip, and the slot-host override-keeps-`overrideUid` case were already pinned by existing tests.
- **Deterministic replay** of run 20260807-161034 against a stub calendar seeded with your real saved shapes (CUBSCOUT Sep-anchored 1FR modelled byte-for-byte on la.ics, B BAR weekly TH, ONYX 2SU): on main all three report `NEW`; on this branch **B BAR → SERIES MATCH (3 instances), CUBSCOUT → SERIES MATCH (2), ONYX → SERIES MATCH (2)**, all `WITHHELD`, ICS still offered. Controls stay honest: JOCKSTRAPPED (one-off) `NEW/CREATE`; Sep MEAT RACK (series with nothing saved) `NEW/WITHHELD`, no false match. The 20260807-114625 CUBSCOUT `found=0` case also flips to SERIES MATCH.
- Diff review: no existing matcher loosened (the lookup is name+place **and** confirmed-series — stricter than the merge ladder's title+date rung); no existing console.log text edited; no `new URL(`/`URLSearchParams`; shared-core/normalizers stay platform-pure (adapter hooks injected, typeof-guarded).

**No new runtime files** — all changes live in the existing shared-core/adapters files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP