### PR TITLE
fix(scheduler): stall-proceed for undrainable phone uploads + auto-pull before scheduled runs

### DIFF
--- a/scripts/tools-serve-results.test.js
+++ b/scripts/tools-serve-results.test.js
@@ -607,6 +607,60 @@ test('run-once: sweep blocks only on storage/ and reports outside-storage datale
 // Defense #3b: JS-side timeouts cannot cancel wedged syscalls — each one
 // leaks a libuv threadpool slot, and the default pool is only 4 slots. Both
 // the run-once entry and the launchd plist give the pool headroom.
+// Stall detection (2026-08-15 05:15 incident): 108 phone-written cache
+// entries sat dataless because their bytes were pending UPLOAD from the
+// phone — undrainable from the Mac — and the sweep rode the 15-min ceiling
+// into a pointless abort. A count that stops falling now proceeds with the
+// bounded-fs-ops defense; a still-falling count keeps waiting.
+test('run-once: materialization sweep proceeds after the dataless count stalls (pending phone uploads)', async () => {
+  const logs = [];
+  const log = (line) => logs.push(String(line));
+  let fakeNow = 0;
+  const result = await runOnce.materializeSharedStorageTree('/shared/root', {
+    platform: 'darwin',
+    countDataless: () => 108, // never drains
+    kickDownload: () => true,
+    ceilingMs: 900 * 1000,
+    pollIntervalMs: 1,
+    sleep: () => { fakeNow += 30 * 1000; },
+    now: () => fakeNow,
+    log
+  });
+  assert.equal(result.undrainable, 108, 'stall reported, not thrown');
+  assert.ok(
+    logs.some((line) => line.includes('have not drained across') && line.includes('pending UPLOAD')),
+    'the stall warning names the pending-upload cause'
+  );
+
+  // A still-falling count never trips the stall path — it drains normally.
+  const counts = [10, 8, 6, 4, 2, 0];
+  const drained = await runOnce.materializeSharedStorageTree('/shared/root', {
+    platform: 'darwin',
+    countDataless: () => counts.shift(),
+    kickDownload: () => true,
+    ceilingMs: 900 * 1000,
+    pollIntervalMs: 1,
+    sleep: () => {},
+    now: () => 0,
+    log
+  });
+  assert.equal(drained.datalessAtStart, 10);
+  assert.equal(drained.undrainable, undefined, 'a draining sweep completes fully');
+});
+
+// Auto-update (owner: "make sure the Mac script is always using up to date
+// code"): the launchd command pulls origin/main before invoking run-once,
+// and a failed pull falls through to running the current checkout.
+test('run-once: launchd plist template pulls origin/main before the run', () => {
+  const fs = require('node:fs');
+  const template = fs.readFileSync(
+    require('node:path').join(__dirname, '..', 'tools', 'launchd', 'com.chunky-dad.scraper-daily.plist.template'),
+    'utf8'
+  );
+  assert.match(template, /git pull --ff-only --quiet origin main/, 'auto-pull present');
+  assert.match(template, /git pull failed — running with the current checkout/, 'pull failure falls through to the run');
+});
+
 test('run-once: UV_THREADPOOL_SIZE headroom is defaulted at the entry point and pinned in the launchd plist template', () => {
   const fs = require('node:fs');
 

--- a/tools/launchd/com.chunky-dad.scraper-daily.plist.template
+++ b/tools/launchd/com.chunky-dad.scraper-daily.plist.template
@@ -25,6 +25,12 @@
   not depend on the unreachable dir. The per-run log itself is written into
   the shared logs/ dir by run-once.
 
+  AUTO-UPDATE: the job pulls origin/main (--ff-only) before every run so the
+  scheduled sweep always executes current code (owner: "make sure the Mac
+  script is always using up to date code"). A failed pull (offline, diverged
+  checkout) logs one line and runs with the existing checkout — a stale run
+  beats no run; a diverged checkout needs a human anyway.
+
   WHY /bin/zsh IS THE PROGRAM (TCC / Full Disk Access): macOS attributes a
   launchd job's file access to the job's main executable. Running node
   directly means the Full Disk Access grant is pinned to one node binary
@@ -45,7 +51,7 @@
     <array>
         <string>/bin/zsh</string>
         <string>-c</string>
-        <string>"__NODE__" "__REPO__/tools/run-once.js"</string>
+        <string>cd "__REPO__" &amp;&amp; { /usr/bin/git pull --ff-only --quiet origin main || echo "run-once: git pull failed — running with the current checkout"; }; "__NODE__" "__REPO__/tools/run-once.js"</string>
     </array>
     <key>WorkingDirectory</key>
     <string>__REPO__</string>

--- a/tools/run-once.js
+++ b/tools/run-once.js
@@ -289,16 +289,35 @@ async function materializeSharedStorageTree(sharedRoot, options = {}) {
     }
     const startedAt = now();
     let count = initialCount;
+    // Stall detection: a count that stops FALLING is not "evicted, still
+    // downloading" — it is content that does not exist in iCloud yet (bytes
+    // pending UPLOAD from the phone; 2026-08-15 05:15 run: 108 fresh cache
+    // entries from the phone's evening runs sat undrainable and the sweep
+    // rode the 15-min ceiling into a pointless abort). Those files are
+    // unreadable no matter how long we wait, and the bounded fs ops treat
+    // each as a cache miss (a refetch, not a degraded run) with
+    // UV_THREADPOOL_SIZE headroom absorbing any wedged slots — so after
+    // STALL_POLLS unchanged polls we PROCEED with a loud warning instead of
+    // aborting. A still-falling count keeps waiting (genuine downloads), and
+    // the ceiling abort remains for that path.
+    const STALL_POLLS = 4;
+    let unchangedPolls = 0;
     while (count > 0) {
         if (now() - startedAt >= ceilingMs) {
             throw new Error(`run-once: shared storage tree still has ${count} dataless file(s) after ${Math.round(ceilingMs / 1000)}s — ABORTING (no-partial-runs: proceeding would wedge fs syscalls or miss shared cache entries). One-time fix: right-click the chunky-dad-scraper folder in Finder and choose "Keep Downloaded" so iCloud never evicts it; or re-run once the download finishes.`);
         }
         await sleep(pollIntervalMs);
-        count = countDataless(sharedRoot);
-        if (count === null) {
+        const nextCount = countDataless(sharedRoot);
+        if (nextCount === null) {
             throw new Error('run-once: dataless probe (find -flags +dataless) broke mid-sweep — ABORTING instead of guessing the tree is materialized (no-partial-runs)');
         }
+        unchangedPolls = nextCount >= count ? unchangedPolls + 1 : 0;
+        count = nextCount;
         log(`run-once: materialization progress — ${count} dataless file(s) remaining under the shared root`);
+        if (unchangedPolls >= STALL_POLLS) {
+            log(`run-once: ${count} dataless file(s) have not drained across ${STALL_POLLS} polls — content likely pending UPLOAD from another device (undrainable from this Mac). Proceeding with bounded fs ops as the defense; each such entry reads as a cache miss.`);
+            return { datalessAtStart: initialCount, waitedMs: now() - startedAt, undrainable: count };
+        }
     }
     const waitedMs = now() - startedAt;
     log(`run-once: shared storage tree fully materialized after ${Math.round(waitedMs / 1000)}s (${initialCount} file(s) downloaded) — safe to start parser work`);


### PR DESCRIPTION
Two scheduler self-healing fixes from this morning's failed 05:15 run:

**Stall-proceed.** The run aborted at the materialization ceiling on 108 dataless cache files — entries the PHONE wrote Thursday evening whose bytes were still pending upload to iCloud. Those are undrainable from the Mac no matter how long the sweep waits (verified live: direct reads time out, `brctl download` no-ops, count static). The sweep now detects the stall signature (count unchanged across 4 polls) and proceeds with the bounded-fs-ops defense — each undrainable entry reads as a cache miss (a refetch; OCR/AI are free locally), which is not a degraded run. A still-falling count (genuine eviction downloads) keeps waiting, and the ceiling abort remains for that path. No existing log/error strings changed.

**Auto-pull.** Owner: "Can you make sure the Mac script is always using up to date code?" The launchd command now runs `git pull --ff-only --quiet origin main` before invoking run-once (public https remote — no auth needed under launchd). A failed pull logs one line and runs the current checkout: a stale run beats no run.

Tests: stall-proceed + still-draining behavior + plist pull assertion; 5 failures on base with sources stashed. Full quiet suite 1884/1884. NOTE: requires one `tools/schedule-mac-run.sh install` re-run after merge to render the new plist — I'll do that and validate live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP