### PR TITLE
promoters: Coach After Dark favicon + Twisted Bear website (scraper-owned identity)

### DIFF
--- a/data/promoters.json
+++ b/data/promoters.json
@@ -13,7 +13,8 @@
     "name": "Coach After Dark",
     "shortName": "COACH",
     "instagram": "https://www.instagram.com/coachafterdark",
-    "bearAffinity": "always"
+    "bearAffinity": "always",
+    "favicon": "https://linktr.ee/bearhappyhour"
   },
   {
     "name": "Bear Happy Hour",
@@ -111,7 +112,8 @@
     "shortName": "TWIST\u00adED BEAR",
     "instagram": "https://www.instagram.com/twistedbearparty",
     "facebook": "https://www.facebook.com/twistedglobal/",
-    "bearAffinity": "always"
+    "bearAffinity": "always",
+    "website": "https://twisted-bear.com"
   },
   {
     "name": "CubScout LA",

--- a/scripts/scraper-promoters.js
+++ b/scripts/scraper-promoters.js
@@ -22,7 +22,8 @@ const scraperPromoters = [
     "name": "Coach After Dark",
     "shortName": "COACH",
     "instagram": "https://www.instagram.com/coachafterdark",
-    "bearAffinity": "always"
+    "bearAffinity": "always",
+    "favicon": "https://linktr.ee/bearhappyhour"
   },
   {
     "name": "Bear Happy Hour",
@@ -120,7 +121,8 @@ const scraperPromoters = [
     "shortName": "TWIST­ED BEAR",
     "instagram": "https://www.instagram.com/twistedbearparty",
     "facebook": "https://www.facebook.com/twistedglobal/",
-    "bearAffinity": "always"
+    "bearAffinity": "always",
+    "website": "https://twisted-bear.com"
   },
   {
     "name": "CubScout LA",


### PR DESCRIPTION
## Why

Three of the remaining icon-less events (Coach After Dark: SF, TWISTED BEAR SF + DC debuts) are **scraper-written** — they come from the "Coach After Dark" (Bear Happy Hour's Eventbrite organizer) and "Twisted Bear" sources. Stanley's rule: their identity belongs in the promoter registry so the scraper stamps it on every event, not in hand edits to the calendar. These were pulled off the manual update page accordingly.

## What changed

`data/promoters.json` (+ the generated `scripts/scraper-promoters.js` twin):
- **Coach After Dark** → `favicon: https://linktr.ee/bearhappyhour`. It's a Bear Happy Hour production with no site of its own; the BHH linktree logo is already cached and is what the Bear Happy Hour events show. BEEFWITCH (`parent: Coach After Dark`) inherits it — same producer.
- **Twisted Bear** → `website: https://twisted-bear.com`. Official site; the 500×500 party logo is pre-cached as a curated icon in #1698.

Targeted text edit — the `­` soft-hyphen escapes in shortNames (#1694) are untouched. Suite 1970/1970.

## What happens next

On the next run the registry stamps these on every matched Coach / Twisted Bear event and the merge back-fills the existing SF and DC records — no calendar paste needed. (The scraper-input sources themselves don't change; per the file's own note, promoter identity lives here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP