### PR TITLE
event-builder: make edit links whole — revision by UID, real diff baseline, favicon in diffs

### DIFF
--- a/testing/event-builder.html
+++ b/testing/event-builder.html
@@ -3031,6 +3031,11 @@
       const dom = {};
       let state;
       let existingSnapshot = null;
+      // True while existingSnapshot was taken from the arriving LINK's own
+      // values (edit=1&euid=… with no loaded record): that baseline diffs the
+      // form against itself and shows no changes. Cleared once the published
+      // record is adopted (adoptPublishedRecordForLink).
+      let existingSnapshotFromLink = false;
       let diffViewMode = 'side'; // 'side' or 'stacked'
       let diffPanelMode = 'diff'; // 'diff', 'similarity', or 'link'
       let diffEditMode = false; // whether to show edit mode UI in the diff
@@ -3131,6 +3136,7 @@
         applyStateToForm();
         if (state.isEditingExisting && !existingSnapshot) {
           existingSnapshot = snapshotFormFields(state);
+          existingSnapshotFromLink = true;
         }
         applyDebugVisibility();
         syncExistingSelectionSummaryFromState();
@@ -3762,6 +3768,7 @@
             rangeEnd: dateFilter.rangeEnd
           });
           existingCalendarIndex = index;
+          adoptPublishedRecordForLink(index);
           existingResults = results;
           renderExistingResults(results);
           refreshEditingContextUi();
@@ -4349,6 +4356,7 @@
         fetchCalendarIndex(cityKey).then(index => {
           if (state && state.city === cityKey) {
             existingCalendarIndex = index;
+            adoptPublishedRecordForLink(index);
             existingResults = buildExistingResults(index, { now: new Date() });
             updateSimilarityWarningUi();
           }
@@ -4535,6 +4543,53 @@
         if (explicit) return explicit;
         if (!state.editingExistingId) return '';
         return parseResultId(state.editingExistingId).uid;
+      }
+
+      // The published record behind an edit link's UID: a series master, or a
+      // one-off from index.events (never an override — those carry their own
+      // SEQUENCE and recurrence-id).
+      function findPublishedRecordByUid(index, uid) {
+        if (!index || !uid) return null;
+        const base = findBaseEventByUid(index, uid);
+        if (base) return base;
+        if (!Array.isArray(index.events)) return null;
+        return index.events.find(record => record && record.uid === uid && !record.recurrenceId) || null;
+      }
+
+      // An edit link names the record (euid) but carries neither its revision
+      // nor its stored values. Once the city's published calendar is in hand,
+      // adopt both from the real record: the SEQUENCE the ICS export needs,
+      // and the diff baseline — without it the form is diffed against the
+      // link's own prefilled values and "Changes:" stays empty even when the
+      // link added a field (review 2026-08-22: favicon added, no diff shown).
+      // Only fills blanks / replaces a link-derived baseline, so a real
+      // "Edit event" load always wins.
+      function adoptPublishedRecordForLink(index) {
+        if (!state || !state.isEditingExisting || !index) return;
+        const uid = getEditingUidFromState();
+        if (!uid) return;
+        const record = findPublishedRecordByUid(index, uid);
+        if (!record) return;
+        if (!normalizeText(state.editingExistingSequence)) {
+          const resolvedSequence = parseIntegerValue(record.sequence);
+          if (resolvedSequence !== null) {
+            state.editingExistingSequence = String(resolvedSequence);
+            scheduleUrlUpdate();
+          }
+        }
+        if (existingSnapshotFromLink) {
+          existingSnapshot = buildExistingSnapshot(record, {
+            cityKey: record.city || state.city,
+            startDate: record.startDate,
+            endDate: record.endDate,
+            recurrence: record.recurrence || ''
+          });
+          existingSnapshotFromLink = false;
+          updateExistingDiff();
+          // Only the action buttons — refreshUi() re-snapshots the baseline
+          // from the form and would erase the diff just established.
+          if (typeof updateActionButtonsState === 'function') updateActionButtonsState();
+        }
       }
 
       function findBaseEventByUid(index, uid) {
@@ -5868,6 +5923,10 @@
           recurrenceMode: 'builder',
           website: normalizeText(eventData.website || ''),
           ticketUrl: normalizeText(eventData.ticketUrl || ''),
+          // Mapped explicitly: unmapped fields inherit the CURRENT form via
+          // ...state above, so a record-based diff baseline could never show
+          // a change to them (review 2026-08-22: favicon added, no diff).
+          favicon: normalizeText(eventData.favicon || ''),
           instagram: normalizeText(eventData.instagram || ''),
           facebook: normalizeText(eventData.facebook || ''),
           gmaps: normalizeText(eventData.gmaps || ''),
@@ -9891,6 +9950,7 @@ Example output:
           const index = await fetchCalendarIndex(state.city);
           if (state && state.city === index.cityKey) {
             existingCalendarIndex = index;
+            adoptPublishedRecordForLink(index);
           }
           return {
             baseEvent: findBaseEventByUid(index, uid),
@@ -10604,15 +10664,7 @@ Example output:
           // (Review 2026-08-22: a one-off edit link opened in Safari hit the
           // refusal with no picker selection to rescue it.)
           const resolved = await loadEditingBaseEventForSwap();
-          // findBaseEventByUid only knows SERIES masters; a one-off lives in
-          // index.events, so look the UID up across every published record
-          // (never an override — those carry their own SEQUENCE).
-          const publishedIndex = resolved && resolved.index ? resolved.index : null;
-          const publishedRecord = resolved && resolved.baseEvent
-            ? resolved.baseEvent
-            : (publishedIndex && Array.isArray(publishedIndex.events)
-              ? publishedIndex.events.find(record => record && record.uid === getEditingUidFromState() && !record.recurrenceId)
-              : null);
+          const publishedRecord = findPublishedRecordByUid(resolved && resolved.index, getEditingUidFromState());
           const resolvedSequence = publishedRecord ? parseIntegerValue(publishedRecord.sequence) : null;
           if (resolvedSequence !== null) {
             existingSequence = resolvedSequence;

--- a/testing/event-builder.html
+++ b/testing/event-builder.html
@@ -10567,7 +10567,7 @@ Example output:
         }, duration);
       }
 
-      function handleAddToCalendar() {
+      async function handleAddToCalendar() {
         const addDisabledReason = getAddToCalendarDisabledReason();
         if (addDisabledReason) {
           showToast(addDisabledReason, 'warn');
@@ -10583,7 +10583,7 @@ Example output:
         const deletingCustomOverride = isDeletingExistingCustomOverride();
         const shouldIncrementSequence = isEditingExisting
           && (!isOccurrenceOverride || isEditingCustomOverrideMode());
-        const existingSequence = shouldIncrementSequence
+        let existingSequence = shouldIncrementSequence
           ? parseIntegerValue(state && state.editingExistingSequence)
           : null;
         // Never guess a revision. SEQUENCE is a counter, not a timestamp, and
@@ -10594,6 +10594,34 @@ Example output:
         // names the record (edit=1&euid=…) arrives without it. Every published
         // event carries a SEQUENCE, so a missing one means "not loaded yet",
         // never "genuinely zero".
+        if (shouldIncrementSequence && existingSequence === null) {
+          // Before refusing, look the record up ourselves. A link that names
+          // the record (edit=1&euid=…) but arrived without eseq — the
+          // scraper's own edit links, any hand-built link — can be resolved
+          // in the published city calendar by UID, which is exactly what
+          // "Edit event" reads. Same source, same number; only a UID that is
+          // not in the published calendar still falls through to the refusal.
+          // (Review 2026-08-22: a one-off edit link opened in Safari hit the
+          // refusal with no picker selection to rescue it.)
+          const resolved = await loadEditingBaseEventForSwap();
+          // findBaseEventByUid only knows SERIES masters; a one-off lives in
+          // index.events, so look the UID up across every published record
+          // (never an override — those carry their own SEQUENCE).
+          const publishedIndex = resolved && resolved.index ? resolved.index : null;
+          const publishedRecord = resolved && resolved.baseEvent
+            ? resolved.baseEvent
+            : (publishedIndex && Array.isArray(publishedIndex.events)
+              ? publishedIndex.events.find(record => record && record.uid === getEditingUidFromState() && !record.recurrenceId)
+              : null);
+          const resolvedSequence = publishedRecord ? parseIntegerValue(publishedRecord.sequence) : null;
+          if (resolvedSequence !== null) {
+            existingSequence = resolvedSequence;
+            if (state) {
+              state.editingExistingSequence = String(resolvedSequence);
+              scheduleUrlUpdate();
+            }
+          }
+        }
         if (shouldIncrementSequence && existingSequence === null) {
           const revisionMessage = 'Load this event with "Edit event" first — its revision number is needed or the calendar will ignore the update';
           updateCalendarStatus(revisionMessage, 'warn');


### PR DESCRIPTION
## Why

Stanley hit two walls today using edit links (`edit=1&euid=…`) in Safari:

1. The ICS-update export refused: *"Load this event with 'Edit event' first — its revision number is needed"*. The link carried `euid` but no `eseq`, and for one-offs there's no `occid` to queue a picker selection, so nothing ever resolved the SEQUENCE. The scraper's own builder links have the same shape.
2. "Changes vs. Existing Event" showed **no diff** for a link that added a favicon — even though the field is in the diff list.

## What changed (`testing/event-builder.html` only)

- **Revision by UID.** `adoptPublishedRecordForLink(index)` runs wherever the city's published calendar index lands (prefetch, results refresh, swap load) and adopts the record's SEQUENCE; the export path does the same lookup as a fallback. `findPublishedRecordByUid` covers series masters *and* one-offs (`index.events`, never an override). A UID absent from the published calendar still hits the original refusal — "never guess a revision" stands.
- **Real diff baseline.** The snapshot taken from a link's own values is now flagged link-derived and replaced by the published record once it's available, so the form is diffed against the calendar, not against itself. A real "Edit event" load still wins.
- **`favicon` mapped in `buildExistingState`.** It was the one `DIFF_FIELD_LABELS` field never mapped; since that function returns `{ ...state, ...mapped }`, every record-based baseline inherited the *form's* favicon and an icon change could never register as a change — in any edit flow, not just links.

## Verification (WebKit, local copy of the site)

One-off edit link (Coach After Dark: SF) carrying `favicon=https://linktr.ee/bearhappyhour` with `eseq` stripped:
- on load the URL gains `eseq=0` (resolved from the published sf calendar);
- "Show changes" renders exactly `Icon URL (empty) → https://linktr.ee/bearhappyhour`;
- export proceeds (status "Preview updated") where the unpatched page refused.

Side note for link producers (fixed on my page already): a builder edit link must carry *every* diffable field of the record — a missing param reads as "cleared" on save (the first probe showed `Tickets → (empty)` because the link omitted `ticketUrl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP