### PR TITLE
Scraper: Thotyssey aggregator + venue-first Rockbar, via generic JSON-API shape support

### DIFF
--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -7578,73 +7578,104 @@ class AiWebParser {
     // One level of attribute-wrapper unwrapping. JSON:API nests everything
     // under `attributes`, Tockify under `content`, some CMSes under
     // `properties`/`fields` — the event-ish keys live one level down while
-    // ids/timestamps stay on the outer object. Outer keys win on collision
-    // (they are the more specific ones — `when` vs a wrapped `date` string).
+    // ids/timestamps stay on the outer object. Key ORDER follows the outer
+    // object (so an outer start_date still beats a wrapped starts_at in the
+    // first-match loops below); on a same-named key the WRAPPED value wins,
+    // because the outer copy is envelope bookkeeping (a record `date`), the
+    // wrapped one is the event's.
     unwrapJsonApiCandidate(obj) {
         if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return obj;
         for (const key of Object.keys(obj)) {
             if (!/^(content|attributes|properties|fields)$/.test(this.normalizeJsonApiKey(key))) continue;
             const wrapped = obj[key];
             if (wrapped && typeof wrapped === 'object' && !Array.isArray(wrapped)) {
-                return { ...wrapped, ...obj };
+                return { ...obj, ...wrapped };
             }
         }
         return obj;
     }
 
-    // Rich-text values arrive as plain strings, or as one-key objects:
-    // { text } (Tockify), { rendered } (WordPress REST), { value }. Unwrap to
-    // the string; '' when neither shape holds a non-empty string.
+    // Rich-text values: a plain string, or Tockify's { text } envelope.
+    // Deliberately NOT WordPress's { rendered }: a /wp-json posts list
+    // ({ title: { rendered }, date }) is not a list of events, and accepting
+    // it turned blog posts into publish-dated pseudo-events.
     jsonApiTextValue(value) {
         if (typeof value === 'string') return value;
-        if (value && typeof value === 'object' && !Array.isArray(value)) {
-            for (const key of ['text', 'rendered', 'value']) {
-                if (typeof value[key] === 'string' && value[key].trim() !== '') return value[key];
-            }
+        if (value && typeof value === 'object' && !Array.isArray(value)
+            && typeof value.text === 'string' && value.text.trim() !== '') {
+            return value.text;
         }
         return '';
     }
 
-    // Resolve a date-ish JSON API value to { date, timezone, timezoneUnresolved }
-    // or null. Handles, generically:
-    //   • ISO-8601-ish strings (delegates to parseJsonLdDateValue, unchanged);
-    //   • epoch-milliseconds members: a bare 12–13 digit number, or
-    //     { millis, tzid? } (Tockify) — an epoch instant is absolute, so
-    //     timezoneUnresolved is false and the tzid rides along when present;
-    //   • when-containers: { start: …, end: … } (Tockify `when`) — `edge`
-    //     picks which member to resolve, one level of recursion only.
-    jsonApiDateCandidateFromValue(value, edge = 'start') {
+    // A single date-ish VALUE: an ISO-8601-ish string (parseJsonLdDateValue,
+    // unchanged), or an epoch-milliseconds envelope { millis, tzid? }
+    // (Tockify when.start/when.end). An epoch instant is absolute, so
+    // timezoneUnresolved is false and the tzid rides along. Bare numbers are
+    // NOT accepted: last_update_date / date_id / created_date are epoch
+    // numbers too, and the key patterns cannot tell them from a start.
+    jsonApiScalarDateCandidate(value) {
         if (this.jsonApiValueIsIsoDateish(value)) {
             const parsed = this.parseJsonLdDateValue(value);
-            return parsed.date ? { date: parsed.date, timezone: null, timezoneUnresolved: parsed.timezoneUnresolved } : null;
+            return parsed.date
+                ? { date: parsed.date, timezone: null, timezoneUnresolved: parsed.timezoneUnresolved }
+                : null;
         }
-        const epochToDate = (millis, tzid) => {
-            const date = new Date(millis);
-            return isNaN(date.getTime()) ? null : { date, timezone: tzid || null, timezoneUnresolved: false };
-        };
-        if (typeof value === 'number' && value > 1e11 && value < 1e13) {
-            return epochToDate(value, null);
-        }
-        if (value && typeof value === 'object' && !Array.isArray(value)) {
-            if (typeof value.millis === 'number' && value.millis > 1e11 && value.millis < 1e13) {
-                return epochToDate(value.millis, typeof value.tzid === 'string' ? value.tzid.trim() : null);
-            }
-            const member = value[edge];
-            if (member !== undefined && member !== value) {
-                if (this.jsonApiValueIsIsoDateish(member)) {
-                    const parsed = this.parseJsonLdDateValue(member);
-                    return parsed.date ? { date: parsed.date, timezone: null, timezoneUnresolved: parsed.timezoneUnresolved } : null;
-                }
-                if (typeof member === 'number' && member > 1e11 && member < 1e13) {
-                    return epochToDate(member, null);
-                }
-                if (member && typeof member === 'object' && !Array.isArray(member)
-                    && typeof member.millis === 'number' && member.millis > 1e11 && member.millis < 1e13) {
-                    return epochToDate(member.millis, typeof member.tzid === 'string' ? member.tzid.trim() : null);
-                }
-            }
+        if (value && typeof value === 'object' && !Array.isArray(value)
+            && typeof value.millis === 'number' && value.millis > 1e11 && value.millis < 1e13) {
+            const date = new Date(value.millis);
+            if (isNaN(date.getTime())) return null;
+            const tzid = typeof value.tzid === 'string' ? value.tzid.trim() : '';
+            return { date, timezone: tzid || null, timezoneUnresolved: false };
         }
         return null;
+    }
+
+    // Resolve a date-ish value for one edge ('start' | 'end'). With
+    // allowScalar the value itself may be the date (start_at: "…",
+    // end: { millis }); a when-container ({ start: …, end: … }) resolves
+    // its `edge` member — and ONLY that member, so a scalar `when` can never
+    // hand the start back as the end.
+    jsonApiDateCandidateFromValue(value, edge = 'start', allowScalar = true) {
+        if (allowScalar) {
+            const scalar = this.jsonApiScalarDateCandidate(value);
+            if (scalar) return scalar;
+        }
+        if (value && typeof value === 'object' && !Array.isArray(value) && value[edge] !== undefined) {
+            return this.jsonApiScalarDateCandidate(value[edge]);
+        }
+        return null;
+    }
+
+    // Key patterns shared by the recognizer, the builder and the
+    // performances expander. Anchored on purpose: `starts_at`, `start_date`,
+    // `first_performance_start_at` qualify; `endorsed_at`, `ends_sale_at`,
+    // `last_update_date` do not.
+    jsonApiStartDateFromEntry(key, value) {
+        const normalizedKey = this.normalizeJsonApiKey(key);
+        if (/(^|_)starts?(_(at|date|time|datetime))?$/.test(normalizedKey)
+            || /(^|_)(date|datetime)(_|$)/.test(normalizedKey)) {
+            return this.jsonApiDateCandidateFromValue(value, 'start', true);
+        }
+        if (/(^|_)when$/.test(normalizedKey)) {
+            return this.jsonApiDateCandidateFromValue(value, 'start', false);
+        }
+        return null;
+    }
+
+    jsonApiEndDateFromEntry(key, value) {
+        const normalizedKey = this.normalizeJsonApiKey(key);
+        if (/(^|_)ends?(_(at|date|time|datetime))?$/.test(normalizedKey)) {
+            return this.jsonApiDateCandidateFromValue(value, 'end', true);
+        }
+        if (/(^|_)(when|date)$/.test(normalizedKey)) {
+            return this.jsonApiDateCandidateFromValue(value, 'end', false);
+        }
+        return null;
+    }
+
+    jsonApiEntryIsDateish(key, value) {
+        return Boolean(this.jsonApiStartDateFromEntry(key, value) || this.jsonApiEndDateFromEntry(key, value));
     }
 
     // "Event-like" = carries a name/title key AND some start/date-ish key
@@ -7663,8 +7694,7 @@ class AiWebParser {
         const hasTitle = keys.some(key => /^(name|title|summary)$/.test(this.normalizeJsonApiKey(key))
             && this.jsonApiTextValue(view[key]).trim() !== '');
         if (!hasTitle) return false;
-        return keys.some(key => /(^|_)(start|date|datetime|when)/.test(this.normalizeJsonApiKey(key))
-            && this.jsonApiDateCandidateFromValue(view[key], 'start') !== null);
+        return keys.some(key => this.jsonApiStartDateFromEntry(key, view[key]) !== null);
     }
 
     // Candidate event objects inside a parsed JSON payload, generically:
@@ -7684,9 +7714,11 @@ class AiWebParser {
             const value = parsed[key];
             if (isArrayOfObjects(value)) return value.filter(item => this.jsonApiObjectLooksEventLike(item));
             // Detail-shaped payload: ONE object (possibly carrying a
-            // performances-style array with the actual dates).
+            // performances-style array with the actual dates) — inspected
+            // through its attribute wrapper like everything else.
             if (isPlainObject(value)
-                && (this.jsonApiObjectLooksEventLike(value) || this.findJsonApiPerformancesArray(value))) {
+                && (this.jsonApiObjectLooksEventLike(value)
+                    || this.findJsonApiPerformancesArray(this.unwrapJsonApiCandidate(value)))) {
                 return [value];
             }
         }
@@ -7699,15 +7731,14 @@ class AiWebParser {
     }
 
     // First array-of-objects value whose EVERY entry carries a start-ish
-    // ISO-dated key — the shape performance/occurrence lists take on detail
+    // dated key — the shape performance/occurrence lists take on detail
     // endpoints. Null when the object has no such array.
     findJsonApiPerformancesArray(obj) {
         if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
         for (const value of Object.values(obj)) {
             if (!Array.isArray(value) || value.length === 0) continue;
             const everyEntryHasStart = value.every(entry => entry && typeof entry === 'object' && !Array.isArray(entry)
-                && Object.keys(entry).some(key => /(^|_)start/.test(this.normalizeJsonApiKey(key))
-                    && this.jsonApiValueIsIsoDateish(entry[key])));
+                && Object.keys(entry).some(key => this.jsonApiStartDateFromEntry(key, entry[key]) !== null));
             if (everyEntryHasStart) return value;
         }
         return null;
@@ -7715,15 +7746,17 @@ class AiWebParser {
 
     // A single object carrying a performances-like array yields one event per
     // entry: outer scalar fields are shared, but outer date fields
-    // (first_performance_start_at …) describe the series, not the individual
-    // performance — each entry's own start/end wins.
+    // (first_performance_start_at, a series-level `when` …) describe the
+    // series, not the individual performance — each entry's own start/end
+    // wins. Works on the unwrapped view so wrapped detail payloads expand too.
     expandJsonApiPerformances(candidate) {
-        const performances = this.findJsonApiPerformancesArray(candidate);
+        const view = this.unwrapJsonApiCandidate(candidate);
+        const performances = this.findJsonApiPerformancesArray(view);
         if (!performances) return [candidate];
         const shared = {};
-        for (const [key, value] of Object.entries(candidate)) {
+        for (const [key, value] of Object.entries(view)) {
             if (value === performances) continue;
-            if (/(^|_)(start|end)/.test(this.normalizeJsonApiKey(key)) && this.jsonApiValueIsIsoDateish(value)) continue;
+            if (this.jsonApiEntryIsDateish(key, value)) continue;
             shared[key] = value;
         }
         return performances.map(entry => ({ ...shared, ...entry }));
@@ -7853,10 +7886,9 @@ class AiWebParser {
             }
             return '';
         };
-        const firstDateValue = (keyPattern, edge = 'start') => {
+        const firstDateBy = (resolver) => {
             for (const key of keys) {
-                if (!keyPattern.test(this.normalizeJsonApiKey(key))) continue;
-                const candidate = this.jsonApiDateCandidateFromValue(view[key], edge);
+                const candidate = resolver(key, view[key]);
                 if (candidate && candidate.date) return candidate;
             }
             return { date: null, timezone: null, timezoneUnresolved: false };
@@ -7867,12 +7899,30 @@ class AiWebParser {
         const summaryText = clean(firstTextValue(/^summary$/));
         let title = clean(firstTextValue(/^(name|title)$/));
         if (!title) title = summaryText;
-        // Explicit start-ish keys first (first_performance_start_at, start_at,
-        // startDate, when-containers …), then bare date/datetime keys.
-        let start = firstDateValue(/(^|_)(start|when)/, 'start');
-        if (!start.date) start = firstDateValue(/(^|_)(date|datetime)(_|$)/, 'start');
+        // Start: explicit start-ish keys, bare date/datetime keys, or a
+        // when-container — the same rule the recognizer applied (see
+        // jsonApiStartDateFromEntry); end likewise, containers resolving
+        // ONLY their end member.
+        const start = firstDateBy((key, value) => this.jsonApiStartDateFromEntry(key, value));
         if (!title || !start.date) return null;
-        const end = firstDateValue(/(^|_)(end|when)/, 'end');
+        const end = firstDateBy((key, value) => this.jsonApiEndDateFromEntry(key, value));
+
+        // Cancelled rows stay in feeds (Tockify keeps status.name='cancelled';
+        // schema.org uses eventStatus 'EventCancelled'). Structured events skip
+        // normalizeAiEvent, so this is the only place to honour it.
+        const statusText = (() => {
+            for (const key of keys) {
+                if (!/^(status|event_status)$/.test(this.normalizeJsonApiKey(key))) continue;
+                const raw = view[key];
+                if (typeof raw === 'string') return raw;
+                if (raw && typeof raw === 'object' && typeof raw.name === 'string') return raw.name;
+            }
+            return '';
+        })();
+        if (/cancel/i.test(statusText)) {
+            console.log(`🤖 AI Web: JSON API event "${title}" is ${statusText.trim()} — skipping`);
+            return null;
+        }
 
         // Address composed from street + locality + state + postal style keys,
         // with the JSON-LD path's duplicate-part guard.
@@ -7908,17 +7958,14 @@ class AiWebParser {
         const rawTicketUrl = firstValue(/(^|_)(ticket|url|link|website)/, isHttpString, imageKeyPattern);
         const ticketUrl = rawTicketUrl ? (this.normalizeHttpUrlValue(rawTicketUrl) || '') : '';
 
-        // The json-api route by definition fetched a machine endpoint: when
-        // the source URL is structurally an API endpoint it is where we
-        // SCRAPED, never an identity link, and must not seed url/website
-        // (run 20260814-191343: the redeyetickets search-API fetch URL
-        // shipped as the published ticketUrl after the url→website fold and
-        // ticketing-platform parking). The payload's own event-page link —
-        // when the API exposes one — still arrives via ticketUrl above.
-        // Fail open: without the core helper, behavior is unchanged.
-        const sourceIsApiEndpoint = this.core && typeof this.core.isApiEndpointUrl === 'function'
-            ? this.core.isApiEndpointUrl(sourceUrl)
-            : false;
+        // The json-api route by definition fetched a machine endpoint — the
+        // body parsed as JSON, which no human event page ever does — so the
+        // source URL is where we SCRAPED, never an identity link, and must not
+        // seed url/website (run 20260814-191343: the redeyetickets search-API
+        // fetch URL shipped as the published ticketUrl after the url→website
+        // fold and ticketing-platform parking). The payload's own event-page
+        // link — when the API exposes one — still arrives via ticketUrl above.
+        //
         // When `summary` became the title, it must not double as the
         // description; a real description key still wins outright.
         let description = clean(firstTextValue(/^description$/));
@@ -7930,7 +7977,7 @@ class AiWebParser {
             endDate: end.date || null,
             bar,
             address,
-            url: sourceIsApiEndpoint ? '' : sourceUrl,
+            url: '',
             ticketUrl,
             image,
             source: this.config.source

--- a/scripts/parsers/ai-web-parser.js
+++ b/scripts/parsers/ai-web-parser.js
@@ -7575,18 +7575,96 @@ class AiWebParser {
         return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}/.test(value.trim());
     }
 
+    // One level of attribute-wrapper unwrapping. JSON:API nests everything
+    // under `attributes`, Tockify under `content`, some CMSes under
+    // `properties`/`fields` — the event-ish keys live one level down while
+    // ids/timestamps stay on the outer object. Outer keys win on collision
+    // (they are the more specific ones — `when` vs a wrapped `date` string).
+    unwrapJsonApiCandidate(obj) {
+        if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return obj;
+        for (const key of Object.keys(obj)) {
+            if (!/^(content|attributes|properties|fields)$/.test(this.normalizeJsonApiKey(key))) continue;
+            const wrapped = obj[key];
+            if (wrapped && typeof wrapped === 'object' && !Array.isArray(wrapped)) {
+                return { ...wrapped, ...obj };
+            }
+        }
+        return obj;
+    }
+
+    // Rich-text values arrive as plain strings, or as one-key objects:
+    // { text } (Tockify), { rendered } (WordPress REST), { value }. Unwrap to
+    // the string; '' when neither shape holds a non-empty string.
+    jsonApiTextValue(value) {
+        if (typeof value === 'string') return value;
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            for (const key of ['text', 'rendered', 'value']) {
+                if (typeof value[key] === 'string' && value[key].trim() !== '') return value[key];
+            }
+        }
+        return '';
+    }
+
+    // Resolve a date-ish JSON API value to { date, timezone, timezoneUnresolved }
+    // or null. Handles, generically:
+    //   • ISO-8601-ish strings (delegates to parseJsonLdDateValue, unchanged);
+    //   • epoch-milliseconds members: a bare 12–13 digit number, or
+    //     { millis, tzid? } (Tockify) — an epoch instant is absolute, so
+    //     timezoneUnresolved is false and the tzid rides along when present;
+    //   • when-containers: { start: …, end: … } (Tockify `when`) — `edge`
+    //     picks which member to resolve, one level of recursion only.
+    jsonApiDateCandidateFromValue(value, edge = 'start') {
+        if (this.jsonApiValueIsIsoDateish(value)) {
+            const parsed = this.parseJsonLdDateValue(value);
+            return parsed.date ? { date: parsed.date, timezone: null, timezoneUnresolved: parsed.timezoneUnresolved } : null;
+        }
+        const epochToDate = (millis, tzid) => {
+            const date = new Date(millis);
+            return isNaN(date.getTime()) ? null : { date, timezone: tzid || null, timezoneUnresolved: false };
+        };
+        if (typeof value === 'number' && value > 1e11 && value < 1e13) {
+            return epochToDate(value, null);
+        }
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+            if (typeof value.millis === 'number' && value.millis > 1e11 && value.millis < 1e13) {
+                return epochToDate(value.millis, typeof value.tzid === 'string' ? value.tzid.trim() : null);
+            }
+            const member = value[edge];
+            if (member !== undefined && member !== value) {
+                if (this.jsonApiValueIsIsoDateish(member)) {
+                    const parsed = this.parseJsonLdDateValue(member);
+                    return parsed.date ? { date: parsed.date, timezone: null, timezoneUnresolved: parsed.timezoneUnresolved } : null;
+                }
+                if (typeof member === 'number' && member > 1e11 && member < 1e13) {
+                    return epochToDate(member, null);
+                }
+                if (member && typeof member === 'object' && !Array.isArray(member)
+                    && typeof member.millis === 'number' && member.millis > 1e11 && member.millis < 1e13) {
+                    return epochToDate(member.millis, typeof member.tzid === 'string' ? member.tzid.trim() : null);
+                }
+            }
+        }
+        return null;
+    }
+
     // "Event-like" = carries a name/title key AND some start/date-ish key
     // holding an ISO-8601-ish string. Mirrored (in compact form) by
     // SharedCore.countJsonApiEventObjects for deterministic page
     // classification — keep the two in sync.
+    // Extended generically (same mirror contract): the object may wrap its
+    // fields in a content/attributes wrapper, the title may be a rich-text
+    // {text}/{rendered} object (with `summary` accepted as the title key —
+    // it is VEVENT's own name for it), and the date may be an epoch-millis
+    // member or a when-container ({ start: { millis } }).
     jsonApiObjectLooksEventLike(obj) {
         if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false;
-        const keys = Object.keys(obj);
-        const hasTitle = keys.some(key => /^(name|title)$/.test(this.normalizeJsonApiKey(key))
-            && typeof obj[key] === 'string' && obj[key].trim() !== '');
+        const view = this.unwrapJsonApiCandidate(obj);
+        const keys = Object.keys(view);
+        const hasTitle = keys.some(key => /^(name|title|summary)$/.test(this.normalizeJsonApiKey(key))
+            && this.jsonApiTextValue(view[key]).trim() !== '');
         if (!hasTitle) return false;
-        return keys.some(key => /(^|_)(start|date|datetime)/.test(this.normalizeJsonApiKey(key))
-            && this.jsonApiValueIsIsoDateish(obj[key]));
+        return keys.some(key => /(^|_)(start|date|datetime|when)/.test(this.normalizeJsonApiKey(key))
+            && this.jsonApiDateCandidateFromValue(view[key], 'start') !== null);
     }
 
     // Candidate event objects inside a parsed JSON payload, generically:
@@ -7748,7 +7826,11 @@ class AiWebParser {
         const clean = (value) => this.normalizeWhitespace(
             this.decodeBasicEntities(this.stripTags(String(value || ''))).replace(/&amp;/gi, '&')
         );
-        const keys = Object.keys(obj);
+        // Attribute-wrapped payloads (Tockify `content`, JSON:API `attributes`)
+        // expose their event fields one level down — match against the
+        // unwrapped view everywhere below.
+        const view = this.unwrapJsonApiCandidate(obj);
+        const keys = Object.keys(view);
         const isHttpString = (value) => typeof value === 'string' && /^https?:\/\//i.test(value.trim());
         const isNonEmptyString = (value) => typeof value === 'string' && value.trim() !== '';
         // First value whose normalized key matches keyPattern (and does not
@@ -7758,27 +7840,39 @@ class AiWebParser {
                 const normalizedKey = this.normalizeJsonApiKey(key);
                 if (!keyPattern.test(normalizedKey)) continue;
                 if (excludePattern && excludePattern.test(normalizedKey)) continue;
-                if (predicate(obj[key])) return obj[key];
+                if (predicate(view[key])) return view[key];
             }
             return '';
         };
-        const firstDateValue = (keyPattern) => {
+        // Rich-text-aware companion: unwraps { text }/{ rendered } members.
+        const firstTextValue = (keyPattern) => {
             for (const key of keys) {
                 if (!keyPattern.test(this.normalizeJsonApiKey(key))) continue;
-                if (!this.jsonApiValueIsIsoDateish(obj[key])) continue;
-                const parsedDate = this.parseJsonLdDateValue(obj[key]);
-                if (parsedDate.date) return parsedDate;
+                const text = this.jsonApiTextValue(view[key]);
+                if (text.trim() !== '') return text;
             }
-            return { date: null, timezoneUnresolved: false };
+            return '';
+        };
+        const firstDateValue = (keyPattern, edge = 'start') => {
+            for (const key of keys) {
+                if (!keyPattern.test(this.normalizeJsonApiKey(key))) continue;
+                const candidate = this.jsonApiDateCandidateFromValue(view[key], edge);
+                if (candidate && candidate.date) return candidate;
+            }
+            return { date: null, timezone: null, timezoneUnresolved: false };
         };
 
-        const title = clean(firstValue(/^(name|title)$/, isNonEmptyString));
+        // name/title first; `summary` (VEVENT's own title key — Tockify) only
+        // as the fallback so payloads carrying both keep their description.
+        const summaryText = clean(firstTextValue(/^summary$/));
+        let title = clean(firstTextValue(/^(name|title)$/));
+        if (!title) title = summaryText;
         // Explicit start-ish keys first (first_performance_start_at, start_at,
-        // startDate …), then bare date/datetime keys.
-        let start = firstDateValue(/(^|_)start/);
-        if (!start.date) start = firstDateValue(/(^|_)(date|datetime)(_|$)/);
+        // startDate, when-containers …), then bare date/datetime keys.
+        let start = firstDateValue(/(^|_)(start|when)/, 'start');
+        if (!start.date) start = firstDateValue(/(^|_)(date|datetime)(_|$)/, 'start');
         if (!title || !start.date) return null;
-        const end = firstDateValue(/(^|_)end/);
+        const end = firstDateValue(/(^|_)(end|when)/, 'end');
 
         // Address composed from street + locality + state + postal style keys,
         // with the JSON-LD path's duplicate-part guard.
@@ -7796,7 +7890,8 @@ class AiWebParser {
         }
         const address = accumulated.join(', ');
 
-        let bar = clean(firstValue(/^(venue|venue_name|location_name)$/, isNonEmptyString));
+        // `place` is schema.org's and Tockify's venue-name key.
+        let bar = clean(firstValue(/^(venue|venue_name|location_name|place)$/, isNonEmptyString));
         if (bar && this.venueNameLooksLikeStreetAddress(bar, address)) {
             console.log(`🤖 AI Web: JSON API venue name "${bar}" looks like a street address — not using it as bar`);
             bar = '';
@@ -7824,9 +7919,13 @@ class AiWebParser {
         const sourceIsApiEndpoint = this.core && typeof this.core.isApiEndpointUrl === 'function'
             ? this.core.isApiEndpointUrl(sourceUrl)
             : false;
+        // When `summary` became the title, it must not double as the
+        // description; a real description key still wins outright.
+        let description = clean(firstTextValue(/^description$/));
+        if (!description && summaryText && summaryText !== title) description = summaryText;
         const event = {
             title,
-            description: clean(firstValue(/^(description|summary)$/, isNonEmptyString)),
+            description,
             startDate: start.date,
             endDate: end.date || null,
             bar,
@@ -7852,7 +7951,7 @@ class AiWebParser {
         // SAME provenance flag the JSON-LD offers path uses: these are live
         // ticket-vendor tier prices (they move as tiers sell out), so the
         // merge layer's stored-door-price rule applies to them identically.
-        const cover = this.formatJsonApiPriceCover(obj);
+        const cover = this.formatJsonApiPriceCover(view);
         if (cover) {
             event.cover = cover;
             event._coverFromJsonLdOffers = true;
@@ -7863,6 +7962,10 @@ class AiWebParser {
             (value) => typeof value === 'string' && /^[A-Za-z]+\/[A-Za-z0-9_+\-/]+$/.test(value.trim()));
         if (timezoneValue) {
             event.timezone = timezoneValue.trim();
+        } else if (start.timezone && /^[A-Za-z]+\/[A-Za-z0-9_+\-/]+$/.test(start.timezone)) {
+            // Epoch-millis date members carry their own IANA tzid (Tockify
+            // when.start.tzid) — same authority as a payload timezone key.
+            event.timezone = start.timezone;
         }
         if (address && cityConfig) {
             const cityKey = this.findCityKeyInText(address, cityConfig);

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -15420,3 +15420,99 @@ test('getCachedOcrTextForImage: verdict store first, then disk cache, on-demand 
   assert.equal(ocrCalls.length, 1);
   assert.equal(ocrCalls[0].hasAdapter, true);
 });
+
+// ---------------------------------------------------------------------------
+// JSON-API generic shape extensions: attribute wrappers ({content}/{attributes}),
+// rich-text values ({text}/{rendered}), and epoch-millis when-containers —
+// the shapes Tockify (aggregator calendars), JSON:API, and WordPress REST
+// feeds actually publish. Fixture mirrors tockify.com/api/ngevent verbatim
+// (trimmed): dates as {millis, tzid} under when.start/when.end, all content
+// under a `content` wrapper, title as summary.{text}.
+// ---------------------------------------------------------------------------
+
+const TOCKIFY_SOURCE_URL = 'https://tockify.com/api/ngevent?max=100&calname=thotyssey&tags=rockbar';
+const TOCKIFY_FEED_PAYLOAD = {
+  events: [
+    {
+      calid: '56b4c54e206d1565183c52cc',
+      eid: { uid: '39689', seq: 0, tid: 1788055200000, rid: 0 },
+      when: {
+        start: { millis: 1788055200000, tzid: 'America/New_York', ltz: 'EDT', offset: -14400000 },
+        end: { millis: 1788076800000, tzid: 'America/New_York', ltz: 'EDT', offset: -14400000 },
+        allDay: false
+      },
+      content: {
+        summary: { text: 'Gorditos at Rockbar' },
+        description: { text: 'DJs Noble Bear &amp; Goodbunny spin a Latin bear party at Rockbar.' },
+        tagset: { tags: { default: ['rockbar', 'bears', 'latin', 'dancing'] } },
+        place: 'Rockbar NYC',
+        address: '185 Christopher St, New York, NY 10014, USA',
+        location: { place_id: 'ChIJlwfqXuxZwokRTlizRW_4cwc', name: 'Rockbar NYC', latitude: 40.7327194, longitude: -74.0097278 }
+      },
+      status: { name: 'scheduled' },
+      kind: 'mod',
+      isExternal: false
+    },
+    {
+      calid: '56b4c54e206d1565183c52cc',
+      eid: { uid: '31035', seq: 0, tid: 1787968800000, rid: 0 },
+      when: {
+        start: { millis: 1787364000000, tzid: 'America/New_York', ltz: 'EDT', offset: -14400000 },
+        end: { millis: 1787385600000, tzid: 'America/New_York', ltz: 'EDT', offset: -14400000 },
+        allDay: false
+      },
+      content: {
+        summary: { text: 'Underbear Party at Rockbar' },
+        description: { text: 'Joe Fiore presents an underwear party at Rockbar, with DJ Brad Scott.' },
+        place: 'Rockbar NYC',
+        address: '185 Christopher St, New York, NY 10014, USA'
+      },
+      status: { name: 'scheduled' },
+      kind: 'mod',
+      isExternal: false
+    }
+  ],
+  metaData: {}
+};
+
+test('jsonApiObjectLooksEventLike recognizes wrapper + epoch-millis shapes (Tockify) and rich-text titles (WP REST)', () => {
+  const parser = createParser();
+  assert.equal(parser.jsonApiObjectLooksEventLike(TOCKIFY_FEED_PAYLOAD.events[0]), true,
+    'content-wrapped summary.text title + when.start.millis date should be event-like');
+  assert.equal(parser.jsonApiObjectLooksEventLike({ title: { rendered: 'Bear Night' }, start_date: '2026-09-04 21:00:00' }), true,
+    'WordPress-REST rendered title + ISO start should be event-like');
+  assert.equal(parser.jsonApiObjectLooksEventLike({ name: 'no dates here', when: { allDay: false } }), false,
+    'a when container without a parseable start must not qualify');
+  assert.equal(parser.jsonApiObjectLooksEventLike({ content: { summary: { text: 'title only' } } }), false,
+    'wrapped title without any date must not qualify');
+});
+
+test('extractEventsFromJsonApiPayload extracts Tockify feed events: millis dates, tzid timezone, place venue, wrapped text', () => {
+  const parser = createParser();
+  const events = parser.extractEventsFromJsonApiPayload(TOCKIFY_FEED_PAYLOAD, TOCKIFY_SOURCE_URL, null);
+  assert.equal(events.length, 2);
+
+  const gorditos = events[0];
+  assert.equal(gorditos.title, 'Gorditos at Rockbar');
+  assert.equal(gorditos.startDate.toISOString(), '2026-08-30T02:00:00.000Z', '10PM EDT Aug 29 = 02:00Z Aug 30');
+  assert.equal(gorditos.endDate.toISOString(), '2026-08-30T08:00:00.000Z');
+  assert.equal(gorditos.timezone, 'America/New_York', 'the when.start tzid is authoritative');
+  assert.equal(gorditos.bar, 'Rockbar NYC');
+  assert.ok(gorditos.address.includes('185 Christopher St'), `address should carry the street: ${gorditos.address}`);
+  assert.equal(gorditos.description, 'DJs Noble Bear & Goodbunny spin a Latin bear party at Rockbar.');
+  assert.equal(gorditos.url, '', 'the tockify api fetch endpoint is never an identity link');
+
+  const underbear = events[1];
+  assert.equal(underbear.title, 'Underbear Party at Rockbar');
+  assert.equal(underbear.startDate.toISOString(), '2026-08-22T02:00:00.000Z', '10PM EDT Aug 21 = 02:00Z Aug 22');
+});
+
+test('extractEventsFromJsonApiPayload handles WordPress-REST rendered titles alongside ISO dates', () => {
+  const parser = createParser();
+  const events = parser.extractEventsFromJsonApiPayload(
+    [{ title: { rendered: 'Bear Night' }, start_date: '2026-09-04 21:00:00', venue: 'Some Bar' }],
+    'https://example.com/wp-json/tribe/events/v1/events', null);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].title, 'Bear Night');
+  assert.equal(events[0].bar, 'Some Bar');
+});

--- a/scripts/parsers/ai-web-parser.test.js
+++ b/scripts/parsers/ai-web-parser.test.js
@@ -15479,8 +15479,8 @@ test('jsonApiObjectLooksEventLike recognizes wrapper + epoch-millis shapes (Tock
   const parser = createParser();
   assert.equal(parser.jsonApiObjectLooksEventLike(TOCKIFY_FEED_PAYLOAD.events[0]), true,
     'content-wrapped summary.text title + when.start.millis date should be event-like');
-  assert.equal(parser.jsonApiObjectLooksEventLike({ title: { rendered: 'Bear Night' }, start_date: '2026-09-04 21:00:00' }), true,
-    'WordPress-REST rendered title + ISO start should be event-like');
+  assert.equal(parser.jsonApiObjectLooksEventLike({ title: { rendered: 'Recap' }, date: '2026-08-01T10:00:00', content: { rendered: '…' } }), false,
+    'a WordPress /wp-json posts row ({ rendered } title + publish date) must NOT be event-like');
   assert.equal(parser.jsonApiObjectLooksEventLike({ name: 'no dates here', when: { allDay: false } }), false,
     'a when container without a parseable start must not qualify');
   assert.equal(parser.jsonApiObjectLooksEventLike({ content: { summary: { text: 'title only' } } }), false,
@@ -15507,12 +15507,79 @@ test('extractEventsFromJsonApiPayload extracts Tockify feed events: millis dates
   assert.equal(underbear.startDate.toISOString(), '2026-08-22T02:00:00.000Z', '10PM EDT Aug 21 = 02:00Z Aug 22');
 });
 
-test('extractEventsFromJsonApiPayload handles WordPress-REST rendered titles alongside ISO dates', () => {
+
+test('JSON-API date recognition ignores bookkeeping epochs and anchors its key patterns', () => {
+  const parser = createParser();
+  // Bare epoch numbers under update/date-id keys are not event starts
+  assert.equal(parser.jsonApiObjectLooksEventLike({ title: 'X', venue: 'Bar', last_update_date: 1787425200000 }), false);
+  assert.equal(parser.jsonApiObjectLooksEventLike({ title: 'X', date_id: 123456789012 }), false);
+  // …and neither is a bare epoch under a real start key: only ISO strings or { millis } envelopes count
+  assert.equal(parser.jsonApiObjectLooksEventLike({ title: 'X', start: 1788055200000 }), false);
+  assert.equal(parser.jsonApiObjectLooksEventLike({ title: 'X', start: { millis: 1788055200000 } }), true);
+  // endorsed_at / ends_sale_at never become an end
+  const ev = parser.extractEventsFromJsonApiPayload(
+    [{ title: 'X', venue: 'Bar', start: '2026-09-04T21:00:00Z', endorsed_at: { millis: 1788055200000 }, ends_sale_at: '2026-08-30T02:00:00Z' }],
+    'https://example.com/api/v1/events', null);
+  assert.equal(ev.length, 1);
+  assert.equal(ev[0].endDate, null);
+});
+
+test('a scalar `when` never hands the start back as the end; containers resolve only their member', () => {
+  const parser = createParser();
+  const scalarWhen = parser.extractEventsFromJsonApiPayload(
+    [{ title: 'X', venue: 'Bar', when: '2026-09-04T21:00:00-04:00' }], 'https://example.com/api/v1/events', null);
+  assert.equal(scalarWhen.length, 0, 'a scalar when is not a start container');
+  const container = parser.extractEventsFromJsonApiPayload(
+    [{ title: 'X', venue: 'Bar', when: { start: { millis: 1788055200000 } } }], 'https://example.com/api/v1/events', null);
+  assert.equal(container.length, 1);
+  assert.equal(container[0].startDate.toISOString(), '2026-08-30T02:00:00.000Z');
+  assert.equal(container[0].endDate, null, 'no end member, no end');
+});
+
+test('a series-level `when` does not leak into performances; wrapped detail payloads expand', () => {
+  const parser = createParser();
+  const series = parser.extractEventsFromJsonApiPayload({
+    data: { title: 'Series', venue: 'Bar', when: { start: { millis: 1788055200000 } },
+      performances: [{ start_at: '2026-09-01T21:00:00-04:00' }, { start_at: '2026-09-08T21:00:00-04:00' }] }
+  }, 'https://example.com/api/v1/events', null);
+  assert.deepEqual(series.map(e => e.startDate.toISOString()), ['2026-09-02T01:00:00.000Z', '2026-09-09T01:00:00.000Z']);
+  const wrapped = parser.extractEventsFromJsonApiPayload({
+    data: { id: '1', attributes: { title: 'BN', venue: 'Bar', performances: [{ start_at: '2026-09-01T21:00:00-04:00' }] } }
+  }, 'https://example.com/api/v1/events', null);
+  assert.equal(wrapped.length, 1);
+  assert.equal(wrapped[0].title, 'BN');
+});
+
+test('wrapper precedence: outer key order wins the first match, wrapped values win same-named keys', () => {
+  const parser = createParser();
+  const outerFirst = parser.extractEventsFromJsonApiPayload(
+    [{ attributes: { title: 'W', starts_at: '2026-09-04T21:00:00Z' }, start_date: '2026-10-01T21:00:00Z', venue: 'Bar' }],
+    'https://example.com/api/v1/events', null);
+  assert.equal(outerFirst[0].startDate.toISOString(), '2026-10-01T21:00:00.000Z', 'the outer start_date is still the first match');
+  const envelopeDate = parser.extractEventsFromJsonApiPayload(
+    [{ date: '2026-01-01T00:00:00Z', content: { summary: { text: 'P' }, place: 'Bar', date: '2026-09-04T21:00:00-04:00' } }],
+    'https://example.com/api/v1/events', null);
+  assert.equal(envelopeDate[0].startDate.toISOString(), '2026-09-05T01:00:00.000Z', 'the wrapped event date beats the envelope record date');
+});
+
+test('cancelled JSON-API rows are skipped (Tockify status.name, schema.org eventStatus)', () => {
+  const parser = createParser();
+  const cancelled = {
+    ...TOCKIFY_FEED_PAYLOAD.events[0],
+    status: { name: 'cancelled' }
+  };
+  const events = parser.extractEventsFromJsonApiPayload({ events: [cancelled, TOCKIFY_FEED_PAYLOAD.events[1]] }, TOCKIFY_SOURCE_URL, null);
+  assert.deepEqual(events.map(e => e.title), ['Underbear Party at Rockbar']);
+  const schemaOrg = parser.extractEventsFromJsonApiPayload(
+    [{ title: 'X', venue: 'Bar', start: '2026-09-04T21:00:00Z', eventStatus: 'https://schema.org/EventCancelled' }],
+    'https://example.com/api/v1/events', null);
+  assert.equal(schemaOrg.length, 0);
+});
+
+test('JSON-API events never carry the fetch URL as their identity link, whatever its query looks like', () => {
   const parser = createParser();
   const events = parser.extractEventsFromJsonApiPayload(
-    [{ title: { rendered: 'Bear Night' }, start_date: '2026-09-04 21:00:00', venue: 'Some Bar' }],
-    'https://example.com/wp-json/tribe/events/v1/events', null);
-  assert.equal(events.length, 1);
-  assert.equal(events[0].title, 'Bear Night');
-  assert.equal(events[0].bar, 'Some Bar');
+    [{ title: 'X', venue: 'Bar', start: '2026-09-04T21:00:00Z' }],
+    'https://tockify.com/api/ngevent?calname=thotyssey&tags=rockbar', null);
+  assert.equal(events[0].url, '');
 });

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -97,6 +97,24 @@ const scraperConfig = {
       },
     },
     {
+      name: "Rockbar",
+      // West Village leather/rock bar (185 Christopher St) with heavy bear
+      // programming (Gorditos, Underbear, Bears Night Out, Rockstrap). Their
+      // own Squarespace site's events listing serves stale content (frozen
+      // Aug 2024), so the live source is Thotyssey's Tockify calendar: the
+      // venue-tagged JSON feed replays browser-free and carries title,
+      // epoch-millis times with tzid, venue name, and full address per
+      // event. Kink/pup nights share the tag — bear check filters, not
+      // alwaysBear.
+      urls: ["https://tockify.com/api/ngevent?max=100&calname=thotyssey&tags=rockbar"],
+      alwaysBear: false,
+      siteRole: "venue",
+      metadata: {
+        website: { value: "https://www.rockbarnyc.com" },
+        instagram: { value: "https://www.instagram.com/rockbarnyc" },
+      },
+    },
+    {
       name: "Twisted Bear",
       // discoveryOnly: true,
       urls: [

--- a/scripts/scraper-input.js
+++ b/scripts/scraper-input.js
@@ -99,14 +99,13 @@ const scraperConfig = {
     {
       name: "Rockbar",
       // West Village leather/rock bar (185 Christopher St) with heavy bear
-      // programming (Gorditos, Underbear, Bears Night Out, Rockstrap). Their
-      // own Squarespace site's events listing serves stale content (frozen
-      // Aug 2024), so the live source is Thotyssey's Tockify calendar: the
-      // venue-tagged JSON feed replays browser-free and carries title,
-      // epoch-millis times with tzid, venue name, and full address per
-      // event. Kink/pup nights share the tag — bear check filters, not
-      // alwaysBear.
-      urls: ["https://tockify.com/api/ngevent?max=100&calname=thotyssey&tags=rockbar"],
+      // programming (Gorditos, Underbear, Bears Night Out, Rockstrap). The
+      // venue's own site is the identity source: Squarespace, one page per
+      // party (/events/<slug>, each with a ?format=ical link) — but the
+      // listing's dates have been frozen since Aug 2024, so live dates come
+      // from the Thotyssey aggregator entry below and merge in here. Kink/pup
+      // nights are on the same calendar — bear check filters, not alwaysBear.
+      urls: ["https://www.rockbarnyc.com/events"],
       alwaysBear: false,
       siteRole: "venue",
       metadata: {
@@ -243,6 +242,21 @@ const scraperConfig = {
       alwaysBear: true,
       urlDiscoveryDepth: 1,
       maxAdditionalUrls: 60,
+    },
+    {
+      name: "Thotyssey",
+      // Aggregator (NYC nightlife calendar, hosted on Tockify). The
+      // bear-tagged JSON feed replays browser-free: title, epoch-millis
+      // times with tzid, venue name (`place`) and full address per row, so
+      // venues (Rockbar, Eagle NYC, 3 Dollar Bill …) are attributed without
+      // any venue role here. Rows are pre-expanded occurrences; the feed
+      // serves 100 per request (server-capped; metaData.hasNext signals
+      // more), ≈3–4 weeks for this tag, refreshed every run — startms=
+      // paging exists if a longer horizon is ever wanted. Editorial tag, so
+      // the bear check still decides, not alwaysBear. Run selection belongs
+      // to the picker (no static automationEnabled flag here).
+      urls: ["https://tockify.com/api/ngevent?max=100&calname=thotyssey&tags=bears"],
+      alwaysBear: false,
     },
     {
       // ── New Site Template ─────────────────────────────────────────────

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -678,13 +678,43 @@ class SharedCore {
         const isPlainObject = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
         const isArrayOfObjects = (value) => Array.isArray(value) && value.length > 0 && value.every(isPlainObject);
         const isIsoDateish = (value) => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}/.test(value.trim());
+        // Mirror extensions (see jsonApiObjectLooksEventLike): one level of
+        // content/attributes wrapper unwrap, rich-text {text}/{rendered}
+        // titles with `summary` accepted, and epoch-millis / when-container
+        // dates ({ millis }, { start: { millis } }).
+        const isEpochMillis = (value) => typeof value === 'number' && value > 1e11 && value < 1e13;
+        const textValue = (value) => {
+            if (typeof value === 'string') return value;
+            if (isPlainObject(value)) {
+                for (const key of ['text', 'rendered', 'value']) {
+                    if (typeof value[key] === 'string') return value[key];
+                }
+            }
+            return '';
+        };
+        const isDateCandidate = (value) => {
+            if (isIsoDateish(value) || isEpochMillis(value)) return true;
+            if (!isPlainObject(value)) return false;
+            if (isEpochMillis(value.millis)) return true;
+            const member = value.start;
+            return isIsoDateish(member) || isEpochMillis(member)
+                || (isPlainObject(member) && isEpochMillis(member.millis));
+        };
+        const unwrap = (obj) => {
+            for (const key of Object.keys(obj)) {
+                if (!/^(content|attributes|properties|fields)$/.test(normalizeKey(key))) continue;
+                if (isPlainObject(obj[key])) return { ...obj[key], ...obj };
+            }
+            return obj;
+        };
         const looksEventLike = (obj) => {
             if (!isPlainObject(obj)) return false;
-            const keys = Object.keys(obj);
-            const hasTitle = keys.some(key => /^(name|title)$/.test(normalizeKey(key))
-                && typeof obj[key] === 'string' && obj[key].trim() !== '');
+            const view = unwrap(obj);
+            const keys = Object.keys(view);
+            const hasTitle = keys.some(key => /^(name|title|summary)$/.test(normalizeKey(key))
+                && textValue(view[key]).trim() !== '');
             if (!hasTitle) return false;
-            return keys.some(key => /(^|_)(start|date|datetime)/.test(normalizeKey(key)) && isIsoDateish(obj[key]));
+            return keys.some(key => /(^|_)(start|date|datetime|when)/.test(normalizeKey(key)) && isDateCandidate(view[key]));
         };
         if (isArrayOfObjects(parsed)) {
             return parsed.filter(looksEventLike).length;
@@ -1303,7 +1333,7 @@ class SharedCore {
         const pathHasApi = segments.includes('api');
         if (!hostIsApi && !pathHasApi) return false;
         const hasVersionSegment = segments.some(segment => /^v\d+$/.test(segment));
-        const hasMachineQuery = /[?&](?:q|query|search|per_page|page|limit|offset|format|callback|api_key|apikey|key|token)=/i.test(raw);
+        const hasMachineQuery = /[?&](?:q|query|search|per_page|page|limit|max|offset|format|callback|api_key|apikey|key|token)=/i.test(raw);
         return hasVersionSegment || hasMachineQuery;
     }
 

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -679,31 +679,31 @@ class SharedCore {
         const isArrayOfObjects = (value) => Array.isArray(value) && value.length > 0 && value.every(isPlainObject);
         const isIsoDateish = (value) => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}/.test(value.trim());
         // Mirror extensions (see jsonApiObjectLooksEventLike): one level of
-        // content/attributes wrapper unwrap, rich-text {text}/{rendered}
-        // titles with `summary` accepted, and epoch-millis / when-container
-        // dates ({ millis }, { start: { millis } }).
-        const isEpochMillis = (value) => typeof value === 'number' && value > 1e11 && value < 1e13;
+        // content/attributes wrapper unwrap (outer key order, wrapped values
+        // win), Tockify { text } titles with `summary` accepted, and dates as
+        // ISO strings or { millis } envelopes — scalar under anchored
+        // start/date keys, or the `start` member of a when-container. No bare
+        // numbers, no { rendered }: bookkeeping timestamps and WordPress post
+        // lists must not count as events.
+        const isEpochEnvelope = (value) => isPlainObject(value)
+            && typeof value.millis === 'number' && value.millis > 1e11 && value.millis < 1e13;
+        const isScalarDate = (value) => isIsoDateish(value) || isEpochEnvelope(value);
         const textValue = (value) => {
             if (typeof value === 'string') return value;
-            if (isPlainObject(value)) {
-                for (const key of ['text', 'rendered', 'value']) {
-                    if (typeof value[key] === 'string') return value[key];
-                }
-            }
+            if (isPlainObject(value) && typeof value.text === 'string') return value.text;
             return '';
         };
-        const isDateCandidate = (value) => {
-            if (isIsoDateish(value) || isEpochMillis(value)) return true;
-            if (!isPlainObject(value)) return false;
-            if (isEpochMillis(value.millis)) return true;
-            const member = value.start;
-            return isIsoDateish(member) || isEpochMillis(member)
-                || (isPlainObject(member) && isEpochMillis(member.millis));
+        const isStartEntry = (key, value) => {
+            if (/(^|_)starts?(_(at|date|time|datetime))?$/.test(key) || /(^|_)(date|datetime)(_|$)/.test(key)) {
+                return isScalarDate(value) || (isPlainObject(value) && isScalarDate(value.start));
+            }
+            if (/(^|_)when$/.test(key)) return isPlainObject(value) && isScalarDate(value.start);
+            return false;
         };
         const unwrap = (obj) => {
             for (const key of Object.keys(obj)) {
                 if (!/^(content|attributes|properties|fields)$/.test(normalizeKey(key))) continue;
-                if (isPlainObject(obj[key])) return { ...obj[key], ...obj };
+                if (isPlainObject(obj[key])) return { ...obj, ...obj[key] };
             }
             return obj;
         };
@@ -714,7 +714,7 @@ class SharedCore {
             const hasTitle = keys.some(key => /^(name|title|summary)$/.test(normalizeKey(key))
                 && textValue(view[key]).trim() !== '');
             if (!hasTitle) return false;
-            return keys.some(key => /(^|_)(start|date|datetime|when)/.test(normalizeKey(key)) && isDateCandidate(view[key]));
+            return keys.some(key => isStartEntry(normalizeKey(key), view[key]));
         };
         if (isArrayOfObjects(parsed)) {
             return parsed.filter(looksEventLike).length;
@@ -1333,7 +1333,7 @@ class SharedCore {
         const pathHasApi = segments.includes('api');
         if (!hostIsApi && !pathHasApi) return false;
         const hasVersionSegment = segments.some(segment => /^v\d+$/.test(segment));
-        const hasMachineQuery = /[?&](?:q|query|search|per_page|page|limit|max|offset|format|callback|api_key|apikey|key|token)=/i.test(raw);
+        const hasMachineQuery = /[?&](?:q|query|search|per_page|page|limit|offset|format|callback|api_key|apikey|key|token)=/i.test(raw);
         return hasVersionSegment || hasMachineQuery;
     }
 

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20514,3 +20514,33 @@ test('improbable-overnight-span fails closed without a timezone', () => {
   });
   assert.equal(flags.find(f => f.code === 'improbable-overnight-span'), undefined);
 });
+
+// ---------------------------------------------------------------------------
+// countJsonApiEventObjects mirror extensions: wrapper/rich-text/epoch shapes
+// (kept in sync with AiWebParser.jsonApiObjectLooksEventLike — Tockify feed
+// shape: content wrapper, summary.{text} title, when.start.{millis} date).
+// ---------------------------------------------------------------------------
+
+test('countJsonApiEventObjects counts Tockify-shaped wrapper/epoch events for page classification', () => {
+  const core = createCore();
+  const body = JSON.stringify({
+    events: [
+      {
+        eid: { uid: '39689' },
+        when: { start: { millis: 1788055200000, tzid: 'America/New_York' }, end: { millis: 1788076800000 } },
+        content: { summary: { text: 'Gorditos at Rockbar' }, place: 'Rockbar NYC' }
+      },
+      {
+        eid: { uid: '31035' },
+        when: { start: { millis: 1787364000000, tzid: 'America/New_York' } },
+        content: { summary: { text: 'Underbear Party at Rockbar' } }
+      }
+    ],
+    metaData: {}
+  });
+  assert.equal(core.countJsonApiEventObjects(body), 2);
+  // Objects that merely carry a when container with no resolvable start stay non-events
+  assert.equal(core.countJsonApiEventObjects(JSON.stringify({
+    events: [{ content: { summary: { text: 'title only' } }, when: { allDay: false } }]
+  })), 0);
+});

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -20544,3 +20544,16 @@ test('countJsonApiEventObjects counts Tockify-shaped wrapper/epoch events for pa
     events: [{ content: { summary: { text: 'title only' } }, when: { allDay: false } }]
   })), 0);
 });
+
+test('countJsonApiEventObjects mirror: no bare epochs, no { rendered } titles, scalar when is not a start', () => {
+  const core = createCore();
+  assert.equal(core.countJsonApiEventObjects(JSON.stringify([
+    { date: '2026-08-01T10:00:00', title: { rendered: 'Recap' }, content: { rendered: '…' } },
+    { date: '2026-08-02T10:00:00', title: { rendered: 'Recap 2' }, content: { rendered: '…' } }
+  ])), 0, 'a WordPress posts list is not a list of events');
+  assert.equal(core.countJsonApiEventObjects(JSON.stringify([{ title: 'X', last_update_date: 1787425200000 }])), 0);
+  assert.equal(core.countJsonApiEventObjects(JSON.stringify([{ title: 'X', when: '2026-09-04T21:00:00Z' }])), 0);
+  assert.equal(core.countJsonApiEventObjects(JSON.stringify([{ title: 'X', when: { start: { millis: 1788055200000 } } }])), 1);
+  assert.equal(core.countJsonApiEventObjects(JSON.stringify([{ content: { summary: { text: '' } }, when: { start: { millis: 1788055200000 } } }])), 0,
+    'an empty rich-text title is no title — same as the parser');
+});


### PR DESCRIPTION
## Route 1 of the manual-flesh replacement: scrape it

Stanley's call after #1698: the missing Rockbar parties (GORDITOS etc.) should come from the scraper, with **Rockbar scraped from Rockbar's own site** and **Thotyssey treated as an aggregator, like The Bear Calendar**.

## Sources

- **Rockbar** (venue, `siteRole: venue`, website/instagram metadata): `rockbarnyc.com/events` — Squarespace, one page per party (`/events/<slug>`, each with a `?format=ical` link). Its listing's dates have been frozen since Aug 2024, so it's the identity source; live dates arrive through the aggregator and merge in.
- **Thotyssey** (aggregator, no venue role, `alwaysBear: false`): Tockify's bear-tagged JSON feed `tockify.com/api/ngevent?max=100&calname=thotyssey&tags=bears` — 100 pre-expanded rows per request (server-capped; `metaData.hasNext` signals more; `startms=` paging exists if we ever want a longer horizon), ≈3–4 weeks rolling, `place` + full address on every row, 12 NYC venues in today's window (Rockbar, Eagle NYC, Ty's, Gym Sportsbar, 3 Dollar Bill…). Run selection stays with the picker — no static `automationEnabled` flag.

## Generic JSON-API shape support (no Tockify-specific code)

The existing JSON-API pathway (the one the Goldiloxx redeyetickets feed uses) only recognized flat objects with string titles and ISO dates. Added, generically and tightly:

- **Attribute-wrapper unwrap** (one level): JSON:API `attributes`, Tockify `content`, CMS `properties`/`fields`. Outer key order wins the first match; wrapped values win same-named keys (envelope `date` vs the event's `date`).
- **Rich-text `{ text }` titles** (Tockify); `summary` accepted as a title key only as fallback. Deliberately **not** WordPress `{ rendered }` — a `/wp-json` posts list must not become publish-dated pseudo-events.
- **Epoch-millis envelopes** `{ millis, tzid? }` and **when-containers** `{ start, end }`. An epoch instant is absolute (`timezoneUnresolved: false`) and the `tzid` stamps `event.timezone`. **No bare numbers** — `last_update_date`/`date_id` are epochs too. Key patterns are anchored (`starts_at`, `start_date`, `first_performance_start_at` qualify; `endorsed_at`, `ends_sale_at` don't). `when` is container-only, and containers resolve only their own edge member, so a scalar `when` can never hand the start back as the end.
- **Performances**: a series-level `when` no longer leaks into each performance; wrapped detail payloads expand on the unwrapped view.
- **`place`** joins the venue-name keys; **cancelled rows are skipped** (Tockify `status.name`, schema.org `eventStatus`) — structured events bypass `normalizeAiEvent`, so this is the only place to honour it.
- **`url` is never the fetch URL** on the JSON-API route — a JSON body is never a human page — which is the structural version of the `isApiEndpointUrl` query-param guard (the earlier `max` tweak is reverted).
- `SharedCore.countJsonApiEventObjects` (the documented classification mirror) updated identically, including empty-title parity.

Constraints respected: no existing console.log line or AI prompt edited (one additive `🤖 AI Web:` skip line); no `new URL(`/`URLSearchParams` under `scripts/`; parsers stay pure.

## Verification

- Independent review pass (medium) on the first revision surfaced 10 probe-confirmed findings; every one is addressed above, with a regression test for each.
- Tests: **1980/1980** (+10 in this PR, written first and proven failing on base).
- Live feeds (Node, real bodies): `tags=rockbar` 100/100 extracted, GORDITOS on `2026-08-30T02:00Z` / `09-27` / `11-01` (last-Saturday 10PM Eastern), bar "Rockbar NYC", 185 Christopher St, `America/New_York`, `url: ''`; `tags=bears` 100/100 across 12 venues, 0 rows missing an address.

## Notes for Stanley

- Feed titles read "Gorditos at Rockbar" — Thotyssey's style; if you want bare "GORDITOS", that's a promoter-registry/shortName call after the first run.
- First Thotyssey run will be busy (≈100 rows, a lot of Eagle NYC / Ty's / Gym Sportsbar weeklies) — expect the bear check to do real work, and a fresh dedupe pass against your existing NYC events (Bears Night Out, Rockstrap, FUZZY…). Run it from the picker and review before letting the daily job own it.
- Rockbar's own pages are evergreen party descriptions without current dates; whatever the venue crawl yields is filtered by the date window until they update the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP