### PR TITLE
feat(scraper): report-only flyer-vs-page start-time conflict flag

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -485,6 +485,240 @@ function combineDateAndTime(dateStr, timeStr) {
     return isNaN(date.getTime()) ? null : date;
 }
 
+// ---------------------------------------------------------------------------
+// Flyer-vs-site time-conflict reading (report-only; proposed in #1681).
+// Run 20260814-195026 (Playground Toronto, bearitmtl.com): the page's
+// JSON-LD/visible schedule stated 10:00 — the venue's own AM/PM entry error —
+// while the event's paired flyer OCR clearly read "10pm to 3am". Doctrine
+// ships what the site states; these helpers only READ the flyer's cached OCR
+// transcription so the disagreement can be SURFACED as a sanity flag
+// (flag, don't drop — never an override, never a write withhold).
+// Deterministic and fail-closed throughout: no unambiguous single start
+// reading in the OCR text → no reading → no flag.
+// ---------------------------------------------------------------------------
+
+// A clock-time token requires an explicit time marker — am/pm (dots
+// optional), a French/European "h" form ("22h", "22h30", "10 h 00 min"), or
+// a colon form ("22:30") — so bare numbers ("6th", "2025", "$10") are never
+// times. Group layout: 1=hour, 2=colon minutes, 3=h-separator marker,
+// 4=h-form minutes, 5=bare trailing h, 6=meridiem letter.
+const FLYER_OCR_TIME_TOKEN_PATTERN = /(?:^|[^0-9A-Za-z])(\d{1,2})(?::(\d{2})|\s*([hH])\s*(\d{2})(?:\s*min\.?)?|\s*([hH])(?![0-9A-Za-z]))?(?:\s*([ap])\.?\s?\.?m\.?(?![0-9A-Za-z]))?/gi;
+
+// A line carries date context when it names a month or weekday (EN/FR — the
+// same language-generic vocabulary the French time support already added), a
+// 4-digit contemporary year, or an ISO date. Context gate only, never a veto.
+const FLYER_OCR_DATE_CONTEXT_PATTERN = /\b(?:jan(?:uary|vier)?|feb(?:ruary)?|f[ée]vr?(?:ier)?|mar(?:ch)?|mars|apr(?:il)?|avr(?:il)?|may|mai|june?|juin|july?|juil(?:let)?|aug(?:ust)?|ao[ûu]t|sep(?:t(?:ember|embre)?)?|oct(?:ober|obre)?|nov(?:ember|embre)?|d[ée]c(?:ember|embre)?)\b|\b(?:mon|tues?|wednes|thurs?|fri|satur|sun)day\b|\b(?:lundi|mardi|mercredi|jeudi|vendredi|samedi|dimanche)\b|\b20\d{2}\b|\b\d{4}-\d{2}-\d{2}\b/i;
+
+// Month-name → month-number tells for the date-contradiction veto (EN/FR,
+// full names and common abbreviations; \b-bounded so "mardi"≠March).
+const FLYER_OCR_MONTH_TOKEN_PATTERNS = [
+    [1, /\bjan(?:uary|vier)?\b/gi], [2, /\bfeb(?:ruary)?\b|\bf[ée]vr?(?:ier)?\b/gi],
+    [3, /\bmar(?:ch)?\b|\bmars\b/gi], [4, /\bapr(?:il)?\b|\bavr(?:il)?\b/gi],
+    [5, /\bmay\b|\bmai\b/gi], [6, /\bjune?\b|\bjuin\b/gi],
+    [7, /\bjuly?\b|\bjuil(?:let)?\b/gi], [8, /\baug(?:ust)?\b|\bao[ûu]t\b/gi],
+    [9, /\bsep(?:t(?:ember|embre)?)?\b/gi], [10, /\boct(?:ober|obre)?\b/gi],
+    [11, /\bnov(?:ember|embre)?\b/gi], [12, /\bd[ée]c(?:ember|embre)?\b/gi]
+];
+
+// Every clock-time reading in an OCR transcription, with just enough
+// structure to tell start candidates from doors times and range ends:
+// [{ minutes, raw, line, unambiguous, isDoors, isRangeEnd, isRangeStart }].
+// A reading is UNAMBIGUOUS when the flyer states which half of the day it
+// means (explicit meridiem, an "h" form — 24h by convention — or a colon
+// hour of 0 or ≥13); a bare 1–12 colon time ("10:00") is ambiguous and can
+// support an agreement check but never a conflict.
+function collectFlyerOcrTimeReadings(ocrText) {
+    const text = String(ocrText || '');
+    if (!text.trim()) return [];
+    const readings = [];
+    const lines = text.split(/\r?\n/);
+    const RANGE_CONNECTOR_PATTERN = /^\s*(?:to|until|till?|thru|through|from|[àa]|au|jusqu'[àa]|[-–—~])\s*$/i;
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+        const line = lines[lineIndex];
+        FLYER_OCR_TIME_TOKEN_PATTERN.lastIndex = 0;
+        let match;
+        let previous = null;
+        let pendingBare = null;
+        while ((match = FLYER_OCR_TIME_TOKEN_PATTERN.exec(line)) !== null) {
+            const hasColonMinutes = match[2] !== undefined;
+            const hasHourSeparator = match[3] !== undefined;
+            const hasBareHourSuffix = match[5] !== undefined;
+            const meridiem = match[6] ? match[6].toLowerCase() : '';
+            const raw = match[0].replace(/^[^0-9]+/, '').trim();
+            const tokenStart = match.index + (match[0].length - match[0].replace(/^[^0-9]+/, '').length);
+            // No explicit time marker → not a time by itself (bare "6",
+            // "2025", "$10") — but a bare 1–12 may still be the start of a
+            // shared-meridiem range ("3-9PM"), so remember the latest one.
+            if (!hasColonMinutes && !hasHourSeparator && !hasBareHourSuffix && !meridiem) {
+                const bareValue = parseInt(match[1], 10);
+                pendingBare = (bareValue >= 1 && bareValue <= 12)
+                    ? { value: bareValue, endIndex: FLYER_OCR_TIME_TOKEN_PATTERN.lastIndex, raw }
+                    : null;
+                continue;
+            }
+            let hour = parseInt(match[1], 10);
+            const minute = hasColonMinutes ? parseInt(match[2], 10)
+                : (hasHourSeparator ? parseInt(match[4], 10) : 0);
+            let unambiguous;
+            if (meridiem) {
+                if (hour < 1 || hour > 12) { pendingBare = null; continue; } // "22pm" is nonsense
+                if (meridiem === 'p' && hour !== 12) hour += 12;
+                if (meridiem === 'a' && hour === 12) hour = 0;
+                unambiguous = true;
+            } else if (hasHourSeparator || hasBareHourSuffix) {
+                unambiguous = true; // "h" forms are 24-hour by convention
+            } else {
+                unambiguous = hour === 0 || hour >= 13;
+            }
+            if (hour > 23 || minute > 59) { pendingBare = null; continue; }
+            const before = line.slice(0, tokenStart);
+            const after = line.slice(FLYER_OCR_TIME_TOKEN_PATTERN.lastIndex);
+            // Doors label next to the time, either side ("DOORS: 9PM",
+            // "7:30PM DOORS" — EN doors / FR portes): reuses the
+            // doors-vs-party vocabulary — a doors time is real but is not
+            // the event's start, so it is never a start candidate.
+            const isDoors = /(?:\bdoors?\b|\bportes?\b)[^0-9\r\n]{0,24}$/i.test(before)
+                || /^[\s:;,.\-–—•|(/]{0,6}(?:doors?|portes?)\b/i.test(after);
+            const reading = {
+                minutes: (hour * 60) + minute,
+                raw,
+                line: lineIndex,
+                unambiguous,
+                isDoors,
+                isRangeEnd: false,
+                isRangeStart: false
+            };
+            // "10pm to 3am" / "22h – 3h" / "10pm-3am": a short connector
+            // between two adjacent times marks a range — the first time is
+            // the start, the second is the end (never a start candidate).
+            if (previous) {
+                const between = line.slice(previous.endIndex, tokenStart);
+                if (between.length <= 12 && RANGE_CONNECTOR_PATTERN.test(between)) {
+                    reading.isRangeEnd = true;
+                    previous.reading.isRangeStart = true;
+                }
+            } else if (pendingBare && meridiem) {
+                // Shared-meridiem range ("3-9PM" = 3 PM to 9 PM): the bare
+                // start borrows the end's meridiem — but only when that
+                // reading is coherent (start strictly before end within the
+                // shared half-day; "11-2PM" is NOT 11 PM, so it stays
+                // unreadable — fail closed) — and the end is always a range
+                // end, never a start candidate.
+                const between = line.slice(pendingBare.endIndex, tokenStart);
+                if (between.length <= 12 && RANGE_CONNECTOR_PATTERN.test(between)) {
+                    reading.isRangeEnd = true;
+                    if (pendingBare.value < parseInt(match[1], 10)) {
+                        let bareHour = pendingBare.value;
+                        if (meridiem === 'p' && bareHour !== 12) bareHour += 12;
+                        if (meridiem === 'a' && bareHour === 12) bareHour = 0;
+                        readings.push({
+                            minutes: bareHour * 60,
+                            raw: `${pendingBare.raw}${meridiem}m`,
+                            line: lineIndex,
+                            unambiguous: true,
+                            isDoors: reading.isDoors,
+                            isRangeEnd: false,
+                            isRangeStart: true
+                        });
+                    }
+                }
+            }
+            readings.push(reading);
+            previous = { endIndex: FLYER_OCR_TIME_TOKEN_PATTERN.lastIndex, reading };
+            pendingBare = null;
+        }
+    }
+    return readings;
+}
+
+// THE deterministic single-start reading of a flyer's OCR text, or null.
+// Fail-closed rules: candidates must be unambiguous, must not be doors
+// times or range ends, and must sit near date/time context (a time range,
+// or a date token on the same/adjacent line); every candidate must agree on
+// ONE clock time; and no ambiguous reading may point anywhere else. Returns
+// { time: 'HH:MM', raw: '10pm', minutes } or null.
+function readFlyerStartTimeFromOcrText(ocrText) {
+    const text = String(ocrText || '');
+    if (!text.trim()) return null;
+    const readings = collectFlyerOcrTimeReadings(text);
+    if (readings.length === 0) return null;
+    const lines = text.split(/\r?\n/);
+    const dateContextLines = lines.map(line => FLYER_OCR_DATE_CONTEXT_PATTERN.test(line));
+    // ±2 lines: flyers stack date / doors / party lines ("SATURDAY DEC 6" /
+    // "DOORS: 9PM" / "PARTY: 10PM"), so the date may sit two lines above the
+    // start time it dates.
+    const nearDateContext = (lineIndex) => dateContextLines
+        .slice(Math.max(0, lineIndex - 2), lineIndex + 3)
+        .some(Boolean);
+    const candidates = readings.filter(reading => reading.unambiguous
+        && !reading.isDoors
+        && !reading.isRangeEnd
+        && (reading.isRangeStart || nearDateContext(reading.line)));
+    if (candidates.length === 0) return null;
+    const distinctMinutes = new Set(candidates.map(reading => reading.minutes));
+    if (distinctMinutes.size !== 1) return null;
+    const chosen = candidates[0];
+    // An ambiguous reading that could mean a DIFFERENT time than the chosen
+    // start is conflicting information — fail closed.
+    for (const reading of readings) {
+        if (reading.unambiguous || reading.isDoors || reading.isRangeEnd) continue;
+        const alternate = (reading.minutes + 720) % 1440;
+        if (reading.minutes !== chosen.minutes && alternate !== chosen.minutes) return null;
+    }
+    const pad = (value) => String(value).padStart(2, '0');
+    return {
+        time: `${pad(Math.floor(chosen.minutes / 60))}:${pad(chosen.minutes % 60)}`,
+        raw: chosen.raw,
+        minutes: chosen.minutes
+    };
+}
+
+// Does the flyer's OCR text state this exact clock time ANYWHERE — as a
+// start, doors, or range-end time? Agreement anywhere means no conflict
+// (the page adopting the doors or end time is a known, legitimate reading).
+// Ambiguous 1–12 readings match under either meridiem interpretation.
+function flyerOcrStatesClockTime(ocrText, timeHHMM) {
+    const timeMatch = /^(\d{2}):(\d{2})$/.exec(String(timeHHMM || ''));
+    if (!timeMatch) return false;
+    const target = (parseInt(timeMatch[1], 10) * 60) + parseInt(timeMatch[2], 10);
+    return collectFlyerOcrTimeReadings(ocrText).some(reading => reading.minutes === target
+        || (!reading.unambiguous && (reading.minutes + 720) % 1440 === target));
+}
+
+// TRUE when the flyer's OCR text names a date that cannot be this event's
+// local start date (or the previous day — an after-midnight start belongs
+// to the prior night's flyer). Absent date tokens are never a
+// contradiction; only positively mismatched years, months, or month+day
+// pairs veto (the flyer is then likely another occurrence's artwork).
+function flyerOcrContradictsEventDate(ocrText, localDates) {
+    const text = String(ocrText || '');
+    if (!text.trim() || !Array.isArray(localDates) || localDates.length === 0) return false;
+    const years = new Set();
+    const yearPattern = /\b(20\d{2})\b/g;
+    let yearMatch;
+    while ((yearMatch = yearPattern.exec(text)) !== null) years.add(parseInt(yearMatch[1], 10));
+    if (years.size > 0 && !localDates.some(date => years.has(date.year))) return true;
+    const monthsFound = new Set();
+    const monthDayPairs = [];
+    for (const [monthNumber, pattern] of FLYER_OCR_MONTH_TOKEN_PATTERNS) {
+        pattern.lastIndex = 0;
+        let match;
+        while ((match = pattern.exec(text)) !== null) {
+            monthsFound.add(monthNumber);
+            const after = text.slice(pattern.lastIndex).match(/^\.?,?\s{0,3}(\d{1,2})(?:st|nd|rd|th|er|e)?\b/i);
+            if (after) monthDayPairs.push({ month: monthNumber, day: parseInt(after[1], 10) });
+            const before = text.slice(0, match.index).match(/(\d{1,2})(?:st|nd|rd|th|er|e)?\s{0,3}$/i);
+            if (before) monthDayPairs.push({ month: monthNumber, day: parseInt(before[1], 10) });
+        }
+    }
+    if (monthsFound.size > 0 && !localDates.some(date => monthsFound.has(date.month))) return true;
+    if (monthDayPairs.length > 0
+        && !localDates.some(date => monthDayPairs.some(pair => pair.month === date.month && pair.day === date.day))) {
+        return true;
+    }
+    return false;
+}
+
 class AiWebParser {
     constructor(config = {}) {
         this.config = {
@@ -1021,6 +1255,10 @@ class AiWebParser {
                 // whether the identity guard + curated precedence would let it
                 // fill a blank location. Writes nothing to event data.
                 this.logMapsLinkCoordinateCandidates(keptStructuredEvents, effectiveHtmlData);
+                // Report-only: does the event's own paired flyer (og-image
+                // adoption above OCR-vetted it into the verdict registry)
+                // state a different start time than the structured data?
+                this.applyFlyerTimeConflictFlag(keptStructuredEvents);
                 return {
                     events: keptStructuredEvents,
                     additionalLinks: additionalLinks,
@@ -1185,6 +1423,10 @@ class AiWebParser {
             // the identity guard + curated precedence would let it fill a
             // blank location. Writes nothing to event data.
             this.logMapsLinkCoordinateCandidates(keptEvents, effectiveHtmlData);
+            // Report-only: does the event's own paired flyer (ocr-all pass /
+            // segment pairing recorded its verdict) state a different start
+            // time than the page-derived one?
+            this.applyFlyerTimeConflictFlag(keptEvents);
 
             return {
                 events: keptEvents,
@@ -15062,6 +15304,110 @@ TEXT:
         return `${pad(Math.floor(party / 60))}:${pad(party % 60)}`;
     }
 
+    // The event's local start date and the previous day, as {year, month,
+    // day} — the two dates its own flyer may legitimately name (a start
+    // after local midnight belongs to the prior night's artwork). Null when
+    // the start is unparseable or the timezone read fails (fail closed:
+    // callers then never flag). Mirrors getEventNightKey's Intl usage.
+    getFlyerLocalDateCandidates(event) {
+        if (!this.core || typeof this.core.toEpochMillis !== 'function') return null;
+        const millis = this.core.toEpochMillis(event.startDate);
+        if (millis === null) return null;
+        const date = new Date(millis);
+        const timezone = typeof event.timezone === 'string' ? event.timezone.trim() : '';
+        let year = date.getUTCFullYear();
+        let month = date.getUTCMonth() + 1;
+        let day = date.getUTCDate();
+        if (timezone && !event._timezoneUnresolved) {
+            if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') return null;
+            try {
+                const formatter = new Intl.DateTimeFormat('en-CA', {
+                    timeZone: timezone,
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit'
+                });
+                const parts = formatter.formatToParts(date);
+                const read = (type) => {
+                    const part = parts.find(entry => entry.type === type);
+                    return part ? parseInt(part.value, 10) : NaN;
+                };
+                const localYear = read('year');
+                const localMonth = read('month');
+                const localDay = read('day');
+                if (![localYear, localMonth, localDay].every(Number.isFinite)) return null;
+                year = localYear;
+                month = localMonth;
+                day = localDay;
+            } catch (_) {
+                return null;
+            }
+        }
+        const previous = new Date(Date.UTC(year, month - 1, day) - (24 * 60 * 60 * 1000));
+        return [
+            { year, month, day },
+            { year: previous.getUTCFullYear(), month: previous.getUTCMonth() + 1, day: previous.getUTCDate() }
+        ];
+    }
+
+    // Report-only flyer-vs-page start-time conflict (proposed in #1681,
+    // Playground Toronto: page stated 10:00 — the venue's AM/PM entry error —
+    // while the event's own flyer read "10pm to 3am"). Runs on BOTH the
+    // structured-data and AI extraction routes, after each route has settled
+    // event.image (the segment↔image pairing / og-image adoption is that
+    // settling). Consults ONLY the in-memory OCR verdict registry — verdicts
+    // this run already paid for (ocr-all, og-image-vet, cache hits) — never
+    // a new vision call. Every rung fails closed: no verdict, a non-flyer
+    // classification, no unambiguous single OCR start reading, agreement
+    // anywhere (doors/end times included), a sub-hour difference, or a
+    // flyer-stated date that contradicts the event's own → nothing. Stamps
+    // the underscore channel only (_flyerTimeConflict, same convention as
+    // _doorsTimeRejected); the site's value always ships unchanged.
+    applyFlyerTimeConflictFlag(events) {
+        if (!Array.isArray(events) || events.length === 0) return;
+        if (!this.core || typeof this.core.formatLocalClockTime !== 'function') return;
+        for (const event of events) {
+            if (!event || typeof event !== 'object' || event._flyerTimeConflict) continue;
+            const imageUrl = typeof event.image === 'string' ? event.image.trim() : '';
+            if (!imageUrl || !event.startDate) continue;
+            const timezone = typeof event.timezone === 'string' ? event.timezone.trim() : '';
+            // No resolved timezone and no wall-clock-as-UTC marker → the local
+            // clock reading below would be a guess; fail closed.
+            if (!timezone && !event._timezoneUnresolved) continue;
+            const verdict = this.getOcrImageVerdict(imageUrl);
+            if (!verdict || verdict.classification !== 'event-flyer') continue;
+            const ocrText = typeof verdict.text === 'string' ? verdict.text : '';
+            if (!ocrText.trim()) continue;
+            const reading = readFlyerStartTimeFromOcrText(ocrText);
+            if (!reading) continue;
+            const pageTime = this.core.formatLocalClockTime(event.startDate, timezone);
+            const pageMatch = /^(\d{2}):(\d{2})$/.exec(pageTime);
+            if (!pageMatch) continue;
+            // A local-midnight start is the missing-time default (extraction
+            // found only a date — the getEventNightKey doctrine): the page
+            // never STATED 00:00, so there is nothing to conflict with
+            // (real FURBALL Boston sweep case: date-only page vs "10pm-3am"
+            // flyer would otherwise flag). Fail closed.
+            if (pageTime === '00:00') continue;
+            const pageMinutes = (parseInt(pageMatch[1], 10) * 60) + parseInt(pageMatch[2], 10);
+            // The flyer stating the page's time ANYWHERE (start, doors, or
+            // range end) is agreement, not a conflict.
+            if (flyerOcrStatesClockTime(ocrText, pageTime)) continue;
+            const linearDiff = Math.abs(reading.minutes - pageMinutes);
+            const circularDiff = Math.min(linearDiff, 1440 - linearDiff);
+            if (circularDiff < 60) continue;
+            const localDates = this.getFlyerLocalDateCandidates(event);
+            if (!localDates || flyerOcrContradictsEventDate(ocrText, localDates)) continue;
+            event._flyerTimeConflict = {
+                pageTime,
+                flyerTime: reading.time,
+                flyerRaw: reading.raw,
+                imageUrl
+            };
+            console.log(`🕐 AI Web: Flyer time conflict for "${event.title || 'Unknown'}" — page states ${pageTime}, flyer OCR reads ${reading.raw} (report-only; the site's value ships)`);
+        }
+    }
+
     normalizeAiEvent(aiEvent, parserConfig, htmlData = null, cityConfig = null, promptFields = null) {
         const scrapedLinks = this.extractLinksFromPage(
             htmlData && typeof htmlData.html === 'string' ? htmlData.html : '',
@@ -20695,17 +21041,19 @@ TEXT:
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { AiWebParser, normalizeCityValue, normalizeStartTimeValue, combineDateAndTime };
+    module.exports = { AiWebParser, normalizeCityValue, normalizeStartTimeValue, combineDateAndTime, readFlyerStartTimeFromOcrText };
 } else if (typeof window !== 'undefined') {
     window.AiWebParser = AiWebParser;
     window.normalizeCityValue = normalizeCityValue;
     window.normalizeStartTimeValue = normalizeStartTimeValue;
     window.combineDateAndTime = combineDateAndTime;
+    window.readFlyerStartTimeFromOcrText = readFlyerStartTimeFromOcrText;
 } else {
     this.AiWebParser = AiWebParser;
     this.normalizeCityValue = normalizeCityValue;
     this.normalizeStartTimeValue = normalizeStartTimeValue;
     this.combineDateAndTime = combineDateAndTime;
+    this.readFlyerStartTimeFromOcrText = readFlyerStartTimeFromOcrText;
 }
 
 // Scriptable gives every imported module its own console binding, so the

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -15003,3 +15003,168 @@ test('URL discovery never promotes resource-hint link origins to crawl candidate
   assert.ok(!urls.some(url => url.includes('i0.wp.com')), 'preconnect origin never becomes a crawl page');
   assert.ok(!urls.some(url => url.includes('stats.wp.com')), 'dns-prefetch origin never becomes a crawl page');
 });
+
+// ===========================================================================
+// Flyer-vs-page time-conflict flag (report-only; proposed in #1681).
+// THE fixture is Playground Toronto (bearitmtl.com, run 20260814-195026): the
+// page's schedule/JSON-LD stated 10:00 (the venue's own AM/PM entry error)
+// while the event's paired flyer OCR read "10pm to 3am". The OCR text below
+// is the REAL cached verdict for Playground-Vignette2.jpg, verbatim.
+// ===========================================================================
+
+const { readFlyerStartTimeFromOcrText } = require('./ai-web-parser');
+
+const PLAYGROUND_TORONTO_FLYER_OCR_TEXT =
+  'PLAYGROUND\nToronto\nDec 6th, 2025\n10pm to 3am\nCanadian PUP & Handler\n' +
+  'OFFICIAL DANCE PARTY\n\nCANADIAN PUP & HANDLER\nCONTEST 2025\n\nPITBULL!\n\n' +
+  'buddies\nIN BAD TIMES THEATRE\n\nBear-It';
+const PLAYGROUND_TORONTO_FLYER_URL =
+  'https://www.bearitmtl.com/wp-content/uploads/2025/11/Playground-Vignette2.jpg';
+
+function createFlyerConflictParser() {
+  const parser = new AiWebParser({ normalizeUrl });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+  return parser;
+}
+
+test('readFlyerStartTimeFromOcrText: the real Playground Toronto flyer reads an unambiguous 22:00 start', () => {
+  const reading = readFlyerStartTimeFromOcrText(PLAYGROUND_TORONTO_FLYER_OCR_TEXT);
+  assert.ok(reading, 'the flyer has exactly one unambiguous start reading');
+  assert.equal(reading.time, '22:00');
+  assert.equal(reading.raw, '10pm');
+});
+
+test('readFlyerStartTimeFromOcrText fails closed on ambiguity', () => {
+  // Multiple distinct candidate times → no reading.
+  assert.equal(readFlyerStartTimeFromOcrText('Dec 6th, 2025\n8pm main room\n10pm patio'), null);
+  // A bare 1–12 clock never states its meridiem → no reading.
+  assert.equal(readFlyerStartTimeFromOcrText('Dec 6th, 2025\n10:00'), null);
+  // An ambiguous reading pointing at a DIFFERENT time than the unambiguous
+  // candidate is conflicting information → no reading.
+  assert.equal(readFlyerStartTimeFromOcrText('Dec 6th, 2025\n9:30\n10pm to 3am'), null);
+  // No time at all → no reading (bare day numbers and years are not times).
+  assert.equal(readFlyerStartTimeFromOcrText('PLAYGROUND\nDec 6th, 2025\nCONTEST 2025'), null);
+  // A time with no date context and no range shape → no reading.
+  assert.equal(readFlyerStartTimeFromOcrText('COVER $10\n10pm'), null);
+});
+
+test('readFlyerStartTimeFromOcrText: doors times are never start candidates, French h-forms read as 24h', () => {
+  // DOORS 9PM is excluded; PARTY 10PM is the single candidate.
+  const doorsParty = readFlyerStartTimeFromOcrText('SATURDAY DEC 6\nDOORS: 9PM\nPARTY: 10PM');
+  assert.ok(doorsParty);
+  assert.equal(doorsParty.time, '22:00');
+  // Doors label AFTER the time too (real Bronze Babez sweep case:
+  // "7:30PM DOORS" was the flyer's only time — a doors time, not a start).
+  assert.equal(readFlyerStartTimeFromOcrText('FRIDAY\nAUGUST 14\n7:30PM DOORS\n$15 DOORS'), null);
+  // French schedule range: "22 h 00 min – 3 h 00 min" → start 22:00.
+  const french = readFlyerStartTimeFromOcrText('Samedi 6 décembre 2025\n22 h 00 min – 3 h 00 min');
+  assert.ok(french);
+  assert.equal(french.time, '22:00');
+});
+
+test('readFlyerStartTimeFromOcrText: shared-meridiem ranges read coherently or not at all', () => {
+  // Real CLUB CHUB sweep case: "3-9PM" means 3 PM to 9 PM — the bare start
+  // borrows the end's meridiem, and 9PM is a range end, never a candidate.
+  const shared = readFlyerStartTimeFromOcrText('LATIN PARTY\nSUNDAY AUGUST 16TH 3-9PM\nDJ SANTO | DRAG SHOW');
+  assert.ok(shared);
+  assert.equal(shared.time, '15:00');
+  // "11-2PM" is NOT 11 PM (the range crosses the half-day): the bare start
+  // stays unreadable and the 2PM end is never a candidate — no reading.
+  assert.equal(readFlyerStartTimeFromOcrText('SUNDAY AUGUST 16TH 11-2PM'), null);
+});
+
+test('applyFlyerTimeConflictFlag: Playground Toronto page 10:00 vs flyer 10pm stamps the report-only conflict', () => {
+  const parser = createFlyerConflictParser();
+  parser.recordOcrImageVerdict(PLAYGROUND_TORONTO_FLYER_URL, {
+    imageClassification: 'event-flyer',
+    text: PLAYGROUND_TORONTO_FLYER_OCR_TEXT
+  });
+  const event = {
+    title: 'Playground Toronto',
+    image: PLAYGROUND_TORONTO_FLYER_URL,
+    // #1681's offset re-anchor ships the site's stated 10:00 as 15:00Z
+    // (10:00 EST) — the value the calendar receives.
+    startDate: new Date('2025-12-06T15:00:00.000Z'),
+    timezone: 'America/Toronto'
+  };
+  parser.applyFlyerTimeConflictFlag([event]);
+  assert.ok(event._flyerTimeConflict, 'the disagreement is stamped');
+  assert.equal(event._flyerTimeConflict.pageTime, '10:00');
+  assert.equal(event._flyerTimeConflict.flyerTime, '22:00');
+  assert.equal(event._flyerTimeConflict.flyerRaw, '10pm');
+  assert.equal(event._flyerTimeConflict.imageUrl, PLAYGROUND_TORONTO_FLYER_URL);
+  assert.equal(event.startDate.toISOString(), '2025-12-06T15:00:00.000Z',
+    'report-only: the shipped start never changes');
+});
+
+test('applyFlyerTimeConflictFlag fails closed on agreement, doors pairs, non-flyers, and date mismatches', () => {
+  const makeEvent = (overrides = {}) => ({
+    title: 'Playground Toronto',
+    image: PLAYGROUND_TORONTO_FLYER_URL,
+    startDate: new Date('2025-12-06T15:00:00.000Z'),
+    timezone: 'America/Toronto',
+    ...overrides
+  });
+
+  // Agreement: page states 22:00 EST (03:00Z next day) — the flyer's own
+  // 10pm — no conflict.
+  const agreeingParser = createFlyerConflictParser();
+  agreeingParser.recordOcrImageVerdict(PLAYGROUND_TORONTO_FLYER_URL, {
+    imageClassification: 'event-flyer',
+    text: PLAYGROUND_TORONTO_FLYER_OCR_TEXT
+  });
+  const agreeing = makeEvent({ startDate: new Date('2025-12-07T03:00:00.000Z') });
+  agreeingParser.applyFlyerTimeConflictFlag([agreeing]);
+  assert.equal(agreeing._flyerTimeConflict, undefined, 'agreeing times never flag');
+
+  // Doors-vs-start: page adopted the DOORS time the flyer also states — a
+  // stated time anywhere on the flyer is agreement, not a conflict.
+  const doorsParser = createFlyerConflictParser();
+  doorsParser.recordOcrImageVerdict(PLAYGROUND_TORONTO_FLYER_URL, {
+    imageClassification: 'event-flyer',
+    text: 'SATURDAY DEC 6\nDOORS: 9PM\nPARTY: 10PM'
+  });
+  const doors = makeEvent({ startDate: new Date('2025-12-07T02:00:00.000Z') }); // 21:00 EST
+  doorsParser.applyFlyerTimeConflictFlag([doors]);
+  assert.equal(doors._flyerTimeConflict, undefined, 'a doors time differing from page start is not a conflict');
+
+  // A multi-event flyer's times belong to many events → never this event's
+  // own start statement.
+  const multiParser = createFlyerConflictParser();
+  multiParser.recordOcrImageVerdict(PLAYGROUND_TORONTO_FLYER_URL, {
+    imageClassification: 'multi-event-flyer',
+    text: PLAYGROUND_TORONTO_FLYER_OCR_TEXT
+  });
+  const multi = makeEvent();
+  multiParser.applyFlyerTimeConflictFlag([multi]);
+  assert.equal(multi._flyerTimeConflict, undefined, 'non event-flyer classifications never flag');
+
+  // No OCR verdict for the image → nothing to read → no flag.
+  const noVerdictParser = createFlyerConflictParser();
+  const noVerdict = makeEvent();
+  noVerdictParser.applyFlyerTimeConflictFlag([noVerdict]);
+  assert.equal(noVerdict._flyerTimeConflict, undefined, 'no paired flyer OCR never flags');
+
+  // The flyer names a DIFFERENT date than the event's local start → the
+  // artwork is likely another occurrence's — no flag.
+  const otherDateParser = createFlyerConflictParser();
+  otherDateParser.recordOcrImageVerdict(PLAYGROUND_TORONTO_FLYER_URL, {
+    imageClassification: 'event-flyer',
+    text: 'PLAYGROUND\nToronto\nJan 17th, 2026\n10pm to 3am'
+  });
+  const otherDate = makeEvent();
+  otherDateParser.applyFlyerTimeConflictFlag([otherDate]);
+  assert.equal(otherDate._flyerTimeConflict, undefined, 'a flyer dated to another occurrence never flags');
+
+  // A local-midnight start is the missing-time default (the page stated a
+  // date, not 00:00 — real FURBALL Boston sweep case) → nothing to
+  // conflict with.
+  const midnightParser = createFlyerConflictParser();
+  midnightParser.recordOcrImageVerdict(PLAYGROUND_TORONTO_FLYER_URL, {
+    imageClassification: 'event-flyer',
+    text: PLAYGROUND_TORONTO_FLYER_OCR_TEXT
+  });
+  const midnight = makeEvent({ startDate: new Date('2025-12-06T05:00:00.000Z') }); // 00:00 EST
+  midnightParser.applyFlyerTimeConflictFlag([midnight]);
+  assert.equal(midnight._flyerTimeConflict, undefined, 'a date-only midnight start never flags');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2261,6 +2261,32 @@ class SharedCore {
             }
         }
 
+        // 10. flyer-time-conflict — the event's own paired flyer's OCR text
+        //     states a start time that disagrees with the page-derived one
+        //     by an hour or more (run 20260814-195026, Playground Toronto:
+        //     the site's schedule said 10:00 — the venue's own AM/PM entry
+        //     error — while the flyer read "10pm to 3am"; #1681 shipped the
+        //     site's value per doctrine and proposed this surfacing).
+        //     Detection lives in the parser (applyFlyerTimeConflictFlag —
+        //     the only place the paired OCR verdict is in scope) and fails
+        //     closed on every ambiguity; this rule only converts its
+        //     _flyerTimeConflict stamp into the report-only flag channel.
+        //     Report-only: the site's value always ships, nothing is
+        //     withheld or rewritten.
+        const flyerConflict = event._flyerTimeConflict;
+        if (flyerConflict && typeof flyerConflict === 'object'
+            && typeof flyerConflict.pageTime === 'string' && flyerConflict.pageTime) {
+            const flyerStated = (typeof flyerConflict.flyerRaw === 'string' && flyerConflict.flyerRaw)
+                || (typeof flyerConflict.flyerTime === 'string' && flyerConflict.flyerTime)
+                || '';
+            if (flyerStated) {
+                flags.push({
+                    code: 'flyer-time-conflict',
+                    detail: `page states ${flyerConflict.pageTime}, flyer OCR reads ${flyerStated}`
+                });
+            }
+        }
+
         return flags;
     }
 
@@ -10656,7 +10682,13 @@ class SharedCore {
         if (typeof newEvent._organizer === 'string' && newEvent._organizer) {
             finalEvent._organizer = newEvent._organizer;
         }
-        
+        // Same carry for the report-only flyer-vs-page time-conflict stamp
+        // (parser-side applyFlyerTimeConflictFlag): getEventSanityFlags reads
+        // it off the FINAL analyzed event, so a merge must not shed it.
+        if (newEvent._flyerTimeConflict && typeof newEvent._flyerTimeConflict === 'object') {
+            finalEvent._flyerTimeConflict = newEvent._flyerTimeConflict;
+        }
+
         // STEP 6: Pass all three objects to rich display for comparison
         
         // Store the three objects for display comparison

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -19223,3 +19223,38 @@ test('final build gmaps tiers: corroborated name+address query, uncorroborated c
   assert.equal(lines.filter(line => line.includes('corroborated bar + address for "FURBALL"')).length, 1,
     'the stable pass is silent — no per-run churn');
 });
+
+// === Sanity rule 10: flyer-time-conflict (report-only; #1681's proposal) ===
+
+test('sanity: flyer-time-conflict surfaces the parser _flyerTimeConflict stamp with both values named', () => {
+  const core = createSanityCore();
+  const event = {
+    title: 'Playground Toronto',
+    startDate: new Date('2026-12-05T15:00:00.000Z'),
+    endDate: new Date('2026-12-06T08:00:00.000Z'),
+    _flyerTimeConflict: {
+      pageTime: '10:00',
+      flyerTime: '22:00',
+      flyerRaw: '10pm',
+      imageUrl: 'https://www.bearitmtl.com/wp-content/uploads/2025/11/Playground-Vignette2.jpg'
+    }
+  };
+  assert.deepEqual(sanityCodes(core, event), ['flyer-time-conflict']);
+  const flag = core.getEventSanityFlags(event, { nowMs: SANITY_NOW_MS })
+    .find(entry => entry.code === 'flyer-time-conflict');
+  assert.equal(flag.detail, 'page states 10:00, flyer OCR reads 10pm');
+});
+
+test('sanity: flyer-time-conflict never fires without a well-formed stamp', () => {
+  const core = createSanityCore();
+  const base = {
+    title: 'Playground Toronto',
+    startDate: new Date('2026-12-05T15:00:00.000Z'),
+    endDate: new Date('2026-12-06T08:00:00.000Z')
+  };
+  assert.deepEqual(sanityCodes(core, base), [], 'no stamp, no flag');
+  assert.deepEqual(sanityCodes(core, { ...base, _flyerTimeConflict: { flyerRaw: '10pm' } }), [],
+    'a stamp missing pageTime is malformed — fail closed');
+  assert.deepEqual(sanityCodes(core, { ...base, _flyerTimeConflict: { pageTime: '10:00' } }), [],
+    'a stamp missing the flyer reading is malformed — fail closed');
+});


### PR DESCRIPTION
Builds the flag #1681 proposed (owner-approved: "the flags like 1 sounds great to do next"). Playground Toronto (run `20260814-195026`): the site's schedule/JSON-LD stated **10:00** — the venue's own AM/PM entry error — while the event's paired flyer OCR clearly read **"10pm to 3am"**. Doctrine ships what the site states (#1681 did that); this PR SURFACES the disagreement, report-only. The site's value always ships, nothing is withheld or rewritten.

## How it works

**Detection (parser, both routes).** `applyFlyerTimeConflictFlag` runs at the end of BOTH extraction routes — the JSON-LD/JSON-API structured short-circuit (which is the route the real Playground Toronto took: `source=jsonld, ocrImages=0`, its flyer verdict coming from the og-image-vet pass) and the AI/OCR route. It joins `event.image` (the segment↔image pairing / og-image adoption has already settled it) to the in-memory OCR verdict registry — verdicts the run already paid for; never a new vision call — and compares a deterministic reading of the flyer's OCR text against `formatLocalClockTime(startDate, timezone)`. On a ≥1-hour circular disagreement it stamps `event._flyerTimeConflict` (underscore channel, same convention as `_doorsTimeRejected`) plus one additive log line.

**Deterministic OCR time reading, fail-closed at every rung** (`readFlyerStartTimeFromOcrText`, exported):
- a time token requires an explicit marker — am/pm, French/European `h` forms (`22h`, `10 h 00 min` — the #1681 vocabulary), or an unambiguously-24h colon time; bare numbers (`6th`, `2025`, `$10`) are never times;
- doors times are excluded on either side of the label (`DOORS: 9PM`, `7:30PM DOORS`; EN/FR) — a doors time differing from page start is NOT a conflict, and the flyer stating the page's time ANYWHERE (start, doors, or range end) is agreement, never a conflict;
- range ends are never candidates (`10pm **to 3am**`), and shared-meridiem ranges read coherently or not at all (`3-9PM` = 15:00 start; `11-2PM` stays unreadable);
- candidates need date/time context (a range shape, or a date token within ±2 lines) and must all agree on ONE clock time; an ambiguous bare `10:00` pointing anywhere else kills the reading;
- non-`event-flyer` classifications (multi-event flyers, logos, thumbnails), missing timezone, local-midnight date-only starts (`00:00` is the missing-time default, not a stated time), and a flyer naming a different date than the event's local start (or its previous day) all fail closed.

**Surfacing (shared-core, platform-pure).** Sanity rule 10 in `getEventSanityFlags` converts the stamp into `{ code: 'flyer-time-conflict', detail: 'page states 10:00, flyer OCR reads 10pm' }` — pure field read, no I/O. It rides the EXISTING `_sanityFlags` channel end to end (verified, zero new UI): the ⚠️ SANITY log line at `buildAnalyzedCalendarEvent`, the web adapter's per-event sanity line, and the scriptable results card's existing `sanity-flag-badge` chip all pick the new code up automatically. The merge path carries the stamp onto the final analyzed event (same explicit carryover as `_promoter`/`_organizer`).

## False-positive sweep (device data, read-only)

Replayed **224** distinct event+paired-flyer-OCR pairs (165 classified event-flyer) from **58 saved runs** against the real implementation. Result: **5 flags, 4 distinct events** — and the sweep drove three tightenings (midnight-placeholder skip, doors-after-time labels, shared-meridiem ranges) that eliminated the FURBALL Boston, Bronze Babez/PACK PARTY, and CLUB CHUB false-positive families (11 → 5):

| Event | Page states | Flyer OCR reads | Verdict |
|---|---|---|---|
| Playground Toronto (the fixture) | 09:00 (pre-#1681 record) | 10pm | genuine — the motivating case |
| MEGAWOOF & BEARMILK MEGAMILK (×2 runs) | 22:00 | 9PM – 4AM | genuine flyer-vs-Eventbrite disagreement |
| CUBSCOUT (Eagle LA) | 19:00 | 9PM TO 2AM | genuine flyer-vs-page disagreement |
| Wild Trek ATV Tours (BeefDip) | 12:00 | 2 PM TO 5 PM | soft — flyer's only stated time is the sign-up window; still a fair report-only surface |

## Tests

**8 new tests** in the two enumerated files (`scripts/parsers/ai-web-parser.test.js`, `scripts/shared-core.test.js`), **7 proven failing on base** (two-file run: 1206/1213 on base → **1213/1213** with the change); the eighth is the deliberate fail-closed absence pin (no stamp / malformed stamp → no flag), which trivially holds on base. The positive test drives the REAL Playground Toronto values — the verbatim cached OCR text of `Playground-Vignette2.jpg` and the #1681-corrected `2025-12-06T15:00:00Z` start — and asserts the shipped start never changes. Negatives: agreeing times, doors-vs-start pairs, ambiguous/multi-time OCR, no flyer, non-flyer classifications, other-date flyers, midnight placeholders, incoherent shared-meridiem ranges.

Full quiet suite: **1890/1890 pass** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`).

End-to-end drive: the real fixture through parser → stamp → sanity flag prints the 🕐 log line and yields `detail: "page states 10:00, flyer OCR reads 10pm"` on the existing chip channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP