### PR TITLE
fix(scheduler): /bin/zsh as launchd program — one Full Disk Access grant survives node upgrades

### DIFF
--- a/tools/launchd/com.chunky-dad.scraper-daily.plist.template
+++ b/tools/launchd/com.chunky-dad.scraper-daily.plist.template
@@ -18,6 +18,18 @@
   the run aborts loudly, and that abort message must land somewhere that does
   not depend on the unreachable dir. The per-run log itself is written into
   the shared logs/ dir by run-once.
+
+  WHY /bin/zsh IS THE PROGRAM (TCC / Full Disk Access): macOS attributes a
+  launchd job's file access to the job's main executable. Running node
+  directly means the Full Disk Access grant is pinned to one node binary
+  path (…/.nvm/versions/node/vX.Y.Z/bin/node) and silently breaks on every
+  node upgrade — proven live 2026-08-12: the identical command read the
+  iCloud shared cache instantly from a shell but wedged in kernel open()
+  under launchd until node was granted access. With /bin/zsh as the program
+  and node as its CHILD (no exec — zsh must stay alive as the responsible
+  process), one grant to /bin/zsh (a stable system binary) covers every
+  future node version. Grant once: System Settings → Privacy & Security →
+  Full Disk Access → add /bin/zsh (⌘⇧G to type the path).
 -->
 <plist version="1.0">
 <dict>
@@ -25,8 +37,9 @@
     <string>__LABEL__</string>
     <key>ProgramArguments</key>
     <array>
-        <string>__NODE__</string>
-        <string>__REPO__/tools/run-once.js</string>
+        <string>/bin/zsh</string>
+        <string>-c</string>
+        <string>"__NODE__" "__REPO__/tools/run-once.js"</string>
     </array>
     <key>WorkingDirectory</key>
     <string>__REPO__</string>

--- a/tools/schedule-mac-run.sh
+++ b/tools/schedule-mac-run.sh
@@ -131,11 +131,15 @@ cmd_install() {
 
     echo "Installed ${LABEL}:"
     echo "  runs daily at $(printf '%02d:%02d' "${hour}" "${minute}") (local time)"
+    echo "  program:     /bin/zsh (TCC responsible process; node runs as its child)"
     echo "  node:        ${node_bin}"
     echo "  repo:        ${REPO_ROOT}"
     echo "  shared dir:  ${shared_dir}"
     echo "  launchd log: ${LAUNCHD_LOG_DIR}/scheduled-run.{out,err}.log"
     echo "  per-run log: ${shared_dir}/logs/<YYYYMMDD-HHMMSS>.log (written by run-once)"
+    echo "ONE-TIME PERMISSION (survives node upgrades): System Settings → Privacy &"
+    echo "Security → Full Disk Access → add /bin/zsh (⌘⇧G to type the path). Without"
+    echo "it, launchd runs hang reading the iCloud shared cache (proven 2026-08-12)."
     echo "Reminder: after prompt-changing script updates, do one manual warm run (see header)."
 }
 


### PR DESCRIPTION
The launchd job currently executes the node binary directly, so the macOS Full Disk Access grant (required to read the iCloud shared cache — proven 2026-08-12: identical command instant from a shell, wedged in kernel `open()` under launchd, 3 reproductions) is pinned to one versioned nvm path and silently breaks on every node upgrade.

This PR makes `/bin/zsh` the job's program with node as its **child** (deliberately no `exec` — zsh must stay alive as the TCC responsible process). One grant to `/bin/zsh` — a stable system binary — then covers every future node version. The install output now prints the one-time permission instructions.

Tradeoff, stated plainly: granting `/bin/zsh` FDA extends to any launchd job run via zsh on this machine — acceptable on a personal Mac, and the owner asked for exactly this ("how to fix it up so I don't have to do this every year").

Rendered plist lints (`plutil -lint`); `bash -n` clean. Note for merge order: #1668 also touches the plist template (adds `UV_THREADPOOL_SIZE`) — whichever merges second may need a trivial both-sides resolution in the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP