### PR TITLE
fix(ui+config): multi-day card dates, empty-run suppression, template entry skip, junk-title withhold, Eagle LA alwaysBear

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -2341,12 +2341,16 @@ class ScriptableAdapter {
 
     const normalizedTarget = this.normalizeParserName(parserName);
     const matchingParser = config.parsers.find((parser) => {
+      // Documentation-only template entries are never runnable, even by
+      // explicit name — remove `template: true` from the entry to go live.
+      if (parser && parser.template === true) return false;
       const name = parser && parser.name ? parser.name : "";
       return this.normalizeParserName(name) === normalizedTarget;
     });
 
     if (!matchingParser) {
       const availableParsers = config.parsers
+        .filter((parser) => !(parser && parser.template === true))
         .map((parser) => (parser && parser.name ? parser.name : ""))
         .filter((name) => this.hasNonEmptyValue(name));
       const availableLabel =
@@ -5033,6 +5037,9 @@ class ScriptableAdapter {
       const automationFilterForSave =
         automationRunForSave && runtimeForSave.automationFilter !== false;
       const activeParsers = parserConfigs.filter((parser) => {
+        // Template entries are never runnable in any mode (mirrors the
+        // template-entry check in SharedCore.evaluateAutomationForParser)
+        if (parser && parser.template === true) return false;
         if (automationFilterForSave) {
           // Mirrors SharedCore.evaluateAutomationForParser: automationEnabled
           // defaults to true, only an explicit false opts out
@@ -5041,10 +5048,25 @@ class ScriptableAdapter {
         return parser?.enabled !== false;
       });
       const hasActiveParsers = activeParsers.length > 0;
+      // Zero parsers PROCESSED is different from zero events found. Each
+      // parser that actually ran pushed an entry onto results.parserResults
+      // (SharedCore.processEvents does this unconditionally per processed
+      // parser, even for 0-event and discovery-only results) — so an empty
+      // parserResults means the run never did anything: start pressed and
+      // closed, picker cancelled, or every parser skipped. Those runs used
+      // to save a junk run file AND pop the results sheet. A run that
+      // processed parsers and found 0 events still has parserResults entries
+      // and MUST still save (audit doctrine: no silent partial/empty holes).
+      const hasProcessedParsers =
+        Array.isArray(results?.parserResults) &&
+        results.parserResults.length > 0;
+      const suppressEmptyRun =
+        !results?._isDisplayingSavedRun && !hasProcessedParsers;
       const shouldSaveRun =
         !results?._isDisplayingSavedRun &&
         hasAnalyzedEvents &&
-        hasActiveParsers;
+        hasActiveParsers &&
+        hasProcessedParsers;
       const retentionDays = 30;
 
       // ------------------------------------------------------------------
@@ -5070,7 +5092,13 @@ class ScriptableAdapter {
       }
 
       const shouldSkipUi = this.shouldSkipResultsUi(results);
-      if (!shouldSkipUi) {
+      if (suppressEmptyRun) {
+        // Nothing ran — nothing to review. Saved-run display is exempt above
+        // (an explicitly requested saved run always presents).
+        console.log(
+          "📱 Scriptable: Zero parsers processed this run — skipping run save and results UI",
+        );
+      } else if (!shouldSkipUi) {
         // Present rich UI display (may update results.calendarEvents if user executes)
         await this.presentRichResults(results);
       } else {
@@ -5087,11 +5115,13 @@ class ScriptableAdapter {
       } else {
         const reason = results?._isDisplayingSavedRun
           ? "display mode"
-          : !hasActiveParsers
-            ? automationFilterForSave
-              ? "no automation-enabled parsers"
-              : "no enabled parsers"
-            : "missing analyzed events";
+          : !hasProcessedParsers
+            ? "zero parsers processed"
+            : !hasActiveParsers
+              ? automationFilterForSave
+                ? "no automation-enabled parsers"
+                : "no enabled parsers"
+              : "missing analyzed events";
         console.log(`📱 Scriptable: Skipping run save (${reason})`);
       }
 
@@ -10710,6 +10740,28 @@ class ScriptableAdapter {
           ...timeZoneOptions,
         })
       : "";
+    // Multi-day events: when the end falls on a DIFFERENT calendar day than
+    // the start in the event's timezone, render the end DATE too — an
+    // Aug 28–31 festival card used to read "Thu, Aug 28 … 9:00 PM - 2:00 AM"
+    // as if it were one Thursday night. Same-calendar-day events render
+    // byte-identically to before. A past-midnight bar night (9 PM - 2 AM)
+    // does cross a calendar day, so its card now says which day the 2 AM
+    // belongs to — that is the disambiguation this exists for. Day equality
+    // is judged in the event's timezone via the same toLocaleDateString
+    // options, never via UTC date math.
+    const isMultiDay =
+      endDate &&
+      endDate.toLocaleDateString("en-US", timeZoneOptions) !==
+        eventDate.toLocaleDateString("en-US", timeZoneOptions);
+    const endDateStr = isMultiDay
+      ? endDate.toLocaleDateString("en-US", {
+          weekday: "short",
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+          ...timeZoneOptions,
+        })
+      : "";
 
     // Also show UTC time for verification
     const utcTimeStr = eventDate.toLocaleTimeString("en-US", {
@@ -10724,6 +10776,21 @@ class ScriptableAdapter {
           timeZone: "UTC",
         })
       : "";
+    // Same multi-day treatment for the UTC verification row, judged in UTC
+    // calendar days (which can differ from the event-timezone judgement
+    // above — each row is honest about its own timezone).
+    const endUtcDateStr =
+      endDate &&
+      endDate.toLocaleDateString("en-US", { timeZone: "UTC" }) !==
+        eventDate.toLocaleDateString("en-US", { timeZone: "UTC" })
+        ? endDate.toLocaleDateString("en-US", {
+            weekday: "short",
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+            timeZone: "UTC",
+          })
+        : "";
 
     // Use the final notes that will actually be saved
     const notes = event.notes || "";
@@ -10788,11 +10855,23 @@ class ScriptableAdapter {
                 ${evidenceBlock}
                 <div class="event-detail">
                     <span>📅</span>
-                    <span>${dateStr} ${timeStr}${endTimeStr ? ` - ${endTimeStr}` : ""}</span>
+                    <span>${dateStr} ${timeStr}${
+                      endDateStr
+                        ? ` - ${endDateStr} ${endTimeStr}`
+                        : endTimeStr
+                          ? ` - ${endTimeStr}`
+                          : ""
+                    }</span>
                 </div>
                 <div class="event-detail" style="font-size: 12px; color: #666; margin-left: 20px;">
                     <span>🌍</span>
-                    <span>UTC: ${utcTimeStr}${endUtcTimeStr ? ` - ${endUtcTimeStr}` : ""}</span>
+                    <span>UTC: ${utcTimeStr}${
+                      endUtcDateStr
+                        ? ` - ${endUtcDateStr} ${endUtcTimeStr}`
+                        : endUtcTimeStr
+                          ? ` - ${endUtcTimeStr}`
+                          : ""
+                    }</span>
                 </div>
                 <div class="event-detail">
                     <span>📱</span>
@@ -12419,7 +12498,11 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
   // parsers run), never as run-as-configured.
   async presentParserPicker(config) {
     try {
-      const parsers = Array.isArray(config?.parsers) ? config.parsers : [];
+      // Documentation-only template entries (template: true) never appear in
+      // the picker — they are config to copy, not parsers to run.
+      const parsers = (
+        Array.isArray(config?.parsers) ? config.parsers : []
+      ).filter((parser) => !(parser && parser.template === true));
       if (parsers.length === 0) return null;
 
       const records = await this.readMetricsRecordsForPicker();
@@ -13851,6 +13934,10 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     // buckets off normalizeWriteAction, not this, so the metrics schema is
     // untouched.
     if (SharedCore.isRecurringSeriesEvent(event)) return "withheld";
+    // junk-title sanity-flagged events are withheld by the same
+    // filterEventsForExecution gate (CTA link text is not an event name) —
+    // the card must say so instead of promising a CREATE that never runs.
+    if (SharedCore.hasJunkTitleSanityFlag(event)) return "withheld";
     // Same display-only treatment for the other direction: a slot-host source
     // fills in ONE dated occurrence of somebody else's series, so the write is
     // neither a new event nor a change to the series. Checked after the

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -7693,3 +7693,147 @@ test('WebAdapter.postForm mirrors the contract too: 5xx throws stamped, 4xx keep
     global.fetch = originalFetch;
   }
 });
+
+// ---------------------------------------------------------------------------
+// Fix wave 4: multi-day card dates, empty-run suppression, template entries,
+// junk-title withhold labeling.
+// ---------------------------------------------------------------------------
+
+test('generateEventCard renders the end date on multi-day events and stays start-only for same-day events', () => {
+  // Real timezone config for the real record: Spooky Bear, run
+  // 20260811-155725 — Oct 29 → Nov 2 2026, ptown (America/New_York).
+  const adapter = new ScriptableAdapter({
+    cities: { ptown: { timezone: 'America/New_York', patterns: ['ptown'] } }
+  });
+  const tz = { timeZone: 'America/New_York' };
+  const fmtDate = (date) => date.toLocaleDateString('en-US', {
+    weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', ...tz
+  });
+  const fmtTime = (date) => date.toLocaleTimeString('en-US', {
+    hour: 'numeric', minute: '2-digit', ...tz
+  });
+
+  const start = new Date('2026-10-29T04:00:00.000Z');
+  const end = new Date('2026-11-02T04:59:59.000Z');
+  assert.notEqual(fmtDate(start), fmtDate(end), 'fixture spans calendar days');
+  const multiDay = adapter.generateEventCard({
+    title: 'Spooky Bear',
+    _action: 'new',
+    startDate: '2026-10-29T04:00:00.000Z',
+    endDate: '2026-11-02T04:59:59.000Z',
+    city: 'ptown'
+  });
+  // Both dates appear, joined as "<start date> <start time> - <end date> <end time>".
+  assert.ok(multiDay.includes(fmtDate(start)), 'start date renders');
+  assert.ok(multiDay.includes(fmtDate(end)), 'end date renders');
+  assert.ok(
+    multiDay.includes(`${fmtDate(start)} ${fmtTime(start)} - ${fmtDate(end)} ${fmtTime(end)}`),
+    'multi-day span renders both dates with their times');
+
+  // Same-calendar-day events keep the original start-only format.
+  const sameStart = new Date('2026-10-29T18:00:00.000Z');
+  const sameEnd = new Date('2026-10-29T23:00:00.000Z');
+  assert.equal(fmtDate(sameStart), fmtDate(sameEnd), 'fixture is one calendar day');
+  const sameDay = adapter.generateEventCard({
+    title: 'Bear Tea',
+    _action: 'new',
+    startDate: '2026-10-29T18:00:00.000Z',
+    endDate: '2026-10-29T23:00:00.000Z',
+    city: 'ptown'
+  });
+  assert.ok(
+    sameDay.includes(`${fmtDate(sameStart)} ${fmtTime(sameStart)} - ${fmtTime(sameEnd)}`),
+    'same-day span is unchanged');
+  assert.ok(
+    !sameDay.includes(` - ${fmtDate(sameEnd)}`),
+    'no end date on a same-day card');
+});
+
+test('zero-parsers-processed runs neither save nor present, but parsers-with-zero-events still save', async () => {
+  const buildResults = (parserResults) => ({
+    totalEvents: 0,
+    rawBearEvents: 0,
+    bearEvents: 0,
+    duplicatesRemoved: 0,
+    calendarEvents: 0,
+    errors: [],
+    analyzedEvents: [],
+    parserResults,
+    config: { parsers: [{ name: 'Live Parser', enabled: true }], runtime: {} }
+  });
+  const drive = async (results) => {
+    const adapter = buildAdapter();
+    const calls = { saved: 0, presented: 0 };
+    // Keep the save/UI decision logic real; stub the heavy display helpers
+    // and every storage side effect.
+    adapter.displayCalendarProperties = async () => {};
+    adapter.compareWithExistingCalendars = async () => {};
+    adapter.displayEnrichedEvents = async () => {};
+    adapter.persistRunSnapshot = async () => { calls.saved += 1; };
+    adapter.presentRichResults = async () => { calls.presented += 1; };
+    adapter.ensureRelativeStorageDirs = async () => {};
+    adapter.appendLogSummary = async () => {};
+    adapter.cleanupOldFiles = async () => 0;
+    adapter.buildMetricsRecord = () => null;
+    const logLines = [];
+    const originalLog = console.log;
+    console.log = (...args) => { logLines.push(args.join(' ')); };
+    try {
+      await adapter.displayResults(results);
+    } finally {
+      console.log = originalLog;
+    }
+    return { calls, logLines };
+  };
+
+  // Start pressed, no parser ever processed (e.g. picker cancelled): no run
+  // file, no results sheet, and the reason is logged.
+  const emptyRun = await drive(buildResults([]));
+  assert.equal(emptyRun.calls.saved, 0, 'zero-parsers-processed run is not saved');
+  assert.equal(emptyRun.calls.presented, 0, 'zero-parsers-processed run presents no UI');
+  assert.ok(
+    emptyRun.logLines.some((line) =>
+      line === '📱 Scriptable: Zero parsers processed this run — skipping run save and results UI'),
+    'the suppression is logged');
+
+  // A run that processed parsers and found 0 events is a REAL run (audit
+  // doctrine): it must still save and still present.
+  const zeroEvents = await drive(buildResults([
+    { name: 'Live Parser', totalEvents: 0, rawBearEvents: 0, bearEvents: 0, duplicatesRemoved: 0 }
+  ]));
+  assert.ok(zeroEvents.calls.saved >= 1, '0-event run with processed parsers still saves');
+  assert.equal(zeroEvents.calls.presented, 1, 'and still presents the results UI');
+});
+
+test('template entries are invisible to parser-name override matching', () => {
+  const adapter = buildAdapter();
+  const config = {
+    parsers: [
+      { name: 'New Site Template', template: true, urls: ['https://example.com/events'] },
+      { name: 'Live Parser', urls: ['https://example.org/events'] }
+    ]
+  };
+  // Even an exact-name request cannot run a template entry, and the error's
+  // available-parsers list does not advertise it.
+  assert.throws(
+    () => adapter.buildParserNameOverrideConfig('New Site Template', config),
+    /not found in scraper-input\.js\. Available parsers: Live Parser$/);
+  const live = adapter.buildParserNameOverrideConfig('Live Parser', config);
+  assert.equal(live.parserConfig.name, 'Live Parser');
+});
+
+test('junk-title flagged events surface Write: withheld instead of promising a CREATE', () => {
+  const adapter = buildAdapter();
+  const event = {
+    title: 'View Event →',
+    _action: 'new',
+    startDate: '2026-08-15T02:00:00.000Z',
+    city: 'unknown',
+    _sanityFlags: [{ code: 'junk-title', detail: 'title reads as link/CTA text' }]
+  };
+  assert.equal(adapter.getWriteActionFromEvent(event), 'withheld');
+  // The card still renders (flag, don't drop) and carries the sanity badge.
+  const html = adapter.generateEventCard(event);
+  assert.ok(html.includes('sanity-flag-badge'));
+  assert.ok(html.includes('junk-title'));
+});

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -181,13 +181,12 @@ const scraperConfig = {
       // the /events/ archive (25 vs 12 in Aug 2026) and is where the
       // month-feed lookahead fetches next month's grid from.
       //
-      // alwaysBear: Eagle LA is a bear/leather venue and the bear check was
-      // dropping its flagship parties as "no bear-specific vocabulary" —
-      // run 20260811-132948 dropped 17/30 events including MEAT RACK, ONYX,
-      // SUNDAY BEER BUST, JUNGLE, BLUF LA. alwaysBear is AI trust context,
-      // not a bypass: not_bear/unsure events are KEPT with review flags for
-      // human judgment instead of silently dropped (flag, don't drop).
-      alwaysBear: true,
+      // NOT alwaysBear (owner call, 2026-08-11): the venue hosts many
+      // non-bear nights, so trusted-source keep-everything would flood the
+      // review pile. The bear check does over-drop flagship parties here
+      // (run 20260811-132948 dropped MEAT RACK, ONYX, SUNDAY BEER BUST as
+      // "no bear-specific vocabulary") — the intended remedy is persistent
+      // manual bear verdicts, not alwaysBear.
       urls: ["https://eaglela.com/events/", "https://eaglela.com/calendar/"],
     },
     {

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -180,6 +180,14 @@ const scraperConfig = {
       // /calendar/ is the MEC month grid — it lists MORE of the month than
       // the /events/ archive (25 vs 12 in Aug 2026) and is where the
       // month-feed lookahead fetches next month's grid from.
+      //
+      // alwaysBear: Eagle LA is a bear/leather venue and the bear check was
+      // dropping its flagship parties as "no bear-specific vocabulary" —
+      // run 20260811-132948 dropped 17/30 events including MEAT RACK, ONYX,
+      // SUNDAY BEER BUST, JUNGLE, BLUF LA. alwaysBear is AI trust context,
+      // not a bypass: not_bear/unsure events are KEPT with review flags for
+      // human judgment instead of silently dropped (flag, don't drop).
+      alwaysBear: true,
       urls: ["https://eaglela.com/events/", "https://eaglela.com/calendar/"],
     },
     {
@@ -227,6 +235,10 @@ const scraperConfig = {
       // 📋 SUGGESTED CONFIG block (with harvested instagram/facebook/website)
       // you can paste right back here.
       name: "New Site Template",
+      // template: documentation-only entry. The parser picker, parser-name
+      // matching, and scheduled automation runs all skip entries carrying
+      // template: true — remove the marker (or copy the entry) to go live.
+      template: true,
       urls: ["https://example.com/events"],
       alwaysBear: false, // set true for trusted bear promoters (AI trust context)
       metadata: {

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1861,6 +1861,36 @@ class SharedCore {
             }
         }
 
+        // 8. junk-title — the title is navigation/CTA link text scraped as an
+        //    event name. Run 20260811-141004 (3 Dollar Bill): six segments
+        //    whose ENTIRE text was "View Event →\nAug\n4:00 PM" each became a
+        //    calendar event titled "View Event →". The tell is generic, not a
+        //    phrase blocklist: the title ENDS in an arrow/chevron glyph — a
+        //    link affordance; real event names don't point anywhere — and what
+        //    precedes the arrow is at most three plain word tokens (letters
+        //    only, so dates/prices/emoji never qualify as link text). "WINK:
+        //    LESBIAN LEATHER & LACE", "Bear Tea", "🍸 Cocktail Party",
+        //    "THE HUNT" carry no terminal arrow and can never flag. A
+        //    title that is ONLY arrows has no letters and is already rule 3's
+        //    case. Unlike the codes above, this one is additionally consumed
+        //    by the calendar write path, which withholds the write for flagged
+        //    records (the card still shows them — flag, don't drop; the
+        //    withhold lives at the write site, not here).
+        if (title) {
+            const arrowTail = title.match(/(?:\s*(?:→|⇒|⟶|➔|➜|›|»|≫|>|▶|►)+)+$/u);
+            if (arrowTail) {
+                const preArrow = title.slice(0, title.length - arrowTail[0].length).trim();
+                const tokens = preArrow ? preArrow.split(/\s+/) : [];
+                if (tokens.length > 0 && tokens.length <= 3
+                    && tokens.every(token => /^\p{L}+$/u.test(token))) {
+                    flags.push({
+                        code: 'junk-title',
+                        detail: `title reads as link/CTA text (${tokens.length} plain word${tokens.length === 1 ? '' : 's'} ending in an arrow/chevron)`
+                    });
+                }
+            }
+        }
+
         return flags;
     }
 
@@ -3702,6 +3732,12 @@ class SharedCore {
     }
 
     evaluateAutomationForParser(parserConfig, automationContext) {
+        // Documentation-only template entries (template: true in
+        // scraper-input.js) are never runnable in ANY mode — checked before
+        // the filterParsers early-return so manual runs skip them too.
+        if (parserConfig && parserConfig.template === true) {
+            return { shouldRun: false, reason: 'template-entry' };
+        }
         if (!automationContext || !automationContext.filterParsers) {
             return { shouldRun: true, reason: null };
         }
@@ -3850,6 +3886,18 @@ class SharedCore {
 
         if (disabledParsers.length > 0) {
             await displayAdapter.logInfo(`SYSTEM: Skipped disabled parsers: ${disabledParsers.join(', ')}`);
+        }
+
+        // Template entries are skipped in every mode; in automation mode the
+        // "Skipped parsers (automation)" line below already names them, so
+        // this line keeps the skip visible on manual runs too.
+        if (!automationContext.filterParsers) {
+            const templateSkipped = automationSkipped
+                .filter(item => item.reason === 'template-entry')
+                .map(item => item.name);
+            if (templateSkipped.length > 0) {
+                await displayAdapter.logInfo(`SYSTEM: Skipped template entries (documentation-only): ${templateSkipped.join(', ')}`);
+            }
         }
 
         if (automationContext.filterParsers) {
@@ -11322,11 +11370,26 @@ class SharedCore {
     // an occurrence object detaches that occurrence instead of editing the
     // series (see the EKSpanThisEvent evidence in buildAnalyzedCalendarEvent).
     // Series edits go through the ICS channel, which owns UID + SEQUENCE.
+    // junk-title sanity-flagged events are withheld the same way: CTA link
+    // text ("View Event →") is not an event name, so the record stays fully
+    // visible in results (flag, don't drop) but never reaches a write — see
+    // getEventSanityFlags rule 8 and the 🚫 JUNK TITLE log at the stamp site.
     static filterEventsForExecution(analyzedEvents) {
         if (!Array.isArray(analyzedEvents)) return [];
         return analyzedEvents.filter(event =>
             event?._parserConfig?.dryRun !== true &&
-            !SharedCore.isRecurringSeriesEvent(event));
+            !SharedCore.isRecurringSeriesEvent(event) &&
+            !SharedCore.hasJunkTitleSanityFlag(event));
+    }
+
+    // True when the stamped sanity flags include the junk-title code — the
+    // one sanity code that is ENFORCED (write withheld) rather than
+    // report-only. Kept as its own predicate so the execution filter, the
+    // stamp-site log, and the adapters' "withheld" labeling all agree on
+    // exactly what counts.
+    static hasJunkTitleSanityFlag(event) {
+        return Array.isArray(event?._sanityFlags)
+            && event._sanityFlags.some(flag => flag && flag.code === 'junk-title');
     }
 
     // An event that DEFINES a recurring series: stamped _recurring in
@@ -12946,10 +13009,20 @@ class SharedCore {
             // serialization like _evidenceLines) and surfaced by the
             // adapters. Flags NEVER change _action, withhold a write, or
             // reorder anything — enforcement, if ever, is a separately
-            // approved change.
+            // approved change. ONE such approval exists: `junk-title`
+            // (rule 8 — CTA link text as an event name) is withheld from
+            // calendar execution by filterEventsForExecution; nothing about
+            // that changes _action or this stamping, and the card stays in
+            // the results UI.
             analyzedEvent._sanityFlags = this.getEventSanityFlags(analyzedEvent);
             if (analyzedEvent._sanityFlags.length > 0) {
                 console.log(`⚠️ SANITY: "${analyzedEvent.title || 'Unknown'}" flagged ${analyzedEvent._sanityFlags.map(flag => flag.code).join(', ')} — ${analyzedEvent._sanityFlags[0].detail}`);
+            }
+            // The one enforced sanity code, logged at the stamp site so the
+            // run log shows the withhold decision next to the flag that
+            // caused it (the actual gate is filterEventsForExecution).
+            if (SharedCore.hasJunkTitleSanityFlag(analyzedEvent)) {
+                console.log(`🚫 JUNK TITLE: "${analyzedEvent.title || 'Unknown'}" withheld from calendar write — CTA/navigation link text (report-only: still shown in results)`);
             }
 
             // Recurring series are display+export only: keep the card in the

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -17023,8 +17023,11 @@ test('junk-title records are withheld from calendar execution with the 🚫 JUNK
   const core = createCore();
   const buildScraped = (title) => ({
     title,
-    startDate: new Date('2026-08-08T02:00:00.000Z'),
-    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    // Future-dated on purpose: a fully-elapsed span would trip wave 3's
+    // span-fully-past flag once both waves land, and this test isolates
+    // the junk-title flag.
+    startDate: new Date('2027-08-08T02:00:00.000Z'),
+    endDate: new Date('2027-08-08T07:00:00.000Z'),
     bar: 'STATION 4',
     city: 'dallas',
     shortName: 'TAGS' // keeps the shortName derivation pass inert

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -16992,3 +16992,89 @@ test('pipeline order: counters stay truthful — duplicatesRemoved covers the FU
     result.events.length + (result.bearDroppedEvents || []).length
   );
 });
+
+// ---------------------------------------------------------------------------
+// junk-title (sanity rule 8) + its write withhold, and template-entry
+// filtering — fix wave 4. junk-title is the ONE enforced sanity code:
+// detection is deterministic (≤3 plain word tokens ending in an arrow/chevron
+// glyph — link-text shape, not a phrase blocklist), the record stays in
+// results (flag, don't drop), and filterEventsForExecution withholds the
+// calendar write.
+// ---------------------------------------------------------------------------
+
+test('sanity: CTA/navigation link text as a title flags junk-title; real titles never do', () => {
+  const core = createSanityCore();
+  // Run 20260811-141004 (3 Dollar Bill): six segments whose whole text was
+  // "View Event →\nAug\n4:00 PM" each became a calendar event.
+  assert.deepEqual(sanityCodes(core, { title: 'View Event →' }), ['junk-title']);
+  assert.deepEqual(sanityCodes(core, { title: 'Tickets »' }), ['junk-title']);
+  // Real titles that must never flag.
+  assert.deepEqual(sanityCodes(core, { title: 'WINK: LESBIAN LEATHER & LACE' }), []);
+  assert.deepEqual(sanityCodes(core, { title: 'Bear Tea' }), []);
+  assert.deepEqual(sanityCodes(core, { title: '🍸 Cocktail Party' }), []);
+  assert.deepEqual(sanityCodes(core, { title: 'THE HUNT' }), []);
+  // Conservative by design: a non-letter token breaks the link-text shape
+  // even with a trailing arrow, and a mid-title ">" is not a terminal glyph.
+  assert.deepEqual(sanityCodes(core, { title: 'MEAT RACK 2026 →' }), []);
+  assert.deepEqual(sanityCodes(core, { title: 'Bears > Twinks' }), []);
+});
+
+test('junk-title records are withheld from calendar execution with the 🚫 JUNK TITLE line, but stay in results', async () => {
+  const core = createCore();
+  const buildScraped = (title) => ({
+    title,
+    startDate: new Date('2026-08-08T02:00:00.000Z'),
+    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    bar: 'STATION 4',
+    city: 'dallas',
+    shortName: 'TAGS' // keeps the shortName derivation pass inert
+  });
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logLines.push(args.join(' ')); };
+  let flagged;
+  let clean;
+  try {
+    flagged = await core.prepareEventsForCalendar(
+      [buildScraped('View Event →')], buildPrepCalendarAdapter([]), {});
+    clean = await core.prepareEventsForCalendar(
+      [buildScraped('Bear Tea')], buildPrepCalendarAdapter([]), {});
+  } finally {
+    console.log = originalLog;
+  }
+  // Flag, don't drop: the record is analyzed, flagged, and visible.
+  assert.equal(flagged.length, 1);
+  assert.deepEqual(flagged[0]._sanityFlags.map(flag => flag.code), ['junk-title']);
+  assert.deepEqual(clean[0]._sanityFlags, []);
+  // The withhold decision is logged at the stamp site.
+  const junkLines = logLines.filter(line => line.startsWith('🚫 JUNK TITLE: '));
+  assert.deepEqual(junkLines, [
+    '🚫 JUNK TITLE: "View Event →" withheld from calendar write — CTA/navigation link text (report-only: still shown in results)'
+  ]);
+  // The gate itself: the flagged record never reaches execution; the clean
+  // twin passes through untouched.
+  assert.deepEqual(
+    SharedCore.filterEventsForExecution([flagged[0], clean[0]]),
+    [clean[0]]);
+  assert.equal(SharedCore.hasJunkTitleSanityFlag(flagged[0]), true);
+  assert.equal(SharedCore.hasJunkTitleSanityFlag(clean[0]), false);
+});
+
+test('template entries are never runnable: evaluateAutomationForParser refuses them in every mode', () => {
+  const core = createCore();
+  const template = { name: 'New Site Template', template: true, automationEnabled: true };
+  // Automation mode (filterParsers) and manual mode both refuse.
+  assert.deepEqual(
+    core.evaluateAutomationForParser(template, { filterParsers: true }),
+    { shouldRun: false, reason: 'template-entry' });
+  assert.deepEqual(
+    core.evaluateAutomationForParser(template, null),
+    { shouldRun: false, reason: 'template-entry' });
+  // Live entries are unaffected in both modes.
+  assert.deepEqual(
+    core.evaluateAutomationForParser({ name: 'Live Parser' }, { filterParsers: true }),
+    { shouldRun: true, reason: null });
+  assert.deepEqual(
+    core.evaluateAutomationForParser({ name: 'Live Parser' }, null),
+    { shouldRun: true, reason: null });
+});


### PR DESCRIPTION
Fix wave 4 ("UI + config") from audited run evidence. One branch, five fixes.

## 1. Multi-day events now show their end date on results cards

**Evidence:** an Aug 28–31 festival card read "Thu, Aug 28 … 9:00 PM – 2:00 AM" — the end side rendered only a time (`endTimeStr`), never a date.

**Mechanism** (`scriptable-adapter.js`, `generateEventCard`): when `endDate` falls on a **different calendar day than `startDate` in the event's timezone** (same `getTimezoneForCityOrUtc`-based options already in scope, compared via `toLocaleDateString` — no UTC date math), the card renders `<start date> <start time> - <end date> <end time>`. Same-calendar-day cards render **byte-identically** to before. The UTC verification row gets the same treatment, judged in UTC calendar days. Note: a past-midnight bar night (9 PM–2 AM) does cross a calendar day, so its card now names the day the 2 AM belongs to — that is the disambiguation this exists for.

**Test** renders the real record — Spooky Bear (run 20260811-155725, `2026-10-29T04:00:00Z → 2026-11-02T04:59:59Z`, ptown/America/New_York) — through the card formatter and asserts both dates appear, plus a same-day card asserting the unchanged format. Other surfaces checked: the UITable fallback list row shows parser-provided `event.day`/`event.time` strings (no end time at all — not this defect); the console sample at `displayEnrichedEvents` uses full `toLocaleString` (date+time). Left untouched.

## 2. Empty runs no longer save a run file or pop the results sheet

**Evidence:** `shouldSaveRun` accepted any run with `Array.isArray(results.analyzedEvents)` — an empty array passes, so hitting start and closing without running any parser wrote a junk run file and presented the sheet.

**Mechanism:** the reliable "actually ran" signal is `results.parserResults` — `SharedCore.processEvents` pushes one entry per parser it *processes*, unconditionally, including 0-event and discovery-only results. Zero entries = nothing ran (picker cancelled, closed at start, every parser skipped): both the save **and** the results-UI presentation are suppressed, with a new log line (`📱 Scriptable: Zero parsers processed this run — skipping run save and results UI`). A run that processed parsers and found **0 events still saves and still presents** (no-partial-runs/audit doctrine). Saved-run display is exempt (an explicitly requested saved run always presents).

**Tests:** zero-parsers-processed → no save, no UI, reason logged; parsers-processed-with-zero-events → still saves, still presents.

## 3. "New Site Template" is no longer a runnable parser option

**Mechanism:** the entry (kept — it's documentation) now carries `template: true`, and entries with the marker are skipped at every enumeration point:
- `SharedCore.evaluateAutomationForParser` — refuses with reason `template-entry`, checked *before* the `filterParsers` early-return so manual runs skip too (the main parser loop routes every parser through it); new manual-run log line `SYSTEM: Skipped template entries (documentation-only): …`
- `presentParserPicker` — filtered out of the menu list (downstream picker plumbing operates on the pre-filtered list)
- `buildParserNameOverrideConfig` — invisible even to an exact-name request, and absent from the "Available parsers" error listing
- the `activeParsers` save-gate filter in the adapter (mirrors the shared-core check)

Nothing is hardcoded per venue — the marker is generic config any entry could carry.

## 4. CTA link text as an event title: `junk-title` sanity flag + write withhold

**Evidence:** run 20260811-141004 (3 Dollar Bill): six segments whose whole text was "View Event →\nAug\n4:00 PM" became events titled "View Event →", kept as unsure-flagged on the calendar. `shared-core.js` had deliberately deferred junk-title detection — this is that wave.

**Mechanism (flag, don't drop — no silent deletion):**
- **Detection** (`getEventSanityFlags` rule 8): deterministic, generic link-text shape — the title *ends* in an arrow/chevron glyph (`→ ⇒ ⟶ ➔ ➜ › » ≫ > ▶ ►`) and what precedes it is ≤3 plain word tokens (letters only). Not a phrase blocklist; a numbered title ("MEAT RACK 2026 →") or mid-title ">" never flags. The segment-corpus corroboration variant was considered and rejected: no segment text survives onto analyzed events, and "segment text = title+month+time" would false-positive on legitimately minimal listing cards.
- **Surfacing:** flagged on the card like every other sanity flag (existing badge machinery), and the card's Write label says **withheld** instead of promising a CREATE.
- **Withhold:** `SharedCore.filterEventsForExecution` — the existing per-event gate both write paths (interactive + headless) already route through, same pattern as the recurring-series withhold. The record stays in `analyzedEvents`/results (report-only visibility), the write never executes, and a new log line at the stamp site records the decision: `🚫 JUNK TITLE: "…" withheld from calendar write — CTA/navigation link text (report-only: still shown in results)`.

**Tests:** "View Event →" flagged + withheld (with exact log line + `filterEventsForExecution` gate assertion), "Tickets »" flagged, and must-NOT-flag: "WINK: LESBIAN LEATHER & LACE", "Bear Tea", "🍸 Cocktail Party", "THE HUNT". The existing "no enforcement twin" test still passes — junk-title changes no `_action`/write fields, only execution membership.

## 5. Config: Eagle LA `alwaysBear: true` — **judgment call, owner can veto**

Run 20260811-132948 bear-dropped 17/30 Eagle LA events including MEAT RACK, MEAT RACK INFERNO, ONYX, SUNDAY BEER BUST, JUNGLE, BLUF LA (MEAT RACK dropped for "no bear-specific vocabulary" — at a leather-bear venue). Per the flag-don't-drop doctrine, `alwaysBear` is AI trust context, not a bypass: not_bear/unsure events are **kept with review flags** for human judgment instead of dropped. Comment in `scraper-input.js` explains. Revert this one-line config change if you disagree.

## Verification

- **Fail-on-main proof:** the two modified test files were run against a detached `origin/main` (6d55930c) worktree: **865 pass / 7 fail — the 7 failures are exactly the 7 new tests** (all four wave items with code changes are covered; item 5 is config).
- **Quiet suite on this branch:** `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test` → **1690 pass / 0 fail** (1683 baseline + 7 new).
- No `new URL(`/`URLSearchParams` added under `scripts/`; shared-core.js stays platform-pure (pure logic + `console.log`, both already used there); **zero existing console.log strings or AI prompt lines edited** (verified via deleted-line audit of the diff — only structural code, HTML template spans, and comments).
- **No new runtime files** — all changes land in files scriptable-script-updater already deploys (`scripts/shared-core.js`, `scripts/adapters/scriptable-adapter.js`, `scripts/scraper-input.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP