### PR TITLE
fix(results-ui): round 4 — labelled builder link, tap-to-enlarge thumbs, atomic date wrap, working Images toggle, debug section dissolved

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -6940,6 +6940,10 @@ class ScriptableAdapter {
 
         .event-headline-main {
             display: flex;
+            /* wrap so an expanded thumbnail can take a full-width row of its
+               own (round 4: tap the image to enlarge it). The collapsed thumb
+               is a fixed 64px slot, so nothing wraps in the default state. */
+            flex-wrap: wrap;
             gap: 10px;
             align-items: flex-start;
         }
@@ -6953,6 +6957,7 @@ class ScriptableAdapter {
            cover — a giant poster can never blow up the card height. */
         .event-thumb {
             flex: 0 0 auto;
+            cursor: pointer;
         }
 
         .event-thumb img {
@@ -6962,6 +6967,27 @@ class ScriptableAdapter {
             object-fit: cover;
             border-radius: 8px;
             border: 1px solid var(--border-color);
+        }
+
+        /* Tap-to-enlarge (owner: "Can the image get bigger when we press it
+           too? Like description"): same in-page toggle pattern as the
+           description clamp — toggleThumbSize flips this class, a second tap
+           shrinks back. Expanded, the thumb takes a full-width row and the
+           poster renders whole (contain, bounded height). */
+        .event-thumb.thumb-expanded {
+            flex: 1 1 100%;
+            width: 100%;
+        }
+
+        .event-thumb.thumb-expanded img {
+            width: 100%;
+            height: auto;
+            max-height: 70vh;
+            object-fit: contain;
+        }
+
+        .event-thumb.thumb-expanded .event-thumb-badge {
+            max-width: none;
         }
 
         .venue-placeholder-thumb img {
@@ -6985,6 +7011,36 @@ class ScriptableAdapter {
             font-size: 13px;
             color: var(--text-primary);
             margin-top: 2px;
+        }
+
+        /* Atomic datetime halves (owner: "can it magically move the whole
+           end date to the next line?"): each start/end datetime is one
+           nowrap unit, so a narrow screen breaks at the separator and the
+           whole end datetime jumps to the next line instead of splitting
+           after the date. */
+        .dt-nowrap {
+            white-space: nowrap;
+        }
+
+        /* UTC verification, folded from the old debug expander onto the date
+           area of the face — smaller, muted, no block of its own. */
+        .event-headline-utc {
+            font-size: 10px;
+            color: var(--text-secondary);
+        }
+
+        /* Target-calendar chip, folded from the old debug expander into the
+           face badges row. */
+        .calendar-chip {
+            display: inline-block;
+            font-size: 10px;
+            font-weight: 600;
+            padding: 2px 7px;
+            border-radius: 10px;
+            margin: 2px;
+            background: var(--background-light);
+            color: var(--text-secondary);
+            border: 1px solid var(--border-color);
         }
 
         .no-end-note {
@@ -7138,26 +7194,10 @@ class ScriptableAdapter {
             font-style: italic;
         }
 
-        /* Per-card debug expander (raw JSON, provenance, field counts). */
-        .event-card-debug {
-            margin-top: 10px;
-        }
-
-        .event-card-debug > summary {
-            cursor: pointer;
-            font-size: 12px;
-            font-weight: 600;
-            color: var(--text-secondary);
-            padding: 4px 0;
-            -webkit-user-select: none;
-            user-select: none;
-        }
-
-        .debug-field-counts {
-            font-size: 12px;
-            color: var(--text-secondary);
-            margin: 6px 0;
-        }
+        /* Round 4: the per-card debug expander is dissolved — UTC and the
+           calendar target live on the face, provenance rows fold into the
+           merge table, and the raw JSON stays embedded (hidden) for Raw mode
+           and the copy button. */
 
         .duplicate-folded-line {
             font-size: 12px;
@@ -7873,82 +7913,21 @@ class ScriptableAdapter {
         }
 
         /* Per-event provenance section (built by event-provenance.js) */
-        .provenance-details {
-            margin-top: 12px;
-            border-top: 1px solid var(--border-color);
-            padding-top: 8px;
-        }
-
-        .provenance-details > summary {
-            cursor: pointer;
-            font-size: 13px;
-            font-weight: 600;
-            color: var(--primary-color);
-            padding: 5px 0;
-        }
-
-        .provenance-meta {
-            font-size: 11px;
-            color: var(--text-secondary);
-            margin: 4px 0;
-        }
-
-        .provenance-url {
-            font-family: monospace;
-            word-break: break-all;
-        }
-
-        .provenance-table-wrap {
-            overflow-x: auto;
-            -webkit-overflow-scrolling: touch;
-            margin-top: 6px;
-        }
-
-        .provenance-table {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: 11px;
-        }
-
-        .provenance-table th {
-            text-align: left;
-            padding: 4px 6px;
-            border-bottom: 1px solid var(--border-color);
-            color: var(--text-primary);
-            white-space: nowrap;
-        }
-
-        .provenance-table td {
-            padding: 4px 6px;
-            border-bottom: 1px solid var(--border-color);
-            color: var(--text-primary);
-            word-break: break-word;
-            vertical-align: top;
-        }
-
-        .provenance-table .provenance-field {
-            font-family: monospace;
-            font-weight: 600;
-            white-space: nowrap;
-        }
-
-        .provenance-table .provenance-missing {
-            color: var(--text-secondary);
-        }
-
-        .provenance-table .provenance-decision {
-            color: var(--text-secondary);
-            font-style: italic;
-        }
-
-        .provenance-note {
-            color: var(--text-secondary);
-            font-size: 11px;
-            margin: 6px 0 0;
-        }
-
+        /* Round 4: the 🔍 Provenance section is dissolved into the merge
+           table; only the export-issue control (now on the card actions row)
+           keeps its classes — the exportProvenanceIssue handler walks them. */
         .provenance-export {
             margin-top: 10px;
+        }
+
+        /* Round 4: the export control rides the card actions row — no top
+           margin there, and its reveal area may take the full row width. */
+        .event-actions-row .provenance-export {
+            margin-top: 0;
+        }
+
+        .event-actions-row .provenance-export-area {
+            min-width: 260px;
         }
 
         .provenance-export-btn {
@@ -8360,13 +8339,6 @@ class ScriptableAdapter {
                     card.classList.remove('raw-mode');
                 }
             });
-            // Raw mode exists to read the debug JSON — pop the per-card
-            // debug expanders open so it is actually visible.
-            if (toggle && toggle.checked) {
-                document.querySelectorAll('details.event-card-debug').forEach(d => {
-                    d.open = true;
-                });
-            }
         }
 
         // Description clamp toggle (pure page JS, no bridge): the face
@@ -8374,6 +8346,13 @@ class ScriptableAdapter {
         // tapping again re-clamps.
         function toggleDescClamp(el) {
             try { el.classList.toggle('clamped'); } catch (ignore) {}
+        }
+
+        // Thumbnail size toggle (round 4, same pattern: pure page JS, no
+        // bridge): tapping the face thumbnail enlarges it to a full-width
+        // contained poster; a second tap shrinks it back to the 64px slot.
+        function toggleThumbSize(el) {
+            try { el.classList.toggle('thumb-expanded'); } catch (ignore) {}
         }
         
         function toggleDiffView(button, safeEventId) {
@@ -8805,7 +8784,10 @@ class ScriptableAdapter {
                 
         function toggleImages() {
             const toggle = document.getElementById('sfwToggle');
-            const imageContainers = document.querySelectorAll('.image-container');
+            // Round 4 fix: round 3's dense face renders images as .event-thumb,
+            // but this handler still queried only .image-container — a class no
+            // card emits anymore — so the Images checkbox silently did nothing.
+            const imageContainers = document.querySelectorAll('.image-container, .event-thumb');
             
             imageContainers.forEach(container => {
                 if (toggle.checked) {
@@ -9514,147 +9496,138 @@ class ScriptableAdapter {
     }
   }
 
-  // Per-event "🔍 Provenance" section (field origins, merge decisions, and the
-  // export-issue payload). Builders live in the pure event-provenance module;
-  // this is just the environment glue. A failure here must never block an
-  // event card, so this degrades to an empty string (mirrors
-  // buildRunHealthBadgeHtml).
-  buildEventProvenanceHtml(event, runInfo = {}) {
+  // Round 4: the "🔍 Provenance" section is DISSOLVED (owner: "I don't like
+  // the debug section, it should be folded in to the other parts right?").
+  // Its merge-shaped rows fold into the merge comparison table through this
+  // helper (same shared row format, same no-op collapse); its source URL
+  // joins the face link chips; its parser/action meta line is dropped (the
+  // card's tags already say both); its export-issue control moved to the
+  // card actions row. Nothing is deleted from the run JSON.
+  //
+  // Only fields the comparison table does NOT already judge fold in
+  // (`coveredFields`) — in practice the routing-only fields the comparison
+  // excludes on purpose, like `city`. Classification keeps the truthful
+  // no-changes doctrine: a folded row is a REAL outcome only when the
+  // calendar side actually tracks the field AND the merge left it different
+  // — "city | london | scraper | took scraped value (calendar had none)" is
+  // a permanent pass-through (the calendar never stores city), so it joins
+  // the "N fields unchanged" summary instead of flagging every merge as
+  // changed forever. A failure here must never block a card: degrade to no
+  // folded rows.
+  buildFoldedProvenanceRecords(event, coveredFields) {
+    try {
+      const model = EventProvenance.buildProvenanceModel(event, {
+        action: this.normalizeIntentAction(event),
+      });
+      if (!model.hasProvenance) return [];
+      const calendarSide =
+        event._original &&
+        event._original.calendar &&
+        typeof event._original.calendar === "object"
+          ? event._original.calendar
+          : {};
+      const records = [];
+      for (const row of model.rows) {
+        if (coveredFields.has(row.field)) continue;
+        const calendarTracks = Object.prototype.hasOwnProperty.call(
+          calendarSide,
+          row.field,
+        );
+        const changed =
+          calendarTracks &&
+          !EventProvenance.valuesEqual(
+            row.field,
+            row.finalValue,
+            row.calendarValue,
+          );
+        const finalText = EventProvenance.formatValueText(row.finalValue);
+        const scraperText = EventProvenance.formatValueText(row.scraperValue);
+        const calendarText = EventProvenance.formatValueText(
+          row.calendarValue,
+        );
+        const matchesScraper =
+          Boolean(finalText) &&
+          Boolean(scraperText) &&
+          EventProvenance.valuesEqual(
+            row.field,
+            row.finalValue,
+            row.scraperValue,
+          );
+        const matchesCalendar =
+          Boolean(finalText) &&
+          Boolean(calendarText) &&
+          EventProvenance.valuesEqual(
+            row.field,
+            row.finalValue,
+            row.calendarValue,
+          );
+        const sourceLabel =
+          matchesScraper && matchesCalendar
+            ? "both agree"
+            : matchesScraper
+              ? "scraper"
+              : matchesCalendar
+                ? "calendar"
+                : finalText
+                  ? "merged"
+                  : "dropped";
+        // Final value first; the losing side(s) as small sub-lines, so
+        // nothing the old Scraper/Calendar columns showed is lost.
+        const valueParts = [this.formatFieldRowValueHtml(row.finalValue)];
+        if (scraperText && !matchesScraper) {
+          valueParts.push(
+            `<div class="field-row-was">scraper: ${this.formatFieldRowValueHtml(row.scraperValue)}</div>`,
+          );
+        }
+        if (calendarText && !matchesCalendar) {
+          valueParts.push(
+            `<div class="field-row-was">calendar: ${this.formatFieldRowValueHtml(row.calendarValue)}</div>`,
+          );
+        }
+        records.push({
+          field: row.field,
+          changed,
+          html: this.buildFieldRowHtml({
+            fieldHtml: `<strong>${this.escapeHtml(row.field)}</strong>`,
+            valueHtml: valueParts.join(""),
+            sourceHtml: this.escapeHtml(sourceLabel),
+            reasonHtml: this.escapeHtml(row.decisionText || ""),
+          }),
+        });
+      }
+      return records;
+    } catch (error) {
+      // Diagnostics must never break the table they annotate.
+      console.log(
+        `📱 Scriptable: Folded provenance rows build failed for "${event?.title || "unknown"}": ${error.message}`,
+      );
+      return [];
+    }
+  }
+
+  // The per-card "📤 Export issue" control, moved from the dissolved
+  // provenance section to the card actions row. Same markup contract as
+  // before — the exportProvenanceIssue page handler walks these exact
+  // classes (.provenance-export wrapper → area/text/status). Degrades to ""
+  // on hostile data instead of blocking the card.
+  buildExportIssueControlHtml(event, runInfo = {}) {
     try {
       const options = {
         action: this.normalizeIntentAction(event),
         runId: runInfo.runId || null,
         timestamp: runInfo.timestamp || null,
       };
-      // ONE FORMAT (owner feedback #5): render the provenance MODEL through
-      // the adapter's shared field-row builder — field | value | source |
-      // reason — instead of the module's own five-column table, so this
-      // section reads exactly like the merge table and the notes preview.
-      // The <details class="provenance-details"> wrapper, the summary text
-      // and the export-issue control markup (exportProvenanceIssue page
-      // handler, .provenance-export* classes) are kept byte-compatible.
-      const model = EventProvenance.buildProvenanceModel(event, options);
-
-      const metaParts = [];
-      if (model.parser) metaParts.push(`Parser: ${model.parser}`);
-      if (model.action) metaParts.push(`Action: ${model.action}`);
-      if (model.arbitrationSummary) metaParts.push(model.arbitrationSummary);
-      const metaLine =
-        metaParts.length > 0
-          ? `<div class="provenance-meta">${this.escapeHtml(metaParts.join(" • "))}</div>`
-          : "";
-      const urlLine = model.sourceUrl
-        ? `<div class="provenance-meta provenance-url" title="${this.escapeHtml(model.sourceUrl)}">Source: ${this.escapeHtml(
-            model.sourceUrl.length > 80
-              ? `${ScriptableAdapter.safeSubstring(model.sourceUrl, 0, 79)}…`
-              : model.sourceUrl,
-          )}</div>`
-        : "";
-
-      let body;
-      if (!model.hasProvenance) {
-        body =
-          '<div class="provenance-note">No provenance recorded for this event (new event or older saved run).</div>';
-      } else if (model.rows.length === 0) {
-        body = `<div class="provenance-note">All ${model.unchangedCount} tracked field${
-          model.unchangedCount === 1 ? "" : "s"
-        } passed through unchanged.</div>`;
-      } else {
-        const rowsHtml = model.rows
-          .map((row) => {
-            const finalText = EventProvenance.formatValueText(row.finalValue);
-            const scraperText = EventProvenance.formatValueText(
-              row.scraperValue,
-            );
-            const calendarText = EventProvenance.formatValueText(
-              row.calendarValue,
-            );
-            const matchesScraper =
-              Boolean(finalText) &&
-              Boolean(scraperText) &&
-              EventProvenance.valuesEqual(
-                row.field,
-                row.finalValue,
-                row.scraperValue,
-              );
-            const matchesCalendar =
-              Boolean(finalText) &&
-              Boolean(calendarText) &&
-              EventProvenance.valuesEqual(
-                row.field,
-                row.finalValue,
-                row.calendarValue,
-              );
-            const sourceLabel =
-              matchesScraper && matchesCalendar
-                ? "both agree"
-                : matchesScraper
-                  ? "scraper"
-                  : matchesCalendar
-                    ? "calendar"
-                    : finalText
-                      ? "merged"
-                      : "dropped";
-            // Final value first; the losing side(s) as small sub-lines, so
-            // nothing the old Scraper/Calendar columns showed is lost.
-            const valueParts = [this.formatFieldRowValueHtml(row.finalValue)];
-            if (scraperText && !matchesScraper) {
-              valueParts.push(
-                `<div class="field-row-was">scraper: ${this.formatFieldRowValueHtml(row.scraperValue)}</div>`,
-              );
-            }
-            if (calendarText && !matchesCalendar) {
-              valueParts.push(
-                `<div class="field-row-was">calendar: ${this.formatFieldRowValueHtml(row.calendarValue)}</div>`,
-              );
-            }
-            return this.buildFieldRowHtml({
-              fieldHtml: `<strong>${this.escapeHtml(row.field)}</strong>`,
-              valueHtml: valueParts.join(""),
-              sourceHtml: this.escapeHtml(sourceLabel),
-              reasonHtml: this.escapeHtml(row.decisionText || ""),
-            });
-          })
-          .join("");
-        const unchangedNote =
-          model.unchangedCount > 0
-            ? `<div class="provenance-note">${model.unchangedCount} field${
-                model.unchangedCount === 1 ? "" : "s"
-              } unchanged</div>`
-            : "";
-        body = `
-            <div class="provenance-table-wrap">
-                ${this.buildFieldRowsTableHtml(rowsHtml)}
-            </div>
-            ${unchangedNote}`;
-      }
-
-      // Same markup contract as EventProvenance.buildExportControlsHtml —
-      // the exportProvenanceIssue page handler walks these exact classes.
       const exportEncoded = encodeURIComponent(
         EventProvenance.buildExportIssueCompactJson(event, options),
       );
-      const exportControls = `
-            <div class="provenance-export">
+      return `<div class="provenance-export">
                 <button type="button" class="provenance-export-btn" onclick="exportProvenanceIssue(this)" data-payload="${this.escapeHtml(exportEncoded)}">📤 Export issue</button>
                 <div class="provenance-export-area" style="display: none;">
                     <textarea class="provenance-export-text" readonly rows="10" spellcheck="false" onfocus="this.select()"></textarea>
                     <div class="provenance-export-status"></div>
                 </div>
             </div>`;
-
-      return `
-        <details class="provenance-details">
-            <summary>🔍 Provenance</summary>
-            ${metaLine}
-            ${urlLine}
-            ${body}
-            ${exportControls}
-        </details>`;
     } catch (error) {
-      console.log(
-        `📱 Scriptable: Provenance section build failed for "${event?.title || "unknown"}": ${error.message}`,
-      );
       return "";
     }
   }
@@ -10302,19 +10275,19 @@ class ScriptableAdapter {
   }
 
   // Per-card actions row: an Event Builder prefill link on EVERY card (rides
-  // the existing open-url bridge), plus the ICS export button on recurring
-  // cards. "" only when no builder URL could be built.
-  buildEventCardActionsHtml(event) {
+  // the existing open-url bridge), the ICS export button on recurring cards,
+  // plus (round 4) the copy-JSON button and the export-issue control that
+  // used to hide behind the dissolved debug expander.
+  buildEventCardActionsHtml(event, runInfo = {}) {
     const parts = [];
     const builderUrl = this.buildEventBuilderUrl(event);
     if (builderUrl) {
       const id = this.registerMapVerifyUrl(builderUrl);
-      // Icon-scale (owner: "Event builder top right? Or next to bear
-      // verdict?") — the row renders beside the verdict pill on the card
-      // face, so the link is one small 🛠 instead of a labelled row. Same
-      // class, same bridge handler, same registry.
+      // Compact but labelled (round 4, owner: "I want a name for the event
+      // builder link") — still beside the verdict pill, same class, same
+      // bridge handler, same registry.
       parts.push(
-        `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="event-builder-link" title="Open in Event Builder" aria-label="Open in Event Builder" style="color:var(--primary-color); text-decoration:none; font-size:15px;">🛠</a>`,
+        `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="event-builder-link" title="Open in Event Builder" aria-label="Open in Event Builder" style="color:var(--primary-color); text-decoration:none; font-size:13px; font-weight:600;">🛠 Builder</a>`,
       );
     }
     if (SharedCore.isRecurringSeriesEvent(event)) {
@@ -10332,8 +10305,18 @@ class ScriptableAdapter {
         );
       }
     }
+    // Copy JSON stayed reachable when the debug expander dissolved: the
+    // button reads this card's embedded pre.raw-json payload, exactly like
+    // the merge-section header's copy of it.
+    parts.push(
+      `<button onclick="copyEventJSON(this)" class="copy-json-btn">📋 Copy JSON</button>`,
+    );
+    // 📤 Export issue moved next to the other card actions (from the
+    // dissolved debug expander's provenance section).
+    const exportControl = this.buildExportIssueControlHtml(event, runInfo);
+    if (exportControl) parts.push(exportControl);
     if (parts.length === 0) return "";
-    return `<div class="event-actions-row" style="display:flex; gap:12px; align-items:center;">${parts.join("")}</div>`;
+    return `<div class="event-actions-row" style="display:flex; flex-wrap:wrap; gap:12px; align-items:center;">${parts.join("")}</div>`;
   }
 
   // ---------------------------------------------------------------------------
@@ -10426,7 +10409,18 @@ class ScriptableAdapter {
         `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="event-link-chip link-chip-${kind}" title="${this.escapeHtml(url)}">${icon} ${this.escapeHtml(label)}</a>`,
       );
     };
-    const website = event.website || event.url;
+    // Round 4 (dissolved provenance meta's "Source:" line): the source URL
+    // joins the chips row. In almost every event it IS the website/url chip
+    // already (url and website are ONE field); when the merged event lost its
+    // own link, fall back to the scraper side's so the chip still exists.
+    const scraperSide =
+      event._original &&
+      event._original.scraper &&
+      typeof event._original.scraper === "object"
+        ? event._original.scraper
+        : {};
+    const website =
+      event.website || event.url || scraperSide.url || scraperSide.website;
     addChip("website", "🌐", website, this.formatLinkChipLabel("website", website));
     addChip(
       "tickets",
@@ -11607,8 +11601,9 @@ class ScriptableAdapter {
     // doesn't really help me") — display placement change, the lines stay in
     // the run JSON untouched.
     const evidenceBlock = this.buildEvidenceLinesHtml(event._evidenceLines);
-    // Event Builder prefill link (every card) + ICS export (recurring cards).
-    const eventActionsRow = this.buildEventCardActionsHtml(event);
+    // Event Builder prefill link (every card) + ICS export (recurring cards)
+    // + copy-JSON + export-issue (round 4: folded out of the debug expander).
+    const eventActionsRow = this.buildEventCardActionsHtml(event, runInfo);
 
     // ----- Dense default face (wave 7, reorganized round 3) ---------------
     // The always-visible face of the card, everything a review needs with no
@@ -11619,14 +11614,27 @@ class ScriptableAdapter {
     // exists), and one compact 📍 route line (bar • short address • pin
     // link). Round 3 dissolved the "Details" expander: the clamped
     // description, link chips, merge comparison and notes preview live on
-    // the card body; only debug material (provenance, raw JSON, field
-    // counts, UTC row) sits behind the 🐞 Debug expander.
-    // ONE date string, used verbatim on the face.
-    const dateLineHtml = `${dateStr} ${timeStr}${
+    // the card body. Round 4 dissolved the debug expander too — UTC and the
+    // calendar chip sit on the face, provenance rows fold into the merge
+    // table, and only the hidden Raw-mode payload remains below the body.
+    // ONE date string, used verbatim on the face. Round 4 (owner: "can it
+    // magically move the whole end date to the next line?"): each datetime
+    // HALF is an atomic .dt-nowrap span and only the separator may break, so
+    // a narrow screen moves the whole end datetime down instead of splitting
+    // it after the date.
+    const dateLineHtml = `<span class="dt-nowrap">${dateStr} ${timeStr}</span>${
       hasRealEnd
-        ? ` - ${endDateStr ? `${endDateStr} ` : ""}${endTimeStr}`
+        ? ` - <span class="dt-nowrap">${endDateStr ? `${endDateStr} ` : ""}${endTimeStr}</span>`
         : ' <span class="no-end-note">(no end listed)</span>'
     }`;
+    // UTC verification, folded from the dissolved debug expander onto the
+    // face date area — smaller, muted, no block of its own. The face's main
+    // line already carries the no-end honesty note, so this stays compact.
+    const utcFaceHtml = `<span class="event-headline-utc">🌍 <span class="dt-nowrap">${utcTimeStr}</span>${
+      endUtcTimeStr
+        ? ` - <span class="dt-nowrap">${endUtcDateStr ? `${endUtcDateStr} ` : ""}${endUtcTimeStr}</span>`
+        : ""
+    } UTC</span>`;
     const headlineVenue = event.venue || event.bar || "";
     // Tappable route line (owner: "Can we make the bar, address, and
     // coordinates be links? Then make the route link on the list too?
@@ -11733,7 +11741,7 @@ class ScriptableAdapter {
     // flag-don't-drop treatment the full image block in the expander uses.
     const thumbHtml =
       typeof event.image === "string" && event.image.trim()
-        ? `<div class="event-thumb${isRepeatedImage ? " venue-placeholder-thumb" : ""}">
+        ? `<div class="event-thumb${isRepeatedImage ? " venue-placeholder-thumb" : ""}" onclick="toggleThumbSize(this)">
                 <img src="${this.escapeHtml(event.image)}" alt="Event image" onerror="this.style.display='none'">
                 ${
                   isRepeatedImage
@@ -11816,7 +11824,6 @@ class ScriptableAdapter {
       event._original && this.normalizeIntentAction(event) !== "new"
     );
     let comparisonHtml = "";
-    let fieldCountsLine = "";
     if (showComparison) {
       const diffChip =
         changedFieldCount === null
@@ -11834,14 +11841,8 @@ class ScriptableAdapter {
         .replace(/&quot;/g, '"')
         .replace(/&#39;/g, "'");
       const safeEventId = decodedEventId.replace(/[^a-zA-Z0-9\-_]/g, "_"); // Create safe ID for DOM elements
-      // The "N fields | N fields | N fields" counts line is debug material,
-      // not review material — it renders in the debug expander below.
-      fieldCountsLine = `
-                <div class="debug-field-counts">
-                    📊 <strong>Scraper:</strong> ${Object.keys(event._original?.scraper || {}).length} fields |
-                    📅 <strong>Calendar:</strong> ${Object.keys(event._original?.calendar || {}).length} fields |
-                    🔀 <strong>Merged:</strong> ${Object.keys(event._original?.merged || {}).length} fields
-                </div>`;
+      // Round 4: the "N fields | N fields | N fields" counts banner is
+      // DELETED from display entirely — the counts stay in the run JSON.
       comparisonHtml = `
             <div class="card-subsection merge-comparison-subsection">
                 <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -11905,7 +11906,7 @@ class ScriptableAdapter {
     let html = `
         <div class="event-card${isDroppedCard ? " bear-dropped-card" : ""}">
             <div class="event-headline">
-                <div class="event-headline-badges">${actionBadge}${writeBadge}${recurringBadge}${seriesMatchBadge}${sanityBadge}${overrideBadge}${seriesProposalBadge}${headlineReasonChip}</div>
+                <div class="event-headline-badges">${actionBadge}${writeBadge}${recurringBadge}${seriesMatchBadge}${sanityBadge}${overrideBadge}${seriesProposalBadge}${headlineReasonChip}<span class="calendar-chip">📱 ${this.escapeHtml(calendarName)}</span></div>
                 <div class="event-headline-main">
                     ${thumbHtml}
                     <div class="event-headline-body">
@@ -11915,7 +11916,7 @@ class ScriptableAdapter {
                               event.price
                                 ? ` <span class="event-headline-price">💵 ${this.escapeHtml(event.price)}</span>`
                                 : ""
-                            }
+                            } ${utcFaceHtml}
                         </div>
                         ${routeLineHtml}
                     </div>
@@ -11992,26 +11993,12 @@ class ScriptableAdapter {
             }
             </div>
 
-            <!-- Debug expander: UTC verification, calendar target, field
-                 counts, provenance (owner: "I don't understand what
-                 provenance is" — it is debug material now) and the raw JSON.
-                 raw-json-details keeps the expander visible in Raw mode. -->
-            <details class="event-card-debug raw-json-details">
-            <summary class="event-card-debug-summary">🐞 Debug</summary>
-            <div class="event-detail" style="font-size: 12px; color: #666;">
-                <span>🌍</span>
-                <span>UTC: ${utcTimeStr}${
-                  endUtcTimeStr
-                    ? ` - ${endUtcDateStr ? `${endUtcDateStr} ` : ""}${endUtcTimeStr}`
-                    : ' <span class="no-end-note">(no end listed)</span>'
-                }</span>
-            </div>
-            <div class="event-detail">
-                <span>📱</span>
-                <span>${this.escapeHtml(calendarName)}</span>
-            </div>
-            ${fieldCountsLine}
-            ${this.buildEventProvenanceHtml(event, runInfo)}
+            <!-- Round 4: the debug expander is dissolved. UTC + calendar
+                 target live on the face, the counts banner is display-deleted,
+                 provenance rows fold into the merge table, export-issue moved
+                 to the card actions. The raw payload stays embedded here —
+                 hidden by default, shown by Raw mode — because Copy JSON and
+                 prettyPrintCardPayloads read this card's pre.raw-json. -->
             <div class="raw-display">
                 ${evidenceBlock}
                 ${(() => {
@@ -12019,27 +12006,33 @@ class ScriptableAdapter {
                   // but drops the AI prompt/validation blobs — see
                   // buildEmbeddedEventJson — and is budgeted so a big run
                   // cannot grow the page without bound (buildBudgetedEventJson).
-                  const payload = this.buildBudgetedEventJson(event, runInfo);
-                  const what = [
-                    payload.dropped.length
-                      ? `dropped ${payload.dropped.join(", ")}`
-                      : "",
-                    payload.truncated && payload.truncated.length
-                      ? `shortened ${payload.truncated.slice(0, 6).join(", ")}`
-                      : "",
-                  ]
-                    .filter(Boolean)
-                    .join("; ");
-                  const notice = payload.capped
-                    ? `<div class="payload-cap-note">✂️ Debug JSON trimmed to fit the page (${this.escapeHtml(
-                        what,
-                      )}). Everything trimmed is still rendered above in this card; the untrimmed event is in the saved run file${
-                        payload.runFile
-                          ? ` <code>${this.escapeHtml(payload.runFile)}</code>`
-                          : ""
-                      }.</div>`
-                    : "";
-                  return `${notice}<pre class="raw-json">${this.escapeHtml(payload.json)}</pre>`;
+                  // Hostile field getters must cost this card its debug dump,
+                  // never the whole results page.
+                  try {
+                    const payload = this.buildBudgetedEventJson(event, runInfo);
+                    const what = [
+                      payload.dropped.length
+                        ? `dropped ${payload.dropped.join(", ")}`
+                        : "",
+                      payload.truncated && payload.truncated.length
+                        ? `shortened ${payload.truncated.slice(0, 6).join(", ")}`
+                        : "",
+                    ]
+                      .filter(Boolean)
+                      .join("; ");
+                    const notice = payload.capped
+                      ? `<div class="payload-cap-note">✂️ Debug JSON trimmed to fit the page (${this.escapeHtml(
+                          what,
+                        )}). Everything trimmed is still rendered above in this card; the untrimmed event is in the saved run file${
+                          payload.runFile
+                            ? ` <code>${this.escapeHtml(payload.runFile)}</code>`
+                            : ""
+                        }.</div>`
+                      : "";
+                    return `${notice}<pre class="raw-json">${this.escapeHtml(payload.json)}</pre>`;
+                  } catch (error) {
+                    return `<pre class="raw-json">{"_error":"debug payload unavailable — see the saved run file"}</pre>`;
+                  }
                 })()}
                 <div style="margin-top: 8px; text-align: right;">
                     <button onclick="copyEventJSON(this)" class="copy-json-btn">
@@ -12047,7 +12040,6 @@ class ScriptableAdapter {
                     </button>
                 </div>
             </div>
-            </details>
         </div>
         `;
 
@@ -14363,6 +14355,14 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         }),
       });
     });
+
+    // Round 4: provenance rows for fields the comparison does not already
+    // judge fold in here, so table view, compressed view, line-view summary
+    // count and the MERGE ·N tag all keep reading from ONE record list. See
+    // buildFoldedProvenanceRecords for the truthful no-op classification.
+    rows.push(
+      ...this.buildFoldedProvenanceRecords(event, new Set(fieldsToCompare)),
+    );
 
     return rows;
   }

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -304,10 +304,12 @@ test('event cards embed the collapsed provenance section with the export control
 
   const card = adapter.generateEventCard(event, { runId: '20260713-090000' });
 
-  assert.ok(card.includes('provenance-details'));
-  assert.ok(card.includes('🔍 Provenance'));
-  assert.ok(card.includes('Parser: bearracuda'));
-  assert.ok(card.includes('AI: calendar end matches doors-close time'));
+  // Round 4: no separate provenance section — the merge decision's reason
+  // renders in the merge comparison table's reason cell, and the export
+  // control rides the card actions row.
+  assert.ok(!card.includes('provenance-details'));
+  assert.ok(!card.includes('🔍 Provenance'));
+  assert.ok(card.includes('calendar end matches doors-close time'), 'decision reason in the merge table');
   assert.ok(card.includes('exportProvenanceIssue(this)'));
 
   // The embedded export payload carries the run id passed through by the card
@@ -318,7 +320,7 @@ test('event cards embed the collapsed provenance section with the export control
   assert.equal(payload.mergeDecisions.length, 1);
 });
 
-test('a provenance build failure degrades to an empty section, never blocks the card', () => {
+test('a hostile export payload degrades to no control, never blocks the card', () => {
   const adapter = buildAdapter();
   const hostile = { title: 'Bad Event', startDate: '2026-08-01T02:00:00.000Z' };
   Object.defineProperty(hostile, '_mergeDecisions', {
@@ -326,9 +328,13 @@ test('a provenance build failure degrades to an empty section, never blocks the 
     enumerable: true
   });
 
-  // The adapter wrapper swallows the throw and returns an empty section —
-  // the card build continues without provenance instead of dying.
-  assert.equal(adapter.buildEventProvenanceHtml(hostile), '');
+  // The payload builder degrades to an error stub inside the module and the
+  // control builder never throws — the card build continues either way, and
+  // whatever payload exists is still exportable.
+  const control = adapter.buildExportIssueControlHtml(hostile, { runId: 'r1' });
+  assert.ok(control.includes('provenance-export-btn'), 'control renders');
+  assert.ok(decodeURIComponent(control.match(/data-payload="([^"]*)"/)[1]).includes('boom'),
+    'the error stub names the failure instead of copying silence');
 });
 
 test('generateRichHTML defines the exportProvenanceIssue page handler once', async () => {
@@ -343,8 +349,10 @@ test('generateRichHTML defines the exportProvenanceIssue page handler once', asy
   });
 
   assert.equal((html.match(/function exportProvenanceIssue\(/g) || []).length, 1);
-  assert.ok(html.includes('provenance-details'));
-  assert.ok(html.includes('No provenance recorded'));
+  // Round 4: the provenance section is dissolved; the handler survives for
+  // the export-issue control on the card actions row.
+  assert.ok(!html.includes('provenance-details'));
+  assert.ok(html.includes('provenance-export-btn'));
 });
 
 // ---------------------------------------------------------------------------
@@ -6243,7 +6251,7 @@ test('web flow: every event on ONE page, nothing shed, no pager', async () => {
     // The rungs the shed ladder would have pulled are all still here.
     assert.ok(html.includes('<div id="line-view-'), 'line-by-line diff panes survive');
     assert.ok(!html.includes(ScriptableAdapter.SHED_DEBUG_JSON_PLACEHOLDER), 'debug JSON survives');
-    assert.ok(html.includes('class="provenance-details"'), 'provenance sections survive');
+    assert.ok(html.includes('class="raw-display"'), 'embedded payload blocks survive');
     // Including the cute icon: it is inlined, not swapped for the remote URL.
     assert.ok(html.includes('src="data:image/'), 'the logo stays inlined on desktop');
   } finally {
@@ -7744,8 +7752,10 @@ test('generateEventCard renders the end date on multi-day events and stays start
   // Both dates appear, joined as "<start date> <start time> - <end date> <end time>".
   assert.ok(multiDay.includes(fmtDate(start)), 'start date renders');
   assert.ok(multiDay.includes(fmtDate(end)), 'end date renders');
+  // Round 4: each datetime half is an atomic .dt-nowrap span with the
+  // separator between them.
   assert.ok(
-    multiDay.includes(`${fmtDate(start)} ${fmtTime(start)} - ${fmtDate(end)} ${fmtTime(end)}`),
+    multiDay.includes(`<span class="dt-nowrap">${fmtDate(start)} ${fmtTime(start)}</span> - <span class="dt-nowrap">${fmtDate(end)} ${fmtTime(end)}</span>`),
     'multi-day span renders both dates with their times');
 
   // Same-calendar-day events keep the original start-only format.
@@ -7760,10 +7770,10 @@ test('generateEventCard renders the end date on multi-day events and stays start
     city: 'ptown'
   });
   assert.ok(
-    sameDay.includes(`${fmtDate(sameStart)} ${fmtTime(sameStart)} - ${fmtTime(sameEnd)}`),
-    'same-day span is unchanged');
+    sameDay.includes(`<span class="dt-nowrap">${fmtDate(sameStart)} ${fmtTime(sameStart)}</span> - <span class="dt-nowrap">${fmtTime(sameEnd)}</span>`),
+    'same-day span is unchanged (modulo the atomic wrap spans)');
   assert.ok(
-    !sameDay.includes(` - ${fmtDate(sameEnd)}`),
+    !sameDay.includes(` - <span class="dt-nowrap">${fmtDate(sameEnd)}`),
     'no end date on a same-day card');
 });
 
@@ -8121,7 +8131,7 @@ test('the dropped pile is collapsed by default and keeps the mark-bear rescue bu
   assert.ok(droppedSection.includes('ai: no bear-specific language'));
 });
 
-test('event cards are headline + main section + debug expander, nothing deleted', async () => {
+test('event cards are headline + main section + hidden raw payload, nothing deleted', async () => {
   const adapter = buildAdapter();
   const event = {
     title: 'Bear Night',
@@ -8140,14 +8150,16 @@ test('event cards are headline + main section + debug expander, nothing deleted'
   // Headline face: title, 📅 date, 📍 venue.
   const headlineIdx = html.indexOf('<div class="event-headline">');
   assert.ok(headlineIdx !== -1, 'card has a headline block');
-  // Round 3: the "Details" expander is dissolved — the card body IS the main
-  // section, and only debug material sits behind the 🐞 Debug expander.
+  // Round 3 dissolved the "Details" expander; round 4 dissolved the debug
+  // expander too — the card body IS the main section, and only the hidden
+  // Raw-mode payload block sits below it.
   assert.ok(!html.includes('<details class="event-card-details">'), 'no monolithic Details expander');
+  assert.ok(!html.includes('event-card-debug'), 'no debug expander either');
   const bodyIdx = html.indexOf('<div class="event-details">');
-  const debugIdx = html.indexOf('<details class="event-card-debug');
+  const rawIdx = html.indexOf('<div class="raw-display">');
   assert.ok(bodyIdx !== -1, 'card has a main section');
-  assert.ok(debugIdx !== -1, 'card has the debug expander');
-  assert.ok(headlineIdx < bodyIdx && bodyIdx < debugIdx, 'headline, then main section, then debug');
+  assert.ok(rawIdx !== -1, 'card keeps its raw payload block');
+  assert.ok(headlineIdx < bodyIdx && bodyIdx < rawIdx, 'headline, then main section, then raw payload');
   const headline = html.slice(headlineIdx, bodyIdx);
   assert.ok(headline.includes('Bear Night'));
   assert.ok(headline.includes('📅'));
@@ -8157,12 +8169,12 @@ test('event cards are headline + main section + debug expander, nothing deleted'
   // The face carries the route info (as bridge links) and the thumbnail.
   assert.ok(headline.includes('1 Main St'), 'address on the face route line');
   assert.ok(headline.includes('event-thumb'), 'image visible on the face');
-  const body = html.slice(bodyIdx, debugIdx);
+  const body = html.slice(bodyIdx, rawIdx);
   assert.ok(body.includes('A very bear night'), 'description on the main section');
   assert.ok(body.includes('📝 Calendar Notes Preview'), 'notes preview kept');
-  const debug = html.slice(debugIdx);
-  assert.ok(debug.includes('raw-json'), 'debug JSON kept');
-  assert.ok(debug.includes('copyEventJSON(this)'), 'copy button kept');
+  const raw = html.slice(rawIdx);
+  assert.ok(raw.includes('raw-json'), 'debug JSON kept');
+  assert.ok(raw.includes('copyEventJSON(this)'), 'copy button kept');
   assert.ok(!html.includes('image-container'), 'no duplicate image block anywhere');
 });
 
@@ -8743,17 +8755,18 @@ test('default card face shows thumbnail, full date line, route line and verdict 
     bearVerdict: 'bear',
     interactive: true
   });
-  const debugIdx = card.indexOf('<details class="event-card-debug');
-  assert.ok(debugIdx !== -1, 'card still has the debug expander');
-  const face = card.slice(0, debugIdx);
+  const rawIdx = card.indexOf('<div class="raw-display">');
+  assert.ok(rawIdx !== -1, 'card still embeds its raw payload block');
+  const face = card.slice(0, rawIdx);
 
   // The image is visible by default again (owner: "it removed the image").
   assert.ok(face.includes('event-thumb'), 'thumbnail block on the face');
   assert.ok(face.includes('<img src="https://example.com/poster.jpg"'), 'the event image itself');
 
-  // Full date line: start AND end time, no tap needed.
+  // Full date line: start AND end time, no tap needed (each half an atomic
+  // nowrap span since round 4).
   assert.ok(face.includes('📅'), 'date line present');
-  assert.ok(face.includes('7:00 PM - 10:00 PM'), 'start and end time on the face');
+  assert.ok(face.includes('7:00 PM</span> - <span class="dt-nowrap">10:00 PM'), 'start and end time on the face');
 
   // Compact route line: bar • short street address • pin link over the
   // existing openMapVerify bridge.
@@ -8788,7 +8801,7 @@ test('zero-duration events render "(no end listed)" and never a fabricated end t
 
   // A REAL end still renders in full — the honesty note never eats real data.
   const real = adapter.generateEventCard(buildDenseFaceEvent());
-  assert.ok(real.includes('7:00 PM - 10:00 PM'));
+  assert.ok(real.includes('7:00 PM</span> - <span class="dt-nowrap">10:00 PM'));
   assert.ok(!real.includes('(no end listed)'));
 });
 
@@ -8840,14 +8853,18 @@ test('merge, provenance and notes-preview rows all share the one field-row forma
   assert.ok(mergeRows.includes('class="field-row"'), 'merge rows use the shared row class');
   assert.ok(mergeRows.includes('field-row-source'), 'merge rows carry the source/outcome cell');
 
-  // 2) Provenance section.
-  const provenance = adapter.buildEventProvenanceHtml(event, { runId: 'r1' });
-  assert.ok(provenance.includes('class="field-row"'), 'provenance rows use the shared row class');
-  assert.ok(provenance.includes(headerRow), 'provenance renders the shared table header');
-  assert.ok(provenance.includes('<details class="provenance-details">'), 'collapsed wrapper kept (pagination shed rung marker)');
-  assert.ok(provenance.includes('🔍 Provenance'));
-  assert.ok(provenance.includes('exportProvenanceIssue(this)'), 'export-issue handler kept');
-  assert.ok(provenance.includes('provenance-export-btn'), 'export control classes kept');
+  // 2) Folded provenance rows (round 4: the provenance section dissolved
+  // into the merge table) use the very same row builder.
+  const folded = adapter.buildFoldedProvenanceRecords(
+    { ...event, _original: { ...event._original, calendar: { ...event._original.calendar, city: 'berlin' } }, city: 'unknown' },
+    new Set(['bar', 'website'])
+  );
+  assert.ok(folded.length > 0, 'provenance-only fields fold into records');
+  assert.ok(folded.every(r => r.html.includes('class="field-row"')), 'folded rows use the shared row class');
+  // Export control markup survives, on the card actions row.
+  const exportControl = adapter.buildExportIssueControlHtml(event, { runId: 'r1' });
+  assert.ok(exportControl.includes('exportProvenanceIssue(this)'), 'export-issue handler kept');
+  assert.ok(exportControl.includes('provenance-export-btn'), 'export control classes kept');
 
   // 3) Calendar-notes preview inside the card.
   const card = adapter.generateEventCard(event);
@@ -8861,26 +8878,24 @@ test('merge, provenance and notes-preview rows all share the one field-row forma
   assert.ok(card.includes(headerRow));
 });
 
-test('review subsections live on the main section; debug material behind the debug expander', () => {
+test('review subsections live on the main section; the raw payload hides below it', () => {
   const adapter = buildAdapter();
   const event = buildSharedFormatMergeEvent();
   const card = adapter.generateEventCard(event);
-  // Round 3: the monolithic Details expander is dissolved.
+  // Round 3 dissolved the Details expander; round 4 the debug expander.
   assert.ok(!card.includes('<details class="event-card-details">'), 'no Details expander');
+  assert.ok(!card.includes('event-card-debug'), 'no debug expander');
   const bodyIdx = card.indexOf('<div class="event-details">');
-  const debugIdx = card.indexOf('<details class="event-card-debug');
-  assert.ok(bodyIdx !== -1 && debugIdx !== -1 && bodyIdx < debugIdx);
+  const rawIdx = card.indexOf('<div class="raw-display">');
+  assert.ok(bodyIdx !== -1 && rawIdx !== -1 && bodyIdx < rawIdx);
 
   // Merge comparison and notes preview are MAIN-SECTION subsections now.
   for (const marker of ['Merge Comparison', '📝 Calendar Notes Preview']) {
     const idx = card.indexOf(marker);
-    assert.ok(idx > bodyIdx && idx < debugIdx, `"${marker}" lives on the main section`);
+    assert.ok(idx > bodyIdx && idx < rawIdx, `"${marker}" lives on the main section`);
   }
-  // Provenance and the raw JSON are debug material.
-  for (const marker of ['<details class="provenance-details">', 'class="raw-json"']) {
-    const idx = card.indexOf(marker);
-    assert.ok(idx > debugIdx, `"${marker}" lives inside the debug expander`);
-  }
+  // The raw JSON payload sits in the hidden Raw-mode block below the body.
+  assert.ok(card.indexOf('class="raw-json"') > rawIdx, 'raw JSON in the raw-display block');
 
   // Every existing action handler still present.
   assert.ok(card.includes('toggleComparisonSection('));
@@ -9092,17 +9107,20 @@ test('main section carries no duplicate route/address/date/image blocks', () => 
   const adapter = buildMapsAdapter();
   const card = adapter.generateEventCard(buildCompressionMergeEvent());
   const bodyIdx = card.indexOf('<div class="event-details">');
-  const debugIdx = card.indexOf('<details class="event-card-debug');
-  assert.ok(bodyIdx !== -1 && debugIdx > bodyIdx, 'main section then debug expander');
-  const body = card.slice(bodyIdx, debugIdx);
+  const rawIdx = card.indexOf('<div class="raw-display">');
+  assert.ok(bodyIdx !== -1 && rawIdx > bodyIdx, 'main section then raw payload block');
+  const body = card.slice(bodyIdx, rawIdx);
 
   assert.ok(!body.includes('map-verify-row'), 'no verify row in the main section');
   assert.ok(!body.includes('<span>📍</span>'), 'no duplicate venue row');
   assert.ok(!body.includes('<span>🏠</span>'), 'no duplicate address row');
   assert.ok(!body.includes('Coordinates:'), 'no duplicate coordinates row');
   assert.ok(!body.includes('<span>📅</span>'), 'no duplicate date row');
-  const debug = card.slice(debugIdx);
-  assert.ok(debug.includes('<span>🌍</span>'), 'UTC verification row kept in the debug expander (unique info)');
+  // Round 4: the UTC verification moved onto the face as a muted secondary
+  // element — unique info, exactly once.
+  const face = card.slice(0, bodyIdx);
+  assert.ok(face.includes('event-headline-utc'), 'UTC verification on the face');
+  assert.equal((card.match(/event-headline-utc/g) || []).length, 1, 'and only once');
   assert.ok(!body.includes('image-container'), 'no duplicate image block');
   assert.ok(!body.includes('View Full Image'));
 });
@@ -9858,8 +9876,8 @@ test('round3: description renders on the card face, clamped, with an in-page tog
   assert.ok(card.includes('class="event-desc clamped"'), 'description clamped by default');
   assert.ok(card.includes('onclick="toggleDescClamp(this)"'), 'tap toggles the clamp');
   assert.ok(card.includes('banana hammocks'), 'the description text itself is on the face');
-  // It is on the MAIN section, before the debug expander.
-  assert.ok(card.indexOf('event-desc clamped') < card.indexOf('<details class="event-card-debug'));
+  // It is on the MAIN section, before the hidden Raw-mode payload block.
+  assert.ok(card.indexOf('event-desc clamped') < card.indexOf('<div class="raw-display">'));
   // The old details description row is gone.
   assert.ok(!card.includes('event-description'), 'no old description row');
 
@@ -9902,23 +9920,17 @@ test('round3: links render as side-by-side chips with domain/handle labels, incl
   assert.ok(!card.includes('>Google Maps</a>'), 'no old Google Maps row');
 });
 
-test('round3: provenance is debug material — absent from the default view, present in the debug expander', () => {
+test('round3→4: the provenance section and the counts line are dissolved, not merely relocated', () => {
   const adapter = buildAdapter();
   const card = adapter.generateEventCard(freshRound3Event(BEEFMINCE_NOOP_EVENT), { runId: 'r1' });
 
-  const bodyIdx = card.indexOf('<div class="event-details">');
-  const debugIdx = card.indexOf('<details class="event-card-debug');
-  const provIdx = card.indexOf('<details class="provenance-details">');
-  assert.ok(bodyIdx !== -1 && debugIdx !== -1 && provIdx !== -1);
-  assert.ok(provIdx > debugIdx, 'provenance lives inside the debug expander');
-  assert.ok(!card.slice(bodyIdx, debugIdx).includes('🔍 Provenance'),
-    'no provenance section in the default view');
-  // The field-counts noise line moved to debug too.
-  const countsIdx = card.indexOf('debug-field-counts');
-  assert.ok(countsIdx > debugIdx, 'Scraper/Calendar/Merged field counts live in debug');
-  assert.ok(card.slice(countsIdx).includes('<strong>Scraper:</strong>'));
-  assert.ok(!card.slice(bodyIdx, debugIdx).includes('<strong>Scraper:</strong>'),
-    'counts line no longer heads the merge comparison');
+  // Round 4 dissolved the debug expander that round 3 had moved these into:
+  // no provenance section anywhere, no counts banner anywhere. The merge
+  // decisions still surface — as reasons inside the merge comparison table.
+  assert.ok(!card.includes('<details class="provenance-details">'), 'no provenance section');
+  assert.ok(!card.includes('🔍 Provenance'));
+  assert.ok(!card.includes('debug-field-counts'), 'no Scraper/Calendar/Merged counts banner');
+  assert.ok(!card.includes('<strong>Scraper:</strong>'));
 });
 
 test('round3: notes preview and merge comparison share ONE container style, no divider above the comparison', () => {
@@ -10035,4 +10047,210 @@ test('round3: every existing bridge handler id and page handler survives the cle
   assert.ok(controls, 'face controls row present');
   assert.ok(controls[1].includes('bear-verdict-row'), 'verdict pill in the controls row');
   assert.ok(controls[1].includes('event-builder-link'), 'builder icon next to the verdict pill');
+});
+
+// ---------------------------------------------------------------------------
+// Round 4 — owner feedback: labelled builder link, tap-to-enlarge thumbnail,
+// atomic datetime wrapping, a WORKING Images toggle, and the 🐞 Debug
+// expander dissolved into the places its contents belong.
+// ---------------------------------------------------------------------------
+
+test('round4: the event-builder link carries a visible label on the same bridge', () => {
+  const adapter = buildAdapter();
+  const card = adapter.generateEventCard(freshRound3Event(BEEFMINCE_NOOP_EVENT), { runId: 'r1' });
+  const link = card.match(/<a[^>]*class="event-builder-link"[^>]*>([\s\S]*?)<\/a>/);
+  assert.ok(link, 'builder link present');
+  assert.ok(link[0].includes('openMapVerify(this)'), 'still rides the openMapVerify bridge');
+  assert.ok(/🛠\s*Builder/.test(link[1]), 'visible "Builder" label, not a bare icon');
+});
+
+test('round4: tapping the thumbnail toggles it large in-page, like the description clamp', async () => {
+  const adapter = buildAdapter();
+  const card = adapter.generateEventCard(buildDenseFaceEvent());
+  const thumb = card.match(/<div class="event-thumb[^"]*"[^>]*>/);
+  assert.ok(thumb, 'thumbnail present');
+  assert.ok(thumb[0].includes('onclick="toggleThumbSize(this)"'), 'tap toggles the size in-page');
+
+  const html = await adapter.generateRichHTML(round3Results());
+  assert.ok(html.includes('function toggleThumbSize('), 'page defines the toggle handler');
+  assert.ok(html.includes('.event-thumb.thumb-expanded'), 'expanded-size CSS present');
+  // Same pattern as toggleDescClamp: pure page JS, never the native bridge.
+  const fnBody = html.match(/function toggleThumbSize\(([\s\S]*?)\n\s*\}/);
+  assert.ok(fnBody && !fnBody[0].includes('chunkyscrape'), 'expand/collapse never leaves the page');
+});
+
+test('round4: start and end datetimes each wrap as one atomic unit', () => {
+  const adapter = buildAdapter();
+  // Multi-day: the end HALF (date + time) must be one nowrap span so a
+  // narrow screen moves the whole end datetime to the next line instead of
+  // splitting it after the date.
+  const multi = adapter.generateEventCard(buildDenseFaceEvent({
+    startDate: '2026-08-28T20:00:00.000Z',
+    endDate: '2026-08-31T20:00:00.000Z'
+  }));
+  assert.match(
+    multi,
+    /<span class="dt-nowrap">[^<]*Aug 28[^<]*<\/span>\s*-\s*<span class="dt-nowrap">[^<]*Aug 31[^<]*<\/span>/,
+    'start and end halves are atomic; only the separator may break'
+  );
+
+  // Same-day: the end time is its own atomic span too.
+  const sameDay = adapter.generateEventCard(buildDenseFaceEvent());
+  assert.match(
+    sameDay,
+    /<span class="dt-nowrap">[^<]*7:00 PM<\/span>\s*-\s*<span class="dt-nowrap">10:00 PM<\/span>/,
+    'same-day end time still wraps as a unit'
+  );
+
+  // No fabricated separator when there is no real end.
+  const noEnd = adapter.generateEventCard(buildDenseFaceEvent({ endDate: null }));
+  assert.ok(noEnd.includes('(no end listed)'));
+});
+
+test('round4: the nowrap rule is actually defined in the page CSS', async () => {
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML(round3Results());
+  assert.match(html, /\.dt-nowrap\s*\{[^}]*white-space:\s*nowrap/, '.dt-nowrap CSS rule present');
+});
+
+test('round4: the Images toggle targets the image class the cards actually render', async () => {
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML({
+    analyzedEvents: [{
+      title: 'Pic Night',
+      _action: 'new',
+      startDate: '2026-09-01T02:00:00.000Z',
+      image: 'https://example.com/p.jpg'
+    }],
+    errors: [],
+    parserResults: []
+  });
+  assert.ok(html.includes('onchange="toggleImages()"'), 'checkbox wired to the handler');
+  assert.equal((html.match(/function toggleImages\(/g) || []).length, 1, 'handler defined once');
+
+  // The regression that made the button dead: the handler queried a class no
+  // card emits anymore. Whatever selector the handler uses must match at
+  // least one class attribute the page actually renders.
+  const fn = html.match(/function toggleImages\(\)[\s\S]*?querySelectorAll\('([^']+)'\)/);
+  assert.ok(fn, 'toggleImages queries a selector');
+  const classes = fn[1].split(',').map(s => s.trim().replace(/^\./, ''));
+  const covered = classes.filter(cls => new RegExp(`class="[^"]*\\b${cls}\\b`).test(html));
+  assert.ok(
+    covered.length > 0,
+    `selector "${fn[1]}" matches no rendered class attribute — the Images button is dead`
+  );
+});
+
+test('round4: the debug expander is dissolved — UTC and calendar chip on the face, counts banner gone', () => {
+  const adapter = buildAdapter();
+  const event = freshRound3Event(BEEFMINCE_NOOP_EVENT);
+  const card = adapter.generateEventCard(event, { runId: 'r1' });
+
+  assert.ok(!card.includes('event-card-debug'), 'debug expander markup gone');
+  assert.ok(!card.includes('🐞'), 'no debug summary anywhere');
+
+  const bodyIdx = card.indexOf('<div class="event-details">');
+  assert.ok(bodyIdx !== -1);
+  const face = card.slice(0, bodyIdx);
+  assert.ok(face.includes('event-headline-utc'), 'UTC rendered on the card face');
+  assert.ok(face.includes('🌍'), 'UTC keeps its globe marker');
+  assert.ok(face.includes('calendar-chip'), 'calendar target is a face chip');
+  assert.ok(
+    face.includes(adapter.getCalendarNameForDisplay(event)),
+    'the chip names the target calendar'
+  );
+
+  // The counts banner is DELETED from display (stays in the run JSON).
+  assert.ok(!card.includes('debug-field-counts'), 'counts banner markup gone');
+  assert.ok(!card.includes('<strong>Scraper:</strong>'), 'no Scraper/Calendar/Merged counts line');
+
+  // Raw JSON payload still embedded for Raw mode + the copy button.
+  assert.ok(card.includes('class="raw-display"'), 'raw display block kept (Raw mode)');
+  assert.ok(card.includes('<pre class="raw-json">'), 'embedded payload kept');
+});
+
+test('round4: provenance rows fold into the merge table under the shared no-op predicate', () => {
+  const adapter = buildAdapter();
+
+  // Real-run shape (run 20260813-223251, BEEFMINCE Trunk Den): the calendar
+  // side never stores `city`, so the old provenance table showed
+  // "city | london | scraper | took scraped value (calendar had none)" on a
+  // card whose merge changed NOTHING. Folded, that row is a no-op: it joins
+  // the "N fields unchanged" summary and the changed count stays 0.
+  const noop = freshRound3Event(BEEFMINCE_NOOP_EVENT);
+  delete noop._original.calendar.city;
+  const card = adapter.generateEventCard(noop, { runId: 'r1' });
+  assert.ok(!card.includes('provenance-details'), 'no separate provenance section');
+  assert.ok(!card.includes('🔍 Provenance'));
+  assert.ok(!card.includes('Parser: ai-web'), 'parser/action meta line dropped — the card tags carry it');
+  // The folded row joins the shared record list as a no-op (the visible
+  // summary line caps how many names it prints, so assert on the records).
+  const records = adapter.buildComparisonRowRecords(noop);
+  const cityRecord = records.find(r => r.field === 'city');
+  assert.ok(cityRecord, 'city folds into the shared record list');
+  assert.equal(cityRecord.changed, false, 'and it is a no-op, joining the unchanged summary');
+  assert.match(card, /\d+ fields unchanged — /, 'the unchanged summary line renders');
+  assert.equal(adapter.countChangedMergeFields(noop), 0, 'a routing-only field never counts as a change');
+  assert.ok(card.includes('MERGE ·0'), 'tag still truthful');
+
+  // But when the calendar DID track the field and the merge changed it, the
+  // folded row is a real outcome and renders normally.
+  const changed = freshRound3Event(BEEFMINCE_NOOP_EVENT);
+  changed._original.calendar.city = 'berlin';
+  const changedCard = adapter.generateEventCard(changed, { runId: 'r1' });
+  assert.match(changedCard, /<strong>city<\/strong>/, 'real city outcome renders as a row');
+  assert.ok(changedCard.includes('took scraped value'), 'with its provenance decision as the reason');
+  assert.equal(adapter.countChangedMergeFields(changed), 1);
+});
+
+test('round4: export-issue and copy-JSON ride the card actions row', () => {
+  const adapter = buildAdapter();
+  const card = adapter.generateEventCard(freshRound3Event(BEEFMINCE_NOOP_EVENT), { runId: 'r1' });
+  const bodyIdx = card.indexOf('<div class="event-details">');
+  const faceControls = card.slice(0, bodyIdx);
+
+  assert.ok(faceControls.includes('exportProvenanceIssue(this)'), 'export issue sits with the card actions');
+  assert.ok(faceControls.includes('provenance-export-area'), 'its reveal area rides inside the same wrapper');
+  assert.ok(faceControls.includes('copyEventJSON(this)'), 'copy JSON reachable without any expander');
+
+  // The export payload still carries the run id and merge decisions.
+  const payloadMatch = card.match(/data-payload="([^"]*)"/);
+  assert.ok(payloadMatch, 'export payload embedded');
+  const payload = JSON.parse(decodeURIComponent(payloadMatch[1]));
+  assert.equal(payload.runId, 'r1');
+});
+
+test('round4: a links row falls back to the scraper source URL when the event lost its own', () => {
+  const adapter = buildAdapter();
+  const event = {
+    title: 'Sourceless',
+    _action: 'merge',
+    startDate: '2026-09-01T02:00:00.000Z',
+    _original: {
+      scraper: { website: 'https://promoter.example/party' },
+      calendar: {},
+      merged: {}
+    }
+  };
+  const row = adapter.buildEventLinksRowHtml(event);
+  assert.ok(row.includes('promoter.example'), 'scraper source URL surfaces as a chip');
+
+  // When the event already links its website, no duplicate source chip.
+  const linked = adapter.buildEventLinksRowHtml({
+    ...event,
+    website: 'https://promoter.example/party'
+  });
+  assert.equal((linked.match(/promoter\.example/g) || []).length >= 1, true);
+});
+
+test('round4: hostile provenance data degrades to a card without the export control, never a crash', () => {
+  const adapter = buildAdapter();
+  const hostile = { title: 'Bad Event', _action: 'new', startDate: '2026-08-01T02:00:00.000Z' };
+  Object.defineProperty(hostile, '_mergeDecisions', {
+    get() { throw new Error('boom'); },
+    enumerable: true
+  });
+  const card = adapter.generateEventCard(hostile, { runId: 'r1' });
+  assert.ok(card.includes('event-card'), 'card still renders');
+  assert.ok(card.includes('Bad Event'));
 });


### PR DESCRIPTION
Round 4 of the results-UI cleanup. Base: plain `origin/main` — round 3 (#1672) was already MERGED when this branch was cut.

## Owner feedback → what changed (all five)

**1. "I want a name for the event builder link"** — the icon-only 🛠 link is now **"🛠 Builder"**: compact, still beside the verdict pill, same `openMapVerify` bridge/class/registry.

**2. "Can the image get bigger when we press it too? Like description"** — tapping the face thumbnail toggles `thumb-expanded` via new in-page `toggleThumbSize` (exact same pattern as the description clamp, no native bridge). Expanded, the thumb takes a full-width row and renders the poster whole (`object-fit: contain`, max-height 70vh); a second tap shrinks it back to the 64px slot.

**3. "When the end date goes to the next line, can it magically move the whole end date to the next line?"** — each datetime HALF (start `date time`, end `date time`) is one `<span class="dt-nowrap">` (`white-space: nowrap`) with the ` - ` separator left breakable. The end datetime now jumps to the next line whole instead of splitting after the date. Pure CSS, no JS measurement. Applied to the face date line and the UTC line.

**4. "The images button doesn't work"** — **root cause:** round 3's dense-face rework (wave 7) replaced the old expander image block (`.image-container`) with face thumbnails (`.event-thumb`), but `toggleImages()` still ran `querySelectorAll('.image-container')` — a class **no card emits anymore** — so the Images checkbox toggled an empty NodeList forever. Proven dead on base by the new regression test, which extracts the selector out of the handler and asserts it matches at least one **rendered `class=` attribute** (CSS text can't satisfy it). Fixed: the handler now targets `'.image-container, .event-thumb'`.

**5. "I don't like the debug section, it should be folded in to the other parts right?"** — the per-card 🐞 Debug expander is **dissolved**, contents folded where they belong:
- 🌍 **UTC line** → face date area, tiny muted `event-headline-utc` element (no new block).
- 📱 **Calendar name** → small `calendar-chip` on the face badges row.
- 📊 **"Scraper: N | Calendar: N | Merged: N" counts banner** → deleted from display entirely (stays in the run JSON).
- 🔍 **Provenance rows** → folded INTO the merge comparison table via `buildFoldedProvenanceRecords`, appended to the same record list the table/compressed view/`MERGE ·N` tag all read. Same shared row format, same no-op collapse: a folded row is a real outcome only when the calendar side actually **tracks** the field and the merge changed it; routing-only pass-throughs like `city | london | scraper | took scraped value (calendar had none)` join the "N fields unchanged" summary — so the BEEFMINCE Trunk Den reference card stays `MERGE ·0` / "no changes" (now "24 fields unchanged", city included). The `Parser: … • Action: …` line is dropped (the card's tags already carry both); the source URL joins the links row (it IS the website chip in practice; a scraper-side fallback covers events that lost their own link).
- 📤 **Export issue** → moved next to the other card actions (with its reveal area — the `exportProvenanceIssue` handler walks the same `.provenance-export` wrapper). **📋 Copy JSON** joins the actions row too, and the raw payload stays embedded (hidden `raw-display`, shown by Raw mode) since the copy button and `prettyPrintCardPayloads` read this card's `pre.raw-json`.

**Bonus hardening found by the new tests:** on base, a hostile field getter (e.g. a throwing `_mergeDecisions`) crashed the ENTIRE card via the raw-JSON embed. Now it costs that card its debug dump / export control only (error-stub payload, never silence).

## Before / after sketch

```
BEFORE (round 3 card)                      AFTER (round 4 card)
┌───────────────────────────────┐          ┌───────────────────────────────┐
│ MERGE ·0  UPDATE              │          │ MERGE ·0  UPDATE  📱 chunky-  │
│ [img] Title                   │          │                    dad-london │
│ 📅 Sat, Aug 15, 2026 9:00     │          │ [img]  Title       (tap img   │
│    PM - Sun, Aug 16, 2026     │          │        to enlarge)            │
│    3:00 AM   ← end SPLITS     │          │ 📅 Sat, Aug 15, 2026 9:00 PM  │
│ 📍 bar • addr • pin • Route   │          │  - Sun, Aug 16, 2026 3:00 AM  │
│ [verdict] 🛠                  │          │    ← end moves WHOLE          │
│ description… links… merge…    │          │  🌍 9:00 PM - … UTC (muted)   │
│ ▸ 🐞 Debug                    │          │ 📍 bar • addr • pin • Route   │
│   🌍 UTC …  📱 calendar       │          │ [verdict] 🛠 Builder          │
│   📊 37 | 25 | 26 fields      │          │  📋 Copy JSON  📤 Export issue│
│   ▸ 🔍 Provenance (table)     │          │ description… links… merge     │
│   raw JSON + copy             │          │  table (+folded prov rows)…   │
└───────────────────────────────┘          │ (raw JSON hidden, Raw mode)   │
                                           └───────────────────────────────┘
```

## Verification
- **10 new round-4 tests, all proven failing on base** (including the Images-button wiring test and the hostile-getter crash), all passing after.
- Doctrine kept and re-asserted by the existing suite: dense card face, sectioned pile, truthful no-changes chip/table/line-view via the shared predicate, every bridge handler id and page handler intact (`round3: every existing bridge handler id…` still green), saved-run display inherits via `displayResults`.
- Full quiet suite green: **1810 pass / 0 fail** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`); adapter file alone 304 pass.
- Smoke-rendered the newest real run (`20260813-223251`, 13 events incl. BEEFMINCE Trunk Den): no debug expander/🐞/provenance section/counts banner anywhere; builder labelled; thumb + Images toggles wired; nowrap spans present; UTC + calendar chip on every face; export/copy on the actions row; Trunk Den still `MERGE ·0` + "no changes" + "24 fields unchanged — … city …"; page pagination behaves (509 KB page 1 under the 512 KB budget).
- Files touched: `scripts/adapters/scriptable-adapter.js` + its test file only; no `evaluateJavaScript`; no existing console.log string edited (one log line was deleted **with** the method that owned it, and the fold's degrade path logs a new line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP