### PR TITLE
Flyer-only segments + OCR title-evidence image merges (+ srcset comma fix)

### DIFF
--- a/scripts/bear-event-scraper-unified.js
+++ b/scripts/bear-event-scraper-unified.js
@@ -330,6 +330,14 @@ class BearEventScraperOrchestrator {
                         });
                         aiParser.core = sharedCore;
                         sharedCore.aiResponseCache = aiParser.getAiResponseCache();
+                        // OCR title-evidence for image merges: shared-core's
+                        // arbitration reads what both image candidates SAY
+                        // (verdict store + persistent OCR cache) through this
+                        // injected lookup — platform-pure, fails open when
+                        // either side has no readable text.
+                        sharedCore.setOcrImageTextLookup(
+                            (imageUrl, httpAdapter) => aiParser.getCachedOcrTextForImage(imageUrl, httpAdapter)
+                        );
                         parsers[name] = aiParser;
                     } else {
                         parsers[name] = new ParserClass();

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -1523,6 +1523,19 @@ class AiWebParser {
             const aiSegments = await this.runAiBoundarySegmentation(html, sourceUrl, ocrResults, parserConfig, httpAdapter, segments.length);
             if (aiSegments.length >= 2) segments = aiSegments;
         }
+        if (segments.length === 0 && parserConfig.discoveryOnly !== true) {
+            // Flyer-only listing pages (run 20260820, Lumberyard
+            // /mothly-events): every event is a poster image with no HTML
+            // text, so neither splitter can find windows — yet OCR already
+            // read the flyers. Give each text-bearing flyer its own segment;
+            // the whole-page fallback below can only ever return ONE event
+            // and silently discarded the rest AFTER OCR paid for them.
+            const flyerSegments = this.buildFlyerOnlySegments(ocrResults, sourceUrl);
+            if (flyerSegments.length >= 2) {
+                console.log(`🤖 AI Web: 🖼️ FLYER SEGMENTS: no text windows but ${flyerSegments.length} OCR'd flyers carry their own text — extracting one segment per flyer`);
+                segments = flyerSegments;
+            }
+        }
         if (segments.length === 0) {
             console.warn('🤖 AI Web: multi-event-page classification produced no valid segments; returning no events');
             // Marker for parseEvents' cached-misclassification self-heal: a
@@ -1578,6 +1591,15 @@ class AiWebParser {
         // flyer↔segment pairings whose flyer text names a sibling listing —
         // BEFORE any per-segment prompt content is built below.
         this.applySegmentOcrConsistencyGate(segments, ocrResults, sourceUrl);
+
+        // Fused-listing split (run 20260820, South Seattle Bear Social): with
+        // pairings corrected, a window still holding 2+ distinct text-bearing
+        // flyers releases the extras into flyer-only segments of their own —
+        // one-event-per-segment extraction was keeping only the neighbor.
+        const flyerTopUpSegments = this.collectFusedFlyerTopUpSegments(segments, ocrResults, sourceUrl);
+        if (flyerTopUpSegments.length > 0) {
+            segments = segments.concat(flyerTopUpSegments);
+        }
 
         // Report-only tripwire: a window carrying a NEIGHBORING card's
         // JSON-LD would have its url/date/image hijacked by the structured
@@ -3872,9 +3894,8 @@ class AiWebParser {
                 const attributeValue = String(match[1] || '').trim();
                 if (!attributeValue) continue;
                 if (pattern.source.includes('srcset')) {
-                    attributeValue.split(',').forEach(part => {
-                        const candidate = String(part || '').trim().split(/\s+/)[0];
-                        if (candidate) addImageRecord(candidate, match.index, pattern.lastIndex);
+                    this.splitSrcsetIntoUrlCandidates(attributeValue).forEach(candidate => {
+                        addImageRecord(candidate, match.index, pattern.lastIndex);
                     });
                 } else {
                     addImageRecord(attributeValue, match.index, pattern.lastIndex);
@@ -3890,6 +3911,24 @@ class AiWebParser {
             if (results.length >= limit) break;
         }
         return results.slice(0, limit);
+    }
+
+    // srcset entries are separated by commas, but URLs may CONTAIN commas
+    // (wixstatic transform params: /v1/fill/w_600,h_800,al_c,…). Split only
+    // at commas that start a new entry: comma + whitespace (the spec's
+    // "url descriptor, url descriptor" shape) or comma directly before a new
+    // absolute URL. In-URL commas match neither, so Wix URLs survive whole —
+    // run 20260820 (Lumberyard): naive comma-splitting produced relative
+    // shards ("enc_auto/quality_auto/…") that were re-rooted onto the page
+    // host as guaranteed-404 OCR candidates wasting cap slots. Known
+    // trade-off: a RELATIVE second entry packed against the comma with no
+    // whitespace is not split — rarer than in-URL commas, and the old code
+    // mangled that shape's sibling anyway.
+    splitSrcsetIntoUrlCandidates(attributeValue) {
+        return String(attributeValue || '')
+            .split(/,\s*(?=https?:\/\/)|,\s+/i)
+            .map(part => String(part || '').trim().split(/\s+/)[0])
+            .filter(Boolean);
     }
 
     extractOrderedImageUrlsFromHtml(html, sourceUrl = '', maxUrls = Infinity) {
@@ -8861,6 +8900,127 @@ class AiWebParser {
         }
 
         return matchedOcrResults;
+    }
+
+    // ── Flyer-only segments (run 20260820, The Lumberyard) ────────────────
+    // Listing pages whose events are POSTER IMAGES with little or no HTML
+    // text defeat both text splitters, yet OCR already read every flyer.
+    // These helpers turn text-bearing flyers into segments of their own so
+    // per-segment extraction sees one event per flyer instead of a
+    // whole-page fallback that can only ever return one.
+
+    // Eligibility: meaningful OCR text, and a flyer-like classification when
+    // one is present. Absent classification pairs on text — the same
+    // fail-open rule filterOcrResultsForSegment's pairing gate uses.
+    isFlyerSegmentCandidateOcrResult(ocrResult) {
+        if (!ocrResult || typeof ocrResult.url !== 'string' || !ocrResult.url) return false;
+        const text = typeof ocrResult.text === 'string' ? ocrResult.text.trim() : '';
+        if (text.length < 12) return false;
+        const classification = String(ocrResult.imageClassification || '').toLowerCase().trim();
+        if (classification && !/flyer|poster/.test(classification)) return false;
+        return true;
+    }
+
+    // One identity key per flyer, aligned with ocrExcludedUrlKeys (stripped
+    // URL) so exclusions and pairing judge the same identity.
+    flyerSegmentImageKey(url) {
+        const normalized = this.normalizeHttpUrlValue(url);
+        if (!normalized) return '';
+        return this.stripSizeParams(normalized) || normalized;
+    }
+
+    // Zero-text pages: one synthetic segment per distinct text-bearing
+    // flyer. Segments carry NO invented page text — the flyer URL rides as
+    // an image hint (pairing its own OCR result into the prompt) and the
+    // OCR text itself is the extraction corpus.
+    buildFlyerOnlySegments(ocrResults, sourceUrl = '') {
+        const segments = [];
+        const seenKeys = new Set();
+        for (const ocrResult of (Array.isArray(ocrResults) ? ocrResults : [])) {
+            if (!this.isFlyerSegmentCandidateOcrResult(ocrResult)) continue;
+            const key = this.flyerSegmentImageKey(ocrResult.url);
+            if (!key || seenKeys.has(key)) continue;
+            if (this.getRepeatedSegmentChromeReason(this.normalizeHttpUrlValue(ocrResult.url), sourceUrl)) continue;
+            seenKeys.add(key);
+            segments.push({ lines: [], html: '', imageHintUrls: [ocrResult.url], _flyerOnlySegment: true });
+        }
+        return segments;
+    }
+
+    // Fused-listing split: a listing whose HTML text has no title line rides
+    // its neighbor's window (South Seattle Bear Social inside "Dolly and the
+    // DJ", run 20260820 — Dolly's description was literally the bear
+    // social's text). After the consistency gate has corrected pairings, a
+    // window still holding 2+ distinct text-bearing flyers keeps the flyer
+    // whose text best matches its own listing title and releases the others
+    // into flyer-only segments — EXCEPT a flyer whose identity another
+    // window also claims (its listing exists elsewhere on the page;
+    // splitting it out would extract the same event twice).
+    collectFusedFlyerTopUpSegments(segments, ocrResults, sourceUrl = '') {
+        const sourceSegments = Array.isArray(segments) ? segments : [];
+        const ocrList = Array.isArray(ocrResults) ? ocrResults : [];
+        if (sourceSegments.length === 0 || ocrList.length === 0) return [];
+        const canTokenize = this.core && typeof this.core.getCrossSourceTitleTokens === 'function';
+
+        const segmentInfos = sourceSegments.map(segment => ({
+            segment,
+            keys: this.getSegmentImageUrlKeys(segment, sourceUrl),
+            titleTokens: canTokenize
+                ? this.core.getCrossSourceTitleTokens(this.deriveSegmentListingTitle(segment))
+                : []
+        }));
+
+        // Raw ownership per flyer identity — exclusions deliberately ignored
+        // so "claimed by 2+ windows" reflects the page's layout, not gate
+        // bookkeeping.
+        const eligible = [];
+        const seenKeys = new Set();
+        for (const ocrResult of ocrList) {
+            if (!this.isFlyerSegmentCandidateOcrResult(ocrResult)) continue;
+            const normalizedUrl = this.normalizeHttpUrlValue(ocrResult.url);
+            const key = this.flyerSegmentImageKey(ocrResult.url);
+            if (!key || seenKeys.has(key)) continue;
+            if (this.getRepeatedSegmentChromeReason(normalizedUrl, sourceUrl)) continue;
+            seenKeys.add(key);
+            const owners = [];
+            segmentInfos.forEach((info, index) => {
+                if (info.keys.normalized.has(normalizedUrl) || info.keys.stripped.has(key)) owners.push(index);
+            });
+            const ocrTokens = canTokenize
+                ? new Set(this.core.getCrossSourceTitleTokens(
+                    `${String(ocrResult.text || '')} ${String(ocrResult.eventSummary || '')}`))
+                : new Set();
+            eligible.push({ ocrResult, key, owners, ocrTokens });
+        }
+
+        const extras = [];
+        segmentInfos.forEach((info, index) => {
+            const mine = eligible.filter(entry => entry.owners.includes(index));
+            if (mine.length < 2) return;
+            // Keep the flyer whose text best matches this window's own
+            // listing title (ties and no-signal keep page order).
+            const matchedCount = entry => info.titleTokens.filter(token => entry.ocrTokens.has(token)).length;
+            let keepIndex = 0;
+            let bestMatched = -1;
+            mine.forEach((entry, mineIndex) => {
+                const matched = matchedCount(entry);
+                if (matched > bestMatched) {
+                    bestMatched = matched;
+                    keepIndex = mineIndex;
+                }
+            });
+            mine.forEach((entry, mineIndex) => {
+                if (mineIndex === keepIndex) return;
+                if (entry.owners.length > 1) return; // listed elsewhere — splitting would duplicate it
+                if (!(info.segment.ocrExcludedUrlKeys instanceof Set)) {
+                    info.segment.ocrExcludedUrlKeys = new Set();
+                }
+                info.segment.ocrExcludedUrlKeys.add(entry.key);
+                extras.push({ lines: [], html: '', imageHintUrls: [entry.ocrResult.url], _flyerOnlySegment: true });
+                console.log(`🤖 AI Web: 🖼️ FLYER SEGMENTS: window ${index + 1} holds ${mine.length} distinct text-bearing flyers — giving ${entry.ocrResult.url} its own segment (fused-listing split)`);
+            });
+        });
+        return extras;
     }
 
     // Post-pairing title↔OCR consistency gate: once segment OCR coverage is
@@ -13850,9 +14010,8 @@ TEXT:
                 const attributeValue = String(match[1] || '').trim();
                 if (!attributeValue) continue;
                 if (pattern.source.includes('srcset')) {
-                    attributeValue.split(',').forEach(part => {
-                        const candidate = String(part || '').trim().split(/\s+/)[0];
-                        if (candidate) rawCandidates.add(candidate);
+                    this.splitSrcsetIntoUrlCandidates(attributeValue).forEach(candidate => {
+                        rawCandidates.add(candidate);
                     });
                 } else {
                     rawCandidates.add(attributeValue);

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -18022,6 +18022,44 @@ TEXT:
         return this.ocrImageVerdictsByUrl.get(key) || null;
     }
 
+    // Merge-time OCR text lookup (owner design 2026-08-20): shared-core's
+    // image title-evidence rung asks "what does this image SAY" for both
+    // merge candidates. This run's verdict store answers for freshly-OCR'd
+    // images; the persistent disk cache answers for images adopted in
+    // EARLIER runs (a stored calendar flyer was og-vetted when adopted, so
+    // its text is on disk). null means unreadable — the rung requires both
+    // sides and fails open. Wired into SharedCore by the orchestrator via
+    // setOcrImageTextLookup; global-default ocrConfig on purpose (a
+    // per-parser prompt override changes the cache signature → miss → null).
+    async getCachedOcrTextForImage(imageUrl, httpAdapter = null) {
+        const verdict = this.getOcrImageVerdict(imageUrl);
+        if (verdict && typeof verdict.text === 'string' && verdict.text.trim()) {
+            return verdict.text;
+        }
+        try {
+            const ocrConfig = this.getOcrConfig({});
+            if (!ocrConfig) return null;
+            if (ocrConfig.cacheEnabled) {
+                const cached = await this.readCachedOcrResult(imageUrl, ocrConfig);
+                const cachedText = cached && typeof cached.text === 'string' && cached.text.trim()
+                    ? cached.text
+                    : (cached && cached.response && typeof cached.response.text === 'string' ? cached.response.text : '');
+                if (cachedText && cachedText.trim()) return cachedText;
+            }
+            // Cache miss with an adapter in hand: OCR the image now. This is
+            // how a calendar flyer stored BEFORE og-vetting existed becomes
+            // readable evidence — one call, then cached like any other OCR.
+            if (httpAdapter) {
+                const fresh = await this.getOcrTextForImage(imageUrl, ocrConfig, 'merge evidence', httpAdapter);
+                const freshText = fresh && typeof fresh.text === 'string' ? fresh.text : '';
+                return freshText && freshText.trim() ? freshText : null;
+            }
+            return null;
+        } catch (_) {
+            return null;
+        }
+    }
+
     /**
      * Why the vision pass says this URL is not an event's artwork ('' when it
      * doesn't say so). TWO conditions, both required, because either alone

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -15393,3 +15393,30 @@ test('a segment fused around two distinct flyers spawns a flyer-only segment for
   const none = parser.collectFusedFlyerTopUpSegments([fusedAgain, owner], ocrResults, sourceUrl);
   assert.equal(none.length, 0, 'a flyer with its own segment elsewhere never spawns a duplicate');
 });
+
+test('getCachedOcrTextForImage: verdict store first, then disk cache, on-demand OCR only when an adapter rides along', async () => {
+  const parser = createParser();
+  // This run's verdict store answers without touching disk or network.
+  parser.recordOcrImageVerdict('https://cdn.example/flyer.jpg', {
+    imageClassification: 'event-flyer',
+    text: 'MEAT MARKET\nThe Eagle Wilton Manors'
+  });
+  assert.equal(await parser.getCachedOcrTextForImage('https://cdn.example/flyer.jpg'),
+    'MEAT MARKET\nThe Eagle Wilton Manors');
+
+  // Full miss with NO adapter: null, and never a fresh OCR request.
+  parser.getOcrTextForImage = async () => { throw new Error('must not OCR without an adapter'); };
+  assert.equal(await parser.getCachedOcrTextForImage('https://cdn.example/never-seen.jpg'), null);
+
+  // Full miss WITH an adapter: one on-demand OCR call answers (a calendar
+  // flyer stored before og-vetting existed becomes readable evidence).
+  const ocrCalls = [];
+  parser.getOcrTextForImage = async (url, cfg, passLabel, adapter) => {
+    ocrCalls.push({ url, passLabel, hasAdapter: Boolean(adapter) });
+    return { text: 'THE WIG OUT PARTY' };
+  };
+  assert.equal(await parser.getCachedOcrTextForImage('https://cdn.example/old-flyer.jpg', { fetch: () => {} }),
+    'THE WIG OUT PARTY');
+  assert.equal(ocrCalls.length, 1);
+  assert.equal(ocrCalls[0].hasAdapter, true);
+});

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -15278,3 +15278,118 @@ test('applyFlyerTimeConflictFlag fails closed on agreement, doors pairs, non-fly
   midnightParser.applyFlyerTimeConflictFlag([midnight]);
   assert.equal(midnight._flyerTimeConflict, undefined, 'a date-only midnight start never flags');
 });
+
+// ── Lumberyard coverage wave (run 20260820): flyer-only segments + srcset ──
+
+test('srcset parsing keeps Wix URLs whole — commas inside transform params are not entry separators (run 20260820 Lumberyard 404s)', () => {
+  const parser = createParser();
+  // Literal shape from thelumberyardbar.com: wixstatic URLs carry commas in
+  // their transform path (w_600,h_800,al_c,…). Splitting srcset on every
+  // comma shredded them; the relative shards ("enc_auto/quality_auto/…")
+  // were then re-rooted onto the page host as guaranteed-404 candidates
+  // that wasted OCR cap slots.
+  const html = '<img srcset="https://static.wixstatic.com/media/f45f1a_bear~mv2.jpeg/v1/fill/w_600,h_800,al_c,q_85,enc_auto/quality_auto/social.jpg 1x, https://static.wixstatic.com/media/f45f1a_bear~mv2.jpeg/v1/fill/w_1200,h_1600,al_c,q_85,enc_auto/quality_auto/social.jpg 2x">';
+  const urls = parser.extractOrderedImageUrlsFromHtml(html, 'https://www.thelumberyardbar.com/events');
+  assert.ok(!urls.some(u => u.includes('thelumberyardbar.com')),
+    `no shard may be re-rooted onto the page host, got: ${JSON.stringify(urls)}`);
+  assert.ok(urls.includes('https://static.wixstatic.com/media/f45f1a_bear~mv2.jpeg/v1/fill/w_600,h_800,al_c,q_85,enc_auto/quality_auto/social.jpg'),
+    'the 1x entry survives whole');
+  // The splitter itself yields BOTH entries whole (downstream dedupe then
+  // rightly collapses the size variants to one identity).
+  const entries = parser.splitSrcsetIntoUrlCandidates(
+    'https://static.wixstatic.com/media/a~mv2.jpg/v1/fill/w_600,h_800,al_c/f.jpg 1x, https://static.wixstatic.com/media/a~mv2.jpg/v1/fill/w_1200,h_1600,al_c/f.jpg 2x');
+  assert.deepEqual(entries, [
+    'https://static.wixstatic.com/media/a~mv2.jpg/v1/fill/w_600,h_800,al_c/f.jpg',
+    'https://static.wixstatic.com/media/a~mv2.jpg/v1/fill/w_1200,h_1600,al_c/f.jpg'
+  ]);
+});
+
+test('buildFlyerOnlySegments: one segment per text-bearing flyer, chrome and non-flyer classifications excluded', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://www.thelumberyardbar.com/mothly-events';
+  const ocrResults = [
+    { url: 'https://static.wixstatic.com/media/a~mv2.jpg', text: 'GAY BINGO\n2nd & 4th Thursdays 7pm', imageClassification: 'event-flyer' },
+    { url: 'https://static.wixstatic.com/media/b~mv2.jpg', text: 'RAT CITY HONKY TONK\nFirst Fridays 9pm', imageClassification: '' },
+    { url: 'https://static.wixstatic.com/media/logo~mv2.png', text: 'The Lumberyard Bar', imageClassification: 'logo' },
+    { url: 'https://static.wixstatic.com/media/thumb~mv2.png', text: 'GAME ON video game party third fridays', imageClassification: 'thumbnail' },
+    { url: 'https://static.wixstatic.com/media/short~mv2.png', text: 'hi', imageClassification: '' },
+    { url: 'https://static.wixstatic.com/media/a~mv2.jpg', text: 'GAY BINGO\n2nd & 4th Thursdays 7pm', imageClassification: 'event-flyer' }
+  ];
+  const segments = parser.buildFlyerOnlySegments(ocrResults, sourceUrl);
+  // a (flyer) + b (no classification, text — same fail-open rule as pairing);
+  // logo/thumbnail classifications and sub-minimal text excluded; the
+  // duplicate of a deduped.
+  assert.equal(segments.length, 2, `expected 2 flyer segments, got ${segments.length}`);
+  assert.deepEqual(segments.map(s => s.imageHintUrls), [
+    ['https://static.wixstatic.com/media/a~mv2.jpg'],
+    ['https://static.wixstatic.com/media/b~mv2.jpg']
+  ]);
+  for (const segment of segments) {
+    assert.equal(segment._flyerOnlySegment, true);
+    assert.deepEqual(segment.lines, [], 'flyer segments carry no invented page text');
+  }
+});
+
+test('zero-text multi-event page with OCR flyers extracts one event per flyer instead of whole-page fallback (Lumberyard /mothly-events)', async () => {
+  const parser = createParser();
+  const sourceUrl = 'https://www.thelumberyardbar.com/mothly-events';
+  const htmlData = {
+    url: sourceUrl,
+    html: '<html><body><img src="https://static.wixstatic.com/media/a~mv2.jpg"><img src="https://static.wixstatic.com/media/b~mv2.jpg"></body></html>'
+  };
+  const ocrResults = [
+    { url: 'https://static.wixstatic.com/media/a~mv2.jpg', text: 'GAY BINGO\n2nd & 4th Thursdays 7pm', imageClassification: 'event-flyer' },
+    { url: 'https://static.wixstatic.com/media/b~mv2.jpg', text: 'RAT CITY HONKY TONK\nFirst Fridays 9pm', imageClassification: 'event-flyer' },
+    { url: 'https://static.wixstatic.com/media/logo~mv2.png', text: 'The Lumberyard Bar', imageClassification: 'logo' }
+  ];
+  const seenSegments = [];
+  parser.extractSingleEvent = async (segmentHtmlData) => {
+    const ownOcr = Array.isArray(segmentHtmlData.ocrResults) ? segmentHtmlData.ocrResults : [];
+    seenSegments.push(ownOcr.map(o => o.url));
+    const first = ownOcr[0];
+    return {
+      title: first ? String(first.text).split('\n')[0] : 'WHOLE PAGE',
+      startDate: '2026-09-03T19:00:00.000Z',
+      image: first ? first.url : undefined
+    };
+  };
+  const events = await parser.extractEventsFromMultiEventPage(
+    htmlData, { name: 'The Lumberyard' }, null, ['title', 'startDate'], ocrResults, null);
+  assert.equal(events.length, 2, `one event per flyer, got ${events.length}: ${JSON.stringify(events.map(e => e.title))}`);
+  assert.deepEqual(events.map(e => e.title).sort(), ['GAY BINGO', 'RAT CITY HONKY TONK']);
+  // Each synthetic segment paired exactly its own flyer's OCR.
+  assert.deepEqual(seenSegments, [
+    ['https://static.wixstatic.com/media/a~mv2.jpg'],
+    ['https://static.wixstatic.com/media/b~mv2.jpg']
+  ]);
+});
+
+test('a segment fused around two distinct flyers spawns a flyer-only segment for the extra (South Seattle Bear Social)', () => {
+  const parser = createParser();
+  const sourceUrl = 'https://www.thelumberyardbar.com/events';
+  const dollyUrl = 'https://static.wixstatic.com/media/35bbb~mv2.jpg';
+  const bearUrl = 'https://static.wixstatic.com/media/eab96~mv2.jpeg';
+  const triviaUrl = 'https://static.wixstatic.com/media/trivia~mv2.jpg';
+  const ocrResults = [
+    { url: dollyUrl, text: 'DOLLY AND THE DJ\nSaturdays 9pm', imageClassification: 'event-flyer' },
+    { url: bearUrl, text: 'SOUTH SEATTLE BEAR SOCIAL\nSundays 2-6pm', imageClassification: 'event-flyer' },
+    { url: triviaUrl, text: 'TACO TRIVIA TUESDAY 7pm', imageClassification: 'event-flyer' }
+  ];
+  const fused = { lines: ['Dolly and the DJ', 'Saturday nights 9pm'], html: '', imageHintUrls: [dollyUrl, bearUrl] };
+  const single = { lines: ['Trivia Taco Tuesday', '7pm weekly'], html: '', imageHintUrls: [triviaUrl] };
+  const extras = parser.collectFusedFlyerTopUpSegments([fused, single], ocrResults, sourceUrl);
+  assert.equal(extras.length, 1, 'exactly the extra flyer gets its own segment');
+  assert.deepEqual(extras[0].imageHintUrls, [bearUrl]);
+  assert.ok(fused.ocrExcludedUrlKeys instanceof Set && fused.ocrExcludedUrlKeys.size === 1,
+    'the fused segment stops claiming the split-off flyer');
+  assert.ok(!(single.ocrExcludedUrlKeys instanceof Set) || single.ocrExcludedUrlKeys.size === 0,
+    'the single-flyer segment is untouched');
+
+  // Uniqueness guard: a flyer claimed by TWO segments (its own text listing
+  // exists elsewhere on the page, Sugar-Bear-style) spawns nothing — no
+  // duplicate events.
+  const owner = { lines: ['South Seattle Bear Social', 'Sundays 2-6pm'], html: '', imageHintUrls: [bearUrl] };
+  const fusedAgain = { lines: ['Dolly and the DJ', 'Saturday nights 9pm'], html: '', imageHintUrls: [dollyUrl, bearUrl] };
+  const none = parser.collectFusedFlyerTopUpSegments([fusedAgain, owner], ocrResults, sourceUrl);
+  assert.equal(none.length, 0, 'a flyer with its own segment elsewhere never spawns a duplicate');
+});

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -3268,6 +3268,42 @@ class SharedCore {
     // event context (currently { cityKey, barNames, eventTitle, sideLabels,
     // records }) for the city-aware title, curated-bar, curated-address, and
     // address-evidence rules.
+    // ── OCR title-evidence plumbing (owner design 2026-08-20) ─────────────
+    // Injection keeps shared-core platform-pure: the orchestrator wires the
+    // ai-web parser's OCR verdict store + disk cache in as a lookup; without
+    // one, preload returns null and every merge behaves exactly as before.
+    setOcrImageTextLookup(lookup) {
+        this.ocrImageTextLookup = typeof lookup === 'function' ? lookup : null;
+    }
+
+    // Reads the OCR text of BOTH records' primary images before the sync
+    // arbitration ladder runs. Only differing http(s) image pairs are looked
+    // up; unreadable sides simply stay absent from the map (the rung
+    // requires both, so absence falls through to existing behavior).
+    async preloadImageOcrTextEvidence(recordA, recordB, httpAdapter = null) {
+        if (typeof this.ocrImageTextLookup !== 'function') return null;
+        const imageA = recordA && typeof recordA.image === 'string' ? recordA.image.trim() : '';
+        const imageB = recordB && typeof recordB.image === 'string' ? recordB.image.trim() : '';
+        if (!imageA || !imageB || imageA === imageB) return null;
+        if (!/^https?:\/\//i.test(imageA) || !/^https?:\/\//i.test(imageB)) return null;
+        const textByUrl = new Map();
+        for (const url of [imageA, imageB]) {
+            try {
+                // The adapter rides along so the lookup may OCR an image the
+                // caches never saw (a calendar flyer stored before vetting
+                // existed) — one bounded call per differing-image merge, then
+                // the persistent cache answers forever. OCR is local-model
+                // work; the owner's standing doctrine is to spend it.
+                const text = await this.ocrImageTextLookup(url, httpAdapter);
+                if (typeof text === 'string' && text.trim()) textByUrl.set(url, text);
+            } catch (_) {
+                // Unreadable side: the rung requires both texts, so this
+                // lookup failure falls through to existing behavior.
+            }
+        }
+        return textByUrl.size > 0 ? textByUrl : null;
+    }
+
     resolveConflictDeterministically(fieldName, valueA, valueB, context = null) {
         // Corrected-time healing (doors-vs-party, run 20260812-001228 FURBALL
         // NOLA): wave 2's extraction fix promoted a DOORS start to the
@@ -3455,6 +3491,52 @@ class SharedCore {
                         winner: placeholderReasonA ? 'b' : 'a',
                         reason: `real image beats placeholder (${placeholderReasonA || placeholderReasonB})`
                     };
+                }
+                // OCR TITLE-EVIDENCE rung (owner design 2026-08-20: "associate
+                // the OCR of the image with the current title"). Both
+                // candidates were OCR'd at some point (og-vet at adoption, or
+                // this run's pass) — read what the images SAY instead of
+                // guessing from URL shapes. The flyer whose text names this
+                // event's CURRENT title decisively harder wins: Wig Out →
+                // Meat Market, the stored flyer still reads "WIG OUT" while
+                // the page's current artwork reads "MEAT MARKET / EAGLE
+                // WILTON MANORS" — no URL heuristic can see that, and the
+                // logo-path rung below actively picked the stale side
+                // (sickening.events hosts real flyers under /saas/logos/).
+                // Strict: both texts must be readable (the preload only maps
+                // what the lookup could serve), the title must carry >= 2
+                // tokens, and the winner needs a real margin (>= 2 matches,
+                // >= 2x the loser, and >= 2 more) — both flyers usually name
+                // the shared brand, so a bare yes/no would tie forever.
+                // Ties, unreadable sides and short titles fall through to
+                // the rungs below unchanged. Primary image only.
+                if (fieldName === 'image' && context && context.ocrTextByImageUrl
+                    && typeof context.ocrTextByImageUrl.get === 'function'
+                    && typeof this.getCrossSourceTitleTokens === 'function') {
+                    const evidenceTextA = context.ocrTextByImageUrl.get(String(valueA).trim());
+                    const evidenceTextB = context.ocrTextByImageUrl.get(String(valueB).trim());
+                    if (typeof evidenceTextA === 'string' && evidenceTextA.trim()
+                        && typeof evidenceTextB === 'string' && evidenceTextB.trim()) {
+                        const evidenceTitleTokens = this.getCrossSourceTitleTokens(String(context.eventTitle || ''));
+                        if (Array.isArray(evidenceTitleTokens) && evidenceTitleTokens.length >= 2) {
+                            const matchedTitleTokensIn = (text) => {
+                                const ocrTokens = new Set(this.getCrossSourceTitleTokens(text));
+                                return evidenceTitleTokens.filter(token => ocrTokens.has(token)).length;
+                            };
+                            const matchedA = matchedTitleTokensIn(evidenceTextA);
+                            const matchedB = matchedTitleTokensIn(evidenceTextB);
+                            const winnerMatched = Math.max(matchedA, matchedB);
+                            const loserMatched = Math.min(matchedA, matchedB);
+                            if (winnerMatched >= 2
+                                && winnerMatched >= 2 * loserMatched
+                                && winnerMatched - loserMatched >= 2) {
+                                return {
+                                    winner: matchedA > matchedB ? 'a' : 'b',
+                                    reason: `flyer text names the event's current title (${winnerMatched} title tokens vs ${loserMatched}) — OCR title evidence`
+                                };
+                            }
+                        }
+                    }
                 }
                 const hasLogoSegment = (parts) => parts.segments.some(segment => /logo/i.test(segment));
                 const logoA = hasLogoSegment(urlA);
@@ -9796,6 +9878,9 @@ class SharedCore {
             sideLabels: { a: 'existing', b: 'incoming' },
             records: { a: existingEvent, b: newEvent }
         };
+        // OCR title-evidence preload: both primary-image candidates' flyer
+        // texts (verdict store or disk cache), read before the sync ladder.
+        mergeContext.ocrTextByImageUrl = await this.preloadImageOcrTextEvidence(existingEvent, newEvent, options && options.httpAdapter ? options.httpAdapter : null);
         const queueArbitrationConflict = (fieldName, existingValue, newValue, fallbackPick, fallbackReason) => {
             const resolved = this.resolveConflictDeterministically(fieldName, existingValue, newValue, mergeContext);
             if (!resolved) {
@@ -10380,6 +10465,9 @@ class SharedCore {
             sideLabels: { a: 'calendar', b: 'scraped' },
             records: { a: calendarObject, b: scraperObject }
         };
+        // OCR title-evidence preload: both primary-image candidates' flyer
+        // texts (verdict store or disk cache), read before the sync ladder.
+        mergeContext.ocrTextByImageUrl = await this.preloadImageOcrTextEvidence(calendarObject, scraperObject, options && options.httpAdapter ? options.httpAdapter : null);
         const queueArbitrationConflict = (fieldName, calendarValue, scraperValue) => {
             const resolved = this.resolveConflictDeterministically(fieldName, calendarValue, scraperValue, mergeContext);
             if (!resolved) {

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20274,3 +20274,96 @@ test('sanity: a real title with a date inside it is NOT withheld', () => {
   assert.equal(SharedCore.filterEventsForExecution([analyzed]).length, 1,
     'the write goes through');
 });
+
+// ── OCR title-evidence rung for image arbitration (owner design 2026-08-20:
+// "associate the OCR of the image with the current title") ──────────────────
+
+const MEAT_MARKET_TITLE = 'Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors';
+const OLD_WIG_OUT_IMAGE = 'https://img.evbuc.com/https%3A%2F%2Fcdn.evbuc.com%2Fimages%2F1181905615%2Foriginal.20260410-211015?w=940&s=ed3b';
+const NEW_MEAT_MARKET_IMAGE = 'https://res.cloudinary.com/eventservice/image/upload/q_auto,f_auto/v1786814606/saas/logos/image_1786814597049.webp';
+const WIG_OUT_FLYER_TEXT = 'CLUB CHUB\nTHE WIG OUT PARTY\nCannonball Weekend\nSunday November 1st';
+const MEAT_MARKET_FLYER_TEXT = 'CLUB CHUB CANNONBALL WEEKEND\nMEAT MARKET\nSunday November 1st 4 to 9PM\nThe Eagle Wilton Manors';
+
+function buildOcrEvidenceContext(textByUrl) {
+  const map = new Map();
+  for (const [url, text] of Object.entries(textByUrl)) map.set(url, text);
+  return {
+    eventTitle: MEAT_MARKET_TITLE,
+    sideLabels: { a: 'calendar', b: 'scraped' },
+    records: { a: {}, b: {} },
+    ocrTextByImageUrl: map
+  };
+}
+
+test('image arbitration: the flyer whose OCR text names the current title wins — even from a /logos/ path (Wig Out → Meat Market)', () => {
+  const core = createCore();
+  const context = buildOcrEvidenceContext({
+    [OLD_WIG_OUT_IMAGE]: WIG_OUT_FLYER_TEXT,
+    [NEW_MEAT_MARKET_IMAGE]: MEAT_MARKET_FLYER_TEXT
+  });
+  const resolved = core.resolveConflictDeterministically('image', OLD_WIG_OUT_IMAGE, NEW_MEAT_MARKET_IMAGE, context);
+  assert.ok(resolved, 'the rung fires deterministically');
+  assert.equal(resolved.winner, 'b', 'the flyer that reads MEAT MARKET / EAGLE WILTON MANORS wins');
+  assert.match(resolved.reason, /OCR title evidence/, `evidence-based reason: ${resolved.reason}`);
+});
+
+test('image arbitration: OCR title evidence works both directions and beats no other rung on ties', () => {
+  const core = createCore();
+  // Reversed sides: the calendar holds the CURRENT flyer, the scrape offers
+  // a stale one — the calendar side wins on the same evidence.
+  const reversed = buildOcrEvidenceContext({
+    [OLD_WIG_OUT_IMAGE]: WIG_OUT_FLYER_TEXT,
+    [NEW_MEAT_MARKET_IMAGE]: MEAT_MARKET_FLYER_TEXT
+  });
+  const keptCurrent = core.resolveConflictDeterministically('image', NEW_MEAT_MARKET_IMAGE, OLD_WIG_OUT_IMAGE, reversed);
+  assert.equal(keptCurrent && keptCurrent.winner, 'a');
+  assert.match(keptCurrent.reason, /OCR title evidence/);
+
+  // Tie: both images read the same text (unchanged artwork re-hosted) —
+  // the rung stays silent and existing behavior decides.
+  const tie = buildOcrEvidenceContext({
+    [OLD_WIG_OUT_IMAGE]: MEAT_MARKET_FLYER_TEXT,
+    [NEW_MEAT_MARKET_IMAGE]: MEAT_MARKET_FLYER_TEXT
+  });
+  const tieResolved = core.resolveConflictDeterministically('image', OLD_WIG_OUT_IMAGE, NEW_MEAT_MARKET_IMAGE, tie);
+  assert.ok(!tieResolved || !/OCR title evidence/.test(tieResolved.reason),
+    'equal evidence never decides via this rung');
+
+  // Unreadable side (no OCR text available): strict fall-through.
+  const oneSided = buildOcrEvidenceContext({ [NEW_MEAT_MARKET_IMAGE]: MEAT_MARKET_FLYER_TEXT });
+  const oneSidedResolved = core.resolveConflictDeterministically('image', OLD_WIG_OUT_IMAGE, NEW_MEAT_MARKET_IMAGE, oneSided);
+  assert.ok(!oneSidedResolved || !/OCR title evidence/.test(oneSidedResolved.reason),
+    'a side with no readable text never loses on evidence it could not present');
+});
+
+test('createFinalEventObject preloads OCR texts through the injected lookup and updates the stale image', async () => {
+  const core = createCore();
+  const lookups = [];
+  core.setOcrImageTextLookup(async (url) => {
+    lookups.push(url);
+    if (url === OLD_WIG_OUT_IMAGE) return WIG_OUT_FLYER_TEXT;
+    if (url === NEW_MEAT_MARKET_IMAGE) return MEAT_MARKET_FLYER_TEXT;
+    return null;
+  });
+  const existing = {
+    title: 'CLUB CHUB: The Wig Out Party',
+    startDate: '2026-11-01T21:00:00.000Z',
+    // Calendar records carry their image in NOTES (parseNotesIntoFields) —
+    // a bare property never reaches the merge's calendarObject.
+    notes: `image: ${OLD_WIG_OUT_IMAGE}`
+  };
+  const scraped = {
+    title: MEAT_MARKET_TITLE,
+    startDate: '2026-11-01T21:00:00.000Z',
+    image: NEW_MEAT_MARKET_IMAGE,
+    source: 'ai-web',
+    // Real scraped events carry the parser's resolved field priorities —
+    // image rides merge:"ai", which is what routes it into arbitration.
+    _fieldPriorities: core.getResolvedFieldPriorities({})
+  };
+  const finalEvent = await core.createFinalEventObject(existing, scraped, { httpAdapter: null });
+  assert.ok(lookups.includes(OLD_WIG_OUT_IMAGE) && lookups.includes(NEW_MEAT_MARKET_IMAGE),
+    'both candidates were looked up');
+  assert.equal(finalEvent.image, NEW_MEAT_MARKET_IMAGE,
+    'the stored stale flyer is replaced by the artwork that names the current event');
+});


### PR DESCRIPTION
Two owner-driven features from the 2026-08-20 wave, both grounded in the same principle: **read the images we already OCR instead of guessing from URL shapes.** No new runtime files.

## 1. Flyer-only segments (Lumberyard coverage)
- **One segment per OCR'd poster on image-only listings**: a multi-event page with zero text windows but 2+ text-bearing flyers extracts one event per flyer instead of the whole-page fallback (which returns ONE event by construction — `/mothly-events` discarded six flyers after OCR had read them).
- **Fused-listing split**: a listing with no HTML title line rides its neighbor's window (South Seattle Bear Social inside "Dolly and the DJ"). After the consistency gate, a window still holding 2+ distinct text-bearing flyers keeps the flyer whose text best matches its own listing title and releases the extras. Guards: flyers claimed by two windows never split (no duplicate events), chrome never spawns, size variants collapse.
- **srcset comma fix**: wixstatic URLs carry commas in transform params; naive comma-splitting shredded them into re-rooted 404 candidates that wasted OCR cap slots.

**Live validation** (run-once, dry-run, this branch): `/mothly-events` → 7 events (was 1); **South Seattle Bear Social extracted and kept as bear**; total 14 extracted vs 7; the non-bear recoveries (Gay Bingo, Honky Tonk, Showtunes, …) correctly land in the dropped pile.

## 2. OCR title-evidence rung for image merges (Wig Out → Meat Market)
Owner design: "associate the OCR of the image with the current title." The stale-image case was unfixable by reruns: the logo-path rung actively picked the stale side (sickening.events hosts real flyers under `/saas/logos/`), binding image stickiness sealed anything the rungs didn't decide, and the resolution rung favored the stale URL's `w=940`. Now, when both candidates' flyer texts are readable and one names the event's current title decisively harder (≥2 title tokens, ≥2× and ≥2 more than the other — margin, because both flyers name the shared brand), it wins deterministically, in either direction.

Plumbing keeps shared-core platform-pure: the orchestrator injects the ai-web parser's OCR lookup — this run's verdict store → persistent OCR cache → **on-demand OCR when the adapter rides along** (a calendar flyer stored before og-vetting existed becomes readable evidence; one bounded local-model call, then cached). Ties, unreadable sides, and short titles fall through to every existing rung unchanged. Primary image only.

Effect after merge: the Meat Market event self-heals on the next phone run — the old flyer OCRs as "WIG OUT", the new one as "MEAT MARKET / EAGLE WILTON MANORS", and the write updates the calendar. Same mechanism retires the junk-logo clobber class by evidence instead of path-sniffing.

## Verification
- Quiet suite **1961/1961** (base 1953 + 8 new tests, failing on base).
- Segmentation regression surface (Sitges day-programmes, Dallas Eagle month grids, BeefDip fence-post shapes) untouched; merge rung ladder tests all green.
- Deferred: `/upcoming-events` client-side calendar widget (roadmap, MEC-family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP