### PR TITLE
fix(run-once): scope the blocking materialization sweep to storage/ (phone-upload-pending files must not abort runs)

### DIFF
--- a/scripts/tools-serve-results.test.js
+++ b/scripts/tools-serve-results.test.js
@@ -545,6 +545,38 @@ test('run-once: materialization sweep skips honestly when it cannot run (non-mac
   assert.deepEqual(await runOnce.materializeSharedStorageTree('', {}), { skipped: 'no-shared-root' });
 });
 
+// Defense #1 SCOPE (2026-08-13 incident): the blocking sweep must cover only
+// the storage/ cache tree a run READS. A real run rode the ceiling toward an
+// abort over five phone LOG files whose bytes had not yet uploaded FROM the
+// phone — undrainable from the Mac side, and irrelevant to the run (logs/
+// and runs/ are write-only here, new filenames, atomic writes). Files
+// outside storage/ are an advisory line, never a blocker.
+test('run-once: sweep blocks only on storage/ and reports outside-storage dataless files as advisory', async () => {
+  const logs = [];
+  const log = (line) => logs.push(String(line));
+  const probedRoots = [];
+  // storage/ tree is clean; 5 phone logs are dataless in the wider root.
+  const countDataless = (root) => {
+    probedRoots.push(root);
+    return root.endsWith('/storage') ? 0 : 5;
+  };
+  const result = await runOnce.sweepSharedStorageBeforeRun('/shared/root', {
+    platform: 'darwin',
+    countDataless,
+    kickDownload: () => { throw new Error('must not kick a download for a clean blocking tree'); },
+    log
+  });
+  assert.equal(result.datalessAtStart, 0, 'blocking sweep saw a clean storage tree');
+  assert.equal(probedRoots[0], '/shared/root/storage', 'the BLOCKING probe is scoped to storage/');
+  assert.ok(probedRoots.includes('/shared/root'), 'the advisory probe covers the whole root');
+  assert.ok(
+    logs.some((line) => line.includes('5 dataless file(s) remain OUTSIDE the storage/ cache tree')),
+    'outside-storage dataless files are reported as advisory, not blocked on'
+  );
+  // And the run did NOT abort: five undrainable phone-log stubs must never
+  // ride the ceiling (the exact 2026-08-13 failure).
+});
+
 // Defense #3b: JS-side timeouts cannot cancel wedged syscalls — each one
 // leaks a libuv threadpool slot, and the default pool is only 4 slots. Both
 // the run-once entry and the launchd plist give the pool headroom.

--- a/tools/run-once.js
+++ b/tools/run-once.js
@@ -305,6 +305,32 @@ async function materializeSharedStorageTree(sharedRoot, options = {}) {
     return { datalessAtStart: initialCount, waitedMs };
 }
 
+// Scope wrapper around the sweep. The BLOCKING sweep covers only what a run
+// actually READS — the storage/ cache tree — because blocking on the whole
+// root wedged a real run (2026-08-13) on five phone LOG files whose content
+// had not yet UPLOADED from the phone: iCloud had the metadata, the bytes
+// were still on the device, so no amount of Mac-side downloading could ever
+// drain the count and the sweep rode the ceiling into a pointless abort.
+// logs/ and runs/ are write-only for a Mac run (new filenames, atomic
+// writes), and the small root-level state files fail soft through the
+// bounded fs ops — dataless files there are reported as an ADVISORY line,
+// never a blocker.
+async function sweepSharedStorageBeforeRun(sharedRoot, options = {}) {
+    const {
+        joinPath = (a, b) => path.join(a, b),
+        countDataless = countDatalessFilesViaFind,
+        log = console.log
+    } = options;
+    if (!sharedRoot) return { skipped: 'no-shared-root' };
+    const blockingRoot = joinPath(sharedRoot, 'storage');
+    const result = await materializeSharedStorageTree(blockingRoot, { ...options, countDataless, log });
+    const totalCount = countDataless(sharedRoot);
+    if (typeof totalCount === 'number' && totalCount > 0) {
+        log(`run-once: ${totalCount} dataless file(s) remain OUTSIDE the storage/ cache tree (logs/runs — typically content still uploading from the phone) — not needed by this run, continuing`);
+    }
+    return result;
+}
+
 // Tee console output into a buffer (still printed) so shared-storage runs can
 // persist a per-run log file the way the phone's FileLogger does.
 function installConsoleTee(lines) {
@@ -351,7 +377,7 @@ async function main() {
         // Defense #1 (dataless iCloud stubs): download every evicted file
         // BEFORE any parser work. A ceiling breach throws — abort loudly to
         // launchd's err log rather than start a run that would wedge.
-        await materializeSharedStorageTree(sharedRoot);
+        await sweepSharedStorageBeforeRun(sharedRoot);
     }
 
     const { WebAdapter } = require(path.join(repoRoot, 'scripts', 'adapters', 'web-adapter'));
@@ -431,5 +457,6 @@ module.exports = {
     installConsoleTee,
     ensureThreadpoolHeadroom,
     resolveMaterializeCeilingMs,
+    sweepSharedStorageBeforeRun,
     materializeSharedStorageTree
 };


### PR DESCRIPTION
Live incident during today's launchd validation: the #1668 preflight blocked on the WHOLE shared root, and five recent phone log files sat dataless because their content had not finished uploading **from the phone** — iCloud had the metadata, the bytes were still on the device. No Mac-side download can drain that count, so the sweep would ride its 15-minute ceiling into an abort over files the run never reads.

Fix: `sweepSharedStorageBeforeRun` wrapper — the BLOCKING sweep covers only `storage/` (the cache tree a run reads); dataless files outside it (logs/, runs/ — write-only for a Mac run, new filenames, atomic writes) are reported as one advisory line and never block. Existing sweep function, tests, and log lines untouched (additions only).

Test proven failing on base (helper absent). Full quiet suite 1801/1801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP