### PR TITLE
fix(scraper): narrow span-fully-past to a 30-day window + skip no-op merge writes

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -15575,9 +15575,15 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       };
     }
     if (
-      this.normalizeIntentAction(event) === "merge" &&
-      Array.isArray(event._changes) &&
-      event._changes.length === 0
+      // _mergeNoOp is the write path's own no-op stamp (shared-core: final
+      // payload field-identical to the calendar record, notes projection
+      // included) — the same skip filterEventsForExecution enforces, so the
+      // pile and the gate agree in live AND dryRun runs. The _changes form
+      // below stays for saved runs recorded before the stamp existed.
+      event._mergeNoOp === true ||
+      (this.normalizeIntentAction(event) === "merge" &&
+        Array.isArray(event._changes) &&
+        event._changes.length === 0)
     ) {
       return {
         section: "saved",
@@ -15620,6 +15626,10 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     // filterEventsForExecution gate (CTA link text is not an event name) —
     // the card must say so instead of promising a CREATE that never runs.
     if (SharedCore.hasJunkTitleSanityFlag(event)) return "withheld";
+    // A merge stamped _mergeNoOp is skipped by the same
+    // filterEventsForExecution gate — the card must not promise an UPDATE
+    // that never runs.
+    if (event._mergeNoOp === true) return "skip";
     // Same display-only treatment for the other direction: a slot-host source
     // fills in ONE dated occurrence of somebody else's series, so the write is
     // neither a new event nor a change to the series. Checked after the

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -10008,6 +10008,28 @@ test('round3: a real change (SPOOKMINCE website added) still shows its diff in B
   assert.match(line, /\d+ fields unchanged — /, 'no-op rows still collapse to the summary');
 });
 
+test('write-policy: a _mergeNoOp merge sits in the already-saved pile and never promises an UPDATE', () => {
+  const adapter = buildAdapter();
+  // The real BEEFMINCE no-op record with the shared-core write-path stamp:
+  // its saved _changes is ['notes'] (ordering-only), so the stamp — not the
+  // legacy _changes.length === 0 form — is what moves it.
+  const event = freshRound3Event(BEEFMINCE_NOOP_EVENT);
+  event._mergeNoOp = true;
+  const placement = adapter.classifyEventForResultsSection(event);
+  assert.equal(placement.section, 'saved', 'no-op merges are already-saved, not actionable');
+  assert.equal(placement.reason, '✅ merge no-op — calendar already has all of this',
+    'reuses the existing merge-no-op bucket label');
+  assert.equal(adapter.getWriteActionFromEvent(event), 'skip',
+    'the card never promises an UPDATE that filterEventsForExecution skips');
+
+  // Without the stamp the same record keeps its old behavior (saved runs
+  // recorded before the stamp existed): _changes ['notes'] → actionable,
+  // write action update.
+  const unstamped = freshRound3Event(BEEFMINCE_NOOP_EVENT);
+  assert.equal(adapter.classifyEventForResultsSection(unstamped).section, 'actionable');
+  assert.equal(adapter.getWriteActionFromEvent(unstamped), 'update');
+});
+
 test('round3: every existing bridge handler id and page handler survives the cleanup', async () => {
   const adapter = buildAdapter();
   // Bridge action ids round-trip through the URL parser.

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -308,6 +308,14 @@ const SANITY_START_LONG_PAST_DAYS = 370;
 // 2026-10-18) flags; note the 9-day WHITE PARTY club night sits UNDER this
 // bound — a deterministic span rule cannot tell it from Bears Sitges Week.
 const SANITY_MAX_EVENT_DURATION_DAYS = 10;
+// span-fully-past: how long after a span's END the review flag and the write
+// withhold engage. A recently-ended span is normal scrape churn — last
+// weekend's party still sitting on the venue page — and behaves like any
+// other event; the flag/withhold exist for the stale-roundup class ("THIS
+// WEEK AT MASSIVE": an Oct 2025 lineup tile proposed as a CREATE ~10 months
+// late). Owner-tunable via config.sanity.pastSpanWithholdDays (0 restores
+// the flag-everything-past behavior).
+const SANITY_PAST_SPAN_WITHHOLD_DAYS = 30;
 
 class SharedCore {
     constructor(cities, options = {}) {
@@ -2054,8 +2062,14 @@ class SharedCore {
         //    because even an UPDATE payload for a fully-elapsed span has no
         //    attendable content to deliver. This flag is the card surface;
         //    the matching write withhold is stamped separately in
-        //    buildAnalyzedCalendarEvent via isEventSpanFullyPast.
-        if (this.isEventSpanFullyPast(event, nowMs)) {
+        //    buildAnalyzedCalendarEvent via the same thresholded predicate.
+        //    Thresholded (owner feedback 2026-08): a span that ended within
+        //    the withhold window (default 30 days, config-overridable via
+        //    sanity.pastSpanWithholdDays through context.config) is recently
+        //    past — no flag, no withhold — while the months-late roundup
+        //    class still trips both.
+        const pastSpanWithholdDays = this.resolvePastSpanWithholdDays(context && context.config);
+        if (this.isEventSpanPastBeyondWithholdWindow(event, nowMs, pastSpanWithholdDays)) {
             const startMs = toMs(event.startDate);
             const endReferenceMs = toMs(event.endDate);
             const spanEndMs = Number.isFinite(endReferenceMs) ? endReferenceMs : startMs;
@@ -2221,6 +2235,32 @@ class SharedCore {
         const endMs = this.toEpochMillis(event.endDate);
         const spanEndMs = endMs === null ? startMs : endMs;
         return spanEndMs < nowMs;
+    }
+
+    // The span-fully-past flag/withhold window, in days. Reads the owner's
+    // config.sanity.pastSpanWithholdDays override when it is a usable
+    // non-negative number; anything else falls back to the 30-day default.
+    resolvePastSpanWithholdDays(config) {
+        const raw = config && config.sanity ? config.sanity.pastSpanWithholdDays : undefined;
+        const parsed = typeof raw === 'number' ? raw : (typeof raw === 'string' && raw.trim() !== '' ? Number(raw) : NaN);
+        return Number.isFinite(parsed) && parsed >= 0 ? parsed : SANITY_PAST_SPAN_WITHHOLD_DAYS;
+    }
+
+    // TRUE only when the whole span is past (isEventSpanFullyPast) AND its
+    // end is MORE than withholdDays behind analysis time. This is the
+    // condition the span-fully-past review flag and the _pastSpanWithheld
+    // write withhold both use: a span that ended within the window (a
+    // last-weekend party) is recently past — normal churn, no flag, no
+    // withhold — while the stale-roundup class (months to a year late)
+    // still trips it. Owner feedback 2026-08: "I don't like
+    // 'span-fully-past' that much (unless it's trying to save an event a
+    // year ago or something)".
+    isEventSpanPastBeyondWithholdWindow(event, nowMs = Date.now(), withholdDays = SANITY_PAST_SPAN_WITHHOLD_DAYS) {
+        if (!this.isEventSpanFullyPast(event, nowMs)) return false;
+        const startMs = this.toEpochMillis(event.startDate);
+        const endMs = this.toEpochMillis(event.endDate);
+        const spanEndMs = endMs === null ? startMs : endMs;
+        return (nowMs - spanEndMs) > withholdDays * 24 * 60 * 60 * 1000;
     }
 
     // A value shaped like a street address is NEVER a venue name. Anchored on
@@ -10539,6 +10579,19 @@ class SharedCore {
         }
         
         // Simple change detection for display
+        finalEvent._changes = this.computeCalendarWriteChanges(finalEvent, existingEvent, calendarObject);
+
+        return finalEvent;
+    }
+
+    // The "changed = merged differs from calendar" change list: exactly the
+    // fields the calendar write applies (title, dates, location, url view,
+    // notes), compared against the live calendar record. Stamped as
+    // _changes on the final merge object above (display: the results-UI
+    // no-changes chip / already-saved pile) and re-evaluated by the merge
+    // no-op gate in buildAnalyzedCalendarEvent AFTER every later notes/title
+    // pass has run.
+    computeCalendarWriteChanges(finalEvent, existingEvent, calendarObject) {
         const changes = [];
         if (finalEvent.title !== existingEvent.title) changes.push('title');
         if (!this.datesEqualForDisplay(finalEvent.startDate, existingEvent.startDate)) changes.push('startDate');
@@ -10550,12 +10603,29 @@ class SharedCore {
         // The 'url' label is kept for display continuity. Comparing a scraped
         // url against Scriptable's always-empty native url flagged 'url' on
         // every run.
-        if (finalEvent.url !== (calendarObject.website || '')) changes.push('url');
+        if (finalEvent.url !== ((calendarObject && calendarObject.website) || '')) changes.push('url');
         if (finalEvent.notes !== existingEvent.notes) changes.push('notes');
-        
-        finalEvent._changes = changes;
-        
-        return finalEvent;
+        return changes;
+    }
+
+    // Notes-projection equality for the merge no-op gate. Line-level and
+    // ORDER-INSENSITIVE: formatEventNotes key order can differ run to run
+    // while the content is identical (the real BEEFMINCE Trunk Den no-op,
+    // run 20260813-211637: every written field equal, notes differing by
+    // key ordering alone), so pure reordering is not a change — but ANY
+    // line-level difference is (a bearReview edit, a manual-verdict
+    // bearSource line, a sanity-driven note line must always land in the
+    // calendar). Fail closed: anything not provably identical writes.
+    notesProjectionsMatch(existingNotes, mergedNotes) {
+        const toSortedLines = (value) => String(value === null || value === undefined ? '' : value)
+            .replace(/\r\n?/g, '\n')
+            .split('\n')
+            .filter(line => line.trim() !== '')
+            .sort();
+        const existingLines = toSortedLines(existingNotes);
+        const mergedLines = toSortedLines(mergedNotes);
+        if (existingLines.length !== mergedLines.length) return false;
+        return existingLines.every((line, index) => line === mergedLines[index]);
     }
 
     // ============================================================================
@@ -12356,6 +12426,11 @@ class SharedCore {
             // stamps _pastSpanWithheld + the span-fully-past review flag)
             // and gated here, exactly like the recurring-series withhold.
             event?._pastSpanWithheld !== true &&
+            // A merge stamped _mergeNoOp writes nothing by definition — the
+            // final payload is field-identical to the calendar record
+            // (stamp site: buildAnalyzedCalendarEvent), so executing it
+            // would only churn the calendar's modification time.
+            event?._mergeNoOp !== true &&
             !SharedCore.isRecurringSeriesEvent(event) &&
             // An occurrence-expanded single whose date/identity the owner's
             // SAVED series already covers (#1655 series-match): writing it
@@ -12407,6 +12482,7 @@ class SharedCore {
             '_sanityFlags',
             '_original',
             '_pastSpanWithheld',
+            '_mergeNoOp',
             '_duplicateOfKept',
             '_seriesAuthority',
             '_recurringExport',
@@ -12438,6 +12514,7 @@ class SharedCore {
         if (SharedCore.isRecurringSeriesEvent(event)) return 'WITHHELD (recurring series — ICS export only)';
         if (SharedCore.isSeriesCoveredOccurrence(event)) return 'WITHHELD (occurrence covered by saved series — SERIES MATCH)';
         if (SharedCore.hasJunkTitleSanityFlag(event)) return 'WITHHELD (junk title)';
+        if (event._mergeNoOp === true) return 'SKIPPED (merge no-op — no field changes)';
         const action = typeof event._action === 'string' && event._action ? event._action : 'new';
         return action.toUpperCase();
     }
@@ -14219,7 +14296,7 @@ class SharedCore {
             // calendar execution by filterEventsForExecution; nothing about
             // that changes _action or this stamping, and the card stays in
             // the results UI.
-            analyzedEvent._sanityFlags = this.getEventSanityFlags(analyzedEvent);
+            analyzedEvent._sanityFlags = this.getEventSanityFlags(analyzedEvent, { config });
             if (analyzedEvent._sanityFlags.length > 0) {
                 console.log(`⚠️ SANITY: "${analyzedEvent.title || 'Unknown'}" flagged ${analyzedEvent._sanityFlags.map(flag => flag.code).join(', ')} — ${analyzedEvent._sanityFlags[0].detail}`);
             }
@@ -14253,8 +14330,11 @@ class SharedCore {
             // calendar write is withheld (filterEventsForExecution), exactly
             // the recurring-series withhold pattern below. Legitimate
             // umbrellas (bear weeks, festivals) are future-dated and never
-            // trip this.
-            if (this.isEventSpanFullyPast(analyzedEvent)) {
+            // trip this. Thresholded (owner feedback 2026-08): only a span
+            // that ended MORE than the withhold window ago (default 30 days,
+            // config sanity.pastSpanWithholdDays) is withheld — a
+            // last-weekend event behaves like any other.
+            if (this.isEventSpanPastBeyondWithholdWindow(analyzedEvent, Date.now(), this.resolvePastSpanWithholdDays(config))) {
                 analyzedEvent._pastSpanWithheld = true;
                 console.log(`⏳ PAST SPAN: "${analyzedEvent.title || 'Unknown'}" withheld from calendar write — entire span (start and end) is already past at analysis time; card kept in results`);
             }
@@ -14480,6 +14560,34 @@ class SharedCore {
                     calendarName: analysis.seriesMatch.calendarName || ''
                 };
                 console.log(`🔁 SHAPE: "${analyzedEvent.title || 'Unknown'}" occurrence is covered by the saved series in ${analyzedEvent._seriesMatch.calendarName || 'the calendar'} — write withheld (SERIES MATCH)`);
+            }
+
+            // MERGE NO-OP SKIP (owner feedback 2026-08: "I wouldn't mind not
+            // merging if there is no change and nothing to merge"): when the
+            // merge payload is field-identical to the live calendar record
+            // there is nothing to write, so the write becomes a no-op —
+            // skipped by filterEventsForExecution, labeled already-saved by
+            // the results UI. Judged against the FINAL payload (every
+            // notes/title pass above has run) with the same changed-fields
+            // predicate _changes / the no-changes chip use, PLUS the notes
+            // projection: ANY real notes-line difference (a bearReview
+            // verdict, a manual-verdict bearSource line, a sanity note)
+            // still writes; only pure line reordering is a no-op. The stamp
+            // is shared by live execution and the dryRun preview, so the
+            // preview shows exactly what execution would skip.
+            if (analyzedEvent._action === 'merge' && analyzedEvent._existingEvent) {
+                const finalWriteChanges = this.computeCalendarWriteChanges(
+                    analyzedEvent,
+                    analyzedEvent._existingEvent,
+                    analyzedEvent._original && analyzedEvent._original.calendar
+                );
+                const changedBeyondNotes = finalWriteChanges.filter(field => field !== 'notes');
+                const notesIdentical = !finalWriteChanges.includes('notes')
+                    || this.notesProjectionsMatch(analyzedEvent._existingEvent.notes, analyzedEvent.notes);
+                if (changedBeyondNotes.length === 0 && notesIdentical) {
+                    analyzedEvent._mergeNoOp = true;
+                    console.log(`⏸️ MERGE: "${analyzedEvent.title || 'Unknown'}" produced no field changes — write skipped`);
+                }
             }
 
             return analyzedEvent;

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -15325,6 +15325,232 @@ test('fully-past span: the write is withheld with a review flag; a future umbrel
 });
 
 // ---------------------------------------------------------------------------
+// span-fully-past narrowing (owner feedback 2026-08: "I don't like
+// 'span-fully-past' that much (I guess unless it's trying to save an event a
+// year ago or something)"): the flag + withhold only fire when the span ended
+// MORE than the withhold window ago (default 30 days, config-overridable via
+// sanity.pastSpanWithholdDays). A last-weekend event behaves like any other;
+// the THIS WEEK AT MASSIVE stale-roundup class (~300 days late) still trips
+// both — that case stays pinned by the test above.
+// ---------------------------------------------------------------------------
+
+test('recently-past span (5 days): no flag, no withhold — a last-weekend event behaves normally', async () => {
+  const core = createCore();
+  const now = Date.now();
+  const lastWeekend = {
+    title: 'Bear Night Last Weekend',
+    startDate: new Date(now - 5 * 24 * 60 * 60 * 1000),
+    endDate: new Date(now - 5 * 24 * 60 * 60 * 1000 + 6 * 60 * 60 * 1000),
+    bar: 'Massive',
+    city: 'seattle',
+    timezone: 'America/Los_Angeles',
+    shortName: 'BNLW' // keeps the shortName derivation pass inert
+  };
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logLines.push(args.join(' ')); };
+  let analyzed;
+  try {
+    analyzed = await core.prepareEventsForCalendar([lastWeekend], buildPrepCalendarAdapter([]), {});
+  } finally {
+    console.log = originalLog;
+  }
+  assert.equal(analyzed.length, 1);
+  assert.equal(analyzed[0]._pastSpanWithheld, undefined, 'a recently-past span is never withheld');
+  assert.ok(!analyzed[0]._sanityFlags.some(flag => flag.code === 'span-fully-past'),
+    'no review flag inside the withhold window');
+  assert.ok(!logLines.some(line => line.startsWith('⏳ PAST SPAN:')), 'no withhold log line');
+  assert.equal(SharedCore.filterEventsForExecution(analyzed).length, 1, 'the write proceeds normally');
+});
+
+test('sanity.pastSpanWithholdDays override: 0 restores flag-everything-past, a wide window clears the stale tile', async () => {
+  const core = createCore();
+  const now = Date.now();
+  const fiveDaysPast = () => ({
+    title: 'Bear Night Last Weekend',
+    startDate: new Date(now - 5 * 24 * 60 * 60 * 1000),
+    endDate: new Date(now - 5 * 24 * 60 * 60 * 1000 + 6 * 60 * 60 * 1000),
+    bar: 'Massive',
+    city: 'seattle',
+    timezone: 'America/Los_Angeles',
+    shortName: 'BNLW'
+  });
+  const strict = await core.prepareEventsForCalendar(
+    [fiveDaysPast()], buildPrepCalendarAdapter([]), { sanity: { pastSpanWithholdDays: 0 } });
+  assert.equal(strict[0]._pastSpanWithheld, true, 'a 0-day window withholds every fully-past span again');
+  assert.ok(strict[0]._sanityFlags.some(flag => flag.code === 'span-fully-past'),
+    'the config override reaches the flag channel too');
+  assert.deepEqual(SharedCore.filterEventsForExecution(strict), []);
+
+  // The real stale tile under a window wider than its lateness sails through.
+  const staleTile = {
+    title: 'THIS WEEK AT MASSIVE',
+    startDate: new Date('2025-10-07T05:00:00.000Z'),
+    endDate: new Date('2025-10-12T05:00:00.000Z'),
+    bar: 'Massive',
+    city: 'seattle',
+    timezone: 'America/Los_Angeles',
+    shortName: 'THIS WEEK'
+  };
+  const permissive = await core.prepareEventsForCalendar(
+    [staleTile], buildPrepCalendarAdapter([]), { sanity: { pastSpanWithholdDays: 100000 } });
+  assert.equal(permissive[0]._pastSpanWithheld, undefined);
+  assert.ok(!permissive[0]._sanityFlags.some(flag => flag.code === 'span-fully-past'));
+  assert.equal(SharedCore.filterEventsForExecution(permissive).length, 1);
+});
+
+test('span-fully-past flag channel: 30-day threshold, detail text unchanged, context.config override honored', () => {
+  const core = createCore();
+  const nowMs = Date.parse('2026-08-02T12:00:00Z');
+  const endedDaysAgo = (days) => ({
+    title: 'Window Probe',
+    startDate: new Date(nowMs - (days * 24 + 4) * 60 * 60 * 1000),
+    endDate: new Date(nowMs - days * 24 * 60 * 60 * 1000)
+  });
+  assert.deepEqual(core.getEventSanityFlags(endedDaysAgo(10), { nowMs }).map(flag => flag.code), [],
+    'inside the window: recently past is not flagged');
+  const flags = core.getEventSanityFlags(endedDaysAgo(40), { nowMs });
+  assert.deepEqual(flags.map(flag => flag.code), ['span-fully-past'], 'beyond the window: still flagged');
+  assert.equal(flags[0].detail,
+    'entire span (start and end) ended 40 day(s) before analysis — nothing left to attend',
+    'the flag text is byte-identical to the pre-threshold wording');
+  assert.deepEqual(
+    core.getEventSanityFlags(endedDaysAgo(10), { nowMs, config: { sanity: { pastSpanWithholdDays: 5 } } })
+      .map(flag => flag.code),
+    ['span-fully-past'],
+    'a tighter configured window flags a 10-day-past span');
+});
+
+// ---------------------------------------------------------------------------
+// Merge no-op skip (owner feedback 2026-08: "I wouldn't mind not merging if
+// there is no change and nothing to merge"): a merge whose FINAL payload is
+// field-identical to the live calendar record — the same changed-fields
+// predicate _changes / the results-UI no-changes chip use, plus the notes
+// projection — writes nothing. Fail closed: ANY real notes-line difference
+// (a bearReview edit, a manual-verdict bearSource line) still writes.
+// BEEFMINCE Trunk Den shape from run 20260813-211637: every written field
+// equal, notes differing by key ordering alone.
+// ---------------------------------------------------------------------------
+
+function scrapedBeefminceShape(startDate, endDate, overrides = {}) {
+  return {
+    title: 'BEEFMINCE Trunk Den',
+    startDate: new Date(startDate),
+    endDate: new Date(endDate),
+    bar: 'Royal Vauxhall Tavern',
+    city: 'london',
+    timezone: 'Europe/London',
+    cover: '£12',
+    website: 'https://beefmince.com',
+    bearSource: 'keyword',
+    shortName: 'BEEF-MINCE',
+    ...overrides
+  };
+}
+
+// Settle the record once (merge into a minimal calendar record) and hand back
+// what the calendar would hold after that write — the input every no-op /
+// changed-twin case below re-scrapes against.
+async function settleBeefminceCalendarRecord(core, startDate, endDate) {
+  const seedRecord = {
+    title: 'BEEFMINCE Trunk Den',
+    startDate: new Date(startDate),
+    endDate: new Date(endDate),
+    // Calendar-as-database: location is the real record's coordinates, and
+    // the empty-scrape merge rule preserves it exactly.
+    location: '51.4863391, -0.1217784',
+    notes: 'bar: Royal Vauxhall Tavern'
+  };
+  const settleRun = await core.prepareEventsForCalendar(
+    [scrapedBeefminceShape(startDate, endDate)], buildPrepCalendarAdapter([seedRecord]), {});
+  assert.equal(settleRun.length, 1);
+  assert.equal(settleRun[0]._action, 'merge');
+  const settled = settleRun[0];
+  return {
+    title: settled.title,
+    startDate: new Date(settled.startDate),
+    endDate: new Date(settled.endDate),
+    location: settled.location || '',
+    notes: settled.notes
+  };
+}
+
+test('merge no-op: a field-identical re-scrape skips the write with the ⏸️ line (BEEFMINCE Trunk Den shape)', async () => {
+  const core = createCore();
+  const start = Date.now() + 30 * 24 * 60 * 60 * 1000;
+  const end = start + 6 * 60 * 60 * 1000;
+  const calendarRecord = await settleBeefminceCalendarRecord(core, start, end);
+
+  const logLines = [];
+  const originalLog = console.log;
+  console.log = (...args) => { logLines.push(args.join(' ')); };
+  let rerun;
+  try {
+    rerun = await core.prepareEventsForCalendar(
+      [scrapedBeefminceShape(start, end)], buildPrepCalendarAdapter([calendarRecord]), {});
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.equal(rerun.length, 1, "flag-don't-drop: the card stays in the results");
+  assert.equal(rerun[0]._action, 'merge', 'analysis still resolves a merge');
+  assert.equal(rerun[0]._mergeNoOp, true, 'a field-identical merge is stamped as a no-op');
+  assert.ok(logLines.some(line => line.startsWith('⏸️ MERGE: "BEEFMINCE Trunk Den" produced no field changes — write skipped')),
+    `no-op line expected, got: ${JSON.stringify(logLines.filter(line => line.includes('MERGE')))}`);
+  assert.deepEqual(SharedCore.filterEventsForExecution(rerun), [], 'nothing reaches the calendar write');
+  assert.equal(SharedCore.describeExecutionDisposition(rerun[0]),
+    'SKIPPED (merge no-op — no field changes)',
+    'the dryRun preview label and the execution gate agree');
+});
+
+test('merge no-op fail-closed: one real field change writes, and a verdict-line-only difference writes', async () => {
+  const core = createCore();
+  const start = Date.now() + 30 * 24 * 60 * 60 * 1000;
+  const end = start + 6 * 60 * 60 * 1000;
+  const calendarRecord = await settleBeefminceCalendarRecord(core, start, end);
+
+  // One-field-changed twin: the scrape now carries an instagram the calendar
+  // lacks — the merge must still write.
+  const changedRun = await core.prepareEventsForCalendar(
+    [scrapedBeefminceShape(start, end, { instagram: 'https://www.instagram.com/rvtofficial' })],
+    buildPrepCalendarAdapter([{ ...calendarRecord, startDate: new Date(calendarRecord.startDate), endDate: new Date(calendarRecord.endDate) }]),
+    {});
+  assert.equal(changedRun[0]._action, 'merge');
+  assert.equal(changedRun[0]._mergeNoOp, undefined, 'a real field change is never stamped as a no-op');
+  assert.equal(SharedCore.filterEventsForExecution(changedRun).length, 1, 'the changed merge still writes');
+
+  // Verdict-line-only twin: same fields, but the owner tapped manual-bear in
+  // the results UI. Title/dates/location are identical — the ONLY difference
+  // is the bearSource notes line, and the notes projection must catch it
+  // (his verdicts always land).
+  const verdictRun = await core.prepareEventsForCalendar(
+    [scrapedBeefminceShape(start, end, { bearSource: 'manual-bear (overrode ai: tapped in results)' })],
+    buildPrepCalendarAdapter([{ ...calendarRecord, startDate: new Date(calendarRecord.startDate), endDate: new Date(calendarRecord.endDate) }]),
+    {});
+  assert.equal(verdictRun[0]._action, 'merge');
+  assert.equal(core.parseNotesIntoFields(verdictRun[0].notes).bearSource,
+    'manual-bear (overrode ai: tapped in results)',
+    'the manual verdict is in the merged payload');
+  assert.equal(verdictRun[0]._mergeNoOp, undefined, 'a verdict-note-only difference is a change');
+  assert.equal(SharedCore.filterEventsForExecution(verdictRun).length, 1, 'the verdict write still lands');
+});
+
+test('notesProjectionsMatch: pure line reordering is a no-op, any real line difference is a change', () => {
+  const core = createCore();
+  const notes = 'bar: Royal Vauxhall Tavern\nwebsite: https://beefmince.com\nbearSource: keyword';
+  const reordered = 'website: https://beefmince.com\nbearSource: keyword\nbar: Royal Vauxhall Tavern';
+  assert.equal(core.notesProjectionsMatch(notes, reordered), true,
+    'formatEventNotes key-order churn alone is not a change (the real BEEFMINCE case)');
+  assert.equal(core.notesProjectionsMatch(notes, `${notes}\nbearReview: confirmed — owner`), false,
+    'an added bearReview line is a change');
+  assert.equal(core.notesProjectionsMatch(notes, notes.replace('keyword', 'manual-bear (overrode ai: tapped)')), false,
+    'a rewritten bearSource verdict line is a change');
+  assert.equal(core.notesProjectionsMatch('', ''), true);
+  assert.equal(core.notesProjectionsMatch(notes, `${notes}\n`), true,
+    'a trailing blank line is not a content difference');
+});
+
+// ---------------------------------------------------------------------------
 // Cross-realm Date handling (2026-08-03 run review).
 //
 // Scriptable loads every file through its own importModule, so shared-core and


### PR DESCRIPTION
Owner feedback (verbatim): *"I don't like 'span-fully-past' that much (I guess unless it's trying to save an event a year ago or something) but I wouldn't mind not merging if there is no change and nothing to merge"*

## 1. span-fully-past narrowed to a threshold window

The `span-fully-past` review flag and the `_pastSpanWithheld` write withhold now fire only when the span ended **more than 30 days** before analysis (`SANITY_PAST_SPAN_WITHHOLD_DAYS`, owner-tunable via `config.sanity.pastSpanWithholdDays`; `0` restores the old flag-everything-past behavior). A last-weekend event now behaves like any other event — no flag, no withhold, no new decorative text for the recently-past region — while the stale-roundup class ("THIS WEEK AT MASSIVE", an Oct-2025 tile proposed ~10 months late) still trips both.

- Flag **code, detail text, and the `⏳ PAST SPAN:` log line are byte-identical** — only *when* they fire changed (verified: `git diff` shows zero removed/edited `console.log`/`detail:` lines).
- Both the flag channel (`getEventSanityFlags`, via `context.config`) and the withhold stamp (`buildAnalyzedCalendarEvent`) share one predicate: `isEventSpanPastBeyondWithholdWindow`.

**Updated pins: none.** Every existing test pinning `span-fully-past`/`_pastSpanWithheld` uses fixtures far beyond 30 days past (ONBEAR FEST 2021, Nark 2024, "Out of Hibernation" ~154 days, MASSIVE ~310 days) — all still fire and stay green unchanged.

## 2. Merge no-op writes are skipped

When calendar analysis resolves `action=merge` and the **final** payload (after every trim/title/notes pass) is field-identical to the live calendar record, the event is stamped `_mergeNoOp`, skipped by `filterEventsForExecution` (nothing written), and labeled through the **existing** already-saved bucket: "✅ merge no-op — calendar already has all of this", write-action pill `skip`, disposition `SKIPPED (merge no-op — no field changes)`. One new log line: `⏸️ MERGE: "X" produced no field changes — write skipped`.

- **Predicate reused, not reimplemented**: the `_changes` "changed = merged differs from calendar" computation (`createFinalEventObject`) is extracted into `computeCalendarWriteChanges` and re-evaluated against the final payload.
- **Notes projection compared too, fail closed**: `notesProjectionsMatch` is line-level and order-insensitive — pure `formatEventNotes` key-order churn (the real BEEFMINCE Trunk Den record from run 20260813-211637, whose only `_changes` entry was ordering-only `notes`) is a no-op, but ANY real line difference — a `bearReview` edit, a manual-verdict `bearSource` line, a sanity-driven note — still writes. Verdicts always land.
- **dryRun preview matches reality**: the stamp is set at analysis time and shared by the pile classification, the disposition label, and the execution gate, so preview and execution can never disagree. `_mergeNoOp` is registered in `getCalendarAnalysisStampKeys` so saved-run re-analysis never replays a stale stamp.
- Adapter changes are label wiring only (two conditions in `classifyEventForResultsSection` / `getWriteActionFromEvent`).

## Verification

Real-data tests (all in the enumerated `shared-core.test.js` / `adapters/scriptable-adapter.test.js`):
- THIS WEEK AT MASSIVE (~310 days past) still withholds — existing pin untouched and green.
- A 5-days-past fixture no longer flags/withholds and reaches the write plan.
- `sanity.pastSpanWithholdDays: 0` restores the old behavior; a wide window clears the stale tile.
- BEEFMINCE-shape field-identical re-scrape: `_mergeNoOp` stamped, `⏸️` line logged, excluded from execution, `SKIPPED` disposition; the adapter places the real `BEEFMINCE_NOOP_EVENT` (with its ordering-only `_changes: ['notes']`) in the already-saved pile with write action `skip`.
- A one-field-changed twin (instagram added) still writes; a verdict-line-only twin (`bearSource: manual-bear (...)`) still writes via the notes-projection comparison.

**Suite**: 1867 pass / 0 fail under `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`.
**Fail-on-base proof**: with `scripts/shared-core.js` + `scripts/adapters/scriptable-adapter.js` reverted to origin/main, 6 of the 7 new tests fail (990 run: 984 pass / 6 fail); the 7th ("merge no-op fail-closed…") is a guard asserting writes still happen, which by design also passes on base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP