### PR TITLE
fix(scraper): duplicate folding + stale roundups (wave 3)

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -4967,11 +4967,17 @@ class AiWebParser {
      * Conservative cadence → RRULE derivation from sorted unique YYYY-MM-DD
      * dates. Only two shapes ever derive a rule; everything else returns null
      * and stays report-only:
-     *   - WEEKLY: every observed date falls on the SAME weekday AND the
-     *     sorted dates contain a run of >= 3 consecutive 7-day gaps (four
-     *     back-to-back weeks). Skipped weeks elsewhere are tolerated — a
+     *   - WEEKLY: every observed date falls on the SAME weekday AND EITHER
+     *     (a) the sorted dates contain a run of >= 3 consecutive 7-day gaps
+     *     (four back-to-back weeks), OR (b) every gap is a positive multiple
+     *     of 7 days and at least 3 of the gaps are exactly 7 days (GEAR
+     *     NIGHT, run 20260811-134734: Saturdays with gaps 7,14,7,7,14 — six
+     *     records, no run of 3 consecutive weeks, plainly weekly with two
+     *     skipped Saturdays). Skipped weeks are tolerated on both paths — a
      *     holiday gap does not un-weekly a residency — but a biweekly
-     *     pattern (all 14-day gaps) can never produce the required run.
+     *     pattern (all 14-day gaps, zero 7-day gaps) can never satisfy
+     *     either acceptance, and two observations 14 days apart are still
+     *     refused (fail closed: too few 7-day gaps to prove weekly).
      *   - MONTHLY: >= 2 observations, every date in a DIFFERENT month, all
      *     on the same ordinal weekday (all "1st Thursday" etc.).
      * Same digit-only date math as describeOccurrenceCadence — no Date
@@ -4992,10 +4998,13 @@ class AiWebParser {
         const BYDAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
         const weekdays = parts.map(part => new Date(part.epochMs).getUTCDay());
         if (!weekdays.every(weekday => weekday === weekdays[0])) return null;
+        const gapsDays = [];
+        for (let i = 1; i < parts.length; i++) {
+            gapsDays.push(Math.round((parts[i].epochMs - parts[i - 1].epochMs) / 86400000));
+        }
         let consecutiveWeeklyGaps = 0;
         let bestWeeklyRun = 0;
-        for (let i = 1; i < parts.length; i++) {
-            const gapDays = Math.round((parts[i].epochMs - parts[i - 1].epochMs) / 86400000);
+        for (const gapDays of gapsDays) {
             if (gapDays === 7) {
                 consecutiveWeeklyGaps++;
                 if (consecutiveWeeklyGaps > bestWeeklyRun) bestWeeklyRun = consecutiveWeeklyGaps;
@@ -5006,6 +5015,19 @@ class AiWebParser {
         if (bestWeeklyRun >= 3) {
             return { rrule: `FREQ=WEEKLY;BYDAY=${BYDAY_CODES[weekdays[0]]}` };
         }
+        // Skipped-week acceptance (additional condition; the consecutive-run
+        // path above is untouched): weekly with holes reads as gaps that are
+        // all positive multiples of 7 on one weekday, anchored by >= 3 gaps
+        // of exactly 7 days. Any non-multiple-of-7 gap refuses this path
+        // entirely (it cannot coexist with the same-weekday check above, but
+        // the guard stays explicit — fail closed, defense in depth), and a
+        // sparse pattern with fewer than three exact 7-day gaps proves
+        // nothing (two observations 14 days apart are biweekly-or-anything).
+        if (gapsDays.length > 0
+            && gapsDays.every(gap => gap > 0 && gap % 7 === 0)
+            && gapsDays.filter(gap => gap === 7).length >= 3) {
+            return { rrule: `FREQ=WEEKLY;BYDAY=${BYDAY_CODES[weekdays[0]]}` };
+        }
         const ordinals = parts.map(part => Math.floor((part.day - 1) / 7) + 1);
         const monthKeys = new Set(parts.map(part => `${part.year}-${part.month}`));
         if (monthKeys.size >= 2 && monthKeys.size === parts.length
@@ -5014,6 +5036,52 @@ class AiWebParser {
             return { rrule: `FREQ=MONTHLY;BYDAY=${ordinals[0]}${BYDAY_CODES[weekdays[0]]}` };
         }
         return null;
+    }
+
+    /**
+     * Strip a trailing guest-performer suffix from a title, for CADENCE
+     * GROUPING ONLY — never for general dedup (lookalike pairs are not
+     * always twins: same title/venue/day can be two real events, so the
+     * general matchers must keep seeing the full titles). Conservative on
+     * purpose: only a clause at the END of the title, introduced by a
+     * with/feat./featuring/w\/ marker followed by a DJ/VJ credit, is cut
+     * ("Discipline Corps Bar Night with DJ Philip Webb" → "Discipline Corps
+     * Bar Night"; run 20260811-134734, where the Sep 11 + Oct 9 2nd-Friday
+     * pair stayed two singletons because each record wore a different DJ's
+     * name). Anything else — "with" clauses that aren't performer credits,
+     * DJ names mid-title, a title that IS a DJ credit — returns unchanged.
+     */
+    stripGuestPerformerSuffix(title) {
+        const text = String(title || '');
+        const stripped = text.replace(/\s*(?:[-–—:|]\s*)?(?:with|w\/|feat\.?|featuring)\s+(?:dj|vj)\s+\S.*$/i, '');
+        // Never strip down to nothing: a title that IS entirely a performer
+        // clause keeps its original form (fail closed).
+        return stripped.trim() ? stripped.trim() : text;
+    }
+
+    /**
+     * Identity-shape name comparison with guest-performer suffixes removed,
+     * used EXCLUSIVELY by the cadence-grouping pass below as an addition to
+     * core.areIdentityNamesSimilar — the venue-identity requirements of that
+     * pass are unchanged, and nothing outside applyDerivedCadenceStamps
+     * consults this. Only pairs where a suffix was actually stripped get the
+     * second comparison, so this can never loosen a comparison the plain
+     * helper already makes.
+     */
+    areShapeNamesSimilarIgnoringGuestSuffix(shapeA, shapeB) {
+        const core = this.core;
+        if (!core || typeof core.areTitlesSimilar !== 'function') return false;
+        const namesA = shapeA && Array.isArray(shapeA.names) ? shapeA.names : [];
+        const namesB = shapeB && Array.isArray(shapeB.names) ? shapeB.names : [];
+        for (const nameA of namesA) {
+            for (const nameB of namesB) {
+                const strippedA = this.stripGuestPerformerSuffix(nameA);
+                const strippedB = this.stripGuestPerformerSuffix(nameB);
+                if (strippedA === nameA && strippedB === nameB) continue;
+                if (core.areTitlesSimilar(strippedA, strippedB)) return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -5076,7 +5144,8 @@ class AiWebParser {
             if (!nightKey) continue; // fail closed: undated records observe nothing
             const shape = core.buildIdentityComparisonShape(event);
             const group = groups.find(candidate => candidate.members.some(member =>
-                core.areIdentityNamesSimilar(member.shape, shape)
+                (core.areIdentityNamesSimilar(member.shape, shape)
+                    || this.areShapeNamesSimilarIgnoringGuestSuffix(member.shape, shape))
                 && core.getCrossSourceVenueIdentity(member.event, event) !== null
                 && !core.areEventsDistinctByPlace(member.event, event)));
             if (group) {
@@ -5115,7 +5184,19 @@ class AiWebParser {
                 const stated = String(member.event.recurrenceRule || member.event.recurrence || '').trim().toUpperCase();
                 if (stated) statedRules.add(stated);
             }
-            const disagreeing = Array.from(statedRules).filter(rule => rule !== derived.rrule);
+            // A derived rule that REFINES a stated one — identical up to the
+            // stated rule's end, with only additional ;KEY=VALUE detail
+            // appended ("FREQ=MONTHLY" stated on both Discipline Corps
+            // records, "FREQ=MONTHLY;BYDAY=2FR" derived from their observed
+            // 2nd Fridays, run 20260811-134734) — is agreement, not
+            // conflict: the observations prove a more specific reading of
+            // the same cadence. The stated rule is still NEVER overridden
+            // (records with a stated rule are excluded from `unstamped`
+            // below); a stated rule whose own detail differs
+            // ("FREQ=MONTHLY;BYDAY=3FR" vs derived 2FR) still conflicts and
+            // fails the whole group closed.
+            const disagreeing = Array.from(statedRules).filter(rule =>
+                rule !== derived.rrule && !derived.rrule.startsWith(`${rule};`));
             if (disagreeing.length > 0) {
                 console.log(`🔁 CADENCE: derived ${derived.rrule} for "${title}" disagrees with stated rule(s) ${disagreeing.join(', ')} — stated cadence kept, nothing stamped (curated data beats derived)`);
                 continue;
@@ -5146,6 +5227,67 @@ class AiWebParser {
                 member.event.recurrenceRule = derived.rrule;
             }
             console.log(`🔁 CADENCE: stamped ${derived.rrule} on ${unstamped.length} "${title}" record(s) — derived from ${sortedDates.length} observed dates (report basis: ${basis.summary})`);
+        }
+    }
+
+    /**
+     * REPORT-ONLY roundup-tile tell (📰), judged at the same post-crawl seam
+     * as applyDerivedCadenceStamps because it needs the whole run's records
+     * in view. "THIS WEEK AT MASSIVE" (run 20260811-132205) — an Instagram
+     * weekly-lineup graphic enumerating five different MON–SAT parties —
+     * extracted as a single 5-day umbrella event and reached a calendar
+     * write: its 5-day span cleared the 10-day duration sanity bound and its
+     * 308-day-old dates cleared the 370-day long-past bound. The structural
+     * tell that separates a listing/roundup tile from a legitimate umbrella
+     * (a bear week, a festival) is that the tile's own extracted text NAMES
+     * the individual events, and the same run extracts those events
+     * separately. No title-phrase blocklists, nothing per-venue: the signal
+     * is purely "multi-day span + its text contains >= 3 other dated
+     * records' titles". This wave logs only — no flag, no withhold, no drop
+     * (report-only before enforce for anything that would suppress data).
+     * Short normalized titles (< 8 chars) never count: a venue's own name
+     * ("MASSIVE") or a generic word appearing in the tile text is not
+     * evidence that a distinct event was enumerated.
+     */
+    reportProbableRoundupTiles(events) {
+        const eventList = Array.isArray(events) ? events : [];
+        if (eventList.length < 4) return; // an umbrella + at least 3 named events
+        const core = this.core;
+        if (!core
+            || typeof core.toEpochMillis !== 'function'
+            || typeof core.normalizeIdentityText !== 'function') {
+            return; // fail closed: report nothing without the shared helpers
+        }
+        const DAY_MS = 24 * 60 * 60 * 1000;
+        for (const event of eventList) {
+            if (!event || typeof event !== 'object') continue;
+            const startMs = core.toEpochMillis(event.startDate);
+            const endMs = core.toEpochMillis(event.endDate);
+            if (startMs === null || endMs === null) continue;
+            if (endMs - startMs < 2 * DAY_MS) continue; // multi-day umbrellas only
+            const ownText = core.normalizeIdentityText(
+                [event.description, event.title]
+                    .filter(value => typeof value === 'string')
+                    .join('\n'));
+            if (!ownText) continue;
+            const ownTitle = core.normalizeIdentityText(event.title || '');
+            const seenTitles = new Set();
+            const matchedTitles = [];
+            for (const other of eventList) {
+                if (other === event || !other || typeof other !== 'object') continue;
+                if (typeof other.title !== 'string') continue;
+                if (core.toEpochMillis(other.startDate) === null) continue; // dated records only
+                const normalizedTitle = core.normalizeIdentityText(other.title);
+                if (normalizedTitle.length < 8) continue;
+                if (normalizedTitle === ownTitle) continue;
+                if (seenTitles.has(normalizedTitle)) continue;
+                if (!ownText.includes(normalizedTitle)) continue;
+                seenTitles.add(normalizedTitle);
+                matchedTitles.push(other.title.trim());
+            }
+            if (matchedTitles.length >= 3) {
+                console.log(`📰 ROUNDUP: "${event.title || 'Unknown'}" is probably a listing/roundup tile, not one event — its own text names ${matchedTitles.length} events this run extracted separately (${matchedTitles.join(', ')}) — report-only, nothing changed`);
+            }
         }
     }
 

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -13702,6 +13702,201 @@ test('applyDerivedCadenceStamps: different venues never share a group, and undat
   }
 });
 
+test('deriveCadenceRrule: weekly with skipped weeks — every gap a multiple of 7 and >=3 exact 7-day gaps (GEAR NIGHT)', () => {
+  const parser = createParser();
+  // The exact GEAR NIGHT night vector from run 20260811-134734 (Dallas
+  // Eagle): Saturdays with gaps 7,14,7,7,14 — the longest consecutive
+  // 7-day run is 2, so the consecutive-run acceptance never fires, yet
+  // three exact 7-day gaps on one weekday with every gap a multiple of 7
+  // is plainly a weekly night with two skipped Saturdays.
+  const gearNight = ['2026-08-15', '2026-08-22', '2026-09-05', '2026-09-12', '2026-09-19', '2026-10-03'];
+  assert.deepEqual(parser.deriveCadenceRrule(gearNight), { rrule: 'FREQ=WEEKLY;BYDAY=SA' });
+  // Two observations 14 days apart are still refused (fail closed:
+  // biweekly-or-anything, zero exact 7-day gaps).
+  assert.equal(parser.deriveCadenceRrule(['2026-08-15', '2026-08-29']), null);
+  // Only two exact 7-day gaps among multiple-of-7 gaps: still refused.
+  assert.equal(parser.deriveCadenceRrule(['2026-08-15', '2026-08-22', '2026-09-12', '2026-09-19']), null);
+  // All-14-day gaps (biweekly-looking) still derive nothing.
+  assert.equal(parser.deriveCadenceRrule(['2026-08-15', '2026-08-29', '2026-09-12', '2026-09-26']), null);
+  // A non-multiple-of-7 gap necessarily lands on a different weekday and
+  // refuses the whole derivation.
+  assert.equal(parser.deriveCadenceRrule(['2026-08-15', '2026-08-22', '2026-08-29', '2026-09-04']), null);
+});
+
+test('applyDerivedCadenceStamps: the six real GEAR NIGHT records fold to one weekly group (skipped weeks + DJ suffixes)', () => {
+  const parser = createParser();
+  // Run 20260811-134734 verbatim: six GEAR NIGHT records on renumbered MEC
+  // slugs (gear-night-5/7/11/17/19/22), two wearing per-record DJ credits,
+  // observed Saturdays Aug 15, 22, Sep 5, 12, 19, Oct 3 (America/Chicago).
+  // On main these survived as six separate calendar writes: the weekly rule
+  // demanded 3 CONSECUTIVE 7-day gaps (longest run here is 2), and the
+  // DJ-suffixed pair could not even join the group.
+  const gearNight = [
+    ['Gear Night with DJ Tristan Jaxx', '2026-08-16T02:00:00.000Z', 'gear-night-5'],
+    ['Gear Night with DJ Philip Webb', '2026-08-23T03:00:00.000Z', 'gear-night-7'],
+    ['Gear Night', '2026-09-06T03:00:00.000Z', 'gear-night-17'],
+    ['GEAR NIGHT', '2026-09-13T02:00:00.000Z', 'gear-night-11'],
+    ['GEAR NIGHT', '2026-09-20T01:00:00.000Z', 'gear-night-19'],
+    ['GEAR NIGHT', '2026-10-04T03:00:00.000Z', 'gear-night-22']
+  ].map(([title, start, slug]) => ({
+    title,
+    bar: 'Dallas Eagle',
+    timezone: 'America/Chicago',
+    startDate: new Date(start),
+    endDate: new Date(new Date(start).getTime() + 4 * 60 * 60 * 1000),
+    url: `https://www.thedallaseagle.com/events/${slug}/`,
+    source: 'ai-web'
+  }));
+  parser.applyDerivedCadenceStamps(gearNight);
+  for (const record of gearNight) {
+    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=SA', `"${record.title}" (${record.url}) joins the weekly stamp`);
+  }
+  const markers = new Set(gearNight.map(record => record._cadenceGroup));
+  assert.equal(markers.size, 1, 'all six records share ONE same-series marker');
+  assert.ok([...markers][0], 'the shared marker is non-empty');
+});
+
+test('applyDerivedCadenceStamps: per-record guest-DJ suffixes group into one monthly series; different parties never do', () => {
+  const parser = createParser();
+  // Run 20260811-134734 verbatim: a genuine 2nd-Friday monthly pair whose
+  // records each wear a different guest DJ's name — no bare-title anchor,
+  // so the plain name similarity never groups them. Both pages state a bare
+  // FREQ=MONTHLY; the derived FREQ=MONTHLY;BYDAY=2FR REFINES it (agreement,
+  // not conflict), so the stated rules stay untouched and the same-series
+  // marker is minted.
+  const disciplinePair = [
+    {
+      title: 'Discipline Corps Bar Night with DJ Philip Webb',
+      bar: 'Dallas Eagle',
+      timezone: 'America/Chicago',
+      startDate: new Date('2026-09-12T02:00:00.000Z'), // Fri Sep 11, 9pm CDT — 2nd Friday
+      endDate: new Date('2026-09-12T07:00:00.000Z'),
+      url: 'https://www.thedallaseagle.com/events/discipline-corps-bar-night-7/',
+      recurrenceRule: 'FREQ=MONTHLY',
+      source: 'ai-web'
+    },
+    {
+      title: 'Discipline Corps Bar Night with DJ Blaine',
+      bar: 'Dallas Eagle',
+      timezone: 'America/Chicago',
+      startDate: new Date('2026-10-10T02:00:00.000Z'), // Fri Oct 9, 9pm CDT — 2nd Friday
+      endDate: new Date('2026-10-10T07:00:00.000Z'),
+      url: 'https://www.thedallaseagle.com/events/discipline-corps-bar-night-with-dj-blaine/',
+      recurrenceRule: 'FREQ=MONTHLY',
+      source: 'ai-web'
+    }
+  ];
+  parser.applyDerivedCadenceStamps(disciplinePair);
+  const markers = new Set(disciplinePair.map(record => record._cadenceGroup));
+  assert.equal(markers.size, 1, 'the DJ-suffixed pair shares ONE same-series marker');
+  assert.match([...markers][0], /FREQ=MONTHLY;BYDAY=2FR$/, 'grouped via the existing >=2-months ordinal rule');
+  for (const record of disciplinePair) {
+    assert.equal(record.recurrenceRule, 'FREQ=MONTHLY', 'the stated rule is NEVER overridden by its refinement');
+  }
+
+  // Two DIFFERENT party names at one venue, each with a guest-DJ suffix,
+  // must not group: the strip only removes the performer clause, and the
+  // remaining base titles are dissimilar.
+  const differentParties = [
+    {
+      title: 'Underwear Night with DJ Philip Webb',
+      bar: 'Dallas Eagle',
+      timezone: 'America/Chicago',
+      startDate: new Date('2026-09-12T02:00:00.000Z'),
+      endDate: new Date('2026-09-12T07:00:00.000Z'),
+      url: 'https://www.thedallaseagle.com/events/underwear-night-9/',
+      source: 'ai-web'
+    },
+    {
+      title: 'Karaoke with DJ Blaine',
+      bar: 'Dallas Eagle',
+      timezone: 'America/Chicago',
+      startDate: new Date('2026-10-10T02:00:00.000Z'),
+      endDate: new Date('2026-10-10T07:00:00.000Z'),
+      url: 'https://www.thedallaseagle.com/events/karaoke-31/',
+      source: 'ai-web'
+    }
+  ];
+  parser.applyDerivedCadenceStamps(differentParties);
+  for (const record of differentParties) {
+    assert.equal(record._cadenceGroup, undefined, 'different parties never share a group');
+    assert.equal(record.recurrenceRule, undefined, 'and two singletons derive nothing');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Roundup-tile tell (📰, report-only): a multi-day umbrella whose own text
+// names >= 3 events the run also extracted separately is probably a
+// listing/roundup graphic, not one attendable event.
+// ---------------------------------------------------------------------------
+
+test('reportProbableRoundupTiles: THIS WEEK AT MASSIVE logs only once enough of its lineup is separately extracted', () => {
+  const parser = createParser();
+  // The real record from run 20260811-132205: an Instagram weekly-lineup
+  // graphic (Oct 6–11 2025) extracted as a 5-day umbrella whose OCR text
+  // became its description.
+  const umbrella = {
+    title: 'THIS WEEK AT MASSIVE',
+    description: [
+      'THIS WEEK AT', 'MASSIVE',
+      'MON OCT 6th', 'DRAGULA TITANS WATCH PARTY', 'MISS MIMI GINA',
+      'WED OCT 8th', 'IMPACT SOCIAL', 'OPEN DECKS', 'BRING YOUR USB AND IMPRESS US',
+      'THUR OCT 9th', 'BUTT BLAST', 'MENS UNDERWEAR NIGHT', 'SPECIAL NUDE PHOTOSSHOOT EDITION',
+      'FRI OCT 10th', 'BEARRACUDA - SERIOUS WOOD', 'MATT CONSOLA + FREDDY KOP',
+      'GOGOS: MIKE WEST | ZEKE | FU22BALL | MICHAEL',
+      'SAT OCT 11th', 'DARK ROOM', 'NICK BERTOSSI (VAN)', 'GOGOS: HALIL | IGNACIO',
+      'Pioneer Dj'
+    ].join('\n'),
+    startDate: new Date('2025-10-07T05:00:00.000Z'),
+    endDate: new Date('2025-10-12T05:00:00.000Z'),
+    bar: 'Massive',
+    source: 'ai-web'
+  };
+  // Separately extracted records from the same run (massive.club calendar).
+  const buttBlast = { title: 'Butt Blast', startDate: new Date('2026-08-14T04:00:00.000Z'), source: 'ai-web' };
+  const bearracuda = { title: 'Bearracuda', startDate: new Date('2026-09-13T04:00:00.000Z'), source: 'ai-web' };
+  const treasureTrail = { title: 'Treasure Trail', startDate: new Date('2026-08-16T04:00:00.000Z'), source: 'ai-web' };
+  const massiveVenueRecord = { title: 'MASSIVE', startDate: new Date('2023-06-22T07:00:00.000Z'), source: 'ai-web' };
+
+  // The real 20260811-132205 population: only TWO of the tile's named
+  // parties were separately extracted (Butt Blast, Bearracuda) — below the
+  // >=3 bar, so the tell stays silent (fail closed). "MASSIVE" is in the
+  // tile text but too short/generic to ever count, and "Treasure Trail" is
+  // not named by the tile at all.
+  let logs = withCapturedLogs(() =>
+    parser.reportProbableRoundupTiles([umbrella, buttBlast, bearracuda, treasureTrail, massiveVenueRecord]));
+  assert.deepEqual(logs.filter(line => line.startsWith('📰 ROUNDUP:')), [],
+    'two separately-extracted lineup names are not enough evidence');
+
+  // A fuller run that also extracts a third named lineup party ("DARK
+  // ROOM", the tile's SAT OCT 11 event) crosses the bar and the tell fires
+  // — report-only, nothing on any record changes.
+  const darkRoom = { title: 'Dark Room', startDate: new Date('2025-10-12T05:00:00.000Z'), source: 'ai-web' };
+  const before = JSON.stringify(umbrella);
+  logs = withCapturedLogs(() =>
+    parser.reportProbableRoundupTiles([umbrella, buttBlast, bearracuda, treasureTrail, darkRoom]));
+  const roundupLines = logs.filter(line => line.startsWith('📰 ROUNDUP:'));
+  assert.equal(roundupLines.length, 1, `expected one 📰 line, got: ${JSON.stringify(logs)}`);
+  assert.ok(roundupLines[0].includes('"THIS WEEK AT MASSIVE"'));
+  assert.ok(roundupLines[0].includes('names 3 events'));
+  assert.ok(roundupLines[0].includes('report-only'));
+  assert.equal(JSON.stringify(umbrella), before, 'report-only: the umbrella record is untouched');
+
+  // A future-dated multi-day umbrella (a real bear week) whose text names
+  // no separately extracted events never trips the tell.
+  const bearWeek = {
+    title: 'Bear Week Provincetown',
+    description: 'Seven days of bear events in Provincetown',
+    startDate: new Date('2027-07-10T00:00:00.000Z'),
+    endDate: new Date('2027-07-17T00:00:00.000Z'),
+    source: 'ai-web'
+  };
+  logs = withCapturedLogs(() =>
+    parser.reportProbableRoundupTiles([bearWeek, buttBlast, bearracuda, treasureTrail, darkRoom]));
+  assert.deepEqual(logs.filter(line => line.startsWith('📰 ROUNDUP:')), [],
+    'a legitimate umbrella whose text does not enumerate the run is silent');
+});
+
 // ---------------------------------------------------------------------------
 // Single-page OCR top-up (ensureSinglePageImageCoverage): a poster sitting
 // past the capped page-level OCR pass on a single-event page gets a bounded

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1861,7 +1861,44 @@ class SharedCore {
             }
         }
 
+        // 8. span-fully-past — the ENTIRE span (start AND end) precedes
+        //    analysis time: there is nothing left to attend, so a write
+        //    proposal for it is describing history, not an event ("THIS WEEK
+        //    AT MASSIVE", run 20260811-132205: an Instagram weekly-lineup
+        //    graphic dated Oct 6–11 2025 proposed as a CREATE ~10 months
+        //    later — 5-day span cleared the duration bound, 308 days past
+        //    cleared the 370-day long-past bound). Objective on purpose:
+        //    unlike start-long-past there is no CREATE-only carve-out,
+        //    because even an UPDATE payload for a fully-elapsed span has no
+        //    attendable content to deliver. This flag is the card surface;
+        //    the matching write withhold is stamped separately in
+        //    buildAnalyzedCalendarEvent via isEventSpanFullyPast.
+        if (this.isEventSpanFullyPast(event, nowMs)) {
+            const startMs = toMs(event.startDate);
+            const endReferenceMs = toMs(event.endDate);
+            const spanEndMs = Number.isFinite(endReferenceMs) ? endReferenceMs : startMs;
+            const daysPast = Math.max(0, Math.round((nowMs - spanEndMs) / (24 * 60 * 60 * 1000)));
+            flags.push({
+                code: 'span-fully-past',
+                detail: `entire span (start and end) ended ${daysPast} day(s) before analysis — nothing left to attend`
+            });
+        }
+
         return flags;
+    }
+
+    // TRUE only when the event's whole span is provably behind analysis
+    // time: a parseable start strictly in the past AND a span end (endDate,
+    // or the start itself when no end parses) strictly in the past. Missing
+    // or unparseable dates return false — fail closed, this helper feeds a
+    // write withhold and must never suppress an event it cannot date.
+    isEventSpanFullyPast(event, nowMs = Date.now()) {
+        if (!event || typeof event !== 'object') return false;
+        const startMs = this.toEpochMillis(event.startDate);
+        if (startMs === null || startMs >= nowMs) return false;
+        const endMs = this.toEpochMillis(event.endDate);
+        const spanEndMs = endMs === null ? startMs : endMs;
+        return spanEndMs < nowMs;
     }
 
     // A value shaped like a street address is NEVER a venue name. Anchored on
@@ -4063,6 +4100,16 @@ class SharedCore {
         // write). Platform-pure: the parser hook receives injected data.
         if (aiWebParser && typeof aiWebParser.applyDerivedCadenceStamps === 'function') {
             aiWebParser.applyDerivedCadenceStamps(allEvents);
+        }
+        // Roundup-tile tell (report-only, parser-derived): a multi-day
+        // umbrella record whose own extracted text names >= 3 events this
+        // run ALSO extracted separately is probably a listing/roundup
+        // graphic ("THIS WEEK AT MASSIVE", run 20260811-132205), not an
+        // attendable umbrella. Judged only here because "also extracted
+        // separately" needs every record of the run in view. Log line only
+        // this wave — no flag, no drop. Platform-pure: injected hook.
+        if (aiWebParser && typeof aiWebParser.reportProbableRoundupTiles === 'function') {
+            aiWebParser.reportProbableRoundupTiles(allEvents);
         }
 
         // Aggregator website pointer (trust the pointer, not the copy —
@@ -8218,6 +8265,9 @@ class SharedCore {
                 const existingSeries = this.getSeriesExportIdentity(existing);
                 if (!existingSeries) return false;
                 if (existingSeries.rrule !== eventSeries.rrule) return false;
+                const eventGroup = typeof event._cadenceGroup === 'string' ? event._cadenceGroup : '';
+                const existingGroup = typeof existing._cadenceGroup === 'string' ? existing._cadenceGroup : '';
+                const sharedCadenceMarker = Boolean(eventGroup) && eventGroup === existingGroup;
                 if (existingSeries.hostPath !== eventSeries.hostPath) {
                     // Renumbered-slug extension (run 20260807-143442: a MEC
                     // install mints a NEW slug per occurrence — karaoke-19,
@@ -8232,13 +8282,23 @@ class SharedCore {
                     // that shared marker (two real weekly slots of one brand,
                     // stated rules, different venues) still never folds —
                     // lookalike pairs are not always twins.
-                    const eventGroup = typeof event._cadenceGroup === 'string' ? event._cadenceGroup : '';
-                    const existingGroup = typeof existing._cadenceGroup === 'string' ? existing._cadenceGroup : '';
-                    if (!eventGroup || eventGroup !== existingGroup) return false;
+                    if (!sharedCadenceMarker) return false;
                 }
-                const shapeA = this.buildIdentityComparisonShape(event);
-                const shapeB = this.buildIdentityComparisonShape(existing);
-                if (!this.areIdentityNamesSimilar(shapeA, shapeB)) return false;
+                // A shared cadence marker IS the name proof: the derived-
+                // cadence pass minted it this run only after judging the
+                // group title-similar (including its grouping-only
+                // guest-performer-suffix comparison — "Discipline Corps Bar
+                // Night with DJ Philip Webb" / "… with DJ Blaine", run
+                // 20260811-134734, whose full titles fail the plain name
+                // check here and left the pair unfolded). Re-checking the
+                // full titles would veto exactly what the marker proved.
+                // Without a shared marker the plain name check stands, and
+                // the positive different-place veto applies in all cases.
+                if (!sharedCadenceMarker) {
+                    const shapeA = this.buildIdentityComparisonShape(event);
+                    const shapeB = this.buildIdentityComparisonShape(existing);
+                    if (!this.areIdentityNamesSimilar(shapeA, shapeB)) return false;
+                }
                 return !this.areEventsDistinctByPlace(event, existing);
             }) : null;
             if (!match) {
@@ -11326,6 +11386,11 @@ class SharedCore {
         if (!Array.isArray(analyzedEvents)) return [];
         return analyzedEvents.filter(event =>
             event?._parserConfig?.dryRun !== true &&
+            // Fully-past spans are display-only: nothing left to attend, so
+            // the write is withheld at analysis (buildAnalyzedCalendarEvent
+            // stamps _pastSpanWithheld + the span-fully-past review flag)
+            // and gated here, exactly like the recurring-series withhold.
+            event?._pastSpanWithheld !== true &&
             !SharedCore.isRecurringSeriesEvent(event));
     }
 
@@ -12952,6 +13017,25 @@ class SharedCore {
                 console.log(`⚠️ SANITY: "${analyzedEvent.title || 'Unknown'}" flagged ${analyzedEvent._sanityFlags.map(flag => flag.code).join(', ')} — ${analyzedEvent._sanityFlags[0].detail}`);
             }
 
+            // FULLY-PAST SPAN WITHHOLD — the one enforced sibling of the
+            // report-only flags above, judged by the same objective test the
+            // `span-fully-past` flag reports (isEventSpanFullyPast, computed
+            // independently here so the flag channel itself still never
+            // withholds anything). An event whose start AND end are both
+            // behind analysis time has nothing left to attend; writing it
+            // publishes history as if it were upcoming ("THIS WEEK AT
+            // MASSIVE", run 20260811-132205: a stale Oct 2025 lineup graphic
+            // reached a calendar CREATE in Aug 2026). Flag, don't drop: the
+            // card stays in the results UI with its review flag; only the
+            // calendar write is withheld (filterEventsForExecution), exactly
+            // the recurring-series withhold pattern below. Legitimate
+            // umbrellas (bear weeks, festivals) are future-dated and never
+            // trip this.
+            if (this.isEventSpanFullyPast(analyzedEvent)) {
+                analyzedEvent._pastSpanWithheld = true;
+                console.log(`⏳ PAST SPAN: "${analyzedEvent.title || 'Unknown'}" withheld from calendar write — entire span (start and end) is already past at analysis time; card kept in results`);
+            }
+
             // Recurring series are display+export only: keep the card in the
             // results UI (flag-don't-drop) but withhold it from calendar
             // execution — the owner saves the series via the ICS export
@@ -13374,9 +13458,31 @@ class SharedCore {
             });
         }
 
+        // Cross-parser reconciliation: same local day + positive venue
+        // identity + title token-subset (getCalendarTitleSubsetSignal —
+        // "Treasure Trail" vs "Treasure Trail Seattle", one real event
+        // reaching the calendar under two parsers' keys). Runs after the
+        // stronger signals above so a ticket-url/event-page/identifier match
+        // always wins first, and before the overlap check below, whose
+        // 60-minute window is exactly what different sources' stated clock
+        // times fail.
+        for (const existing of existingEventsData) {
+            const subsetSignal = this.getCalendarTitleSubsetSignal(event, existing);
+            if (!subsetSignal) continue;
+            const recurringMergeDecision = this.resolveRecurringMergeCandidate(existingEventsData, existing);
+            if (recurringMergeDecision) {
+                return finalize(recurringMergeDecision);
+            }
+            return finalize({
+                action: 'merge',
+                reason: `Same-day venue title-subset match (${subsetSignal})`,
+                existingEvent: existing
+            });
+        }
+
         // Check for overlapping events - only merge when time and title/venue are similar
-        const timeConflicts = existingEventsData.filter(existing => 
-            this.doDatesOverlap(existing.startDate, existing.endDate, 
+        const timeConflicts = existingEventsData.filter(existing =>
+            this.doDatesOverlap(existing.startDate, existing.endDate,
                                event.startDate, event.endDate || event.startDate)
         );
         
@@ -14453,6 +14559,55 @@ class SharedCore {
         const longerSet = new Set(longer);
         if (!shorter.every(token => longerSet.has(token))) return null;
         return 'venue+night+title-subset';
+    }
+
+    // Calendar-side sibling of getCrossSourceDuplicateSignal, for
+    // analyzeEventAction: two PARSERS name one real event with variant
+    // titles — one a token-subset of the other, typically base name vs base
+    // name + a city/location token ("Treasure Trail" from massive.club vs
+    // "Treasure Trail Seattle" from bearracuda, runs 20260811-132205 /
+    // -133948, keys treasure-trail|2026-08-16|massive vs
+    // treasure-trail-seattle|2026-08-16|massive) — so findEventByKey can
+    // never reconcile them across runs, the 1-minute "Similar event found"
+    // window misses whenever the two sources state different clock times,
+    // and the place-time-name identity signal gives up beyond 2 hours.
+    // Everything fails closed:
+    //   - EXACT same local calendar day, resolved through the identity
+    //     shapes (which read a calendar record's timezone/bar out of its
+    //     notes and its coordinates out of `location`) — different days
+    //     never match, however similar the titles: the within-run relaxation
+    //     for degraded start times already demands the same local day, and
+    //     the lookalike-pairs doctrine (same title/venue/day can be two real
+    //     events when a DATE was fabricated) is precisely about crossing
+    //     days;
+    //   - POSITIVE venue identity via areIdentityPlacesSimilar (bar-name
+    //     match, bar-in-location, address, or coordinates) — a side with no
+    //     place evidence never matches;
+    //   - title TOKEN subset via getCrossSourceTitleTokens (performer
+    //     clauses cut, city tokens dropped, venue tokens dropped): every
+    //     significant token of the shorter title must appear in the longer.
+    //     Unrelated titles sharing a token ("Treasure Hunt" / "Treasure
+    //     Trail") never match — the subset must be total.
+    getCalendarTitleSubsetSignal(newEvent, existingEvent) {
+        if (!newEvent || typeof newEvent !== 'object' || !existingEvent || typeof existingEvent !== 'object') {
+            return null;
+        }
+        const incoming = this.buildIdentityComparisonShape(newEvent);
+        const existing = this.buildIdentityComparisonShape(existingEvent);
+        if (!this.areIdentityDatesOnSameLocalDay(incoming, existing)) return null;
+        if (!this.areIdentityPlacesSimilar(incoming, existing)) return null;
+        const venueKeys = [
+            this.normalizeBarNameKey(incoming.bar),
+            this.normalizeBarNameKey(existing.bar)
+        ].filter(Boolean);
+        const tokensA = this.getCrossSourceTitleTokens(newEvent.title || newEvent.name, venueKeys);
+        if (tokensA.length === 0) return null;
+        const tokensB = this.getCrossSourceTitleTokens(existingEvent.title || existingEvent.name, venueKeys);
+        if (tokensB.length === 0) return null;
+        const [shorter, longer] = tokensA.length <= tokensB.length ? [tokensA, tokensB] : [tokensB, tokensA];
+        const longerSet = new Set(longer);
+        if (!shorter.every(token => longerSet.has(token))) return null;
+        return 'place+day+title-subset';
     }
 
     // Primary designation for a cross-source merge: the record with more

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -110,6 +110,96 @@ test('analyzeEventAction keeps genuinely different same-venue events separate', 
   assert.equal(analysis.action, 'new');
 });
 
+// === Cross-parser calendar reconciliation (runs 20260811-132205 / -133948) ===
+// One real event — 2026-08-16 at Massive, Seattle — reached the calendar as
+// "Treasure Trail" (massive.club, key treasure-trail|2026-08-16|massive) and
+// "Treasure Trail Seattle" (bearracuda, key
+// treasure-trail-seattle|2026-08-16|massive). findEventByKey can never
+// reconcile the two keys, the "Similar event found" path needs the stated
+// clock times within ONE minute, and the place-time-name identity signal
+// gives up beyond 2 hours — so whenever the two sources state different
+// times, the same night is written twice. The reconciliation is fail-closed:
+// exact same local day + POSITIVE venue identity + total title token-subset.
+
+function buildTreasureTrailIncoming(overrides = {}) {
+  // The real bearracuda-side record (run 20260811-133948).
+  return {
+    title: 'Treasure Trail Seattle',
+    startDate: new Date('2026-08-16T04:00:00.000Z'), // Sat Aug 15, 9pm PDT
+    endDate: new Date('2026-08-16T10:00:00.000Z'),
+    bar: 'Massive',
+    address: '619 E Pine St, Seattle, WA 98122',
+    location: '47.6150824, -122.3237201',
+    timezone: 'America/Los_Angeles',
+    city: 'seattle',
+    url: 'https://bearracuda.com/',
+    key: 'treasure-trail-seattle|2026-08-16|massive',
+    source: 'ai-web',
+    ...overrides
+  };
+}
+
+function buildTreasureTrailSaved(overrides = {}) {
+  // The massive.club-side calendar record, saved with an earlier stated
+  // clock time (doors listing) — 3 hours from the incoming start, so every
+  // pre-existing match path refuses while the local day is identical.
+  return {
+    name: 'Treasure Trail',
+    startDate: new Date('2026-08-16T01:00:00.000Z'), // Sat Aug 15, 6pm PDT
+    endDate: new Date('2026-08-16T02:00:00.000Z'),
+    location: '47.6150824, -122.3237201',
+    calendarTimezone: 'America/Los_Angeles',
+    notes: [
+      'bar: Massive',
+      'timezone: America/Los_Angeles',
+      'key: treasure-trail|2026-08-16|massive'
+    ].join('\n'),
+    ...overrides
+  };
+}
+
+test('analyzeEventAction reconciles cross-parser title-subset duplicates at the same day and venue (Treasure Trail)', () => {
+  const core = createCore();
+  const analysis = core.analyzeEventAction(buildTreasureTrailIncoming(), [buildTreasureTrailSaved()]);
+  assert.equal(analysis.action, 'merge',
+    'same local day + venue identity + title token-subset is the same event');
+  assert.match(analysis.reason, /Same-day venue title-subset match/);
+
+  // The same pair in the OTHER direction (bare title incoming, suffixed
+  // title saved) reconciles too.
+  const reversed = core.analyzeEventAction(
+    buildTreasureTrailIncoming({ title: 'Treasure Trail', key: 'treasure-trail|2026-08-16|massive' }),
+    [buildTreasureTrailSaved({ name: 'Treasure Trail Seattle', notes: buildTreasureTrailSaved().notes.replace('treasure-trail|', 'treasure-trail-seattle|') })]);
+  assert.equal(reversed.action, 'merge');
+  assert.match(reversed.reason, /Same-day venue title-subset match/);
+
+  // --- Fail-closed guards, same test so the vectors stay side by side ---
+  // Different local day — same titles, same venue: NEVER a match (the
+  // lookalike-pairs doctrine lives on the day axis).
+  const nextWeek = core.analyzeEventAction(
+    buildTreasureTrailIncoming({
+      startDate: new Date('2026-08-23T04:00:00.000Z'),
+      endDate: new Date('2026-08-23T10:00:00.000Z'),
+      key: 'treasure-trail-seattle|2026-08-23|massive'
+    }),
+    [buildTreasureTrailSaved()]);
+  assert.equal(nextWeek.action, 'new', 'a different day is a different night, however similar the titles');
+
+  // Unrelated titles sharing ONE token at the same day + venue: the subset
+  // must be total, so "Treasure Hunt" never folds into "Treasure Trail".
+  const sharedToken = core.analyzeEventAction(
+    buildTreasureTrailIncoming({ title: 'Treasure Hunt', key: 'treasure-hunt|2026-08-16|massive' }),
+    [buildTreasureTrailSaved()]);
+  assert.equal(sharedToken.action, 'new', 'sharing a token is not a subset — two real events stay separate');
+
+  // No venue evidence on the saved side (empty notes, no coordinates): the
+  // POSITIVE venue-identity requirement refuses, whatever the titles say.
+  const noVenue = core.analyzeEventAction(
+    buildTreasureTrailIncoming(),
+    [buildTreasureTrailSaved({ location: null, notes: '' })]);
+  assert.equal(noVenue.action, 'new', 'no positive venue identity → fail closed');
+});
+
 test('parseAiEventResponse rejects array responses', () => {
   const core = createCore();
   assert.equal(core.parseAiEventResponse('[0]'), null, 'bare arrays are not event objects');
@@ -4155,6 +4245,47 @@ test('deduplicateEvents never folds different base pages without a shared cadenc
     buildRenumberedSlugSeriesExport(nextWeek, 20, { recurrenceRule: 'FREQ=MONTHLY;BYDAY=1TH' })
   ], null);
   assert.equal(differentRules.length, 2, 'different rules are different series claims — never fold them');
+});
+
+test('deduplicateEvents: a shared cadence marker IS the name proof — the DJ-suffixed Discipline Corps pair folds', async () => {
+  const core = createCore();
+  // Run 20260811-134734 verbatim: a 2nd-Friday monthly pair whose records
+  // each wear a different guest DJ's name. The derived-cadence pass groups
+  // them (guest-suffix-stripped comparison) and mints one marker; the
+  // series collapse must not re-veto the fold by re-checking the FULL
+  // titles, which are deliberately dissimilar (that is exactly why the
+  // marker exists). Venue identity still applies: the different-place veto
+  // is untouched (covered by the different-venues case above).
+  const buildDisciplineRecord = (title, start, slug) => ({
+    title,
+    bar: 'Dallas Eagle',
+    city: 'dallas',
+    timezone: 'America/Chicago',
+    startDate: new Date(start),
+    endDate: new Date(new Date(start).getTime() + 5 * 60 * 60 * 1000),
+    url: `https://www.thedallaseagle.com/events/${slug}/`,
+    recurrenceRule: 'FREQ=MONTHLY',
+    _cadenceGroup: 'cadence-1:FREQ=MONTHLY;BYDAY=2FR',
+    source: 'ai-web'
+  });
+  const pair = [
+    buildDisciplineRecord('Discipline Corps Bar Night with DJ Philip Webb', '2026-09-12T02:00:00.000Z', 'discipline-corps-bar-night-7'),
+    buildDisciplineRecord('Discipline Corps Bar Night with DJ Blaine', '2026-10-10T02:00:00.000Z', 'discipline-corps-bar-night-with-dj-blaine')
+  ];
+  const result = await core.deduplicateEvents(pair, null);
+  assert.equal(result.length, 1, 'the marker-shared pair folds to one withheld series export');
+  assert.equal(result[0].startDate.getTime(), Date.parse('2026-09-12T02:00:00.000Z'),
+    'the earliest occurrence is kept');
+  assert.equal(result[0].recurrenceRule, 'FREQ=MONTHLY', 'the stated rule survives the fold');
+
+  // Without the shared marker the same pair NEVER folds — full titles are
+  // dissimilar and the plain name check stands (lookalike pairs are not
+  // always twins).
+  const withMarker = buildDisciplineRecord('Discipline Corps Bar Night with DJ Philip Webb', '2026-09-12T02:00:00.000Z', 'discipline-corps-bar-night-7');
+  const withoutMarker = buildDisciplineRecord('Discipline Corps Bar Night with DJ Blaine', '2026-10-10T02:00:00.000Z', 'discipline-corps-bar-night-with-dj-blaine');
+  delete withoutMarker._cadenceGroup;
+  const unmarked = await core.deduplicateEvents([withMarker, withoutMarker], null);
+  assert.equal(unmarked.length, 2, 'a one-sided marker still proves nothing');
 });
 
 // === Run 20260802-135030: 3dollarbillbk.com + its eventim ticketing pages ===
@@ -12084,17 +12215,20 @@ test('isRecurringSeriesEvent: _recurring stamp or non-empty recurrenceRule', () 
 test('recurring events are excluded from calendar-write execution but present in results', async () => {
   const core = createCore();
   const adapter = buildPrepCalendarAdapter([]);
+  // Future-dated relative to the wall clock: a fixed past date would now trip
+  // the (separate) fully-past-span withhold and hide what THIS test proves.
+  const upcoming = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
   const recurring = {
     title: 'FUZZY',
-    startDate: new Date('2026-08-08T02:00:00.000Z'),
-    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    startDate: upcoming,
+    endDate: new Date(upcoming.getTime() + 5 * 60 * 60 * 1000),
     bar: 'Dallas Eagle',
     city: 'dallas',
     recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR'
   };
   const plain = {
     title: 'ONE-OFF',
-    startDate: new Date('2026-08-09T02:00:00.000Z'),
+    startDate: new Date(upcoming.getTime() + 24 * 60 * 60 * 1000),
     city: 'dallas'
   };
 
@@ -14821,24 +14955,31 @@ test('sanity: sentence fragments and filler announcements are DELIBERATELY not f
 
 test('sanity: a CREATE more than 370 days past flags start-long-past; updates and recent creates never do', () => {
   const core = createSanityCore();
+  // Every fixture below is fully elapsed at SANITY_NOW_MS, so since wave 3
+  // each also carries the (action-independent) span-fully-past flag — the
+  // start-long-past rule itself is unchanged: CREATE-shaped only, 370-day
+  // bound.
   // Real case: ONBEAR FEST proposed as NEW at 2021-01-31 — five years past.
   assert.deepEqual(
     sanityCodes(core, { title: 'ONBEAR FEST', _action: 'new', startDate: '2021-01-31T20:00:00Z' }),
-    ['start-long-past']);
-  // A normal past-event UPDATE is routine calendar maintenance.
+    ['start-long-past', 'span-fully-past']);
+  // A normal past-event UPDATE is routine calendar maintenance for THIS
+  // rule; the fully-past span still gets its own flag (and write withhold —
+  // an update payload for an elapsed span has nothing attendable to say).
   assert.deepEqual(
     sanityCodes(core, { title: 'ONBEAR FEST', _action: 'merge', startDate: '2021-01-31T20:00:00Z' }),
-    []);
+    ['span-fully-past']);
   // Real case under the bound: ursamen's "Out of Hibernation" carried a date
-  // ~5 months past — inside 370 days, so this rule stays silent (the bound
-  // exists to keep just-passed annual events out of the flag).
+  // ~5 months past — inside 370 days, so start-long-past stays silent (the
+  // bound exists to keep just-passed annual events out of THAT flag); the
+  // span-fully-past flag is exactly the one that should speak here.
   assert.deepEqual(
     sanityCodes(core, { title: 'Out of Hibernation', _action: 'new', startDate: '2026-03-01T20:00:00Z' }),
-    []);
+    ['span-fully-past']);
   // _analysis.action counts as CREATE-shaped too.
   assert.deepEqual(
     sanityCodes(core, { title: 'ONBEAR FEST', _analysis: { action: 'new' }, startDate: '2021-01-31T20:00:00Z' }),
-    ['start-long-past']);
+    ['start-long-past', 'span-fully-past']);
 });
 
 test('sanity: spans longer than any curated festival flag duration-implausible; festival-length spans never do', () => {
@@ -14884,10 +15025,13 @@ test('sanity: getEventSanityFlags never mutates the event and stacks multiple fl
 test('sanity flags are stamped on the analyzed event with the ⚠️ SANITY log line', async () => {
   const core = createCore();
   const adapter = buildPrepCalendarAdapter([]); // no existing events → CREATE
+  // Future-dated so the (separate) span-fully-past flag stays out of the
+  // exact single-flag log-line assertion below.
+  const upcomingStart = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
   const scraped = {
     title: 'DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE',
-    startDate: new Date('2026-08-08T02:00:00.000Z'),
-    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    startDate: upcomingStart,
+    endDate: new Date(upcomingStart.getTime() + 5 * 60 * 60 * 1000),
     bar: 'STATION 4',
     city: 'dallas',
     shortName: 'TAGS' // keeps the shortName derivation pass inert
@@ -14912,10 +15056,14 @@ test('sanity flags are stamped on the analyzed event with the ⚠️ SANITY log 
 
 test('no enforcement: a flagged event\'s action and write fields are byte-identical to an unflagged twin\'s', async () => {
   const core = createCore();
+  // Future-dated: a fixed past date would add the span-fully-past flag (and
+  // its separate withhold) to BOTH twins and muddy the no-enforcement claim
+  // this test pins for the report-only flags.
+  const twinStart = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
   const buildTwin = (title) => ({
     title,
-    startDate: new Date('2026-08-08T02:00:00.000Z'),
-    endDate: new Date('2026-08-08T07:00:00.000Z'),
+    startDate: twinStart,
+    endDate: new Date(twinStart.getTime() + 5 * 60 * 60 * 1000),
     bar: 'STATION 4',
     city: 'dallas',
     shortName: 'TAGS'
@@ -14945,6 +15093,78 @@ test('no enforcement: a flagged event\'s action and write fields are byte-identi
     notes: event.notes
   });
   assert.equal(writeShape(flagged[0]), writeShape(twin[0]));
+});
+
+test('fully-past span: the write is withheld with a review flag; a future umbrella is untouched (THIS WEEK AT MASSIVE)', async () => {
+  const core = createCore();
+  const adapter = buildPrepCalendarAdapter([]); // no existing events → CREATE
+  // The real record from run 20260811-132205: an Instagram weekly-lineup
+  // graphic (Oct 6–11 2025) extracted as a 5-day umbrella and PROPOSED AS A
+  // CALENDAR CREATE ten months after it ended — 5-day span under the 10-day
+  // duration bound, 308 days under the 370-day long-past bound, so no
+  // pre-existing rule spoke. Span fully past is objective: nothing left to
+  // attend, so the write is withheld while the card stays in results
+  // (flag, don't drop).
+  const staleTile = {
+    title: 'THIS WEEK AT MASSIVE',
+    startDate: new Date('2025-10-07T05:00:00.000Z'),
+    endDate: new Date('2025-10-12T05:00:00.000Z'),
+    bar: 'Massive',
+    city: 'seattle',
+    timezone: 'America/Los_Angeles',
+    ticketUrl: 'https://tixr.com/e/202303',
+    shortName: 'THIS WEEK' // keeps the shortName derivation pass inert
+  };
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logLines.push(args.join(' ')); };
+  let analyzed;
+  try {
+    analyzed = await core.prepareEventsForCalendar([staleTile], adapter, {});
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(analyzed.length, 1, "flag-don't-drop: the card stays in the results");
+  assert.equal(analyzed[0]._pastSpanWithheld, true, 'the write withhold is stamped at analysis');
+  assert.ok(analyzed[0]._sanityFlags.some(flag => flag.code === 'span-fully-past'),
+    'the review flag rides the existing sanity-flag card surface');
+  assert.ok(logLines.some(line => line.startsWith('⏳ PAST SPAN: "THIS WEEK AT MASSIVE" withheld from calendar write')),
+    `withhold line expected, got: ${JSON.stringify(logLines.filter(line => line.includes('PAST')))}`);
+  assert.deepEqual(SharedCore.filterEventsForExecution(analyzed), [],
+    'a fully-past span never reaches a calendar write');
+
+  // A legitimate FUTURE multi-day umbrella (a bear week) is untouched:
+  // no flag, no stamp, still executable.
+  const upcoming = new Date(Date.now() + 150 * 24 * 60 * 60 * 1000);
+  const bearWeek = {
+    title: 'Bear Week Kickoff',
+    startDate: upcoming,
+    endDate: new Date(upcoming.getTime() + 5 * 24 * 60 * 60 * 1000),
+    bar: 'Massive',
+    city: 'seattle',
+    timezone: 'America/Los_Angeles',
+    shortName: 'BWK'
+  };
+  const futureAnalyzed = await core.prepareEventsForCalendar([bearWeek], buildPrepCalendarAdapter([]), {});
+  assert.equal(futureAnalyzed.length, 1);
+  assert.equal(futureAnalyzed[0]._pastSpanWithheld, undefined, 'future spans are never stamped');
+  assert.ok(!futureAnalyzed[0]._sanityFlags.some(flag => flag.code === 'span-fully-past'));
+  assert.equal(SharedCore.filterEventsForExecution(futureAnalyzed).length, 1,
+    'a future umbrella still reaches the write plan');
+
+  // An event that has STARTED but not ENDED (ongoing) is not fully past.
+  const ongoing = {
+    title: 'Ongoing Weekender',
+    startDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    endDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    bar: 'Massive',
+    city: 'seattle',
+    timezone: 'America/Los_Angeles',
+    shortName: 'OW'
+  };
+  const ongoingAnalyzed = await core.prepareEventsForCalendar([ongoing], buildPrepCalendarAdapter([]), {});
+  assert.equal(ongoingAnalyzed[0]._pastSpanWithheld, undefined, 'an ongoing span still has something to attend');
+  assert.equal(SharedCore.filterEventsForExecution(ongoingAnalyzed).length, 1);
 });
 
 // ---------------------------------------------------------------------------
@@ -15031,7 +15251,7 @@ test('cross-realm: sanity flags fire on foreign Dates (start-long-past, duration
   };
   assert.deepEqual(
     core.getEventSanityFlags(nark, { nowMs }).map(flag => flag.code),
-    ['start-long-past']
+    ['start-long-past', 'span-fully-past']
   );
 
   // The real Lumberyard record: 2025-03-22 → 2026-10-17 from JSON-LD.
@@ -15512,8 +15732,11 @@ function buildBhhSeriesRecord(overrides = {}) {
   return {
     identifier: '2DDBF0E6-6877-4FBF-BB94-EC2708DFD113:9vnvsm6kjpievu62279lco139k@google.com',
     title: 'Bear Happy Hour',
-    startDate: new Date('2026-08-07T00:00:00.000Z'),
-    endDate: new Date('2026-08-07T04:00:00.000Z'),
+    // A first Thursday far in the future: the occurrence being overridden
+    // must be upcoming, or the (unrelated) fully-past-span withhold would
+    // hide the write this suite asserts.
+    startDate: new Date('2030-08-01T00:00:00.000Z'),
+    endDate: new Date('2030-08-01T04:00:00.000Z'),
     location: null,
     recurrence: 'FREQ=WEEKLY',
     notes: [
@@ -15531,8 +15754,8 @@ function buildBhhScrapedEvent(overrides = {}) {
   return {
     title: 'BEAR HAPPY HOUR',
     description: 'Bear Happy Hour First Thursdays 5pm',
-    startDate: new Date('2026-08-07T00:00:00.000Z'),
-    endDate: new Date('2026-08-07T04:00:00.000Z'),
+    startDate: new Date('2030-08-01T00:00:00.000Z'),
+    endDate: new Date('2030-08-01T04:00:00.000Z'),
     bar: 'Eagle LA',
     barSource: 'venue-site',
     address: '4219 Santa Monica Blvd, Los Angeles, CA 90029',
@@ -15693,7 +15916,7 @@ test('series authority end-to-end: BHH at Eagle LA keeps its override and writes
   // The override identity survives (#1588 dropped it here) and the per-night
   // facts the calendar was missing are exactly what gets written.
   assert.equal(analyzed.overrideUid, '9vnvsm6kjpievu62279lco139k@google.com');
-  assert.equal(analyzed.overrideRecurrenceId, '20260807T000000Z');
+  assert.equal(analyzed.overrideRecurrenceId, '20300801T000000Z');
   assert.equal(analyzed.bar, 'Eagle LA');
   assert.equal(analyzed.address, '4219 Santa Monica Blvd, Los Angeles, CA 90029');
   assert.equal(analyzed.location, '34.0912127, -118.2840632');


### PR DESCRIPTION
Fix wave 3 from the audited 2026-08-11 full-run evidence (runs 20260811-134734 Dallas Eagle, 20260811-132205 massive.club, 20260811-133948 bearracuda). Four defects, each with mechanism, evidence, and fail-on-main proof below. **No new runtime files** — all changes live in `scripts/shared-core.js`, `scripts/parsers/ai-web-parser.js`, and the two enumerated test files.

## 1. Weekly cadence defeated by skipped weeks (GEAR NIGHT)

**Evidence:** run 20260811-134734 — GEAR NIGHT observed Saturdays Aug 15, 22, Sep 5, 12, 19, Oct 3 (gaps 7,14,7,7,14) on renumbered MEC slugs gear-night-5/7/11/17/19/22. `deriveCadenceRrule` required ≥3 CONSECUTIVE 7-day gaps; the longest run here is 2 → no rrule, no `_cadenceGroup`, no fold → six separate records survived to write plans (Underwear/Karaoke/Motley Clue folded fine).

**Mechanism:** additional fail-closed acceptance in `deriveCadenceRrule` (the existing consecutive-run path is untouched): emit WEEKLY when all observations share a weekday AND every gap is a positive multiple of 7 AND ≥3 gaps are exactly 7 days. Two observations 14 apart still refuse (zero 7-gaps); all-14-day biweekly still refuses; a non-multiple-of-7 gap refuses (it cannot even coexist with the same-weekday gate, but the guard is explicit).

## 2. Same-series records with per-record DJ suffixes never group (Discipline Corps)

**Evidence:** same run — "Discipline Corps Bar Night with DJ Philip Webb" (Fri Sep 11) + "…with DJ Blaine" (Fri Oct 9), a genuine 2nd-Friday monthly pair, stayed two singletons: no bare-title anchor, and containment similarity fails both directions.

**Mechanism (three coordinated pieces):**
- `stripGuestPerformerSuffix` + `areShapeNamesSimilarIgnoringGuestSuffix` in the ai-web parser: a conservative end-of-title `with/w\// feat./featuring + DJ/VJ + name` strip, consulted ONLY by the cadence-grouping pass (an OR alongside `areIdentityNamesSimilar`; venue-identity requirements unchanged). It never touches general dedup — lookalike-pairs doctrine intact, and only pairs where a suffix was actually stripped get the second comparison.
- Refinement-agreement in `applyDerivedCadenceStamps`: both pages state bare `FREQ=MONTHLY` (MEC "Monthly" text); the derived `FREQ=MONTHLY;BYDAY=2FR` starts with `stated + ";"` → agreement, not conflict. Stated rules are still NEVER overridden (they are excluded from stamping); a stated rule with differing detail (`BYDAY=3FR`) still fails the whole group closed.
- Series collapse in `deduplicateEvents`: a SHARED `_cadenceGroup` marker now substitutes for the full-title name re-check (the marker was minted this run only after the grouping pass proved names+venue — re-checking the full titles vetoed exactly what it proved). No shared marker → plain name check stands; the positive different-place veto applies in all cases; the same-`_cadenceGroup`-marker requirement in shared-core stays (fail-closed doctrine unchanged).

**Replay:** the 8 real Dallas records (6 GEAR NIGHT + 2 Discipline) through stamps→dedup now yield 2 records (earliest occurrence kept each, `FREQ=WEEKLY;BYDAY=SA` derived / stated `FREQ=MONTHLY` kept) and 0 calendar writes — series stay withheld to the ICS export path (the scraper never writes series).

## 3. Stale multi-event roundup tile became a calendar event (THIS WEEK AT MASSIVE)

**Evidence:** run 20260811-132205 — an Instagram weekly-lineup graphic listing MON–SAT Oct 6–11 2025 parties extracted as a 5-day umbrella dated ~10 months past and proposed as a calendar CREATE (`this-week-at-massive|2025-10-07|massive`, `_action: new`, `_sanityFlags: []`). It slipped every bound: 5d < 10d duration, 308d < 370d long-past, bear keyword inside the lineup text.

**Mechanism:**
- **(a) enforced, flag-don't-drop:** new `isEventSpanFullyPast` (start AND end both elapsed; missing/unparseable dates fail closed to "not past") drives a new `span-fully-past` sanity flag (rides the existing `_sanityFlags` card surface) and a separate `_pastSpanWithheld` stamp in `buildAnalyzedCalendarEvent` with a new `⏳ PAST SPAN:` log line; `filterEventsForExecution` gates the stamp exactly like the recurring-series withhold. The card stays in results; only the write is withheld. Objective by construction: span fully past = nothing left to attend; legitimate umbrellas are future-dated (asserted). Ongoing events (started, not ended) are untouched.
- **(b) report-only:** new `reportProbableRoundupTiles` (ai-web parser, called from the same post-crawl seam as `applyDerivedCadenceStamps`, injected — shared-core stays platform-pure): a multi-day (≥2d) umbrella whose own text contains ≥3 other DISTINCT dated records' titles (normalized, ≥8 chars so venue names/generic words never count) logs a new `📰 ROUNDUP:` line. No behavior change this wave, no title-phrase blocklists. On the real run only 2 lineup parties (Butt Blast, Bearracuda) were separately extracted → the tell stays silent there; the test proves both the fail-closed silence at 2 and the fire at 3.

**Note for review:** (a) withholds ALL fully-past-span writes, including merge-shaped updates to already-saved past records. This intersects with `allowPastEvents` (which keeps past events in results so the site reads full — those cards all remain; they just no longer generate calendar writes). Two pre-existing sanity tests were updated for the new flag, and four time-rotted fixtures (dated Aug 7–9 2026, now past) were moved to future dates so they keep testing what they always tested.

## 4. Cross-parser duplicate keys never reconcile (Treasure Trail)

**Evidence:** one real event (2026-08-16, Massive, Seattle) carries `treasure-trail|2026-08-16|massive` (massive.club) and `treasure-trail-seattle|2026-08-16|massive` (bearracuda). **Why the matcher misses:** `findEventByKey` can never reconcile different slugs; the "Similar event found" path requires start times equal within ONE minute (`areDatesEqual(…, 1)`); the `place-time-name` identity signal caps at 120 minutes. In the captured runs both sources happened to state 04:00Z and merged ("Similar event found" / "Key match found") — whenever the stated clock times drift beyond those windows (doors vs headline time, midnight-default degradation), the same night is written twice and the two keys ping-pong on the saved record (the 132205 merge log shows `key` in the clobbered-fields list).

**Mechanism:** new `getCalendarTitleSubsetSignal` in shared-core — the calendar-side sibling of the within-run `getCrossSourceDuplicateSignal`, consulted by `analyzeEventAction` after the stronger signals (identifier/key/1-min/identity) and before the 60-min overlap check. Fail-closed on every axis: EXACT same local day via the identity shapes (which read a calendar record's timezone/bar from notes and coordinates from `location`); POSITIVE venue identity via `areIdentityPlacesSimilar`; total title token-subset via the existing `getCrossSourceTitleTokens` (performer clauses cut, city + venue tokens dropped). Different days never match (the lookalike-pairs doctrine is about date fabrication — crossing days); unrelated titles sharing one token never match (subset must be total); no venue evidence → no match. Tests assert both directions (bare↔suffixed) and all three negatives.

## Verification

- Quiet suite green on the branch: `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test` → **1690 pass / 0 fail** (was 1683 on main; +7 new test blocks).
- **Fail-on-main proof:** copying only the two test files onto a pristine `origin/main` worktree (6d55930c) and running them yields exactly 9 failures — the 7 NEW test blocks (Gear Night rrule vector; six-record GEAR NIGHT stamp; Discipline grouping + negative; roundup tell; Treasure Trail reconciliation + fail-closed guards; Discipline series-collapse fold; fully-past-span withhold) plus the 2 UPDATED sanity tests whose expectations now include `span-fully-past`. All test vectors are built from the REAL records in the run JSONs (20260811-134734, 20260811-132205, 20260811-133948).
- Replay check: the 8 real Dallas records through `applyDerivedCadenceStamps` → `deduplicateEvents` → `filterEventsForExecution` = 2 kept series records, 0 calendar writes.
- Constraints held: no `new URL`/`URLSearchParams` under scripts/; shared-core/normalizers platform-pure (parser hooks injected); zero existing console.log strings or AI prompt lines edited (additions only — verified via diff of removed lines); nothing hardcoded per venue/promoter/city/domain (real names appear only in test fixtures); series collapse stays fail-closed on the `_cadenceGroup` marker; the roundup tell is report-only before any enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP