### PR TITLE
feat(scraper): shared Mac↔phone cache root + scheduled Mac runs (phases 1+3)

### DIFF
--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -18,6 +18,12 @@
 
 const PAGE_CACHE_MAX_FILE_BASENAME = 120;
 const PAGE_CACHE_TRUNCATED_PREFIX_LENGTH = 80;
+// Sentinel for the bounded shared-root cache read (dataless iCloud stubs).
+const SHARED_CACHE_READ_TIMED_OUT = Symbol('shared-cache-read-timed-out');
+// Copy of the Scriptable adapter's SIMPLE_URL_PARSE_REGEX (device-parity page
+// cache keys — see getDeviceParityPageCachePathParts).
+// Captures: 1=scheme, 2=authority, 3=path, 4=query (without fragment).
+const DEVICE_PARITY_URL_PARSE_REGEX = /^([a-z][a-z0-9+.-]*):\/\/([^/?#]+)([^?#]*)(\?[^#]*)?/i;
 
 class WebAdapter {
     constructor(config = {}) {
@@ -37,6 +43,8 @@ class WebAdapter {
         this.path = null;
         this.pageStorageDir = null;
 
+        this.sharedStorageRoot = null;
+
         if (this.isNode) {
             try {
                 this.fs = require('fs');
@@ -46,7 +54,72 @@ class WebAdapter {
             } catch (error) {
                 console.log(`🟢 Node.js: Page cache setup unavailable: ${error.message}`);
             }
+
+            // Shared Mac↔phone cache root (opt-in): CHUNKY_SHARED_STORAGE_DIR
+            // points at the phone's `chunky-dad-scraper` tree (the directory
+            // that CONTAINS storage/, runs/ and logs/ — on the real device
+            // dir that is .../iCloud~dk~simonbs~Scriptable/Documents/
+            // chunky-dad-scraper). The on-disk key derivation and JSON
+            // envelopes are already byte-identical across platforms, so
+            // repointing the roots makes device entries and Mac entries
+            // interchangeable. Validation is deliberately OUTSIDE the
+            // try/catch above: an unreachable shared root must ABORT the run
+            // loudly (no-partial-runs doctrine) — a silent fallback to the
+            // local cache would produce a degraded run that later syncs
+            // confusing state.
+            const sharedRoot = this.resolveSharedStorageRootSetting();
+            if (sharedRoot) {
+                this.assertSharedStorageRootUsable(sharedRoot);
+                this.sharedStorageRoot = sharedRoot;
+                this.pageStorageDir = this.path.join(sharedRoot, 'storage', 'pages');
+                console.log(`🟢 Node.js: Shared storage root active: ${sharedRoot} — caches, runs and logs read/write the phone's tree; retention pruning is deferred to the cache owner (the phone)`);
+            }
         }
+    }
+
+    // The raw CHUNKY_SHARED_STORAGE_DIR setting (trimmed), or '' when the
+    // feature is off. Node-only by construction: browsers have no process.env.
+    resolveSharedStorageRootSetting() {
+        if (!this.isNode || typeof process === 'undefined' || !process.env) return '';
+        return String(process.env.CHUNKY_SHARED_STORAGE_DIR || '').trim();
+    }
+
+    // NO PARTIAL RUNS: the shared root must already exist AND contain the
+    // phone-created storage/ subtree. Never mkdir here — if iCloud is signed
+    // out or the path is wrong, creating the tree would silently fork a local
+    // orphan that later syncs confusing state into the real cache.
+    assertSharedStorageRootUsable(sharedRoot) {
+        if (!this.fs || !this.path) {
+            throw new Error(`CHUNKY_SHARED_STORAGE_DIR is set but Node fs/path are unavailable — aborting instead of running with a local cache`);
+        }
+        let rootStat = null;
+        try {
+            rootStat = this.fs.statSync(sharedRoot);
+        } catch (_) {
+            rootStat = null;
+        }
+        if (!rootStat || !rootStat.isDirectory()) {
+            throw new Error(`Shared storage root unreachable: ${sharedRoot} does not exist or is not a directory (iCloud signed out? wrong path?) — aborting the run instead of silently falling back to the local cache`);
+        }
+        const storageDir = this.path.join(sharedRoot, 'storage');
+        let storageStat = null;
+        try {
+            storageStat = this.fs.statSync(storageDir);
+        } catch (_) {
+            storageStat = null;
+        }
+        if (!storageStat || !storageStat.isDirectory()) {
+            throw new Error(`Shared storage root ${sharedRoot} has no storage/ subtree — expected the phone's chunky-dad-scraper directory (did you point at .../Documents instead of .../Documents/chunky-dad-scraper?) — aborting the run`);
+        }
+    }
+
+    // Cache writes under an iCloud-synced tree must never leave a torn file
+    // for the sync engine to ship: write the full payload to a temp file in
+    // the SAME directory, then rename over the final name (atomic on APFS).
+    async writeFileAtomicallyNode(filePath, contents) {
+        const tmpPath = `${filePath}.tmp-${process.pid.toString(36)}-${Date.now().toString(36)}`;
+        await this.fs.promises.writeFile(tmpPath, contents, 'utf8');
+        await this.fs.promises.rename(tmpPath, filePath);
     }
 
     // Apple's native reverse geocoder is a Scriptable-only capability; Node has
@@ -137,7 +210,70 @@ class WebAdapter {
         return (hash >>> 0).toString(36);
     }
 
+    // Device-parity page cache keys. The phone's JavaScriptCore has no
+    // URL/URLSearchParams, so ScriptableAdapter.normalizePageCacheUrl ALWAYS
+    // lands in its catch (raw trimmed URL, query order preserved) and
+    // parsePageCacheUrl always takes its regex fallback. Node's `new URL`
+    // branch re-sorts and re-encodes the query, so the SAME page would get a
+    // DIFFERENT filename (verified against the real device entry
+    // api__v1__events__search--q-1b8y3s1.json — the sorted-query hash is
+    // 10f5jmh). When the shared root is active the phone's derivation is
+    // canonical, so this replicates its regex path byte-for-byte.
+    getDeviceParityPageCachePathParts(url) {
+        // Device normalizePageCacheUrl: `new URL` throws (undefined) → catch.
+        const normalizedUrl = String(url || '').trim();
+        const match = normalizedUrl.match(DEVICE_PARITY_URL_PARSE_REGEX);
+        if (!match) {
+            return {
+                normalizedUrl,
+                hostDir: 'unknown-host',
+                fileName: `${this.hashPageCacheValue(normalizedUrl || url)}.json`
+            };
+        }
+
+        // Device parsePageCacheUrl regex path: lowercase authority, strip
+        // userinfo, keep the port in `host` (which names the host dir).
+        const authority = String(match[2] || '').toLowerCase();
+        let host = authority;
+        const authSeparatorIndex = host.lastIndexOf('@');
+        if (authSeparatorIndex >= 0) {
+            host = host.slice(authSeparatorIndex + 1);
+        }
+        let hostname = host;
+        if (host.startsWith('[')) {
+            const ipv6EndIndex = host.indexOf(']');
+            hostname = ipv6EndIndex > 0 ? host.slice(0, ipv6EndIndex + 1) : host;
+        } else {
+            hostname = host.split(':')[0] || '';
+        }
+        const pathname = match[3] || '/';
+        const search = match[4] || '';
+
+        const hostDir = this.sanitizePageCacheSegment(host || hostname || 'unknown-host');
+        const pathSegments = pathname
+            .split('/')
+            .filter(Boolean)
+            .map(segment => this.sanitizePageCacheSegment(segment));
+
+        let fileBase = pathSegments.length > 0 ? pathSegments.join('__') : 'index';
+        if (search) {
+            fileBase += `--q-${this.hashPageCacheValue(search)}`;
+        }
+        if (fileBase.length > PAGE_CACHE_MAX_FILE_BASENAME) {
+            fileBase = `${fileBase.slice(0, PAGE_CACHE_TRUNCATED_PREFIX_LENGTH)}--${this.hashPageCacheValue(fileBase)}`;
+        }
+
+        return {
+            normalizedUrl,
+            hostDir,
+            fileName: `${fileBase}.json`
+        };
+    }
+
     getPageCachePathParts(url) {
+        if (this.sharedStorageRoot) {
+            return this.getDeviceParityPageCachePathParts(url);
+        }
         const normalizedUrl = this.normalizePageCacheUrl(url);
 
         try {
@@ -186,7 +322,13 @@ class WebAdapter {
                 return null;
             }
 
-            const cachedText = await this.fs.promises.readFile(cachePath, 'utf8');
+            const cachedText = await this.readCacheFileBounded(cachePath);
+            // Dataless-file handling: macOS evicts iCloud files to placeholder
+            // stubs, and an evicted/timed-out/empty entry is a cache MISS, not
+            // a crash — the run refetches and rewrites it (fail open).
+            if (typeof cachedText !== 'string' || cachedText.trim().length === 0) {
+                return null;
+            }
             const cached = JSON.parse(cachedText);
             const fetchState = typeof cached.fetchState === 'string' ? cached.fetchState.toLowerCase() : '';
             if (fetchState === 'failed' && cached.failure && cached.failure.nonRetryable === true) {
@@ -230,6 +372,34 @@ class WebAdapter {
         }
     }
 
+    // Read a cache file with an upper bound when the shared root is active:
+    // opening a dataless iCloud stub normally blocks while fileproviderd
+    // downloads the bytes (which IS the cheap materialization trigger), but a
+    // dead network could park that read forever, so it is raced against the
+    // adapter's existing timeout and a timeout is reported as a miss.
+    async readCacheFileBounded(cachePath) {
+        const readPromise = this.fs.promises.readFile(cachePath, 'utf8');
+        if (!this.sharedStorageRoot) {
+            return readPromise;
+        }
+        let timer = null;
+        const timeoutMs = this.config.timeout;
+        const timeoutPromise = new Promise((resolve) => {
+            timer = setTimeout(() => resolve(SHARED_CACHE_READ_TIMED_OUT), timeoutMs);
+        });
+        try {
+            const result = await Promise.race([readPromise, timeoutPromise]);
+            if (result === SHARED_CACHE_READ_TIMED_OUT) {
+                readPromise.catch(() => {});
+                console.log(`🟢 Node.js: Shared cache read timed out after ${timeoutMs}ms (dataless iCloud stub still downloading?) — treating ${cachePath} as a cache miss`);
+                return null;
+            }
+            return result;
+        } finally {
+            if (timer) clearTimeout(timer);
+        }
+    }
+
     // Hours below 24h ("5.3h"), days otherwise ("2.1d"); null when unknown.
     formatPageCacheAge(ageMs) {
         if (!Number.isFinite(ageMs) || ageMs < 0) {
@@ -267,7 +437,9 @@ class WebAdapter {
 
         try {
             await this.fs.promises.mkdir(cacheDir, { recursive: true });
-            await this.fs.promises.writeFile(cachePath, JSON.stringify(payload, null, 2), 'utf8');
+            // temp-file-then-rename: under the shared iCloud root a plain
+            // writeFile can be synced mid-write; the rename is atomic.
+            await this.writeFileAtomicallyNode(cachePath, JSON.stringify(payload, null, 2));
         } catch (error) {
             console.log(`🟢 Node.js: Page cache write failed for ${url}: ${error.message}`);
         }
@@ -291,11 +463,245 @@ class WebAdapter {
     getRunContext() {
         const isNode = typeof window === 'undefined';
         const environment = isNode ? 'node' : 'web';
+        // Scheduled Mac runs (tools/schedule-mac-run.sh → tools/run-once.js
+        // with CHUNKY_RUN_AUTOMATION set) mirror the phone's automation runs:
+        // the run context says so, so saved runs and the results header report
+        // the honest trigger instead of "manual".
+        if (this.isAutomationRunRequested()) {
+            return {
+                type: 'automated',
+                environment,
+                trigger: 'scheduled',
+                automationRun: true
+            };
+        }
         return {
             type: 'manual',
             environment,
             trigger: environment
         };
+    }
+
+    // Truthy CHUNKY_RUN_AUTOMATION (Node only) marks this process's run as an
+    // automation run — same meaning as the phone's scheduled automation.
+    isAutomationRunRequested() {
+        if (!this.isNode || typeof process === 'undefined' || !process.env) return false;
+        const raw = String(process.env.CHUNKY_RUN_AUTOMATION || '').trim().toLowerCase();
+        return raw === '1' || raw === 'true' || raw === 'yes';
+    }
+
+    // ------------------------------------------------------------------
+    // Shared runs/logs (Mac↔phone). When the shared storage root is active,
+    // Mac runs persist into the SAME runs/ and logs/ dirs the phone writes,
+    // with the phone's YYYYMMDD-HHMMSS naming and version-2 run envelope, so
+    // the phone's saved-run browser (display-saved-run.js) and the tailnet
+    // server list Mac runs exactly like phone runs. Timestamp-second ids
+    // keep Mac and phone writes from colliding. The phone's "save before UI"
+    // ordering maps here to "save before the caller renders/publishes":
+    // tools/run-once.js calls this FIRST, before writing its own
+    // latest-run.json for the server to render.
+    // ------------------------------------------------------------------
+
+    // Same filesystem-friendly local-time id the Scriptable adapter mints.
+    getRunId(timestamp = new Date()) {
+        const pad = (n) => String(n).padStart(2, '0');
+        const y = timestamp.getFullYear();
+        const m = pad(timestamp.getMonth() + 1);
+        const d = pad(timestamp.getDate());
+        const hh = pad(timestamp.getHours());
+        const mm = pad(timestamp.getMinutes());
+        const ss = pad(timestamp.getSeconds());
+        return `${y}${m}${d}-${hh}${mm}${ss}`;
+    }
+
+    // Node copy of ScriptableAdapter.sanitizeEventForRunSave — same slimming
+    // rules so a Mac-saved run renders identically in the phone's browser.
+    sanitizeEventForRunSave(event) {
+        if (!event || typeof event !== 'object') return event;
+        const seen = new WeakSet();
+        try {
+            return JSON.parse(JSON.stringify(event, (key, value) => {
+                if (key === '_parserConfig' && value) {
+                    return {
+                        name: value.name,
+                        parser: value.parser,
+                        dryRun: value.dryRun,
+                        city: value.city,
+                        calendarSearchRangeDays: value.calendarSearchRangeDays
+                    };
+                }
+                if (key === '_existingEvent' && value) {
+                    return {
+                        title: value.title,
+                        identifier: value.identifier,
+                        startDate: value.startDate,
+                        endDate: value.endDate,
+                        location: value.location,
+                        url: value.url
+                    };
+                }
+                if (key === '_conflicts' && value && Array.isArray(value)) {
+                    return value.map((conflict) => ({
+                        title: conflict.title,
+                        startDate: conflict.startDate,
+                        endDate: conflict.endDate,
+                        identifier: conflict.identifier
+                    }));
+                }
+                if (key === 'calendar' && value && value.title && value.identifier) {
+                    return {
+                        title: value.title,
+                        identifier: value.identifier
+                    };
+                }
+                if (typeof value === 'function') {
+                    return undefined;
+                }
+                if (value && typeof value === 'object') {
+                    if (seen.has(value)) {
+                        return undefined;
+                    }
+                    seen.add(value);
+                }
+                return value;
+            }));
+        } catch (error) {
+            console.log(`🟢 Node.js: Failed to serialize event "${event.title || event.name || 'unknown'}" for run save: ${error.message}`);
+            return {
+                title: event.title || event.name || '',
+                startDate: event.startDate || null,
+                endDate: event.endDate || null,
+                location: event.location || event.venue || '',
+                url: event.url || '',
+                city: event.city || '',
+                _action: event._action || null,
+                _analysis: event._analysis || null,
+                _mergeDiff: event._mergeDiff || null,
+                _original: event._original || null
+            };
+        }
+    }
+
+    sanitizeEventsForRunSave(events) {
+        if (!Array.isArray(events)) return [];
+        return events
+            .map((event) => this.sanitizeEventForRunSave(event))
+            .filter(Boolean);
+    }
+
+    // Node copy of ScriptableAdapter.sanitizeDroppedEntriesForRunSave.
+    sanitizeDroppedEntriesForRunSave(entries) {
+        if (!Array.isArray(entries)) return [];
+        return entries.map((entry) => {
+            if (!entry || typeof entry !== 'object') return entry;
+            const copy = { ...entry };
+            delete copy._parserConfig;
+            if (copy.event && typeof copy.event === 'object') {
+                const event = {};
+                for (const key of Object.keys(copy.event)) {
+                    if (key.startsWith('_')) continue;
+                    event[key] = copy.event[key];
+                }
+                copy.event = event;
+            }
+            return copy;
+        });
+    }
+
+    // The phone stringifies its run payload plainly (and a cycle fails the
+    // save); Node results occasionally self-reference, so try the identical
+    // plain stringify first and only fall back to dropping repeated object
+    // branches — the same semantics sanitizeEventForRunSave already applies
+    // per event.
+    stringifyRunPayload(payload) {
+        try {
+            return JSON.stringify(payload);
+        } catch (_) {
+            const seen = new WeakSet();
+            return JSON.stringify(payload, (key, value) => {
+                if (value && typeof value === 'object') {
+                    if (seen.has(value)) return undefined;
+                    seen.add(value);
+                }
+                return value;
+            });
+        }
+    }
+
+    // Persist this run's JSON and log into the shared root's runs/ and logs/
+    // dirs. `results` may be null for a FAILED run — the log (the evidence of
+    // what went wrong) is still written; the run JSON is not. Returns the
+    // runId, or null when the shared root is off or the save failed.
+    async saveRunToSharedStorage(results, options = {}) {
+        if (!this.isNode || !this.sharedStorageRoot || !this.fs || !this.path) return null;
+        try {
+            const ts = new Date();
+            const runId = this.getRunId(ts);
+            const runsDir = this.path.join(this.sharedStorageRoot, 'runs');
+            const logsDir = this.path.join(this.sharedStorageRoot, 'logs');
+            await this.fs.promises.mkdir(runsDir, { recursive: true });
+            await this.fs.promises.mkdir(logsDir, { recursive: true });
+
+            const runContext = (results && results.runContext) || this.getRunContext();
+            const totals = {
+                totalEvents: (results && results.totalEvents) || 0,
+                bearEvents: (results && results.bearEvents) || 0,
+                calendarEvents: (results && results.calendarEvents) || 0,
+                errors: ((results && results.errors) || []).length
+            };
+
+            if (results && typeof results === 'object') {
+                const summary = {
+                    runId,
+                    timestamp: ts.toISOString(),
+                    runContext,
+                    totals,
+                    parserSummaries: (results.parserResults || []).map((r) => ({
+                        name: r.name,
+                        bearEvents: r.bearEvents,
+                        totalEvents: r.totalEvents
+                    }))
+                };
+                const payload = {
+                    version: 2,
+                    summary,
+                    runContext,
+                    config: results.config || null,
+                    analyzedEvents: this.sanitizeEventsForRunSave(results.analyzedEvents || []),
+                    bearDroppedEvents: this.sanitizeDroppedEntriesForRunSave(results.bearDroppedEvents),
+                    parserResults: results.parserResults || [],
+                    errors: results.errors || [],
+                    calendarHygiene: Array.isArray(results.calendarHygiene)
+                        ? results.calendarHygiene
+                        : []
+                };
+                const runFilePath = this.path.join(runsDir, `${runId}.json`);
+                await this.writeFileAtomicallyNode(runFilePath, this.stringifyRunPayload(payload));
+                results.savedRunId = runId;
+                results.savedRunPath = runFilePath;
+                console.log(`🟢 Node.js: 💾 Saved run ${runId} to ${runFilePath} (shared storage — the phone's saved-run browser lists it like a phone run)`);
+            }
+
+            // Same first-line shape as the phone's appendLogSummary, so log
+            // tooling can parse phone and Mac logs identically.
+            const logSummary = {
+                timestamp: new Date().toISOString(),
+                runId,
+                runContext,
+                totals,
+                ...(options.failure ? { failure: String(options.failure) } : {})
+            };
+            const summaryLine = `${new Date().toISOString()} - ${JSON.stringify(logSummary)}`;
+            const logText = typeof options.logText === 'string' ? options.logText : '';
+            const content = logText ? `${summaryLine}\n${logText}` : `${summaryLine}\n`;
+            const logFilePath = this.path.join(logsDir, `${runId}.log`);
+            await this.writeFileAtomicallyNode(logFilePath, content);
+            console.log(`🟢 Node.js: 💾 Log for run ${runId} written to ${logFilePath} (shared storage)`);
+            return runId;
+        } catch (error) {
+            console.log(`🟢 Node.js: ✗ Failed to save run to shared storage: ${error.message}`);
+            return null;
+        }
     }
 
     // Get calendar name for a city (matching scriptable-adapter pattern)
@@ -564,7 +970,7 @@ async saveFailureNote(url, error, metadata = {}) {
         };
 
         await this.fs.promises.mkdir(cacheDir, { recursive: true });
-        await this.fs.promises.writeFile(cachePath, JSON.stringify(payload, null, 2), 'utf8');
+        await this.writeFileAtomicallyNode(cachePath, JSON.stringify(payload, null, 2));
         console.log(`🌐 Web: 📝 Saved non-retryable failure cache entry to ${cachePath}`);
         return true;
     }

--- a/scripts/adapters/web-adapter.test.js
+++ b/scripts/adapters/web-adapter.test.js
@@ -343,3 +343,270 @@ test('displayCalendarEvents prints the sanity line only for flagged events', () 
   const sanityLines = lines.filter(line => line.includes('⚠️ Sanity:'));
   assert.deepEqual(sanityLines, ['   ⚠️ Sanity: title-is-date-phrase']);
 });
+
+// ---------------------------------------------------------------------------
+// Shared Mac↔phone storage root (CHUNKY_SHARED_STORAGE_DIR). Opt-in: the env
+// var points at the phone's chunky-dad-scraper tree and the Node adapter then
+// reads/writes the SAME cache entries the phone does (device-parity keys),
+// persists runs/logs with the phone's naming, defers all pruning to the
+// phone, and ABORTS LOUDLY when the root is unreachable (no-partial-runs).
+// ---------------------------------------------------------------------------
+
+function makeSharedRootFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chunky-shared-root-'));
+  fs.mkdirSync(path.join(root, 'storage', 'pages'), { recursive: true });
+  return root;
+}
+
+async function withSharedRootEnv(value, run) {
+  const prev = process.env.CHUNKY_SHARED_STORAGE_DIR;
+  if (value === undefined) {
+    delete process.env.CHUNKY_SHARED_STORAGE_DIR;
+  } else {
+    process.env.CHUNKY_SHARED_STORAGE_DIR = value;
+  }
+  try {
+    return await run();
+  } finally {
+    if (prev === undefined) {
+      delete process.env.CHUNKY_SHARED_STORAGE_DIR;
+    } else {
+      process.env.CHUNKY_SHARED_STORAGE_DIR = prev;
+    }
+  }
+}
+
+// The real device page entry this key derivation is verified against
+// (READ-only evidence from the phone's tree):
+//   storage/pages/api.redeyetickets.com/api__v1__events__search--q-1b8y3s1.json
+// The phone's JavaScriptCore has no URL/URLSearchParams, so its --q- hash is
+// computed over the RAW query order; Node's sorted-query derivation yields
+// --q-10f5jmh for the same URL and would orphan every phone entry.
+const DEVICE_PAGE_URL = 'https://api.redeyetickets.com/api/v1/events/search?q=goldiloxx&per_page=25';
+const DEVICE_PAGE_HOST_DIR = 'api.redeyetickets.com';
+const DEVICE_PAGE_FILE = 'api__v1__events__search--q-1b8y3s1.json';
+
+test('shared root: env repoints the page cache at the phone tree, logs prune deferral, and adds no prune paths', async () => {
+  const root = makeSharedRootFixture();
+  try {
+    await withSharedRootEnv(root, async () => {
+      const lines = [];
+      const originalLog = console.log;
+      console.log = (...args) => { lines.push(args.join(' ')); };
+      let adapter;
+      try {
+        adapter = makeAdapter();
+      } finally {
+        console.log = originalLog;
+      }
+      assert.equal(adapter.sharedStorageRoot, root);
+      assert.equal(adapter.pageStorageDir, path.join(root, 'storage', 'pages'));
+      const deferral = lines.filter((line) => line.includes('retention pruning is deferred to the cache owner'));
+      assert.equal(deferral.length, 1, 'one loud line says the phone owns deletion');
+      // The web adapter must never grow a deletion path of its own: the
+      // phone owns retention for the shared tree.
+      assert.equal(typeof adapter.cleanupOldFiles, 'undefined');
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('shared root: unreachable or malformed root ABORTS construction (never a silent local fallback)', async () => {
+  await withSharedRootEnv(path.join(os.tmpdir(), `chunky-missing-${Date.now()}`), async () => {
+    assert.throws(() => makeAdapter(), /unreachable/i, 'missing dir aborts');
+  });
+  const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'chunky-bare-root-'));
+  try {
+    await withSharedRootEnv(bare, async () => {
+      assert.throws(() => makeAdapter(), /storage\/ subtree/i, 'a root without storage/ is the wrong directory');
+    });
+  } finally {
+    fs.rmSync(bare, { recursive: true, force: true });
+  }
+});
+
+test('shared root: device-parity page keys — a phone-written entry (raw query order) is a HIT', async () => {
+  const root = makeSharedRootFixture();
+  try {
+    await withSharedRootEnv(root, async () => {
+      const adapter = makeAdapter({ pageCache: { enabled: true, ttlDays: 3 } });
+      const parts = adapter.getPageCachePathParts(DEVICE_PAGE_URL);
+      assert.equal(parts.hostDir, DEVICE_PAGE_HOST_DIR);
+      assert.equal(parts.fileName, DEVICE_PAGE_FILE, 'derived name matches the real device entry byte-for-byte');
+      assert.equal(parts.normalizedUrl, DEVICE_PAGE_URL, 'the phone stores the raw trimmed URL');
+
+      const hostDir = path.join(root, 'storage', 'pages', DEVICE_PAGE_HOST_DIR);
+      fs.mkdirSync(hostDir, { recursive: true });
+      fs.writeFileSync(path.join(hostDir, DEVICE_PAGE_FILE), JSON.stringify({
+        url: DEVICE_PAGE_URL,
+        fetchedAt: new Date().toISOString(),
+        statusCode: 200,
+        headers: {},
+        fetchState: 'downloaded',
+        html: '{"events":[]}'
+      }, null, 2));
+
+      const cached = await adapter.readCachedPage(DEVICE_PAGE_URL, adapter.getPageCacheConfig());
+      assert.ok(cached, 'phone-seeded entry is served to the Mac run');
+      assert.equal(cached.html, '{"events":[]}');
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('shared root: cache writes are temp-file-then-rename in the same dir, device envelope preserved', async () => {
+  const root = makeSharedRootFixture();
+  try {
+    await withSharedRootEnv(root, async () => {
+      const adapter = makeAdapter({ pageCache: { enabled: true, ttlDays: 3 } });
+      const realFs = adapter.fs;
+      const renames = [];
+      adapter.fs = {
+        ...realFs,
+        promises: {
+          ...realFs.promises,
+          rename: async (from, to) => { renames.push({ from, to }); return realFs.promises.rename(from, to); }
+        }
+      };
+
+      await adapter.writeCachedPage(DEVICE_PAGE_URL, {
+        html: '{"events":[1]}', url: DEVICE_PAGE_URL, statusCode: 200, headers: {}
+      }, adapter.getPageCacheConfig());
+
+      assert.equal(renames.length, 1, 'write goes through rename');
+      assert.equal(path.dirname(renames[0].from), path.dirname(renames[0].to), 'temp file lives in the same directory (atomic rename)');
+      const finalPath = path.join(root, 'storage', 'pages', DEVICE_PAGE_HOST_DIR, DEVICE_PAGE_FILE);
+      assert.equal(renames[0].to, finalPath);
+
+      const written = JSON.parse(fs.readFileSync(finalPath, 'utf8'));
+      assert.deepEqual(Object.keys(written), ['url', 'fetchedAt', 'statusCode', 'headers', 'fetchState', 'html'],
+        'exact device envelope (field order included)');
+      assert.equal(written.fetchState, 'downloaded');
+
+      const leftovers = fs.readdirSync(path.dirname(finalPath)).filter((name) => name.includes('.tmp-'));
+      assert.deepEqual(leftovers, [], 'no torn temp files left for iCloud to sync');
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('shared root: dataless iCloud stub (0-byte placeholder) is a cache MISS, never a crash', async () => {
+  const root = makeSharedRootFixture();
+  try {
+    await withSharedRootEnv(root, async () => {
+      const adapter = makeAdapter({ pageCache: { enabled: true, ttlDays: 3 } });
+      assert.equal(adapter.pageStorageDir, path.join(root, 'storage', 'pages'), 'reads target the shared tree');
+      const hostDir = path.join(root, 'storage', 'pages', DEVICE_PAGE_HOST_DIR);
+      fs.mkdirSync(hostDir, { recursive: true });
+      fs.writeFileSync(path.join(hostDir, DEVICE_PAGE_FILE), '');
+      const cached = await adapter.readCachedPage(DEVICE_PAGE_URL, adapter.getPageCacheConfig());
+      assert.equal(cached, null, 'evicted stub fails open to a refetch');
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('shared root: saveRunToSharedStorage writes the phone version-2 run JSON + log with YYYYMMDD-HHMMSS naming', async () => {
+  const root = makeSharedRootFixture();
+  try {
+    await withSharedRootEnv(root, async () => {
+      const adapter = makeAdapter();
+      const circular = { name: 'loop' };
+      circular.self = circular;
+      const results = {
+        totalEvents: 3,
+        bearEvents: 2,
+        calendarEvents: 0,
+        errors: ['one error'],
+        runContext: { type: 'manual', environment: 'node', trigger: 'node' },
+        config: { config: { dryRun: true } },
+        analyzedEvents: [{
+          title: 'Test Bear Night',
+          startDate: '2026-08-15T02:00:00.000Z',
+          _action: 'new',
+          _parserConfig: { name: 'p', parser: 'ai', dryRun: true, city: 'la', calendarSearchRangeDays: 2, urls: ['x'], hugeBlob: 'y' },
+          onTap: () => {},
+          circular
+        }],
+        bearDroppedEvents: [{ reason: 'not bear', _parserConfig: { big: true }, event: { title: 'Drop', _working: 'x' } }],
+        parserResults: [{ name: 'p', bearEvents: 2, totalEvents: 3 }],
+        calendarHygiene: []
+      };
+
+      const runId = await adapter.saveRunToSharedStorage(results, { logText: 'line one\nline two' });
+      assert.match(runId, /^\d{8}-\d{6}$/, 'phone-format run id');
+      assert.equal(results.savedRunId, runId);
+
+      const runPath = path.join(root, 'runs', `${runId}.json`);
+      const payload = JSON.parse(fs.readFileSync(runPath, 'utf8'));
+      assert.equal(payload.version, 2, 'phone saved-run envelope version');
+      assert.equal(payload.summary.runId, runId);
+      assert.deepEqual(payload.summary.totals, { totalEvents: 3, bearEvents: 2, calendarEvents: 0, errors: 1 });
+      assert.deepEqual(payload.summary.parserSummaries, [{ name: 'p', bearEvents: 2, totalEvents: 3 }]);
+      const savedEvent = payload.analyzedEvents[0];
+      assert.deepEqual(Object.keys(savedEvent._parserConfig).sort(),
+        ['calendarSearchRangeDays', 'city', 'dryRun', 'name', 'parser'],
+        'parser config slimmed exactly like the phone save');
+      assert.equal(savedEvent.onTap, undefined, 'functions stripped');
+      assert.equal(payload.bearDroppedEvents[0]._parserConfig, undefined);
+      assert.equal(payload.bearDroppedEvents[0].event._working, undefined);
+
+      const logPath = path.join(root, 'logs', `${runId}.log`);
+      const logContent = fs.readFileSync(logPath, 'utf8');
+      const [firstLine] = logContent.split('\n');
+      assert.match(firstLine, /^\d{4}-\d{2}-\d{2}T.* - \{/, 'phone log summary first line');
+      const summary = JSON.parse(firstLine.slice(firstLine.indexOf(' - ') + 3));
+      assert.equal(summary.runId, runId);
+      assert.deepEqual(summary.totals, { totalEvents: 3, bearEvents: 2, calendarEvents: 0, errors: 1 });
+      assert.ok(logContent.includes('line one\nline two'), 'teed console lines persisted');
+
+      const tmpLeftovers = [...fs.readdirSync(path.join(root, 'runs')), ...fs.readdirSync(path.join(root, 'logs'))]
+        .filter((name) => name.includes('.tmp-'));
+      assert.deepEqual(tmpLeftovers, [], 'run/log writes are atomic too');
+
+      // FAILED run: the log (the evidence) is still written; no run JSON.
+      const runsBefore = fs.readdirSync(path.join(root, 'runs')).length;
+      const failedId = await adapter.saveRunToSharedStorage(null, { logText: 'boom trace', failure: 'pipeline exploded' });
+      assert.match(failedId, /^\d{8}-\d{6}$/);
+      assert.equal(fs.readdirSync(path.join(root, 'runs')).length, runsBefore, 'no run JSON for a failed run');
+      const failedLog = fs.readFileSync(path.join(root, 'logs', `${failedId}.log`), 'utf8');
+      assert.ok(failedLog.includes('pipeline exploded'));
+      assert.ok(failedLog.includes('boom trace'));
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('shared root off: saveRunToSharedStorage is a no-op and page keys keep the existing local derivation', async () => {
+  await withSharedRootEnv(undefined, async () => {
+    const adapter = makeAdapter();
+    assert.equal(adapter.sharedStorageRoot, null);
+    assert.equal(await adapter.saveRunToSharedStorage({ totalEvents: 0 }, {}), null);
+    // Local derivation (sorted query) is untouched for the local cache tree.
+    const parts = adapter.getPageCachePathParts(DEVICE_PAGE_URL);
+    assert.equal(parts.fileName, 'api__v1__events__search--q-10f5jmh.json');
+  });
+});
+
+test('CHUNKY_RUN_AUTOMATION marks the run context as a scheduled automation run', async () => {
+  const prev = process.env.CHUNKY_RUN_AUTOMATION;
+  try {
+    process.env.CHUNKY_RUN_AUTOMATION = '1';
+    const context = makeAdapter().getRunContext();
+    assert.equal(context.type, 'automated');
+    assert.equal(context.trigger, 'scheduled');
+    assert.equal(context.automationRun, true);
+
+    delete process.env.CHUNKY_RUN_AUTOMATION;
+    const manual = makeAdapter().getRunContext();
+    assert.equal(manual.type, 'manual');
+  } finally {
+    if (prev === undefined) delete process.env.CHUNKY_RUN_AUTOMATION;
+    else process.env.CHUNKY_RUN_AUTOMATION = prev;
+  }
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -5797,9 +5797,38 @@ class AiWebParser {
                 const fs = require('fs');
                 const path = require('path');
                 const os = require('os');
+                // Shared Mac↔phone cache root (opt-in, Node only): when
+                // CHUNKY_SHARED_STORAGE_DIR points at the phone's
+                // chunky-dad-scraper tree, the OCR/classification/AI caches
+                // read and write the phone's storage/<subdir> dirs — the
+                // key derivation and envelopes above are already identical on
+                // both platforms. An explicit per-parser overrideDir still
+                // wins. Scriptable never reaches this branch (FileManager is
+                // checked first), so phone behavior is untouched.
+                const sharedRoot = (typeof process !== 'undefined' && process.env)
+                    ? String(process.env.CHUNKY_SHARED_STORAGE_DIR || '').trim()
+                    : '';
+                if (!overrideDir && sharedRoot) {
+                    // NO PARTIAL RUNS: an unreachable shared root must abort
+                    // the run loudly, never degrade to the local cache — a
+                    // degraded run that later syncs is worse than no run.
+                    let sharedStorageDir = null;
+                    try {
+                        sharedStorageDir = fs.statSync(path.join(sharedRoot, 'storage'));
+                    } catch (_) {
+                        sharedStorageDir = null;
+                    }
+                    if (!sharedStorageDir || !sharedStorageDir.isDirectory()) {
+                        const abort = new Error(`Shared storage root unreachable for ${subdir} cache: ${sharedRoot} has no storage/ subtree (iCloud signed out? wrong path?) — aborting instead of falling back to the local cache`);
+                        abort.sharedStorageAbort = true;
+                        throw abort;
+                    }
+                }
                 const baseDir = overrideDir
                     ? String(overrideDir)
-                    : path.join(os.homedir(), '.chunky-dad-scraper', 'storage', subdir);
+                    : (sharedRoot
+                        ? path.join(sharedRoot, 'storage', subdir)
+                        : path.join(os.homedir(), '.chunky-dad-scraper', 'storage', subdir));
                 return {
                     type: 'node',
                     fs,
@@ -5807,11 +5836,23 @@ class AiWebParser {
                     baseDir
                 };
             } catch (error) {
+                // The shared-root abort must not be swallowed into the
+                // fail-open "no cache" path — rethrow it so the run stops.
+                if (error && error.sharedStorageAbort) throw error;
                 console.log(`🤖 AI Web: ${subdir} cache setup unavailable in Node: ${error.message}`);
                 return null;
             }
         }
         return null;
+    }
+
+    // Node cache writes go temp-file-then-rename (same directory) so an
+    // iCloud-synced shared root never ships a torn file. Scriptable writes
+    // stay fm.writeString — iOS-side writes are not the torn-file risk here.
+    async writeNodeCacheFileAtomically(runtime, cachePath, contents) {
+        const tmpPath = `${cachePath}.tmp-${process.pid.toString(36)}-${Date.now().toString(36)}`;
+        await runtime.fs.promises.writeFile(tmpPath, contents, 'utf8');
+        await runtime.fs.promises.rename(tmpPath, cachePath);
     }
 
     // "Touch" a cache entry on a hit so pruning can work from last USE instead
@@ -5833,11 +5874,24 @@ class AiWebParser {
             if (runtime.type === 'scriptable') {
                 runtime.fm.writeString(cachePath, JSON.stringify(cached, null, 2));
             } else {
-                await runtime.fs.promises.writeFile(cachePath, JSON.stringify(cached, null, 2), 'utf8');
+                await this.writeNodeCacheFileAtomically(runtime, cachePath, JSON.stringify(cached, null, 2));
             }
         } catch (_) {
             // A failed touch is harmless — the entry just keeps aging by mtime
         }
+    }
+
+    // Device-parity cache keys: Scriptable's JavaScriptCore has no
+    // URL/URLSearchParams, so the phone derives OCR cache filenames WITHOUT
+    // the query-sorting normalization below — the raw query order is what its
+    // `--q-` hash is computed over. When the shared Mac↔phone storage root is
+    // active, the phone's derivation is canonical, so Node must skip that
+    // normalization too or the same image gets a second, differently-named
+    // entry. Phone behavior is untouched (FileManager check → always false).
+    isSharedCacheParityModeActive() {
+        if (typeof FileManager !== 'undefined') return false;
+        if (typeof process === 'undefined' || !process.env) return false;
+        return String(process.env.CHUNKY_SHARED_STORAGE_DIR || '').trim() !== '';
     }
 
     getOcrCachePathParts(imageUrl, ocrConfig = {}) {
@@ -5845,7 +5899,7 @@ class AiWebParser {
         const normalizedSource = this.normalizeHttpUrlValue(this.unwrapImageProxyUrl(rawUrl) || rawUrl);
         let normalizedUrl = normalizedSource || rawUrl;
         try {
-            if (typeof URL === 'function' && normalizedUrl) {
+            if (typeof URL === 'function' && normalizedUrl && !this.isSharedCacheParityModeActive()) {
                 const parsed = new URL(normalizedUrl);
                 parsed.hash = '';
                 parsed.protocol = String(parsed.protocol || '').toLowerCase();
@@ -6025,7 +6079,7 @@ class AiWebParser {
             const hostDirPath = runtime.path.join(runtime.baseDir, hostDir);
             await runtime.fs.promises.mkdir(hostDirPath, { recursive: true });
             const cachePath = runtime.path.join(hostDirPath, fileName);
-            await runtime.fs.promises.writeFile(cachePath, JSON.stringify(payload, null, 2), 'utf8');
+            await this.writeNodeCacheFileAtomically(runtime, cachePath, JSON.stringify(payload, null, 2));
             return cachePath;
         } catch (error) {
             console.log(`🤖 AI Web: classification cache write failed for ${url}: ${error.message}`);
@@ -6177,7 +6231,7 @@ class AiWebParser {
                 const hostDirPath = runtime.path.join(runtime.baseDir, hostDir);
                 await runtime.fs.promises.mkdir(hostDirPath, { recursive: true });
                 cachePath = runtime.path.join(hostDirPath, fileName);
-                await runtime.fs.promises.writeFile(cachePath, JSON.stringify(payload, null, 2), 'utf8');
+                await this.writeNodeCacheFileAtomically(runtime, cachePath, JSON.stringify(payload, null, 2));
             }
             return cachePath;
         } catch (error) {
@@ -6353,7 +6407,7 @@ class AiWebParser {
                 const passDirPath = runtime.path.join(runtime.baseDir, dirSegments[0]);
                 await runtime.fs.promises.mkdir(passDirPath, { recursive: true });
                 cachePath = runtime.path.join(passDirPath, fileName);
-                await runtime.fs.promises.writeFile(cachePath, JSON.stringify(payload, null, 2), 'utf8');
+                await this.writeNodeCacheFileAtomically(runtime, cachePath, JSON.stringify(payload, null, 2));
             }
             this.aiResponseCacheStats.writes += 1;
             return cachePath;

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -14399,3 +14399,119 @@ test('text-bearing logos NOT explained by the brand still pass (misclassified re
   assert.equal(parser.getNonEventImageOcrReason(brandFlyerUrl, htmlData), '',
     'event-flyer classifications are never refused by the brand gate');
 });
+
+// ---------------------------------------------------------------------------
+// Shared Mac↔phone storage root (CHUNKY_SHARED_STORAGE_DIR): the OCR /
+// classification / AI-response caches repoint at the phone's tree, derive
+// device-parity keys (the phone has no URL/URLSearchParams, so its --q-
+// hashes preserve raw query order), write atomically, and ABORT LOUDLY when
+// the root is unreachable instead of silently degrading to the local cache.
+// ---------------------------------------------------------------------------
+
+test('shared storage root repoints OCR/classification/AI cache runtimes; explicit overrideDir still wins', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chunky-shared-ai-'));
+  for (const subdir of ['ocr', 'classification', 'ai-responses']) {
+    fs.mkdirSync(path.join(root, 'storage', subdir), { recursive: true });
+  }
+  const prev = process.env.CHUNKY_SHARED_STORAGE_DIR;
+  process.env.CHUNKY_SHARED_STORAGE_DIR = root;
+  try {
+    const parser = new AiWebParser({ normalizeUrl });
+    assert.equal(parser.getOcrCacheRuntime().baseDir, path.join(root, 'storage', 'ocr'));
+    assert.equal(parser.getAiClassificationCacheRuntime().baseDir, path.join(root, 'storage', 'classification'));
+    assert.equal(parser.getAiResponseCacheRuntime().baseDir, path.join(root, 'storage', 'ai-responses'));
+
+    const overridden = new AiWebParser({ normalizeUrl, ocrCacheDir: '/tmp/explicit-ocr-dir' });
+    assert.equal(overridden.getOcrCacheRuntime().baseDir, '/tmp/explicit-ocr-dir',
+      'per-parser cache dir overrides beat the shared root');
+  } finally {
+    if (prev === undefined) delete process.env.CHUNKY_SHARED_STORAGE_DIR;
+    else process.env.CHUNKY_SHARED_STORAGE_DIR = prev;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('unreachable shared storage root ABORTS the cache runtime (no silent local fallback)', async () => {
+  const os = require('os');
+  const path = require('path');
+  const prev = process.env.CHUNKY_SHARED_STORAGE_DIR;
+  process.env.CHUNKY_SHARED_STORAGE_DIR = path.join(os.tmpdir(), `chunky-gone-${Date.now()}`);
+  try {
+    const parser = new AiWebParser({ normalizeUrl });
+    assert.throws(() => parser.getOcrCacheRuntime(), /unreachable/i,
+      'a missing shared root must stop the run, not degrade it');
+  } finally {
+    if (prev === undefined) delete process.env.CHUNKY_SHARED_STORAGE_DIR;
+    else process.env.CHUNKY_SHARED_STORAGE_DIR = prev;
+  }
+});
+
+test('shared root: OCR cache keys preserve raw query order (device parity) and writes are atomic with the device envelope', async () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'chunky-shared-ocr-'));
+  fs.mkdirSync(path.join(root, 'storage', 'ocr'), { recursive: true });
+  const prev = process.env.CHUNKY_SHARED_STORAGE_DIR;
+  process.env.CHUNKY_SHARED_STORAGE_DIR = root;
+  try {
+    const parser = new AiWebParser({ normalizeUrl });
+    const ocrConfig = {
+      cacheEnabled: true,
+      endpoint: 'http://localhost:1',
+      model: 'test-model',
+      prompt: 'ocr prompt',
+      numCtx: 4096,
+      numPredict: 900,
+      temperature: 0,
+      think: false,
+      keepAlive: '5m'
+    };
+
+    // Device parity: the phone hashes the RAW query string (its runtime has
+    // no URL/URLSearchParams to re-sort it with).
+    const queryUrl = 'https://cdn.example.com/flyer.jpg?b=2&a=1';
+    const parts = parser.getOcrCachePathParts(queryUrl, ocrConfig);
+    assert.ok(parts.fileName.includes(`--q-${parser.hashCacheValue('?b=2&a=1')}`),
+      `raw-order query hash expected, got ${parts.fileName}`);
+
+    // Atomic write with the exact device envelope.
+    const realRuntime = parser.getOcrCacheRuntime();
+    const renames = [];
+    const recordingRuntime = {
+      ...realRuntime,
+      fs: {
+        ...realRuntime.fs,
+        promises: {
+          ...realRuntime.fs.promises,
+          rename: async (from, to) => { renames.push({ from, to }); return realRuntime.fs.promises.rename(from, to); }
+        }
+      }
+    };
+    parser.getOcrCacheRuntime = () => recordingRuntime;
+
+    const cachePath = await parser.writeCachedOcrResult(queryUrl, ocrConfig, JSON.stringify({ text: 'OCR TEXT' }));
+    assert.ok(cachePath, 'write succeeded');
+    assert.equal(renames.length, 1, 'temp-file-then-rename');
+    assert.equal(path.dirname(renames[0].from), path.dirname(renames[0].to), 'temp file in the same directory');
+    const written = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
+    assert.deepEqual(Object.keys(written), ['url', 'cachedAt', 'cacheKeyVersion', 'request', 'response'],
+      'exact device OCR envelope (field order included)');
+    assert.equal(written.cacheKeyVersion, 1);
+    assert.deepEqual(Object.keys(written.request), ['endpoint', 'model', 'prompt', 'signatureHash', 'options']);
+    const leftovers = fs.readdirSync(path.dirname(cachePath)).filter((name) => name.includes('.tmp-'));
+    assert.deepEqual(leftovers, [], 'no torn temp files');
+
+    // Dataless iCloud stub (0-byte placeholder) → miss, never a crash.
+    fs.writeFileSync(cachePath, '');
+    const missed = await parser.readCachedOcrResult(queryUrl, ocrConfig);
+    assert.equal(missed, null, 'evicted stub fails open to a fresh OCR call');
+  } finally {
+    if (prev === undefined) delete process.env.CHUNKY_SHARED_STORAGE_DIR;
+    else process.env.CHUNKY_SHARED_STORAGE_DIR = prev;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/tools-serve-results.test.js
+++ b/scripts/tools-serve-results.test.js
@@ -379,3 +379,76 @@ test('tailLines keeps only the last N lines', () => {
   assert.ok(tail.startsWith('line 100'));
   assert.ok(tail.endsWith('line 599'));
 });
+
+// ---------------------------------------------------------------------------
+// tools/run-once.js exported helpers (safe to require: execution and the
+// WebAdapter prototype patch only happen when run-once is the main module).
+// ---------------------------------------------------------------------------
+const runOnce = require(path.join(__dirname, '..', 'tools', 'run-once.js'));
+
+test('run-once: shapeRunOnceConfig stamps automation runtime and always re-forces dryRun last', () => {
+  const config = {
+    parsers: [
+      { name: 'AutoOff', automationEnabled: false },
+      { name: 'AutoOn' }
+    ],
+    config: {}
+  };
+  const shaped = runOnce.shapeRunOnceConfig(config, {
+    CHUNKY_RUN_AUTOMATION: '1',
+    CHUNKY_RUN_OVERRIDES: JSON.stringify({ config: { dryRun: false } })
+  });
+  assert.equal(shaped.runtime.automationRun, true,
+    'automation env marks the run so SharedCore applies the automationEnabled parser filter');
+  assert.equal(shaped.config.dryRun, true,
+    'dryRun is forced AFTER the override merge — the phone stays the only calendar writer');
+
+  const manual = runOnce.shapeRunOnceConfig({ parsers: [], config: {} }, {});
+  assert.equal(manual.runtime, undefined, 'no automation stamp without the env');
+  assert.equal(manual.config.dryRun, true, 'dryRun forced on manual runs too');
+});
+
+test('run-once: parser filter still selects exactly the named parser and throws on unknown names', () => {
+  const shaped = runOnce.shapeRunOnceConfig({
+    parsers: [{ name: 'A', enabled: false }, { name: 'B', enabled: true }],
+    config: {}
+  }, { CHUNKY_RUN_PARSER: 'A' });
+  assert.deepEqual(shaped.parsers.map((p) => p.enabled), [true, false]);
+
+  assert.throws(() => runOnce.shapeRunOnceConfig({ parsers: [{ name: 'A' }], config: {} },
+    { CHUNKY_RUN_PARSER: 'Nope' }), /no parser named "Nope"/);
+});
+
+test('run-once: shared-storage preflight aborts loudly on unreachable/malformed roots and passes valid ones', () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+
+  assert.equal(runOnce.assertSharedStorageRootUsable({}, fs), null, 'env unset → feature off, no check');
+
+  assert.throws(
+    () => runOnce.assertSharedStorageRootUsable({ CHUNKY_SHARED_STORAGE_DIR: path.join(os.tmpdir(), `gone-${Date.now()}`) }, fs),
+    /unreachable/i,
+    'missing root aborts before the pipeline starts'
+  );
+
+  const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'runonce-bare-'));
+  try {
+    assert.throws(
+      () => runOnce.assertSharedStorageRootUsable({ CHUNKY_SHARED_STORAGE_DIR: bare }, fs),
+      /storage\/ subtree/i,
+      'a root without storage/ is the wrong directory — abort, never mkdir'
+    );
+    fs.mkdirSync(path.join(bare, 'storage'));
+    assert.equal(runOnce.assertSharedStorageRootUsable({ CHUNKY_SHARED_STORAGE_DIR: bare }, fs), bare);
+  } finally {
+    fs.rmSync(bare, { recursive: true, force: true });
+  }
+});
+
+test('run-once: isAutomationEnv accepts the documented truthy spellings only', () => {
+  assert.equal(runOnce.isAutomationEnv({ CHUNKY_RUN_AUTOMATION: '1' }), true);
+  assert.equal(runOnce.isAutomationEnv({ CHUNKY_RUN_AUTOMATION: 'true' }), true);
+  assert.equal(runOnce.isAutomationEnv({ CHUNKY_RUN_AUTOMATION: 'yes' }), true);
+  assert.equal(runOnce.isAutomationEnv({ CHUNKY_RUN_AUTOMATION: '0' }), false);
+  assert.equal(runOnce.isAutomationEnv({}), false);
+});

--- a/tools/launchd/com.chunky-dad.scraper-daily.plist.template
+++ b/tools/launchd/com.chunky-dad.scraper-daily.plist.template
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Template for the daily scheduled Mac scraper run (Node-only tooling; never
+  ships to the phone). Rendered and installed by tools/schedule-mac-run.sh —
+  do not install this file directly; the __PLACEHOLDERS__ must be substituted.
+
+  The job runs tools/run-once.js with:
+    - CHUNKY_SHARED_STORAGE_DIR → the phone's chunky-dad-scraper tree, so the
+      run shares the phone's page/OCR/AI caches and writes its run JSON + log
+      into the shared runs/ and logs/ dirs (dry-run only; the phone remains
+      the ONLY calendar writer).
+    - CHUNKY_RUN_AUTOMATION=1 → parsers with automationEnabled: false are
+      skipped, exactly like the phone's scheduled automation runs.
+
+  launchd's own stdout/stderr streams go to ~/Library/Logs/chunky-dad-scraper/
+  ON PURPOSE (not the shared logs dir): when the shared root is unreachable
+  the run aborts loudly, and that abort message must land somewhere that does
+  not depend on the unreachable dir. The per-run log itself is written into
+  the shared logs/ dir by run-once.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>__LABEL__</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__NODE__</string>
+        <string>__REPO__/tools/run-once.js</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>CHUNKY_SHARED_STORAGE_DIR</key>
+        <string>__SHARED_DIR__</string>
+        <key>CHUNKY_RUN_AUTOMATION</key>
+        <string>1</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>__HOUR__</integer>
+        <key>Minute</key>
+        <integer>__MINUTE__</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>__LAUNCHD_LOG_DIR__/scheduled-run.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>__LAUNCHD_LOG_DIR__/scheduled-run.err.log</string>
+</dict>
+</plist>

--- a/tools/run-once.js
+++ b/tools/run-once.js
@@ -13,9 +13,12 @@
 //   .loadConfiguration in THIS process only (require-cache shared with the
 //   orchestrator's own require of web-adapter).
 // - dryRun is FORCED on: v1 of the server is report-only, no calendar writes.
+//   The phone remains the ONLY calendar writer.
 // - This file must be run in a CHILD process, never required by the server:
 //   the orchestrator/pipeline expects clean globals (no Scriptable stubs),
 //   and the server parent installs Scriptable stubs for rendering.
+//   (Requiring it for its exported helpers is safe — execution and the
+//   prototype patch only happen when run-once is the main module.)
 //
 // Env contract (all optional):
 //   CHUNKY_RUN_PARSER    — run only the parser with this exact name
@@ -27,6 +30,24 @@
 //                          test to point parsers/AI at local fixture servers.
 //                          NOTE: config.config.dryRun is re-forced to true
 //                          after the merge — overrides cannot disable it.
+//   CHUNKY_SHARED_STORAGE_DIR
+//                        — opt-in shared Mac↔phone storage root: the phone's
+//                          `chunky-dad-scraper` tree (the directory containing
+//                          storage/, runs/ and logs/). Page/OCR/AI caches then
+//                          read+write the phone's entries, and this run's JSON
+//                          and log are ALSO written into the shared runs/ and
+//                          logs/ dirs with the phone's YYYYMMDD-HHMMSS naming.
+//                          If the root is unreachable the run ABORTS LOUDLY at
+//                          startup — never a silent local-cache fallback
+//                          (no-partial-runs doctrine). Retention pruning is
+//                          never performed here: the phone owns deletion.
+//   CHUNKY_RUN_AUTOMATION — truthy ("1"/"true"/"yes") marks this run as an
+//                          automation run, exactly like the phone's scheduled
+//                          runs: config.runtime.automationRun is stamped so
+//                          SharedCore.resolveAutomationContext applies the
+//                          per-parser automationEnabled filter (parsers with
+//                          automationEnabled: false are skipped). Used by
+//                          tools/schedule-mac-run.sh.
 // ============================================================================
 
 'use strict';
@@ -69,28 +90,32 @@ function safeStringify(value) {
     });
 }
 
-// ---------------------------------------------------------------------------
-// Config injection: wrap the Node loadConfiguration path. The orchestrator's
-// own `require('./adapters/web-adapter')` returns this same patched module.
-// ---------------------------------------------------------------------------
-const { WebAdapter } = require(path.join(repoRoot, 'scripts', 'adapters', 'web-adapter'));
-const originalLoadConfiguration = WebAdapter.prototype.loadConfiguration;
+// Truthy CHUNKY_RUN_AUTOMATION values (same set WebAdapter accepts).
+function isAutomationEnv(env) {
+    const raw = String((env && env.CHUNKY_RUN_AUTOMATION) || '').trim().toLowerCase();
+    return raw === '1' || raw === 'true' || raw === 'yes';
+}
 
-WebAdapter.prototype.loadConfiguration = async function patchedLoadConfiguration(...args) {
-    const config = await originalLoadConfiguration.apply(this, args);
+// ---------------------------------------------------------------------------
+// Config shaping applied on top of the loaded configuration. Order matters:
+// 1. CHUNKY_RUN_OVERRIDES first (may replace the parsers array),
+// 2. CHUNKY_RUN_PARSER exact-name filter over the FINAL parser list,
+// 3. CHUNKY_RUN_AUTOMATION stamps config.runtime.automationRun so the
+//    shared-core automation filter (per-parser automationEnabled) applies —
+//    the scheduled Mac run behaves like the phone's automation runs,
+// 4. SAFETY LAST: dryRun re-forced true — nothing can switch it back off.
+// ---------------------------------------------------------------------------
+function shapeRunOnceConfig(config, env = process.env) {
     config.config = config.config || {};
 
-    // Test/smoke overrides FIRST (fixture URLs, stub AI endpoint, cache
-    // toggles) — they may replace the parsers array, and the parser filter
-    // below must see the final list.
-    const overridesRaw = String(process.env.CHUNKY_RUN_OVERRIDES || '').trim();
+    const overridesRaw = String((env && env.CHUNKY_RUN_OVERRIDES) || '').trim();
     if (overridesRaw) {
         deepMergeInto(config, JSON.parse(overridesRaw));
     }
 
     // Parser filter: run exactly the named parser (even if disabled in the
     // checked-in config — picking it in the UI is an explicit request).
-    const parserFilter = String(process.env.CHUNKY_RUN_PARSER || '').trim();
+    const parserFilter = String((env && env.CHUNKY_RUN_PARSER) || '').trim();
     if (parserFilter && Array.isArray(config.parsers)) {
         config.parsers = config.parsers.map((parser) => ({
             ...parser,
@@ -102,26 +127,134 @@ WebAdapter.prototype.loadConfiguration = async function patchedLoadConfiguration
         }
     }
 
+    if (isAutomationEnv(env)) {
+        config.runtime = (config.runtime && typeof config.runtime === 'object')
+            ? config.runtime
+            : {};
+        config.runtime.automationRun = true;
+    }
+
     // SAFETY LAST: v1 server runs are report-only, no calendar writes —
     // forced after the override merge so nothing can switch it back off.
     config.config.dryRun = true;
 
     return config;
-};
+}
 
-// Safe to require AFTER the patch above: the orchestrator only auto-executes
-// when it is the require.main module (here, run-once.js is).
-const { BearEventScraperOrchestrator } = require(
-    path.join(repoRoot, 'scripts', 'bear-event-scraper-unified')
-);
+// ---------------------------------------------------------------------------
+// Shared-storage preflight (NO PARTIAL RUNS). When the shared root env is
+// set, the root and its phone-created storage/ subtree must already exist —
+// otherwise abort BEFORE the pipeline starts. Never mkdir here: creating the
+// tree while iCloud is signed out (or at a mistyped path) would fork a local
+// orphan whose later sync writes confusing state into the real cache.
+// ---------------------------------------------------------------------------
+function assertSharedStorageRootUsable(env = process.env, fsLike = fs) {
+    const sharedRoot = String((env && env.CHUNKY_SHARED_STORAGE_DIR) || '').trim();
+    if (!sharedRoot) return null;
+    const isDir = (p) => {
+        try {
+            return fsLike.statSync(p).isDirectory();
+        } catch (_) {
+            return false;
+        }
+    };
+    if (!isDir(sharedRoot)) {
+        throw new Error(`run-once: shared storage root unreachable: ${sharedRoot} does not exist or is not a directory (iCloud signed out? wrong path?) — ABORTING instead of silently falling back to the local cache`);
+    }
+    if (!isDir(path.join(sharedRoot, 'storage'))) {
+        throw new Error(`run-once: shared storage root ${sharedRoot} has no storage/ subtree — expected the phone's chunky-dad-scraper directory (did you point at .../Documents instead of .../Documents/chunky-dad-scraper?) — ABORTING`);
+    }
+    return sharedRoot;
+}
 
-(async () => {
+// Tee console output into a buffer (still printed) so shared-storage runs can
+// persist a per-run log file the way the phone's FileLogger does.
+function installConsoleTee(lines) {
+    const wrap = (level, original) => (...args) => {
+        try {
+            lines.push(args.map((arg) => {
+                if (typeof arg === 'string') return arg;
+                try {
+                    return JSON.stringify(arg);
+                } catch (_) {
+                    return String(arg);
+                }
+            }).join(' '));
+        } catch (_) { /* the tee must never break the run */ }
+        original.apply(console, args);
+    };
+    console.log = wrap('log', console.log);
+    console.warn = wrap('warn', console.warn);
+    console.error = wrap('error', console.error);
+}
+
+// ---------------------------------------------------------------------------
+// Config injection: wrap the Node loadConfiguration path. The orchestrator's
+// own `require('./adapters/web-adapter')` returns this same patched module.
+// Only applied when run-once IS the process entry point — requiring this file
+// for its helpers must not mutate WebAdapter for the requiring process.
+// ---------------------------------------------------------------------------
+function patchLoadConfiguration(WebAdapter) {
+    const originalLoadConfiguration = WebAdapter.prototype.loadConfiguration;
+    WebAdapter.prototype.loadConfiguration = async function patchedLoadConfiguration(...args) {
+        const config = await originalLoadConfiguration.apply(this, args);
+        return shapeRunOnceConfig(config, process.env);
+    };
+}
+
+async function main() {
+    // Abort loudly BEFORE any module of the pipeline runs (the WebAdapter
+    // constructor re-checks this — belt and suspenders).
+    const sharedRoot = assertSharedStorageRootUsable(process.env, fs);
+
+    const logLines = [];
+    if (sharedRoot) {
+        installConsoleTee(logLines);
+    }
+
+    const { WebAdapter } = require(path.join(repoRoot, 'scripts', 'adapters', 'web-adapter'));
+    patchLoadConfiguration(WebAdapter);
+
+    // Safe to require AFTER the patch above: the orchestrator only
+    // auto-executes when it is the require.main module (here, run-once.js is).
+    const { BearEventScraperOrchestrator } = require(
+        path.join(repoRoot, 'scripts', 'bear-event-scraper-unified')
+    );
+
     const startedAt = new Date().toISOString();
     const parserFilter = String(process.env.CHUNKY_RUN_PARSER || '').trim();
-    console.log(`run-once: starting pipeline (dryRun forced)${parserFilter ? ` — parser filter: ${parserFilter}` : ''}`);
+    const automationRun = isAutomationEnv(process.env);
+    console.log(`run-once: starting pipeline (dryRun forced)${parserFilter ? ` — parser filter: ${parserFilter}` : ''}${automationRun ? ' — automation run (automationEnabled parser filter applies)' : ''}`);
+    if (sharedRoot) {
+        console.log(`run-once: shared storage root ${sharedRoot} — caches, run JSON and log are shared with the phone; retention pruning deferred to the cache owner (the phone)`);
+    }
 
     const orchestrator = new BearEventScraperOrchestrator();
-    const results = await orchestrator.run();
+    let results;
+    try {
+        results = await orchestrator.run();
+    } catch (error) {
+        // A failed shared-storage run still writes its log — that log is the
+        // only evidence of what went wrong (mirrors the phone's pre-UI log
+        // persistence). The run JSON is deliberately NOT written.
+        if (sharedRoot) {
+            try {
+                const adapter = new WebAdapter({});
+                await adapter.saveRunToSharedStorage(null, {
+                    logText: logLines.join('\n'),
+                    failure: error && error.message ? error.message : String(error)
+                });
+            } catch (_) { /* the failure below is the primary signal */ }
+        }
+        throw error;
+    }
+
+    // Shared save FIRST (the Node analog of the phone's save-before-UI
+    // ordering: persist before the parent server renders/publishes anything).
+    if (sharedRoot) {
+        const adapter = new WebAdapter({});
+        await adapter.saveRunToSharedStorage(results, { logText: logLines.join('\n') });
+    }
 
     const outPath = process.env.CHUNKY_RUN_OUT ||
         path.join(os.homedir(), '.chunky-dad-scraper', 'server', 'latest-run.json');
@@ -138,7 +271,20 @@ const { BearEventScraperOrchestrator } = require(
     fs.writeFileSync(tmpPath, safeStringify(payload));
     fs.renameSync(tmpPath, outPath);
     console.log(`run-once: results written to ${outPath}`);
-})().catch((error) => {
-    console.error(`run-once: pipeline failed: ${error && error.stack ? error.stack : error}`);
-    process.exitCode = 1;
-});
+}
+
+if (require.main === module) {
+    main().catch((error) => {
+        console.error(`run-once: pipeline failed: ${error && error.stack ? error.stack : error}`);
+        process.exitCode = 1;
+    });
+}
+
+module.exports = {
+    deepMergeInto,
+    safeStringify,
+    isAutomationEnv,
+    shapeRunOnceConfig,
+    assertSharedStorageRootUsable,
+    installConsoleTee
+};

--- a/tools/schedule-mac-run.sh
+++ b/tools/schedule-mac-run.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# ============================================================================
+# SCHEDULED MAC SCRAPER RUN — launchd install/uninstall/status helper
+# (Node/Mac-only tooling; never ships to the phone)
+# ============================================================================
+#
+# Installs a per-user launchd agent that runs the full parser sweep daily via
+# tools/run-once.js with the shared Mac↔phone storage root active:
+#
+#   - CHUNKY_SHARED_STORAGE_DIR points at the phone's chunky-dad-scraper tree
+#     (iCloud Scriptable Documents), so the Mac run shares the phone's
+#     page/OCR/AI caches and writes its run JSON + log into the shared runs/
+#     and logs/ dirs (phone naming: YYYYMMDD-HHMMSS). Retention pruning is
+#     never performed by the Mac — the phone owns deletion.
+#   - CHUNKY_RUN_AUTOMATION=1 makes the sweep behave like the phone's
+#     scheduled automation runs: parsers with automationEnabled: false are
+#     skipped.
+#   - Runs are DRY-RUN (run-once forces it): the phone remains the ONLY
+#     calendar writer.
+#   - If the shared root is unreachable (iCloud signed out, wrong path) the
+#     run ABORTS LOUDLY at startup instead of degrading to a local cache —
+#     check ~/Library/Logs/chunky-dad-scraper/scheduled-run.err.log.
+#
+# RECOMMENDED CADENCE: daily (the default). Additionally, after script
+# updates that change AI/OCR prompts, run one MANUAL warm run — prompt
+# changes rotate the AI cache keys, so the first post-update sweep re-pays
+# every AI call; warming it on the Mac (mains power, no iOS time limits)
+# means the phone's next run hits the fresh shared entries instead:
+#
+#   CHUNKY_SHARED_STORAGE_DIR="$HOME/Library/Mobile Documents/iCloud~dk~simonbs~Scriptable/Documents/chunky-dad-scraper" \
+#   CHUNKY_RUN_AUTOMATION=1 node tools/run-once.js
+#
+# USAGE:
+#   tools/schedule-mac-run.sh install [--hour H] [--minute M] [--shared-dir PATH] [--node PATH]
+#   tools/schedule-mac-run.sh uninstall
+#   tools/schedule-mac-run.sh status
+#
+# DEFAULTS: hour 05, minute 15, shared dir = the real iCloud Scriptable tree,
+# node = `command -v node` at install time (baked in absolute — launchd's PATH
+# is minimal).
+# ============================================================================
+
+set -euo pipefail
+
+LABEL="com.chunky-dad.scraper-daily"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TEMPLATE="${SCRIPT_DIR}/launchd/${LABEL}.plist.template"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+LAUNCHD_LOG_DIR="${HOME}/Library/Logs/chunky-dad-scraper"
+DEFAULT_SHARED_DIR="${HOME}/Library/Mobile Documents/iCloud~dk~simonbs~Scriptable/Documents/chunky-dad-scraper"
+
+usage() {
+    sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 1
+}
+
+require_template() {
+    if [[ ! -f "${TEMPLATE}" ]]; then
+        echo "ERROR: plist template not found at ${TEMPLATE}" >&2
+        exit 1
+    fi
+}
+
+# XML-escape for plist string values (paths can contain & etc.).
+xml_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"
+    s="${s//</&lt;}"
+    s="${s//>/&gt;}"
+    printf '%s' "$s"
+}
+
+cmd_install() {
+    local hour=5 minute=15 shared_dir="${DEFAULT_SHARED_DIR}" node_bin=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --hour) hour="$2"; shift 2 ;;
+            --minute) minute="$2"; shift 2 ;;
+            --shared-dir) shared_dir="$2"; shift 2 ;;
+            --node) node_bin="$2"; shift 2 ;;
+            *) echo "Unknown option: $1" >&2; usage ;;
+        esac
+    done
+
+    if ! [[ "${hour}" =~ ^[0-9]+$ ]] || (( hour < 0 || hour > 23 )); then
+        echo "ERROR: --hour must be 0-23 (got: ${hour})" >&2; exit 1
+    fi
+    if ! [[ "${minute}" =~ ^[0-9]+$ ]] || (( minute < 0 || minute > 59 )); then
+        echo "ERROR: --minute must be 0-59 (got: ${minute})" >&2; exit 1
+    fi
+
+    if [[ -z "${node_bin}" ]]; then
+        node_bin="$(command -v node || true)"
+    fi
+    if [[ -z "${node_bin}" || ! -x "${node_bin}" ]]; then
+        echo "ERROR: node binary not found (pass --node /path/to/node)" >&2; exit 1
+    fi
+
+    # Same no-partial-runs stance as the runtime: refuse to install pointing
+    # at a tree that does not look like the phone's chunky-dad-scraper dir.
+    if [[ ! -d "${shared_dir}/storage" ]]; then
+        echo "ERROR: ${shared_dir} has no storage/ subtree — expected the phone's chunky-dad-scraper directory (iCloud signed out? wrong path?)" >&2
+        exit 1
+    fi
+
+    require_template
+    mkdir -p "${HOME}/Library/LaunchAgents" "${LAUNCHD_LOG_DIR}"
+
+    local esc_node esc_repo esc_shared esc_logs
+    esc_node="$(xml_escape "${node_bin}")"
+    esc_repo="$(xml_escape "${REPO_ROOT}")"
+    esc_shared="$(xml_escape "${shared_dir}")"
+    esc_logs="$(xml_escape "${LAUNCHD_LOG_DIR}")"
+
+    sed \
+        -e "s|__LABEL__|${LABEL}|g" \
+        -e "s|__NODE__|${esc_node}|g" \
+        -e "s|__REPO__|${esc_repo}|g" \
+        -e "s|__SHARED_DIR__|${esc_shared}|g" \
+        -e "s|__HOUR__|${hour}|g" \
+        -e "s|__MINUTE__|${minute}|g" \
+        -e "s|__LAUNCHD_LOG_DIR__|${esc_logs}|g" \
+        "${TEMPLATE}" > "${PLIST_PATH}"
+
+    plutil -lint "${PLIST_PATH}" >/dev/null
+
+    # Reinstall-safe: boot out any previous copy, then bootstrap the new one.
+    launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+    launchctl bootstrap "gui/$(id -u)" "${PLIST_PATH}"
+
+    echo "Installed ${LABEL}:"
+    echo "  runs daily at $(printf '%02d:%02d' "${hour}" "${minute}") (local time)"
+    echo "  node:        ${node_bin}"
+    echo "  repo:        ${REPO_ROOT}"
+    echo "  shared dir:  ${shared_dir}"
+    echo "  launchd log: ${LAUNCHD_LOG_DIR}/scheduled-run.{out,err}.log"
+    echo "  per-run log: ${shared_dir}/logs/<YYYYMMDD-HHMMSS>.log (written by run-once)"
+    echo "Reminder: after prompt-changing script updates, do one manual warm run (see header)."
+}
+
+cmd_uninstall() {
+    launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+    if [[ -f "${PLIST_PATH}" ]]; then
+        rm "${PLIST_PATH}"
+        echo "Removed ${PLIST_PATH}"
+    else
+        echo "No plist at ${PLIST_PATH} (nothing to remove)"
+    fi
+    echo "Uninstalled ${LABEL} (launchd job booted out if it was loaded)."
+}
+
+cmd_status() {
+    if [[ -f "${PLIST_PATH}" ]]; then
+        echo "plist: ${PLIST_PATH}"
+    else
+        echo "plist: NOT INSTALLED (${PLIST_PATH})"
+    fi
+    if launchctl print "gui/$(id -u)/${LABEL}" >/dev/null 2>&1; then
+        echo "launchd: loaded"
+        launchctl print "gui/$(id -u)/${LABEL}" | grep -E "state|last exit code|runs" | sed 's/^/  /' || true
+    else
+        echo "launchd: not loaded"
+    fi
+    if [[ -f "${LAUNCHD_LOG_DIR}/scheduled-run.err.log" ]]; then
+        echo "recent stderr (${LAUNCHD_LOG_DIR}/scheduled-run.err.log):"
+        tail -n 5 "${LAUNCHD_LOG_DIR}/scheduled-run.err.log" | sed 's/^/  /'
+    fi
+}
+
+case "${1:-}" in
+    install) shift; cmd_install "$@" ;;
+    uninstall) cmd_uninstall ;;
+    status) cmd_status ;;
+    *) usage ;;
+esac


### PR DESCRIPTION
## Design summary

**Shared cache root (opt-in).** `CHUNKY_SHARED_STORAGE_DIR` (env, Node-only) points at the phone's `chunky-dad-scraper` tree — the directory containing `storage/`, `runs/`, `logs/`. When set:

- `WebAdapter` repoints the page cache at `<root>/storage/pages`; `AiWebParser.getCacheRuntime` repoints OCR/classification/AI-response caches at `<root>/storage/{ocr,classification,ai-responses}`. Explicit per-parser `ocrCacheDir`-style overrides still win.
- **Device-parity key derivation**: the phone's JavaScriptCore has no `URL`/`URLSearchParams`, so it always derives cache filenames from the RAW url (query order preserved) via regex fallbacks. Node's `new URL` branch re-sorts/re-encodes — same page, different filename. Under the shared root, Node now replicates the phone's regex derivation (page keys) and skips the OCR query-sort block. Off the shared root, local derivation is byte-identical to before.
- **Atomic writes**: every Node cache/run/log write under the adapter goes temp-file-then-rename in the same directory, so iCloud never syncs a torn file. Scriptable-side writes untouched.
- **Prune ownership**: the Node side performs no retention pruning (it never did — now locked by a test asserting no `cleanupOldFiles` exists) and logs one line: *"retention pruning is deferred to the cache owner (the phone)"*.
- **Dataless files**: macOS-evicted iCloud stubs (empty/failed reads) are cache MISSES, never crashes; shared-root reads are bounded by the adapter's existing timeout (`Promise.race`) since opening a stub blocks-and-downloads.
- **Shared runs/logs**: run-once writes phone-format artifacts into the shared tree — `runs/YYYYMMDD-HHMMSS.json` with the exact version-2 envelope (`summary/totals/parserSummaries`, sanitized `analyzedEvents`, slimmed `bearDroppedEvents` — same slimming rules as `ScriptableAdapter.saveRun`) and `logs/YYYYMMDD-HHMMSS.log` with the phone's `ISO - {json}` first line + full console tee. The phone's saved-run browser lists Mac runs like phone runs. Save happens BEFORE `latest-run.json` is written for the server (the Node analog of save-before-UI). A FAILED run still writes its log (the evidence); no run JSON.

**Abort-loudly (no partial runs).** If `CHUNKY_SHARED_STORAGE_DIR` is set but the root is missing, not a directory, or lacks the phone-created `storage/` subtree (e.g. pointed at `.../Documents` instead of `.../Documents/chunky-dad-scraper`, or iCloud signed out), the run aborts at startup — run-once preflight AND the `WebAdapter` constructor AND `getCacheRuntime` all throw; nothing ever mkdirs a stray local tree or silently falls back to the local cache.

**Scheduler (phase 3).** `tools/schedule-mac-run.sh install|uninstall|status` renders `tools/launchd/com.chunky-dad.scraper-daily.plist.template` into `~/Library/LaunchAgents` and bootstraps a daily run (default 05:15, `--hour/--minute/--shared-dir/--node` flags) of `tools/run-once.js` with the shared root + `CHUNKY_RUN_AUTOMATION=1`. Automation runs stamp `config.runtime.automationRun`, so SharedCore's existing `resolveAutomationContext` applies the per-parser `automationEnabled` filter — scheduled Mac runs behave exactly like the phone's automation runs (and the run context honestly reports `automated/scheduled`). `dryRun` remains force-enabled (unchanged) — **the phone stays the only calendar writer**. launchd's own stdout/stderr go to `~/Library/Logs/chunky-dad-scraper/` on purpose: the abort-loudly message must land somewhere that doesn't depend on the unreachable shared dir; the per-run log goes to the shared `logs/`. NOT installed on this machine — install is a one-line opt-in.

**Recommended cadence:** daily; plus one MANUAL warm run after script updates that change AI/OCR prompts (prompt changes rotate the AI cache keys — warming on the Mac means the phone's next run hits fresh shared entries). Documented in the script header.

## Format-parity evidence (verified against the REAL device tree, read-only)

Picked entries per the plan, then swept samples:

- **Page** (the required real-URL check): device entry `storage/pages/api.redeyetickets.com/api__v1__events__search--q-1b8y3s1.json` for `https://api.redeyetickets.com/api/v1/events/search?q=goldiloxx&per_page=25`. The stock Node derivation produced `--q-10f5jmh` (sorted query) — **mismatch found and fixed**: `1b8y3s1` is the FNV-1a hash of the raw `?q=goldiloxx&per_page=25`, proving the phone hashes unsorted queries (no `URL` in JavaScriptCore). With device-parity mode, Node derives `api.redeyetickets.com/api__v1__events__search--q-1b8y3s1.json` exactly. Sweep: **150/150 sampled device page entries re-derive to their exact on-disk names**. Envelope fields/order/indent identical (`url,fetchedAt,statusCode,headers,fetchState,html`, 2-space).
- **OCR**: device entry `storage/ocr/bearracuda.com/wp-content__uploads__2023__06__marcela-laskoski-118684-unsplash-1024x683.jpg--ocr-11ds5w7.json` re-derives byte-identically (signature hash `11ds5w7` matches the stored `request.signatureHash`). Sweep: **119/120**. The 1 residual: a URL with literal spaces, which Node's `normalizeHttpUrlValue` percent-encodes before key derivation — **loud caveat**: URLs whose raw form `new URL` re-encodes (literal spaces etc.) may still derive differently; the cost is a duplicate cache entry / one extra OCR call, never corruption.
- **Classification**: sweep **60/60** (its derivation never had a sort block).
- **AI responses**: derivation is platform-shared code with no URL branch — structurally parity-exact. A sweep vs historical files showed 45/60, and all 15 mismatches were proven to be **legacy pre-SEGMENT_INDEX-canonicalization orphans** (their stored `signatureHash` equals the raw-prompt hash; today's PHONE code would derive the same canonical name Node does — those files are already unreadable by the current phone build too).

## End-to-end smoke

`CHUNKY_RUN_PARSER=Goldiloxx CHUNKY_SHARED_STORAGE_DIR=<temp fixture seeded with the real device redeyetickets entry> node tools/run-once.js` → exit 0, log shows `Page cache hit (age 21.2h, ttl 3d)` for the seeded phone entry; full pipeline ran (6 events → 3 bear, 0 errors, dry run); new page/OCR/classification/AI entries written into the fixture under device-format names; **0** `.tmp-` leftovers; `runs/20260812-104738.json` (version 2) + `logs/20260812-104738.log` (phone-format first line) created.

## Tests

Quiet suite green: **1741 pass / 0 fail** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`). 15 new tests, all in existing enumerated files (`web-adapter.test.js` +8, `ai-web-parser.test.js` +3, `tools-serve-results.test.js` +4), covering key parity, atomic writes, prune deferral, dataless-stub miss, abort-on-missing-dir, shared run/log format, automation shaping, dryRun re-force. **All 15 proven failing on base** (fresh origin/main worktree + copied test files: 539 pass / 15 fail — exactly the new ones).

## New tool files (flagging per convention)

- `tools/schedule-mac-run.sh` (new, executable)
- `tools/launchd/com.chunky-dad.scraper-daily.plist.template` (new)

Both are Mac-only tools — NOT phone runtime, no updater entries needed. `scripts/parsers/ai-web-parser.js` and `scripts/adapters/web-adapter.js` are existing runtime files with additive, Node-/env-guarded changes only (phone behavior byte-identical: `FileManager`/`typeof process` guards; Scriptable branches untouched; no existing log strings edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP