### PR TITLE
fix(scraper): post-merge rewrites record their merge decisions; rows never claim both changed and unchanged

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -14375,12 +14375,26 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       // record, the row says so in plain words — source AND outcome — instead
       // of leaving the reader to reverse-engineer it from two value cells and
       // a bare strategy name. The strategy-heuristic chain below stays as the
-      // fallback for fields (and older saved runs) with no record.
+      // fallback for fields (and older saved runs) with no record. LAST
+      // record wins: post-merge deterministic rewrites append AFTER the
+      // arbitration records, and the row must describe the final state.
       const decisionRecord = Array.isArray(event._mergeDecisions)
-        ? event._mergeDecisions.find(
-            (record) => record && record.field === field,
+        ? event._mergeDecisions.reduce(
+            (latest, record) =>
+              record && record.field === field ? record : latest,
+            null,
           )
         : null;
+
+      // Value truth FIRST: did the merge leave this field different from
+      // what the calendar already had? Computed before any outcome branch so
+      // a row can never label itself "no change" while counting as changed —
+      // run 20260815-083809 ("TWISTED BEAR San Francisco Debut") rendered a
+      // rebuilt gmaps link as "AI-arbitrated … KEPT EXISTING (no change)" on
+      // a row whose value genuinely changed. Same predicate as the chip and
+      // the compressed view (mergeRowIsNoop).
+      const rowIsNoop = this.mergeRowIsNoop(finalValue, existingValue);
+      const arbitration = event._original?.aiArbitration;
 
       // Determine flow direction and result. The WHY of a recorded decision
       // goes into its own reason cell (the shared row format's fourth
@@ -14390,13 +14404,12 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       let reasonCellHtml = "";
 
       if (decisionRecord) {
-        const keptExisting = mergeValuesLookIdentical(
-          decisionRecord.chosenValue,
-          existingValue,
-        );
+        // Outcome is judged by the FINAL value (what the calendar write
+        // saves), not the record's chosenValue: it must agree with the
+        // changed/no-op classification above even against a stale record.
+        const keptExisting = rowIsNoop;
         const tookNew =
-          !keptExisting &&
-          mergeValuesLookIdentical(decisionRecord.chosenValue, newValue);
+          !keptExisting && mergeValuesLookIdentical(finalValue, newValue);
         const outcome = keptExisting
           ? "kept existing"
           : tookNew
@@ -14409,7 +14422,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         flowIcon = keptExisting ? "←" : "→";
         if (source === "deterministic") {
           resultText = `<span style="color: #007aff;">🔒 DETERMINISTIC — ${outcome}</span>`;
-        } else if (source === "sticky") {
+        } else if (source === "sticky" && keptExisting) {
           flowIcon = "←";
           resultText = `<span style="color: #007aff;">🧊 KEPT EXISTING (calendar stickiness)</span>`;
         } else if (source === "ai") {
@@ -14429,7 +14442,6 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         resultText = '<span style="color: #999;">SAME VALUE</span>';
       } else if (strategy === "ai") {
         // AI-arbitrated strategy — show which side the AI picked (or that it fell back)
-        const arbitration = event._original?.aiArbitration;
         if (arbitration?.fallbacks?.includes(field)) {
           flowIcon = "→";
           resultText = '<span style="color: #ff9500;">AI FALLBACK (CLOBBERED)</span>';
@@ -14448,6 +14460,14 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         } else if (!newValue && !finalValue) {
           flowIcon = "→";
           resultText = '<span style="color: #ff9500;">CLEARED</span>';
+        } else if (!rowIsNoop) {
+          // The value DID change but no decision record names the writer
+          // (saved runs recorded before post-merge rewrites logged their
+          // provenance). Never claim "no change" on a changed row — and
+          // never credit the AI with a change it did not make.
+          flowIcon = "→";
+          resultText =
+            '<span style="color: #ff9500;">CHANGED (no decision recorded)</span>';
         } else {
           flowIcon = "—";
           resultText = '<span style="color: #999;">KEPT EXISTING (no change)</span>';
@@ -14541,6 +14561,12 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         // Merged/combined value
         flowIcon = "↔";
         resultText = '<span style="color: #32d74b;">MERGED</span>';
+      } else if (!rowIsNoop) {
+        // Same guard as the ai-strategy chain: a changed value with no
+        // recorded writer must render as a change, never as "no change".
+        flowIcon = "→";
+        resultText =
+          '<span style="color: #ff9500;">CHANGED (no decision recorded)</span>';
       } else {
         flowIcon = "—";
         resultText = '<span style="color: #999;">KEPT EXISTING (no change)</span>';
@@ -14549,12 +14575,29 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       // Plain-words strategy label: "ai" under a field name read as a
       // mystery token (owner pasted a `website ai … NO CHANGE` row as the
       // example of the confusion). Unknown strategies fall through verbatim.
-      const strategyLabel =
-        {
-          ai: "AI-arbitrated",
-          preserve: "preserve saved",
-          clobber: "fresh wins",
-        }[strategy] || strategy;
+      // "AI-arbitrated" is reserved for rows the AI actually touched: a
+      // recorded decision labels by its SOURCE (the TWISTED BEAR gmaps row
+      // wore "AI-arbitrated" over a deterministic rebuild while aiArbitration
+      // was null), and an ai-strategy field the arbitration never saw says
+      // so instead of borrowing the AI's name.
+      const aiTouchedField =
+        arbitration?.arbitrated?.includes(field) ||
+        arbitration?.fallbacks?.includes(field);
+      const strategyLabel = decisionRecord
+        ? {
+            deterministic: "deterministic",
+            sticky: "calendar stickiness",
+            ai: "AI-arbitrated",
+            fallback: "clobber fallback",
+          }[String(decisionRecord.source || "").toLowerCase()] ||
+          "recorded decision"
+        : strategy === "ai" && !aiTouchedField
+          ? "ai (not arbitrated)"
+          : {
+              ai: "AI-arbitrated",
+              preserve: "preserve saved",
+              clobber: "fresh wins",
+            }[strategy] || strategy;
 
       // Shared row format (field | value | source/outcome | reason): the
       // value cell leads with the FINAL value; when the sides disagreed, the
@@ -14581,10 +14624,9 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         }
       }
 
-      // No-op detection for the compressed view — the shared mergeRowIsNoop
-      // (one definition for the table view, the line view and the chip).
-      const rowIsNoop = this.mergeRowIsNoop(finalValue, existingValue);
-
+      // No-op classification for the compressed view: rowIsNoop was computed
+      // above (before the outcome branches) from the shared mergeRowIsNoop —
+      // one definition for the table view, the line view and the chip.
       rows.push({
         field,
         changed: !rowIsNoop,

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -8380,6 +8380,128 @@ test('merge rows label calendar stickiness and clobber fallback', () => {
   assert.ok(fallbackHtml.includes('⚠️ NO AI ANSWER — took new (clobber fallback)'));
 });
 
+// ---------------------------------------------------------------------------
+// Display truth for post-merge deterministic rewrites — the REAL record from
+// run 20260815-083809, "TWISTED BEAR San Francisco Debut": the merge-time
+// gmaps regeneration replaced the calendar's 73-char coordinate query with
+// the 139-char bar+address query, nothing recorded the decision, and the row
+// rendered "AI-arbitrated … KEPT EXISTING (no change)" while counting as
+// changed. A row must never claim both.
+// ---------------------------------------------------------------------------
+
+const TWISTED_CAL_GMAPS =
+  'https://www.google.com/maps/search/?api=1&query=37.7699933%2C-122.4133375';
+const TWISTED_REBUILT_GMAPS =
+  'https://www.google.com/maps/search/?api=1&query=San%20Francisco%20Eagle%20Bar%2C%20398%2012th%20Street%2C%20San%20Francisco%2C%20CA%2094103';
+
+function twistedBearEvent(overrides = {}) {
+  const bar = 'San Francisco Eagle Bar';
+  const address = '398 12th Street, San Francisco, CA 94103';
+  return {
+    title: 'TWISTED BEAR San Francisco Debut',
+    _action: 'merge',
+    startDate: '2026-08-23T04:00:00.000Z',
+    endDate: '2026-08-23T09:00:00.000Z',
+    location: '37.7699933, -122.4133375',
+    bar,
+    address,
+    gmaps: TWISTED_REBUILT_GMAPS,
+    city: 'sf',
+    key: 'twisted-bear-san-francisco-debut|2026-08-23|san francisco eagle bar',
+    _original: {
+      // The scraper offered NO gmaps at all ("scraped: undefined" in the
+      // owner's paste); the calendar stored the coordinate query.
+      scraper: {
+        bar,
+        address,
+        location: '37.7699927, -122.4134077',
+        key: 'twisted-bear-san-francisco-debut|2026-08-23|san francisco eagle bar'
+      },
+      calendar: {
+        bar,
+        address,
+        gmaps: TWISTED_CAL_GMAPS,
+        location: '37.7699933, -122.4133375',
+        title: 'TWISTED BEAR San Francisco Debut',
+        startDate: '2026-08-23T04:00:00.000Z',
+        endDate: '2026-08-23T09:00:00.000Z',
+        key: 'twisted-bear-san-francisco-debut|2026-08-23|san francisco eagle bar'
+      },
+      merged: { bar, address, gmaps: TWISTED_REBUILT_GMAPS }
+    },
+    _fieldPriorities: {
+      gmaps: { merge: 'ai' },
+      bar: { merge: 'ai' },
+      address: { merge: 'ai' }
+    },
+    ...overrides
+  };
+}
+
+test('TWISTED BEAR: a recorded deterministic gmaps rebuild renders once, as a change, with its reason', () => {
+  const adapter = buildAdapter();
+  const event = twistedBearEvent({
+    _mergeDecisions: [
+      {
+        field: 'gmaps',
+        existingValue: TWISTED_CAL_GMAPS,
+        newValue: undefined,
+        chosenValue: TWISTED_REBUILT_GMAPS,
+        reason:
+          'gmaps rebuilt from the final merged bar + address (derived field — replaces the stored link)',
+        source: 'deterministic'
+      }
+    ]
+  });
+
+  const records = adapter.buildComparisonRowRecords(event);
+  const gmapsRows = records.filter((record) => record.field === 'gmaps');
+  assert.equal(gmapsRows.length, 1, 'the gmaps row renders exactly once');
+  const row = gmapsRows[0];
+  assert.equal(row.changed, true, 'a rebuilt link IS a change');
+  assert.ok(row.html.includes('🔒 DETERMINISTIC — rewrote'), `truthful outcome label: ${row.html}`);
+  assert.ok(row.html.includes('rebuilt from the final merged bar + address'), 'the rebuild reason rides in the reason cell');
+  assert.ok(row.html.includes('<small>deterministic</small>'), 'the strategy slot names the real source');
+  assert.ok(!row.html.includes('KEPT EXISTING (no change)'), 'a changed row never claims no change');
+  assert.ok(!row.html.includes('AI-arbitrated'), 'the AI touched nothing on this field');
+
+  assert.equal(adapter.countChangedMergeFields(event), 1, 'the chip counts the one real change');
+  const card = adapter.generateEventCard(event);
+  assert.ok(!card.includes('KEPT EXISTING (no change)'), 'no self-contradiction anywhere on the card');
+  assert.ok(!card.includes('AI-arbitrated'), 'no AI credit anywhere on the card');
+});
+
+test('TWISTED BEAR without a decision record (older saved runs) still never self-contradicts', () => {
+  const adapter = buildAdapter();
+  const event = twistedBearEvent(); // no _mergeDecisions — the pre-fix run shape
+
+  const records = adapter.buildComparisonRowRecords(event);
+  const row = records.find((record) => record.field === 'gmaps');
+  assert.equal(row.changed, true, 'value truth: merged differs from calendar');
+  assert.ok(row.html.includes('CHANGED (no decision recorded)'),
+    `an unattributed change says so plainly: ${row.html}`);
+  assert.ok(!row.html.includes('KEPT EXISTING (no change)'), 'the contradictory composite is dead');
+  assert.ok(!row.html.includes('AI-arbitrated'),
+    'aiArbitration is null for this event — the AI is never blamed');
+  assert.ok(row.html.includes('<small>ai (not arbitrated)</small>'),
+    'the strategy slot admits arbitration never ran');
+});
+
+test('TWISTED BEAR unchanged twin renders "no changes"', () => {
+  const adapter = buildAdapter();
+  const event = twistedBearEvent({ gmaps: TWISTED_CAL_GMAPS });
+  event._original = {
+    ...event._original,
+    merged: { ...event._original.merged, gmaps: TWISTED_CAL_GMAPS }
+  };
+
+  const records = adapter.buildComparisonRowRecords(event);
+  const row = records.find((record) => record.field === 'gmaps');
+  assert.equal(row.changed, false, 'identical link → no-op');
+  assert.ok(row.html.includes('KEPT EXISTING (no change)'), 'the no-op label is reserved for true no-ops');
+  assert.equal(adapter.countChangedMergeFields(event), 0, 'the twin card says "no changes"');
+});
+
 test('every existing card action survives the headline redesign (live + saved run)', async () => {
   const results = {
     analyzedEvents: [

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -10596,6 +10596,7 @@ class SharedCore {
             let finalGmaps = calendarHasGmaps
                 ? calendarObject.gmaps
                 : (scraperHasGmaps ? scraperObject.gmaps : '');
+            let regeneratedFromMergedFacts = false;
             if ((calendarHasGmaps || scraperHasGmaps) && (finalBar || finalAddressForGmaps)) {
                 const regenerated = SharedCore.generateGoogleMapsUrl({
                     coordinates: null,
@@ -10604,7 +10605,10 @@ class SharedCore {
                     venueName: finalBar || null,
                     cityName: null
                 });
-                if (regenerated) finalGmaps = regenerated;
+                if (regenerated) {
+                    finalGmaps = regenerated;
+                    regeneratedFromMergedFacts = true;
+                }
             }
             if (finalGmaps !== '' || allFields.has('gmaps')) {
                 mergedObject.gmaps = finalGmaps;
@@ -10614,6 +10618,22 @@ class SharedCore {
             const calendarGmaps = calendarHasGmaps ? String(calendarObject.gmaps).trim() : '';
             if (String(finalGmaps || '').trim() !== calendarGmaps) {
                 clobberedFields.push('gmaps');
+                // Display truth: this regeneration changed the saved value
+                // WITHOUT an arbitration conflict, so nothing else records it —
+                // run 20260815-083809 ("TWISTED BEAR San Francisco Debut")
+                // rendered exactly this rewrite as "AI-arbitrated … KEPT
+                // EXISTING (no change)" because the decisions channel was
+                // empty. Record it where the merge table reads.
+                aiDecisionRecords.push({
+                    field: 'gmaps',
+                    existingValue: calendarObject.gmaps,
+                    newValue: scraperObject.gmaps,
+                    chosenValue: finalGmaps,
+                    reason: regeneratedFromMergedFacts
+                        ? 'gmaps rebuilt from the final merged bar + address (derived field — replaces the stored link)'
+                        : 'scraped gmaps adopted (calendar had none)',
+                    source: 'deterministic'
+                });
             }
         }
 
@@ -13956,6 +13976,39 @@ class SharedCore {
         }) || '';
     }
 
+    // Post-merge deterministic rewrites (the final-build gmaps rebuild, the
+    // link folds, the description sanitizer) mutate the FINAL event AFTER
+    // createFinalEventObject stamped _mergeDecisions — so the merge table
+    // showed their changes with nobody's name on them (run 20260815-083809,
+    // "TWISTED BEAR San Francisco Debut": the gmaps row claimed
+    // "AI-arbitrated … KEPT EXISTING (no change)" for a change the rebuild
+    // made). Every such rewrite records itself HERE, in the same channel the
+    // table reads, as source 'deterministic' with the actual reason. Merge
+    // results only (a NEW event has no calendar side to diff against), and a
+    // rewrite that lands back on the calendar's own value records nothing —
+    // there is no change to attribute. Records APPEND: a later rewrite of the
+    // same field supersedes earlier records by position (readers take the
+    // last), keeping the full decision history for the provenance view.
+    recordDeterministicFieldRewrite(analyzedEvent, field, reason) {
+        if (!analyzedEvent || typeof analyzedEvent !== 'object') return;
+        const original = analyzedEvent._original;
+        if (!original || !original.calendar || typeof original.calendar !== 'object') return;
+        const calendarValue = original.calendar[field];
+        const chosenValue = analyzedEvent[field];
+        if (this.mergeValuesEqualForTracking(chosenValue, calendarValue)) return;
+        const bothEmpty = this.isEmptyArbitrationValue(chosenValue) && this.isEmptyArbitrationValue(calendarValue);
+        if (bothEmpty) return;
+        if (!Array.isArray(analyzedEvent._mergeDecisions)) analyzedEvent._mergeDecisions = [];
+        analyzedEvent._mergeDecisions.push({
+            field,
+            existingValue: calendarValue,
+            newValue: original.scraper && typeof original.scraper === 'object' ? original.scraper[field] : undefined,
+            chosenValue,
+            reason,
+            source: 'deterministic'
+        });
+    }
+
     async buildAnalyzedCalendarEvent(event, analysis, calendarAdapter, config = {}) {
         // (Block wrapper keeps the extracted loop body byte-identical to its
         // original prepareEventsForCalendar form — minimal, reviewable diff.)
@@ -14126,6 +14179,8 @@ class SharedCore {
                     analyzedEvent.description = sanitizedDescription;
                     notesNeedRebuild = true;
                     console.log(`🧼 DESCRIPTION: stripped formatting markup for "${analyzedEvent.title || 'event'}"`);
+                    this.recordDeterministicFieldRewrite(analyzedEvent, 'description',
+                        'description formatting sanitized at final build (markup stripped)');
                 }
             }
 
@@ -14138,6 +14193,10 @@ class SharedCore {
                     analyzedEvent, analyzedEvent.title || 'event');
                 if (purgedLinkFields.length > 0) {
                     notesNeedRebuild = true;
+                    for (const purgedField of purgedLinkFields) {
+                        this.recordDeterministicFieldRewrite(analyzedEvent, purgedField,
+                            'cleared at final build — an asset file/API endpoint is never an identity or ticket link');
+                    }
                 }
             }
 
@@ -14182,6 +14241,12 @@ class SharedCore {
                         }
                         notesNeedRebuild = true;
                         console.log(`🔗 LINKS: replaced platform website ${platformWebsite} with ${curatedWebsite}${existingTicketUrl ? '' : ' (platform link moved to ticketUrl)'} — curated identity of "${promoterEntry.name}" for "${analyzedEvent.title || 'event'}"`);
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'website',
+                            'platform website replaced by the promoter\'s curated identity link at final build');
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'url',
+                            'platform website replaced by the promoter\'s curated identity link at final build');
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'ticketUrl',
+                            'platform link parked in empty ticketUrl (curated identity adopted for website)');
                     } else if (!curatedWebsite && this.isPlatformOrganizerHomeUrl(platformWebsite)) {
                         // A branded subdomain with a bare path is the
                         // organizer's HOME on that platform, not a ticket
@@ -14233,6 +14298,12 @@ class SharedCore {
                             ? `existing ticketUrl ${existingTicketUrl} kept`
                             : 'moved to ticketUrl';
                         console.log(`🔗 LINKS: cleared platform website ${platformWebsite} — a ticketing/social link is never the identity link (${parked}, website/url left empty) for "${analyzedEvent.title || 'event'}"`);
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'website',
+                            'platform website cleared at final build — a ticketing/social link is never the identity link');
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'url',
+                            'platform website cleared at final build — a ticketing/social link is never the identity link');
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'ticketUrl',
+                            'platform link parked in empty ticketUrl (website/url cleared)');
                     }
                 }
             }
@@ -14278,6 +14349,12 @@ class SharedCore {
                         delete analyzedEvent.ticketUrl;
                         notesNeedRebuild = true;
                         console.log(`🔗 LINKS: "${analyzedEvent.title || 'event'}" ticketUrl ${ticketUrl} is a page on the venue's own site, not a ticket vendor — promoted to website/url${canonicalWebsite ? ` over ${canonicalWebsite}` : ''}`);
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'website',
+                            'venue-site event page promoted from ticketUrl to website/url at final build');
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'url',
+                            'venue-site event page promoted from ticketUrl to website/url at final build');
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'ticketUrl',
+                            'moved to website/url — a page on the venue\'s own site is not a ticket vendor link');
                     } else if (canonicalWebsite && this.isBareRootBuryingSameSiteEventPage(ticketUrl, canonicalWebsite)) {
                         // The mirror shape: the ticketUrl is the same site's
                         // bare front door while website already names the
@@ -14287,6 +14364,8 @@ class SharedCore {
                         delete analyzedEvent.ticketUrl;
                         notesNeedRebuild = true;
                         console.log(`🔗 LINKS: dropped ticketUrl ${ticketUrl} for "${analyzedEvent.title || 'event'}" — it is the same site's homepage, not a ticket link`);
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'ticketUrl',
+                            'ticketUrl dropped at final build — the same site\'s homepage, not a ticket link');
                     }
                 }
             }
@@ -14306,6 +14385,8 @@ class SharedCore {
                     delete analyzedEvent.ticketUrl;
                     notesNeedRebuild = true;
                     console.log(`🔗 LINKS: dropped ticketUrl duplicating website for "${analyzedEvent.title || 'event'}"`);
+                    this.recordDeterministicFieldRewrite(analyzedEvent, 'ticketUrl',
+                        'ticketUrl dropped at final build — byte-identical to the canonical website');
                 }
             }
 
@@ -14338,6 +14419,8 @@ class SharedCore {
                         analyzedEvent.gmaps = curatedGmaps;
                         notesNeedRebuild = true;
                         console.log(`🗺️ GMAPS: adopted curated googleMaps link for "${analyzedEvent.title || 'event'}"`);
+                        this.recordDeterministicFieldRewrite(analyzedEvent, 'gmaps',
+                            'gmaps rebuilt: curated bar googleMaps link adopted (curated beats derived)');
                     } else if (!curatedGmaps && finalCoordinates && !existingGmaps.includes('place_id')) {
                         // Built-link precedence (owner ask 2026-08-14):
                         //   1. place_id — curated googleMaps adoption above /
@@ -14359,6 +14442,8 @@ class SharedCore {
                                 analyzedEvent.gmaps = placeQueryGmaps;
                                 notesNeedRebuild = true;
                                 console.log(`🗺️ GMAPS: rebuilt link from corroborated bar + address for "${analyzedEvent.title || 'event'}"`);
+                                this.recordDeterministicFieldRewrite(analyzedEvent, 'gmaps',
+                                    'gmaps rebuilt: corroborated bar+address query replaces the previous link');
                             }
                         } else {
                             const coordinateGmaps = SharedCore.generateGoogleMapsUrl({
@@ -14372,6 +14457,8 @@ class SharedCore {
                                 analyzedEvent.gmaps = coordinateGmaps;
                                 notesNeedRebuild = true;
                                 console.log(`🗺️ GMAPS: rebuilt link from verified coordinates for "${analyzedEvent.title || 'event'}"`);
+                                this.recordDeterministicFieldRewrite(analyzedEvent, 'gmaps',
+                                    'gmaps rebuilt: verified final coordinates replace the previous link');
                             }
                         }
                     }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -13683,6 +13683,197 @@ test('final build drops a ticketUrl byte-identical to the canonical website', as
     `got: ${JSON.stringify(lines)}`);
 });
 
+// ---------------------------------------------------------------------------
+// Post-merge deterministic rewrites must RECORD themselves in _mergeDecisions
+// (run 20260815-083809, "TWISTED BEAR San Francisco Debut"): the merge-time
+// gmaps regeneration replaced the calendar's coordinate link with a
+// bar+address query, no decision recorded it, and the card rendered the
+// change as "AI-arbitrated … KEPT EXISTING (no change)".
+// ---------------------------------------------------------------------------
+
+const TWISTED_CAL_GMAPS = 'https://www.google.com/maps/search/?api=1&query=37.7699933%2C-122.4133375';
+const TWISTED_REBUILT_GMAPS = 'https://www.google.com/maps/search/?api=1&query=San%20Francisco%20Eagle%20Bar%2C%20398%2012th%20Street%2C%20San%20Francisco%2C%20CA%2094103';
+
+test('merge-time gmaps regeneration records a deterministic merge decision (TWISTED BEAR)', async () => {
+  const core = new SharedCore(
+    { sf: { timezone: 'America/Los_Angeles', patterns: ['san francisco'] } },
+    { eventSchema: EventSchema }
+  );
+  // The real pair from run 20260815-083809: scraper carries NO gmaps, the
+  // calendar carries the coordinate query, and the merged bar + address
+  // regenerate the labeled place query.
+  const scraped = {
+    title: 'TWISTED BEAR San Francisco Debut',
+    startDate: new Date('2026-08-23T04:00:00.000Z'),
+    endDate: new Date('2026-08-23T09:00:00.000Z'),
+    bar: 'San Francisco Eagle Bar',
+    address: '398 12th Street, San Francisco, CA 94103',
+    location: '37.7699927, -122.4134077',
+    city: 'sf',
+    source: 'ai-web',
+    _fieldPriorities: null
+  };
+  scraped._fieldPriorities = core.getResolvedFieldPriorities({});
+  const existing = {
+    title: 'TWISTED BEAR San Francisco Debut',
+    startDate: new Date('2026-08-23T04:00:00.000Z'),
+    endDate: new Date('2026-08-23T09:00:00.000Z'),
+    location: '37.7699933, -122.4133375',
+    url: '',
+    notes: [
+      'bar: San Francisco Eagle Bar',
+      'address: 398 12th Street, San Francisco, CA 94103',
+      `gmaps: ${TWISTED_CAL_GMAPS}`
+    ].join('\n')
+  };
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, {});
+
+  // Sanity (true before and after the fix): the rebuild itself.
+  assert.equal(finalEvent.gmaps, TWISTED_REBUILT_GMAPS, 'bar+address query replaces the coordinate link');
+
+  // THE FIX: the rewrite names itself in the channel the merge table reads.
+  const records = (finalEvent._mergeDecisions || []).filter(record => record.field === 'gmaps');
+  assert.equal(records.length, 1, 'exactly one gmaps decision record');
+  assert.equal(records[0].source, 'deterministic');
+  assert.equal(records[0].chosenValue, TWISTED_REBUILT_GMAPS);
+  assert.equal(records[0].existingValue, TWISTED_CAL_GMAPS);
+  assert.equal(records[0].newValue, undefined, 'scraper offered no gmaps');
+  assert.match(records[0].reason, /rebuilt from the final merged bar \+ address/);
+  assert.deepEqual(finalEvent._original.aiArbitration.deterministic, ['gmaps'],
+    'arbitration summary lists the rewrite as deterministic — the AI touched nothing');
+  assert.deepEqual(finalEvent._original.aiArbitration.arbitrated, []);
+});
+
+test('merge-time gmaps regeneration landing on the calendar value records nothing', async () => {
+  const core = new SharedCore(
+    { sf: { timezone: 'America/Los_Angeles', patterns: ['san francisco'] } },
+    { eventSchema: EventSchema }
+  );
+  const scraped = {
+    title: 'TWISTED BEAR San Francisco Debut',
+    startDate: new Date('2026-08-23T04:00:00.000Z'),
+    endDate: new Date('2026-08-23T09:00:00.000Z'),
+    bar: 'San Francisco Eagle Bar',
+    address: '398 12th Street, San Francisco, CA 94103',
+    location: '37.7699933, -122.4133375',
+    city: 'sf',
+    source: 'ai-web',
+    _fieldPriorities: null
+  };
+  scraped._fieldPriorities = core.getResolvedFieldPriorities({});
+  // The genuinely unchanged twin: the calendar already stores the rebuilt link.
+  const existing = {
+    title: 'TWISTED BEAR San Francisco Debut',
+    startDate: new Date('2026-08-23T04:00:00.000Z'),
+    endDate: new Date('2026-08-23T09:00:00.000Z'),
+    location: '37.7699933, -122.4133375',
+    url: '',
+    notes: [
+      'bar: San Francisco Eagle Bar',
+      'address: 398 12th Street, San Francisco, CA 94103',
+      `gmaps: ${TWISTED_REBUILT_GMAPS}`
+    ].join('\n')
+  };
+
+  const finalEvent = await core.createFinalEventObject(existing, scraped, {});
+
+  assert.equal(finalEvent.gmaps, TWISTED_REBUILT_GMAPS, 'value unchanged');
+  const records = (finalEvent._mergeDecisions || []).filter(record => record.field === 'gmaps');
+  assert.equal(records.length, 0, 'no change → no decision record → the card says "no changes"');
+});
+
+test('recordDeterministicFieldRewrite: merge results only, genuine changes only, appends supersede', () => {
+  const core = createCore();
+
+  // A rewrite that lands back on the calendar's own value records nothing.
+  const analyzed = { gmaps: 'https://maps.example/a', _original: { calendar: { gmaps: 'https://maps.example/a' }, scraper: {} } };
+  core.recordDeterministicFieldRewrite(analyzed, 'gmaps', 'noise');
+  assert.equal(analyzed._mergeDecisions, undefined);
+
+  // A NEW event (no _original/calendar side) records nothing.
+  const fresh = { gmaps: 'https://maps.example/b' };
+  core.recordDeterministicFieldRewrite(fresh, 'gmaps', 'noise');
+  assert.equal(fresh._mergeDecisions, undefined);
+
+  // A genuine change records field, sides, chosen value, reason, source.
+  analyzed.gmaps = 'https://maps.example/rebuilt';
+  core.recordDeterministicFieldRewrite(analyzed, 'gmaps', 'gmaps rebuilt: test reason');
+  assert.deepEqual(analyzed._mergeDecisions, [{
+    field: 'gmaps',
+    existingValue: 'https://maps.example/a',
+    newValue: undefined,
+    chosenValue: 'https://maps.example/rebuilt',
+    reason: 'gmaps rebuilt: test reason',
+    source: 'deterministic'
+  }]);
+
+  // A later rewrite APPENDS — readers take the last record for the field.
+  analyzed.gmaps = 'https://maps.example/curated';
+  core.recordDeterministicFieldRewrite(analyzed, 'gmaps', 'gmaps rebuilt: curated adoption');
+  assert.equal(analyzed._mergeDecisions.length, 2);
+  assert.equal(analyzed._mergeDecisions[1].chosenValue, 'https://maps.example/curated');
+});
+
+test('final-build curated gmaps adoption on a MERGE appends a superseding decision record', async () => {
+  const CURATED_EAGLE_GMAPS = 'https://www.google.com/maps/place/?q=place_id:ChIJLwuhHU_HwoARdQQ1PfOn6B4';
+  const core = createFinalBuildCore({
+    bars: {
+      la: [{
+        name: 'Eagle LA',
+        city: 'la',
+        coordinates: '34.0912127, -118.2840632',
+        googleMaps: CURATED_EAGLE_GMAPS
+      }]
+    }
+  });
+  const scraped = {
+    title: 'CUBSCOUT LA',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T08:00:00.000Z'),
+    bar: 'Eagle LA',
+    address: '4219 Santa Monica Blvd, Los Angeles, CA 90029',
+    location: '34.0912127, -118.2840632',
+    city: 'la',
+    source: 'ai-web',
+    _fieldPriorities: null
+  };
+  scraped._fieldPriorities = core.getResolvedFieldPriorities({});
+  const existing = {
+    title: 'CUBSCOUT LA',
+    startDate: new Date('2026-09-05T04:00:00.000Z'),
+    endDate: new Date('2026-09-05T08:00:00.000Z'),
+    location: '34.0912127, -118.2840632',
+    url: '',
+    notes: [
+      'bar: Eagle LA',
+      'address: 4219 Santa Monica Blvd, Los Angeles, CA 90029',
+      'gmaps: https://www.google.com/maps/search/?api=1&query=Eagle%20LA'
+    ].join('\n')
+  };
+  const analysis = { action: 'merge', reason: 'same event', existingEvent: existing, sourceEvent: null, overrideIdentity: null };
+
+  const lines = [];
+  const restore = captureFinalBuildLogs(lines);
+  let analyzed;
+  try {
+    analyzed = await core.buildAnalyzedCalendarEvent(scraped, analysis, {}, {});
+  } finally {
+    restore();
+  }
+
+  assert.equal(analyzed.gmaps, CURATED_EAGLE_GMAPS, 'curated place link wins the final build');
+  const records = (analyzed._mergeDecisions || []).filter(record => record.field === 'gmaps');
+  assert.equal(records.length, 2, 'merge-time regeneration + final-build curated adoption both recorded');
+  assert.equal(records[0].source, 'deterministic');
+  assert.match(records[0].reason, /rebuilt from the final merged bar \+ address/);
+  const last = records[records.length - 1];
+  assert.equal(last.source, 'deterministic');
+  assert.match(last.reason, /curated bar googleMaps link adopted/);
+  assert.equal(last.chosenValue, CURATED_EAGLE_GMAPS, 'the LAST record describes the final saved value');
+  assert.equal(last.existingValue, 'https://www.google.com/maps/search/?api=1&query=Eagle%20LA');
+});
+
 test('final build keeps a ticketUrl that differs from the website', async () => {
   const core = createFinalBuildCore();
   const event = {


### PR DESCRIPTION
## The symptom (owner report, run 20260815-083809)

"TWISTED BEAR San Francisco Debut" rendered ONE merge row:

`gmaps | AI-arbitrated | <139-char link> | calendar: <73-char link> | scraped: undefined | — KEPT EXISTING (no change)`

— labeled both AI-arbitrated/changed AND "kept existing no change", while the run JSON's `mergeDecisions` was EMPTY and `aiArbitration` null. Owner: "This event says there is a diff but then says there isn't."

## The mechanism (verified against the real record)

`_original.calendar.gmaps` = the 73-char coordinate query; `_original.merged.gmaps` = the 139-char bar+address query; scraper gmaps absent. The **merge-time STEP 4 gmaps regeneration** (gmaps is a derived field, rebuilt from the final merged bar + address) made the change — legitimately — but pushed nothing into the `_mergeDecisions` channel, and with `strategy === "ai"` + null arbitration the renderer fell through every branch into the contradictory composite, while the value-based no-op predicate correctly counted the row as changed.

## The fix

**Shared-core** (tight to the rebuild/decision seams):
- STEP 4 gmaps regeneration records itself as source `deterministic` with the actual reason whenever it leaves gmaps different from the calendar value.
- New `recordDeterministicFieldRewrite()`: every post-merge deterministic rewrite in the final-build sweep records its change in the same channel — sibling sweep found: 3-rung final-build gmaps rebuild (curated adoption / corroborated bar+address query / verified coordinates), platform-website curated-adopt and clear, venue-site ticketUrl promotion, homepage-ticketUrl drop, duplicate-ticketUrl drop, non-identity link purge, description formatting sanitizer. (Overlong-field trims already have their own `_fieldTrims` channel; provenance stamps have dedicated row handling; shortName derivation is AI, not deterministic — all left as-is. No favicon rewrite exists post-merge.) Merge results only; landing back on the calendar's own value records nothing; records append so the LAST record for a field describes the final saved value.

**Adapter** (minimal, display truth):
- Rows classify by merged-vs-calendar VALUE difference (`mergeRowIsNoop`, computed before the outcome branches) plus the recorded decision — a row can never render both "changed" and "no change".
- Decision lookup takes the last record per field; recorded decisions label by source (`deterministic` / `calendar stickiness` / `AI-arbitrated` / `clobber fallback`).
- "AI-arbitrated" appears ONLY when aiArbitration actually touched the field; otherwise `ai (not arbitrated)`.
- A changed value with no record (older saved runs) renders `CHANGED (no decision recorded)`.

No existing console.log strings edited; shared-core stays platform-pure.

## Proof with the real record

Replaying the actual saved TWISTED BEAR record (pre-fix shape) through the new renderer: 1 gmaps row, `changed: true`, `CHANGED (no decision recorded)`, label `ai (not arbitrated)`, no "AI-arbitrated", no "KEPT EXISTING (no change)", chip counts 1 change. A fresh run of the same merge records `deterministic — "gmaps rebuilt from the final merged bar + address (derived field — replaces the stored link)"` and renders `🔒 DETERMINISTIC — rewrote` with the reason in the reason cell. The genuinely unchanged twin renders "no changes" (0 changed fields).

## Tests

7 new tests driven by the real TWISTED BEAR values (`scripts/shared-core.test.js`, `scripts/adapters/scriptable-adapter.test.js`) — 5 proven failing on base; the other 2 are no-regression companions (unchanged twin renders "no changes"; a rewrite landing on the calendar value records nothing). Quiet suite: **1899 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP