### PR TITLE
Crawl junk-tail hygiene, year-back past-event writes, collapsed saved pile, Goldiloxx row fix

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -8293,13 +8293,16 @@ class ScriptableAdapter {
       view.savedCards.length > 0
         ? `
     <div class="section">
-        <div class="section-header">
-            <span class="section-icon">✅</span>
-            <span class="section-title">Already Saved (No Action)</span>
-            <span class="section-count">${view.savedCountLabel}</span>
-        </div>
-        <div class="section-blurb">These matched what the calendar already has — a saved series, or a merge with nothing new to add. Nothing will be written.</div>
-        ${view.savedCards.join("")}
+        <details class="bear-dropped-details saved-noop-details">
+            <summary class="bear-dropped-summary">
+                <span class="section-icon">✅</span>
+                <span class="section-title">Already Saved (No Action)</span>
+                <span class="section-count">${view.savedCountLabel}</span>
+                <span class="bear-dropped-hint">collapsed — tap to review</span>
+            </summary>
+            <div class="section-blurb">These matched what the calendar already has — a saved series, or a merge with nothing new to add. Nothing will be written.</div>
+            ${view.savedCards.join("")}
+        </details>
     </div>
     `
         : ""

--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -14187,6 +14187,12 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       // Search helper fields used only for identifier matching
       "searchStartDate",
       "searchEndDate",
+      // Promoter-registry matching plumbing (run 20260820, Goldiloxx): the
+      // registry stamps matchKey onto the FRESH event every run, but the
+      // field is notes-excluded and never persists to the calendar — the
+      // calendar side is undefined by construction, so its row would read
+      // "calendar: undefined → ADDED" on every run forever.
+      "matchKey",
       // Location-specific fields that are internal to geocoding
       "placeId",
       // Coordinate helpers that should not show in comparisons

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -8151,6 +8151,21 @@ test('the dropped pile is collapsed by default and keeps the mark-bear rescue bu
   assert.ok(droppedSection.includes('ai: no bear-specific language'));
 });
 
+test('the already-saved pile is collapsed by default (owner 2026-08-20: no-update events can fold away)', async () => {
+  const adapter = buildAdapter();
+  const html = await adapter.generateRichHTML(buildWave6Results());
+
+  const idx = html.indexOf('<details class="bear-dropped-details saved-noop-details">');
+  assert.ok(idx !== -1, 'saved section wraps its cards in a <details>');
+  assert.ok(!html.includes('<details class="bear-dropped-details saved-noop-details" open'),
+    'the saved <details> starts collapsed');
+
+  const savedDetails = html.slice(idx, html.indexOf('Withheld (Not Written)'));
+  assert.ok(savedDetails.includes('Already Saved (No Action)'), 'summary keeps the section title');
+  assert.ok(savedDetails.includes('✅ merge no-op — calendar already has all of this'),
+    'no-op card rendered inside the collapsed pile');
+});
+
 test('event cards are headline + main section + hidden raw payload, nothing deleted', async () => {
   const adapter = buildAdapter();
   const event = {

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -8513,6 +8513,33 @@ test('TWISTED BEAR without a decision record (older saved runs) still never self
     'the strategy slot admits arbitration never ran');
 });
 
+test('matchKey never renders a comparison row (Goldiloxx: calendar cannot hold it, so "→ ADDED" repeated forever)', () => {
+  const adapter = buildAdapter();
+  // Goldiloxx shape from run 20260820: the promoter registry stamps
+  // matchKey onto the FRESH event every run, but the field is in
+  // DEFAULT_NOTES_EXCLUDED_FIELDS and never serializes into calendar
+  // notes — the calendar side is undefined by construction, so the row
+  // "fresh wins / calendar: undefined → ADDED" can never resolve.
+  const event = {
+    title: 'GOLDILOXX',
+    startDate: '2026-08-30T23:00:00.000Z',
+    matchKey: 'goldiloxx*|2026-08-*|*',
+    _action: 'merge',
+    _original: {
+      scraper: { title: 'GOLDILOXX', startDate: '2026-08-30T23:00:00.000Z', matchKey: 'goldiloxx*|2026-08-*|*' },
+      calendar: { title: 'GOLDILOXX', startDate: '2026-08-30T23:00:00.000Z' },
+      merged: { title: 'GOLDILOXX', startDate: '2026-08-30T23:00:00.000Z', matchKey: 'goldiloxx*|2026-08-*|*' }
+    },
+    _fieldPriorities: { matchKey: { merge: 'clobber' } }
+  };
+  const records = adapter.buildComparisonRowRecords(event);
+  assert.ok(Array.isArray(records), 'comparison records computed');
+  assert.equal(records.find((record) => record.field === 'matchKey'), undefined,
+    'registry matching plumbing renders no row');
+  assert.equal(adapter.countChangedMergeFields(event), 0,
+    'plumbing does not count toward the changed-fields chip');
+});
+
 test('TWISTED BEAR unchanged twin renders "no changes"', () => {
   const adapter = buildAdapter();
   const event = twistedBearEvent({ gmaps: TWISTED_CAL_GMAPS });

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -9649,6 +9649,17 @@ class AiWebParser {
             return { valid: false, reason: 'unresolved-code-syntax' };
         }
         const lowerHostname = (parsedUrl.hostname || '').toLowerCase();
+        // IP-LITERAL HOSTS (run 20260820, phone): a widget's raw-IP origin
+        // ("https://52.60.137.136/") survived discovery and then spent the
+        // whole per-URL retry budget timing out as a crawl page. No event
+        // page is addressed by a bare IP — reject the literal shape itself.
+        // Pure syntax, no address list. Checked before the dotless-hostname
+        // rule because bracketed IPv6 literals carry no dot. The iOS regex
+        // fallback keeps ":port" in hostname, so strip a trailing port first.
+        const hostWithoutPort = lowerHostname.replace(/:\d+$/, '');
+        if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostWithoutPort) || hostWithoutPort.startsWith('[')) {
+            return { valid: false, reason: 'ip-literal-host' };
+        }
         if (!lowerHostname.includes('.') && lowerHostname !== 'localhost') {
             return { valid: false, reason: 'implausible-hostname' };
         }
@@ -9665,7 +9676,11 @@ class AiWebParser {
             // Generic non-event site sections, anchored to WHOLE path segments so
             // event slugs containing these words survive (e.g. /events/all-about-bears).
             // /login is already covered by the substring list above.
-            /\/(?:shop|store|merch|cart|checkout|contact|about|faq|account|signin|signup)(?:\/|[?#]|$)/i,
+            // my-account/lost-password/boutique (run 20260820, phone): the
+            // segment anchor means "account" never matches "/my-account/", so
+            // WooCommerce account pages and the FR shop segment each got a
+            // classify + AI extraction pass for 0 events.
+            /\/(?:shop|store|merch|boutique|cart|checkout|contact|about|faq|account|my-account|lost-password|signin|signup)(?:\/|[?#]|$)/i,
             // Wix internal API endpoints (e.g. chunk-party.com/_api/...)
             '/_api/',
             // Eventbrite's Next.js image proxy (/e/_next/image?url=…) — an image

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -5894,6 +5894,46 @@ test('validateEventUrl keeps legitimate plus-in-query and parens-in-path URLs va
     { valid: true, reason: 'valid' });
 });
 
+test('validateEventUrl rejects IP-literal hosts (https://52.60.137.136/ burned the retry budget in run 20260820)', () => {
+  const parser = createParser();
+  // The literal raw-IP crawl candidate from the phone run: a widget's origin
+  // scraped as a page URL. No event page lives at a bare IP.
+  assert.deepEqual(
+    parser.validateEventUrl('https://52.60.137.136/', 'https://www.bearitmtl.com/'),
+    { valid: false, reason: 'ip-literal-host' });
+  // With a port (the regex URL fallback on iOS keeps ":port" in hostname).
+  assert.deepEqual(
+    parser.validateEventUrl('https://52.60.137.136:8443/events', 'https://www.bearitmtl.com/'),
+    { valid: false, reason: 'ip-literal-host' });
+  // Bracketed IPv6 literals are equally not event pages.
+  assert.deepEqual(
+    parser.validateEventUrl('https://[2607:f8b0::1]/events', 'https://www.bearitmtl.com/'),
+    { valid: false, reason: 'ip-literal-host' });
+  // A dotted DOMAIN that merely starts with digits is not an IP literal.
+  const numericPrefixDomain = parser.validateEventUrl('https://4bears.example.com/events', 'https://4bears.example.com/');
+  assert.notEqual(numericPrefixDomain.reason, 'ip-literal-host');
+});
+
+test('validateEventUrl rejects account/commerce path segments the segment-anchor missed (run 20260820: /my-account/, /boutique/)', () => {
+  const parser = createParser();
+  // Literal junk crawl pages from the Bear it MTL phone run — each one got
+  // classified and fed to AI extraction for 0 events.
+  const junk = [
+    'https://www.bearitmtl.com/my-account/',
+    'https://www.bearitmtl.com/my-account/lost-password/',
+    'https://www.bearitmtl.com/boutique/'
+  ];
+  for (const url of junk) {
+    const result = parser.validateEventUrl(url, 'https://www.bearitmtl.com/events/');
+    assert.equal(result.valid, false, `${url} must be rejected`);
+    assert.ok(String(result.reason).startsWith('blocked-pattern'), `${url} rejected as blocked-pattern, got: ${result.reason}`);
+  }
+  // Segment anchoring still protects event slugs CONTAINING these words.
+  assert.deepEqual(
+    parser.validateEventUrl('https://www.bearitmtl.com/event/my-account-of-a-bear-night/', 'https://www.bearitmtl.com/events/'),
+    { valid: true, reason: 'valid' });
+});
+
 test('discovery end-to-end: script-concat residue and placeholder hosts are rejected with counted reasons', () => {
   const core = new SharedCore({}, { eventSchema: EventSchema });
   const parser = new AiWebParser({ normalizeUrl: core.normalizeUrl.bind(core) });

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -330,6 +330,12 @@ const scraperConfig = {
     // scrape time — the website reads fuller with history on it. Applies to
     // every parser; flip to false (or remove) to go back to future-only.
     allowPastEvents: true,
+    // Companion knob (owner 2026-08-20): keep WRITING updates to past events
+    // up to a year back, so recent-past cards with script-format diffs write
+    // once instead of re-showing the same diff forever. Only spans that ended
+    // MORE than this many days ago are withheld from calendar writes
+    // (span-fully-past). Remove to fall back to the 30-day default.
+    sanity: { pastSpanWithholdDays: 365 },
     // dryRun: true, // Preview mode: analyze + display without writing to the calendar (default: false)
     // Parser picker at run start OWNS run selection (default: false).
     // Manual Scriptable runs only; the selection is session-scoped and never

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -12056,6 +12056,17 @@ test('the repo scraper-input config resolves the promoter registry to enforce mo
   assert.equal(core.getPromoterRegistryMode(repoConfig), 'enforce');
 });
 
+test('the repo scraper-input config keeps writing past events up to a year back', () => {
+  // Owner 2026-08-20: "keep saving old events (maybe up to a year or so
+  // back) so the website looks more full" — and recent-past CHUNK diffs must
+  // WRITE once instead of re-showing forever. The shipped config must
+  // resolve the past-span withhold window to 365 days; removing the sanity
+  // block falls back to the 30-day default and fails here.
+  const core = createCore();
+  const repoConfig = require('./scraper-input');
+  assert.equal(core.resolvePastSpanWithholdDays(repoConfig.config), 365);
+});
+
 test('matcher: padded-token title containment matches a full name, never a bare substring', () => {
   const core = createRegistryCore();
   const match = core.matchEventToPromoter({ title: 'Bearracuda Atlanta 17 Year Anniversary' });


### PR DESCRIPTION
Findings from the canceled Bear it MTL phone run (20260820 ~10:55) plus owner notes, one batched wave. **No new runtime files** — all edits land in existing files, no script-updater entries needed.

## Crawl junk-tail (run 20260820 evidence)
- **`ip-literal-host` rejection in `validateEventUrl`**: a widget's raw-IP origin (`https://52.60.137.136/`) survived URL discovery and burned the whole per-URL retry budget timing out (~19 min wall clock, most of it app-suspension freeze). Pure syntax check — IPv4 dotted quad (port-tolerant for the iOS regex-fallback hostname) + bracketed IPv6 — no address list. Placed before the dotless-host rule so IPv6 literals don't misreport as `implausible-hostname`.
- **blocked-pattern gains `my-account` | `lost-password` | `boutique`**: the whole-segment anchor means `account` never matches `/my-account/`, so WooCommerce account pages and the FR shop segment each got a classify + AI-extraction pass for 0 events. Segment anchoring still protects event slugs containing these words.

## Owner notes (2026-08-20)
- **`sanity: { pastSpanWithholdDays: 365 }`** in scraper-input config: `allowPastEvents: true` (2026-07-30) already keeps past events through parse/analysis; the only write gate was the 30-day span-fully-past withhold. At 365, recent-past cards with script-format diffs (CHUNK) write once and go quiet instead of re-showing the same diff forever; only spans ended >1 year back stay withheld. Flag and write-gate read the same resolver, so they move together.
- **"Already Saved (No Action)" pile collapsed by default** — same `<details>` shell as the dropped-as-non-bear pile, count chip still visible in the summary row.
- **Goldiloxx perpetual "matchKey → ADDED" row killed**: matchKey is registry matching plumbing, stamped fresh every run and *never* serialized to calendar notes (`DEFAULT_NOTES_EXCLUDED_FIELDS`) — the calendar side is undefined by construction, so the row could never resolve. It joins the comparison exclusion set; wildcard matching itself is untouched.

Not needed after investigation: Sugar Bear 2027 is already curated in `data/festivals.json` with official dates; the per-URL retry ladder already carries a 4-minute time budget (the observed 19-minute stall was Scriptable app suspension freezing the clock mid-attempt — the budget killed it on resume).

## Verification
- Quiet suite **1953/1953** (base 1948 + 5 new tests, each proven failing on base).
- New tests: IP-literal rejection (IPv4/port/IPv6 + numeric-prefix-domain counter-case), junk-segment rejection (+ slug-survival counter-case), repo config resolves 365-day withhold, saved pile renders collapsed, matchKey renders no row and doesn't count toward the changed-fields chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP