### PR TITLE
feat(scraper): same-venue overlap report flag + linked-ICS-feed discovery (report-only)

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -11463,6 +11463,19 @@ class ScriptableAdapter {
             sanityFlags.map((flag) => flag.code).join(", "),
           )}</span>`
         : "";
+    // Same-venue overlap chip (report-only, stamped by the ⚔️ OVERLAP pass in
+    // shared-core): another DIFFERENT event claims overlapping time at this
+    // venue — the venue's own data may double-book the slot (ONYX vs SUNDAY
+    // BEER BUST). Surfaced only; the owner resolves it.
+    const venueOverlaps = Array.isArray(event && event._venueOverlap)
+      ? event._venueOverlap.filter((entry) => entry && entry.withTitle)
+      : [];
+    const venueOverlapBadge =
+      venueOverlaps.length > 0
+        ? `<span class="action-badge badge-warning venue-overlap-badge">⚔️ overlaps: ${this.escapeHtml(
+            venueOverlaps.map((entry) => entry.withTitle).join(", "),
+          )}</span>`
+        : "";
     // Additive fourth badge, same pattern again: a slot-host source writes a
     // single-occurrence override of a series it does not own. Neither NEW nor
     // a series change — say which night it replaces so the action badge above
@@ -11920,7 +11933,7 @@ class ScriptableAdapter {
     let html = `
         <div class="event-card${isDroppedCard ? " bear-dropped-card" : ""}">
             <div class="event-headline">
-                <div class="event-headline-badges">${actionBadge}${writeBadge}${recurringBadge}${seriesMatchBadge}${sanityBadge}${overrideBadge}${seriesProposalBadge}${headlineReasonChip}<span class="calendar-chip">📱 ${this.escapeHtml(calendarName)}</span></div>
+                <div class="event-headline-badges">${actionBadge}${writeBadge}${recurringBadge}${seriesMatchBadge}${sanityBadge}${venueOverlapBadge}${overrideBadge}${seriesProposalBadge}${headlineReasonChip}<span class="calendar-chip">📱 ${this.escapeHtml(calendarName)}</span></div>
                 <div class="event-headline-main">
                     ${thumbHtml}
                     <div class="event-headline-body">

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -10378,3 +10378,27 @@ test('round5: bridge handler ids, page handlers and the Images toggle survive th
   const covered = classes.filter((cls) => new RegExp(`class="[^"]*\\b${cls}\\b`).test(html));
   assert.ok(covered.length > 0, `selector "${fn[1]}" matches no rendered class`);
 });
+
+test('generateEventCard renders the venue-overlap chip only when the report-only flag is stamped', () => {
+  const adapter = buildAdapter();
+  const flagged = adapter.generateEventCard({
+    title: 'SUNDAY BEER BUST',
+    _action: 'new',
+    startDate: '2026-09-13T21:00:00.000Z',
+    bar: 'Eagle LA',
+    _venueOverlap: [
+      { withTitle: 'ONYX <2nd Sunday>', date: '2026-09-13', venue: 'Eagle LA', window: '14:00–20:00 (assumed end)', otherWindow: '16:00–20:00', source: 'run' }
+    ]
+  });
+  assert.ok(flagged.includes('venue-overlap-badge'), 'overlap chip rendered');
+  assert.ok(flagged.includes('⚔️ overlaps: ONYX &lt;2nd Sunday&gt;'), 'colliding title named and escaped');
+  assert.ok(!flagged.includes('ONYX <2nd Sunday>'), 'no raw markup from the overlap payload');
+
+  const plain = adapter.generateEventCard({
+    title: 'SUNDAY BEER BUST',
+    _action: 'new',
+    startDate: '2026-09-13T21:00:00.000Z',
+    bar: 'Eagle LA'
+  });
+  assert.ok(!plain.includes('venue-overlap-badge'), 'no chip without the stamp');
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -5113,6 +5113,67 @@ class AiWebParser {
     }
 
     /**
+     * SOURCE-SHAPE CLASSIFICATION (owner doctrine): "we only create series
+     * for single-events that are clearly recurring (a flyer, etc.) and we do
+     * single events for calendar websites that do the expansion for us" —
+     * plus "we can't condense the event with diff URLs".
+     *
+     * An event family is `occurrence-expanded` when the SITE already expands
+     * the recurrence and publishes per-date artifacts — the observed records
+     * carry DISTINCT per-date identity artifacts:
+     *   - ?occurrence=YYYY-MM-DD links harvested off the family's own pages
+     *     (the link format itself is a per-date publication), or
+     *   - different event-page URLs / ticket URLs / posters on different
+     *     dates (dice.fm per-event links, MEC renumbered slugs, per-date
+     *     flyers).
+     * It is `stated-series` when nothing is individually published per date:
+     * one page/flyer states or implies the schedule and every observed date
+     * shares the same artifact set. Detection is purely structural (value
+     * comparison across dates) — nothing per-site, nothing per-domain.
+     *
+     * Artifact comparison: for each identity-artifact field, a date whose
+     * value set contains a value ABSENT from another date's non-empty value
+     * set is per-date evidence. Two dates carrying the identical value
+     * (both pointing at the one series page) prove nothing; a value only
+     * one date wears is exactly a per-date publication. Same-date variance
+     * (listing stub + detail page of ONE night) never counts — only
+     * cross-date differences classify. Fail closed per the doctrine: when
+     * the artifacts say per-date, the family stays individual occurrences —
+     * unsure never converts to a series.
+     */
+    classifyCadenceSourceShape(group, hasOccurrenceLinkObservations) {
+        if (hasOccurrenceLinkObservations) {
+            return { shape: 'occurrence-expanded', reason: 'the site publishes per-date ?occurrence= links' };
+        }
+        const ARTIFACT_FIELDS = ['url', 'website', 'ticketUrl', 'image'];
+        for (const field of ARTIFACT_FIELDS) {
+            const valuesByDate = new Map();
+            for (const member of group.members) {
+                const value = typeof member.event[field] === 'string' ? member.event[field].trim() : '';
+                if (!value) continue;
+                if (!valuesByDate.has(member.nightKey)) valuesByDate.set(member.nightKey, new Set());
+                valuesByDate.get(member.nightKey).add(value);
+            }
+            if (valuesByDate.size < 2) continue;
+            const entries = Array.from(valuesByDate.values());
+            for (let i = 0; i < entries.length; i++) {
+                for (let j = 0; j < entries.length; j++) {
+                    if (i === j) continue;
+                    for (const value of entries[i]) {
+                        if (!entries[j].has(value)) {
+                            return {
+                                shape: 'occurrence-expanded',
+                                reason: `distinct per-date ${field} artifacts across ${valuesByDate.size} dates`
+                            };
+                        }
+                    }
+                }
+            }
+        }
+        return { shape: 'stated-series', reason: 'no per-date identity artifacts observed' };
+    }
+
+    /**
      * Post-crawl derived-cadence enforcement (called by shared-core's
      * processParser once every page of the run has been crawled, BEFORE
      * dedup — the same seam as applyVenueSiteAddressConsensus, and for the
@@ -5129,6 +5190,15 @@ class AiWebParser {
      *      what catches MEC installs that renumber slugs per occurrence
      *      (karaoke-19, karaoke-20 …), where URL-keyed observation never
      *      accumulates.
+     *
+     * SOURCE SHAPE comes first (owner doctrine, see
+     * classifyCadenceSourceShape): a family whose observed records carry
+     * distinct per-date identity artifacts (?occurrence= links, per-date
+     * event/ticket URLs or posters, renumbered slugs) is occurrence-expanded
+     * — the site already did the expansion, so the family gets report-only
+     * _seriesInfo metadata and every occurrence stays an individual event.
+     * Only a stated-series-shaped family (no per-date artifacts) continues
+     * into the stamping below.
      *
      * A qualifying group (deriveCadenceRrule) gets recurrenceRule stamped on
      * every member that lacks one, so the EXISTING series machinery folds the
@@ -5184,6 +5254,7 @@ class AiWebParser {
         }
 
         let groupIndex = 0;
+        let shapeIndex = 0;
         for (const group of groups) {
             const dates = new Set(group.members.map(member => member.nightKey));
             // Fold in the ?occurrence= observations whose page identity
@@ -5196,13 +5267,74 @@ class AiWebParser {
                     if (pathKey) memberPathKeys.add(pathKey);
                 }
             }
+            let occurrenceLinksObserved = false;
             if (observations) {
                 for (const [pathKey, dateSet] of observations) {
                     if (!memberPathKeys.has(pathKey)) continue;
+                    occurrenceLinksObserved = true;
                     for (const date of dateSet) dates.add(date);
                 }
             }
             const sortedDates = Array.from(dates).sort();
+
+            // SOURCE-SHAPE CLASSIFICATION (see classifyCadenceSourceShape):
+            // an occurrence-expanded family — the site publishes per-date
+            // artifacts — is NEVER converted to a series. No recurrenceRule
+            // stamp, no _cadenceGroup marker (so the same-series export
+            // collapse can never fold it across dates), stated rules demoted
+            // to report-only metadata. Every member instead carries
+            // _seriesInfo = { rrule, basis, occurrences, family }: the
+            // cadence stays visible (UI chip + family grouping) while each
+            // occurrence keeps its own date, ticketUrl, website and poster
+            // and is written/merged individually like any single event.
+            const shapeVerdict = sortedDates.length >= 2
+                ? this.classifyCadenceSourceShape(group, occurrenceLinksObserved)
+                : null;
+            if (shapeVerdict && shapeVerdict.shape === 'occurrence-expanded') {
+                shapeIndex++;
+                const derivedForInfo = this.deriveCadenceRrule(sortedDates);
+                const statedRuleSet = new Set();
+                for (const member of group.members) {
+                    const stated = String(member.event.recurrenceRule || member.event.recurrence || '').trim().toUpperCase();
+                    if (stated) statedRuleSet.add(stated);
+                }
+                // The report-only rrule: derived when every stated rule
+                // agrees with (or is refined by) it; the single stated rule
+                // when nothing was derivable; '' on disagreement or multiple
+                // stated rules — fail closed, the observed-dates basis
+                // string still describes the family.
+                const statedRuleList = Array.from(statedRuleSet);
+                const derivedRrule = derivedForInfo ? derivedForInfo.rrule : '';
+                let infoRrule = '';
+                if (derivedRrule && statedRuleList.every(rule =>
+                    rule === derivedRrule || derivedRrule.startsWith(`${rule};`))) {
+                    infoRrule = derivedRrule;
+                } else if (!derivedRrule && statedRuleList.length === 1) {
+                    infoRrule = statedRuleList[0];
+                }
+                const shapeBasis = this.describeOccurrenceCadence(sortedDates);
+                const shapeTitle = group.members[0].event.title;
+                let demotedCount = 0;
+                for (const member of group.members) {
+                    member.event._seriesInfo = {
+                        rrule: infoRrule,
+                        basis: shapeBasis.summary,
+                        occurrences: sortedDates.length,
+                        family: `shape-${shapeIndex}`
+                    };
+                    if (String(member.event.recurrenceRule || member.event.recurrence || '').trim()) {
+                        delete member.event.recurrenceRule;
+                        delete member.event.recurrence;
+                        demotedCount++;
+                    }
+                    if (member.event._recurring === true) {
+                        delete member.event._recurring;
+                    }
+                }
+                console.log(`🔁 SHAPE: "${shapeTitle}" is occurrence-expanded (${shapeVerdict.reason}) — ${group.members.length} record(s) over ${sortedDates.length} date(s) kept individual, no series conversion${demotedCount > 0 ? `; ${demotedCount} stated rule(s) demoted to report-only _seriesInfo` : ''}`);
+                continue;
+            }
+
             const derived = this.deriveCadenceRrule(sortedDates);
             if (!derived) continue; // existing report-only line already covered it
 
@@ -5228,6 +5360,9 @@ class AiWebParser {
             if (disagreeing.length > 0) {
                 console.log(`🔁 CADENCE: derived ${derived.rrule} for "${title}" disagrees with stated rule(s) ${disagreeing.join(', ')} — stated cadence kept, nothing stamped (curated data beats derived)`);
                 continue;
+            }
+            if (shapeVerdict) {
+                console.log(`🔁 SHAPE: "${title}" is stated-series (${shapeVerdict.reason}) — series flow retained`);
             }
             const unstamped = group.members.filter(member =>
                 !String(member.event.recurrenceRule || member.event.recurrence || '').trim());

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -13745,9 +13745,13 @@ test('a lone "-WxH" thumbnail keeps its own identity and still gets OCR coverage
 });
 
 // ===========================================================================
-// Derived-cadence enforcement (occurrence links + same-title record groups →
-// conservative recurrenceRule stamps; stated rules always win). Venue names
-// below are fixtures only.
+// Derived-cadence enforcement + source-shape classification (owner doctrine:
+// series only for stated schedules with no per-date publications; a family
+// whose records carry DISTINCT per-date identity artifacts — ?occurrence=
+// links, per-date event/ticket URLs, renumbered slugs, per-date posters — is
+// occurrence-expanded: every occurrence stays an individual event carrying
+// its own links, with report-only _seriesInfo metadata instead of a
+// recurrenceRule stamp). Venue names below are fixtures only.
 // ===========================================================================
 
 function buildCadenceStampRecord(overrides = {}) {
@@ -13797,7 +13801,11 @@ test('deriveCadenceRrule: weekly needs same weekday + a run of 3 consecutive 7-d
   assert.equal(parser.deriveCadenceRrule(['2026-08-05']), null);
 });
 
-test('applyDerivedCadenceStamps: weekly stamp from ?occurrence= link observations', () => {
+// PIN UPDATED (series doctrine rework): ?occurrence= links ARE per-date
+// publications — the site expands the recurrence itself — so the family is
+// occurrence-expanded: no recurrenceRule stamp, no _cadenceGroup marker,
+// report-only _seriesInfo instead. Previously this pinned a weekly stamp.
+test('applyDerivedCadenceStamps: ?occurrence= link observations classify occurrence-expanded — no stamp, _seriesInfo metadata', () => {
   const parser = createParser();
   const sourceUrl = 'https://fixture-eagle.example/calendar/';
   const html = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26']
@@ -13809,32 +13817,79 @@ test('applyDerivedCadenceStamps: weekly stamp from ?occurrence= link observation
     url: 'https://fixture-eagle.example/events/hump-night/?occurrence=2026-08-05'
   });
   const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps([record]));
-  assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'link observations alone carry the weekly proof');
-  assert.ok(typeof record._cadenceGroup === 'string' && record._cadenceGroup, 'group marker stamped');
-  assert.ok(logs.some(line => line.includes('🔁 CADENCE: stamped FREQ=WEEKLY;BYDAY=WE on 1 "HUMP NIGHT" record(s)')),
-    `enforce line expected, got: ${JSON.stringify(logs)}`);
+  assert.equal(record.recurrenceRule, undefined, 'occurrence-expanded families are never converted to a series');
+  assert.equal(record._cadenceGroup, undefined, 'no collapse marker on an occurrence-expanded family');
+  assert.ok(record._seriesInfo, 'report-only family metadata stamped');
+  assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE', 'the derived cadence survives as metadata');
+  assert.equal(record._seriesInfo.occurrences, 4, 'observation dates counted');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "HUMP NIGHT" is occurrence-expanded')
+    && line.includes('?occurrence=')),
+    `shape line expected, got: ${JSON.stringify(logs)}`);
 });
 
-test('applyDerivedCadenceStamps: weekly stamp from same-title records on renumbered slugs (no occurrence links)', () => {
+// PIN UPDATED (series doctrine rework): renumbered MEC slugs are per-date
+// event pages, so the family is occurrence-expanded — each occurrence keeps
+// its own URL and stays an individual event. Previously this pinned a weekly
+// stamp plus a shared _cadenceGroup marker.
+test('applyDerivedCadenceStamps: renumbered slugs classify occurrence-expanded — occurrences kept individual', () => {
   const parser = createParser();
   // MEC renumbering (run 20260807-143442): one weekly night, a NEW slug per
-  // occurrence — URL-keyed observation can never accumulate these.
+  // occurrence — the slugs themselves are the per-date artifacts.
   const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
     buildCadenceStampRecord({
       startDate: new Date(`${date}T20:00:00.000Z`),
       endDate: new Date(`${date}T23:00:00.000Z`),
       url: `https://fixture-eagle.example/events/karaoke-${19 + index}/`
     }));
-  parser.applyDerivedCadenceStamps(records);
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  const families = new Set();
+  records.forEach((record, index) => {
+    assert.equal(record.recurrenceRule, undefined, 'no series conversion');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, 'family metadata on every member');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE');
+    assert.equal(record._seriesInfo.occurrences, 4);
+    assert.equal(record.url, `https://fixture-eagle.example/events/karaoke-${19 + index}/`,
+      'each occurrence keeps its own per-date URL');
+    families.add(record._seriesInfo.family);
+  });
+  assert.equal(families.size, 1, 'all four records share ONE family marker');
+  assert.ok([...families][0], 'the family marker is non-empty');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "KARAOKE" is occurrence-expanded')
+    && line.includes('distinct per-date url artifacts')),
+    `shape line expected, got: ${JSON.stringify(logs)}`);
+});
+
+// Stamping-path coverage (stated-series shape): the SAME multi-date family
+// with NO per-date artifacts — every record pointing at the one page that
+// states the schedule — still stamps the derived rule and mints the collapse
+// marker, exactly the pre-rework flow.
+test('applyDerivedCadenceStamps: a shared-page family (no per-date artifacts) is stated-series — weekly stamp fires', () => {
+  const parser = createParser();
+  const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map(date =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      endDate: new Date(`${date}T23:00:00.000Z`),
+      url: 'https://fixture-eagle.example/events/karaoke/'
+    }));
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
   for (const record of records) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE');
+    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'stated-series shape keeps the stamping flow');
+    assert.equal(record._seriesInfo, undefined, 'no occurrence-expanded metadata on a stated-series family');
   }
   const markers = new Set(records.map(record => record._cadenceGroup));
   assert.equal(markers.size, 1, 'all four records share ONE same-series marker');
   assert.ok([...markers][0], 'the shared marker is non-empty');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "KARAOKE" is stated-series')),
+    `stated-series shape line expected, got: ${JSON.stringify(logs)}`);
+  assert.ok(logs.some(line => line.includes('🔁 CADENCE: stamped FREQ=WEEKLY;BYDAY=WE on 4 "KARAOKE" record(s)')),
+    `enforce line expected, got: ${JSON.stringify(logs)}`);
 });
 
-test('applyDerivedCadenceStamps: monthly stamp from two same-ordinal observations in different months', () => {
+// PIN UPDATED (series doctrine rework): distinct per-date slugs → the
+// monthly pair is occurrence-expanded; the derived monthly cadence becomes
+// _seriesInfo metadata. Previously this pinned a FREQ=MONTHLY;BYDAY=1FR stamp.
+test('applyDerivedCadenceStamps: a monthly pair on per-date slugs keeps both occurrences individual', () => {
   const parser = createParser();
   const records = [
     buildCadenceStampRecord({
@@ -13851,8 +13906,12 @@ test('applyDerivedCadenceStamps: monthly stamp from two same-ordinal observation
     })
   ];
   parser.applyDerivedCadenceStamps(records);
-  assert.equal(records[0].recurrenceRule, 'FREQ=MONTHLY;BYDAY=1FR');
-  assert.equal(records[1].recurrenceRule, 'FREQ=MONTHLY;BYDAY=1FR');
+  for (const record of records) {
+    assert.equal(record.recurrenceRule, undefined, 'no series conversion on per-date slugs');
+    assert.ok(record._seriesInfo, 'family metadata stamped');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=MONTHLY;BYDAY=1FR', 'derived cadence kept as metadata');
+    assert.equal(record._seriesInfo.occurrences, 2);
+  }
 });
 
 test('applyDerivedCadenceStamps: mixed weekdays stamp nothing', () => {
@@ -13870,16 +13929,43 @@ test('applyDerivedCadenceStamps: mixed weekdays stamp nothing', () => {
   }
 });
 
-test('applyDerivedCadenceStamps: stated rule beats derived — conflict logs, nothing stamped, stated kept', () => {
+// PIN UPDATED (series doctrine rework): the per-date slugs make this family
+// occurrence-expanded, so the conflicting stated rule is DEMOTED to
+// report-only metadata rather than kept as a series claim — each occurrence
+// is written individually either way, and _seriesInfo.rrule fails closed to
+// '' on the disagreement (the observed-dates basis still describes the
+// family). Previously this pinned "stated kept, nothing stamped".
+test('applyDerivedCadenceStamps: stated-vs-derived disagreement on an occurrence-expanded family demotes, rrule fails closed', () => {
   const parser = createParser();
-  // The model extracted an explicit stated cadence on one record; the derived
-  // weekday disagrees. Curated/stated data beats derived — fail closed for
-  // the WHOLE group.
   const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
     buildCadenceStampRecord({
       startDate: new Date(`${date}T20:00:00.000Z`),
       endDate: new Date(`${date}T23:00:00.000Z`),
       url: `https://fixture-eagle.example/events/karaoke-${19 + index}/`
+    }));
+  records[0].recurrenceRule = 'FREQ=WEEKLY;BYDAY=FR';
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  for (const record of records) {
+    assert.equal(record.recurrenceRule, undefined, 'occurrence-expanded members carry no series claim');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, 'family metadata on every member');
+    assert.equal(record._seriesInfo.rrule, '', 'disagreeing rules fail closed to no metadata rrule');
+    assert.ok(record._seriesInfo.basis, 'the observed-dates basis still describes the family');
+  }
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "KARAOKE" is occurrence-expanded')
+    && line.includes('1 stated rule(s) demoted to report-only _seriesInfo')),
+    `shape+demotion line expected, got: ${JSON.stringify(logs)}`);
+});
+
+// Stated-beats-derived conflict coverage on the STAMPING path (stated-series
+// shape — no per-date artifacts): unchanged pre-rework behavior.
+test('applyDerivedCadenceStamps: stated rule beats derived on a stated-series family — conflict logs, nothing stamped', () => {
+  const parser = createParser();
+  const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map(date =>
+    buildCadenceStampRecord({
+      startDate: new Date(`${date}T20:00:00.000Z`),
+      endDate: new Date(`${date}T23:00:00.000Z`),
+      url: 'https://fixture-eagle.example/events/karaoke/'
     }));
   records[0].recurrenceRule = 'FREQ=WEEKLY;BYDAY=FR';
   const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
@@ -13892,11 +13978,14 @@ test('applyDerivedCadenceStamps: stated rule beats derived — conflict logs, no
     `conflict line expected, got: ${JSON.stringify(logs)}`);
 });
 
-test('applyDerivedCadenceStamps: derived agreeing with stated is a no-op stamp but still marks the same-series group', () => {
+// PIN UPDATED (series doctrine rework): the renumbered underwear-N slugs are
+// per-date publications, so the stated-rule group is occurrence-expanded —
+// the five records each stay an individual Wednesday with their own page,
+// stated rules demoted to _seriesInfo (rrule preserved there: derived agrees
+// with stated). Previously this pinned "marker only, rules untouched" so the
+// series collapse could fold them; UI grouping now replaces that fold.
+test('applyDerivedCadenceStamps: stated rules on renumbered slugs are demoted — occurrences kept individual', () => {
   const parser = createParser();
-  // Run 20260807-143442: all five "Underwear Happy Hour" records already
-  // state FREQ=WEEKLY;BYDAY=WE, each on its own renumbered slug. The rules
-  // stay untouched; the marker is what lets the series collapse fold them.
   const records = ['2026-08-05', '2026-08-12', '2026-08-19', '2026-08-26'].map((date, index) =>
     buildCadenceStampRecord({
       startDate: new Date(`${date}T20:00:00.000Z`),
@@ -13906,14 +13995,18 @@ test('applyDerivedCadenceStamps: derived agreeing with stated is a no-op stamp b
       recurrenceRule: 'FREQ=WEEKLY;BYDAY=WE'
     }));
   const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
-  const markers = new Set(records.map(record => record._cadenceGroup));
-  assert.equal(markers.size, 1, 'one shared marker across the stated-rule group');
-  assert.ok([...markers][0]);
+  const families = new Set();
   for (const record of records) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'stated rules untouched');
+    assert.equal(record.recurrenceRule, undefined, 'stated rules demoted on an occurrence-expanded family');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, 'family metadata on every member');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE', 'the agreed cadence survives as metadata');
+    families.add(record._seriesInfo.family);
   }
-  assert.ok(logs.some(line => line.includes('same-series marker only, nothing stamped')),
-    `marker-only line expected, got: ${JSON.stringify(logs)}`);
+  assert.equal(families.size, 1, 'one shared family across the demoted group');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "UNDERWEAR HAPPY HOUR" is occurrence-expanded')
+    && line.includes('4 stated rule(s) demoted to report-only _seriesInfo')),
+    `shape+demotion line expected, got: ${JSON.stringify(logs)}`);
 });
 
 test('applyDerivedCadenceStamps: different venues never share a group, and undated records are never stamped', () => {
@@ -13951,10 +14044,16 @@ test('applyDerivedCadenceStamps: different venues never share a group, and undat
   const before = dated.map(record => record.startDate.getTime());
   parser.applyDerivedCadenceStamps([undated, ...dated]);
   assert.equal(undated.recurrenceRule, undefined, 'an undated record is never stamped');
+  assert.equal(undated._seriesInfo, undefined, 'an undated record never joins a family');
   assert.equal(undated.startDate, null, 'an undated record gains no fabricated date');
-  assert.deepEqual(dated.map(record => record.startDate.getTime()), before, 'stamping never mutates startDate');
+  assert.deepEqual(dated.map(record => record.startDate.getTime()), before, 'classification never mutates startDate');
+  // PIN UPDATED (series doctrine rework): the dated group sits on renumbered
+  // karaoke-N slugs — occurrence-expanded, so it now carries _seriesInfo
+  // metadata instead of the weekly stamp it previously pinned.
   for (const record of dated) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=WE', 'the dated group still stamps normally');
+    assert.equal(record.recurrenceRule, undefined, 'per-date slugs never convert to a series');
+    assert.ok(record._seriesInfo, 'the dated family still classifies and carries metadata');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=WE');
   }
 });
 
@@ -13979,14 +14078,18 @@ test('deriveCadenceRrule: weekly with skipped weeks — every gap a multiple of 
   assert.equal(parser.deriveCadenceRrule(['2026-08-15', '2026-08-22', '2026-08-29', '2026-09-04']), null);
 });
 
-test('applyDerivedCadenceStamps: the six real GEAR NIGHT records fold to one weekly group (skipped weeks + DJ suffixes)', () => {
+// PIN UPDATED (series doctrine rework): the renumbered gear-night-N slugs
+// are per-date publications — Dallas Eagle's MEC install expands the series
+// itself — so the six records classify occurrence-expanded and each Saturday
+// stays an individual event carrying its own page URL, with the weekly
+// cadence preserved as _seriesInfo metadata and ONE shared family for UI
+// grouping. Previously this pinned a FREQ=WEEKLY;BYDAY=SA stamp plus a
+// shared _cadenceGroup marker (collapse-to-next-occurrence).
+test('applyDerivedCadenceStamps: the six real GEAR NIGHT records classify occurrence-expanded — one family, no stamps', () => {
   const parser = createParser();
   // Run 20260811-134734 verbatim: six GEAR NIGHT records on renumbered MEC
   // slugs (gear-night-5/7/11/17/19/22), two wearing per-record DJ credits,
   // observed Saturdays Aug 15, 22, Sep 5, 12, 19, Oct 3 (America/Chicago).
-  // On main these survived as six separate calendar writes: the weekly rule
-  // demanded 3 CONSECUTIVE 7-day gaps (longest run here is 2), and the
-  // DJ-suffixed pair could not even join the group.
   const gearNight = [
     ['Gear Night with DJ Tristan Jaxx', '2026-08-16T02:00:00.000Z', 'gear-night-5'],
     ['Gear Night with DJ Philip Webb', '2026-08-23T03:00:00.000Z', 'gear-night-7'],
@@ -14004,22 +14107,74 @@ test('applyDerivedCadenceStamps: the six real GEAR NIGHT records fold to one wee
     source: 'ai-web'
   }));
   parser.applyDerivedCadenceStamps(gearNight);
-  for (const record of gearNight) {
-    assert.equal(record.recurrenceRule, 'FREQ=WEEKLY;BYDAY=SA', `"${record.title}" (${record.url}) joins the weekly stamp`);
-  }
-  const markers = new Set(gearNight.map(record => record._cadenceGroup));
-  assert.equal(markers.size, 1, 'all six records share ONE same-series marker');
-  assert.ok([...markers][0], 'the shared marker is non-empty');
+  const families = new Set();
+  gearNight.forEach((record, index) => {
+    assert.equal(record.recurrenceRule, undefined, `"${record.title}" is never converted to a series`);
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.ok(record._seriesInfo, `"${record.title}" (${record.url}) joins the family metadata`);
+    assert.equal(record._seriesInfo.rrule, 'FREQ=WEEKLY;BYDAY=SA', 'the weekly cadence survives as metadata');
+    assert.equal(record._seriesInfo.occurrences, 6);
+    assert.ok(record.url.includes('gear-night-'), 'each occurrence keeps its own per-date slug URL');
+    families.add(record._seriesInfo.family);
+  });
+  assert.equal(families.size, 1, 'all six records share ONE family (grouped in the UI, never folded in data)');
+  assert.ok([...families][0], 'the shared family is non-empty');
 });
 
-test('applyDerivedCadenceStamps: per-record guest-DJ suffixes group into one monthly series; different parties never do', () => {
+// Run 20260814-000011 verbatim (the evidence that drove the doctrine): three
+// observed 3rd-Saturday BEEFMINCE x RVT occurrences, each with its OWN
+// dice.fm per-event ticket link. On main these were stamped
+// FREQ=MONTHLY;BYDAY=3SA and collapsed to the Sep 19 occurrence — whose
+// ticketUrl is the Sep-19-SPECIFIC dice link, discarding October's and
+// November's. "We can't condense the event with diff URLs": the distinct
+// per-date ticketUrls classify the family occurrence-expanded, every
+// occurrence keeps its own dice link, and the cadence survives as metadata.
+test('applyDerivedCadenceStamps: BEEFMINCE x RVT — distinct per-date dice links keep every occurrence and its own ticketUrl', () => {
+  const parser = createParser();
+  const diceLinks = [
+    ['2026-09-19T21:00:00.000Z', 'https://dice.fm/event/yoepxa-beefmince-x-rvt-19th-sep-the-royal-vauxhall-tavern-london-tickets'],
+    ['2026-10-17T21:00:00.000Z', 'https://dice.fm/event/xednya-beefmince-x-rvt-17th-oct-the-royal-vauxhall-tavern-london-tickets'],
+    ['2026-11-21T22:00:00.000Z', 'https://dice.fm/event/927gr7-beefmince-x-rvt-21st-nov-the-royal-vauxhall-tavern-london-tickets']
+  ];
+  const records = diceLinks.map(([start, ticketUrl]) => ({
+    title: 'BEEFMINCE x RVT',
+    bar: 'The Royal Vauxhall Tavern',
+    timezone: 'Europe/London',
+    startDate: new Date(start),
+    endDate: new Date(new Date(start).getTime() + 6 * 60 * 60 * 1000),
+    website: 'https://beefmince.com',
+    ticketUrl,
+    source: 'ai-web'
+  }));
+  const logs = withCapturedLogs(() => parser.applyDerivedCadenceStamps(records));
+  const families = new Set();
+  records.forEach((record, index) => {
+    assert.equal(record.recurrenceRule, undefined, 'no FREQ=MONTHLY;BYDAY=3SA stamp — the site expands the dates itself');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker — October and November keep their own dice links');
+    assert.ok(record._seriesInfo, 'family metadata on every occurrence');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=MONTHLY;BYDAY=3SA', 'the derived cadence survives as report-only metadata');
+    assert.equal(record._seriesInfo.occurrences, 3);
+    assert.equal(record.ticketUrl, diceLinks[index][1], 'each occurrence keeps its own per-date dice link');
+    families.add(record._seriesInfo.family);
+  });
+  assert.equal(families.size, 1, 'one family across the three Saturdays');
+  assert.ok(logs.some(line => line.includes('🔁 SHAPE: "BEEFMINCE x RVT" is occurrence-expanded')
+    && line.includes('distinct per-date ticketUrl artifacts')),
+    `shape line expected, got: ${JSON.stringify(logs)}`);
+});
+
+// PIN UPDATED (series doctrine rework): the pair sits on distinct per-date
+// slugs, so it is occurrence-expanded — the guest-DJ grouping still proves
+// the family (that identity logic is untouched), but the stated bare
+// FREQ=MONTHLY rules are demoted and the refined 2FR cadence lands in
+// _seriesInfo. Previously this pinned "marker minted, stated rules kept".
+test('applyDerivedCadenceStamps: per-record guest-DJ suffixes still group into one family; different parties never do', () => {
   const parser = createParser();
   // Run 20260811-134734 verbatim: a genuine 2nd-Friday monthly pair whose
   // records each wear a different guest DJ's name — no bare-title anchor,
   // so the plain name similarity never groups them. Both pages state a bare
   // FREQ=MONTHLY; the derived FREQ=MONTHLY;BYDAY=2FR REFINES it (agreement,
-  // not conflict), so the stated rules stay untouched and the same-series
-  // marker is minted.
+  // not conflict), so the refined rule is what the metadata carries.
   const disciplinePair = [
     {
       title: 'Discipline Corps Bar Night with DJ Philip Webb',
@@ -14043,11 +14198,13 @@ test('applyDerivedCadenceStamps: per-record guest-DJ suffixes group into one mon
     }
   ];
   parser.applyDerivedCadenceStamps(disciplinePair);
-  const markers = new Set(disciplinePair.map(record => record._cadenceGroup));
-  assert.equal(markers.size, 1, 'the DJ-suffixed pair shares ONE same-series marker');
-  assert.match([...markers][0], /FREQ=MONTHLY;BYDAY=2FR$/, 'grouped via the existing >=2-months ordinal rule');
+  const families = new Set(disciplinePair.map(record => record._seriesInfo && record._seriesInfo.family));
+  assert.equal(families.size, 1, 'the DJ-suffixed pair shares ONE family');
+  assert.ok([...families][0], 'the shared family is non-empty');
   for (const record of disciplinePair) {
-    assert.equal(record.recurrenceRule, 'FREQ=MONTHLY', 'the stated rule is NEVER overridden by its refinement');
+    assert.equal(record.recurrenceRule, undefined, 'stated rules demoted on the occurrence-expanded pair');
+    assert.equal(record._cadenceGroup, undefined, 'no collapse marker');
+    assert.equal(record._seriesInfo.rrule, 'FREQ=MONTHLY;BYDAY=2FR', 'the refining derived rule is the metadata cadence');
   }
 
   // Two DIFFERENT party names at one venue, each with a guest-DJ suffix,

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -8978,6 +8978,12 @@ class SharedCore {
         if (!mergedEvent._fieldTrims && existingEvent && Array.isArray(existingEvent._fieldTrims) && existingEvent._fieldTrims.length > 0) {
             mergedEvent._fieldTrims = existingEvent._fieldTrims;
         }
+        // Same carry for the occurrence-expanded family stamp (_seriesInfo):
+        // a same-night stub+detail merge must keep the family metadata so the
+        // UI chip/grouping and the saved-series protection still see it.
+        if (!mergedEvent._seriesInfo && existingEvent && existingEvent._seriesInfo && typeof existingEvent._seriesInfo === 'object') {
+            mergedEvent._seriesInfo = existingEvent._seriesInfo;
+        }
 
         // Helper function to check if a value is empty/null/undefined
         const isEmpty = (value) => {
@@ -11158,8 +11164,14 @@ class SharedCore {
         // B BAR/CUBSCOUT/ONYX all "new" the day after their series were
         // saved). Reporting-only: the analysis action stays 'new' and the
         // write stays withheld — a match only changes what the run SAYS.
+        // Occurrence-expanded family members run the SAME lookup: the family's
+        // cadence evidence says the event recurs, which is exactly when the
+        // owner's calendar may already hold the series covering this date —
+        // and an occurrence write must never fight his imported series. For
+        // these the match is ENFORCED downstream (isSeriesCoveredOccurrence
+        // gates the write with the SERIES MATCH label), not report-only.
         if (analysis.action === 'new' && !analysis.existingEvent && !analysis.sourceEvent &&
-            SharedCore.isRecurringSeriesEvent(event)) {
+            (SharedCore.isRecurringSeriesEvent(event) || SharedCore.isOccurrenceExpandedEvent(event))) {
             try {
                 const seriesMatch = await this.findSavedSeriesMatch(event, calendarAdapter);
                 if (seriesMatch) {
@@ -12029,6 +12041,10 @@ class SharedCore {
             // and gated here, exactly like the recurring-series withhold.
             event?._pastSpanWithheld !== true &&
             !SharedCore.isRecurringSeriesEvent(event) &&
+            // An occurrence-expanded single whose date/identity the owner's
+            // SAVED series already covers (#1655 series-match): writing it
+            // would plant a duplicate single next to his imported series.
+            !SharedCore.isSeriesCoveredOccurrence(event) &&
             !SharedCore.hasJunkTitleSanityFlag(event));
     }
 
@@ -12104,6 +12120,7 @@ class SharedCore {
         if (event._parserConfig && event._parserConfig.dryRun === true) return 'WITHHELD (dry-run parser)';
         if (event._pastSpanWithheld === true) return 'WITHHELD (span fully past)';
         if (SharedCore.isRecurringSeriesEvent(event)) return 'WITHHELD (recurring series — ICS export only)';
+        if (SharedCore.isSeriesCoveredOccurrence(event)) return 'WITHHELD (occurrence covered by saved series — SERIES MATCH)';
         if (SharedCore.hasJunkTitleSanityFlag(event)) return 'WITHHELD (junk title)';
         const action = typeof event._action === 'string' && event._action ? event._action : 'new';
         return action.toUpperCase();
@@ -12205,6 +12222,26 @@ class SharedCore {
         // an existing series (see the pinned override-survival test).
         if (event.overrideUid || event.overrideRecurrenceId) return false;
         return typeof event.recurrence === 'string' && event.recurrence.trim() !== '';
+    }
+
+    // A member of an occurrence-expanded family (owner doctrine, stamped by
+    // the ai-web parser's source-shape classification): the site publishes
+    // each date individually, so the record is a plain single occurrence —
+    // but the family's cadence evidence says the event RECURS, which is
+    // exactly when the owner's calendar may already hold a saved series
+    // covering it.
+    static isOccurrenceExpandedEvent(event) {
+        return Boolean(event && typeof event === 'object' && event._seriesInfo);
+    }
+
+    // An occurrence-expanded single positively matched to a SAVED series
+    // (#1655 series-match, extended to occurrence singles): the write is
+    // withheld — planting a single next to the owner's imported series would
+    // fight it. Its own predicate (mirroring hasJunkTitleSanityFlag) so the
+    // execution gate, the disposition label, and the adapters' labeling can
+    // never disagree.
+    static isSeriesCoveredOccurrence(event) {
+        return SharedCore.isOccurrenceExpandedEvent(event) && Boolean(event._seriesMatch);
     }
 
     // Scriptable identifiers look like `<calendarUUID>:<icsUid>` — the suffix
@@ -13488,6 +13525,15 @@ class SharedCore {
                 hasOverrideIdentity: Boolean(analysis.overrideIdentity)
             };
 
+            // The occurrence-expanded family stamp (parse-time _seriesInfo)
+            // survives the same wholesale replacement: createFinalEventObject
+            // skips underscore fields, and the UI chip, the family grouping,
+            // and the saved-series occurrence withhold all read it off the
+            // analyzed event.
+            if (event._seriesInfo && !analyzedEvent._seriesInfo) {
+                analyzedEvent._seriesInfo = event._seriesInfo;
+            }
+
             // Final-stage field cleanups. Both run at the FINAL analyzed-event
             // build (so every parser, merge result, and cached AI response
             // passes through them) and BEFORE the notes generation/rebuild
@@ -14068,6 +14114,27 @@ class SharedCore {
                     console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" matches the saved series already in ${analyzedEvent._seriesMatch.calendarName} (${analyzedEvent._seriesMatch.instances} instances) — not a new event`);
                 }
                 console.log(`🔁 RECURRING: "${event.title || 'Unknown'}" withheld from calendar write — save via ICS export`);
+            }
+
+            // Occurrence-expanded singles vs the owner's imported series
+            // (#1655 series-match, extended): the saved-series lookup matched
+            // this occurrence's identity, so its write is withheld with the
+            // SERIES MATCH label — occurrence-expansion must never fight a
+            // series he saved. Scalars only; the run JSON persists this
+            // stamp, and the execution gate (isSeriesCoveredOccurrence)
+            // reads exactly it.
+            if (analysis.seriesMatch && !analyzedEvent._seriesMatch &&
+                SharedCore.isOccurrenceExpandedEvent(analyzedEvent)) {
+                analyzedEvent._seriesMatch = {
+                    identifier: analysis.seriesMatch.identifier || '',
+                    title: analysis.seriesMatch.title || '',
+                    startDate: analysis.seriesMatch.startDate || null,
+                    endDate: analysis.seriesMatch.endDate || null,
+                    reason: analysis.seriesMatch.reason || 'Saved series match',
+                    instances: Number.isFinite(analysis.seriesMatch.instances) ? analysis.seriesMatch.instances : 0,
+                    calendarName: analysis.seriesMatch.calendarName || ''
+                };
+                console.log(`🔁 SHAPE: "${analyzedEvent.title || 'Unknown'}" occurrence is covered by the saved series in ${analyzedEvent._seriesMatch.calendarName || 'the calendar'} — write withheld (SERIES MATCH)`);
             }
 
             return analyzedEvent;
@@ -15143,6 +15210,12 @@ class SharedCore {
     //     cross-realm Dates).
     getSeriesExportIdentity(event) {
         if (!SharedCore.isRecurringSeriesEvent(event)) return null;
+        // Occurrence-expanded family member (owner doctrine): the site
+        // publishes each date individually, so the record is a real single
+        // occurrence — never a series export, never collapsed across dates.
+        // Its rules were already demoted to _seriesInfo at classification
+        // time, so this guard is defense-in-depth (fail closed).
+        if (event._seriesInfo) return null;
         if (event._seriesAuthority === 'slot-host') return null;
         if (event._recurringExport === false) return null;
         const rrule = String(event.recurrenceRule || event.recurrence || '').trim().toUpperCase();

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -4222,6 +4222,21 @@ class SharedCore {
             await displayAdapter.logInfo(results.discoveredVenueSummary);
         }
 
+        // Linked ICS feeds discovered during crawls (report-only): aggregated
+        // onto the run results as evidence for future enforcement — the feed
+        // is not a source this wave. Per-feed 📅 ICS FEED lines were already
+        // logged when each parser finalized its findings.
+        const icsFeedFindings = [];
+        for (const parserResult of results.parserResults) {
+            if (!parserResult || !Array.isArray(parserResult.icsFeedFindings)) continue;
+            for (const finding of parserResult.icsFeedFindings) {
+                icsFeedFindings.push({ parser: parserResult.name || '', ...finding });
+            }
+        }
+        if (icsFeedFindings.length > 0) {
+            results.icsFeedFindings = icsFeedFindings;
+        }
+
         // Cross-org crawl drops: events found on another promoter's/parser's
         // own site during this parser's crawl. Flagged, never silently dropped.
         const foreignOrgCrawlDrops = this.buildForeignOrgCrawlDrops(results.parserResults);
@@ -4356,6 +4371,9 @@ class SharedCore {
         // Events found on another org's site and NOT ingested (cross-org crawl
         // guard) — flagged, never silently dropped.
         const foreignOrgDropCollector = [];
+        // Linked ICS feeds discovered during the crawl (report-only evidence,
+        // never a source this wave) — see collectIcsFeedFindings.
+        const icsFeedCollector = { seen: new Set(), findings: [] };
 
         await this.crawlUrlsForEvents({
             urls: effectiveParserConfig.urls || [],
@@ -4378,7 +4396,8 @@ class SharedCore {
             enrichDropCollector,
             crawlErrorCollector,
             crawlGoneCollector,
-            foreignOrgDropCollector
+            foreignOrgDropCollector,
+            icsFeedCollector
         });
 
         // Venue-site address consensus (deterministic, parser-derived): the
@@ -4511,6 +4530,17 @@ class SharedCore {
 
         if (foreignOrgDropCollector.length > 0) {
             result.foreignOrgDrops = foreignOrgDropCollector;
+        }
+
+        // Linked ICS feeds (report-only): summarize each feed against this
+        // parser's full extracted set + lookahead window, then carry the
+        // findings on the parser result for the run-level aggregation.
+        if (icsFeedCollector.findings.length > 0) {
+            result.icsFeedFindings = this.finalizeIcsFeedFindings(
+                icsFeedCollector.findings,
+                allEvents,
+                effectiveParserConfig.daysToLookAhead
+            );
         }
 
         if (bearDropCollector.length > 0) {
@@ -5746,6 +5776,167 @@ class SharedCore {
         return true;
     }
 
+    // === Linked-ICS-feed discovery (report-only) ===
+    // Some venue/promoter sites publish a REAL machine-readable calendar feed
+    // (webcal:// links, .ics hrefs, type="text/calendar" links, WordPress
+    // calendar-plugin export params like ?ical=1). Doctrine: calendar websites
+    // do the expansion for us — a published feed is exactly the structured
+    // occurrence source the scraper wants. This wave is DISCOVERY + REPORT
+    // only: detect, fetch once through the injected http adapter (page-cached
+    // like any page), parse with the existing published-calendar VEVENT parser
+    // (parsePublishedCalendarIcs — rrules stay raw strings, never expanded),
+    // log one 📅 ICS FEED line, and stash the parse on the run results
+    // (results.icsFeedFindings) as evidence for future enforcement. No
+    // extraction or merge behavior changes. Generic patterns only — nothing
+    // per-site. The #1559 calendar-export CRAWL reject in the ai-web parser is
+    // untouched: these URLs are still never crawl candidates; this is a
+    // separate evidence channel.
+
+    // Pure scan of one page's HTML for ICS-feed candidates. Returns
+    // [{ url, fetchUrl, via }] capped at 3 per page; webcal:// links keep the
+    // original url for display and fetch over https.
+    detectIcsFeedLinks(html, pageUrl) {
+        if (!html || typeof html !== 'string') return [];
+        const candidates = new Map();
+        const addCandidate = (rawUrl, via) => {
+            if (candidates.size >= 3) return;
+            const trimmed = String(rawUrl || '').replace(/&amp;/gi, '&').trim();
+            if (!trimmed) return;
+            const isWebcal = /^webcal:\/\//i.test(trimmed);
+            const resolved = isWebcal ? trimmed : this.normalizeUrl(trimmed, pageUrl);
+            if (!resolved) return;
+            const fetchUrl = String(resolved).replace(/^webcal:\/\//i, 'https://');
+            if (!/^https?:\/\//i.test(fetchUrl)) return;
+            if (!candidates.has(fetchUrl)) {
+                candidates.set(fetchUrl, { url: String(resolved), fetchUrl, via });
+            }
+        };
+
+        // <link>/<a> tags that declare the calendar MIME type outright.
+        const typedTagRegex = /<[a-zA-Z][^>]*type\s*=\s*["']text\/calendar["'][^>]*>/gi;
+        let tagMatch;
+        while ((tagMatch = typedTagRegex.exec(html)) !== null) {
+            const hrefMatch = tagMatch[0].match(/href\s*=\s*["']([^"']+)["']/i);
+            if (hrefMatch) addCandidate(hrefMatch[1], 'text-calendar-link');
+        }
+
+        // webcal:// links anywhere in the document.
+        const webcalRegex = /webcal:\/\/[^\s"'<>()]+/gi;
+        let webcalMatch;
+        while ((webcalMatch = webcalRegex.exec(html)) !== null) {
+            addCandidate(webcalMatch[0], 'webcal');
+        }
+
+        // Plain hrefs: .ics files and the generic WordPress calendar-plugin
+        // export param (?ical=1 / ?outlook-ical=1 — the same shapes the #1559
+        // crawl reject names, consumed here as a feed channel instead).
+        const hrefRegex = /href\s*=\s*["']([^"']+)["']/gi;
+        let hrefMatch;
+        while ((hrefMatch = hrefRegex.exec(html)) !== null) {
+            const candidateText = hrefMatch[1].replace(/&amp;/gi, '&');
+            const lower = candidateText.toLowerCase();
+            const pathOnly = lower.split(/[?#]/)[0];
+            if (pathOnly.endsWith('.ics')) {
+                addCandidate(candidateText, 'ics-href');
+            } else if (/[?&](?:outlook-)?ical=1(?!\d)/.test(lower)) {
+                addCandidate(candidateText, 'ical-query');
+            }
+        }
+
+        return [...candidates.values()];
+    }
+
+    // Fetch + parse newly discovered feed candidates through the injected
+    // http adapter (transparently page-cached by the adapter). Collector:
+    // { seen: Set, findings: [] } scoped to one parser run; at most 5 feeds
+    // are fetched per parser. Degrades gracefully — a bad candidate logs and
+    // is skipped, never aborts the crawl.
+    async collectIcsFeedFindings({ html, pageUrl, httpAdapter, icsFeedCollector }) {
+        if (!icsFeedCollector || !httpAdapter || typeof httpAdapter.fetchData !== 'function') return;
+        const candidates = this.detectIcsFeedLinks(html, pageUrl);
+        for (const candidate of candidates) {
+            if (icsFeedCollector.seen.has(candidate.fetchUrl)) continue;
+            icsFeedCollector.seen.add(candidate.fetchUrl);
+            if (icsFeedCollector.findings.length >= 5) return;
+            try {
+                const response = await httpAdapter.fetchData(candidate.fetchUrl);
+                const body = response && typeof response.html === 'string' ? response.html : '';
+                if (!/BEGIN:VCALENDAR/i.test(body)) {
+                    console.log(`📅 ICS FEED: candidate ${candidate.url} (found on ${pageUrl}) did not return calendar data — skipped`);
+                    continue;
+                }
+                const records = SharedCore.parsePublishedCalendarIcs(body) || [];
+                icsFeedCollector.findings.push({
+                    feedUrl: candidate.url,
+                    fetchUrl: candidate.fetchUrl,
+                    discoveredOn: pageUrl,
+                    discoveredVia: candidate.via,
+                    vevents: records.length,
+                    // Concrete instances only — rrule text is carried as a
+                    // boolean flag for future enforcement, never expanded.
+                    records: records.slice(0, 200).map(record => ({
+                        uid: record.uid,
+                        summary: record.summary,
+                        url: record.url,
+                        location: record.location,
+                        start: record.start && record.start.date ? record.start.date.toISOString() : null,
+                        end: record.end && record.end.date ? record.end.date.toISOString() : null,
+                        isAllDay: Boolean(record.isAllDay),
+                        hasRrule: Boolean(record.rrule)
+                    }))
+                });
+            } catch (error) {
+                console.log(`📅 ICS FEED: fetch failed for ${candidate.url} (${error && error.message ? error.message : error}) — skipped`);
+            }
+        }
+    }
+
+    // After a parser's crawl: count each feed's concrete VEVENT starts inside
+    // the parser's lookahead window and how many match events this run
+    // extracted (same-event identity signals, with a title+night fallback for
+    // feeds that carry no venue/url evidence), then emit the one 📅 ICS FEED
+    // summary line per feed. Mutates and returns the findings (report-only).
+    finalizeIcsFeedFindings(findings, events, daysToLookAhead = null, nowMs = Date.now()) {
+        if (!Array.isArray(findings) || findings.length === 0) return findings;
+        const runEvents = Array.isArray(events) ? events : [];
+        const lookAheadDays = Number(daysToLookAhead);
+        const windowEndMs = Number.isFinite(lookAheadDays) && lookAheadDays > 0
+            ? nowMs + (lookAheadDays * 24 * 60 * 60 * 1000)
+            : null;
+        for (const finding of findings) {
+            let withinWindow = 0;
+            let matched = 0;
+            const records = Array.isArray(finding.records) ? finding.records : [];
+            for (const record of records) {
+                const startMs = this.toEpochMillis(record.start);
+                if (startMs !== null && startMs >= nowMs && (windowEndMs === null || startMs <= windowEndMs)) {
+                    withinWindow += 1;
+                }
+                const pseudoEvent = {
+                    title: record.summary,
+                    startDate: record.start,
+                    endDate: record.end,
+                    url: record.url,
+                    location: record.location
+                };
+                const matchedEvent = runEvents.find(event =>
+                    this.areEventsSameIdentity(pseudoEvent, event) ||
+                    this.areEventsSameIdentity(event, pseudoEvent) ||
+                    (this.areTitlesSimilar(record.summary, event.title || event.name || '') &&
+                        Boolean(this.getEventNightKey(pseudoEvent)) &&
+                        this.getEventNightKey(pseudoEvent) === this.getEventNightKey(event))) || null;
+                if (matchedEvent) {
+                    matched += 1;
+                    record.matchedRunEventTitle = matchedEvent.title || matchedEvent.name || '';
+                }
+            }
+            finding.veventsWithinWindow = withinWindow;
+            finding.matchedRunEvents = matched;
+            console.log(`📅 ICS FEED: ${finding.feedUrl} — ${finding.vevents} VEVENTs, ${withinWindow} within the lookahead window; ${matched} match events this run extracted (by identity)`);
+        }
+        return findings;
+    }
+
     async crawlUrlsForEvents({
         urls,
         allEvents,
@@ -5776,7 +5967,10 @@ class SharedCore {
         crawlGoneCollector = null,
         // Events dropped by the cross-org crawl guard (flag, don't drop):
         // collected per host with the owning org so the run surfaces them.
-        foreignOrgDropCollector = null
+        foreignOrgDropCollector = null,
+        // Linked-ICS-feed discovery (report-only): { seen: Set, findings: [] }
+        // scoped to one parser run — see collectIcsFeedFindings.
+        icsFeedCollector = null
     }) {
         const adaptiveCrawl = maxDepth === ADAPTIVE_CRAWL_DEPTH;
         const urlsToProcess = currentDepth > 0
@@ -5880,6 +6074,17 @@ class SharedCore {
 
                 if (currentDepth === 0 && urlClassifications && typeof urlClassifications === 'object') {
                     urlClassifications[url] = pageClassification;
+                }
+
+                // Linked-ICS-feed discovery (report-only, never aborts the
+                // crawl): scan this page's raw HTML for feed links and fetch
+                // new candidates once through the same adapter + page cache.
+                if (icsFeedCollector && htmlData && typeof htmlData.html === 'string' && htmlData.html) {
+                    try {
+                        await this.collectIcsFeedFindings({ html: htmlData.html, pageUrl: url, httpAdapter, icsFeedCollector });
+                    } catch (error) {
+                        console.warn(`⚠️ SharedCore: ICS feed discovery failed on ${url} (report-only, crawl unaffected): ${error && error.message ? error.message : error}`);
+                    }
                 }
 
                 const eventCount = discoveryOnly ? 0 : (parseResult?.events?.length || 0);
@@ -6159,7 +6364,8 @@ class SharedCore {
                             enrichDropCollector,
                             crawlErrorCollector,
                             crawlGoneCollector,
-                            foreignOrgDropCollector
+                            foreignOrgDropCollector,
+                            icsFeedCollector
                         });
                     }
                 } else {
@@ -13098,6 +13304,11 @@ class SharedCore {
 
         // Analyze each event against existing calendar events
         const analyzedEvents = [];
+        // Same-venue overlap surfacing (report-only): each analyzed entry is
+        // kept alongside the existing-event candidates already fetched for its
+        // merge analysis, so the overlap pass below needs no extra calendar
+        // reads. See applyVenueOverlapFlags.
+        const venueOverlapEntries = [];
 
         for (const event of events) {
             // Get existing events from the adapter
@@ -13166,7 +13377,12 @@ class SharedCore {
                 }
             }
 
-            analyzedEvents.push(await this.buildAnalyzedCalendarEvent(preparedEvent, analysis, calendarAdapter, config));
+            const analyzedEntry = await this.buildAnalyzedCalendarEvent(preparedEvent, analysis, calendarAdapter, config);
+            analyzedEvents.push(analyzedEntry);
+            venueOverlapEntries.push({
+                event: analyzedEntry,
+                existingEvents: Array.isArray(existingEvents) ? existingEvents : []
+            });
         }
 
         // Manual override, rescue direction: an enforce-mode dropped event whose
@@ -13282,6 +13498,15 @@ class SharedCore {
                 dropped._duplicateOfKept = kept.title || 'Unknown';
                 console.log(`🐻 BEAR CHECK: dropped "${droppedEvent.title || 'Unknown'}" duplicates kept "${dropped._duplicateOfKept}" (place+day+title-subset) — folded out of the dropped list`);
             }
+        }
+
+        // Same-venue overlap surfacing (report-only, never throws): stamp
+        // colliding cards + one ⚔️ OVERLAP line per pair. Actions, merges and
+        // writes are untouched — the owner resolves double-booked slots.
+        try {
+            this.applyVenueOverlapFlags(venueOverlapEntries);
+        } catch (error) {
+            console.warn(`⚠️ SharedCore: venue-overlap pass failed (report-only, run unaffected): ${error && error.message ? error.message : error}`);
         }
 
         this.logCalendarStickinessSummary();
@@ -15252,6 +15477,197 @@ class SharedCore {
 
     areEventsSameIdentity(newEvent, existingEvent) {
         return Boolean(this.getSameEventIdentitySignal(newEvent, existingEvent));
+    }
+
+    // === Same-venue overlap surfacing (report-only) ===
+    // ONYX/BEER BUST incident: Eagle LA's site published the weekly SUNDAY
+    // BEER BUST listing even on the 2nd Sunday when ONYX takes over the slot —
+    // two scraped events, same venue, overlapping times, both "real" per the
+    // site, one factually wrong. The pipeline SURFACES the collision (stamp +
+    // one ⚔️ OVERLAP log line + a results-UI chip) and never resolves it —
+    // the owner decides. Every rung fails closed: no positive venue identity,
+    // no shared local day, or no genuine time information → nothing.
+
+    // Local wall-clock reading of a date in a timezone, or null when the date
+    // is unparseable. Mirrors getEventNightKey's Intl usage (UTC fallback when
+    // Intl or the timezone is unavailable — _timezoneUnresolved events store
+    // wall-clock components labeled UTC, so the UTC read IS the local one).
+    getLocalClockParts(dateInput, timezone) {
+        const millis = this.toEpochMillis(dateInput);
+        if (millis === null) return null;
+        const date = new Date(millis);
+        if (timezone && typeof Intl !== 'undefined' && typeof Intl.DateTimeFormat === 'function') {
+            try {
+                const formatter = new Intl.DateTimeFormat('en-CA', {
+                    timeZone: timezone,
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    hourCycle: 'h23'
+                });
+                const parts = formatter.formatToParts(date);
+                const read = (type) => {
+                    const part = parts.find(entry => entry.type === type);
+                    return part ? parseInt(part.value, 10) : NaN;
+                };
+                const hour = read('hour');
+                const minute = read('minute');
+                if (Number.isFinite(hour) && Number.isFinite(minute)) {
+                    return { hour, minute };
+                }
+            } catch (_) {
+                // fall through to the UTC read
+            }
+        }
+        return { hour: date.getUTCHours(), minute: date.getUTCMinutes() };
+    }
+
+    formatLocalClockTime(dateInput, timezone) {
+        const parts = this.getLocalClockParts(dateInput, timezone);
+        if (!parts) return '';
+        return `${String(parts.hour).padStart(2, '0')}:${String(parts.minute).padStart(2, '0')}`;
+    }
+
+    // The time window an event claims for overlap purposes, as epoch millis,
+    // or null when the event carries no genuine time information (fail closed).
+    // - A real positive-duration end → [start, end).
+    // - A degenerate end (missing, or end <= start — the normalization
+    //   artifact hasDegenerateEnd documents) with a REAL clock time → the
+    //   listing claims the slot from its stated start; assume a conservative
+    //   6-hour span (the real BEER BUST record is exactly this shape: "BAR
+    //   OPENS 2PM", zero duration, while ONYX runs 4–8PM the same Sunday).
+    // - A degenerate end at exactly local midnight → the missing-time default
+    //   (extraction found only a date, per the getEventNightKey doctrine) —
+    //   no genuine time info, never compared.
+    getVenueOverlapWindow(event, shape) {
+        const startMs = this.toEpochMillis(shape.startDate);
+        if (startMs === null) return null;
+        const endMs = this.toEpochMillis(event && event.endDate);
+        if (endMs !== null && endMs > startMs) {
+            return { startMs, endMs, assumedEnd: false };
+        }
+        const clock = this.getLocalClockParts(shape.startDate, shape.timezone);
+        if (!clock || (clock.hour === 0 && clock.minute === 0)) return null;
+        const ASSUMED_OPEN_ENDED_SPAN_MS = 6 * 60 * 60 * 1000;
+        return { startMs, endMs: startMs + ASSUMED_OPEN_ENDED_SPAN_MS, assumedEnd: true };
+    }
+
+    // Report-only finding for one pair, or null. Fails closed at every step;
+    // adjacency is never overlap (strict half-open interval test); rrules are
+    // never expanded — only the concrete dated instances in hand compare.
+    getVenueOverlapFinding(eventA, eventB) {
+        if (!eventA || typeof eventA !== 'object' || !eventB || typeof eventB !== 'object') return null;
+        const shapeA = this.buildIdentityComparisonShape(eventA);
+        const shapeB = this.buildIdentityComparisonShape(eventB);
+
+        // Same local calendar day (multi-day series-range artifacts die here:
+        // they only ever compare against events starting the same local day).
+        if (!this.areIdentityDatesOnSameLocalDay(shapeA, shapeB)) return null;
+
+        // POSITIVE venue identity — a side with no place evidence never flags.
+        if (!this.areIdentityPlacesSimilar(shapeA, shapeB)) return null;
+
+        // NOT the same event / title family. A stub+detail pair of one event,
+        // a merge target, or a title-subset twin must never read as a
+        // double-booking.
+        const keyA = eventA.key === undefined || eventA.key === null ? '' : String(eventA.key);
+        const keyB = eventB.key === undefined || eventB.key === null ? '' : String(eventB.key);
+        if (keyA && keyA === keyB) return null;
+        const idA = eventA.identifier || eventA.id;
+        const idB = eventB.identifier || eventB.id;
+        if (idA && idB && String(idA) === String(idB)) return null;
+        if (this.areEventsSameIdentity(eventA, eventB) || this.areEventsSameIdentity(eventB, eventA)) return null;
+        if (this.getCalendarTitleSubsetSignal(eventA, eventB) || this.getCalendarTitleSubsetSignal(eventB, eventA)) return null;
+        if (this.areIdentityNamesSimilar(shapeA, shapeB)) return null;
+
+        const windowA = this.getVenueOverlapWindow(eventA, shapeA);
+        if (!windowA) return null;
+        const windowB = this.getVenueOverlapWindow(eventB, shapeB);
+        if (!windowB) return null;
+        if (!(windowA.startMs < windowB.endMs && windowB.startMs < windowA.endMs)) return null;
+
+        const timezone = shapeA.timezone || shapeB.timezone || null;
+        const describeWindow = (window, ownTimezone) => {
+            const start = this.formatLocalClockTime(new Date(window.startMs), ownTimezone || timezone);
+            const end = this.formatLocalClockTime(new Date(window.endMs), ownTimezone || timezone);
+            return `${start}–${end}${window.assumedEnd ? ' (assumed end)' : ''}`;
+        };
+        const firstLocationLine = (shape) => String(shape.locationText || '').split('\n')[0].trim();
+        return {
+            date: this.normalizeEventDateLocal(shapeA.startDate, timezone),
+            venue: shapeA.bar || shapeB.bar || firstLocationLine(shapeA) || firstLocationLine(shapeB) || 'the same venue',
+            titleA: (shapeA.names[0] || 'Unknown'),
+            titleB: (shapeB.names[0] || 'Unknown'),
+            windowA: describeWindow(windowA, shapeA.timezone),
+            windowB: describeWindow(windowB, shapeB.timezone)
+        };
+    }
+
+    // Stamp `_venueOverlap` (report-only) on analyzed events that collide with
+    // another same-run analyzed event or an existing calendar record at the
+    // same venue. entries: [{ event: analyzedEvent, existingEvents: [...] }].
+    // Never throws; never changes actions, merges, or writes.
+    applyVenueOverlapFlags(entries) {
+        if (!Array.isArray(entries) || entries.length === 0) return;
+        const seenPairs = new Set();
+        const pairKeyFor = (finding) => {
+            const names = [this.normalizeIdentityText(finding.titleA), this.normalizeIdentityText(finding.titleB)].sort();
+            return `${names[0]}|${names[1]}|${finding.date}`;
+        };
+        const stamp = (event, finding, withTitle, ownWindow, otherWindow, source) => {
+            if (!Array.isArray(event._venueOverlap)) event._venueOverlap = [];
+            event._venueOverlap.push({
+                withTitle,
+                date: finding.date,
+                venue: finding.venue,
+                window: ownWindow,
+                otherWindow,
+                source
+            });
+        };
+        const logFinding = (finding) => {
+            console.log(`⚔️ OVERLAP: "${finding.titleA}" and "${finding.titleB}" overlap at ${finding.venue} on ${finding.date} — report-only, venue data may double-book the slot`);
+        };
+
+        // Same-run analyzed pairs: both cards get the chip.
+        for (let i = 0; i < entries.length; i++) {
+            for (let j = i + 1; j < entries.length; j++) {
+                const eventA = entries[i] && entries[i].event;
+                const eventB = entries[j] && entries[j].event;
+                if (!eventA || !eventB) continue;
+                const finding = this.getVenueOverlapFinding(eventA, eventB);
+                if (!finding) continue;
+                const pairKey = pairKeyFor(finding);
+                if (seenPairs.has(pairKey)) continue;
+                seenPairs.add(pairKey);
+                stamp(eventA, finding, finding.titleB, finding.windowA, finding.windowB, 'run');
+                stamp(eventB, finding, finding.titleA, finding.windowB, finding.windowA, 'run');
+                logFinding(finding);
+            }
+        }
+
+        // Analyzed event vs existing calendar records (the candidates already
+        // fetched for merge analysis — no extra calendar reads). The event's
+        // own merge target is excluded; a colliding record that ALSO arrived
+        // in this run dedupes to one finding via the title-pair key above.
+        for (const entry of entries) {
+            const event = entry && entry.event;
+            if (!event || !Array.isArray(entry.existingEvents)) continue;
+            const target = event._existingEvent && event._existingEvent.identifier
+                ? String(event._existingEvent.identifier)
+                : (event._existingKey ? String(event._existingKey) : '');
+            for (const record of entry.existingEvents) {
+                if (!record || typeof record !== 'object') continue;
+                const recordId = record.identifier || record.id;
+                if (target && recordId && String(recordId) === target) continue;
+                const finding = this.getVenueOverlapFinding(event, record);
+                if (!finding) continue;
+                const pairKey = pairKeyFor(finding);
+                if (seenPairs.has(pairKey)) continue;
+                seenPairs.add(pairKey);
+                stamp(event, finding, finding.titleB, finding.windowA, finding.windowB, 'calendar');
+                logFinding(finding);
+            }
+        }
     }
 
     // === Cross-source duplicate detection (within one parser run) ===

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -18311,3 +18311,312 @@ test('registry pass + canonicalization end-to-end: BEEFMINCE match routes the pl
   assert.equal(event.ticketUrl, 'https://dice.fm/event/yoepxa-beefmince-x-rvt-19th-sep-the-royal-vauxhall-tavern-london-tickets');
   assert.equal(event.url, undefined, 'url never exists post-canonicalization');
 });
+
+// ===========================================================================
+// Same-venue overlap surfacing (report-only) — the ONYX/BEER BUST incident.
+// Real record shapes from run 20260811-132948 (Eagle LA venue site, MEC):
+// the weekly SUNDAY BEER BUST occurrence is published even on the 2nd Sunday
+// when ONYX takes over the slot. BEER BUST is zero-duration ("BAR OPENS
+// 2PM" — start == end at 2PM PDT); ONYX runs 4–8PM PDT the same Sunday.
+// The pipeline SURFACES the collision and never resolves it.
+// ===========================================================================
+
+function buildBeerBustEvent(overrides = {}) {
+  return {
+    title: 'SUNDAY BEER BUST',
+    description: 'BAR OPENS 2PM\nNO COVER\n$5 DOMESTIC DRAFTS',
+    startDate: new Date('2026-09-13T21:00:00.000Z'),
+    endDate: new Date('2026-09-13T21:00:00.000Z'),
+    bar: 'Eagle LA',
+    url: 'https://eaglela.com/events/sunday-beer-bust-4/?occurrence=2026-09-13',
+    ticketUrl: 'https://eaglela.com/events/sunday-beer-bust-4/?occurrence=2026-09-13',
+    city: 'la',
+    timezone: 'America/Los_Angeles',
+    address: '4219 Santa Monica Blvd, Los Angeles, CA 90029',
+    location: '34.0912127, -118.2840632',
+    key: 'sunday-beer-bust|2026-09-13|eagle la',
+    ...overrides
+  };
+}
+
+function buildOnyxEvent(overrides = {}) {
+  return {
+    title: 'ONYX',
+    startDate: new Date('2026-09-13T23:00:00.000Z'),
+    endDate: new Date('2026-09-14T03:00:00.000Z'),
+    bar: 'Eagle LA',
+    url: 'https://eaglela.com/events/onyx-2/',
+    ticketUrl: 'https://eaglela.com/events/onyx-2/',
+    city: 'la',
+    timezone: 'America/Los_Angeles',
+    address: '4219 Santa Monica Blvd, Los Angeles, CA 90029',
+    location: '34.0912127, -118.2840632',
+    key: 'onyx|2026-09-13|eagle la',
+    ...overrides
+  };
+}
+
+test('venue overlap: ONYX and the double-booked SUNDAY BEER BUST occurrence flag each other (report-only)', () => {
+  const core = createCore();
+  const beerBust = buildBeerBustEvent();
+  const onyx = buildOnyxEvent();
+  core.applyVenueOverlapFlags([
+    { event: beerBust, existingEvents: [] },
+    { event: onyx, existingEvents: [] }
+  ]);
+  assert.equal(beerBust._venueOverlap.length, 1, 'beer bust stamped once');
+  assert.equal(beerBust._venueOverlap[0].withTitle, 'ONYX');
+  assert.equal(beerBust._venueOverlap[0].date, '2026-09-13');
+  assert.equal(beerBust._venueOverlap[0].venue, 'Eagle LA');
+  assert.equal(beerBust._venueOverlap[0].source, 'run');
+  assert.ok(beerBust._venueOverlap[0].window.includes('(assumed end)'),
+    'the zero-duration listing claims the slot via the conservative assumed span');
+  assert.equal(onyx._venueOverlap.length, 1, 'onyx stamped once');
+  assert.equal(onyx._venueOverlap[0].withTitle, 'SUNDAY BEER BUST');
+  assert.equal(onyx._venueOverlap[0].window, '16:00–20:00', 'onyx window rendered in local time');
+});
+
+test('venue overlap: the same event scraped twice (listing stub + crawled page) never flags', () => {
+  const core = createCore();
+  const detail = buildOnyxEvent();
+  const stub = buildOnyxEvent({
+    title: 'ONYX at Eagle LA',
+    key: 'onyx-at-eagle-la|2026-09-13|eagle la',
+    endDate: new Date('2026-09-13T23:00:00.000Z')
+  });
+  core.applyVenueOverlapFlags([
+    { event: detail, existingEvents: [] },
+    { event: stub, existingEvents: [] }
+  ]);
+  assert.equal(detail._venueOverlap, undefined, 'detail record unflagged');
+  assert.equal(stub._venueOverlap, undefined, 'its own stub unflagged');
+});
+
+test('venue overlap: different venues never flag, even with identical times', () => {
+  const core = createCore();
+  const onyx = buildOnyxEvent();
+  const elsewhere = buildBeerBustEvent({
+    bar: 'The Bullet Bar',
+    address: '10522 Burbank Blvd, North Hollywood, CA 91601',
+    location: '34.1683000, -118.3585000',
+    url: 'https://bulletbarla.com/events/beer-bust/',
+    ticketUrl: 'https://bulletbarla.com/events/beer-bust/',
+    key: 'sunday-beer-bust|2026-09-13|the bullet bar',
+    startDate: new Date('2026-09-13T23:00:00.000Z'),
+    endDate: new Date('2026-09-14T03:00:00.000Z')
+  });
+  core.applyVenueOverlapFlags([
+    { event: onyx, existingEvents: [] },
+    { event: elsewhere, existingEvents: [] }
+  ]);
+  assert.equal(onyx._venueOverlap, undefined, 'no positive venue identity → nothing');
+  assert.equal(elsewhere._venueOverlap, undefined);
+});
+
+test('venue overlap: adjacent-but-not-overlapping windows never flag (strict intervals)', () => {
+  const core = createCore();
+  const onyx = buildOnyxEvent(); // 16:00–20:00 PDT
+  const later = buildBeerBustEvent({
+    title: 'MEAT RACK',
+    url: 'https://eaglela.com/events/meat-rack-9/',
+    ticketUrl: 'https://eaglela.com/events/meat-rack-9/',
+    key: 'meat-rack|2026-09-13|eagle la',
+    startDate: new Date('2026-09-14T03:00:00.000Z'), // 20:00 PDT, still Sunday
+    endDate: new Date('2026-09-14T06:00:00.000Z') // 23:00 PDT
+  });
+  core.applyVenueOverlapFlags([
+    { event: onyx, existingEvents: [] },
+    { event: later, existingEvents: [] }
+  ]);
+  assert.equal(onyx._venueOverlap, undefined, 'touching endpoints are adjacency, not overlap');
+  assert.equal(later._venueOverlap, undefined);
+});
+
+test('venue overlap: local-midnight zero-duration placeholders carry no time info and fail closed', () => {
+  const core = createCore();
+  // Real shapes from the same run: BLUF LA and the MR REGIMENT meet-and-greet
+  // are both published at 07:00Z = exactly local midnight PDT with zero
+  // duration — MEC's missing-time default, not a genuine slot claim.
+  const blufLa = buildBeerBustEvent({
+    title: 'BLUF LA',
+    url: 'https://eaglela.com/events/bluf-la-5/',
+    ticketUrl: 'https://eaglela.com/events/bluf-la-5/',
+    key: 'bluf-la|2026-09-18|eagle la',
+    startDate: new Date('2026-09-18T07:00:00.000Z'),
+    endDate: new Date('2026-09-18T07:00:00.000Z')
+  });
+  const meetAndGreet = buildBeerBustEvent({
+    title: 'MR REGIMENT LEATHER 2027 CONTEST MEET AND GREET',
+    url: 'https://eaglela.com/events/mr-regiment-meet-and-greet/',
+    ticketUrl: 'https://eaglela.com/events/mr-regiment-meet-and-greet/',
+    key: 'mr-regiment-leather-2027-contest-meet-and-greet|2026-09-18|eagle la',
+    startDate: new Date('2026-09-18T07:00:00.000Z'),
+    endDate: new Date('2026-09-18T07:00:00.000Z')
+  });
+  core.applyVenueOverlapFlags([
+    { event: blufLa, existingEvents: [] },
+    { event: meetAndGreet, existingEvents: [] }
+  ]);
+  assert.equal(blufLa._venueOverlap, undefined, 'no genuine time overlap → nothing');
+  assert.equal(meetAndGreet._venueOverlap, undefined);
+});
+
+test('venue overlap: an analyzed event flags against a colliding existing calendar record', () => {
+  const core = createCore();
+  const onyx = buildOnyxEvent();
+  const calendarBeerBust = {
+    name: 'SUNDAY BEER BUST',
+    startDate: new Date('2026-09-13T21:00:00.000Z'),
+    endDate: new Date('2026-09-13T21:00:00.000Z'),
+    location: '34.0912127, -118.2840632',
+    notes: 'bar: Eagle LA\ntimezone: America/Los_Angeles',
+    identifier: 'CAL-BEER-BUST-1'
+  };
+  core.applyVenueOverlapFlags([{ event: onyx, existingEvents: [calendarBeerBust] }]);
+  assert.equal(onyx._venueOverlap.length, 1);
+  assert.equal(onyx._venueOverlap[0].withTitle, 'SUNDAY BEER BUST');
+  assert.equal(onyx._venueOverlap[0].source, 'calendar');
+});
+
+test('venue overlap: the analyzed event\'s own merge target is never treated as a collision', () => {
+  const core = createCore();
+  const onyx = buildOnyxEvent();
+  onyx._existingEvent = { identifier: 'CAL-ONYX-1' };
+  const mergeTarget = {
+    name: 'SUNDAY BEER BUST',
+    startDate: new Date('2026-09-13T21:00:00.000Z'),
+    endDate: new Date('2026-09-13T21:00:00.000Z'),
+    location: '34.0912127, -118.2840632',
+    notes: 'bar: Eagle LA\ntimezone: America/Los_Angeles',
+    identifier: 'CAL-ONYX-1'
+  };
+  core.applyVenueOverlapFlags([{ event: onyx, existingEvents: [mergeTarget] }]);
+  assert.equal(onyx._venueOverlap, undefined, 'merge target excluded regardless of shape');
+});
+
+// ===========================================================================
+// Linked-ICS-feed discovery (report-only): detect feed links with generic
+// patterns, fetch once through the injected adapter, parse with the existing
+// published-calendar VEVENT machinery — rrules are never expanded.
+// ===========================================================================
+
+const ICS_FEED_FIXTURE = [
+  'BEGIN:VCALENDAR',
+  'VERSION:2.0',
+  'PRODID:-//Test//Feed//EN',
+  'BEGIN:VEVENT',
+  'UID:beer-bust-1@example.com',
+  'SUMMARY:SUNDAY BEER BUST',
+  'DTSTART:20260913T210000Z',
+  'DTEND:20260913T230000Z',
+  'RRULE:FREQ=WEEKLY;BYDAY=SU',
+  'URL:https://example.com/events/sunday-beer-bust/',
+  'LOCATION:Eagle LA',
+  'END:VEVENT',
+  'BEGIN:VEVENT',
+  'UID:onyx-1@example.com',
+  'SUMMARY:ONYX',
+  'DTSTART;TZID=America/Los_Angeles:20260913T160000',
+  'DTEND;TZID=America/Los_Angeles:20260913T200000',
+  'URL:https://example.com/events/onyx/',
+  'LOCATION:Eagle LA',
+  'END:VEVENT',
+  'BEGIN:VEVENT',
+  'UID:far-future@example.com',
+  'SUMMARY:NEW YEARS 2030',
+  'DTSTART:20301231T200000Z',
+  'END:VEVENT',
+  'END:VCALENDAR'
+].join('\r\n');
+
+test('ICS discovery: detects text/calendar links, webcal links, .ics hrefs and ?ical=1 exports (generic patterns, capped per page)', () => {
+  const core = createCore();
+  const html = [
+    '<link rel="alternate" type="text/calendar" href="/events/feed/ical" />',
+    '<a href="webcal://example.com/calendar.ics">Subscribe</a>',
+    '<a href="/events/list/?ical=1">Export Events</a>',
+    '<a href="/files/summer.ics">Download</a>',
+    '<a href="/events/party/">A normal link</a>'
+  ].join('\n');
+  const candidates = core.detectIcsFeedLinks(html, 'https://example.com/events/');
+  assert.equal(candidates.length, 3, 'capped at 3 candidates per page');
+  assert.deepEqual(candidates[0], {
+    url: 'https://example.com/events/feed/ical',
+    fetchUrl: 'https://example.com/events/feed/ical',
+    via: 'text-calendar-link'
+  });
+  assert.equal(candidates[1].via, 'webcal');
+  assert.equal(candidates[1].url, 'webcal://example.com/calendar.ics', 'original webcal url kept for display');
+  assert.equal(candidates[1].fetchUrl, 'https://example.com/calendar.ics', 'webcal fetches over https');
+  assert.equal(candidates[2].via, 'ical-query');
+  assert.equal(candidates[2].fetchUrl, 'https://example.com/events/list/?ical=1');
+});
+
+test('ICS discovery: a page without feed links yields nothing', () => {
+  const core = createCore();
+  const html = '<a href="/events/party/">Party</a> <img src="/pic.jpg">';
+  assert.deepEqual(core.detectIcsFeedLinks(html, 'https://example.com/'), []);
+});
+
+test('ICS discovery: fetches a feed once through the adapter and parses VEVENTs without expanding rrules', async () => {
+  const core = createCore();
+  const fetched = [];
+  const httpAdapter = {
+    fetchData: async (url) => {
+      fetched.push(url);
+      return { html: ICS_FEED_FIXTURE, url, statusCode: 200, headers: {} };
+    }
+  };
+  const collector = { seen: new Set(), findings: [] };
+  const html = '<a href="/?ical=1">Export</a>';
+  await core.collectIcsFeedFindings({ html, pageUrl: 'https://example.com/events/', httpAdapter, icsFeedCollector: collector });
+  // Second page advertising the SAME feed: never fetched twice per run.
+  await core.collectIcsFeedFindings({ html, pageUrl: 'https://example.com/other/', httpAdapter, icsFeedCollector: collector });
+  assert.equal(fetched.length, 1, 'one fetch per unique feed url');
+  assert.equal(collector.findings.length, 1);
+  const finding = collector.findings[0];
+  assert.equal(finding.discoveredVia, 'ical-query');
+  assert.equal(finding.discoveredOn, 'https://example.com/events/');
+  assert.equal(finding.vevents, 3);
+  assert.equal(finding.records.length, 3, 'concrete instances only — the weekly rrule was NOT expanded');
+  assert.equal(finding.records[0].hasRrule, true, 'rrule carried as evidence, not expanded');
+  assert.equal(finding.records[1].hasRrule, false);
+  assert.equal(finding.records[0].start, '2026-09-13T21:00:00.000Z');
+  assert.equal(finding.records[1].summary, 'ONYX');
+});
+
+test('ICS discovery: a candidate returning HTML is skipped, not recorded', async () => {
+  const core = createCore();
+  const httpAdapter = {
+    fetchData: async (url) => ({ html: '<!DOCTYPE html><html><body>nope</body></html>', url, statusCode: 200, headers: {} })
+  };
+  const collector = { seen: new Set(), findings: [] };
+  await core.collectIcsFeedFindings({
+    html: '<a href="/?ical=1">Export</a>',
+    pageUrl: 'https://example.com/',
+    httpAdapter,
+    icsFeedCollector: collector
+  });
+  assert.equal(collector.findings.length, 0, 'non-calendar body never becomes a finding');
+  assert.equal(collector.seen.size, 1, 'candidate still marked seen — no refetch loops');
+});
+
+test('ICS report: counts lookahead-window instances and identity matches against run events', () => {
+  const core = createCore();
+  const nowMs = new Date('2026-09-01T00:00:00.000Z').getTime();
+  const finding = {
+    feedUrl: 'https://example.com/?ical=1',
+    vevents: 3,
+    records: [
+      { summary: 'SUNDAY BEER BUST', start: '2026-09-13T21:00:00.000Z', end: '2026-09-13T23:00:00.000Z', url: 'https://example.com/events/sunday-beer-bust/', location: 'Eagle LA', hasRrule: true },
+      { summary: 'ONYX', start: '2026-09-13T23:00:00.000Z', end: '2026-09-14T03:00:00.000Z', url: 'https://example.com/events/onyx/', location: 'Eagle LA', hasRrule: false },
+      { summary: 'NEW YEARS 2030', start: '2030-12-31T20:00:00.000Z', end: null, url: '', location: '', hasRrule: false }
+    ]
+  };
+  const runEvents = [buildOnyxEvent()];
+  core.finalizeIcsFeedFindings([finding], runEvents, 30, nowMs);
+  assert.equal(finding.veventsWithinWindow, 2, 'the 2030 instance is outside the 30-day window');
+  assert.equal(finding.matchedRunEvents, 1, 'only ONYX was extracted this run');
+  assert.equal(finding.records[1].matchedRunEventTitle, 'ONYX');
+  assert.equal(finding.records[0].matchedRunEventTitle, undefined, 'beer bust matched nothing this run');
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -4086,6 +4086,23 @@ test('deduplicateEvents collapses two full-series exports of one series to the n
   assert.equal(kept.recurrenceRule, 'FREQ=WEEKLY;BYDAY=TH', 'the series rule survives the collapse');
 });
 
+// Series doctrine rework ("we can't condense the event with diff URLs"): an
+// occurrence-expanded family member carries report-only _seriesInfo — and
+// even if a recurrence claim survives on the record (defense in depth; the
+// classification pass normally demotes it), the series collapse must never
+// fold occurrence-expanded records across dates.
+test('deduplicateEvents never series-collapses records carrying _seriesInfo (occurrence-expanded)', async () => {
+  const core = createCore();
+  const thisWeek = new Date(Date.now() + 7 * SERIES_DAY_MS);
+  const nextWeek = new Date(thisWeek.getTime() + 7 * SERIES_DAY_MS);
+  const info = { rrule: 'FREQ=WEEKLY;BYDAY=TH', basis: '2 dates', occurrences: 2, family: 'shape-1' };
+  const first = buildWeeklySeriesExport(thisWeek, { _seriesInfo: info });
+  const second = buildWeeklySeriesExport(nextWeek, { _seriesInfo: info });
+  assert.equal(core.getSeriesExportIdentity(first), null, '_seriesInfo disqualifies the record as a series export');
+  const result = await core.deduplicateEvents([first, second], null);
+  assert.equal(result.length, 2, 'occurrence-expanded records keep every date individual');
+});
+
 test('deduplicateEvents keeps two distinct single occurrences of a recurring event separate', async () => {
   // Behavior-preservation guard (passes on main and on the collapse branch):
   // run 20260802-221204's SUNDAY BEER BUST extracted two genuinely distinct
@@ -12669,6 +12686,108 @@ test('saved-series lookup: fails open on adapter errors and never runs for non-s
   const plainAnalysis = await core.resolveCalendarAnalysisWithSeriesProbe(plain, [], 'upsert', counting);
   assert.equal(plainAnalysis.action, 'new');
   assert.equal(lookupCalls, 0, 'a non-series event never triggers the lookup');
+});
+
+// ---------------------------------------------------------------------------
+// Occurrence-expanded doctrine (series rework): a member of an
+// occurrence-expanded family carries report-only _seriesInfo (stamped by the
+// ai-web parser's source-shape classification) and is written like any
+// single event — EXCEPT when the owner's calendar already holds the series
+// covering it: then the write is withheld with the SERIES MATCH label, so
+// occurrence-expansion never fights his imported series.
+// ---------------------------------------------------------------------------
+
+function buildScrapedCubscoutOccurrence() {
+  // Future-relative (like the series-collapse fixtures): a past span would
+  // trip the _pastSpanWithheld gate before the doctrine under test.
+  const start = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+  return {
+    title: 'CUBSCOUT',
+    startDate: start,
+    endDate: new Date(start.getTime() + 5 * 60 * 60 * 1000),
+    bar: 'Eagle LA',
+    city: 'la',
+    ticketUrl: 'https://dice.fm/event/abc123-cubscout-aug-7-tickets',
+    _seriesInfo: { rrule: 'FREQ=MONTHLY;BYDAY=1FR', basis: '3× 1st Friday', occurrences: 3, family: 'shape-1' }
+  };
+}
+
+test('occurrence-expanded predicates: isOccurrenceExpandedEvent / isSeriesCoveredOccurrence', () => {
+  const occurrence = buildScrapedCubscoutOccurrence();
+  assert.equal(SharedCore.isOccurrenceExpandedEvent(occurrence), true);
+  assert.equal(SharedCore.isOccurrenceExpandedEvent({ title: 'ONE OFF' }), false);
+  assert.equal(SharedCore.isRecurringSeriesEvent(occurrence), false, '_seriesInfo alone is never a series claim');
+  assert.equal(SharedCore.isSeriesCoveredOccurrence(occurrence), false, 'no saved-series match, no withhold');
+  occurrence._seriesMatch = { identifier: 'CAL-UUID:x', calendarName: 'chunky-dad-la' };
+  assert.equal(SharedCore.isSeriesCoveredOccurrence(occurrence), true);
+  assert.equal(SharedCore.isSeriesCoveredOccurrence({ _seriesMatch: { identifier: 'CAL-UUID:x' } }), false,
+    'a series-export _seriesMatch alone never trips the occurrence gate');
+});
+
+test('occurrence-expanded single vs saved series: lookup runs, write withheld with SERIES MATCH', async () => {
+  const core = createLaCore();
+  const saved = [
+    buildSavedCubscoutOccurrence('2026-09-05T04:00:00.000Z'),
+    buildSavedCubscoutOccurrence('2026-10-03T04:00:00.000Z')
+  ];
+  const adapter = buildSeriesLookupAdapter(saved);
+  const occurrence = buildScrapedCubscoutOccurrence();
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(occurrence, [], 'upsert', adapter);
+  assert.equal(analysis.action, 'new', 'the analysis action itself is untouched');
+  assert.ok(analysis.seriesMatch, 'the saved-series lookup runs for occurrence-expanded singles too');
+  assert.equal(analysis.seriesMatch.identifier, 'CAL-UUID:cubscout-20260731T193113Z@chunky.dad');
+
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (message) => { lines.push(String(message)); };
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(occurrence, analysis, adapter, {});
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.ok(analyzed._seriesInfo, 'the family metadata survives onto the analyzed event');
+  assert.ok(analyzed._seriesMatch, 'the saved-series match is stamped');
+  assert.equal(analyzed._seriesMatch.calendarName, 'chunky-dad-la');
+  assert.equal(analyzed._recurring, undefined, 'never turned into a series');
+  assert.equal(analyzed._recurringExport, undefined, 'no ICS-export series framing for an occurrence');
+  assert.equal(analyzed.ticketUrl, occurrence.ticketUrl, 'the occurrence keeps its own ticket link');
+  assert.ok(
+    lines.some(l => l.includes('🔁 SHAPE:') && l.includes('covered by the saved series in chunky-dad-la') && l.includes('SERIES MATCH')),
+    `the withhold says so out loud: ${JSON.stringify(lines)}`
+  );
+  assert.equal(SharedCore.isSeriesCoveredOccurrence(analyzed), true);
+  assert.equal(SharedCore.describeExecutionDisposition(analyzed),
+    'WITHHELD (occurrence covered by saved series — SERIES MATCH)');
+  assert.deepEqual(SharedCore.filterEventsForExecution([analyzed]), [], 'and nothing is written');
+});
+
+test('occurrence-expanded single with NO saved series: written like any single event', async () => {
+  const core = createLaCore();
+  const adapter = buildSeriesLookupAdapter([]);
+  const occurrence = buildScrapedCubscoutOccurrence();
+
+  const analysis = await core.resolveCalendarAnalysisWithSeriesProbe(occurrence, [], 'upsert', adapter);
+  assert.equal(analysis.action, 'new');
+  assert.equal(analysis.seriesMatch, undefined, 'nothing saved, nothing matched');
+
+  const analyzed = await core.buildAnalyzedCalendarEvent(occurrence, analysis, adapter, {});
+  assert.equal(analyzed._seriesMatch, undefined);
+  assert.ok(analyzed._seriesInfo, 'the report-only metadata rides along');
+  assert.equal(SharedCore.describeExecutionDisposition(analyzed), 'NEW');
+  assert.equal(SharedCore.filterEventsForExecution([analyzed]).length, 1,
+    'an uncovered occurrence writes exactly like any single event');
+});
+
+test('mergeParsedEvents carries _seriesInfo from the secondary record (same-night stub+detail fold)', async () => {
+  const core = createLaCore();
+  const info = { rrule: 'FREQ=MONTHLY;BYDAY=1FR', basis: '3× 1st Friday', occurrences: 3, family: 'shape-1' };
+  const stub = { ...buildScrapedCubscoutOccurrence(), _seriesInfo: info };
+  const detail = { title: 'CUBSCOUT', startDate: new Date('2026-08-08T02:00:00.000Z'), bar: 'Eagle LA', city: 'la' };
+  const merged = await core.mergeParsedEvents(stub, detail, {});
+  assert.deepEqual(merged._seriesInfo, info, 'the family stamp survives a merge that keeps the other record');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Two long-pinned features, both report-only, one branch.

**Note:** this branch merges in `feat/series-doctrine-rework` (#1677, still open at branch time) — its commits appear in this diff until #1677 lands; the new work here is commit 87540dd1 only.

## Feature 1 — Same-venue overlap report flag (⚔️ OVERLAP)

The ONYX/BEER BUST incident: Eagle LA's site published the weekly SUNDAY BEER BUST listing even on the 2nd Sunday when ONYX takes the slot — two scraped events, same venue, overlapping times, both "real" per the site, one factually wrong. The pipeline now SURFACES the collision and never resolves it.

- During `prepareEventsForCalendar`, same-run analyzed pairs and analyzed-vs-existing-calendar-record pairs (candidates already fetched for merge analysis — no extra calendar reads) that share **positive venue identity** (`areIdentityPlacesSimilar`) AND **overlapping time windows on the same local day** AND are **not the same event/title family** (identity signals, dedup key, title-subset, name similarity — a listing stub + its crawled detail page never flags) are stamped `_venueOverlap` (who, date, venue, both windows) and logged once per pair:
  `⚔️ OVERLAP: "SUNDAY BEER BUST" and "ONYX" overlap at Eagle LA on 2026-09-13 — report-only, venue data may double-book the slot`
- **Time semantics** (driven by the real record shapes): real intervals compare strictly — adjacency is never overlap. A degenerate end (start == end, the normalization artifact `hasDegenerateEnd` documents) with a real clock time claims a conservative 6-hour span — the real BEER BUST record is exactly this shape ("BAR OPENS 2PM", zero duration). A degenerate end at exactly local midnight is the missing-time default (per the `getEventNightKey` doctrine) — no genuine time info, fails closed. Rrules are never expanded; only concrete dated instances compare.
- Results UI: one new conditional reason-chip (`⚔️ overlaps: <title>`) on affected cards, same mechanism as the sanity chip. No other UI changes. `_venueOverlap` rides the existing pass-through run-save serialization on both adapters.
- Actions/merges/writes untouched; the whole pass is wrapped so a failure can never affect the run.

**Real-run verification:** all 30 Eagle LA records from run 20260811-132948 through the pass → **0 flags** (midnight placeholders fail closed, the month-long MOVIE MONDAYS series-range artifact dies at the same-start-day gate, real adjacent events stay silent). The incident shape (beer-bust occurrence dated to the colliding 2nd Sunday, as the site itself publishes via `?occurrence=`) flags both cards through the real `prepareEventsForCalendar` path with actions unchanged.

## Feature 2 — Linked-ICS-feed discovery (📅 ICS FEED, report-only)

Per doctrine ("calendar websites do the expansion for us"), a published ICS feed is exactly the structured occurrence source the scraper wants. This wave is discovery + report only:

- Generic detection during crawls (no per-site rules): `webcal://` links, `.ics` hrefs, `type="text/calendar"` links, WordPress calendar-plugin export params (`?ical=1` / `?outlook-ical=1` — the same shapes the #1559 crawl reject names, consumed here as a separate evidence channel; **the #1559 calendar-export crawl reject is untouched** and these URLs are still never crawl candidates).
- Each new candidate is fetched once per parser run through the injected http adapter (transparently page-cached like any page), validated (`BEGIN:VCALENDAR`), and parsed with the **existing** `parsePublishedCalendarIcs` machinery — rrules stay raw strings, never expanded; concrete VEVENT instances only.
- Per feed: `📅 ICS FEED: <url> — N VEVENTs, M within the lookahead window; K match events this run extracted (by identity)` and the parse is stashed on `results.icsFeedFindings` (aggregated from parser results, `discoveredVenueCalendars` pattern) as evidence for future enforcement.
- Caps: 3 candidates/page, 5 feeds/parser, 200 stored records/feed; failures log and skip, never abort the crawl.

**What enforcement would look like next:** promote a corroborated feed to a structured source that occurrence-expands for us — feed VEVENTs (concrete instances, plus plugin-side rrule expansion where the feed publishes it) become extraction inputs that enrich/corroborate page-scraped events by identity, with page extraction still primary per the structured-data-enriches-never-bypasses rule, and per-occurrence records staying individual events per the source-shape doctrine (#1677).

**Live probes (read-only):** neither eaglela.com nor thedallaseagle.com currently exposes a linkable ICS feed — `?ical=1`, `?mec-ical-feed=1`, and `?method=ical` all return HTML (200) or 406, and no `webcal:`/`.ics`/`text/calendar` links exist in their markup (MEC's iCal export there is JS/admin-ajax driven). Honest negative: discovery will fire the day a target site publishes one; The-Events-Calendar sites expose `?ical=1` feeds natively.

## Tests

- 13 new tests (8 overlap incl. all negative cases, 5 ICS discovery/report), all in already-enumerated files (`shared-core.test.js`, `scriptable-adapter.test.js`), **proven failing on base** (13/13 fail with the implementation stashed) and passing with it.
- Quiet suite: **1836 pass, 0 fail** (was 1823 on this branch's base).
- No new runtime files — no updater entries needed.
- Constraints held: shared-core stays platform-pure (feed fetches go through the injected adapter, precedent `httpAdapter.fetchData` at the crawl loop), no `new URL`/`URLSearchParams` in new code (existing `normalizeUrl` helper reused), zero existing console.log/prompt strings edited (verified: the diff's only removed lines are the 5 intentionally replaced wiring lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP