### PR TITLE
feat(scraper): festival-aware multi-day handling — curated umbrellas withheld, sub-events inherit context

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -3403,6 +3403,58 @@ class ScriptableAdapter {
     };
   }
 
+  // Curated festival dataset: data/festivals.json served from chunky.dad is
+  // the phone's source (there is no local scraper-festivals module — the
+  // repo file is the Node-side source). Same fetch helper and 1-day TTL
+  // cache as bars/promoters; any failure — offline, 404, unparseable —
+  // quietly keeps the injected local list. Union by key so an injected
+  // local-only entry survives until the site serves it, remote wins for a
+  // shared key. Returns { festivals, counts } for the freshness log line.
+  async refreshRemoteFestivals(localFestivals) {
+    const local = Array.isArray(localFestivals) ? localFestivals : [];
+    const festivalsCacheConfig = {
+      enabled: this.getPageCacheConfig().enabled,
+      ttlDays: 1,
+    };
+    const remoteRaw = await this.fetchRemoteBarsJson(
+      "https://chunky.dad/data/festivals.json",
+      festivalsCacheConfig,
+    );
+    const remote =
+      remoteRaw && Array.isArray(remoteRaw.festivals)
+        ? remoteRaw.festivals
+        : Array.isArray(remoteRaw)
+          ? remoteRaw
+          : null;
+    if (!remote) {
+      console.log(
+        `📱 Scriptable: Festivals data — 0 from chunky.dad, ${local.length} local-only`,
+      );
+      return { festivals: local, counts: { remote: 0, localOnly: local.length } };
+    }
+    const festivalIdentityKey = (entry) =>
+      String((entry && (entry.key || entry.name)) || "")
+        .trim()
+        .toLowerCase();
+    const seen = new Set(remote.map(festivalIdentityKey).filter(Boolean));
+    const merged = remote.slice();
+    let localOnly = 0;
+    for (const entry of local) {
+      const key = festivalIdentityKey(entry);
+      if (key && seen.has(key)) continue;
+      merged.push(entry);
+      localOnly += 1;
+      if (key) seen.add(key);
+    }
+    console.log(
+      `📱 Scriptable: Festivals data — ${remote.length} from chunky.dad, ${localOnly} local-only`,
+    );
+    return {
+      festivals: merged,
+      counts: { remote: remote.length, localOnly },
+    };
+  }
+
   // Get existing events for a specific event (called by shared-core)
   async getExistingEvents(event) {
     try {
@@ -5683,6 +5735,7 @@ class ScriptableAdapter {
       conflict: [],
       missing_calendar: [],
       series_match: [],
+      festival_match: [],
       other: [],
     };
 
@@ -5710,6 +5763,14 @@ class ScriptableAdapter {
     if (eventsByAction.series_match.length > 0) {
       console.log(
         `   🔁 Series match: ${eventsByAction.series_match.length} events (already saved — withheld)`,
+      );
+    }
+    // Additive bucket, same rule (line only when non-zero): scraped records
+    // matching a curated festival — the curated dataset renders these, so
+    // they are withheld, never counted toward ➕ New.
+    if (eventsByAction.festival_match.length > 0) {
+      console.log(
+        `   🎪 Festival match: ${eventsByAction.festival_match.length} events (curated festival — withheld)`,
       );
     }
     if (eventsByAction.other.length > 0) {
@@ -15574,6 +15635,16 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
         reason: "🔁 already saved — matches this series",
       };
     }
+    // Curated-festival umbrella (shared-core _festivalMatch): the curated
+    // dataset renders the festival on the site, so the write is withheld —
+    // the chip names the matched festival, mirroring the series-match
+    // labeling seam.
+    if (event._festivalMatch) {
+      return {
+        section: "withheld",
+        reason: `🎪 ${event._festivalMatch.reason || "matches curated festival"}`,
+      };
+    }
     if (
       // _mergeNoOp is the write path's own no-op stamp (shared-core: final
       // payload field-identical to the calendar record, notes projection
@@ -15626,6 +15697,9 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     // filterEventsForExecution gate (CTA link text is not an event name) —
     // the card must say so instead of promising a CREATE that never runs.
     if (SharedCore.hasJunkTitleSanityFlag(event)) return "withheld";
+    // A curated-festival umbrella is withheld by the same gate — the curated
+    // dataset renders the festival, the scraper contributes parties only.
+    if (SharedCore.isCuratedFestivalUmbrella(event)) return "withheld";
     // A merge stamped _mergeNoOp is skipped by the same
     // filterEventsForExecution gate — the card must not promise an UPDATE
     // that never runs.
@@ -15794,6 +15868,7 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     if (normalized === "conflict") return "CONFLICT";
     if (normalized === "missing_calendar") return "MISSING_CALENDAR";
     if (normalized === "series_match") return "SERIES MATCH";
+    if (normalized === "festival_match") return "FESTIVAL MATCH";
     return "OTHER";
   }
 
@@ -15814,6 +15889,10 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
     // Display/summary intent only; normalizeMetricsIntentAction keeps the
     // base derivation so the metrics schema and its buckets are untouched.
     if (action && event && event._seriesMatch) return "series_match";
+    // Same honest-terminal-state rule for a curated-festival umbrella:
+    // nothing will be written (the curated dataset renders the festival), so
+    // counting it as NEW would re-offer the umbrella every run.
+    if (action && event && event._festivalMatch) return "festival_match";
     return action;
   }
 

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -10615,3 +10615,104 @@ test('saveRun persists results.icsExports into the run JSON (and omits the key w
   const emptyPayload = JSON.parse(writes[0].content);
   assert.ok(!('icsExports' in emptyPayload), 'no ledger key on runs that exported nothing');
 });
+
+// ---------------------------------------------------------------------------
+// Curated festival dataset — refreshRemoteFestivals fetches the published
+// data/festivals.json with the same helper and 1-day TTL as bars/promoters;
+// the results UI labels _festivalMatch records via the existing chip/bucket
+// mechanisms.
+// ---------------------------------------------------------------------------
+
+const REMOTE_FESTIVALS_URL = 'https://chunky.dad/data/festivals.json';
+
+function buildRemoteFestivalsAdapter(remotePayload) {
+  const adapter = buildAdapter();
+  adapter.getPageCacheConfig = () => ({ enabled: true, ttlDays: 3 });
+  adapter.cacheReads = [];
+  adapter.cacheWrites = [];
+  adapter.fetches = [];
+  adapter.readCachedPage = async (url, config) => {
+    adapter.cacheReads.push({ url, config });
+    return null;
+  };
+  adapter.writeCachedPage = async (url, responseData, config) => {
+    adapter.cacheWrites.push({ url, config });
+  };
+  adapter.fetchData = async (url, options) => {
+    adapter.fetches.push({ url, options });
+    if (remotePayload === undefined) {
+      throw new Error(`HTTP 404 error from ${url}`);
+    }
+    return {
+      html: typeof remotePayload === 'string' ? remotePayload : JSON.stringify(remotePayload),
+      url,
+      statusCode: 200,
+      headers: {}
+    };
+  };
+  return adapter;
+}
+
+test('refreshRemoteFestivals fetches the published dataset and unions by key (remote wins)', async () => {
+  const local = [
+    { key: 'beefdip-bear-week', name: 'BeefDip STALE' },
+    { key: 'local-only-fest', name: 'Local Only Fest' }
+  ];
+  const adapter = buildRemoteFestivalsAdapter({
+    festivals: [
+      { key: 'beefdip-bear-week', name: 'BeefDip Bear Week', cityKey: 'pv' },
+      { key: 'spooky-bear', name: 'Spooky Bear', cityKey: 'ptown' }
+    ]
+  });
+
+  const result = await adapter.refreshRemoteFestivals(local);
+
+  assert.equal(adapter.fetches.length, 1);
+  assert.equal(adapter.fetches[0].url, REMOTE_FESTIVALS_URL);
+  assert.deepEqual(result.festivals.map((entry) => entry.key),
+    ['beefdip-bear-week', 'spooky-bear', 'local-only-fest'],
+    'remote entries lead; the local-only festival survives the refresh');
+  assert.equal(result.festivals[0].name, 'BeefDip Bear Week', 'remote wins for a shared key');
+  assert.deepEqual(result.counts, { remote: 2, localOnly: 1 });
+});
+
+test('refreshRemoteFestivals caches with a 1-day TTL and keeps local on any failure', async () => {
+  const adapter = buildRemoteFestivalsAdapter({ festivals: [{ key: 'spooky-bear', name: 'Spooky Bear' }] });
+  await adapter.refreshRemoteFestivals([]);
+  assert.equal(adapter.cacheReads[0].config.ttlDays, 1, 'festivals cache reads use the 1-day TTL');
+  assert.equal(adapter.cacheWrites[0].config.ttlDays, 1, 'festivals cache writes use the 1-day TTL');
+
+  const local = [{ key: 'beefdip-bear-week', name: 'BeefDip Bear Week' }];
+  const failed = await buildRemoteFestivalsAdapter(undefined).refreshRemoteFestivals(local);
+  assert.deepEqual(failed.festivals, local, '404/offline keeps the injected list');
+  assert.deepEqual(failed.counts, { remote: 0, localOnly: 1 });
+
+  const invalid = await buildRemoteFestivalsAdapter('not json at all').refreshRemoteFestivals(local);
+  assert.deepEqual(invalid.festivals, local, 'invalid JSON keeps the injected list');
+
+  const wrongShape = await buildRemoteFestivalsAdapter({ object: 'not festivals' }).refreshRemoteFestivals(local);
+  assert.deepEqual(wrongShape.festivals, local, 'a payload without a festivals array never becomes data');
+});
+
+test('results UI: a _festivalMatch record lands in the withheld pile with the festival chip and bucket', () => {
+  const adapter = buildAdapter();
+  const umbrella = {
+    title: 'BeefDip Bear Week',
+    _action: 'new',
+    _festivalMatch: {
+      key: 'beefdip-bear-week',
+      name: 'BeefDip Bear Week',
+      reason: 'matches curated festival: BeefDip Bear Week'
+    }
+  };
+
+  assert.deepEqual(adapter.classifyEventForResultsSection(umbrella), {
+    section: 'withheld',
+    reason: '🎪 matches curated festival: BeefDip Bear Week'
+  });
+  assert.equal(adapter.normalizeIntentAction(umbrella), 'festival_match',
+    'the umbrella is never counted toward New');
+  assert.equal(adapter.formatIntentActionLabel('festival_match'), 'FESTIVAL MATCH');
+  assert.equal(adapter.getWriteActionFromEvent(umbrella), 'withheld',
+    'the card never promises a CREATE the gate withholds');
+});

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -277,6 +277,17 @@ class WebAdapter {
         };
     }
 
+    // Same honest pass-through for the curated festival dataset: on Node the
+    // repo checkout IS the source chunky.dad deploys data/festivals.json
+    // from, so the local list is already current.
+    async refreshRemoteFestivals(localFestivals) {
+        const festivals = Array.isArray(localFestivals) ? localFestivals : [];
+        return {
+            festivals,
+            counts: { remote: 0, localOnly: festivals.length }
+        };
+    }
+
     getPageCacheConfig() {
         const pageCache = this.config.pageCache || {};
         const ttlDays = Number(pageCache.ttlDays);
@@ -1126,6 +1137,23 @@ async saveFailureNote(url, error, metadata = {}) {
                 } else {
                     config.promoters = [];
                 }
+
+                // Curated festival dataset ships as pure JSON (data/festivals.json,
+                // the same file chunky.dad serves) — no generated module needed.
+                // Fail-soft: a missing/unparseable file means no festival
+                // awareness, never a failed run.
+                const festivalsPath = require('path').join(__dirname, '..', '..', 'data', 'festivals.json');
+                config.festivals = [];
+                if (require('fs').existsSync(festivalsPath)) {
+                    try {
+                        const festivalsRaw = JSON.parse(require('fs').readFileSync(festivalsPath, 'utf8'));
+                        if (festivalsRaw && Array.isArray(festivalsRaw.festivals)) {
+                            config.festivals = festivalsRaw.festivals;
+                        }
+                    } catch (e) {
+                        config.festivals = [];
+                    }
+                }
             } else {
                 // Browser environment - use pre-loaded globals if available (loaded via script tags),
                 // otherwise fall back to fetching (only works when page is served from scripts/ directory)
@@ -1209,8 +1237,24 @@ async saveFailureNote(url, error, metadata = {}) {
                         config.promoters = [];
                     }
                 }
+
+                // Curated festival dataset (browser): fetched relative to the
+                // scripts/ directory the page is served from. Fail-soft like
+                // bars/promoters — no festivals means no festival awareness.
+                config.festivals = [];
+                try {
+                    const festivalsResponse = await fetch('../data/festivals.json');
+                    if (festivalsResponse.ok) {
+                        const festivalsRaw = await festivalsResponse.json();
+                        if (festivalsRaw && Array.isArray(festivalsRaw.festivals)) {
+                            config.festivals = festivalsRaw.festivals;
+                        }
+                    }
+                } catch (e) {
+                    config.festivals = [];
+                }
             }
-            
+
             // Validate configuration structure
             if (!config.parsers || !Array.isArray(config.parsers)) {
                 throw new Error('Configuration missing parsers array');

--- a/scripts/adapters/web-adapter.test.js
+++ b/scripts/adapters/web-adapter.test.js
@@ -765,3 +765,29 @@ test('bear verdict store: web adapter round-trips bear-verdicts.json under its l
     fs.rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Curated festival dataset (data/festivals.json) — injected like bars and
+// promoters; on Node the repo checkout IS the deploy source.
+// ---------------------------------------------------------------------------
+
+test('loadConfiguration (Node) injects config.festivals from data/festivals.json', async () => {
+  const adapter = new WebAdapter();
+  const config = await adapter.loadConfiguration();
+  assert.ok(Array.isArray(config.festivals), 'festivals is an array');
+  assert.ok(config.festivals.length > 0, 'the curated dataset is non-empty');
+  const beefdip = config.festivals.find((entry) => entry.key === 'beefdip-bear-week');
+  assert.ok(beefdip, 'the curated BeefDip entry rides along');
+  assert.equal(beefdip.cityKey, 'pv');
+  assert.ok(beefdip.nextDates && beefdip.nextDates.start, 'nextDates survive the load');
+});
+
+test('refreshRemoteFestivals (Node) is an honest pass-through of the repo dataset', async () => {
+  const adapter = new WebAdapter();
+  const local = [{ key: 'beefdip-bear-week', name: 'BeefDip Bear Week' }];
+  const result = await adapter.refreshRemoteFestivals(local);
+  assert.deepEqual(result.festivals, local, 'the repo checkout is already current — no network');
+  assert.deepEqual(result.counts, { remote: 0, localOnly: 1 });
+  const empty = await adapter.refreshRemoteFestivals(null);
+  assert.deepEqual(empty.festivals, [], 'a missing list normalizes to an empty array');
+});

--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -221,6 +221,7 @@ class BearEventScraperOrchestrator {
 
             const bars = config.bars || {};
             const promoters = config.promoters || [];
+            const festivals = Array.isArray(config.festivals) ? config.festivals : [];
 
             // Create the normalizer pipeline first
             const normalizerPipeline = new this.modules.NormalizerPipeline();
@@ -232,7 +233,8 @@ class BearEventScraperOrchestrator {
                 additionalExcludedFields: this.modules.adapter.NOTES_EXCLUDED_FIELDS,
                 pageClassificationRules: config.config?.pageClassificationRules || [],
                 bars,
-                promoters
+                promoters,
+                festivals
             });
             
             // Wire the core back into the pipeline
@@ -294,6 +296,23 @@ class BearEventScraperOrchestrator {
                     }
                 } catch (error) {
                     console.log(`🐻 Orchestrator: Promoter data refresh failed (${error.message}) — continuing with local promoters`);
+                }
+            }
+
+            // Curated festival dataset: same freshness story as bars and
+            // promoters — data/festivals.json is served from chunky.dad, the
+            // phone refreshes it with the same 1-day-TTL cached fetch, and on
+            // Node the repo checkout IS the deploy source (honest
+            // pass-through). Fail-soft: any error keeps the injected local
+            // list, and adapters without the method are tolerated.
+            if (typeof finalAdapter.refreshRemoteFestivals === 'function') {
+                try {
+                    const refreshed = await finalAdapter.refreshRemoteFestivals(festivals);
+                    if (refreshed && Array.isArray(refreshed.festivals)) {
+                        sharedCore.festivals = refreshed.festivals;
+                    }
+                } catch (error) {
+                    console.log(`🐻 Orchestrator: Festival data refresh failed (${error.message}) — continuing with local festivals`);
                 }
             }
 

--- a/scripts/bear-event-scraper-unified.test.js
+++ b/scripts/bear-event-scraper-unified.test.js
@@ -29,8 +29,8 @@ function buildConfig(overrides = {}) {
 // so recorded calls live in a closure shared by all instances. refreshBars
 // (optional) becomes the adapter's refreshRemoteBars implementation — omit it
 // to model an adapter without the method (web-adapter-shaped tolerance).
-function createStubAdapter({ config, executeError = null, omitExecute = false, refreshBars = null, refreshPromoters = null } = {}) {
-  const calls = { executeCalendarActions: [], displayResults: [], showError: [], refreshRemoteBars: [], refreshRemotePromoters: [] };
+function createStubAdapter({ config, executeError = null, omitExecute = false, refreshBars = null, refreshPromoters = null, refreshFestivals = null } = {}) {
+  const calls = { executeCalendarActions: [], displayResults: [], showError: [], refreshRemoteBars: [], refreshRemotePromoters: [], refreshRemoteFestivals: [] };
 
   class StubAdapter {
     constructor(options = {}) {
@@ -69,6 +69,13 @@ function createStubAdapter({ config, executeError = null, omitExecute = false, r
     };
   }
 
+  if (refreshFestivals) {
+    StubAdapter.prototype.refreshRemoteFestivals = async function refreshRemoteFestivals(localFestivals) {
+      calls.refreshRemoteFestivals.push({ localFestivals });
+      return refreshFestivals(localFestivals);
+    };
+  }
+
   return { StubAdapter, calls };
 }
 
@@ -89,6 +96,7 @@ function createSharedCoreStub(events, coreOptionsLog = null) {
       if (coreOptionsLog && coreOptionsLog.length > 0) {
         coreOptionsLog[coreOptionsLog.length - 1].barsAtProcessEvents = this.bars;
         coreOptionsLog[coreOptionsLog.length - 1].promotersAtProcessEvents = this.promoters;
+        coreOptionsLog[coreOptionsLog.length - 1].festivalsAtProcessEvents = this.festivals;
       }
       return {
         totalEvents: events.length,
@@ -373,4 +381,66 @@ test('wireConsoleTees survives a module whose helper throws', () => {
 
   assert.deepEqual(wired, ['ok'], 'later modules still get wired');
   assert.equal(restores.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Curated festival dataset wiring — config.festivals reaches the SharedCore
+// constructor, refreshRemoteFestivals refreshes it fail-soft, and adapters
+// without the method are tolerated.
+// ---------------------------------------------------------------------------
+
+test('run() wires config.festivals into SharedCore and applies the remote refresh', async () => {
+  const localFestivals = [{ key: 'beefdip-bear-week', name: 'BeefDip STALE' }];
+  const remoteFestivals = [
+    { key: 'beefdip-bear-week', name: 'BeefDip Bear Week', cityKey: 'pv' },
+    { key: 'spooky-bear', name: 'Spooky Bear', cityKey: 'ptown' }
+  ];
+  const config = buildConfig({ config: { dryRun: true } });
+  config.festivals = localFestivals;
+  const coreOptionsLog = [];
+  const { orch, calls } = createOrchestrator({
+    config,
+    events: buildEvents(),
+    coreOptionsLog,
+    adapterOptions: {
+      refreshFestivals: async () => ({ festivals: remoteFestivals, counts: { remote: 2, localOnly: 0 } })
+    }
+  });
+
+  await orch.run();
+
+  assert.deepEqual(coreOptionsLog[0].festivals, localFestivals,
+    'config.festivals reaches the SharedCore constructor');
+  assert.equal(calls.refreshRemoteFestivals.length, 1, 'exactly one festivals refresh per run');
+  assert.deepEqual(calls.refreshRemoteFestivals[0].localFestivals, localFestivals,
+    'the injected local list is offered as the fallback');
+  assert.deepEqual(coreOptionsLog[0].festivalsAtProcessEvents, remoteFestivals,
+    'the refreshed dataset is what festival matching actually sees');
+});
+
+test('run() tolerates an adapter without refreshRemoteFestivals and a failing refresh keeps local festivals', async () => {
+  const localFestivals = [{ key: 'spooky-bear', name: 'Spooky Bear' }];
+
+  const config = buildConfig({ config: { dryRun: true } });
+  config.festivals = localFestivals;
+  const coreOptionsLog = [];
+  const { orch } = createOrchestrator({ config, events: buildEvents(), coreOptionsLog });
+  await orch.run();
+  assert.deepEqual(coreOptionsLog[0].festivalsAtProcessEvents, localFestivals,
+    'no refresh method → the injected list flows through unchanged');
+
+  const failingConfig = buildConfig({ config: { dryRun: true } });
+  failingConfig.festivals = localFestivals;
+  const failingLog = [];
+  const { orch: failingOrch } = createOrchestrator({
+    config: failingConfig,
+    events: buildEvents(),
+    coreOptionsLog: failingLog,
+    adapterOptions: {
+      refreshFestivals: async () => { throw new Error('offline'); }
+    }
+  });
+  await failingOrch.run();
+  assert.deepEqual(failingLog[0].festivalsAtProcessEvents, localFestivals,
+    'a failing refresh is fail-soft — local festivals stand');
 });

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -391,6 +391,15 @@ class SharedCore {
         // computeBearCheckDecision) so an owner tap survives runs where the
         // event was never written to the calendar.
         this.bearVerdicts = Array.isArray(options.bearVerdicts) ? options.bearVerdicts : [];
+        // Curated festival dataset (data/festivals.json via the adapters —
+        // injected like bars/promoters; shared-core never loads files itself).
+        // The curated dataset is the authority on festivals: the scraper
+        // contributes parties, never umbrellas (see findCuratedFestivalMatch).
+        // Entries: { key, name, category, cityKey?, website?, nextDates? }.
+        this.festivals = Array.isArray(options.festivals) ? options.festivals : [];
+        // One drift report per festival key per prepareEventsForCalendar pass
+        // (report-only — the scraper NEVER writes festivals.json).
+        this.festivalDriftLogged = new Set();
         this.notesExcludedFields = new Set([
             ...this.eventSchema.DEFAULT_NOTES_EXCLUDED_FIELDS,
             ...(options.additionalExcludedFields || [])
@@ -12566,6 +12575,12 @@ class SharedCore {
             // SAVED series already covers (#1655 series-match): writing it
             // would plant a duplicate single next to his imported series.
             !SharedCore.isSeriesCoveredOccurrence(event) &&
+            // A curated-festival UMBRELLA (identity matches data/festivals.json):
+            // the curated dataset already renders the festival on the site, so
+            // the scraper contributes parties, never umbrellas. Writing it would
+            // also suppress the website's curated banner via its name-collision
+            // guard.
+            !SharedCore.isCuratedFestivalUmbrella(event) &&
             !SharedCore.hasJunkTitleSanityFlag(event));
     }
 
@@ -12611,6 +12626,8 @@ class SharedCore {
             '_evidenceLines',
             '_sanityFlags',
             '_original',
+            '_festivalMatch',
+            '_festivalContext',
             '_pastSpanWithheld',
             '_mergeNoOp',
             '_duplicateOfKept',
@@ -12643,6 +12660,7 @@ class SharedCore {
         if (event._pastSpanWithheld === true) return 'WITHHELD (span fully past)';
         if (SharedCore.isRecurringSeriesEvent(event)) return 'WITHHELD (recurring series — ICS export only)';
         if (SharedCore.isSeriesCoveredOccurrence(event)) return 'WITHHELD (occurrence covered by saved series — SERIES MATCH)';
+        if (SharedCore.isCuratedFestivalUmbrella(event)) return 'WITHHELD (matches curated festival — curated dataset renders it)';
         if (SharedCore.hasJunkTitleSanityFlag(event)) return 'WITHHELD (junk title)';
         if (event._mergeNoOp === true) return 'SKIPPED (merge no-op — no field changes)';
         const action = typeof event._action === 'string' && event._action ? event._action : 'new';
@@ -12765,6 +12783,221 @@ class SharedCore {
     // never disagree.
     static isSeriesCoveredOccurrence(event) {
         return SharedCore.isOccurrenceExpandedEvent(event) && Boolean(event._seriesMatch);
+    }
+
+    // =========================================================================
+    // CURATED FESTIVAL AWARENESS (data/festivals.json, injected via adapters)
+    //
+    // Doctrine: the curated festival dataset is the authority; the scraper
+    // contributes parties, never umbrellas. A scraped record whose IDENTITY
+    // matches a curated festival (name-family + city agreement + date overlap
+    // with nextDates ±7d) is a FESTIVAL UMBRELLA: the write is withheld — the
+    // curated dataset already renders the festival on the site (the website's
+    // mergeFestivalEvents injection), so writing the scraped copy would both
+    // duplicate it and suppress the curated banner via the site's
+    // name-collision guard. Sub-events from a festival's own site inherit
+    // BLANK city/timezone from the curated entry and get the festival window
+    // as a report-only sanity boundary (catches year-split extractions).
+    // Fail closed everywhere: no nextDates, no date overlap, or a clashing
+    // explicit city → not a match; nothing here is hardcoded per festival.
+    // =========================================================================
+
+    // ±7 days: curated nextDates are next-edition dates; scraped pages carry
+    // pre/post parties and off-by-one range endpoints, never whole seasons.
+    getFestivalWindowGraceMillis() {
+        return 7 * 24 * 60 * 60 * 1000;
+    }
+
+    // nextDates {start, end} (date-only ISO) → epoch-millis window with the
+    // END DAY INCLUSIVE ("end": "2027-01-31" covers all of Jan 31). Null when
+    // absent or unparseable — the fail-closed "never matches" signal.
+    getCuratedFestivalWindowMillis(festival) {
+        const nextDates = festival && festival.nextDates;
+        const startMs = this.toEpochMillis(nextDates && nextDates.start);
+        const endMs = this.toEpochMillis(nextDates && nextDates.end);
+        if (startMs === null || endMs === null || endMs < startMs) return null;
+        return { startMs, endMs: endMs + (24 * 60 * 60 * 1000) };
+    }
+
+    // City agreement: an UNKNOWN/blank event city agrees with anything (the
+    // whole point is rescuing city-less festival records); a festival without
+    // a cityKey constrains nothing. An explicit clash fails closed.
+    festivalCityAgrees(event, festival) {
+        const eventCity = String((event && event.city) || '').trim().toLowerCase();
+        if (!eventCity || eventCity === 'unknown') return true;
+        const festivalCity = String((festival && festival.cityKey) || '').trim().toLowerCase();
+        if (!festivalCity) return true;
+        return eventCity === festivalCity;
+    }
+
+    // Date overlap between the event's [start, end] and the curated window
+    // widened by the grace margin. Missing event dates fail closed.
+    eventOverlapsFestivalWindow(event, festival) {
+        const window = this.getCuratedFestivalWindowMillis(festival);
+        if (!window) return false;
+        const startMs = this.toEpochMillis(event && event.startDate);
+        if (startMs === null) return false;
+        const endMsRaw = this.toEpochMillis(event && event.endDate);
+        const endMs = endMsRaw === null ? startMs : Math.max(endMsRaw, startMs);
+        const grace = this.getFestivalWindowGraceMillis();
+        return startMs <= (window.endMs + grace) && endMs >= (window.startMs - grace);
+    }
+
+    // FESTIVAL UMBRELLA match: name-family similarity (the same
+    // areTitlesSimilar rung dedup identity uses) + city agreement + date
+    // overlap with nextDates ±7d. Returns the curated entry or null.
+    findCuratedFestivalMatch(event) {
+        if (!event || !event.title) return null;
+        for (const festival of this.festivals) {
+            if (!festival || !festival.name) continue;
+            if (!this.areTitlesSimilar(event.title, festival.name)) continue;
+            if (!this.festivalCityAgrees(event, festival)) continue;
+            if (!this.eventOverlapsFestivalWindow(event, festival)) continue;
+            return festival;
+        }
+        return null;
+    }
+
+    // Curated festival whose official website host matches the given host
+    // (www-insensitive, same rung as areUrlHostsSameSite). Source-host is the
+    // page-family signal: everything extracted from beefdip.com is BeefDip
+    // context, whatever the individual record managed to extract.
+    findCuratedFestivalBySourceHost(host) {
+        if (!host) return null;
+        for (const festival of this.festivals) {
+            const festivalHost = festival && festival.website
+                ? this.getHostFromUrl(festival.website)
+                : '';
+            if (festivalHost && this.areUrlHostsSameSite(festivalHost, host)) {
+                return festival;
+            }
+        }
+        return null;
+    }
+
+    // The host a record was extracted from (venue-site stamp first, then the
+    // source page URL) — '' when neither survives.
+    getFestivalSourceHost(event) {
+        if (!event || typeof event !== 'object') return '';
+        const stamped = typeof event._venueSitePageHost === 'string' ? event._venueSitePageHost.trim() : '';
+        if (stamped) return stamped;
+        return this.getHostFromUrl(event._sourcePageUrl || '') || '';
+    }
+
+    // Pre-pass over the whole batch: hosts whose pages produced a curated
+    // festival UMBRELLA match extend festival context to sibling records from
+    // the same source even when the source host differs from the curated
+    // website (aggregators). Direct website-host matches don't need this map.
+    collectFestivalSourceHosts(events) {
+        const hosts = new Map();
+        if (!Array.isArray(events)) return hosts;
+        for (const event of events) {
+            const festival = this.findCuratedFestivalMatch(event);
+            if (!festival) continue;
+            const host = this.getFestivalSourceHost(event);
+            if (!host) continue;
+            const key = String(host).toLowerCase().replace(/^www\./, '');
+            if (!hosts.has(key)) hosts.set(key, festival);
+        }
+        return hosts;
+    }
+
+    // Resolve the curated festival a record's SOURCE belongs to: the source
+    // host is the festival's own website, or an umbrella from the same source
+    // matched earlier in this batch (collectFestivalSourceHosts).
+    resolveFestivalForSource(event, festivalSourceHosts) {
+        const host = this.getFestivalSourceHost(event);
+        if (!host) return null;
+        const direct = this.findCuratedFestivalBySourceHost(host);
+        if (direct) return direct;
+        if (festivalSourceHosts && typeof festivalSourceHosts.get === 'function') {
+            const key = String(host).toLowerCase().replace(/^www\./, '');
+            const viaUmbrella = festivalSourceHosts.get(key);
+            if (viaUmbrella && this.eventOverlapsFestivalWindow(event, viaUmbrella)) {
+                return viaUmbrella;
+            }
+        }
+        return null;
+    }
+
+    // FESTIVAL CONTEXT inheritance for sub-events: fills BLANKS only. An
+    // explicitly extracted different city is never overwritten — the
+    // disagreement is reported instead. Stamps _festivalContext (key, name,
+    // cityKey, window) for the report-only window sanity check downstream.
+    applyCuratedFestivalContext(event, festival) {
+        if (!event || typeof event !== 'object' || !festival) return null;
+        const context = {
+            key: festival.key || '',
+            name: festival.name || '',
+            cityKey: festival.cityKey || null,
+            nextDates: festival.nextDates
+                ? { start: festival.nextDates.start || null, end: festival.nextDates.end || null }
+                : null
+        };
+        const eventCity = String(event.city || '').trim().toLowerCase();
+        const cityIsBlank = !eventCity || eventCity === 'unknown';
+        if (context.cityKey && cityIsBlank) {
+            event.city = context.cityKey;
+            event._citySource = 'curated-festival';
+            context.inheritedCity = true;
+            console.log(`🎪 FESTIVAL: "${event.title || 'Unknown'}" inherited city ${context.cityKey} from curated festival "${context.name}" (source ${this.getFestivalSourceHost(event) || 'unknown host'})`);
+        } else if (context.cityKey && eventCity !== context.cityKey.toLowerCase()) {
+            context.cityDisagreement = { eventCity: event.city, festivalCity: context.cityKey };
+            console.log(`🎪 FESTIVAL: "${event.title || 'Unknown'}" city ${event.city} differs from curated festival "${context.name}" city ${context.cityKey} — keeping the extracted city (report-only)`);
+        }
+        if (!event.timezone) {
+            const timezone = this.getCityTimezone(event.city);
+            if (timezone) {
+                event.timezone = timezone;
+                context.inheritedTimezone = true;
+            }
+        }
+        event._festivalContext = context;
+        return context;
+    }
+
+    // Report-only window sanity boundary for inherited-context sub-events:
+    // dates resolving OUTSIDE nextDates ±7d are the year-split signature
+    // (run 20260815-083809: BeefDip pages dated Jan 26 2026 extracted as
+    // 2027). Flag, don't drop — the flag never changes any action.
+    getFestivalWindowSanityFlag(event) {
+        const context = event && event._festivalContext;
+        if (!context || !context.nextDates) return null;
+        const pseudoFestival = { nextDates: context.nextDates };
+        if (this.toEpochMillis(event.startDate) === null) return null;
+        if (this.eventOverlapsFestivalWindow(event, pseudoFestival)) return null;
+        return {
+            code: 'festival-window-violation',
+            detail: `dates resolve outside curated "${context.name}" window ${context.nextDates.start || '?'} – ${context.nextDates.end || '?'} (±7d) — possible year-split extraction`
+        };
+    }
+
+    // ONE report-only drift line per festival per pass when a scraped
+    // umbrella's date range disagrees with curated nextDates. Curated wins;
+    // the scraper NEVER writes festivals.json.
+    reportCuratedFestivalDrift(event, festival) {
+        const window = festival && festival.nextDates;
+        if (!window || !window.start || !window.end) return;
+        const startMs = this.toEpochMillis(event && event.startDate);
+        if (startMs === null) return;
+        const endMsRaw = this.toEpochMillis(event && event.endDate);
+        const endMs = endMsRaw === null ? startMs : endMsRaw;
+        const toDay = (ms) => new Date(ms).toISOString().slice(0, 10);
+        const scrapedStart = toDay(startMs);
+        const scrapedEnd = toDay(endMs);
+        if (scrapedStart === window.start && scrapedEnd === window.end) return;
+        const driftKey = String(festival.key || festival.name || '');
+        if (this.festivalDriftLogged.has(driftKey)) return;
+        this.festivalDriftLogged.add(driftKey);
+        console.log(`📆 FESTIVAL: scraped ${festival.name} dates ${scrapedStart} – ${scrapedEnd} differ from curated ${window.start} – ${window.end} — curated wins; update data/festivals.json from the official source if real`);
+    }
+
+    // A record stamped as a curated-festival umbrella (_festivalMatch, set in
+    // prepareEventsForCalendar). Its own predicate — mirroring
+    // hasJunkTitleSanityFlag / isSeriesCoveredOccurrence — so the execution
+    // gate, the disposition label, and the adapters' labeling never disagree.
+    static isCuratedFestivalUmbrella(event) {
+        return Boolean(event && typeof event === 'object' && event._festivalMatch);
     }
 
     // Scriptable identifiers look like `<calendarUUID>:<icsUid>` — the suffix
@@ -13626,6 +13859,13 @@ class SharedCore {
         // Per-run calendar-stickiness tally (report-only observation phase).
         this.resetCalendarStickinessStats();
 
+        // Curated festival awareness: one drift line per festival per pass,
+        // and a batch pre-pass mapping source hosts whose pages produced an
+        // umbrella match — sibling records from the same source inherit the
+        // festival's context even when the host isn't the curated website.
+        this.festivalDriftLogged = new Set();
+        const festivalSourceHosts = this.collectFestivalSourceHosts(events);
+
         // Analyze each event against existing calendar events
         const analyzedEvents = [];
         // Same-venue overlap surfacing (report-only): each analyzed entry is
@@ -13635,6 +13875,16 @@ class SharedCore {
         const venueOverlapEntries = [];
 
         for (const event of events) {
+            // FESTIVAL CONTEXT: a record extracted from a curated festival's
+            // source inherits BLANK city/timezone from the curated entry.
+            // Must run BEFORE the calendar lookup so an inherited city routes
+            // the existing-event search to the right city calendar. Explicit
+            // extracted values are never overwritten (report-only).
+            const sourceFestival = this.resolveFestivalForSource(event, festivalSourceHosts);
+            if (sourceFestival) {
+                this.applyCuratedFestivalContext(event, sourceFestival);
+            }
+
             // Get existing events from the adapter
             const existingEvents = await calendarAdapter.getExistingEvents(event);
 
@@ -13702,6 +13952,38 @@ class SharedCore {
             }
 
             const analyzedEntry = await this.buildAnalyzedCalendarEvent(preparedEvent, analysis, calendarAdapter, config);
+            // The merge path rebuilds the analyzed object from the calendar
+            // record (createFinalEventObject), which can drop the pre-analysis
+            // festival-context stamp — carry it over so the window check and
+            // the results UI see it either way.
+            if (event._festivalContext && !analyzedEntry._festivalContext) {
+                analyzedEntry._festivalContext = event._festivalContext;
+            }
+            // FESTIVAL UMBRELLA: identity matches a curated festival — the
+            // curated dataset already renders it on the site, so the write is
+            // withheld (filterEventsForExecution) and date drift against
+            // curated nextDates is reported once, report-only.
+            const curatedFestival = this.findCuratedFestivalMatch(analyzedEntry);
+            if (curatedFestival) {
+                analyzedEntry._festivalMatch = {
+                    key: curatedFestival.key || '',
+                    name: curatedFestival.name || '',
+                    cityKey: curatedFestival.cityKey || null,
+                    nextDates: curatedFestival.nextDates
+                        ? { start: curatedFestival.nextDates.start || null, end: curatedFestival.nextDates.end || null }
+                        : null,
+                    reason: `matches curated festival: ${curatedFestival.name}`
+                };
+                console.log(`🎪 FESTIVAL: "${analyzedEntry.title || 'Unknown'}" matches curated festival "${curatedFestival.name}" — write withheld (curated dataset renders it)`);
+                this.reportCuratedFestivalDrift(analyzedEntry, curatedFestival);
+            } else if (analyzedEntry._festivalContext) {
+                const windowFlag = this.getFestivalWindowSanityFlag(analyzedEntry);
+                if (windowFlag) {
+                    if (!Array.isArray(analyzedEntry._sanityFlags)) analyzedEntry._sanityFlags = [];
+                    analyzedEntry._sanityFlags.push(windowFlag);
+                    console.log(`⚠️ FESTIVAL: "${analyzedEntry.title || 'Unknown'}" ${windowFlag.detail} (report-only)`);
+                }
+            }
             analyzedEvents.push(analyzedEntry);
             venueOverlapEntries.push({
                 event: analyzedEntry,

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -19258,3 +19258,342 @@ test('sanity: flyer-time-conflict never fires without a well-formed stamp', () =
   assert.deepEqual(sanityCodes(core, { ...base, _flyerTimeConflict: { pageTime: '10:00' } }), [],
     'a stamp missing the flyer reading is malformed — fail closed');
 });
+
+// ===========================================================================
+// Curated festival awareness (data/festivals.json) — the curated dataset is
+// the authority; the scraper contributes parties, never umbrellas.
+// Real-data fixtures from run 20260815-083809 (BeefDip planned-events page).
+// ===========================================================================
+
+const FESTIVAL_CITIES = {
+  pv: { timezone: 'America/Mexico_City', patterns: ['puerto vallarta', 'pv'] },
+  ptown: { timezone: 'America/New_York', patterns: ['provincetown', 'ptown'] },
+  dallas: { timezone: 'America/Chicago', patterns: ['dallas'] },
+  sf: { timezone: 'America/Los_Angeles', patterns: ['san francisco', 'sf'] }
+};
+
+// Verbatim curated entries (subset of data/festivals.json); the last one has
+// no nextDates on purpose — it must never match (fail closed).
+const CURATED_FESTIVALS = [
+  {
+    key: 'beefdip-bear-week',
+    name: 'BeefDip Bear Week',
+    category: 'bear-run',
+    cityKey: 'pv',
+    recurring: 'annual',
+    website: 'https://beefdip.com/planned-events/',
+    nextDates: { start: '2027-01-23', end: '2027-01-31' }
+  },
+  {
+    key: 'spooky-bear',
+    name: 'Spooky Bear',
+    category: 'bear-run',
+    cityKey: 'ptown',
+    recurring: 'annual',
+    website: 'https://www.ursamen.org/spookybear',
+    nextDates: { start: '2026-10-29', end: '2026-11-01' }
+  },
+  {
+    key: 'amsterdam-bear-pride',
+    name: 'Amsterdam Bear Pride',
+    category: 'pride',
+    cityKey: 'amsterdam',
+    recurring: 'annual',
+    website: 'https://amsterdambearpride.com/en/'
+  }
+];
+
+function createFestivalCore(festivals = CURATED_FESTIVALS) {
+  return new SharedCore(FESTIVAL_CITIES, { eventSchema: EventSchema, festivals });
+}
+
+function buildFestivalPrepAdapter(records = []) {
+  const calls = [];
+  return {
+    calls,
+    getExistingEvents: async (event) => {
+      calls.push({ title: event.title, city: event.city });
+      return records;
+    }
+  };
+}
+
+// Run 20260815-083809: the zero-duration Jan 23 impostor ("BeefDip Bear
+// Week", startDate === endDate, action new) scraped off the planned-events
+// page — the AI split "BeefDip Bear Week 2026 / Jan 23 – 31" into 2027.
+function buildBeefdipUmbrellaEvent(overrides = {}) {
+  return {
+    title: 'BeefDip Bear Week',
+    startDate: '2027-01-23T06:00:00.000Z',
+    endDate: '2027-01-23T06:00:00.000Z',
+    city: 'pv',
+    timezone: 'America/Mexico_City',
+    source: 'ai-web',
+    isBearEvent: true,
+    _venueSitePageHost: 'beefdip.com',
+    _sourcePageUrl: 'https://beefdip.com/planned-events/',
+    _parserConfig: { name: 'BeefDip' },
+    ...overrides
+  };
+}
+
+// Run 20260815-083809: "🍸 Cocktail Party" from the same page, city unknown.
+function buildCocktailPartyEvent(overrides = {}) {
+  return {
+    title: '🍸 Cocktail Party',
+    startDate: '2027-01-24T00:00:00.000Z',
+    endDate: '2027-01-24T00:00:00.000Z',
+    city: 'unknown',
+    source: 'ai-web',
+    isBearEvent: true,
+    _venueSitePageHost: 'beefdip.com',
+    _sourcePageUrl: 'https://beefdip.com/planned-events/',
+    _parserConfig: { name: 'BeefDip' },
+    ...overrides
+  };
+}
+
+test('festival umbrella: run 20260815-083809 BeefDip impostor is withheld with the festival reason', async () => {
+  const core = createFestivalCore();
+  const adapter = buildFestivalPrepAdapter();
+  const analyzed = await core.prepareEventsForCalendar([buildBeefdipUmbrellaEvent()], adapter, {});
+
+  assert.equal(analyzed.length, 1);
+  const umbrella = analyzed[0];
+  assert.ok(umbrella._festivalMatch, 'the umbrella is stamped with the curated match');
+  assert.equal(umbrella._festivalMatch.key, 'beefdip-bear-week');
+  assert.equal(umbrella._festivalMatch.reason, 'matches curated festival: BeefDip Bear Week');
+  assert.equal(SharedCore.isCuratedFestivalUmbrella(umbrella), true);
+  assert.deepEqual(SharedCore.filterEventsForExecution(analyzed), [],
+    'a curated-festival umbrella never reaches a calendar write');
+  assert.equal(SharedCore.describeExecutionDisposition(umbrella),
+    'WITHHELD (matches curated festival — curated dataset renders it)');
+  assert.equal(umbrella._action, 'new', 'the withhold is a gate, not an action rewrite');
+});
+
+test('festival umbrella: a scraped Spooky Bear umbrella from ursamen.org gets the same treatment', async () => {
+  // ursamen.org is curated (key spooky-bear); the parser was disabled in run
+  // 20260815-083809, so this models the record it would produce when enabled.
+  const core = createFestivalCore();
+  const adapter = buildFestivalPrepAdapter();
+  const analyzed = await core.prepareEventsForCalendar([{
+    title: 'Spooky Bear',
+    startDate: '2026-10-29T16:00:00.000Z',
+    endDate: '2026-11-01T20:00:00.000Z',
+    city: 'unknown',
+    source: 'ai-web',
+    _venueSitePageHost: 'www.ursamen.org',
+    _sourcePageUrl: 'https://www.ursamen.org/spookybear',
+    _parserConfig: { name: 'Spooky Bear' }
+  }], adapter, {});
+
+  const umbrella = analyzed[0];
+  assert.equal(umbrella._festivalMatch && umbrella._festivalMatch.key, 'spooky-bear');
+  assert.deepEqual(SharedCore.filterEventsForExecution(analyzed), [],
+    'with the umbrella withheld, no scraped same-name event reaches the ptown calendar — the website name-collision guard finds no collision and the curated banner renders');
+});
+
+test('festival context: run 20260815-083809 "🍸 Cocktail Party" inherits city pv and timezone (blanks only)', async () => {
+  const core = createFestivalCore();
+  const adapter = buildFestivalPrepAdapter();
+  const analyzed = await core.prepareEventsForCalendar([buildCocktailPartyEvent()], adapter, {});
+
+  const party = analyzed[0];
+  assert.equal(party.city, 'pv', 'unknown city is filled from the curated festival');
+  assert.equal(party.timezone, 'America/Mexico_City', 'timezone follows the inherited cityKey');
+  assert.equal(party._citySource, 'curated-festival');
+  assert.ok(party._festivalContext, 'the sub-event carries the festival context stamp');
+  assert.equal(party._festivalContext.key, 'beefdip-bear-week');
+  assert.equal(party._festivalContext.inheritedCity, true);
+  assert.equal(adapter.calls[0].city, 'pv',
+    'inheritance runs BEFORE the calendar lookup so the search hits the pv calendar');
+  assert.ok(!party._festivalMatch, 'a sub-party is NOT an umbrella');
+  assert.ok(!(party._sanityFlags || []).some(flag => flag.code === 'festival-window-violation'),
+    'Jan 24 2027 sits inside the curated window — no violation');
+  assert.equal(SharedCore.filterEventsForExecution(analyzed).length, 1,
+    'sub-parties are normal events on the normal write path');
+});
+
+test('festival context: a year-split record resolving outside the curated window gets the report-only flag', async () => {
+  // Run 20260815-083809 evidence: the FOAM POOL PARTY record's own OCR reads
+  // "MONDAY JANUARY 26" with source image 2026-01-26, but extraction produced
+  // 2027-01-25 — this is the 2026-dated twin of that year-split.
+  const core = createFestivalCore();
+  const adapter = buildFestivalPrepAdapter();
+  const analyzed = await core.prepareEventsForCalendar([{
+    title: 'Foam Pool Party',
+    startDate: '2026-01-26T18:00:00.000Z',
+    endDate: '2026-01-27T00:00:00.000Z',
+    city: 'unknown',
+    source: 'ai-web',
+    _venueSitePageHost: 'beefdip.com',
+    _sourcePageUrl: 'https://beefdip.com/planned-events/',
+    _parserConfig: { name: 'BeefDip' }
+  }], adapter, {});
+
+  const twin = analyzed[0];
+  const flag = (twin._sanityFlags || []).find(entry => entry.code === 'festival-window-violation');
+  assert.ok(flag, 'dates a year off the curated window are flagged');
+  assert.match(flag.detail, /BeefDip Bear Week/);
+  assert.equal(twin._action, 'new', 'the flag never changes the action');
+});
+
+test('festival context: the window flag is report-only — a future out-of-window record still executes', async () => {
+  const core = createFestivalCore();
+  const adapter = buildFestivalPrepAdapter();
+  const analyzed = await core.prepareEventsForCalendar([{
+    title: 'Warm-Up Party',
+    startDate: '2026-11-20T02:00:00.000Z',
+    endDate: '2026-11-20T06:00:00.000Z',
+    city: 'unknown',
+    source: 'ai-web',
+    _venueSitePageHost: 'beefdip.com',
+    _sourcePageUrl: 'https://beefdip.com/planned-events/',
+    _parserConfig: { name: 'BeefDip' }
+  }], adapter, {});
+
+  assert.ok((analyzed[0]._sanityFlags || []).some(flag => flag.code === 'festival-window-violation'));
+  assert.equal(SharedCore.filterEventsForExecution(analyzed).length, 1,
+    'flag, do not drop: the write is NOT withheld by the window flag');
+});
+
+test('festival context: an explicitly extracted different city is never overwritten', async () => {
+  const core = createFestivalCore();
+  const adapter = buildFestivalPrepAdapter();
+  const analyzed = await core.prepareEventsForCalendar([buildCocktailPartyEvent({
+    title: 'Roadtrip Party',
+    city: 'sf',
+    timezone: 'America/Los_Angeles'
+  })], adapter, {});
+
+  const party = analyzed[0];
+  assert.equal(party.city, 'sf', 'explicit city stands');
+  assert.equal(party.timezone, 'America/Los_Angeles');
+  assert.ok(party._festivalContext.cityDisagreement, 'the disagreement is reported, not resolved');
+  assert.equal(party._festivalContext.cityDisagreement.festivalCity, 'pv');
+  assert.equal(party._festivalContext.inheritedCity, undefined);
+});
+
+test('festival matching fails closed: no date overlap, clashing city, or missing nextDates never match', () => {
+  const core = createFestivalCore();
+
+  // Same name + city, dates nowhere near the window → no match.
+  assert.equal(core.findCuratedFestivalMatch(buildBeefdipUmbrellaEvent({
+    startDate: '2026-06-15T06:00:00.000Z',
+    endDate: '2026-06-16T06:00:00.000Z'
+  })), null, 'no date overlap → not a match');
+
+  // Same name + dates, explicit clashing city → no match.
+  assert.equal(core.findCuratedFestivalMatch(buildBeefdipUmbrellaEvent({
+    city: 'dallas'
+  })), null, 'a clashing explicit city → not a match');
+
+  // Curated entry without nextDates can never umbrella-match.
+  assert.equal(core.findCuratedFestivalMatch({
+    title: 'Amsterdam Bear Pride',
+    startDate: '2026-06-18T12:00:00.000Z',
+    endDate: '2026-06-21T12:00:00.000Z',
+    city: 'unknown'
+  }), null, 'missing nextDates → fail closed');
+
+  // No event dates at all → fail closed.
+  assert.equal(core.findCuratedFestivalMatch(buildBeefdipUmbrellaEvent({
+    startDate: null,
+    endDate: null
+  })), null, 'a dateless record → not a match');
+
+  // The ±7d grace admits an off-by-a-few-days umbrella.
+  const grace = core.findCuratedFestivalMatch(buildBeefdipUmbrellaEvent({
+    startDate: '2027-01-20T06:00:00.000Z',
+    endDate: '2027-01-21T06:00:00.000Z'
+  }));
+  assert.equal(grace && grace.key, 'beefdip-bear-week', 'within the ±7d grace → match');
+});
+
+test('festival drift: ONE report-only line when a scraped umbrella disagrees with curated nextDates', async () => {
+  const core = createFestivalCore();
+  const adapter = buildFestivalPrepAdapter();
+  const originalLog = console.log;
+  const logLines = [];
+  console.log = (message) => { logLines.push(String(message)); };
+  try {
+    await core.prepareEventsForCalendar([
+      buildBeefdipUmbrellaEvent({
+        startDate: '2027-01-22T06:00:00.000Z',
+        endDate: '2027-01-30T06:00:00.000Z'
+      }),
+      buildBeefdipUmbrellaEvent({
+        title: 'BeefDip Bear Week 2027',
+        startDate: '2027-01-22T06:00:00.000Z',
+        endDate: '2027-01-30T06:00:00.000Z'
+      })
+    ], adapter, {});
+  } finally {
+    console.log = originalLog;
+  }
+  const driftLines = logLines.filter(line => line.startsWith('📆 FESTIVAL:'));
+  assert.equal(driftLines.length, 1, 'one drift line per festival per pass, not per record');
+  assert.equal(driftLines[0],
+    '📆 FESTIVAL: scraped BeefDip Bear Week dates 2027-01-22 – 2027-01-30 differ from curated 2027-01-23 – 2027-01-31 — curated wins; update data/festivals.json from the official source if real');
+});
+
+test('festival negative: a non-festival multi-day event is untouched', async () => {
+  const core = createFestivalCore();
+  const adapter = buildFestivalPrepAdapter();
+  const analyzed = await core.prepareEventsForCalendar([{
+    title: 'Hotel Takeover Weekend',
+    startDate: '2026-09-18T20:00:00.000Z',
+    endDate: '2026-09-20T20:00:00.000Z',
+    city: 'dallas',
+    timezone: 'America/Chicago',
+    source: 'ai-web',
+    _venueSitePageHost: 'hotelbears.example',
+    _sourcePageUrl: 'https://hotelbears.example/takeover',
+    _parserConfig: { name: 'Hotel Bears' }
+  }], adapter, {});
+
+  const event = analyzed[0];
+  assert.ok(!event._festivalMatch, 'no umbrella stamp');
+  assert.ok(!event._festivalContext, 'no inherited context');
+  assert.equal(event.city, 'dallas');
+  assert.ok(!(event._sanityFlags || []).some(flag => flag.code === 'festival-window-violation'));
+  assert.equal(SharedCore.filterEventsForExecution(analyzed).length, 1, 'normal write path');
+});
+
+test('festival context extends to siblings of an umbrella scraped from a NON-curated host (aggregator)', async () => {
+  // The source host differs from the curated website — the umbrella match
+  // itself (name+city+dates) teaches the run that this host is festival
+  // context, and in-window siblings from the same host inherit it.
+  const core = createFestivalCore();
+  const adapter = buildFestivalPrepAdapter();
+  const analyzed = await core.prepareEventsForCalendar([
+    buildBeefdipUmbrellaEvent({
+      _venueSitePageHost: 'gaytravel4u.example',
+      _sourcePageUrl: 'https://gaytravel4u.example/event/beefdip/',
+      city: 'unknown'
+    }),
+    buildCocktailPartyEvent({
+      title: 'Aggregator Pool Party',
+      _venueSitePageHost: 'gaytravel4u.example',
+      _sourcePageUrl: 'https://gaytravel4u.example/event/beefdip/'
+    })
+  ], adapter, {});
+
+  assert.ok(analyzed[0]._festivalMatch, 'the umbrella matches by identity regardless of host');
+  assert.equal(analyzed[1].city, 'pv', 'the sibling inherits the city via the umbrella-taught host');
+  assert.equal(analyzed[1]._festivalContext.key, 'beefdip-bear-week');
+});
+
+test('festival stamps are analysis-time: replay strips _festivalMatch/_festivalContext for fresh re-analysis', () => {
+  const stampKeys = SharedCore.getCalendarAnalysisStampKeys();
+  assert.ok(stampKeys.includes('_festivalMatch'));
+  assert.ok(stampKeys.includes('_festivalContext'));
+});
+
+test('festival data is injected, never loaded: a core without festivals behaves exactly as before', async () => {
+  const core = new SharedCore(FESTIVAL_CITIES, { eventSchema: EventSchema });
+  const adapter = buildFestivalPrepAdapter();
+  const analyzed = await core.prepareEventsForCalendar([buildBeefdipUmbrellaEvent()], adapter, {});
+  assert.ok(!analyzed[0]._festivalMatch, 'no injected festivals → no matching, no withhold');
+  assert.equal(SharedCore.filterEventsForExecution(analyzed).length, 1);
+});


### PR DESCRIPTION
## The plan (owner-approved, implemented exactly)

Principle: **the curated festival dataset is the authority; the scraper contributes parties, never umbrellas.**

1. **Festival matching** — `data/festivals.json` is now a runtime input injected the way curated bars/promoters are. An analyzed event whose identity matches a curated festival — name-family similarity (`areTitlesSimilar`, the existing title-identity rung) + city agreement (unknown/blank city tolerated, explicit clash fails closed) + date overlap with `nextDates` ±7d grace — is a **FESTIVAL UMBRELLA**: write WITHHELD, card reason `matches curated festival: <name>`, own summary bucket — same labeling seams as the #1655 saved-series match. Fail closed: missing `nextDates`, no date overlap, or a clashing city → not a match. Nothing is hardcoded per festival — BeefDip and Spooky Bear are caught by the generic rules.
2. **Festival context for sub-events** — an event whose source host is a curated festival's website host (or whose source host produced an umbrella match in the same batch) inherits **blanks only**: city (`🍸 Cocktail Party` city=unknown → `pv`), timezone (via cityKey), and gets the festival window as a **report-only** sanity boundary (`festival-window-violation` flag for dates outside `nextDates` ±7d — the year-split catcher). An explicitly extracted different city is never overwritten; the disagreement is reported.
3. **Drift reporting** — ONE report-only line per festival per pass when a scraped umbrella's dates disagree with curated `nextDates` (`📆 FESTIVAL: scraped … differ from curated … — curated wins; update data/festivals.json from the official source if real`). The scraper NEVER writes festivals.json.
4. **Sub-parties are normal events** — normal write path to the city calendar, individual links per the occurrence doctrine, no export-only behavior.

## Mechanisms

- **Injection seam (mirrors bars/promoters exactly):** `SharedCore` constructor takes `options.festivals` (`this.festivals`, sibling of `this.bars`/`this.promoters` — shared-core never loads files). Orchestrator passes `config.festivals` and applies an optional fail-soft `finalAdapter.refreshRemoteFestivals(festivals)` mirroring the bars/promoters refresh blocks.
- **Node/web adapter:** `loadConfiguration` reads `data/festivals.json` directly (pure JSON — no generated module needed, no new runtime file); `refreshRemoteFestivals` is the honest pass-through (the repo checkout IS the deploy source). Browser branch fetches `../data/festivals.json`, fail-soft.
- **Scriptable adapter:** `refreshRemoteFestivals` fetches `https://chunky.dad/data/festivals.json` with the same `fetchRemoteBarsJson` helper and 1-day-TTL cache as bars/promoters, unions by `key` (remote wins per key, injected local-only entries survive), fail-soft to the injected list. New `📱 Scriptable: Festivals data — N from chunky.dad, M local-only` log line (additive).
- **Classification:** in `prepareEventsForCalendar` — context inheritance runs BEFORE the calendar lookup (so an inherited city routes the existing-event search to the right city calendar); the umbrella stamp (`_festivalMatch`) is applied to the analyzed entry after `buildAnalyzedCalendarEvent`. Withhold enforced by a new clause in `filterEventsForExecution` + `isCuratedFestivalUmbrella` predicate + `describeExecutionDisposition` label, so gate/label/UI can never disagree (same doctrine as series-match/junk-title). `_festivalMatch`/`_festivalContext` added to `getCalendarAnalysisStampKeys` so saved-run re-analysis recomputes them fresh.
- **UI (existing chip/bucket mechanisms only):** `classifyEventForResultsSection` → withheld pile with chip `🎪 matches curated festival: <name>`; `normalizeIntentAction` → `festival_match` bucket; `formatIntentActionLabel` → `FESTIVAL MATCH`; `getWriteActionFromEvent` → `withheld`; additive non-zero-only summary line `🎪 Festival match: N events (curated festival — withheld)`. Display-only: `normalizeMetricsIntentAction` untouched, metrics schema unchanged.
- Platform purity preserved: no `new URL`/`URLSearchParams` (host matching via existing `getHostFromUrl`/`areUrlHostsSameSite`); dates via `toEpochMillis`. No existing console.log or AI-prompt string edited — additions only.

## Evidence (run 20260815-083809)

- **BeefDip umbrella impostor** (`BeefDip Bear Week`, zero-duration `2027-01-23`, action `new`, from beefdip.com/planned-events): classifies as umbrella and withholds with the festival reason — locked by test with the verbatim record.
- **`🍸 Cocktail Party`** (city=unknown, same source): inherits city `pv` + `America/Mexico_City`, stays on the normal write path, and the calendar lookup already sees `pv`.
- **Year-split**: the run holds only the `FOAM POOL PARTY` `2027-01-25` record; its own OCR evidence (source image `2026-01-26 Foam Pool Party.webp`, OCR "MONDAY JANUARY 26") dates it to Jan 26 **2026** — the test reconstructs that 2026-dated twin from this evidence and it gets the report-only `festival-window-violation` flag. A separate future-dated out-of-window test proves the flag never withholds.
- **Spooky Bear**: the run contains no scraped ursamen.org record (parser `automationEnabled:false` that day), so the test models the umbrella the parser produces when enabled (title `Spooky Bear`, host `www.ursamen.org`, Oct 29–Nov 1) — it withholds via the same generic rules, key `spooky-bear`.
- **Negative**: a non-festival multi-day hotel-takeover event is untouched (no stamp, no inheritance, no flags, normal write path).

## Spooky Bear website-interaction analysis

The site's name-collision guard (`js/dynamic-calendar-loader.js` `mergeFestivalEvents`, ~1887–1903) suppresses the curated festival injection only when a **saved, non-festival calendar event** with the same normalized name overlaps the festival span. With the scraped umbrella now WITHHELD, no such saved event is ever written, so the guard finds no collision and **the curated banner simply renders** — the intended end state. The story also degrades safely: if a same-name umbrella was saved before this change, the guard still suppresses the curated copy (no doubles), and once that record is removed the curated banner takes over. No website JS was touched.

## New runtime data flows (flagged)

- **Phone:** one new remote fetch per run — `https://chunky.dad/data/festivals.json` (same cached-fetch helper, 1-day TTL, fail-soft to the injected list; offline runs behave exactly as before). No new runtime FILE is introduced (no generated `scraper-festivals.js`, nothing new for the script updater).
- **Node:** `data/festivals.json` read at configuration load (fail-soft to `[]`).

## Conflict-prone areas (two other agents active in shared-core)

My shared-core diff touches: the constructor injection block (adjacent to `bearVerdicts`), a new self-contained section after `isSeriesCoveredOccurrence`, one clause in `filterEventsForExecution`, one line in `describeExecutionDisposition`, two keys in `getCalendarAnalysisStampKeys`, and the `prepareEventsForCalendar` loop head/tail. If the dead-end-suppression or gmaps-decision-recording branches touch `prepareEventsForCalendar` or `filterEventsForExecution`, expect small, mechanical merge conflicts there; everything else is a distinct seam.

## Tests

- 19 new tests, all in already-enumerated files (`shared-core.test.js` +12, `scriptable-adapter.test.js` +3, `web-adapter.test.js` +2, `bear-event-scraper-unified.test.js` +2).
- **Fail-on-base proof:** 17/19 fail on base (`pass 1037 / fail 17` with implementation stashed); the two base-passing tests are deliberate no-regression guards (non-festival event untouched; no injected festivals → exactly today's behavior).
- Full quiet suite: **1911 pass / 0 fail** (base: 1892 / 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP