### PR TITLE
fix(scraper): Bear it MTL batch — venue casing, JSON-LD offset drift, French times, resource-hint crawl leak

### DIFF
--- a/scripts/normalizers.js
+++ b/scripts/normalizers.js
@@ -317,7 +317,19 @@ class BasicDataNormalizer extends BaseNormalizer {
 
 class BarDataNormalizer extends BaseNormalizer {
     normalize(event) {
-        if (!event || !this.core || !this.core.bars) return event;
+        if (!event || typeof event !== 'object') return event;
+
+        // A bar name that arrived with NO capitals at all is a casing defect
+        // of the source, not a styling choice (run 20260814-195026:
+        // bearitmtl.com's own JSON-LD published location.name "buddies in bad
+        // times theatre" verbatim). Title-case that one shape before curated
+        // matching — matching is case-insensitive, so a curated display name
+        // still wins below, and this covers only venues curated data does not
+        // know. Names containing ANY capital ("mister Sister", all-caps
+        // brands) are intentional stylings and are never touched.
+        this.titleCaseAllLowercaseBar(event);
+
+        if (!this.core || !this.core.bars) return event;
 
         const cityBars = this.core.bars[event.city];
         if (!cityBars || !Array.isArray(cityBars)) return event;
@@ -545,6 +557,48 @@ class BarDataNormalizer extends BaseNormalizer {
     // On upgrade: address becomes the curated street address, addressSource
     // is stamped 'curated', and an additive 🗺️ GEOCODE VERIFY line records
     // the replacement. Returns true when the event was modified.
+    // Title-case event.bar ONLY when it contains no capitals at all (see the
+    // call site in normalize). Returns true when the bar was rewritten.
+    titleCaseAllLowercaseBar(event) {
+        if (!event || typeof event.bar !== 'string') return false;
+        const cased = this.titleCaseAllLowercaseName(event.bar);
+        if (!cased || cased === event.bar) return false;
+        console.log(`🏷️ BarDataNormalizer: Title-cased all-lowercase bar name "${event.bar}" → "${cased}"`);
+        event.bar = cased;
+        return true;
+    }
+
+    // "buddies in bad times theatre" → "Buddies in Bad Times Theatre".
+    // Returns '' (leave the name alone) unless the input is a non-empty name
+    // with letters and not a single capital anywhere. French and English
+    // connector words stay lowercase mid-name; the first word always
+    // capitalizes; hyphenated parts ("saint-laurent") and single-letter
+    // French elisions ("l'ours") capitalize each segment.
+    titleCaseAllLowercaseName(name) {
+        const text = typeof name === 'string' ? name.trim() : '';
+        if (!text) return '';
+        // Any capital anywhere → intentional styling, never touched.
+        if (text !== text.toLowerCase()) return '';
+        // No letters at all (digits/punctuation only) → nothing to case.
+        if (text === text.toUpperCase()) return '';
+        const smallWords = new Set([
+            // English connectors
+            'a', 'an', 'and', 'at', 'by', 'for', 'in', 'of', 'on', 'or', 'the', 'to',
+            // French connectors
+            'à', 'au', 'aux', 'de', 'des', 'du', 'en', 'et', 'la', 'le', 'les', 'sur'
+        ]);
+        const capitalize = (token) => token.charAt(0).toUpperCase() + token.slice(1);
+        return text.split(/\s+/).map((word, index) => {
+            if (index > 0 && smallWords.has(word)) return word;
+            return word.split('-').map(part => {
+                if (!part) return part;
+                const elision = part.match(/^([a-zà-öø-ÿ])(['’])(.+)$/);
+                if (elision) return capitalize(elision[1]) + elision[2] + capitalize(elision[3]);
+                return capitalize(part);
+            }).join('-');
+        }).join(' ');
+    }
+
     upgradeDistrictAddressToCurated(event) {
         if (!event || !this.core) return false;
         if (typeof this.core.findCuratedBarByName !== 'function'

--- a/scripts/normalizers.test.js
+++ b/scripts/normalizers.test.js
@@ -4357,3 +4357,57 @@ test('BasicDataNormalizer folds url into website and deletes url at ingest', () 
   assert.equal(site.website, 'https://beefmince.com');
   assert.equal('url' in site, false, 'no url twin is minted from website');
 });
+
+// ---------------------------------------------------------------------------
+// All-lowercase venue title-casing (run 20260814-195026: bearitmtl.com's own
+// JSON-LD published location.name "buddies in bad times theatre" verbatim and
+// the record shipped that casing — proper nouns should be capitalized)
+// ---------------------------------------------------------------------------
+
+test('BarDataNormalizer title-cases a bar name that arrived with no capitals at all', () => {
+  const core = new SharedCore(CITIES, { eventSchema: EventSchema, bars: {} });
+  const normalizer = new BarDataNormalizer(core);
+
+  const event = { title: 'Playground Toronto', city: 'toronto', bar: 'buddies in bad times theatre' };
+  normalizer.normalize(event);
+  assert.equal(event.bar, 'Buddies in Bad Times Theatre', 'connector "in" stays lowercase, every other word capitalizes');
+
+  // French connectors stay lowercase mid-name; the first word always capitalizes.
+  const french = { title: 'Soirée', city: 'montreal', bar: 'le bar de la montagne' };
+  normalizer.normalize(french);
+  assert.equal(french.bar, 'Le Bar de la Montagne');
+
+  // Hyphenated parts and single-letter French elisions both capitalize.
+  const hyphenated = { title: 'Soirée', city: 'montreal', bar: "cabaret l'ours saint-laurent" };
+  normalizer.normalize(hyphenated);
+  assert.equal(hyphenated.bar, "Cabaret L'Ours Saint-Laurent");
+});
+
+test('BarDataNormalizer never touches a venue name containing ANY capital', () => {
+  const core = new SharedCore(CITIES, { eventSchema: EventSchema, bars: {} });
+  const normalizer = new BarDataNormalizer(core);
+
+  const styledNames = ['mister Sister', 'BUT', 'The Eagle NYC', 'REDVoLUTiON'];
+  for (const name of styledNames) {
+    const event = { title: 'X', city: 'nyc', bar: name };
+    normalizer.normalize(event);
+    assert.equal(event.bar, name, `intentional styling "${name}" must survive verbatim`);
+  }
+
+  // Letterless / missing bars: no crash, no write.
+  const digitsOnly = { title: 'X', city: 'nyc', bar: '3030' };
+  normalizer.normalize(digitsOnly);
+  assert.equal(digitsOnly.bar, '3030');
+  const noBar = { title: 'X', city: 'nyc' };
+  normalizer.normalize(noBar);
+  assert.equal(noBar.bar, undefined);
+});
+
+test('curated canonicalization still wins for a known bar arriving all-lowercase', () => {
+  // Behavior-preservation pin for the fix's ordering: title-casing runs before
+  // curated matching, and the curated display name must still win.
+  const normalizer = createBarNormalizerWithBar();
+  const event = { title: 'Bear Night', city: 'nyc', bar: 'the eagle nyc' };
+  normalizer.normalize(event);
+  assert.equal(event.bar, 'The Eagle NYC', 'curated display name outranks generic title-casing');
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -409,8 +409,11 @@ function normalizeStartTimeValue(value) {
         }
     }
 
-    // Handle European "20h30" / "20 h 30" format (h as hour-minute separator)
-    const europeanSeparatorMatch = timeStr.match(/^(\d{1,2})\s*[hH]\s*(\d{2})$/);
+    // Handle European "20h30" / "20 h 30" format (h as hour-minute separator).
+    // French schedule displays append a minute unit — "10 h 00 min"
+    // (bearitmtl.com tribe-events schedule text, run 20260814-195026) — so an
+    // optional trailing "min" token is accepted too.
+    const europeanSeparatorMatch = timeStr.match(/^(\d{1,2})\s*[hH]\s*(\d{2})(?:\s*min\.?)?$/i);
     if (europeanSeparatorMatch) {
         const hour = parseInt(europeanSeparatorMatch[1], 10);
         const minute = parseInt(europeanSeparatorMatch[2], 10);
@@ -4570,8 +4573,26 @@ class AiWebParser {
 
             const rawUrlCandidates = this.extractUrlCandidatesFromRawHtml(html);
             discoveryStats.rawHtmlCandidates = rawUrlCandidates.length;
+            // The raw scan reads the whole document, so resource-hint <link>
+            // hrefs (see collectResourceHintHrefs — asset origins, never
+            // pages) resurface here even though extractHrefCandidates already
+            // skips them. Compare on the normalized URL: the tag holds
+            // "//i0.wp.com" while the raw scan may capture either form.
+            const resourceHintUrls = new Set();
+            for (const hintHref of this.collectResourceHintHrefs(html)) {
+                const normalizedHint = this.stripTrackingParams(this.normalizeUrl(hintHref, sourceUrl));
+                if (normalizedHint) resourceHintUrls.add(this.getUrlDedupeKey(normalizedHint));
+            }
             for (const candidate of rawUrlCandidates) {
-                this.addAdditionalUrlCandidate(urls, candidate.url || candidate, sourceUrl, candidate.context || '', discoveryStats, parserConfig);
+                const candidateUrl = candidate.url || candidate;
+                if (resourceHintUrls.size > 0) {
+                    const normalizedCandidate = this.stripTrackingParams(this.normalizeUrl(candidateUrl, sourceUrl));
+                    if (normalizedCandidate && resourceHintUrls.has(this.getUrlDedupeKey(normalizedCandidate))) {
+                        this.recordRejectedCandidate(discoveryStats, 'resource-hint-origin', candidateUrl, normalizedCandidate);
+                        continue;
+                    }
+                }
+                this.addAdditionalUrlCandidate(urls, candidateUrl, sourceUrl, candidate.context || '', discoveryStats, parserConfig);
             }
 
             const jsonLdDiagnostics = {};
@@ -5534,6 +5555,10 @@ class AiWebParser {
     extractHrefCandidates(html) {
         if (!html) return [];
         const candidates = [];
+        // Resource-hint <link> hrefs never name navigable pages — see
+        // collectResourceHintHrefs. The generic href scan below has no tag
+        // context, so they are collected first and kept out of the pool.
+        const resourceHintHrefs = this.collectResourceHintHrefs(html);
         const anchorRegex = /<a\b[^>]*href\s*=\s*["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
         let match;
         while ((match = anchorRegex.exec(html)) !== null) {
@@ -5545,9 +5570,31 @@ class AiWebParser {
 
         const hrefRegex = /href\s*=\s*["']([^"']+)["']/gi;
         while ((match = hrefRegex.exec(html)) !== null) {
+            if (resourceHintHrefs.has(match[1])) continue;
             candidates.push({ url: match[1], context: match[0] });
         }
         return candidates;
+    }
+
+    // The hrefs of resource-hint <link> tags (dns-prefetch/preconnect/preload/
+    // modulepreload): asset ORIGINS or bundles the browser should warm up,
+    // never navigable pages — WordPress heads publish
+    // <link rel='preconnect' href='//i0.wp.com'>, and run 20260814-195026
+    // queued and fetched the bare image-CDN origin "https://i0.wp.com" as a
+    // crawl page (HTTP 400, run error). rel=prefetch is deliberately NOT
+    // collected — it can legitimately reference next-page documents.
+    collectResourceHintHrefs(html) {
+        const hrefs = new Set();
+        if (!html) return hrefs;
+        const linkTagRegex = /<link\b[^>]*>/gi;
+        let linkMatch;
+        while ((linkMatch = linkTagRegex.exec(html)) !== null) {
+            const relMatch = linkMatch[0].match(/\brel\s*=\s*["']([^"']*)["']/i);
+            if (!relMatch || !/(?:^|\s)(?:dns-prefetch|preconnect|preload|modulepreload)(?:\s|$)/i.test(relMatch[1])) continue;
+            const hrefMatch = linkMatch[0].match(/\bhref\s*=\s*["']([^"']+)["']/i);
+            if (hrefMatch) hrefs.add(hrefMatch[1]);
+        }
+        return hrefs;
     }
 
     // Onboarding harvest (discoveryOnly runs only): instagram/facebook links are
@@ -6713,12 +6760,73 @@ class AiWebParser {
                 if (timezone) event.timezone = timezone;
             }
         }
+        // The Events Calendar emits JSON-LD datetimes with the site's CURRENT
+        // UTC offset, not the offset in force on the event's date (run
+        // 20260814-195026: bearitmtl.com published "2025-12-06T10:00:00-04:00"
+        // for a December Toronto event — EST, -05:00 — so the page's stated
+        // "10 h 00 min" shipped as 9:00). The wall-clock digits are what the
+        // page displays and what the venue entered; when the resolved event
+        // timezone disagrees with the claimed offset AT THAT DATE, keep the
+        // wall clock and re-anchor it in the event timezone. 'Z' instants and
+        // matching offsets are trusted verbatim; without a resolved timezone
+        // nothing changes (fail open).
+        if (event.timezone) {
+            const startReanchor = this.reanchorMismatchedJsonLdOffset(startDateRawText, event.startDate, event.timezone);
+            if (startReanchor) {
+                console.log(`🤖 AI Web: JSON-LD startDate offset ${startReanchor.claimedOffsetText} disagrees with ${event.timezone} (${startReanchor.zoneOffsetText} on that date) — kept wall clock ${startReanchor.wallClockText}: ${event.startDate.toISOString()} → ${startReanchor.date.toISOString()}`);
+                event.startDate = startReanchor.date;
+            }
+            if (event.endDate) {
+                const endDateRawText = typeof node.endDate === 'string' ? node.endDate.trim() : '';
+                const endReanchor = this.reanchorMismatchedJsonLdOffset(endDateRawText, event.endDate, event.timezone);
+                if (endReanchor) {
+                    console.log(`🤖 AI Web: JSON-LD endDate offset ${endReanchor.claimedOffsetText} disagrees with ${event.timezone} (${endReanchor.zoneOffsetText} on that date) — kept wall clock ${endReanchor.wallClockText}: ${event.endDate.toISOString()} → ${endReanchor.date.toISOString()}`);
+                    event.endDate = endReanchor.date;
+                }
+            }
+        }
         // Dates without an explicit offset are wall-clock times anchored as UTC;
         // LocationNormalizer re-anchors them once the city/timezone is known.
         if (start.timezoneUnresolved || (end.date && end.timezoneUnresolved)) {
             event._timezoneUnresolved = true;
         }
         return event;
+    }
+
+    // A raw ISO datetime whose explicit NUMERIC offset does not match
+    // `timezone` at that date gets its wall clock re-anchored in the zone
+    // (DST-converged via convertLocalDateTimeToUtc). Returns null — caller
+    // keeps the instant it already has — when the string has no numeric
+    // offset ('Z' is an intentional UTC anchor and is never second-guessed),
+    // the claimed offset is correct, or anything fails to parse.
+    reanchorMismatchedJsonLdOffset(rawText, parsedDate, timezone) {
+        if (!rawText || !timezone || !parsedDate || typeof parsedDate.getTime !== 'function'
+            || Number.isNaN(parsedDate.getTime())) {
+            return null;
+        }
+        const match = String(rawText).trim().match(
+            /^(\d{4}-\d{2}-\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d+)?\s*([+-]\d{2}):?(\d{2})$/
+        );
+        if (!match) return null;
+        const claimedSign = match[5].charAt(0) === '-' ? -1 : 1;
+        const claimedOffsetMinutes = claimedSign * ((Math.abs(parseInt(match[5], 10)) * 60) + parseInt(match[6], 10));
+        const wallClockText = `${match[1]}T${match[2]}:${match[3]}:${match[4] || '00'}`;
+        const reanchored = this.convertLocalDateTimeToUtc(wallClockText, timezone);
+        if (!reanchored || Number.isNaN(reanchored.getTime())) return null;
+        const zoneOffsetMinutes = this.getTimezoneOffsetMinutes(reanchored, timezone);
+        if (!Number.isFinite(zoneOffsetMinutes) || zoneOffsetMinutes === claimedOffsetMinutes) return null;
+        if (reanchored.getTime() === parsedDate.getTime()) return null;
+        const formatOffset = (minutes) => {
+            const sign = minutes < 0 ? '-' : '+';
+            const abs = Math.abs(minutes);
+            return `${sign}${String(Math.floor(abs / 60)).padStart(2, '0')}:${String(abs % 60).padStart(2, '0')}`;
+        };
+        return {
+            date: reanchored,
+            wallClockText,
+            claimedOffsetText: formatOffset(claimedOffsetMinutes),
+            zoneOffsetText: formatOffset(zoneOffsetMinutes)
+        };
     }
 
     parseJsonLdDateValue(value) {

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { AiWebParser } = require('./ai-web-parser');
+const { AiWebParser, normalizeStartTimeValue } = require('./ai-web-parser');
 const { SharedCore } = require('../shared-core');
 const { EventSchema } = require('../event-schema');
 
@@ -14787,4 +14787,97 @@ test('doors-vs-party: promotion stamps the rejected doors time so the merge can 
   assert.ok(untouched, 'the control event survives normalization');
   assert.equal(untouched._doorsTimeRejected, undefined, 'no stamp without a promotion');
   assert.equal(untouched._doorsTimePromoted, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Bear it MTL batch (run 20260814-195026, bearitmtl.com)
+// ---------------------------------------------------------------------------
+
+// The Events Calendar emits JSON-LD datetimes with the site's CURRENT UTC
+// offset, not the offset in force on the event's date: the cached
+// playground-toronto page (fetched Aug 2026, EDT) published
+// "2025-12-06T10:00:00-04:00" for a December Toronto event — EST, -05:00 —
+// so the page's stated "10 h 00 min – 3 h 00 min" shipped as 9:00–2:00.
+test('buildEventFromJsonLdNode re-anchors an explicit offset that disagrees with the event timezone', () => {
+  const parser = createParser();
+  const cityConfig = { toronto: { timezone: 'America/Toronto', patterns: ['toronto'] } };
+  const event = parser.buildEventFromJsonLdNode({
+    '@type': 'Event',
+    name: 'Playground Toronto',
+    startDate: '2025-12-06T10:00:00-04:00',
+    endDate: '2025-12-07T03:00:00-04:00',
+    location: {
+      '@type': 'Place',
+      name: 'buddies in bad times theatre',
+      address: { '@type': 'PostalAddress', streetAddress: '12 Alexander Street', addressLocality: 'Toronto', postalCode: 'M4Y1B4', addressCountry: 'Canada' }
+    }
+  }, 'https://www.bearitmtl.com/event/playground-toronto/', cityConfig);
+  assert.ok(event, 'node builds an event');
+  assert.equal(event.timezone, 'America/Toronto');
+  // Wall clock 10:00 is kept and re-anchored in EST (-05:00): 15:00Z, not 14:00Z.
+  assert.equal(event.startDate.toISOString(), '2025-12-06T15:00:00.000Z');
+  assert.equal(event.endDate.toISOString(), '2025-12-07T08:00:00.000Z');
+  // The raw string stays verbatim for the title strip.
+  assert.equal(event._startDateRawText, '2025-12-06T10:00:00-04:00');
+});
+
+test('buildEventFromJsonLdNode trusts correct offsets and Z instants verbatim', () => {
+  const parser = createParser();
+  const cityConfig = { toronto: { timezone: 'America/Toronto', patterns: ['toronto'] } };
+  const node = (startDate) => ({
+    '@type': 'Event',
+    name: 'POP Playground',
+    startDate,
+    location: {
+      '@type': 'Place',
+      name: 'Bain Mathieu',
+      address: { '@type': 'PostalAddress', streetAddress: '2915 Rue Ontario E', addressLocality: 'Toronto', postalCode: 'H2K 1X7' }
+    }
+  });
+
+  // July: -04:00 IS Toronto's offset (EDT) — untouched.
+  const summer = parser.buildEventFromJsonLdNode(node('2026-07-03T22:00:00-04:00'), 'https://www.bearitmtl.com/event/pop-playground/', cityConfig);
+  assert.equal(summer.timezone, 'America/Toronto');
+  assert.equal(summer.startDate.toISOString(), '2026-07-04T02:00:00.000Z');
+
+  // 'Z' is an intentional UTC anchor — never second-guessed.
+  const utc = parser.buildEventFromJsonLdNode(node('2025-12-06T15:00:00Z'), 'https://www.bearitmtl.com/event/pop-playground/', cityConfig);
+  assert.equal(utc.startDate.toISOString(), '2025-12-06T15:00:00.000Z');
+
+  // No resolved timezone (no cityConfig) → the claimed offset stands.
+  const noTz = parser.buildEventFromJsonLdNode(node('2025-12-06T10:00:00-04:00'), 'https://www.bearitmtl.com/event/pop-playground/');
+  assert.equal(noTz.timezone, undefined);
+  assert.equal(noTz.startDate.toISOString(), '2025-12-06T14:00:00.000Z');
+});
+
+// bearitmtl.com renders schedule times in the French 24-hour display format
+// "10 h 00 min" (tribe-events-schedule__time) — the deterministic helper's
+// European branch stopped at "20h30" and returned '' for the "min" suffix.
+test('normalizeStartTimeValue accepts the French "HH h MM min" display format', () => {
+  assert.equal(normalizeStartTimeValue('10 h 00 min'), '10:00');
+  assert.equal(normalizeStartTimeValue('21 h 00 min'), '21:00');
+  assert.equal(normalizeStartTimeValue('3 h 00 min'), '03:00');
+  assert.equal(normalizeStartTimeValue('22h30min'), '22:30');
+  // Existing European forms keep parsing.
+  assert.equal(normalizeStartTimeValue('20h30'), '20:30');
+  assert.equal(normalizeStartTimeValue('20 h 30'), '20:30');
+});
+
+// WordPress heads publish resource-hint tags whose href is a bare asset
+// ORIGIN (<link rel='preconnect' href='//i0.wp.com'>). The generic href scan
+// has no tag context, so run 20260814-195026 queued and fetched
+// "https://i0.wp.com" as a crawl page (HTTP 400, run error).
+test('URL discovery never promotes resource-hint link origins to crawl candidates', () => {
+  const parser = createParser();
+  const html = `<html><head>
+      <link rel='dns-prefetch' href='//stats.wp.com' />
+      <link rel='preconnect' href='//i0.wp.com' />
+      <link rel="preload" href="https://www.bearitmtl.com/wp-content/themes/x/app.css" as="style" />
+    </head><body>
+      <a href="https://www.bearitmtl.com/event/pop-playground/">POP Playground</a>
+    </body></html>`;
+  const urls = parser.extractAdditionalUrls(html, 'https://www.bearitmtl.com/events/', {});
+  assert.ok(urls.includes('https://www.bearitmtl.com/event/pop-playground/'), 'real anchors keep flowing');
+  assert.ok(!urls.some(url => url.includes('i0.wp.com')), 'preconnect origin never becomes a crawl page');
+  assert.ok(!urls.some(url => url.includes('stats.wp.com')), 'dns-prefetch origin never becomes a crawl page');
 });


### PR DESCRIPTION
Four owner-reported issues from the Bear it MTL run, investigated against the cached pages, OCR cache, and the run log (run `20260814-195026`, 55 events → 12 bear events) before any code was written. One fix per proven mechanism; honest no-fix where the evidence says the site is the limit.

## 1. "buddies in bad times theatre" casing — FIXED

**Root cause:** bearitmtl.com's own JSON-LD publishes the venue name all-lowercase — `"location":{"@type":"Place","name":"buddies in bad times theatre",…}` on the cached `event/playground-toronto/` page. The scraper adopted it verbatim (`_barFromJsonLd: true`); no properly-cased form exists anywhere in the page's display text. The geocoder even corroborated the POI as "Buddies in Bad Times" but bar provenance never rewrites the name.

**Fix:** `BarDataNormalizer` now title-cases a bar name **only when it contains no capitals at all**. French/English connector words (`de, la, du, le, les, et, the, in, at, of, …`) stay lowercase mid-name; the first word always capitalizes; hyphenated parts and single-letter French elisions (`l'ours` → `L'Ours`) capitalize. Names with ANY capital ("mister Sister", all-caps brands) are never touched, and curated canonicalization still wins for known bars (matching is case-insensitive; ordering pinned by test).

## 2. Playground Toronto 9 PM–2 AM vs the site's 10–3 — FIXED (the 1-hour shift)

**Root cause (proven, two distinct deltas):**
- **The 1-hour shift is ours.** The Events Calendar emits JSON-LD with the site's *current* UTC offset, not the offset in force on the event's date: the page (cached in August, EDT) publishes `"startDate":"2025-12-06T10:00:00-04:00"` / `"endDate":"2025-12-07T03:00:00-04:00"` for a December Toronto event — December Toronto is EST, `-05:00`. `parseJsonLdDateValue` trusted the offset verbatim → 14:00Z → 9:00 local (and 2:00 end). The site's July events carry `-04:00` correctly, which pins the mechanism.
- **The AM/PM half is the site's data.** The visible schedule text is 24-hour French — `Décembre 6, 2025 @ 10 h 00 min – Décembre 7, 2025 @ 3 h 00 min` (compare THE HUNT: `21 h 00 min` = 9 PM) — i.e. the venue entered 10:00 **AM**. The flyer OCR (cached) reads `10pm to 3am`, but extraction was `source=jsonld, ocrImages=0`; nothing overrode the structured time. We now ship exactly what the site states (10:00–3:00); the flyer/site conflict is proposed below, not silently arbitrated.

**Fix:** after the event timezone is resolved from the JSON-LD address, an explicit *numeric* offset that disagrees with that zone's offset **at that date** is discarded in favor of the wall clock, re-anchored via the existing DST-converged `convertLocalDateTimeToUtc`. `Z` instants and correct offsets are trusted verbatim; no timezone resolved → no change (fail open). Replayed against the real cached page: `2025-12-06T14:00:00Z → 15:00Z` (10:00 EST) and `07:00Z → 08:00Z` (3:00 EST) with an additive log line; the cached POP Playground page (July, correct `-04:00`) is untouched.

**Also:** `normalizeStartTimeValue` now parses the site's French display format `10 h 00 min` / `22h30min` (optional `min` suffix on the existing European branch — it previously returned `''` for every schedule string this site renders).

## 3. POP Playground image — NO FIX (site publishes none)

The cached `event/pop-playground/` page has **no** `og:image`/`twitter:image` (6 og: tags, none an image), **no** poster `<img>` (all 21 img tags are site chrome or `{{ }}` template placeholders), and **no** JSON-LD image on the Event or WebPage node — the only ImageObject is the org logo. The run log agrees: `JSON-LD coverage … missing=[…, image]`. The image-adoption path works when the site provides artwork (Playground Toronto got its poster via og:image on the same run). There is nothing to adopt; the site owner didn't upload artwork for this event.

## 4. Performance — audited; one cheap fix + proposals

Timing breakdown of run `20260814-195026` (parser `durationMs = 1,396,780` ≈ **23.3 min**; the log's extra ~14 min tail is the human reviewing the results UI):

| Phase | Calls | Total | Avg | % of run |
|---|---|---|---|---|
| ocr-all (vision) | 16 | 381.2 s | 23.8 s | 27.3% |
| ocr-segment (vision) | 12 | 264.5 s | 22.0 s | 18.9% |
| og-image-vet (vision) | 10 | 146.6 s | 14.7 s | 10.5% |
| extraction (text AI) | 33 | 163.9 s | 5.0 s | 11.7% |
| merge-arbitration | 15 | 104.6 s | 7.0 s | 7.5% |
| classify-page | 12 | 32.1 s | 2.7 s | 2.3% |
| context-prep | 16 | 29.5 s | 1.8 s | 2.1% |
| bear-check | 1 | 2.1 s | — | 0.2% |
| **All AI** | **115** | **1,124.5 s** | | **80.5%** |
| Non-AI (fetch/parse/geocode/overhead) | — | ~272 s | | ~19.5% |

- **Vision inference is 57% of the whole run** (25–38 s per cold call on local MLX). Every one of the top scraper-side time gaps is a cold `ocr-all`/`ocr-segment`/`og-image-vet` pass. Per doctrine (MLX calls are free, never optimized away) this is reported, not "fixed".
- **Caching is healthy:** ~312 cache hits (176 AI-response, 78+29 OCR, 58 context-prep, 14 classification) vs 115 executed calls; no URL fetched twice; no double segmentation; no backoff sleep ladders.
- **The multiplier is crawl breadth:** 59 pages fetched, only 8 produced events. ~11 empty per-day date-pagination pages (`events/2026-06-29/`…), `my-account/` + `my-account/lost-password/`, promoter bios, off-site `outlook.office.com/owa` calendar-subscribe links — each still costing classify/vet passes. 14 known dead-ends were already skipped via the 30-day memoizer.
- **1 hard error, fixed here:** `<link rel='preconnect' href='//i0.wp.com'>` (WordPress head resource hint) was promoted to a crawl page and fetched — HTTP 400, the run's only error. URL discovery now keeps resource-hint `<link>` hrefs (dns-prefetch/preconnect/preload/modulepreload) out of the candidate pool, in both the href scan and the raw-HTML scan (generic tag semantics, no host/domain list; `rel=prefetch` deliberately still allowed since it can name real documents).

**Proposed, not built** (owner call before any of these):
1. **Date-pagination pruning:** day-view calendar pages that only re-list events already discovered on the month/list views could be recognized (same tribe-events day/month URL shapes, zero *new* event links) and skipped before classify/OCR — would cut a large slice of the 51 zero-yield pages. Risk: day pages did yield events on this run (`events/2026-08-01/` → 2), so the guard must be "no NEW links", not "day page".
2. **Site-chrome OCR skip:** header/background images (`FOnd-ENtete.jpg`, grunge overlay) were OCR-checked on nearly every page (13–15× each, cache-absorbed after the first cold call). A cross-page-recurrence signal (same image on ≥N crawled pages → chrome) could skip the first cold vision pass too.
3. **Flyer-vs-structured time conflict flag:** OCR read `10pm to 3am` while JSON-LD said 10:00; today OCR never contests a structured time. A report-only notes flag when flyer OCR time conflicts with the adopted start time (no auto-override — flag, don't drop) would have surfaced the site's own AM/PM entry error.
4. **JSON-LD `@id` IP-literal origins:** the site's misconfigured `WebSite @id` (`https://52.60.137.136/`) enters URL discovery; an IP-literal-host rejection rung in `validateEventUrl` would drop it generically.
5. The same offset-sanity re-anchor could be extended to the JSON-API structured route (`time_zone` payloads) — not done here because no repro exists in this run.

## Tests

4 new behavior tests, all **proven failing on base** (686/690 → 690/690 in the two files), plus 3 behavior-preservation pins (styled names survive, correct offsets/Z trusted, curated canonicalization still wins). Full quiet suite: **1867/1867 pass** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`).

Verification against real cached data (read-only): replaying `event__playground-toronto.json` through the fixed parser yields 10:00 AM–3:00 AM Toronto local and "Buddies in Bad Times Theatre"; `event__pop-playground.json` is byte-identical in outcome (correct offset untouched, image honestly empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP
