### PR TITLE
fix(results-ui): enlarged thumbnail breaks out above the title block

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -6984,12 +6984,13 @@ class ScriptableAdapter {
         .event-thumb.thumb-expanded {
             flex: 1 1 100%;
             width: 100%;
-            /* Round 5: the full-width breakout row renders BELOW the title
-               block (the thumb is first in the DOM so the left slot works;
-               order moves only the EXPANDED state after the text). Tapping
-               again removes the class and the thumb returns to the left
-               slot. */
-            order: 2;
+            /* Round 6 (owner): the full-width breakout row renders ABOVE the
+               title block — the thumb is first in the DOM, so the expanded
+               state simply keeps DOM order (order: -1 pins it ahead of the
+               text even if siblings ever gain explicit orders). Tapping
+               again removes the class and the thumb returns to the compact
+               left slot. */
+            order: -1;
         }
 
         .event-thumb.thumb-expanded img {

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -10283,11 +10283,12 @@ test('round5: compact card keeps the thumbnail LEFT of the title block; enlargin
   assert.match(bodyRule[1], /flex:\s*1\s+1\s+0/,
     'compact state: zero flex-basis keeps the title block beside the thumb');
 
-  // Enlarged: the breakout row renders BELOW the title block, not above it.
+  // Enlarged: the breakout row renders ABOVE the title block (round 6,
+  // owner request — flipped from round 5's below-the-title placement).
   const expandedRule = html.match(/\.event-thumb\.thumb-expanded\s*\{([^}]*)\}/);
   assert.ok(expandedRule, 'expanded rule present');
   assert.match(expandedRule[1], /flex:\s*1\s+1\s+100%/, 'expanded thumb takes a full-width row');
-  assert.match(expandedRule[1], /order:\s*2/, 'the full-width row moves below the title block');
+  assert.match(expandedRule[1], /order:\s*-1/, 'the full-width row stays above the title block');
 
   // Round 4's toggle survives: the same tap returns the thumb to the slot.
   assert.ok(card.includes('onclick="toggleThumbSize(this)"'), 'tap-to-enlarge toggle intact');


### PR DESCRIPTION
Owner request: the tap-to-enlarge poster should render ABOVE the title/date block, not below it. One-property flip (`order: 2` → `order: -1` on `.event-thumb.thumb-expanded`), test assertion updated to pin the new placement (fails on main: 1 failure). Compact left-slot layout and the toggle untouched. Full quiet suite 1815/1815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP