### PR TITLE
promoters: GORDITOS registry entry (shortName GOR·DITOS)

### DIFF
--- a/data/promoters.json
+++ b/data/promoters.json
@@ -108,6 +108,12 @@
     "bearAffinity": "always"
   },
   {
+    "name": "Gorditos",
+    "keywords": ["gorditos"],
+    "shortName": "GOR\u00adDITOS",
+    "bearAffinity": "always"
+  },
+  {
     "name": "Twisted Bear",
     "shortName": "TWIST\u00adED BEAR",
     "instagram": "https://www.instagram.com/twistedbearparty",

--- a/scripts/scraper-promoters.js
+++ b/scripts/scraper-promoters.js
@@ -117,6 +117,14 @@ const scraperPromoters = [
     "bearAffinity": "always"
   },
   {
+    "name": "Gorditos",
+    "keywords": [
+      "gorditos"
+    ],
+    "shortName": "GOR­DITOS",
+    "bearAffinity": "always"
+  },
+  {
     "name": "Twisted Bear",
     "shortName": "TWIST­ED BEAR",
     "instagram": "https://www.instagram.com/twistedbearparty",


### PR DESCRIPTION
Registry entry for Rockbar's monthly last-Saturday Latin bear party, now scraped via the Thotyssey aggregator (#1699) as "Gorditos at Rockbar". Pills show **GOR­DITOS** (soft hyphen, #1694 convention), `bearAffinity: always`. Twin regenerated; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP