### PR TITLE
fix(scraper): extraction hygiene — junk-title sibling families, crawl-candidate syntax/host validation, B BAR probe no-repro

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -5113,6 +5113,67 @@ class AiWebParser {
     }
 
     /**
+     * SOURCE-SHAPE CLASSIFICATION (owner doctrine): "we only create series
+     * for single-events that are clearly recurring (a flyer, etc.) and we do
+     * single events for calendar websites that do the expansion for us" —
+     * plus "we can't condense the event with diff URLs".
+     *
+     * An event family is `occurrence-expanded` when the SITE already expands
+     * the recurrence and publishes per-date artifacts — the observed records
+     * carry DISTINCT per-date identity artifacts:
+     *   - ?occurrence=YYYY-MM-DD links harvested off the family's own pages
+     *     (the link format itself is a per-date publication), or
+     *   - different event-page URLs / ticket URLs / posters on different
+     *     dates (dice.fm per-event links, MEC renumbered slugs, per-date
+     *     flyers).
+     * It is `stated-series` when nothing is individually published per date:
+     * one page/flyer states or implies the schedule and every observed date
+     * shares the same artifact set. Detection is purely structural (value
+     * comparison across dates) — nothing per-site, nothing per-domain.
+     *
+     * Artifact comparison: for each identity-artifact field, a date whose
+     * value set contains a value ABSENT from another date's non-empty value
+     * set is per-date evidence. Two dates carrying the identical value
+     * (both pointing at the one series page) prove nothing; a value only
+     * one date wears is exactly a per-date publication. Same-date variance
+     * (listing stub + detail page of ONE night) never counts — only
+     * cross-date differences classify. Fail closed per the doctrine: when
+     * the artifacts say per-date, the family stays individual occurrences —
+     * unsure never converts to a series.
+     */
+    classifyCadenceSourceShape(group, hasOccurrenceLinkObservations) {
+        if (hasOccurrenceLinkObservations) {
+            return { shape: 'occurrence-expanded', reason: 'the site publishes per-date ?occurrence= links' };
+        }
+        const ARTIFACT_FIELDS = ['url', 'website', 'ticketUrl', 'image'];
+        for (const field of ARTIFACT_FIELDS) {
+            const valuesByDate = new Map();
+            for (const member of group.members) {
+                const value = typeof member.event[field] === 'string' ? member.event[field].trim() : '';
+                if (!value) continue;
+                if (!valuesByDate.has(member.nightKey)) valuesByDate.set(member.nightKey, new Set());
+                valuesByDate.get(member.nightKey).add(value);
+            }
+            if (valuesByDate.size < 2) continue;
+            const entries = Array.from(valuesByDate.values());
+            for (let i = 0; i < entries.length; i++) {
+                for (let j = 0; j < entries.length; j++) {
+                    if (i === j) continue;
+                    for (const value of entries[i]) {
+                        if (!entries[j].has(value)) {
+                            return {
+                                shape: 'occurrence-expanded',
+                                reason: `distinct per-date ${field} artifacts across ${valuesByDate.size} dates`
+                            };
+                        }
+                    }
+                }
+            }
+        }
+        return { shape: 'stated-series', reason: 'no per-date identity artifacts observed' };
+    }
+
+    /**
      * Post-crawl derived-cadence enforcement (called by shared-core's
      * processParser once every page of the run has been crawled, BEFORE
      * dedup — the same seam as applyVenueSiteAddressConsensus, and for the
@@ -5129,6 +5190,15 @@ class AiWebParser {
      *      what catches MEC installs that renumber slugs per occurrence
      *      (karaoke-19, karaoke-20 …), where URL-keyed observation never
      *      accumulates.
+     *
+     * SOURCE SHAPE comes first (owner doctrine, see
+     * classifyCadenceSourceShape): a family whose observed records carry
+     * distinct per-date identity artifacts (?occurrence= links, per-date
+     * event/ticket URLs or posters, renumbered slugs) is occurrence-expanded
+     * — the site already did the expansion, so the family gets report-only
+     * _seriesInfo metadata and every occurrence stays an individual event.
+     * Only a stated-series-shaped family (no per-date artifacts) continues
+     * into the stamping below.
      *
      * A qualifying group (deriveCadenceRrule) gets recurrenceRule stamped on
      * every member that lacks one, so the EXISTING series machinery folds the
@@ -5184,6 +5254,7 @@ class AiWebParser {
         }
 
         let groupIndex = 0;
+        let shapeIndex = 0;
         for (const group of groups) {
             const dates = new Set(group.members.map(member => member.nightKey));
             // Fold in the ?occurrence= observations whose page identity
@@ -5196,13 +5267,74 @@ class AiWebParser {
                     if (pathKey) memberPathKeys.add(pathKey);
                 }
             }
+            let occurrenceLinksObserved = false;
             if (observations) {
                 for (const [pathKey, dateSet] of observations) {
                     if (!memberPathKeys.has(pathKey)) continue;
+                    occurrenceLinksObserved = true;
                     for (const date of dateSet) dates.add(date);
                 }
             }
             const sortedDates = Array.from(dates).sort();
+
+            // SOURCE-SHAPE CLASSIFICATION (see classifyCadenceSourceShape):
+            // an occurrence-expanded family — the site publishes per-date
+            // artifacts — is NEVER converted to a series. No recurrenceRule
+            // stamp, no _cadenceGroup marker (so the same-series export
+            // collapse can never fold it across dates), stated rules demoted
+            // to report-only metadata. Every member instead carries
+            // _seriesInfo = { rrule, basis, occurrences, family }: the
+            // cadence stays visible (UI chip + family grouping) while each
+            // occurrence keeps its own date, ticketUrl, website and poster
+            // and is written/merged individually like any single event.
+            const shapeVerdict = sortedDates.length >= 2
+                ? this.classifyCadenceSourceShape(group, occurrenceLinksObserved)
+                : null;
+            if (shapeVerdict && shapeVerdict.shape === 'occurrence-expanded') {
+                shapeIndex++;
+                const derivedForInfo = this.deriveCadenceRrule(sortedDates);
+                const statedRuleSet = new Set();
+                for (const member of group.members) {
+                    const stated = String(member.event.recurrenceRule || member.event.recurrence || '').trim().toUpperCase();
+                    if (stated) statedRuleSet.add(stated);
+                }
+                // The report-only rrule: derived when every stated rule
+                // agrees with (or is refined by) it; the single stated rule
+                // when nothing was derivable; '' on disagreement or multiple
+                // stated rules — fail closed, the observed-dates basis
+                // string still describes the family.
+                const statedRuleList = Array.from(statedRuleSet);
+                const derivedRrule = derivedForInfo ? derivedForInfo.rrule : '';
+                let infoRrule = '';
+                if (derivedRrule && statedRuleList.every(rule =>
+                    rule === derivedRrule || derivedRrule.startsWith(`${rule};`))) {
+                    infoRrule = derivedRrule;
+                } else if (!derivedRrule && statedRuleList.length === 1) {
+                    infoRrule = statedRuleList[0];
+                }
+                const shapeBasis = this.describeOccurrenceCadence(sortedDates);
+                const shapeTitle = group.members[0].event.title;
+                let demotedCount = 0;
+                for (const member of group.members) {
+                    member.event._seriesInfo = {
+                        rrule: infoRrule,
+                        basis: shapeBasis.summary,
+                        occurrences: sortedDates.length,
+                        family: `shape-${shapeIndex}`
+                    };
+                    if (String(member.event.recurrenceRule || member.event.recurrence || '').trim()) {
+                        delete member.event.recurrenceRule;
+                        delete member.event.recurrence;
+                        demotedCount++;
+                    }
+                    if (member.event._recurring === true) {
+                        delete member.event._recurring;
+                    }
+                }
+                console.log(`🔁 SHAPE: "${shapeTitle}" is occurrence-expanded (${shapeVerdict.reason}) — ${group.members.length} record(s) over ${sortedDates.length} date(s) kept individual, no series conversion${demotedCount > 0 ? `; ${demotedCount} stated rule(s) demoted to report-only _seriesInfo` : ''}`);
+                continue;
+            }
+
             const derived = this.deriveCadenceRrule(sortedDates);
             if (!derived) continue; // existing report-only line already covered it
 
@@ -5228,6 +5360,9 @@ class AiWebParser {
             if (disagreeing.length > 0) {
                 console.log(`🔁 CADENCE: derived ${derived.rrule} for "${title}" disagrees with stated rule(s) ${disagreeing.join(', ')} — stated cadence kept, nothing stamped (curated data beats derived)`);
                 continue;
+            }
+            if (shapeVerdict) {
+                console.log(`🔁 SHAPE: "${title}" is stated-series (${shapeVerdict.reason}) — series flow retained`);
             }
             const unstamped = group.members.filter(member =>
                 !String(member.event.recurrenceRule || member.event.recurrence || '').trim());

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -9194,6 +9194,29 @@ class AiWebParser {
             return { valid: false, reason: 'template-url' };
         }
 
+        // CRAWL CANDIDATE HYGIENE (run 20260814-000011): the raw-HTML scan
+        // reads script bodies too, so a JS string concatenation around a real
+        // base URL was scraped as a candidate whose path is unevaluated CODE
+        // ("https://www.thelumberyardbar.com/+encodeURIComponent(l)+"), and a
+        // placeholder yielded a hostname no DNS could resolve
+        // ("https://empty/"). Both checks are pure syntax — generic, no
+        // domain or identifier list:
+        // - unresolved-code-syntax: concat-shaped call residue ("+ident(" or
+        //   ")+"), an encode/decodeURIComponent identifier, unterminated
+        //   template residue ("${"), or a RAW quote/backtick anywhere in the
+        //   host/path/query (legal URLs carry them percent-encoded). A bare
+        //   "+" stays valid — it is an encoded space in queries.
+        // - implausible-hostname: a hostname with no dot that is not
+        //   localhost. Real page hosts are dotted; "empty" is not a host.
+        const hostPathAndQuery = `${parsedUrl.hostname || ''}${parsedUrl.pathname || ''}${parsedUrl.search || ''}${parsedUrl.hash || ''}`;
+        if (/\$\{|["'`]|(?:en|de)codeURIComponent|\+\s*[A-Za-z_$][\w$]*\s*\(|\)\s*\+/.test(hostPathAndQuery)) {
+            return { valid: false, reason: 'unresolved-code-syntax' };
+        }
+        const lowerHostname = (parsedUrl.hostname || '').toLowerCase();
+        if (!lowerHostname.includes('.') && lowerHostname !== 'localhost') {
+            return { valid: false, reason: 'implausible-hostname' };
+        }
+
         const invalidUrlPatterns = [
             '/admin', '/login', '/wp-admin', '/wp-login', '/user/', '/profile/',
             '/wp-content', '/terms', '/privacy',

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -5780,6 +5780,73 @@ test('validateEventUrl rejects .avif assets (literal URL fetched as a crawl page
   assert.deepEqual(result, { valid: false, reason: 'static-asset-extension' });
 });
 
+test('validateEventUrl rejects unresolved JS concat residue as a crawl candidate (run 20260814-000011)', () => {
+  const parser = createParser();
+  // Literal candidates from the run: a script tag's string concatenation
+  // scraped as URLs — the "path" is unevaluated CODE, not a page.
+  assert.deepEqual(
+    parser.validateEventUrl('https://www.thelumberyardbar.com/+encodeURIComponent(l)+', 'https://www.thelumberyardbar.com/'),
+    { valid: false, reason: 'unresolved-code-syntax' });
+  assert.deepEqual(
+    parser.validateEventUrl('https://www.clubchubusa.com/+encodeURIComponent(l)+', 'https://www.clubchubusa.com/'),
+    { valid: false, reason: 'unresolved-code-syntax' });
+  // Generic syntax checks, not an identifier list: any concat-shaped call
+  // residue, raw quote/backtick residue, and unterminated template residue
+  // are equally rejected.
+  assert.deepEqual(
+    parser.validateEventUrl('https://example.com/+buildPath(slug)+', 'https://example.com/'),
+    { valid: false, reason: 'unresolved-code-syntax' });
+  assert.deepEqual(
+    parser.validateEventUrl("https://example.com/'+t.link+'", 'https://example.com/'),
+    { valid: false, reason: 'unresolved-code-syntax' });
+});
+
+test('validateEventUrl rejects implausible dotless hostnames (https://empty/ from the run)', () => {
+  const parser = createParser();
+  assert.deepEqual(
+    parser.validateEventUrl('https://empty/', 'https://www.thelumberyardbar.com/'),
+    { valid: false, reason: 'implausible-hostname' });
+  // localhost is the one legitimate dotless host (dev parsing targets).
+  const localhostResult = parser.validateEventUrl('http://localhost/events', 'http://localhost/');
+  assert.notEqual(localhostResult.reason, 'implausible-hostname');
+});
+
+test('validateEventUrl keeps legitimate plus-in-query and parens-in-path URLs valid', () => {
+  const parser = createParser();
+  // "+" as an encoded space in a query is not concat residue.
+  assert.deepEqual(
+    parser.validateEventUrl('https://www.thelumberyardbar.com/events?q=bear+night', 'https://www.thelumberyardbar.com/'),
+    { valid: true, reason: 'valid' });
+  // Wikipedia-style parenthetical path segments carry no "+ident(" / ")+"
+  // shape and never trip the syntax check.
+  assert.deepEqual(
+    parser.validateEventUrl('https://en.wikipedia.org/wiki/Bear_(gay_culture)', 'https://en.wikipedia.org/wiki/LGBT_culture'),
+    { valid: true, reason: 'valid' });
+});
+
+test('discovery end-to-end: script-concat residue and placeholder hosts are rejected with counted reasons', () => {
+  const core = new SharedCore({}, { eventSchema: EventSchema });
+  const parser = new AiWebParser({ normalizeUrl: core.normalizeUrl.bind(core) });
+  parser.core = core;
+  // Unquoted concat expression + a placeholder host, as the raw-HTML scan
+  // (which reads script bodies) captures them.
+  const html = '<script>u = https://www.clubchubusa.com/+encodeURIComponent(l)+ ; v = "https://empty/";</script>';
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logLines.push(args.join(' ')); };
+  let links;
+  try {
+    links = parser.extractAdditionalUrls(html, 'https://www.clubchubusa.com/events', {});
+  } finally {
+    console.log = originalLog;
+  }
+  assert.deepEqual(links.slice(), [], `no code fragment may survive discovery, got: ${JSON.stringify(links.slice())}`);
+  const statsLine = logLines.find(line => line.includes('URL discovery stats'));
+  assert.ok(statsLine, 'discovery stats line is emitted');
+  assert.ok(statsLine.includes('unresolved-code-syntax'), `stats count the concat rejection: ${statsLine}`);
+  assert.ok(statsLine.includes('implausible-hostname'), `stats count the host rejection: ${statsLine}`);
+});
+
 test('getUrlDedupeKey fallback (no URL global, as on iOS JavaScriptCore) still merges www and bare-host variants', () => {
   const parser = createParser();
   const originalUrl = global.URL;

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -13745,9 +13745,13 @@ test('a lone "-WxH" thumbnail keeps its own identity and still gets OCR coverage
 });
 
 // ===========================================================================
-// Derived-cadence enforcement (occurrence links + same-title record groups →
-// conservative recurrenceRule stamps; stated rules always win). Venue names
-// below are fixtures only.
+// Derived-cadence enforcement + source-shape classification (owner doctrine:
+// series only for stated schedules with no per-date publications; a family
+// whose records carry DISTINCT per-date identity artifacts — ?occurrence=
+// links, per-date event/ticket URLs, renumbered slugs, per-date posters — is
+// occurrence-expanded: every occurrence stays an individual event carrying
+// its own links, with report-only _seriesInfo metadata instead of a
+// recurrenceRule stamp). Venue names below are fixtures only.
 // ===========================================================================
 
 function buildCadenceStampRecord(overrides = {}) {
@@ -13797,7 +13801,11 @@ test('deriveCadenceRrule: weekly needs same weekday + a run of 3 consecutive 7-d
   assert.equal(parser.deriveCadenceRrule(['2026-08-05']), null);
 });
 
-test('applyDerivedCadenceStamps: weekly stamp from ?occurrence= link observations', () => {
+// PIN UPDATED (series doctrine rework): ?occurrence= links ARE per-date
+// publications — the site expands the recurrence itself — so the family is
+// occurrence-expanded: no recurrenceRule stamp, no _cadenceGroup marker,
+// report-only _seriesInfo instead. Previously this pinned a weekly stamp.
+test('applyDerivedCadenceStamps: ?occurrence= link observations classify occurrence-expanded — no stamp, _seriesInfo metadata', () => {
   const parser = createParser();
   const sourceUrl = 'https://fixture-eagle.example/calendar/';
   const html = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26']
@@ -13809,32 +13817,79 @@ test('applyDerivedCadenceStamps: weekly stamp from ?occurrence= link observation
     url: 'https://fixture-eagle.example/events/hump-night/?occurrence=2026-08-05'
   });
   const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps([record]));
-  assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'link observations alone carry the weekly proof');
-  assert.ok(typeof record._cadenceGroup === 'string' && record._cadenceGroup, 'group marker stamped');
-  assert.ok(logs.some(line => line.includes('🔁 CADENCE: stamped FREQ=WEEKLY;BYDAY=WE on 1 "HUMP NIGHT" record(s)')),
-    `enforce line expected, got: ${JSON.stringify(logs)}`);
+  assert.equal(record.recurrenceRule, undefined, 'occurrence-expanded families are never converted to a series');
+  assert.equal(record._cadenceGroup, undefined, 'no collapse marker on an occurrence-expanded family');
+  assert.ok(record._seriesInfo, 'report-only family metadata stamped');
+  assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE', 'the derived cadence survives as metadata');
+  assert.equal(record._seriesInfo.occurrences, 4, 'observation dates counted');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "HUMP NIGHT" is occurrence-expanded')
+    && line.includes('?occurrence=')),
+    `shape line expected, got: ${JSON.stringify(logs)}`);
 });
 
-test('applyDerivedCadenceStamps: weekly stamp from same-title records on renumbered slugs (no occurrence links)', () => {
+// PIN UPDATED (series doctrine rework): renumbered MEC slugs are per-date
+// event pages, so the family is occurrence-expanded — each occurrence keeps
+// its own URL and stays an individual event. Previously this pinned a weekly
+// stamp plus a shared _cadenceGroup marker.
+test('applyDerivedCadenceStamps: renumbered slugs classify occurrence-expanded — occurrences kept individual', () => {
   const parser = createParser();
   // MEC renumbering (run 20260807-143442): one weekly night, a NEW slug per
-  // occurrence — URL-keyed observation can never accumulate these.
+  // occurrence — the slugs themselves are the per-date artifacts.
   const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
     buildCadenceStampRecord({
       startDate: new Date(`${date}T20:00:00.000Z`),
       endDate: new Date(`${date}T23:00:00.000Z`),
       url: `https://fixture-eagle.example/events/karaoke-${19 + index}/`
     }));
-  parser.applyDerivedCadenceStamps(records);
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  const families = new Set();
+  records.forEach((record, index) => {
+    assert.equal(record.recurrenceRule, undefined, 'no series conversion');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, 'family metadata on every member');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE');
+    assert.equal(record._seriesInfo.occurrences, 4);
+    assert.equal(record.url, `https://fixture-eagle.example/events/karaoke-${19 + index}/`,
+      'each occurrence keeps its own per-date URL');
+    families.add(record._seriesInfo.family);
+  });
+  assert.equal(families.size, 1, 'all four records share ONE family marker');
+  assert.ok([...families][0], 'the family marker is non-empty');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "KARAOKE" is occurrence-expanded')
+    && line.includes('distinct per-date url artifacts')),
+    `shape line expected, got: ${JSON.stringify(logs)}`);
+});
+
+// Stamping-path coverage (stated-series shape): the SAME multi-date family
+// with NO per-date artifacts — every record pointing at the one page that
+// states the schedule — still stamps the derived rule and mints the collapse
+// marker, exactly the pre-rework flow.
+test('applyDerivedCadenceStamps: a shared-page family (no per-date artifacts) is stated-series — weekly stamp fires', () => {
+  const parser = createParser();
+  const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map(date =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      endDate: new Date(`${date}T23:00:00.000Z`),
+      url: 'https://fixture-eagle.example/events/karaoke/'
+    }));
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
   for (const record of records) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE');
+    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'stated-series shape keeps the stamping flow');
+    assert.equal(record._seriesInfo, undefined, 'no occurrence-expanded metadata on a stated-series family');
   }
   const markers = new Set(records.map(record => record._cadenceGroup));
   assert.equal(markers.size, 1, 'all four records share ONE same-series marker');
   assert.ok([...markers][0], 'the shared marker is non-empty');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "KARAOKE" is stated-series')),
+    `stated-series shape line expected, got: ${JSON.stringify(logs)}`);
+  assert.ok(logs.some(line => line.includes('🔁 CADENCE: stamped FREQ=WEEKLY;BYDAY=WE on 4 "KARAOKE" record(s)')),
+    `enforce line expected, got: ${JSON.stringify(logs)}`);
 });
 
-test('applyDerivedCadenceStamps: monthly stamp from two same-ordinal observations in different months', () => {
+// PIN UPDATED (series doctrine rework): distinct per-date slugs → the
+// monthly pair is occurrence-expanded; the derived monthly cadence becomes
+// _seriesInfo metadata. Previously this pinned a FREQ=MONTHLY;BYDAY=1FR stamp.
+test('applyDerivedCadenceStamps: a monthly pair on per-date slugs keeps both occurrences individual', () => {
   const parser = createParser();
   const records = [
     buildCadenceStampRecord({
@@ -13851,8 +13906,12 @@ test('applyDerivedCadenceStamps: monthly stamp from two same-ordinal observation
     })
   ];
   parser.applyDerivedCadenceStamps(records);
-  assert.equal(records[0].recurrenceRule, 'FREQ=MONTHLY;BYDAY=1FR');
-  assert.equal(records[1].recurrenceRule, 'FREQ=MONTHLY;BYDAY=1FR');
+  for (const record of records) {
+    assert.equal(record.recurrenceRule, undefined, 'no series conversion on per-date slugs');
+    assert.ok(record._seriesInfo, 'family metadata stamped');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=MONTHLY;BYDAY=1FR', 'derived cadence kept as metadata');
+    assert.equal(record._seriesInfo.occurrences, 2);
+  }
 });
 
 test('applyDerivedCadenceStamps: mixed weekdays stamp nothing', () => {
@@ -13870,16 +13929,43 @@ test('applyDerivedCadenceStamps: mixed weekdays stamp nothing', () => {
   }
 });
 
-test('applyDerivedCadenceStamps: stated rule beats derived — conflict logs, nothing stamped, stated kept', () => {
+// PIN UPDATED (series doctrine rework): the per-date slugs make this family
+// occurrence-expanded, so the conflicting stated rule is DEMOTED to
+// report-only metadata rather than kept as a series claim — each occurrence
+// is written individually either way, and _seriesInfo.rrule fails closed to
+// '' on the disagreement (the observed-dates basis still describes the
+// family). Previously this pinned "stated kept, nothing stamped".
+test('applyDerivedCadenceStamps: stated-vs-derived disagreement on an occurrence-expanded family demotes, rrule fails closed', () => {
   const parser = createParser();
-  // The model extracted an explicit stated cadence on one record; the derived
-  // weekday disagrees. Curated/stated data beats derived — fail closed for
-  // the WHOLE group.
   const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
     buildCadenceStampRecord({
       startDate: new Date(`${date}T20:00:00.000Z`),
       endDate: new Date(`${date}T23:00:00.000Z`),
       url: `https://fixture-eagle.example/events/karaoke-${19 + index}/`
+    }));
+  records[0].recurrenceRule = 'FREQ=WEEKLY;BYDAY=FR';
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  for (const record of records) {
+    assert.equal(record.recurrenceRule, undefined, 'occurrence-expanded members carry no series claim');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, 'family metadata on every member');
+    assert.equal(record._seriesInfo.rrule, '', 'disagreeing rules fail closed to no metadata rrule');
+    assert.ok(record._seriesInfo.basis, 'the observed-dates basis still describes the family');
+  }
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "KARAOKE" is occurrence-expanded')
+    && line.includes('1 stated rule(s) demoted to report-only _seriesInfo')),
+    `shape+demotion line expected, got: ${JSON.stringify(logs)}`);
+});
+
+// Stated-beats-derived conflict coverage on the STAMPING path (stated-series
+// shape — no per-date artifacts): unchanged pre-rework behavior.
+test('applyDerivedCadenceStamps: stated rule beats derived on a stated-series family — conflict logs, nothing stamped', () => {
+  const parser = createParser();
+  const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map(date =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      endDate: new Date(`${date}T23:00:00.000Z`),
+      url: 'https://fixture-eagle.example/events/karaoke/'
     }));
   records[0].recurrenceRule = 'FREQ=WEEKLY;BYDAY=FR';
   const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
@@ -13892,11 +13978,14 @@ test('applyDerivedCadenceStamps: stated rule beats derived — conflict logs, no
     `conflict line expected, got: ${JSON.stringify(logs)}`);
 });
 
-test('applyDerivedCadenceStamps: derived agreeing with stated is a no-op stamp but still marks the same-series group', () => {
+// PIN UPDATED (series doctrine rework): the renumbered underwear-N slugs are
+// per-date publications, so the stated-rule group is occurrence-expanded —
+// the five records each stay an individual Wednesday with their own page,
+// stated rules demoted to _seriesInfo (rrule preserved there: derived agrees
+// with stated). Previously this pinned "marker only, rules untouched" so the
+// series collapse could fold them; UI grouping now replaces that fold.
+test('applyDerivedCadenceStamps: stated rules on renumbered slugs are demoted — occurrences kept individual', () => {
   const parser = createParser();
-  // Run 20260807-143442: all five "Underwear Happy Hour" records already
-  // state FREQ=WEEKLY;BYDAY=WE, each on its own renumbered slug. The rules
-  // stay untouched; the marker is what lets the series collapse fold them.
   const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
     buildCadenceStampRecord({
       startDate: new Date(`${date}T20:00:00.000Z`),
@@ -13906,14 +13995,18 @@ test('applyDerivedCadenceStamps: derived agreeing with stated is a no-op stamp b
       recurrenceRule: 'FREQ=WEEKLY;BYDAY=WE'
     }));
   const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
-  const markers = new Set(records.map(record => record._cadenceGroup));
-  assert.equal(markers.size, 1, 'one shared marker across the stated-rule group');
-  assert.ok([...markers][0]);
+  const families = new Set();
   for (const record of records) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'stated rules untouched');
+    assert.equal(record.recurrenceRule, undefined, 'stated rules demoted on an occurrence-expanded family');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, 'family metadata on every member');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE', 'the agreed cadence survives as metadata');
+    families.add(record._seriesInfo.family);
   }
-  assert.ok(logs.some(line => line.includes('same-series marker only, nothing stamped')),
-    `marker-only line expected, got: ${JSON.stringify(logs)}`);
+  assert.equal(families.size, 1, 'one shared family across the demoted group');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "UNDERWEAR HAPPY HOUR" is occurrence-expanded')
+    && line.includes('4 stated rule(s) demoted to report-only _seriesInfo')),
+    `shape+demotion line expected, got: ${JSON.stringify(logs)}`);
 });
 
 test('applyDerivedCadenceStamps: different venues never share a group, and undated records are never stamped', () => {
@@ -13951,10 +14044,16 @@ test('applyDerivedCadenceStamps: different venues never share a group, and undat
   const before = dated.map(record => record.startDate.getTime());
   parser.applyDerivedCadenceStamps([undated, ...dated]);
   assert.equal(undated.recurrenceRule, undefined, 'an undated record is never stamped');
+  assert.equal(undated._seriesInfo, undefined, 'an undated record never joins a family');
   assert.equal(undated.startDate, null, 'an undated record gains no fabricated date');
-  assert.deepEqual(dated.map(record => record.startDate.getTime()), before, 'stamping never mutates startDate');
+  assert.deepEqual(dated.map(record => record.startDate.getTime()), before, 'classification never mutates startDate');
+  // PIN UPDATED (series doctrine rework): the dated group sits on renumbered
+  // karaoke-N slugs — occurrence-expanded, so it now carries _seriesInfo
+  // metadata instead of the weekly stamp it previously pinned.
   for (const record of dated) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'the dated group still stamps normally');
+    assert.equal(record.recurrenceRule, undefined, 'per-date slugs never convert to a series');
+    assert.ok(record._seriesInfo, 'the dated family still classifies and carries metadata');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE');
   }
 });
 
@@ -13979,14 +14078,18 @@ test('deriveCadenceRrule: weekly with skipped weeks — every gap a multiple of 
   assert.equal(parser.deriveCadenceRrule(['2026-08-15', '2026-08-22', '2026-08-29', '2026-09-04']), null);
 });
 
-test('applyDerivedCadenceStamps: the six real GEAR NIGHT records fold to one weekly group (skipped weeks + DJ suffixes)', () => {
+// PIN UPDATED (series doctrine rework): the renumbered gear-night-N slugs
+// are per-date publications — Dallas Eagle's MEC install expands the series
+// itself — so the six records classify occurrence-expanded and each Saturday
+// stays an individual event carrying its own page URL, with the weekly
+// cadence preserved as _seriesInfo metadata and ONE shared family for UI
+// grouping. Previously this pinned a FREQ=WEEKLY;BYDAY=SA stamp plus a
+// shared _cadenceGroup marker (collapse-to-next-occurrence).
+test('applyDerivedCadenceStamps: the six real GEAR NIGHT records classify occurrence-expanded — one family, no stamps', () => {
   const parser = createParser();
   // Run 20260811-134734 verbatim: six GEAR NIGHT records on renumbered MEC
   // slugs (gear-night-5/7/11/17/19/22), two wearing per-record DJ credits,
   // observed Saturdays Aug 15, 22, Sep 5, 12, 19, Oct 3 (America/Chicago).
-  // On main these survived as six separate calendar writes: the weekly rule
-  // demanded 3 CONSECUTIVE 7-day gaps (longest run here is 2), and the
-  // DJ-suffixed pair could not even join the group.
   const gearNight = [
     ['Gear Night with DJ Tristan Jaxx', '2026-08-16T02:00:00.000Z', 'gear-night-5'],
     ['Gear Night with DJ Philip Webb', '2026-08-23T03:00:00.000Z', 'gear-night-7'],
@@ -14004,22 +14107,74 @@ test('applyDerivedCadenceStamps: the six real GEAR NIGHT records fold to one wee
     source: 'ai-web'
   }));
   parser.applyDerivedCadenceStamps(gearNight);
-  for (const record of gearNight) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=SA', `"${record.title}" (${record.url}) joins the weekly stamp`);
-  }
-  const markers = new Set(gearNight.map(record => record._cadenceGroup));
-  assert.equal(markers.size, 1, 'all six records share ONE same-series marker');
-  assert.ok([...markers][0], 'the shared marker is non-empty');
+  const families = new Set();
+  gearNight.forEach((record, index) => {
+    assert.equal(record.recurrenceRule, undefined, `"${record.title}" is never converted to a series`);
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, `"${record.title}" (${record.url}) joins the family metadata`);
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=SA', 'the weekly cadence survives as metadata');
+    assert.equal(record._seriesInfo.occurrences, 6);
+    assert.ok(record.url.includes('gear-night-'), 'each occurrence keeps its own per-date slug URL');
+    families.add(record._seriesInfo.family);
+  });
+  assert.equal(families.size, 1, 'all six records share ONE family (grouped in the UI, never folded in data)');
+  assert.ok([...families][0], 'the shared family is non-empty');
 });
 
-test('applyDerivedCadenceStamps: per-record guest-DJ suffixes group into one monthly series; different parties never do', () => {
+// Run 20260814-000011 verbatim (the evidence that drove the doctrine): three
+// observed 3rd-Saturday BEEFMINCE x RVT occurrences, each with its OWN
+// dice.fm per-event ticket link. On main these were stamped
+// FREQ=MONTHLY;BYDAY=3SA and collapsed to the Sep 19 occurrence — whose
+// ticketUrl is the Sep-19-SPECIFIC dice link, discarding October's and
+// November's. "We can't condense the event with diff URLs": the distinct
+// per-date ticketUrls classify the family occurrence-expanded, every
+// occurrence keeps its own dice link, and the cadence survives as metadata.
+test('applyDerivedCadenceStamps: BEEFMINCE x RVT — distinct per-date dice links keep every occurrence and its own ticketUrl', () => {
+  const parser = createParser();
+  const diceLinks = [
+    ['2026-09-19T21:00:00.000Z', 'https://dice.fm/event/yoepxa-beefmince-x-rvt-19th-sep-the-royal-vauxhall-tavern-london-tickets'],
+    ['2026-10-17T21:00:00.000Z', 'https://dice.fm/event/xednya-beefmince-x-rvt-17th-oct-the-royal-vauxhall-tavern-london-tickets'],
+    ['2026-11-21T22:00:00.000Z', 'https://dice.fm/event/927gr7-beefmince-x-rvt-21st-nov-the-royal-vauxhall-tavern-london-tickets']
+  ];
+  const records = diceLinks.map(([start, ticketUrl]) => ({
+    title: 'BEEFMINCE x RVT',
+    bar: 'The Royal Vauxhall Tavern',
+    timezone: 'Europe/London',
+    startDate: new Date(start),
+    endDate: new Date(new Date(start).getTime() + 6 * 60 * 60 * 1000),
+    website: 'https://beefmince.com',
+    ticketUrl,
+    source: 'ai-web'
+  }));
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  const families = new Set();
+  records.forEach((record, index) => {
+    assert.equal(record.recurrenceRule, undefined, 'no FREQ=MONTHLY;BYDAY=3SA stamp — the site expands the dates itself');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker — October and November keep their own dice links');
+    assert.ok(record._seriesInfo, 'family metadata on every occurrence');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=MONTHLY;BYDAY=3SA', 'the derived cadence survives as report-only metadata');
+    assert.equal(record._seriesInfo.occurrences, 3);
+    assert.equal(record.ticketUrl, diceLinks[index][1], 'each occurrence keeps its own per-date dice link');
+    families.add(record._seriesInfo.family);
+  });
+  assert.equal(families.size, 1, 'one family across the three Saturdays');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "BEEFMINCE x RVT" is occurrence-expanded')
+    && line.includes('distinct per-date ticketUrl artifacts')),
+    `shape line expected, got: ${JSON.stringify(logs)}`);
+});
+
+// PIN UPDATED (series doctrine rework): the pair sits on distinct per-date
+// slugs, so it is occurrence-expanded — the guest-DJ grouping still proves
+// the family (that identity logic is untouched), but the stated bare
+// FREQ=MONTHLY rules are demoted and the refined 2FR cadence lands in
+// _seriesInfo. Previously this pinned "marker minted, stated rules kept".
+test('applyDerivedCadenceStamps: per-record guest-DJ suffixes still group into one family; different parties never do', () => {
   const parser = createParser();
   // Run 20260811-134734 verbatim: a genuine 2nd-Friday monthly pair whose
   // records each wear a different guest DJ's name — no bare-title anchor,
   // so the plain name similarity never groups them. Both pages state a bare
   // FREQ=MONTHLY; the derived FREQ=MONTHLY;BYDAY=2FR REFINES it (agreement,
-  // not conflict), so the stated rules stay untouched and the same-series
-  // marker is minted.
+  // not conflict), so the refined rule is what the metadata carries.
   const disciplinePair = [
     {
       title: 'Discipline Corps Bar Night with DJ Philip Webb',
@@ -14043,11 +14198,13 @@ test('applyDerivedCadenceStamps: per-record guest-DJ suffixes group into one mon
     }
   ];
   parser.applyDerivedCadenceStamps(disciplinePair);
-  const markers = new Set(disciplinePair.map(record => record._cadenceGroup));
-  assert.equal(markers.size, 1, 'the DJ-suffixed pair shares ONE same-series marker');
-  assert.match([...markers][0], /FREQ=MONTHLY;BYDAY=2FR$/, 'grouped via the existing >=2-months ordinal rule');
+  const families = new Set(disciplinePair.map(record => record._seriesInfo && record._seriesInfo.family));
+  assert.equal(families.size, 1, 'the DJ-suffixed pair shares ONE family');
+  assert.ok([...families][0], 'the shared family is non-empty');
   for (const record of disciplinePair) {
-    assert.equal(record.recurrenceRule, 'FREQ=MONTHLY', 'the stated rule is NEVER overridden by its refinement');
+    assert.equal(record.recurrenceRule, undefined, 'stated rules demoted on the occurrence-expanded pair');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=MONTHLY;BYDAY=2FR', 'the refining derived rule is the metadata cadence');
   }
 
   // Two DIFFERENT party names at one venue, each with a guest-DJ suffix,

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2096,6 +2096,116 @@ class SharedCore {
             }
         }
 
+        // 9b–9d. junk-title sibling families (extraction hygiene wave,
+        //    BeefDip run 20260811-161424): three more non-event title shapes
+        //    shipped as calendar events. They join the SAME flag + write
+        //    withhold as the CTA family — flag, don't drop, the card always
+        //    stays in results — and each tell is deterministic and biased to
+        //    NOT flagging when unsure. At most one junk-title flag is pushed.
+        const hasJunkTitleFlag = () => flags.some(flag => flag.code === 'junk-title');
+        const titleBarKey = title ? this.normalizeBarNameKey(title) : '';
+        const ownBarKey = typeof event.bar === 'string' ? this.normalizeBarNameKey(event.bar) : '';
+        const titleIsOwnBar = Boolean(titleBarKey) && titleBarKey === ownBarKey;
+        // Shared fold: diacritics folded, punctuation collapsed to single
+        // spaces — the same normalization rule 3 uses for phrase matching.
+        const foldForCompare = (value) => this.foldDiacritics(value).replace(/[^a-z0-9]+/g, ' ').replace(/\s+/g, ' ').trim();
+
+        // 9b. ADDRESS-SHAPED titles ("Malecón 4, Zona Romántica, Puerto
+        //     Vallarta" — the venue's address block scraped as an event
+        //     name). Two branches, both gated on the title NOT being the
+        //     venue's own name:
+        //     - looksLikeStreetAddress: leading house number + street-type
+        //       word ("4219 Santa Monica Blvd") — self-evident, and "3
+        //       Dollar Bill" is its documented non-match (number, no street
+        //       word).
+        //     - comma-chain: ≥3 comma segments, exactly ONE carrying a
+        //       street+number shape (either order — Latin addresses put the
+        //       number LAST, which looksLikeStreetAddress cannot anchor on),
+        //       the rest digit-free, AND a segment must be corroborated by
+        //       the event's OWN address field. No address field → no flag
+        //       (fail closed; a shape alone is not proof — "DISCO 2000, The
+        //       Eagle, NYC" stays untouched).
+        if (title && !hasJunkTitleFlag() && !titleIsOwnBar) {
+            let addressDetail = '';
+            if (this.looksLikeStreetAddress(title)) {
+                addressDetail = 'leading house number + street-type word';
+            } else {
+                const segments = title.split(',').map(segment => segment.trim()).filter(Boolean);
+                if (segments.length >= 3) {
+                    const streetNumberShape = /^\p{L}[\p{L}\s.'’-]*\s\d{1,6}$|^\d{1,6}\s\p{L}[\p{L}\s.'’-]*$/u;
+                    const numbered = segments.filter(segment => streetNumberShape.test(segment));
+                    const plain = segments.filter(segment => !streetNumberShape.test(segment));
+                    if (numbered.length === 1 && plain.every(segment => !/\d/.test(segment))) {
+                        const foldedAddress = typeof event.address === 'string' ? foldForCompare(event.address) : '';
+                        const corroborated = Boolean(foldedAddress) && segments.some(segment => {
+                            const foldedSegment = foldForCompare(segment);
+                            return foldedSegment.length >= 4 && foldedAddress.includes(foldedSegment);
+                        });
+                        if (corroborated) {
+                            addressDetail = 'comma-separated locality chain corroborated by the event\'s own address';
+                        }
+                    }
+                }
+            }
+            if (addressDetail) {
+                flags.push({
+                    code: 'junk-title',
+                    detail: `title is address-shaped (${addressDetail}), not an event name`
+                });
+            }
+        }
+
+        // 9c. VENUE-NAME-ONLY ghosts ("Blue Chairs Beach" / "CC Slaughters" /
+        //     "Hotel Delfin" — a listing line's VENUE slot promoted to the
+        //     title, so the record carries no event identity at all). Fires
+        //     only when BOTH hold:
+        //     - the title is EXACTLY a known venue identity (identity-key
+        //       equality, the curated-matching strictness): the event's own
+        //       bar field, or a curated bar (rule 2's match) not
+        //       contradicted by a different own bar field. Fuzzy never
+        //       flags.
+        //     - the event's own copy never restates the title: a party
+        //       genuinely named for its venue advertises that name in its
+        //       description ("MASSIVE returns…"); a mis-promoted venue slot
+        //       describes a differently-named party and never does. When
+        //       the description restates the name, we assume a real
+        //       venue-named party — bias to NOT flagging.
+        if (title && titleBarKey && !hasJunkTitleFlag()) {
+            const curatedTitleMatch = flags.some(flag => flag.code === 'title-is-curated-bar');
+            const isKnownVenueIdentity = titleIsOwnBar
+                || (curatedTitleMatch && (!ownBarKey || ownBarKey === titleBarKey));
+            if (isKnownVenueIdentity) {
+                const foldedDescription = typeof event.description === 'string' ? foldForCompare(event.description) : '';
+                const foldedTitle = foldForCompare(title);
+                const descriptionRestatesTitle = Boolean(foldedDescription) && Boolean(foldedTitle)
+                    && foldedDescription.includes(foldedTitle);
+                if (!descriptionRestatesTitle) {
+                    flags.push({
+                        code: 'junk-title',
+                        detail: `title is only the venue name ("${title}") and the event's own copy never restates it`
+                    });
+                }
+            }
+        }
+
+        // 9d. FINE-PRINT titles ("DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON
+        //     TRANSFERABLE"). The tell is rule 3's existing tiny legalese
+        //     table (generic ticketing-terms vocabulary — no new phrase
+        //     list): a title carrying one is policy text, never an event
+        //     name, so the report-only boilerplate flag gains the enforced
+        //     junk-title sibling. The letterless branch of rule 3 stays
+        //     report-only (no letters ≠ fine-print).
+        if (title && !hasJunkTitleFlag() && /\p{L}/u.test(title)) {
+            const paddedTitle = ` ${foldForCompare(title)} `;
+            const legalese = TITLE_LEGALESE_PHRASES.find(phrase => paddedTitle.includes(` ${phrase} `));
+            if (legalese) {
+                flags.push({
+                    code: 'junk-title',
+                    detail: `title is ticketing fine-print ("${legalese}")`
+                });
+            }
+        }
+
         return flags;
     }
 
@@ -13892,7 +14002,17 @@ class SharedCore {
             // run log shows the withhold decision next to the flag that
             // caused it (the actual gate is filterEventsForExecution).
             if (SharedCore.hasJunkTitleSanityFlag(analyzedEvent)) {
-                console.log(`🚫 JUNK TITLE: "${analyzedEvent.title || 'Unknown'}" withheld from calendar write — CTA/navigation link text (report-only: still shown in results)`);
+                const junkFlag = analyzedEvent._sanityFlags.find(flag => flag && flag.code === 'junk-title');
+                const junkDetail = junkFlag && typeof junkFlag.detail === 'string' ? junkFlag.detail : '';
+                if (junkDetail && !junkDetail.startsWith('title reads as link/CTA text')) {
+                    // Sibling junk-title families (address-shaped /
+                    // venue-name-only / fine-print) log their own flag
+                    // detail; the historical CTA wording below stays
+                    // reserved for the original arrow/CTA family.
+                    console.log(`🚫 JUNK TITLE: "${analyzedEvent.title || 'Unknown'}" withheld from calendar write — ${junkDetail} (report-only: still shown in results)`);
+                } else {
+                    console.log(`🚫 JUNK TITLE: "${analyzedEvent.title || 'Unknown'}" withheld from calendar write — CTA/navigation link text (report-only: still shown in results)`);
+                }
             }
 
             // FULLY-PAST SPAN WITHHOLD — the one enforced sibling of the

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -8978,6 +8978,12 @@ class SharedCore {
         if (!mergedEvent._fieldTrims && existingEvent && Array.isArray(existingEvent._fieldTrims) && existingEvent._fieldTrims.length > 0) {
             mergedEvent._fieldTrims = existingEvent._fieldTrims;
         }
+        // Same carry for the occurrence-expanded family stamp (_seriesInfo):
+        // a same-night stub+detail merge must keep the family metadata so the
+        // UI chip/grouping and the saved-series protection still see it.
+        if (!mergedEvent._seriesInfo && existingEvent && existingEvent._seriesInfo && typeof existingEvent._seriesInfo === 'object') {
+            mergedEvent._seriesInfo = existingEvent._seriesInfo;
+        }
 
         // Helper function to check if a value is empty/null/undefined
         const isEmpty = (value) => {
@@ -11158,8 +11164,14 @@ class SharedCore {
         // B BAR/CUBSCOUT/ONYX all "new" the day after their series were
         // saved). Reporting-only: the analysis action stays 'new' and the
         // write stays withheld — a match only changes what the run SAYS.
+        // Occurrence-expanded family members run the SAME lookup: the family's
+        // cadence evidence says the event recurs, which is exactly when the
+        // owner's calendar may already hold the series covering this date —
+        // and an occurrence write must never fight his imported series. For
+        // these the match is ENFORCED downstream (isSeriesCoveredOccurrence
+        // gates the write with the SERIES MATCH label), not report-only.
         if (analysis.action === 'new' && !analysis.existingEvent && !analysis.sourceEvent &&
-            SharedCore.isRecurringSeriesEvent(event)) {
+            (SharedCore.isRecurringSeriesEvent(event) || SharedCore.isOccurrenceExpandedEvent(event))) {
             try {
                 const seriesMatch = await this.findSavedSeriesMatch(event, calendarAdapter);
                 if (seriesMatch) {
@@ -12029,6 +12041,10 @@ class SharedCore {
             // and gated here, exactly like the recurring-series withhold.
             event?._pastSpanWithheld !== true &&
             !SharedCore.isRecurringSeriesEvent(event) &&
+            // An occurrence-expanded single whose date/identity the owner's
+            // SAVED series already covers (#1655 series-match): writing it
+            // would plant a duplicate single next to his imported series.
+            !SharedCore.isSeriesCoveredOccurrence(event) &&
             !SharedCore.hasJunkTitleSanityFlag(event));
     }
 
@@ -12104,6 +12120,7 @@ class SharedCore {
         if (event._parserConfig && event._parserConfig.dryRun === true) return 'WITHHELD (dry-run parser)';
         if (event._pastSpanWithheld === true) return 'WITHHELD (span fully past)';
         if (SharedCore.isRecurringSeriesEvent(event)) return 'WITHHELD (recurring series — ICS export only)';
+        if (SharedCore.isSeriesCoveredOccurrence(event)) return 'WITHHELD (occurrence covered by saved series — SERIES MATCH)';
         if (SharedCore.hasJunkTitleSanityFlag(event)) return 'WITHHELD (junk title)';
         const action = typeof event._action === 'string' && event._action ? event._action : 'new';
         return action.toUpperCase();
@@ -12205,6 +12222,26 @@ class SharedCore {
         // an existing series (see the pinned override-survival test).
         if (event.overrideUid || event.overrideRecurrenceId) return false;
         return typeof event.recurrence === 'string' && event.recurrence.trim() !== '';
+    }
+
+    // A member of an occurrence-expanded family (owner doctrine, stamped by
+    // the ai-web parser's source-shape classification): the site publishes
+    // each date individually, so the record is a plain single occurrence —
+    // but the family's cadence evidence says the event RECURS, which is
+    // exactly when the owner's calendar may already hold a saved series
+    // covering it.
+    static isOccurrenceExpandedEvent(event) {
+        return Boolean(event && typeof event === 'object' && event._seriesInfo);
+    }
+
+    // An occurrence-expanded single positively matched to a SAVED series
+    // (#1655 series-match, extended to occurrence singles): the write is
+    // withheld — planting a single next to the owner's imported series would
+    // fight it. Its own predicate (mirroring hasJunkTitleSanityFlag) so the
+    // execution gate, the disposition label, and the adapters' labeling can
+    // never disagree.
+    static isSeriesCoveredOccurrence(event) {
+        return SharedCore.isOccurrenceExpandedEvent(event) && Boolean(event._seriesMatch);
     }
 
     // Scriptable identifiers look like `<calendarUUID>:<icsUid>` — the suffix
@@ -13488,6 +13525,15 @@ class SharedCore {
                 hasOverrideIdentity: Boolean(analysis.overrideIdentity)
             };
 
+            // The occurrence-expanded family stamp (parse-time _seriesInfo)
+            // survives the same wholesale replacement: createFinalEventObject
+            // skips underscore fields, and the UI chip, the family grouping,
+            // and the saved-series occurrence withhold all read it off the
+            // analyzed event.
+            if (event._seriesInfo && !analyzedEvent._seriesInfo) {
+                analyzedEvent._seriesInfo = event._seriesInfo;
+            }
+
             // Final-stage field cleanups. Both run at the FINAL analyzed-event
             // build (so every parser, merge result, and cached AI response
             // passes through them) and BEFORE the notes generation/rebuild
@@ -14068,6 +14114,27 @@ class SharedCore {
                     console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" matches the saved series already in ${analyzedEvent._seriesMatch.calendarName} (${analyzedEvent._seriesMatch.instances} instances) — not a new event`);
                 }
                 console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" withheld from calendar write — save via ICS export`);
+            }
+
+            // Occurrence-expanded singles vs the owner's imported series
+            // (#1655 series-match, extended): the saved-series lookup matched
+            // this occurrence's identity, so its write is withheld with the
+            // SERIES MATCH label — occurrence-expansion must never fight a
+            // series he saved. Scalars only; the run JSON persists this
+            // stamp, and the execution gate (isSeriesCoveredOccurrence)
+            // reads exactly it.
+            if (analysis.seriesMatch && !analyzedEvent._seriesMatch &&
+                SharedCore.isOccurrenceExpandedEvent(analyzedEvent)) {
+                analyzedEvent._seriesMatch = {
+                    identifier: analysis.seriesMatch.identifier || '',
+                    title: analysis.seriesMatch.title || '',
+                    startDate: analysis.seriesMatch.startDate || null,
+                    endDate: analysis.seriesMatch.endDate || null,
+                    reason: analysis.seriesMatch.reason || 'Saved series match',
+                    instances: Number.isFinite(analysis.seriesMatch.instances) ? analysis.seriesMatch.instances : 0,
+                    calendarName: analysis.seriesMatch.calendarName || ''
+                };
+                console.log(`🔁 SHAPE: "${analyzedEvent.title || 'Unknown'}" occurrence is covered by the saved series in ${analyzedEvent._seriesMatch.calendarName || 'the calendar'} — write withheld (SERIES MATCH)`);
             }
 
             return analyzedEvent;
@@ -15143,6 +15210,12 @@ class SharedCore {
     //     cross-realm Dates).
     getSeriesExportIdentity(event) {
         if (!SharedCore.isRecurringSeriesEvent(event)) return null;
+        // Occurrence-expanded family member (owner doctrine): the site
+        // publishes each date individually, so the record is a real single
+        // occurrence — never a series export, never collapsed across dates.
+        // Its rules were already demoted to _seriesInfo at classification
+        // time, so this guard is defense-in-depth (fail closed).
+        if (event._seriesInfo) return null;
         if (event._seriesAuthority === 'slot-host') return null;
         if (event._recurringExport === false) return null;
         const rrule = String(event.recurrenceRule || event.recurrence || '').trim().toUpperCase();

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4086,6 +4086,23 @@ test('deduplicateEvents collapses two full-series exports of one series to the n
   assert.equal(kept.recurrenceRule, 'FREQ=WEEKLY;BYDAY=TH', 'the series rule survives the collapse');
 });
 
+// Series doctrine rework ("we can't condense the event with diff URLs"): an
+// occurrence-expanded family member carries report-only _seriesInfo — and
+// even if a recurrence claim survives on the record (defense in depth; the
+// classification pass normally demotes it), the series collapse must never
+// fold occurrence-expanded records across dates.
+test('deduplicateEvents never series-collapses records carrying _seriesInfo (occurrence-expanded)', async () => {
+  const core = createCore();
+  const thisWeek = new Date(Date.now() + 7 * SERIES_DAY_MS);
+  const nextWeek = new Date(thisWeek.getTime() + 7 * SERIES_DAY_MS);
+  const info = { rrule: 'FREQ=WEEKLY;BYDAY=TH', basis: '2 dates', occurrences: 2, family: 'shape-1' };
+  const first = buildWeeklySeriesExport(thisWeek, { _seriesInfo: info });
+  const second = buildWeeklySeriesExport(nextWeek, { _seriesInfo: info });
+  assert.equal(core.getSeriesExportIdentity(first), null, '_seriesInfo disqualifies the record as a series export');
+  const result = await core.deduplicateEvents([first, second], null);
+  assert.equal(result.length, 2, 'occurrence-expanded records keep every date individual');
+});
+
 test('deduplicateEvents keeps two distinct single occurrences of a recurring event separate', async () => {
   // Behavior-preservation guard (passes on main and on the collapse branch):
   // run 20260802-221204's SUNDAY BEER BUST extracted two genuinely distinct
@@ -12669,6 +12686,108 @@ test('saved-series lookup: fails open on adapter errors and never runs for non-s
   const plainAnalysis = await core.resolveCalendarAnalysisWithSeriesProbe(plain, [], 'upsert', counting);
   assert.equal(plainAnalysis.action, 'new');
   assert.equal(lookupCalls, 0, 'a non-series event never triggers the lookup');
+});
+
+// ---------------------------------------------------------------------------
+// Occurrence-expanded doctrine (series rework): a member of an
+// occurrence-expanded family carries report-only _seriesInfo (stamped by the
+// ai-web parser's source-shape classification) and is written like any
+// single event — EXCEPT when the owner's calendar already holds the series
+// covering it: then the write is withheld with the SERIES MATCH label, so
+// occurrence-expansion never fights his imported series.
+// ---------------------------------------------------------------------------
+
+function buildScrapedCubscoutOccurrence() {
+  // Future-relative (like the series-collapse fixtures): a past span would
+  // trip the _pastSpanWithheld gate before the doctrine under test.
+  const start = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+  return {
+    title: 'CUBSCOUT',
+    startDate: start,
+    endDate: new Date(start.getTime() + 5 * 60 * 60 * 1000),
+    bar: 'Eagle LA',
+    city: 'la',
+    ticketUrl: 'https://dice.fm/event/abc123-cubscout-aug-7-tickets',
+    _seriesInfo: { rrule: 'FREQ=MONTHLY;BYDAY=1FR', basis: '3× 1st Friday', occurrences: 3, family: 'shape-1' }
+  };
+}
+
+test('occurrence-expanded predicates: isOccurrenceExpandedEvent / isSeriesCoveredOccurrence', () => {
+  const occurrence = buildScrapedCubscoutOccurrence();
+  assert.equal(SharedCore.isOccurrenceExpandedEvent(occurrence), true);
+  assert.equal(SharedCore.isOccurrenceExpandedEvent({ title: 'ONE OFF' }), false);
+  assert.equal(SharedCore.isRecurringSeriesEvent(occurrence), false, '_seriesInfo alone is never a series claim');
+  assert.equal(SharedCore.isSeriesCoveredOccurrence(occurrence), false, 'no saved-series match, no withhold');
+  occurrence._seriesMatch = { identifier: 'CAL-UUID:x', calendarName: 'chunky-dad-la' };
+  assert.equal(SharedCore.isSeriesCoveredOccurrence(occurrence), true);
+  assert.equal(SharedCore.isSeriesCoveredOccurrence({ _seriesMatch: { identifier: 'CAL-UUID:x' } }), false,
+    'a series-export _seriesMatch alone never trips the occurrence gate');
+});
+
+test('occurrence-expanded single vs saved series: lookup runs, write withheld with SERIES MATCH', async () => {
+  const core = createLaCore();
+  const saved = [
+    buildSavedCubscoutOccurrence('2026-09-05T04:00:00.000Z'),
+    buildSavedCubscoutOccurrence('2026-10-03T04:00:00.000Z')
+  ];
+  const adapter = buildSeriesLookupAdapter(saved);
+  const occurrence = buildScrapedCubscoutOccurrence();
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(occurrence, [], 'upsert', adapter);
+  assert.equal(analysis.action, 'new', 'the analysis action itself is untouched');
+  assert.ok(analysis.seriesMatch, 'the saved-series lookup runs for occurrence-expanded singles too');
+  assert.equal(analysis.seriesMatch.identifier, 'CAL-UUID:cubscout-20260731T193113Z@chunky.dad');
+
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (message) => { lines.push(String(message)); };
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(occurrence, analysis, adapter, {});
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.ok(analyzed._seriesInfo, 'the family metadata survives onto the analyzed event');
+  assert.ok(analyzed._seriesMatch, 'the saved-series match is stamped');
+  assert.equal(analyzed._seriesMatch.calendarName, 'chunky-dad-la');
+  assert.equal(analyzed._recurring, undefined, 'never turned into a series');
+  assert.equal(analyzed._recurringExport, undefined, 'no ICS-export series framing for an occurrence');
+  assert.equal(analyzed.ticketUrl, occurrence.ticketUrl, 'the occurrence keeps its own ticket link');
+  assert.ok(
+    lines.some(l => l.includes('🔁 SHAPE:') && l.includes('covered by the saved series in chunky-dad-la') && l.includes('SERIES MATCH')),
+    `the withhold says so out loud: ${JSON.stringify(lines)}`
+  );
+  assert.equal(SharedCore.isSeriesCoveredOccurrence(analyzed), true);
+  assert.equal(SharedCore.describeExecutionDisposition(analyzed),
+    'WITHHELD (occurrence covered by saved series — SERIES MATCH)');
+  assert.deepEqual(SharedCore.filterEventsForExecution([analyzed]), [], 'and nothing is written');
+});
+
+test('occurrence-expanded single with NO saved series: written like any single event', async () => {
+  const core = createLaCore();
+  const adapter = buildSeriesLookupAdapter([]);
+  const occurrence = buildScrapedCubscoutOccurrence();
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(occurrence, [], 'upsert', adapter);
+  assert.equal(analysis.action, 'new');
+  assert.equal(analysis.seriesMatch, undefined, 'nothing saved, nothing matched');
+
+  const analyzed = await core.buildAnalyzedCalendarEvent(occurrence, analysis, adapter, {});
+  assert.equal(analyzed._seriesMatch, undefined);
+  assert.ok(analyzed._seriesInfo, 'the report-only metadata rides along');
+  assert.equal(SharedCore.describeExecutionDisposition(analyzed), 'NEW');
+  assert.equal(SharedCore.filterEventsForExecution([analyzed]).length, 1,
+    'an uncovered occurrence writes exactly like any single event');
+});
+
+test('mergeParsedEvents carries _seriesInfo from the secondary record (same-night stub+detail fold)', async () => {
+  const core = createLaCore();
+  const info = { rrule: 'FREQ=MONTHLY;BYDAY=1FR', basis: '3× 1st Friday', occurrences: 3, family: 'shape-1' };
+  const stub = { ...buildScrapedCubscoutOccurrence(), _seriesInfo: info };
+  const detail = { title: 'CUBSCOUT', startDate: new Date('2026-08-08T02:00:00.000Z'), bar: 'Eagle LA', city: 'la' };
+  const merged = await core.mergeParsedEvents(stub, detail, {});
+  assert.deepEqual(merged._seriesInfo, info, 'the family stamp survives a merge that keeps the other record');
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -15067,16 +15067,19 @@ test('sanity: titles with real words beyond the date phrase never flag as date p
 test('sanity: a curated bar name as the whole title flags; containment never does', () => {
   const core = createSanityCore();
   // Real case: "CC Slaughters" (a curated bar) as the title of a party.
-  assert.deepEqual(sanityCodes(core, { title: 'CC Slaughters', city: 'portland' }), ['title-is-curated-bar']);
+  // Since the extraction hygiene wave, a bare venue-identity title with no
+  // distinguishing copy ALSO carries the enforced junk-title flag (the
+  // venue-name-ghost family; see its dedicated tests below).
+  assert.deepEqual(sanityCodes(core, { title: 'CC Slaughters', city: 'portland' }), ['title-is-curated-bar', 'junk-title']);
   // Identity-key equality only — an event AT the bar keeps its name.
   assert.deepEqual(sanityCodes(core, { title: 'Bearracuda at CC Slaughters', city: 'portland' }), []);
   // Key normalization: "The CC-Slaughters!" collapses to the same key.
-  assert.deepEqual(sanityCodes(core, { title: 'The CC-Slaughters!', city: 'portland' }), ['title-is-curated-bar']);
+  assert.deepEqual(sanityCodes(core, { title: 'The CC-Slaughters!', city: 'portland' }), ['title-is-curated-bar', 'junk-title']);
 });
 
 test('sanity: with no resolved city, any city\'s curated bars can claim the title', () => {
   const core = createSanityCore();
-  assert.deepEqual(sanityCodes(core, { title: 'CC Slaughters' }), ['title-is-curated-bar']);
+  assert.deepEqual(sanityCodes(core, { title: 'CC Slaughters' }), ['title-is-curated-bar', 'junk-title']);
   // No bars data at all → fail open, no flag.
   assert.deepEqual(sanityCodes(createSanityCore(null), { title: 'CC Slaughters' }), []);
 });
@@ -15085,11 +15088,13 @@ test('sanity: legalese markers and letterless titles flag title-looks-like-boile
   const core = createSanityCore();
   // Real case: a liability waiver proposed as a CREATE (beefdip,
   // run 20260802-142231).
+  // Legalese titles also carry the enforced junk-title flag since the
+  // extraction hygiene wave (fine-print family; dedicated tests below).
   assert.deepEqual(
     sanityCodes(core, { title: 'DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE' }),
-    ['title-looks-like-boilerplate']);
+    ['title-looks-like-boilerplate', 'junk-title']);
   // Diacritic-folded + punctuation-collapsed matching.
-  assert.deepEqual(sanityCodes(core, { title: 'Entradas NON-REFUNDÁBLE' }), ['title-looks-like-boilerplate']);
+  assert.deepEqual(sanityCodes(core, { title: 'Entradas NON-REFUNDÁBLE' }), ['title-looks-like-boilerplate', 'junk-title']);
   // No letters at all.
   assert.deepEqual(sanityCodes(core, { title: '*** !!! ***' }), ['title-looks-like-boilerplate']);
 });
@@ -15198,12 +15203,12 @@ test('sanity flags are stamped on the analyzed event with the ⚠️ SANITY log 
     console.log = originalLog;
   }
   assert.equal(analyzed.length, 1);
-  assert.deepEqual(analyzed[0]._sanityFlags.map(flag => flag.code), ['title-looks-like-boilerplate']);
+  assert.deepEqual(analyzed[0]._sanityFlags.map(flag => flag.code), ['title-looks-like-boilerplate', 'junk-title']);
   const sanityLines = logLines.filter(line => line.startsWith('⚠️ SANITY: '));
   assert.equal(sanityLines.length, 1);
   assert.equal(
     sanityLines[0],
-    '⚠️ SANITY: "DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE" flagged title-looks-like-boilerplate — title carries legalese ("non refundable")');
+    '⚠️ SANITY: "DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE" flagged title-looks-like-boilerplate, junk-title — title carries legalese ("non refundable")');
 });
 
 test('no enforcement: a flagged event\'s action and write fields are byte-identical to an unflagged twin\'s', async () => {
@@ -17658,6 +17663,140 @@ test('junk-title records are withheld from calendar execution with the 🚫 JUNK
     [clean[0]]);
   assert.equal(SharedCore.hasJunkTitleSanityFlag(flagged[0]), true);
   assert.equal(SharedCore.hasJunkTitleSanityFlag(clean[0]), false);
+});
+
+// ---------------------------------------------------------------------------
+// junk-title sibling families (extraction hygiene wave, BeefDip run
+// 20260811-161424): three more non-event title shapes shipped as calendar
+// events and join the SAME junk-title flag + write withhold (flag, don't
+// drop — every card stays in results). Fixtures below are the run's real
+// records verbatim.
+// ---------------------------------------------------------------------------
+
+test('sanity: an address-shaped title that is not the venue\'s own name flags junk-title', () => {
+  const core = createSanityCore();
+  // Real record: Blue Chairs Resort's street-address block scraped as an
+  // event name. "Malecón 4" is the Latin "street Number" order, which
+  // looksLikeStreetAddress cannot anchor on (no LEADING house number), so
+  // the comma-chain branch must corroborate a title segment against the
+  // event's OWN address field ("Puerto Vallarta" appears in both).
+  assert.deepEqual(sanityCodes(core, {
+    title: 'Malecón 4, Zona Romántica, Puerto Vallarta',
+    bar: 'Blue Chairs Resort',
+    address: '4 Malecon, Puerto Vallarta, Jalisco'
+  }), ['junk-title']);
+  // US-shaped titles (leading house number + street-type word) are
+  // self-evident — looksLikeStreetAddress needs no corroboration.
+  assert.deepEqual(sanityCodes(core, { title: '4219 Santa Monica Blvd', bar: 'Eagle LA' }), ['junk-title']);
+  // Fail closed: the same comma chain WITHOUT the event's own address to
+  // corroborate never flags — a shape alone is not proof.
+  assert.deepEqual(sanityCodes(core, {
+    title: 'Malecón 4, Zona Romántica, Puerto Vallarta',
+    bar: 'Blue Chairs Resort'
+  }), []);
+  // "3 Dollar Bill" is the documented looksLikeStreetAddress non-match
+  // (leading number but no street-type word) — venue names with numbers
+  // never flag.
+  assert.deepEqual(sanityCodes(core, { title: '3 Dollar Bill' }), []);
+  // Comma-rich party names carry no street-number segment.
+  assert.deepEqual(sanityCodes(core, { title: 'Bears, Beers & Queers', address: 'Beers Ave 1, Portland' }), []);
+});
+
+test('sanity: venue-name-only ghost titles flag junk-title; parties that restate their venue name never do', () => {
+  const core = createSanityCore();
+  // Real ghosts: BeefDip listing-line venue slots ("Thu Jan 28 • 7PM–1AM •
+  // Blue Chairs Beach") promoted to titles — the event's own copy describes
+  // a differently-named party and never restates the venue.
+  assert.deepEqual(sanityCodes(core, {
+    title: 'Blue Chairs Beach',
+    bar: 'Blue Chairs Beach',
+    description: 'Glow on the sand with live drummers, fire dancers, and DJ Matt Consola . Primal beats under the stars.'
+  }), ['junk-title']);
+  assert.deepEqual(sanityCodes(core, {
+    title: 'Hotel Delfin',
+    bar: 'Hotel Delfin',
+    description: 'Our biggest pool party of the week, definitely honors its name! DJs Benjamin Koll from Spain and Division 4 from Australia will power an all-day pool and beach takeover with massive BeefDip energy.'
+  }), ['junk-title']);
+  // Curated-bar identity (rule 2's exact-key match) escalates the same way
+  // when the event's own bar field agrees with the title.
+  assert.deepEqual(sanityCodes(core, {
+    title: 'CC Slaughters',
+    city: 'portland',
+    bar: 'CC Slaughters',
+    description: 'Step into a full-throttle Mardi Gras frenzy at Vallarta’s hottest dance floor. Beads, glitter, and music by international guest DJ Josh Peace .'
+  }), ['title-is-curated-bar', 'junk-title']);
+  // Fail closed, three ways:
+  // 1. A party whose own copy RESTATES the title is a genuinely
+  //    venue-named event, not a ghost — bias to NOT flagging.
+  assert.deepEqual(sanityCodes(core, {
+    title: 'MASSIVE',
+    bar: 'MASSIVE',
+    description: 'MASSIVE returns to the warehouse with dirty grooves all night long.'
+  }), []);
+  // 2. Any token beyond the venue name is a real name (identity-key
+  //    EQUALITY only, exactly like curated matching).
+  assert.deepEqual(sanityCodes(core, { title: 'FURBALL POOL PARTY', bar: 'FURBALL' }), []);
+  assert.deepEqual(sanityCodes(core, { title: 'Bearracuda at CC Slaughters', bar: 'CC Slaughters' }), []);
+  // 3. Fuzzy is not identity: near-miss names never flag, and a curated
+  //    title contradicted by a DIFFERENT own venue is unproven — the
+  //    report-only curated flag stays, the withhold stays off.
+  assert.deepEqual(sanityCodes(core, { title: 'CC Slaughter', bar: 'CC Slaughters' }), []);
+  assert.deepEqual(sanityCodes(core, {
+    title: 'CC Slaughters',
+    city: 'portland',
+    bar: 'Hotel Delfin',
+    description: 'A party at some other venue entirely.'
+  }), ['title-is-curated-bar']);
+});
+
+test('sanity: ticketing fine-print titles flag junk-title alongside the report-only boilerplate flag', () => {
+  const core = createSanityCore();
+  // Real record: a liability waiver proposed as a CREATE. The tell is the
+  // existing tiny legalese table (generic ticketing-terms vocabulary), not
+  // a new phrase list.
+  assert.deepEqual(
+    sanityCodes(core, { title: 'DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE' }),
+    ['title-looks-like-boilerplate', 'junk-title']);
+  // The letterless-boilerplate branch is NOT fine-print: report-only stays.
+  assert.deepEqual(sanityCodes(core, { title: '*** !!! ***' }), ['title-looks-like-boilerplate']);
+  // Policy-adjacent words without a table phrase never flag.
+  assert.deepEqual(sanityCodes(core, { title: 'Terms of Endearment Party' }), []);
+  // Time-range titles are already title-is-date-phrase (rule 1) — verified
+  // here to stay OUT of junk-title (no duplication between rules).
+  assert.deepEqual(sanityCodes(core, { title: 'Saturday Jan 23 12 PM – 5 PM' }), ['title-is-date-phrase']);
+});
+
+test('junk-title sibling families are withheld with a detail-bearing 🚫 JUNK TITLE line; the CTA line is unchanged', async () => {
+  const core = createCore();
+  const scraped = {
+    title: 'Malecón 4, Zona Romántica, Puerto Vallarta',
+    address: '4 Malecon, Puerto Vallarta, Jalisco',
+    bar: 'Blue Chairs Resort',
+    city: 'dallas',
+    startDate: new Date('2027-08-08T02:00:00.000Z'),
+    endDate: new Date('2027-08-08T07:00:00.000Z'),
+    shortName: 'TAGS' // keeps the shortName derivation pass inert
+  };
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logLines.push(args.join(' ')); };
+  let flagged;
+  try {
+    flagged = await core.prepareEventsForCalendar([scraped], buildPrepCalendarAdapter([]), {});
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(flagged.length, 1, 'flag, don\'t drop: the card stays in results');
+  assert.deepEqual(flagged[0]._sanityFlags.map(flag => flag.code), ['junk-title']);
+  // The sibling families log their own flag detail; the historical CTA
+  // wording is reserved for the original arrow/CTA family.
+  const junkLines = logLines.filter(line => line.startsWith('🚫 JUNK TITLE: '));
+  assert.deepEqual(junkLines, [
+    '🚫 JUNK TITLE: "Malecón 4, Zona Romántica, Puerto Vallarta" withheld from calendar write — title is address-shaped (comma-separated locality chain corroborated by the event\'s own address), not an event name (report-only: still shown in results)'
+  ]);
+  // Same gate as the CTA family: withheld from execution, visible verdict.
+  assert.deepEqual(SharedCore.filterEventsForExecution([flagged[0]]), []);
+  assert.equal(SharedCore.describeExecutionDisposition(flagged[0]), 'WITHHELD (junk title)');
 });
 
 test('template entries are never runnable: evaluateAutomationForParser refuses them in every mode', () => {


### PR DESCRIPTION
Extraction hygiene wave: three audited leftover defects, one branch. Stacked on #1677 (`feat/series-doctrine-rework` was OPEN and is merged into this branch per its touching ai-web-parser/shared-core; once #1677 lands this PR's diff reduces to the hygiene commit `86baac74`).

## 1. Junk-title family extension (BeefDip audit, run 20260811-161424)

The junk-title sanity flag (+ write withhold via `hasJunkTitleSanityFlag` in `filterEventsForExecution`) previously caught only arrow/CTA link text ("View Event →"). Three sibling families of non-event titles shipped as calendar events in the audited run; all three now join the SAME `junk-title` flag + withhold — flag, don't drop: every card stays in the results UI, only the calendar write is withheld.

**a. Address-shaped titles** — real record: `"Malecón 4, Zona Romántica, Puerto Vallarta"` (bar "Blue Chairs Resort", address "4 Malecon, Puerto Vallarta, Jalisco"). Rule (rule 9b, `getEventSanityFlags`), gated on the title NOT being the venue's own name:
- `looksLikeStreetAddress(title)` (leading house number + street-type word, e.g. "4219 Santa Monica Blvd") is self-evident. Verified: **"3 Dollar Bill" is that helper's documented non-match** (leading number, no street word) and never flags.
- The Malecón title has NO leading house number (Latin "street Number" order), so a second branch handles it: ≥3 comma segments, exactly ONE with a street+number shape (either order), the rest digit-free, AND a title segment must appear inside the event's OWN `address` field ("puerto vallarta" does). **No address field → no flag** (fail closed; shape alone is not proof — "DISCO 2000, The Eagle, NYC" can never flag).

**b. Venue-name-only ghosts** — real records: `"CC Slaughters"`, `"Blue Chairs Beach"`, `"Hotel Delfin"`, each with `title == bar` (listing-line venue slots like "Thu Jan 28 • 7PM–1AM • Blue Chairs Beach" promoted to titles). Rule (9c): flag only when BOTH hold:
- the title is EXACTLY a known venue identity (identity-key equality via `normalizeBarNameKey`, the curated-matching strictness): the event's own `bar` field, or rule 2's curated-bar match not contradicted by a different own bar. Fuzzy/near-miss never flags.
- the event's own copy never restates the title. This is the fail-closed answer to "a party genuinely named for its venue could exist": all three real ghosts carry descriptions of *differently-named* parties that never mention the venue name, while a genuine venue-named party advertises its name in its own copy ("MASSIVE returns…" → NOT flagged). When the description restates the name, we bias to NOT flagging.
- Consequence stated explicitly: bare curated-bar titles that previously got only the report-only `title-is-curated-bar` flag now also carry the enforced `junk-title` — four existing test expectations were updated for exactly this escalation (the run's real "CC Slaughters" record was among the shipped ghosts).

**c. Fine-print titles** — real record: `"DOG TAGS ARE NON REFUNDABLE · TAGS ARE NON TRANSFERABLE"`. Rule (9d): the deterministic tell is the EXISTING tiny `TITLE_LEGALESE_PHRASES` table ('non refundable', 'non transferable', 'terms and conditions', 'all sales final') — no new phrase list, no growth. Rule 3's letterless-boilerplate branch stays report-only (no letters ≠ fine-print).

*(Time-range titles: verified `"Saturday Jan 23 12 PM – 5 PM"` is already covered by `title-is-date-phrase` and stays OUT of junk-title — asserted in the new tests, no duplication.)*

**Log handling:** the historical `🚫 JUNK TITLE: … CTA/navigation link text …` string is byte-identical and still fires for exactly the CTA family; the new families log an added sibling line carrying their own flag detail. No existing console.log string was edited.

**Regression sweep:** all **175 analyzedEvents across 24 real run JSONs** (fullrun-0811 + rerun-0812) swept through the new detectors wired with the full curated bars data (33 cities): junk-title fires on exactly the 6 pre-existing "View Event →" records + the 5 audited defects above. **Zero false positives** on the other 164 real events (incl. "FURBALL POOL PARTY" at bar "FURBALL", "Furball" at Hotel Delfin, every Eagle LA weekly).

## 2. Crawl candidate hygiene (run 20260814-000011)

Mechanism found: `extractUrlCandidatesFromRawHtml` scans the whole page including `<script>` bodies with a bare-URL regex, so a JS string concatenation around a real base URL was captured as a candidate (`https://www.thelumberyardbar.com/+encodeURIComponent(l)+`, same for clubchubusa.com), and `looksLikeNonUrlJsFragment` explicitly bails for anything starting `https?://`. `https://empty/` passed because the existing `empty-placeholder-url` reason only matches a `/empty` PATH, and no host-shape check existed.

Fix in `validateEventUrl` (the shared gate for both regular and month-feed discovery), two new ADDITIVE rejection reasons counted by the existing `recordRejectedCandidate` stats machinery — generic syntax, no domain/identifier list:
- `unresolved-code-syntax`: concat-shaped call residue (`+ident(` / `)+`), `encode/decodeURIComponent`, unterminated `${`, or raw quotes/backticks in host/path/query. A bare `+` stays valid (encoded space); parenthetical paths like `Bear_(gay_culture)` stay valid (no adjacent `+`). Complete `{…}` placeholders keep their historical `template-url` reason (check ordered after it).
- `implausible-hostname`: hostname with no dot that is not `localhost` (rejects `empty`).

End-to-end test proves the discovery stats line counts both new reasons and returns zero surviving candidates.

## 3. B BAR weekly saved-series probe gap (Eagle LA audit, run 20260811-132948) — NO CODE CHANGE, premise disproven

Investigated first, as instructed. Root cause with evidence: **there was no saved B BAR series for the probe to find.**

- The published LA calendar mirror `data/calendars/la.ics` (the pull of the real `chunky-dad-la` calendar) at run time = commit `3a0fc387` (2026-08-08): 15 VEVENTs, none titled B BAR under any spelling. `git log --all -S "B BAR"` / `-S "bbar"` over `data/calendars/` returns **nothing, ever** — no pull in the repo's entire history has contained a B BAR VEVENT in any city.
- The pull workflow was live and brackets the run tightly: pulls at 2026-08-11 14:52 UTC (before the run) and 2026-08-12 05:41 UTC (after) changed other cities' calendars but left `la.ics` untouched — the LA calendar genuinely had no changes, so "B BAR saved via ICS import" did not exist on the calendar at run time.
- The wide-window `found=27` = RRULE expansion of those 15 VEVENTs (Bear Happy Hour weekly, SUNDAY BEER BUST, monthly CUBSCOUT/Club Chub/MEAT RACK…). Wired replay (SharedCore + EventSchema, real run record): `matchesSavedSeriesIdentity(B BAR, …)` is false for every plausible candidate — including the closest one, the *differently named* weekly Thursday "Bear Happy Hour" series — while the control `matchesSavedSeriesIdentity(scraped CUBSCOUT, saved CUBSCOUT)` is true. The identity gate works; it correctly refused to equate "B BAR" with a different series name, and weakening that fail-closed identity is explicitly out of scope.
- CUBSCOUT matched because its scraped record carried `uid: cubscout-…@chunky.dad` resolving to 2 saved instances sharing an identifier; B BAR had `uid: null` and nothing saved to match. The run's outcome — withheld as "recurring series — ICS export only" — is exactly the recurring-events doctrine for a series not yet on the calendar.

Honest conclusion: `findSavedSeriesMatch` returning null was CORRECT. Implementing a "fix" would have meant guessing at a mechanism the data disproves.

## Tests

- Base (origin/main + #1677): 1823 pass. This branch: **1831 pass, 0 fail** (quiet suite, `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`).
- Fail-on-base proof: the new/updated tests were run against the unimplemented base first — **12 failures, all of them the new/updated tests** (4 in ai-web-parser.test.js: concat residue, dotless host, plus/parens negatives, end-to-end discovery; 8 in shared-core.test.js: the three family tests, the sibling-line withhold test, and the four deliberately updated expectations for the curated-bar/legalese escalation).
- All fixtures are the runs' REAL titles/URLs verbatim; tests only in enumerated files; shared-core stays platform-pure (no `new URL`/`URLSearchParams`; the parser check reuses the existing `parseUrlComponents` fallback parser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
