### PR TITLE
fix(scraper): dead-end store actually suppresses repeat crawl errors (eventim 403s, dead hosts) on every adapter

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -1222,7 +1222,10 @@ class ScriptableAdapter {
 
   // ---------------------------------------------------------------------
   // Learned dead-end store persistence: dead-ends.json alongside the other
-  // scraper storage. Shape: { "<url>": { firstSeen, lastSeen, misses } }.
+  // scraper storage. Shape: { "<url>": { firstSeen, lastSeen, misses } },
+  // plus shared-core's reserved "::hosts" section for host-level bot-wall
+  // stats (persisted opaquely here — Mac runs write the same file when the
+  // shared storage root is active).
   // The semantics (skip/retry/prune) live in shared-core; the orchestrator
   // loads the store before the run and saves the updated store after it.
   // ---------------------------------------------------------------------

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -442,6 +442,17 @@ test('loadDeadEnds/saveDeadEnds round-trip through dead-ends.json', async () => 
       firstSeen: '2026-06-01T00:00:00.000Z',
       lastSeen: '2026-07-01T00:00:00.000Z',
       misses: 3
+    },
+    // Host-level bot-wall stats section (shared-core's "::hosts" key) must
+    // survive the phone round-trip untouched — Mac and phone share this file
+    // when the shared storage root is active.
+    '::hosts': {
+      'wl.eventim.us': {
+        firstSeen: '2026-08-15T08:38:09.000Z',
+        lastSeen: '2026-08-15T08:38:09.000Z',
+        misses: 2,
+        lastStatus: 403
+      }
     }
   };
   await adapter.saveDeadEnds(store);

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -37,8 +37,9 @@ class WebAdapter {
         
         // Store cities configuration for calendar mapping
         this.cities = config.cities || {};
-        // In-memory learned dead-end store (web/Node runs don't persist it;
-        // the Scriptable adapter is the durable home for dead-ends.json)
+        // Learned dead-end store: Node runs persist dead-ends.json (shared
+        // storage root when active, local state dir otherwise — see
+        // getDeadEndsFilePath); this in-memory copy is the browser fallback.
         this.deadEndStore = {};
         this.isNode = typeof process !== 'undefined' && !!(process.versions && process.versions.node);
         this.fs = null;
@@ -562,18 +563,70 @@ class WebAdapter {
         }
     }
     
-    // In-memory equivalents of the Scriptable adapter's dead-end persistence:
-    // same interface, survives only for the adapter instance's lifetime.
-    async loadDeadEnds() {
-        if (!this.deadEndStore || typeof this.deadEndStore !== 'object' || Array.isArray(this.deadEndStore)) {
-            this.deadEndStore = {};
+    // Learned dead-end store persistence — the Node twin of the Scriptable
+    // adapter's dead-ends.json. Before run 20260815-083809 this was
+    // in-memory only, so scheduled Mac runs re-crawled the same 403'd
+    // eventim deep-links on every run: the store learned them and threw
+    // them away at process exit. Location mirrors the phone's contract:
+    // at the shared storage root when active (the phone's tree keeps ONE
+    // dead-ends.json both devices read and write), under the local state
+    // dir otherwise. Browser runs keep the old in-memory fallback.
+    getDeadEndsFilePath() {
+        if (!this.isNode || !this.path) return null;
+        if (this.sharedStorageRoot) {
+            return this.path.join(this.sharedStorageRoot, 'dead-ends.json');
         }
-        return this.deadEndStore;
+        if (!this.localStateDir) return null;
+        return this.path.join(this.localStateDir, 'dead-ends.json');
+    }
+
+    async loadDeadEnds() {
+        const filePath = this.getDeadEndsFilePath();
+        if (!filePath || !this.fs) {
+            if (!this.deadEndStore || typeof this.deadEndStore !== 'object' || Array.isArray(this.deadEndStore)) {
+                this.deadEndStore = {};
+            }
+            return this.deadEndStore;
+        }
+        try {
+            if (!this.fs.existsSync(filePath)) return {};
+            const raw = await this.boundedSharedFsOp(
+                () => this.fs.promises.readFile(filePath, 'utf8'),
+                `read ${filePath}`
+            );
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                console.log('🟢 Node.js: Dead-end store has unexpected shape — starting with empty store');
+                return {};
+            }
+            return parsed;
+        } catch (error) {
+            // Corrupt or unreadable file must never break a run — the store
+            // is a pure optimization and rebuilds itself over later runs.
+            console.log(`🟢 Node.js: Dead-end store read failed (${error.message}) — starting with empty store`);
+            return {};
+        }
     }
 
     async saveDeadEnds(store) {
-        if (store && typeof store === 'object' && !Array.isArray(store)) {
+        if (!store || typeof store !== 'object' || Array.isArray(store)) {
+            return;
+        }
+        const filePath = this.getDeadEndsFilePath();
+        if (!filePath || !this.fs) {
             this.deadEndStore = store;
+            return;
+        }
+        try {
+            if (!this.sharedStorageRoot) {
+                // Never mkdir under the shared root (the phone owns that
+                // tree); the local state dir is ours to create.
+                await this.fs.promises.mkdir(this.localStateDir, { recursive: true });
+            }
+            await this.writeFileAtomicallyNode(filePath, JSON.stringify(store, null, 2));
+            console.log(`🟢 Node.js: ✓ Saved dead-end store (${Object.keys(store).length} entries) to ${filePath}`);
+        } catch (error) {
+            console.log(`🟢 Node.js: Dead-end store write failed: ${error.message}`);
         }
     }
 

--- a/scripts/adapters/web-adapter.test.js
+++ b/scripts/adapters/web-adapter.test.js
@@ -765,3 +765,72 @@ test('bear verdict store: web adapter round-trips bear-verdicts.json under its l
     fs.rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Learned dead-end store persistence (run 20260815-083809: scheduled Mac runs
+// re-crawled the same 403'd eventim deep-links every run because the Node
+// adapter's store was in-memory only — it learned dead ends and threw them
+// away at process exit). Same dead-ends.json contract as the phone: at the
+// shared storage root when active (the phone's tree keeps ONE store for both
+// devices), under the local state dir otherwise.
+// ---------------------------------------------------------------------------
+
+const DEAD_END_STORE_FIXTURE = {
+  'https://wl.eventim.us/event/out-and-abt-august/700533?afflky=3dollarbill': {
+    firstSeen: '2026-08-15T08:38:09.000Z',
+    lastSeen: '2026-08-15T08:38:09.000Z',
+    misses: 1,
+    lastStatus: 403
+  },
+  '::hosts': {
+    'wl.eventim.us': {
+      firstSeen: '2026-08-15T08:38:09.000Z',
+      lastSeen: '2026-08-15T08:38:09.000Z',
+      misses: 2,
+      lastStatus: 403
+    }
+  }
+};
+
+test('dead-end store: node adapter round-trips dead-ends.json under its local state dir', async () => {
+  const adapter = makeAdapter();
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chunky-deadends-'));
+  adapter.localStateDir = stateDir;
+  try {
+    assert.deepEqual(await adapter.loadDeadEnds(), {}, 'missing file → empty store');
+
+    await adapter.saveDeadEnds(DEAD_END_STORE_FIXTURE);
+    assert.ok(fs.existsSync(path.join(stateDir, 'dead-ends.json')), 'store written to dead-ends.json');
+
+    // A FRESH adapter instance (i.e. the next scheduled run's process) reads it back
+    const nextRun = makeAdapter();
+    nextRun.localStateDir = stateDir;
+    assert.deepEqual(await nextRun.loadDeadEnds(), DEAD_END_STORE_FIXTURE, 'store survives across processes');
+
+    // Corrupt file fails soft to an empty store, never throws.
+    fs.writeFileSync(path.join(stateDir, 'dead-ends.json'), '{nope');
+    assert.deepEqual(await nextRun.loadDeadEnds(), {});
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test('dead-end store: node adapter reads and writes dead-ends.json at the shared storage root when active', async () => {
+  const root = makeSharedRootFixture();
+  try {
+    await withSharedRootEnv(root, async () => {
+      const adapter = makeAdapter();
+      assert.equal(
+        adapter.getDeadEndsFilePath(),
+        path.join(root, 'dead-ends.json'),
+        'same location the phone keeps its store (chunky-dad-scraper root)'
+      );
+      await adapter.saveDeadEnds(DEAD_END_STORE_FIXTURE);
+
+      const nextRun = makeAdapter();
+      assert.deepEqual(await nextRun.loadDeadEnds(), DEAD_END_STORE_FIXTURE, 'both devices share one store');
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -6290,6 +6290,11 @@ class SharedCore {
                     await displayAdapter.logInfo(`SYSTEM: Skipping known dead-end URL (${Number(deadEndEntry.misses) || 0} prior misses): ${url}`);
                     continue;
                 }
+                const deadEndHostEntry = this.getSkippableDeadEndHostEntry(url, discoveryOnly);
+                if (deadEndHostEntry) {
+                    await displayAdapter.logInfo(`SYSTEM: Skipping URL on bot-walled host (${Number(deadEndHostEntry.misses) || 0} distinct 401/403 URL(s), zero successful fetches): ${url}`);
+                    continue;
+                }
             }
 
             try {
@@ -6644,6 +6649,13 @@ class SharedCore {
                 const permanentlyGone = SharedCore.isPermanentlyGoneHttpStatus(failureStatusCode);
                 if (failureStatusCode === 403 || failureStatusCode === 401 || permanentlyGone) {
                     this.recordDeadEndFetchFailure({ url, currentDepth, statusCode: failureStatusCode });
+                } else if (failureStatusCode === null && /HTTP request failed/i.test(message)) {
+                    // Statusless transport failure from the HTTP adapter
+                    // (dead DNS, refused connection — the adapters' fetch
+                    // wrapper is the only source of this marker, so parser/
+                    // extraction errors can't land here). Staged, two-strike,
+                    // and only committed when the run had successful fetches.
+                    this.recordDeadEndNetworkFailure({ url, currentDepth });
                 }
                 try {
                     if (!(error && error.cachedFailure === true)) {
@@ -7095,8 +7107,174 @@ class SharedCore {
             skippedSamples: [],
             learned: [],
             recovered: [],
-            prunedCount: 0
+            prunedCount: 0,
+            // Host-level bot-wall stats (see the "::hosts" section of the
+            // store) and statusless-transport-failure staging, all per-run:
+            successfulFetchCount: 0,
+            pendingNetworkFailures: [],
+            learnedHosts: [],
+            recoveredHosts: [],
+            hostSkippedCount: 0,
+            hostSkippedSamples: []
         };
+    }
+
+    // ------------------------------------------------------------------
+    // Host-level bot-wall stats. Run 20260815-083809: 11 of 13 crawl errors
+    // were eventim.us / wl.eventim.us ticket deep-links returning HTTP 403 —
+    // the platform blocks every non-browser fetch, and each week's events
+    // mint NEW deep-link URLs, so per-URL learning is permanently one run
+    // behind. The store therefore keeps a reserved "::hosts" section (the
+    // key can never collide with a URL entry — those always start with
+    // "http") mapping bare hostnames to { firstSeen, lastSeen, misses,
+    // lastStatus, successes, lastSuccess }:
+    //   - `misses` counts DISTINCT bot-walled (401/403) URLs on the host,
+    //   - `successes`/`lastSuccess` record that ANY page on the host ever
+    //     fetched successfully.
+    // A host is blocked only when it has at least two distinct bot-walled
+    // URLs AND zero recorded successes — fail-closed: one recorded success,
+    // ever, immunizes the host (a mixed host is not a bot wall; its dead
+    // pages are handled per-URL). Generic rule — no host is named in source.
+    // Blocking only applies to DISCOVERED crawl URLs: configured root URLs
+    // bypass every dead-end check, and events' ticketUrl fields are never
+    // touched (the link is for humans; we just stop crawling it).
+    // ------------------------------------------------------------------
+
+    getDeadEndHostsStoreKey() {
+        return '::hosts';
+    }
+
+    getDeadEndHostKey(url) {
+        const parsed = this.parseUrl(String(url || ''));
+        if (!parsed) return '';
+        return String(parsed.hostname || '').toLowerCase().replace(/^www\./, '');
+    }
+
+    getDeadEndHostStore(context, createIfMissing = false) {
+        if (!context || !context.store) return null;
+        const key = this.getDeadEndHostsStoreKey();
+        let hosts = context.store[key];
+        if (!hosts || typeof hosts !== 'object' || Array.isArray(hosts)) {
+            if (!createIfMissing) return null;
+            hosts = {};
+            context.store[key] = hosts;
+        }
+        return hosts;
+    }
+
+    // How many distinct bot-walled URLs a success-free host needs before it
+    // is blocked. Floored at 2 regardless of deadEndMinMisses: a SINGLE
+    // 403'd page can be page-level access control on an otherwise fine host.
+    getDeadEndHostMinMisses(context) {
+        const minMisses = Number.isFinite(Number(context && context.minMisses)) ? Number(context.minMisses) : 2;
+        return Math.max(2, minMisses);
+    }
+
+    isBlockedDeadEndHostEntry(context, entry) {
+        if (!entry) return false;
+        if (Number(entry.successes) > 0) return false; // fail-closed: any success, ever, immunizes
+        return (Number(entry.misses) || 0) >= this.getDeadEndHostMinMisses(context);
+    }
+
+    // The host entry that currently blocks this URL's host, or null. Young
+    // entries only — past the retry window the host gets retried once and
+    // either refreshes the block or self-heals via a recorded success.
+    getBlockedDeadEndHostEntry(context, url, nowMs = Date.now()) {
+        const hosts = this.getDeadEndHostStore(context);
+        if (!hosts) return null;
+        const hostKey = this.getDeadEndHostKey(url);
+        if (!hostKey) return null;
+        const entry = hosts[hostKey];
+        if (!entry || !this.isBlockedDeadEndHostEntry(context, entry)) return null;
+        const lastSeenMs = entry.lastSeen ? Date.parse(entry.lastSeen) : NaN;
+        const retryMs = context.retryDays * 24 * 60 * 60 * 1000;
+        if (!Number.isFinite(lastSeenMs) || (nowMs - lastSeenMs) >= retryMs) return null;
+        return entry;
+    }
+
+    // Record that a page on this host fetched successfully. Writes are rare
+    // by design so unchanged runs do not dirty the store: a new host is
+    // recorded once, a bot-walled host self-heals immediately, and an
+    // established entry only refreshes after a full retry window.
+    recordDeadEndHostSuccess(context, url, nowMs = Date.now()) {
+        const hostKey = this.getDeadEndHostKey(url);
+        if (!hostKey) return;
+        const nowIso = new Date(nowMs).toISOString();
+        const hosts = this.getDeadEndHostStore(context, true);
+        const entry = hosts[hostKey];
+        if (!entry) {
+            hosts[hostKey] = { firstSeen: nowIso, lastSeen: nowIso, successes: 1, lastSuccess: nowIso };
+            context.dirty = true;
+            return;
+        }
+        const hadBotWallMisses = (Number(entry.misses) || 0) > 0;
+        const lastSuccessMs = entry.lastSuccess ? Date.parse(entry.lastSuccess) : NaN;
+        const refreshMs = context.retryDays * 24 * 60 * 60 * 1000;
+        const refreshDue = !Number.isFinite(lastSuccessMs) || (nowMs - lastSuccessMs) > refreshMs;
+        if (!hadBotWallMisses && !refreshDue) return;
+        entry.successes = (Number(entry.successes) || 0) + 1;
+        entry.lastSuccess = nowIso;
+        entry.lastSeen = nowIso;
+        if (hadBotWallMisses) {
+            delete entry.misses;
+            delete entry.lastStatus;
+            if (!context.recoveredHosts.includes(hostKey)) {
+                context.recoveredHosts.push(hostKey);
+            }
+        }
+        context.dirty = true;
+    }
+
+    // ------------------------------------------------------------------
+    // URL entries are keyed by getUrlDedupeKey (www/tracking-param/case
+    // variants share ONE entry — the device store held www/bare twins of the
+    // same eventim page). Legacy stores keyed by raw normalized URLs still
+    // suppress via the exact-string fallback and migrate to the dedupe key
+    // the next time the URL is observed.
+    // ------------------------------------------------------------------
+
+    findDeadEndUrlEntry(context, url) {
+        const dedupeKey = this.getUrlDedupeKey(url) || String(url || '');
+        const store = context.store;
+        if (Object.prototype.hasOwnProperty.call(store, dedupeKey) && dedupeKey !== this.getDeadEndHostsStoreKey()) {
+            return { key: dedupeKey, dedupeKey, entry: store[dedupeKey] };
+        }
+        if (url && url !== dedupeKey && Object.prototype.hasOwnProperty.call(store, url)) {
+            return { key: url, dedupeKey, entry: store[url] };
+        }
+        return { key: dedupeKey, dedupeKey, entry: null };
+    }
+
+    // Shared write path for both HTTP-status failures and statusless network
+    // failures: bump-or-create the URL entry under the dedupe key (migrating
+    // a legacy raw-URL entry when present). statusCode null = inferred miss
+    // (no lastStatus stamped), which needs minMisses confirmations to
+    // suppress; a stamped 401/403/404/410 is origin-stated and one-strike.
+    recordDeadEndUrlMiss(context, url, statusCode, nowMs = Date.now()) {
+        const nowIso = new Date(nowMs).toISOString();
+        const found = this.findDeadEndUrlEntry(context, url);
+        const entry = found.entry;
+        if (entry) {
+            if (found.key !== found.dedupeKey) {
+                delete context.store[found.key];
+                context.store[found.dedupeKey] = entry;
+            }
+            entry.lastSeen = nowIso;
+            entry.misses = (Number(entry.misses) || 0) + 1;
+            if (statusCode !== null && statusCode !== undefined) {
+                entry.lastStatus = statusCode;
+            }
+            context.dirty = true;
+            return { entry, wasNew: false };
+        }
+        const created = { firstSeen: nowIso, lastSeen: nowIso, misses: 1 };
+        if (statusCode !== null && statusCode !== undefined) {
+            created.lastStatus = statusCode;
+        }
+        context.store[found.dedupeKey] = created;
+        context.dirty = true;
+        context.learned.push(found.dedupeKey);
+        return { entry: created, wasNew: true };
     }
 
     // Drop discovered URLs whose dead-end entry is younger than the retry
@@ -7123,13 +7301,20 @@ class SharedCore {
         const retryMs = context.retryDays * 24 * 60 * 60 * 1000;
         const allowed = [];
         for (const url of list) {
-            const entry = context.store[url];
+            const { entry } = this.findDeadEndUrlEntry(context, url);
             const lastSeenMs = entry && entry.lastSeen ? Date.parse(entry.lastSeen) : NaN;
             if (entry && this.isConfirmedDeadEndEntry(context, entry)
                 && Number.isFinite(lastSeenMs) && (nowMs - lastSeenMs) < retryMs) {
                 context.skippedCount += 1;
                 if (context.skippedSamples.length < 3 && !context.skippedSamples.includes(url)) {
                     context.skippedSamples.push(url);
+                }
+                continue;
+            }
+            if (this.getBlockedDeadEndHostEntry(context, url, nowMs)) {
+                context.hostSkippedCount += 1;
+                if (context.hostSkippedSamples.length < 3 && !context.hostSkippedSamples.includes(url)) {
+                    context.hostSkippedSamples.push(url);
                 }
                 continue;
             }
@@ -7150,7 +7335,7 @@ class SharedCore {
         if (!context || !context.enabled || discoveryOnly || !url) {
             return null;
         }
-        const entry = context.store[url];
+        const { entry } = this.findDeadEndUrlEntry(context, url);
         const lastSeenMs = entry && entry.lastSeen ? Date.parse(entry.lastSeen) : NaN;
         const retryMs = context.retryDays * 24 * 60 * 60 * 1000;
         if (entry && this.isConfirmedDeadEndEntry(context, entry)
@@ -7162,6 +7347,24 @@ class SharedCore {
             return entry;
         }
         return null;
+    }
+
+    // Processing-time twin for host-level blocks (bot-walled ticketing
+    // platforms): same guards as getSkippableDeadEndEntry — never in
+    // discovery mode, and the call site only runs it at currentDepth > 0 so
+    // configured root URLs are never suppressed.
+    getSkippableDeadEndHostEntry(url, discoveryOnly = false, nowMs = Date.now()) {
+        const context = this.deadEndRunContext;
+        if (!context || !context.enabled || discoveryOnly || !url) {
+            return null;
+        }
+        const entry = this.getBlockedDeadEndHostEntry(context, url, nowMs);
+        if (!entry) return null;
+        context.hostSkippedCount += 1;
+        if (context.hostSkippedSamples.length < 3 && !context.hostSkippedSamples.includes(url)) {
+            context.hostSkippedSamples.push(url);
+        }
+        return entry;
     }
 
     // Learned dead ends from FETCH FAILURES are limited to statuses that are
@@ -7181,18 +7384,53 @@ class SharedCore {
             // Configured root URLs are never dead-ended
             return;
         }
-        const nowIso = new Date(nowMs).toISOString();
-        const entry = context.store[url];
-        if (entry) {
-            entry.lastSeen = nowIso;
-            entry.misses = (Number(entry.misses) || 0) + 1;
-            entry.lastStatus = statusCode;
-            context.dirty = true;
-        } else {
-            context.store[url] = { firstSeen: nowIso, lastSeen: nowIso, misses: 1, lastStatus: statusCode };
-            context.dirty = true;
-            context.learned.push(url);
+        const { wasNew } = this.recordDeadEndUrlMiss(context, url, statusCode, nowMs);
+        // Bot-wall statuses additionally feed the host-level stats: a host
+        // whose pages ONLY ever 401/403 (and never once fetched) is a
+        // bot-walled platform, and new URLs on it are pre-lost. Distinct
+        // URLs only — a retried URL is one wall, not two.
+        if (statusCode === 401 || statusCode === 403) {
+            const hostKey = this.getDeadEndHostKey(url);
+            if (hostKey) {
+                const nowIso = new Date(nowMs).toISOString();
+                const hosts = this.getDeadEndHostStore(context, true);
+                let entry = hosts[hostKey];
+                const blockedBefore = this.isBlockedDeadEndHostEntry(context, entry);
+                if (!entry) {
+                    entry = { firstSeen: nowIso, lastSeen: nowIso };
+                    hosts[hostKey] = entry;
+                }
+                entry.lastSeen = nowIso;
+                entry.lastStatus = statusCode;
+                if (wasNew) {
+                    entry.misses = (Number(entry.misses) || 0) + 1;
+                }
+                context.dirty = true;
+                if (!blockedBefore && this.isBlockedDeadEndHostEntry(context, entry)
+                    && !context.learnedHosts.includes(hostKey)) {
+                    context.learnedHosts.push(hostKey);
+                }
+            }
         }
+    }
+
+    // Statusless transport failures (dead DNS, refused connections — e.g.
+    // iqosvape.com's "fetch failed" on every run of the 2026-08 corpus) are
+    // staged here and only committed by finalizeDeadEndRun when the run had
+    // at least one SUCCESSFUL fetch: with zero successes the network itself
+    // is the prime suspect, and an offline run must never poison the store.
+    // Committed entries carry no lastStatus, so they need minMisses
+    // confirmations (default 2, across runs) before they suppress anything.
+    recordDeadEndNetworkFailure({ url, currentDepth }) {
+        const context = this.deadEndRunContext;
+        if (!context || !context.enabled || !url) {
+            return;
+        }
+        if (currentDepth === 0) {
+            // Configured root URLs are never dead-ended
+            return;
+        }
+        context.pendingNetworkFailures.push(url);
     }
 
     // Record the outcome of a successfully-fetched page. Productive pages are
@@ -7206,6 +7444,13 @@ class SharedCore {
         if (!context || !context.enabled || !url) {
             return;
         }
+        // This method only runs for pages that FETCHED successfully — which
+        // is exactly the host-level success signal (any 2xx page, productive
+        // or not, proves the host is not a pure bot wall) and the proof the
+        // network works that finalizeDeadEndRun's statusless-failure commit
+        // gate requires.
+        context.successfulFetchCount += 1;
+        this.recordDeadEndHostSuccess(context, url, nowMs);
         // RAW pre-filter counts: a page whose events are all in the past still
         // produced events — it is NOT a dead end.
         const rawEventCount = Array.isArray(parseResult?.events) ? parseResult.events.length : 0;
@@ -7220,13 +7465,12 @@ class SharedCore {
         const productive = pageClassification !== 'ad'
             && (rawEventCount > 0 || segmentCount > 0 || uniqueValidLinkCount > 0);
 
-        const store = context.store;
-        const entry = store[url];
+        const found = this.findDeadEndUrlEntry(context, url);
         if (productive) {
-            if (entry) {
-                delete store[url];
+            if (found.entry) {
+                delete context.store[found.key];
                 context.dirty = true;
-                context.recovered.push(url);
+                context.recovered.push(found.key);
             }
             return;
         }
@@ -7234,16 +7478,7 @@ class SharedCore {
             // Configured root URLs are never dead-ended
             return;
         }
-        const nowIso = new Date(nowMs).toISOString();
-        if (entry) {
-            entry.lastSeen = nowIso;
-            entry.misses = (Number(entry.misses) || 0) + 1;
-            context.dirty = true;
-        } else {
-            store[url] = { firstSeen: nowIso, lastSeen: nowIso, misses: 1 };
-            context.dirty = true;
-            context.learned.push(url);
-        }
+        this.recordDeadEndUrlMiss(context, url, null, nowMs);
     }
 
     // End-of-run retention pass: entries unseen for 2× the retry window are
@@ -7254,12 +7489,30 @@ class SharedCore {
             return;
         }
         const horizonMs = 2 * context.retryDays * 24 * 60 * 60 * 1000;
+        const hostsKey = this.getDeadEndHostsStoreKey();
         for (const [url, entry] of Object.entries(context.store)) {
+            if (url === hostsKey) continue; // host stats pruned by their own lastSeen below
             const lastSeenMs = entry && entry.lastSeen ? Date.parse(entry.lastSeen) : NaN;
             if (!Number.isFinite(lastSeenMs) || (nowMs - lastSeenMs) > horizonMs) {
                 delete context.store[url];
                 context.prunedCount += 1;
                 context.dirty = true;
+            }
+        }
+        const hosts = this.getDeadEndHostStore(context);
+        if (hosts) {
+            let prunedHosts = 0;
+            for (const [hostKey, entry] of Object.entries(hosts)) {
+                const lastSeenMs = entry && entry.lastSeen ? Date.parse(entry.lastSeen) : NaN;
+                if (!Number.isFinite(lastSeenMs) || (nowMs - lastSeenMs) > horizonMs) {
+                    delete hosts[hostKey];
+                    prunedHosts += 1;
+                    context.prunedCount += 1;
+                    context.dirty = true;
+                }
+            }
+            if (prunedHosts > 0 && Object.keys(hosts).length === 0) {
+                delete context.store[hostsKey];
             }
         }
     }
@@ -7271,6 +7524,21 @@ class SharedCore {
             return;
         }
         if (context.enabled) {
+            // Commit staged statusless network failures — only when the run
+            // proved the network works (see recordDeadEndNetworkFailure).
+            if (context.pendingNetworkFailures.length > 0) {
+                if (context.successfulFetchCount > 0) {
+                    const committed = [];
+                    for (const url of context.pendingNetworkFailures) {
+                        const dedupeKey = this.getUrlDedupeKey(url) || String(url || '');
+                        if (committed.includes(dedupeKey)) continue; // one miss per URL per run
+                        committed.push(dedupeKey);
+                        this.recordDeadEndUrlMiss(context, url, null, nowMs);
+                    }
+                } else {
+                    await displayAdapter.logInfo(`SYSTEM: Not learning ${context.pendingNetworkFailures.length} network-failure URL(s) — this run had zero successful fetches, so the network itself is suspect`);
+                }
+            }
             this.pruneDeadEndStore(context, nowMs);
             if (context.skippedCount > 0) {
                 const samples = context.skippedSamples.length > 0 ? `: ${context.skippedSamples.join(', ')}` : '';
@@ -7281,6 +7549,16 @@ class SharedCore {
             }
             if (context.recovered.length > 0) {
                 await displayAdapter.logInfo(`SYSTEM: Removed ${context.recovered.length} recovered URL(s) from dead-end store: ${context.recovered.join(', ')}`);
+            }
+            if (context.hostSkippedCount > 0) {
+                const hostSamples = context.hostSkippedSamples.length > 0 ? `: ${context.hostSkippedSamples.join(', ')}` : '';
+                await displayAdapter.logInfo(`SYSTEM: Skipped ${context.hostSkippedCount} URL(s) on bot-walled host(s) (only 401/403 responses on record, zero successful fetches; retry after ${context.retryDays}d)${hostSamples}`);
+            }
+            if (context.learnedHosts.length > 0) {
+                await displayAdapter.logInfo(`SYSTEM: Learned ${context.learnedHosts.length} bot-walled host(s) — every crawl fetch got 401/403 and none ever succeeded, so new URLs on them will be skipped: ${context.learnedHosts.join(', ')}`);
+            }
+            if (context.recoveredHosts.length > 0) {
+                await displayAdapter.logInfo(`SYSTEM: Removed bot-wall flag from ${context.recoveredHosts.length} recovered host(s): ${context.recoveredHosts.join(', ')}`);
             }
             if (context.prunedCount > 0) {
                 await displayAdapter.logInfo(`SYSTEM: Pruned ${context.prunedCount} stale dead-end URL(s) (last seen more than ${2 * context.retryDays}d ago)`);

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -7836,7 +7836,8 @@ test('dead-end store: barren discovered pages are learned; productive, failed-fe
 
   const results = await core.processEvents(config, httpAdapter, display, parsers);
 
-  assert.deepEqual(Object.keys(results.deadEndStore), ['https://site.example/dead']);
+  // '::hosts' is the host-level bot-wall stats section, not a URL entry
+  assert.deepEqual(Object.keys(results.deadEndStore).filter(k => k !== '::hosts'), ['https://site.example/dead']);
   const entry = results.deadEndStore['https://site.example/dead'];
   assert.equal(entry.misses, 1);
   assert.ok(Date.parse(entry.firstSeen) > 0 && entry.firstSeen === entry.lastSeen);
@@ -7854,7 +7855,12 @@ test('dead-end store: young entries are skipped before enqueueing, with the rese
   // single unproductive observation no longer suppresses a URL on its own
   // (see the confirmation test below).
   const store = {
-    'https://site.example/dead': { firstSeen: youngLastSeen, lastSeen: youngLastSeen, misses: 2 }
+    'https://site.example/dead': { firstSeen: youngLastSeen, lastSeen: youngLastSeen, misses: 2 },
+    // Fresh host success stats for every host this run fetches, so the run
+    // writes nothing new and "skipping does not touch the store" stays exact.
+    '::hosts': {
+      'hub.example': { firstSeen: youngLastSeen, lastSeen: youngLastSeen, successes: 3, lastSuccess: youngLastSeen }
+    }
   };
   const pages = {
     'https://hub.example/': { additionalLinks: ['https://site.example/dead'] },
@@ -7893,7 +7899,7 @@ test('dead-end store: expired entries retry once — removed when productive, re
     const results = await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
 
     assert.ok(fetched.includes('https://site.example/revived'), 'expired entry is retried');
-    assert.deepEqual(results.deadEndStore, {}, 'productive page self-heals out of the store');
+    assert.ok(!('https://site.example/revived' in results.deadEndStore), 'productive page self-heals out of the store');
     assert.equal(results.deadEndStoreChanged, true);
   }
 
@@ -7933,7 +7939,7 @@ test('dead-end store: entries unseen for 2× the retry window are pruned at end 
 
   const results = await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
 
-  assert.deepEqual(Object.keys(results.deadEndStore), ['https://site.example/recent']);
+  assert.deepEqual(Object.keys(results.deadEndStore).filter(k => k !== '::hosts'), ['https://site.example/recent']);
   assert.equal(results.deadEndStoreChanged, true);
   assert.ok(display.logs.some(line => line.includes('Pruned 1 stale dead-end URL(s)')));
 });
@@ -8025,7 +8031,319 @@ test('dead-end store: maxAdditionalUrls 0 cannot fake a dead end when the parser
     parseResult: { events: [], additionalLinks: budgetedLinks },
     pageClassification: 'multi-event-page'
   });
-  assert.deepEqual(core.deadEndRunContext.store, {}, 'valid-but-budget-capped links keep the page productive');
+  assert.deepEqual(
+    Object.keys(core.deadEndRunContext.store).filter(k => k !== '::hosts'),
+    [],
+    'valid-but-budget-capped links keep the page productive'
+  );
+  core.deadEndRunContext = null;
+});
+
+// ---------------------------------------------------------------------------
+// Bot-walled hosts (run 20260815-083809: 11 of 13 crawl errors were
+// eventim.us / wl.eventim.us ticket deep-links returning HTTP 403 — the
+// platform blocks non-browser fetches on EVERY page, and each week's new
+// event IDs mint fresh URLs, so per-URL learning is always one run behind).
+// Generic rule, no host named in source: 401/403 crawl failures on a host
+// with ZERO recorded successful fetches host-block that host; ANY recorded
+// success immunizes it (fail-closed).
+// ---------------------------------------------------------------------------
+
+// Literal ticket deep-links from run 20260815-083809's crawl errors
+const EVENTIM_403_URL_1 = 'https://wl.eventim.us/event/CONFESSIONS-RENAISSANCE/700030?afflky=3DollarBill';
+const EVENTIM_403_URL_2 = 'https://wl.eventim.us/event/MICHAEL-JACKSON-DANCE-PARTY/700845?afflky=9BobNote';
+const EVENTIM_403_URL_3 = 'https://wl.eventim.us/event/OUT-and-ABT-August/700533?afflky=3DollarBill';
+
+function botWallFailure(url) {
+  return { fail: `HTTP request failed for ${url}: HTTP 403: ` };
+}
+
+test('dead-end store: a host whose crawl pages only ever 403 is host-blocked — new URLs on it are skipped next run', async () => {
+  // Run 1: two distinct eventim deep-links 403 → host learned
+  const core1 = deadEndCore();
+  const display1 = createDisplayAdapterStub();
+  const pages1 = {
+    'https://hub.example/': { additionalLinks: [EVENTIM_403_URL_1, EVENTIM_403_URL_2] },
+    [EVENTIM_403_URL_1]: botWallFailure(EVENTIM_403_URL_1),
+    [EVENTIM_403_URL_2]: botWallFailure(EVENTIM_403_URL_2)
+  };
+  const harness1 = createCrawlHarness(pages1);
+  const results1 = await core1.processEvents(deadEndConfig({}), harness1.httpAdapter, display1, harness1.parsers);
+
+  const key1 = core1.getUrlDedupeKey(EVENTIM_403_URL_1);
+  assert.equal(results1.deadEndStore[key1]?.lastStatus, 403, 'each 403 URL still gets its own one-strike entry');
+  const hosts1 = results1.deadEndStore['::hosts'];
+  assert.ok(hosts1 && typeof hosts1 === 'object', 'host stats section exists in the store');
+  const hostEntry = hosts1['wl.eventim.us'];
+  assert.ok(hostEntry, 'bot-walled host recorded');
+  assert.equal(hostEntry.misses, 2, 'two DISTINCT bot-walled URLs counted');
+  assert.equal(hostEntry.lastStatus, 403);
+  assert.ok(!(hostEntry.successes > 0), 'no successes ever recorded for the host');
+  assert.equal(results1.deadEndStoreChanged, true);
+
+  // Run 2: a brand-new event ID on the same host is never fetched
+  const core2 = deadEndCore();
+  const display2 = createDisplayAdapterStub();
+  const pages2 = {
+    'https://hub.example/': { additionalLinks: [EVENTIM_403_URL_3] },
+    [EVENTIM_403_URL_3]: botWallFailure(EVENTIM_403_URL_3)
+  };
+  const harness2 = createCrawlHarness(pages2);
+  const results2 = await core2.processEvents(
+    deadEndConfig({ store: results1.deadEndStore }), harness2.httpAdapter, display2, harness2.parsers
+  );
+
+  const key3 = core2.getUrlDedupeKey(EVENTIM_403_URL_3);
+  assert.ok(!(key3 in results2.deadEndStore), 'skipped URL was never fetched, so no per-URL entry was recorded');
+  assert.ok(
+    display2.logs.some(line => line.includes('bot-walled host') && line.includes(EVENTIM_403_URL_3)),
+    'host-block skip is logged with the URL'
+  );
+  assert.ok(results2.deadEndStore['::hosts']['wl.eventim.us'], 'host entry survives the second run');
+});
+
+test('dead-end store: fail-closed — a host with ANY recorded successful fetch is never host-blocked', async () => {
+  // Run 1: one page on the host fetches fine, two others 403
+  const goodUrl = 'https://wl.eventim.us/event/GOOD-BEAR-NIGHT/123456?afflky=3DollarBill';
+  const core1 = deadEndCore();
+  const display1 = createDisplayAdapterStub();
+  const pages1 = {
+    'https://hub.example/': { additionalLinks: [goodUrl, EVENTIM_403_URL_1, EVENTIM_403_URL_2] },
+    [goodUrl]: { additionalLinks: ['https://site.example/party'] },
+    'https://site.example/party': {},
+    [EVENTIM_403_URL_1]: botWallFailure(EVENTIM_403_URL_1),
+    [EVENTIM_403_URL_2]: botWallFailure(EVENTIM_403_URL_2)
+  };
+  const harness1 = createCrawlHarness(pages1);
+  const results1 = await core1.processEvents(deadEndConfig({}), harness1.httpAdapter, display1, harness1.parsers);
+
+  const hostEntry = results1.deadEndStore['::hosts']['wl.eventim.us'];
+  assert.ok(hostEntry.successes >= 1, 'the successful fetch is recorded on the host');
+
+  // Run 2: a new URL on the host is still fetched (it 403s and earns only a per-URL entry)
+  const core2 = deadEndCore();
+  const display2 = createDisplayAdapterStub();
+  const pages2 = {
+    'https://hub.example/': { additionalLinks: [EVENTIM_403_URL_3] },
+    [EVENTIM_403_URL_3]: botWallFailure(EVENTIM_403_URL_3)
+  };
+  const harness2 = createCrawlHarness(pages2);
+  const results2 = await core2.processEvents(
+    deadEndConfig({ store: results1.deadEndStore }), harness2.httpAdapter, display2, harness2.parsers
+  );
+
+  assert.ok(
+    !display2.logs.some(line => line.includes('Skipping URL on bot-walled host')),
+    'host with a prior success never host-blocks'
+  );
+  const key3 = core2.getUrlDedupeKey(EVENTIM_403_URL_3);
+  assert.equal(results2.deadEndStore[key3]?.lastStatus, 403, 'the URL was fetched and earned its own entry');
+});
+
+test('dead-end store: a single 403 URL never host-blocks its host', async () => {
+  const core1 = deadEndCore();
+  const display1 = createDisplayAdapterStub();
+  const pages1 = {
+    'https://hub.example/': { additionalLinks: [EVENTIM_403_URL_1] },
+    [EVENTIM_403_URL_1]: botWallFailure(EVENTIM_403_URL_1)
+  };
+  const harness1 = createCrawlHarness(pages1);
+  const results1 = await core1.processEvents(deadEndConfig({}), harness1.httpAdapter, display1, harness1.parsers);
+
+  const core2 = deadEndCore();
+  const display2 = createDisplayAdapterStub();
+  const pages2 = {
+    'https://hub.example/': { additionalLinks: [EVENTIM_403_URL_3] },
+    [EVENTIM_403_URL_3]: botWallFailure(EVENTIM_403_URL_3)
+  };
+  const harness2 = createCrawlHarness(pages2);
+  const results2 = await core2.processEvents(
+    deadEndConfig({ store: results1.deadEndStore }), harness2.httpAdapter, display2, harness2.parsers
+  );
+
+  assert.ok(
+    !display2.logs.some(line => line.includes('Skipping URL on bot-walled host')),
+    'one bot-walled URL is not enough to block a whole host'
+  );
+  const key3 = core2.getUrlDedupeKey(EVENTIM_403_URL_3);
+  assert.ok(key3 in results2.deadEndStore, 'the second URL was fetched normally');
+});
+
+test('dead-end store: a configured ROOT on a bot-walled host is still fetched, and its success recovers the host', async () => {
+  const nowIso = new Date().toISOString();
+  const store = {
+    '::hosts': {
+      'hub.example': { firstSeen: nowIso, lastSeen: nowIso, misses: 5, lastStatus: 403 }
+    }
+  };
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  const pages = {
+    'https://hub.example/': { additionalLinks: ['https://site.example/party'] },
+    'https://site.example/party': {}
+  };
+  const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
+  const results = await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
+
+  assert.ok(fetched.includes('https://hub.example/'), 'configured start URL is never suppressed');
+  const hostEntry = results.deadEndStore['::hosts']['hub.example'];
+  assert.ok(hostEntry.successes >= 1, 'success recorded');
+  assert.ok(!('misses' in hostEntry), 'bot-wall misses cleared by the successful fetch');
+  assert.ok(
+    display.logs.some(line => line.includes('recovered host') && line.includes('hub.example')),
+    'host recovery is logged'
+  );
+});
+
+test('dead-end store: events keep a ticketUrl that points at a bot-walled host — only the CRAWL is suppressed', async () => {
+  const nowIso = new Date().toISOString();
+  const store = {
+    '::hosts': {
+      'wl.eventim.us': { firstSeen: nowIso, lastSeen: nowIso, misses: 11, lastStatus: 403 }
+    }
+  };
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  const pages = {
+    'https://hub.example/': {
+      events: [{
+        title: 'Bear Ball',
+        startDate: new Date(Date.now() + 7 * 86400000),
+        city: 'dallas',
+        timezone: 'America/Chicago',
+        ticketUrl: EVENTIM_403_URL_3
+      }],
+      additionalLinks: [EVENTIM_403_URL_3]
+    },
+    [EVENTIM_403_URL_3]: botWallFailure(EVENTIM_403_URL_3)
+  };
+  const { httpAdapter, parsers } = createCrawlHarness(pages);
+  const results = await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
+
+  assert.ok(
+    display.logs.some(line => line.includes('bot-walled host') && line.includes(EVENTIM_403_URL_3)),
+    'the ticket deep-link is not crawled'
+  );
+  const parsedEvents = (results.parserResults || []).flatMap(p => p.events || []);
+  const event = parsedEvents.find(e => (e.title || '').includes('Bear Ball'));
+  assert.ok(event, 'the event itself survives');
+  assert.equal(event.ticketUrl, EVENTIM_403_URL_3, 'the human-facing ticket link is untouched');
+});
+
+// ---------------------------------------------------------------------------
+// Statusless transport failures (run 20260815-083809: dead iqosvape.com fails
+// "fetch failed" on every run — no HTTP status, so it was never learnable).
+// Two-strike like other inferred dead ends, and committed only when the run
+// had at least one successful fetch (an offline run must not poison the store).
+// ---------------------------------------------------------------------------
+
+const IQOS_URL = 'https://www.iqosvape.com/';
+const IQOS_FAILURE = { fail: `HTTP request failed for ${IQOS_URL}: fetch failed` };
+
+test('dead-end store: statusless fetch failures are learned two-strike and then skipped', async () => {
+  const pages = {
+    'https://hub.example/': { additionalLinks: [IQOS_URL] },
+    [IQOS_URL]: IQOS_FAILURE
+  };
+
+  // Run 1: first miss recorded, no status stamped
+  const core1 = deadEndCore();
+  const display1 = createDisplayAdapterStub();
+  const harness1 = createCrawlHarness(pages);
+  const results1 = await core1.processEvents(deadEndConfig({}), harness1.httpAdapter, display1, harness1.parsers);
+  const key = core1.getUrlDedupeKey(IQOS_URL);
+  assert.equal(results1.deadEndStore[key]?.misses, 1, 'first network failure recorded');
+  assert.ok(!('lastStatus' in results1.deadEndStore[key]), 'no HTTP status was invented');
+
+  // Run 2: retried (one miss is not proof), second miss confirms
+  const core2 = deadEndCore();
+  const display2 = createDisplayAdapterStub();
+  const harness2 = createCrawlHarness(pages);
+  const results2 = await core2.processEvents(
+    deadEndConfig({ store: results1.deadEndStore }), harness2.httpAdapter, display2, harness2.parsers
+  );
+  assert.equal(results2.deadEndStore[key]?.misses, 2, 'second run confirms the dead end');
+
+  // Run 3: suppressed
+  const core3 = deadEndCore();
+  const display3 = createDisplayAdapterStub();
+  const harness3 = createCrawlHarness(pages);
+  const results3 = await core3.processEvents(
+    deadEndConfig({ store: results2.deadEndStore }), harness3.httpAdapter, display3, harness3.parsers
+  );
+  assert.equal(results3.deadEndStore[key]?.misses, 2, 'no fetch attempt, so no third miss');
+  assert.ok(
+    display3.logs.some(line => line.includes('known dead-end URL') && line.includes(IQOS_URL)),
+    'third run skips the URL'
+  );
+});
+
+test('dead-end store: network failures are NOT learned when the run had zero successful fetches', async () => {
+  const core = deadEndCore();
+  const display = createDisplayAdapterStub();
+  core.deadEndRunContext = core.createDeadEndRunContext({ deadEndStore: {} });
+  core.recordDeadEndNetworkFailure({ url: IQOS_URL, currentDepth: 1 });
+  assert.equal(core.deadEndRunContext.successfulFetchCount, 0);
+  const results = {};
+  await core.finalizeDeadEndRun(display, results);
+  assert.deepEqual(Object.keys(results.deadEndStore), [], 'offline run learns nothing');
+  assert.equal(results.deadEndStoreChanged, false);
+
+  // Same failure with one successful fetch in the run → committed at finalize
+  const core2 = deadEndCore();
+  const display2 = createDisplayAdapterStub();
+  core2.deadEndRunContext = core2.createDeadEndRunContext({ deadEndStore: {} });
+  core2.deadEndRunContext.successfulFetchCount = 1;
+  core2.recordDeadEndNetworkFailure({ url: IQOS_URL, currentDepth: 1 });
+  const results2 = {};
+  await core2.finalizeDeadEndRun(display2, results2);
+  const key = core2.getUrlDedupeKey(IQOS_URL);
+  assert.equal(results2.deadEndStore[key]?.misses, 1, 'network is up, so the failure is trustworthy');
+});
+
+// ---------------------------------------------------------------------------
+// Store keying: entries live under the URL dedupe key (www/tracking-param/
+// case variants share ONE entry — the phone store held eventim www-variant
+// twins), and legacy raw-URL entries from existing dead-ends.json files still
+// suppress and migrate on their next observation.
+// ---------------------------------------------------------------------------
+
+test('dead-end store: URL variants share one entry via the dedupe key', () => {
+  const core = deadEndCore();
+  core.deadEndRunContext = core.createDeadEndRunContext({ deadEndStore: {} });
+  core.recordDeadEndFetchFailure({
+    url: 'https://www.tickets.example/Event/42?utm_source=promo&id=7',
+    currentDepth: 1,
+    statusCode: 403
+  });
+  core.recordDeadEndFetchFailure({
+    url: 'https://tickets.example/Event/42/?id=7',
+    currentDepth: 1,
+    statusCode: 403
+  });
+  const store = core.deadEndRunContext.store;
+  const urlKeys = Object.keys(store).filter(k => k !== '::hosts');
+  assert.equal(urlKeys.length, 1, 'variants did not mint separate entries');
+  assert.equal(store[urlKeys[0]].misses, 2, 'both observations landed on the same entry');
+  const skippable = core.getSkippableDeadEndEntry('https://tickets.example/EVENT/42?id=7&utm_source=later');
+  assert.ok(skippable, 'any variant of the URL is skippable');
+  core.deadEndRunContext = null;
+});
+
+test('dead-end store: legacy raw-URL entries still suppress and migrate to the dedupe key when re-observed', () => {
+  const nowIso = new Date().toISOString();
+  const legacyKey = 'https://legacy.example/Path/';
+  const core = deadEndCore();
+  core.deadEndRunContext = core.createDeadEndRunContext({
+    deadEndStore: { [legacyKey]: { firstSeen: nowIso, lastSeen: nowIso, misses: 3 } }
+  });
+  assert.ok(core.getSkippableDeadEndEntry(legacyKey), 'legacy entry still suppresses its URL');
+
+  core.recordDeadEndFetchFailure({ url: legacyKey, currentDepth: 1, statusCode: 404 });
+  const store = core.deadEndRunContext.store;
+  assert.ok(!(legacyKey in store), 'legacy key removed');
+  const migratedKey = core.getUrlDedupeKey(legacyKey);
+  assert.equal(store[migratedKey].misses, 4, 'entry migrated with its history intact');
   core.deadEndRunContext = null;
 });
 
@@ -8082,9 +8400,12 @@ test('crawl queue: a recorded dead end is skipped even when the queued string di
   await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
 
   assert.ok(!fetched.includes('https://site.example/gallery'), 'known dead end is not refetched');
+  // Dedupe-key store lookups now catch the mangled candidate at ENQUEUE time
+  // (both strings normalize to one key), so the skip shows up in the run
+  // summary; the processing-time check remains as the last line of defense.
   assert.ok(
-    display.logs.includes('SYSTEM: Skipping known dead-end URL (3 prior misses): https://site.example/gallery'),
-    `expected processing-time skip log, got: ${JSON.stringify(display.logs.filter(line => line.includes('dead-end')))}`
+    display.logs.some(line => line.includes('known dead-end URL') && line.includes('https://site.example/gallery')),
+    `expected a dead-end skip log, got: ${JSON.stringify(display.logs.filter(line => line.includes('dead-end')))}`
   );
 });
 
@@ -15841,10 +16162,12 @@ test('crawl queue: HTTP 410 pages are learned as dead ends and are NOT run error
 
   const results = await core.processEvents(deadEndConfig({ name: 'Gone Run' }), httpAdapter, display, parsers);
 
-  const entry = results.deadEndStore[goneUrl];
+  // Entries are keyed by the URL dedupe key (www stripped, lowercased)
+  const goneKey = core.getUrlDedupeKey(goneUrl);
+  const entry = results.deadEndStore[goneKey];
   assert.ok(entry, '410 Gone is the strongest never-retry signal — it must be learned');
   assert.equal(entry.lastStatus, 410);
-  assert.ok(display.logs.includes(`SYSTEM: Learned 1 new dead-end URL(s): ${goneUrl}`));
+  assert.ok(display.logs.includes(`SYSTEM: Learned 1 new dead-end URL(s): ${goneKey}`));
   // Severity split: 42 × 410 across 2026-08-02 produced a standing `errors: 7`
   // on runs where nothing was wrong, which is exactly the noise that hides a
   // real regression. Recorded and surfaced — just not as an error.
@@ -15870,9 +16193,11 @@ test('crawl queue: HTTP 404 pages are dead ends too, while 503 stays an ordinary
 
   const results = await core.processEvents(deadEndConfig({ name: 'Gone Run 404' }), httpAdapter, display, parsers);
 
-  assert.ok(results.deadEndStore[missingUrl], '404 is the ordinary shape of an expired event page');
-  assert.equal(results.deadEndStore[missingUrl].lastStatus, 404);
+  const missingKey = core.getUrlDedupeKey(missingUrl);
+  assert.ok(results.deadEndStore[missingKey], '404 is the ordinary shape of an expired event page');
+  assert.equal(results.deadEndStore[missingKey].lastStatus, 404);
   assert.ok(!(flakyUrl in results.deadEndStore), '503 is transient and must stay un-learned');
+  assert.ok(!(core.getUrlDedupeKey(flakyUrl) in results.deadEndStore), '503 is not learned under the dedupe key either');
   assert.equal(results.errors.length, 1, 'only the transient failure counts as an error');
   assert.ok(results.errors[0].includes(flakyUrl));
   assert.equal(results.permanentlyGone.length, 1);
@@ -16006,7 +16331,8 @@ test('dead-end store: one unproductive fetch is not enough — a second confirms
     const { fetched, httpAdapter, parsers } = createCrawlHarness(pages);
     const results = await core.processEvents(deadEndConfig({ store }), httpAdapter, display, parsers);
     assert.ok(fetched.includes(url), 'a single unproductive observation must not suppress a URL');
-    assert.equal(results.deadEndStore[url].misses, 2, 'the retry records the confirming miss');
+    // The retry migrates the legacy raw-URL entry to its dedupe key
+    assert.equal(results.deadEndStore[core.getUrlDedupeKey(url)].misses, 2, 'the retry records the confirming miss');
   }
 
   // Two prior misses → confirmed, suppressed for the retry window


### PR DESCRIPTION
## Symptom

Run `20260815-083809` (scheduled Mac run): 13 crawl-page errors — 11 eventim.us / wl.eventim.us ticket deep-links (`afflky=3DollarBill/9BobNote`) returning HTTP 403, the purple-carrot affiliate link (403), and dead iqosvape.com (`fetch failed`). Run `20260815-083109`, 7 minutes earlier, has the **byte-identical 13 errors** — these URLs/hosts error on every run, every time, despite the dead-end store existing to learn exactly this.

## Investigation (evidence)

**1. The Node adapter never persisted the store — primary cause.** `web-adapter.js` `loadDeadEnds`/`saveDeadEnds` were in-memory only, by design ("the Scriptable adapter is the durable home for dead-ends.json"). Both failing runs have `runContext: { environment: node, trigger: scheduled }` — scheduled Mac runs learned every 403 and discarded the store at process exit. The identical error lists 7 minutes apart are the proof of zero cross-run learning.

**2. Per-URL learning can never catch up with a bot-walled ticketing platform.** The phone's dead-ends.json already held 7 eventim entries (learned 2026-08-03, one-strike via `lastStatus`), but only 1 of the 11 URLs failing on 2026-08-15 was among them — the other 10 were event IDs minted since. eventim 403s every non-browser fetch, and each week's events mint fresh deep-links, so URL-level learning is permanently one run behind. (The phone store also held www/bare host-variant twins of the same eventim page — two entries for one page.)

**3. Statusless transport failures were structurally unlearnable.** iqosvape.com fails `fetch failed` (dead host, no HTTP status); the learning path only accepted 401/403/404/410, so it errored on every run forever.

**4. 403 classification itself was fine** — `recordDeadEndFetchFailure` already handled 401/403/404/410. Nothing wrong on the phone path; the phone runs from 2026-08-14 show zero eventim errors because its store suppresses what it learned.

## Fix

- **Node persistence**: `dead-ends.json` at the shared storage root when active (the SAME file the phone reads/writes — one store for both devices), else under the local state dir (`~/.chunky-dad-scraper`). Atomic writes via the existing dataless-file-safe helper; corrupt/missing file fails soft to empty. Browser runs keep the in-memory fallback.
- **Generic bot-walled-host rule** (no host named in source): ≥ 2 **distinct** 401/403 crawl URLs on a host with **zero recorded successful fetches** block the host for the retry window (30d), then retried once. Fail-closed: ANY successful fetch, ever, immunizes the host — success stats are persisted per host in the store's reserved `::hosts` section, so one prior success survives across runs. Takes effect mid-run: in the verification drive, run 1 fetched only 4 of the 11 eventim URLs before both hosts were learned and the rest skipped.
- **Statusless network failures**: staged during the run and committed at finalize **only if the run had ≥ 1 successful fetch** (an offline run must never poison the store); no `lastStatus` stamped, so they need the normal two-strike confirmation across runs before suppressing.
- **Dedupe-key store keying**: entries keyed by the existing `getUrlDedupeKey` (www/tracking-param/case/trailing-slash variants share one entry); legacy raw-URL entries in existing dead-ends.json files still suppress via exact-string fallback and migrate on their next observation.

**Scope guards** (unchanged semantics, now regression-tested): configured root URLs are never suppressed or recorded (a root on a blocked host is still fetched, and its success recovers the host); events keep `ticketUrl`s pointing at blocked hosts — only the CRAWL is suppressed; discoveryOnly fetches everything; `deadEndRetryDays ≤ 0` kill switch disables all of it. New log lines are additions only; no existing log string was edited; no `new URL`/`URLSearchParams`; shared-core stays platform-pure.

## Verification

- **11 new tests, all proven failing on base** (`pass 703 / fail 11` before the implementation, in the enumerated files `shared-core.test.js`, `web-adapter.test.js`): host-block after 2 distinct 403s using the literal run-20260815-083809 URLs; fail-closed prior-success immunity; single-403 never host-blocks; root-URL protection + host recovery; ticketUrl preservation; statusless two-strike; zero-success-run commit gate; dedupe-key variant folding; legacy entry migration; Node local-dir round-trip across adapter instances; shared-root round-trip at the phone's file location.
- **End-to-end drive** with the real 13 failing URLs through the orchestrator's exact load/save wiring and the real `WebAdapter` persistence: run 1 learns (5 URL entries + 2 blocked hosts persisted to dead-ends.json), run 2 attempts **zero** eventim/purple-carrot fetches, iqosvape confirms on its second strike.
- **Full quiet suite green: 1903/1903** (`NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test`). Pre-existing dead-end assertions were updated only where the store legitimately gained the `::hosts` section or keys moved to dedupe keys; their original semantics (skip-not-dirty, self-heal, prune, one-strike-vs-two-strike) are asserted unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP