### PR TITLE
fix(results-ui): round 5 — thumb back left in compact state, notes above merge comparison, one arrow convention for all text links

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -4338,7 +4338,7 @@ class ScriptableAdapter {
     return `
                 <div class="pin-block">
                     <span class="pin-coords">📍 ${this.escapeHtml(`${lat}, ${lon}`)}</span>
-                    <a class="pin-link" href="${this.escapeHtml(appleUrl)}"> Apple Maps</a>
+                    <a class="pin-link" href="${this.escapeHtml(appleUrl)}"> ${this.textLinkLabelHtml("Apple Maps")}</a>
                     <details class="map-details" ontoggle="loadMapFrame(this)">
                         <summary>🗺️ Map preview</summary>
                         <iframe class="osm-frame" data-src="${this.escapeHtml(embedUrl)}"></iframe>
@@ -6949,7 +6949,14 @@ class ScriptableAdapter {
         }
 
         .event-headline-body {
-            flex: 1 1 auto;
+            /* Round 5 (owner: "Can the image still be to the left of the
+               title... It was much better before at saving space"): basis 0,
+               NOT auto. With the wrapping container round 4 added, an auto
+               basis sized this block from its content, so any long
+               title/date line wrapped the WHOLE block below the thumb and
+               the image sat on top of the card. Basis 0 always shares the
+               row with the fixed 64px thumb — image left, text right. */
+            flex: 1 1 0;
             min-width: 0;
         }
 
@@ -6977,6 +6984,12 @@ class ScriptableAdapter {
         .event-thumb.thumb-expanded {
             flex: 1 1 100%;
             width: 100%;
+            /* Round 5: the full-width breakout row renders BELOW the title
+               block (the thumb is first in the DOM so the left slot works;
+               order moves only the EXPANDED state after the text). Tapping
+               again removes the class and the thumb returns to the left
+               slot. */
+            order: 2;
         }
 
         .event-thumb.thumb-expanded img {
@@ -10002,7 +10015,7 @@ class ScriptableAdapter {
     const anchors = links
       .map(({ label, url }) => {
         const id = this.registerMapVerifyUrl(url);
-        return `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="map-verify-link" style="color:var(--primary-color); text-decoration:none;">${label} ↗</a>`;
+        return `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="map-verify-link" style="color:var(--primary-color); text-decoration:none;">${this.textLinkLabelHtml(label)}</a>`;
       })
       .join("");
     return `<div class="map-verify-row" style="display:flex; gap:10px; align-items:center; font-size:12px; margin:4px 0;"><span style="color:var(--text-secondary);">Verify:</span>${anchors}</div>`;
@@ -10287,7 +10300,7 @@ class ScriptableAdapter {
       // builder link") — still beside the verdict pill, same class, same
       // bridge handler, same registry.
       parts.push(
-        `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="event-builder-link" title="Open in Event Builder" aria-label="Open in Event Builder" style="color:var(--primary-color); text-decoration:none; font-size:13px; font-weight:600;">🛠 Builder</a>`,
+        `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="event-builder-link" title="Open in Event Builder" aria-label="Open in Event Builder" style="color:var(--primary-color); text-decoration:none; font-size:13px; font-weight:600;">${this.textLinkLabelHtml("🛠 Builder")}</a>`,
       );
     }
     if (SharedCore.isRecurringSeriesEvent(event)) {
@@ -10406,7 +10419,7 @@ class ScriptableAdapter {
       if (!this.isSafeExternalUrl(url) || !label) return;
       const id = this.registerMapVerifyUrl(url);
       chips.push(
-        `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="event-link-chip link-chip-${kind}" title="${this.escapeHtml(url)}">${icon} ${this.escapeHtml(label)}</a>`,
+        `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="event-link-chip link-chip-${kind}" title="${this.escapeHtml(url)}">${this.textLinkLabelHtml(`${icon} ${this.escapeHtml(label)}`)}</a>`,
       );
     };
     // Round 4 (dissolved provenance meta's "Source:" line): the source URL
@@ -10887,7 +10900,7 @@ class ScriptableAdapter {
       .map((proposal) => {
         const sourceLink = proposal.sourceUrl
           ? this.isSafeExternalUrl(proposal.sourceUrl)
-            ? `<a href="${this.escapeHtml(proposal.sourceUrl)}" target="_blank" rel="noopener" style="font-size:12px; color:var(--primary-color); word-break:break-all;">${this.escapeHtml(proposal.sourceUrl)}</a>`
+            ? `<a href="${this.escapeHtml(proposal.sourceUrl)}" target="_blank" rel="noopener" style="font-size:12px; color:var(--primary-color); word-break:break-all;">${this.textLinkLabelHtml(this.escapeHtml(proposal.sourceUrl))}</a>`
             : `<span style="font-size:12px; color:var(--text-secondary); word-break:break-all;">${this.escapeHtml(proposal.sourceUrl)}</span>`
           : "";
         const columnStyle =
@@ -11308,7 +11321,7 @@ class ScriptableAdapter {
             <div id="mermaid_${safeId}" class="disc-tab-panel"${hasSuggestedConfig ? ' style="display:none"' : ""}>
                 <div style="display:flex; gap:6px; margin-bottom:6px; flex-wrap:wrap;">
                     <button onclick="copyDiscoveryText(this)" class="log-copy-btn" data-encoded="${this.escapeHtml(mermaidEncoded)}">📋 Copy Mermaid</button>
-                    <a href="https://mermaid.live" target="_blank" style="padding:4px 10px; background:var(--background-light); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--primary-color); text-decoration:none;">Open mermaid.live ↗</a>
+                    <a href="https://mermaid.live" target="_blank" style="padding:4px 10px; background:var(--background-light); border:1px solid var(--border-color); border-radius:6px; font-size:12px; color:var(--primary-color); text-decoration:none;">${this.textLinkLabelHtml("Open mermaid.live")}</a>
                 </div>
                 <pre class="discovery-output">${this.escapeHtml(r.mermaidGraph || "")}</pre>
             </div>
@@ -11334,7 +11347,7 @@ class ScriptableAdapter {
             <span class="section-title">URL Discovery</span>
             <span class="section-count">${discoveryParsers.length}</span>
         </div>
-        <p style="font-size:12px; color:var(--text-secondary); margin:0 0 12px;">Discovery-only mode: links found up to configured depth. Paste the Mermaid graph at <a href="https://mermaid.live" target="_blank">mermaid.live</a> to visualize.</p>
+        <p style="font-size:12px; color:var(--text-secondary); margin:0 0 12px;">Discovery-only mode: links found up to configured depth. Paste the Mermaid graph at <a href="https://mermaid.live" target="_blank">${this.textLinkLabelHtml("mermaid.live")}</a> to visualize.</p>
         ${sections}
     </div>
         `;
@@ -11650,7 +11663,7 @@ class ScriptableAdapter {
     const routeBridgeLink = (url, labelHtml, extraClass) => {
       if (!url) return "";
       const id = this.registerMapVerifyUrl(url);
-      return `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="map-verify-link ${extraClass}">${labelHtml}</a>`;
+      return `<a href="#" onclick="return openMapVerify(this)" data-map-url-id="${id}" class="map-verify-link ${extraClass}">${this.textLinkLabelHtml(labelHtml)}</a>`;
     };
     const routeStreetAddress =
       typeof event.address === "string"
@@ -11689,7 +11702,7 @@ class ScriptableAdapter {
       routeParts.push(
         routeBridgeLink(
           routePinUrl,
-          `${this.escapeHtml(this.buildPinMapsQuery(event.location))} ↗`,
+          this.escapeHtml(this.buildPinMapsQuery(event.location)),
           "route-pin-link",
         ),
       );
@@ -11702,7 +11715,7 @@ class ScriptableAdapter {
     });
     if (routeDirectionsUrl) {
       routeParts.push(
-        routeBridgeLink(routeDirectionsUrl, "Route ↗", "route-directions-link"),
+        routeBridgeLink(routeDirectionsUrl, "Route", "route-directions-link"),
       );
     }
     const routeLineHtml =
@@ -11932,8 +11945,11 @@ class ScriptableAdapter {
             ${descriptionHtml}
             ${teaHtml}
             ${linksRowHtml}
-            ${comparisonHtml}
+            <!-- Round 5 (owner: "Can merge comparison be below calendar
+                 notes preview?"): notes preview FIRST, merge comparison
+                 after it. -->
             ${notesPreviewHtml}
+            ${comparisonHtml}
 
             <!-- Simplified metadata -->
             ${
@@ -12934,6 +12950,20 @@ class ScriptableAdapter {
       "'": "&#039;",
     };
     return text.toString().replace(/[&<>"']/g, (m) => map[m]);
+  }
+
+  // Round 5 (owner: "If you're going to have arrows on some text links, can
+  // you put them in all (non-Button links)"): the ONE place the trailing-
+  // arrow convention for text links lives. Every renderer of a tappable <a>
+  // that reads as text — link chips, route-line parts, verify links, the
+  // builder link, inline/source URLs — routes its label through here, so
+  // the convention cannot drift. Real <button> controls never carry it.
+  // Appends exactly once; a label already ending in the glyph is unchanged.
+  textLinkLabelHtml(labelHtml) {
+    const label = String(labelHtml == null ? "" : labelHtml);
+    if (!label.trim()) return label;
+    if (label.trimEnd().endsWith("↗")) return label;
+    return `${label} ↗`;
   }
 
   // Fallback to UITable if WebView fails

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -10254,3 +10254,126 @@ test('round4: hostile provenance data degrades to a card without the export cont
   assert.ok(card.includes('event-card'), 'card still renders');
   assert.ok(card.includes('Bad Event'));
 });
+
+// ---------------------------------------------------------------------------
+// Round 5 — owner feedback: thumbnail back to the LEFT of the title block in
+// the compact state (round 4's flex-basis:auto wrapped the whole title block
+// under the image), calendar notes preview ABOVE the merge comparison, and
+// the trailing-arrow convention on EVERY non-button text link via one shared
+// helper.
+// ---------------------------------------------------------------------------
+
+test('round5: compact card keeps the thumbnail LEFT of the title block; enlarging breaks it out below and a tap returns it', async () => {
+  const adapter = buildAdapter();
+  const card = adapter.generateEventCard(buildDenseFaceEvent());
+
+  // Structural order: the thumb markup sits BEFORE the title block inside
+  // the flex row, so the compact state reads image-left, text-right.
+  const main = card.match(/<div class="event-headline-main">([\s\S]*?)<div class="event-headline-body">/);
+  assert.ok(main, 'headline main row present');
+  assert.ok(main[1].includes('class="event-thumb'), 'thumb sits before the title block in the row');
+
+  const html = await adapter.generateRichHTML(round3Results());
+  // Compact layout class: the title block shares the row with the fixed
+  // 64px thumb. flex-basis MUST be 0 — round 4's `flex: 1 1 auto` sized the
+  // basis from the content, so any long title/date line wrapped the whole
+  // body BELOW the image (the "image on top" regression).
+  const bodyRule = html.match(/\.event-headline-body\s*\{([^}]*)\}/);
+  assert.ok(bodyRule, '.event-headline-body rule present');
+  assert.match(bodyRule[1], /flex:\s*1\s+1\s+0/,
+    'compact state: zero flex-basis keeps the title block beside the thumb');
+
+  // Enlarged: the breakout row renders BELOW the title block, not above it.
+  const expandedRule = html.match(/\.event-thumb\.thumb-expanded\s*\{([^}]*)\}/);
+  assert.ok(expandedRule, 'expanded rule present');
+  assert.match(expandedRule[1], /flex:\s*1\s+1\s+100%/, 'expanded thumb takes a full-width row');
+  assert.match(expandedRule[1], /order:\s*2/, 'the full-width row moves below the title block');
+
+  // Round 4's toggle survives: the same tap returns the thumb to the slot.
+  assert.ok(card.includes('onclick="toggleThumbSize(this)"'), 'tap-to-enlarge toggle intact');
+  assert.ok(html.includes('function toggleThumbSize('), 'page still defines the toggle');
+});
+
+test('round5: calendar notes preview renders ABOVE the merge comparison', () => {
+  const adapter = buildAdapter();
+  const card = adapter.generateEventCard(freshRound3Event(BEEFMINCE_NOOP_EVENT), { runId: 'r1' });
+  const notesIdx = card.indexOf('notes-preview-subsection');
+  const mergeIdx = card.indexOf('merge-comparison-subsection');
+  assert.ok(notesIdx !== -1, 'notes preview subsection present');
+  assert.ok(mergeIdx !== -1, 'merge comparison subsection present');
+  assert.ok(notesIdx < mergeIdx, 'notes preview sits above the merge comparison');
+});
+
+test('round5: every non-button text link carries the shared arrow via the one helper', async () => {
+  const adapter = buildAdapter();
+
+  // The helper IS the convention: appends the glyph once, never doubles it,
+  // leaves empty labels alone.
+  assert.equal(adapter.textLinkLabelHtml('The Eagle'), 'The Eagle ↗');
+  assert.equal(adapter.textLinkLabelHtml('Route ↗'), 'Route ↗', 'never doubles the glyph');
+  assert.equal(adapter.textLinkLabelHtml(''), '', 'empty label stays empty');
+
+  // Sweep every rendered surface: a full results page, a fully-loaded merge
+  // card, a plain dense card, the verify row and the review pin block. ZERO
+  // anchors may render without the glyph; buttons must never carry it.
+  adapter.resetMapVerifyUrls();
+  const surfaces = [
+    await adapter.generateRichHTML(round3Results()),
+    adapter.generateEventCard(freshRound3Event(BEEFMINCE_NOOP_EVENT), { runId: 'r1' }),
+    adapter.generateEventCard(buildDenseFaceEvent()),
+    adapter.buildMapVerifyLinksHtml({
+      bar: 'The Eagle', city: 'los angeles',
+      address: '4444 Hollywood Blvd, Los Angeles, CA', coordinates: '34.0522,-118.2437'
+    }),
+    adapter.buildReviewPinHtml('51.4863, -0.1217', 'BEEFMINCE')
+  ];
+  for (const html of surfaces) {
+    const anchors = [...html.matchAll(/<a\b[^>]*>([\s\S]*?)<\/a>/g)];
+    assert.ok(anchors.length > 0 || html === surfaces[4], 'sweep surfaces render anchors');
+    const missing = anchors.filter((m) => !m[1].includes('↗'));
+    assert.equal(missing.length, 0,
+      `text links without the arrow: ${missing.map((m) => m[0]).slice(0, 5).join(' | ')}`);
+    const buttons = [...html.matchAll(/<button\b[^>]*>([\s\S]*?)<\/button>/g)];
+    const glyphButtons = buttons.filter((m) => m[1].includes('↗'));
+    assert.equal(glyphButtons.length, 0, 'buttons never carry the text-link glyph');
+  }
+
+  // The chips row and the route line specifically (the owner's examples).
+  const card = adapter.generateEventCard(freshRound3Event(BEEFMINCE_NOOP_EVENT), { runId: 'r1' });
+  const chip = card.match(/<a\b[^>]*event-link-chip[^>]*>([\s\S]*?)<\/a>/);
+  assert.ok(chip && chip[1].includes('↗'), 'link chips carry the arrow');
+  const routeBar = card.match(/<a\b[^>]*route-bar-link[^>]*>([\s\S]*?)<\/a>/);
+  assert.ok(routeBar && routeBar[1].includes('↗'), 'route-line venue link carries the arrow');
+});
+
+test('round5: bridge handler ids, page handlers and the Images toggle survive the reshuffle', async () => {
+  const adapter = buildAdapter();
+  for (const action of [
+    'page', 'page-done', 'copy-venue', 'mark-bear', 'mark-not-bear',
+    'execute-run', 'queue-venue', 'open-url', 'export-ics', 'copy-logs',
+    'ai-prompts', 'beacon'
+  ]) {
+    const params = adapter.parseReviewActionUrl(`chunkyscrape://act?a=${action}&n=1`);
+    assert.equal(params.a, action, `${action} still round-trips through the bridge URL`);
+  }
+  const html = await adapter.generateRichHTML(round3Results());
+  for (const fn of [
+    'function copyVenueEntry(', 'function markBearOverride(',
+    'function requestSavedRunExecute(', 'function queueVenueCandidate(',
+    'function openMapVerify(', 'function exportRecurringIcs(',
+    'function requestNativeLogCopy(', 'function showAiPromptPicker(',
+    'function exportProvenanceIssue(', 'function copyEventJSON(',
+    'function toggleComparisonSection(', 'function toggleDiffView(',
+    'function toggleDisplayMode(', 'function toggleImages(',
+    'function filterEvents(', 'function toggleDescClamp(',
+    'function toggleThumbSize(', 'function sendResultsBeacon('
+  ]) {
+    assert.ok(html.includes(fn), `${fn} still defined in the page script`);
+  }
+  // Images toggle still targets a class the cards actually render.
+  const fn = html.match(/function toggleImages\(\)[\s\S]*?querySelectorAll\('([^']+)'\)/);
+  assert.ok(fn, 'toggleImages queries a selector');
+  const classes = fn[1].split(',').map((s) => s.trim().replace(/^\./, ''));
+  const covered = classes.filter((cls) => new RegExp(`class="[^"]*\\b${cls}\\b`).test(html));
+  assert.ok(covered.length > 0, `selector "${fn[1]}" matches no rendered class`);
+});


### PR DESCRIPTION
Results-UI polish round 5 — three owner asks, verbatim, one PR. `scripts/adapters/scriptable-adapter.js` + its test file only; shouldAllowRequest bridge untouched; no console.log strings edited.

## 1. "Can the image still be to the left of the title, date, etc. until I press it to make it bigger?"

Round 4 added `flex-wrap: wrap` to `.event-headline-main` (needed for the tap-to-enlarge breakout) but left `.event-headline-body` at `flex: 1 1 auto`. With a wrapping container, an `auto` basis sizes the title block from its content — and the round-4 nowrap datetime spans make that content wide — so the whole title/date block wrapped BELOW the thumb on nearly every card: image stacked on top, cards twice as tall.

Fix: `flex: 1 1 0` on the body (always shares the row with the fixed 64px thumb), plus `order: 2` on `.thumb-expanded` so the enlarged poster breaks out full-width BELOW the title block. Tap-to-enlarge stays; a second tap returns the thumb to the left slot.

```
BEFORE (round 4, compact)          AFTER (round 5, compact)
┌─────────────────────────┐        ┌─────────────────────────┐
│ [ thumb ]               │        │ [thumb] Title           │
│ Title                   │        │ [ 64px] 📅 date  💵     │
│ 📅 date  💵 price       │        │ [     ] 📍 route line   │
│ 📍 route line           │        └─────────────────────────┘
└─────────────────────────┘
                                   AFTER (tapped = enlarged)
                                   ┌─────────────────────────┐
                                   │ Title / date / route    │
                                   │ [ full-width poster   ] │
                                   └─────────────────────────┘
```

## 2. "Can merge comparison be below calendar notes preview?"

Card section order swapped: `📝 Calendar Notes Preview` now renders first, `📊 Merge Comparison` after it. Pure reorder of the two subsection blocks — both keep their `.card-subsection` container, chips, and toggles.

## 3. "If you're going to have arrows on some text links, can you put them in all (non-Button links)"

New shared helper `textLinkLabelHtml()` is the ONE place the trailing `↗` convention lives — appends exactly once, never doubles, empty labels untouched. Every non-button text link now routes through it:

- link chips (🌐 website / 🎟️ tickets / 📸 instagram / 📍 gmaps)
- route-line parts (venue, address, pin, Route — pin/Route had hardcoded arrows, now centralized)
- verify-row links, 🛠 Builder link, review pin's Apple Maps link
- series-proposal source URL, mermaid.live links

`<button>` controls never carry the glyph (asserted).

## Kept intact (regression-asserted)

Dense card face (thumb visible by default, nowrap date line, tappable route line, chips incl. gmaps, MERGE·N tags, clamped description, labelled 🛠 Builder, verdict pill, UTC line, calendar chip), truthful no-changes predicate, sectioned pile, Images toggle (`.image-container, .event-thumb`), all bridge handler ids, saved-run display via displayResults.

## Verification

- Quiet suite: **1815 pass / 0 fail** (base: 1811). 4 new round-5 tests; the 3 feature tests proven failing on base (`flex: 1 1 0` + `order: 2` missing; sections in old order; arrows missing on chips/route/builder links).
- Smoke-rendered the real full-sweep run `20260814-000011.json` (208 cards): page 1 = 210 anchors, 0 without the arrow; 165 buttons, 0 with it; all 47 merged-with-notes cards render notes above the merge comparison; every thumb precedes its title block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
