### PR TITLE
fix(scraper): merge integrity wave 1 — binding stickiness, aggregator self-pointers, og:image chrome, brand-logo gate

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -690,6 +690,15 @@ class AiWebParser {
         // ("Tightwad Tuesday", "Lucky Break"), so rejecting it would throw away
         // real flyers. 'multi-event-flyer' is absent for the same reason.
         this.nonEventOcrImageClassifications = new Set(['logo', 'thumbnail', 'hero-banner']);
+        // Page-meta (og:image family) artwork sightings for THIS run:
+        // canonical image key → Set of page keys that published it as their
+        // social card. A meta image repeated across multiple distinct pages
+        // of one host is the site's DEFAULT card, never any single event's
+        // artwork — fillImageFromPageMetaArtwork refuses it (site-default
+        // tell; run 20260811-162602 adopted thebearcalendar.com/og-default.png
+        // as an event image). In-memory, this parser instance only, exactly
+        // like the OCR verdicts above.
+        this.pageMetaImagePagesByImageKey = new Map();
         // How far into an image the header scan reads. PNG/GIF/WebP answer in
         // the first 30 bytes; a JPEG's frame header sits after its EXIF/ICC
         // blocks, which on real camera-sourced flyers routinely run past 32KB.
@@ -940,11 +949,17 @@ class AiWebParser {
                 // placeholder rejection above: reject BEFORE the og:image fill,
                 // so the event trades site chrome for the page's real artwork
                 // instead of simply losing its picture.
-                structuredEvents.forEach(event => this.rejectNonEventImageValues(event));
+                structuredEvents.forEach(event => this.rejectNonEventImageValues(event, effectiveHtmlData));
                 // A single structured event whose node carried no image adopts
                 // the page's own og:image artwork (multi-event pages never do:
                 // one shared meta image cannot be attributed to one event).
+                // OCR-vet the would-be adoption FIRST: this short-circuit path
+                // never runs the ocr-all pass, so without the vet the fill's
+                // furniture gate fails open on "unknown" (run 20260811-162602:
+                // thebearcalendar.com/og-default.png became "Leipzig Bear
+                // Weekend"'s image). OCR is free — local MLX.
                 if (structuredEvents.length === 1) {
+                    await this.vetPageMetaArtworkCandidates(structuredEvents[0], effectiveHtmlData, parserConfig, httpAdapter);
                     this.fillImageFromPageMetaArtwork(structuredEvents[0], effectiveHtmlData);
                 }
                 // Images the structured nodes carried are already stamped
@@ -14994,7 +15009,7 @@ TEXT:
         // hero-banner it found no text on is site chrome, never this event's
         // flyer. Also before the og:image fill, so the slot can be refilled
         // with real artwork rather than left empty.
-        this.rejectNonEventImageValues(event);
+        this.rejectNonEventImageValues(event, htmlData);
 
         // A single-event page (never a multi-event segment — one shared meta
         // image cannot be attributed to one segment) whose extraction found no
@@ -16181,10 +16196,108 @@ TEXT:
                 }
             }
         }
+        // Sightings are recorded exactly once per page (the cache above makes
+        // re-entry return early), feeding the cross-page site-default tell.
+        this.recordPageMetaImageSightings(htmlData, candidates);
         if (Object.isExtensible(htmlData)) {
             htmlData.pageMetaImageCandidates = candidates;
         }
         return candidates;
+    }
+
+    // Remember which page published each og:image-family candidate this run.
+    // Keyed by the page's own URL with query string AND fragment stripped
+    // (trailing slashes ignored, lowercased): ?occurrence= variants of ONE
+    // event page legitimately share that event's real artwork and must count
+    // as one page (fail open), and the same page recording twice is a no-op.
+    recordPageMetaImageSightings(htmlData, candidates) {
+        const pageUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url.trim() : '';
+        if (!pageUrl || !Array.isArray(candidates) || candidates.length === 0) return;
+        const pageKey = this.getPageKeyForMetaImageSightings(pageUrl);
+        if (!pageKey) return;
+        for (const candidate of candidates) {
+            if (!candidate || !candidate.url) continue;
+            const imageKey = this.canonicalizeImageUrlForComparison(candidate.url);
+            if (!imageKey) continue;
+            let pages = this.pageMetaImagePagesByImageKey.get(imageKey);
+            if (!pages) {
+                pages = new Set();
+                this.pageMetaImagePagesByImageKey.set(imageKey, pages);
+            }
+            pages.add(pageKey);
+        }
+    }
+
+    getPageKeyForMetaImageSightings(pageUrl) {
+        return String(pageUrl || '').split('#')[0].split('?')[0].replace(/\/+$/, '').toLowerCase();
+    }
+
+    // Deterministic site-default tells for a page-meta (og:image) candidate.
+    // Two generic signals, no domain rules:
+    //   1. filename convention — a basename like "og-default" / "og-image"
+    //      names the site's fallback social card, not an event (run
+    //      20260811-162602: thebearcalendar.com/og-default.png became
+    //      "Leipzig Bear Weekend"'s image);
+    //   2. cross-page reuse — the SAME image published as the page-meta
+    //      artwork of two or more distinct pages on this host this run is
+    //      the site's shared card (one event's artwork belongs to one page).
+    // '' means no tell; unknown always fails open.
+    getSiteDefaultMetaImageReason(url, htmlData = null) {
+        const value = String(url || '').trim();
+        if (!value) return '';
+        const pathMatch = value.match(/^https?:\/\/[^/?#]+\/(?:[^?#]*\/)?([^/?#]+)/i);
+        const basename = pathMatch ? pathMatch[1].replace(/\.[A-Za-z0-9]+$/, '').toLowerCase() : '';
+        if (/^(?:og[-_]?(?:default|image|img)|default[-_]?og|open-?graph(?:[-_](?:default|image))?)$/.test(basename)) {
+            return `its "${basename}" filename is a site-default social-card convention`;
+        }
+        const imageKey = this.canonicalizeImageUrlForComparison(value);
+        const pages = imageKey && this.pageMetaImagePagesByImageKey
+            ? this.pageMetaImagePagesByImageKey.get(imageKey) : null;
+        if (pages && pages.size >= 2) {
+            const pageHost = htmlData && typeof htmlData.url === 'string'
+                ? this.getRegistrableDomainFromUrl(htmlData.url) : '';
+            const sameHostPages = pageHost
+                ? Array.from(pages).filter(pageKey => this.getRegistrableDomainFromUrl(pageKey) === pageHost)
+                : Array.from(pages);
+            if (sameHostPages.length >= 2) {
+                return `the same og:image is the page-meta artwork of ${sameHostPages.length} distinct ${pageHost || 'same-site'} pages this run (site default, not this event's)`;
+            }
+        }
+        return '';
+    }
+
+    // OCR-vet every page-meta candidate fillImageFromPageMetaArtwork could
+    // adopt, so its existing furniture gate (getNonEventImageOcrReason) has a
+    // verdict to consult instead of failing open on "unknown". Used by the
+    // structured-data short-circuit, which never runs the ocr-all pass. OCR
+    // is free (local MLX) — never optimized for fewer calls. No-ops when the
+    // event already has an image, OCR is disabled, or a candidate already has
+    // a verdict; a failed OCR read leaves the candidate unknown (fail open,
+    // same as before this vet existed).
+    async vetPageMetaArtworkCandidates(event, htmlData, parserConfig, httpAdapter) {
+        if (!event || typeof event !== 'object') return;
+        const existingImage = typeof event.image === 'string' ? event.image.trim() : '';
+        if (existingImage) return;
+        const ocrConfig = this.getOcrConfig(parserConfig);
+        if (!ocrConfig.enabled) return;
+        for (const candidate of this.collectPageMetaImageCandidates(htmlData)) {
+            const upgraded = candidate.url;
+            if (!upgraded || this.isLikelyUninterestingImageUrl(upgraded)) continue;
+            // Already refused deterministically — no verdict needed.
+            if (this.getSiteDefaultMetaImageReason(upgraded, htmlData)) continue;
+            if (this.getOcrImageVerdict(upgraded)) continue;
+            const rawResult = await this.getOcrTextForImage(upgraded, ocrConfig, 'og-image-vet', httpAdapter).catch(() => null);
+            const normalized = this.normalizeOcrResult(rawResult);
+            if (!normalized) continue;
+            // Same seam-level recording as the OCR top-ups: idempotent with
+            // the inner recording, and it is what the fill's gate consults —
+            // keyed under the candidate URL itself so the fill's own lookup
+            // always finds it (recordOcrImageVerdict also keys the result's
+            // own url forms).
+            this.recordOcrImageVerdict(upgraded, normalized);
+            const verdict = this.getOcrImageVerdict(upgraded);
+            console.log(`🤖 AI Web: OCR-vetted page og:image ${upgraded} before adoption — ${verdict ? verdict.classification : 'no classification'}`);
+        }
     }
 
     fillImageFromPageMetaArtwork(event, htmlData) {
@@ -16194,9 +16307,17 @@ TEXT:
         for (const candidate of this.collectPageMetaImageCandidates(htmlData)) {
             const upgraded = candidate.url;
             if (!upgraded || this.isLikelyUninterestingImageUrl(upgraded)) continue;
+            // A site-default social card (filename convention or cross-page
+            // reuse) is the page template's chrome, never this event's
+            // artwork — refuse it before the OCR gate even asks.
+            const siteDefaultReason = this.getSiteDefaultMetaImageReason(upgraded, htmlData);
+            if (siteDefaultReason) {
+                console.log(`🤖 AI Web: Refused page og:image ${upgraded} for "${event.title || ''}" — ${siteDefaultReason}`);
+                continue;
+            }
             // A page whose og:image is its own brand logo must not hand that
             // logo to the event the URL-shape test just let through.
-            if (this.getNonEventImageOcrReason(upgraded)) continue;
+            if (this.getNonEventImageOcrReason(upgraded, htmlData)) continue;
             event.image = upgraded;
             event.imageSource = 'og-image';
             console.log(`🤖 AI Web: Filled image from page og:image for "${event.title}"`);
@@ -16570,7 +16691,11 @@ TEXT:
             // model DID transcribe something, so the withhold reason can say
             // so instead of claiming "no readable text".
             hasText: this.ocrTextHasMeaningfulContent(rawText),
-            hasGlyphNoiseOnly: Boolean(rawText) && !this.ocrTextHasMeaningfulContent(rawText)
+            hasGlyphNoiseOnly: Boolean(rawText) && !this.ocrTextHasMeaningfulContent(rawText),
+            // The transcription itself, for the brand-token furniture gate in
+            // getNonEventImageOcrReason: a logo whose only readable text is
+            // the page's own brand/venue name is still page furniture.
+            text: rawText
         };
         let recorded = false;
         for (const url of [imageUrl, result.imageUrl, result.url, this.normalizeHttpUrlValue(imageUrl)]) {
@@ -16614,10 +16739,23 @@ TEXT:
      * Unknown is always keep: an image nobody OCR'd, an OCR result with no
      * classification, or a classification outside the set all return ''.
      */
-    getNonEventImageOcrReason(url) {
+    getNonEventImageOcrReason(url, htmlData = null) {
         const verdict = this.getOcrImageVerdict(url);
         if (!verdict) return '';
-        if (verdict.hasText) return '';
+        if (verdict.hasText) {
+            // A text-bearing logo normally passes (condition 2 above — the two
+            // misclassified real flyers in the corpus carry 500+ chars). But
+            // when EVERY meaningful token the model read is explained by the
+            // page's own brand/venue name, the "text" is just the brand
+            // wordmark: a venue logo transcribing "LUMBER YARD BAR" on
+            // thelumberyardbar.com (run 20260811-141654, South Seattle Bear
+            // Social) is page furniture, and hasText must not immunize it.
+            // Callers without page context (htmlData) keep the historical
+            // fail-open behavior unchanged.
+            if (!this.nonEventOcrImageClassifications.has(verdict.classification)) return '';
+            if (!htmlData || !this.isOcrTextExplainedByPageBrand(verdict.text, htmlData)) return '';
+            return `the vision pass classified it as ${verdict.classification} and its only readable text is the page's own brand/venue name`;
+        }
         if (!this.nonEventOcrImageClassifications.has(verdict.classification)) return '';
         if (verdict.hasGlyphNoiseOnly) {
             // New wording for the new case only — the model DID transcribe
@@ -16646,12 +16784,38 @@ TEXT:
      * Clearing `image` clears its imageSource stamp with it, exactly like the
      * placeholder rejection — provenance is a companion of the value.
      */
-    rejectNonEventImageValues(event) {
+    // Do the page's own brand/venue names explain EVERY meaningful token of an
+    // OCR transcription? Token = 3+ word characters (the same bar
+    // ocrTextHasMeaningfulContent sets), matched as a substring of the brand
+    // corpus with separators stripped, so "LUMBER YARD BAR" is explained by
+    // "The Lumberyard Bar" AND by the page host's own label
+    // ("thelumberyardbar"). The corpus is the page's derived brand names
+    // (getPageBrandNames — JSON-LD Organization/WebSite + og:site_name) plus
+    // the registrable domain's first label; empty transcriptions and pages
+    // with no derivable brand always answer false (fail open — the furniture
+    // gate never fires on them).
+    isOcrTextExplainedByPageBrand(text, htmlData) {
+        const tokens = String(text || '').toLowerCase().match(/[\p{L}\p{N}]{3,}/gu) || [];
+        if (tokens.length === 0) return false;
+        const corpus = [];
+        for (const name of this.getPageBrandNames(htmlData)) {
+            const squashed = String(name || '').toLowerCase().replace(/[^\p{L}\p{N}]+/gu, '');
+            if (squashed.length >= 3) corpus.push(squashed);
+        }
+        const pageUrl = htmlData && typeof htmlData.url === 'string' ? htmlData.url : '';
+        const registrable = pageUrl ? this.getRegistrableDomainFromUrl(pageUrl) : '';
+        const hostLabel = registrable ? registrable.split('.')[0] : '';
+        if (hostLabel.length >= 3) corpus.push(hostLabel);
+        if (corpus.length === 0) return false;
+        return tokens.every(token => corpus.some(brand => brand.includes(token)));
+    }
+
+    rejectNonEventImageValues(event, htmlData = null) {
         if (!event || typeof event !== 'object') return event;
         for (const field of ['image', 'imageVertical', 'imageHorizontal']) {
             const value = typeof event[field] === 'string' ? event[field].trim() : '';
             if (!value) continue;
-            const reason = this.getNonEventImageOcrReason(value);
+            const reason = this.getNonEventImageOcrReason(value, htmlData);
             if (!reason) continue;
             console.log(`🤖 AI Web: Rejected non-event ${field} ${value} for "${event.title || ''}" — ${reason}`);
             delete event[field];
@@ -16828,7 +16992,7 @@ TEXT:
             // …and neither is an image the vision pass read as page furniture.
             // Without this a rejected `image` could walk straight back in as an
             // orientation slot, because `image` is a slot candidate itself.
-            if (this.getNonEventImageOcrReason(candidate.url)) continue;
+            if (this.getNonEventImageOcrReason(candidate.url, htmlData)) continue;
             const orientation = this.resolveImageCandidateOrientation(candidate);
             if (orientation !== 'portrait' && orientation !== 'landscape') continue;
             const incumbent = bySlot[orientation];

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -13809,3 +13809,142 @@ test('single-page top-up: explicit ocr.maxImages still caps the page-level pass 
   await parser.extractOcrFromAllImages(htmlData, ocrConfig, null, ocrConfig.maxImages);
   assert.equal(ocrCalls.length, 3, 'the capped pass reads exactly the configured number of images');
 });
+
+// ---------------------------------------------------------------------------
+// Merge integrity wave 1 — og:image chrome and venue-brand logos as event
+// images (runs 20260811-162602 "Leipzig Bear Weekend" og-default.png,
+// 20260811-141654 "South Seattle Bear Social" venue logo).
+// ---------------------------------------------------------------------------
+
+test('fillImageFromPageMetaArtwork refuses site-default og:image filenames (og-default / og-image)', () => {
+  const parser = createParser();
+  for (const filename of ['og-default.png', 'og-image.jpg', 'og_default.png', 'ogimage.png', 'default-og.webp']) {
+    const event = { title: 'Leipzig Bear Weekend' };
+    const htmlData = {
+      url: 'https://thebearcalendar.com/events/leipzig-baren-weekend-2026/',
+      html: `<meta property="og:image" content="https://thebearcalendar.com/${filename}" />`
+    };
+    parser.fillImageFromPageMetaArtwork(event, htmlData);
+    assert.equal(event.image, undefined, `${filename} is a site-default social card, never an event image`);
+  }
+  // A real per-event og:image still fills as before.
+  const event = { title: 'Leipzig Bear Weekend' };
+  const htmlData = {
+    url: 'https://promoter.example/events/leipzig-weekend/',
+    html: '<meta property="og:image" content="https://promoter.example/media/leipzig-weekend-flyer.jpg" />'
+  };
+  parser.fillImageFromPageMetaArtwork(event, htmlData);
+  assert.equal(event.image, 'https://promoter.example/media/leipzig-weekend-flyer.jpg');
+});
+
+test('fillImageFromPageMetaArtwork refuses an og:image shared by multiple event pages of the same host', () => {
+  const parser = createParser();
+  const sharedCard = 'https://aggregator.example/media/social/site-card.jpg';
+  const pageOne = {
+    url: 'https://aggregator.example/events/first-party-2026/',
+    html: `<meta property="og:image" content="${sharedCard}" />`
+  };
+  const pageTwo = {
+    url: 'https://aggregator.example/events/second-party-2026/',
+    html: `<meta property="og:image" content="${sharedCard}" />`
+  };
+  // Page one is seen first (its candidates get collected during its own parse).
+  parser.collectPageMetaImageCandidates(pageOne);
+  const event = { title: 'Second Party' };
+  parser.fillImageFromPageMetaArtwork(event, pageTwo);
+  assert.equal(event.image, undefined,
+    'an og:image published by two distinct pages of one host is the site default');
+  // A different host publishing the same-shaped card on ONE page still fills.
+  const soloEvent = { title: 'Solo Party' };
+  const soloPage = {
+    url: 'https://solo.example/events/solo-party/',
+    html: '<meta property="og:image" content="https://solo.example/media/social/solo-card.jpg" />'
+  };
+  parser.fillImageFromPageMetaArtwork(soloEvent, soloPage);
+  assert.equal(soloEvent.image, 'https://solo.example/media/social/solo-card.jpg');
+});
+
+test('vetPageMetaArtworkCandidates OCRs the would-be og:image so the furniture gate can refuse it', async () => {
+  const parser = createParser();
+  const ocrCalls = [];
+  parser.getOcrConfig = () => ({ enabled: true });
+  parser.getOcrTextForImage = async (imageUrl, _ocrConfig, passLabel) => {
+    ocrCalls.push({ imageUrl, passLabel });
+    return { imageUrl, text: '', imageClassification: 'logo' };
+  };
+  const event = { title: 'Leipzig Bear Weekend' };
+  const htmlData = {
+    url: 'https://aggregator.example/events/leipzig-weekend/',
+    html: '<meta property="og:image" content="https://aggregator.example/media/site-hero.jpg" />'
+  };
+  await parser.vetPageMetaArtworkCandidates(event, htmlData, {}, null);
+  assert.equal(ocrCalls.length, 1, 'the adoptable candidate is OCR-read');
+  assert.equal(ocrCalls[0].imageUrl, 'https://aggregator.example/media/site-hero.jpg');
+  const verdict = parser.getOcrImageVerdict('https://aggregator.example/media/site-hero.jpg');
+  assert.ok(verdict, 'the vet records the verdict for the fill to consult');
+  assert.equal(verdict.classification, 'logo');
+  parser.fillImageFromPageMetaArtwork(event, htmlData);
+  assert.equal(event.image, undefined, 'the textless-logo verdict now refuses the adoption');
+
+  // Fail open: OCR disabled → no calls, and the fill behaves as before.
+  const offParser = createParser();
+  offParser.getOcrConfig = () => ({ enabled: false });
+  let called = false;
+  offParser.getOcrTextForImage = async () => { called = true; return null; };
+  await offParser.vetPageMetaArtworkCandidates({ title: 'X' }, htmlData, {}, null);
+  assert.equal(called, false, 'disabled OCR never issues requests');
+});
+
+test('a logo whose only OCR text is the page brand/venue name is refused (venue-logo blind spot)', () => {
+  const parser = createParser();
+  // Run 20260811-141654: the venue banner OCR'd classification=logo,
+  // text="LUMBER YARD\nBAR" — brand-explained text must not immunize it.
+  const bannerUrl = 'https://static.wixstatic.com/media/f45f1a_62d985d6be0d4852bffc072c1ef3c7d2~mv2_d_2400_1200_s_2.jpg';
+  parser.recordOcrImageVerdict(bannerUrl, { imageClassification: 'logo', text: 'LUMBER YARD\nBAR' });
+  const htmlData = {
+    url: 'https://www.thelumberyardbar.com/events',
+    html: '<meta property="og:site_name" content="The Lumber Yard Bar" />'
+  };
+  const reason = parser.getNonEventImageOcrReason(bannerUrl, htmlData);
+  assert.ok(reason, 'brand-only logo text is treated as no text');
+  assert.match(reason, /brand/i);
+  const event = { title: 'South Seattle Bear Social', image: bannerUrl, imageSource: 'page' };
+  parser.rejectNonEventImageValues(event, htmlData);
+  assert.equal(event.image, undefined, 'the venue-brand logo is rejected as the event image');
+  assert.equal(event.imageSource, undefined, 'provenance clears with the value');
+
+  // Without page context the historical fail-open behavior is unchanged.
+  assert.equal(parser.getNonEventImageOcrReason(bannerUrl), '', 'no htmlData → text-bearing logo still passes');
+});
+
+test('text-bearing logos NOT explained by the brand still pass (misclassified real flyers)', () => {
+  const parser = createParser();
+  const htmlData = {
+    url: 'https://www.thelumberyardbar.com/events',
+    html: '<meta property="og:site_name" content="The Lumber Yard Bar" />'
+  };
+  // The OCR corpus holds two images classified 'logo' carrying 500+ chars of
+  // real flyer text — the two conditions of the gate must keep passing them.
+  const flyerUrl = 'https://static.wixstatic.com/media/misclassified-flyer.jpg';
+  const flyerText = [
+    'LUMBER YARD BAR EVENTS', 'TUE AUG 11', 'TRIVIA TUESDAY W/ NATHAN 7:30PM + TACO TUESDAY',
+    'WED AUG 12', "QUEERAOKE! LET'S SING LOUD & PROUD 8PM-MIDNIGHT", 'THU AUG 13',
+    'GAY BINGO! FREE TO PLAY + PLUS PRIZES! 7PM', 'FRI AUG 14',
+    'EXPOSED SOAKED THEME: GET WET & WILD 9PM + WET UNDERWEAR CONTEST AT 11PM',
+    'W/ DJ REDLINE & DJ CLOVER $5 DOOR FREE CLOTHES CHK', 'SAT AUG 15',
+    'QUEER MARKET: GAY MADE & GAY OWNED 1PM-5PM',
+    'LEZ OUT W/ THE BURLESIANS (TIX AVAIL) 6PM-8PM',
+    'DOLLY & THE DJ DRAG SHOW NO COVER 9PM', 'SUN AUG 16',
+    'SOUTH SEATTLE BEAR SOCIAL 2PM-7PM'
+  ].join('\n');
+  assert.ok(flyerText.length > 500, 'regression fixture mirrors the 500+ char corpus flyers');
+  parser.recordOcrImageVerdict(flyerUrl, { imageClassification: 'logo', text: flyerText });
+  assert.equal(parser.getNonEventImageOcrReason(flyerUrl, htmlData), '',
+    'flyer text beyond the brand name keeps immunizing the image');
+  // …and an event-flyer classification never enters the furniture gate at all,
+  // even when its text happens to be brand-only.
+  const brandFlyerUrl = 'https://static.wixstatic.com/media/brand-flyer.jpg';
+  parser.recordOcrImageVerdict(brandFlyerUrl, { imageClassification: 'event-flyer', text: 'LUMBER YARD BAR' });
+  assert.equal(parser.getNonEventImageOcrReason(brandFlyerUrl, htmlData), '',
+    'event-flyer classifications are never refused by the brand gate');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1157,6 +1157,96 @@ class SharedCore {
             normalized === platform || normalized.endsWith(`.${platform}`));
     }
 
+    // Registrable domain for an already-extracted host (companion of
+    // getRegistrableDomainFromUrl, which wants a full URL). '' for empty input.
+    getRegistrableDomainFromHost(host) {
+        const cleaned = String(host || '').trim();
+        if (!cleaned) return '';
+        return this.getRegistrableDomainFromUrl(`https://${cleaned}/`);
+    }
+
+    // A link-shortener-shaped URL: a SUBDOMAIN of its registrable domain (the
+    // apex never counts — getUrlRuleParts already strips www) whose entire
+    // path is ONE opaque token — letters and digits only, no word-separating
+    // hyphens or underscores — with no query. link.dice.fm/C5d572326aa6 is
+    // the observed shape (run 20260811-162602); the test is pure URL shape,
+    // never a host list.
+    isOpaqueShortlinkUrlParts(parts) {
+        if (!parts || !parts.host) return false;
+        const registrable = this.getRegistrableDomainFromHost(parts.host);
+        if (!registrable || parts.host === registrable) return false;
+        if (!Array.isArray(parts.segments) || parts.segments.length !== 1 || parts.hasQuery) return false;
+        return /^[A-Za-z0-9]{6,24}$/.test(parts.segments[0]);
+    }
+
+    // The opposite shape: the registrable APEX host serving a path with a
+    // hyphenated slug segment (words joined by "-"), i.e. a URL that NAMES an
+    // event rather than encoding it as an opaque token.
+    isApexEventSlugUrlParts(parts) {
+        if (!parts || !parts.host) return false;
+        const registrable = this.getRegistrableDomainFromHost(parts.host);
+        if (!registrable || parts.host !== registrable) return false;
+        if (!Array.isArray(parts.segments) || parts.segments.length === 0) return false;
+        return parts.segments.some(segment => /[a-z0-9]-[a-z0-9]/i.test(segment) && segment.length >= 8);
+    }
+
+    // Image-conflict rung body (see the call in the IMAGE_MERGE_FIELDS block of
+    // resolveConflictDeterministically): "the ticketing platform's own artwork
+    // beats the scrape source's re-hosted copy", derived entirely from host
+    // relationships available at merge time:
+    //   - the PLATFORM is the registrable domain of either record's ticketUrl;
+    //   - a candidate is the platform's artwork when its host is on that
+    //     domain OR carries the platform's name as a hyphen-bounded DNS label
+    //     (dice.fm → dice-media.imgix.net), the platform-media-CDN convention;
+    //   - the OTHER candidate is a source re-host only under strict
+    //     attribution: it IS some record's own value for this field, that
+    //     record was scraped from a page (_sourcePageUrl) on a registrable
+    //     domain that is NOT the platform, and that source is NOT the event's
+    //     own site (record website/url domains) — an aggregator serving its
+    //     copy of someone else's event, the weakest provenance there is.
+    // Any missing piece returns null (fail open → later rungs / AI).
+    resolvePlatformArtworkVsSourceRehost(fieldName, valueA, valueB, urlA, urlB, context) {
+        const records = context && context.records && typeof context.records === 'object' ? context.records : null;
+        if (!records || !urlA || !urlB) return null;
+        const hostReferencesPlatform = (host, platformDomain) => {
+            if (!host || !platformDomain) return false;
+            if (this.getRegistrableDomainFromHost(host) === platformDomain) return true;
+            const base = platformDomain.split('.')[0];
+            if (base.length < 3) return false;
+            return host.split('.').some(label => label === base || label.startsWith(`${base}-`) || label.endsWith(`-${base}`));
+        };
+        const platformDomains = [];
+        for (const side of ['a', 'b']) {
+            const record = records[side];
+            const ticketUrl = record && typeof record.ticketUrl === 'string' ? record.ticketUrl.trim() : '';
+            const domain = ticketUrl ? this.getRegistrableDomainFromUrl(ticketUrl) : '';
+            if (domain && !platformDomains.includes(domain)) platformDomains.push(domain);
+        }
+        for (const platformDomain of platformDomains) {
+            const referencesA = hostReferencesPlatform(urlA.host, platformDomain);
+            const referencesB = hostReferencesPlatform(urlB.host, platformDomain);
+            if (referencesA === referencesB) continue;
+            const rehostValue = String(referencesA ? valueB : valueA).trim();
+            for (const side of ['a', 'b']) {
+                const record = records[side];
+                if (!record || typeof record !== 'object') continue;
+                const ownValue = typeof record[fieldName] === 'string' ? record[fieldName].trim() : '';
+                if (!ownValue || ownValue !== rehostValue) continue;
+                const sourceDomain = this.getRegistrableDomainFromUrl(record._sourcePageUrl);
+                if (!sourceDomain || sourceDomain === platformDomain) continue;
+                const identityDomains = [record.website, record.url]
+                    .map(value => typeof value === 'string' ? this.getRegistrableDomainFromUrl(value) : '')
+                    .filter(Boolean);
+                if (identityDomains.includes(sourceDomain)) continue;
+                return {
+                    winner: referencesA ? 'a' : 'b',
+                    reason: `ticketing platform's own artwork (${platformDomain}) beats the scrape source's re-hosted copy`
+                };
+            }
+        }
+        return null;
+    }
+
     // True when `candidate` is a bare domain root and `incumbent` is an
     // event-specific page on the SAME site. Used by the identity fields
     // (website/url), where a venue's front door must never replace the page
@@ -2860,6 +2950,30 @@ class SharedCore {
                     }
                 }
             }
+            // Same-domain shortlink rung (2026-08-11, run 20260811-162602):
+            // ticketing platforms publish BOTH a canonical event page
+            // (dice.fm/event/<slug>) and an opaque tracking shortlink on a
+            // sibling subdomain (link.dice.fm/<token>), and the arbitration
+            // model flip-flopped between them with self-contradictory reasons
+            // — it called the shortlink "canonical" on 3 of 5 events and the
+            // slug URL "canonical" on the other 2, in the same run. When both
+            // candidates live on the SAME registrable domain and exactly one
+            // is an opaque short-token link on a subdomain while the other is
+            // a slug-bearing path on the apex host, the slug URL names the
+            // event and wins deterministically. Generic URL shape only — no
+            // platform names; different registrable domains, two shortlinks,
+            // or two slug URLs all still arbitrate (fail open).
+            if (fieldName === 'ticketUrl' && urlA.host !== urlB.host
+                && this.getRegistrableDomainFromHost(urlA.host) === this.getRegistrableDomainFromHost(urlB.host)) {
+                const shortlinkA = this.isOpaqueShortlinkUrlParts(urlA);
+                const shortlinkB = this.isOpaqueShortlinkUrlParts(urlB);
+                if (shortlinkA !== shortlinkB && (shortlinkA ? this.isApexEventSlugUrlParts(urlB) : this.isApexEventSlugUrlParts(urlA))) {
+                    return {
+                        winner: shortlinkA ? 'b' : 'a',
+                        reason: 'event-slug URL beats opaque shortlink on the same domain'
+                    };
+                }
+            }
             // A logo-path image never beats a non-logo image: ticketing
             // services attach their own ".../saas/logos/..." asset, which the
             // model picked over the actual event poster. Matches path
@@ -2896,6 +3010,21 @@ class SharedCore {
                 if (logoA !== logoB) {
                     return { winner: logoA ? 'b' : 'a', reason: 'event artwork beats logo-path image' };
                 }
+                // Platform-artwork rung (2026-08-11, run 20260811-162602): an
+                // aggregator page serves its OWN re-hosted copy of another
+                // platform's event artwork, and the arbitration model
+                // preferred the re-host on 4 of 5 events with confabulated
+                // provenance claims ("hosted directly by the organizer").
+                // When the event's tickets are sold on a third-party platform
+                // (either record's ticketUrl), a candidate hosted BY that
+                // platform beats a candidate that is merely the scraping
+                // source's own copy. Everything derives from the records'
+                // ticketUrl/_sourcePageUrl/website host relationships — no
+                // named CDNs — and attribution is strict, so a first-party
+                // venue or promoter page hosting its own artwork never loses
+                // here (fail open).
+                const platformArtworkResolution = this.resolvePlatformArtworkVsSourceRehost(fieldName, valueA, valueB, urlA, urlB, context);
+                if (platformArtworkResolution) return platformArtworkResolution;
                 // Provenance rung: an image that IS the event page's own
                 // artwork — its og:image/twitter:image meta ('og-image') or
                 // its published structured data ('jsonld'), as stamped at
@@ -4197,14 +4326,42 @@ class SharedCore {
             const website = typeof event.website === 'string' ? event.website.trim() : '';
             const ticketUrl = typeof event.ticketUrl === 'string' ? event.ticketUrl.trim() : '';
             const sourcePageUrl = typeof event._sourcePageUrl === 'string' ? event._sourcePageUrl.trim() : '';
-            if (!website || !ticketUrl || !sourcePageUrl) continue;
+            if (!sourcePageUrl) continue;
             const sourceHost = this.getHostFromUrl(sourcePageUrl).toLowerCase().replace(/^www\./, '');
             if (!sourceHost || !aggregatorHosts.has(sourceHost)) continue;
-            if (this.getUrlDedupeKey(website) !== this.getUrlDedupeKey(sourcePageUrl)) continue;
-            const ticketHost = this.getHostFromUrl(ticketUrl);
-            if (!ticketHost || this.areUrlHostsSameSite(ticketHost, sourceHost)) continue;
-            event.website = ticketUrl;
-            console.log(`🤖 AI Web: website set to original source ${ticketHost} (aggregator page pointer)`);
+            const sourcePageKey = this.getUrlDedupeKey(sourcePageUrl);
+            const websiteIsOwnSourcePage = Boolean(website) && this.getUrlDedupeKey(website) === sourcePageKey;
+            const ticketHost = ticketUrl ? this.getHostFromUrl(ticketUrl) : '';
+            const ticketUrlIsOutbound = Boolean(ticketHost) && !this.areUrlHostsSameSite(ticketHost, sourceHost);
+            if (websiteIsOwnSourcePage && ticketUrlIsOutbound) {
+                event.website = ticketUrl;
+                console.log(`🤖 AI Web: website set to original source ${ticketHost} (aggregator page pointer)`);
+                continue;
+            }
+            // Offer-less aggregator listing (2026-08-11, run 20260811-162602:
+            // six events shipped website = their own aggregator page because
+            // the rescue above had no outbound ticketUrl to hand them). Every
+            // pointer field equal to the event's own source page is a copy of
+            // where we scraped, not a pointer to the event — empty beats that
+            // self-reference. Cleared ONLY under the rescue pass's own
+            // applicability conditions (the source's root classified
+            // 'link-aggregator'), so a venue site's legitimate self-pointer
+            // never gets here; an outbound website or ticketUrl leaves the
+            // event untouched. url is cleared alongside website (they are ONE
+            // field — createFinalEventObject folds url back into website, so
+            // a surviving self-referential url would resurrect the pointer at
+            // merge time).
+            if (ticketUrlIsOutbound || (website && !websiteIsOwnSourcePage)) continue;
+            const clearedFields = [];
+            for (const field of ['website', 'url', 'ticketUrl']) {
+                const value = typeof event[field] === 'string' ? event[field].trim() : '';
+                if (!value || this.getUrlDedupeKey(value) !== sourcePageKey) continue;
+                event[field] = '';
+                clearedFields.push(field);
+            }
+            if (clearedFields.length > 0) {
+                console.log(`🤖 AI Web: cleared self-referential aggregator pointer (${clearedFields.join(', ')}) for "${event.title || 'event'}" — the ${sourceHost} listing has no outbound link, empty beats a copy of the source page`);
+            }
         }
     }
 
@@ -8959,6 +9116,34 @@ class SharedCore {
         const queueArbitrationConflict = (fieldName, calendarValue, scraperValue) => {
             const resolved = this.resolveConflictDeterministically(fieldName, calendarValue, scraperValue, mergeContext);
             if (!resolved) {
+                // BINDING calendar stickiness for image/ticketUrl (2026-08-11):
+                // run 20260811-162602 clobbered platform artwork on 4 of 5
+                // events and canonical slug ticket URLs on 3 of 5 while the
+                // 🧊 STICKY report logged the correct preference every time.
+                // For these two fields an AI opinion alone — no deterministic
+                // rung fired, or the sticky preconditions hold — must never
+                // overwrite saved calendar data: the saved value wins outright
+                // and the conflict is never sent to the AI. Every other field
+                // keeps the existing report/enforce behavior unchanged.
+                if ((fieldName === 'image' || fieldName === 'ticketUrl')
+                    && this.shouldReportCalendarStickiness(fieldName, calendarValue, scraperValue, 'scraped')) {
+                    const stickyPreview = (value) => {
+                        const text = this.serializeArbitrationValue(fieldName, value);
+                        return text.length > 60 ? `${text.slice(0, 57)}...` : text;
+                    };
+                    mergedObject[fieldName] = calendarValue;
+                    console.log(`🧊 STICKY: "${mergeTitle}" field=${fieldName} kept calendar "${stickyPreview(calendarValue)}" over scraped "${stickyPreview(scraperValue)}" — binding for ${fieldName} (no deterministic reason to overwrite; AI arbitration skipped)`);
+                    this.recordCalendarStickinessObservation(mergeTitle);
+                    aiDecisionRecords.push({
+                        field: fieldName,
+                        existingValue: calendarValue,
+                        newValue: scraperValue,
+                        chosenValue: calendarValue,
+                        reason: 'calendar stickiness (binding) — saved value kept without AI arbitration',
+                        source: 'sticky'
+                    });
+                    return;
+                }
                 pendingAiConflicts.push({
                     field: fieldName,
                     values: { calendar: calendarValue, scraped: scraperValue }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -6537,7 +6537,9 @@ test('applyAggregatorWebsitePointers prefers the cross-host ticketUrl over the a
     ticketUrl: 'https://dice.fm/event/cubscout',
     _sourcePageUrl: 'https://eaglela.com/events/cub-scout-3/'
   };
-  // Same-host ticketUrl on the aggregator: no better pointer exists — untouched.
+  // Same-host ticketUrl on the aggregator: no OUTBOUND pointer exists, so the
+  // self-referential website is cleared (run 20260811-162602: empty beats a
+  // copy of the source page); the distinct same-host tickets page survives.
   const sameHostEvent = {
     title: 'BEAR NIGHT',
     website: 'https://thebearcalendar.com/events/bear-night-2026/',
@@ -6559,8 +6561,10 @@ test('applyAggregatorWebsitePointers prefers the cross-host ticketUrl over the a
     'aggregator-page website is replaced by the original ticketing URL');
   assert.equal(venueEvent.website, 'https://eaglela.com/events/cub-scout-3/',
     'non-aggregator pages are unchanged');
-  assert.equal(sameHostEvent.website, 'https://thebearcalendar.com/events/bear-night-2026/',
-    'a same-host ticketUrl never rewrites website');
+  assert.equal(sameHostEvent.website, '',
+    'a same-host ticketUrl is not an outbound pointer — the self-referential website is cleared');
+  assert.equal(sameHostEvent.ticketUrl, 'https://www.thebearcalendar.com/tickets/bear-night-2026',
+    'a same-host ticketUrl that is not the source page itself survives the clear');
   assert.equal(alreadyOriginalEvent.website, 'https://megawoof.com/houston',
     'a website already pointing at the original source is untouched');
 });
@@ -16991,4 +16995,222 @@ test('pipeline order: counters stay truthful — duplicatesRemoved covers the FU
     result.totalEvents - result.duplicatesRemoved,
     result.events.length + (result.bearDroppedEvents || []).length
   );
+});
+
+// ---------------------------------------------------------------------------
+// Merge integrity wave 1 (run 20260811-162602, The Bear Calendar): the AI
+// arbiter clobbered saved calendar data — platform artwork lost to the
+// aggregator's storage re-host on 4/5 events, canonical slug ticket URLs lost
+// to opaque link.* shortlinks on 3/5 — while the 🧊 STICKY report logged the
+// correct preference every time. These tests replay the run's REAL field
+// pairs (BOATMINCE / SPOOKMINCE / BEEFMINCE x Bear Brum 2026).
+// ---------------------------------------------------------------------------
+
+test('ticketUrl same-domain shortlink rung: event-slug apex URL beats opaque link.* shortlink', () => {
+  const core = createCore();
+  // Real pairs from run 20260811-162602 (calendar slug URL vs scraped shortlink).
+  const pairs = [
+    ['https://dice.fm/event/g5dyeb-boatmince-30th-aug-westminster-pier-london-tickets', 'https://link.dice.fm/hcad51b9f844'],
+    ['https://dice.fm/event/v3x3n7-spookmince-31st-oct-venue-tba-london-london-tickets', 'https://link.dice.fm/Gffadd9feb4a'],
+    ['https://dice.fm/event/oepd2a-beefmince-x-bear-brum-2026-26th-sep-eden-birmingham-tickets', 'https://link.dice.fm/k485cb41bf1e']
+  ];
+  for (const [slugUrl, shortlink] of pairs) {
+    const forward = core.resolveConflictDeterministically('ticketUrl', slugUrl, shortlink);
+    assert.ok(forward, `slug vs shortlink must resolve deterministically (${shortlink})`);
+    assert.equal(forward.winner, 'a', 'the slug-bearing apex URL wins');
+    const reversed = core.resolveConflictDeterministically('ticketUrl', shortlink, slugUrl);
+    assert.ok(reversed, 'order independence: reversed orientation still resolves');
+    assert.equal(reversed.winner, 'b', 'the slug-bearing apex URL wins from either slot');
+  }
+  // Fail open: different registrable domains — a shortlink-shaped URL on an
+  // unrelated host is a genuine conflict, not a same-platform alias.
+  assert.equal(
+    core.resolveConflictDeterministically('ticketUrl',
+      'https://dice.fm/event/g5dyeb-boatmince-30th-aug-westminster-pier-london-tickets',
+      'https://link.otherplatform.example/hcad51b9f844'),
+    null, 'cross-domain shortlink pairs still arbitrate');
+  // Fail open: two slug URLs on the same domain are a genuine question.
+  assert.equal(
+    core.resolveConflictDeterministically('ticketUrl',
+      'https://dice.fm/event/g5dyeb-boatmince-30th-aug-tickets',
+      'https://dice.fm/event/aaaaaa-boatmince-31st-aug-tickets'),
+    null, 'two slug URLs on one domain still arbitrate');
+});
+
+test('image platform-artwork rung: ticketing platform artwork beats the aggregator source re-host', () => {
+  const core = createCore();
+  // Real BOATMINCE records from run 20260811-162602 _original.
+  const calendarRecord = {
+    image: 'https://dice-media.imgix.net/attachments/2025-01-15/aa1288a2-6cf8-4c42-8c29-581b1cfe5ba2.jpg?rect=0%2C0%2C768%2C768',
+    ticketUrl: 'https://dice.fm/event/g5dyeb-boatmince-30th-aug-westminster-pier-london-tickets',
+    imageSource: 'jsonld'
+  };
+  const scrapedRecord = {
+    image: 'https://acqvlhciredwtlbpisso.supabase.co/storage/v1/object/public/event-images/5e1181f38157ddbb.jpg',
+    ticketUrl: 'https://link.dice.fm/hcad51b9f844',
+    website: 'https://link.dice.fm/hcad51b9f844',
+    url: 'https://beefmince.com',
+    imageSource: 'jsonld',
+    _sourcePageUrl: 'https://thebearcalendar.com/events/boatmince-2026/'
+  };
+  const context = {
+    cityKey: 'london',
+    barNames: [],
+    eventTitle: 'BOATMINCE',
+    sideLabels: { a: 'calendar', b: 'scraped' },
+    records: { a: calendarRecord, b: scrapedRecord }
+  };
+  const resolved = core.resolveConflictDeterministically('image', calendarRecord.image, scrapedRecord.image, context);
+  assert.ok(resolved, 'platform artwork vs source re-host must resolve deterministically');
+  assert.equal(resolved.winner, 'a', "the ticketing platform's own artwork wins");
+  assert.match(resolved.reason, /platform/i);
+
+  // Strict-attribution guard: a FIRST-PARTY page hosting its own artwork is
+  // never a "re-host" — same shape but the scrape source IS the event's own
+  // site (record website/url domain) → fall through (null, AI arbitrates).
+  const firstPartyRecord = {
+    ...scrapedRecord,
+    image: 'https://beefmince.com/media/own-flyer.jpg',
+    website: 'https://beefmince.com',
+    url: 'https://beefmince.com',
+    _sourcePageUrl: 'https://beefmince.com/events/boatmince/'
+  };
+  const firstPartyContext = { ...context, records: { a: calendarRecord, b: firstPartyRecord } };
+  assert.equal(
+    core.resolveConflictDeterministically('image', calendarRecord.image, firstPartyRecord.image, firstPartyContext),
+    null, "a promoter site's own artwork never loses to the platform rung");
+});
+
+test('calendar stickiness is BINDING for image and ticketUrl — the AI is never asked', async () => {
+  const core = createCore();
+  // No deterministic rung can decide these pairs (unrelated hosts, no
+  // shortlink/platform/asset/logo shape), so on the old behavior they went to
+  // the position-biased arbiter, which clobbered the saved calendar values.
+  const scraped = {
+    title: 'CLUB NIGHT',
+    startDate: new Date('2026-09-05T21:00:00.000Z'),
+    endDate: new Date('2026-09-06T02:00:00.000Z'),
+    image: 'https://elsewhere.example/media/fresh-flyer.jpg',
+    ticketUrl: 'https://tickets-b.example/e/99887/order',
+    city: 'seattle',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: { ai: { provider: 'ollama', endpoint: 'http://ai.example/api/generate', model: 'test-model' } }
+  };
+  const existing = {
+    title: 'CLUB NIGHT',
+    startDate: new Date('2026-09-05T21:00:00.000Z'),
+    endDate: new Date('2026-09-06T02:00:00.000Z'),
+    url: '',
+    notes: [
+      'image: https://calendar-images.example/artwork/saved-flyer.jpg',
+      'ticketUrl: https://tickets-a.example/event/bear-night'
+    ].join('\n')
+  };
+  // An adapter that would pick the scraped side for both fields — it must
+  // never even be consulted for image/ticketUrl.
+  const adapter = buildArbitrationAdapter({
+    image: { pick: 'scraped', value: 'https://elsewhere.example/media/fresh-flyer.jpg' },
+    ticketUrl: { pick: 'scraped', value: 'https://tickets-b.example/e/99887/order' }
+  });
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(finalEvent.image, 'https://calendar-images.example/artwork/saved-flyer.jpg',
+    'binding stickiness keeps the saved calendar image');
+  assert.equal(finalEvent.ticketUrl, 'https://tickets-a.example/event/bear-night',
+    'binding stickiness keeps the saved calendar ticketUrl');
+  assert.equal(adapter.calls.length, 0,
+    'image/ticketUrl conflicts with a saved calendar value are never sent to the AI');
+
+  // An EMPTY calendar side is not sticky: the scraped value must still fill it.
+  const fillAdapter = buildArbitrationAdapter({});
+  const filled = await core.createFinalEventObject(
+    { title: 'CLUB NIGHT', startDate: new Date('2026-09-05T21:00:00.000Z'), endDate: new Date('2026-09-06T02:00:00.000Z'), url: '', notes: '' },
+    { ...scraped },
+    { httpAdapter: fillAdapter }
+  );
+  assert.equal(filled.image, 'https://elsewhere.example/media/fresh-flyer.jpg',
+    'an empty calendar image is filled by the scrape, never held empty by stickiness');
+});
+
+test('replay 20260811-162602: BOATMINCE merge keeps the calendar image and slug ticketUrl deterministically', async () => {
+  const core = createCore();
+  const scraped = {
+    title: 'BOATMINCE',
+    startDate: new Date('2026-08-30T13:00:00.000Z'),
+    endDate: new Date('2026-08-30T17:00:00.000Z'),
+    image: 'https://acqvlhciredwtlbpisso.supabase.co/storage/v1/object/public/event-images/5e1181f38157ddbb.jpg',
+    ticketUrl: 'https://link.dice.fm/hcad51b9f844',
+    website: 'https://link.dice.fm/hcad51b9f844',
+    url: 'https://beefmince.com',
+    imageSource: 'jsonld',
+    _sourcePageUrl: 'https://thebearcalendar.com/events/boatmince-2026/',
+    city: 'london',
+    source: 'ai-web',
+    _fieldPriorities: core.getResolvedFieldPriorities({}),
+    _parserConfig: { ai: { provider: 'ollama', endpoint: 'http://ai.example/api/generate', model: 'test-model' } }
+  };
+  const existing = {
+    title: 'BOATMINCE',
+    startDate: new Date('2026-08-30T13:00:00.000Z'),
+    endDate: new Date('2026-08-30T17:00:00.000Z'),
+    url: '',
+    notes: [
+      'image: https://dice-media.imgix.net/attachments/2025-01-15/aa1288a2-6cf8-4c42-8c29-581b1cfe5ba2.jpg?rect=0%2C0%2C768%2C768',
+      'ticketUrl: https://dice.fm/event/g5dyeb-boatmince-30th-aug-westminster-pier-london-tickets',
+      'imageSource: jsonld'
+    ].join('\n')
+  };
+  // The run's arbiter picked the supabase re-host and (on the sibling events)
+  // the shortlink; feed those same answers — they must not matter anymore.
+  const adapter = buildArbitrationAdapter({
+    image: { pick: 'scraped', value: scraped.image },
+    ticketUrl: { pick: 'scraped', value: scraped.ticketUrl }
+  });
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: adapter });
+  assert.equal(finalEvent.image,
+    'https://dice-media.imgix.net/attachments/2025-01-15/aa1288a2-6cf8-4c42-8c29-581b1cfe5ba2.jpg?rect=0%2C0%2C768%2C768',
+    'the dice-media platform artwork survives the merge');
+  assert.equal(finalEvent.ticketUrl,
+    'https://dice.fm/event/g5dyeb-boatmince-30th-aug-westminster-pier-london-tickets',
+    'the canonical slug ticket URL survives the merge');
+});
+
+test('applyAggregatorWebsitePointers clears self-referential pointers on offer-less aggregator listings', () => {
+  const core = createCore();
+  const urlClassifications = { 'https://thebearcalendar.com/events/': 'link-aggregator' };
+  // Run 20260811-162602: six offer-less listings shipped
+  // website=url=ticketUrl=their own aggregator page (San Francisco Bear
+  // Weekend shape) — every self-referential pointer must clear so nothing
+  // survives for the merge-time url→website fold to resurrect.
+  const offerLess = {
+    title: 'San Francisco Bear Weekend',
+    website: 'https://thebearcalendar.com/events/san-francisco-bear-weekend-2026/',
+    url: 'https://thebearcalendar.com/events/san-francisco-bear-weekend-2026/',
+    ticketUrl: 'https://thebearcalendar.com/events/san-francisco-bear-weekend-2026/',
+    _sourcePageUrl: 'https://thebearcalendar.com/events/san-francisco-bear-weekend-2026/'
+  };
+  // Outbound website (Leipzig shape): untouched even though url is a self-pointer.
+  const outboundWebsite = {
+    title: 'Leipzig Bear Weekend',
+    website: 'https://www.leipzig-baeren.de/party/#ticketshop',
+    url: 'https://thebearcalendar.com/events/leipzig-baren-weekend-2026/',
+    ticketUrl: 'https://www.leipzig-baeren.de/party/#ticketshop',
+    _sourcePageUrl: 'https://thebearcalendar.com/events/leipzig-baren-weekend-2026/'
+  };
+  // A venue site's legitimate self-pointer: its root is never classified
+  // 'link-aggregator', so the clear can never reach it.
+  const venueSelfPointer = {
+    title: 'Gear Night',
+    website: 'https://eaglela.com/events/gear-night/',
+    url: 'https://eaglela.com/events/gear-night/',
+    ticketUrl: '',
+    _sourcePageUrl: 'https://eaglela.com/events/gear-night/'
+  };
+  core.applyAggregatorWebsitePointers([offerLess, outboundWebsite, venueSelfPointer], urlClassifications);
+  assert.equal(offerLess.website, '', 'self-referential website clears (empty beats a copy of the source page)');
+  assert.equal(offerLess.url, '', 'the url alias clears with it — nothing left for the merge-time fold');
+  assert.equal(offerLess.ticketUrl, '', 'a ticketUrl equal to the source page is not a ticket link');
+  assert.equal(outboundWebsite.website, 'https://www.leipzig-baeren.de/party/#ticketshop', 'an outbound website is never cleared');
+  assert.equal(venueSelfPointer.website, 'https://eaglela.com/events/gear-night/', 'venue-site self-pointers are untouched');
+  assert.equal(venueSelfPointer.url, 'https://eaglela.com/events/gear-night/', 'venue-site url alias is untouched');
 });


### PR DESCRIPTION
Fix wave 1 ("merge integrity") from audited run evidence: run **20260811-162602** (The Bear Calendar) and run **20260811-141654** (The Lumberyard). One branch, four fixes, no new runtime files (nothing for the updater manifest).

## 1. AI merge arbitration clobbers good calendar data (image / ticketUrl)

**Evidence** (log 20260811-162602, lines ~2247-2248, 2356-2360, 2422-2424, 2539-2558): the arbiter replaced `dice-media.imgix.net` platform artwork with the aggregator's `…supabase.co/storage/…` re-host on 4/5 events, and canonical `dice.fm/event/<slug>` URLs with opaque `link.dice.fm/<token>` shortlinks on 3/5 — with self-contradictory reasoning across events (it called the shortlink "canonical" on 3 events and the slug URL "canonical" on 2, in the same run). The 🧊 STICKY layer logged the correct preference every time but could not override.

**Mechanism** (`scripts/shared-core.js`):
- **Binding stickiness**: in `createFinalEventObject`'s `queueArbitrationConflict`, when no deterministic rung fires and `shouldReportCalendarStickiness` holds for `image`/`ticketUrl`, the saved calendar value now wins outright and the conflict is **never sent to the AI** (new `🧊 STICKY: … binding for <field>` log line; existing STICKY lines untouched). All other fields keep the existing report/enforce behavior.
- **Same-domain shortlink rung** (generic, no host lists): both candidates on one registrable domain, exactly one an opaque single-token subdomain link, the other a hyphen-slug path on the apex host → the slug URL wins (`isOpaqueShortlinkUrlParts` / `isApexEventSlugUrlParts`).
- **Platform-artwork rung** (generic, derived from the records' `ticketUrl`/`_sourcePageUrl`/`website` host relationships — no named CDNs): when the event's tickets sell on a third-party platform, a candidate hosted by that platform (same registrable domain, or a hyphen-bounded DNS label carrying the platform name, e.g. `dice.fm` → `dice-media.*`) beats a candidate that is the scrape source's own re-hosted copy. Strict attribution: the losing value must be its record's own field value, scraped from a page that is neither the platform nor the event's own site — first-party venue/promoter artwork never loses here.

## 2. Aggregator page URL leaks into `website` on offer-less listings

**Evidence**: `applyAggregatorWebsitePointers` rescued 32 events but its `if (!website || !ticketUrl || !sourcePageUrl) continue;` skipped offer-less listings, leaving `website` = the aggregator's own page for 6 events (SF Bear Weekend, Monthly Trivia, Croatia Cruise4Bears, Northern Exposure BUILT, Bear Carnival 2027, Bear Jamboree). At scrape time those events carry `website = url = ticketUrl = _sourcePageUrl`, and `createFinalEventObject`'s url→website fold can resurrect a cleared website from the surviving `url` alias.

**Mechanism** (`scripts/shared-core.js`, inside the rescue pass only): when the source's root classified `link-aggregator` and no **outbound** pointer exists, every pointer field equal to the event's own source page (`website`, `url`, `ticketUrl`) is cleared — empty beats a self-referential copy — with a new log line. Clearing `url` too is what keeps the merge-time fold from resurrecting the pointer. Venue-site self-pointers are structurally safe (their roots are never classified `link-aggregator`); an outbound website or ticketUrl leaves the event untouched, and the existing cross-host rescue is byte-identical (its log line moved but did not change).

## 3. og:image chrome adopted as event image

**Evidence** (log 20260811-162602 lines 528-529): "Leipzig Bear Weekend" adopted `https://thebearcalendar.com/og-default.png` via `fillImageFromPageMetaArtwork` — the JSON-LD short-circuit never OCRs anything, so the existing furniture gate failed open on "unknown".

**Mechanism** (`scripts/parsers/ai-web-parser.js`):
- **OCR vet**: new `vetPageMetaArtworkCandidates` runs before the fill in the JSON-LD short-circuit — OCRs each adoptable meta candidate (OCR is free, local MLX) and records the verdict, so the fill's existing `getNonEventImageOcrReason` gate can refuse per the existing `nonEventOcrImageClassifications` rules. Fail-open on OCR errors, no-op when disabled — same seams as the existing OCR top-ups.
- **Deterministic guards** in the fill: refuse site-default filename conventions (`og-default`, `og-image`, `og_default`, `ogimage`, `default-og` basenames — filename convention, not a domain rule), and refuse an og:image published as the page-meta artwork of ≥2 distinct pages of the same host this run (cross-page reuse tell, recorded in `collectPageMetaImageCandidates`; `?occurrence=` variants of one page deliberately collapse to one page so a real event's artwork on its own occurrence pages can't trip it).

## 4. Venue-name-only logo blind spot

**Evidence** (run 20260811-141654): "South Seattle Bear Social" shipped the venue's banner/logo (OCR verdict `classification=logo`, text `"LUMBER YARD\nBAR"`) — `getNonEventImageOcrReason` only refused logo+NO-text, so a logo transcribing the site's own brand passed.

**Mechanism** (`scripts/parsers/ai-web-parser.js`): the recorded OCR verdict now carries the transcription; when the classification is logo/thumbnail/hero-banner **and** every meaningful token (3+ word chars) of the text is explained by the page's own brand corpus (reusing `getPageBrandNames` + the page host's registrable-domain label, separator-stripped substring match — `"LUMBER YARD BAR"` ⊆ `"thelumberyardbar"`), it is treated as no-text and refused. Callers without page context keep the historical fail-open behavior; the per-comment corpus flyers (two misclassified logos with 500+ chars of real flyer text) still pass — regression-covered.

## Tests

All in existing package.json-enumerated files. Suite: `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test` → **1693 pass, 0 fail** (was 1683 on origin/main).

New/updated tests, **proven to fail against unmodified origin/main** (`git stash push scripts/shared-core.js scripts/parsers/ai-web-parser.js`, then `node --test scripts/shared-core.test.js scripts/parsers/ai-web-parser.test.js`):

- ✖ ticketUrl same-domain shortlink rung (real BOATMINCE/SPOOKMINCE/Bear Brum pairs, both orientations + fail-open negatives)
- ✖ image platform-artwork rung (real BOATMINCE `_original` records + first-party guard)
- ✖ calendar stickiness is BINDING for image and ticketUrl — the AI is never asked (asserts zero adapter calls; empty-calendar fill still works)
- ✖ replay 20260811-162602: BOATMINCE merge keeps the calendar image and slug ticketUrl deterministically (full `createFinalEventObject` with the run's real field values and an adapter replaying the run's bad AI answers)
- ✖ applyAggregatorWebsitePointers clears self-referential pointers on offer-less aggregator listings (SF Bear Weekend shape; Leipzig outbound + venue-site untouched)
- ✖ applyAggregatorWebsitePointers … (existing test: the `sameHostEvent` expectation encoded the old defect — a same-host ticketUrl left `website` as the aggregator self-pointer — updated to the new contract)
- ✖ fillImageFromPageMetaArtwork refuses site-default og:image filenames
- ✖ fillImageFromPageMetaArtwork refuses an og:image shared by multiple event pages of the same host
- ✖ vetPageMetaArtworkCandidates OCRs the would-be og:image so the furniture gate can refuse it
- ✖ a logo whose only OCR text is the page brand/venue name is refused (venue-logo blind spot)
- ✔ (regression guard, passes on both by design) text-bearing logos NOT explained by the brand still pass — pins the 500+ char misclassified-flyer behavior that must not change

## Constraint proofs

- No `new URL(` / `URLSearchParams` in any added line (grep of the diff: zero hits).
- shared-core.js stays platform-pure — additions are string/regex logic only.
- **No existing console.log string or AI prompt line edited**: the only removed `console.log` in the diff is the aggregator rescue line, re-added byte-identical inside the restructured block (`git diff` shows the identical `+` line); the arbitration prompt block is untouched. All other log lines are additions.
- No per-venue/promoter/domain literals in runtime logic (grep of added runtime lines: platform names appear only in evidence-citation comments); all rules derive from URL shape and the event's own host relationships.
- No new runtime files — all changes live in `scripts/shared-core.js` and `scripts/parsers/ai-web-parser.js` (updater manifest unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP