### PR TITLE
fix(shared-storage): defend scheduled runs against dataless iCloud stub syscall wedges

### DIFF
--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -18,7 +18,9 @@
 
 const PAGE_CACHE_MAX_FILE_BASENAME = 120;
 const PAGE_CACHE_TRUNCATED_PREFIX_LENGTH = 80;
-// Sentinel for the bounded shared-root cache read (dataless iCloud stubs).
+// Sentinel for bounded shared-root fs operations (dataless iCloud stubs).
+// Originally only the cache read was bounded; the 2026-08 scheduled-run hang
+// proved EVERY fs op against an evicted file can wedge (see boundedSharedFsOp).
 const SHARED_CACHE_READ_TIMED_OUT = Symbol('shared-cache-read-timed-out');
 // Copy of the Scriptable adapter's SIMPLE_URL_PARSE_REGEX (device-parity page
 // cache keys — see getDeviceParityPageCachePathParts).
@@ -120,10 +122,77 @@ class WebAdapter {
     // Cache writes under an iCloud-synced tree must never leave a torn file
     // for the sync engine to ship: write the full payload to a temp file in
     // the SAME directory, then rename over the final name (atomic on APFS).
+    //
+    // DATALESS-TARGET HAZARD (2026-08 scheduled-run hang): renaming a temp
+    // file OVER a dataless (evicted) iCloud placeholder deadlocks inside
+    // fileproviderd — the rename syscall never returns and the awaited
+    // promise never settles, silently hanging the whole run. So when the
+    // shared root is active, the destination is unlinked FIRST. The unlink
+    // itself can also wedge on a dataless file, which is why (a) the startup
+    // materialization sweep in tools/run-once.js downloads every evicted file
+    // before parser work begins, and (b) every op here is bounded by
+    // boundedSharedFsOp as belt-and-braces on top of that sweep.
     async writeFileAtomicallyNode(filePath, contents) {
         const tmpPath = `${filePath}.tmp-${process.pid.toString(36)}-${Date.now().toString(36)}`;
-        await this.fs.promises.writeFile(tmpPath, contents, 'utf8');
-        await this.fs.promises.rename(tmpPath, filePath);
+        await this.boundedSharedFsOp(() => this.fs.promises.writeFile(tmpPath, contents, 'utf8'), `write ${tmpPath}`);
+        if (this.sharedStorageRoot) {
+            // Never rename over a possibly-dataless target (fileproviderd
+            // deadlock). ENOENT is the normal first-write case.
+            try {
+                await this.boundedSharedFsOp(() => this.fs.promises.unlink(filePath), `unlink ${filePath}`);
+            } catch (error) {
+                if (!error || error.code !== 'ENOENT') {
+                    throw error;
+                }
+            }
+        }
+        await this.boundedSharedFsOp(() => this.fs.promises.rename(tmpPath, filePath), `rename ${tmpPath} -> ${filePath}`);
+    }
+
+    // Run a shared-root fs operation with an upper bound. When the shared
+    // root is OFF this is a pure passthrough (no timers, byte-identical
+    // behavior for local-cache runs).
+    //
+    // WHY THIS EXISTS: syscalls against dataless (evicted) iCloud files can
+    // block in the kernel indefinitely (open/read/stat/rename/unlink alike —
+    // the 2026-08 incident sampled two of them wedged for 22+ minutes). A
+    // JS-side timeout CANNOT cancel the syscall: the libuv threadpool slot
+    // stays hostage even after this helper gives up, and four wedged ops
+    // exhaust the default 4-slot pool and starve every later fs/dns call.
+    // That is why (1) tools/run-once.js materializes the whole tree BEFORE
+    // parser work — this helper is only the last line of defense — and
+    // (2) run-once bumps UV_THREADPOOL_SIZE so a few leaked slots cannot
+    // stall the loop. On timeout the op is treated as FAILED (reads report a
+    // miss, writes are skipped by the caller's catch) with a loud log line,
+    // and the run keeps moving.
+    async boundedSharedFsOp(startOp, label, options = {}) {
+        if (!this.sharedStorageRoot) {
+            return startOp();
+        }
+        const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : this.config.timeout;
+        const opPromise = startOp();
+        let timer = null;
+        const timeoutPromise = new Promise((resolve) => {
+            timer = setTimeout(() => resolve(SHARED_CACHE_READ_TIMED_OUT), timeoutMs);
+        });
+        try {
+            const result = await Promise.race([opPromise, timeoutPromise]);
+            if (result === SHARED_CACHE_READ_TIMED_OUT) {
+                // The abandoned promise may still settle (or reject) later;
+                // never let it surface as an unhandled rejection.
+                opPromise.catch(() => {});
+                if (!options.quiet) {
+                    console.log(`🟢 Node.js: Shared storage fs op timed out after ${timeoutMs}ms (dataless iCloud stub? fileproviderd wedge?) — treating as failed: ${label}`);
+                }
+                const error = new Error(`Shared storage fs op timed out after ${timeoutMs}ms: ${label}`);
+                error.code = 'ESHAREDFSTIMEOUT';
+                error.sharedFsTimeout = true;
+                throw error;
+            }
+            return result;
+        } finally {
+            if (timer) clearTimeout(timer);
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -365,7 +434,11 @@ class WebAdapter {
         const cachePath = this.path.join(this.pageStorageDir, hostDir, fileName);
 
         try {
-            const stats = await this.fs.promises.stat(cachePath);
+            // stat can also wedge against a dataless stub (the incident's
+            // kernel samples were open() and rename(), but any path-based
+            // syscall on an evicted file qualifies) — bounded like the read;
+            // a timeout throws, lands in the catch below, and reads as a miss.
+            const stats = await this.boundedSharedFsOp(() => this.fs.promises.stat(cachePath), `stat ${cachePath}`);
             const maxAgeMs = pageCacheConfig.ttlDays * 24 * 60 * 60 * 1000;
             if ((Date.now() - stats.mtimeMs) > maxAgeMs) {
                 return null;
@@ -426,26 +499,21 @@ class WebAdapter {
     // downloads the bytes (which IS the cheap materialization trigger), but a
     // dead network could park that read forever, so it is raced against the
     // adapter's existing timeout and a timeout is reported as a miss.
+    // Built on boundedSharedFsOp (quiet: this path keeps its own miss line).
     async readCacheFileBounded(cachePath) {
-        const readPromise = this.fs.promises.readFile(cachePath, 'utf8');
-        if (!this.sharedStorageRoot) {
-            return readPromise;
-        }
-        let timer = null;
         const timeoutMs = this.config.timeout;
-        const timeoutPromise = new Promise((resolve) => {
-            timer = setTimeout(() => resolve(SHARED_CACHE_READ_TIMED_OUT), timeoutMs);
-        });
         try {
-            const result = await Promise.race([readPromise, timeoutPromise]);
-            if (result === SHARED_CACHE_READ_TIMED_OUT) {
-                readPromise.catch(() => {});
+            return await this.boundedSharedFsOp(
+                () => this.fs.promises.readFile(cachePath, 'utf8'),
+                `read ${cachePath}`,
+                { timeoutMs, quiet: true }
+            );
+        } catch (error) {
+            if (error && error.sharedFsTimeout) {
                 console.log(`🟢 Node.js: Shared cache read timed out after ${timeoutMs}ms (dataless iCloud stub still downloading?) — treating ${cachePath} as a cache miss`);
                 return null;
             }
-            return result;
-        } finally {
-            if (timer) clearTimeout(timer);
+            throw error;
         }
     }
 

--- a/scripts/adapters/web-adapter.test.js
+++ b/scripts/adapters/web-adapter.test.js
@@ -510,6 +510,128 @@ test('shared root: dataless iCloud stub (0-byte placeholder) is a cache MISS, ne
   }
 });
 
+// 2026-08 incident: writeFileAtomicallyNode renamed a temp file OVER a
+// dataless (evicted) iCloud placeholder, which deadlocks inside fileproviderd
+// — the awaited rename never resolves and the run hangs silently. Defense:
+// under the shared root the destination is unlinked before the rename.
+test('shared root: writeFileAtomicallyNode unlinks an existing destination BEFORE the rename (never rename over a possibly-dataless target)', async () => {
+  const root = makeSharedRootFixture();
+  try {
+    await withSharedRootEnv(root, async () => {
+      const adapter = makeAdapter({ pageCache: { enabled: true, ttlDays: 3 } });
+      const realFs = adapter.fs;
+      const ops = [];
+      adapter.fs = {
+        ...realFs,
+        promises: {
+          ...realFs.promises,
+          unlink: async (p) => { ops.push(['unlink', p]); return realFs.promises.unlink(p); },
+          rename: async (from, to) => { ops.push(['rename', to]); return realFs.promises.rename(from, to); }
+        }
+      };
+
+      const hostDir = path.join(root, 'storage', 'pages', DEVICE_PAGE_HOST_DIR);
+      fs.mkdirSync(hostDir, { recursive: true });
+      const finalPath = path.join(hostDir, DEVICE_PAGE_FILE);
+      fs.writeFileSync(finalPath, 'stale entry (a dataless stub in production)');
+
+      await adapter.writeFileAtomicallyNode(finalPath, 'fresh contents');
+
+      const unlinkIndex = ops.findIndex(([op, p]) => op === 'unlink' && p === finalPath);
+      const renameIndex = ops.findIndex(([op, p]) => op === 'rename' && p === finalPath);
+      assert.notEqual(unlinkIndex, -1, 'existing destination is unlinked (a dataless target would deadlock the rename in fileproviderd)');
+      assert.notEqual(renameIndex, -1, 'write still lands via rename');
+      assert.ok(unlinkIndex < renameIndex, 'unlink happens BEFORE the rename');
+      assert.equal(fs.readFileSync(finalPath, 'utf8'), 'fresh contents');
+    });
+
+    // Shared root OFF: the pure atomic rename is preserved (no unlink — the
+    // local tree has no dataless files and the rename-over is what makes the
+    // write atomic for concurrent readers).
+    await withSharedRootEnv(undefined, async () => {
+      const adapter = makeAdapter();
+      const realFs = adapter.fs;
+      const unlinks = [];
+      adapter.fs = {
+        ...realFs,
+        promises: {
+          ...realFs.promises,
+          unlink: async (p) => { unlinks.push(p); return realFs.promises.unlink(p); }
+        }
+      };
+      const localDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chunky-local-write-'));
+      try {
+        const target = path.join(localDir, 'entry.json');
+        fs.writeFileSync(target, 'old');
+        await adapter.writeFileAtomicallyNode(target, 'new');
+        assert.deepEqual(unlinks, [], 'local writes keep the pure atomic rename');
+        assert.equal(fs.readFileSync(target, 'utf8'), 'new');
+      } finally {
+        fs.rmSync(localDir, { recursive: true, force: true });
+      }
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// JS-side timeouts cannot cancel a wedged syscall, but they MUST stop the
+// run from awaiting it forever: a wedged rename/unlink under the shared root
+// is treated as a failed write (loud line, error thrown to the caller's
+// catch) instead of hanging the pipeline — the incident's 22-minute silence.
+test('shared root: a wedged rename/unlink is bounded — fails loudly instead of hanging the run', async () => {
+  const root = makeSharedRootFixture();
+  const HUNG = Symbol('hung');
+  const raceAgainstGuard = (promise) => Promise.race([
+    promise.then(() => 'resolved', (error) => error),
+    new Promise((resolve) => setTimeout(() => resolve(HUNG), 2000))
+  ]);
+  try {
+    await withSharedRootEnv(root, async () => {
+      const hostDir = path.join(root, 'storage', 'pages', DEVICE_PAGE_HOST_DIR);
+      fs.mkdirSync(hostDir, { recursive: true });
+      const finalPath = path.join(hostDir, DEVICE_PAGE_FILE);
+
+      const lines = [];
+      const originalLog = console.log;
+      console.log = (...args) => { lines.push(args.join(' ')); originalLog.apply(console, args); };
+      try {
+        // Wedged rename (kernel-stuck syscall in production; a promise that
+        // never settles here — the destination does not exist, so no unlink).
+        const renameAdapter = makeAdapter({ timeout: 80 });
+        const realFs = renameAdapter.fs;
+        renameAdapter.fs = {
+          ...realFs,
+          promises: { ...realFs.promises, rename: () => new Promise(() => {}) }
+        };
+        const renameOutcome = await raceAgainstGuard(renameAdapter.writeFileAtomicallyNode(finalPath, 'contents'));
+        assert.notEqual(renameOutcome, HUNG, 'a wedged rename must not hang the run (bounded shared-root fs op)');
+        assert.match(renameOutcome.message, /timed out/i, 'the bounded op reports the timeout as a failed write');
+
+        // Wedged unlink (destination exists → the unlink-first path runs).
+        fs.writeFileSync(finalPath, 'existing');
+        const unlinkAdapter = makeAdapter({ timeout: 80 });
+        const realFs2 = unlinkAdapter.fs;
+        unlinkAdapter.fs = {
+          ...realFs2,
+          promises: { ...realFs2.promises, unlink: () => new Promise(() => {}) }
+        };
+        const unlinkOutcome = await raceAgainstGuard(unlinkAdapter.writeFileAtomicallyNode(finalPath, 'contents'));
+        assert.notEqual(unlinkOutcome, HUNG, 'a wedged unlink must not hang the run either');
+        assert.match(unlinkOutcome.message, /timed out/i);
+      } finally {
+        console.log = originalLog;
+      }
+      assert.ok(
+        lines.some((line) => line.includes('Shared storage fs op timed out')),
+        'timed-out shared-root fs ops say so loudly'
+      );
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('shared root: saveRunToSharedStorage writes the phone version-2 run JSON + log with YYYYMMDD-HHMMSS naming', async () => {
   const root = makeSharedRootFixture();
   try {

--- a/scripts/tools-serve-results.test.js
+++ b/scripts/tools-serve-results.test.js
@@ -452,3 +452,123 @@ test('run-once: isAutomationEnv accepts the documented truthy spellings only', (
   assert.equal(runOnce.isAutomationEnv({ CHUNKY_RUN_AUTOMATION: '0' }), false);
   assert.equal(runOnce.isAutomationEnv({}), false);
 });
+
+// ---------------------------------------------------------------------------
+// Dataless-stub defenses (2026-08 incident: the first scheduled run hung 22+
+// minutes with libuv threads kernel-wedged in open()/rename() against evicted
+// iCloud files). Defense #1 is the startup materialization sweep: download
+// everything BEFORE parser work, poll the dataless count to 0, abort loudly
+// at the ceiling — a run that would wedge or miss the shared cache must not
+// limp (no-partial-runs).
+// ---------------------------------------------------------------------------
+test('run-once: materialization sweep waits for the dataless count to reach 0, then proceeds', async () => {
+  const logs = [];
+  const log = (line) => logs.push(String(line));
+  let fakeNow = 0;
+  const counts = [2, 1, 0]; // initial probe, then one per poll
+  const kicked = [];
+
+  const result = await runOnce.materializeSharedStorageTree('/shared/root', {
+    platform: 'darwin',
+    countDataless: () => counts.shift(),
+    kickDownload: (root) => { kicked.push(root); return true; },
+    ceilingMs: 90000,
+    pollIntervalMs: 30000,
+    sleep: async (ms) => { fakeNow += ms; },
+    now: () => fakeNow,
+    log
+  });
+
+  assert.deepEqual(result, { datalessAtStart: 2, waitedMs: 60000 });
+  assert.deepEqual(kicked, ['/shared/root'], 'brctl download is kicked once, on the whole root');
+  assert.ok(logs.some((line) => line.includes('materialization progress')), 'each poll logs progress');
+  assert.ok(logs.some((line) => line.includes('fully materialized')), 'the all-clear is loud');
+
+  // Already-clean tree: no download kick, no waiting.
+  const clean = await runOnce.materializeSharedStorageTree('/shared/root', {
+    platform: 'darwin',
+    countDataless: () => 0,
+    kickDownload: () => { throw new Error('must not kick a clean tree'); },
+    log: () => {}
+  });
+  assert.deepEqual(clean, { datalessAtStart: 0, waitedMs: 0 });
+});
+
+test('run-once: materialization sweep ABORTS LOUDLY at the ceiling (no-partial-runs) and recommends Keep Downloaded', async () => {
+  let fakeNow = 0;
+  await assert.rejects(
+    runOnce.materializeSharedStorageTree('/shared/root', {
+      platform: 'darwin',
+      countDataless: () => 2, // never drains — fileproviderd wedged / offline
+      kickDownload: () => true,
+      ceilingMs: 90000,
+      pollIntervalMs: 30000,
+      sleep: async (ms) => { fakeNow += ms; },
+      now: () => fakeNow,
+      log: () => {}
+    }),
+    /ABORTING[\s\S]*Keep Downloaded/,
+    'a tree that will not materialize must abort the run, not limp into wedged syscalls'
+  );
+
+  // A probe that breaks mid-sweep is also an abort — never guess "clean".
+  let firstProbe = true;
+  await assert.rejects(
+    runOnce.materializeSharedStorageTree('/shared/root', {
+      platform: 'darwin',
+      countDataless: () => { if (firstProbe) { firstProbe = false; return 3; } return null; },
+      kickDownload: () => true,
+      ceilingMs: 90000,
+      pollIntervalMs: 30000,
+      sleep: async () => {},
+      now: () => 0,
+      log: () => {}
+    }),
+    /probe[\s\S]*ABORTING/i
+  );
+});
+
+test('run-once: materialization sweep skips honestly when it cannot run (non-macOS, no find probe, no brctl)', async () => {
+  const log = () => {};
+  assert.deepEqual(
+    await runOnce.materializeSharedStorageTree('/x', { platform: 'linux', log }),
+    { skipped: 'non-macos' }
+  );
+  assert.deepEqual(
+    await runOnce.materializeSharedStorageTree('/x', { platform: 'darwin', countDataless: () => null, log }),
+    { skipped: 'probe-unavailable' }
+  );
+  assert.deepEqual(
+    await runOnce.materializeSharedStorageTree('/x', { platform: 'darwin', countDataless: () => 3, kickDownload: () => false, log }),
+    { skipped: 'brctl-unavailable' }
+  );
+  assert.deepEqual(await runOnce.materializeSharedStorageTree('', {}), { skipped: 'no-shared-root' });
+});
+
+// Defense #3b: JS-side timeouts cannot cancel wedged syscalls — each one
+// leaks a libuv threadpool slot, and the default pool is only 4 slots. Both
+// the run-once entry and the launchd plist give the pool headroom.
+test('run-once: UV_THREADPOOL_SIZE headroom is defaulted at the entry point and pinned in the launchd plist template', () => {
+  const fs = require('node:fs');
+
+  const env = {};
+  assert.equal(runOnce.ensureThreadpoolHeadroom(env), '16');
+  assert.equal(env.UV_THREADPOOL_SIZE, '16');
+  assert.equal(
+    runOnce.ensureThreadpoolHeadroom({ UV_THREADPOOL_SIZE: '32' }),
+    '32',
+    'an explicit caller value is respected'
+  );
+  assert.ok(String(process.env.UV_THREADPOOL_SIZE || '').trim() !== '',
+    'requiring run-once ensured the headroom for this process (entry-point call, pre-set values respected)');
+
+  const template = fs.readFileSync(
+    path.join(__dirname, '..', 'tools', 'launchd', 'com.chunky-dad.scraper-daily.plist.template'),
+    'utf8'
+  );
+  assert.match(
+    template,
+    /<key>UV_THREADPOOL_SIZE<\/key>\s*<string>16<\/string>/,
+    'scheduled runs get the headroom even if the entry-point default ever moves'
+  );
+});

--- a/tools/launchd/com.chunky-dad.scraper-daily.plist.template
+++ b/tools/launchd/com.chunky-dad.scraper-daily.plist.template
@@ -12,6 +12,12 @@
       the ONLY calendar writer).
     - CHUNKY_RUN_AUTOMATION=1 → parsers with automationEnabled: false are
       skipped, exactly like the phone's scheduled automation runs.
+    - UV_THREADPOOL_SIZE=16 → headroom against wedged syscalls on dataless
+      (evicted) iCloud files: a JS-side timeout cannot cancel the syscall, so
+      each wedge leaks a libuv threadpool slot; with the default pool of 4,
+      four leaks starve every later fs/dns call (the 2026-08 22-minute hang).
+      run-once also materializes the whole shared tree at startup, so this is
+      belt-and-braces.
 
   launchd's own stdout/stderr streams go to ~/Library/Logs/chunky-dad-scraper/
   ON PURPOSE (not the shared logs dir): when the shared root is unreachable
@@ -36,6 +42,8 @@
         <string>__SHARED_DIR__</string>
         <key>CHUNKY_RUN_AUTOMATION</key>
         <string>1</string>
+        <key>UV_THREADPOOL_SIZE</key>
+        <string>16</string>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>

--- a/tools/run-once.js
+++ b/tools/run-once.js
@@ -48,15 +48,49 @@
 //                          per-parser automationEnabled filter (parsers with
 //                          automationEnabled: false are skipped). Used by
 //                          tools/schedule-mac-run.sh.
+//   CHUNKY_SHARED_MATERIALIZE_CEILING_MS
+//                        — upper bound (ms) for the shared-root dataless-file
+//                          materialization sweep at startup (default 15 min).
+//                          macOS evicts iCloud files to dataless stubs, and
+//                          ANY fs syscall against a stub can wedge a libuv
+//                          threadpool thread in the kernel forever (the
+//                          2026-08 scheduled run hung 22+ minutes this way),
+//                          so before parser work the sweep force-downloads
+//                          every evicted file (`brctl download`) and polls
+//                          `find -flags +dataless` until the tree is clean.
+//                          Ceiling breach ABORTS LOUDLY (no-partial-runs).
+//   UV_THREADPOOL_SIZE   — defaulted to 16 below (and set explicitly in the
+//                          launchd plist template): JS-side timeouts cannot
+//                          cancel a wedged syscall, so each one leaks a
+//                          threadpool slot; with the default pool of 4, four
+//                          leaks starve every later fs/dns call.
 // ============================================================================
 
 'use strict';
 
+// Threadpool headroom FIRST, before anything can touch the async fs pool:
+// libuv reads UV_THREADPOOL_SIZE lazily at first threadpool use, so setting
+// it at entry works for direct `node tools/run-once.js` invocations too (the
+// launchd plist also sets it for scheduled runs — belt and braces).
+ensureThreadpoolHeadroom(process.env);
+
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const childProcess = require('child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
+
+// Default UV_THREADPOOL_SIZE to 16 unless the caller already chose a value.
+// Hoisted function declaration so the entry-point call above can run before
+// the requires. Returns the effective value for observability/tests.
+function ensureThreadpoolHeadroom(env) {
+    if (!env || typeof env !== 'object') return null;
+    if (!String(env.UV_THREADPOOL_SIZE || '').trim()) {
+        env.UV_THREADPOOL_SIZE = '16';
+    }
+    return env.UV_THREADPOOL_SIZE;
+}
 
 // Plain-object deep merge: objects merge key-wise, arrays and scalars replace.
 function deepMergeInto(target, source) {
@@ -167,6 +201,110 @@ function assertSharedStorageRootUsable(env = process.env, fsLike = fs) {
     return sharedRoot;
 }
 
+// ---------------------------------------------------------------------------
+// Shared-root MATERIALIZATION sweep (defense #1 against dataless iCloud
+// stubs). macOS evicts synced files to dataless placeholders; ANY fs syscall
+// against one (open/read/stat/rename/unlink) can block in the kernel until
+// fileproviderd materializes it — or forever when fileproviderd wedges, as it
+// did on the first scheduled run (two libuv threads sampled stuck 22+ minutes
+// in open() and rename()). JS-side promise timeouts cannot cancel those
+// syscalls, so the ONLY safe order is: download everything FIRST, then run.
+//
+// Detection deliberately never opens the files: `find -type f -flags
+// +dataless` reads only directory entries + inode flags. `brctl download`
+// asks fileproviderd to materialize the tree; the poll then watches the
+// dataless count fall to 0. Ceiling breach ABORTS LOUDLY (no-partial-runs: a
+// run that would wedge or silently miss shared cache entries must not limp).
+// Non-macOS, or find/brctl unavailable → sweep skipped (feature is Mac-only
+// in practice; the bounded fs ops in web-adapter remain as last defense).
+// ---------------------------------------------------------------------------
+const MATERIALIZE_CEILING_DEFAULT_MS = 15 * 60 * 1000;
+const MATERIALIZE_POLL_INTERVAL_MS = 30 * 1000;
+
+function resolveMaterializeCeilingMs(env = process.env) {
+    const raw = Number(String((env && env.CHUNKY_SHARED_MATERIALIZE_CEILING_MS) || '').trim());
+    return Number.isFinite(raw) && raw > 0 ? raw : MATERIALIZE_CEILING_DEFAULT_MS;
+}
+
+// Count dataless files under root without opening any of them.
+// Returns a number, or null when the probe is unavailable (non-macOS find,
+// missing binary) — null means "cannot sweep", never "zero".
+function countDatalessFilesViaFind(root) {
+    try {
+        const result = childProcess.spawnSync(
+            '/usr/bin/find',
+            [root, '-type', 'f', '-flags', '+dataless'],
+            { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+        );
+        if (result.error || result.status !== 0 || typeof result.stdout !== 'string') {
+            return null;
+        }
+        return result.stdout.split('\n').filter(Boolean).length;
+    } catch (_) {
+        return null;
+    }
+}
+
+// Ask fileproviderd to materialize the whole tree. Returns false when brctl
+// is unavailable/failed (caller skips the sweep instead of polling forever).
+function kickDatalessDownloadViaBrctl(root) {
+    try {
+        const result = childProcess.spawnSync('/usr/bin/brctl', ['download', root], { encoding: 'utf8' });
+        return !result.error && result.status === 0;
+    } catch (_) {
+        return false;
+    }
+}
+
+async function materializeSharedStorageTree(sharedRoot, options = {}) {
+    const {
+        platform = process.platform,
+        countDataless = countDatalessFilesViaFind,
+        kickDownload = kickDatalessDownloadViaBrctl,
+        ceilingMs = resolveMaterializeCeilingMs(process.env),
+        pollIntervalMs = MATERIALIZE_POLL_INTERVAL_MS,
+        sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+        now = Date.now,
+        log = console.log
+    } = options;
+
+    if (!sharedRoot) return { skipped: 'no-shared-root' };
+    if (platform !== 'darwin') {
+        log(`run-once: dataless materialization sweep skipped (platform ${platform} — the shared iCloud root is Mac-only in practice)`);
+        return { skipped: 'non-macos' };
+    }
+    const initialCount = countDataless(sharedRoot);
+    if (initialCount === null) {
+        log('run-once: dataless materialization sweep skipped (find -flags probe unavailable) — bounded fs ops remain the only dataless defense this run');
+        return { skipped: 'probe-unavailable' };
+    }
+    if (initialCount === 0) {
+        log('run-once: shared storage tree fully materialized (0 dataless files) — safe to start parser work');
+        return { datalessAtStart: 0, waitedMs: 0 };
+    }
+    log(`run-once: ${initialCount} dataless (evicted) file(s) under ${sharedRoot} — kicking iCloud download BEFORE parser work (touching a stub mid-run wedges libuv threadpool slots at syscall level)`);
+    if (!kickDownload(sharedRoot)) {
+        log('run-once: dataless materialization sweep skipped (brctl download unavailable/failed) — bounded fs ops remain the only dataless defense this run');
+        return { skipped: 'brctl-unavailable' };
+    }
+    const startedAt = now();
+    let count = initialCount;
+    while (count > 0) {
+        if (now() - startedAt >= ceilingMs) {
+            throw new Error(`run-once: shared storage tree still has ${count} dataless file(s) after ${Math.round(ceilingMs / 1000)}s — ABORTING (no-partial-runs: proceeding would wedge fs syscalls or miss shared cache entries). One-time fix: right-click the chunky-dad-scraper folder in Finder and choose "Keep Downloaded" so iCloud never evicts it; or re-run once the download finishes.`);
+        }
+        await sleep(pollIntervalMs);
+        count = countDataless(sharedRoot);
+        if (count === null) {
+            throw new Error('run-once: dataless probe (find -flags +dataless) broke mid-sweep — ABORTING instead of guessing the tree is materialized (no-partial-runs)');
+        }
+        log(`run-once: materialization progress — ${count} dataless file(s) remaining under the shared root`);
+    }
+    const waitedMs = now() - startedAt;
+    log(`run-once: shared storage tree fully materialized after ${Math.round(waitedMs / 1000)}s (${initialCount} file(s) downloaded) — safe to start parser work`);
+    return { datalessAtStart: initialCount, waitedMs };
+}
+
 // Tee console output into a buffer (still printed) so shared-storage runs can
 // persist a per-run log file the way the phone's FileLogger does.
 function installConsoleTee(lines) {
@@ -210,6 +348,10 @@ async function main() {
     const logLines = [];
     if (sharedRoot) {
         installConsoleTee(logLines);
+        // Defense #1 (dataless iCloud stubs): download every evicted file
+        // BEFORE any parser work. A ceiling breach throws — abort loudly to
+        // launchd's err log rather than start a run that would wedge.
+        await materializeSharedStorageTree(sharedRoot);
     }
 
     const { WebAdapter } = require(path.join(repoRoot, 'scripts', 'adapters', 'web-adapter'));
@@ -286,5 +428,8 @@ module.exports = {
     isAutomationEnv,
     shapeRunOnceConfig,
     assertSharedStorageRootUsable,
-    installConsoleTee
+    installConsoleTee,
+    ensureThreadpoolHeadroom,
+    resolveMaterializeCeilingMs,
+    materializeSharedStorageTree
 };

--- a/tools/schedule-mac-run.sh
+++ b/tools/schedule-mac-run.sh
@@ -20,6 +20,15 @@
 #   - If the shared root is unreachable (iCloud signed out, wrong path) the
 #     run ABORTS LOUDLY at startup instead of degrading to a local cache —
 #     check ~/Library/Logs/chunky-dad-scraper/scheduled-run.err.log.
+#   - DATALESS (EVICTED) iCLOUD FILES: macOS can evict synced files to
+#     placeholder stubs, and any fs syscall against a stub can wedge in the
+#     kernel (the 2026-08 first scheduled run hung 22+ minutes this way).
+#     run-once now materializes the whole shared tree at startup (brctl
+#     download + find -flags +dataless polling, 15-min ceiling → loud abort)
+#     and runs with UV_THREADPOOL_SIZE=16 headroom. RECOMMENDED one-time
+#     mitigation: right-click the chunky-dad-scraper folder in Finder and
+#     choose "Keep Downloaded" — iCloud then never evicts it and the sweep
+#     is always instant.
 #
 # RECOMMENDED CADENCE: daily (the default). Additionally, after script
 # updates that change AI/OCR prompts, run one MANUAL warm run — prompt
@@ -51,7 +60,7 @@ LAUNCHD_LOG_DIR="${HOME}/Library/Logs/chunky-dad-scraper"
 DEFAULT_SHARED_DIR="${HOME}/Library/Mobile Documents/iCloud~dk~simonbs~Scriptable/Documents/chunky-dad-scraper"
 
 usage() {
-    sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '2,49p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
     exit 1
 }
 
@@ -166,6 +175,19 @@ cmd_status() {
         echo "recent stderr (${LAUNCHD_LOG_DIR}/scheduled-run.err.log):"
         tail -n 5 "${LAUNCHD_LOG_DIR}/scheduled-run.err.log" | sed 's/^/  /'
     fi
+    # Dataless (evicted) iCloud files wedge fs syscalls at kernel level;
+    # run-once materializes them at startup, but a standing non-zero count
+    # here means slower starts (or an abort at the 15-min ceiling).
+    local shared_dir=""
+    if [[ -f "${PLIST_PATH}" ]]; then
+        shared_dir="$(plutil -extract EnvironmentVariables.CHUNKY_SHARED_STORAGE_DIR raw "${PLIST_PATH}" 2>/dev/null || true)"
+    fi
+    if [[ -n "${shared_dir}" && -d "${shared_dir}" ]]; then
+        local dataless_count
+        dataless_count="$(/usr/bin/find "${shared_dir}" -type f -flags +dataless 2>/dev/null | wc -l | tr -d ' ' || true)"
+        echo "dataless (evicted) files under shared dir: ${dataless_count:-unknown}"
+    fi
+    echo 'tip: right-click the chunky-dad-scraper folder in Finder and choose "Keep Downloaded" — prevents iCloud eviction entirely, so scheduled runs never wait on (or abort over) dataless-file materialization.'
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## The incident (first scheduled run after #1666)

The launchd job hung **22+ minutes on parser 1/21**. A process sample showed two libuv worker threads wedged in **kernel** syscalls against the iCloud tree:

- one in `open()` on a **dataless (evicted) stub** — the JS-side 30s bounded read fired and honestly reported a cache miss (`Shared cache read timed out after 30000ms (dataless iCloud stub still downloading?)` in `~/Library/Logs/chunky-dad-scraper/scheduled-run.out.log`), but the underlying syscall kept its threadpool slot hostage forever;
- one in `rename()` where `writeFileAtomicallyNode` renamed a temp file **over** a dataless placeholder, which **deadlocks inside fileproviderd** — the awaited rename never resolves, so the run hangs silently. The out-log shows that one timeout line, then 22 minutes of nothing.

**Lesson:** JS-side promise timeouts do NOT protect the libuv threadpool. Every fs op (open/read/stat/rename/unlink) against an evicted iCloud file can wedge at syscall level, and four wedged ops exhaust the default 4-slot pool — after which every later fs/dns call starves.

## The four defenses (defense in depth)

1. **Materialize at startup** (`tools/run-once.js`): when the shared root is active, before any parser work, count dataless files via `/usr/bin/find <root> -type f -flags +dataless` (never opens them), kick `brctl download <root>`, and poll with a progress line every 30s until the count reaches 0. Ceiling (default 15 min, `CHUNKY_SHARED_MATERIALIZE_CEILING_MS`) → **abort loudly** (no-partial-runs: a run that would wedge or miss the shared cache must not limp). Non-macOS / find / brctl unavailable → sweep skipped honestly.
2. **Never rename over a possibly-dataless target** (`web-adapter.js`): under the shared root, `writeFileAtomicallyNode` unlinks the destination before the rename (ENOENT = normal first write). Local-tree writes keep the pure atomic rename.
3. **Bounded fs ops + threadpool headroom**: the 30s bounded read is generalized into `boundedSharedFsOp`, now wrapping every shared-root fs op (read/write/rename/unlink/stat) — timeout ⇒ op treated as failed (read = miss, write = skipped by the caller's existing catch) with a loud log line. Comments document that the syscall may still hold a threadpool slot — which is exactly why defense 1 runs first — and `UV_THREADPOOL_SIZE=16` is defaulted at the run-once entry **and** pinned in the launchd plist template so a few leaked slots can't starve the loop.
4. **Scheduler preflight docs + status**: `tools/schedule-mac-run.sh` header documents the hazard/sweep; `status` now prints a live dataless-file count for the installed shared dir plus the mitigation tip.

## 👉 Recommended one-time manual mitigation (owner action)

**Right-click the `chunky-dad-scraper` folder in Finder → "Keep Downloaded".** iCloud then never evicts the tree, so scheduled runs never wait on (or abort over) materialization. Everything in this PR is belt-and-braces around that.

## Verification

- **Fail-on-base proof**: all 6 new tests were run against a pristine `origin/main` worktree and fail there — the wedged-rename/unlink test fails via its own 2s guard (i.e. base genuinely hangs forever), unlink-before-rename finds no unlink, the materialization/threadpool tests hit missing functions and a missing plist key.
- **Quiet suite green on the branch**: `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test` → **1775 pass, 0 fail** (1769 base + 6 new).
- **Grep-proof**: the diff removes zero `console.log` lines (additions only; the existing bounded-read miss line is byte-identical) and adds no `new URL`/`URLSearchParams` under `scripts/`.
- **Real-probe smoke**: `materializeSharedStorageTree` with the real `find -flags +dataless` probe on a fixture tree → `{"datalessAtStart":0,"waitedMs":0}`; rendered plist lints (`plutil -lint`) with `UV_THREADPOOL_SIZE=16` extractable; `schedule-mac-run.sh status` runs live and reports the dataless count.
- **Phone untouched**: only `web-adapter.js`, `tools/`, and the two enumerated test files change; `shared-core.js` and the Scriptable adapter are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP