### PR TITLE
Dusk city page — the redesign, ported from the live demo

### DIFF
--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Atlanta - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Atlanta - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/atlanta/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=8c5a9e97">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=a3d7dff7">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/birmingham/index.html
+++ b/birmingham/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Birmingham - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Birmingham - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/birmingham/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=ad7a9bfa">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=1e711427">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/boston/index.html
+++ b/boston/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Boston - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Boston - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/boston/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=b5da5a11">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=e5e45827">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/brighton/index.html
+++ b/brighton/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Brighton - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Brighton - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/brighton/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=50e09102">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=de95e0f7">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Chicago - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Chicago - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/chicago/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=35812a0f">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=13c950f2">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/city.html
+++ b/city.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -121,13 +121,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -183,5 +183,6 @@
     <script src="js/filename-utils.js"></script>
     <script src="js/dynamic-calendar-loader.js"></script>
     <script src="js/app.js"></script>
+    <script src="js/dusk-ui.js"></script>
 </body>
 </html>

--- a/dallas/index.html
+++ b/dallas/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Dallas - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Dallas - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/dallas/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=719cbe63">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=9dc74761">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/dc/index.html
+++ b/dc/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="DC - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to DC - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/dc/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=4ca60a30">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=4b757dbe">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/denver/index.html
+++ b/denver/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Denver - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Denver - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/denver/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=02a0f699">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=bd9f16c7">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/img/favicons/favicon-furball.nyc-256px.ico.meta
+++ b/img/favicons/favicon-furball.nyc-256px.ico.meta
@@ -5,6 +5,6 @@
   "size": "256",
   "contentType": "image/jpeg",
   "contentLength": "2820",
-  "downloadedAt": "2026-08-21T23:38:04.006Z",
+  "downloadedAt": "2026-08-21T23:39:52.648Z",
   "lastModified": "Thu, 17 Sep 2026 17:06:46 GMT"
 }

--- a/img/favicons/favicon-furball.nyc-64px.ico.meta
+++ b/img/favicons/favicon-furball.nyc-64px.ico.meta
@@ -5,6 +5,6 @@
   "size": "64",
   "contentType": "image/jpeg",
   "contentLength": "1164",
-  "downloadedAt": "2026-08-21T23:38:03.887Z",
+  "downloadedAt": "2026-08-21T23:39:52.566Z",
   "lastModified": "Thu, 17 Sep 2026 17:06:46 GMT"
 }

--- a/js/calendar-core.js
+++ b/js/calendar-core.js
@@ -1587,7 +1587,12 @@ class CalendarCore {
             localHour = this.getLocalHour(logicalDate, this.calendarTimezone);
         }
 
-        if (!isAllDay && localHour !== null && localHour < 6) {
+        // A party that runs until 6-something AM is still the same night.
+        // The start-side cutoff shifts a 1AM start back a day; ending the
+        // shift at 05:59 made a 1AM-6AM event span two logical days and
+        // render as a multi-day bar (owner report, 2026-08: BEEFMINCE
+        // Sitges, GOLDILOXX NYC). End times through 06:59 now shift too.
+        if (!isAllDay && localHour !== null && localHour < 7) {
             logicalDate.setDate(logicalDate.getDate() - 1);
         }
         return logicalDate;

--- a/js/dusk-ui.js
+++ b/js/dusk-ui.js
@@ -1,0 +1,510 @@
+// Dusk city-page UI mechanics — ported from the approved demo overlay
+// (2026-08-21). Runs at the end of <body> so its first pass lands before
+// first paint. Everything here is display-side composition on top of the
+// loader's renders: header mounting, per-event pill colours, multi-day
+// lane packing and flowing labels, card masonry, per-view map homing.
+// The loader owns data and rendering; this file owns arrangement.
+(function () {
+    // The dusk scope class lives on <html> — the site's own JS rewrites the
+    // body class at load time, so body is not a safe carrier for it.
+    if (!document.documentElement.classList.contains('dusk')) return;
+
+    // ==== aurora derivation, ported verbatim from js/dynamic-calendar-loader.js ====
+    const AURORA_BASE_RGB = { r: 23, g: 26, b: 51 };
+    const AURORA_MIN_CHROMA = 0.05;
+    const AURORA_MIN_STOP_SHARE = 0.10;
+    const AURORA_MIN_SEPARATION = 0.2;
+    const AURORA_SIBLING_LIGHTNESS = 0.55;
+    const AURORA_SIBLING_CHROMA_BOOST = 1.12;
+
+    function parseHexColor(hex) {
+        const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(String(hex || '').trim());
+        if (!m) return null;
+        let v = m[1];
+        if (v.length === 3) v = v.split('').map(c => c + c).join('');
+        return { r: parseInt(v.slice(0, 2), 16), g: parseInt(v.slice(2, 4), 16), b: parseInt(v.slice(4, 6), 16) };
+    }
+    function rgbToHexColor(rgb) {
+        const ch = v => Math.max(0, Math.min(255, Math.round(v))).toString(16).padStart(2, '0');
+        return `#${ch(rgb.r)}${ch(rgb.g)}${ch(rgb.b)}`;
+    }
+    function mixRgbColors(from, to, amount) {
+        return { r: from.r + (to.r - from.r) * amount, g: from.g + (to.g - from.g) * amount, b: from.b + (to.b - from.b) * amount };
+    }
+    function rgbBrightness(rgb) { return (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255; }
+    function toneForAurora(rgb, minB, maxB) {
+        const b = rgbBrightness(rgb);
+        if (b > maxB) { const s = maxB / b; return { r: rgb.r * s, g: rgb.g * s, b: rgb.b * s }; }
+        if (b < minB) { const a = (minB - b) / (1 - b); return mixRgbColors(rgb, { r: 255, g: 255, b: 255 }, a); }
+        return rgb;
+    }
+    function rgbColorfulness(rgb) {
+        const max = Math.max(rgb.r, rgb.g, rgb.b), min = Math.min(rgb.r, rgb.g, rgb.b);
+        return max <= 0 ? 0 : (max - min) / max;
+    }
+    function rgbSeparation(a, b) {
+        const l = rgbBrightness(a) - rgbBrightness(b);
+        const rg = ((a.r - a.g) - (b.r - b.g)) / 255;
+        const yb = (((a.r + a.g) / 2 - a.b) - ((b.r + b.g) / 2 - b.b)) / 255;
+        return Math.sqrt(l * l + rg * rg + yb * yb);
+    }
+    function deepenRgb(rgb, lf, cb = 1) {
+        const mean = (rgb.r + rgb.g + rgb.b) / 3;
+        const push = c => Math.max(0, Math.min(255, (mean + (c - mean) * cb) * lf));
+        return { r: push(rgb.r), g: push(rgb.g), b: push(rgb.b) };
+    }
+    function parsePaletteEntries(palette) {
+        if (typeof palette !== 'string') return [];
+        const entries = [];
+        palette.trim().split(/\s+/).forEach(token => {
+            const parts = token.split(':');
+            const rgb = parseHexColor(parts[0]);
+            if (!rgb) return;
+            entries.push({ rgb, share: Math.max(0, Number(parts[1]) || 0) / 100, chroma: Math.max(0, Number(parts[2]) || 0) / 100 });
+        });
+        return entries;
+    }
+    function deriveAuroraFromPalette(entries, accentRgb) {
+        if (!accentRgb) return deriveAchromaticAurora(entries);
+        const candidates = entries
+            .filter(e => e.chroma >= AURORA_MIN_CHROMA && e.share >= AURORA_MIN_STOP_SHARE)
+            .map(e => ({ rgb: e.rgb, separation: rgbSeparation(e.rgb, accentRgb) }))
+            .filter(c => c.separation >= AURORA_MIN_SEPARATION)
+            .sort((a, b) => b.separation - a.separation);
+        const second = candidates.length > 0 ? candidates[0].rgb
+            : deepenRgb(accentRgb, AURORA_SIBLING_LIGHTNESS, AURORA_SIBLING_CHROMA_BOOST);
+        return bandAuroraStops(accentRgb, second, 0.2, 0.52, 0.16, 0.48);
+    }
+    function deriveAchromaticAurora(entries) {
+        if (entries.length === 0) return null;
+        const sorted = [...entries].sort((a, b) => rgbBrightness(b.rgb) - rgbBrightness(a.rgb));
+        const tint = rgb => mixRgbColors(rgb, AURORA_BASE_RGB, 0.45);
+        return bandAuroraStops(tint(sorted[0].rgb), tint(sorted[sorted.length - 1].rgb), 0.22, 0.4, 0.06, 0.14);
+    }
+    function bandAuroraStops(first, second, fMin, fMax, sMin, sMax) {
+        const c1 = toneForAurora(first, fMin, fMax);
+        const c2 = toneForAurora(second, sMin, sMax);
+        const blended = mixRgbColors(c1, c2, 0.5);
+        return {
+            c1: rgbToHexColor(c1),
+            c2: rgbToHexColor(c2),
+            c3: rgbToHexColor(toneForAurora(mixRgbColors(blended, AURORA_BASE_RGB, 0.62), 0.05, 0.22))
+        };
+    }
+    function deriveAuroraColors(record) {
+        if (!record) return null;
+        const entries = parsePaletteEntries(record.palette);
+        if (entries.length > 0) return deriveAuroraFromPalette(entries, parseHexColor(record.accent));
+        const bg = parseHexColor(record.faviconBg);
+        if (!bg) return null;
+        const fg = parseHexColor(record.faviconFg) || bg;
+        if (Math.max(rgbColorfulness(bg), rgbColorfulness(fg)) < 0.18) return null;
+        const blended = mixRgbColors(bg, fg, 0.5);
+        return {
+            c1: rgbToHexColor(toneForAurora(bg, 0.18, 0.5)),
+            c2: rgbToHexColor(toneForAurora(fg, 0.18, 0.5)),
+            c3: rgbToHexColor(toneForAurora(mixRgbColors(blended, AURORA_BASE_RGB, 0.6), 0.05, 0.22))
+        };
+    }
+
+    // ==== color lookup ====
+    let recordsBySlug = null;
+    function currentCity() {
+        const m = /[?&]city=([a-z0-9-]+)/i.exec(window.location.search);
+        if (m) return m[1].toLowerCase();
+        const seg = window.location.pathname.split('/').filter(Boolean)[0];
+        return seg && !/\.html?$/.test(seg) ? seg.toLowerCase() : 'nyc';
+    }
+    function loadColors() {
+        return fetch(`/data/event-colors/${currentCity()}.json`)
+            .then(r => (r.ok ? r.json() : []))
+            .catch(() => [])
+            .then(list => {
+                recordsBySlug = new Map();
+                (Array.isArray(list) ? list : []).forEach(rec => {
+                    if (rec && rec.slug) recordsBySlug.set(rec.slug, rec);
+                });
+            });
+    }
+
+    const derived = new Map(); // slug -> {aurora, acc, accBright} | null
+    function colorsFor(slug) {
+        if (!recordsBySlug) return null;
+        if (derived.has(slug)) return derived.get(slug);
+        const rec = recordsBySlug.get(slug);
+        const aurora = deriveAuroraColors(rec);
+        let out = null;
+        if (aurora) {
+            const raw = (rec && parseHexColor(rec.accent)) || parseHexColor(aurora.c1);
+            out = {
+                aurora,
+                acc: rgbToHexColor(toneForAurora(raw, 0.22, 0.5)),
+                accBright: rgbToHexColor(toneForAurora(raw, 0.62, 0.85))
+            };
+        }
+        derived.set(slug, out);
+        return out;
+    }
+
+    // ==== apply to the grid pills ====
+    function paintPills() {
+        if (recordsBySlug) {
+            document.querySelectorAll('.event-item[data-event-slug]').forEach(pill => {
+                const c = colorsFor(pill.getAttribute('data-event-slug'));
+                if (!c) return;
+                pill.style.setProperty('--c1', c.aurora.c1);
+                pill.style.setProperty('--c2', c.aurora.c2);
+                pill.style.setProperty('--acc', c.acc);
+                pill.style.setProperty('--accBright', c.accBright);
+            });
+        }
+        paintMultiDayRuns();
+    }
+
+    // Multi-day events render as one segment per day cell. Stamp each segment
+    // with the run length and its offset so a single oversized gradient
+    // continues seamlessly across the cells and reads as ONE item.
+    const chunkRun = segments => {
+        // Group the run's segments by visual row; the first segment in a
+        // row keeps its text and gets the row-chunk's pixel width so the
+        // words can flow across the whole bar.
+        segments.forEach(el => {
+            el.classList.remove('md-chunk-lead', 'md-chunk-follow');
+            el.style.removeProperty('--chunkw');
+            const nameEl = el.querySelector('.event-name');
+            if (nameEl) { nameEl.style.removeProperty('width'); nameEl.style.removeProperty('max-width'); }
+        });
+        let chunk = [];
+        const flushChunk = () => {
+            if (!chunk.length) return;
+            const lead = chunk[0];
+            lead.classList.add('md-chunk-lead');
+            chunk.slice(1).forEach(el => el.classList.add('md-chunk-follow'));
+            const first = lead.getBoundingClientRect();
+            const last = chunk[chunk.length - 1].getBoundingClientRect();
+            const chunkWidth = Math.max(first.width, last.right - first.left);
+            lead.style.setProperty('--chunkw', `${chunkWidth}px`);
+            // Inline pixel width on the name itself — Safari resolves the
+            // max-content/var() combination differently, so don't rely on it
+            const leadName = lead.querySelector('.event-name');
+            if (leadName && chunkWidth > 0) {
+                leadName.style.width = `${Math.max(20, chunkWidth - 12)}px`;
+                leadName.style.maxWidth = 'none';
+                // The site's smart-name logic truncates the STRING to one
+                // cell's width before we ever get here — give the lead the
+                // real name and let CSS ellipsis do any needed trimming.
+                // (Guarded: only write on change, or the MutationObserver
+                // would refire forever.)
+                const slug = lead.getAttribute('data-event-slug');
+                const events = (window.calendarLoader && window.calendarLoader.allEvents) || [];
+                const ev = events.find(e => e && e.slug === slug);
+                const label = ev ? (ev.shortName || ev.nickname || ev.name) : null;
+                if (label && leadName.textContent !== label) leadName.textContent = label;
+            }
+            chunk = [];
+        };
+        let rowTop = null;
+        segments.forEach(el => {
+            const top = Math.round(el.getBoundingClientRect().top);
+            if (rowTop !== null && Math.abs(top - rowTop) > 4) flushChunk();
+            rowTop = top;
+            chunk.push(el);
+        });
+        flushChunk();
+    };
+
+    function paintMultiDayRuns() {
+        const segs = [...document.querySelectorAll('.event-item.multi-day[data-event-slug]')];
+        // Group by event first: two multi-day events running in parallel
+        // interleave in document order and would scramble run detection.
+        const bySlug = new Map();
+        segs.forEach(el => {
+            const key = el.getAttribute('data-event-slug') || '';
+            if (!bySlug.has(key)) bySlug.set(key, []);
+            bySlug.get(key).push(el);
+        });
+        bySlug.forEach(group => {
+            const n = group.length;
+            group.forEach((el, i) => {
+                el.style.setProperty('--mdspan', n);
+                el.style.setProperty('--mdpos', n > 1 ? `${(i / (n - 1)) * 100}%` : '0%');
+            });
+            chunkRun(group);
+        });
+    }
+
+    // Re-render happens via wholesale innerHTML swaps — observe and repaint.
+    let scheduled = false;
+    const observer = new MutationObserver(() => {
+        if (scheduled) return;
+        scheduled = true;
+        requestAnimationFrame(() => { scheduled = false; refreshAll(); });
+    });
+
+
+    // Move the calendar controls into a second row of the purple header
+    // (event-builder mechanism: the header is one auto-height block and its
+    // real height is measured into --hdr-h for the body padding).
+    function mountControlsInHeader() {
+        const nav = document.querySelector('header nav');
+        const controls = document.querySelector('.calendar-controls');
+        if (!nav || !controls) return;
+        let row = nav.querySelector('.header-controls-row');
+        if (!row) {
+            row = document.createElement('div');
+            row.className = 'header-controls-row';
+            nav.appendChild(row);
+        }
+        if (controls.parentElement !== row) row.appendChild(controls);
+        // desktop: the picker PHYSICALLY sits beside the city switcher —
+        // position by structure, not by flex-margin arithmetic
+        const toggle = document.querySelector('.view-toggle');
+        const switcher = document.querySelector('header .city-switcher');
+        if (toggle && switcher) {
+            if (window.innerWidth >= 769) {
+                if (toggle.nextElementSibling !== switcher) switcher.before(toggle);
+            } else if (toggle.parentElement !== controls) {
+                controls.appendChild(toggle);
+            }
+        }
+        const labels = { week: 'Week', month: 'Month' };
+        document.querySelectorAll('.view-btn').forEach(btn => {
+            const view = btn.getAttribute('data-view');
+            if (labels[view]) btn.textContent = labels[view];
+        });
+        const prev = document.getElementById('prev-period');
+        const next = document.getElementById('next-period');
+        if (prev) prev.textContent = '\u2039';
+        if (next) next.textContent = '\u203a';
+    }
+
+    function trackHeaderHeight() {
+        const header = document.querySelector('header');
+        if (!header) return;
+        const set = () => {
+            document.documentElement.style.setProperty('--hdr-h', header.offsetHeight + 'px');
+            // header height shifts the whole page — the week map must re-size
+            requestAnimationFrame(() => { try { sizeWeekMap(); } catch (e) {} });
+        };
+        if (window.ResizeObserver) new ResizeObserver(set).observe(header);
+        window.addEventListener('resize', set);
+        set();
+    }
+
+    // One event = one lane across a week row. The site stacks each cell
+    // independently, so a run's segments land at different heights and the
+    // bar reads broken. Assign lanes per row and hold empty lanes open with
+    // transparent spacers; the signature guard keeps the MutationObserver
+    // from re-triggering forever.
+    function alignMultiDayLanes() {
+        const cells = [...document.querySelectorAll('.calendar-day[data-date]')];
+        if (!cells.length) return;
+        const rows = [];
+        cells.forEach(cell => {
+            const top = Math.round(cell.getBoundingClientRect().top);
+            let row = rows.find(r => Math.abs(r.top - top) < 4);
+            if (!row) { row = { top, cells: [] }; rows.push(row); }
+            row.cells.push(cell);
+        });
+        rows.forEach(row => {
+            row.cells.sort((a, b) => a.getBoundingClientRect().left - b.getBoundingClientRect().left);
+            // first-fit lane packing: earlier/longer runs claim lanes first,
+            // and a later run slots UP into any lane that is free over its
+            // span (interweave) instead of always cascading downwards
+            const coverage = new Map();
+            row.cells.forEach((cell, ci) => {
+                cell.querySelectorAll('.event-item.multi-day[data-event-slug]').forEach(p => {
+                    const slug = p.getAttribute('data-event-slug');
+                    if (!coverage.has(slug)) coverage.set(slug, { min: ci, max: ci });
+                    const c = coverage.get(slug);
+                    c.min = Math.min(c.min, ci);
+                    c.max = Math.max(c.max, ci);
+                });
+            });
+            const runs = [...coverage.entries()]
+                .sort((a, b) => (a[1].min - b[1].min)
+                    || ((b[1].max - b[1].min) - (a[1].max - a[1].min))
+                    || (a[0] < b[0] ? -1 : 1));
+            if (!runs.length) return;
+            const laneRuns = []; // lane index -> [{slug,min,max}]
+            runs.forEach(([slug, c]) => {
+                let li = 0;
+                while (laneRuns[li] && laneRuns[li].some(o => !(c.max < o.min || c.min > o.max))) li++;
+                if (!laneRuns[li]) laneRuns[li] = [];
+                laneRuns[li].push({ slug, min: c.min, max: c.max });
+            });
+            row.cells.forEach((cell) => {
+                const container = cell.querySelector('.day-events') || cell.querySelector('.daily-events');
+                if (!container) return;
+                const bySlug = new Map();
+                container.querySelectorAll('.event-item.multi-day[data-event-slug]').forEach(p =>
+                    bySlug.set(p.getAttribute('data-event-slug'), p));
+                const ci = row.cells.indexOf(cell);
+                const slotSlugs = laneRuns.map(list => {
+                    const o = list.find(o => o.min <= ci && ci <= o.max);
+                    return o && bySlug.has(o.slug) ? o.slug : null;
+                });
+                let maxActive = -1;
+                slotSlugs.forEach((slug, li) => { if (slug) maxActive = li; });
+                const sig = slotSlugs.slice(0, maxActive + 1)
+                    .map(slug => (slug ? 'p:' + slug : 's')).join('|');
+                if (cell.dataset.mdLaneSig === sig) return;
+                cell.dataset.mdLaneSig = sig;
+                container.querySelectorAll('.md-lane-spacer').forEach(sp => sp.remove());
+                const ordered = [];
+                for (let li = 0; li <= maxActive; li++) {
+                    if (slotSlugs[li]) ordered.push(bySlug.get(slotSlugs[li]));
+                    else {
+                        // a real (invisible) pill skeleton: always exactly lane
+                        // height, with no measurement race against font loading
+                        const spacer = document.createElement('div');
+                        spacer.className = 'event-item multi-day md-lane-spacer';
+                        spacer.innerHTML = '<div class="event-name">&nbsp;</div><div class="event-time">&nbsp;</div>';
+                        ordered.push(spacer);
+                    }
+                }
+                const rest = [...container.children].filter(n => !ordered.includes(n));
+                ordered.concat(rest).forEach(n => container.appendChild(n));
+            });
+        });
+    }
+
+    // Desktop right rail: events + map become one pinned flex column so
+    // the geometry is structural instead of sticky-offset arithmetic.
+    function mountRightRail() {
+        const page = document.querySelector('main.city-page');
+        if (!page) return;
+        const ev = page.querySelector('.events');
+        const map = page.querySelector('.events-map-section');
+        if (!ev || !map) return;
+        let rail = page.querySelector(':scope > .right-rail');
+        if (window.innerWidth < 769) {
+            if (rail) { rail.before(ev, map); rail.remove(); }
+            return;
+        }
+        if (!rail) {
+            rail = document.createElement('div');
+            rail.className = 'right-rail';
+            (map.parentElement === page ? map : ev).before(rail);
+        }
+        // week: map on the page (bottom-left). Month: page middle column
+        // when three columns fit (>=1200), else it rides the rail under the
+        // cards.
+        const isWeekView = !!page.querySelector('.calendar-grid.week-view-grid');
+        const mapHome = (isWeekView || window.innerWidth >= 1200) ? page : rail;
+        let moved = false;
+        if (ev.parentElement !== rail) { rail.appendChild(ev); moved = true; }
+        if (map.parentElement !== mapHome) { mapHome.appendChild(map); moved = true; }
+        // maplibre sizes its canvas to the container — nudge it after re-homing
+        if (moved) setTimeout(() => window.dispatchEvent(new Event('resize')), 60);
+    }
+
+    // Week view: the map must fill from under the grid to the page bottom.
+    // Percentage heights through grid tracks proved racy against the site's
+    // re-renders — set the pixel height directly and converge.
+    function sizeWeekMap() {
+        const page = document.querySelector('main.city-page');
+        const mapEl = document.getElementById('events-map');
+        if (!page || !mapEl) return;
+        const sec = mapEl.closest('.events-map-section');
+        const onPage = sec && sec.parentElement === page;
+        const isWeek = window.innerWidth >= 769 && onPage && !!page.querySelector('.calendar-grid.week-view-grid');
+        const isMonth = window.innerWidth >= 1200 && onPage && !!page.querySelector('.calendar-grid.month-view-grid');
+        let want = null;
+        if (isWeek) {
+            const pageRect = page.getBoundingClientRect();
+            const cal = page.querySelector('.weekly-calendar');
+            const calBottom = cal ? cal.getBoundingClientRect().bottom : pageRect.top;
+            want = Math.max(220, Math.round(pageRect.bottom - calBottom - 20));
+        } else if (isMonth) {
+            // the section's height is a viewport calc; the map fills it
+            const secRect = sec.getBoundingClientRect();
+            want = Math.max(240, Math.round(secRect.bottom - mapEl.getBoundingClientRect().top - 6));
+        }
+        if (want === null) {
+            if (mapEl.style.height) {
+                mapEl.style.height = '';
+                window.dispatchEvent(new Event('resize'));
+            }
+            return;
+        }
+        if (Math.abs(mapEl.getBoundingClientRect().height - want) > 4) {
+            mapEl.style.height = `${want}px`;
+            window.dispatchEvent(new Event('resize'));
+        }
+    }
+
+    // Masonry interweave: place each card, in order, into whichever column
+    // is currently shorter — a short card never strands a half-empty row.
+    // Below desktop the columns dissolve via CSS (display: contents), and on
+    // a resize down we physically unwrap so DOM order returns to chronology.
+    function interleaveCards() {
+        const list = document.querySelector('.events-list');
+        if (!list) return;
+        const cols = list.querySelectorAll(':scope > .ml-col');
+        const monthDesktop = window.innerWidth >= 769
+            && !!document.querySelector('.calendar-grid.month-view-grid');
+        // two fixed 400px columns need the room — below that, one ordered file
+        const tooNarrow = list.getBoundingClientRect().width < 2 * 400 + 16;
+        if (window.innerWidth < 769 || monthDesktop || tooNarrow) {
+            if (cols.length) {
+                const cards = [...list.querySelectorAll('.ml-col > *')]
+                    .sort((a, b) => (+a.dataset.mlIndex || 0) - (+b.dataset.mlIndex || 0));
+                cards.forEach(c => list.appendChild(c));
+                cols.forEach(c => c.remove());
+            }
+            return;
+        }
+        const orphans = [...list.children].filter(n =>
+            n.classList && n.classList.contains('event-card'));
+        if (!orphans.length) return;
+        let colA = list.querySelector(':scope > .ml-col.a');
+        let colB = list.querySelector(':scope > .ml-col.b');
+        if (!colA) {
+            colA = document.createElement('div'); colA.className = 'ml-col a';
+            colB = document.createElement('div'); colB.className = 'ml-col b';
+            list.append(colA, colB);
+        }
+        orphans.forEach((card, i) => {
+            card.dataset.mlIndex = String(i);
+            const hA = colA.getBoundingClientRect().height;
+            const hB = colB.getBoundingClientRect().height;
+            // heights can both read ~0 before layout/images settle — fall
+            // back to strict alternation so column A never swallows the lot
+            const target = (hA < 10 && hB < 10)
+                ? (colA.childElementCount <= colB.childElementCount ? colA : colB)
+                : (hA <= hB ? colA : colB);
+            target.appendChild(card);
+        });
+    }
+
+    // Today only earns a spot when today's cell is not on screen.
+    function updateTodayChip() {
+        const row = document.querySelector('.header-controls-row');
+        if (!row) return;
+        if (!document.querySelector('.calendar-grid .calendar-day')) return;
+        row.classList.toggle('off-today', !document.querySelector('.calendar-day.current'));
+    }
+
+    function refreshAll() {
+        mountControlsInHeader();
+        alignMultiDayLanes();
+        paintPills();
+        mountRightRail();
+        sizeWeekMap();
+        interleaveCards();
+        updateTodayChip();
+    }
+
+    // Mount immediately — this script runs at the end of <body>, so the
+    // controls are already in the header on the very first paint and the
+    // header never grows after load.
+    mountControlsInHeader();
+    trackHeaderHeight();
+    observer.observe(document.body, { childList: true, subtree: true });
+    window.addEventListener('resize', () => refreshAll());
+    // chunk widths and lane heights depend on final font metrics — do a
+    // full refresh once fonts land
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(() => refreshAll());
+    loadColors().then(() => refreshAll());
+})();

--- a/js/dusk-ui.js
+++ b/js/dusk-ui.js
@@ -496,6 +496,19 @@
         updateTodayChip();
     }
 
+    // The static markup hardcodes WEEK as active; the loader corrects it
+    // from the URL during its (async) init — this pre-paint pass prevents
+    // the wrong underline from ever being painted at all.
+    (function () {
+        try {
+            const m = /[?&]view=(week|month)/.exec(window.location.search);
+            if (!m) return;
+            document.querySelectorAll('.view-btn').forEach(btn => {
+                btn.classList.toggle('active', btn.getAttribute('data-view') === m[1]);
+            });
+        } catch (e) {}
+    })();
+
     // Mount immediately — this script runs at the end of <body>, so the
     // controls are already in the header on the very first paint and the
     // header never grows after load.

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -479,6 +479,12 @@ class DynamicCalendarLoader extends CalendarCore {
             // View
             if (viewParam === 'week' || viewParam === 'month') {
                 this.currentView = viewParam;
+                // The static markup hardcodes WEEK as the active toggle and
+                // nothing else ever syncs it from the URL — a deep-linked
+                // month page kept the wrong underline forever.
+                document.querySelectorAll('.view-btn').forEach(btn => {
+                    btn.classList.toggle('active', btn.getAttribute('data-view') === viewParam);
+                });
             }
             
             // Date (YYYY-MM-DD)
@@ -2658,6 +2664,37 @@ class DynamicCalendarLoader extends CalendarCore {
     // Rounded-square favicon tile for the card title row. Rendered only when a
     // favicon path exists; a load failure removes the tile so no empty frame is
     // left behind.
+    // Dusk cards: each time sits next to its own day — "1AM" is
+    // unambiguously the start day's and "6PM" the end day's. A small-hours
+    // event shown on the previous day says "night": that one word explains
+    // why a Wednesday card carries Thursday clock times.
+    formatDuskWhenText(event) {
+        try {
+            if (!event || !event.startDate) return null;
+            const WD = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+            const md = d => `${d.getMonth() + 1}/${d.getDate()}`;
+            const ls = this.getLogicalStartDate(event);
+            if (!ls) return null;
+            const times = typeof event.time === 'string' && event.time.includes('-')
+                ? event.time.split('-').map(t => t.trim())
+                : (event.time ? [String(event.time).trim()] : []);
+            if (this.isMultiDay(event)) {
+                const le = this.getLogicalEndDate(event);
+                if (!le) return null;
+                const startPart = `${WD[ls.getDay()]} ${md(ls)}${times[0] ? ' ' + times[0] : ''}`;
+                const endPart = `${WD[le.getDay()]} ${md(le)}${times[1] ? ' ' + times[1] : ''}`;
+                return `${startPart} \u2013 ${endPart}`;
+            }
+            const literalStart = new Date(event.startDate);
+            if (event.time && ls.getDate() !== literalStart.getDate()) {
+                return `${WD[ls.getDay()]} ${md(ls)} night \u00b7 ${event.time}`;
+            }
+            return null;
+        } catch (err) {
+            return null;
+        }
+    }
+
     generateAuroraFaviconHtml(event) {
         let faviconUrl = null;
         try {
@@ -2730,6 +2767,8 @@ class DynamicCalendarLoader extends CalendarCore {
 
         // Event badges
         const formatDayTime = (event) => {
+            const paired = this.formatDuskWhenText(event);
+            if (paired) return paired;
             if (this.isMultiDay(event) && window.formatEventDates) {
                 return window.formatEventDates(event);
             }
@@ -3660,9 +3699,15 @@ class DynamicCalendarLoader extends CalendarCore {
             const otherMonthClass = isCurrentMonth ? '' : ' other-month';
             const hasEventsClass = filteredDayEvents.length > 0 ? ' has-events' : '';
 
-            // Ultra-simplified month view: show only 2 events with shortened names for better mobile viewing
-            const eventsToShow = filteredDayEvents.slice(0, 2);
-            const additionalEventsCount = Math.max(0, filteredDayEvents.length - 2);
+            // Multi-day SEGMENTS always render — dropping one silently broke
+            // the bar mid-run whenever a cell was crowded (owner-reported:
+            // BEEFMINCE Sitges week). Single-day events cap at 2, and a LONE
+            // hidden single renders itself instead of a pointless "+1" chip.
+            const multiDaySegments = filteredDayEvents.filter(event => this.isMultiDay(event));
+            const singleDayEvents = filteredDayEvents.filter(event => !this.isMultiDay(event));
+            const singleCap = singleDayEvents.length === 3 ? 3 : 2;
+            const eventsToShow = multiDaySegments.concat(singleDayEvents.slice(0, singleCap));
+            const additionalEventsCount = Math.max(0, singleDayEvents.length - singleCap);
             
             const eventsHtml = eventsToShow.length > 0 
                 ? eventsToShow.map(event => {

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1541,17 +1541,17 @@ class DynamicCalendarLoader extends CalendarCore {
     }
 
     formatDateRange(start, end) {
-        const options = { month: 'short', day: 'numeric' };
-        
+        // All-numeric (owner request): "8/16-22", "12/27 - 1/2", "9/2026" —
+        // the header's fixed date slot can stay genuinely small because the
+        // widest possible string is short and known.
         if (this.currentView === 'week') {
+            const startText = `${start.getMonth() + 1}/${start.getDate()}`;
             if (start.getMonth() === end.getMonth()) {
-                return `${start.toLocaleDateString('en-US', { month: 'short' })} ${start.getDate()}-${end.getDate()}`;
-            } else {
-                return `${start.toLocaleDateString('en-US', options)} - ${end.toLocaleDateString('en-US', options)}`;
+                return `${startText}-${end.getDate()}`;
             }
-        } else {
-            return start.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+            return `${startText} - ${end.getMonth() + 1}/${end.getDate()}`;
         }
+        return `${start.getMonth() + 1}/${start.getFullYear()}`;
     }
 
     // Load calendar data for specific city (uses cached data from GitHub Actions)

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -1545,11 +1545,9 @@ class DynamicCalendarLoader extends CalendarCore {
         // the header's fixed date slot can stay genuinely small because the
         // widest possible string is short and known.
         if (this.currentView === 'week') {
-            const startText = `${start.getMonth() + 1}/${start.getDate()}`;
-            if (start.getMonth() === end.getMonth()) {
-                return `${startText}-${end.getDate()}`;
-            }
-            return `${startText} - ${end.getMonth() + 1}/${end.getDate()}`;
+            // both ends always carry the month number — uniform string
+            // shapes keep the fixed slot visually full in every week
+            return `${start.getMonth() + 1}/${start.getDate()} - ${end.getMonth() + 1}/${end.getDate()}`;
         }
         return `${start.getMonth() + 1}/${start.getFullYear()}`;
     }

--- a/la/index.html
+++ b/la/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Los Angeles - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Los Angeles - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/la/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=e336eea2">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=a2820819">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/london/index.html
+++ b/london/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="London - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to London - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/london/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=ef11c8a4">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=85876a2a">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/nola/index.html
+++ b/nola/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="New Orleans - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to New Orleans - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/nola/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=c8058a31">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=2ba060a6">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/nyc/index.html
+++ b/nyc/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="New York - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to New York - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/nyc/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=fe53091e">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=3d22b1e7">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Palm Springs - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Palm Springs - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/palm-springs/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=1b5ce5c9">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=76af1c15">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/philly/index.html
+++ b/philly/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Philadelphia - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Philadelphia - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/philly/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=f37c3503">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=24fe9302">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/phoenix/index.html
+++ b/phoenix/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Phoenix - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Phoenix - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/phoenix/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=480894a9">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=8ea89350">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/portland/index.html
+++ b/portland/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Portland - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Portland - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/portland/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=31ec7349">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=22e60f04">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/ptown/index.html
+++ b/ptown/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Provincetown - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Provincetown - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/ptown/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=bbcdc147">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=8c5e6522">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/san-diego/index.html
+++ b/san-diego/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Seattle - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Seattle - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/seattle/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=160f20af">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=e1cab2fc">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/sf/index.html
+++ b/sf/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="San Francisco - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to San Francisco - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/sf/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=68400ed1">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=037957f3">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Sitges - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Sitges - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/sitges/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=31fe404f">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=02ddddbf">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -6455,3 +6455,654 @@ body.loaded {
 #events-map .favicon-marker-container.text-marker {
     background: var(--primary-color);
 }
+
+
+/* ════════════════════════════════════════════════════════════════════
+   DUSK — the city-page redesign (owner-approved via the live demo,
+   2026-08-21). Scoped by class="dusk" on <html> in city.html so other
+   pages keep the existing look until they get their own pass.
+
+   Ported from the demo overlay verbatim; the demo remains the reference
+   implementation. Load-bearing subtleties are commented inline — the
+   overflow/min-width pair on cells, the will-change removal, and the
+   day-padding variable that the multi-day bleed margins read.
+   ════════════════════════════════════════════════════════════════════ */
+
+/* ================================================================
+   DUSK theme core.
+   - Page background = the event-builder's dark radial
+   - Calendar melts into the page
+   - Mini cards + main cards: SOLID per-event color
+   - Header: ONE purple block, two rows, auto height (event-builder
+     mechanism: JS measures real height into --hdr-h)
+   - Controls: quiet text in the purple second row — no boxes.
+     Today only appears when you've navigated off today.
+   - Selection: spotlight (dim the rest), no white border
+   - Motion: nothing moves unless touched; feedback = fast fades
+   - Map water: back to the site's brand purple (no override)
+   ================================================================ */
+
+html.dusk body {
+    background: radial-gradient(circle at top, #1b2033 0%, #0b0d13 45%, #07090f 100%);
+    background-attachment: fixed;
+}
+
+/* ---------- header: one purple block that grows to fit its rows ---------- */
+html.dusk header {
+    height: auto !important;              /* base CSS clamps it to 60px on phones */
+    border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
+}
+html.dusk body {
+    padding-top: var(--hdr-h, 104px) !important;
+}
+.dusk main.city-page { padding-top: 0.35rem; }
+/* the controls moved into the header and the h2 title is unused — the empty
+   block's padding was the mystery gap above the grid */
+.dusk .calendar-header { display: none; }
+
+/* ---------- spacing: mobile IS the design ----------
+   No overrides at phone widths — the base mobile values stand untouched.
+   Desktop/tablet ADOPT the base mobile numbers instead of the base CSS's
+   inflated wide-screen cells and typography. */
+@media (min-width: 769px) {
+    .dusk .calendar-day { --day-padding: 0.3rem; padding: var(--day-padding); min-height: 80px; }
+    /* week cells: slimmer side padding buys the text lane the width a
+       six-letter name needs; the multi-day bleed reads the same variable
+       so bars stay exactly flush */
+    .dusk .calendar-day.week-view,
+    .dusk .calendar-day.month-day { --day-padding: 0.2rem; padding: var(--day-padding); }
+    .dusk .calendar-day.month-day { min-height: 60px; }
+    .dusk .event-item { padding: 0.2rem; }
+    .dusk .event-item .event-name { font-size: 0.75rem; }
+    .dusk .event-item .event-time { font-size: 0.7rem; }
+}
+/* the calendar shows name+time only — venue lives on the card */
+.dusk .event-item .event-venue { display: none; }
+
+/* day numbers tuck into the cell corner; events reclaim the header row.
+   position:relative alone creates no stacking context, so the multi-day
+   z-index machinery is unaffected; the today circle survives because the
+   number keeps its fixed 1.5em round box, just smaller */
+.dusk .calendar-day { position: relative; }
+.dusk .calendar-day .day-header {
+    position: absolute;
+    top: 2px;
+    left: 5px;
+    right: auto;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+/* numbers are plain text — the base gives EVERY number a reserved 1.4em
+   circle box, which misaligns them against the weekday label. Sizes stay
+   the base's own; only the box goes. */
+.dusk .day-date, .dusk .day-number {
+    width: auto;
+    height: auto;
+    display: inline;
+    border-radius: 0;
+    flex: none;
+    line-height: inherit;
+}
+/* week header spans the cell: weekday left, date right (as before) */
+.dusk .calendar-day.week-view .day-header { right: 5px; }
+.dusk .calendar-day.week-view .day-header { justify-content: space-between; }
+/* today's circle paints BEHIND the number and may bleed — it costs no
+   layout, so today's number aligns exactly like every other day's */
+.dusk .calendar-day.current .day-date,
+.dusk .calendar-day.current .day-number {
+    position: relative;
+    z-index: 1;
+    background: none !important;
+    color: var(--text-inverse) !important;
+}
+.dusk .calendar-day.current .day-date::before,
+.dusk .calendar-day.current .day-number::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 1.45em;
+    height: 1.45em;
+    border-radius: 50%;
+    background: var(--primary-color);
+    z-index: -1;
+}
+.dusk .day-indicator { display: none; }
+.dusk .calendar-day .day-events,
+.dusk .calendar-day .daily-events { padding-top: 1.45rem; padding-bottom: 0.45rem; }
+
+/* ---------- calendar = the page ---------- */
+.dusk .calendar-grid {
+    background: transparent;
+    background-color: transparent;
+    border: none;
+    box-shadow: none;
+}
+/* month only: 7 equal columns that can shrink (week view stacks on phones) */
+.dusk .calendar-grid.month-view-grid { grid-template-columns: repeat(7, minmax(0, 1fr)); }
+.dusk .calendar-day {
+    background: transparent;
+    border-right: 1px solid rgba(255, 255, 255, 0.06);
+}
+.dusk .calendar-day:last-child { border-right: none; }
+.dusk .day-header h3 { color: rgba(255, 255, 255, 0.65); }
+.dusk .day-date, .dusk .day-number {
+    color: rgba(255, 255, 255, 0.9);
+    font-variant-numeric: tabular-nums;
+}
+/* today's column keeps the same hairline as everyone else — no blue edge */
+.dusk .calendar-day.current,
+.dusk .calendar-day.week-view.current {
+    border-color: rgba(255, 255, 255, 0.06) !important;
+}
+.dusk .calendar-day.current:last-child,
+.dusk .calendar-day.week-view.current:last-child { border-right: none !important; }
+/* month weekday strip: quiet, no bright divider */
+.dusk .calendar-day-header { border-color: rgba(255, 255, 255, 0.14); background: transparent; }
+.dusk .calendar-day-header h4 { color: rgba(255, 255, 255, 0.55); }
+.dusk .day-indicator { color: #ff9d9d; }
+.dusk .calendar-day.other-month { opacity: 0.45; }
+
+/* ---------- mini cards: solid per-event color ---------- */
+.dusk .event-item {
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    color: #fff;
+    background: var(--c1, var(--primary-color));
+    min-width: 0;
+    overflow: hidden;
+}
+.dusk .event-item .event-name { color: #fff; }
+.dusk .event-item .event-time { color: rgba(255, 255, 255, 0.82); }
+.dusk .event-item .event-venue { color: rgba(255, 255, 255, 0.7); }
+.dusk .event-favicon-chip { background: rgba(255, 255, 255, 0.9); }
+.dusk .more-events {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.16);
+    color: rgba(255, 255, 255, 0.85);
+}
+
+/* ---------- selection = spotlight: the pick stays vivid, the rest recede ---------- */
+.dusk .event-item.selected,
+.dusk .event-item.enhanced.selected {
+    background: var(--c1, var(--primary-color)) !important;
+    color: #fff !important;
+    outline: none;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.45);
+}
+/* dim via filter, not opacity: multi-day segments deliberately overlap by
+   ~2px, and translucent overlaps double-composite into a visible seam line */
+.dusk .calendar-grid:has(.event-item.selected) .event-item:not(.selected) {
+    opacity: 1;
+    filter: saturate(0.35) brightness(0.4);
+}
+.dusk .calendar-grid:has(.event-item.selected) .event-item.selected {
+    opacity: 1;
+    filter: none;
+}
+/* a selected multi-day run: every segment carries .selected, and per-segment
+   drop shadows fall on their neighbours as dark bands — no shadow on runs */
+.dusk .event-item.multi-day.selected { box-shadow: none; }
+
+/* ---------- multi-day: solid = trivially continuous ---------- */
+/* the base grid clips every cell (overflow: hidden), which slices the bar at
+   each day boundary AND clips the flowing title at the first cell's edge —
+   dusk cells must not clip. min-width: 0 is load-bearing: the clip was what
+   kept grid tracks equal (clipped cells have no content minimum), so without
+   it cells would size to their content and the columns go ragged */
+/* will-change:transform (perf hint in base) makes EVERY cell a stacking
+   context, trapping the lead's z-index inside its cell — the follow segment
+   in the next cell then paints over the flowing title. Drop the hint. */
+.dusk .calendar-day { overflow: visible; min-width: 0; will-change: auto; }
+.dusk .event-item.multi-day {
+    border: none;
+    color: #fff;
+    background: var(--c1, var(--primary-color));
+}
+/* overlap the neighbour by a hair so no page background can peek through */
+.dusk .event-item.multi-day-start { margin-right: calc(-1 * var(--day-padding, 0.5rem) - 2px) !important; }
+.dusk .event-item.multi-day-middle {
+    margin-left: calc(-1 * var(--day-padding, 0.5rem) - 2px) !important;
+    margin-right: calc(-1 * var(--day-padding, 0.5rem) - 2px) !important;
+}
+.dusk .event-item.multi-day-end { margin-left: calc(-1 * var(--day-padding, 0.5rem) - 2px) !important; }
+/* a continuation segment that LEADS a row shows its text: the base 12px
+   padding (meant to clear the bleed) indents it farther than every other
+   pill — realign so the text lands at the standard pill indent whether or
+   not the bleed got clipped at the grid edge */
+.dusk .event-item.multi-day-middle.md-chunk-lead,
+.dusk .event-item.multi-day-end.md-chunk-lead {
+    padding-left: calc(var(--day-padding, 0.5rem) + 2px + 0.2rem);
+}
+/* one object per row: only the first segment in a row keeps its text,
+   and that text flows across the whole bar (JS stamps the chunk classes
+   and --chunkw with the run's pixel width in this row) */
+/* the lead must stack ABOVE its follow segments: each segment is its own
+   stacking context (position:relative; z-index:1 from base), and later DOM
+   siblings otherwise paint over the lead's flowing text */
+.dusk .event-item.multi-day.md-chunk-lead { overflow: visible; z-index: 3; }
+/* every segment computes the same single-line text metrics so the bar is one
+   even thickness — hidden follow text must not wrap taller than the lead */
+.dusk .event-item.multi-day .event-name {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-line-clamp: unset;
+    max-height: none;
+}
+.dusk .event-item.multi-day.md-chunk-lead .event-name {
+    width: max-content;
+    max-width: calc(var(--chunkw, 100%) - 10px);
+    position: relative;
+    z-index: 5;
+}
+.dusk .event-item.multi-day.md-chunk-follow > * { visibility: hidden; }
+
+/* ---------- main cards: solid too ---------- */
+.dusk .event-card.detailed.aurora {
+    background: var(--c1, var(--primary-color));
+}
+
+/* ---------- controls: quiet text inside the purple header ---------- */
+.dusk .header-controls-row {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 0 1rem 0.55rem;
+    gap: 0.75rem;
+}
+.dusk .header-controls-row .calendar-controls {
+    background: transparent;
+    border: none;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    gap: 0.9rem;
+    flex-wrap: nowrap !important;
+}
+/* date group reads first; Week/Month pinned flush right; Today fades into
+   the elastic middle so nothing ever shifts */
+.dusk .header-controls-row .date-navigation {
+    order: -1;
+    margin-right: auto;
+    background: transparent;
+    border: none;
+    padding: 0;
+    gap: 0.15rem;
+}
+.dusk .header-controls-row .today-btn { order: 1; }
+.dusk .header-controls-row .view-toggle { order: 2; }
+.dusk .nav-btn {
+    background: transparent;
+    color: rgba(255, 255, 255, 0.75);
+    width: 32px;
+    height: 32px;
+    min-height: 32px;
+    border-radius: 8px;
+    font-size: 1.15rem;
+    line-height: 1;
+}
+.dusk .nav-btn:hover { background: rgba(255, 255, 255, 0.12); color: #fff; transform: none; }
+.dusk .date-range {
+    color: #fff;
+    font-size: 0.95rem;
+    font-weight: 600;
+    min-width: 8.75rem;
+    text-align: center;
+    padding: 0 0.35rem;
+    white-space: nowrap;
+}
+.dusk .view-toggle {
+    background: transparent;
+    border: none;
+    padding: 0;
+    gap: 1.1rem;
+}
+.dusk .view-btn {
+    background: transparent;
+    color: rgba(255, 255, 255, 0.6);
+    padding: 0.1rem 0.05rem 2px;
+    min-height: 0;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border-radius: 0;
+    border-bottom: 2px solid transparent;
+    align-self: center;
+    line-height: 1.2;
+}
+.dusk .view-btn.active {
+    background: transparent;
+    color: #fff;
+    border-bottom-color: var(--secondary-color, #f5576c);
+}
+.dusk .view-btn:hover:not(.active) { color: rgba(255, 255, 255, 0.9); }
+
+/* Today: space always reserved; it fades in when you're off today
+   so the other controls never shift */
+.dusk .today-btn {
+    display: inline-flex;
+    visibility: hidden;
+    opacity: 0;
+    background: transparent;
+    color: #ff9d9d;
+    padding: 0.1rem 0.5rem 2px;
+    min-height: 0;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border-radius: 0;
+    border-bottom: 2px solid transparent;
+    align-self: center;
+    line-height: 1.2;
+    position: relative;
+    top: 1px;             /* optical: sit on the date's baseline */
+    transition: opacity 0.12s ease;
+}
+.dusk .header-controls-row.off-today .today-btn { visibility: visible; opacity: 1; }
+.dusk .today-btn:hover { transform: none; background: rgba(255, 255, 255, 0.08); }
+
+/* phone: same row, one size down */
+@media (max-width: 480px) {
+    .dusk .header-controls-row { padding: 0 0.6rem 0.5rem; gap: 0.4rem; }
+    .dusk .header-controls-row .calendar-controls { gap: 0.55rem; }
+    .dusk .date-range { font-size: 0.82rem; padding: 0 0.2rem; }
+    .dusk .nav-btn { width: 28px; height: 28px; min-height: 28px; font-size: 1rem; }
+    .dusk .view-btn, .dusk .today-btn { font-size: 0.7rem; }
+}
+
+/* ---------- motion: keep the load reveal and the swipe flight; ----------
+   ---------- kill only the press-time popping                   ----------
+   The section slide-ins on page load and the JS swipe/nav transition on the
+   calendar grid are the site's own and stay untouched. (The grid also relies
+   on inline opacity:0 to hide the width-measurement sample event at load —
+   never override its opacity from CSS.) */
+/* cards flying up on every list re-render (every tap re-renders the list) */
+.dusk .event-card, .dusk .category-card { animation: none !important; }
+/* what remains: fast fades as press feedback */
+.dusk .event-item,
+.dusk .event-card {
+    transition: opacity 0.15s ease, filter 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+}
+.dusk .view-btn, .dusk .nav-btn, .dusk .today-btn {
+    transition: color 0.12s ease, background-color 0.12s ease, border-color 0.12s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+    .dusk *, .dusk *::before, .dusk *::after {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
+/* pre-mount safety: the controls are invisible in their original in-page
+   slot — they only ever show once mounted inside the purple header row */
+.dusk .calendar-header .calendar-controls { visibility: hidden; }
+
+/* ---------- one header row + phone-true spacing for EVERYTHING wider
+   than a phone (769px+): picker docked beside the switcher, no container
+   padding inflating the calendar ---------- */
+@media (min-width: 769px) {
+/* ---------- desktop: one header row when there is room ----------
+   Order reads left-to-right by scope: brand+date (where am I), then the
+   view controls, then the city switcher as the global control at the far
+   edge. display:contents promotes logo/switcher to nav flex items so the
+   appended controls row can sit BETWEEN them. */
+    .dusk header nav {
+        display: flex;
+        align-items: center;
+        min-height: 60px;
+        max-width: 1600px;
+        margin: 0 auto;
+        padding: 0 1.5rem;
+    }
+    .dusk .nav-container { display: contents; }
+    .dusk header .logo { order: 0; flex: 0 0 auto; margin-right: 1.5rem; }
+    .dusk .header-controls-row {
+        order: 1;
+        flex: 1 1 auto;
+        width: auto;
+        margin: 0;
+        padding: 0;
+    }
+    .dusk header .city-switcher { order: 2; flex: 0 0 auto; margin-left: 0.9rem; }
+    /* the date text changes width per period — a fixed slot keeps the
+       arrows and the picker from drifting on every switch */
+    .dusk .header-controls-row .date-range { min-width: 9.5rem; }
+    .dusk .header-controls-row .date-navigation { margin-right: 0; }
+    /* the picker rides in the nav beside the switcher (JS moves it there) */
+    .dusk header .nav-container > .view-toggle,
+    .dusk header nav > .view-toggle { order: 2; margin-right: 0.9rem; }
+    .dusk header .city-switcher-btn { padding: 0.35rem 0.8rem; gap: 0.4rem; }
+    .dusk header .city-emoji { font-size: 1.1rem !important; }
+    .dusk header .city-name { font-size: 0.92rem; }
+    .dusk .header-controls-row .calendar-controls { width: 100%; }
+
+    /* ---------- desktop density: same compact pieces, more of them ---------- */
+    /* ---------- desktop split: calendar pinned left, cards scroll right,
+       map pinned bottom-right (both views) ---------- */
+    .dusk .city-page {
+        /* the calendar IS the phone calendar, docked left at phone width —
+           the cards get the remaining majority for the two-column look.
+           display:grid is ours: the base only grants it at >=1025 */
+        display: grid;
+        max-width: 1600px;
+        margin: 0 auto;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        width: 100%;
+        grid-template-columns: 430px minmax(0, 1fr);
+        grid-template-rows: auto auto;
+        gap: 0 1.5rem;
+    }
+    .dusk .city-page .weekly-calendar { margin: 0; padding: 0; }
+    .dusk .city-page .weekly-calendar .container { padding: 0; }
+    .dusk .city-page .weekly-calendar {
+        grid-column: 1;
+        grid-row: 1 / 3;
+        position: sticky;
+        top: calc(var(--hdr-h, 60px) + 0.5rem);
+        align-self: start;
+    }
+    .dusk .city-page .weekly-calendar { margin: 0; padding: 0; }
+    .dusk .city-page .weekly-calendar .container { padding: 0; }
+
+    /* WEEK VIEW: app layout — nothing scrolls but the cards. Week grid
+       top-left, the map fills the REMAINING left column, cards scroll in
+       the right rail. (Month view keeps the tall grid on a scrolling page
+       with cards+map in the pinned rail — JS re-homes the map per view.) */
+    .dusk .city-page:has(.week-view-grid) {
+        height: calc(100vh - var(--hdr-h, 60px) - 3.5rem);
+        overflow: hidden;
+        grid-template-rows: auto minmax(0, 1fr);
+        padding-top: 0.5rem;
+    }
+    .dusk .city-page:has(.week-view-grid) > .weekly-calendar {
+        grid-column: 1;
+        grid-row: 1;
+        position: static;
+    }
+    .dusk .city-page:has(.week-view-grid) > .events-map-section {
+        grid-column: 1;
+        grid-row: 2;
+        min-height: 0;
+        align-self: start;    /* JS grows the map to the page bottom */
+        height: auto;
+        max-height: none;
+        padding: 0.75rem 0 0;
+        margin: 0;
+        position: static;
+        display: flex;
+        flex-direction: column;
+    }
+    .dusk .city-page:has(.week-view-grid) > .events-map-section .container {
+        padding: 0;
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
+    .dusk .city-page:has(.week-view-grid) > .events-map-section .map-container {
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+    .dusk .city-page:has(.week-view-grid) #events-map {
+        height: 100%;
+        min-height: 200px;
+        max-height: none;
+    }
+    .dusk .city-page:has(.week-view-grid) .right-rail {
+        position: static;
+        height: 100%;
+        grid-row: 1 / 3;
+    }
+
+    /* compact desktop cards: the base flyer treatment is already right
+       (natural size, centred, shadow on the IMAGE) — only the cap changes.
+       Never force width/object-fit here: that stretches the img element and
+       paints empty colour bands inside its rounded shadow box. */
+    .dusk .event-card.detailed.aurora .event-flyer img { max-height: 240px; }
+    .dusk .event-card.detailed.aurora .event-flyer[data-flyer-orientation="portrait"] img { max-height: 290px; }
+    /* cards have a working range, not a stretch-to-fill */
+    .dusk .events-list { flex-wrap: wrap; }
+    .dusk .events-list .ml-col { flex: 0 0 400px; max-width: 400px; }
+    .dusk .events-list > .event-card { max-width: 460px; }
+    .dusk .event-card.detailed.aurora .ec-panel { padding: 0.65rem 0.75rem 0.6rem; }
+    .dusk .event-card.detailed.aurora h3.ec-title { font-size: 0.98rem; }
+    .dusk .event-card.detailed.aurora .ec-row { font-size: 0.8rem; }
+    .dusk .event-card.detailed.aurora .ec-tea { font-size: 0.8rem; }
+
+    /* the overlay re-homes and re-sizes the map section — the base's
+       entrance animation and transition:all replay as a slide every time */
+    .dusk .city-page .events-map-section,
+    .dusk .right-rail .events-map-section {
+        animation: none !important;
+        transition: none !important;
+    }
+
+    /* the fixed week screen has no scroll — the footer would paint over
+       the bottom of the map; it stays on month view and mobile */
+    html.dusk body:has(.city-page .week-view-grid) footer { display: none; }
+
+    /* the right side is ONE pinned rail (JS mounts .events — and in month
+       view also the map — into it): cards scroll inside.
+       Page scroll only ever moves the calendar. */
+    .dusk .city-page .right-rail {
+        grid-column: 2;
+        grid-row: 1 / 3;
+        position: sticky;
+        top: calc(var(--hdr-h, 60px) + 0.5rem);
+        align-self: start;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        height: calc(100vh - var(--hdr-h, 60px) - 7.5rem);
+        min-width: 0;
+    }
+    .dusk .right-rail .events {
+        flex: 1 1 0px;
+        min-height: 0;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        padding: 0;
+        margin: 0;
+    }
+    .dusk .right-rail .events .container { padding: 0 0.25rem 0 0; }
+    .dusk .right-rail .events-map-section {
+        flex: 0 0 auto;
+        padding: 0;
+        margin: 0;
+        max-height: none;
+        height: auto;
+    }
+    .dusk .right-rail .events-map-section .container { padding: 0; }
+    .dusk .right-rail #events-map {
+        height: 34vh;
+        max-height: none;
+        min-height: 220px;
+    }
+
+    /* ---------- cards: masonry interweave (JS fills the shorter column,
+       so a short card never strands a row) ---------- */
+    .dusk .events-list .ml-col > * { min-width: 0; max-width: 100%; }
+    .dusk .event-card .ec-tea { overflow-wrap: anywhere; }
+    .dusk .events-list { display: flex; gap: 1rem; align-items: flex-start; }
+    .dusk .events-list .ml-col {
+        flex: 0 0 400px;
+        max-width: 400px;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+    /* a selected card takes the full width again */
+    .dusk .events-list.selection-mode .ml-col { display: contents; }}
+
+/* month spreads to three columns only when three columns actually fit */
+@media (min-width: 1200px) {
+    /* MONTH VIEW: three columns — the tall calendar, a full-height map,
+       and ONE file of events scrolling on the right */
+    .dusk .city-page:has(.month-view-grid) {
+        grid-template-columns: 430px minmax(260px, 1fr) minmax(380px, 470px);
+        grid-template-rows: auto;
+        gap: 0 1.25rem;
+    }
+    .dusk .city-page:has(.month-view-grid) > .weekly-calendar { grid-column: 1; grid-row: 1; }
+    .dusk .city-page:has(.month-view-grid) > .events-map-section {
+        grid-column: 2;
+        grid-row: 1;
+        position: sticky;
+        top: calc(var(--hdr-h, 60px) + 0.5rem);
+        align-self: start;
+        height: calc(100vh - var(--hdr-h, 60px) - 5.5rem);
+        max-height: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+    }
+    .dusk .city-page:has(.month-view-grid) > .events-map-section .container {
+        padding: 0;
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
+    .dusk .city-page:has(.month-view-grid) > .events-map-section .map-container {
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+    .dusk .city-page:has(.month-view-grid) #events-map {
+        height: 100%;
+        min-height: 240px;
+        max-height: none;
+    }
+    .dusk .city-page:has(.month-view-grid) .right-rail { grid-column: 3; grid-row: 1; }
+
+}
+
+/* below desktop the columns dissolve back into the normal flow */
+@media (max-width: 768.9px) {
+    .dusk .events-list .ml-col { display: contents; }
+}
+
+/* lane spacers: invisible pill skeletons that hold an empty lane open so
+   runs stay level across the row */
+.dusk .event-item.md-lane-spacer {
+    visibility: hidden;
+    background: transparent;
+    border: none;
+    pointer-events: none;
+}

--- a/styles.css
+++ b/styles.css
@@ -6756,8 +6756,10 @@ html.dusk body {
     border-radius: 8px;
     font-size: 1.15rem;
     line-height: 1;
-    padding-bottom: 4px;  /* optical: chevron glyphs centre on the x-height
-                             and read low beside caps text without this */
+    /* optical: chevron glyphs centre on the x-height — measured ~5px low
+       against the date's midline at this size */
+    padding-bottom: 4px;
+    transform: translateY(-3px);
 }
 .dusk .nav-btn:hover { background: rgba(255, 255, 255, 0.12); color: #fff; transform: none; }
 .dusk .date-range {

--- a/styles.css
+++ b/styles.css
@@ -6758,9 +6758,11 @@ html.dusk body {
     color: #fff;
     font-size: 0.95rem;
     font-weight: 600;
-    min-width: 8.75rem;
+    /* just wider than the widest real string ("September 2026" = 8.4em):
+       constant across periods, no dead air around short week ranges */
+    min-width: 8.9em;
     text-align: center;
-    padding: 0 0.35rem;
+    padding: 0 0.25rem;
     white-space: nowrap;
 }
 .dusk .view-toggle {
@@ -6880,7 +6882,6 @@ html.dusk body {
     .dusk header .city-switcher { order: 2; flex: 0 0 auto; margin-left: 0.9rem; }
     /* the date text changes width per period — a fixed slot keeps the
        arrows and the picker from drifting on every switch */
-    .dusk .header-controls-row .date-range { min-width: 9.5rem; }
     .dusk .header-controls-row .date-navigation { margin-right: 0; }
     /* the picker rides in the nav beside the switcher (JS moves it there) */
     .dusk header .nav-container > .view-toggle,

--- a/styles.css
+++ b/styles.css
@@ -6715,14 +6715,17 @@ html.dusk body {
     background: var(--c1, var(--primary-color));
 }
 
-/* ---------- controls: quiet text inside the purple header ---------- */
+/* ---------- controls: segmented pills (owner-picked) ----------
+   Two self-aligned clusters: a soft pill holding ‹ date ›, and a true
+   segmented control for Week/Month with a filled active half. Boxes align
+   themselves — no optical baseline arithmetic. ---------- */
 .dusk .header-controls-row {
     display: flex;
     align-items: center;
     width: 100%;
     max-width: 1600px;
     margin: 0 auto;
-    padding: 0 1rem 0.55rem;
+    padding: 0 1rem 0.6rem;
     gap: 0.75rem;
 }
 .dusk .header-controls-row .calendar-controls {
@@ -6732,112 +6735,93 @@ html.dusk body {
     display: flex;
     align-items: center;
     width: 100%;
-    gap: 0.9rem;
+    gap: 0.6rem;
     flex-wrap: nowrap !important;
 }
-/* date group reads first; Week/Month pinned flush right; Today fades into
-   the elastic middle so nothing ever shifts */
 .dusk .header-controls-row .date-navigation {
     order: -1;
     margin-right: auto;
-    background: transparent;
-    border: none;
-    padding: 0;
-    gap: 0.15rem;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 10px;
+    padding: 2px;
+    gap: 0;
 }
-.dusk .header-controls-row .today-btn { order: 1; }
-.dusk .header-controls-row .view-toggle { order: 2; }
 .dusk .nav-btn {
     background: transparent;
-    color: rgba(255, 255, 255, 0.75);
-    width: 32px;
-    height: 32px;
-    min-height: 32px;
+    color: rgba(255, 255, 255, 0.85);
+    width: 28px;
+    height: 26px;
+    min-height: 26px;
     border-radius: 8px;
-    font-size: 1.15rem;
+    font-size: 1.05rem;
     line-height: 1;
-    padding-bottom: 4px;  /* optical: chevron glyphs centre on the x-height
-                             and read low beside caps text without this */
+    padding-bottom: 2px;   /* chevron ink centres on the x-height */
 }
-.dusk .nav-btn:hover { background: rgba(255, 255, 255, 0.12); color: #fff; transform: none; }
+.dusk .nav-btn:hover { background: rgba(255, 255, 255, 0.16); color: #fff; transform: none; }
 .dusk .date-range {
     color: #fff;
-    font-size: 0.95rem;
+    font-size: 0.88rem;
     font-weight: 600;
-    /* just wider than the widest real string ("12/27 - 1/2" numeric):
-       constant across periods, no dead air around short week ranges */
-    min-width: 7em;
+    /* fixed slot: widest string is a cross-month week ("12/27 - 1/2") */
+    min-width: 6.6em;
     text-align: center;
-    padding: 0 0.25rem;
+    padding: 0 0.2rem;
     white-space: nowrap;
 }
 .dusk .view-toggle {
-    background: transparent;
-    border: none;
-    padding: 0;
-    gap: 1.1rem;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 10px;
+    padding: 2px;
+    gap: 2px;
 }
 .dusk .view-btn {
     background: transparent;
-    color: rgba(255, 255, 255, 0.6);
-    padding: 0.1rem 0.05rem;
-    min-height: 0;
-    font-size: 0.78rem;
+    color: rgba(255, 255, 255, 0.8);
+    padding: 0.22rem 0.7rem;
+    min-height: 26px;
+    font-size: 0.8rem;
     font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    border-radius: 0;
-    align-self: center;
-    line-height: 1.2;
-    position: relative;
+    letter-spacing: 0;
+    text-transform: none;
+    border-radius: 8px;
 }
-/* the active underline is a positioned decoration, NOT a border — a border
-   participates in layout and lifted the label 1px off the shared ink line,
-   which made TODAY (borderless) read as sitting low beside it */
 .dusk .view-btn.active {
-    background: transparent;
-    color: #fff;
+    background: rgba(255, 255, 255, 0.95);
+    color: #4d5ac9;
+    font-weight: 700;
 }
-.dusk .view-btn.active::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: -4px;
-    height: 2px;
-    background: var(--secondary-color, #f5576c);
-}
-.dusk .view-btn:hover:not(.active) { color: rgba(255, 255, 255, 0.9); }
-
-/* Today: space always reserved; it fades in when you're off today
-   so the other controls never shift */
+.dusk .view-btn:hover:not(.active) { color: #fff; transform: none; }
+/* Today: a small coral pill; space reserved so nothing shifts */
 .dusk .today-btn {
     display: inline-flex;
     visibility: hidden;
     opacity: 0;
-    background: transparent;
-    color: #ff9d9d;
-    padding: 0.1rem 0.5rem;
-    min-height: 0;
+    background: var(--secondary-color, #f5576c);
+    color: #fff;
+    padding: 0.24rem 0.65rem;
+    min-height: 26px;
     font-size: 0.78rem;
     font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    border-radius: 0;
+    letter-spacing: 0.02em;
+    text-transform: none;
+    border-radius: 9px;
     align-self: center;
     line-height: 1.2;
     transition: opacity 0.12s ease;
 }
 .dusk .header-controls-row.off-today .today-btn { visibility: visible; opacity: 1; }
-.dusk .today-btn:hover { transform: none; background: rgba(255, 255, 255, 0.08); }
+.dusk .today-btn:hover { transform: none; filter: brightness(1.08); }
 
-/* phone: same row, one size down */
+/* phone: same pills, one size down */
 @media (max-width: 480px) {
     .dusk .header-controls-row { padding: 0 0.6rem 0.5rem; gap: 0.4rem; }
-    .dusk .header-controls-row .calendar-controls { gap: 0.55rem; }
-    .dusk .date-range { font-size: 0.82rem; padding: 0 0.2rem; }
-    .dusk .nav-btn { width: 28px; height: 28px; min-height: 28px; font-size: 1rem; }
-    .dusk .view-btn, .dusk .today-btn { font-size: 0.7rem; }
+    .dusk .header-controls-row .calendar-controls { gap: 0.4rem; }
+    .dusk .date-range { font-size: 0.8rem; min-width: 6.4em; }
+    .dusk .nav-btn { width: 26px; height: 24px; min-height: 24px; font-size: 0.95rem; }
+    .dusk .view-btn { padding: 0.18rem 0.55rem; font-size: 0.74rem; min-height: 24px; }
+    .dusk .today-btn { padding: 0.2rem 0.5rem; font-size: 0.72rem; min-height: 24px; }
 }
 
 /* ---------- motion: keep the load reveal and the swipe flight; ----------

--- a/styles.css
+++ b/styles.css
@@ -6482,6 +6482,10 @@ body.loaded {
    - Map water: back to the site's brand purple (no override)
    ================================================================ */
 
+html.dusk {
+    background: #07090f;   /* shows on overscroll and when the fixed week
+                              layout leaves body shorter than the viewport */
+}
 html.dusk body {
     background: radial-gradient(circle at top, #1b2033 0%, #0b0d13 45%, #07090f 100%);
     background-attachment: fixed;
@@ -6758,9 +6762,9 @@ html.dusk body {
     color: #fff;
     font-size: 0.95rem;
     font-weight: 600;
-    /* just wider than the widest real string ("September 2026" = 8.4em):
+    /* just wider than the widest real string ("12/27 - 1/2" numeric):
        constant across periods, no dead air around short week ranges */
-    min-width: 8.9em;
+    min-width: 6.4em;
     text-align: center;
     padding: 0 0.25rem;
     white-space: nowrap;
@@ -6800,18 +6804,15 @@ html.dusk body {
     opacity: 0;
     background: transparent;
     color: #ff9d9d;
-    padding: 0.1rem 0.5rem 2px;
+    padding: 0.1rem 0.5rem;
     min-height: 0;
     font-size: 0.78rem;
     font-weight: 600;
     letter-spacing: 0.06em;
     text-transform: uppercase;
     border-radius: 0;
-    border-bottom: 2px solid transparent;
     align-self: center;
     line-height: 1.2;
-    position: relative;
-    top: 1px;             /* optical: sit on the date's baseline */
     transition: opacity 0.12s ease;
 }
 .dusk .header-controls-row.off-today .today-btn { visibility: visible; opacity: 1; }

--- a/styles.css
+++ b/styles.css
@@ -6715,17 +6715,14 @@ html.dusk body {
     background: var(--c1, var(--primary-color));
 }
 
-/* ---------- controls: segmented pills (owner-picked) ----------
-   Two self-aligned clusters: a soft pill holding ‹ date ›, and a true
-   segmented control for Week/Month with a filled active half. Boxes align
-   themselves — no optical baseline arithmetic. ---------- */
+/* ---------- controls: quiet text inside the purple header ---------- */
 .dusk .header-controls-row {
     display: flex;
     align-items: center;
     width: 100%;
     max-width: 1600px;
     margin: 0 auto;
-    padding: 0 1rem 0.6rem;
+    padding: 0 1rem 0.55rem;
     gap: 0.75rem;
 }
 .dusk .header-controls-row .calendar-controls {
@@ -6735,93 +6732,112 @@ html.dusk body {
     display: flex;
     align-items: center;
     width: 100%;
-    gap: 0.6rem;
+    gap: 0.9rem;
     flex-wrap: nowrap !important;
 }
+/* date group reads first; Week/Month pinned flush right; Today fades into
+   the elastic middle so nothing ever shifts */
 .dusk .header-controls-row .date-navigation {
     order: -1;
     margin-right: auto;
-    background: rgba(255, 255, 255, 0.12);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 10px;
-    padding: 2px;
-    gap: 0;
+    background: transparent;
+    border: none;
+    padding: 0;
+    gap: 0.15rem;
 }
+.dusk .header-controls-row .today-btn { order: 1; }
+.dusk .header-controls-row .view-toggle { order: 2; }
 .dusk .nav-btn {
     background: transparent;
-    color: rgba(255, 255, 255, 0.85);
-    width: 28px;
-    height: 26px;
-    min-height: 26px;
+    color: rgba(255, 255, 255, 0.75);
+    width: 32px;
+    height: 32px;
+    min-height: 32px;
     border-radius: 8px;
-    font-size: 1.05rem;
+    font-size: 1.15rem;
     line-height: 1;
-    padding-bottom: 2px;   /* chevron ink centres on the x-height */
+    padding-bottom: 4px;  /* optical: chevron glyphs centre on the x-height
+                             and read low beside caps text without this */
 }
-.dusk .nav-btn:hover { background: rgba(255, 255, 255, 0.16); color: #fff; transform: none; }
+.dusk .nav-btn:hover { background: rgba(255, 255, 255, 0.12); color: #fff; transform: none; }
 .dusk .date-range {
     color: #fff;
-    font-size: 0.88rem;
+    font-size: 0.95rem;
     font-weight: 600;
-    /* fixed slot: widest string is a cross-month week ("12/27 - 1/2") */
-    min-width: 6.6em;
+    /* just wider than the widest real string ("12/27 - 1/2" numeric):
+       constant across periods, no dead air around short week ranges */
+    min-width: 7em;
     text-align: center;
-    padding: 0 0.2rem;
+    padding: 0 0.25rem;
     white-space: nowrap;
 }
 .dusk .view-toggle {
-    background: rgba(255, 255, 255, 0.12);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 10px;
-    padding: 2px;
-    gap: 2px;
+    background: transparent;
+    border: none;
+    padding: 0;
+    gap: 1.1rem;
 }
 .dusk .view-btn {
     background: transparent;
-    color: rgba(255, 255, 255, 0.8);
-    padding: 0.22rem 0.7rem;
-    min-height: 26px;
-    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.6);
+    padding: 0.1rem 0.05rem;
+    min-height: 0;
+    font-size: 0.78rem;
     font-weight: 600;
-    letter-spacing: 0;
-    text-transform: none;
-    border-radius: 8px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border-radius: 0;
+    align-self: center;
+    line-height: 1.2;
+    position: relative;
 }
+/* the active underline is a positioned decoration, NOT a border — a border
+   participates in layout and lifted the label 1px off the shared ink line,
+   which made TODAY (borderless) read as sitting low beside it */
 .dusk .view-btn.active {
-    background: rgba(255, 255, 255, 0.95);
-    color: #4d5ac9;
-    font-weight: 700;
+    background: transparent;
+    color: #fff;
 }
-.dusk .view-btn:hover:not(.active) { color: #fff; transform: none; }
-/* Today: a small coral pill; space reserved so nothing shifts */
+.dusk .view-btn.active::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -4px;
+    height: 2px;
+    background: var(--secondary-color, #f5576c);
+}
+.dusk .view-btn:hover:not(.active) { color: rgba(255, 255, 255, 0.9); }
+
+/* Today: space always reserved; it fades in when you're off today
+   so the other controls never shift */
 .dusk .today-btn {
     display: inline-flex;
     visibility: hidden;
     opacity: 0;
-    background: var(--secondary-color, #f5576c);
-    color: #fff;
-    padding: 0.24rem 0.65rem;
-    min-height: 26px;
+    background: transparent;
+    color: #ff9d9d;
+    padding: 0.1rem 0.5rem;
+    min-height: 0;
     font-size: 0.78rem;
     font-weight: 600;
-    letter-spacing: 0.02em;
-    text-transform: none;
-    border-radius: 9px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border-radius: 0;
     align-self: center;
     line-height: 1.2;
     transition: opacity 0.12s ease;
 }
 .dusk .header-controls-row.off-today .today-btn { visibility: visible; opacity: 1; }
-.dusk .today-btn:hover { transform: none; filter: brightness(1.08); }
+.dusk .today-btn:hover { transform: none; background: rgba(255, 255, 255, 0.08); }
 
-/* phone: same pills, one size down */
+/* phone: same row, one size down */
 @media (max-width: 480px) {
     .dusk .header-controls-row { padding: 0 0.6rem 0.5rem; gap: 0.4rem; }
-    .dusk .header-controls-row .calendar-controls { gap: 0.4rem; }
-    .dusk .date-range { font-size: 0.8rem; min-width: 6.4em; }
-    .dusk .nav-btn { width: 26px; height: 24px; min-height: 24px; font-size: 0.95rem; }
-    .dusk .view-btn { padding: 0.18rem 0.55rem; font-size: 0.74rem; min-height: 24px; }
-    .dusk .today-btn { padding: 0.2rem 0.5rem; font-size: 0.72rem; min-height: 24px; }
+    .dusk .header-controls-row .calendar-controls { gap: 0.55rem; }
+    .dusk .date-range { font-size: 0.82rem; padding: 0 0.2rem; }
+    .dusk .nav-btn { width: 28px; height: 28px; min-height: 28px; font-size: 1rem; }
+    .dusk .view-btn, .dusk .today-btn { font-size: 0.7rem; }
 }
 
 /* ---------- motion: keep the load reveal and the swipe flight; ----------

--- a/styles.css
+++ b/styles.css
@@ -6756,6 +6756,8 @@ html.dusk body {
     border-radius: 8px;
     font-size: 1.15rem;
     line-height: 1;
+    padding-bottom: 4px;  /* optical: chevron glyphs centre on the x-height
+                             and read low beside caps text without this */
 }
 .dusk .nav-btn:hover { background: rgba(255, 255, 255, 0.12); color: #fff; transform: none; }
 .dusk .date-range {
@@ -6764,7 +6766,7 @@ html.dusk body {
     font-weight: 600;
     /* just wider than the widest real string ("12/27 - 1/2" numeric):
        constant across periods, no dead air around short week ranges */
-    min-width: 6.4em;
+    min-width: 7em;
     text-align: center;
     padding: 0 0.25rem;
     white-space: nowrap;
@@ -6778,21 +6780,32 @@ html.dusk body {
 .dusk .view-btn {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
-    padding: 0.1rem 0.05rem 2px;
+    padding: 0.1rem 0.05rem;
     min-height: 0;
     font-size: 0.78rem;
     font-weight: 600;
     letter-spacing: 0.06em;
     text-transform: uppercase;
     border-radius: 0;
-    border-bottom: 2px solid transparent;
     align-self: center;
     line-height: 1.2;
+    position: relative;
 }
+/* the active underline is a positioned decoration, NOT a border — a border
+   participates in layout and lifted the label 1px off the shared ink line,
+   which made TODAY (borderless) read as sitting low beside it */
 .dusk .view-btn.active {
     background: transparent;
     color: #fff;
-    border-bottom-color: var(--secondary-color, #f5576c);
+}
+.dusk .view-btn.active::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -4px;
+    height: 2px;
+    background: var(--secondary-color, #f5576c);
 }
 .dusk .view-btn:hover:not(.active) { color: rgba(255, 255, 255, 0.9); }
 

--- a/styles.css
+++ b/styles.css
@@ -6979,7 +6979,10 @@ html.dusk body {
     /* cards have a working range, not a stretch-to-fill */
     .dusk .events-list { flex-wrap: wrap; }
     .dusk .events-list .ml-col { flex: 0 0 400px; max-width: 400px; }
-    .dusk .events-list > .event-card { max-width: 460px; }
+    /* single-file cards (masonry unwrapped): uniform width, not
+       content-sized — flex children default to their content width and
+       cards came out ragged */
+    .dusk .events-list > .event-card { width: 100%; max-width: 460px; }
     .dusk .event-card.detailed.aurora .ec-panel { padding: 0.65rem 0.75rem 0.6rem; }
     .dusk .event-card.detailed.aurora h3.ec-title { font-size: 0.98rem; }
     .dusk .event-card.detailed.aurora .ec-row { font-size: 0.8rem; }

--- a/styles.css
+++ b/styles.css
@@ -6739,6 +6739,10 @@ html.dusk body {
    the elastic middle so nothing ever shifts */
 .dusk .header-controls-row .date-navigation {
     order: -1;
+    /* the chevron BUTTON box carries ~10px of internal slack before its
+       glyph ink — pull it left so the ink sits the same distance from the
+       edge as MONTH's text does on the right */
+    margin-left: -10px;
     margin-right: auto;
     background: transparent;
     border: none;

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!-- generated: chunky.dad city page -->
-<html lang="en">
+<html lang="en" class="dusk">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -85,7 +85,7 @@
   <meta property="og:title" content="Las Vegas - chunky.dad Bear Guide">
   <meta property="og:description" content="Complete gay bear guide to Las Vegas - events, bars, and the hottest bear scene">
   <meta property="og:url" content="https://chunky.dad/vegas/">
-  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=6e13efa3">
+  <meta property="og:image" content="https://chunky.dad/Rising_Star_Ryan_Head_Compressed.png?v=9bfbcef6">
 </head>
 <body>
         <header>
@@ -240,13 +240,13 @@
                     <h2 id="calendar-title"></h2>
                     <div class="calendar-controls">
                         <div class="view-toggle">
-                            <button class="view-btn active" data-view="week">📅 Week</button>
-                            <button class="view-btn" data-view="month">📊 Month</button>
+                            <button class="view-btn active" data-view="week">Week</button>
+                            <button class="view-btn" data-view="month">Month</button>
                         </div>
                         <div class="date-navigation">
-                            <button class="nav-btn" id="prev-period">←</button>
+                            <button class="nav-btn" id="prev-period">‹</button>
                             <span class="date-range" id="date-range"></span>
-                            <button class="nav-btn" id="next-period">→</button>
+                            <button class="nav-btn" id="next-period">›</button>
                         </div>
                         <button class="today-btn" id="today-btn">Today</button>
                     </div>
@@ -302,5 +302,6 @@
     <script src="../js/filename-utils.js"></script>
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/dusk-ui.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## What this is

The city-page redesign we iterated live on the `:8741` demo (Aug 15–21), ported into real site files. The demo overlay remains running as the reference implementation; this PR is its consolidation.

**Scope: city pages only** — `class="dusk"` on `<html>` in `city.html` gates every new rule; index/about/directory keep the current look until they get their own pass. All 24 city pages regenerated from the template.

## The design (owner-approved on the demo)

- Dark radial theme; the calendar *is* the page (no white panel); solid per-event-color pills from the extracted palettes
- Two-row purple header (one row from 769px, picker docked beside the city switcher), quiet text controls, contextual TODAY, fixed-width date slot
- Corner day numbers as plain text, bleeding purple circle on today only
- Multi-day events as lane-packed continuous bars (first-fit interweave), labels flowing across the run, spacer skeletons keeping lanes level
- Spotlight selection (filter-dim, no white borders, no per-segment shadows)
- Phone spacing at **every** width; desktop layouts: week = grid top-left + map filling bottom-left + fixed-width masonry cards right; month = three columns from 1200px (calendar | full-height map | single file of cards), two columns below
- Motion: load reveal and swipe flight stay; press-time popping (card fly-ups) is gone

## Renderer-native fixes (bugs the overlay could only patch around)

- **calendar-core**: logical END times through 06:59 shift to the previous night — a 1AM–6AM party renders on its one true night, not as a two-day bar
- **loader month view**: multi-day segments ALWAYS render (crowded cells silently broke bars mid-run); singles cap at 2 and a lone hidden single renders itself instead of a "+1" chip — the "+1 bug", killed at the source, recurrence included
- **loader cards**: paired when-lines — `Thu 9/17 – Sat 9/19`, `Wed 9/9 night · 1AM-6AM`; each time sits beside its own day
- **loader**: view toggle syncs from the URL (deep-linked month pages showed WEEK underlined forever)

## NEW runtime file

`js/dusk-ui.js` — display-side composition (header mounting, pill colours, lane packing/flowing labels, masonry, per-view map homing). Served by the site; **not** a Scriptable-updater concern.

## Verification

- Quiet suite **1970/1970** (scraper untouched; calendar-core change exercised via the extraction tool which parses ICS through it)
- WebKit + Chrome probes at 390/960/1100/1440, both views: layouts, scroll regions, lane geometry (segment tops equal across cells), and header placement all match the demo's approved end-state
- Live preview of THIS branch: `http://rybook.taila7523c.ts.net:8742/la/` — compare against the demo on `:8741`

## Known follow-ups (not in this PR)

- Smart-name width calibration for the new cell sizes (mid-word breaks at very narrow widths predate dusk)
- Other pages (index, directory, about) themed to match
- The demo overlay + servers can be retired once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP