### PR TITLE
feat(results-ui): skimmable cards + sectioned pile (wave 6)

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -6296,50 +6296,100 @@ class ScriptableAdapter {
     const newVenueSectionHtml =
       await this.generateNewVenueCandidateSection(results);
 
+    // Per-run image reuse census for the venue-placeholder badge: the same
+    // image URL on 3+ cards in one run is a venue's generic tile (e.g. Eagle
+    // LA's MORE-INFO-Coming-Soon poster on 11 events), not any event's own
+    // artwork. Pure URL counting across kept AND dropped cards — the tile
+    // does not care which side of the bear check an event landed on — and no
+    // filename/domain matching, ever. generateEventCard feature-detects the
+    // map, so standalone card renders (tests, other callers) badge nothing.
+    const imageUseCounts = new Map();
+    const countImageUse = (candidate) => {
+      const url =
+        candidate && typeof candidate.image === "string"
+          ? candidate.image.trim()
+          : "";
+      if (!url) return;
+      imageUseCounts.set(url, (imageUseCounts.get(url) || 0) + 1);
+    };
+    allEvents.forEach(countImageUse);
+    (Array.isArray(results.bearDroppedEvents)
+      ? results.bearDroppedEvents
+      : []
+    ).forEach((entry) => countImageUse(entry && entry.event));
+    this._repeatedImageCounts = imageUseCounts;
+    const repeatedImageUrls = [...imageUseCounts].filter(
+      ([, count]) => count >= 3,
+    );
+    if (repeatedImageUrls.length > 0) {
+      console.log(
+        `📱 Scriptable: 🖼️ ${repeatedImageUrls.length} image URL(s) appear on 3+ cards this run — badged as venue placeholder: ${repeatedImageUrls
+          .map(([url, count]) => `${count}x ${url}`)
+          .join(", ")}`,
+      );
+    }
+
     // Group events by intent actions (intent can differ from write action for overrides).
     // Each entry keeps its index into allEvents — which IS the index into
     // results.analyzedEvents (getAllEventsFromResults preserves order) — so a
     // card's bear-verdict buttons address the right event over the bridge.
+    // Wave 6 splits two more piles out of the actionable sections so records
+    // the run will NOT write stop reading as actionable bugs:
+    //   saved    — already in the calendar (series match / merge no-op)
+    //   withheld — visible but never written (recurring export / span fully
+    //              past / junk title), reason chip on the card headline
     const newEvents = [];
     const mergeEvents = [];
     const conflictEvents = [];
+    const savedEvents = [];
+    const withheldEvents = [];
 
     allEvents.forEach((event, index) => {
       const entry = { event, index };
-      switch (this.normalizeIntentAction(event)) {
-        case "new":
-          newEvents.push(entry);
-          break;
-        case "merge":
-          mergeEvents.push(entry);
-          break;
-        // A series-matched (already saved, withheld) event matched an
-        // existing record — its card belongs with the matches, never in the
-        // New section whose framing is what re-offered saved series.
-        case "series_match":
-          mergeEvents.push(entry);
-          break;
-        case "conflict":
-        case "missing_calendar":
-          conflictEvents.push(entry);
-          break;
-        default:
-          // Fallback for events without analysis
-          newEvents.push(entry);
-          break;
+      const intent = this.normalizeIntentAction(event);
+      // Conflicts stay in the review pile whatever else is true of them —
+      // requiring review outranks the saved/withheld shelves.
+      if (intent === "conflict" || intent === "missing_calendar") {
+        conflictEvents.push(entry);
+        return;
       }
+      const placement = this.classifyEventForResultsSection(event);
+      if (placement.section === "saved") {
+        // A series-matched event matched an existing record — its card
+        // belongs with the already-saved pile, never in the New section
+        // whose framing is what re-offered saved series.
+        savedEvents.push({ ...entry, sectionReason: placement.reason });
+        return;
+      }
+      if (placement.section === "withheld") {
+        withheldEvents.push({ ...entry, sectionReason: placement.reason });
+        return;
+      }
+      if (intent === "merge") {
+        mergeEvents.push(entry);
+        return;
+      }
+      // "new" and the no-analysis fallback both land in the New pile.
+      newEvents.push(entry);
     });
 
     // Kept events are, by definition, the cascade's "bear" verdicts: their
     // cards show that verdict active with a one-tap "Mark as not bear" beside
     // it. Saved-run display renders the verdict read-only (no execution).
     const keptCardsInteractive = results?._isDisplayingSavedRun !== true;
-    const keptCard = (entry) =>
-      this.generateEventCard(entry.event, provenanceRunInfo, {
+    const keptCard = (entry) => {
+      // Duplicate-folding stamp (feature-detected, never required): a record
+      // an upstream pass marked as the duplicate of a kept card renders as a
+      // one-liner pointing at the kept card, not as a second full card.
+      const foldedLine = this.buildDuplicateFoldedLineHtml(entry.event);
+      if (foldedLine) return foldedLine;
+      return this.generateEventCard(entry.event, provenanceRunInfo, {
         bearIdx: `k${entry.index}`,
         bearVerdict: "bear",
         interactive: keptCardsInteractive,
+        sectionReason: entry.sectionReason || "",
       });
+    };
 
     // Every card is built EXACTLY ONCE, up front, and the page template below
     // only ever slices these arrays. generateEventCard is not a pure function
@@ -6350,6 +6400,8 @@ class ScriptableAdapter {
     const newCards = newEvents.map(keptCard);
     const mergeCards = mergeEvents.map(keptCard);
     const conflictCards = conflictEvents.map(keptCard);
+    const savedCards = savedEvents.map(keptCard);
+    const withheldCards = withheldEvents.map(keptCard);
     const droppedCards = this.buildBearDroppedCards(results);
     // Same rule for the non-card sections: hoisted out of the template so
     // they are generated once and reused verbatim on every page.
@@ -6710,6 +6762,107 @@ class ScriptableAdapter {
            events; the accent stripe is the only visual difference. */
         .event-card.bear-dropped-card {
             border-left: 4px solid var(--secondary-color);
+        }
+
+        /* Wave 6 — skimmable headline + collapsed per-card detail expander. */
+        .event-headline {
+            margin-bottom: 8px;
+        }
+
+        .event-headline-badges {
+            margin-bottom: 6px;
+        }
+
+        .event-headline-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px 16px;
+            font-size: 14px;
+            color: var(--text-primary);
+            margin-top: 6px;
+        }
+
+        .headline-reason-chip {
+            display: inline-block;
+            font-size: 11px;
+            font-weight: 600;
+            padding: 3px 8px;
+            border-radius: 10px;
+            margin: 2px;
+            background: var(--background-light);
+            color: var(--text-secondary);
+            border: 1px solid var(--border-color);
+        }
+
+        .event-card-details > summary {
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--primary-color);
+            padding: 6px 0;
+            -webkit-user-select: none;
+            user-select: none;
+        }
+
+        .duplicate-folded-line {
+            font-size: 12px;
+            color: var(--text-secondary);
+            padding: 6px 12px;
+            margin-bottom: 8px;
+            border-left: 3px solid var(--border-color);
+            background: var(--background-light);
+            border-radius: 6px;
+        }
+
+        .section-blurb {
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-bottom: 12px;
+        }
+
+        /* Collapsed dropped pile: the summary row doubles as the section
+           header, chevron on the right so the count chip stays put. */
+        .bear-dropped-details > summary {
+            display: flex;
+            align-items: center;
+            cursor: pointer;
+            padding-bottom: 15px;
+            border-bottom: 2px solid var(--border-color);
+            margin-bottom: 20px;
+            list-style: none;
+        }
+
+        .bear-dropped-details > summary::-webkit-details-marker {
+            display: none;
+        }
+
+        .bear-dropped-details > summary::after {
+            content: "▸";
+            margin-left: 8px;
+            color: var(--text-secondary);
+        }
+
+        .bear-dropped-details[open] > summary::after {
+            content: "▾";
+        }
+
+        .bear-dropped-hint {
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-left: 10px;
+        }
+
+        /* Venue placeholder tile: greyed, badged, still viewable in full. */
+        .venue-placeholder-image .image-container img {
+            filter: grayscale(1);
+            opacity: 0.5;
+        }
+
+        .venue-placeholder-badge {
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--text-secondary);
+            margin-bottom: 4px;
         }
 
         /* Bear verdict row: both directions on every card, active one filled. */
@@ -7803,7 +7956,39 @@ class ScriptableAdapter {
     `
         : ""
     }
-    
+
+    ${
+      view.savedCards.length > 0
+        ? `
+    <div class="section">
+        <div class="section-header">
+            <span class="section-icon">✅</span>
+            <span class="section-title">Already Saved (No Action)</span>
+            <span class="section-count">${view.savedCountLabel}</span>
+        </div>
+        <div class="section-blurb">These matched what the calendar already has — a saved series, or a merge with nothing new to add. Nothing will be written.</div>
+        ${view.savedCards.join("")}
+    </div>
+    `
+        : ""
+    }
+
+    ${
+      view.withheldCards.length > 0
+        ? `
+    <div class="section">
+        <div class="section-header">
+            <span class="section-icon">⏸️</span>
+            <span class="section-title">Withheld (Not Written)</span>
+            <span class="section-count">${view.withheldCountLabel}</span>
+        </div>
+        <div class="section-blurb">Kept visible but never written this run — each card's headline chip says why (recurring series save via ICS, span fully past, junk title).</div>
+        ${view.withheldCards.join("")}
+    </div>
+    `
+        : ""
+    }
+
     ${
       results.errors && results.errors.length > 0
         ? `
@@ -8544,6 +8729,8 @@ class ScriptableAdapter {
       ...newCards.map((html) => ({ group: "new", html })),
       ...mergeCards.map((html) => ({ group: "merge", html })),
       ...conflictCards.map((html) => ({ group: "conflict", html })),
+      ...savedCards.map((html) => ({ group: "saved", html })),
+      ...withheldCards.map((html) => ({ group: "withheld", html })),
       ...droppedCards.map((html) => ({ group: "dropped", html })),
     ];
     const fullView = {
@@ -8552,9 +8739,13 @@ class ScriptableAdapter {
       newCards,
       mergeCards,
       conflictCards,
+      savedCards,
+      withheldCards,
       newCountLabel: newEvents.length,
       mergeCountLabel: mergeEvents.length,
       conflictCountLabel: conflictEvents.length,
+      savedCountLabel: savedEvents.length,
+      withheldCountLabel: withheldEvents.length,
       droppedSectionHtml: droppedCards.length
         ? this.buildBearDroppedSectionHtml(
             droppedCards,
@@ -8594,6 +8785,8 @@ class ScriptableAdapter {
     const pageNewCards = take("new");
     const pageMergeCards = take("merge");
     const pageConflictCards = take("conflict");
+    const pageSavedCards = take("saved");
+    const pageWithheldCards = take("withheld");
     const pageDroppedCards = take("dropped");
     const label = (shown, total) =>
       shown === total ? total : `${shown} of ${total}`;
@@ -8609,9 +8802,16 @@ class ScriptableAdapter {
       newCards: pageNewCards,
       mergeCards: pageMergeCards,
       conflictCards: pageConflictCards,
+      savedCards: pageSavedCards,
+      withheldCards: pageWithheldCards,
       newCountLabel: label(pageNewCards.length, newEvents.length),
       mergeCountLabel: label(pageMergeCards.length, mergeEvents.length),
       conflictCountLabel: label(pageConflictCards.length, conflictEvents.length),
+      savedCountLabel: label(pageSavedCards.length, savedEvents.length),
+      withheldCountLabel: label(
+        pageWithheldCards.length,
+        withheldEvents.length,
+      ),
       droppedSectionHtml: pageDroppedCards.length
         ? this.buildBearDroppedSectionHtml(
             pageDroppedCards,
@@ -10092,6 +10292,13 @@ class ScriptableAdapter {
               startDate: entry.startDate,
               bar: entry.venue,
             };
+        // Duplicate-folding stamp (feature-detected on the entry or its
+        // nested event, wherever the folding pass put it): render the
+        // one-liner instead of a full duplicate card.
+        const foldedLine = this.buildDuplicateFoldedLineHtml(
+          entry._duplicateOfKept ? entry : event,
+        );
+        if (foldedLine) return foldedLine;
         // Two rescue flags, one treatment: `rescued` (a calendar manual-bear
         // record pre-empted the drop) and `manuallyMarkedBear` (the owner
         // rescued it during the run via the verdict buttons — saved runs
@@ -10120,18 +10327,49 @@ class ScriptableAdapter {
       .filter((card) => typeof card === "string" && card.length > 0);
   }
 
+  // Duplicate-folding one-liner. `_duplicateOfKept` is stamped by the
+  // duplicate-folding pass when a record is the same real-world event as a
+  // card the run already keeps; a second full card would only re-present
+  // information the kept card carries. Feature-detected: the stamp may be
+  // absent from every run this code ever sees (older runs, the stamp's
+  // branch unmerged) and then this returns null and the caller renders the
+  // normal full card. The stamp is accepted as a string (kept title/key) or
+  // an object carrying title/key — no schema dependency either way.
+  buildDuplicateFoldedLineHtml(record) {
+    const stamp = record && record._duplicateOfKept;
+    if (!stamp) return null;
+    const keptLabel =
+      typeof stamp === "string"
+        ? stamp
+        : (stamp && typeof stamp === "object" && (stamp.title || stamp.key)) ||
+          "";
+    const title = (record && (record.title || record.name)) || "Unknown";
+    return `<div class="duplicate-folded-line">↩︎ "${this.escapeHtml(
+      title,
+    )}" — duplicate of ${
+      keptLabel ? `"${this.escapeHtml(String(keptLabel))}"` : "a kept event"
+    }, folded into the kept card</div>`;
+  }
+
   // `countLabel` is what the section-count chip shows: the plain total on a
   // one-page render (unchanged), "n of N" once the cards are spread out.
+  // The whole pile is COLLAPSED by default (wave 6): drops are review
+  // surface, not part of the write plan, and 17 of them above the fold made
+  // a healthy run read as a pile of bugs. The <details> keeps every card —
+  // and its mark-bear rescue buttons — one tap away.
   buildBearDroppedSectionHtml(cards, countLabel) {
     return `
-    <div class="section">
-        <div class="section-header">
-            <span class="section-icon">🚫</span>
-            <span class="section-title">Dropped as non-bear</span>
-            <span class="section-count">${countLabel}</span>
-        </div>
-        <div style="font-size:12px; color:var(--text-secondary); margin-bottom:12px;">These events were filtered out by the bear check and will NOT be written. Tap "Mark as bear" to pull one back into this run's write plan — the verdict sticks on the calendar record for future scrapes.</div>
-        ${cards.join("")}
+    <div class="section bear-dropped-section">
+        <details class="bear-dropped-details">
+            <summary class="bear-dropped-summary">
+                <span class="section-icon">🚫</span>
+                <span class="section-title">Dropped as non-bear</span>
+                <span class="section-count">${countLabel}</span>
+                <span class="bear-dropped-hint">collapsed — tap to review</span>
+            </summary>
+            <div style="font-size:12px; color:var(--text-secondary); margin-bottom:12px;">These events were filtered out by the bear check and will NOT be written. Tap "Mark as bear" to pull one back into this run's write plan — the verdict sticks on the calendar record for future scrapes.</div>
+            ${cards.join("")}
+        </details>
     </div>
     `;
   }
@@ -10811,13 +11049,63 @@ class ScriptableAdapter {
     // Event Builder prefill link (every card) + ICS export (recurring cards).
     const eventActionsRow = this.buildEventCardActionsHtml(event);
 
+    // ----- Skimmable headline (wave 6) -----------------------------------
+    // The always-visible face of the card: badges, title, 📅 date (with the
+    // end DATE when it falls on a different day) and 📍 venue. Everything
+    // else the card used to show up front — field tables, merge provenance,
+    // notes preview, debug JSON — moves into the collapsed
+    // <details class="event-card-details"> expander below. Relocated, never
+    // removed: the expander contains the card body byte-for-byte.
+    const headlineDate = `${dateStr} ${timeStr}${
+      endDateStr
+        ? ` - ${endDateStr} ${endTimeStr}`
+        : endTimeStr
+          ? ` - ${endTimeStr}`
+          : ""
+    }`;
+    const headlineVenue = event.venue || event.bar || "";
+    // Reason chip ON the headline: a card that will not be written says why
+    // without expanding. Dropped cards reuse the bear-check reason; withheld
+    // and already-saved cards get the section reason passed in by the pile
+    // classifier (sectionReason is '' for plain actionable cards).
+    const headlineReason = isDroppedCard
+      ? dropDetail
+      : bearOpts.sectionReason
+        ? String(bearOpts.sectionReason)
+        : "";
+    const headlineReasonChip = headlineReason
+      ? `<span class="headline-reason-chip">${this.escapeHtml(headlineReason)}</span>`
+      : "";
+    // Repeated-image badge: generateRichHTML censuses image URLs across the
+    // whole run; the same URL on 3+ cards is a venue placeholder tile, not
+    // this event's artwork. Feature-detected — standalone card renders (no
+    // census map) badge nothing. Generic counting only, no filename/domain
+    // matching.
+    const repeatedImageCount =
+      this._repeatedImageCounts instanceof Map &&
+      typeof event.image === "string"
+        ? this._repeatedImageCounts.get(event.image.trim()) || 0
+        : 0;
+    const isRepeatedImage = repeatedImageCount >= 3;
+
     let html = `
         <div class="event-card${isDroppedCard ? " bear-dropped-card" : ""}">
-            ${actionBadge}${recurringBadge}${seriesMatchBadge}${sanityBadge}${overrideBadge}${seriesProposalBadge}
-            ${actionNote}${cadenceHintNote}
-            <div class="event-title">${this.escapeHtml(event.title || event.name)}</div>
+            <div class="event-headline">
+                <div class="event-headline-badges">${actionBadge}${recurringBadge}${seriesMatchBadge}${sanityBadge}${overrideBadge}${seriesProposalBadge}${headlineReasonChip}</div>
+                <div class="event-title">${this.escapeHtml(event.title || event.name)}</div>
+                <div class="event-headline-meta">
+                    <span class="event-headline-date">📅 ${headlineDate}</span>
+                    ${
+                      headlineVenue
+                        ? `<span class="event-headline-venue">📍 ${this.escapeHtml(headlineVenue)}</span>`
+                        : ""
+                    }
+                </div>
+            </div>
             ${bearVerdictRow}
-            
+            <details class="event-card-details">
+            <summary class="event-card-details-summary">Details</summary>
+            ${actionNote}${cadenceHintNote}
             <!-- Main Event Info -->
             <div class="event-details">
                 ${
@@ -10900,7 +11188,12 @@ class ScriptableAdapter {
                 ${
                   event.image
                     ? `
-                    <div class=\"event-image\">
+                    <div class=\"event-image${isRepeatedImage ? " venue-placeholder-image" : ""}\">
+                        ${
+                          isRepeatedImage
+                            ? `<div class=\"venue-placeholder-badge\">🖼️ venue placeholder image — same image on ${repeatedImageCount} events this run</div>`
+                            : ""
+                        }
                         <a href=\"${this.escapeHtml(event.image)}\" target=\"_blank\" rel=\"noopener\" style=\"color: var(--primary-color); font-weight: 500;\">View Full Image</a>
                         <div class=\"image-container\" style=\"margin-top: 8px; display: block;\">
                             <img src=\"${this.escapeHtml(event.image)}\" alt=\"Event Image\" onerror=\"this.style.display='none'\">
@@ -11210,6 +11503,7 @@ class ScriptableAdapter {
                     </button>
                 </div>
             </div>
+            </details>
         </div>
         `;
 
@@ -13213,11 +13507,54 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         return false;
       };
 
+      // The merge pipeline records WHY each contested field resolved the way
+      // it did (_mergeDecisions: deterministic rung 🔒 / calendar stickiness
+      // 🧊 / AI arbitration 🤝 / clobber fallback). When this field carries a
+      // record, the row says so in plain words — source AND outcome — instead
+      // of leaving the reader to reverse-engineer it from two value cells and
+      // a bare strategy name. The strategy-heuristic chain below stays as the
+      // fallback for fields (and older saved runs) with no record.
+      const decisionRecord = Array.isArray(event._mergeDecisions)
+        ? event._mergeDecisions.find(
+            (record) => record && record.field === field,
+          )
+        : null;
+
       // Determine flow direction and result
       let flowIcon = "";
       let resultText = "";
 
-      if (!existingValue && newValue) {
+      if (decisionRecord) {
+        const keptExisting = mergeValuesLookIdentical(
+          decisionRecord.chosenValue,
+          existingValue,
+        );
+        const tookNew =
+          !keptExisting &&
+          mergeValuesLookIdentical(decisionRecord.chosenValue, newValue);
+        const outcome = keptExisting
+          ? "kept existing"
+          : tookNew
+            ? "took new"
+            : "rewrote";
+        const reason = decisionRecord.reason
+          ? ` — ${this.escapeHtml(String(decisionRecord.reason))}`
+          : "";
+        const source = String(decisionRecord.source || "").toLowerCase();
+        flowIcon = keptExisting ? "←" : "→";
+        if (source === "deterministic") {
+          resultText = `<span style="color: #007aff;">🔒 DETERMINISTIC — ${outcome}${reason}</span>`;
+        } else if (source === "sticky") {
+          flowIcon = "←";
+          resultText = `<span style="color: #007aff;">🧊 KEPT EXISTING (calendar stickiness)${reason}</span>`;
+        } else if (source === "ai") {
+          resultText = `<span style="color: #34c759;">🤝 AI — ${keptExisting ? "chose existing" : "chose new"}${reason}</span>`;
+        } else if (source === "fallback") {
+          resultText = `<span style="color: #ff9500;">⚠️ NO AI ANSWER — ${outcome} (clobber fallback)${reason}</span>`;
+        } else {
+          resultText = `<span style="color: #999;">${this.escapeHtml(source || "resolved")} — ${outcome}${reason}</span>`;
+        }
+      } else if (!existingValue && newValue) {
         // New field being added
         flowIcon = "→";
         resultText = '<span style="color: #34c759;">ADDED</span>';
@@ -13248,7 +13585,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
           resultText = '<span style="color: #ff9500;">CLEARED</span>';
         } else {
           flowIcon = "—";
-          resultText = '<span style="color: #999;">NO CHANGE</span>';
+          resultText = '<span style="color: #999;">KEPT EXISTING (no change)</span>';
         }
       } else if (strategy === "clobber") {
         // Clobber strategy - should always use new value (even if empty)
@@ -13322,15 +13659,15 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       } else if (wasUsed === "existing") {
         // Merge strategy explicitly chose existing value
         flowIcon = "←";
-        resultText = '<span style="color: #007aff;">EXISTING</span>';
+        resultText = '<span style="color: #007aff;">KEPT EXISTING</span>';
       } else if (finalValue === newValue) {
         // Replaced with new value
         flowIcon = "→";
-        resultText = '<span style="color: #ff9500;">NEW</span>';
+        resultText = '<span style="color: #ff9500;">TOOK NEW</span>';
       } else if (finalValue === existingValue && existingValue !== newValue) {
         // Preserved existing value when values differ
         flowIcon = "←";
-        resultText = '<span style="color: #007aff;">EXISTING</span>';
+        resultText = '<span style="color: #007aff;">KEPT EXISTING</span>';
       } else if (
         finalValue &&
         finalValue !== existingValue &&
@@ -13341,11 +13678,21 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         resultText = '<span style="color: #32d74b;">MERGED</span>';
       } else {
         flowIcon = "—";
-        resultText = '<span style="color: #999;">NO CHANGE</span>';
+        resultText = '<span style="color: #999;">KEPT EXISTING (no change)</span>';
       }
 
+      // Plain-words strategy label: "ai" under a field name read as a
+      // mystery token (owner pasted a `website ai … NO CHANGE` row as the
+      // example of the confusion). Unknown strategies fall through verbatim.
+      const strategyLabel =
+        {
+          ai: "AI-arbitrated",
+          preserve: "preserve saved",
+          clobber: "fresh wins",
+        }[strategy] || strategy;
+
       rows.push(
-        `<tr><td class="cmp-field"><strong>${field}</strong><br><small>${strategy}</small></td>` +
+        `<tr><td class="cmp-field"><strong>${field}</strong><br><small>${strategyLabel}</small></td>` +
           `<td>${formatValue(existingValue, diffAnchor)}</td>` +
           `<td class="cmp-flow">${flowIcon}</td>` +
           `<td>${formatValue(newValue, diffAnchor)}</td>` +
@@ -13923,6 +14270,57 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     if (action === "key_conflict" || action === "time_conflict")
       return "conflict";
     return action;
+  }
+
+  // Which results-sheet pile a kept event belongs to (wave 6). DISPLAY ONLY:
+  // the real execution gate stays SharedCore.filterEventsForExecution — this
+  // helper only decides where the card sits and what its headline reason
+  // chip says, so already-saved and withheld records stop reading as
+  // actionable bugs. Returns { section: 'actionable'|'saved'|'withheld',
+  // reason } where reason is the headline chip text ('' for actionable).
+  // Order matters: a matched series is reported as already saved (the honest
+  // terminal state) even though it is also a withheld recurring export.
+  classifyEventForResultsSection(event) {
+    if (!event || typeof event !== "object") {
+      return { section: "actionable", reason: "" };
+    }
+    if (event._seriesMatch) {
+      return {
+        section: "saved",
+        reason: "🔁 already saved — matches this series",
+      };
+    }
+    if (
+      this.normalizeIntentAction(event) === "merge" &&
+      Array.isArray(event._changes) &&
+      event._changes.length === 0
+    ) {
+      return {
+        section: "saved",
+        reason: "✅ merge no-op — calendar already has all of this",
+      };
+    }
+    // The withheld reasons below mirror filterEventsForExecution's
+    // predicates one-for-one, so the pile and the gate can never disagree.
+    if (event._pastSpanWithheld === true) {
+      return {
+        section: "withheld",
+        reason: "⏳ span fully past — nothing left to attend",
+      };
+    }
+    if (SharedCore.hasJunkTitleSanityFlag(event)) {
+      return {
+        section: "withheld",
+        reason: "🚫 junk title — write withheld",
+      };
+    }
+    if (SharedCore.isRecurringSeriesEvent(event)) {
+      return {
+        section: "withheld",
+        reason: "🔁 recurring — save via ICS, never auto-written",
+      };
+    }
+    return { section: "actionable", reason: "" };
   }
 
   getWriteActionFromEvent(event) {

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -7837,3 +7837,452 @@ test('junk-title flagged events surface Write: withheld instead of promising a C
   assert.ok(html.includes('sanity-flag-badge'));
   assert.ok(html.includes('junk-title'));
 });
+
+// ---------------------------------------------------------------------------
+// Wave 6 — results-UI skimmability: sectioned pile, headline+expander cards,
+// collapsed dropped pile, repeated-image badge, plain merge-row labels.
+// ---------------------------------------------------------------------------
+
+// One event per pile plus a dropped entry, so section order and counts are
+// all observable in a single render.
+function buildWave6Results() {
+  return {
+    analyzedEvents: [
+      { title: 'Actionable New', _action: 'new', startDate: '2026-09-01T02:00:00.000Z' },
+      {
+        title: 'Actionable Merge',
+        _action: 'merge',
+        startDate: '2026-09-02T02:00:00.000Z',
+        _changes: ['image'],
+        _analysis: { reason: 'matched existing calendar event' }
+      },
+      {
+        title: 'Saved Series Match',
+        _action: 'merge',
+        startDate: '2026-09-03T02:00:00.000Z',
+        _seriesMatch: true
+      },
+      {
+        title: 'Saved Merge NoOp',
+        _action: 'merge',
+        startDate: '2026-09-04T02:00:00.000Z',
+        _changes: []
+      },
+      {
+        title: 'Withheld Recurring',
+        _action: 'new',
+        startDate: '2026-09-05T02:00:00.000Z',
+        recurrenceRule: 'FREQ=WEEKLY;BYDAY=FR'
+      },
+      {
+        title: 'Withheld Past Span',
+        _action: 'new',
+        startDate: '2026-01-05T02:00:00.000Z',
+        _pastSpanWithheld: true
+      },
+      {
+        title: 'View Event →',
+        _action: 'new',
+        startDate: '2026-09-06T02:00:00.000Z',
+        _sanityFlags: [{ code: 'junk-title', detail: 'title reads as link/CTA text' }]
+      }
+    ],
+    bearDroppedEvents: [
+      {
+        title: 'Trivia Night',
+        startDate: '2026-09-07T02:00:00.000Z',
+        venue: 'Some Bar',
+        reason: 'ai: no bear-specific language',
+        host: 'somebar.example',
+        event: { title: 'Trivia Night', startDate: '2026-09-07T02:00:00.000Z', bar: 'Some Bar' }
+      }
+    ],
+    errors: [],
+    parserResults: []
+  };
+}
+
+test('results sheet renders the skim piles in order with counts (live run)', async () => {
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML(buildWave6Results());
+
+  const order = [
+    'New Events to Add',
+    'Events to Merge (Adding Info)',
+    'Already Saved (No Action)',
+    'Withheld (Not Written)',
+    'Dropped as non-bear'
+  ];
+  const positions = order.map((title) => html.indexOf(title));
+  positions.forEach((pos, i) => {
+    assert.ok(pos !== -1, `section "${order[i]}" is present`);
+    if (i > 0) {
+      assert.ok(positions[i - 1] < pos, `"${order[i - 1]}" renders before "${order[i]}"`);
+    }
+  });
+
+  // Counts: 2 already-saved (series match + merge no-op), 3 withheld
+  // (recurring, past span, junk title), 1 dropped.
+  const savedSection = html.slice(html.indexOf('Already Saved (No Action)'), html.indexOf('Withheld (Not Written)'));
+  assert.ok(savedSection.includes('<span class="section-count">2</span>'), 'already-saved count chip says 2');
+  const withheldSection = html.slice(html.indexOf('Withheld (Not Written)'), html.indexOf('Dropped as non-bear'));
+  assert.ok(withheldSection.includes('<span class="section-count">3</span>'), 'withheld count chip says 3');
+
+  // The withheld/saved reasons ride the card headline as chips.
+  assert.ok(html.includes('🔁 already saved — matches this series'));
+  assert.ok(html.includes('✅ merge no-op — calendar already has all of this'));
+  assert.ok(html.includes('⏳ span fully past — nothing left to attend'));
+  assert.ok(html.includes('🚫 junk title — write withheld'));
+  assert.ok(html.includes('🔁 recurring — save via ICS, never auto-written'));
+
+  // The saved/withheld events left the actionable piles: New counts only the
+  // one actionable new event.
+  const newSection = html.slice(html.indexOf('New Events to Add'), html.indexOf('Events to Merge (Adding Info)'));
+  assert.ok(newSection.includes('<span class="section-count">1</span>'), 'New pile holds only the actionable event');
+});
+
+test('saved-run display renders the same skim piles (rehydration path)', async () => {
+  const adapter = buildAdapter();
+  adapter.loadRunLogsForDisplay = async () => ({ runId: '20260812-000000', exists: false });
+  const html = await adapter.generateRichHTML({
+    ...buildWave6Results(),
+    _isDisplayingSavedRun: true,
+    savedRunId: '20260812-000000'
+  });
+  for (const title of [
+    'New Events to Add',
+    'Already Saved (No Action)',
+    'Withheld (Not Written)',
+    'Dropped as non-bear'
+  ]) {
+    assert.ok(html.includes(title), `saved-run render has "${title}"`);
+  }
+  assert.ok(html.includes('⏳ span fully past — nothing left to attend'));
+  // Saved-run cards render verdicts read-only, but the buttons still exist.
+  assert.ok(html.includes('markBearOverride(this)'));
+});
+
+test('the dropped pile is collapsed by default and keeps the mark-bear rescue button', async () => {
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML(buildWave6Results());
+
+  const detailsIdx = html.indexOf('<details class="bear-dropped-details">');
+  assert.ok(detailsIdx !== -1, 'dropped section wraps its cards in a <details>');
+  assert.ok(!html.includes('<details class="bear-dropped-details" open'), 'the dropped <details> starts collapsed');
+
+  const droppedSection = html.slice(detailsIdx);
+  assert.ok(droppedSection.includes('data-bear-act="mark-bear"'), 'mark-bear rescue button rendered inside');
+  assert.ok(droppedSection.includes('🚫 DROPPED — NOT BEAR'), 'dropped card badge rendered inside');
+  // The bear-check reason is on the collapsed card headline, not buried.
+  assert.ok(droppedSection.includes('headline-reason-chip'));
+  assert.ok(droppedSection.includes('ai: no bear-specific language'));
+});
+
+test('event cards are headline + collapsed details, nothing deleted', async () => {
+  const adapter = buildAdapter();
+  const event = {
+    title: 'Bear Night',
+    _action: 'new',
+    startDate: '2026-09-01T02:00:00.000Z',
+    endDate: '2026-09-01T05:00:00.000Z',
+    bar: 'The Eagle',
+    address: '1 Main St',
+    city: 'unknown',
+    description: 'A very bear night',
+    notes: 'website: https://example.com',
+    image: 'https://example.com/poster.jpg'
+  };
+  const html = adapter.generateEventCard(event);
+
+  // Headline face: title, 📅 date, 📍 venue.
+  const headlineIdx = html.indexOf('<div class="event-headline">');
+  assert.ok(headlineIdx !== -1, 'card has a headline block');
+  const detailsIdx = html.indexOf('<details class="event-card-details">');
+  assert.ok(detailsIdx !== -1, 'card has the detail expander');
+  assert.ok(headlineIdx < detailsIdx, 'headline renders before the expander');
+  const headline = html.slice(headlineIdx, detailsIdx);
+  assert.ok(headline.includes('Bear Night'));
+  assert.ok(headline.includes('📅'));
+  assert.ok(headline.includes('📍'));
+  assert.ok(headline.includes('The Eagle'));
+
+  // Everything else moved INTO the expander — still present, not deleted.
+  const details = html.slice(detailsIdx);
+  assert.ok(details.includes('1 Main St'), 'address kept');
+  assert.ok(details.includes('A very bear night'), 'description kept');
+  assert.ok(details.includes('📝 Calendar Notes Preview'), 'notes preview kept');
+  assert.ok(details.includes('raw-json'), 'debug JSON kept');
+  assert.ok(details.includes('copyEventJSON(this)'), 'copy button kept');
+  assert.ok(details.includes('image-container'), 'image kept');
+});
+
+test('multi-day headline carries the end date, same-day only the end time', () => {
+  const adapter = buildAdapter();
+  const multiDay = adapter.generateEventCard({
+    title: 'Festival',
+    _action: 'new',
+    startDate: '2026-08-28T20:00:00.000Z',
+    endDate: '2026-08-31T20:00:00.000Z',
+    city: 'unknown'
+  });
+  const headline = multiDay.slice(
+    multiDay.indexOf('<div class="event-headline">'),
+    multiDay.indexOf('<details class="event-card-details">')
+  );
+  assert.ok(/Aug 28.*Aug 31/s.test(headline), 'headline shows both start and end dates');
+});
+
+test('repeated-image badge fires at 3+ uses in one run and never at 2', async () => {
+  const sharedImage = 'https://venue.example/MORE-INFO-Coming-Soon.jpg';
+  const makeEvent = (i) => ({
+    title: `Event ${i}`,
+    _action: 'new',
+    startDate: '2026-09-01T02:00:00.000Z',
+    image: sharedImage
+  });
+
+  const adapter3 = buildAdapter();
+  const html3 = await adapter3.generateRichHTML({
+    analyzedEvents: [makeEvent(1), makeEvent(2), makeEvent(3)],
+    errors: [],
+    parserResults: []
+  });
+  assert.ok(html3.includes('venue placeholder image'), 'badge fires at 3 uses');
+  assert.ok(html3.includes('same image on 3 events this run'));
+  // The class lands on the image block itself (the bare selector string also
+  // lives in the page CSS, so assert the applied class, not the substring).
+  assert.ok(html3.includes('event-image venue-placeholder-image'), 'image block greyed via class');
+
+  const adapter2 = buildAdapter();
+  const html2 = await adapter2.generateRichHTML({
+    analyzedEvents: [makeEvent(1), makeEvent(2)],
+    errors: [],
+    parserResults: []
+  });
+  assert.ok(!html2.includes('venue placeholder image'), 'no badge at 2 uses');
+  assert.ok(!html2.includes('event-image venue-placeholder-image'));
+});
+
+test('dropped cards count toward the repeated-image census', async () => {
+  const sharedImage = 'https://venue.example/placeholder.jpg';
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML({
+    analyzedEvents: [
+      { title: 'Kept 1', _action: 'new', startDate: '2026-09-01T02:00:00.000Z', image: sharedImage },
+      { title: 'Kept 2', _action: 'new', startDate: '2026-09-02T02:00:00.000Z', image: sharedImage }
+    ],
+    bearDroppedEvents: [
+      {
+        title: 'Dropped 1',
+        reason: 'ai: not bear',
+        host: 'venue.example',
+        event: { title: 'Dropped 1', startDate: '2026-09-03T02:00:00.000Z', image: sharedImage }
+      }
+    ],
+    errors: [],
+    parserResults: []
+  });
+  assert.ok(html.includes('venue placeholder image'), '2 kept + 1 dropped = 3 uses, badge fires');
+});
+
+test('merge rows label deterministic vs AI vs no-op decisions in plain words', () => {
+  const adapter = buildAdapter();
+  const event = {
+    title: 'Merge Labels',
+    _action: 'merge',
+    startDate: '2026-09-01T02:00:00.000Z',
+    city: 'unknown',
+    website: 'https://www.furball.example',
+    image: 'https://cdn.example/new-poster.jpg',
+    bar: 'Same Bar',
+    key: 'merge-labels',
+    _original: {
+      scraper: {
+        website: 'https://events.ticketleap.example/furball',
+        image: 'https://cdn.example/new-poster.jpg',
+        bar: 'Same Bar'
+      },
+      calendar: {
+        website: 'https://www.furball.example',
+        image: 'https://cdn.example/old-poster.jpg',
+        bar: 'Same Bar'
+      },
+      merged: {
+        website: 'https://www.furball.example',
+        image: 'https://cdn.example/new-poster.jpg',
+        bar: 'Same Bar'
+      }
+    },
+    _fieldPriorities: {
+      website: { merge: 'ai' },
+      image: { merge: 'ai' }
+    },
+    _mergeDecisions: [
+      {
+        field: 'website',
+        existingValue: 'https://www.furball.example',
+        newValue: 'https://events.ticketleap.example/furball',
+        chosenValue: 'https://www.furball.example',
+        reason: 'identity link beats a ticketing/social platform URL',
+        source: 'deterministic'
+      },
+      {
+        field: 'image',
+        existingValue: 'https://cdn.example/old-poster.jpg',
+        newValue: 'https://cdn.example/new-poster.jpg',
+        chosenValue: 'https://cdn.example/new-poster.jpg',
+        reason: 'poster names this event',
+        source: 'ai'
+      }
+    ]
+  };
+  const html = adapter.generateEventCard(event);
+
+  // Deterministic resolution: labeled as such, with outcome and reason.
+  assert.ok(html.includes('🔒 DETERMINISTIC — kept existing — identity link beats a ticketing/social platform URL'));
+  // AI arbitration: labeled AI with the pick.
+  assert.ok(html.includes('🤝 AI — chose new — poster names this event'));
+  // No-decision identical field: a clear no-op label, not a mystery token.
+  assert.ok(html.includes('SAME VALUE'));
+  // Strategy under the field name reads as words, not a bare "ai".
+  assert.ok(html.includes('<small>AI-arbitrated</small>'));
+  assert.ok(!html.includes('<small>ai</small>'));
+});
+
+test('merge rows label calendar stickiness and clobber fallback', () => {
+  const adapter = buildAdapter();
+  const base = {
+    title: 'Sticky Labels',
+    _action: 'merge',
+    startDate: '2026-09-01T02:00:00.000Z',
+    city: 'unknown',
+    key: 'sticky-labels',
+    _original: {
+      scraper: { ticketUrl: 'https://tickets.example/new' },
+      calendar: { ticketUrl: 'https://tickets.example/saved' },
+      merged: { ticketUrl: 'https://tickets.example/saved' }
+    },
+    _fieldPriorities: { ticketUrl: { merge: 'ai' } }
+  };
+  const stickyHtml = adapter.generateEventCard({
+    ...base,
+    ticketUrl: 'https://tickets.example/saved',
+    _mergeDecisions: [{
+      field: 'ticketUrl',
+      existingValue: 'https://tickets.example/saved',
+      newValue: 'https://tickets.example/new',
+      chosenValue: 'https://tickets.example/saved',
+      reason: 'calendar stickiness (binding) — saved value kept without AI arbitration',
+      source: 'sticky'
+    }]
+  });
+  assert.ok(stickyHtml.includes('🧊 KEPT EXISTING (calendar stickiness)'));
+
+  const fallbackHtml = adapter.generateEventCard({
+    ...base,
+    ticketUrl: 'https://tickets.example/new',
+    _mergeDecisions: [{
+      field: 'ticketUrl',
+      existingValue: 'https://tickets.example/saved',
+      newValue: 'https://tickets.example/new',
+      chosenValue: 'https://tickets.example/new',
+      reason: 'ai unavailable/rejected — clobber fallback',
+      source: 'fallback'
+    }]
+  });
+  assert.ok(fallbackHtml.includes('⚠️ NO AI ANSWER — took new (clobber fallback)'));
+});
+
+test('every existing card action survives the headline redesign (live + saved run)', async () => {
+  const results = {
+    analyzedEvents: [
+      {
+        title: 'Recurring With Everything',
+        _action: 'new',
+        startDate: '2026-09-04T02:00:00.000Z',
+        recurrenceRule: 'FREQ=WEEKLY;BYDAY=TH',
+        bar: 'The Eagle',
+        city: 'unknown',
+        address: '1 Main St',
+        location: '34.05,-118.24'
+      }
+    ],
+    bearDroppedEvents: [
+      {
+        title: 'Dropped One',
+        reason: 'ai: not bear',
+        host: 'x.example',
+        event: { title: 'Dropped One', startDate: '2026-09-05T02:00:00.000Z', bar: 'Bar X' }
+      }
+    ],
+    errors: [],
+    parserResults: []
+  };
+
+  const assertActions = (html, label) => {
+    // ICS export for the recurring card.
+    assert.ok(html.includes('exportRecurringIcs(this)'), `${label}: ICS export button`);
+    assert.ok(html.includes('data-ics-export-id='), `${label}: ICS export id registered`);
+    // Event Builder prefill link.
+    assert.ok(html.includes('event-builder-link'), `${label}: event-builder link`);
+    // Map verify links (bar/address/pin → openMapVerify bridge).
+    assert.ok(html.includes('openMapVerify(this)'), `${label}: map verify handler`);
+    assert.ok(html.includes('data-map-url-id='), `${label}: map verify id registered`);
+    // Bear verdict buttons (kept card and dropped card).
+    assert.ok(html.includes('markBearOverride(this)'), `${label}: bear verdict buttons`);
+    assert.ok(html.includes('data-bear-act="mark-bear"'), `${label}: mark-bear action`);
+    assert.ok(html.includes('data-bear-act="mark-not-bear"'), `${label}: mark-not-bear action`);
+    // Copy buttons.
+    assert.ok(html.includes('copyEventJSON(this)'), `${label}: copy JSON button`);
+    // The chunkyscrape:// bridge page handlers are still installed.
+    assert.ok(html.includes("chunkyscrape://act?a="), `${label}: chunkyscrape bridge`);
+  };
+
+  const liveAdapter = buildAdapter();
+  assertActions(await liveAdapter.generateRichHTML(results), 'live');
+
+  const savedAdapter = buildAdapter();
+  savedAdapter.loadRunLogsForDisplay = async () => ({ runId: '20260812-000001', exists: false });
+  assertActions(
+    await savedAdapter.generateRichHTML({
+      ...results,
+      _isDisplayingSavedRun: true,
+      savedRunId: '20260812-000001'
+    }),
+    'saved run'
+  );
+});
+
+test('_duplicateOfKept records render as one-liners, not full cards (feature-detected)', async () => {
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML({
+    analyzedEvents: [
+      { title: 'Kept Event', _action: 'new', startDate: '2026-09-01T02:00:00.000Z' },
+      {
+        title: 'Second Copy',
+        _action: 'new',
+        startDate: '2026-09-01T02:00:00.000Z',
+        _duplicateOfKept: 'Kept Event'
+      }
+    ],
+    bearDroppedEvents: [
+      {
+        title: 'Dropped Copy',
+        reason: 'ai: not bear',
+        host: 'x.example',
+        _duplicateOfKept: { title: 'Kept Event' },
+        event: { title: 'Dropped Copy', startDate: '2026-09-01T02:00:00.000Z' }
+      }
+    ],
+    errors: [],
+    parserResults: []
+  });
+
+  assert.ok(html.includes('duplicate-folded-line'), 'one-liner rendered');
+  assert.ok(html.includes('"Second Copy" — duplicate of "Kept Event"'), 'analyzed duplicate folded');
+  assert.ok(html.includes('"Dropped Copy" — duplicate of "Kept Event"'), 'dropped duplicate folded');
+  // The folded records never render as full cards: their bear-verdict button
+  // ids (k1 for the analyzed copy, d0 for the dropped copy) must not exist.
+  assert.ok(!html.includes('data-bear-idx="k1"'), 'no full card for the analyzed duplicate');
+  assert.ok(!html.includes('data-bear-idx="d0"'), 'no full card for the dropped duplicate');
+});


### PR DESCRIPTION
Owner ask: "The cards have way too much info on them and should be redesigned to be skimmable (but don't lose info either)" — plus withheld/dropped records mixing into the pile and reading as bugs. One branch, surgical changes to the existing renderer; no rewrite.

Base already contains #1660 and #1661 (both merged to main before branching), so no branch merges were needed.

## Before / after card layout

**Before** (everything above the fold, per card):
```
[NEW] [🔁 recurring] [⚠️ sanity: …]
Intent: NEW • Write: CREATE
TITLE
[bear verdict row]
📍 venue  🏠 address  🌐 coords  [map verify] [🛠 builder] [💾 ics]
evidence lines… 📅 date 🌍 UTC 📱 calendar 📝 description ☕ tea
[image] 📸 IG 👥 FB 🎟️ tickets 🌐 website 🗺️ maps 💵 price
▸ notes preview   ▸ 📊 merge comparison   ▸ 🔍 provenance
{ raw debug JSON }  [📋 Copy JSON]
```

**After**:
```
[NEW] [⚠️ sanity: …] [reason chip when saved/withheld/dropped]
TITLE
📅 Thu, Aug 13 7:00 PM - 11:00 PM   📍 Eagle LA        ← headline row
[bear verdict row]                                      ← still one tap
▸ Details                                               ← collapsed <details>
    (everything the card showed before, byte-for-byte:
     intent/write note, address/coords/links, evidence,
     UTC row, notes preview, merge comparison, provenance,
     conflict info, raw debug JSON, copy buttons)
```

## Mechanism per change

1. **Headline + expander** (`generateEventCard`): the card body was wrapped in `<details class="event-card-details">` — the same `<details>` pattern the hygiene section and notes preview already use. Nothing was deleted; the headline duplicates title/date/venue for skimming. Multi-day end-date rendering (already shipped) rides the headline date.
2. **Sectioned pile** (`generateRichHTML` + new `classifyEventForResultsSection`): piles render in order (a) actionable — New / Merge (incl. override-creates) / Requiring Review, (b) **Already Saved** (series match, merge no-op via empty `_changes`), (c) **Withheld** (recurring→ICS, ⏳ `_pastSpanWithheld`, 🚫 junk-title — predicates mirror `filterEventsForExecution` one-for-one), (d) **Dropped as non-bear**, now collapsed by default behind a `<details>` summary carrying the count chip; mark-bear rescue buttons unchanged inside. Withheld/saved/dropped reasons render as a headline chip. Display-only: metrics buckets and the execution gate are untouched. Pagination carries the two new groups (`saved`/`withheld`) like the existing ones.
3. **Repeated-image badge**: `generateRichHTML` censuses `event.image` URLs across kept + dropped cards; a URL on ≥3 cards gets "🖼️ venue placeholder image — same image on N events this run" and a greyscale treatment, with a full-size link kept. Pure per-run URL counting — no filename/domain matching. Eagle LA's run badges exactly the 11 MORE-INFO-Coming-Soon tiles. Feature-detected, so standalone card renders badge nothing. One additive log line; no existing log strings edited.
4. **Merge-row clarity** (`generateComparisonRows`): when a field has a `_mergeDecisions` record the row states source + outcome + reason: `🔒 DETERMINISTIC — kept existing — identity link beats a ticketing/social platform URL`, `🧊 KEPT EXISTING (calendar stickiness)`, `🤝 AI — chose new — …`, `⚠️ NO AI ANSWER — took new (clobber fallback)`. Fields without a record (older saved runs) keep the heuristic chain, with the no-op labels renamed `KEPT EXISTING (no change)` / `KEPT EXISTING` / `TOOK NEW`, and the bare strategy token under the field name now reads `AI-arbitrated` / `preserve saved` / `fresh wins`. This is the exact `website ai … NO CHANGE` confusion pasted by the owner.
5. **`_duplicateOfKept`** (wave-5 stamp, currently absent from the repo — feature-detected, never required): a stamped record renders as a one-liner `↩︎ "X" — duplicate of "Y", folded into the kept card` instead of a full card, on both the analyzed and dropped paths.
6. **Both render paths**: `display-saved-run.js` delegates entirely to `adapter.displayResults` (verified — no duplicated rendering), so saved-run replay gets all of this for free; tests assert the saved-run render (`_isDisplayingSavedRun: true`) explicitly. No changes needed to that file.

## Verification

- Quiet suite green: `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test` → **1725 pass / 0 fail** (base: 1714).
- 11 new render-string tests in `scripts/adapters/scriptable-adapter.test.js` covering: section order + counts (live AND saved-run), dropped pile collapsed with rescue buttons, repeated-image badge at 3 and not at 2 (incl. dropped cards counting toward the census), deterministic/AI/sticky/fallback merge-row labels, headline+expander with nothing deleted, multi-day headline date, `_duplicateOfKept` one-liners, and a regression guard asserting every existing action button/handler URL (ICS export, event-builder, map verify, mark-bear/not-bear, copy JSON, `chunkyscrape://` bridge) survives in both render paths.
- **Fail-on-base proof**: the new test file run against a clean `origin/main` worktree → **10 of 11 new tests fail** (253 pass / 10 fail); the one passer is the action-button regression guard, which must pass on both sides by design.
- Real-data smoke: the messy Eagle LA saved run (13 analyzed + 17 dropped, `20260811-132948.json`) rendered through the new code — 30/30 cards get headline + expander, all 5 sections in order, dropped `<details>` collapsed, 11 placeholder badges, 20 reason chips, all button registries intact (12 ICS, 30 builder links, 31 mark-bear).
- WebView bridge untouched: buttons still navigate `chunkyscrape://` intercepted by `shouldAllowRequest`; no `evaluateJavaScript` on presented views. No AI prompt changes; no existing console.log strings edited (additions only). New runtime files: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP