### PR TITLE
Sanity: improbable-overnight-span — AM/PM typo detector (both directions)

### DIFF
--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2328,15 +2328,20 @@ class SharedCore {
             }
         }
 
-        // 11. overnight-span-into-evening — a start in the small hours
-        //     (00:00-05:59 local) whose span runs more than 8 hours lands in
-        //     the EVENING of the same day: a club night that "ends" at 6 PM.
-        //     Every observed case is an AM/PM entry error at the source
-        //     (BEEFMINCE Sitges 2026-09: the venue page said 1AM-6PM for what
-        //     is plainly a 1AM-6AM party). Report-only — the stated value
-        //     always ships; this just surfaces the improbable span for the
-        //     owner to notice. Fails closed without an event timezone: a
-        //     wrong-zone local hour would manufacture false positives.
+        // 11. improbable-overnight-span — two mirrored shapes of the same
+        //     AM/PM entry error at the source, both report-only:
+        //     (a) a start in the small hours (00:00-05:59 local) whose span
+        //         runs more than 8 hours lands in the EVENING of the same
+        //         day — BEEFMINCE Sitges 2026-09 said 1AM-6PM for what is
+        //         plainly a 1AM-6AM party;
+        //     (b) an evening start (18:00+ local) whose span runs more than
+        //         12 hours lands in the next AFTERNOON — GOLIDLOXX AUGUST
+        //         (NYC, 2026-08-30) said 9PM-4PM for a 9PM-4AM party, which
+        //         also made it render as a Sat-Sun multi-day event.
+        //     The stated value always ships; this just surfaces the
+        //     improbable span for the owner to notice. Fails closed without
+        //     an event timezone: a wrong-zone local hour would manufacture
+        //     false positives.
         if (typeof event.timezone === 'string' && event.timezone) {
             const overnightStartMs = toMs(event.startDate);
             const overnightEndMs = toMs(event.endDate);
@@ -2348,8 +2353,13 @@ class SharedCore {
                     const spanHours = (overnightEndMs - overnightStartMs) / (60 * 60 * 1000);
                     if (localStartHour <= 5 && spanHours > 8) {
                         flags.push({
-                            code: 'overnight-span-into-evening',
+                            code: 'improbable-overnight-span',
                             detail: `starts ${localStartHour}:00-ish local yet runs ${Math.round(spanHours)}h into the evening — likely an AM/PM typo at the source`
+                        });
+                    } else if (localStartHour >= 18 && spanHours > 12) {
+                        flags.push({
+                            code: 'improbable-overnight-span',
+                            detail: `starts ${localStartHour - 12}PM local yet runs ${Math.round(spanHours)}h into the next afternoon — likely an AM/PM typo at the source`
                         });
                     }
                 }

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -2328,6 +2328,34 @@ class SharedCore {
             }
         }
 
+        // 11. overnight-span-into-evening — a start in the small hours
+        //     (00:00-05:59 local) whose span runs more than 8 hours lands in
+        //     the EVENING of the same day: a club night that "ends" at 6 PM.
+        //     Every observed case is an AM/PM entry error at the source
+        //     (BEEFMINCE Sitges 2026-09: the venue page said 1AM-6PM for what
+        //     is plainly a 1AM-6AM party). Report-only — the stated value
+        //     always ships; this just surfaces the improbable span for the
+        //     owner to notice. Fails closed without an event timezone: a
+        //     wrong-zone local hour would manufacture false positives.
+        if (typeof event.timezone === 'string' && event.timezone) {
+            const overnightStartMs = toMs(event.startDate);
+            const overnightEndMs = toMs(event.endDate);
+            if (Number.isFinite(overnightStartMs) && Number.isFinite(overnightEndMs)
+                && overnightEndMs > overnightStartMs) {
+                const overnightOffsetMin = this.getTimezoneOffsetMinutes(new Date(overnightStartMs), event.timezone);
+                if (overnightOffsetMin !== null) {
+                    const localStartHour = new Date(overnightStartMs + (overnightOffsetMin * 60000)).getUTCHours();
+                    const spanHours = (overnightEndMs - overnightStartMs) / (60 * 60 * 1000);
+                    if (localStartHour <= 5 && spanHours > 8) {
+                        flags.push({
+                            code: 'overnight-span-into-evening',
+                            detail: `starts ${localStartHour}:00-ish local yet runs ${Math.round(spanHours)}h into the evening — likely an AM/PM typo at the source`
+                        });
+                    }
+                }
+            }
+        }
+
         return flags;
     }
 

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20440,3 +20440,53 @@ test('identity-priority match stamps the brand identity but website only fills b
   assert.equal(stated.website, 'https://beefdip.com/planned-events/furball-pool-party/',
     'a real page-stated event site is never displaced by the brand site');
 });
+
+// ── Sanity rule: overnight-span-into-evening (AM/PM typo detector) ──────────
+// A club night that starts in the small hours and runs into the EVENING is
+// almost certainly an AM/PM entry error at the source (BEEFMINCE Sitges,
+// 2026-09: "1AM-6PM" on the venue page for what is plainly a 1AM-6AM party).
+// Report-only: surfaces for the owner to notice; the stated value ships.
+test('overnight start running into the evening flags as a likely AM/PM typo', () => {
+  const core = new SharedCore({}, { eventSchema: EventSchema });
+  const flags = core.getEventSanityFlags({
+    title: 'BEEFMINCE DISCO',
+    startDate: new Date('2026-09-10T01:00:00+02:00'),
+    endDate: new Date('2026-09-10T18:00:00+02:00'),
+    timezone: 'Europe/Madrid'
+  });
+  const flag = flags.find(f => f.code === 'overnight-span-into-evening');
+  assert.ok(flag, 'a 1AM start running 17h to 6PM must flag');
+  assert.match(flag.detail, /AM\/PM/);
+});
+
+test('a genuine 1AM-6AM club night never flags overnight-span-into-evening', () => {
+  const core = new SharedCore({}, { eventSchema: EventSchema });
+  const flags = core.getEventSanityFlags({
+    title: 'BEEFMINCE SPORTS ZONE',
+    startDate: new Date('2026-09-11T01:00:00+02:00'),
+    endDate: new Date('2026-09-11T06:00:00+02:00'),
+    timezone: 'Europe/Madrid'
+  });
+  assert.equal(flags.find(f => f.code === 'overnight-span-into-evening'), undefined);
+});
+
+test('a long afternoon-into-night event (beer bust 2PM-2AM) never flags overnight-span-into-evening', () => {
+  const core = new SharedCore({}, { eventSchema: EventSchema });
+  const flags = core.getEventSanityFlags({
+    title: 'SUNDAY BEER BUST',
+    startDate: new Date('2026-09-06T14:00:00-07:00'),
+    endDate: new Date('2026-09-07T02:00:00-07:00'),
+    timezone: 'America/Los_Angeles'
+  });
+  assert.equal(flags.find(f => f.code === 'overnight-span-into-evening'), undefined);
+});
+
+test('overnight-span-into-evening fails closed without a timezone', () => {
+  const core = new SharedCore({}, { eventSchema: EventSchema });
+  const flags = core.getEventSanityFlags({
+    title: 'MYSTERY NIGHT',
+    startDate: new Date('2026-09-10T01:00:00+02:00'),
+    endDate: new Date('2026-09-10T18:00:00+02:00')
+  });
+  assert.equal(flags.find(f => f.code === 'overnight-span-into-evening'), undefined);
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20441,11 +20441,35 @@ test('identity-priority match stamps the brand identity but website only fills b
     'a real page-stated event site is never displaced by the brand site');
 });
 
-// ── Sanity rule: overnight-span-into-evening (AM/PM typo detector) ──────────
+// ── Sanity rule: improbable-overnight-span (AM/PM typo detector) ──────────
 // A club night that starts in the small hours and runs into the EVENING is
 // almost certainly an AM/PM entry error at the source (BEEFMINCE Sitges,
 // 2026-09: "1AM-6PM" on the venue page for what is plainly a 1AM-6AM party).
 // Report-only: surfaces for the owner to notice; the stated value ships.
+test('an evening start running into the next afternoon flags as a likely AM/PM typo (GOLIDLOXX)', () => {
+  const core = new SharedCore({}, { eventSchema: EventSchema });
+  const flags = core.getEventSanityFlags({
+    title: 'GOLIDLOXX AUGUST',
+    startDate: new Date('2026-08-30T01:00:00Z'),   // Sat 9PM EDT
+    endDate: new Date('2026-08-30T20:00:00Z'),     // Sun 4PM EDT — 19h
+    timezone: 'America/New_York'
+  });
+  const flag = flags.find(f => f.code === 'improbable-overnight-span');
+  assert.ok(flag, 'a 9PM start running 19h to the next 4PM must flag');
+  assert.match(flag.detail, /AM\/PM/);
+});
+
+test('a genuine 10PM-8AM circuit party never flags improbable-overnight-span', () => {
+  const core = new SharedCore({}, { eventSchema: EventSchema });
+  const flags = core.getEventSanityFlags({
+    title: 'ALL NIGHT',
+    startDate: new Date('2026-09-05T22:00:00-04:00'),
+    endDate: new Date('2026-09-06T08:00:00-04:00'),
+    timezone: 'America/New_York'
+  });
+  assert.equal(flags.find(f => f.code === 'improbable-overnight-span'), undefined);
+});
+
 test('overnight start running into the evening flags as a likely AM/PM typo', () => {
   const core = new SharedCore({}, { eventSchema: EventSchema });
   const flags = core.getEventSanityFlags({
@@ -20454,12 +20478,12 @@ test('overnight start running into the evening flags as a likely AM/PM typo', ()
     endDate: new Date('2026-09-10T18:00:00+02:00'),
     timezone: 'Europe/Madrid'
   });
-  const flag = flags.find(f => f.code === 'overnight-span-into-evening');
+  const flag = flags.find(f => f.code === 'improbable-overnight-span');
   assert.ok(flag, 'a 1AM start running 17h to 6PM must flag');
   assert.match(flag.detail, /AM\/PM/);
 });
 
-test('a genuine 1AM-6AM club night never flags overnight-span-into-evening', () => {
+test('a genuine 1AM-6AM club night never flags improbable-overnight-span', () => {
   const core = new SharedCore({}, { eventSchema: EventSchema });
   const flags = core.getEventSanityFlags({
     title: 'BEEFMINCE SPORTS ZONE',
@@ -20467,10 +20491,10 @@ test('a genuine 1AM-6AM club night never flags overnight-span-into-evening', () 
     endDate: new Date('2026-09-11T06:00:00+02:00'),
     timezone: 'Europe/Madrid'
   });
-  assert.equal(flags.find(f => f.code === 'overnight-span-into-evening'), undefined);
+  assert.equal(flags.find(f => f.code === 'improbable-overnight-span'), undefined);
 });
 
-test('a long afternoon-into-night event (beer bust 2PM-2AM) never flags overnight-span-into-evening', () => {
+test('a long afternoon-into-night event (beer bust 2PM-2AM) never flags improbable-overnight-span', () => {
   const core = new SharedCore({}, { eventSchema: EventSchema });
   const flags = core.getEventSanityFlags({
     title: 'SUNDAY BEER BUST',
@@ -20478,15 +20502,15 @@ test('a long afternoon-into-night event (beer bust 2PM-2AM) never flags overnigh
     endDate: new Date('2026-09-07T02:00:00-07:00'),
     timezone: 'America/Los_Angeles'
   });
-  assert.equal(flags.find(f => f.code === 'overnight-span-into-evening'), undefined);
+  assert.equal(flags.find(f => f.code === 'improbable-overnight-span'), undefined);
 });
 
-test('overnight-span-into-evening fails closed without a timezone', () => {
+test('improbable-overnight-span fails closed without a timezone', () => {
   const core = new SharedCore({}, { eventSchema: EventSchema });
   const flags = core.getEventSanityFlags({
     title: 'MYSTERY NIGHT',
     startDate: new Date('2026-09-10T01:00:00+02:00'),
     endDate: new Date('2026-09-10T18:00:00+02:00')
   });
-  assert.equal(flags.find(f => f.code === 'overnight-span-into-evening'), undefined);
+  assert.equal(flags.find(f => f.code === 'improbable-overnight-span'), undefined);
 });


### PR DESCRIPTION
## Why

Two live specimens of the same source-data typo class:

- **BEEFMINCE Sitges** (2026-09): two parties listed as **1AM–6PM** — 17-hour "club nights" that are plainly 1AM–6AM with a PM typo.
- **GOLIDLOXX AUGUST** (NYC, caught while this PR was open): stored as **Sat 9PM → Sun 4PM** EDT — 19 hours, 4PM for 4AM — and the bogus afternoon end is also exactly why it renders as a Sat–Sun multi-day event on the city page.

## Change

New report-only sanity rule **11. improbable-overnight-span** in `getEventSanityFlags`, covering both mirrored shapes:

- **(a)** start in the small hours (00:00–05:59 event-local) + span **> 8h** → "runs into the evening"
- **(b)** evening start (18:00+ event-local) + span **> 12h** → "runs into the next afternoon"

Guards: genuine overnight events never trip it (1AM–6AM = 5h; 10PM–8AM circuit party = 10h); long afternoon events never trip it (beer bust 2PM–2AM starts at hour 14); **fails closed without an event timezone**. Report-only per doctrine — the stated value always ships; the flag surfaces on the results card so the owner notices.

Suite **1964 → 1970**; positive tests proven failing on base.

## Related display change (demo only, not in this PR)

The city-page logical-end cutoff (`< 6`) makes a 1AM–6AM party render as a two-day bar (start shifts to the previous night, a 6:00 AM end keeps its morning date). The dusk demo now treats 6-o'clock-hour ends as the same night; that one-line `calendar-core.js` change will ride the dusk port PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP