### PR TITLE
feat(scraper): source-shape doctrine — occurrence-expanded families stay individual events, series only for stated schedules

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -5113,6 +5113,67 @@ class AiWebParser {
     }
 
     /**
+     * SOURCE-SHAPE CLASSIFICATION (owner doctrine): "we only create series
+     * for single-events that are clearly recurring (a flyer, etc.) and we do
+     * single events for calendar websites that do the expansion for us" —
+     * plus "we can't condense the event with diff URLs".
+     *
+     * An event family is `occurrence-expanded` when the SITE already expands
+     * the recurrence and publishes per-date artifacts — the observed records
+     * carry DISTINCT per-date identity artifacts:
+     *   - ?occurrence=YYYY-MM-DD links harvested off the family's own pages
+     *     (the link format itself is a per-date publication), or
+     *   - different event-page URLs / ticket URLs / posters on different
+     *     dates (dice.fm per-event links, MEC renumbered slugs, per-date
+     *     flyers).
+     * It is `stated-series` when nothing is individually published per date:
+     * one page/flyer states or implies the schedule and every observed date
+     * shares the same artifact set. Detection is purely structural (value
+     * comparison across dates) — nothing per-site, nothing per-domain.
+     *
+     * Artifact comparison: for each identity-artifact field, a date whose
+     * value set contains a value ABSENT from another date's non-empty value
+     * set is per-date evidence. Two dates carrying the identical value
+     * (both pointing at the one series page) prove nothing; a value only
+     * one date wears is exactly a per-date publication. Same-date variance
+     * (listing stub + detail page of ONE night) never counts — only
+     * cross-date differences classify. Fail closed per the doctrine: when
+     * the artifacts say per-date, the family stays individual occurrences —
+     * unsure never converts to a series.
+     */
+    classifyCadenceSourceShape(group, hasOccurrenceLinkObservations) {
+        if (hasOccurrenceLinkObservations) {
+            return { shape: 'occurrence-expanded', reason: 'the site publishes per-date ?occurrence= links' };
+        }
+        const ARTIFACT_FIELDS = ['url', 'website', 'ticketUrl', 'image'];
+        for (const field of ARTIFACT_FIELDS) {
+            const valuesByDate = new Map();
+            for (const member of group.members) {
+                const value = typeof member.event[field] === 'string' ? member.event[field].trim() : '';
+                if (!value) continue;
+                if (!valuesByDate.has(member.nightKey)) valuesByDate.set(member.nightKey, new Set());
+                valuesByDate.get(member.nightKey).add(value);
+            }
+            if (valuesByDate.size < 2) continue;
+            const entries = Array.from(valuesByDate.values());
+            for (let i = 0; i < entries.length; i++) {
+                for (let j = 0; j < entries.length; j++) {
+                    if (i === j) continue;
+                    for (const value of entries[i]) {
+                        if (!entries[j].has(value)) {
+                            return {
+                                shape: 'occurrence-expanded',
+                                reason: `distinct per-date ${field} artifacts across ${valuesByDate.size} dates`
+                            };
+                        }
+                    }
+                }
+            }
+        }
+        return { shape: 'stated-series', reason: 'no per-date identity artifacts observed' };
+    }
+
+    /**
      * Post-crawl derived-cadence enforcement (called by shared-core's
      * processParser once every page of the run has been crawled, BEFORE
      * dedup — the same seam as applyVenueSiteAddressConsensus, and for the
@@ -5129,6 +5190,15 @@ class AiWebParser {
      *      what catches MEC installs that renumber slugs per occurrence
      *      (karaoke-19, karaoke-20 …), where URL-keyed observation never
      *      accumulates.
+     *
+     * SOURCE SHAPE comes first (owner doctrine, see
+     * classifyCadenceSourceShape): a family whose observed records carry
+     * distinct per-date identity artifacts (?occurrence= links, per-date
+     * event/ticket URLs or posters, renumbered slugs) is occurrence-expanded
+     * — the site already did the expansion, so the family gets report-only
+     * _seriesInfo metadata and every occurrence stays an individual event.
+     * Only a stated-series-shaped family (no per-date artifacts) continues
+     * into the stamping below.
      *
      * A qualifying group (deriveCadenceRrule) gets recurrenceRule stamped on
      * every member that lacks one, so the EXISTING series machinery folds the
@@ -5184,6 +5254,7 @@ class AiWebParser {
         }
 
         let groupIndex = 0;
+        let shapeIndex = 0;
         for (const group of groups) {
             const dates = new Set(group.members.map(member => member.nightKey));
             // Fold in the ?occurrence= observations whose page identity
@@ -5196,13 +5267,74 @@ class AiWebParser {
                     if (pathKey) memberPathKeys.add(pathKey);
                 }
             }
+            let occurrenceLinksObserved = false;
             if (observations) {
                 for (const [pathKey, dateSet] of observations) {
                     if (!memberPathKeys.has(pathKey)) continue;
+                    occurrenceLinksObserved = true;
                     for (const date of dateSet) dates.add(date);
                 }
             }
             const sortedDates = Array.from(dates).sort();
+
+            // SOURCE-SHAPE CLASSIFICATION (see classifyCadenceSourceShape):
+            // an occurrence-expanded family — the site publishes per-date
+            // artifacts — is NEVER converted to a series. No recurrenceRule
+            // stamp, no _cadenceGroup marker (so the same-series export
+            // collapse can never fold it across dates), stated rules demoted
+            // to report-only metadata. Every member instead carries
+            // _seriesInfo = { rrule, basis, occurrences, family }: the
+            // cadence stays visible (UI chip + family grouping) while each
+            // occurrence keeps its own date, ticketUrl, website and poster
+            // and is written/merged individually like any single event.
+            const shapeVerdict = sortedDates.length >= 2
+                ? this.classifyCadenceSourceShape(group, occurrenceLinksObserved)
+                : null;
+            if (shapeVerdict && shapeVerdict.shape === 'occurrence-expanded') {
+                shapeIndex++;
+                const derivedForInfo = this.deriveCadenceRrule(sortedDates);
+                const statedRuleSet = new Set();
+                for (const member of group.members) {
+                    const stated = String(member.event.recurrenceRule || member.event.recurrence || '').trim().toUpperCase();
+                    if (stated) statedRuleSet.add(stated);
+                }
+                // The report-only rrule: derived when every stated rule
+                // agrees with (or is refined by) it; the single stated rule
+                // when nothing was derivable; '' on disagreement or multiple
+                // stated rules — fail closed, the observed-dates basis
+                // string still describes the family.
+                const statedRuleList = Array.from(statedRuleSet);
+                const derivedRrule = derivedForInfo ? derivedForInfo.rrule : '';
+                let infoRrule = '';
+                if (derivedRrule && statedRuleList.every(rule =>
+                    rule === derivedRrule || derivedRrule.startsWith(`${rule};`))) {
+                    infoRrule = derivedRrule;
+                } else if (!derivedRrule && statedRuleList.length === 1) {
+                    infoRrule = statedRuleList[0];
+                }
+                const shapeBasis = this.describeOccurrenceCadence(sortedDates);
+                const shapeTitle = group.members[0].event.title;
+                let demotedCount = 0;
+                for (const member of group.members) {
+                    member.event._seriesInfo = {
+                        rrule: infoRrule,
+                        basis: shapeBasis.summary,
+                        occurrences: sortedDates.length,
+                        family: `shape-${shapeIndex}`
+                    };
+                    if (String(member.event.recurrenceRule || member.event.recurrence || '').trim()) {
+                        delete member.event.recurrenceRule;
+                        delete member.event.recurrence;
+                        demotedCount++;
+                    }
+                    if (member.event._recurring === true) {
+                        delete member.event._recurring;
+                    }
+                }
+                console.log(`🔁 SHAPE: "${shapeTitle}" is occurrence-expanded (${shapeVerdict.reason}) — ${group.members.length} record(s) over ${sortedDates.length} date(s) kept individual, no series conversion${demotedCount > 0 ? `; ${demotedCount} stated rule(s) demoted to report-only _seriesInfo` : ''}`);
+                continue;
+            }
+
             const derived = this.deriveCadenceRrule(sortedDates);
             if (!derived) continue; // existing report-only line already covered it
 
@@ -5228,6 +5360,9 @@ class AiWebParser {
             if (disagreeing.length > 0) {
                 console.log(`🔁 CADENCE: derived ${derived.rrule} for "${title}" disagrees with stated rule(s) ${disagreeing.join(', ')} — stated cadence kept, nothing stamped (curated data beats derived)`);
                 continue;
+            }
+            if (shapeVerdict) {
+                console.log(`🔁 SHAPE: "${title}" is stated-series (${shapeVerdict.reason}) — series flow retained`);
             }
             const unstamped = group.members.filter(member =>
                 !String(member.event.recurrenceRule || member.event.recurrence || '').trim());

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -13745,9 +13745,13 @@ test('a lone "-WxH" thumbnail keeps its own identity and still gets OCR coverage
 });
 
 // ===========================================================================
-// Derived-cadence enforcement (occurrence links + same-title record groups →
-// conservative recurrenceRule stamps; stated rules always win). Venue names
-// below are fixtures only.
+// Derived-cadence enforcement + source-shape classification (owner doctrine:
+// series only for stated schedules with no per-date publications; a family
+// whose records carry DISTINCT per-date identity artifacts — ?occurrence=
+// links, per-date event/ticket URLs, renumbered slugs, per-date posters — is
+// occurrence-expanded: every occurrence stays an individual event carrying
+// its own links, with report-only _seriesInfo metadata instead of a
+// recurrenceRule stamp). Venue names below are fixtures only.
 // ===========================================================================
 
 function buildCadenceStampRecord(overrides = {}) {
@@ -13797,7 +13801,11 @@ test('deriveCadenceRrule: weekly needs same weekday + a run of 3 consecutive 7-d
   assert.equal(parser.deriveCadenceRrule(['2026-08-05']), null);
 });
 
-test('applyDerivedCadenceStamps: weekly stamp from ?occurrence= link observations', () => {
+// PIN UPDATED (series doctrine rework): ?occurrence= links ARE per-date
+// publications — the site expands the recurrence itself — so the family is
+// occurrence-expanded: no recurrenceRule stamp, no _cadenceGroup marker,
+// report-only _seriesInfo instead. Previously this pinned a weekly stamp.
+test('applyDerivedCadenceStamps: ?occurrence= link observations classify occurrence-expanded — no stamp, _seriesInfo metadata', () => {
   const parser = createParser();
   const sourceUrl = 'https://fixture-eagle.example/calendar/';
   const html = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26']
@@ -13809,32 +13817,79 @@ test('applyDerivedCadenceStamps: weekly stamp from ?occurrence= link observation
     url: 'https://fixture-eagle.example/events/hump-night/?occurrence=2026-08-05'
   });
   const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps([record]));
-  assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'link observations alone carry the weekly proof');
-  assert.ok(typeof record._cadenceGroup === 'string' && record._cadenceGroup, 'group marker stamped');
-  assert.ok(logs.some(line => line.includes('🔁 CADENCE: stamped FREQ=WEEKLY;BYDAY=WE on 1 "HUMP NIGHT" record(s)')),
-    `enforce line expected, got: ${JSON.stringify(logs)}`);
+  assert.equal(record.recurrenceRule, undefined, 'occurrence-expanded families are never converted to a series');
+  assert.equal(record._cadenceGroup, undefined, 'no collapse marker on an occurrence-expanded family');
+  assert.ok(record._seriesInfo, 'report-only family metadata stamped');
+  assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE', 'the derived cadence survives as metadata');
+  assert.equal(record._seriesInfo.occurrences, 4, 'observation dates counted');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "HUMP NIGHT" is occurrence-expanded')
+    && line.includes('?occurrence=')),
+    `shape line expected, got: ${JSON.stringify(logs)}`);
 });
 
-test('applyDerivedCadenceStamps: weekly stamp from same-title records on renumbered slugs (no occurrence links)', () => {
+// PIN UPDATED (series doctrine rework): renumbered MEC slugs are per-date
+// event pages, so the family is occurrence-expanded — each occurrence keeps
+// its own URL and stays an individual event. Previously this pinned a weekly
+// stamp plus a shared _cadenceGroup marker.
+test('applyDerivedCadenceStamps: renumbered slugs classify occurrence-expanded — occurrences kept individual', () => {
   const parser = createParser();
   // MEC renumbering (run 20260807-143442): one weekly night, a NEW slug per
-  // occurrence — URL-keyed observation can never accumulate these.
+  // occurrence — the slugs themselves are the per-date artifacts.
   const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
     buildCadenceStampRecord({
       startDate: new Date(`${date}T20:00:00.000Z`),
       endDate: new Date(`${date}T23:00:00.000Z`),
       url: `https://fixture-eagle.example/events/karaoke-${19 + index}/`
     }));
-  parser.applyDerivedCadenceStamps(records);
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  const families = new Set();
+  records.forEach((record, index) => {
+    assert.equal(record.recurrenceRule, undefined, 'no series conversion');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, 'family metadata on every member');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE');
+    assert.equal(record._seriesInfo.occurrences, 4);
+    assert.equal(record.url, `https://fixture-eagle.example/events/karaoke-${19 + index}/`,
+      'each occurrence keeps its own per-date URL');
+    families.add(record._seriesInfo.family);
+  });
+  assert.equal(families.size, 1, 'all four records share ONE family marker');
+  assert.ok([...families][0], 'the family marker is non-empty');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "KARAOKE" is occurrence-expanded')
+    && line.includes('distinct per-date url artifacts')),
+    `shape line expected, got: ${JSON.stringify(logs)}`);
+});
+
+// Stamping-path coverage (stated-series shape): the SAME multi-date family
+// with NO per-date artifacts — every record pointing at the one page that
+// states the schedule — still stamps the derived rule and mints the collapse
+// marker, exactly the pre-rework flow.
+test('applyDerivedCadenceStamps: a shared-page family (no per-date artifacts) is stated-series — weekly stamp fires', () => {
+  const parser = createParser();
+  const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map(date =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      endDate: new Date(`${date}T23:00:00.000Z`),
+      url: 'https://fixture-eagle.example/events/karaoke/'
+    }));
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
   for (const record of records) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE');
+    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'stated-series shape keeps the stamping flow');
+    assert.equal(record._seriesInfo, undefined, 'no occurrence-expanded metadata on a stated-series family');
   }
   const markers = new Set(records.map(record => record._cadenceGroup));
   assert.equal(markers.size, 1, 'all four records share ONE same-series marker');
   assert.ok([...markers][0], 'the shared marker is non-empty');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "KARAOKE" is stated-series')),
+    `stated-series shape line expected, got: ${JSON.stringify(logs)}`);
+  assert.ok(logs.some(line => line.includes('🔁 CADENCE: stamped FREQ=WEEKLY;BYDAY=WE on 4 "KARAOKE" record(s)')),
+    `enforce line expected, got: ${JSON.stringify(logs)}`);
 });
 
-test('applyDerivedCadenceStamps: monthly stamp from two same-ordinal observations in different months', () => {
+// PIN UPDATED (series doctrine rework): distinct per-date slugs → the
+// monthly pair is occurrence-expanded; the derived monthly cadence becomes
+// _seriesInfo metadata. Previously this pinned a FREQ=MONTHLY;BYDAY=1FR stamp.
+test('applyDerivedCadenceStamps: a monthly pair on per-date slugs keeps both occurrences individual', () => {
   const parser = createParser();
   const records = [
     buildCadenceStampRecord({
@@ -13851,8 +13906,12 @@ test('applyDerivedCadenceStamps: monthly stamp from two same-ordinal observation
     })
   ];
   parser.applyDerivedCadenceStamps(records);
-  assert.equal(records[0].recurrenceRule, 'FREQ=MONTHLY;BYDAY=1FR');
-  assert.equal(records[1].recurrenceRule, 'FREQ=MONTHLY;BYDAY=1FR');
+  for (const record of records) {
+    assert.equal(record.recurrenceRule, undefined, 'no series conversion on per-date slugs');
+    assert.ok(record._seriesInfo, 'family metadata stamped');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=MONTHLY;BYDAY=1FR', 'derived cadence kept as metadata');
+    assert.equal(record._seriesInfo.occurrences, 2);
+  }
 });
 
 test('applyDerivedCadenceStamps: mixed weekdays stamp nothing', () => {
@@ -13870,16 +13929,43 @@ test('applyDerivedCadenceStamps: mixed weekdays stamp nothing', () => {
   }
 });
 
-test('applyDerivedCadenceStamps: stated rule beats derived — conflict logs, nothing stamped, stated kept', () => {
+// PIN UPDATED (series doctrine rework): the per-date slugs make this family
+// occurrence-expanded, so the conflicting stated rule is DEMOTED to
+// report-only metadata rather than kept as a series claim — each occurrence
+// is written individually either way, and _seriesInfo.rrule fails closed to
+// '' on the disagreement (the observed-dates basis still describes the
+// family). Previously this pinned "stated kept, nothing stamped".
+test('applyDerivedCadenceStamps: stated-vs-derived disagreement on an occurrence-expanded family demotes, rrule fails closed', () => {
   const parser = createParser();
-  // The model extracted an explicit stated cadence on one record; the derived
-  // weekday disagrees. Curated/stated data beats derived — fail closed for
-  // the WHOLE group.
   const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
     buildCadenceStampRecord({
       startDate: new Date(`${date}T20:00:00.000Z`),
       endDate: new Date(`${date}T23:00:00.000Z`),
       url: `https://fixture-eagle.example/events/karaoke-${19 + index}/`
+    }));
+  records[0].recurrenceRule = 'FREQ=WEEKLY;BYDAY=FR';
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  for (const record of records) {
+    assert.equal(record.recurrenceRule, undefined, 'occurrence-expanded members carry no series claim');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, 'family metadata on every member');
+    assert.equal(record._seriesInfo.rrule, '', 'disagreeing rules fail closed to no metadata rrule');
+    assert.ok(record._seriesInfo.basis, 'the observed-dates basis still describes the family');
+  }
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "KARAOKE" is occurrence-expanded')
+    && line.includes('1 stated rule(s) demoted to report-only _seriesInfo')),
+    `shape+demotion line expected, got: ${JSON.stringify(logs)}`);
+});
+
+// Stated-beats-derived conflict coverage on the STAMPING path (stated-series
+// shape — no per-date artifacts): unchanged pre-rework behavior.
+test('applyDerivedCadenceStamps: stated rule beats derived on a stated-series family — conflict logs, nothing stamped', () => {
+  const parser = createParser();
+  const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map(date =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      endDate: new Date(`${date}T23:00:00.000Z`),
+      url: 'https://fixture-eagle.example/events/karaoke/'
     }));
   records[0].recurrenceRule = 'FREQ=WEEKLY;BYDAY=FR';
   const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
@@ -13892,11 +13978,14 @@ test('applyDerivedCadenceStamps: stated rule beats derived — conflict logs, no
     `conflict line expected, got: ${JSON.stringify(logs)}`);
 });
 
-test('applyDerivedCadenceStamps: derived agreeing with stated is a no-op stamp but still marks the same-series group', () => {
+// PIN UPDATED (series doctrine rework): the renumbered underwear-N slugs are
+// per-date publications, so the stated-rule group is occurrence-expanded —
+// the five records each stay an individual Wednesday with their own page,
+// stated rules demoted to _seriesInfo (rrule preserved there: derived agrees
+// with stated). Previously this pinned "marker only, rules untouched" so the
+// series collapse could fold them; UI grouping now replaces that fold.
+test('applyDerivedCadenceStamps: stated rules on renumbered slugs are demoted — occurrences kept individual', () => {
   const parser = createParser();
-  // Run 20260807-143442: all five "Underwear Happy Hour" records already
-  // state FREQ=WEEKLY;BYDAY=WE, each on its own renumbered slug. The rules
-  // stay untouched; the marker is what lets the series collapse fold them.
   const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
     buildCadenceStampRecord({
       startDate: new Date(`${date}T20:00:00.000Z`),
@@ -13906,14 +13995,18 @@ test('applyDerivedCadenceStamps: derived agreeing with stated is a no-op stamp b
       recurrenceRule: 'FREQ=WEEKLY;BYDAY=WE'
     }));
   const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
-  const markers = new Set(records.map(record => record._cadenceGroup));
-  assert.equal(markers.size, 1, 'one shared marker across the stated-rule group');
-  assert.ok([...markers][0]);
+  const families = new Set();
   for (const record of records) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'stated rules untouched');
+    assert.equal(record.recurrenceRule, undefined, 'stated rules demoted on an occurrence-expanded family');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, 'family metadata on every member');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE', 'the agreed cadence survives as metadata');
+    families.add(record._seriesInfo.family);
   }
-  assert.ok(logs.some(line => line.includes('same-series marker only, nothing stamped')),
-    `marker-only line expected, got: ${JSON.stringify(logs)}`);
+  assert.equal(families.size, 1, 'one shared family across the demoted group');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "UNDERWEAR HAPPY HOUR" is occurrence-expanded')
+    && line.includes('4 stated rule(s) demoted to report-only _seriesInfo')),
+    `shape+demotion line expected, got: ${JSON.stringify(logs)}`);
 });
 
 test('applyDerivedCadenceStamps: different venues never share a group, and undated records are never stamped', () => {
@@ -13951,10 +14044,16 @@ test('applyDerivedCadenceStamps: different venues never share a group, and undat
   const before = dated.map(record => record.startDate.getTime());
   parser.applyDerivedCadenceStamps([undated, ...dated]);
   assert.equal(undated.recurrenceRule, undefined, 'an undated record is never stamped');
+  assert.equal(undated._seriesInfo, undefined, 'an undated record never joins a family');
   assert.equal(undated.startDate, null, 'an undated record gains no fabricated date');
-  assert.deepEqual(dated.map(record => record.startDate.getTime()), before, 'stamping never mutates startDate');
+  assert.deepEqual(dated.map(record => record.startDate.getTime()), before, 'classification never mutates startDate');
+  // PIN UPDATED (series doctrine rework): the dated group sits on renumbered
+  // karaoke-N slugs — occurrence-expanded, so it now carries _seriesInfo
+  // metadata instead of the weekly stamp it previously pinned.
   for (const record of dated) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'the dated group still stamps normally');
+    assert.equal(record.recurrenceRule, undefined, 'per-date slugs never convert to a series');
+    assert.ok(record._seriesInfo, 'the dated family still classifies and carries metadata');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE');
   }
 });
 
@@ -13979,14 +14078,18 @@ test('deriveCadenceRrule: weekly with skipped weeks — every gap a multiple of 
   assert.equal(parser.deriveCadenceRrule(['2026-08-15', '2026-08-22', '2026-08-29', '2026-09-04']), null);
 });
 
-test('applyDerivedCadenceStamps: the six real GEAR NIGHT records fold to one weekly group (skipped weeks + DJ suffixes)', () => {
+// PIN UPDATED (series doctrine rework): the renumbered gear-night-N slugs
+// are per-date publications — Dallas Eagle's MEC install expands the series
+// itself — so the six records classify occurrence-expanded and each Saturday
+// stays an individual event carrying its own page URL, with the weekly
+// cadence preserved as _seriesInfo metadata and ONE shared family for UI
+// grouping. Previously this pinned a FREQ=WEEKLY;BYDAY=SA stamp plus a
+// shared _cadenceGroup marker (collapse-to-next-occurrence).
+test('applyDerivedCadenceStamps: the six real GEAR NIGHT records classify occurrence-expanded — one family, no stamps', () => {
   const parser = createParser();
   // Run 20260811-134734 verbatim: six GEAR NIGHT records on renumbered MEC
   // slugs (gear-night-5/7/11/17/19/22), two wearing per-record DJ credits,
   // observed Saturdays Aug 15, 22, Sep 5, 12, 19, Oct 3 (America/Chicago).
-  // On main these survived as six separate calendar writes: the weekly rule
-  // demanded 3 CONSECUTIVE 7-day gaps (longest run here is 2), and the
-  // DJ-suffixed pair could not even join the group.
   const gearNight = [
     ['Gear Night with DJ Tristan Jaxx', '2026-08-16T02:00:00.000Z', 'gear-night-5'],
     ['Gear Night with DJ Philip Webb', '2026-08-23T03:00:00.000Z', 'gear-night-7'],
@@ -14004,22 +14107,74 @@ test('applyDerivedCadenceStamps: the six real GEAR NIGHT records fold to one wee
     source: 'ai-web'
   }));
   parser.applyDerivedCadenceStamps(gearNight);
-  for (const record of gearNight) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=SA', `"${record.title}" (${record.url}) joins the weekly stamp`);
-  }
-  const markers = new Set(gearNight.map(record => record._cadenceGroup));
-  assert.equal(markers.size, 1, 'all six records share ONE same-series marker');
-  assert.ok([...markers][0], 'the shared marker is non-empty');
+  const families = new Set();
+  gearNight.forEach((record, index) => {
+    assert.equal(record.recurrenceRule, undefined, `"${record.title}" is never converted to a series`);
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, `"${record.title}" (${record.url}) joins the family metadata`);
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=SA', 'the weekly cadence survives as metadata');
+    assert.equal(record._seriesInfo.occurrences, 6);
+    assert.ok(record.url.includes('gear-night-'), 'each occurrence keeps its own per-date slug URL');
+    families.add(record._seriesInfo.family);
+  });
+  assert.equal(families.size, 1, 'all six records share ONE family (grouped in the UI, never folded in data)');
+  assert.ok([...families][0], 'the shared family is non-empty');
 });
 
-test('applyDerivedCadenceStamps: per-record guest-DJ suffixes group into one monthly series; different parties never do', () => {
+// Run 20260814-000011 verbatim (the evidence that drove the doctrine): three
+// observed 3rd-Saturday BEEFMINCE x RVT occurrences, each with its OWN
+// dice.fm per-event ticket link. On main these were stamped
+// FREQ=MONTHLY;BYDAY=3SA and collapsed to the Sep 19 occurrence — whose
+// ticketUrl is the Sep-19-SPECIFIC dice link, discarding October's and
+// November's. "We can't condense the event with diff URLs": the distinct
+// per-date ticketUrls classify the family occurrence-expanded, every
+// occurrence keeps its own dice link, and the cadence survives as metadata.
+test('applyDerivedCadenceStamps: BEEFMINCE x RVT — distinct per-date dice links keep every occurrence and its own ticketUrl', () => {
+  const parser = createParser();
+  const diceLinks = [
+    ['2026-09-19T21:00:00.000Z', 'https://dice.fm/event/yoepxa-beefmince-x-rvt-19th-sep-the-royal-vauxhall-tavern-london-tickets'],
+    ['2026-10-17T21:00:00.000Z', 'https://dice.fm/event/xednya-beefmince-x-rvt-17th-oct-the-royal-vauxhall-tavern-london-tickets'],
+    ['2026-11-21T22:00:00.000Z', 'https://dice.fm/event/927gr7-beefmince-x-rvt-21st-nov-the-royal-vauxhall-tavern-london-tickets']
+  ];
+  const records = diceLinks.map(([start, ticketUrl]) => ({
+    title: 'BEEFMINCE x RVT',
+    bar: 'The Royal Vauxhall Tavern',
+    timezone: 'Europe/London',
+    startDate: new Date(start),
+    endDate: new Date(new Date(start).getTime() + 6 * 60 * 60 * 1000),
+    website: 'https://beefmince.com',
+    ticketUrl,
+    source: 'ai-web'
+  }));
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  const families = new Set();
+  records.forEach((record, index) => {
+    assert.equal(record.recurrenceRule, undefined, 'no FREQ=MONTHLY;BYDAY=3SA stamp — the site expands the dates itself');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker — October and November keep their own dice links');
+    assert.ok(record._seriesInfo, 'family metadata on every occurrence');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=MONTHLY;BYDAY=3SA', 'the derived cadence survives as report-only metadata');
+    assert.equal(record._seriesInfo.occurrences, 3);
+    assert.equal(record.ticketUrl, diceLinks[index][1], 'each occurrence keeps its own per-date dice link');
+    families.add(record._seriesInfo.family);
+  });
+  assert.equal(families.size, 1, 'one family across the three Saturdays');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "BEEFMINCE x RVT" is occurrence-expanded')
+    && line.includes('distinct per-date ticketUrl artifacts')),
+    `shape line expected, got: ${JSON.stringify(logs)}`);
+});
+
+// PIN UPDATED (series doctrine rework): the pair sits on distinct per-date
+// slugs, so it is occurrence-expanded — the guest-DJ grouping still proves
+// the family (that identity logic is untouched), but the stated bare
+// FREQ=MONTHLY rules are demoted and the refined 2FR cadence lands in
+// _seriesInfo. Previously this pinned "marker minted, stated rules kept".
+test('applyDerivedCadenceStamps: per-record guest-DJ suffixes still group into one family; different parties never do', () => {
   const parser = createParser();
   // Run 20260811-134734 verbatim: a genuine 2nd-Friday monthly pair whose
   // records each wear a different guest DJ's name — no bare-title anchor,
   // so the plain name similarity never groups them. Both pages state a bare
   // FREQ=MONTHLY; the derived FREQ=MONTHLY;BYDAY=2FR REFINES it (agreement,
-  // not conflict), so the stated rules stay untouched and the same-series
-  // marker is minted.
+  // not conflict), so the refined rule is what the metadata carries.
   const disciplinePair = [
     {
       title: 'Discipline Corps Bar Night with DJ Philip Webb',
@@ -14043,11 +14198,13 @@ test('applyDerivedCadenceStamps: per-record guest-DJ suffixes group into one mon
     }
   ];
   parser.applyDerivedCadenceStamps(disciplinePair);
-  const markers = new Set(disciplinePair.map(record => record._cadenceGroup));
-  assert.equal(markers.size, 1, 'the DJ-suffixed pair shares ONE same-series marker');
-  assert.match([...markers][0], /FREQ=MONTHLY;BYDAY=2FR$/, 'grouped via the existing >=2-months ordinal rule');
+  const families = new Set(disciplinePair.map(record => record._seriesInfo && record._seriesInfo.family));
+  assert.equal(families.size, 1, 'the DJ-suffixed pair shares ONE family');
+  assert.ok([...families][0], 'the shared family is non-empty');
   for (const record of disciplinePair) {
-    assert.equal(record.recurrenceRule, 'FREQ=MONTHLY', 'the stated rule is NEVER overridden by its refinement');
+    assert.equal(record.recurrenceRule, undefined, 'stated rules demoted on the occurrence-expanded pair');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=MONTHLY;BYDAY=2FR', 'the refining derived rule is the metadata cadence');
   }
 
   // Two DIFFERENT party names at one venue, each with a guest-DJ suffix,

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -8978,6 +8978,12 @@ class SharedCore {
         if (!mergedEvent._fieldTrims && existingEvent && Array.isArray(existingEvent._fieldTrims) && existingEvent._fieldTrims.length > 0) {
             mergedEvent._fieldTrims = existingEvent._fieldTrims;
         }
+        // Same carry for the occurrence-expanded family stamp (_seriesInfo):
+        // a same-night stub+detail merge must keep the family metadata so the
+        // UI chip/grouping and the saved-series protection still see it.
+        if (!mergedEvent._seriesInfo && existingEvent && existingEvent._seriesInfo && typeof existingEvent._seriesInfo === 'object') {
+            mergedEvent._seriesInfo = existingEvent._seriesInfo;
+        }
 
         // Helper function to check if a value is empty/null/undefined
         const isEmpty = (value) => {
@@ -11158,8 +11164,14 @@ class SharedCore {
         // B BAR/CUBSCOUT/ONYX all "new" the day after their series were
         // saved). Reporting-only: the analysis action stays 'new' and the
         // write stays withheld — a match only changes what the run SAYS.
+        // Occurrence-expanded family members run the SAME lookup: the family's
+        // cadence evidence says the event recurs, which is exactly when the
+        // owner's calendar may already hold the series covering this date —
+        // and an occurrence write must never fight his imported series. For
+        // these the match is ENFORCED downstream (isSeriesCoveredOccurrence
+        // gates the write with the SERIES MATCH label), not report-only.
         if (analysis.action === 'new' && !analysis.existingEvent && !analysis.sourceEvent &&
-            SharedCore.isRecurringSeriesEvent(event)) {
+            (SharedCore.isRecurringSeriesEvent(event) || SharedCore.isOccurrenceExpandedEvent(event))) {
             try {
                 const seriesMatch = await this.findSavedSeriesMatch(event, calendarAdapter);
                 if (seriesMatch) {
@@ -12029,6 +12041,10 @@ class SharedCore {
             // and gated here, exactly like the recurring-series withhold.
             event?._pastSpanWithheld !== true &&
             !SharedCore.isRecurringSeriesEvent(event) &&
+            // An occurrence-expanded single whose date/identity the owner's
+            // SAVED series already covers (#1655 series-match): writing it
+            // would plant a duplicate single next to his imported series.
+            !SharedCore.isSeriesCoveredOccurrence(event) &&
             !SharedCore.hasJunkTitleSanityFlag(event));
     }
 
@@ -12104,6 +12120,7 @@ class SharedCore {
         if (event._parserConfig && event._parserConfig.dryRun === true) return 'WITHHELD (dry-run parser)';
         if (event._pastSpanWithheld === true) return 'WITHHELD (span fully past)';
         if (SharedCore.isRecurringSeriesEvent(event)) return 'WITHHELD (recurring series — ICS export only)';
+        if (SharedCore.isSeriesCoveredOccurrence(event)) return 'WITHHELD (occurrence covered by saved series — SERIES MATCH)';
         if (SharedCore.hasJunkTitleSanityFlag(event)) return 'WITHHELD (junk title)';
         const action = typeof event._action === 'string' && event._action ? event._action : 'new';
         return action.toUpperCase();
@@ -12205,6 +12222,26 @@ class SharedCore {
         // an existing series (see the pinned override-survival test).
         if (event.overrideUid || event.overrideRecurrenceId) return false;
         return typeof event.recurrence === 'string' && event.recurrence.trim() !== '';
+    }
+
+    // A member of an occurrence-expanded family (owner doctrine, stamped by
+    // the ai-web parser's source-shape classification): the site publishes
+    // each date individually, so the record is a plain single occurrence —
+    // but the family's cadence evidence says the event RECURS, which is
+    // exactly when the owner's calendar may already hold a saved series
+    // covering it.
+    static isOccurrenceExpandedEvent(event) {
+        return Boolean(event && typeof event === 'object' && event._seriesInfo);
+    }
+
+    // An occurrence-expanded single positively matched to a SAVED series
+    // (#1655 series-match, extended to occurrence singles): the write is
+    // withheld — planting a single next to the owner's imported series would
+    // fight it. Its own predicate (mirroring hasJunkTitleSanityFlag) so the
+    // execution gate, the disposition label, and the adapters' labeling can
+    // never disagree.
+    static isSeriesCoveredOccurrence(event) {
+        return SharedCore.isOccurrenceExpandedEvent(event) && Boolean(event._seriesMatch);
     }
 
     // Scriptable identifiers look like `<calendarUUID>:<icsUid>` — the suffix
@@ -13488,6 +13525,15 @@ class SharedCore {
                 hasOverrideIdentity: Boolean(analysis.overrideIdentity)
             };
 
+            // The occurrence-expanded family stamp (parse-time _seriesInfo)
+            // survives the same wholesale replacement: createFinalEventObject
+            // skips underscore fields, and the UI chip, the family grouping,
+            // and the saved-series occurrence withhold all read it off the
+            // analyzed event.
+            if (event._seriesInfo && !analyzedEvent._seriesInfo) {
+                analyzedEvent._seriesInfo = event._seriesInfo;
+            }
+
             // Final-stage field cleanups. Both run at the FINAL analyzed-event
             // build (so every parser, merge result, and cached AI response
             // passes through them) and BEFORE the notes generation/rebuild
@@ -14068,6 +14114,27 @@ class SharedCore {
                     console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" matches the saved series already in ${analyzedEvent._seriesMatch.calendarName} (${analyzedEvent._seriesMatch.instances} instances) — not a new event`);
                 }
                 console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" withheld from calendar write — save via ICS export`);
+            }
+
+            // Occurrence-expanded singles vs the owner's imported series
+            // (#1655 series-match, extended): the saved-series lookup matched
+            // this occurrence's identity, so its write is withheld with the
+            // SERIES MATCH label — occurrence-expansion must never fight a
+            // series he saved. Scalars only; the run JSON persists this
+            // stamp, and the execution gate (isSeriesCoveredOccurrence)
+            // reads exactly it.
+            if (analysis.seriesMatch && !analyzedEvent._seriesMatch &&
+                SharedCore.isOccurrenceExpandedEvent(analyzedEvent)) {
+                analyzedEvent._seriesMatch = {
+                    identifier: analysis.seriesMatch.identifier || '',
+                    title: analysis.seriesMatch.title || '',
+                    startDate: analysis.seriesMatch.startDate || null,
+                    endDate: analysis.seriesMatch.endDate || null,
+                    reason: analysis.seriesMatch.reason || 'Saved series match',
+                    instances: Number.isFinite(analysis.seriesMatch.instances) ? analysis.seriesMatch.instances : 0,
+                    calendarName: analysis.seriesMatch.calendarName || ''
+                };
+                console.log(`🔁 SHAPE: "${analyzedEvent.title || 'Unknown'}" occurrence is covered by the saved series in ${analyzedEvent._seriesMatch.calendarName || 'the calendar'} — write withheld (SERIES MATCH)`);
             }
 
             return analyzedEvent;
@@ -15143,6 +15210,12 @@ class SharedCore {
     //     cross-realm Dates).
     getSeriesExportIdentity(event) {
         if (!SharedCore.isRecurringSeriesEvent(event)) return null;
+        // Occurrence-expanded family member (owner doctrine): the site
+        // publishes each date individually, so the record is a real single
+        // occurrence — never a series export, never collapsed across dates.
+        // Its rules were already demoted to _seriesInfo at classification
+        // time, so this guard is defense-in-depth (fail closed).
+        if (event._seriesInfo) return null;
         if (event._seriesAuthority === 'slot-host') return null;
         if (event._recurringExport === false) return null;
         const rrule = String(event.recurrenceRule || event.recurrence || '').trim().toUpperCase();

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4086,6 +4086,23 @@ test('deduplicateEvents collapses two full-series exports of one series to the n
   assert.equal(kept.recurrenceRule, 'FREQ=WEEKLY;BYDAY=TH', 'the series rule survives the collapse');
 });
 
+// Series doctrine rework ("we can't condense the event with diff URLs"): an
+// occurrence-expanded family member carries report-only _seriesInfo — and
+// even if a recurrence claim survives on the record (defense in depth; the
+// classification pass normally demotes it), the series collapse must never
+// fold occurrence-expanded records across dates.
+test('deduplicateEvents never series-collapses records carrying _seriesInfo (occurrence-expanded)', async () => {
+  const core = createCore();
+  const thisWeek = new Date(Date.now() + 7 * SERIES_DAY_MS);
+  const nextWeek = new Date(thisWeek.getTime() + 7 * SERIES_DAY_MS);
+  const info = { rrule: 'FREQ=WEEKLY;BYDAY=TH', basis: '2 dates', occurrences: 2, family: 'shape-1' };
+  const first = buildWeeklySeriesExport(thisWeek, { _seriesInfo: info });
+  const second = buildWeeklySeriesExport(nextWeek, { _seriesInfo: info });
+  assert.equal(core.getSeriesExportIdentity(first), null, '_seriesInfo disqualifies the record as a series export');
+  const result = await core.deduplicateEvents([first, second], null);
+  assert.equal(result.length, 2, 'occurrence-expanded records keep every date individual');
+});
+
 test('deduplicateEvents keeps two distinct single occurrences of a recurring event separate', async () => {
   // Behavior-preservation guard (passes on main and on the collapse branch):
   // run 20260802-221204's SUNDAY BEER BUST extracted two genuinely distinct
@@ -12669,6 +12686,108 @@ test('saved-series lookup: fails open on adapter errors and never runs for non-s
   const plainAnalysis = await core.resolveCalendarAnalysisWithSeriesProbe(plain, [], 'upsert', counting);
   assert.equal(plainAnalysis.action, 'new');
   assert.equal(lookupCalls, 0, 'a non-series event never triggers the lookup');
+});
+
+// ---------------------------------------------------------------------------
+// Occurrence-expanded doctrine (series rework): a member of an
+// occurrence-expanded family carries report-only _seriesInfo (stamped by the
+// ai-web parser's source-shape classification) and is written like any
+// single event — EXCEPT when the owner's calendar already holds the series
+// covering it: then the write is withheld with the SERIES MATCH label, so
+// occurrence-expansion never fights his imported series.
+// ---------------------------------------------------------------------------
+
+function buildScrapedCubscoutOccurrence() {
+  // Future-relative (like the series-collapse fixtures): a past span would
+  // trip the _pastSpanWithheld gate before the doctrine under test.
+  const start = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+  return {
+    title: 'CUBSCOUT',
+    startDate: start,
+    endDate: new Date(start.getTime() + 5 * 60 * 60 * 1000),
+    bar: 'Eagle LA',
+    city: 'la',
+    ticketUrl: 'https://dice.fm/event/abc123-cubscout-aug-7-tickets',
+    _seriesInfo: { rrule: 'FREQ=MONTHLY;BYDAY=1FR', basis: '3× 1st Friday', occurrences: 3, family: 'shape-1' }
+  };
+}
+
+test('occurrence-expanded predicates: isOccurrenceExpandedEvent / isSeriesCoveredOccurrence', () => {
+  const occurrence = buildScrapedCubscoutOccurrence();
+  assert.equal(SharedCore.isOccurrenceExpandedEvent(occurrence), true);
+  assert.equal(SharedCore.isOccurrenceExpandedEvent({ title: 'ONE OFF' }), false);
+  assert.equal(SharedCore.isRecurringSeriesEvent(occurrence), false, '_seriesInfo alone is never a series claim');
+  assert.equal(SharedCore.isSeriesCoveredOccurrence(occurrence), false, 'no saved-series match, no withhold');
+  occurrence._seriesMatch = { identifier: 'CAL-UUID:x', calendarName: 'chunky-dad-la' };
+  assert.equal(SharedCore.isSeriesCoveredOccurrence(occurrence), true);
+  assert.equal(SharedCore.isSeriesCoveredOccurrence({ _seriesMatch: { identifier: 'CAL-UUID:x' } }), false,
+    'a series-export _seriesMatch alone never trips the occurrence gate');
+});
+
+test('occurrence-expanded single vs saved series: lookup runs, write withheld with SERIES MATCH', async () => {
+  const core = createLaCore();
+  const saved = [
+    buildSavedCubscoutOccurrence('2026-09-05T04:00:00.000Z'),
+    buildSavedCubscoutOccurrence('2026-10-03T04:00:00.000Z')
+  ];
+  const adapter = buildSeriesLookupAdapter(saved);
+  const occurrence = buildScrapedCubscoutOccurrence();
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(occurrence, [], 'upsert', adapter);
+  assert.equal(analysis.action, 'new', 'the analysis action itself is untouched');
+  assert.ok(analysis.seriesMatch, 'the saved-series lookup runs for occurrence-expanded singles too');
+  assert.equal(analysis.seriesMatch.identifier, 'CAL-UUID:cubscout-20260731T193113Z@chunky.dad');
+
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (message) => { lines.push(String(message)); };
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(occurrence, analysis, adapter, {});
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.ok(analyzed._seriesInfo, 'the family metadata survives onto the analyzed event');
+  assert.ok(analyzed._seriesMatch, 'the saved-series match is stamped');
+  assert.equal(analyzed._seriesMatch.calendarName, 'chunky-dad-la');
+  assert.equal(analyzed._recurring, undefined, 'never turned into a series');
+  assert.equal(analyzed._recurringExport, undefined, 'no ICS-export series framing for an occurrence');
+  assert.equal(analyzed.ticketUrl, occurrence.ticketUrl, 'the occurrence keeps its own ticket link');
+  assert.ok(
+    lines.some(l => l.includes('🔁 SHAPE:') && l.includes('covered by the saved series in chunky-dad-la') && l.includes('SERIES MATCH')),
+    `the withhold says so out loud: ${JSON.stringify(lines)}`
+  );
+  assert.equal(SharedCore.isSeriesCoveredOccurrence(analyzed), true);
+  assert.equal(SharedCore.describeExecutionDisposition(analyzed),
+    'WITHHELD (occurrence covered by saved series — SERIES MATCH)');
+  assert.deepEqual(SharedCore.filterEventsForExecution([analyzed]), [], 'and nothing is written');
+});
+
+test('occurrence-expanded single with NO saved series: written like any single event', async () => {
+  const core = createLaCore();
+  const adapter = buildSeriesLookupAdapter([]);
+  const occurrence = buildScrapedCubscoutOccurrence();
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(occurrence, [], 'upsert', adapter);
+  assert.equal(analysis.action, 'new');
+  assert.equal(analysis.seriesMatch, undefined, 'nothing saved, nothing matched');
+
+  const analyzed = await core.buildAnalyzedCalendarEvent(occurrence, analysis, adapter, {});
+  assert.equal(analyzed._seriesMatch, undefined);
+  assert.ok(analyzed._seriesInfo, 'the report-only metadata rides along');
+  assert.equal(SharedCore.describeExecutionDisposition(analyzed), 'NEW');
+  assert.equal(SharedCore.filterEventsForExecution([analyzed]).length, 1,
+    'an uncovered occurrence writes exactly like any single event');
+});
+
+test('mergeParsedEvents carries _seriesInfo from the secondary record (same-night stub+detail fold)', async () => {
+  const core = createLaCore();
+  const info = { rrule: 'FREQ=MONTHLY;BYDAY=1FR', basis: '3× 1st Friday', occurrences: 3, family: 'shape-1' };
+  const stub = { ...buildScrapedCubscoutOccurrence(), _seriesInfo: info };
+  const detail = { title: 'CUBSCOUT', startDate: new Date('2026-08-08T02:00:00.000Z'), bar: 'Eagle LA', city: 'la' };
+  const merged = await core.mergeParsedEvents(stub, detail, {});
+  assert.deepEqual(merged._seriesInfo, info, 'the family stamp survives a merge that keeps the other record');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The doctrine (owner's words, now the rule)

> "Maybe we only create series for single-events that are clearly recurring? (A flyer, etc.) and we do single events for calendar websites that do the expansion for us?"
> "We can't condense the event with diff URLs"

Scope note: per the owner's follow-up, this wave is **pipeline-only** — no card text additions and no UI changes ("UI should stay the same"; the per-series note idea is explicitly deferred). `scripts/adapters/*` and `scripts/event-schema.js` are untouched.

## The evidence (run 20260814-000011)

BEEFMINCE x RVT was observed on three 3rd-Saturdays, **each with its own dice.fm per-event ticket link**:

- `dice.fm/event/yoepxa-beefmince-x-rvt-19th-sep-…`
- `dice.fm/event/xednya-beefmince-x-rvt-17th-oct-…`
- `dice.fm/event/927gr7-beefmince-x-rvt-21st-nov-…`

The old pass stamped `FREQ=MONTHLY;BYDAY=3SA` on all records and the series collapse folded them to the Sep 19 occurrence — discarding October's and November's dice links (log: `🔁 SERIES: collapsed 3 same-series exports … to the next occurrence 2026-09-19`). Same shape as the Eagle LA / Dallas MEC calendars (`?occurrence=YYYY-MM-DD` links, renumbered `gear-night-N` slugs): the SITE expands occurrences and publishes per-date artifacts.

## Classification rules (structural, nothing per-site)

`classifyCadenceSourceShape` runs at the top of the derived-cadence pass, per family:

- **occurrence-expanded** when the observed records carry DISTINCT per-date identity artifacts:
  - `?occurrence=YYYY-MM-DD` links harvested off the family's own pages, or
  - a `url` / `website` / `ticketUrl` / `image` value that one date wears and another date's non-empty set lacks (dice per-event links, renumbered slugs, per-date posters). Same-date variance (listing stub + detail page of ONE night) never counts — only cross-date differences classify.
- **stated-series** when nothing is individually published per date (one page/flyer states or implies the schedule; all dates share one artifact set).

Fail closed per the doctrine: per-date artifacts always mean individual occurrences — unsure never converts to a series.

## What each shape now does

**Occurrence-expanded** → no `recurrenceRule` stamp, no `_cadenceGroup` marker, stated rules demoted; every member carries report-only `_seriesInfo { rrule, basis, occurrences, family }` and stays an individual event with its own links, written/merged like any single event. `getSeriesExportIdentity` fails closed on `_seriesInfo` (defense in depth — the cross-date collapse can never fold them), same-date stub+detail folding is untouched, and `mergeParsedEvents` carries `_seriesInfo` across those folds. New log line:
`🔁 SHAPE: "X" is occurrence-expanded (distinct per-date ticketUrl artifacts across 3 dates) — 3 record(s) over 3 date(s) kept individual, no series conversion`

**Stated-series** → the existing series flow, byte-identical: stamping, same-series collapse, 🔁 withhold, ICS export, series rematch.

**Saved-series protection (#1655), extended** → the saved-series lookup now also runs for occurrence-expanded singles; a positive match withholds the write (`isSeriesCoveredOccurrence` gate + `WITHHELD (occurrence covered by saved series — SERIES MATCH)` disposition), so occurrence-expansion never fights a series the owner imported. Unmatched occurrences write exactly like any single event. The scraper still never writes recurring series (invariant untouched; the gate only got stricter).

## Deliberate behavior shifts

- **BEEFMINCE x RVT** → individual Saturdays, each with its own dice link, no rrule stamped; cadence survives as `_seriesInfo` (`FREQ=MONTHLY;BYDAY=3SA`, one shared family).
- **Dallas GEAR NIGHT** → same, via renumbered `gear-night-N` slugs.
- **B BAR-style `?occurrence=` twins** (run 20260806-171735) → two individual Thursdays each keeping its own `?occurrence=` URL, no collapse-to-next-occurrence.
- **Underwear Happy Hour-style stated rules on renumbered slugs** (run 20260807-143442) → stated rules demoted to `_seriesInfo`; occurrences individual (previously folded to one withheld series export).
- **Lumberyard "every Sunday" flyer (dateless-weekly, #1616)** → unchanged: stated-series, synthesized, withheld, ICS.

## Changed test pins (`scripts/parsers/ai-web-parser.test.js`) — each justified by the doctrine above

1. `weekly stamp from ?occurrence= link observations` → now pins occurrence-expanded: no stamp/marker, `_seriesInfo` with the weekly rrule, SHAPE log.
2. `weekly stamp from same-title records on renumbered slugs` → now pins occurrence-expanded; **new sibling test** keeps the stamping path covered for a shared-page (no per-date artifacts) family.
3. `monthly stamp from two same-ordinal observations` → per-date `cub-scout-N` slugs now pin individual occurrences + `_seriesInfo`.
4. `stated rule beats derived — nothing stamped, stated kept` → on per-date slugs the family is occurrence-expanded: stated rule demoted, `_seriesInfo.rrule` fails closed to `''` on the disagreement; **new sibling test** preserves the original stated-beats-derived pin on a stated-series-shaped family.
5. `derived agreeing with stated marks the same-series group` → renumbered `underwear-N` slugs now pin demotion + one shared family (the collapse marker is gone; UI grouping is deferred with the UI wave).
6. `different venues / undated records` → the dated `karaoke-N` group's expectation flipped from weekly stamp to `_seriesInfo`; undated records still never classify.
7. `six real GEAR NIGHT records fold to one weekly group` → now pins one FAMILY with six individual Saturdays, each keeping its own slug URL.
8. `guest-DJ suffixes group into one monthly series` → grouping identity unchanged; the pair now pins demoted stated rules with the refined `FREQ=MONTHLY;BYDAY=2FR` in `_seriesInfo`.

New tests (proven failing on base — 14 failures when the new test files run against base source): BEEFMINCE x RVT verbatim-evidence test (parser), `_seriesInfo` collapse guard, occurrence predicates, SERIES-MATCH withhold + uncovered-occurrence write, `mergeParsedEvents` `_seriesInfo` carry (shared-core).

## Verification

- Full quiet suite: **1823/1823 pass** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`).
- Real-data replay of run 20260814-000011 (read-only): the run's 4 surviving GEAR NIGHT records classify occurrence-expanded, keep 4 distinct slug links, demote their stamped rules into `_seriesInfo` (`FREQ=WEEKLY;BYDAY=SA`); with rules stripped, the 4-date subset (gaps 7,14,7) correctly fails closed to no metadata rrule. BEEFMINCE's three dice-linked occurrences classify occurrence-expanded and each keeps its own link. The run's real South Seattle Bear Social record stays a stated series, untouched.
- Constraints held: no existing console.log or AI-prompt line edited (3 log lines added); no `new URL`/`URLSearchParams`; shared-core/normalizers platform-pure; nothing per-venue/per-domain; tests only in enumerated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP