### PR TITLE
Registry shortNames: line-break hyphens become soft hyphens (BEEFMINCE audit)

### DIFF
--- a/data/promoters.json
+++ b/data/promoters.json
@@ -4,7 +4,7 @@
     "aliases": [
       "MEGAWOOF"
     ],
-    "shortName": "MEGA-WOOF",
+    "shortName": "MEGA\u00adWOOF",
     "instagram": "https://www.instagram.com/megawoof_america",
     "website": "https://linktr.ee/megawoof_america",
     "bearAffinity": "always"
@@ -47,7 +47,7 @@
     "aliases": [
       "Bearracuda Events"
     ],
-    "shortName": "Bear-rac-uda",
+    "shortName": "Bear\u00adrac\u00aduda",
     "instagram": "https://www.instagram.com/bearracuda",
     "website": "https://bearracuda.com/",
     "urlPatterns": [
@@ -70,7 +70,7 @@
     "keywords": [
       "treasure trail"
     ],
-    "shortName": "TREAS-URE TRAIL"
+    "shortName": "TREAS\u00adURE TRAIL"
   },
   {
     "name": "CHUNK",
@@ -81,7 +81,7 @@
   },
   {
     "name": "Furball",
-    "shortName": "FUR-BALL",
+    "shortName": "FUR\u00adBALL",
     "instagram": "https://instagram.com/furballnyc/",
     "website": "https://www.furball.nyc",
     "favicon": "https://linktr.ee/furballnyc",
@@ -89,14 +89,14 @@
   },
   {
     "name": "Cubhouse",
-    "shortName": "CUB-HOUSE",
+    "shortName": "CUB\u00adHOUSE",
     "instagram": "https://www.instagram.com/cubhouse.philly",
     "website": "https://linktr.ee/cubhouse",
     "bearAffinity": "always"
   },
   {
     "name": "Goldiloxx",
-    "shortName": "GOLDI-LOXX",
+    "shortName": "GOLDI\u00adLOXX",
     "shorterName": "GLX",
     "favicon": "https://linktr.ee/goldiloxx",
     "instagram": "https://www.instagram.com/goldiloxx__",
@@ -108,14 +108,14 @@
   },
   {
     "name": "Twisted Bear",
-    "shortName": "TWIST-ED BEAR",
+    "shortName": "TWIST\u00adED BEAR",
     "instagram": "https://www.instagram.com/twistedbearparty",
     "facebook": "https://www.facebook.com/twistedglobal/",
     "bearAffinity": "always"
   },
   {
     "name": "CubScout LA",
-    "shortName": "CUB-SCOUT",
+    "shortName": "CUB\u00adSCOUT",
     "aliases": [
       "CUBSCOUT"
     ],
@@ -123,13 +123,13 @@
   },
   {
     "name": "BEEFMINCE",
-    "shortName": "BEEF-MINCE",
+    "shortName": "BEEF\u00adMINCE",
     "website": "https://beefmince.com",
     "bearAffinity": "always"
   },
   {
     "name": "SPOOKMINCE",
-    "shortName": "SPOOK-MINCE",
+    "shortName": "SPOOK\u00adMINCE",
     "parent": "BEEFMINCE",
     "keywords": [
       "spookmince"
@@ -138,7 +138,7 @@
   },
   {
     "name": "BOATMINCE",
-    "shortName": "BOAT-MINCE",
+    "shortName": "BOAT\u00adMINCE",
     "parent": "BEEFMINCE",
     "keywords": [
       "boatmince"
@@ -147,7 +147,7 @@
   },
   {
     "name": "BeefDip",
-    "shortName": "BEEF-DIP",
+    "shortName": "BEEF\u00adDIP",
     "website": "https://beefdip.com",
     "bearAffinity": "always"
   },
@@ -216,7 +216,7 @@
   },
   {
     "name": "Northeast Ursamen",
-    "shortName": "URSA-MEN",
+    "shortName": "URSA\u00adMEN",
     "aliases": [
       "NE Ursamen",
       "Ursamen",

--- a/scripts/promoter-registry.test.js
+++ b/scripts/promoter-registry.test.js
@@ -227,7 +227,7 @@ test('migrated Furball identity (incl. favicon) stamps on match exactly like the
   core.applyPromoterRegistryMatches([event], { name: 'Furball' }, enforceConfig);
   assert.equal(event._promoter, 'Furball');
   // The exact values the removed parser-config metadata block used to stamp
-  assert.equal(event.shortName, 'FUR-BALL');
+  assert.equal(event.shortName, 'FUR\u00adBALL');
   assert.equal(event.instagram, 'https://instagram.com/furballnyc/');
   // url/website are ONE canonical field now: the registry stamps no distinct
   // `url` value — canonicalizeIdentityLinks fills the blank `website` from
@@ -238,7 +238,7 @@ test('migrated Furball identity (incl. favicon) stamps on match exactly like the
   assert.equal(event.favicon, 'https://linktr.ee/furballnyc', 'favicon migrated into the registry');
   // Same static machinery: stamped fields are tracked for de-circularization
   assert.equal(event._staticFields.favicon, 'https://linktr.ee/furballnyc');
-  assert.equal(event._staticFields.shortName, 'FUR-BALL');
+  assert.equal(event._staticFields.shortName, 'FUR\u00adBALL');
   // Bear trust now comes from the entry, with the parser carrying no alwaysBear
   const trust = core.getEventBearTrust(event, { name: 'Furball' });
   assert.equal(trust.trusted, true);

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -241,7 +241,7 @@ const scraperConfig = {
       urls: ["https://example.com/events"],
       alwaysBear: false, // set true for trusted bear promoters (AI trust context)
       metadata: {
-        shortName: { value: "NEW-SITE" }, // add a hyphen where it should line-break
+        shortName: { value: "NEW-SITE" }, // use a soft hyphen (\u00ad) where it may line-break; it stays invisible until needed
         instagram: { value: "https://www.instagram.com/example" },
       },
       // ── Optional fields — exhaustive reference (defaults noted) ────────

--- a/scripts/scraper-promoters.js
+++ b/scripts/scraper-promoters.js
@@ -13,7 +13,7 @@ const scraperPromoters = [
     "aliases": [
       "MEGAWOOF"
     ],
-    "shortName": "MEGA-WOOF",
+    "shortName": "MEGA­WOOF",
     "instagram": "https://www.instagram.com/megawoof_america",
     "website": "https://linktr.ee/megawoof_america",
     "bearAffinity": "always"
@@ -56,7 +56,7 @@ const scraperPromoters = [
     "aliases": [
       "Bearracuda Events"
     ],
-    "shortName": "Bear-rac-uda",
+    "shortName": "Bear­rac­uda",
     "instagram": "https://www.instagram.com/bearracuda",
     "website": "https://bearracuda.com/",
     "urlPatterns": [
@@ -79,7 +79,7 @@ const scraperPromoters = [
     "keywords": [
       "treasure trail"
     ],
-    "shortName": "TREAS-URE TRAIL"
+    "shortName": "TREAS­URE TRAIL"
   },
   {
     "name": "CHUNK",
@@ -90,7 +90,7 @@ const scraperPromoters = [
   },
   {
     "name": "Furball",
-    "shortName": "FUR-BALL",
+    "shortName": "FUR­BALL",
     "instagram": "https://instagram.com/furballnyc/",
     "website": "https://www.furball.nyc",
     "favicon": "https://linktr.ee/furballnyc",
@@ -98,14 +98,14 @@ const scraperPromoters = [
   },
   {
     "name": "Cubhouse",
-    "shortName": "CUB-HOUSE",
+    "shortName": "CUB­HOUSE",
     "instagram": "https://www.instagram.com/cubhouse.philly",
     "website": "https://linktr.ee/cubhouse",
     "bearAffinity": "always"
   },
   {
     "name": "Goldiloxx",
-    "shortName": "GOLDI-LOXX",
+    "shortName": "GOLDI­LOXX",
     "shorterName": "GLX",
     "favicon": "https://linktr.ee/goldiloxx",
     "instagram": "https://www.instagram.com/goldiloxx__",
@@ -117,14 +117,14 @@ const scraperPromoters = [
   },
   {
     "name": "Twisted Bear",
-    "shortName": "TWIST-ED BEAR",
+    "shortName": "TWIST­ED BEAR",
     "instagram": "https://www.instagram.com/twistedbearparty",
     "facebook": "https://www.facebook.com/twistedglobal/",
     "bearAffinity": "always"
   },
   {
     "name": "CubScout LA",
-    "shortName": "CUB-SCOUT",
+    "shortName": "CUB­SCOUT",
     "aliases": [
       "CUBSCOUT"
     ],
@@ -132,13 +132,13 @@ const scraperPromoters = [
   },
   {
     "name": "BEEFMINCE",
-    "shortName": "BEEF-MINCE",
+    "shortName": "BEEF­MINCE",
     "website": "https://beefmince.com",
     "bearAffinity": "always"
   },
   {
     "name": "SPOOKMINCE",
-    "shortName": "SPOOK-MINCE",
+    "shortName": "SPOOK­MINCE",
     "parent": "BEEFMINCE",
     "keywords": [
       "spookmince"
@@ -147,7 +147,7 @@ const scraperPromoters = [
   },
   {
     "name": "BOATMINCE",
-    "shortName": "BOAT-MINCE",
+    "shortName": "BOAT­MINCE",
     "parent": "BEEFMINCE",
     "keywords": [
       "boatmince"
@@ -156,7 +156,7 @@ const scraperPromoters = [
   },
   {
     "name": "BeefDip",
-    "shortName": "BEEF-DIP",
+    "shortName": "BEEF­DIP",
     "website": "https://beefdip.com",
     "bearAffinity": "always"
   },
@@ -225,7 +225,7 @@ const scraperPromoters = [
   },
   {
     "name": "Northeast Ursamen",
-    "shortName": "URSA-MEN",
+    "shortName": "URSA­MEN",
     "aliases": [
       "NE Ursamen",
       "Ursamen",


### PR DESCRIPTION
## Why

BEEFMINCE displays as **BEEF-MINCE** on the city page (and everywhere else): its registry `shortName` carries a hard hyphen that was meant as a line-break hint. Owner audit request: convert to soft hyphens and check the rest of the file.

## Audit result

**13 of 25 promoters** use the same hard-hyphen-as-break-hint pattern: MEGA-WOOF, Bear-rac-uda, TREAS-URE TRAIL, FUR-BALL, CUB-HOUSE, GOLDI-LOXX, TWIST-ED BEAR, CUB-SCOUT, BEEF-MINCE, SPOOK-MINCE, BOAT-MINCE, BEEF-DIP, URSA-MEN.

## Change

- `data/promoters.json`: all 13 shortNames now use U+00AD soft hyphens, written as the **visible `­` escape** so no invisible characters lurk in the canonical file. Renders as `BEEFMINCE`; still breaks as `BEEF-` / `MINCE` when a narrow pill needs it (site CSS already sets `hyphens: manual`). Matching fields (titlePhrases/urlTokens/matchKey) untouched — only display names changed.
- `scripts/scraper-promoters.js`: regenerated twin (`tools/generate-scraper-promoters.js`); the in-sync test enforces this. Note the generated file contains the *raw* U+00AD characters (JSON.stringify does not escape them) — it is generated-only, header says do not hand-edit.
- `scripts/promoter-registry.test.js`: the two `FUR-BALL` stamp pins updated to the soft-hyphen value.
- `scripts/scraper-input.js`: NEW-SITE template comment now documents the soft-hyphen convention (comment-only edit).

## Expected fallout

One-time diff wave on the next phone run: every registry-matched event rewrites `shortName` in its notes (hard → soft hyphen), so the results UI will show a pile of one-field merges once, then go quiet.

Suite: **1964/1964** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP