### PR TITLE
Registry: title-brand identity beats url-only co-matches; taxonomy archives never promoted to website

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -1410,6 +1410,13 @@ class SharedCore {
         if (!candidateParts || !incumbentParts) return false;
         if (!this.areUrlHostsSameSite(candidateParts.host, incumbentParts.host)) return false;
         const candidateIsRoot = candidateParts.segments.length === 0 && !candidateParts.hasQuery;
+        // A taxonomy/platform archive (/tags/, /category/…) is site
+        // navigation, never an event page — treating it as one promoted
+        // beefdip.com/tags/ over the real canonical website (run 20260820,
+        // MAD.BEAR FOAM PARTY). Anchored on the FIRST path segment; event
+        // slugs deeper in the path are unaffected.
+        const incumbentFirstSegment = String(incumbentParts.segments[0] || '').toLowerCase();
+        if (/^(?:tags?|categor(?:y|ies)|archives?|labels?|topics?)$/.test(incumbentFirstSegment)) return false;
         return candidateIsRoot && incumbentParts.segments.length > 0;
     }
 
@@ -2938,6 +2945,18 @@ class SharedCore {
                 && other.entry.parent === match.entry.name
                 && matchedNames.has(other.entry.name)));
         if (withoutMatchedParents.length === 1) return withoutMatchedParents[0];
+        // TITLE-BRAND priority (run 20260820: "FURBALL POOL PARTY" listed on
+        // beefdip.com matched Furball by title and BeefDip by url, and the
+        // refusal left the event with NO website at all). Evidence kinds are
+        // not equal: organizer/title evidence means the event's OWN identity
+        // wears the brand; url evidence only says whose site hosts the
+        // listing — a festival's page lends its url token to every guest
+        // brand's collab event. When exactly one candidate has identity
+        // evidence and the rest matched only by url, the named brand wins.
+        // Two identity matches are genuinely ambiguous and still refuse.
+        const identityMatches = withoutMatchedParents.filter(match =>
+            !String(match.evidence || '').startsWith('url:'));
+        if (identityMatches.length === 1) return identityMatches[0];
         return { ambiguous: withoutMatchedParents.map(match => match.entry.name) };
     }
 

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20403,3 +20403,40 @@ test('a taxonomy archive path is never a same-site event page (beefdip.com/tags/
   // Real same-site event pages still bury the bare root.
   assert.equal(core.isBareRootBuryingSameSiteEventPage('https://beefdip.com/', 'https://beefdip.com/planned-events/foam-party/'), true);
 });
+
+test('identity-priority match stamps the brand identity but website only fills blanks — never displaces a stated page', () => {
+  const registry = [
+    { name: 'Furball', website: 'https://www.furball.nyc', favicon: 'https://linktr.ee/furballnyc', instagram: 'https://instagram.com/furballnyc/', shortName: 'FUR-BALL', urlPatterns: ['furball.nyc'], bearAffinity: 'always' },
+    { name: 'BeefDip', website: 'https://beefdip.com', urlPatterns: ['beefdip.com'], bearAffinity: 'always' }
+  ];
+  // Blank-website collab event on the host's site: identity fields stamp
+  // from the TITLE brand; the identity-link ladder then fills the blank.
+  const blankCore = createRegistryCore(registry);
+  const blank = {
+    title: 'FURBALL POOL PARTY',
+    startDate: new Date('2027-02-05T21:00:00.000Z'),
+    ticketUrl: 'https://beefdip.com/planned-events/'
+  };
+  blankCore.applyPromoterRegistryMatches([blank], { name: 'p' }, ENFORCE_REGISTRY_CONFIG);
+  assert.equal(blank._promoter, 'Furball');
+  assert.equal(blank.favicon, 'https://linktr.ee/furballnyc', 'explicit registry favicon stamps');
+  assert.equal(blank.shortName, 'FUR-BALL');
+  blankCore.canonicalizeIdentityLinks([blank]);
+  assert.equal(blank.website, 'https://www.furball.nyc', 'the ladder fills a BLANK with the brand site');
+
+  // Same event but the page stated its own beefdip event page: the stated
+  // page survives — the brand site never displaces it (owner spec
+  // 2026-08-21: website must stay a useful page ABOUT THIS EVENT).
+  const statedCore = createRegistryCore(registry);
+  const stated = {
+    title: 'FURBALL POOL PARTY',
+    startDate: new Date('2027-02-05T21:00:00.000Z'),
+    website: 'https://beefdip.com/planned-events/furball-pool-party/'
+  };
+  statedCore.applyPromoterRegistryMatches([stated], { name: 'p' }, ENFORCE_REGISTRY_CONFIG);
+  assert.equal(stated._promoter, 'Furball');
+  assert.equal(stated.favicon, 'https://linktr.ee/furballnyc', 'brand favicon still rides the collab event');
+  statedCore.canonicalizeIdentityLinks([stated]);
+  assert.equal(stated.website, 'https://beefdip.com/planned-events/furball-pool-party/',
+    'a real page-stated event site is never displaced by the brand site');
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20367,3 +20367,39 @@ test('createFinalEventObject preloads OCR texts through the injected lookup and 
   assert.equal(finalEvent.image, NEW_MEAT_MARKET_IMAGE,
     'the stored stale flyer is replaced by the artwork that names the current event');
 });
+
+// ── Title-brand registry priority + taxonomy-archive guard (run 20260820) ──
+
+test('title identity outranks url-only co-matches in the promoter registry (FURBALL POOL PARTY on beefdip.com)', () => {
+  const core = createRegistryCore([
+    { name: 'Furball', website: 'https://www.furball.nyc', urlPatterns: ['furball.nyc'], bearAffinity: 'always' },
+    { name: 'BeefDip', website: 'https://beefdip.com', urlPatterns: ['beefdip.com'], bearAffinity: 'always' }
+  ]);
+  // The event's own name wears the Furball brand; beefdip.com only HOSTS the
+  // listing (its url token matches every guest brand's collab event).
+  const match = core.matchEventToPromoter({
+    title: 'FURBALL POOL PARTY',
+    ticketUrl: 'https://beefdip.com/planned-events/'
+  });
+  assert.ok(match && match.entry, `identity match expected, got: ${JSON.stringify(match)}`);
+  assert.equal(match.entry.name, 'Furball');
+  assert.equal(match.evidence, 'title');
+
+  // TWO identity matches remain genuinely ambiguous — still refused.
+  const both = core.matchEventToPromoter({
+    title: 'FURBALL x BEEFDIP TAKEOVER',
+    ticketUrl: 'https://beefdip.com/planned-events/'
+  });
+  assert.ok(both && Array.isArray(both.ambiguous), `two title brands still refuse: ${JSON.stringify(both)}`);
+  assert.deepEqual(both.ambiguous.slice().sort(), ['BeefDip', 'Furball']);
+});
+
+test('a taxonomy archive path is never a same-site event page (beefdip.com/tags/ was promoted to canonical website)', () => {
+  const core = createCore();
+  // The Wix tag-archive link must not read as "an event page buried by the
+  // bare root" — that promoted /tags/ over the real beefdip.com website.
+  assert.equal(core.isBareRootBuryingSameSiteEventPage('https://beefdip.com/', 'https://beefdip.com/tags/'), false);
+  assert.equal(core.isBareRootBuryingSameSiteEventPage('https://beefdip.com/', 'https://beefdip.com/category/parties/'), false);
+  // Real same-site event pages still bury the bare root.
+  assert.equal(core.isBareRootBuryingSameSiteEventPage('https://beefdip.com/', 'https://beefdip.com/planned-events/foam-party/'), true);
+});


### PR DESCRIPTION
Two fixes for the Furball/BeefDip notes (run 20260820), refined per owner spec 2026-08-21 ("website = a useful page about the event; favicon = brand identity override"). **No new runtime files.**

1. **Title identity outranks url-only co-matches** in the promoter registry: "FURBALL POOL PARTY" on beefdip.com matched Furball (title) and BeefDip (url), and the ambiguity refusal left the event with no promoter identity at all. Now the identity-evidenced brand wins when the other candidates matched only by url. Two identity matches (e.g. "FURBALL x BEEFDIP TAKEOVER") still refuse, fail-closed.

   **What the match actually stamps (verified + pinned by test, not changed):** `shortName`/`instagram`/`favicon` — the brand identity, exactly the part the owner wants riding collab events. `website` is deliberately NOT in the registry's static stamp (pre-existing design); it flows through the identity-link ladder, which **fills a blank** with the brand site, **replaces a platform link**, and **never displaces a real page-stated event site**. So a FURBALL event carrying its beefdip.com event page keeps it — with the Furball favicon on top. The new test pins both halves so a future stamp change can't silently clobber host-site event pages.

2. **Taxonomy archives are never event pages**: MAD.BEAR FOAM PARTY's website became `beefdip.com/tags/` because the tag-archive link rode ticketUrl and the "bare root buries same-site event page" rule promoted it. First-segment taxonomy paths (tags/category/archive/label/topic families) are now rejected at the single shared helper all three promotion sites use.

Verification: quiet suite **1964/1964** (base 1961 + 3 new tests, proven failing on base).

Parked idea from the owner: showing multiple links per event (brand site + host event page) — not designed yet, noted for a future wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP