### PR TITLE
fix(images): site-default og:image must not enter orientation slots

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -17336,6 +17336,13 @@ TEXT:
             // Without this a rejected `image` could walk straight back in as an
             // orientation slot, because `image` is a slot candidate itself.
             if (this.getNonEventImageOcrReason(candidate.url, htmlData)) continue;
+            // …and neither is the site's default social card. The og:image
+            // fill refuses these (getSiteDefaultMetaImageReason), but page-meta
+            // candidates also arrive here directly, so without the same check
+            // a refused og-default walks into a slot anyway (local run
+            // 2026-08-12: Leipzig Bear Weekend's image was correctly refused
+            // yet imageHorizontal still got thebearcalendar.com/og-default.png).
+            if (this.getSiteDefaultMetaImageReason(candidate.url, htmlData)) continue;
             const orientation = this.resolveImageCandidateOrientation(candidate);
             if (orientation !== 'portrait' && orientation !== 'landscape') continue;
             const incumbent = bySlot[orientation];

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -9500,6 +9500,26 @@ test('image slots: og:image:width / og:image:height are parsed and drive orienta
   assert.equal(event.imageHorizontal, undefined);
 });
 
+test('image slots: a site-default og:image (og-default basename) never lands in a slot', () => {
+  // Local run 2026-08-12: fillImageFromPageMetaArtwork correctly REFUSED
+  // thebearcalendar.com/og-default.png for "Leipzig Bear Weekend", but the
+  // slot pass consumes page-meta candidates directly and assigned the same
+  // refused URL to imageHorizontal anyway. The slot loop must apply the same
+  // site-default tell (getSiteDefaultMetaImageReason) the fill uses.
+  const parser = createParser();
+  const html = `
+    <html><head>
+      <meta property="og:image" content="https://aggregator.example/og-default.png" />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+    </head><body></body></html>`;
+
+  const event = { title: 'Leipzig Bear Weekend' };
+  parser.applyImageSlots(event, { url: 'https://aggregator.example/events/leipzig/', html });
+  assert.equal(event.imageHorizontal, undefined, 'site-default social card must not fill the landscape slot');
+  assert.equal(event.imageVertical, undefined);
+});
+
 test('image slots: two og:image tags on one page are BOTH considered', () => {
   const parser = createParser();
   const html = `


### PR DESCRIPTION
Follow-up to #1660, caught by a local verification run (not by the phone runs).

**Bug:** `fillImageFromPageMetaArtwork` correctly refused `thebearcalendar.com/og-default.png` for "Leipzig Bear Weekend" (`Refused page og:image … site-default social-card convention`), but `applyImageSlots` consumes page-meta candidates directly and applied no such check — the very next log line assigned the refused URL to `imageHorizontal`. The event shipped with `image: null` but `imageHorizontal: og-default.png`.

**Fix:** the slot loop now consults `getSiteDefaultMetaImageReason` alongside its existing OCR-furniture (`getNonEventImageOcrReason`) and uninteresting-URL gates — same tell, same fail-open semantics for unknowns.

**Tests:** new slot test with an `og-default.png` page-meta candidate (fails on main: assigned to `imageHorizontal`; passes with fix). Full quiet suite 1715/1715. No existing log lines or prompts touched; no new runtime files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP