### PR TITLE
fix(scraper): field-correctness wave 2 — time-evidence symmetry, prose covers, JSON-API prices, fail-closed geocode

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -242,8 +242,36 @@ class BasicDataNormalizer extends BaseNormalizer {
         // Sync URL and website fields
         event = this.syncUrlAndWebsiteFields(event);
 
+        // Cover shape gate: prose never ships as a cover (see dropProseCover).
+        event = this.dropProseCover(event);
+
         // Normalize basic text fields
         return this.core.normalizeEventTextFields(event);
+    }
+
+    // Cover is the ONE money field, and non-price prose kept shipping in it
+    // (run 20260811-133948, Bearracuda: cover "21+" — the flyer's AGE
+    // RESTRICTION — plus "ADV. TICKETS", "ADV. TIX AT BEARRACUDA.COM",
+    // "SUPER EARLY tix available"; the cover-not-a-price sanity flag fired
+    // but flags never rewrite). At normalization time — before the record is
+    // final — a cover whose shape classifies as 'prose' (neither a price nor
+    // a free-admission phrase, SharedCore.classifyCoverShape) is dropped
+    // with a log line. One carve-out: bare numeric amounts/ranges ("10",
+    // "15-20", "12.50") are prices whose currency marker the flyer omitted —
+    // the classifier calls them prose (no currency symbol/ISO code), but
+    // they survive. The getEventSanityFlags flag itself is untouched: it
+    // still covers every path that does not run this pipeline. Platform-pure
+    // (classifyCoverShape is pure); no core → fail open, change nothing.
+    dropProseCover(event) {
+        if (!event || typeof event !== 'object') return event;
+        if (!this.core || typeof this.core.classifyCoverShape !== 'function') return event;
+        const coverText = typeof event.cover === 'string' ? event.cover.trim() : '';
+        if (!coverText) return event;
+        if (this.core.classifyCoverShape(coverText) !== 'prose') return event;
+        if (/^\d{1,4}(?:[.,]\d{1,2})?(?:\s*[-–—/]\s*\d{1,4}(?:[.,]\d{1,2})?)?$/.test(coverText)) return event;
+        console.log(`🧹 NORMALIZE: dropped cover "${coverText}" for "${event.title || 'unknown'}" — neither a price nor a free-admission phrase (age restrictions and ticket-availability prose are not a cover)`);
+        delete event.cover;
+        return event;
     }
 
     stampPageProvenanceDefaults(event) {
@@ -2142,8 +2170,9 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
     // against the input address (Apple placemark via the adapter, when that
     // capability exists) plus suspect flagging per verification mode. Returns
     // { location, crossCheck, poiNames } — the "lat, lon" string to write, the
-    // cross-check verdict ('pass' | 'fail' | 'skipped'; 'fail' only survives
-    // in report mode), and any POI names harvested from the reverse placemark
+    // cross-check verdict ('pass' | 'fail' | 'skipped'; a 'fail' NEVER
+    // returns a location — a check that ran and failed refuses the pin in
+    // every mode that runs checks), and any POI names harvested from the reverse placemark
     // the cross-check already fetched (geo-POI bar corroboration; empty when
     // no placemark or no name) — or, when enforce mode sends the ladder on to
     // its next rung, { location: null, crossCheck } carrying the rejection
@@ -2214,6 +2243,17 @@ class OpenStreetMapNormalizer extends BaseNormalizer {
                     if (!matched) {
                         console.warn(`🗺️ GEOCODE VERIFY: "${title}" pin failed reverse cross-check ("${comparison.got}" vs "${address}") — verify pin`);
                         if (verifyMode === 'enforce') return { location: null, crossCheck: 'fail' };
+                        // Fail closed in report mode too (run 20260811-133948,
+                        // Bearracuda Phoenix: reverse cross-checks FAILED yet a
+                        // pin for the same address was still accepted). A
+                        // cross-check that RAN and FAILED is positive evidence
+                        // the pin is wrong — "flag, don't drop" covers the
+                        // suspect-but-unverifiable shapes below, never a
+                        // verification that affirmatively failed. The event
+                        // stays unpinned (gmaps falls back to the text query
+                        // downstream); pass/skipped acceptance is untouched.
+                        console.warn(`🗺️ GEOCODE VERIFY: "${title}" pin refused — reverse cross-check ran and failed, so the pin is not written (left unpinned; later rungs may still verify one)`);
+                        return { location: null, crossCheck: 'fail' };
                     }
                 }
             }

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -907,7 +907,13 @@ test('geocode verification: enforce mode exhausts the ladder on street-grade res
   );
 });
 
-test('geocode verification: cross-check mismatch keeps the pin but flags it in report mode', async () => {
+test('geocode verification: cross-check mismatch refuses the pin in report mode too (run 20260811-133948, Bearracuda Phoenix)', async () => {
+  // Doctrine: curated data beats derived, FAIL CLOSED — a reverse
+  // cross-check that RAN and FAILED is positive evidence the pin is wrong.
+  // "Flag, don't drop" covers suspect-but-unverifiable pins (street-grade,
+  // vague input, skipped checks); an affirmatively failed verification must
+  // never be silently accepted in any mode (the Phoenix run stored
+  // 33.497757,-112.077333 after two failed cross-checks for the address).
   const normalizer = createOsmNormalizer();
   normalizer.delayForRateLimit = async () => {};
   const httpAdapter = createRoutedStubAdapter(
@@ -920,10 +926,14 @@ test('geocode verification: cross-check mismatch keeps the pin but flags it in r
     normalizer.normalizeAsync(event, httpAdapter, { geocodeVerification: { mode: 'report' } })
   );
 
-  assert.equal(event.location, '37.7752000, -122.4180000', 'report mode keeps the suspect pin');
+  assert.equal(event.location, undefined, 'a pin whose reverse cross-check failed must not be written');
   assert.ok(
     lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "CHUNK" pin failed reverse cross-check') && l.includes('— verify pin')),
     `the mismatch flag must be logged: ${lines.join(' | ')}`
+  );
+  assert.ok(
+    lines.some(l => l.includes('🗺️ GEOCODE VERIFY: "CHUNK" pin refused — reverse cross-check ran and failed')),
+    `the refusal must be explained with its own line: ${lines.join(' | ')}`
   );
 });
 
@@ -1156,8 +1166,8 @@ test('geocode verdict: report-mode cross-check failure and street-grade accepts 
   await withCapturedConsole(() =>
     normalizer.normalizeAsync(failEvent, failAdapter, { geocodeVerification: { mode: 'report' } })
   );
-  assert.equal(failEvent.location, '37.7752000, -122.4180000', 'report mode still keeps the suspect pin');
-  assert.equal(failEvent._geocodeCrossCheck, 'fail');
+  assert.equal(failEvent.location, undefined, 'a failed cross-check refuses the pin in report mode too');
+  assert.equal(failEvent._geocodeCrossCheck, 'fail', 'the unpinned event carries the rejection breadcrumb');
   assert.equal(failEvent._geocodeGrade, 'exact');
 
   const streetNormalizer = createOsmNormalizer();
@@ -1488,6 +1498,51 @@ test('BasicDataNormalizer never overwrites a source that is already set', () => 
   normalizer.normalize(event);
   assert.equal(event.pinSource, 'curated');
   assert.equal(event.addressSource, 'curated');
+});
+
+// ---------------------------------------------------------------------------
+// Cover shape gate at normalization (run 20260811-133948, Bearracuda):
+// cover "21+" — the flyer's AGE RESTRICTION — shipped to the record (the
+// cover-not-a-price sanity flag fired at log 1882 but flags never rewrite),
+// alongside "ADV. TICKETS", "ADV. TIX AT BEARRACUDA.COM", and "SUPER EARLY
+// tix available". Prose is not money: it drops at normalization, before the
+// record is final. The sanity flag itself is untouched.
+// ---------------------------------------------------------------------------
+
+test('cover gate: Phoenix "21+" and ticket-availability prose drop at normalization with a log line', () => {
+  const normalizer = createBasicNormalizer();
+  // Literal run values (Bearracuda 20260811-133948) plus FURBALL's "TICKLEAP".
+  const proseCovers = ['21+', 'ADV. TICKETS', 'ADV. TIX AT BEARRACUDA.COM', 'SUPER EARLY tix available', 'TICKLEAP'];
+  for (const cover of proseCovers) {
+    const event = { title: 'BEARRACUDA: PHOENIX PRIDE', city: 'nyc', cover };
+    const lines = [];
+    const realLog = console.log;
+    console.log = (message) => { lines.push(String(message)); };
+    try {
+      normalizer.normalize(event);
+    } finally {
+      console.log = realLog;
+    }
+    assert.equal(event.cover, undefined, `prose cover "${cover}" must not survive normalization`);
+    assert.ok(
+      lines.some(l => l.includes(`🧹 NORMALIZE: dropped cover "${cover}"`) && l.includes('neither a price nor a free-admission phrase')),
+      `the drop states the value and the reason: ${lines.join(' | ')}`
+    );
+  }
+
+  // Survivor guards, same test so the gate ships with its boundaries:
+  // genuine prices, free phrases, and bare numeric amounts pass untouched.
+  const genuineCovers = ['$10', '10', 'free', 'no cover', '£8 adv / £10 door', '$15-$20'];
+  for (const cover of genuineCovers) {
+    const event = { title: 'REAL PRICE', city: 'nyc', cover };
+    normalizer.normalize(event);
+    assert.equal(event.cover, cover, `genuine cover "${cover}" must survive unchanged`);
+  }
+  // No core wired → fail open, never delete.
+  const bare = new BasicDataNormalizer();
+  const uncored = { title: 'NO CORE', cover: '21+' };
+  bare.normalize(uncored);
+  assert.equal(uncored.cover, '21+', 'without a core the gate fails open');
 });
 
 function createBarNormalizerWithBar() {

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -98,6 +98,19 @@ const END_MARKER_START_FIELDS = new Map([
     ['starttime', 'endtime']
 ]);
 
+// Start-marker misattribution — the INVERSE of the end-marker gate above
+// (run 20260811-102550, FURBALL NOLA): the flyer prints
+// "DOORS: 9PM • PARTY: 10PM", the confidence retry returned endtime "22:00"
+// citing that exact line, and the gate passed it (10PM IS verbatim in the
+// corpus) — but 10PM is the party's START, so the event shipped 9PM-10PM
+// instead of 10PM-late. An END field whose evidence cites only start-side
+// markers (doors/party/show/starts) carries misattributed START data — its
+// own rejection class, symmetric with END_MARKER_CITED_REASON. Evidence that
+// also carries a genuine end signal ("Doors 8pm until 2am", "10PM-2AM")
+// fails open: the cited value may genuinely be the end of a stated range.
+const START_MARKER_CITED_REASON = 'start-marker-cited-evidence';
+const START_MARKER_END_FIELDS = new Set(['enddate', 'endtime']);
+
 // rrule rejection class (run 20260728-113040, CubScout): an iCal RRULE is a
 // DERIVED TRANSLATION of schedule prose ("1ST FRIDAY OF THE MONTH" →
 // FREQ=MONTHLY;BYDAY=1FR) and is never verbatim on the page, so the default
@@ -6892,6 +6905,67 @@ class AiWebParser {
         }
     }
 
+    // Generic price harvest from an event-like JSON API object (run
+    // 20260811-133623, Goldiloxx: redeyetickets' detail payload carries
+    // performances[].ticket_options[].price_cents = 2500/3000/3500, but the
+    // converter mapped no price field at all and the NYC event lost its
+    // cover). Key-PATTERN matching, never a vendor schema: any depth-limited
+    // scalar whose normalized key names a price (price/ticket_price/cost/
+    // price_min/price_max, with or without a _cents suffix) counts;
+    // presentation/surcharge keys (display_*, tax/fee/service) and currency/
+    // id keys are excluded. Amounts under *cents* keys are divided by 100.
+    // Formatting follows formatJsonLdOffersCover's conventions exactly:
+    // min==max → "$25"; range → "$25-$35"; a non-USD currency key renders
+    // "25 EUR" style. Empty string when the object states no price (the
+    // search-endpoint shape) — fail open, never fabricate.
+    formatJsonApiPriceCover(obj) {
+        try {
+            const amounts = [];
+            let currency = '';
+            const priceKeyPattern = /(^|_)(price|cost)(_|$)/;
+            const excludedKeyPattern = /(^|_)(display|tax|fee|service|id|status|currency)(_|$)|display/;
+            const visit = (node, depth) => {
+                if (!node || depth > 3) return;
+                if (Array.isArray(node)) {
+                    node.forEach(item => visit(item, depth + 1));
+                    return;
+                }
+                if (typeof node !== 'object') return;
+                for (const [key, value] of Object.entries(node)) {
+                    const normalizedKey = this.normalizeJsonApiKey(key);
+                    if (value && typeof value === 'object') {
+                        visit(value, depth + 1);
+                        continue;
+                    }
+                    if (!currency && /(^|_)currency(_|$)/.test(normalizedKey)
+                        && typeof value === 'string' && /^[A-Za-z]{3}$|^[$€£¥]$/.test(value.trim())) {
+                        currency = value.trim().toUpperCase();
+                        continue;
+                    }
+                    if (!priceKeyPattern.test(normalizedKey)) continue;
+                    if (excludedKeyPattern.test(normalizedKey)) continue;
+                    const amount = Number(String(value === null || value === undefined ? '' : value).trim());
+                    if (!Number.isFinite(amount) || amount <= 0) continue;
+                    amounts.push(/cents/.test(normalizedKey) ? amount / 100 : amount);
+                }
+            };
+            visit(obj, 0);
+            if (amounts.length === 0) return '';
+            const min = Math.min(...amounts);
+            const max = Math.max(...amounts);
+            const formatAmount = (amount) => Number.isInteger(amount) ? String(amount) : amount.toFixed(2);
+            if (!currency || currency === 'USD' || currency === '$') {
+                return min === max ? `$${formatAmount(min)}` : `$${formatAmount(min)}-$${formatAmount(max)}`;
+            }
+            return min === max
+                ? `${formatAmount(min)} ${currency}`
+                : `${formatAmount(min)}-${formatAmount(max)} ${currency}`;
+        } catch (error) {
+            console.warn(`🤖 AI Web: JSON API price→cover mapping failed: ${error && error.message ? error.message : error}`);
+            return '';
+        }
+    }
+
     // Field mapping from one event-like JSON object, case/snake/camel-
     // insensitive first match. Shares the JSON-LD path's cleaning
     // (tag-strip + entity-decode), date parsing (trailing-Z instants are
@@ -6990,6 +7064,16 @@ class AiWebParser {
         // data the API itself published. Absent image → no stamp (fail open).
         if (event.image) {
             event.imageSource = 'json-api';
+        }
+        // Price → cover from the payload's own price-ish keys (generic
+        // pattern harvest, see formatJsonApiPriceCover). Stamped with the
+        // SAME provenance flag the JSON-LD offers path uses: these are live
+        // ticket-vendor tier prices (they move as tiers sell out), so the
+        // merge layer's stored-door-price rule applies to them identically.
+        const cover = this.formatJsonApiPriceCover(obj);
+        if (cover) {
+            event.cover = cover;
+            event._coverFromJsonLdOffers = true;
         }
         // Timezone: an IANA name in the payload is authoritative; otherwise the
         // address→city resolution below may supply the city's timezone.
@@ -13181,6 +13265,35 @@ TEXT:
     }
 
     /**
+     * START-marker-cited evidence for an END field — the inverse of
+     * evidenceCitesEndMarker (run 20260811-102550, FURBALL NOLA: the
+     * confidence retry returned endtime "22:00" citing
+     * "DOORS: 9PM • PARTY: 10PM" and passed the gate — 10PM is the PARTY's
+     * start, not an end). True only when the evidence carries a start-side
+     * marker (doors/party/show/starts/begins/from) and NO end-side signal.
+     * Deliberately fails open on any genuine end signal: an end-marker word
+     * (til/until/close/end — the same vocabulary the end-marker gate above
+     * detects) or an explicit time RANGE ("10PM-2AM", "8pm to 2am") means
+     * the cited value may really be the end.
+     */
+    evidenceCitesStartMarker(evidence) {
+        const text = String(evidence || '').trim();
+        if (!text) return false;
+        // Genuine end-side signal anywhere → fail open.
+        const endMarker = /\bend(?:s|ed|ing)?\s*(?:at\b|:|by\b)?|\bdoors?\s+clos(?:e|es|ed|ing)\b|\bclos(?:e|es|ed|ing)\b|\buntil\b|\btill?\b|'til+\b|\blate\b/i;
+        if (endMarker.test(text)) return false;
+        // A time range ("10PM-2AM", "10:00 PM to 2:00 AM") states an end.
+        const timeToken = "\\d{1,2}(?::\\d{2})?\\s*(?:am|pm)|\\d{1,2}:\\d{2}";
+        const timeRange = new RegExp(`(?:${timeToken})\\s*(?:-|–|—|to|thru|through)\\s*(?:${timeToken})`, 'i');
+        if (timeRange.test(text)) return false;
+        // Start-side markers. Broader than the end-marker gate's startMarker
+        // regex on purpose: flyers write "DOORS: 9PM" and "PARTY: 10PM" —
+        // bare doors/party/show labels with a colon are start statements.
+        const startMarker = /\bdoors?\s*(?:[:@]|at\b|open(?:s|ed|ing)?\b)|\bpart(?:y|ies)\s*(?:[:@]|at\b|starts?\b)|\bshow\s*(?:[:@]|at\b|time\b|starts?\b)|\bstart(?:s|ed|ing)?\s*(?:at\b|[:@])|\bbegin(?:s|ning)?\s*(?:at\b|[:@])|\bfrom\s*\d/i;
+        return startMarker.test(text);
+    }
+
+    /**
      * Evidence citing the ADDITIONAL CONTEXT block. That block is injected
      * with an explicit DO-NOT-EXTRACT instruction, so evidence referencing it
      * is a violation by definition — for ANY field. Observed in run
@@ -13680,6 +13793,16 @@ TEXT:
         const endMarkerStart = !citesForbiddenContext
             && END_MARKER_START_FIELDS.has(rule.field)
             && this.evidenceCitesEndMarker(modelEvidence);
+        // The inverse class: END fields whose model-cited evidence is a
+        // start-marker statement ("DOORS: 9PM • PARTY: 10PM" — run
+        // 20260811-102550, FURBALL NOLA retry endtime "22:00") carry
+        // misattributed START data. Like the end-marker class, the value is
+        // often verbatim in the corpus, so corroboration alone cannot catch
+        // it. The value is dropped, never reassigned: the doors-vs-party
+        // disambiguation at normalization owns start-time correction.
+        const startMarkerEnd = !citesForbiddenContext
+            && START_MARKER_END_FIELDS.has(rule.field)
+            && this.evidenceCitesStartMarker(modelEvidence);
         // rrule/recurrence ('schedule-evidence' mode): the value is a derived
         // translation, never verbatim — validated against the model's cited
         // EVIDENCE phrase instead (see validateRruleScheduleEvidence).
@@ -13690,6 +13813,7 @@ TEXT:
             && !brandOnlyCityEvidence
             && !inventedTime
             && !endMarkerStart
+            && !startMarkerEnd
             && !datelessDateEvidence
             && (scheduleEvidence
                 ? scheduleEvidence.valid
@@ -13706,6 +13830,10 @@ TEXT:
             if (citesForbiddenContext) droppedEntry.reason = 'context-cited-evidence';
             else if (brandOnlyCityEvidence) droppedEntry.reason = 'brand-cited-evidence';
             else if (endMarkerStart) droppedEntry.reason = END_MARKER_CITED_REASON;
+            else if (startMarkerEnd) {
+                droppedEntry.reason = START_MARKER_CITED_REASON;
+                console.log(`🤖 AI Web: Dropped ${rule.field} "${this.trimToMaxLength(String(value), 40)}" — cited evidence "${this.trimToMaxLength(String(modelEvidence), 60)}" states a start-side marker (doors/party/show/starts), not an end`);
+            }
             else if (datelessDateEvidence) {
                 droppedEntry.reason = 'dateless-cited-evidence';
                 console.log(`🤖 AI Web: Dropped ${rule.field} "${this.trimToMaxLength(String(value), 40)}" — cited evidence "${this.trimToMaxLength(String(modelEvidence), 60)}" carries no concrete date (weekday/schedule words cannot corroborate a specific date)`);
@@ -13752,6 +13880,7 @@ TEXT:
                 brandOnlyCityEvidence,
                 inventedTime,
                 endMarkerStart,
+                startMarkerEnd,
                 datelessDateEvidence
             });
             return false;
@@ -13782,7 +13911,7 @@ TEXT:
         try {
             if (!EVIDENCE_RESCUE_FIELDS.has(rule.field)) return;
             // ONLY the plain "value not verbatim" rejection class qualifies.
-            if (dropFlags && (dropFlags.citesForbiddenContext || dropFlags.brandOnlyCityEvidence || dropFlags.inventedTime || dropFlags.endMarkerStart || dropFlags.datelessDateEvidence)) return;
+            if (dropFlags && (dropFlags.citesForbiddenContext || dropFlags.brandOnlyCityEvidence || dropFlags.inventedTime || dropFlags.endMarkerStart || dropFlags.startMarkerEnd || dropFlags.datelessDateEvidence)) return;
             const evidence = String(modelEvidence || '').trim();
             if (!evidence) return;
             // Inference language or context citations anywhere in the
@@ -14355,6 +14484,65 @@ TEXT:
         return '';
     }
 
+    // Doors-vs-party disambiguation (run 20260811-102550, FURBALL NOLA): the
+    // flyer prints "DOORS: 9PM • PARTY: 10PM" and extraction adopted 21:00
+    // (the DOORS time) as startTime — the event starts when the party starts,
+    // not when the doors open. Deterministic and page-derived: when the
+    // event's own source corpus states exactly ONE doors time X and exactly
+    // ONE distinct party/show/start time Y later than X, and the extracted
+    // startTime equals X, the start is promoted to Y. Fails closed on any
+    // ambiguity (multiple distinct doors or party times, Y not after X, or
+    // the extracted start not matching the doors time) — then nothing
+    // changes. Returns the promoted "HH:MM" or '' when no promotion applies.
+    resolveDoorsVsPartyStartTime(startTimeRaw, htmlData) {
+        const normalizedStart = String(startTimeRaw || '').trim();
+        const startMatch = normalizedStart.match(/^(\d{2}):(\d{2})$/);
+        if (!startMatch) return '';
+        const html = htmlData && typeof htmlData.html === 'string' ? htmlData.html : '';
+        if (!html) return '';
+        const corpus = this.stripTags(html);
+        // A time token: "9PM", "9:30 PM", or 24h "21:00".
+        const timeToken = '(\\d{1,2})(?::(\\d{2}))?\\s*(am|pm)|(\\d{1,2}):(\\d{2})';
+        const toMinutes = (match) => {
+            if (match[3]) {
+                let hour = parseInt(match[1], 10);
+                const minute = match[2] ? parseInt(match[2], 10) : 0;
+                const ampm = match[3].toLowerCase();
+                if (ampm === 'pm' && hour !== 12) hour += 12;
+                if (ampm === 'am' && hour === 12) hour = 0;
+                if (hour > 23 || minute > 59) return null;
+                return (hour * 60) + minute;
+            }
+            const hour = parseInt(match[4], 10);
+            const minute = parseInt(match[5], 10);
+            if (hour > 23 || minute > 59) return null;
+            return (hour * 60) + minute;
+        };
+        const collectTimes = (labelPattern) => {
+            const times = new Set();
+            const re = new RegExp(`(?:${labelPattern})\\s*(?:${timeToken})`, 'gi');
+            let match;
+            while ((match = re.exec(corpus)) !== null) {
+                const minutes = toMinutes(match);
+                if (minutes !== null) times.add(minutes);
+            }
+            return times;
+        };
+        // Linguistic-generic label vocabulary (no per-site terms): doors on
+        // one side, party/show/start statements on the other.
+        const doorsTimes = collectTimes('\\bdoors?\\s*(?:[:@]|at\\b|open(?:s|ed|ing)?\\b\\s*(?:[:@]|at\\b)?)');
+        const partyTimes = collectTimes('\\b(?:part(?:y|ies)|show|event|music)\\s*(?:[:@]|at\\b|starts?\\s*(?:[:@]|at\\b)?)|\\bstart(?:s|ed|ing)?\\s*(?:[:@]|at\\b)');
+        // Fail closed: exactly one of each, distinct, party strictly later.
+        if (doorsTimes.size !== 1 || partyTimes.size !== 1) return '';
+        const doors = [...doorsTimes][0];
+        const party = [...partyTimes][0];
+        if (party <= doors) return '';
+        const startMinutes = (parseInt(startMatch[1], 10) * 60) + parseInt(startMatch[2], 10);
+        if (startMinutes !== doors) return '';
+        const pad = (value) => String(value).padStart(2, '0');
+        return `${pad(Math.floor(party / 60))}:${pad(party % 60)}`;
+    }
+
     normalizeAiEvent(aiEvent, parserConfig, htmlData = null, cityConfig = null, promptFields = null) {
         const scrapedLinks = this.extractLinksFromPage(
             htmlData && typeof htmlData.html === 'string' ? htmlData.html : '',
@@ -14600,6 +14788,19 @@ TEXT:
         console.log(`🤖 AI Web: Date normalization — rawStartDate=${aiEvent.startDate}, rawStartTime=${aiEvent.startTime}, rawStart=${aiEvent.start}, rawEndDate=${aiEvent.endDate}, rawEndTime=${aiEvent.endTime}, rawEnd=${aiEvent.end}`);
         console.log(`🤖 AI Web: Parsed raw values — startDateRaw=${startDateRaw instanceof Date ? startDateRaw.toISOString() : startDateRaw}, startTimeRaw=${startTimeRaw}, endDateRaw=${endDateRaw instanceof Date ? endDateRaw.toISOString() : endDateRaw}, endTimeRaw=${endTimeRaw}`);
 
+        // Doors-vs-party disambiguation (run 20260811-102550, FURBALL NOLA):
+        // an extracted start equal to the corpus's stated DOORS time, when
+        // the corpus also states one distinct later party/show/start time,
+        // is the doors-open time — the event starts at the party time. The
+        // doors information itself stays wherever the page put it
+        // (description/notes untouched); only the start-of-event moves.
+        let effectiveStartTime = startTimeRaw;
+        const doorsPromotedStart = this.resolveDoorsVsPartyStartTime(startTimeRaw, htmlData);
+        if (doorsPromotedStart) {
+            console.log(`🤖 AI Web: Start time ${startTimeRaw} matches the page's DOORS time — promoted start to the party/show time ${doorsPromotedStart} (doors-vs-party disambiguation)`);
+            effectiveStartTime = doorsPromotedStart;
+        }
+
         // Check if start/end were explicitly provided (full datetime format)
         // These contain full datetime like "2026-05-12T22:30" or "2026-05-12 22:30" - use directly without combining
         const startProvided = aiEvent.start && this.parseDateValue(aiEvent.start, timezone) !== null;
@@ -14614,10 +14815,10 @@ TEXT:
             combinedStartDate = this.parseDateValue(aiEvent.start, timezone);
         } else if (startDateRaw) {
             // Default to local midnight if no start time provided
-            const timeStr = startTimeRaw || '00:00:00';
-            combinedStartDate = this.convertLocalDateTimeToUtc(startDateRaw.toISOString().split('T')[0] + ' ' + timeStr, timezone) || combineDateAndTime(startDateRaw, startTimeRaw || '00:00') || startDateRaw;
-        } else if (startTimeRaw) {
-            combinedStartDate = this.parseDateValue(startTimeRaw, timezone);
+            const timeStr = effectiveStartTime || '00:00:00';
+            combinedStartDate = this.convertLocalDateTimeToUtc(startDateRaw.toISOString().split('T')[0] + ' ' + timeStr, timezone) || combineDateAndTime(startDateRaw, effectiveStartTime || '00:00') || startDateRaw;
+        } else if (effectiveStartTime) {
+            combinedStartDate = this.parseDateValue(effectiveStartTime, timezone);
         }
 
         let combinedEndDate = null;
@@ -14776,7 +14977,7 @@ TEXT:
                 ? schema.computeNextRruleOccurrence(recurrenceRule, this.now())
                 : null;
             if (nextOccurrence) {
-                const derivedStartTime = startTimeRaw || (dayPhraseSynthesis && dayPhraseSynthesis.startTime) || '';
+                const derivedStartTime = effectiveStartTime || (dayPhraseSynthesis && dayPhraseSynthesis.startTime) || '';
                 const derivedStart = this.convertLocalDateTimeToUtc(`${nextOccurrence} ${derivedStartTime || '00:00:00'}`, timezone)
                     || combineDateAndTime(nextOccurrence, derivedStartTime || '00:00')
                     || null;

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -6290,6 +6290,157 @@ test('end-marker steering: getFieldContext appends the END-line sentence to star
 });
 
 // ---------------------------------------------------------------------------
+// Start-marker misattribution + doors-vs-party disambiguation (run
+// 20260811-102550, FURBALL NOLA). The flyer prints
+// "DOORS: 9PM • PARTY: 10PM"; extraction adopted 21:00 (doors) as startTime,
+// dropped endTime at confidence 0, and the confidence retry then returned
+// endtime "22:00" citing the very same line — which PASSED the evidence gate
+// (10PM is verbatim in the corpus). Final event: 9PM-10PM instead of
+// 10PM-late. The values below are the LITERAL model outputs from the run log.
+// ---------------------------------------------------------------------------
+
+const FURBALL_NOLA_SEGMENT = [
+  'OCR_IMAGE_TEXT',
+  'JOE FIORE', 'PRESENTS', 'FURBALL', 'SOUTHERN DECADENCE',
+  'MR. BEAR', 'GERMANY', '2026', 'JOCKS', 'UNDERWEAR GEAR',
+  'CLOTHES CHECK', 'AVAILABLE', 'MUSIC:', 'GSP',
+  'SATURDAY, SEPTEMBER 5', 'LABOR DAY WEEKEND',
+  'DOORS: 9PM • PARTY: 10PM',
+  'TWO FLOORS • BALCONY • DARK ROOM',
+  'TICKETS: TICKLEAP', 'SANTOS', '1135 DECATUR ST, NEW ORLEANS',
+  'FURBALL NOLA', 'Southern Decadence', 'September 5, 2026',
+  'Santos Bar - New Orleans, LA'
+].join('\n');
+
+test('start-marker gate: retry endtime citing "DOORS: 9PM • PARTY: 10PM" is dropped (FURBALL NOLA)', () => {
+  const parser = createParser();
+  const evidenceContext = parser.buildAiEvidenceContextFromText(FURBALL_NOLA_SEGMENT);
+  const validationContext = { imageEvidenceUrls: new Set() };
+
+  // Literal retry output from the run log: endtime 22:00, confidence 95.
+  const result = parser.validateAiEventEvidence(
+    {
+      title: 'FURBALL NOLA',
+      endtime: '22:00',
+      __fieldEvidence: { endtime: 'DOORS: 9PM • PARTY: 10PM' }
+    },
+    { html: FURBALL_NOLA_SEGMENT }, {}, null,
+    { evidenceContext, validationContext }
+  );
+
+  assert.equal(result.event.endtime, undefined,
+    'an end value whose evidence cites only start-side markers (doors/party) must not survive');
+  const dropped = result.report.dropped.find(entry => entry.field === 'endtime');
+  assert.ok(dropped, 'the drop is recorded');
+  assert.equal(dropped.reason, 'start-marker-cited-evidence', 'the drop carries its own rejection class');
+
+  // Fail-open guards, same test so the class ships with its boundaries:
+  // genuine end evidence ("until", a stated time range) keeps the end value.
+  const source = 'BEAR NIGHT Doors 9pm until 2am SHOW: 10PM-2AM';
+  const guardContext = parser.buildAiEvidenceContextFromText(source);
+  const untilResult = parser.validateAiEventEvidence(
+    { endtime: '02:00', __fieldEvidence: { endtime: 'Doors 9pm until 2am' } },
+    { html: source }, {}, null, { evidenceContext: guardContext, validationContext }
+  );
+  assert.equal(untilResult.event.endtime, '02:00', 'an end marker in the evidence keeps the end value');
+  const rangeResult = parser.validateAiEventEvidence(
+    { endtime: '02:00', __fieldEvidence: { endtime: 'SHOW: 10PM-2AM' } },
+    { html: source }, {}, null, { evidenceContext: guardContext, validationContext }
+  );
+  assert.equal(rangeResult.event.endtime, '02:00', 'a time range in the evidence keeps the end value');
+});
+
+test('start-marker detection: doors/party/show colon labels detected, end-side signals fail open', () => {
+  const parser = createParser();
+  // Literal run evidence string.
+  assert.ok(parser.evidenceCitesStartMarker('DOORS: 9PM • PARTY: 10PM'));
+  assert.ok(parser.evidenceCitesStartMarker('Doors 9pm') === false, 'bare doors with no [:@]/at/open is not claimed');
+  assert.ok(parser.evidenceCitesStartMarker('Doors: 9pm'));
+  assert.ok(parser.evidenceCitesStartMarker('PARTY: 10PM'));
+  assert.ok(parser.evidenceCitesStartMarker('Show starts 10pm'));
+  assert.ok(parser.evidenceCitesStartMarker('Starts at 10pm'));
+  // End-side or range signals fail open.
+  assert.ok(!parser.evidenceCitesStartMarker('Doors 8pm until 2am'));
+  assert.ok(!parser.evidenceCitesStartMarker('PARTY: 10PM til late'));
+  assert.ok(!parser.evidenceCitesStartMarker('SHOW: 10PM-2AM'));
+  assert.ok(!parser.evidenceCitesStartMarker('doors close at 2'));
+  assert.ok(!parser.evidenceCitesStartMarker('Ends: 2am'));
+  assert.ok(!parser.evidenceCitesStartMarker(''));
+});
+
+test('doors-vs-party: FURBALL NOLA start 21:00 (doors) is promoted to 22:00 (party), end stays absent', () => {
+  global.EventSchema = EventSchema; // earlier tests leak a mocked schema — pin the real one
+  const parser = createParser();
+  const cityConfig = {
+    'new orleans': { timezone: 'America/Chicago', patterns: ['new orleans', 'nola'] }
+  };
+
+  // The first-pass values exactly as the run log recorded them AFTER the
+  // gate: startDate 2026-09-05, startTime 21:00 ("DOORS: 9PM"), end fields
+  // dropped (confidence 0 / start-marker gate).
+  const logs = captureLogs(() => {
+    const event = parser.normalizeAiEvent(
+      {
+        title: 'FURBALL NOLA',
+        startDate: '2026-09-05',
+        startTime: '21:00',
+        city: 'new orleans',
+        bar: 'Santos Bar',
+        address: '1135 DECATUR ST'
+      },
+      {},
+      { html: FURBALL_NOLA_SEGMENT, url: 'https://www.furball.nyc' },
+      cityConfig,
+      null
+    );
+    assert.ok(event, 'the event survives normalization');
+    // 10PM CDT (UTC-5) on Sep 5 = 03:00 UTC Sep 6 — the run shipped
+    // 2026-09-06T02:00:00.000Z (9PM doors) instead.
+    assert.equal(event.startDate.toISOString(), '2026-09-06T03:00:00.000Z',
+      'start must be the PARTY time (22:00 local), not the doors time');
+    // No end was stated: the end matches the start exactly (the existing
+    // ambiguous-end convention) — no invented 10PM end survives anywhere.
+    assert.equal(event.endDate.getTime(), event.startDate.getTime(), 'no end is invented');
+  });
+  assert.ok(
+    logs.some(l => l.includes('promoted start to the party/show time 22:00 (doors-vs-party disambiguation)')),
+    `the correction logs its own line: ${logs.join(' | ')}`
+  );
+});
+
+test('doors-vs-party: ambiguity fails closed, non-doors starts untouched', () => {
+  const parser = createParser();
+
+  // Two distinct doors times → no promotion.
+  assert.equal(
+    parser.resolveDoorsVsPartyStartTime('21:00', { html: 'DOORS: 9PM • PARTY: 10PM\nDOORS: 8PM' }),
+    '', 'multiple candidate doors times must change nothing'
+  );
+  // Two distinct party-side times → no promotion.
+  assert.equal(
+    parser.resolveDoorsVsPartyStartTime('21:00', { html: 'DOORS: 9PM • PARTY: 10PM\nSHOW: 11PM' }),
+    '', 'multiple candidate party times must change nothing'
+  );
+  // Extracted start is NOT the doors time → no promotion.
+  assert.equal(
+    parser.resolveDoorsVsPartyStartTime('22:00', { html: 'DOORS: 9PM • PARTY: 10PM' }),
+    '', 'a start already at the party time is untouched'
+  );
+  // Party not later than doors → no promotion.
+  assert.equal(
+    parser.resolveDoorsVsPartyStartTime('21:00', { html: 'DOORS: 9PM • PARTY: 8PM' }),
+    '', 'a party time before doors is not a promotion target'
+  );
+  // No corpus → no promotion.
+  assert.equal(parser.resolveDoorsVsPartyStartTime('21:00', null), '');
+  // The clean FURBALL shape promotes.
+  assert.equal(
+    parser.resolveDoorsVsPartyStartTime('21:00', { html: 'DOORS: 9PM • PARTY: 10PM' }),
+    '22:00'
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Venue-hours notice guard (runs 20260724-161423 / 20260725-170031:
 // massive.club's "Hours … Tuesday Closed …" block became a calendar-bound
 // bear event titled "Tuesday Closed" with a startDate hallucinated from the
@@ -7405,6 +7556,91 @@ test('buildEventFromJsonApiObject strips HTML from descriptions and never invent
   assert.equal(event.ticketUrl, '', 'a slug is not an absolute URL — nothing is fabricated');
   assert.equal(event.image, 'https://cdn.example/flyer.jpg');
   assert.equal(event.imageSource, 'json-api');
+});
+
+// Captured live 2026-08-11 from
+// GET https://api.redeyetickets.com/api/v1/events/golidloxx-august (trimmed to
+// the fields the converter reads): prices live at
+// performances[].ticket_options[].price_cents (integer cents, base sticker
+// price) beside display_price_cents (fee-inclusive presentation copy). Run
+// 20260811-133623 lost this event's cover because the converter mapped no
+// price field at all.
+const REDEYE_GOLDILOXX_DETAIL_PAYLOAD = {
+  data: {
+    id: 'd0e392c4-a05b-48fa-bb70-95daba4ad447',
+    slug: 'golidloxx-august',
+    status: 'approved',
+    name: 'GOLIDLOXX AUGUST ',
+    headline: 'GOLDILOXX ',
+    description: '<p>GOLDILOXX is an NYC based monthly bear party for bears and their admirers.</p>',
+    venue: 'Red Eye NY',
+    venue_time_zone: 'America/New_York',
+    first_performance_start_at: '2026-08-30T01:00:00Z',
+    first_performance_end_at: '2026-08-30T20:00:00Z',
+    twenty_one_plus: true,
+    tax_rate: 0.0,
+    max_tickets_per_user: 9999,
+    performances: [{
+      performance_id: '1e3f8838-ace3-49a6-9687-e1179cdb59d1',
+      start_at: '2026-08-30T01:00:00Z',
+      end_at: '2026-08-30T20:00:00Z',
+      time_zone: 'America/New_York',
+      position: 0,
+      ticket_options: [
+        { ticket_option_id: '6255abdd', price_cents: 2500, display_price_cents: 2748, tier_name: 'EARLY BEAR ', quantity_remaining: 33, sale_state: 'on_sale' },
+        { ticket_option_id: 'da5bae48', price_cents: 3000, display_price_cents: 3297, tier_name: 'Tier 1', quantity_remaining: 100, sale_state: 'upcoming' },
+        { ticket_option_id: '2d72b298', price_cents: 3500, display_price_cents: 3847, tier_name: 'Tier 2', quantity_remaining: 150, sale_state: 'upcoming' }
+      ]
+    }],
+    venue_address_line_1: '355 West 41st Street',
+    venue_locality: 'New York',
+    venue_admin_area: 'NY',
+    venue_postal_code: '10036',
+    venue_city: 'New York',
+    venue_state: 'NY',
+    venue_zip: '10036'
+  }
+};
+
+test('JSON-API price mapping: Goldiloxx ticket_options price_cents materialize as the cover (run 20260811-133623)', () => {
+  const parser = createParser();
+  const cityConfig = { nyc: { timezone: 'America/New_York', patterns: ['new york', 'nyc'] } };
+  const events = parser.extractEventsFromJsonApiPayload(
+    REDEYE_GOLDILOXX_DETAIL_PAYLOAD,
+    'https://api.redeyetickets.com/api/v1/events/golidloxx-august',
+    cityConfig
+  );
+
+  assert.equal(events.length, 1);
+  const event = events[0];
+  assert.equal(event.title, 'GOLIDLOXX AUGUST');
+  assert.equal(event.cover, '$25-$35',
+    'base tier prices (price_cents 2500/3000/3500) form the cover range');
+  assert.equal(event._coverFromJsonLdOffers, true,
+    'ticket-vendor tier prices carry the offers provenance flag for the merge layer');
+  // display_price_cents (fee-inclusive presentation copies) must not leak in:
+  // their max would be $38.47.
+  assert.ok(!String(event.cover).includes('38'), 'display_* keys are excluded from the price harvest');
+});
+
+test('JSON-API price mapping: generic key patterns, cents handling, currency, and fail-open on priceless payloads', () => {
+  const parser = createParser();
+  // The search-endpoint shape (run 20260811-133623's actual fetch) carries
+  // NO price keys at all — no cover is fabricated.
+  assert.equal(parser.formatJsonApiPriceCover(REDEYE_SEARCH_PAYLOAD.data[0]), '');
+  // Conventional flat keys.
+  assert.equal(parser.formatJsonApiPriceCover({ price: 20 }), '$20');
+  assert.equal(parser.formatJsonApiPriceCover({ ticket_price: '12.50' }), '$12.50');
+  assert.equal(parser.formatJsonApiPriceCover({ price_min: 10, price_max: 15 }), '$10-$15');
+  assert.equal(parser.formatJsonApiPriceCover({ tickets: [{ price: 10 }, { price: 15 }] }), '$10-$15');
+  // Cents variants divide by 100.
+  assert.equal(parser.formatJsonApiPriceCover({ price_cents: 2500 }), '$25');
+  // A currency key renders ISO style for non-USD.
+  assert.equal(parser.formatJsonApiPriceCover({ price: 8, currency: 'GBP' }), '8 GBP');
+  // Zero/negative/unparseable prices and excluded key families never count.
+  assert.equal(parser.formatJsonApiPriceCover({ price: 0 }), '');
+  assert.equal(parser.formatJsonApiPriceCover({ display_price_cents: 2748, tax_rate: 5, service_fee: 3 }), '');
+  assert.equal(parser.formatJsonApiPriceCover(null), '');
 });
 
 test('linearizeJsonForPrompt emits keyPath lines for scalar leaves, skipping null/empty and stripping tags', () => {


### PR DESCRIPTION
Fix wave 2 ("field correctness") from the audited 2026-08-11 full-run evidence. One branch, four fixes, no new runtime files (all changes live in existing `scripts/parsers/ai-web-parser.js`, `scripts/normalizers.js`, and the two matching test files).

## 1. Asymmetric time-evidence gate (run 20260811-102550, FURBALL NOLA)

**Evidence** (log lines ~1022-1120): flyer OCR `DOORS: 9PM • PARTY: 10PM` → first pass adopted startTime `21:00` (evidence `OCR_IMAGE_TEXT: "DOORS: 9PM"`), endTime dropped at confidence 0 — then the confidence retry returned `endtime "22:00"` with evidence `"DOORS: 9PM • PARTY: 10PM"` at confidence 95, and it PASSED the gate (10PM is verbatim in the corpus). Final event 9PM-10PM instead of 10PM-late.

**Mechanism, two parts (post-processing only — zero prompt edits):**
- **Inverse gate**: `START_MARKER_END_FIELDS` + `evidenceCitesStartMarker()` — an end-side field (endtime/enddate) whose evidence cites only start-side markers (`doors[:@/at/open]`, `party:`, `show:`, `starts at`…) is dropped with its own rejection class `start-marker-cited-evidence` (new log line, new reason tag; the tagged value is never echoed back on retry). Fails open on any genuine end signal: end-marker vocabulary (til/until/close/end — same vocabulary the existing end-marker gate detects) or a stated time range (`10PM-2AM`).
- **Doors-vs-party disambiguation** at normalization (`resolveDoorsVsPartyStartTime`): when the event's own corpus states exactly ONE doors time X and exactly ONE distinct party/show/start time Y later than X, and the extracted startTime equals X, start is promoted to Y (new log line). Fails closed on any ambiguity (multiple candidates on either side, Y ≤ X, start ≠ doors). Doors info in description/notes untouched.

Test drives the LITERAL run values: retry endtime 22:00 + evidence string dropped; full `normalizeAiEvent` with the run's OCR corpus asserts final start `2026-09-06T03:00:00.000Z` (= 22:00 America/Chicago) and no invented end (endDate === startDate, the ambiguous-end convention).

## 2. Cover accepts non-price prose (run 20260811-133948, Bearracuda)

**Evidence**: `cover: "21+"` stored for Phoenix (sanity-flagged `cover-not-a-price` at log 1882, but flags never rewrite); same run kept `ADV. TICKETS`, `ADV. TIX AT BEARRACUDA.COM`, `SUPER EARLY tix available` (and FURBALL kept `TICKLEAP`).

**Mechanism**: `BasicDataNormalizer.dropProseCover()` — at normalization, a cover whose `classifyCoverShape` is `'prose'` is deleted with a new log line naming the value and reason. Carve-out: bare numeric amounts/ranges (`10`, `15-20`, `12.50`) are prices with the currency marker omitted — the classifier calls them prose but they survive. The `getEventSanityFlags` flag site is untouched. Both directions tested (all five run values drop; `$10`, `10`, `free`, `no cover`, `£8 adv / £10 door`, `$15-$20` survive; no core → fail open).

## 3. redeyetickets JSON-API converter never maps price → cover (run 20260811-133623, Goldiloxx)

**Observed live payload shape** (captured 2026-08-11 from `GET https://api.redeyetickets.com/api/v1/events/golidloxx-august`): prices live at `performances[].ticket_options[].price_cents` — integer cents, base sticker price (2500/3000/3500 for tiers "EARLY BEAR"/"Tier 1"/"Tier 2") — beside `display_price_cents` (fee-inclusive presentation copies: 2748/3297/3847). The search endpoint the run fetched (`/events/search?q=goldiloxx`) carries NO price keys at all — so the converter maps nothing there and fabricates nothing.

**Mechanism**: `formatJsonApiPriceCover()` — generic key-pattern harvest (never a vendor schema): depth-limited walk collecting scalars whose normalized key carries a `price`/`cost` segment; `*cents*` keys ÷ 100; `display_*`/tax/fee/service/currency/id excluded; optional `currency` key → ISO style for non-USD; formatting identical to `formatJsonLdOffersCover` (`$25` / `$25-$35`). Stamped `_coverFromJsonLdOffers` — the same provenance the JSON-LD offers path uses, so the merge layer's stored-door-price rule applies (tier minimums move as tiers sell out). Test uses the inline captured detail payload → cover `$25-$35`, display prices proven excluded; verified end-to-end against the full live payload.

## 4. Geocode accepts pins that failed reverse verification (Bearracuda Phoenix, log ~1680-1685)

**Evidence**: `Royale, 4230 N. 6th Drive, PHOENIX` → photon 0 results → address-only rung picked a candidate 5.5 km from center; reverse cross-check FAILED twice (`4251 4th Ave NW` then `635 W Glenrosa Ave` vs the input) — yet rung 5 accepted an exact pin, storing `33.497757,-112.077333`. (Note for the record: the saved run's verdict metadata stamps rung 5's own cross-check as `pass` — the photon candidate's distinct coordinates reverse-resolved differently from the two rejected candidates. The structural hole this PR closes is that a cross-check verdict of `fail` could return a pin at all: report mode accepted failed pins by design.)

**Mechanism**: in `confirmGeocodeCandidate`, a reverse cross-check that RAN and FAILED now refuses the pin in every mode that runs checks — report mode previously kept it ("flag, don't drop"); doctrine is curated-beats-derived, FAIL CLOSED: an affirmatively failed verification is positive evidence the pin is wrong. New log line explains the report-mode refusal; the ladder continues to later rungs, which may still earn a verified pin. **Preserved unchanged**: cross-check `pass` accepts; `skipped` accepts (adapters without the placemark hook / hook returns null — no regression to accept paths that never attempted verification); enforce-mode behavior; curated-coordinate paths; the coarse grade gate. Two existing report-mode doctrine tests were rewritten to the new behavior; the la/nyc replay and golden-pipeline suites pass untouched — no previously-accepted good pin drops.

## Verification

- Quiet suite green in the worktree: `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test` → **1690 pass, 0 fail**.
- **Fail-on-main proof**: copied both modified test files onto a pristine `origin/main` (6d55930c) checkout and ran `node --test scripts/parsers/ai-web-parser.test.js scripts/normalizers.test.js` — all **9** new/updated tests fail there:
  - `start-marker gate: retry endtime citing "DOORS: 9PM • PARTY: 10PM" is dropped (FURBALL NOLA)`
  - `start-marker detection: doors/party/show colon labels detected, end-side signals fail open`
  - `doors-vs-party: FURBALL NOLA start 21:00 (doors) is promoted to 22:00 (party), end stays absent`
  - `doors-vs-party: ambiguity fails closed, non-doors starts untouched`
  - `cover gate: Phoenix "21+" and ticket-availability prose drop at normalization with a log line`
  - `JSON-API price mapping: Goldiloxx ticket_options price_cents materialize as the cover (run 20260811-133623)`
  - `JSON-API price mapping: generic key patterns, cents handling, currency, and fail-open on priceless payloads`
  - `geocode verification: cross-check mismatch refuses the pin in report mode too (run 20260811-133948, Bearracuda Phoenix)`
  - `geocode verdict: report-mode cross-check failure and street-grade accepts are recorded truthfully` (rewritten from the old keeps-the-pin doctrine)
- End-to-end: the FULL live redeye detail payload through `extractEventsFromJsonApiPayload` → 1 event, cover `$25-$35`, `_coverFromJsonLdOffers: true`, bar/city intact.
- Constraints: no `new URL(`/`URLSearchParams` under scripts/; shared-core.js untouched, normalizers.js additions platform-pure; every existing console.log string and all AI prompt lines byte-identical (diff shows zero removed log/prompt lines); tests only in package.json-enumerated files; nothing hardcoded per venue/promoter/city/domain/CDN; **no NEW runtime files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP