### PR TITLE
fix(scriptable): saved-run browser never blocks on iCloud placeholders

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -445,6 +445,132 @@ class ScriptableAdapter {
     // pass. Promoted into results.errors by presentRichResults — see
     // recordCalendarWriteFailures.
     this.lastExecutionFailures = [];
+    // Bounded wait for on-demand iCloud downloads of saved-run artifacts
+    // (run JSON on open, run log for the Run Logs section). The Mac scheduler
+    // writes 1.5MB+ run files into the shared iCloud runs/ dir; on the phone
+    // those exist as not-yet-downloaded placeholders and an unbounded
+    // downloadFileFromiCloud on one mid-upload file hangs the whole screen.
+    this.savedFileDownloadTimeoutMs = Number.isFinite(
+      config.savedFileDownloadTimeoutMs,
+    )
+      ? config.savedFileDownloadTimeoutMs
+      : 30000;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Saved-run browser file access (static: display-saved-run.js calls these
+  // without constructing an adapter).
+  //
+  // THE RULE: list building NEVER downloads. Scriptable's listContents /
+  // isDirectory / isFileDownloaded are metadata-only and safe on iCloud
+  // placeholders; downloadFileFromiCloud BLOCKS until the file is local and
+  // readString on a placeholder is version-dependent (fails or force-syncs) —
+  // both are open-time operations, never enumeration-time ones. The
+  // YYYYMMDD-HHMMSS.json filename already carries the list's primary label,
+  // so a not-yet-synced run can appear in the list (marked as syncing) with
+  // zero file reads.
+  // ---------------------------------------------------------------------------
+  static listSavedRunEntries(fm, runsDir) {
+    const names = fm.listContents(runsDir) || [];
+    const entries = [];
+    const errors = [];
+    for (const rawName of names) {
+      let name = rawName;
+      let placeholder = false;
+      // Undownloaded iCloud items can surface as ".<name>.icloud" wrappers
+      // depending on OS/Scriptable version — unwrap to the logical name.
+      if (name.startsWith(".") && name.endsWith(".icloud")) {
+        name = name.slice(1, -".icloud".length);
+        placeholder = true;
+      }
+      if (!name.endsWith(".json")) continue;
+      const filePath = fm.joinPath(runsDir, rawName);
+      let isDir = false;
+      try {
+        isDir = fm.isDirectory(filePath);
+      } catch (dirError) {
+        errors.push({ file: name, error: dirError.message });
+      }
+      if (isDir) continue;
+      let downloaded = !placeholder;
+      if (downloaded) {
+        try {
+          if (typeof fm.isFileDownloaded === "function") {
+            downloaded = fm.isFileDownloaded(filePath) === true;
+          }
+        } catch (_) {
+          // Metadata probe failed — assume downloaded; open-time download is
+          // bounded anyway.
+        }
+      }
+      entries.push({
+        runId: name.replace(/\.json$/, ""),
+        timestamp: null,
+        downloaded,
+      });
+    }
+    entries.sort((a, b) => (b.runId || "").localeCompare(a.runId || ""));
+    return { entries, errors };
+  }
+
+  // Bounded, single-file iCloud download for open-time use. Resolves
+  // { ok: true } once local, { ok: false, timedOut: true } when the sync
+  // outlasts timeoutMs (the underlying download keeps running in the
+  // background — the raced promise is not cancelled, so a later reopen
+  // usually finds the file already local), or { ok: false, error } when the
+  // download itself rejects.
+  static async downloadFileBounded(fm, filePath, timeoutMs = 30000) {
+    try {
+      if (
+        typeof fm.isFileDownloaded === "function" &&
+        fm.isFileDownloaded(filePath) === true
+      ) {
+        return { ok: true, timedOut: false };
+      }
+    } catch (_) {}
+
+    const downloadPromise = Promise.resolve()
+      .then(() => fm.downloadFileFromiCloud(filePath))
+      .then(() => ({ ok: true, timedOut: false }))
+      .catch((error) => ({
+        ok: false,
+        timedOut: false,
+        error:
+          error && error.message ? String(error.message) : String(error),
+      }));
+
+    let timerHandle = null;
+    let timeoutPromise = null;
+    if (typeof setTimeout !== "undefined") {
+      timeoutPromise = new Promise((resolve) => {
+        timerHandle = setTimeout(
+          () => resolve({ ok: false, timedOut: true }),
+          timeoutMs,
+        );
+      });
+    } else if (typeof Timer !== "undefined") {
+      timeoutPromise = new Promise((resolve) => {
+        const timer = new Timer();
+        timer.timeInterval = timeoutMs;
+        timer.schedule(() => resolve({ ok: false, timedOut: true }));
+        timerHandle = timer;
+      });
+    }
+
+    // No timer facility (bare test double): degrade to an unbounded await —
+    // real Scriptable always has Timer, Node always has setTimeout.
+    const result = timeoutPromise
+      ? await Promise.race([downloadPromise, timeoutPromise])
+      : await downloadPromise;
+
+    if (!result.timedOut && timerHandle) {
+      if (typeof timerHandle.invalidate === "function") {
+        timerHandle.invalidate(); // Scriptable Timer
+      } else if (typeof clearTimeout !== "undefined") {
+        clearTimeout(timerHandle);
+      }
+    }
+    return result;
   }
 
   getScriptableRuntimeContext() {
@@ -9253,6 +9379,8 @@ class ScriptableAdapter {
         emptyMessage = `Log file for ${runLabel} is empty.`;
       } else if (logInfo.reason === "read-failed") {
         emptyMessage = `Log file for ${runLabel} could not be read.`;
+      } else if (logInfo.reason === "icloud-sync-pending") {
+        emptyMessage = `Log for ${runLabel} is still syncing from iCloud — reopen this run shortly.`;
       }
       return `
     <div class="section log-section">
@@ -16548,11 +16676,22 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     }
 
     try {
-      try {
-        await fm.downloadFileFromiCloud(logPath);
-      } catch (downloadError) {
+      // Bounded download: an undownloaded iCloud log (Mac-written) must not
+      // hang the results screen — skip the log section instead.
+      const download = await ScriptableAdapter.downloadFileBounded(
+        fm,
+        logPath,
+        this.savedFileDownloadTimeoutMs,
+      );
+      if (!download.ok && download.timedOut) {
         console.log(
-          `📱 Scriptable: Log iCloud download failed: ${downloadError.message}`,
+          `📱 Scriptable: Log for run ${runId} is still syncing from iCloud after ${this.savedFileDownloadTimeoutMs}ms — skipping log display`,
+        );
+        return { runId, exists: false, reason: "icloud-sync-pending" };
+      }
+      if (!download.ok && download.error) {
+        console.log(
+          `📱 Scriptable: Log iCloud download failed: ${download.error}`,
         );
       }
       const content = fm.readString(logPath);

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -10615,3 +10615,133 @@ test('saveRun persists results.icsExports into the run JSON (and omits the key w
   const emptyPayload = JSON.parse(writes[0].content);
   assert.ok(!('icsExports' in emptyPayload), 'no ledger key on runs that exported nothing');
 });
+
+// ---------------------------------------------------------------------------
+// Saved-run browser: iCloud placeholders must never block the screen.
+// Incident 2026-08-15: Mac-written 1.5MB run JSONs sit in the shared iCloud
+// runs/ dir as not-yet-downloaded placeholders on the phone; enumeration used
+// to await downloadFileFromiCloud on EVERY file, so one file mid-upload hung
+// "display saved runs" forever right after the frozen
+// "📱 Display: Checking for saved runs" log line.
+// ---------------------------------------------------------------------------
+
+function buildRunsDirFm(overrides = {}) {
+  const calls = { downloads: [], reads: [] };
+  const fm = {
+    joinPath: (a, b) => `${a}/${b}`,
+    listContents: () => ['20260814-010101.json', '20260815-020202.json', 'notes.txt', 'archive.json'],
+    isDirectory: (p) => p.endsWith('/archive.json'),
+    isFileDownloaded: (p) => !p.includes('20260815-020202'),
+    downloadFileFromiCloud: (p) => {
+      calls.downloads.push(p);
+      throw new Error('BLOCKING iCloud download during enumeration');
+    },
+    readString: (p) => {
+      calls.reads.push(p);
+      throw new Error('read of possibly-undownloaded file during enumeration');
+    },
+    ...overrides
+  };
+  return { fm, calls };
+}
+
+test('list building never downloads or reads run files — undownloaded runs still appear, marked as syncing', () => {
+  const { fm, calls } = buildRunsDirFm();
+
+  const { entries, errors } = ScriptableAdapter.listSavedRunEntries(fm, '/icloud/runs');
+
+  assert.equal(calls.downloads.length, 0, 'no downloadFileFromiCloud during enumeration');
+  assert.equal(calls.reads.length, 0, 'no readString during enumeration');
+  assert.equal(errors.length, 0, 'metadata-only listing has no errors');
+  assert.deepEqual(entries.map(e => e.runId), ['20260815-020202', '20260814-010101'], 'json runs only (no dirs, no non-json), newest first');
+  assert.equal(entries[0].downloaded, false, 'placeholder run is marked not-downloaded');
+  assert.equal(entries[1].downloaded, true, 'local run is marked downloaded');
+});
+
+test('list building unwraps .<name>.json.icloud placeholder names and treats fms without isFileDownloaded as downloaded', () => {
+  const { fm } = buildRunsDirFm({
+    listContents: () => ['.20260816-030303.json.icloud', '20260814-010101.json'],
+    isFileDownloaded: undefined,
+    isDirectory: () => false
+  });
+
+  const { entries } = ScriptableAdapter.listSavedRunEntries(fm, '/icloud/runs');
+
+  assert.deepEqual(
+    entries.map(e => [e.runId, e.downloaded]),
+    [['20260816-030303', false], ['20260814-010101', true]],
+    'icloud wrapper name yields the logical runId, marked syncing; no isFileDownloaded → assume local'
+  );
+});
+
+test('downloadFileBounded skips the download entirely for an already-local file', async () => {
+  let downloads = 0;
+  const fm = {
+    isFileDownloaded: () => true,
+    downloadFileFromiCloud: async () => { downloads += 1; }
+  };
+
+  const result = await ScriptableAdapter.downloadFileBounded(fm, '/icloud/runs/a.json', 50);
+
+  assert.deepEqual(result, { ok: true, timedOut: false });
+  assert.equal(downloads, 0, 'no iCloud call for a local file');
+});
+
+test('downloadFileBounded times out on a stalled iCloud sync instead of hanging (download stays kicked in the background)', async () => {
+  let downloads = 0;
+  const fm = {
+    isFileDownloaded: () => false,
+    downloadFileFromiCloud: () => {
+      downloads += 1;
+      return new Promise(() => {}); // never settles — file mid-upload from the Mac
+    }
+  };
+
+  const result = await ScriptableAdapter.downloadFileBounded(fm, '/icloud/runs/a.json', 25);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.timedOut, true);
+  assert.equal(downloads, 1, 'the download was kicked once and left running in the background');
+});
+
+test('downloadFileBounded resolves ok when the download completes within the bound, and surfaces rejections as errors', async () => {
+  const okFm = {
+    isFileDownloaded: () => false,
+    downloadFileFromiCloud: async () => {}
+  };
+  assert.deepEqual(
+    await ScriptableAdapter.downloadFileBounded(okFm, '/icloud/runs/a.json', 1000),
+    { ok: true, timedOut: false }
+  );
+
+  const failFm = {
+    isFileDownloaded: () => false,
+    downloadFileFromiCloud: async () => { throw new Error('icloud says no'); }
+  };
+  const failed = await ScriptableAdapter.downloadFileBounded(failFm, '/icloud/runs/a.json', 1000);
+  assert.equal(failed.ok, false);
+  assert.equal(failed.timedOut, false);
+  assert.equal(failed.error, 'icloud says no');
+});
+
+test('loadRunLogsForDisplay returns icloud-sync-pending (bounded) for an undownloaded log instead of hanging, and the section renders a syncing message', async () => {
+  const adapter = buildAdapter();
+  adapter.savedFileDownloadTimeoutMs = 25;
+  adapter.fm = {
+    joinPath: (a, b) => `${a}/${b}`,
+    fileExists: () => true,
+    isFileDownloaded: () => false,
+    downloadFileFromiCloud: () => new Promise(() => {}), // stalled sync
+    readString: () => { throw new Error('must not read an undownloaded log'); }
+  };
+  adapter.logsDir = '/icloud/logs';
+
+  const logInfo = await adapter.loadRunLogsForDisplay({ savedRunId: '20260815-020202', _isDisplayingSavedRun: true });
+
+  assert.equal(logInfo.exists, false);
+  assert.equal(logInfo.reason, 'icloud-sync-pending');
+  assert.equal(logInfo.runId, '20260815-020202');
+
+  const html = adapter.buildRunLogSectionHtml(logInfo);
+  assert.ok(html.includes('still syncing from iCloud'), 'run-logs section explains the pending sync');
+});

--- a/scripts/display-saved-run.js
+++ b/scripts/display-saved-run.js
@@ -44,46 +44,29 @@ class SavedRunDisplay {
                 return [];
             }
             
-            // Ensure iCloud files are downloaded before listing
-            try {
-                await fm.downloadFileFromiCloud(runsDir);
-            } catch (downloadError) {
-                console.log(`📱 Display: iCloud sync failed: ${downloadError.message}`);
-            }
-            
-            const files = fm.listContents(runsDir) || [];
-            
-            // Filter out directories and only keep JSON files
-            const jsonFiles = [];
-            const fileErrors = [];
-            for (const name of files) {
-                if (!name.endsWith('.json')) continue;
-                const filePath = fm.joinPath(runsDir, name);
-                try {
-                    await fm.downloadFileFromiCloud(filePath);
-                } catch (error) {
-                    fileErrors.push({ file: name, error: error.message });
-                }
-                let isDir = false;
-                try {
-                    isDir = fm.isDirectory(filePath);
-                } catch (dirError) {
-                    fileErrors.push({ file: name, error: dirError.message });
-                }
-                if (!isDir) {
-                    jsonFiles.push(name);
-                }
-            }
-            
+            // LIST WITHOUT DOWNLOADING: enumeration is metadata-only
+            // (listContents/isDirectory/isFileDownloaded). The old per-file
+            // downloadFileFromiCloud here blocked the entire screen on one
+            // Mac-written run file still uploading to iCloud (2026-08-15
+            // hang). The YYYYMMDD-HHMMSS filename already carries the list
+            // label; the actual download happens on OPEN, bounded — see
+            // loadSavedRun.
+            const { ScriptableAdapter } = importModule('adapters/scriptable-adapter');
+            const { entries: jsonFiles, errors: fileErrors } =
+                ScriptableAdapter.listSavedRunEntries(fm, runsDir);
+
             console.log(`📱 Display: Found ${jsonFiles.length} saved runs${fileErrors.length > 0 ? ` (${fileErrors.length} files had errors)` : ''}`);
-            
+
             if (jsonFiles.length === 0) {
                 console.log(`📱 Display: No .json run files found in directory`);
             }
-            
-            return jsonFiles
-                .map(name => ({ runId: name.replace('.json',''), timestamp: null }))
-                .sort((a, b) => (b.runId || '').localeCompare(a.runId || ''));
+
+            const syncingCount = jsonFiles.filter(e => e.downloaded === false).length;
+            if (syncingCount > 0) {
+                console.log(`📱 Display: ${syncingCount} run(s) not yet downloaded from iCloud — listed as syncing, downloaded on open`);
+            }
+
+            return jsonFiles;
         } catch (e) {
             console.log(`📱 Display: Failed to read runs directory: ${e.message}`);
             return [];
@@ -110,7 +93,24 @@ class SavedRunDisplay {
                 console.log(`📱 Display: Run file does not exist: ${runFilePath}`);
                 return null;
             }
-            
+
+            // DOWNLOAD ON OPEN, BOUNDED: fetch just this run's file with a
+            // 30s cap so an iCloud sync stall surfaces an alert and returns
+            // to the list instead of hanging the screen. On timeout the
+            // kicked download keeps running in the background, so trying
+            // again shortly usually finds the file already local.
+            const { ScriptableAdapter } = importModule('adapters/scriptable-adapter');
+            const syncTimeoutMs = 30000;
+            console.log(`📱 Display: Ensuring run file is local (bounded ${syncTimeoutMs / 1000}s iCloud download): ${fileName}`);
+            const download = await ScriptableAdapter.downloadFileBounded(fm, runFilePath, syncTimeoutMs);
+            if (!download.ok && download.timedOut) {
+                console.log(`📱 Display: Run ${runId} is still syncing from iCloud after ${syncTimeoutMs / 1000}s — not blocking the list`);
+                return { __icloudSyncPending: true, runId };
+            }
+            if (!download.ok && download.error) {
+                console.log(`📱 Display: Bounded iCloud download reported: ${download.error} — falling through to read retries`);
+            }
+
             // Robust iCloud download with multiple retries
             let content = null;
             const maxRetries = 3;
@@ -163,45 +163,63 @@ class SavedRunDisplay {
 
     async displaySavedRun(options = {}) {
         try {
-            let runToShow = null;
             const runs = await this.listSavedRuns();
             if (!runs || runs.length === 0) {
                 await this.showError('No saved runs', 'No saved runs were found to display.\n\nTo create runs, first run the bear-event-scraper-unified.js script.\n\nRuns are saved in the chunky-dad-scraper/runs/ directory relative to where this script is located.');
                 return;
             }
 
-            if (options.runId) {
-                runToShow = options.runId;
-            } else if (options.last) {
-                runToShow = runs[0].runId || runs[0];
-            } else if (options.presentHistory) {
-                // Simple selection UI using Alert
-                const alert = new Alert();
-                alert.title = 'Select Saved Run';
-                alert.message = 'Choose a run to display';
-                runs.slice(0, 25).forEach((r, idx) => {
-                    const label = r.timestamp ? `${idx + 1}. ${r.timestamp}` : `${idx + 1}. ${r.runId}`;
-                    alert.addAction(label);
-                });
-                alert.addCancelAction('Cancel');
-                const idx = await alert.present();
-                if (idx < 0 || idx >= runs.length) return;
-                runToShow = runs[idx].runId || runs[idx];
+            // Interactive mode loops back to the picker when a run's iCloud
+            // download times out, instead of hanging or dead-ending.
+            const interactive = !options.runId && !options.last && options.presentHistory;
+            let saved = null;
+            let runIdString = null;
+            for (;;) {
+                let runToShow = null;
+                if (options.runId) {
+                    runToShow = options.runId;
+                } else if (options.last) {
+                    runToShow = runs[0].runId || runs[0];
+                } else if (options.presentHistory) {
+                    // Simple selection UI using Alert
+                    const alert = new Alert();
+                    alert.title = 'Select Saved Run';
+                    alert.message = 'Choose a run to display';
+                    runs.slice(0, 25).forEach((r, idx) => {
+                        const syncMark = r.downloaded === false ? ' ☁️ syncing…' : '';
+                        const label = (r.timestamp ? `${idx + 1}. ${r.timestamp}` : `${idx + 1}. ${r.runId}`) + syncMark;
+                        alert.addAction(label);
+                    });
+                    alert.addCancelAction('Cancel');
+                    const idx = await alert.present();
+                    if (idx < 0 || idx >= runs.length) return;
+                    runToShow = runs[idx].runId || runs[idx];
+                }
+
+                if (!runToShow) {
+                    runToShow = runs[0].runId || runs[0];
+                }
+
+                console.log(`📱 Display: About to load runToShow: ${JSON.stringify(runToShow)} (type: ${typeof runToShow})`);
+
+                // Ensure runToShow is a string, not an object
+                runIdString = typeof runToShow === 'string' ? runToShow : runToShow.runId || runToShow.toString();
+                console.log(`📱 Display: Final runId to load: ${runIdString}`);
+
+                saved = await this.loadSavedRun(runIdString);
+                if (saved && saved.__icloudSyncPending === true) {
+                    await this.showError('Still syncing from iCloud', `Run ${runIdString} is still syncing from iCloud — try again shortly.`);
+                    if (interactive) {
+                        saved = null;
+                        continue; // back to the run list
+                    }
+                    return;
+                }
+                break;
             }
 
-            if (!runToShow) {
-                runToShow = runs[0].runId || runs[0];
-            }
-
-            console.log(`📱 Display: About to load runToShow: ${JSON.stringify(runToShow)} (type: ${typeof runToShow})`);
-            
-            // Ensure runToShow is a string, not an object
-            const runIdString = typeof runToShow === 'string' ? runToShow : runToShow.runId || runToShow.toString();
-            console.log(`📱 Display: Final runId to load: ${runIdString}`);
-
-            const saved = await this.loadSavedRun(runIdString);
             if (!saved) {
-                await this.showError('Load failed', `Could not load saved run: ${runToShow}`);
+                await this.showError('Load failed', `Could not load saved run: ${runIdString}`);
                 return;
             }
 


### PR DESCRIPTION
## Incident

2026-08-15: "display saved runs" hangs on the phone right after logging `📱 Display: Checking for saved runs in …/chunky-dad-scraper/runs`. The Mac scheduler now writes 1.5MB+ run JSONs into the shared iCloud `runs/` dir; on the phone they exist as not-yet-downloaded placeholders, and the browser blocked on syncing EVERY one of them just to draw the list. Mirror image of the Mac-side dataless stall-proceed fix in `tools/run-once.js` — same lesson, phone direction.

Note on scope: the enumeration that hangs lives in `scripts/display-saved-run.js` (the adapter only displays), so the testable logic went into `scriptable-adapter.js` as static helpers and `display-saved-run.js` became a thin delegator. Tests live only in `scriptable-adapter.test.js`. No frozen log string was edited (additions only); WebView bridge and run-save paths untouched.

## Per-file call map — BEFORE

**LIST building** (`display-saved-run.js listSavedRuns`), per enumeration:
1. `await fm.downloadFileFromiCloud(runsDir)` — blocking, on the directory
2. `fm.listContents(runsDir)` — metadata-only (safe)
3. **Per `.json` file:** `await fm.downloadFileFromiCloud(filePath)` — blocking full download of every run JSON ← **the hang**
4. Per file: `fm.isDirectory(filePath)`

**OPEN** (`loadSavedRun`): up to 3 × { unbounded `await fm.downloadFileFromiCloud(runFilePath)` → `fm.readString` → 2s wait } — each attempt can block forever.

**LOG** (`scriptable-adapter.js loadRunLogsForDisplay`): unbounded `await fm.downloadFileFromiCloud(logPath)` → `fm.readString` — a stalled log sync hung the results screen.

## Per-file call map — AFTER

**LIST building** (`ScriptableAdapter.listSavedRunEntries`, static), per enumeration:
1. `fm.listContents(runsDir)` — metadata-only
2. Per file: `fm.isDirectory` + `fm.isFileDownloaded` — metadata-only
3. **Zero** `downloadFileFromiCloud`, **zero** `readString`. The `YYYYMMDD-HHMMSS.json` filename is the label; undownloaded runs (including `.<name>.json.icloud` wrapper names, unwrapped defensively) appear marked **☁️ syncing…** in the picker. (The old list never parsed file contents for metadata, so nothing was lost.)

**OPEN** (`ScriptableAdapter.downloadFileBounded`, 30s): already-local (`isFileDownloaded`) → no iCloud call at all; otherwise the single selected file is downloaded raced against a 30s timer (Scriptable `Timer` / `setTimeout` ladder, timer invalidated on completion).

**LOG**: same bounded helper inside `loadRunLogsForDisplay`; timeout returns a new `icloud-sync-pending` reason and the Run Logs section renders "still syncing from iCloud — reopen this run shortly" instead of hanging.

## Bounded-open behavior

- On select, a log line announces the bounded download; on **timeout (30s)** an alert says "Run &lt;id&gt; is still syncing from iCloud — try again shortly", and interactive mode **returns to the run list** (runId/widget modes exit cleanly). No path can hang the screen.
- The raced download promise is **not cancelled** on timeout — that is the fire-and-forget background kick (Scriptable's `downloadFileFromiCloud` keeps syncing; the promise is pre-`.catch`ed), so reopening shortly usually finds the file local and opens instantly.
- Download rejections (vs timeouts) fall through to the existing 3-attempt read/retry loop, which is only reached once the file is confirmed local or the failure is fast — never a placeholder hang.

## Tests (scripts/adapters/scriptable-adapter.test.js, +6)

Proven failing on base:
- *list building never downloads or reads run files* — mock fm **throws** on `downloadFileFromiCloud`/`readString`; on origin/main this fails (`listSavedRunEntries is not a function` — base enumeration downloads every file).
- *loadRunLogsForDisplay icloud-sync-pending* — mock download never settles; on origin/main this test **hangs the suite**, reproducing the phone incident exactly. On this branch it returns bounded in ~27ms.

Plus: `.icloud` wrapper unwrapping / missing-`isFileDownloaded` tolerance, already-local skip (zero iCloud calls), timeout-leaves-download-kicked, ok-within-bound + rejection-as-error, and the syncing Run Logs section rendering.

Quiet suite: **1898 pass / 0 fail** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`). `display-saved-run.js` verified to parse under Scriptable's async wrapper.

No new runtime files — existing updater entries cover all three touched scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP