### PR TITLE
fix(scraper): 5xx/429 POST responses throw into the retry ladder + single-page OCR top-up for imageless events

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1587,7 +1587,28 @@ class ScriptableAdapter {
     );
   }
 
+  // A non-2xx status the server ANSWERED with used to come back as
+  // {ok: false} — a SUCCESSFUL operation as far as withNetworkResilience
+  // could see, so a 503 from the local AI server (model loading, busy)
+  // never engaged the #1643 retry ladder and the run degraded instead of
+  // riding it out. Transient statuses (5xx/429 — the exact list
+  // SharedCore.isRetryableHttpStatus keeps, the same one isRetryableFailure
+  // classifies by) now THROW from inside the resilience-wrapped attempt
+  // with `error.statusCode` stamped as ground truth; client rejections
+  // (4xx) keep the {ok: false} return shape callers already branch on.
+  throwIfRetryableHttpStatus(label, url, statusCode, responseText) {
+    if (!Number.isFinite(statusCode)) return;
+    if (statusCode >= 200 && statusCode < 300) return;
+    if (!SharedCore.isRetryableHttpStatus(statusCode)) return;
+    const error = new Error(`${label} failed: HTTP ${statusCode} from ${url}`);
+    error.statusCode = statusCode;
+    error.responseText = typeof responseText === "string" ? responseText : "";
+    throw error;
+  }
+
   async postJsonOnce(url, payload, options = {}) {
+    let responseText;
+    let statusCode;
     try {
       const request = new Request(url);
       request.method = "POST";
@@ -1599,16 +1620,17 @@ class ScriptableAdapter {
       if (options.timeoutSeconds) {
         request.timeoutInterval = options.timeoutSeconds;
       }
-      const responseText = await request.loadString();
-      const statusCode = request.response ? request.response.statusCode : 200;
-      return {
-        ok: statusCode >= 200 && statusCode < 300,
-        status: statusCode,
-        text: responseText,
-      };
+      responseText = await request.loadString();
+      statusCode = request.response ? request.response.statusCode : 200;
     } catch (error) {
       throw new Error(`POST request failed: ${error.message}`);
     }
+    this.throwIfRetryableHttpStatus("POST request", url, statusCode, responseText);
+    return {
+      ok: statusCode >= 200 && statusCode < 300,
+      status: statusCode,
+      text: responseText,
+    };
   }
 
   // Form-encoded POST (application/x-www-form-urlencoded) — the shape
@@ -1660,6 +1682,8 @@ class ScriptableAdapter {
   }
 
   async postFormOnce(url, body, options = {}) {
+    let responseText;
+    let statusCode;
     try {
       const request = new Request(url);
       request.method = "POST";
@@ -1672,16 +1696,19 @@ class ScriptableAdapter {
       if (options.timeoutSeconds) {
         request.timeoutInterval = options.timeoutSeconds;
       }
-      const responseText = await request.loadString();
-      const statusCode = request.response ? request.response.statusCode : 200;
-      return {
-        ok: statusCode >= 200 && statusCode < 300,
-        status: statusCode,
-        text: responseText,
-      };
+      responseText = await request.loadString();
+      statusCode = request.response ? request.response.statusCode : 200;
     } catch (error) {
       throw new Error(`Form POST request failed: ${error.message}`);
     }
+    // Same transient-status contract as postJsonOnce: 5xx/429 throw into the
+    // ladder, everything else keeps the {ok:false} shape.
+    this.throwIfRetryableHttpStatus("Form POST request", url, statusCode, responseText);
+    return {
+      ok: statusCode >= 200 && statusCode < 300,
+      status: statusCode,
+      text: responseText,
+    };
   }
 
   async saveFailureNote(url, error, metadata = {}) {

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -7415,3 +7415,165 @@ test('generateRichHTML puts the truncation banner above everything else on the p
   assert.ok(bannerIndex < headerIndex,
     'above the header: the header scrolls away and the stat tiles below read like a finished run');
 });
+
+// ---------------------------------------------------------------------------
+// Transient HTTP statuses on the POST paths: a 503 the AI server answered
+// with (model loading, busy) is a failure the retry ladder exists for — it
+// must THROW from inside the resilience-wrapped attempt with the status
+// stamped, while 4xx client rejections keep the {ok:false} return shape.
+// ---------------------------------------------------------------------------
+
+test('postJson: a 503 the AI server answered with engages the retry ladder and succeeds on attempt 2', async () => {
+  const adapter = buildAdapter();
+  let attempts = 0;
+  const slept = [];
+  adapter.sleepForNetworkRetry = async (ms) => { slept.push(ms); };
+  global.Request = class {
+    constructor() { this.response = null; }
+    async loadString() {
+      attempts += 1;
+      if (attempts === 1) {
+        this.response = { statusCode: 503 };
+        return '{"error":"model is loading"}';
+      }
+      this.response = { statusCode: 200 };
+      return '{"choices":[{"message":{"content":"ok"}}]}';
+    }
+  };
+  try {
+    const response = await adapter.postJson('http://rybook.example:8001/v1/chat/completions', { prompt: 'x' });
+    assert.equal(response.ok, true, 'the retried attempt came back as an ordinary success');
+    assert.equal(response.status, 200);
+  } finally {
+    delete global.Request;
+  }
+  assert.equal(attempts, 2, 'the 503 threw into the ladder and a second attempt went out');
+  assert.deepEqual(slept, [5000], 'exactly one ladder wait — the first rung');
+});
+
+// Behavior guard (passes before and after the fix): genuine client
+// rejections keep the return shape every caller already branches on.
+test('postJson: a 400 client rejection keeps the {ok:false} return shape with zero retries', async () => {
+  const adapter = buildAdapter();
+  let attempts = 0;
+  const slept = [];
+  adapter.sleepForNetworkRetry = async (ms) => { slept.push(ms); };
+  global.Request = class {
+    constructor() { this.response = null; }
+    async loadString() {
+      attempts += 1;
+      this.response = { statusCode: 400 };
+      return 'bad request';
+    }
+  };
+  try {
+    const response = await adapter.postJson('http://rybook.example:8001/v1/chat/completions', { prompt: 'x' });
+    assert.deepEqual(response, { ok: false, status: 400, text: 'bad request' },
+      'callers that log the error body still get it');
+  } finally {
+    delete global.Request;
+  }
+  assert.equal(attempts, 1, 'a permanent rejection never buys a retry');
+  assert.deepEqual(slept, [], 'and never a millisecond of waiting');
+});
+
+test('postJson: a sustained 503 exhausts the ladder into the existing stop semantics, never into give-up', async () => {
+  const adapter = buildAdapter();
+  let attempts = 0;
+  const slept = [];
+  adapter.sleepForNetworkRetry = async (ms) => { slept.push(ms); };
+  global.Request = class {
+    constructor() { this.response = null; }
+    async loadString() {
+      attempts += 1;
+      this.response = { statusCode: 503 };
+      return 'busy';
+    }
+  };
+  try {
+    await assert.rejects(
+      adapter.postJson('http://rybook.example:8001/v1/chat/completions', { prompt: 'x' }),
+      (error) => error.statusCode === 503 && /HTTP\s+503/.test(error.message)
+    );
+    assert.equal(attempts, 6, 'first attempt plus all five ladder rungs');
+    assert.deepEqual(slept, [5000, 15000, 30000, 60000, 90000], 'the whole #1643 ladder, unchanged');
+    assert.equal(adapter.getNetworkResilience().isGivenUp(), false,
+      'the server ANSWERED every time — a 503 storm is proof the network is up, never a give-up');
+    // Existing exhaustion semantics take over: the host burned its budget,
+    // so the next call to it gets one attempt and no waiting.
+    slept.length = 0;
+    const attemptsBefore = attempts;
+    await assert.rejects(adapter.postJson('http://rybook.example:8001/v1/chat/completions', { prompt: 'x' }));
+    assert.equal(attempts - attemptsBefore, 1, 'exhausted host: one attempt');
+    assert.deepEqual(slept, [], 'exhausted host: no waiting');
+  } finally {
+    delete global.Request;
+  }
+});
+
+test('postForm: a 503 month feed rides the same ladder as postJson and recovers', async () => {
+  const adapter = buildAdapter();
+  let attempts = 0;
+  const slept = [];
+  adapter.sleepForNetworkRetry = async (ms) => { slept.push(ms); };
+  global.Request = class {
+    constructor() { this.response = null; }
+    async loadString() {
+      attempts += 1;
+      if (attempts === 1) {
+        this.response = { statusCode: 502 };
+        return 'bad gateway';
+      }
+      this.response = { statusCode: 200 };
+      return '{"month":"<div></div>"}';
+    }
+  };
+  try {
+    const response = await adapter.postForm('https://venue.example/wp-admin/admin-ajax.php', 'action=x');
+    assert.equal(response.ok, true);
+  } finally {
+    delete global.Request;
+  }
+  assert.equal(attempts, 2, 'the 502 threw into the ladder and the retry landed');
+  assert.deepEqual(slept, [5000], 'same ladder, same first rung');
+});
+
+// The Node-side mirror: WebAdapter has no ladder of its own, but the two POST
+// methods must keep ONE contract across platforms — transient statuses throw
+// with the status stamped (callers catch and degrade exactly as they do when
+// the Scriptable ladder exhausts), client rejections keep {ok:false}.
+test('WebAdapter.postJson mirrors the contract: 503 throws with the status stamped, 400 keeps {ok:false}', async () => {
+  const { WebAdapter } = require('./web-adapter');
+  const adapter = new WebAdapter({ cities: {} });
+  const originalFetch = global.fetch;
+  try {
+    global.fetch = async () => ({ ok: false, status: 503, text: async () => 'busy' });
+    await assert.rejects(
+      adapter.postJson('http://rybook.example:8000/v1/chat/completions', { prompt: 'x' }),
+      (error) => error.statusCode === 503 && /HTTP\s+503/.test(error.message)
+    );
+    global.fetch = async () => ({ ok: false, status: 400, text: async () => 'bad request' });
+    const rejected = await adapter.postJson('http://rybook.example:8000/v1/chat/completions', { prompt: 'x' });
+    assert.deepEqual(rejected, { ok: false, status: 400, text: 'bad request' });
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('WebAdapter.postForm mirrors the contract too: 5xx throws stamped, 4xx keeps {ok:false}', async () => {
+  const { WebAdapter } = require('./web-adapter');
+  const adapter = new WebAdapter({ cities: {} });
+  const originalFetch = global.fetch;
+  try {
+    global.fetch = async () => ({ ok: false, status: 500, text: async () => 'server error' });
+    await assert.rejects(
+      adapter.postForm('https://venue.example/wp-admin/admin-ajax.php', 'action=x'),
+      (error) => error.statusCode === 500 && /HTTP\s+500/.test(error.message)
+    );
+    global.fetch = async () => ({ ok: false, status: 404, text: async () => 'no such action' });
+    const rejected = await adapter.postForm('https://venue.example/wp-admin/admin-ajax.php', 'action=x');
+    assert.deepEqual(rejected, { ok: false, status: 404, text: 'no such action' });
+  } finally {
+    global.fetch = originalFetch;
+  }
+});

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -438,8 +438,29 @@ class WebAdapter {
         }
     }
 
+    // Mirror of ScriptableAdapter.throwIfRetryableHttpStatus so the two POST
+    // methods keep one contract on both platforms: transient statuses
+    // (5xx/429 — SharedCore.isRetryableHttpStatus, the same list
+    // isRetryableFailure classifies stamped statuses by) THROW with
+    // `error.statusCode` stamped; client rejections (4xx) keep the
+    // {ok: false} return shape callers already branch on. If SharedCore is
+    // unavailable (browser page without the script tag) the pre-fix
+    // {ok: false} return survives unchanged.
+    throwIfRetryableHttpStatus(label, url, statusCode, responseText) {
+        if (!Number.isFinite(statusCode)) return;
+        if (statusCode >= 200 && statusCode < 300) return;
+        const core = this.getSharedCoreRef();
+        if (!core || typeof core.isRetryableHttpStatus !== 'function') return;
+        if (!core.isRetryableHttpStatus(statusCode)) return;
+        const error = new Error(`${label} failed: HTTP ${statusCode} from ${url}`);
+        error.statusCode = statusCode;
+        error.responseText = typeof responseText === 'string' ? responseText : '';
+        throw error;
+    }
+
     async postJson(url, payload, options = {}) {
         const timeout = options.timeoutSeconds ? options.timeoutSeconds * 1000 : this.config.timeout;
+        let result;
         try {
             const response = await fetch(url, {
                 method: 'POST',
@@ -450,7 +471,7 @@ class WebAdapter {
                 body: JSON.stringify(payload),
                 signal: AbortSignal.timeout(timeout)
             });
-            return {
+            result = {
                 ok: response.ok,
                 status: response.status,
                 text: await response.text()
@@ -458,6 +479,8 @@ class WebAdapter {
         } catch (error) {
             throw new Error(`POST request failed: ${error.message}`);
         }
+        this.throwIfRetryableHttpStatus('POST request', url, result.status, result.text);
+        return result;
     }
 
     // Node-side mirror of ScriptableAdapter.postForm: form-encoded POST (the
@@ -500,6 +523,9 @@ class WebAdapter {
         } catch (error) {
             throw new Error(`Form POST request failed: ${error.message}`);
         }
+        // Same transient-status contract as postJson: 5xx/429 throw with the
+        // status stamped, everything else keeps the {ok:false} shape.
+        this.throwIfRetryableHttpStatus('Form POST request', url, result.status, result.text);
         if (canUseCache && result.ok && typeof result.text === 'string' && result.text.length > 0) {
             await this.writeCachedPage(
                 cacheUrl,

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -626,6 +626,14 @@ class AiWebParser {
         // GEAR NIGHT's `image`. 300x300 poster thumbs are deliberately ABOVE
         // this bound — eaglela.com serves real flyers as -300x300 renditions.
         this.iconScaleRenditionMaxDimension = 200;
+        // Single-event pages: how many candidate images BEYOND the capped
+        // page-level OCR pass the imageless-event top-up may read (see
+        // ensureSinglePageImageCoverage). Corpus of 37 cached Eagle LA /
+        // Dallas Eagle detail pages: 7-9 distinct post-filter candidates per
+        // page, full-size poster at position 3 wherever one exists — cap 2 + 4
+        // reaches every observed poster; positions 7+ were emoji-CDN paths and
+        // plugin icons on every measured page.
+        this.singlePageOcrTopUpMaxImages = 4;
         // An image identity offered by at least this many DISTINCT segments'
         // own HTML on ONE multi-event page is site furniture by definition
         // (social icons, sponsor strips, footer chrome) — no single event's
@@ -1219,6 +1227,12 @@ class AiWebParser {
         const adjustedPromptFields = this.getAiPromptFields(parserConfig, dataFlags, htmlData && htmlData.url ? htmlData.url : '');
 
         const event = await this.extractSingleEvent(segmentHtmlData, parserConfig, cityConfig, adjustedPromptFields, dataFlags, httpAdapter);
+        if (event) {
+            // Bounded rescue for an event that came out imageless — see
+            // ensureSinglePageImageCoverage (single-page sibling of the
+            // multi-event segment top-up).
+            await this.ensureSinglePageImageCoverage(event, htmlData, parserConfig, ocrResults, httpAdapter);
+        }
         return event ? [event] : [];
     }
 
@@ -7794,6 +7808,102 @@ class AiWebParser {
             ocrResults.push(normalized);
         }
         return ocrResults;
+    }
+
+    // Single-event pages: the page-level OCR pass stops at ocrConfig.maxImages
+    // (clamped 1..4, default 2) and the segment top-up above runs ONLY on the
+    // multi-event path — so a genuine poster sitting 3rd or later in the
+    // page's <img> order was never OCR'd, and the og:image fill was the one
+    // rescue. Bounded top-up, AFTER extraction and only when it matters: when
+    // the extracted event carries NO image (nothing the AI offered survived
+    // the placeholder/furniture gates, and the og:image fill found nothing),
+    // read the candidate images the cap skipped — same filter chain as the
+    // capped pass (uninteresting-URL filter, resized-variant collapse) plus
+    // the #1652 vet rules (icon-scale renditions, placeholder pixels) and the
+    // post-#1648 stripped-identity collapse — up to singlePageOcrTopUpMaxImages
+    // more, then adopt the first one the vision pass POSITIVELY classified as
+    // an event flyer with meaningful text. Never fail-open: no flyer verdict,
+    // no adoption. Why not vet ALL candidates up front instead: the measured
+    // corpus (37 cached Eagle LA / Dallas Eagle detail pages) carries 7-9
+    // distinct post-filter candidates per page, so an up-front vet would
+    // spend 5-7 extra OCR calls (~10-14s wall clock) on EVERY page — including
+    // the majority whose top-2 pass or og:image already lands the poster —
+    // and would grow every extraction prompt (invalidating the AI response
+    // cache across the board). The conditional pass costs at most 4 reads
+    // (~8s) and only on pages that would otherwise ship imageless.
+    // ocrConfig.maxImages semantics are untouched: the capped pass still
+    // honors an explicitly configured value exactly as before.
+    async ensureSinglePageImageCoverage(event, htmlData, parserConfig, ocrResults, httpAdapter) {
+        if (!event || typeof event !== 'object') return event;
+        const existingImage = typeof event.image === 'string' ? event.image.trim() : '';
+        if (existingImage) return event;
+        // Never on the multi-event whole-page fallback: that page's <img>
+        // order is a stack of SIBLING events' flyers, and "first flyer on the
+        // page" would ship a neighbor's poster.
+        if (htmlData && htmlData._wholePageFallback === true) return event;
+        const ocrConfig = this.getOcrConfig(parserConfig);
+        if (!ocrConfig.enabled) return event;
+        const sourceUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
+        const html = htmlData && typeof htmlData.html === 'string' ? htmlData.html : '';
+        if (!html) return event;
+
+        // Same candidate pipeline as extractOcrFromAllImages, read past the cap.
+        const candidateUrls = this.extractOrderedImageUrlsFromHtml(html, sourceUrl, 20);
+        const interestingUrls = candidateUrls.filter(url => !this.isLikelyUninterestingImageUrl(url));
+        const orderedUrls = this.dropResizedImageUrlsWithOriginal(interestingUrls);
+
+        // What the extraction prompt already saw: identities carried by the
+        // ocrResults handed to the AI. Those images were offered and judged —
+        // re-reading them cannot change the outcome.
+        const offeredIdentities = new Set(
+            (Array.isArray(ocrResults) ? ocrResults : [])
+                .map(ocr => this.stripSizeParams(this.normalizeHttpUrlValue(ocr && ocr.url)))
+                .filter(Boolean)
+        );
+
+        const seenIdentities = new Set();
+        const targets = [];
+        for (const rawUrl of orderedUrls) {
+            const url = this.normalizeHttpUrlValue(rawUrl);
+            if (!url) continue;
+            if (this.isIconScaleImageRendition(url)) continue;
+            if (this.getPlaceholderImageReason(url)) continue;
+            const identity = this.stripSizeParams(url) || url;
+            if (seenIdentities.has(identity) || offeredIdentities.has(identity)) continue;
+            seenIdentities.add(identity);
+            targets.push(url);
+            if (targets.length >= this.singlePageOcrTopUpMaxImages) break;
+        }
+        if (targets.length === 0) return event;
+
+        console.log(`🤖 AI Web: Single-page OCR top-up reading ${targets.length} image(s) beyond the cap for imageless event "${event.title || ''}" (bound ${this.singlePageOcrTopUpMaxImages})`);
+        const rawResults = await this.mapWithConcurrencyLimit(targets, ocrConfig.maxConcurrentRequests || 1, url =>
+            this.getOcrTextForImage(url, ocrConfig, 'ocr-topup', httpAdapter).catch(() => null)
+        );
+        for (const rawResult of rawResults) {
+            const normalized = this.normalizeOcrResult(rawResult);
+            if (!normalized) continue;
+            // Same seam-level verdict recording as the segment top-up:
+            // idempotent with the inner recording, and it is what the
+            // adoption test below and rejectNonEventImageValues consult.
+            this.recordOcrImageVerdict(normalized.url, normalized);
+            if (!normalized.text || normalized.text.trim().length === 0) continue;
+            if (Array.isArray(ocrResults)) ocrResults.push(normalized);
+        }
+
+        for (const url of targets) {
+            const verdict = this.getOcrImageVerdict(url);
+            if (!verdict || verdict.classification !== 'event-flyer' || !verdict.hasText) continue;
+            event.image = url;
+            console.log(`🤖 AI Web: Single-page OCR top-up adopted event flyer ${url} for "${event.title || ''}"`);
+            // Same companions the normalize pipeline gives every image value:
+            // a provenance stamp and an orientation-slot pass over the final
+            // value (both fail open and are idempotent on re-run).
+            this.stampImageProvenance(event, htmlData);
+            this.applyImageSlots(event, htmlData, { allowPageMetaCandidates: true });
+            break;
+        }
+        return event;
     }
 
     // Every image URL a segment's prompt could emit as a SEGMENT_IMAGE_HINT_URL

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -13701,3 +13701,111 @@ test('applyDerivedCadenceStamps: different venues never share a group, and undat
     assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'the dated group still stamps normally');
   }
 });
+
+// ---------------------------------------------------------------------------
+// Single-page OCR top-up (ensureSinglePageImageCoverage): a poster sitting
+// past the capped page-level OCR pass on a single-event page gets a bounded
+// second look when the extracted event came out imageless.
+// ---------------------------------------------------------------------------
+
+function buildSinglePageTopUpFixture() {
+  const sourceUrl = 'https://fixture-eagle.example/events/bear-night/';
+  const html = [
+    '<img src="https://fixture-eagle.example/wp-content/uploads/first-square.jpg" />',
+    '<img src="https://fixture-eagle.example/wp-content/uploads/second-photo.jpg" />',
+    '<img src="https://fixture-eagle.example/wp-content/uploads/main-poster.jpg" />',
+    '<img src="https://fixture-eagle.example/wp-content/uploads/fourth-mural.jpg" />'
+  ].join('\n');
+  // The capped pass (maxImages 2) read the first two images already.
+  const ocrResults = [
+    { url: 'https://fixture-eagle.example/wp-content/uploads/first-square.jpg', text: 'happy hour daily', imageClassification: 'hero-banner' },
+    { url: 'https://fixture-eagle.example/wp-content/uploads/second-photo.jpg', text: 'patio view', imageClassification: 'hero-banner' }
+  ];
+  return { sourceUrl, htmlData: { html, url: sourceUrl }, ocrResults };
+}
+
+test('single-page top-up: the position-3 poster the cap skipped is OCR d once and becomes the event image', async () => {
+  const parser = createParser();
+  const { htmlData, ocrResults } = buildSinglePageTopUpFixture();
+  const ocrCalls = [];
+  parser.getOcrTextForImage = async (url) => {
+    ocrCalls.push(url);
+    if (url.includes('main-poster')) {
+      return { url, text: 'BEAR NIGHT SATURDAY 9PM FIXTURE EAGLE', imageClassification: 'event-flyer' };
+    }
+    return { url, text: '', imageClassification: 'hero-banner' };
+  };
+  const event = { title: 'BEAR NIGHT' };
+  await parser.ensureSinglePageImageCoverage(event, htmlData, {}, ocrResults, null);
+  assert.equal(event.image, 'https://fixture-eagle.example/wp-content/uploads/main-poster.jpg',
+    'the poster the capped pass never reached is now the event image');
+  assert.equal(ocrCalls.filter((url) => url.includes('main-poster')).length, 1, 'the poster was OCR d exactly once');
+  assert.ok(!ocrCalls.some((url) => url.includes('first-square') || url.includes('second-photo')),
+    'identities the extraction prompt already saw are never re-read');
+  assert.ok(ocrResults.some((r) => r.url.includes('main-poster')),
+    'the poster text joined the OCR results, so it is offerable downstream');
+});
+
+test('single-page top-up: an event that already has an image costs zero OCR calls', async () => {
+  const parser = createParser();
+  const { htmlData, ocrResults } = buildSinglePageTopUpFixture();
+  let ocrCalls = 0;
+  parser.getOcrTextForImage = async () => { ocrCalls += 1; return null; };
+  const event = { title: 'BEAR NIGHT', image: 'https://fixture-eagle.example/wp-content/uploads/first-square.jpg' };
+  await parser.ensureSinglePageImageCoverage(event, htmlData, {}, ocrResults, null);
+  assert.equal(ocrCalls, 0, 'nothing to rescue, nothing spent');
+});
+
+test('single-page top-up: never adopts without a POSITIVE event-flyer verdict, and never on the whole-page fallback', async () => {
+  const parser = createParser();
+  const { htmlData, ocrResults } = buildSinglePageTopUpFixture();
+  parser.getOcrTextForImage = async (url) => ({ url, text: '', imageClassification: 'hero-banner' });
+  const event = { title: 'BEAR NIGHT' };
+  await parser.ensureSinglePageImageCoverage(event, htmlData, {}, ocrResults.slice(), null);
+  assert.equal(event.image, undefined, 'furniture verdicts fill nothing — no fail-open adoption');
+
+  let fallbackCalls = 0;
+  parser.getOcrTextForImage = async (url) => { fallbackCalls += 1; return { url, text: 'SIBLING EVENT', imageClassification: 'event-flyer' }; };
+  const fallbackEvent = { title: 'WHITE CENTER' };
+  await parser.ensureSinglePageImageCoverage(
+    fallbackEvent, { ...htmlData, _wholePageFallback: true }, {}, ocrResults.slice(), null);
+  assert.equal(fallbackCalls, 0, 'a multi-event page extracted whole never runs the top-up');
+  assert.equal(fallbackEvent.image, undefined, 'so a sibling flyer can never be adopted');
+});
+
+test('single-page top-up: the +4 bound is respected and OCR-off disables the pass', async () => {
+  const parser = createParser();
+  const sourceUrl = 'https://fixture-eagle.example/events/busy-page/';
+  const imageTags = [];
+  for (let i = 1; i <= 10; i++) {
+    imageTags.push(`<img src="https://fixture-eagle.example/wp-content/uploads/candidate-${i}.jpg" />`);
+  }
+  const htmlData = { html: imageTags.join('\n'), url: sourceUrl };
+  const ocrCalls = [];
+  parser.getOcrTextForImage = async (url) => { ocrCalls.push(url); return { url, text: '', imageClassification: 'hero-banner' }; };
+  const event = { title: 'BUSY NIGHT' };
+  await parser.ensureSinglePageImageCoverage(event, htmlData, {}, [], null);
+  assert.equal(ocrCalls.length, parser.singlePageOcrTopUpMaxImages, 'the top-up reads at most its bound');
+  assert.deepEqual(ocrCalls, [1, 2, 3, 4].map((i) => `https://fixture-eagle.example/wp-content/uploads/candidate-${i}.jpg`),
+    'candidates are taken in page order');
+
+  ocrCalls.length = 0;
+  await parser.ensureSinglePageImageCoverage(
+    { title: 'BUSY NIGHT' }, htmlData, { ai: { ocr: { enabled: false } } }, [], null);
+  assert.equal(ocrCalls.length, 0, 'OCR off means no top-up either');
+});
+
+// Behavior guard (passes before and after the top-up): an explicitly
+// configured ocr.maxImages still caps the page-level pass exactly as before —
+// the top-up is a separate, conditional mechanism.
+test('single-page top-up: explicit ocr.maxImages still caps the page-level pass exactly as configured', async () => {
+  const parser = createParser();
+  const { htmlData } = buildSinglePageTopUpFixture();
+  const ocrCalls = [];
+  parser.getOcrTextForImage = async (url) => { ocrCalls.push(url); return { url, text: 'text', imageClassification: 'event-flyer' }; };
+  const parserConfig = { ai: { ocr: { maxImages: 3 } } };
+  const ocrConfig = parser.getOcrConfig(parserConfig);
+  assert.equal(ocrConfig.maxImages, 3, 'the clamp and default are untouched');
+  await parser.extractOcrFromAllImages(htmlData, ocrConfig, null, ocrConfig.maxImages);
+  assert.equal(ocrCalls.length, 3, 'the capped pass reads exactly the configured number of images');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -5136,6 +5136,17 @@ class SharedCore {
         return statusCode === 410 || statusCode === 404;
     }
 
+    // The single list of TRANSIENT HTTP statuses (server overloaded/loading,
+    // rate limited, timed out at a proxy). Static + pure so the adapters can
+    // consult the SAME definition isRetryableFailure classifies stamped
+    // statuses against: a non-2xx POST response with one of these statuses
+    // must THROW from inside the resilience-wrapped attempt (engaging the
+    // #1643 ladder), while every other non-2xx keeps the {ok:false} return
+    // shape callers already branch on. One list, never a second classifier.
+    static isRetryableHttpStatus(statusCode) {
+        return [408, 425, 429, 500, 502, 503, 504].includes(statusCode);
+    }
+
     isRetryableFailure(error) {
         if (error && typeof error.retryable === 'boolean') {
             return error.retryable;
@@ -5152,7 +5163,7 @@ class SharedCore {
             ? error.statusCode
             : this.extractHttpStatusCodeFromError(error);
         if (typeof statusCode === 'number') {
-            return [408, 425, 429, 500, 502, 503, 504].includes(statusCode);
+            return SharedCore.isRetryableHttpStatus(statusCode);
         }
 
         const message = error && typeof error.message === 'string'


### PR DESCRIPTION
Two small, unrelated-but-both-robustness fixes.

## Fix 1 — postJson swallowed non-2xx, so the retry ladder never engaged

`ScriptableAdapter.postJson` returned `{ok:false, status, text}` on any non-2xx — a SUCCESSFUL operation as far as `withNetworkResilience` could see. A 503 from the local AI server (model loading/busy) therefore never engaged the #1643 ladder; the run degraded instead of riding it out.

Now: **transient statuses throw from inside the resilience-wrapped attempt** with `error.statusCode` stamped (ground truth for `isRetryableFailure`), engaging the ladder. **4xx client rejections keep the `{ok:false}` return shape** — no caller behavior changes for genuine rejections. The status list is the exact one `isRetryableFailure` already classified stamped statuses by, extracted as `SharedCore.isRetryableHttpStatus` (408/425/429/500/502/503/504) so there is still only one classifier. `postForm` gets the identical contract; the Node-side `WebAdapter.postJson`/`postForm` mirror both (they had the same swallow-bug).

**Who depends on `{ok:false}` today** (mapped before changing anything):
- `SharedCore.callAiGenerate` (shared-core.js:14621) — the ONLY runtime `postJson` caller (every AI/OCR path funnels through it). `!response.ok` → warn + return null. After the ladder exhausts, the thrown error lands in its existing catch → same warn + null, so downstream degradation is byte-identical to today's — just after the ladder rode out the outage first.
- `AiWebParser` MEC month feed (ai-web-parser.js:4801) — the ONLY runtime `postForm` caller. Already converts `ok === false` into a local throw caught by its own degrade path; a post-ladder throw lands in the same catch.
- Test doubles returning `{ok:false, status:500}` exercise `callAiGenerate`'s response-shape handling, which is unchanged.

Ladder/give-up machinery untouched: a 503 storm marks the host exhausted after the ladder (existing #1643 stop semantics) and correctly never triggers network give-up ("a failure the SERVER answered proves the network is up").

## Fix 2 — single-event pages: OCR cap 2 with no top-up

`extractOcrFromAllImages` caps single pages at `ocrConfig.maxImages` (clamped 1..4, default 2) and `ensureSegmentOcrCoverage` runs only on the multi-event path — a poster that is the 3rd `<img>` on a busy detail page was never OCR'd; og:image was the only rescue.

New `ensureSinglePageImageCoverage`: **conditional, bounded top-up** — only when the extracted event came out imageless (nothing the AI offered survived the placeholder/furniture gates AND the og:image fill found nothing), read up to **+4** candidates past the cap (same filter chain as the capped pass + the #1652 vet rules + post-#1648 stripped-identity collapse, identities already offered to the AI excluded) and adopt the first one the vision pass **positively** classified `event-flyer` with meaningful text. Never fail-open; never on the multi-event whole-page fallback (its `<img>` order is sibling events' flyers). OCR request options/prompt untouched — cache signature identical.

**Corpus measurement** (all 37 cached single-event detail pages: 22 eaglela.com [1 corrupt-free set: 21 usable + listing excluded], 17 www.thedallaseagle.com, minus the two `events.json` listings = 37 measured): distinct post-filter candidate identities per page — **7: 2 pages, 8: 19 pages, 9: 16 pages** (max 9). The full-size poster sits at position 3 wherever one exists (e.g. `cubscoutAug-Medium.jpeg`, `Wed-HUMP-NIGHT-poster-2024-web-1-1.jpg`, `Eagle_LA_poster_11x17.jpg`); positions 7-9 are emoji-CDN paths, search-URL templates, and plugin icons on every measured page. **Why not vet all up front**: that's 5-7 extra OCR calls (~10-14s wall clock) on EVERY page — including the majority whose top-2 pass or og:image already lands the poster — and it grows every extraction prompt, invalidating the AI-response cache across the board. Cap 2 + 4 reaches every observed poster.

**Wall-clock bound**: capped pass ≤ maxImages (≤4, default 2) + top-up ≤ 4 → default worst case 6 OCR calls ≈ 12s/page at ~2s/call, and the +4 only on pages that would otherwise ship imageless; OCR reads are URL-cached so repeat runs pay nothing. Explicit `ocr.maxImages` semantics unchanged (behavior-guard test).

## Verification

- `node --check` clean on all 4 runtime files; **full suite: 1672 pass / 0 fail** on branch vs **measured clean origin/main (e4123ca8) baseline: 1661 pass / 0 fail** (+11 new tests, nothing else moved).
- New tests, each run against clean origin/main and the branch:
  - **FAIL on main / PASS on branch (9)**: 503 → ladder retries → success on attempt 2 (sleeper spied: `[5000]`); sustained 503 → 6 attempts, sleeps `[5000,15000,30000,60000,90000]`, give-up NOT triggered, next call to the exhausted host = 1 attempt/no waiting; postForm 502 → ladder → recovery; WebAdapter postJson 503-throws/400-returns; WebAdapter postForm 500-throws/404-returns; poster at position 3 → topped up, OCR'd exactly once, becomes the event image and joins ocrResults; event-with-image → zero top-up calls; no positive flyer verdict → no adoption + whole-page fallback → no top-up; +4 bound respected in page order + OCR-off disables.
  - **Declared behavior guards, PASS on main and branch (2)**: 400 → `{ok:false,status:400,text}` returned once, zero retries, zero waits; explicit `ocr.maxImages: 3` → capped pass reads exactly 3.
- Diff audit: ai-web-parser.js diff is 0 removed lines (pure addition); only 2 NEW console.log lines added, no existing log/prompt text modified; no `NetworkResilience` internals touched; no `new URL`/`URLSearchParams`; shared-core stays platform-pure.
- **No new runtime files** (all changes inside existing modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP