### PR TITLE
fix(links): end the website/url duplication debacle — ONE canonical website resolved before the merge

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -11841,11 +11841,11 @@ class ScriptableAdapter {
                     : ""
                 }
                 ${
-                  event.url || event.website
+                  event.website || event.url
                     ? `
                     <div class="event-detail">
                         <span>🌐</span>
-                        <span><a href="${this.escapeHtml(event.url || event.website)}" target="_blank" rel="noopener" style="color: var(--primary-color);">Website</a></span>
+                        <span><a href="${this.escapeHtml(event.website || event.url)}" target="_blank" rel="noopener" style="color: var(--primary-color);">Website</a></span>
                     </div>
                 `
                     : ""
@@ -13789,6 +13789,9 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     // even though they are not stored in notes.
     const excludeFields = new Set([
       "notes",
+      // url is an alias/view of website (ONE canonical field) — comparing it
+      // separately rendered a phantom second links row on every diff.
+      "url",
       "isBearEvent",
       "source",
       "city",

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -8874,3 +8874,25 @@ test('placeholder-badged thumbnails stay visible on the face with their badge', 
   assert.ok(html.includes('event-thumb-badge'), 'compact placeholder badge on the thumb');
   assert.ok(html.includes('🖼️ placeholder ×3'), 'badge states the reuse count');
 });
+
+// ---------------------------------------------------------------------------
+// url/website are ONE field: the comparison display never renders a separate
+// `url` row (run 20260811-135556: every merge card carried a phantom scraped
+// `url` differing from the calendar's native empty one).
+// ---------------------------------------------------------------------------
+test('getFieldsForComparison excludes url — one links row, never a url twin', () => {
+  const adapter = new ScriptableAdapter({ cities: {} });
+  const event = {
+    title: 'BEEFMINCE x RVT',
+    website: 'https://beefmince.com',
+    url: 'https://beefmince.com',
+    _original: {
+      scraper: { website: 'https://beefmince.com' },
+      calendar: { website: 'https://beefmince.com', url: undefined },
+      merged: { website: 'https://beefmince.com' }
+    }
+  };
+  const fields = adapter.getFieldsForComparison(event);
+  assert.equal(fields.includes('website'), true, 'website is the ONE canonical links field');
+  assert.equal(fields.includes('url'), false, 'url is an alias/view — never a comparison row of its own');
+});

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -689,7 +689,9 @@ class WebAdapter {
                 startDate: event.startDate || null,
                 endDate: event.endDate || null,
                 location: event.location || event.venue || '',
-                url: event.url || '',
+                // url/website are ONE field — website is canonical; the url
+                // key is kept for older saved-run readers as a view of it.
+                url: event.website || event.url || '',
                 city: event.city || '',
                 _action: event._action || null,
                 _analysis: event._analysis || null,
@@ -1270,7 +1272,7 @@ async saveFailureNote(url, error, metadata = {}) {
                 console.log(`   Title: ${event.title}`);
                 console.log(`   Date: ${event.startDate}`);
                 console.log(`   Venue: ${event.venue || 'N/A'}`);
-                console.log(`   URL: ${event.url || 'N/A'}`);
+                console.log(`   URL: ${event.website || event.url || 'N/A'}`);
                 // Additive line: report-only sanity flags stamped by
                 // SharedCore.getEventSanityFlags (absent → nothing printed).
                 if (Array.isArray(event._sanityFlags) && event._sanityFlags.length > 0) {
@@ -1316,7 +1318,7 @@ async saveFailureNote(url, error, metadata = {}) {
                 `SUMMARY:${event.title}`,
                 `DESCRIPTION:${event.description || ''}`,
                 `LOCATION:${event.venue || ''}`,
-                event.url ? `URL:${event.url}` : '',
+                (event.website || event.url) ? `URL:${event.website || event.url}` : '',
                 `UID:${event.title}-${startDate}@chunkydad.com`,
                 'END:VEVENT'
             );

--- a/scripts/event-schema.test.js
+++ b/scripts/event-schema.test.js
@@ -731,3 +731,30 @@ test('computeNextRruleOccurrence: coercion accepts an ISO string but still rejec
   assert.equal(f('FREQ=WEEKLY;BYDAY=WE', undefined), null);
   assert.equal(f('FREQ=WEEKLY;BYDAY=WE', {}), null);
 });
+
+// ---------------------------------------------------------------------------
+// url/website are ONE field: notes carry exactly one `website:` line, `url`
+// never lands in any write path (notes or ICS export).
+// ---------------------------------------------------------------------------
+test('write paths: website is canonical — url is notes-excluded and the ICS URL line reads website', () => {
+  const event = {
+    title: 'BEEFMINCE x RVT',
+    website: 'https://beefmince.com',
+    url: 'https://beefmince.com', // legacy alias still present on old records
+    ticketUrl: 'https://dice.fm/event/yoepxa-beefmince-x-rvt-19th-sep-the-royal-vauxhall-tavern-london-tickets',
+    recurrenceRule: 'FREQ=MONTHLY;BYDAY=3SA',
+    startDate: new Date('2026-09-19T21:00:00.000Z')
+  };
+
+  const notes = EventSchema.formatEventNotes(event);
+  const noteLines = notes.split('\n');
+  assert.equal(noteLines.filter((line) => line.startsWith('website:')).length, 1,
+    'exactly one website: line in notes');
+  assert.equal(noteLines.some((line) => /^url:/.test(line)), false,
+    'url is notes-excluded on every write');
+
+  const ics = EventSchema.buildRecurringEventIcs(event);
+  assert.ok(ics.includes('URL:https://beefmince.com'), 'ICS URL property reads the canonical website');
+  assert.equal((ics.match(/^URL:/gm) || []).length, 1, 'one URL property per VEVENT');
+  assert.equal(/DESCRIPTION:[^\r\n]*url:/.test(ics), false, 'no url: key leaks into the ICS description notes');
+});

--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -239,8 +239,9 @@ class BasicDataNormalizer extends BaseNormalizer {
         }
 
         if (!this.core) return event;
-        // Sync URL and website fields
-        event = this.syncUrlAndWebsiteFields(event);
+        // url and website are ONE field — fold the alias into the canonical
+        // `website` and drop `url` (it never exists post-normalization)
+        event = this.canonicalizeIdentityLink(event);
 
         // Cover shape gate: prose never ships as a cover (see dropProseCover).
         event = this.dropProseCover(event);
@@ -285,7 +286,17 @@ class BasicDataNormalizer extends BaseNormalizer {
         return event;
     }
 
-    syncUrlAndWebsiteFields(event) {
+    // url and website are ONE field (aliases; canonical `website`, written as
+    // `website:` in calendar notes). The old bidirectional sync MINTED a
+    // `url` copy of every website, and that phantom twin resurfaced across
+    // every seam downstream (merge candidates, comparison rows, notes
+    // exclusions) — the website/url duplication debacle. Canonical form now:
+    // fold `url` into an empty `website`, then delete `url` so it ceases to
+    // exist as a distinct stored value the moment an event is normalized.
+    // Platform-link ROUTING (dice/eventbrite/social links offered as website)
+    // happens later in SharedCore.canonicalizeIdentityLinks — after dedup,
+    // which needs the raw scraped link for same-event URL identity.
+    canonicalizeIdentityLink(event) {
         if (!event || typeof event !== 'object') {
             return event;
         }
@@ -296,9 +307,8 @@ class BasicDataNormalizer extends BaseNormalizer {
         if (!hasWebsite && hasUrl) {
             event.website = event.url;
         }
-
-        if (!hasUrl && hasWebsite) {
-            event.url = event.website;
+        if ('url' in event) {
+            delete event.url;
         }
 
         return event;

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -4327,3 +4327,33 @@ test('city routing: the generated scraper-cities config carries the pv patterns 
   assert.equal(normalizer.extractCityFromEvent({ title: 'DOG TAGS ARE NON REFUNDABLE OR TRANSFERABLE' }), 'unknown');
   assert.equal(normalizer.extractCityFromEvent({ title: 'Improv Comedy Night' }), 'unknown');
 });
+
+// ---------------------------------------------------------------------------
+// url/website are ONE field — canonicalized the moment an event is normalized
+// (the website/url duplication debacle: the old bidirectional sync MINTED a
+// `url` twin of every website, which then resurfaced as phantom merge
+// candidates and diff rows on every run).
+// ---------------------------------------------------------------------------
+test('BasicDataNormalizer folds url into website and deletes url at ingest', () => {
+  const core = new SharedCore(CITIES, { eventSchema: require('./event-schema').EventSchema });
+  const normalizer = new BasicDataNormalizer(core);
+
+  // Lone url (JSON-LD/structured routes set the page they read as `url`)
+  const folded = normalizer.normalize({ title: 'CHUNK', url: 'https://www.chunk-party.com/events/brooklyn-return' });
+  assert.equal(folded.website, 'https://www.chunk-party.com/events/brooklyn-return', 'url becomes the canonical website');
+  assert.equal('url' in folded, false, 'url ceases to exist post-normalization');
+
+  // Both present: website wins, the alias is dropped (never synced back)
+  const both = normalizer.normalize({
+    title: 'DETAIL',
+    website: 'https://sitgesbearcave.com/event/wednesday-beefmince-meet-market/',
+    url: 'https://beefmince.com'
+  });
+  assert.equal(both.website, 'https://sitgesbearcave.com/event/wednesday-beefmince-meet-market/');
+  assert.equal('url' in both, false, 'the alias never survives alongside website');
+
+  // Website only: no url twin is ever minted (the old sync did exactly that)
+  const site = normalizer.normalize({ title: 'PARTY', website: 'https://beefmince.com' });
+  assert.equal(site.website, 'https://beefmince.com');
+  assert.equal('url' in site, false, 'no url twin is minted from website');
+});

--- a/scripts/promoter-registry.test.js
+++ b/scripts/promoter-registry.test.js
@@ -229,7 +229,12 @@ test('migrated Furball identity (incl. favicon) stamps on match exactly like the
   // The exact values the removed parser-config metadata block used to stamp
   assert.equal(event.shortName, 'FUR-BALL');
   assert.equal(event.instagram, 'https://instagram.com/furballnyc/');
-  assert.equal(event.url, 'https://www.furball.nyc', 'website maps to the canonical url field');
+  // url/website are ONE canonical field now: the registry stamps no distinct
+  // `url` value — canonicalizeIdentityLinks fills the blank `website` from
+  // the entry's identity link instead.
+  assert.equal(event.url, undefined, 'url never exists as a distinct stored value');
+  core.canonicalizeIdentityLinks([event]);
+  assert.equal(event.website, 'https://www.furball.nyc', 'identity ladder fills the blank website');
   assert.equal(event.favicon, 'https://linktr.ee/furballnyc', 'favicon migrated into the registry');
   // Same static machinery: stamped fields are tracked for de-circularization
   assert.equal(event._staticFields.favicon, 'https://linktr.ee/furballnyc');
@@ -259,7 +264,12 @@ test('migrated festival identities: Bears Sitges shortName and the Spooky Bear s
   assert.equal(spooky.entry.parent, 'Northeast Ursamen');
   const block = core.promoterEntryToMetadataBlock(spooky.entry);
   assert.equal(block.shortName.value, 'SPOOKY BEAR');
-  assert.equal(block.url.value, 'https://www.ursamen.org/spookybear');
+  // url/website are ONE canonical field: the identity link is no longer a
+  // static block stamp (that minted a distinct `url` value on every matched
+  // event) — it is carried by getPromoterEntryIdentityWebsite and applied to
+  // `website` by canonicalizeIdentityLinks.
+  assert.equal(block.url, undefined, 'no url key in the static block — url never exists as a stored field');
+  assert.equal(core.getPromoterEntryIdentityWebsite(spooky.entry), 'https://www.ursamen.org/spookybear');
   assert.equal(block.instagram.value, 'https://www.instagram.com/ne.ursamen', 'inherited from Northeast Ursamen');
   assert.equal(block.facebook.value, 'https://www.facebook.com/NEUrsamen', 'inherited from Northeast Ursamen');
   assert.equal(spooky.entry.bearAffinity, 'always',

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -120,6 +120,35 @@ function isPlatformIdentityHost(host) {
         normalized === platform || normalized.endsWith(`.${platform}`));
 }
 
+// Social platform → the event field a PROFILE link on that platform belongs
+// in. Every host here is already named in PLATFORM_IDENTITY_HOSTS — this maps
+// existing classification to a destination field, it is not a new host list.
+// '' = social platform with no dedicated event field (the link is dropped
+// rather than parked in ticketUrl, because a social link is not a ticket
+// link). Used by canonicalizeIdentityLinks to route a social PROFILE offered
+// as `website` into its own field instead of losing it.
+const SOCIAL_IDENTITY_FIELD_BY_HOST = {
+    'instagram.com': 'instagram',
+    'facebook.com': 'facebook',
+    'twitter.com': 'twitter',
+    'x.com': 'twitter',
+    'tiktok.com': ''
+};
+
+// The social destination field for a host: a field name, '' (social host with
+// no field), or undefined (not a social host). Suffix matching mirrors
+// isPlatformIdentityHost so m.facebook.com routes like facebook.com.
+function getSocialIdentityFieldForHost(host) {
+    const normalized = String(host || '').toLowerCase();
+    if (!normalized) return undefined;
+    for (const domain of Object.keys(SOCIAL_IDENTITY_FIELD_BY_HOST)) {
+        if (normalized === domain || normalized.endsWith(`.${domain}`)) {
+            return SOCIAL_IDENTITY_FIELD_BY_HOST[domain];
+        }
+    }
+    return undefined;
+}
+
 // Path extensions that mark a URL as a static ASSET (image/font/stylesheet/
 // script) — a file, never a page a person visits (observed 2026-08-02: a
 // webflow CDN ".../image-asset%20(4).jpeg" beat https://www.massive.club/ for
@@ -2664,8 +2693,13 @@ class SharedCore {
     // Registry entry → static-metadata block in the exact {field: {value}}
     // shape parser metadata uses, so curated facts flow through the SAME
     // application machinery (applyStaticMetadataBlock). Sub-brands inherit
-    // unspecified fields from their parent entry; website maps to the
-    // canonical url field (url and website are ONE field).
+    // unspecified fields from their parent entry. The entry's identity
+    // website is deliberately NOT in this block: url and website are ONE
+    // canonical field (`website`), and a static clobber stamp here would
+    // overwrite a venue's own event page on every registry-matched event.
+    // The curated identity link is applied by canonicalizeIdentityLinks
+    // instead (fill a blank, replace a platform link, never displace a real
+    // page-stated site) — see getPromoterEntryIdentityWebsite.
     promoterEntryToMetadataBlock(entry) {
         if (!entry || typeof entry !== 'object') return {};
         const parent = typeof entry.parent === 'string' && entry.parent
@@ -2682,16 +2716,30 @@ class SharedCore {
             const value = pick(field);
             if (value) block[field] = { value };
         }
-        const website = pick('website');
-        if (website) block.url = { value: website };
         return block;
+    }
+
+    // The registry entry's curated identity link (own `website`, else the
+    // parent's — same inheritance as promoterEntryToMetadataBlock's pick).
+    // This is the top rung of the identity-link ladder: registry/venue
+    // identity link > official non-platform site stated on the page > empty.
+    getPromoterEntryIdentityWebsite(entry) {
+        if (!entry || typeof entry !== 'object') return '';
+        const own = typeof entry.website === 'string' && entry.website.trim() ? entry.website.trim() : '';
+        if (own) return own;
+        const parent = typeof entry.parent === 'string' && entry.parent
+            ? this.getPromoterEntryByName(entry.parent)
+            : null;
+        return parent && typeof parent.website === 'string' && parent.website.trim()
+            ? parent.website.trim()
+            : '';
     }
 
     // Enforce-mode stamp: curated promoter facts through the same
     // static-metadata machinery as parser metadata (registry runs after the
     // parser-time application, so its static clobber wins on match; parser
     // metadata remains the no-match fallback).
-    applyPromoterMetadata(event, metadataBlock) {
+    applyPromoterMetadata(event, metadataBlock, identityWebsite = '') {
         const fieldPriorities = this.getResolvedFieldPriorities({ metadata: metadataBlock });
         if (!event._fieldPriorities) {
             event._fieldPriorities = {};
@@ -2712,8 +2760,8 @@ class SharedCore {
         // scraped favicon always survives it.
         if (!metadataBlock.favicon
             && this.isEmptyArbitrationValue(event.favicon)
-            && metadataBlock.url && metadataBlock.url.value) {
-            event.favicon = metadataBlock.url.value;
+            && typeof identityWebsite === 'string' && identityWebsite.trim()) {
+            event.favicon = identityWebsite.trim();
             event._fieldPriorities.favicon = { priority: ['ai-web'], merge: 'upsert' };
         }
         return stamped;
@@ -2806,14 +2854,21 @@ class SharedCore {
                 else counts.url++;
             }
             const metadataBlock = this.promoterEntryToMetadataBlock(match.entry);
+            // The curated identity link is not part of the static block (see
+            // promoterEntryToMetadataBlock) — it rides along for the favicon
+            // fallback here and is applied to `website` by
+            // canonicalizeIdentityLinks after dedup. Listed in the stamp log
+            // as 'website' so the line keeps naming every curated fact in play.
+            const identityWebsite = this.getPromoterEntryIdentityWebsite(match.entry);
             const stampKeys = Object.keys(metadataBlock);
+            if (identityWebsite) stampKeys.push('website');
             if (mode === 'enforce') {
                 event._promoter = match.entry.name;
                 if (!event._organizer && match.evidence !== 'organizer') {
                     event._organizer = match.entry.name;
                 }
                 if (stampKeys.length > 0) {
-                    this.applyPromoterMetadata(event, metadataBlock);
+                    this.applyPromoterMetadata(event, metadataBlock, identityWebsite);
                 }
             }
             const stampLabel = mode === 'enforce' ? 'stamped' : 'would-stamp';
@@ -4413,6 +4468,13 @@ class SharedCore {
         if (duplicatesRemoved > 0) {
             await displayAdapter.logInfo(`SYSTEM: Deduplicated ${futureEvents.length} → ${deduplicatedEvents.length} before bear filtering (${duplicatesRemoved} duplicate record(s) folded)`);
         }
+        // ONE canonical `website` per event before anything downstream sees
+        // it: after dedup (whose URL-identity keys need the raw scraped link)
+        // and the registry pass (whose curated identity the ladder consults),
+        // before the bear check and the calendar merge. Platform links are
+        // routed or dropped here, so they never surface as website candidates
+        // in merge arbitration — see canonicalizeIdentityLinks.
+        this.canonicalizeIdentityLinks(deduplicatedEvents);
         const bearEvents = await this.filterBearEvents(deduplicatedEvents, effectiveParserConfig, httpAdapter, bearDropCollector);
 
         await displayAdapter.logInfo(`SYSTEM: Event filtering complete: ${allEvents.length} → ${futureEvents.length} future → ${bearEvents.length} bear → ${bearEvents.length} final`);
@@ -4508,8 +4570,26 @@ class SharedCore {
             const ticketHost = ticketUrl ? this.getHostFromUrl(ticketUrl) : '';
             const ticketUrlIsOutbound = Boolean(ticketHost) && !this.areUrlHostsSameSite(ticketHost, sourceHost);
             if (websiteIsOwnSourcePage && ticketUrlIsOutbound) {
-                event.website = ticketUrl;
-                console.log(`🤖 AI Web: website set to original source ${ticketHost} (aggregator page pointer)`);
+                // The outbound pointer is only adoptable as `website` when it
+                // is NOT a ticketing/social platform link: url/website are the
+                // ONE canonical identity field, and a platform link is never
+                // the identity link (it already lives in ticketUrl). Adopting
+                // dice/eventbrite here just re-offered the platform link as a
+                // website candidate at merge time, forever. The aggregator's
+                // own copy is still cleared — empty beats a copy of the
+                // source page — and the platform link survives in ticketUrl.
+                const normalizedTicketHost = String(ticketHost).toLowerCase().replace(/^www\./, '');
+                if (!isPlatformIdentityHost(normalizedTicketHost)
+                    && !this.isKnownTicketingPlatformHost(normalizedTicketHost)) {
+                    event.website = ticketUrl;
+                    console.log(`🤖 AI Web: website set to original source ${ticketHost} (aggregator page pointer)`);
+                } else {
+                    event.website = '';
+                    if (typeof event.url === 'string' && this.getUrlDedupeKey(event.url) === sourcePageKey) {
+                        event.url = '';
+                    }
+                    console.log(`🤖 AI Web: cleared aggregator self-pointer website for "${event.title || 'event'}" — outbound ${normalizedTicketHost} is a ticketing/social platform link, never the identity link (it stays in ticketUrl)`);
+                }
                 continue;
             }
             // Offer-less aggregator listing (2026-08-11, run 20260811-162602:
@@ -4535,6 +4615,125 @@ class SharedCore {
             }
             if (clearedFields.length > 0) {
                 console.log(`🤖 AI Web: cleared self-referential aggregator pointer (${clearedFields.join(', ')}) for "${event.title || 'event'}" — the ${sourceHost} listing has no outbound link, empty beats a copy of the source page`);
+            }
+        }
+    }
+
+    // ONE `website` per event, resolved BEFORE the merge — the once-and-for-
+    // all canonicalization of the url/website field (they are ONE field;
+    // canonical `website`). Runs after dedup (URL-identity dedup needs the
+    // raw scraped link) and after the promoter-registry pass (the curated
+    // identity and self-identity exceptions need the match), and before the
+    // bear check and calendar analysis, so a platform link NEVER reaches
+    // merge arbitration as a website candidate. That is what killed the
+    // owner's forever-rows: the merge OUTCOME was always right ("identity
+    // link beats a ticketing/social platform URL"), but the scraped side
+    // kept re-offering dice/eventbrite links as `website`, so the same
+    // "kept existing / ignored new value" row rendered on every run.
+    //
+    // The deterministic ladder per event:
+    //   1. curated registry/venue identity link (promoter match) — replaces a
+    //      platform website, fills an empty one; never displaces a real
+    //      non-platform site the page itself stated;
+    //   2. official non-platform site stated on the page — kept untouched;
+    //   3. empty — strictly better than a platform link (owner ruling
+    //      2026-08-03).
+    // Platform links routed OFF website are never lost: a social PROFILE
+    // goes to its own field (instagram/facebook/twitter) when empty, a
+    // ticket-ish link parks in an EMPTY ticketUrl; everything else drops
+    // with one log line. Exceptions mirror the final-build LINKS pass (which
+    // stays as the backstop for cached/merged objects): a platform organizer
+    // HOME page and the promoter's own curated presence on a platform are
+    // identity links and are kept. Statically stamped websites are curated
+    // config and never re-routed. Generic host classification only —
+    // PLATFORM_IDENTITY_HOSTS / TICKETING_PLATFORM_HOSTS / opaque-shortlink
+    // URL shape; nothing per venue.
+    canonicalizeIdentityLinks(events) {
+        if (!Array.isArray(events) || events.length === 0) return;
+        for (const event of events) {
+            if (!event || typeof event !== 'object') continue;
+            // Alias fold backstop: normalization already folded url→website
+            // and dropped url (BasicDataNormalizer.canonicalizeIdentityLink);
+            // repeat here for records that reached this pass some other way,
+            // so `url` never exists as a distinct stored value past this line.
+            const legacyUrl = typeof event.url === 'string' ? event.url.trim() : '';
+            if (legacyUrl && !(typeof event.website === 'string' && event.website.trim())) {
+                event.website = legacyUrl;
+            }
+            if ('url' in event) delete event.url;
+
+            const website = typeof event.website === 'string' ? event.website.trim() : '';
+            const staticFields = event._staticFields && typeof event._staticFields === 'object'
+                ? event._staticFields
+                : {};
+            const websiteIsStatic = Object.prototype.hasOwnProperty.call(staticFields, 'website')
+                || Object.prototype.hasOwnProperty.call(staticFields, 'url');
+            const promoterEntry = this.getCuratedPromoterIdentityEntry(event);
+            const curatedWebsite = promoterEntry ? this.getPromoterEntryIdentityWebsite(promoterEntry) : '';
+            const title = event.title || 'event';
+
+            if (!website) {
+                // Ladder rung 1 on a blank: the curated identity link fills it
+                // (what the old registry `url` stamp + merge-time fold used to
+                // do). Marked static — the value is registry branding, so it
+                // must never count as same-event dedup identity or as registry
+                // match evidence (de-circularization).
+                if (curatedWebsite && !websiteIsStatic) {
+                    event.website = curatedWebsite;
+                    if (!event._staticFields) event._staticFields = {};
+                    event._staticFields.website = curatedWebsite;
+                    console.log(`🔗 LINKS: website set to curated identity link ${curatedWebsite} of "${promoterEntry.name}" for "${title}" — registry identity beats an empty website (url/website are ONE field)`);
+                }
+                continue;
+            }
+            if (websiteIsStatic) continue;
+
+            const host = this.getHostFromUrl(website).toLowerCase().replace(/^www\./, '');
+            if (!host) continue;
+            const parts = this.getUrlRuleParts(website);
+            const isPlatform = isPlatformIdentityHost(host)
+                || this.isKnownTicketingPlatformHost(host)
+                || (parts ? this.isOpaqueShortlinkUrlParts(parts) : false);
+            if (!isPlatform) continue; // rung 2: a real page-stated site is kept
+            if (this.isPlatformOrganizerHomeUrl(website)) continue;
+            if (this.isCuratedPlatformSelfIdentityUrl(event, website)) continue;
+
+            // Route the platform link off `website` without losing it: social
+            // PROFILE (single path segment on a social host) → its own empty
+            // field; anything else ticket-ish → an EMPTY ticketUrl.
+            const socialField = getSocialIdentityFieldForHost(host);
+            const isSocialProfile = socialField !== undefined
+                && parts && Array.isArray(parts.segments)
+                && parts.segments.length === 1 && !parts.hasQuery
+                && parts.segments[0].toLowerCase() !== 'events';
+            let routedTo = '';
+            if (isSocialProfile && socialField
+                && !(typeof event[socialField] === 'string' && event[socialField].trim())) {
+                event[socialField] = website;
+                routedTo = socialField;
+            } else if (!isSocialProfile || !socialField) {
+                // Everything that is not a routable social profile parks in an
+                // EMPTY ticketUrl — the same flag-don't-drop parking the
+                // final-build LINKS pass has always used (owner ruling
+                // 2026-08-03: a real ticketUrl is never overwritten).
+                const existingTicketUrl = typeof event.ticketUrl === 'string' ? event.ticketUrl.trim() : '';
+                if (!existingTicketUrl) {
+                    event.ticketUrl = website;
+                    routedTo = 'ticketUrl';
+                }
+            }
+            const parked = routedTo ? `routed to ${routedTo}` : 'dropped (destination field already set)';
+
+            if (curatedWebsite && curatedWebsite !== website) {
+                // Ladder rung 1: curated identity replaces the platform link.
+                event.website = curatedWebsite;
+                if (!event._staticFields) event._staticFields = {};
+                event._staticFields.website = curatedWebsite;
+                console.log(`🔗 LINKS: platform website ${website} replaced with curated identity link ${curatedWebsite} of "${promoterEntry.name}" for "${title}" (${parked}) — a ticketing/social link is never the identity link`);
+            } else {
+                // Ladder rung 3: empty beats a platform link.
+                delete event.website;
+                console.log(`🔗 LINKS: cleared platform website ${website} for "${title}" (${parked}) — a ticketing/social link is never the identity link, canonicalized before the merge`);
             }
         }
     }
@@ -5746,21 +5945,31 @@ class SharedCore {
                     // A page that describes exactly ONE event IS that event's
                     // page, so it can name itself. The structured-data routes
                     // already do this (JSON-LD and the JSON-API reader both set
-                    // url from the page they read); the AI-extraction route had
-                    // no equivalent, so a crawled detail page left `url` on
-                    // whatever the parser's static metadata supplied — the
-                    // venue's bare homepage. That also killed the
-                    // `event-page-url` dedup rung, which returns nothing for a
-                    // domain root, leaving these events to match on name+time
-                    // alone. Only fills a blank or replaces a same-site bare
-                    // root: a listing page (many events) is skipped by the
-                    // count, and a URL the page actually named is never
-                    // displaced.
+                    // the page they read as the event's link, which the
+                    // pipeline folds into the canonical `website`); the
+                    // AI-extraction route had no equivalent, so a crawled
+                    // detail page left the identity link on whatever the
+                    // parser's static metadata supplied — the venue's bare
+                    // homepage. That also killed the `event-page-url` dedup
+                    // rung, which returns nothing for a domain root, leaving
+                    // these events to match on name+time alone. Only fills a
+                    // blank or replaces a same-site bare root: a listing page
+                    // (many events) is skipped by the count, and a URL the
+                    // page actually named is never displaced. Writes the
+                    // canonical `website` (url/website are ONE field; `url`
+                    // no longer exists post-normalization); when it replaces
+                    // a statically stamped root, the static marker goes too —
+                    // the value is now organic (the page named itself), so it
+                    // must count as same-event dedup identity again.
                     if (parsedEvents.length === 1) {
                         const soleEvent = parsedEvents[0];
-                        const existingUrl = typeof soleEvent.url === 'string' ? soleEvent.url.trim() : '';
+                        const existingUrl = typeof soleEvent.website === 'string' ? soleEvent.website.trim() : '';
                         if (!existingUrl || this.isBareRootBuryingSameSiteEventPage(existingUrl, url)) {
-                            soleEvent.url = url;
+                            soleEvent.website = url;
+                            if (soleEvent._staticFields
+                                && Object.prototype.hasOwnProperty.call(soleEvent._staticFields, 'website')) {
+                                delete soleEvent._staticFields.website;
+                            }
                             console.log(`🔗 LINKS: "${soleEvent.title || 'event'}" takes its own page ${url} as its url${existingUrl ? ` (was ${existingUrl})` : ''} — one event on the page`);
                         }
                     }
@@ -9253,6 +9462,27 @@ class SharedCore {
     // Create complete merged event object that represents exactly what will be saved
     // Following the 6-step process: 1) scraper object, 2) calendar object, 3) simple merge, 4) gmaps, 5) notes, 6) display
     //
+    // A Google Maps link anchored to a verified place: it names a place_id
+    // (maps/place/?q=place_id:… or &query_place_id=…) or its query is a bare
+    // coordinate pair (query=51.50,-0.12, comma raw or %2C-encoded). String
+    // shape only — the WHATWG URL parser is banned in scripts/ (platform
+    // purity, no `new URL(`).
+    isPlaceAnchoredGmapsUrl(value) {
+        const raw = typeof value === 'string' ? value.trim() : '';
+        if (!raw) return false;
+        if (/[?&](?:q=)?place_id:/i.test(raw)) return true;
+        if (/[?&]query_place_id=/i.test(raw)) return true;
+        return /[?&]query=-?\d{1,3}(?:\.\d+)?(?:%2C|,)\s*-?\d{1,3}(?:\.\d+)?(?:&|$)/i.test(raw);
+    }
+
+    // A Google Maps link whose query is TEXT (venue name/address prose) —
+    // i.e. it has a query= but is not place/coordinate-anchored.
+    isTextQueryGmapsUrl(value) {
+        const raw = typeof value === 'string' ? value.trim() : '';
+        if (!raw || this.isPlaceAnchoredGmapsUrl(raw)) return false;
+        return /[?&]query=/i.test(raw);
+    }
+
     // url vs website: they are ONE logical field. Notes persist only a "website:"
     // line (url is notes-excluded) and Scriptable cannot read or write the native
     // CalendarEvent.url property, so `website` is the canonical field that merges
@@ -9267,6 +9497,12 @@ class SharedCore {
         if (this.isEmptyArbitrationValue(scraperObject.website) && scraperObject.url) {
             scraperObject.website = scraperObject.url;
         }
+        // The alias then ceases to exist on the scraped side: `url` is never a
+        // distinct stored value post-normalization (canonicalizeIdentityLinks
+        // already dropped it for pipeline events; this covers replayed/cached
+        // records), so the comparison display never sees a phantom scraped
+        // `url` differing from the calendar's native one.
+        if ('url' in scraperObject) delete scraperObject.url;
 
         // STEP 2: Build calendar object using calendar data
         const calendarObject = {
@@ -9286,6 +9522,21 @@ class SharedCore {
         // shadow the notes-parsed website.
         if (this.isEmptyArbitrationValue(calendarObject.website) && existingEvent.url) {
             calendarObject.website = existingEvent.url;
+        }
+
+        // gmaps candidate hygiene (calendar-as-database: location is always
+        // coordinates, and gmaps is rebuilt from verified coords). A scraped
+        // text-query gmaps ("?query=The Royal Vauxhall Tavern, london") is
+        // derived from page prose; when the calendar link is anchored to a
+        // place_id or a coordinate pair it is strictly more precise, so the
+        // text query is not a candidate at all — deleting it here keeps the
+        // comparison display from rendering a no-op "kept existing / ignored
+        // new value" row for gmaps on every run. Deterministic and quiet:
+        // gmaps never merges anyway (STEP 4 below regenerates it), this only
+        // removes the noise the display would otherwise show forever.
+        if (this.isPlaceAnchoredGmapsUrl(calendarObject.gmaps)
+            && this.isTextQueryGmapsUrl(scraperObject.gmaps)) {
+            delete scraperObject.gmaps;
         }
 
         // STEP 3: Simple merge - respect merge logic, grab from correct object
@@ -13284,8 +13535,10 @@ class SharedCore {
                     : '';
                 if (websiteHost && isPlatformIdentityHost(websiteHost)) {
                     const promoterEntry = this.getCuratedPromoterIdentityEntry(analyzedEvent);
-                    const curatedWebsite = promoterEntry && typeof promoterEntry.website === 'string'
-                        ? promoterEntry.website.trim()
+                    // Sub-brands (BOATMINCE, SPOOKMINCE) inherit the parent's
+                    // identity link, same as the ingest-time ladder.
+                    const curatedWebsite = promoterEntry
+                        ? this.getPromoterEntryIdentityWebsite(promoterEntry)
                         : '';
                     if (curatedWebsite && curatedWebsite !== platformWebsite) {
                         const existingTicketUrl = typeof analyzedEvent.ticketUrl === 'string' ? analyzedEvent.ticketUrl.trim() : '';

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -6655,11 +6655,23 @@ test('applyAggregatorWebsitePointers prefers the cross-host ticketUrl over the a
   // website=url=their thebearcalendar.com page while ticketUrl pointed at
   // the ORIGINAL ticketing host. Trust the pointer, not the copy.
   const urlClassifications = { 'https://thebearcalendar.com/events/': 'link-aggregator' };
+  // Outbound pointer on a TICKETING PLATFORM (dice.fm): never adopted as
+  // website — url/website are the ONE canonical identity field and a platform
+  // link is never the identity link. The self-referential copy is cleared,
+  // the dice link stays in ticketUrl.
   const aggregatorEvent = {
     title: 'D>U>R>O',
     website: 'https://thebearcalendar.com/events/d-u-r-o-2026/',
     ticketUrl: 'https://dice.fm/event/duro-la-2026',
     _sourcePageUrl: 'https://thebearcalendar.com/events/d-u-r-o-2026/'
+  };
+  // Outbound pointer on the promoter's OWN (non-platform) site: still adopted
+  // — trust the pointer, not the copy.
+  const promoterPointerEvent = {
+    title: 'FURBALL TAMPA',
+    website: 'https://thebearcalendar.com/events/furball-tampa-2026/',
+    ticketUrl: 'https://www.furball.nyc/tampa-2026',
+    _sourcePageUrl: 'https://thebearcalendar.com/events/furball-tampa-2026/'
   };
   // Non-aggregator page: untouched even with a cross-host ticketUrl.
   const venueEvent = {
@@ -6685,11 +6697,15 @@ test('applyAggregatorWebsitePointers prefers the cross-host ticketUrl over the a
     _sourcePageUrl: 'https://thebearcalendar.com/events/megawoof-houston-richs-2026/'
   };
   core.applyAggregatorWebsitePointers(
-    [aggregatorEvent, venueEvent, sameHostEvent, alreadyOriginalEvent],
+    [aggregatorEvent, promoterPointerEvent, venueEvent, sameHostEvent, alreadyOriginalEvent],
     urlClassifications
   );
-  assert.equal(aggregatorEvent.website, 'https://dice.fm/event/duro-la-2026',
-    'aggregator-page website is replaced by the original ticketing URL');
+  assert.equal(aggregatorEvent.website, '',
+    'a platform outbound pointer is never adopted as website — the self-referential copy is cleared');
+  assert.equal(aggregatorEvent.ticketUrl, 'https://dice.fm/event/duro-la-2026',
+    'the platform link survives where it belongs: ticketUrl');
+  assert.equal(promoterPointerEvent.website, 'https://www.furball.nyc/tampa-2026',
+    'a non-platform outbound pointer (the promoter\'s own site) is still adopted');
   assert.equal(venueEvent.website, 'https://eaglela.com/events/cub-scout-3/',
     'non-aggregator pages are unchanged');
   assert.equal(sameHostEvent.website, '',
@@ -11800,7 +11816,17 @@ test('registry pass: enforce stamps _promoter, curated metadata, and a title/url
   assert.equal(event._organizer, 'Bearracuda', 'empty organizer is backfilled on title/url evidence');
   assert.equal(event.shortName, 'Bear-rac-uda');
   assert.equal(event.instagram, 'https://www.instagram.com/bearracuda');
-  assert.equal(event.url, 'https://bearracuda.com/', 'website maps to the canonical url field');
+  // url and website are ONE field (canonical `website`): the registry no
+  // longer stamps a distinct `url` value — the identity link is applied to
+  // `website` by canonicalizeIdentityLinks (fill a blank / replace a platform
+  // link), never as a static clobber over a page-stated site.
+  assert.equal(event.url, undefined, 'url never exists as a distinct stored value');
+  assert.equal(event.website, undefined, 'the stamp pass itself leaves website alone');
+  core.canonicalizeIdentityLinks([event]);
+  assert.equal(event.website, 'https://bearracuda.com/', 'the identity ladder fills the blank website from the registry');
+  assert.equal(event.url, undefined, 'canonicalization never re-mints url');
+  assert.equal(event._staticFields.website, 'https://bearracuda.com/',
+    'the filled value is registry branding — marked static so it is never dedup identity or match evidence');
   assert.equal(event._staticFields.shortName, 'Bear-rac-uda');
 
   // A non-empty organizer is never overwritten
@@ -11819,9 +11845,12 @@ test('registry application parity: registry stamp ≡ parser metadata through ap
   // Parser path: the same facts as parser-config metadata
   const viaParser = core.applyFieldPriorities(baseEvent(), { name: 'p', metadata: block }, {});
 
-  // Registry path: bare parser first (no metadata), then the registry stamp
+  // Registry path: bare parser first (no metadata), then the registry stamp.
+  // The identity website rides along OUTSIDE the static block (url/website
+  // are ONE canonical field applied by canonicalizeIdentityLinks) — here it
+  // only feeds the favicon fallback.
   const viaRegistry = core.applyFieldPriorities(baseEvent(), { name: 'p' }, {});
-  core.applyPromoterMetadata(viaRegistry, block);
+  core.applyPromoterMetadata(viaRegistry, block, entry.website);
 
   const publicFields = (event) => {
     const copy = {};
@@ -11851,13 +11880,13 @@ test('registry favicon fallback never overrides an existing favicon and loses th
 
   // Scraped event already carries the VENUE's favicon: untouched.
   const withVenueIcon = { title: 'Portland PRIDE FRIDAY', startDate: new Date('2026-08-01T21:00:00.000Z'), favicon: 'https://venue.example/icon.png' };
-  core.applyPromoterMetadata(withVenueIcon, block);
+  core.applyPromoterMetadata(withVenueIcon, block, REGISTRY_FIXTURE[0].website);
   assert.equal(withVenueIcon.favicon, 'https://venue.example/icon.png', 'existing favicon is never replaced by the fallback');
 
   // Blank favicon: filled — but a stored calendar favicon must win the merge
   // (review 2026-07-30: the clobber version silently reverted hand-fixes).
   const blank = { title: 'Portland PRIDE FRIDAY', startDate: new Date('2026-08-01T21:00:00.000Z') };
-  core.applyPromoterMetadata(blank, block);
+  core.applyPromoterMetadata(blank, block, REGISTRY_FIXTURE[0].website);
   assert.equal(blank.favicon, REGISTRY_FIXTURE[0].website, 'blank favicon filled from identity link');
   const existingEvent = {
     title: 'Portland PRIDE FRIDAY',
@@ -16665,10 +16694,14 @@ test('a crawled single-event page names itself; a listing page does not', async 
   const byTitle = {};
   for (const event of result.events) byTitle[event.title] = event;
 
-  assert.equal(byTitle['Underwear Night'].url, 'https://venuehub.example/events/underwear-night',
-    'the single-event page becomes that event\'s url');
-  assert.equal(byTitle['Bear Tea Dance'].url, 'https://venuehub.example',
-    'a listing page never overwrites its events\' urls');
+  // url/website are ONE canonical field: the self-naming pass now writes
+  // `website`, and `url` never exists as a distinct stored value.
+  assert.equal(byTitle['Underwear Night'].website, 'https://venuehub.example/events/underwear-night',
+    'the single-event page becomes that event\'s website');
+  assert.equal(byTitle['Underwear Night'].url, undefined, 'url is never re-minted');
+  assert.equal(byTitle['Bear Tea Dance'].website, 'https://venuehub.example',
+    'a listing page never overwrites its events\' identity links');
+  assert.equal(byTitle['Bear Tea Dance'].url, undefined, 'url is never re-minted');
 });
 
 // ---------------------------------------------------------------------------
@@ -17938,4 +17971,224 @@ test('formatRunAgeLabel prefers the ISO timestamp and falls back to the runId', 
   assert.equal(SharedCore.formatRunAgeLabel('2026-08-13T12:00:00.000Z', '', now), '0 minutes old');
   assert.equal(SharedCore.formatRunAgeLabel(null, 'not-a-run-id', now), 'of unknown age');
   assert.equal(SharedCore.formatRunAgeLabel('garbage', '', now), 'of unknown age');
+});
+
+// ---------------------------------------------------------------------------
+// url/website canonicalization — ONE identity field, resolved BEFORE the merge
+//
+// The "website/url duplication debacle", pinned with the owner's own pasted
+// evidence (run 20260811-135556, BEEFMINCE x RVT):
+//   website: ═ https://beefmince.com (kept existing)
+//            ~ https://link.dice.fm/V0890510c6bd (ignored new value)
+//   gmaps:   ═ …place_id:ChIJ… (kept existing)
+//            ~ …query=The Royal Vauxhall Tavern… (ignored new value)
+// The merge OUTCOME was right every run, but the scraper re-offered platform
+// links as `website` candidates forever, so the same no-op conflict rows
+// rendered on every run. These tests pin the fix: canonicalizeIdentityLinks
+// resolves ONE `website` per event before the merge, and `url` ceases to
+// exist as a distinct stored value post-normalization.
+// ---------------------------------------------------------------------------
+
+const LINKS_REGISTRY = [
+  { name: 'BEEFMINCE', shortName: 'BEEF-MINCE', website: 'https://beefmince.com', bearAffinity: 'always' },
+  { name: 'BOATMINCE', shortName: 'BOAT-MINCE', parent: 'BEEFMINCE', keywords: ['boatmince'], bearAffinity: 'always' }
+];
+
+test('canonicalizeIdentityLinks: the real BEEFMINCE shapes — platform links never survive as website', () => {
+  const core = createRegistryCore(LINKS_REGISTRY);
+  // Run 20260811-135556, verbatim scraped fields: the dice shortlink from the
+  // page's ticket widget sat in `website`, the real slug URL in ticketUrl.
+  const trunkDen = {
+    title: 'BEEFMINCE Trunk Den',
+    website: 'https://link.dice.fm/V0890510c6bd',
+    ticketUrl: 'https://dice.fm/event/mxdpgl-beefmince-trunk-den-15th-aug-the-royal-vauxhall-tavern-london-tickets',
+    _promoter: 'BEEFMINCE'
+  };
+  // The dice event page offered as website AND ticketUrl (BOATMINCE shape).
+  const boatmince = {
+    title: 'BOATMINCE',
+    website: 'https://dice.fm/event/g5dyeb-boatmince-30th-aug-westminster-pier-london-tickets',
+    ticketUrl: 'https://dice.fm/event/g5dyeb-boatmince-30th-aug-westminster-pier-london-tickets',
+    _promoter: 'BOATMINCE'
+  };
+  // Venue-site event (Sitges Bear Cave): its own page IS the identity link.
+  const venueSite = {
+    title: 'BEEFMINCE MEET MARKET',
+    website: 'https://sitgesbearcave.com/event/wednesday-beefmince-meet-market/',
+    _promoter: 'BEEFMINCE'
+  };
+  const noPromoter = {
+    title: 'RANDOM PARTY',
+    website: 'https://www.eventbrite.com/e/random-party-tickets-1234567890'
+  };
+  const socialProfile = {
+    title: 'WOOF NIGHT',
+    website: 'https://www.instagram.com/megawoof_america'
+  };
+  const organizerHome = {
+    title: 'Lazy Bear Week 2026',
+    website: 'https://lazybearweek.eventbrite.com/'
+  };
+  const curatedStamp = {
+    title: 'CURATED LINKTREE',
+    website: 'https://linktr.ee/cubhouse',
+    _staticFields: { website: 'https://linktr.ee/cubhouse' }
+  };
+
+  core.canonicalizeIdentityLinks([
+    trunkDen, boatmince, venueSite, noPromoter, socialProfile, organizerHome, curatedStamp
+  ]);
+
+  assert.equal(trunkDen.website, 'https://beefmince.com',
+    'the dice shortlink is replaced by the curated identity link');
+  assert.equal(trunkDen.ticketUrl,
+    'https://dice.fm/event/mxdpgl-beefmince-trunk-den-15th-aug-the-royal-vauxhall-tavern-london-tickets',
+    'the real ticketUrl is never overwritten — the shortlink is dropped');
+  assert.equal(trunkDen._staticFields.website, 'https://beefmince.com',
+    'the replacement is registry branding — static-marked, never dedup identity or match evidence');
+
+  assert.equal(boatmince.website, 'https://beefmince.com',
+    'a sub-brand inherits the parent identity link');
+
+  assert.equal(venueSite.website, 'https://sitgesbearcave.com/event/wednesday-beefmince-meet-market/',
+    'a venue-site event keeps its own page — curated never displaces a real non-platform site');
+  assert.equal(venueSite._staticFields, undefined, 'an untouched organic website is not static-marked');
+
+  assert.equal(noPromoter.website, undefined,
+    'platform link with no curated identity: empty beats a platform link (owner ruling 2026-08-03)');
+  assert.equal(noPromoter.ticketUrl, 'https://www.eventbrite.com/e/random-party-tickets-1234567890',
+    'flag, don\'t drop: the link parks in the EMPTY ticketUrl');
+
+  assert.equal(socialProfile.website, undefined, 'a social profile is never the identity link');
+  assert.equal(socialProfile.instagram, 'https://www.instagram.com/megawoof_america',
+    'a social PROFILE routes to its own field, not to ticketUrl');
+
+  assert.equal(organizerHome.website, 'https://lazybearweek.eventbrite.com/',
+    'a platform organizer HOME page is an identity link — kept (same exception as the final-build pass)');
+  assert.equal(curatedStamp.website, 'https://linktr.ee/cubhouse',
+    'a statically stamped website is curated config — never re-routed');
+});
+
+test('canonicalizeIdentityLinks: url folds into website and ceases to exist as a stored value', () => {
+  const core = createRegistryCore(LINKS_REGISTRY);
+  const folded = { title: 'CHUNK BROOKLYN', url: 'https://www.chunk-party.com/events/brooklyn-return' };
+  const both = { title: 'DETAIL', url: 'https://beefmince.com', website: 'https://sitgesbearcave.com/event/x/' };
+  core.canonicalizeIdentityLinks([folded, both]);
+  assert.equal(folded.website, 'https://www.chunk-party.com/events/brooklyn-return',
+    'a lone url becomes the canonical website');
+  assert.equal('url' in folded, false, 'url never survives canonicalization');
+  assert.equal(both.website, 'https://sitgesbearcave.com/event/x/',
+    'an existing website is never overwritten by the alias');
+  assert.equal('url' in both, false, 'url never survives canonicalization');
+});
+
+test('canonicalizeIdentityLinks: registry identity fills an EMPTY website (ladder: registry > page > empty)', () => {
+  const core = createRegistryCore(LINKS_REGISTRY);
+  const blank = { title: 'SPOOKMINCE', _promoter: 'BOATMINCE' };
+  const noMatch = { title: 'UNRELATED NIGHT' };
+  core.canonicalizeIdentityLinks([blank, noMatch]);
+  assert.equal(blank.website, 'https://beefmince.com', 'the curated identity link fills the blank');
+  assert.equal(blank._staticFields.website, 'https://beefmince.com', 'the fill is branding — static-marked');
+  assert.equal(noMatch.website, undefined, 'no promoter, no page site → empty is correct');
+});
+
+test('final merge: the pasted BEEFMINCE x RVT rows are gone at the source', async () => {
+  const core = createRegistryCore(LINKS_REGISTRY);
+  const existingEvent = {
+    title: 'BEEFMINCE x RVT',
+    startDate: new Date('2026-09-19T21:00:00.000Z'),
+    endDate: new Date('2026-09-20T03:00:00.000Z'),
+    location: '51.48598,-0.11556',
+    notes: [
+      'website: https://beefmince.com',
+      'ticketUrl: https://dice.fm/event/yoepxa-beefmince-x-rvt-19th-sep-the-royal-vauxhall-tavern-london-tickets',
+      'gmaps: https://www.google.com/maps/place/?q=place_id:ChIJuYgA--wEdkgRD-0ylWTyMkw'
+    ].join('\n')
+  };
+  // The scraped record as it now reaches the merge: canonicalizeIdentityLinks
+  // already replaced the dice link with the curated identity, and gmaps still
+  // carries the page-derived text query.
+  const scraped = {
+    title: 'BEEFMINCE x RVT',
+    startDate: new Date('2026-09-19T21:00:00.000Z'),
+    website: 'https://beefmince.com',
+    _staticFields: { website: 'https://beefmince.com' },
+    ticketUrl: 'https://dice.fm/event/yoepxa-beefmince-x-rvt-19th-sep-the-royal-vauxhall-tavern-london-tickets',
+    gmaps: 'https://www.google.com/maps/search/?api=1&query=The%20Royal%20Vauxhall%20Tavern%2C%20london',
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const finalEvent = await core.createFinalEventObject(existingEvent, scraped, { httpAdapter: null });
+
+  assert.equal(finalEvent.website, 'https://beefmince.com');
+  assert.equal(finalEvent.url, 'https://beefmince.com', 'url is only an output view of website');
+  const decisions = finalEvent._mergeDecisions || [];
+  assert.equal(decisions.find((decision) => decision.field === 'website'), undefined,
+    'no website conflict is recorded — the sides agree, no row to render');
+  assert.equal(decisions.find((decision) => decision.field === 'gmaps'), undefined,
+    'no gmaps conflict is recorded');
+  assert.equal(finalEvent._original.scraper.gmaps, undefined,
+    'a text-query gmaps is not a candidate against a place-anchored calendar link (calendar-as-database)');
+  assert.equal(finalEvent._original.scraper.url, undefined,
+    'the scraped side offers no distinct url — the phantom url diff row is dead');
+  assert.equal(finalEvent.gmaps, 'https://www.google.com/maps/place/?q=place_id:ChIJuYgA--wEdkgRD-0ylWTyMkw',
+    'the place-anchored calendar link survives');
+
+  const noteLines = String(finalEvent.notes || '').split('\n');
+  assert.equal(noteLines.filter((line) => line.startsWith('website:')).length, 1,
+    'exactly one website: line lands in notes');
+  assert.equal(noteLines.some((line) => /^url:/.test(line)), false,
+    'url never lands in notes');
+});
+
+test('final merge: a legacy scraped url (replay/cached record) folds into website and is dropped', async () => {
+  const core = createRegistryCore(LINKS_REGISTRY);
+  const existingEvent = {
+    title: 'BEEFMINCE Brighton Pride',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    notes: ''
+  };
+  const scraped = {
+    title: 'BEEFMINCE Brighton Pride',
+    startDate: new Date('2026-08-01T21:00:00.000Z'),
+    url: 'https://beefmince.com'
+  };
+  const finalEvent = await core.createFinalEventObject(existingEvent, scraped, { httpAdapter: null });
+  assert.equal(finalEvent.website, 'https://beefmince.com', 'the alias folds into the canonical field');
+  assert.equal(finalEvent._original.scraper.url, undefined, 'the alias is dropped from the scraped side');
+});
+
+test('gmaps URL classification: place/coordinate-anchored vs text query (real run shapes)', () => {
+  const core = createCore();
+  // place_id-anchored (calendar, BEEFMINCE x RVT)
+  assert.equal(core.isPlaceAnchoredGmapsUrl('https://www.google.com/maps/place/?q=place_id:ChIJuYgA--wEdkgRD-0ylWTyMkw'), true);
+  // query_place_id variant
+  assert.equal(core.isPlaceAnchoredGmapsUrl('https://www.google.com/maps/search/?api=1&query=51.48%2C-0.11&query_place_id=ChIJx'), true);
+  // encoded coordinate pair (calendar, BEEFMINCE Brighton Pride)
+  assert.equal(core.isPlaceAnchoredGmapsUrl('https://www.google.com/maps/search/?api=1&query=50.819936%2C-0.140382'), true);
+  // raw-comma coordinate pair
+  assert.equal(core.isPlaceAnchoredGmapsUrl('https://www.google.com/maps/search/?api=1&query=51.5022544,-0.1231736'), true);
+  // text query (scraped, the pasted row) — %2C inside prose is not a coordinate
+  assert.equal(core.isPlaceAnchoredGmapsUrl('https://www.google.com/maps/search/?api=1&query=The%20Royal%20Vauxhall%20Tavern%2C%20london'), false);
+  assert.equal(core.isTextQueryGmapsUrl('https://www.google.com/maps/search/?api=1&query=The%20Royal%20Vauxhall%20Tavern%2C%20london'), true);
+  assert.equal(core.isTextQueryGmapsUrl('https://www.google.com/maps/search/?api=1&query=Venue%20TBA%2C%20London'), true);
+  assert.equal(core.isTextQueryGmapsUrl('https://www.google.com/maps/place/?q=place_id:ChIJuYgA--wEdkgRD-0ylWTyMkw'), false);
+  assert.equal(core.isTextQueryGmapsUrl(''), false);
+  assert.equal(core.isPlaceAnchoredGmapsUrl(''), false);
+});
+
+test('registry pass + canonicalization end-to-end: BEEFMINCE match routes the platform link and adopts the curated identity', () => {
+  const core = createRegistryCore(LINKS_REGISTRY);
+  const event = {
+    title: 'BEEFMINCE x RVT',
+    startDate: new Date('2026-09-19T21:00:00.000Z'),
+    website: 'https://link.dice.fm/V0890510c6bd',
+    ticketUrl: 'https://dice.fm/event/yoepxa-beefmince-x-rvt-19th-sep-the-royal-vauxhall-tavern-london-tickets'
+  };
+  core.applyPromoterRegistryMatches([event], { name: 'p' }, ENFORCE_REGISTRY_CONFIG);
+  assert.equal(event._promoter, 'BEEFMINCE', 'title evidence matches the registry');
+  assert.equal(event.url, undefined, 'the registry no longer stamps a distinct url value');
+  core.canonicalizeIdentityLinks([event]);
+  assert.equal(event.website, 'https://beefmince.com', 'the ladder lands on the curated identity link');
+  assert.equal(event.ticketUrl, 'https://dice.fm/event/yoepxa-beefmince-x-rvt-19th-sep-the-royal-vauxhall-tavern-london-tickets');
+  assert.equal(event.url, undefined, 'url never exists post-canonicalization');
 });


### PR DESCRIPTION
Ends the website/url duplication debacle once and for all: **`url` and `website` are ONE field** (canonical `website`), resolved to **one deterministic value before the merge**, so platform links never reach arbitration as website candidates and the no-op "kept existing / ignored new value" rows die at the source.

## The evidence this is built on

Run 20260811-135556, BEEFMINCE x RVT (owner's pasted rows), scraped record verbatim:

```
scraper:  website = https://link.dice.fm/V0890510c6bd   (dice ticket-widget shortlink)
          url     = https://beefmince.com               (registry url stamp)
          ticketUrl = https://dice.fm/event/…            gmaps = …query=The Royal Vauxhall Tavern…
calendar: website = https://beefmince.com                gmaps = …place_id:ChIJ…
```

The merge outcome was correct every run — and the same conflict rows rendered every run, because the scraped side kept re-offering the platform link as `website` and a text-query gmaps against a place-anchored calendar link.

## Complete seam inventory (every place a website/url value was produced, folded, cleared, merged, or displayed)

| # | Seam | Was | Now |
|---|------|-----|-----|
| 1 | AI extraction prompt (`web` param, event-schema.js) | → `website` | untouched (prompts frozen); canonicalized after extraction |
| 2 | JSON-LD / JSON-API routes (`buildEventFromJsonLdNode` et al.) | set `url` = source page | untouched; the pipeline folds it into `website` |
| 3 | event-schema alias map (`url`/`link`/`eventurl` → `website`) + notes exclusion of `url` | already canonical | unchanged, now pinned by test |
| 4 | **`BasicDataNormalizer.syncUrlAndWebsiteFields`** (normalizers.js) | bidirectional sync — **minted a `url` twin of every website** | `canonicalizeIdentityLink`: fold `url`→`website`, then delete `url` — it ceases to exist post-normalization |
| 5 | Single-event page self-naming (shared-core `processParser` crawl loop) | re-minted `soleEvent.url` after normalization | writes `website`; clears a replaced static stamp marker so the organic page counts as dedup identity again |
| 6 | Same-event URL dedup identity (`getEventIdentityUrlKey`) | `url` first, `website` fallback | unchanged code; website now carries the organic value (registry fills are static-marked and stay excluded) |
| 7 | Promoter-registry stamp (`promoterEntryToMetadataBlock`) | **stamped `block.url = {value: website}`** — a distinct static `url` on every matched event | no url key; identity link carried via `getPromoterEntryIdentityWebsite` (sub-brands inherit) and applied by the ladder (#8); favicon fallback reads it directly |
| 8 | **NEW: `canonicalizeIdentityLinks`** (processParser: after dedup + registry, before bear check/merge) | — | the once-and-for-all ladder, one value per event (below) |
| 9 | `applyAggregatorWebsitePointers` (#1660) | adopted ANY outbound ticketUrl as website — incl. dice/eventbrite | platform outbound is never adopted (stays in ticketUrl; self-pointer cleared); non-platform pointer adoption + offer-less clearing unchanged |
| 10 | `createFinalEventObject` fold (~9280) | folded `scraperObject.url`→website, kept `url` in `_original.scraper` | fold kept (replay/cached backstop), then `delete scraperObject.url` — no phantom scraped url in the diff |
| 11 | gmaps at merge | merge-skipped + STEP-4 regenerated, but the raw text-query candidate stayed in `_original.scraper` → forever row | calendar place/coordinate-anchored + scraped text-query → candidate deleted (new `isPlaceAnchoredGmapsUrl`/`isTextQueryGmapsUrl`, regex only) |
| 12 | Deterministic merge rung "identity link beats a ticketing/social platform URL" | primary defense | kept, now a backstop for cached/replayed records |
| 13 | Final-build 🔗 LINKS pass (~13280) | the only platform-website cleanup — ran POST-merge, so rows already rendered | kept verbatim as backstop (all log strings untouched); sub-brands now inherit the parent identity link |
| 14 | `finalEvent.url` output view / `_changes` 'url' label | view of website | unchanged (a view is not a distinct value) |
| 15 | Notes + ICS write paths (`formatEventNotes`, `buildRecurringEventIcs`, web-adapter ICS) | url notes-excluded; ICS read website-first | unchanged + pinned; web-adapter serializer/ICS/log readers now website-first |
| 16 | Display: `getFieldsForComparison` (scriptable-adapter) | union of raw keys — **`url` rendered as its own diff row** | `url` excluded; links row reads `website` first (kept mechanical — a parallel UI PR is touching this file) |
| 17 | Remaining `.url` reads (`_sourcePageUrl \|\| url \|\| website` fallbacks, calendar-native `existingEvent.url` input, promoter evidence) | defensive alias fallbacks | left in place: calendar-native url is an INPUT the fold consumes; on scraped records url no longer exists so `website` carries the same value |

## The ladder (canonicalizeIdentityLinks)

1. **Curated registry/venue identity link** (promoter match, parent-inherited) — replaces a platform website, fills an empty one, **never displaces a real non-platform page-stated site** (Sitges venue-page regression pinned). Marked `_staticFields.website`: branding is never dedup identity or match evidence.
2. **Official non-platform site stated on the page** — kept untouched.
3. **Empty** — strictly better than a platform link (owner ruling 2026-08-03).

Routing (flag, don't drop): social PROFILE → its own empty field (instagram/facebook/twitter); everything else ticket-ish → EMPTY ticketUrl; otherwise dropped with one log line. Exceptions mirror the final-build pass byte-for-byte: platform organizer HOME pages and the promoter's own curated platform presence are identity links. Host classification is entirely the existing machinery (`PLATFORM_IDENTITY_HOSTS`, `TICKETING_PLATFORM_HOSTS`, opaque-shortlink URL shape) — the only addition is a field-routing map over social hosts already in the platform list. Nothing per venue.

## Verification — real pasted case, replayed

Driving the verbatim run-20260811-135556 record through registry pass → canonicalizeIdentityLinks → createFinalEventObject against the real calendar notes:

- website resolves to `https://beefmince.com` **pre-merge** → sides agree → **no website decision, no row**
- `link.dice.fm/V0890510c6bd` shortlink: dropped (real ticketUrl already present) — never a website candidate
- scraped text-query gmaps: not a candidate; final gmaps = calendar `place_id:ChIJ…` → **no gmaps row**
- `_original.scraper.url`: gone → **no url row** (also excluded in the display)
- notes: exactly one `website:` line, zero `url:` lines
- the one surviving decision is the genuine Sep-vs-Oct ticketUrl difference (sticky-kept) — a real conflict, correctly shown

## Tests (all in existing enumerated test files)

**Fail-on-base proof**: with only the test files applied to origin/main, **14 tests fail**; with the implementation, the full quiet suite is green — **1785 pass / 0 fail** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`; base was 1775/0).

New pins (failing on base):
- `canonicalizeIdentityLinks: the real BEEFMINCE shapes …` — shortlink→curated replacement, sub-brand inheritance, venue-site kept, no-promoter park-in-ticketUrl, instagram profile→field, organizer home kept, static stamp untouched (shared-core.test.js)
- `canonicalizeIdentityLinks: url folds into website and ceases to exist …`
- `canonicalizeIdentityLinks: registry identity fills an EMPTY website …`
- `final merge: the pasted BEEFMINCE x RVT rows are gone at the source` — no website/gmaps decisions, no scraped url/gmaps candidates, one `website:` notes line
- `final merge: a legacy scraped url (replay/cached record) folds …`
- `gmaps URL classification: place/coordinate-anchored vs text query (real run shapes)`
- `registry pass + canonicalization end-to-end: BEEFMINCE match …`
- `BasicDataNormalizer folds url into website and deletes url at ingest` (normalizers.test.js)
- `getFieldsForComparison excludes url — one links row, never a url twin` (scriptable-adapter.test.js)
- `write paths: website is canonical — url is notes-excluded and the ICS URL line reads website` (event-schema.test.js)

Updated to the new doctrine (were pinning the old url-minting behavior): registry enforce-stamp test, Furball/Spooky-Bear migration tests (`block.url` → identity-website helper), registry↔parser parity + favicon fallback tests (explicit identity-website arg), aggregator pointer test (platform outbound never adopted; non-platform adoption + #1660 offer-less clearing still pinned), single-event self-naming test (writes website).

## Regression checks

- Venue-site events keep their own site as website (Sitges Bear Cave shapes, pinned)
- Aggregator clearing #1660 unaffected (existing test still green); pointer adoption for non-platform originals still works (new assertion)
- Promoter-registry stamps still win: identity link fills/replaces via the ladder, favicon fallback intact, registry↔parser static parity test green
- Recurring/dedup: URL-identity dedup runs BEFORE canonicalization, so raw scraped links still fold twins; registry fills are static-marked and excluded from identity, organic self-named pages count again
- Platform purity: no `new URL(`/`URLSearchParams`; existing console.log strings and AI prompt lines byte-identical (the extraction prompt still requests both — canonicalization happens after extraction)

## Overlap note

`scripts/adapters/scriptable-adapter.js` changes are deliberately minimal and mechanical (exclude `url` from the comparison field list; website-first in the links row) because a parallel UI PR is being built in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
