### PR TITLE
fix(scraper): festival path identity + date-phrase write gate + og-vet image downscale (run 20260815-102447)

### DIFF
--- a/data/festivals.json
+++ b/data/festivals.json
@@ -169,7 +169,7 @@
       "location": "Provincetown, MA",
       "typicalTiming": "second week of July",
       "recurring": "annual",
-      "website": "https://www.eventbrite.com/o/ptownbears-78481077703",
+      "website": "https://www.ptownbears.events/",
       "nextDates": { "start": "2027-07-10", "end": "2027-07-17" }
     },
     {

--- a/scripts/adapters/web-adapter.js
+++ b/scripts/adapters/web-adapter.js
@@ -1000,13 +1000,132 @@ class WebAdapter {
     }
 
 
-    async fetchImageAsBase64(url, timeoutSeconds = 30) {
+    // Longest-side cap decision for the Node image fetch below: returns the
+    // target {width, height} when the image exceeds maxDimension, null when it
+    // already fits (or the inputs are unusable — fail open, no resize). Pure
+    // math, extracted so the downscale decision is unit-testable without
+    // sharp or network. Mirrors ScriptableAdapter.fetchImageAsBase64Once's
+    // inline DrawContext math exactly.
+    static getDownscaledImageDimensions(width, height, maxDimension) {
+        const w = Number(width);
+        const h = Number(height);
+        const max = Number(maxDimension);
+        if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return null;
+        if (!Number.isFinite(max) || max <= 0) return null;
+        if (Math.max(w, h) <= max) return null;
+        const scale = max / Math.max(w, h);
+        return {
+            width: Math.max(1, Math.round(w * scale)),
+            height: Math.max(1, Math.round(h * scale))
+        };
+    }
+
+    // Resolve the platform's image-resize capability ONCE per adapter:
+    //   - sharp: the resize library the repo already ships for its image
+    //     tooling (tools/download-images.js) — present wherever npm install
+    //     ran (CI, tools environments);
+    //   - macOS sips: the Mac scheduler runs WITHOUT node_modules, and
+    //     /usr/bin/sips is part of the OS — the same system-binary precedent
+    //     as tools/run-once.js calling /usr/bin/brctl;
+    //   - none: announced LOUDLY once; callers keep the pre-fix full-size
+    //     behavior, and the parser's overflow warnings make every skipped
+    //     downscale visible per image.
+    getImageResizeCapability() {
+        if (this._imageResizeCapability !== undefined) return this._imageResizeCapability;
+        let capability = null;
+        try {
+            capability = { kind: 'sharp', sharp: require('sharp') };
+        } catch (_) {
+            try {
+                if (typeof process !== 'undefined' && process.platform === 'darwin'
+                    && this.fs && this.path && this.fs.existsSync('/usr/bin/sips')) {
+                    capability = { kind: 'sips' };
+                }
+            } catch (ignored) {}
+        }
+        if (!capability) {
+            console.warn(`🌐 Web: No image-resize capability on this platform (sharp not installed, sips unavailable) — OCR images will be sent full-size and oversized ones may overflow the vision model context`);
+        }
+        this._imageResizeCapability = capability;
+        return capability;
+    }
+
+    // Vision-model image tokens scale with pixel count, not file size —
+    // oversized payloads overflow the model context and come back as 0 tokens
+    // with finish_reason "length" (run 20260815-102447: six og-image-vet
+    // passes silently decided nothing this way). ScriptableAdapter has capped
+    // the longest side at 1024 via DrawContext all along; this is the Node
+    // twin. Every failure path is LOUD and falls back to the original bytes:
+    // behavior degrades to exactly the pre-fix payload, never silently to
+    // something else. JPEG re-encode matches ScriptableAdapter
+    // (Data.fromJPEG): the downscaled rendition only ever feeds the vision
+    // model, never the stored event image URL.
+    async downscaleImageBufferForOcr(buffer, maxDimension, url) {
+        if (!Number.isFinite(Number(maxDimension)) || Number(maxDimension) <= 0) return buffer;
+        const capability = this.getImageResizeCapability();
+        if (!capability) return buffer;
+        try {
+            if (capability.kind === 'sharp') {
+                const image = capability.sharp(buffer);
+                const metadata = await image.metadata();
+                const target = WebAdapter.getDownscaledImageDimensions(metadata.width, metadata.height, maxDimension);
+                if (!target) return buffer;
+                const resized = await image.resize(target.width, target.height).jpeg({ quality: 85 }).toBuffer();
+                console.log(`🌐 Web: Downscaled image ${metadata.width}x${metadata.height} → ${target.width}x${target.height} for OCR: ${url}`);
+                return resized;
+            }
+            return await this.downscaleImageBufferWithSips(buffer, maxDimension, url);
+        } catch (error) {
+            console.warn(`🌐 Web: Image downscale failed for ${url} (${error.message}) — sending full-size image; oversized images may overflow the vision model context`);
+            return buffer;
+        }
+    }
+
+    // sips leg of downscaleImageBufferForOcr: probe dimensions, decide with
+    // the same helper as the sharp leg (byte-identical passthrough when the
+    // image already fits), then resample the longest side and re-encode JPEG.
+    // Errors propagate to the caller's LOUD fallback.
+    async downscaleImageBufferWithSips(buffer, maxDimension, url) {
+        const os = require('os');
+        const { execFile } = require('child_process');
+        const tmpDir = this.fs.mkdtempSync(this.path.join(os.tmpdir(), 'chunky-ocr-resize-'));
+        const inPath = this.path.join(tmpDir, 'image-in');
+        const outPath = this.path.join(tmpDir, 'image-out.jpg');
+        const runSips = (args) => new Promise((resolve, reject) => {
+            execFile('/usr/bin/sips', args, { timeout: 30000 }, (error, stdout) => {
+                if (error) reject(error);
+                else resolve(String(stdout || ''));
+            });
+        });
+        try {
+            await this.fs.promises.writeFile(inPath, buffer);
+            const probe = await runSips(['-g', 'pixelWidth', '-g', 'pixelHeight', inPath]);
+            const width = Number((probe.match(/pixelWidth:\s*(\d+)/) || [])[1]);
+            const height = Number((probe.match(/pixelHeight:\s*(\d+)/) || [])[1]);
+            const target = WebAdapter.getDownscaledImageDimensions(width, height, maxDimension);
+            if (!target) return buffer;
+            await runSips(['-Z', String(Number(maxDimension)), '-s', 'format', 'jpeg', '-s', 'formatOptions', '85', inPath, '--out', outPath]);
+            const resized = await this.fs.promises.readFile(outPath);
+            console.log(`🌐 Web: Downscaled image ${width}x${height} → ${target.width}x${target.height} for OCR: ${url}`);
+            return resized;
+        } finally {
+            try { this.fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) {}
+        }
+    }
+
+    // Default maxDimension of 1024 matches ScriptableAdapter.fetchImageAsBase64:
+    // full-size first attempts reliably overflowed the vision model's context
+    // (0 tokens, finish_reason "length") on Node because this adapter used to
+    // ignore the cap entirely — including the overflow retry's explicit 768px
+    // request, which therefore returned identical bytes and was skipped.
+    async fetchImageAsBase64(url, timeoutSeconds = 30, maxDimension = 1024) {
         if (this.isNode) {
             try {
                 const response = await fetch(url, { signal: AbortSignal.timeout(timeoutSeconds * 1000) });
                 if (!response.ok) throw new Error(`HTTP ${response.status}`);
                 const buffer = await response.arrayBuffer();
-                return Buffer.from(buffer).toString('base64');
+                const payload = await this.downscaleImageBufferForOcr(Buffer.from(buffer), maxDimension, url);
+                return payload.toString('base64');
             } catch (error) {
                 throw new Error(`Failed to fetch image as base64: ${error.message}`);
             }

--- a/scripts/adapters/web-adapter.test.js
+++ b/scripts/adapters/web-adapter.test.js
@@ -860,3 +860,146 @@ test('dead-end store: node adapter reads and writes dead-ends.json at the shared
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+// ---------------------------------------------------------------------------
+// OCR image downscale (run 20260815-102447: six og-image-vet passes returned
+// 0 tokens with finish_reason "length" — Node sent full-size images while
+// ScriptableAdapter has always capped the longest side at 1024, and the
+// overflow retry's 768px request returned identical bytes so it was skipped).
+// ---------------------------------------------------------------------------
+
+test('getDownscaledImageDimensions: longest-side cap decision, fail-open on bad input', () => {
+  // Landscape and portrait both scale by the longest side, aspect preserved.
+  assert.deepEqual(WebAdapter.getDownscaledImageDimensions(2000, 500, 1024), { width: 1024, height: 256 });
+  assert.deepEqual(WebAdapter.getDownscaledImageDimensions(500, 2000, 1024), { width: 256, height: 1024 });
+  // Already fits (or exactly fits) → no resize.
+  assert.equal(WebAdapter.getDownscaledImageDimensions(800, 600, 1024), null);
+  assert.equal(WebAdapter.getDownscaledImageDimensions(1024, 1024, 1024), null);
+  // Unusable inputs fail open — no resize rather than a guessed one.
+  assert.equal(WebAdapter.getDownscaledImageDimensions(0, 500, 1024), null);
+  assert.equal(WebAdapter.getDownscaledImageDimensions(undefined, 500, 1024), null);
+  assert.equal(WebAdapter.getDownscaledImageDimensions(2000, 500, 0), null);
+  assert.equal(WebAdapter.getDownscaledImageDimensions(2000, 500, NaN), null);
+  // A pathologically thin strip never collapses to zero.
+  assert.deepEqual(WebAdapter.getDownscaledImageDimensions(5000, 2, 1024), { width: 1024, height: 1 });
+});
+
+// Dependency-free PNG generator (node:zlib): 8-bit RGB, one solid color.
+function makeTestPng(width, height) {
+  const zlib = require('node:zlib');
+  const chunk = (type, data) => {
+    const body = Buffer.concat([Buffer.from(type, 'ascii'), data]);
+    const length = Buffer.alloc(4);
+    length.writeUInt32BE(data.length, 0);
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(zlib.crc32(body) >>> 0, 0);
+    return Buffer.concat([length, body, crc]);
+  };
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // color type RGB
+  const row = Buffer.concat([Buffer.from([0]), Buffer.alloc(width * 3, 0x77)]);
+  const raw = Buffer.concat(Array.from({ length: height }, () => row));
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', zlib.deflateSync(raw)),
+    chunk('IEND', Buffer.alloc(0))
+  ]);
+}
+
+// Independent JPEG dimension reader (SOF frame header) so the resized output
+// is verified without sharp/sips.
+function readJpegSize(buffer) {
+  if (buffer[0] !== 0xFF || buffer[1] !== 0xD8) return null;
+  let offset = 2;
+  while (offset + 9 < buffer.length) {
+    if (buffer[offset] !== 0xFF) { offset++; continue; }
+    const marker = buffer[offset + 1];
+    if (marker >= 0xC0 && marker <= 0xCF && marker !== 0xC4 && marker !== 0xC8 && marker !== 0xCC) {
+      return { height: buffer.readUInt16BE(offset + 5), width: buffer.readUInt16BE(offset + 7) };
+    }
+    offset += 2 + buffer.readUInt16BE(offset + 2);
+  }
+  return null;
+}
+
+// The CI test job runs WITHOUT npm install (see .github/workflows/tests.yml),
+// so resize-behavior tests only run where a capability exists: sharp
+// (anywhere npm install ran) or macOS sips (the Mac scheduler's environment).
+// Probed locally — not via the adapter — so these tests still RUN (and fail)
+// against code without the capability ladder.
+function probeLocalResizeCapability() {
+  try { require('sharp'); return true; } catch (_) {}
+  try {
+    return process.platform === 'darwin' && require('node:fs').existsSync('/usr/bin/sips');
+  } catch (_) { return false; }
+}
+const RESIZE_CAPABLE = probeLocalResizeCapability();
+
+// fetch stub returning raw image bytes for the Node image-fetch tests.
+async function withImageFetchStub(imageBuffer, run) {
+  const originalFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => imageBuffer.buffer.slice(imageBuffer.byteOffset, imageBuffer.byteOffset + imageBuffer.byteLength)
+  });
+  try {
+    return await run();
+  } finally {
+    global.fetch = originalFetch;
+  }
+}
+
+test('fetchImageAsBase64 (Node) caps the longest side at the default 1024 before encoding', { skip: !RESIZE_CAPABLE }, async () => {
+  const bigPng = makeTestPng(2000, 500);
+  await withImageFetchStub(bigPng, async () => {
+    const adapter = new WebAdapter();
+    const base64 = await adapter.fetchImageAsBase64('https://cdn.example/big.png');
+    const size = readJpegSize(Buffer.from(base64, 'base64'));
+    assert.ok(size, 'the downscaled payload is a decodable JPEG');
+    assert.equal(size.width, 1024);
+    assert.equal(size.height, 256);
+  });
+});
+
+test('fetchImageAsBase64 (Node) honors an explicit smaller maxDimension (the overflow retry contract)', { skip: !RESIZE_CAPABLE }, async () => {
+  const bigPng = makeTestPng(1600, 1600);
+  await withImageFetchStub(bigPng, async () => {
+    const adapter = new WebAdapter();
+    const base64 = await adapter.fetchImageAsBase64('https://cdn.example/square.png', 30, 768);
+    const size = readJpegSize(Buffer.from(base64, 'base64'));
+    assert.ok(size, 'the downscaled payload is a decodable JPEG');
+    assert.equal(size.width, 768);
+    assert.equal(size.height, 768);
+  });
+});
+
+test('fetchImageAsBase64 (Node) passes small images through byte-identical (no re-encode)', async () => {
+  const smallPng = makeTestPng(300, 200);
+  await withImageFetchStub(smallPng, async () => {
+    const adapter = new WebAdapter();
+    const base64 = await adapter.fetchImageAsBase64('https://cdn.example/small.png');
+    assert.equal(base64, smallPng.toString('base64'),
+      'an image that already fits is never recompressed');
+  });
+});
+
+test('fetchImageAsBase64 (Node) with maxDimension 0 disables the cap entirely', async () => {
+  const bigPng = makeTestPng(2000, 500);
+  await withImageFetchStub(bigPng, async () => {
+    const adapter = new WebAdapter();
+    const base64 = await adapter.fetchImageAsBase64('https://cdn.example/full.png', 30, 0);
+    assert.equal(base64, bigPng.toString('base64'), 'cap disabled → original bytes');
+  });
+});
+
+test('downscaleImageBufferForOcr falls back LOUDLY to the original buffer on undecodable bytes', async () => {
+  const adapter = new WebAdapter();
+  const garbage = Buffer.from('not an image at all');
+  const result = await adapter.downscaleImageBufferForOcr(garbage, 1024, 'https://cdn.example/garbage.bin');
+  assert.equal(result, garbage, 'undecodable bytes degrade to the pre-fix payload, never throw');
+});

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -6608,6 +6608,11 @@ class AiWebParser {
                 return {
                     imageUrl: cached.url || normalizedUrl,
                     failureKind: String(parsed.failureKind),
+                    // Additive: how many times a context-overflow entry has
+                    // been re-attempted at capped resolution (overflow-heal
+                    // path in getOcrTextForImage). Absent on entries never
+                    // retried.
+                    ...(Number.isFinite(Number(parsed.overflowHealRetries)) ? { overflowHealRetries: Number(parsed.overflowHealRetries) } : {}),
                     cachePath,
                     cached: true
                 };
@@ -9298,6 +9303,30 @@ class AiWebParser {
         const cached = await this.readCachedOcrResult(imageUrl, ocrConfig);
         if (cached) {
             if (cached.failureKind) {
+                // Heal context-overflow negative entries: they were written
+                // when this platform sent the image at FULL resolution (the
+                // Node adapter ignored the downscale cap entirely), so the
+                // "deterministic failure" they cache describes a payload we
+                // no longer send. Retry the same request — the fetch now caps
+                // the longest side — and let the fresh result overwrite the
+                // entry. Bounded like the salvage heal (2 attempts, counter
+                // persisted in the entry) so a genuinely oversized image
+                // stops costing a download+call every run forever. A failed
+                // heal keeps the negative entry and the run continues exactly
+                // as before.
+                if (cached.failureKind === 'context-overflow') {
+                    const priorOverflowRetries = Number.isFinite(Number(cached.overflowHealRetries)) ? Number(cached.overflowHealRetries) : 0;
+                    if (priorOverflowRetries < 2) {
+                        console.log(`🤖 AI Web: OCR negative cache entry (context-overflow) for ${cached.imageUrl || imageUrl} predates downscaled payloads — retrying at capped resolution to heal it (attempt ${priorOverflowRetries + 1}/2)`);
+                        let healed = null;
+                        try {
+                            healed = await this.requestAndCacheOcrResult(imageUrl, ocrConfig, passLabel, httpAdapter, { priorOverflowRetries });
+                        } catch (error) {
+                            console.log(`🤖 AI Web: OCR overflow-heal attempt failed for ${cached.imageUrl || imageUrl} (${error.message}) — keeping the negative cache entry`);
+                        }
+                        if (healed) return healed;
+                    }
+                }
                 console.log(`🤖 AI Web: OCR negative cache hit (${cached.failureKind}) for ${cached.imageUrl || imageUrl} — skipping known-bad image`);
                 return null;
             }
@@ -9387,6 +9416,12 @@ class AiWebParser {
                     rawResponse = await this.core.callAiGenerate(ocrConfig, ocrConfig.prompt, passLabel, httpAdapter, this.recordAiPrompt.bind(this), retryImage, retryDiagnostics);
                     retrySucceeded = Boolean(rawResponse);
                     diagnostics.failureKind = retryDiagnostics.failureKind || (rawResponse ? null : diagnostics.failureKind);
+                } else if (retryImage) {
+                    // An adapter without a resize capability returns the same
+                    // bytes — say so instead of silently skipping the retry
+                    // (run 20260815-102447: this skip was invisible and the
+                    // vet quietly decided nothing six times).
+                    console.warn(`🚨 AI Web: OCR overflow retry skipped for ${normalizedUrl} — the adapter returned no smaller rendition (${retryImage.length} base64 chars, was ${base64Image.length}); no image-resize capability on this platform, so this image cannot fit the model context`);
                 }
             } catch (error) {
                 console.warn(`🤖 AI Web: Reduced-resolution OCR retry failed for ${normalizedUrl}: ${error.message}`);
@@ -9401,8 +9436,17 @@ class AiWebParser {
             // page (and every run) that references it.
             // Never during a salvage heal, though: the existing cache entry
             // holds legitimate OCR text and must survive a failed retry.
-            if (diagnostics.failureKind === 'context-overflow' && !healContext) {
-                const cachePath = await this.writeCachedOcrResult(imageUrl, ocrConfig, JSON.stringify({ failureKind: diagnostics.failureKind }));
+            // An OVERFLOW heal (healContext.priorOverflowRetries) is the
+            // opposite case: the existing entry is itself the failure record,
+            // so a still-failing retry rewrites it with the bumped counter —
+            // that is what bounds the heal loop at 2 attempts.
+            const isSalvageHeal = Boolean(healContext) && !Number.isFinite(Number(healContext.priorOverflowRetries));
+            if (diagnostics.failureKind === 'context-overflow' && !isSalvageHeal) {
+                const failurePayload = { failureKind: diagnostics.failureKind };
+                if (healContext && Number.isFinite(Number(healContext.priorOverflowRetries))) {
+                    failurePayload.overflowHealRetries = Number(healContext.priorOverflowRetries) + 1;
+                }
+                const cachePath = await this.writeCachedOcrResult(imageUrl, ocrConfig, JSON.stringify(failurePayload));
                 if (cachePath) {
                     console.warn(`🤖 AI Web: Cached OCR failure (${diagnostics.failureKind}) for ${normalizedUrl} so it is not retried`);
                 }

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -829,7 +829,15 @@ test('getOcrTextForImage negative-caches context-overflow failures and skips the
   assert.equal(first, null);
   assert.equal(aiCalls, 1);
 
-  // Second call: the cached failure short-circuits before download or AI request
+  // The next two calls spend the bounded overflow-heal budget: the entry was
+  // written by a full-size sender, so it earns two capped-resolution retries
+  // (see the dedicated heal test below). Both still overflow here.
+  await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', httpAdapter);
+  await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', httpAdapter);
+  assert.equal(aiCalls, 3);
+
+  // With the heal budget spent, the cached failure short-circuits before
+  // download or AI request.
   parser.core.callAiGenerate = async () => {
     throw new Error('AI should not be called for a negative-cached image');
   };
@@ -852,6 +860,68 @@ test('getOcrTextForImage negative-caches context-overflow failures and skips the
   };
   await parser.getOcrTextForImage(otherUrl, ocrConfig, 'ocr-all', httpAdapter);
   assert.equal(retried, 1, 'a transient empty response should be retried on the next call');
+
+  fs.rmSync(cacheDir, { recursive: true, force: true });
+});
+
+test('getOcrTextForImage heals context-overflow negative cache entries once the payload is capped', async () => {
+  // Run 20260815-102447: dozens of "OCR negative cache hit (context-overflow)"
+  // entries were written back when the Node adapter sent images at FULL
+  // resolution. The cached "deterministic failure" describes a payload we no
+  // longer send, so the entry earns a bounded (2-attempt) retry — a success
+  // overwrites it, exhaustion restores the permanent skip.
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ocr-heal-test-'));
+
+  const parser = new AiWebParser({ normalizeUrl, ocrCacheDir: cacheDir });
+  parser.core = new SharedCore({}, { eventSchema: EventSchema });
+  const ocrConfig = {
+    cacheEnabled: true,
+    model: 'mlx-community/Qwen3-VL-4B-Instruct-4bit',
+    prompt: 'ocr prompt',
+    timeoutSeconds: 5
+  };
+  const httpAdapter = { fetchImageAsBase64: async () => 'base64imagedata' };
+
+  // Seed a negative entry, exactly how the pre-fix full-size sender did.
+  const imageUrl = 'https://cdn.example/formerly-huge.png';
+  parser.core.callAiGenerate = async (cfg, prompt, label, http, rec, image, diagnostics) => {
+    if (diagnostics) diagnostics.failureKind = 'context-overflow';
+    return null;
+  };
+  assert.equal(await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', httpAdapter), null);
+
+  // Next run: the heal retries the SAME request (payload now capped) and the
+  // fresh success overwrites the negative entry.
+  let healCalls = 0;
+  parser.core.callAiGenerate = async () => {
+    healCalls++;
+    return JSON.stringify({ text: 'FLYER TEXT', imageClassification: 'event-flyer', eventSummary: 's', confidence: 90, reason: 'r' });
+  };
+  const healed = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', httpAdapter);
+  assert.equal(healed.text, 'FLYER TEXT');
+  assert.equal(healCalls, 1);
+
+  // The healed result is now an ordinary cache hit — no more AI calls.
+  parser.core.callAiGenerate = async () => {
+    throw new Error('a healed entry must be served from cache');
+  };
+  const hit = await parser.getOcrTextForImage(imageUrl, ocrConfig, 'ocr-all', httpAdapter);
+  assert.equal(hit.text, 'FLYER TEXT');
+  assert.equal(hit.cached, true);
+
+  // A download failure during a heal keeps the negative entry and returns
+  // null exactly as before the heal existed.
+  const flakyUrl = 'https://cdn.example/flaky.png';
+  parser.core.callAiGenerate = async (cfg, prompt, label, http, rec, image, diagnostics) => {
+    if (diagnostics) diagnostics.failureKind = 'context-overflow';
+    return null;
+  };
+  assert.equal(await parser.getOcrTextForImage(flakyUrl, ocrConfig, 'ocr-all', httpAdapter), null);
+  const brokenAdapter = { fetchImageAsBase64: async () => { throw new Error('network down'); } };
+  assert.equal(await parser.getOcrTextForImage(flakyUrl, ocrConfig, 'ocr-all', brokenAdapter), null);
 
   fs.rmSync(cacheDir, { recursive: true, force: true });
 });

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2270,6 +2270,31 @@ class SharedCore {
             }
         }
 
+        // 9e. DATE-PHRASE titles ("Saturday Jan 23 12 PM – 5 PM", run
+        //     20260815-102447 beefdip.com/tags/: a schedule card's date/time
+        //     line reached a CREATE while its address-shaped and fine-print
+        //     siblings were withheld). Rule 1 already detects the shape (the
+        //     whole title is a date/time expression); here it joins the
+        //     enforced junk-title family — same flag + write withhold, card
+        //     stays fully visible in results. Titles with real words around
+        //     a date ("NYE 2027 Bash") keep ≥3 word characters of residue in
+        //     rule 1 and can never reach this.
+        if (title && !hasJunkTitleFlag() && flags.some(flag => flag.code === 'title-is-date-phrase')) {
+            flags.push({
+                code: 'junk-title',
+                detail: 'title is entirely a date/time expression, not an event name'
+            });
+            // Report-only companion: a date/time-only title is usually a
+            // SHARD of a real event whose NAME failed to extract (this run:
+            // the date-phrase shard and an address-titled shard were two
+            // pieces of one shattered schedule card for a real Saturday
+            // 12–5 PM party). Hint only — no rescue machinery.
+            flags.push({
+                code: 'date-phrase-untitled-shard',
+                detail: 'date/time-only title suggests the source page has a real event whose name failed to extract (report-only hint, no rescue attempted)'
+            });
+        }
+
         // 10. flyer-time-conflict — the event's own paired flyer's OCR text
         //     states a start time that disagrees with the page-derived one
         //     by an hour or more (run 20260814-195026, Playground Toronto:
@@ -13156,17 +13181,43 @@ class SharedCore {
         return null;
     }
 
-    // Curated festival whose official website host matches the given host
+    // Path portion of an http(s) URL for identity-prefix comparison:
+    // lowercased, query/fragment dropped, trailing slashes stripped ('' for a
+    // root or absent path). Built on parseUrl, never `new URL` (iOS
+    // JavaScriptCore has no URL global) — same contract as getHostFromUrl.
+    getUrlPathForPrefixMatch(url) {
+        const parsed = this.parseUrl(String(url || '').trim());
+        if (!parsed) return '';
+        return String(parsed.pathname || '').replace(/\/+$/, '').toLowerCase();
+    }
+
+    // Curated festival whose official website matches the given source host
     // (www-insensitive, same rung as areUrlHostsSameSite). Source-host is the
     // page-family signal: everything extracted from beefdip.com is BeefDip
     // context, whatever the individual record managed to extract.
-    findCuratedFestivalBySourceHost(host) {
+    //
+    // The curated URL's own specificity decides how much identity the host
+    // carries (run 20260815-102447: a curated eventbrite.com organizer URL
+    // host-matched five unrelated Eventbrite events into Ptown context):
+    //   - root-ish website (path empty or "/") — the host IS the festival's
+    //     identity, host match suffices;
+    //   - website with a path (eventbrite.com/o/…, instagram.com/…) — the
+    //     host is shared platform infrastructure, so the source URL must
+    //     additionally live UNDER the curated path prefix (case-insensitive,
+    //     trailing-slash tolerant). No source URL → fail closed.
+    // Generic by construction: no platform/domain lists anywhere.
+    findCuratedFestivalBySourceHost(host, sourceUrl = '') {
         if (!host) return null;
         for (const festival of this.festivals) {
-            const festivalHost = festival && festival.website
-                ? this.getHostFromUrl(festival.website)
-                : '';
-            if (festivalHost && this.areUrlHostsSameSite(festivalHost, host)) {
+            const website = festival && typeof festival.website === 'string' ? festival.website.trim() : '';
+            const festivalHost = website ? this.getHostFromUrl(website) : '';
+            if (!festivalHost || !this.areUrlHostsSameSite(festivalHost, host)) continue;
+            const curatedPath = this.getUrlPathForPrefixMatch(website);
+            if (!curatedPath) return festival;
+            const sourceHost = this.getHostFromUrl(sourceUrl);
+            if (!sourceHost || !this.areUrlHostsSameSite(sourceHost, festivalHost)) continue;
+            const sourcePath = this.getUrlPathForPrefixMatch(sourceUrl);
+            if (sourcePath === curatedPath || sourcePath.startsWith(`${curatedPath}/`)) {
                 return festival;
             }
         }
@@ -13206,7 +13257,8 @@ class SharedCore {
     resolveFestivalForSource(event, festivalSourceHosts) {
         const host = this.getFestivalSourceHost(event);
         if (!host) return null;
-        const direct = this.findCuratedFestivalBySourceHost(host);
+        const sourceUrl = event && typeof event._sourcePageUrl === 'string' ? event._sourcePageUrl : '';
+        const direct = this.findCuratedFestivalBySourceHost(host, sourceUrl);
         if (direct) return direct;
         if (festivalSourceHosts && typeof festivalSourceHosts.get === 'function') {
             const key = String(host).toLowerCase().replace(/^www\./, '');
@@ -15157,6 +15209,16 @@ class SharedCore {
                     console.log(`🚫 JUNK TITLE: "${analyzedEvent.title || 'Unknown'}" withheld from calendar write — ${junkDetail} (report-only: still shown in results)`);
                 } else {
                     console.log(`🚫 JUNK TITLE: "${analyzedEvent.title || 'Unknown'}" withheld from calendar write — CTA/navigation link text (report-only: still shown in results)`);
+                }
+            }
+            // Report-only companion to the date-phrase junk-title family: the
+            // shard hint is surfaced next to the withhold decision it rides
+            // with, so review sees "this page probably has a real, untitled
+            // event" without any rescue machinery engaging.
+            {
+                const untitledShardFlag = analyzedEvent._sanityFlags.find(flag => flag && flag.code === 'date-phrase-untitled-shard');
+                if (untitledShardFlag) {
+                    console.log(`🧩 DATE-PHRASE SHARD: "${analyzedEvent.title || 'Unknown'}" (source ${analyzedEvent._sourcePageUrl || 'unknown'}) — ${untitledShardFlag.detail}`);
                 }
             }
 

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -15561,9 +15561,14 @@ function sanityCodes(core, event) {
 test('sanity: a title that is entirely a date/time expression flags title-is-date-phrase', () => {
   const core = createSanityCore();
   // Real write-plan titles: the whole title is a date+time range; an event
-  // literally titled "6:30 PM" (earlier run).
-  assert.deepEqual(sanityCodes(core, { title: 'Saturday Jan 23 12 PM – 5 PM' }), ['title-is-date-phrase']);
-  assert.deepEqual(sanityCodes(core, { title: '6:30 PM' }), ['title-is-date-phrase']);
+  // literally titled "6:30 PM" (earlier run). Since run 20260815-102447
+  // (beefdip.com/tags/ shipped "Saturday Jan 23 12 PM – 5 PM" as a CREATE)
+  // the shape also joins the ENFORCED junk-title family (rule 9e) and
+  // carries the report-only untitled-shard hint.
+  assert.deepEqual(sanityCodes(core, { title: 'Saturday Jan 23 12 PM – 5 PM' }),
+    ['title-is-date-phrase', 'junk-title', 'date-phrase-untitled-shard']);
+  assert.deepEqual(sanityCodes(core, { title: '6:30 PM' }),
+    ['title-is-date-phrase', 'junk-title', 'date-phrase-untitled-shard']);
 });
 
 test('sanity: titles with real words beyond the date phrase never flag as date phrases', () => {
@@ -18504,9 +18509,12 @@ test('sanity: ticketing fine-print titles flag junk-title alongside the report-o
   assert.deepEqual(sanityCodes(core, { title: '*** !!! ***' }), ['title-looks-like-boilerplate']);
   // Policy-adjacent words without a table phrase never flag.
   assert.deepEqual(sanityCodes(core, { title: 'Terms of Endearment Party' }), []);
-  // Time-range titles are already title-is-date-phrase (rule 1) — verified
-  // here to stay OUT of junk-title (no duplication between rules).
-  assert.deepEqual(sanityCodes(core, { title: 'Saturday Jan 23 12 PM – 5 PM' }), ['title-is-date-phrase']);
+  // Time-range titles are title-is-date-phrase (rule 1) and, since run
+  // 20260815-102447, ALSO the enforced junk-title sibling via rule 9e — but
+  // never through the fine-print family exercised here (rule 9e pushes at
+  // most one junk-title flag, after 9d declined).
+  assert.deepEqual(sanityCodes(core, { title: 'Saturday Jan 23 12 PM – 5 PM' }),
+    ['title-is-date-phrase', 'junk-title', 'date-phrase-untitled-shard']);
 });
 
 test('junk-title sibling families are withheld with a detail-bearing 🚫 JUNK TITLE line; the CTA line is unchanged', async () => {
@@ -20113,4 +20121,145 @@ test('festival data is injected, never loaded: a core without festivals behaves 
   const analyzed = await core.prepareEventsForCalendar([buildBeefdipUmbrellaEvent()], adapter, {});
   assert.ok(!analyzed[0]._festivalMatch, 'no injected festivals → no matching, no withhold');
   assert.equal(SharedCore.filterEventsForExecution(analyzed).length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Festival source identity respects the curated URL's PATH, not just its host
+// (run 20260815-102447: bear-week-provincetown's curated website was an
+// eventbrite.com organizer URL, and host-only matching stamped five unrelated
+// Eventbrite events — Megawoof Houston/Vegas, Coach After Dark SF, Cubhouse
+// Philly, Twisted Bear SF — with Ptown _festivalContext + bogus
+// festival-window-violation flags). Synthetic curated fixtures on purpose:
+// the rule is generic, not data-dependent.
+// ---------------------------------------------------------------------------
+
+const PATH_IDENTITY_FESTIVALS = [
+  {
+    key: 'platform-fest',
+    name: 'Platform Fest',
+    cityKey: 'ptown',
+    recurring: 'annual',
+    website: 'https://www.eventbrite.com/o/someorg-12345',
+    nextDates: { start: '2027-07-10', end: '2027-07-17' }
+  },
+  {
+    key: 'insta-fest',
+    name: 'Insta Fest',
+    cityKey: 'sf',
+    recurring: 'annual',
+    website: 'https://www.instagram.com/some-account/',
+    nextDates: { start: '2027-05-01', end: '2027-05-03' }
+  },
+  {
+    key: 'root-fest',
+    name: 'Root Fest',
+    cityKey: 'pv',
+    recurring: 'annual',
+    website: 'https://example-fest.com/',
+    nextDates: { start: '2027-01-23', end: '2027-01-31' }
+  }
+];
+
+test('festival source identity: a platform-hosted curated website only claims URLs under its own path', () => {
+  const core = createFestivalCore(PATH_IDENTITY_FESTIVALS);
+  // A random event page on the shared platform host: host matches, path does
+  // not — no festival identity.
+  assert.equal(
+    core.findCuratedFestivalBySourceHost('www.eventbrite.com', 'https://www.eventbrite.com/e/random-party-tickets-999'),
+    null);
+  // A page UNDER the curated organizer path DOES match (case-insensitive,
+  // trailing-slash tolerant, www-insensitive).
+  assert.equal(
+    core.findCuratedFestivalBySourceHost('eventbrite.com', 'https://www.eventbrite.com/O/SomeOrg-12345/').key,
+    'platform-fest');
+  assert.equal(
+    core.findCuratedFestivalBySourceHost('www.eventbrite.com', 'https://www.eventbrite.com/o/someorg-12345/events/').key,
+    'platform-fest');
+  // Prefix means path-SEGMENT prefix: /o/someorg-12345-other is a different
+  // organizer, not a sub-path.
+  assert.equal(
+    core.findCuratedFestivalBySourceHost('www.eventbrite.com', 'https://www.eventbrite.com/o/someorg-12345-other'),
+    null);
+  // No source URL at all (only a stamped host) fails closed for a
+  // path-carrying curated website.
+  assert.equal(core.findCuratedFestivalBySourceHost('www.eventbrite.com'), null);
+});
+
+test('festival source identity: an instagram-account curated website never claims other accounts', () => {
+  const core = createFestivalCore(PATH_IDENTITY_FESTIVALS);
+  assert.equal(
+    core.findCuratedFestivalBySourceHost('instagram.com', 'https://www.instagram.com/other-account'),
+    null);
+  assert.equal(
+    core.findCuratedFestivalBySourceHost('instagram.com', 'https://www.instagram.com/some-account').key,
+    'insta-fest');
+  assert.equal(
+    core.findCuratedFestivalBySourceHost('instagram.com', 'https://www.instagram.com/some-account/p/xyz123/').key,
+    'insta-fest');
+});
+
+test('festival source identity: a root-path curated site still matches any URL on its host', () => {
+  const core = createFestivalCore(PATH_IDENTITY_FESTIVALS);
+  assert.equal(
+    core.findCuratedFestivalBySourceHost('example-fest.com', 'https://example-fest.com/schedule/day-2').key,
+    'root-fest');
+  // Host-only signal (no source URL) is still enough for a root-ish site.
+  assert.equal(core.findCuratedFestivalBySourceHost('www.example-fest.com').key, 'root-fest');
+  // A different host never matches, path or no path.
+  assert.equal(core.findCuratedFestivalBySourceHost('other-site.com', 'https://other-site.com/'), null);
+});
+
+test('festival source identity: a blank-city platform event no longer inherits the festival city', () => {
+  const core = createFestivalCore(PATH_IDENTITY_FESTIVALS);
+  // The latent danger from run 20260815-102447: a city-less Eventbrite event
+  // inside the festival window would have inherited city ptown via the
+  // host-only match. With path identity it resolves no festival at all.
+  const event = {
+    title: 'Some Unrelated Party',
+    city: 'unknown',
+    startDate: '2027-07-12T00:00:00.000Z',
+    _sourcePageUrl: 'https://www.eventbrite.com/e/some-unrelated-party-tickets-42'
+  };
+  assert.equal(core.resolveFestivalForSource(event, new Map()), null);
+  // The same event sourced from the organizer's own path resolves normally.
+  const organizerEvent = {
+    ...event,
+    _sourcePageUrl: 'https://www.eventbrite.com/o/someorg-12345/some-party'
+  };
+  assert.equal(core.resolveFestivalForSource(organizerEvent, new Map()).key, 'platform-fest');
+});
+
+// ---------------------------------------------------------------------------
+// Date-phrase titles are write-gated like their junk-title siblings (run
+// 20260815-102447: "Saturday Jan 23 12 PM – 5 PM" from beefdip.com/tags/
+// carried _action "new" and would have been WRITTEN while its address-shaped
+// and fine-print siblings were withheld).
+// ---------------------------------------------------------------------------
+
+test('sanity: a date-phrase title is withheld at the write gate, still visible in results', () => {
+  const core = createSanityCore();
+  const flags = core.getEventSanityFlags(
+    { title: 'Saturday Jan 23 12 PM – 5 PM' }, { nowMs: SANITY_NOW_MS });
+  const analyzed = {
+    title: 'Saturday Jan 23 12 PM – 5 PM',
+    _action: 'new',
+    _sanityFlags: flags
+  };
+  assert.equal(SharedCore.hasJunkTitleSanityFlag(analyzed), true);
+  assert.deepEqual(SharedCore.filterEventsForExecution([analyzed]), [],
+    'the date-phrase record never reaches a calendar write');
+  assert.equal(SharedCore.describeExecutionDisposition(analyzed), 'WITHHELD (junk title)');
+  assert.equal(analyzed._action, 'new', 'the withhold is a gate, not an action rewrite');
+  // The report-only shard hint rides along: a date/time-only title suggests
+  // an untitled REAL event on the source page. Hint only — nothing else.
+  assert.ok(flags.some(flag => flag.code === 'date-phrase-untitled-shard'));
+});
+
+test('sanity: a real title with a date inside it is NOT withheld', () => {
+  const core = createSanityCore();
+  const flags = core.getEventSanityFlags({ title: 'NYE 2027 Bash' }, { nowMs: SANITY_NOW_MS });
+  const analyzed = { title: 'NYE 2027 Bash', _action: 'new', _sanityFlags: flags };
+  assert.deepEqual(flags, [], 'no sanity flags at all for a dated real name');
+  assert.equal(SharedCore.filterEventsForExecution([analyzed]).length, 1,
+    'the write goes through');
 });


### PR DESCRIPTION
Three defects found in Mac run 20260815-102447, one batched PR.

## Fix 1 — Festival identity respects the curated URL's path, not just its host

**Evidence:** log lines ~16946–17206 — bear-week-provincetown's curated `website` was `https://www.eventbrite.com/o/ptownbears-78481077703`, and `findCuratedFestivalBySourceHost` matched by HOST ONLY, so five unrelated Eventbrite events (Megawoof Houston/Vegas, Coach After Dark SF, Cubhouse Philly, Twisted Bear SF) were stamped with Ptown `_festivalContext` + bogus `festival-window-violation` flags. Latent danger: a blank-city Eventbrite event inside the window would have inherited city `ptown`.

**Mechanism (`scripts/shared-core.js`):** `findCuratedFestivalBySourceHost(host, sourceUrl)` now derives identity from the curated URL's own specificity — a root-ish curated website (path empty or `/`) keeps host-only matching; a curated website carrying a path (`eventbrite.com/o/…`, `instagram.com/account/`) only matches source URLs that share the host AND live under that path prefix (case-insensitive, trailing-slash tolerant, path-segment-boundary aware). New `getUrlPathForPrefixMatch` helper is built on the existing `parseUrl` (no `new URL` anywhere). No platform/domain lists — this automatically fixes bear-pride-chicago's Instagram organizer URL too, and disambiguates theurbanbear.com hosting two curated festivals.

**Data:** `data/festivals.json` bear-week-provincetown `website` → `https://www.ptownbears.events/` (the real official site; the Eventbrite URL was their ticketing outlet). The code fix stands on its own even with platform URLs in curated data.

**Known behavior change:** curated entries whose website already carries a path (e.g. `beefdip.com/planned-events/`) now only direct-match sources under that path; sources elsewhere on the same host still gain context through the existing umbrella-taught host map (`collectFestivalSourceHosts`), which is unchanged.

## Fix 2 — `title-is-date-phrase` events are write-gated like their junk-title siblings

**Evidence:** run JSON — event titled "Saturday Jan 23 12 PM – 5 PM" (source `http://beefdip.com/tags/`, city pv, start 2027-01-23) carried `_action: "new"` and only `[title-is-date-phrase]` in `_sanityFlags`, so it would have been WRITTEN, while its sibling junk shapes ("Malecón 4, Zona Romántica, Puerto Vallarta", "Hotel Delfin", "DOG TAGS ARE NON REFUNDABLE…") were withheld. Root cause: rule 1 stamps `title-is-date-phrase`, but only the `junk-title` code is enforced by `hasJunkTitleSanityFlag`/`filterEventsForExecution`.

**Mechanism (`scripts/shared-core.js`):** new rule 9e in `getEventSanityFlags` escalates a rule-1 date-phrase title into the enforced junk-title family (same `at most one junk-title flag` discipline as 9b–9d). Flag-don't-drop: the card stays in results, only the calendar write is withheld. Titles with real words around a date ("NYE 2027 Bash") keep ≥3 chars of residue in rule 1 and never reach 9e. Additionally a report-only `date-phrase-untitled-shard` flag + a NEW `🧩 DATE-PHRASE SHARD` log line note that a date/time-only title suggests an untitled REAL event on the source page (this run: the date-phrase shard + the address-titled shard were two pieces of one shattered schedule card for a real Saturday 12–5 PM party). Log/flag only — no rescue machinery.

## Fix 3 — og-image vet silently no-oped on oversized images

**Evidence:** log — six `og-image-vet` AI passes returned 0 tokens with finish_reason "length" (256k–607k base64 chars). Two compounding holes: (a) `WebAdapter.fetchImageAsBase64` (Node) ignored the `maxDimension` parameter entirely while `ScriptableAdapter` has always capped the longest side at 1024 via DrawContext; (b) the existing overflow retry asked the adapter for a 768px rendition, got identical bytes back, and skipped SILENTLY. The run also read dozens of `context-overflow` negative cache entries written during the full-size era.

**Mechanism:**
- `scripts/adapters/web-adapter.js`: `fetchImageAsBase64(url, timeout, maxDimension = 1024)` now downscales via a capability ladder resolved once per adapter — `sharp` (the resize library the repo already ships for tools/download-images.js, wherever npm install ran) → macOS `/usr/bin/sips` (the Mac scheduler runs with NO node_modules; same system-binary precedent as tools/run-once.js calling `/usr/bin/brctl`; semantics verified locally: 2000x500 → 1024x256) → none, announced with a LOUD warn. Images that already fit pass through byte-identical. Decision math lives in the pure `WebAdapter.getDownscaledImageDimensions`, mirroring the Scriptable inline math.
- `scripts/parsers/ai-web-parser.js`: the overflow retry's silent skip (same-size rendition) now emits a NEW `🚨` warn — no partial-silent behavior on any platform.
- `scripts/parsers/ai-web-parser.js`: `context-overflow` negative cache entries earn a bounded heal (2 attempts, `overflowHealRetries` persisted in the entry, modeled on the existing salvage-heal) — without this, stale caches from the full-size era would make the fix look un-shipped on the Mac. A success overwrites the entry; exhaustion restores the permanent skip.
- The og-image-vet AI prompt text is untouched; no call-count "optimization" anywhere — only making the input fit.

## Tests (all in files already enumerated in package.json)

Full quiet suite: `NODE_OPTIONS="--require ./scripts/test-quiet-console.js" npm test` → **1948/1948 passing** (baseline 1935; 0 skipped locally — the resize tests exercised the sips leg since this machine has no node_modules; on CI, which runs without npm install, resize-behavior tests skip via an explicit capability probe).

**Fail-on-base proof:** with the new/updated test files kept and `scripts/shared-core.js`, `scripts/adapters/web-adapter.js`, `scripts/parsers/ai-web-parser.js`, `data/festivals.json` checked out from origin/main, exactly these 12 tests fail (verified in this worktree before restoring):
- festival source identity: a platform-hosted curated website only claims URLs under its own path
- festival source identity: an instagram-account curated website never claims other accounts
- festival source identity: a blank-city platform event no longer inherits the festival city
- sanity: a title that is entirely a date/time expression flags title-is-date-phrase (updated expectations)
- sanity: ticketing fine-print titles flag junk-title alongside the report-only boilerplate flag (updated expectations)
- sanity: a date-phrase title is withheld at the write gate, still visible in results
- getDownscaledImageDimensions: longest-side cap decision, fail-open on bad input
- fetchImageAsBase64 (Node) caps the longest side at the default 1024 before encoding
- fetchImageAsBase64 (Node) honors an explicit smaller maxDimension (the overflow retry contract)
- downscaleImageBufferForOcr falls back LOUDLY to the original buffer on undecodable bytes
- getOcrTextForImage negative-caches context-overflow failures and skips them next time (updated for the bounded heal)
- getOcrTextForImage heals context-overflow negative cache entries once the payload is capped

Festival tests use synthetic curated fixtures, independent of the shipped data.

## No new runtime files

All changes live in existing files (`shared-core.js`, `web-adapter.js`, `ai-web-parser.js`, `data/festivals.json`) — nothing new for the phone updater. No existing console.log line or AI prompt line was edited (verified against the diff); no `new URL(`/`URLSearchParams` introduced.

## Deliberately NOT done

- No rescue machinery for date-phrase shards (log/flag only, per the brief).
- No heal for `salvaged-from-truncated-response` entries whose 2-attempt budget is already spent — that truncation is not proven resize-related.
- The browser (non-Node) branch of `fetchImageAsBase64` gained no resize; its skipped overflow retry is covered by the new loud warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP