### PR TITLE
fix(results-ui): compress cards — tappable route line, counted MERGE tag, changed-rows-only details, Evidence to debug

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -7026,6 +7026,33 @@ class ScriptableAdapter {
             opacity: 0.6;
         }
 
+        /* Every route-line part is a tappable bridge link (owner: "make the
+           bar, address, and coordinates be links"). */
+        .event-route-line .map-verify-link {
+            color: var(--primary-color);
+            text-decoration: none;
+        }
+
+        /* Compact write tag on the face (the expander's "Intent … • Write …"
+           note, compressed to a badge). */
+        .badge-write {
+            background: var(--background-light);
+            color: var(--text-secondary);
+            border: 1px solid var(--border-color);
+        }
+
+        .badge-write::before {
+            content: "✍️ ";
+        }
+
+        /* One muted line standing in for all the merge rows that changed
+           nothing (owner: the merge section should just be the changes). */
+        .merge-noop-summary td {
+            font-size: 11px;
+            color: var(--text-secondary);
+            font-style: italic;
+        }
+
         .headline-reason-chip {
             display: inline-block;
             font-size: 11px;
@@ -10106,6 +10133,25 @@ class ScriptableAdapter {
     return url;
   }
 
+  // Best single maps URL for a compact list row (owner: "make the route
+  // link on the list too"): the Route directions link when >= 2 location
+  // points exist, else the strongest single point (pin → address → bar).
+  // "" when the event carries no location signal at all.
+  buildEventListRowMapsUrl(event) {
+    if (!event || typeof event !== "object") return "";
+    return (
+      this.buildRouteMapsDirectionsUrl({
+        bar: event.venue || event.bar,
+        city: event.city,
+        address: event.address,
+        coordinates: event.location,
+      }) ||
+      this.buildPinMapsSearchUrl(event.location) ||
+      this.buildAddressMapsSearchUrl(event.address, event.city) ||
+      this.buildBarMapsSearchUrl(event.venue || event.bar, event.city)
+    );
+  }
+
   // Keyless OpenStreetMap embed centered on the pin (~400m box, marker on
   // the pin). OSM because it needs no API key and matches the Nominatim
   // stack the scraper already geocodes with; Google Maps embeds require an
@@ -11424,6 +11470,14 @@ class ScriptableAdapter {
     const bearVerdictRow = this.buildBearVerdictActionsHtml(bearOpts);
     const intentAction = this.normalizeIntentAction(event) || "other";
     const writeAction = this.getWriteActionFromEvent(event);
+    // Compressed merge state (owner: "the merge/write section in the
+    // expanded details should just be the merge tag and maybe a new write
+    // tag on the main card"): the MERGE badge carries the changed-field
+    // count (·N), computed from the SAME per-field records the details
+    // table renders, so the tag and the table can never disagree.
+    const changedFieldCount = this.countChangedMergeFields(event);
+    const mergeCountSuffix =
+      changedFieldCount === null ? "" : ` ·${changedFieldCount}`;
     // Dropped-as-non-bear cards never reached calendar analysis, so their
     // intent/write labels would read "OTHER / OTHER" — the drop badge and the
     // bear-check reason say something true instead.
@@ -11431,7 +11485,7 @@ class ScriptableAdapter {
       ? '<span class="action-badge badge-error">🚫 DROPPED — NOT BEAR</span>'
       : {
           new: '<span class="action-badge badge-new">NEW</span>',
-          merge: '<span class="action-badge badge-merge">MERGE</span>',
+          merge: `<span class="action-badge badge-merge">MERGE${mergeCountSuffix}</span>`,
           conflict: '<span class="action-badge badge-warning">CONFLICT</span>',
           missing_calendar:
             '<span class="action-badge badge-error">MISSING CALENDAR</span>',
@@ -11503,11 +11557,19 @@ class ScriptableAdapter {
     ]
       .filter(Boolean)
       .join(" • ");
+    // The expander's "Intent: … • Write: …" note is compressed onto the
+    // face: intent is the action badge, the write plan is the write tag
+    // below. Only dropped cards keep an expander note (the bear-check
+    // reason, which has no badge of its own).
+    const writeBadge =
+      !isDroppedCard && writeAction
+        ? `<span class="action-badge badge-write write-badge">${this.formatWriteActionLabel(writeAction)}</span>`
+        : "";
     const actionNote = isDroppedCard
       ? dropDetail
         ? `<div class="write-action-note">Bear check: ${this.escapeHtml(dropDetail)}</div>`
         : ""
-      : `<div class="write-action-note">Intent: ${this.formatIntentActionLabel(intentAction)} • Write: ${this.formatWriteActionLabel(writeAction)}</div>`;
+      : "";
 
     const eventDate = new Date(event.startDate);
     const endDate = event.endDate ? new Date(event.endDate) : null;
@@ -11603,17 +11665,11 @@ class ScriptableAdapter {
     const notes = event.notes || "";
     const calendarName = this.getCalendarNameForDisplay(event);
 
-    // Secondary verification surface (kept small): the same Bar/Address/Pin
-    // Google Maps links as the new-venue-candidates section, rendered only
-    // when the card has data for them (empty string otherwise).
-    const mapVerifyRow = this.buildMapVerifyLinksHtml({
-      bar: event.bar || event.venue,
-      city: event.city,
-      address: event.address,
-      coordinates: event.location,
-    });
     // Computed evidence panel (SharedCore attaches _evidenceLines during
     // calendar prep); "" when absent — e.g. saved-run display (fail open).
+    // Rendered inside the debug raw-display block ONLY (owner: "This section
+    // doesn't really help me") — display placement change, the lines stay in
+    // the run JSON untouched.
     const evidenceBlock = this.buildEvidenceLinesHtml(event._evidenceLines);
     // Event Builder prefill link (every card) + ICS export (recurring cards).
     const eventActionsRow = this.buildEventCardActionsHtml(event);
@@ -11635,26 +11691,73 @@ class ScriptableAdapter {
         : ' <span class="no-end-note">(no end listed)</span>'
     }`;
     const headlineVenue = event.venue || event.bar || "";
-    // Compact route line (owner feedback #3: "I miss the route info … show
-    // the bar/address/coordinates in a smaller more easy to view way"):
-    // bar • street part of the address • the stored pin as a small Google
-    // Maps link through the SAME openMapVerify bridge the Verify row uses
-    // (full Bar/Address/Pin/Route verify links stay in the expander).
+    // Tappable route line (owner: "Can we make the bar, address, and
+    // coordinates be links? Then make the route link on the list too?
+    // Instead of having it in both the main card and expanded details"):
+    // every part links out through the SAME openMapVerify bridge — bar →
+    // the event's own gmaps/place link when it has one, else a
+    // "<bar>, <city>" maps search; address → a maps search on the FULL
+    // stored address (short street form stays the visible label); pin → the
+    // stored coordinates; plus the Route directions link that used to live
+    // in the expander's Verify row. The expander's venue/address/coordinates
+    // rows and Verify row are GONE — this line is the one place a card
+    // carries route info.
+    const routeBridgeLink = (url, labelHtml, extraClass) => {
+      if (!url) return "";
+      const id = this.registerMapVerifyUrl(url);
+      return `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="map-verify-link ${extraClass}">${labelHtml}</a>`;
+    };
     const routeStreetAddress =
       typeof event.address === "string"
         ? event.address.split(",")[0].trim()
         : "";
     const routePinUrl = this.buildPinMapsSearchUrl(event.location);
     const routeParts = [];
-    if (headlineVenue) routeParts.push(this.escapeHtml(headlineVenue));
-    if (routeStreetAddress && routeStreetAddress !== headlineVenue)
-      routeParts.push(this.escapeHtml(routeStreetAddress));
-    if (routePinUrl) {
-      const routePinId = this.registerMapVerifyUrl(routePinUrl);
+    if (headlineVenue) {
+      const ownGmapsLink = [event.gmaps, event.googleMapsLink].find((url) =>
+        this.isSafeExternalUrl(url),
+      );
+      const barUrl =
+        ownGmapsLink || this.buildBarMapsSearchUrl(headlineVenue, event.city);
       routeParts.push(
-        `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${routePinId}" class="map-verify-link route-pin-link">${this.escapeHtml(
-          this.buildPinMapsQuery(event.location),
-        )} ↗</a>`,
+        routeBridgeLink(
+          barUrl,
+          this.escapeHtml(headlineVenue),
+          "route-bar-link",
+        ) || this.escapeHtml(headlineVenue),
+      );
+    }
+    if (routeStreetAddress && routeStreetAddress !== headlineVenue) {
+      const addressUrl = this.buildAddressMapsSearchUrl(
+        event.address,
+        event.city,
+      );
+      routeParts.push(
+        routeBridgeLink(
+          addressUrl,
+          this.escapeHtml(routeStreetAddress),
+          "route-address-link",
+        ) || this.escapeHtml(routeStreetAddress),
+      );
+    }
+    if (routePinUrl) {
+      routeParts.push(
+        routeBridgeLink(
+          routePinUrl,
+          `${this.escapeHtml(this.buildPinMapsQuery(event.location))} ↗`,
+          "route-pin-link",
+        ),
+      );
+    }
+    const routeDirectionsUrl = this.buildRouteMapsDirectionsUrl({
+      bar: headlineVenue,
+      city: event.city,
+      address: event.address,
+      coordinates: event.location,
+    });
+    if (routeDirectionsUrl) {
+      routeParts.push(
+        routeBridgeLink(routeDirectionsUrl, "Route ↗", "route-directions-link"),
       );
     }
     const routeLineHtml =
@@ -11706,7 +11809,7 @@ class ScriptableAdapter {
     let html = `
         <div class="event-card${isDroppedCard ? " bear-dropped-card" : ""}">
             <div class="event-headline">
-                <div class="event-headline-badges">${actionBadge}${recurringBadge}${seriesMatchBadge}${sanityBadge}${overrideBadge}${seriesProposalBadge}${headlineReasonChip}</div>
+                <div class="event-headline-badges">${actionBadge}${writeBadge}${recurringBadge}${seriesMatchBadge}${sanityBadge}${overrideBadge}${seriesProposalBadge}${headlineReasonChip}</div>
                 <div class="event-headline-main">
                     ${thumbHtml}
                     <div class="event-headline-body">
@@ -11722,45 +11825,12 @@ class ScriptableAdapter {
             <details class="event-card-details">
             <summary class="event-card-details-summary">Details</summary>
             ${actionNote}${cadenceHintNote}
-            <!-- Main Event Info -->
+            <!-- Main Event Info. The face already carries venue/address/pin
+                 (as bridge links), the date line, and the thumbnail — none of
+                 them repeat here (owner: "I don't want to duplicate it in the
+                 details"). -->
             <div class="event-details">
-                ${
-                  event.venue || event.bar
-                    ? `
-                    <div class="event-detail">
-                        <span>📍</span>
-                        <span>${this.escapeHtml(event.venue || event.bar)}</span>
-                    </div>
-                `
-                    : ""
-                }
-                ${
-                  event.address
-                    ? `
-                    <div class="event-detail">
-                        <span>🏠</span>
-                        <span>${this.escapeHtml(event.address)}</span>
-                    </div>
-                `
-                    : ""
-                }
-                ${
-                  event.location
-                    ? `
-                    <div class="event-detail coordinates">
-                        <span>🌐</span>
-                        <span>Coordinates: ${this.escapeHtml(event.location)}</span>
-                    </div>
-                `
-                    : ""
-                }
-                ${mapVerifyRow}
                 ${eventActionsRow}
-                ${evidenceBlock}
-                <div class="event-detail">
-                    <span>📅</span>
-                    <span>${dateLineHtml}</span>
-                </div>
                 <div class="event-detail" style="font-size: 12px; color: #666; margin-left: 20px;">
                     <span>🌍</span>
                     <span>UTC: ${utcTimeStr}${
@@ -11789,23 +11859,6 @@ class ScriptableAdapter {
                     <div class="event-detail" style="background: #e8f5e9; padding: 8px; border-radius: 5px; margin-top: 8px;">
                         <span>☕</span>
                         <span style="font-style: italic;">${this.escapeHtml(event.tea)}</span>
-                    </div>
-                `
-                    : ""
-                }
-                ${
-                  event.image
-                    ? `
-                    <div class=\"event-image${isRepeatedImage ? " venue-placeholder-image" : ""}\">
-                        ${
-                          isRepeatedImage
-                            ? `<div class=\"venue-placeholder-badge\">🖼️ venue placeholder image — same image on ${repeatedImageCount} events this run</div>`
-                            : ""
-                        }
-                        <a href=\"${this.escapeHtml(event.image)}\" target=\"_blank\" rel=\"noopener\" style=\"color: var(--primary-color); font-weight: 500;\">View Full Image</a>
-                        <div class=\"image-container\" style=\"margin-top: 8px; display: block;\">
-                            <img src=\"${this.escapeHtml(event.image)}\" alt=\"Event Image\" onerror=\"this.style.display='none'\">
-                        </div>
                     </div>
                 `
                     : ""
@@ -11990,7 +12043,7 @@ class ScriptableAdapter {
                         ${this.buildFieldRowsTableHtml(
                           this.claimMergeDiffBudget(
                             "field-by-field comparison",
-                            this.generateComparisonRows(event),
+                            this.generateComparisonRowsCompressed(event),
                             event,
                             { asTableRow: true },
                           ),
@@ -12079,6 +12132,7 @@ class ScriptableAdapter {
             }
             
             <div class="raw-display">
+                ${evidenceBlock}
                 ${(() => {
                   // ONE payload per card. Keeps _original (merge provenance)
                   // but drops the AI prompt/validation blobs — see
@@ -13111,6 +13165,23 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
           eventCell.subtitleText = subtitle.join(" • ") || "Event details";
           eventCell.subtitleColor = Color.gray();
 
+          // Route link on the list row too (owner: "make the route link on
+          // the list too") — a native button cell opening the same maps URL
+          // the card's route line uses. Native UITable API, no WebView
+          // bridge involved (this fallback only renders when the WebView
+          // could not).
+          const rowMapsUrl = this.buildEventListRowMapsUrl(event);
+          if (rowMapsUrl) {
+            eventRow.dismissOnSelect = false;
+            eventCell.widthWeight = 75;
+            const routeCell = eventRow.addButton("📍 Route");
+            routeCell.widthWeight = 25;
+            routeCell.rightAligned();
+            routeCell.onTap = () => {
+              Safari.open(rowMapsUrl);
+            };
+          }
+
           table.addRow(eventRow);
         });
 
@@ -13958,9 +14029,56 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     });
   }
 
-  // Generate comparison rows for conflict display
+  // Generate comparison rows for conflict display (every row, uncompressed).
   generateComparisonRows(event) {
-    if (!event._original) return "";
+    const records = this.buildComparisonRowRecords(event);
+    if (!records) return "";
+    return records.map((record) => record.html).join("");
+  }
+
+  // Compressed variant for the card expander (owner: "the merge/write
+  // section in the expanded details should just be the merge tag"): only
+  // rows that CHANGED something render; no-op rows ("same in both", "kept
+  // existing" with an ignored candidate) collapse to one muted summary line
+  // naming the untouched fields.
+  generateComparisonRowsCompressed(event) {
+    const records = this.buildComparisonRowRecords(event);
+    if (!records) return "";
+    const parts = records
+      .filter((record) => record.changed)
+      .map((record) => record.html);
+    const noopFields = records
+      .filter((record) => !record.changed)
+      .map((record) => record.field);
+    if (noopFields.length > 0) {
+      const MAX_NAMES = 8;
+      const names =
+        noopFields.slice(0, MAX_NAMES).join(", ") +
+        (noopFields.length > MAX_NAMES ? ", …" : "");
+      parts.push(
+        `<tr class="field-row merge-noop-summary"><td colspan="4">${noopFields.length} field${
+          noopFields.length === 1 ? "" : "s"
+        } unchanged — ${this.escapeHtml(names)}</td></tr>`,
+      );
+    }
+    return parts.join("");
+  }
+
+  // Changed-field count behind the card's "MERGE ·N" tag. null when the
+  // event has no merge provenance to count (e.g. NEW events, saved runs
+  // stripped of _original) — the badge then renders without a count.
+  countChangedMergeFields(event) {
+    const records = this.buildComparisonRowRecords(event);
+    if (!records) return null;
+    return records.filter((record) => record.changed).length;
+  }
+
+  // One record per comparison field: { field, changed, html }. `changed`
+  // means the merge left the field DIFFERENT from what the calendar already
+  // had (added/clobbered/cleared/rewrote); kept-existing and same-value
+  // rows are no-ops. null (not []) when the event has no _original.
+  buildComparisonRowRecords(event) {
+    if (!event || !event._original) return null;
 
     // Use the same field logic as comparison (includes core fields not in notes)
     const fieldsToCompare = this.getFieldsForComparison(event);
@@ -14329,17 +14447,46 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         }
       }
 
-      rows.push(
-        this.buildFieldRowHtml({
+      // No-op detection for the compressed view: the merge left this field
+      // as the calendar already had it. Date-aware via
+      // mergeValuesLookIdentical, empty-aware (undefined/null/"" are all
+      // "nothing"), and object-aware (JSON-equal). Anything unclear counts
+      // as changed — better a superfluous row than a hidden change.
+      const isEmptyish = (value) =>
+        value === undefined || value === null || value === "";
+      const valuesJsonEqual = (a, b) => {
+        if (
+          typeof a !== "object" ||
+          a === null ||
+          typeof b !== "object" ||
+          b === null
+        ) {
+          return false;
+        }
+        try {
+          return JSON.stringify(a) === JSON.stringify(b);
+        } catch (error) {
+          return false;
+        }
+      };
+      const rowIsNoop =
+        mergeValuesLookIdentical(finalValue, existingValue) ||
+        (isEmptyish(finalValue) && isEmptyish(existingValue)) ||
+        valuesJsonEqual(finalValue, existingValue);
+
+      rows.push({
+        field,
+        changed: !rowIsNoop,
+        html: this.buildFieldRowHtml({
           fieldHtml: `<strong>${field}</strong><br><small>${strategyLabel}</small>`,
           valueHtml: valueParts.join(""),
           sourceHtml: `${flowIcon ? `<span class="field-row-flow">${flowIcon}</span> ` : ""}${resultText}`,
           reasonHtml: reasonCellHtml,
         }),
-      );
+      });
     });
 
-    return rows.join("");
+    return rows;
   }
 
   // Longest slice of any single value the line-by-line diff will render.

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -2546,8 +2546,9 @@ test('candidate rows carry the verify row and a lazy inline dual-map toggle', as
   assert.ok(noCoords.includes('Bar ↗'), 'other links unaffected');
 });
 
-test('event cards carry the compact verify row only when venue-ish data exists', () => {
+test('event cards carry the verify links on the face route line, never a details verify row', () => {
   const adapter = buildMapsAdapter();
+  adapter.resetMapVerifyUrls();
   const html = adapter.generateEventCard({
     title: 'Bear Night',
     startDate: '2026-08-01T02:00:00.000Z',
@@ -2557,8 +2558,17 @@ test('event cards carry the compact verify row only when venue-ish data exists',
     location: '47.6135, -122.3163',
     _action: 'new'
   });
-  assert.ok(html.includes('map-verify-row'), 'compact row on the card');
-  assert.ok(html.includes('Bar ↗') && html.includes('Address ↗') && html.includes('Pin ↗'));
+  // The old expander Verify row is gone (owner: "Instead of having it in
+  // both the main card and expanded details") — its four links now ARE the
+  // route-line parts on the face, all through the same bridge registry.
+  assert.ok(!html.includes('map-verify-row'), 'no separate verify row on cards');
+  for (const cls of ['route-bar-link', 'route-address-link', 'route-pin-link', 'route-directions-link']) {
+    assert.ok(html.includes(cls), `${cls} on the face route line`);
+  }
+  const urls = Object.values(adapter._mapVerifyUrls);
+  assert.ok(urls.some((u) => u.startsWith(MAPS_SEARCH_PREFIX) && u.includes('Massive')), 'bar search URL registered');
+  assert.ok(urls.some((u) => u.startsWith(MAPS_SEARCH_PREFIX) && u.includes('1400%2012th%20Ave')), 'address search URL registered');
+  assert.ok(urls.some((u) => u.startsWith(MAPS_DIR_PREFIX)), 'route directions URL registered');
 
   const bare = adapter.generateEventCard({
     title: 'No venue data',
@@ -2566,6 +2576,7 @@ test('event cards carry the compact verify row only when venue-ish data exists',
     _action: 'new'
   });
   assert.ok(!bare.includes('map-verify-row'), 'no row without bar/address/location');
+  assert.ok(!bare.includes('route-bar-link'), 'no links without venue data');
 });
 
 test('presentRichResults opens verify links in Safari via the open-url bridge', async () => {
@@ -4571,13 +4582,14 @@ test('override card: slot-host events are badged as a single-occurrence override
   // Which occurrence: the RECURRENCE-ID rendered in the calendar's timezone —
   // 2026-08-07T00:00Z is Thursday Aug 6 in Los Angeles, not Friday Aug 7.
   assert.ok(card.includes('Thu, Aug 6, 2026'), `expected the LA-local occurrence date, got: ${card.slice(0, 900)}`);
-  // Distinct from NEW/CREATE in the write plan line, not only in the badge.
-  assert.ok(card.includes('Write: OVERRIDE'), 'write plan line says OVERRIDE');
-  assert.ok(!card.includes('Write: CREATE'), 'an override is never reported as a plain create');
+  // Distinct from NEW/CREATE in the write tag on the face, not only in the
+  // override badge (the old expander "Write: …" note is compressed to a tag).
+  assert.ok(card.includes('write-badge">OVERRIDE</span>'), 'write tag says OVERRIDE');
+  assert.ok(!card.includes('write-badge">CREATE</span>'), 'an override is never reported as a plain create');
 
   const plain = adapter.generateEventCard({ title: 'Plain', _action: 'new', startDate: '2026-08-07T00:00:00.000Z' });
   assert.ok(!plain.includes('series-override-badge'), 'no badge without the stamp');
-  assert.ok(plain.includes('Write: CREATE'), 'unstamped events keep their old write label');
+  assert.ok(plain.includes('write-badge">CREATE</span>'), 'unstamped events keep their old write label');
 });
 
 test('override label falls back to the event start, and a floating RECURRENCE-ID is read as a wall clock', () => {
@@ -4600,7 +4612,7 @@ test('a recurring series stamped slot-host stays WITHHELD — the label never pr
   const event = buildSlotHostOverrideEvent({ _recurring: true });
   assert.equal(adapter.getWriteActionFromEvent(event), 'withheld');
   const card = adapter.generateEventCard(event);
-  assert.ok(card.includes('Write: WITHHELD'), 'filterEventsForExecution is the real gate');
+  assert.ok(card.includes('write-badge">WITHHELD</span>'), 'filterEventsForExecution is the real gate');
   assert.ok(card.includes('series-override-badge'), 'the override state is still surfaced (flag, do not drop)');
 });
 
@@ -4616,7 +4628,7 @@ test('cadence hints are reported on the card and never become a series write', (
   assert.ok(card.includes('Cadence hint (not written): FREQ=WEEKLY;BYDAY=TH'), 'hint surfaced');
   assert.ok(!card.includes('<script>alert(1)</script>'), 'page-derived evidence is escaped');
   assert.ok(card.includes('&lt;script&gt;'), 'escaped rather than dropped');
-  assert.ok(card.includes('Write: OVERRIDE'), 'a cadence hint does not upgrade the write to a series');
+  assert.ok(card.includes('write-badge">OVERRIDE</span>'), 'a cadence hint does not upgrade the write to a series');
 });
 
 test('series-change proposals render current vs proposed with evidence, source and calendar', () => {
@@ -8136,14 +8148,17 @@ test('event cards are headline + collapsed details, nothing deleted', async () =
   assert.ok(headline.includes('📍'));
   assert.ok(headline.includes('The Eagle'));
 
-  // Everything else moved INTO the expander — still present, not deleted.
+  // The face carries the route info (as bridge links) and the thumbnail;
+  // the expander keeps ONLY what the face does not show — nothing deleted,
+  // nothing duplicated (owner: "I don't want to duplicate it in the details").
+  assert.ok(headline.includes('1 Main St'), 'address on the face route line');
+  assert.ok(headline.includes('event-thumb'), 'image visible on the face');
   const details = html.slice(detailsIdx);
-  assert.ok(details.includes('1 Main St'), 'address kept');
   assert.ok(details.includes('A very bear night'), 'description kept');
   assert.ok(details.includes('📝 Calendar Notes Preview'), 'notes preview kept');
   assert.ok(details.includes('raw-json'), 'debug JSON kept');
   assert.ok(details.includes('copyEventJSON(this)'), 'copy button kept');
-  assert.ok(details.includes('image-container'), 'image kept');
+  assert.ok(!details.includes('image-container'), 'no duplicate image block in the details');
 });
 
 test('multi-day headline carries the end date, same-day only the end time', () => {
@@ -8177,11 +8192,10 @@ test('repeated-image badge fires at 3+ uses in one run and never at 2', async ()
     errors: [],
     parserResults: []
   });
-  assert.ok(html3.includes('venue placeholder image'), 'badge fires at 3 uses');
-  assert.ok(html3.includes('same image on 3 events this run'));
-  // The class lands on the image block itself (the bare selector string also
-  // lives in the page CSS, so assert the applied class, not the substring).
-  assert.ok(html3.includes('event-image venue-placeholder-image'), 'image block greyed via class');
+  // The census surfaces on the face thumbnail (the details image block is
+  // gone — the thumb IS the card's image now): greyed class + count chip.
+  assert.ok(html3.includes('🖼️ placeholder ×3'), 'badge fires at 3 uses');
+  assert.ok(html3.includes('event-thumb venue-placeholder-thumb'), 'thumb greyed via class');
 
   const adapter2 = buildAdapter();
   const html2 = await adapter2.generateRichHTML({
@@ -8189,8 +8203,8 @@ test('repeated-image badge fires at 3+ uses in one run and never at 2', async ()
     errors: [],
     parserResults: []
   });
-  assert.ok(!html2.includes('venue placeholder image'), 'no badge at 2 uses');
-  assert.ok(!html2.includes('event-image venue-placeholder-image'));
+  assert.ok(!html2.includes('🖼️ placeholder ×'), 'no badge at 2 uses');
+  assert.ok(!html2.includes('event-thumb venue-placeholder-thumb'));
 });
 
 test('dropped cards count toward the repeated-image census', async () => {
@@ -8212,7 +8226,7 @@ test('dropped cards count toward the repeated-image census', async () => {
     errors: [],
     parserResults: []
   });
-  assert.ok(html.includes('venue placeholder image'), '2 kept + 1 dropped = 3 uses, badge fires');
+  assert.ok(html.includes('🖼️ placeholder ×3'), '2 kept + 1 dropped = 3 uses, badge fires');
 });
 
 test('merge rows label deterministic vs AI vs no-op decisions in plain words', () => {
@@ -8268,18 +8282,27 @@ test('merge rows label deterministic vs AI vs no-op decisions in plain words', (
   };
   const html = adapter.generateEventCard(event);
 
-  // Deterministic resolution: labeled as such, with outcome; the WHY lives
-  // in the shared row format's own reason cell.
-  assert.ok(html.includes('🔒 DETERMINISTIC — kept existing'));
-  assert.ok(html.includes('identity link beats a ticketing/social platform URL'));
-  // AI arbitration: labeled AI with the pick, reason in its own cell.
+  // The card table renders ONLY rows that changed something: the AI adoption
+  // in full, reason in the shared row format's own reason cell.
   assert.ok(html.includes('🤝 AI — chose new'));
   assert.ok(html.includes('poster names this event'));
-  // No-decision identical field: a clear no-op label, not a mystery token.
-  assert.ok(html.includes('SAME VALUE'));
+  // No-op rows (deterministic kept-existing, same-value) compress into one
+  // summary line naming the untouched fields (owner: the merge section
+  // should just be the changes).
+  assert.ok(!html.includes('🔒 DETERMINISTIC — kept existing'));
+  assert.ok(!html.includes('SAME VALUE'));
+  assert.ok(html.includes('2 fields unchanged'), 'summary line counts the no-ops');
+  assert.ok(/2 fields unchanged — [^<]*website/.test(html), 'summary names the untouched fields');
   // Strategy under the field name reads as words, not a bare "ai".
   assert.ok(html.includes('<small>AI-arbitrated</small>'));
   assert.ok(!html.includes('<small>ai</small>'));
+
+  // The uncompressed renderer keeps EVERY row — deterministic label and its
+  // reason intact for tooling and the provenance-preserve tests.
+  const fullRows = adapter.generateComparisonRows(event);
+  assert.ok(fullRows.includes('🔒 DETERMINISTIC — kept existing'));
+  assert.ok(fullRows.includes('identity link beats a ticketing/social platform URL'));
+  assert.ok(fullRows.includes('SAME VALUE'));
 });
 
 test('merge rows label calendar stickiness and clobber fallback', () => {
@@ -8297,7 +8320,7 @@ test('merge rows label calendar stickiness and clobber fallback', () => {
     },
     _fieldPriorities: { ticketUrl: { merge: 'ai' } }
   };
-  const stickyHtml = adapter.generateEventCard({
+  const stickyEvent = {
     ...base,
     ticketUrl: 'https://tickets.example/saved',
     _mergeDecisions: [{
@@ -8308,8 +8331,13 @@ test('merge rows label calendar stickiness and clobber fallback', () => {
       reason: 'calendar stickiness (binding) — saved value kept without AI arbitration',
       source: 'sticky'
     }]
-  });
-  assert.ok(stickyHtml.includes('🧊 KEPT EXISTING (calendar stickiness)'));
+  };
+  const stickyHtml = adapter.generateEventCard(stickyEvent);
+  // A sticky keep is a no-op — compressed off the card table into the
+  // summary line; the labeled row survives in the uncompressed renderer.
+  assert.ok(!stickyHtml.includes('🧊 KEPT EXISTING (calendar stickiness)'));
+  assert.ok(/\d+ fields? unchanged — [^<]*ticketUrl/.test(stickyHtml), 'ticketUrl named in the unchanged summary');
+  assert.ok(adapter.generateComparisonRows(stickyEvent).includes('🧊 KEPT EXISTING (calendar stickiness)'));
 
   const fallbackHtml = adapter.generateEventCard({
     ...base,
@@ -8873,4 +8901,245 @@ test('placeholder-badged thumbnails stay visible on the face with their badge', 
   assert.ok(html.includes('event-thumb venue-placeholder-thumb'), 'thumb greyed via class');
   assert.ok(html.includes('event-thumb-badge'), 'compact placeholder badge on the thumb');
   assert.ok(html.includes('🖼️ placeholder ×3'), 'badge states the reuse count');
+});
+
+// ---------------------------------------------------------------------------
+// Results-UI compression (owner feedback): tappable route line, merge tag +
+// changed-rows-only details, Evidence in the debug block only
+// ---------------------------------------------------------------------------
+
+function buildCompressionMergeEvent(overrides = {}) {
+  const shared = {
+    bar: 'Massive',
+    address: '1400 12th Ave, Seattle, WA 98122',
+    location: '47.6135, -122.3163',
+    title: 'Compressed Night',
+    startDate: '2026-09-01T02:00:00.000Z',
+    endDate: '2026-09-01T05:00:00.000Z',
+    // Real runs stamp key on BOTH _original sides (checked against
+    // rerun-0812) — an absent key would inflate the changed-field count.
+    key: 'compressed-night'
+  };
+  return {
+    ...shared,
+    _action: 'merge',
+    city: 'seattle',
+    image: 'https://cdn.example/new-poster.jpg',
+    website: 'https://www.example.com',
+    _evidenceLines: ['pin is 0 m from curated pin', 'bar corroborated: curated'],
+    _original: {
+      scraper: { ...shared, image: 'https://cdn.example/new-poster.jpg', website: 'https://tickets.example/x' },
+      calendar: { ...shared, image: 'https://cdn.example/old-poster.jpg', website: 'https://www.example.com' },
+      merged: { ...shared, image: 'https://cdn.example/new-poster.jpg', website: 'https://www.example.com' }
+    },
+    _fieldPriorities: { image: { merge: 'ai' }, website: { merge: 'ai' } },
+    _mergeDecisions: [
+      {
+        field: 'image',
+        existingValue: 'https://cdn.example/old-poster.jpg',
+        newValue: 'https://cdn.example/new-poster.jpg',
+        chosenValue: 'https://cdn.example/new-poster.jpg',
+        reason: 'poster names this event',
+        source: 'ai'
+      },
+      {
+        field: 'website',
+        existingValue: 'https://www.example.com',
+        newValue: 'https://tickets.example/x',
+        chosenValue: 'https://www.example.com',
+        reason: 'identity link beats a ticketing URL',
+        source: 'deterministic'
+      }
+    ],
+    ...overrides
+  };
+}
+
+test('route line parts are tappable bridge links: bar (own gmaps first), address, pin, and Route', () => {
+  const adapter = buildMapsAdapter();
+  adapter.resetMapVerifyUrls();
+  const card = adapter.generateEventCard(
+    buildCompressionMergeEvent({ gmaps: 'https://maps.app.goo.gl/abc123' })
+  );
+  const face = card.slice(0, card.indexOf('<details class="event-card-details">'));
+
+  const urlFor = (cls) => {
+    const m = face.match(new RegExp(`data-map-url-id="(\\d+)" class="map-verify-link ${cls}"`));
+    return m ? adapter._mapVerifyUrls[m[1]] : undefined;
+  };
+  assert.equal(urlFor('route-bar-link'), 'https://maps.app.goo.gl/abc123',
+    'bar links the event\'s own gmaps/place link when it has one');
+  assert.ok(urlFor('route-address-link').startsWith(MAPS_SEARCH_PREFIX), 'address links a maps search');
+  assert.ok(urlFor('route-address-link').includes('1400%2012th%20Ave'), 'search carries the stored address');
+  assert.ok(urlFor('route-pin-link').endsWith('47.6135%2C-122.3163'), 'pin links the stored coordinates');
+  assert.ok(urlFor('route-directions-link').startsWith(MAPS_DIR_PREFIX),
+    'the Route directions link rides the face route line now');
+  // Every part goes through the SAME shouldAllowRequest bridge — no plain
+  // https hrefs that would navigate the results WebView away.
+  assert.ok(!face.includes('href="https'), 'no plain https hrefs on the route line');
+
+  // Without an own gmaps link the bar falls back to a "<bar>, <city>" search.
+  adapter.resetMapVerifyUrls();
+  const fallbackCard = adapter.generateEventCard(buildCompressionMergeEvent());
+  const fallbackFace = fallbackCard.slice(0, fallbackCard.indexOf('<details class="event-card-details">'));
+  const m = fallbackFace.match(/data-map-url-id="(\d+)" class="map-verify-link route-bar-link"/);
+  assert.ok(m, 'bar link present without gmaps');
+  assert.ok(adapter._mapVerifyUrls[m[1]].startsWith(MAPS_SEARCH_PREFIX));
+  assert.ok(adapter._mapVerifyUrls[m[1]].includes('Massive'));
+});
+
+test('UITable fallback list rows carry a tappable route link', async () => {
+  const adapter = buildMapsAdapter();
+  const rows = [];
+  const makeCell = (type, title) => ({
+    type,
+    title,
+    rightAligned() {},
+    leftAligned() {},
+    centerAligned() {}
+  });
+  class FakeUITableRow {
+    constructor() { this.cells = []; }
+    addText(title) { const c = makeCell('text', title); this.cells.push(c); return c; }
+    addButton(title) { const c = makeCell('button', title); this.cells.push(c); return c; }
+  }
+  class FakeUITable {
+    constructor() { this.rows = []; }
+    addRow(row) { rows.push(row); this.rows.push(row); }
+    async present() {}
+  }
+  const opened = [];
+  global.UITable = FakeUITable;
+  global.UITableRow = FakeUITableRow;
+  global.Font = {
+    boldSystemFont: () => ({}),
+    systemFont: () => ({}),
+    italicSystemFont: () => ({})
+  };
+  global.Color = {
+    white: () => ({}), brown: () => ({}), gray: () => ({}),
+    blue: () => ({}), green: () => ({}), red: () => ({})
+  };
+  global.Safari = { open: (url) => opened.push(url) };
+  try {
+    await adapter.presentUITableFallback({
+      totalEvents: 1,
+      bearEvents: 1,
+      calendarEvents: 0,
+      errors: [],
+      parserResults: [],
+      analyzedEvents: [{
+        title: 'Bear Night',
+        _action: 'new',
+        startDate: '2026-08-01T02:00:00.000Z',
+        city: 'seattle',
+        bar: 'Massive',
+        address: '1400 12th Ave',
+        location: '47.6135, -122.3163'
+      }]
+    });
+    const routeCells = rows.flatMap((row) =>
+      row.cells.filter((cell) => cell.type === 'button' && cell.title === '📍 Route'));
+    assert.equal(routeCells.length, 1, 'the event list row got a route button');
+    routeCells[0].onTap();
+    assert.equal(opened.length, 1, 'tap opens the maps URL natively');
+    assert.ok(opened[0].startsWith(MAPS_DIR_PREFIX), 'route directions URL — same builders as the card');
+  } finally {
+    delete global.UITable;
+    delete global.UITableRow;
+    delete global.Font;
+    delete global.Color;
+    delete global.Safari;
+  }
+
+  // The row URL degrades gracefully as location data thins out.
+  assert.ok(adapter.buildEventListRowMapsUrl({ location: '47.61, -122.33' }).startsWith(MAPS_SEARCH_PREFIX));
+  assert.ok(adapter.buildEventListRowMapsUrl({ bar: 'Massive', city: 'seattle' }).includes('Massive'));
+  assert.equal(adapter.buildEventListRowMapsUrl({}), '');
+  assert.equal(adapter.buildEventListRowMapsUrl(null), '');
+});
+
+test('expanded details carry no duplicate route/address/date/image blocks', () => {
+  const adapter = buildMapsAdapter();
+  const card = adapter.generateEventCard(buildCompressionMergeEvent());
+  const detailsIdx = card.indexOf('<details class="event-card-details">');
+  const rawIdx = card.indexOf('class="raw-display"');
+  assert.ok(detailsIdx !== -1 && rawIdx > detailsIdx, 'expander then debug block');
+  const details = card.slice(detailsIdx, rawIdx);
+
+  assert.ok(!details.includes('map-verify-row'), 'no verify row in the details');
+  assert.ok(!details.includes('<span>📍</span>'), 'no duplicate venue row');
+  assert.ok(!details.includes('<span>🏠</span>'), 'no duplicate address row');
+  assert.ok(!details.includes('Coordinates:'), 'no duplicate coordinates row');
+  assert.ok(!details.includes('<span>📅</span>'), 'no duplicate date row');
+  assert.ok(details.includes('<span>🌍</span>'), 'UTC verification row kept (unique info)');
+  assert.ok(!details.includes('image-container'), 'no duplicate image block');
+  assert.ok(!details.includes('View Full Image'));
+});
+
+test('merge state compresses to a counted MERGE tag plus a write tag on the card face', () => {
+  const adapter = buildMapsAdapter();
+  const card = adapter.generateEventCard(buildCompressionMergeEvent());
+  const face = card.slice(0, card.indexOf('<details class="event-card-details">'));
+
+  // Face: MERGE ·N (N = changed fields) + the write plan as a tag.
+  assert.ok(face.includes('MERGE ·1</span>'), 'MERGE tag carries the changed-field count');
+  assert.ok(face.includes('write-badge">UPDATE</span>'), 'write tag on the face');
+  // The expander note that used to duplicate this is gone.
+  assert.ok(!card.includes('Intent: MERGE'), 'no Intent/Write note in the details');
+
+  // Details table: ONLY the changed row, plus one summary line for no-ops.
+  assert.ok(card.includes('🤝 AI — chose new'), 'the changed row renders in full');
+  assert.ok(!card.includes('🔒 DETERMINISTIC'), 'no-op decision row compressed out');
+  const summary = card.match(/(\d+) fields? unchanged/);
+  assert.ok(summary, 'one summary line for the unchanged fields');
+  assert.ok(Number(summary[1]) >= 5, 'the untouched fields are counted, not rendered as rows');
+  assert.ok(card.includes('merge-noop-summary'), 'summary rides the shared table as one row');
+  // Tag and table agree by construction.
+  assert.equal(adapter.countChangedMergeFields(buildCompressionMergeEvent()), 1);
+});
+
+test('Evidence lines render only inside the debug raw-display block', () => {
+  const adapter = buildMapsAdapter();
+  const card = adapter.generateEventCard(buildCompressionMergeEvent());
+  const rawIdx = card.indexOf('class="raw-display"');
+  const evidenceIdx = card.indexOf('evidence-block');
+  assert.ok(evidenceIdx !== -1, 'evidence still reachable in the debug expander');
+  assert.ok(evidenceIdx > rawIdx, 'evidence lives in the debug block, not the default details');
+  assert.ok(card.indexOf('pin is 0 m from curated pin') > rawIdx, 'the lines render there');
+
+  const bare = adapter.generateEventCard(buildCompressionMergeEvent({ _evidenceLines: [] }));
+  assert.ok(!bare.includes('evidence-block'), 'no lines → no block anywhere (fail open)');
+});
+
+test('compression keeps every bridge action id and card handler intact', () => {
+  const adapter = buildMapsAdapter();
+  // Every chunkyscrape action id round-trips through the bridge URL parser.
+  for (const action of [
+    'page', 'page-done', 'copy-venue', 'mark-bear', 'mark-not-bear',
+    'execute-run', 'queue-venue', 'open-url', 'export-ics', 'copy-logs',
+    'ai-prompts', 'beacon'
+  ]) {
+    const params = adapter.parseReviewActionUrl(`chunkyscrape://act?a=${action}&n=1`);
+    assert.equal(params.a, action, `${action} round-trips through the bridge URL`);
+  }
+  // The compressed card still wires every existing handler.
+  const event = buildCompressionMergeEvent({ recurrenceRule: 'FREQ=WEEKLY;BYDAY=TH' });
+  const card = adapter.generateEventCard(event, { runId: 'r1' }, {
+    bearIdx: 'k0',
+    bearVerdict: 'bear',
+    interactive: true
+  });
+  assert.ok(card.includes('route-directions-link'), 'compressed layout marker present');
+  for (const handler of [
+    'openMapVerify(this)',
+    'markBearOverride(this)',
+    'copyEventJSON(this)',
+    'exportRecurringIcs(this)',
+    'exportProvenanceIssue(this)',
+    'toggleComparisonSection(',
+    'toggleDiffView(this'
+  ]) {
+    assert.ok(card.includes(handler), `${handler} intact on the compressed card`);
+  }
 });


### PR DESCRIPTION
Implements the three results-UI compression asks, display-only, in `scripts/adapters/scriptable-adapter.js` + its test file. `scripts/display-saved-run.js` inherits everything via `adapter.displayResults` (verified at its call site — no forked rendering). PRs #1668/#1669 were both already MERGED (tools/-only, no adapter overlap), so this sits directly on origin/main.

## 1. "Make the bar, address, and coordinates be links… route link on the list too… instead of having it in both"
- Face route line: **bar** links the event's own `gmaps`/`googleMapsLink` when present, else a `"<bar>, <city>"` maps search; **address** links a maps search on the full stored address (short street form stays the label); **pin** keeps its coordinates link; the **Route** directions link is promoted from the expander's Verify row onto the line.
- All through the EXISTING `openMapVerify` → `chunkyscrape://act?a=open-url` → `shouldAllowRequest` bridge. No `evaluateJavaScript`, no new handler ids.
- The expander's duplicate venue (📍) / address (🏠) / coordinates (🌐) rows and the Verify row are **removed** (`buildMapVerifyLinksHtml` stays — the new-venue-candidates section still uses it).
- The UITable fallback — the non-card list rendering — gets a native "📍 Route" button per event row (`buildEventListRowMapsUrl`: route → pin → address → bar as data thins), opened via `Safari.open`. Native UITable API; no WebView involved in that path.

## 2. "Merge/write section should just be the merge tag and maybe a new write tag on the main card"
- Face: `MERGE ·N` (N = changed-field count, computed from the SAME per-field records the table renders, so tag and table cannot disagree) + a new write tag (`CREATE/UPDATE/SKIP/WITHHELD/OVERRIDE`) replacing the expander's "Intent: … • Write: …" note.
- Details merge table: ONLY rows that changed something; no-ops ("same in both", kept-existing with an ignored candidate, sticky keeps) collapse to one line: `19 fields unchanged — bar, website, …`. `generateComparisonRows` stays uncompressed (records builder `buildComparisonRowRecords` is the shared core).
- Duplication sweep: details also lose the duplicate date row (UTC verification row stays — unique info) and the full image block (the face thumbnail, with its placeholder census badge, is the card's image).

## 3. "This section doesn't really help me: Evidence / pin is 0 m from curated pin…"
- The Evidence block renders ONLY inside the debug `raw-display` section (next to Copy JSON). Display-only: `_evidenceLines` stay in the run JSON untouched.

## Before/after (real run 20260812-001632, BEARRACUDA: Seattle card)

**Before**
```
FACE:    [MERGE]  BEARRACUDA: Seattle💦
         📅 Sun, Sep 13, 2026 4:00 AM - Mon, Sep 14, 2026 5:00 AM
         📍 Massive • 619 E. Pine • 47.6150824,-122.3237201 ↗        (only pin tappable)
DETAILS: Intent: MERGE • Write: UPDATE
         📍 Massive
         🏠 619 E. Pine, Seattle, WA, 98122
         🌐 Coordinates: 47.6150824, -122.3237201
         Verify: Bar ↗ Address ↗ Pin ↗ Route ↗
         Evidence: pin is 0 m from curated "Massive" pin / pin is 1.2 km from seattle center / …
         📅 Sun, Sep 13, 2026 4:00 AM - …   (duplicate)
         … View Full Image + inline image (duplicate) …
         📊 Merge Comparison: 24 rows incl. 19 "SAME VALUE"/"KEPT EXISTING"
```

**After**
```
FACE:    [MERGE ·5] [✍️ UPDATE]  BEARRACUDA: Seattle💦
         📅 Sun, Sep 13, 2026 4:00 AM - Mon, Sep 14, 2026 5:00 AM
         📍 Massive • 619 E. Pine • 47.6150824,-122.3237201 ↗ • Route ↗   (ALL tappable)
DETAILS: 🛠 Event Builder
         🌍 UTC: 4:00 AM - Mon, Sep 14, 2026 5:00 AM
         📱 chunky-dad-unknown
         📝 description / 📸 Instagram / 🎟️ Tickets / 🌐 Website / notes preview
         📊 Merge Comparison: 5 changed rows + "19 fields unchanged — …"
         [debug raw-display]: Evidence block + Copy JSON
```

Smoke render (24 cards): every card's route parts link through the bridge registry, 0 verify-row duplicates, all 3 evidence blocks inside debug, `MERGE ·5`/`MERGE ·6` tags match their tables.

## Verification
- Quiet suite green: **1781/1781** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`).
- Adapter file: **284/284**; **6 new tests proven failing on base** (checked out base adapter source → 13 failures: the 6 new + 7 old-layout assertions; restored → all green):
  (a) route parts are bridge links on card AND UITable list row, (b) details carry no route/address/date/image duplicates, (c) `MERGE ·N` tag + changed-rows-only table + one no-op summary line, (d) Evidence absent from details / present in debug, (e) every `chunkyscrape://` action id (`page, page-done, copy-venue, mark-bear, mark-not-bear, execute-run, queue-venue, open-url, export-ics, copy-logs, ai-prompts, beacon`) round-trips and every card handler (`openMapVerify, markBearOverride, copyEventJSON, exportRecurringIcs, exportProvenanceIssue, toggleComparisonSection, toggleDiffView`) survives.
- No existing `console.log` strings edited (diff checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP