### PR TITLE
Ship the DENSE mobile view: trifold week, live swipe selection, bottom sheet

### DIFF
--- a/atlanta/index.html
+++ b/atlanta/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/berlin/index.html
+++ b/berlin/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/birmingham/index.html
+++ b/birmingham/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/boston/index.html
+++ b/boston/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/brighton/index.html
+++ b/brighton/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/chicago/index.html
+++ b/chicago/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/city.html
+++ b/city.html
@@ -184,5 +184,6 @@
     <script src="js/dynamic-calendar-loader.js"></script>
     <script src="js/app.js"></script>
     <script src="js/dusk-ui.js"></script>
+    <script src="js/dusk-rail.js"></script>
 </body>
 </html>

--- a/dallas/index.html
+++ b/dallas/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/dc/index.html
+++ b/dc/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/denver/index.html
+++ b/denver/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/js/dusk-rail.js
+++ b/js/dusk-rail.js
@@ -1,12 +1,14 @@
-// dusk-rail.js — the mobile COZY/DENSE view system (dusk pages only).
+// dusk-rail.js — the mobile DENSE view (dusk pages only).
 //
-// COZY  = today's production behavior: the vertical list, selecting a card
-//         hides the rest — with the full description always expanded.
-// DENSE = a fixed-screen trifold: week grid / 246px card rail with corner
-//         flyer thumbs (tap -> lightbox) + bottom sheet / map. Swiping the
-//         rail drives the site's real selection live.
-// Month view (both modes): the grid alone; tapping an event pill opens the
-// bottom sheet for it in place — no navigation.
+// Mobile week view is a trifold: week grid / 246px card rail with corner
+// flyer thumbs (tap -> lightbox) + bottom sheet / map. Swiping the rail
+// drives the site's real selection live. When a big week outgrows the
+// screen the page grows downward (the map keeps a floor height and the
+// page scrolls) rather than layers overlapping.
+// Month view: the grid alone; tapping an event pill opens the bottom
+// sheet for it in place — no navigation.
+// (COZY — a vertical-list alternate mode — was built, field-tested, and
+// removed 2026-08-25; mobile has exactly one mode now.)
 //
 // Contract with the rest of the site (no MutationObservers, no retry timers):
 //   'chunky:events-rendered'   the loader finished swapping grid+list DOM
@@ -49,58 +51,9 @@
     dbgBox.textContent = dbg.join('\n');
   };
 
-  // ---------- mode: cozy (default) | dense ----------
-  const MODE_KEY = 'chunky-view-mode';
-  let mode = params.get('mode');
-  if (mode !== 'cozy' && mode !== 'dense') {
-    try { mode = localStorage.getItem(MODE_KEY); } catch (e) { mode = null; }
-  }
-  if (mode !== 'dense') mode = 'cozy';
-  const isDense = () => mode === 'dense';
-  const applyModeClass = () => {
-    html.classList.remove('mode-cozy', 'mode-dense');
-    html.classList.add('mode-' + mode);
-  };
-  applyModeClass();
-  if (params.get('mode') === mode) {
-    try { localStorage.setItem(MODE_KEY, mode); } catch (e) {}
-  }
-
-  const modeBtn = document.createElement('button');
-  modeBtn.type = 'button';
-  modeBtn.className = 'mode-toggle';
-  modeBtn.setAttribute('aria-label', 'Switch view density');
-  const paintModeLabel = () => { modeBtn.textContent = isDense() ? 'DENSE' : 'COZY'; };
-  const mountToggle = () => {
-    const switcher = document.querySelector('header .city-switcher');
-    if (!switcher) return;
-    if (modeBtn.parentElement !== switcher.parentElement || modeBtn.nextElementSibling !== switcher) {
-      switcher.parentElement.insertBefore(modeBtn, switcher);
-    }
-    paintModeLabel();
-  };
-  document.addEventListener('dusk:controls-mounted', mountToggle);
-  const setMode = (m) => {
-    if ((m !== 'cozy' && m !== 'dense') || m === mode) return;
-    mode = m;
-    try { localStorage.setItem(MODE_KEY, m); } catch (e) {}
-    try {
-      const u = new URL(location.href);
-      u.searchParams.set('mode', m);
-      history.replaceState(history.state, '', u);
-    } catch (e) {}
-    applyModeClass();
-    paintModeLabel();
-    denseMapH = -1;
-    if (isDense()) markOverflows();
-    syncRailState('mode-switch');
-    // the week grid's pill cap is mode-dependent (dense caps singles at 4)
-    // — re-render so the calendar reflects the new mode
-    const l = loader();
-    if (l && l.updateCalendarDisplay) { try { l.updateCalendarDisplay(); } catch (e) {} }
-    dbgNote('mode -> ' + m);
-  };
-  modeBtn.addEventListener('click', (e) => { e.preventDefault(); setMode(isDense() ? 'cozy' : 'dense'); });
+  // the single mobile mode — the class is the CSS anchor for every dense rule
+  html.classList.remove('mode-cozy');
+  html.classList.add('mode-dense');
 
   // ---------- flyer lightbox (corner-thumb + sheet-image tap target) ----------
   let lightbox = null;
@@ -237,7 +190,7 @@
   };
   const teaOverflows = (el) => !!el && el.scrollHeight > el.clientHeight + 1;
   const markOverflows = () => {
-    if (!isMobile() || !isDense()) return;
+    if (!isMobile()) return;
     document.querySelectorAll('.events-list .event-card').forEach((card) => {
       const tea = card.querySelector('.ec-tea');
       if (!tea) return;
@@ -255,7 +208,7 @@
     });
   };
   document.addEventListener('click', (e) => {
-    if (!isMobile() || !isDense()) return;
+    if (!isMobile()) return;
     const chip = e.target.closest && e.target.closest('.ec-more');
     const teaHit = !chip && e.target.closest && e.target.closest('.ec-tea');
     if (!chip && !teaHit) return;
@@ -384,15 +337,6 @@
         landedSlug = c.getAttribute('data-event-slug') || landedSlug;
         dbgNote('landed ' + (landedSlug || '?').slice(0, 16));
         realSelect(landedSlug);
-        // dense caps the week grid's pills at 4/day — if the landed event's
-        // pill is one of the hidden ones, re-render (the cap always swaps
-        // the SELECTED event into view). Only ever at settle: a re-render
-        // mid-gesture would fight the finger.
-        if (isDense() && landedSlug
-            && !document.querySelector('.calendar-grid .event-item[data-event-slug="' + cssEscape(landedSlug) + '"]')) {
-          const l = loader();
-          if (l && l.updateCalendarDisplay) { try { l.updateCalendarDisplay(); } catch (e) {} }
-        }
       }
     }
     flushUrl();
@@ -514,14 +458,18 @@
   const sizeDenseMap = () => {
     const sec = document.querySelector('.events-map-section');
     if (!sec) return;
-    if (!isMobile() || !isDense() || html.classList.contains('month-full')) {
+    if (!isMobile() || html.classList.contains('month-full')) {
       if (sec.style.height) { sec.style.height = ''; sec.style.flex = ''; resizeMap(); }
       denseMapH = -1;
       return;
     }
-    const main = document.querySelector('main.city-page');
-    if (!main) return;
-    const h = Math.max(140, Math.floor(main.getBoundingClientRect().bottom - sec.getBoundingClientRect().top - 6));
+    // fill from the section's DOCUMENT position to the viewport bottom —
+    // when the week grid outgrows the screen this hits the floor and the
+    // PAGE grows downward instead (the map never overlaps the cards).
+    // Document coords, not viewport rect alone: the page can be scrolled
+    // when this runs, and a viewport-relative top would feed back.
+    const secDocTop = sec.getBoundingClientRect().top + window.scrollY;
+    const h = Math.max(200, Math.floor(window.innerHeight - secDocTop - 6));
     if (h === denseMapH) return;
     denseMapH = h;
     sec.style.height = h + 'px';
@@ -552,7 +500,7 @@
     }
     updateMonthFull();
     sizeDenseMap();
-    const want = isDense() && !html.classList.contains('month-full');
+    const want = !html.classList.contains('month-full');
     const has = el.classList.contains('rail-active');
     if (want && !has) {
       el.classList.add('rail-active');
@@ -590,20 +538,7 @@
   };
 
   // ---------- the two loader events + environment changes ----------
-  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-  let lastScrollSlug = null;
-  document.addEventListener('chunky:selection-changed', (e) => {
-    // cozy select: bring the week grid + the (now lone) card into view
-    const slug = (e.detail && e.detail.slug) || null;
-    if (isMobile() && !isDense() && slug && slug !== lastScrollSlug
-        && !html.classList.contains('month-full')) {
-      try {
-        window.scrollTo({ top: 0, behavior: prefersReducedMotion.matches ? 'auto' : 'smooth' });
-      } catch (e2) { window.scrollTo(0, 0); }
-    }
-    lastScrollSlug = slug;
-    syncRailState('selection');
-  });
+  document.addEventListener('chunky:selection-changed', () => syncRailState('selection'));
   document.addEventListener('chunky:events-rendered', () => {
     armThumbs();
     markOverflows();
@@ -621,20 +556,17 @@
     syncRailState('breakpoint');
   });
   document.addEventListener('DOMContentLoaded', () => {
-    mountToggle();
     armThumbs();
     syncRailState('boot');
   });
-  mountToggle();
   syncRailState('boot');
 
   // ---------- debug surface ----------
   window.duskRail = {
-    setMode,
     openLightbox,
     openSheet,
     state: () => ({
-      mode, phase, railOwner, landedSlug, grantSlug, touchActive,
+      phase, railOwner, landedSlug, grantSlug, touchActive,
       programmatic, interacted, railActive: railActive()
     }),
     geom: () => geom.map((g) => ({ slug: g.slug.slice(0, 14), center: g.center }))

--- a/js/dusk-rail.js
+++ b/js/dusk-rail.js
@@ -565,6 +565,7 @@
     touchActive = true;
     gestureScrolled = false;
     railOwner = 'user';
+    grantSlug = null; // a new gesture invalidates any pending grant
     lastUserTouch = performance.now();
     const el = list();
     if (el && el.classList.contains('rail-active')) {
@@ -587,9 +588,13 @@
   document.addEventListener('pointerdown', onTouch, { passive: true, capture: true });
   ['touchend', 'touchcancel', 'pointerup', 'pointercancel'].forEach((ev) =>
     document.addEventListener(ev, offTouch, { passive: true, capture: true }));
-  // a REAL tap (trusted) on a pill or card grants centering for that slug
+  // a REAL tap (trusted) on a pill or card grants centering for that slug —
+  // but not taps on the card's inner controls (thumb/share/links): those
+  // never change the selection, and an unconsumed grant would later yank
+  // the rail back to this card mid-swipe
   document.addEventListener('click', (e) => {
     if (!e.isTrusted) return;
+    if (e.target.closest && e.target.closest('.rail-thumb, .share-event-btn, .event-links, .ec-more')) return;
     const pill = e.target.closest && e.target.closest('.calendar-grid .event-item');
     const card = !pill && e.target.closest && e.target.closest('.events-list .event-card');
     const src = pill || card;
@@ -724,6 +729,16 @@
       else if (grantSlug) {
         const g = cardBySlug(grantSlug);
         if (g) centerOn(g, reason);
+      } else if (reason === 'selection' && phase === 'idle' && !userBusy()) {
+        // a selection that arrived from OUTSIDE the rail (a map-marker tap
+        // has no card/pill to grant through) — adopt it so the rail follows
+        // instead of silently re-selecting the centered card later
+        const slug = selectedSlug();
+        const sel = slug && slug !== landedSlug && cardBySlug(slug);
+        if (sel) {
+          grantSlug = slug;
+          centerOn(sel, 'external-selection');
+        }
       }
     }
   };
@@ -754,7 +769,12 @@
       el.classList.add('rail-settling');
       commitFrame();
       clearTimeout(settleTimer);
-      settleTimer = setTimeout(() => el.classList.remove('rail-settling'), 200);
+      settleTimer = setTimeout(() => {
+        el.classList.remove('rail-settling');
+        // this timer can replace settle()'s own — carry its phase reset or
+        // an image landing in the settle tail wedges phase at 'settle'
+        if (phase === 'settle') phase = 'idle';
+      }, 200);
     } else {
       applyE(g, 0);
       commitFrame();

--- a/js/dusk-rail.js
+++ b/js/dusk-rail.js
@@ -124,6 +124,54 @@
         if (!(e.target.closest && e.target.closest('.sheet-panel'))) closeSheet();
       });
       document.body.appendChild(sheet);
+      // pull-down-to-dismiss: the panel scrolls normally, but when it sits
+      // at its very TOP a downward drag grabs the whole sheet instead —
+      // it rides the finger, then dismisses past ~110px or a quick flick,
+      // else springs back. Drags starting on the map stay the map's.
+      const panel0 = sheet.querySelector('.sheet-panel');
+      let dragY0 = -1, dragging = false, lastY = 0, lastT = 0, dragV = 0;
+      panel0.addEventListener('touchstart', (e) => {
+        if (e.target.closest && e.target.closest('.sheet-map')) { dragY0 = -1; return; }
+        dragY0 = e.touches[0].clientY;
+        lastY = dragY0;
+        lastT = performance.now();
+        dragging = false;
+        dragV = 0;
+      }, { passive: true });
+      panel0.addEventListener('touchmove', (e) => {
+        if (dragY0 < 0) return;
+        const y = e.touches[0].clientY;
+        const dy = y - dragY0;
+        const now = performance.now();
+        dragV = (y - lastY) / Math.max(1, now - lastT);
+        lastY = y;
+        lastT = now;
+        if (!dragging) {
+          if (panel0.scrollTop <= 0 && dy > 6) dragging = true;
+          else if (panel0.scrollTop > 0 || dy < 0) { dragY0 = -1; return; } // the scroll owns this gesture
+        }
+        if (dragging) {
+          e.preventDefault(); // no scroll/rubber-band while the sheet rides the finger
+          panel0.style.transition = 'none';
+          panel0.style.transform = 'translateY(' + Math.max(0, dy) + 'px)';
+        }
+      }, { passive: false });
+      const endDrag = () => {
+        if (!dragging) { dragY0 = -1; return; }
+        dragging = false;
+        const dy = Math.max(0, lastY - dragY0);
+        dragY0 = -1;
+        // hand the transform back to the stylesheet in one style recalc:
+        // the 300ms transition picks up from the dragged position, so both
+        // the dismiss (on to translateY(100%)) and the spring-back (to 0)
+        // continue smoothly from under the finger
+        panel0.style.transition = '';
+        panel0.style.transform = '';
+        // deep pull OR a real flick (velocity alone can't dismiss a jiggle)
+        if (dy > 110 || (dy > 30 && dragV > 0.55)) closeSheet();
+      };
+      panel0.addEventListener('touchend', endDrag, { passive: true });
+      panel0.addEventListener('touchcancel', endDrag, { passive: true });
     }
     const panel = sheet.querySelector('.sheet-panel');
     panel.innerHTML = '';

--- a/js/dusk-rail.js
+++ b/js/dusk-rail.js
@@ -1,8 +1,12 @@
 // dusk-rail.js — the mobile COZY/DENSE view system (dusk pages only).
 //
-// COZY  = the production vertical list until an event is selected, then a
-//         horizontal swipe rail whose card expansion is scroll-linked.
-// DENSE = a fixed-screen trifold: week grid / 246px card rail / map.
+// COZY  = today's production behavior: the vertical list, selecting a card
+//         hides the rest — with the full description always expanded.
+// DENSE = a fixed-screen trifold: week grid / 246px card rail with corner
+//         flyer thumbs (tap -> lightbox) + bottom sheet / map. Swiping the
+//         rail drives the site's real selection live.
+// Month view (both modes): the grid alone; tapping an event pill opens the
+// bottom sheet for it in place — no navigation.
 //
 // Contract with the rest of the site (no MutationObservers, no retry timers):
 //   'chunky:events-rendered'   the loader finished swapping grid+list DOM
@@ -11,13 +15,11 @@
 //
 // Owner laws baked in:
 //   - the map CAMERA never moves programmatically (marker highlight only)
-//   - geometry NEVER keys off .selected — a mid-flight re-render's stale
-//     .selected must not be able to move or resize anything
+//   - nothing here keys off .selected — a mid-flight re-render's stale
+//     .selected must not be able to move anything
 //   - no programmatic rail scrolling during a user gesture or within 600ms
 //     after it; programmatic centering only on init, a trusted tap's grant,
 //     or restoring the landed card after a re-render
-//   - transitions exist ONLY under .rail-settling; the per-frame writer and
-//     CSS transitions are mutually exclusive by state machine, not by luck
 (function () {
   'use strict';
   const html = document.documentElement;
@@ -31,12 +33,12 @@
   const resizeMap = () => { try { window.eventsMap && window.eventsMap.resize(); } catch (e) {} };
   const cssEscape = (s) => (window.CSS && CSS.escape) ? CSS.escape(s) : String(s).replace(/["\\]/g, '\\$&');
 
-  // ---------- field debug (?swipelog=1 / ?bandlog=1): on-screen stamps ----------
+  // ---------- field debug (?swipelog=1): on-screen stamps ----------
   const swipelog = params.get('swipelog') === '1';
-  const bandlog = params.get('bandlog') === '1';
   const dbg = [];
   let dbgBox = null;
-  const pushNote = (line) => {
+  const dbgNote = (line) => {
+    if (!swipelog) return;
     dbg.push(new Date().toISOString().slice(11, 23) + ' ' + line);
     if (dbg.length > 6) dbg.shift();
     if (!dbgBox) {
@@ -46,8 +48,6 @@
     }
     dbgBox.textContent = dbg.join('\n');
   };
-  const dbgNote = (line) => { if (swipelog) pushNote(line); };
-  const bandNote = (line) => { if (bandlog) pushNote(line); };
 
   // ---------- mode: cozy (default) | dense ----------
   const MODE_KEY = 'chunky-view-mode';
@@ -98,7 +98,7 @@
   };
   modeBtn.addEventListener('click', (e) => { e.preventDefault(); setMode(isDense() ? 'cozy' : 'dense'); });
 
-  // ---------- flyer lightbox (corner-thumb tap target) ----------
+  // ---------- flyer lightbox (corner-thumb + sheet-image tap target) ----------
   let lightbox = null;
   const openLightbox = (url) => {
     if (!url) return;
@@ -111,6 +111,13 @@
     lightbox.innerHTML = '<img alt="">';
     lightbox.querySelector('img').src = url;
     lightbox.classList.add('open');
+  };
+  const flyerUrlOf = (card) => {
+    if (!card) return null;
+    const img = card.querySelector('.event-flyer img');
+    if (img && (img.currentSrc || img.src)) return img.currentSrc || img.src;
+    const flyer = card.querySelector('.event-flyer[data-flyer-url]');
+    return flyer ? flyer.getAttribute('data-flyer-url') : null;
   };
   // the loader emits .rail-thumb empty; give it its art only on mobile so the
   // desktop's display:none thumb never triggers an image fetch
@@ -129,15 +136,12 @@
     if (!btn) return;
     e.preventDefault();
     e.stopPropagation(); // a thumb tap must not toggle the card's selection
-    const card = btn.closest('.event-card');
-    const img = card && card.querySelector('.event-flyer img');
-    const flyer = card && card.querySelector('.event-flyer[data-flyer-url]');
-    openLightbox((img && (img.currentSrc || img.src)) || (flyer && flyer.getAttribute('data-flyer-url')));
+    openLightbox(flyerUrlOf(btn.closest('.event-card')));
   }, true);
 
-  // ---------- dense description sheet (+ '…more' chip) ----------
-  // cozy shows the full description inline (the rail expansion IS the sheet);
-  // only dense clamps text and offers the bottom sheet.
+  // ---------- the bottom sheet: image + title + rows + links + description ----
+  // dense uses it for clamped descriptions ('…more' chip); month view (both
+  // modes) opens it in place of navigating to the event's week.
   let sheet = null;
   const closeSheet = () => {
     if (!sheet) return;
@@ -145,6 +149,7 @@
     setTimeout(() => sheet.classList.remove('open'), 320);
   };
   const openSheet = (card) => {
+    if (!card) return;
     if (!sheet) {
       sheet = document.createElement('div');
       sheet.className = 'rail-sheet';
@@ -156,6 +161,18 @@
     }
     const panel = sheet.querySelector('.sheet-panel');
     panel.innerHTML = '';
+    const flyerUrl = flyerUrlOf(card);
+    if (flyerUrl) {
+      const fig = document.createElement('div');
+      fig.className = 'sheet-flyer';
+      const img = document.createElement('img');
+      img.alt = '';
+      img.decoding = 'async';
+      img.src = flyerUrl;
+      img.addEventListener('click', () => openLightbox(flyerUrl));
+      fig.appendChild(img);
+      panel.appendChild(fig);
+    }
     const h = document.createElement('h3');
     h.className = 'sheet-title';
     h.textContent = ((card.querySelector('.ec-title') || {}).textContent || '').trim();
@@ -165,6 +182,15 @@
       const r = rows.cloneNode(true);
       r.classList.add('sheet-rows');
       panel.appendChild(r);
+    }
+    const links = card.querySelector('.event-links');
+    if (links) {
+      const l = links.cloneNode(true);
+      l.classList.add('sheet-links');
+      // the share button's listener doesn't clone — drop it rather than
+      // shipping a dead control; the plain anchors work as-is
+      l.querySelectorAll('.share-event-btn').forEach((b) => b.remove());
+      if (l.children.length) panel.appendChild(l);
     }
     const tea = card.querySelector('.ec-tea');
     if (tea) {
@@ -212,7 +238,7 @@
     }
   }, true);
 
-  // ---------- mobile month view: the grid alone; a pill opens its week ----------
+  // ---------- mobile month view: the grid alone; a pill opens the sheet ----
   const updateMonthFull = () => {
     const isMonth = !!document.querySelector('.calendar-day.month-day');
     html.classList.toggle('month-full', isMonth && isMobile());
@@ -222,34 +248,38 @@
     const pill = e.target.closest && e.target.closest('.calendar-grid .event-item');
     const day = !pill && e.target.closest && e.target.closest('.calendar-day.month-day');
     if (!pill && !day) return;
-    const dayEl = pill ? pill.closest('[data-date]') : day;
-    const date = dayEl && dayEl.getAttribute('data-date');
-    if (!date) return;
     e.preventDefault();
     e.stopImmediatePropagation();
     const l = loader();
-    if (!l) return;
-    const slug = pill && pill.getAttribute('data-event-slug');
-    if (slug && l.openWeekAt) l.openWeekAt(slug, date);
-    else if (l.switchToWeekView) l.switchToWeekView(date);
+    if (pill) {
+      // the sheet, in place — no navigation, no reload feel
+      const slug = pill.getAttribute('data-event-slug');
+      const card = slug && document.querySelector('.events-list .event-card[data-event-slug="' + cssEscape(slug) + '"]');
+      if (card) { openSheet(card); return; }
+      // the month list should always carry the card; if it somehow doesn't,
+      // fall back to opening the event's week rather than doing nothing
+      const dayEl = pill.closest('[data-date]');
+      const date = dayEl && dayEl.getAttribute('data-date');
+      if (l && l.openWeekAt && slug && date) l.openWeekAt(slug, date);
+      return;
+    }
+    const date = day.getAttribute('data-date');
+    if (l && l.switchToWeekView && date) l.switchToWeekView(date);
   }, true);
 
-  // ================= the rail =================
+  // ================= the DENSE rail =================
+  // fixed 246px cards, snap-x — no geometry ever animates. The swipe drives
+  // the site's real selection live (pill spotlight, marker highlight), with
+  // ONE deferred URL write per gesture.
   const USER_QUIET = 600;
-  const DENSE_MIN = 246;
-  const BAND_PAD = 16;
-  const V_LO = 0.3, V_HI = 1.2, TAU = 100; // damping: px/ms band + filter time constant
-
   let touchActive = false, lastUserTouch = -1e9, interacted = false, gestureScrolled = false;
   let railOwner = 'init', landedSlug = null, grantSlug = null;
-  let phase = 'idle'; // idle | scrub | settle
+  let phase = 'idle'; // idle | scrub
   let programmatic = false;
   let geom = [], step = 0, railWidth = 0;
-  let committedH = 0, lastBandT = -1;
-  let vSmooth = 0, lastFrameSL = -1, lastFrameT = 0;
   let urlDirty = false;
   let frameRaf = 0, holdTimer = 0, holdSlug = null;
-  let settleRaf = 0, settleTimer = 0, stillFrames = 0, lastLeft = -1;
+  let settleRaf = 0, stillFrames = 0, lastLeft = -1;
 
   const userBusy = () => touchActive || (performance.now() - lastUserTouch) < USER_QUIET;
   const cards = () => { const el = list(); return el ? Array.from(el.querySelectorAll('.event-card')) : []; };
@@ -268,67 +298,21 @@
     });
     return best;
   };
-  const bandBox = () => { const el = list(); return el ? (el.closest('.container') || el.parentElement) : null; };
-  const mapSection = () => document.querySelector('.events-map-section');
   const railActive = () => { const el = list(); return !!el && el.classList.contains('rail-active'); };
-  const cozyRail = () => isMobile() && !isDense() && railActive();
 
-  const lineHeightOf = (el) => {
-    const cs = getComputedStyle(el);
-    const lh = parseFloat(cs.lineHeight);
-    return Number.isFinite(lh) ? lh : Math.round(parseFloat(cs.fontSize) * 1.4);
-  };
-
-  // ---------- geometry: measured, never left mutated across a paint ----------
-  // buildGeom unlocks every card, reads its expanded metrics, re-locks to the
-  // dense state and reads that — ALL in one synchronous task. Layout is
-  // forced twice but paint cannot happen between synchronous DOM writes, so
-  // nothing ever flashes. Callers MUST follow with commitFrame()/railFrame()
-  // in the same task to write the live values back.
   const buildGeom = () => {
     geom = [];
     const el = list();
     if (!el || !el.classList.contains('rail-active')) return;
     railWidth = el.clientWidth;
-    const cs = cards();
-    if (!cs.length) return;
-    const expanding = !isDense();
-    geom = cs.map((card) => ({
+    geom = cards().map((card) => ({
       el: card,
       slug: card.getAttribute('data-event-slug') || '',
-      tea: expanding ? card.querySelector('.ec-tea') : null,
-      flyer: expanding ? card.querySelector('.event-flyer') : null,
-      thumb: card.querySelector('.rail-thumb'),
-      center: 0, teaClamp: 0, teaFull: 0, flyerFull: 0,
-      denseH: 0, growth: 0, expandedH: 0,
-      lastE: -1, lastTea: -1, lastFly: -1, lastOp: -1, lastThumbOp: -1
+      center: card.offsetLeft + card.offsetWidth / 2
     }));
-    if (expanding) {
-      geom.forEach((g) => {
-        if (g.tea) g.tea.style.maxHeight = 'none';
-        if (g.flyer) g.flyer.style.maxHeight = 'none';
-      });
-      geom.forEach((g) => {
-        if (g.tea) {
-          g.teaFull = g.tea.offsetHeight;
-          g.teaClamp = Math.min(g.teaFull, Math.round(2 * lineHeightOf(g.tea)));
-        }
-        g.flyerFull = g.flyer ? g.flyer.offsetHeight : 0;
-        g.expandedH = g.el.offsetHeight;
-      });
-      geom.forEach((g) => {
-        if (g.tea) g.tea.style.maxHeight = g.teaClamp + 'px';
-        if (g.flyer) g.flyer.style.maxHeight = '0px';
-      });
-    }
-    geom.forEach((g) => {
-      g.denseH = g.el.offsetHeight;
-      g.center = g.el.offsetLeft + g.el.offsetWidth / 2;
-      g.growth = expanding ? Math.max(0, g.expandedH - g.denseH) : 0;
-    });
     step = geom.length > 1
       ? Math.max(1, geom[1].center - geom[0].center)
-      : Math.max(1, geom[0].el.offsetWidth || railWidth);
+      : Math.max(1, (geom[0] && geom[0].el.offsetWidth) || railWidth);
   };
   const geomStale = () => geom.length > 0 && !geom[0].el.isConnected;
   const nearestGeom = (sl) => {
@@ -341,147 +325,39 @@
     return best;
   };
 
-  // one card's interpolated state at expansion e (0 dense .. 1 open),
-  // 1px write granularity, skip-unchanged
-  const applyE = (g, e) => {
-    e = e < 0 ? 0 : e > 1 ? 1 : e;
-    if (g.tea) {
-      const teaPx = Math.round(g.teaClamp + e * (g.teaFull - g.teaClamp));
-      if (teaPx !== g.lastTea) { g.tea.style.maxHeight = teaPx + 'px'; g.lastTea = teaPx; }
-    }
-    if (g.flyer) {
-      const flyPx = Math.round(e * g.flyerFull);
-      if (flyPx !== g.lastFly) { g.flyer.style.maxHeight = flyPx + 'px'; g.lastFly = flyPx; }
-      const op = Math.round(e * 100) / 100;
-      if (op !== g.lastOp) { g.flyer.style.opacity = String(op); g.lastOp = op; }
-    }
-    if (g.thumb) {
-      const to = Math.round((1 - e) * 100) / 100;
-      if (to !== g.lastThumbOp) { g.thumb.style.opacity = String(to); g.lastThumbOp = to; }
-    }
-    g.lastE = e;
+  // ---------- live selection during the scrub ----------
+  const realSelect = (slug) => {
+    const l = loader();
+    if (!l || !slug || l.selectedEventSlug === slug) return;
+    const pill = document.querySelector('.calendar-grid .event-item[data-event-slug="' + cssEscape(slug) + '"]');
+    const dayEl = pill && pill.closest('[data-date]');
+    const dateISO = dayEl ? dayEl.getAttribute('data-date') : null;
+    try { l.toggleEventSelection(slug, dateISO, { deferUrl: true }); } catch (e) {}
+    urlDirty = true;
+    landedSlug = slug;
   };
-
-  const clearBand = () => {
-    const box = bandBox();
-    if (box) box.style.height = '';
-    const m = mapSection();
-    if (m) m.style.transform = '';
-    committedH = 0; lastBandT = -1; vSmooth = 0; lastFrameSL = -1;
-  };
-  const clearWrites = () => {
-    document.querySelectorAll('.events-list .ec-tea').forEach((t) => { if (t.style.maxHeight) t.style.maxHeight = ''; });
-    document.querySelectorAll('.events-list .event-flyer').forEach((f) => { f.style.maxHeight = ''; f.style.opacity = ''; });
-    document.querySelectorAll('.events-list .rail-thumb').forEach((t) => { if (t.style.opacity) t.style.opacity = ''; });
-  };
-
-  const smoothstep = (a, b, x) => {
-    const t = Math.max(0, Math.min(1, (x - a) / (b - a)));
-    return t * t * (3 - 2 * t);
-  };
-
-  // ---------- the per-frame writer (cozy rail scrub only) ----------
-  // p is a pure function of scroll position with support = the measured
-  // center-to-center step, so adjacent cards' p sum to exactly 1 and the
-  // band interpolates flat/linear between them instead of pumping.
-  const railFrame = () => {
-    if (!cozyRail() || !geom.length) return;
-    const el = list();
-    const sl = el.scrollLeft;
-    const now = performance.now();
-    if (lastFrameSL >= 0) {
-      const dt = Math.max(4, Math.min(64, now - lastFrameT));
-      const v = Math.min(5, Math.abs(sl - lastFrameSL) / dt);
-      // dt-aware one-pole low-pass; NOTHING ever resets this estimator —
-      // a reset mid-gesture is exactly what made damp whipsaw before
-      vSmooth += (v - vSmooth) * (1 - Math.exp(-dt / TAU));
-    }
-    lastFrameSL = sl; lastFrameT = now;
-    const damp = 1 - smoothstep(V_LO, V_HI, vSmooth);
-    const mid = sl + railWidth / 2;
-    let denseBlend = 0, growthSum = 0, wSum = 0;
-    for (let i = 0; i < geom.length; i++) {
-      const g = geom[i];
-      const d = Math.abs(g.center - mid);
-      if (d >= step) { applyE(g, 0); continue; }
-      const p = 1 - d / step;
-      applyE(g, p * damp);
-      denseBlend += p * g.denseH;
-      growthSum += p * damp * g.growth;
-      wSum += p;
-    }
-    const box = bandBox();
-    if (!box) return;
-    const t = wSum > 0
-      ? Math.round(Math.max(DENSE_MIN, denseBlend / wSum + growthSum)) + BAND_PAD
-      : committedH || (DENSE_MIN + BAND_PAD);
-    // gesture frames: the band's LAYOUT height stays frozen (zero relayout
-    // below the rail); the map rides a compositor transform by the delta
-    if (!committedH) {
-      committedH = Math.round(parseFloat(box.style.height)) || t;
-      if (!box.style.height) box.style.height = committedH + 'px';
-    }
-    if (t !== lastBandT) {
-      lastBandT = t;
-      const m = mapSection();
-      if (m) {
-        const shift = t - committedH;
-        m.style.transform = shift ? ('translateY(' + shift + 'px)') : '';
-      }
-      bandNote('band ' + t + ' damp ' + damp.toFixed(2));
+  const flushUrl = () => {
+    const l = loader();
+    if (l && urlDirty) {
+      urlDirty = false;
+      try { l.syncUrl(true); } catch (e) {}
     }
   };
 
-  // ---------- commit: the resting frame (centered card open, others dense) ----------
-  const commitFrame = () => {
-    const el = list();
-    if (!el || !geom.length) return null;
-    const best = nearestGeom(el.scrollLeft);
-    if (!isDense()) {
-      // dense never writes card geometry (fixed 246px boxes, thumbs always
-      // on) — the resting frame is a cozy concept
-      geom.forEach((g) => applyE(g, g === best ? 1 : 0));
-      const t = (best ? Math.max(DENSE_MIN, best.denseH + best.growth) : DENSE_MIN) + BAND_PAD;
-      const box = bandBox();
-      if (box) box.style.height = t + 'px';
-      const m = mapSection();
-      if (m) m.style.transform = '';
-      committedH = t; lastBandT = t;
-      bandNote('commit ' + t);
-    }
-    return best;
-  };
-
-  // ---------- settle: writer OFF first, then one transitioned write ----------
   const settle = (fromUser) => {
-    const el = list();
-    if (!el) return;
     clearTimeout(holdTimer);
-    let bestEl = null;
-    if (cozyRail() && geom.length) {
-      phase = 'settle';
-      el.classList.add('rail-settling'); // enables the ONLY transitions in the system
-      const best = commitFrame();
-      bestEl = best && best.el;
-      clearTimeout(settleTimer);
-      settleTimer = setTimeout(() => {
-        el.classList.remove('rail-settling');
-        if (phase === 'settle') phase = 'idle';
-      }, 200);
-    } else {
-      phase = 'idle';
-      bestEl = centeredCard();
-    }
-    if (fromUser && bestEl) {
-      railOwner = 'user';
-      landedSlug = bestEl.getAttribute('data-event-slug') || landedSlug;
-      dbgNote('landed ' + (landedSlug || '?').slice(0, 16));
-      realSelect(landedSlug);
+    phase = 'idle';
+    if (fromUser) {
+      const c = centeredCard();
+      if (c) {
+        railOwner = 'user';
+        landedSlug = c.getAttribute('data-event-slug') || landedSlug;
+        dbgNote('landed ' + (landedSlug || '?').slice(0, 16));
+        realSelect(landedSlug);
+      }
     }
     flushUrl();
-    predecodeNear(bestEl || centeredCard());
   };
-
   const armSettleWatch = () => {
     if (settleRaf) return;
     stillFrames = 0; lastLeft = -1;
@@ -509,32 +385,10 @@
     finishGesture();
   }, true);
 
-  // ---------- live selection during the scrub ----------
-  // drives the SITE'S real selection (pill spotlight, marker highlight) with
-  // the URL write deferred to one flush per gesture
-  const realSelect = (slug) => {
-    const l = loader();
-    if (!l || !slug || l.selectedEventSlug === slug) return;
-    const pill = document.querySelector('.calendar-grid .event-item[data-event-slug="' + cssEscape(slug) + '"]');
-    const dayEl = pill && pill.closest('[data-date]');
-    const dateISO = dayEl ? dayEl.getAttribute('data-date') : null;
-    try { l.toggleEventSelection(slug, dateISO, { deferUrl: true }); } catch (e) {}
-    urlDirty = true;
-    landedSlug = slug;
-  };
-  const flushUrl = () => {
-    const l = loader();
-    if (l && urlDirty) {
-      urlDirty = false;
-      try { l.syncUrl(true); } catch (e) {}
-    }
-  };
-
   const onScrubFrame = () => {
     frameRaf = 0;
     if (phase !== 'scrub' || !railActive()) return;
-    if (geomStale()) buildGeom();
-    railFrame();
+    if (geomStale() || !geom.length) buildGeom();
     const el = list();
     const g = el && nearestGeom(el.scrollLeft);
     if (g && g.slug && g.slug !== holdSlug) {
@@ -543,21 +397,11 @@
       holdTimer = setTimeout(() => { if (phase === 'scrub') realSelect(g.slug); }, 120);
     }
   };
-
   document.addEventListener('scroll', (e) => {
     if (!isMobile()) return;
     const t = e.target;
     if (!t || !t.classList || !t.classList.contains('events-list') || !t.classList.contains('rail-active')) return;
-    if (phase === 'settle') return; // transition tail; new input restarts scrub
-    if (phase === 'idle' && !programmatic) {
-      // wheel/trackpad gestures have no touchstart — do its cleanup here:
-      // the writer must never run while settle transitions are enabled
-      phase = 'scrub';
-      clearTimeout(settleTimer);
-      t.classList.remove('rail-settling');
-      lastFrameSL = t.scrollLeft;
-      lastFrameT = performance.now();
-    }
+    if (phase === 'idle' && !programmatic) phase = 'scrub'; // wheel/trackpad gestures have no touchstart
     if (phase === 'scrub') {
       gestureScrolled = true;
       if (!frameRaf) frameRaf = requestAnimationFrame(onScrubFrame);
@@ -575,16 +419,7 @@
     railOwner = 'user';
     grantSlug = null; // a new gesture invalidates any pending grant
     lastUserTouch = performance.now();
-    const el = list();
-    if (el && el.classList.contains('rail-active')) {
-      // a new gesture cancels any settle in flight — transitions off NOW,
-      // synchronously, before the finger moves a single pixel
-      clearTimeout(settleTimer);
-      el.classList.remove('rail-settling');
-      phase = 'scrub';
-      lastFrameSL = el.scrollLeft;
-      lastFrameT = performance.now();
-    }
+    if (railActive()) phase = 'scrub';
   };
   const offTouch = () => {
     if (!touchActive) return;
@@ -635,10 +470,10 @@
     return true;
   };
 
-  // ---------- rail structure: synchronous, single-frame switches ----------
+  // ---------- rail structure ----------
   let denseMapH = -1;
   const sizeDenseMap = () => {
-    const sec = mapSection();
+    const sec = document.querySelector('.events-map-section');
     if (!sec) return;
     if (!isMobile() || !isDense() || html.classList.contains('month-full')) {
       if (sec.style.height) { sec.style.height = ''; sec.style.flex = ''; resizeMap(); }
@@ -657,110 +492,48 @@
 
   const selectedSlug = () => { const l = loader(); return (l && l.selectedEventSlug) || null; };
 
-  const enterRail = (targetSlug) => {
+  const centerRestingCard = (instant) => {
     const el = list();
     if (!el) return;
-    el.classList.add('rail-active');
-    armThumbs();
-    buildGeom();
-    const target = cardBySlug(targetSlug) || cardBySlug(landedSlug) || cards()[0];
-    if (target) {
-      landedSlug = target.getAttribute('data-event-slug') || landedSlug;
-      if (grantSlug === landedSlug) grantSlug = null;
-      const t = Math.round(target.offsetLeft + target.offsetWidth / 2 - el.clientWidth / 2);
-      if (Math.abs(el.scrollLeft - t) >= 1) { programmatic = true; el.scrollLeft = t; }
-    }
-    if (!isDense() && geom.length) {
-      // cozy entry is a BLOOM, not a snap: the first paint shows the rail in
-      // its dense frame (buildGeom already locked every card to e=0 — just
-      // add the thumb opacities and the dense band), then the tapped card
-      // eases open under .rail-settling. Double-rAF so the dense keyframe
-      // actually paints before the transition starts.
-      geom.forEach((g) => applyE(g, 0));
-      const b = nearestGeom(el.scrollLeft);
-      const box = bandBox();
-      if (box && b) {
-        committedH = Math.round(b.denseH) + BAND_PAD;
-        lastBandT = committedH;
-        box.style.height = committedH + 'px';
-      }
-      requestAnimationFrame(() => requestAnimationFrame(() => {
-        if (!cozyRail() || phase !== 'idle' || touchActive) return;
-        el.classList.add('rail-settling');
-        commitFrame();
-        clearTimeout(settleTimer);
-        settleTimer = setTimeout(() => {
-          el.classList.remove('rail-settling');
-          if (phase === 'settle') phase = 'idle';
-        }, 200);
-      }));
-    } else {
-      commitFrame(); // dense: same task as the class flip — ONE paint
-    }
-    resizeMap();
-    dbgNote('rail ON');
-  };
-  const exitRail = () => {
-    const el = list();
-    if (!el) return;
-    clearTimeout(settleTimer);
-    el.classList.remove('rail-active', 'rail-settling');
-    phase = 'idle';
-    clearBand();
-    clearWrites();
-    const back = cardBySlug(landedSlug);
-    geom = [];
-    if (back) { try { back.scrollIntoView({ block: 'nearest' }); } catch (e) {} }
-    resizeMap();
-    dbgNote('rail OFF');
-  };
-
-  // rebuild + restore after a loader re-render while railed (fresh DOM means
-  // all inline writes and geometry are gone; landedSlug is the anchor)
-  const restoreRail = () => {
-    const el = list();
-    if (!el) return;
-    armThumbs();
-    buildGeom();
-    const back = cardBySlug(landedSlug) || cardBySlug(selectedSlug()) || cards()[0];
-    if (back) {
-      const t = Math.round(back.offsetLeft + back.offsetWidth / 2 - el.clientWidth / 2);
-      if (Math.abs(el.scrollLeft - t) >= 1) { programmatic = true; el.scrollLeft = t; }
-    }
-    commitFrame();
+    const target = cardBySlug(landedSlug) || cardBySlug(selectedSlug()) || cards()[0];
+    if (!target) return;
+    landedSlug = target.getAttribute('data-event-slug') || landedSlug;
+    if (grantSlug === landedSlug) grantSlug = null;
+    const t = Math.round(target.offsetLeft + target.offsetWidth / 2 - el.clientWidth / 2);
+    if (Math.abs(el.scrollLeft - t) >= 1 && instant) { programmatic = true; el.scrollLeft = t; }
   };
 
   const syncRailState = (reason) => {
     const el = list();
     if (!el) return;
     if (!isMobile()) {
-      if (el.classList.contains('rail-active')) {
-        el.classList.remove('rail-active', 'rail-settling');
-        phase = 'idle';
-        clearBand();
-        clearWrites();
-        geom = [];
-      }
+      if (el.classList.contains('rail-active')) { el.classList.remove('rail-active'); phase = 'idle'; geom = []; }
       updateMonthFull();
       return;
     }
     updateMonthFull();
     sizeDenseMap();
-    const want = !html.classList.contains('month-full') && (isDense() || !!selectedSlug());
+    const want = isDense() && !html.classList.contains('month-full');
     const has = el.classList.contains('rail-active');
-    if (want && !has) enterRail(selectedSlug());
-    else if (!want && has) exitRail();
-    else if (want && has) {
-      if (reason === 'render' || geomStale()) restoreRail();
-      else if (reason === 'mode-switch') {
-        // the outgoing mode's inline writes (cozy band height, flyer/tea
-        // max-heights) must not leak into the incoming one
-        clearBand();
-        clearWrites();
+    if (want && !has) {
+      el.classList.add('rail-active');
+      armThumbs();
+      buildGeom();
+      centerRestingCard(true);
+      resizeMap();
+      dbgNote('rail ON');
+    } else if (!want && has) {
+      el.classList.remove('rail-active');
+      phase = 'idle';
+      geom = [];
+      resizeMap();
+      dbgNote('rail OFF');
+    } else if (want && has) {
+      if (reason === 'render' || reason === 'resize' || geomStale()) {
+        armThumbs();
         buildGeom();
-        commitFrame();
-      }
-      else if (grantSlug) {
+        centerRestingCard(reason === 'render');
+      } else if (grantSlug) {
         const g = cardBySlug(grantSlug);
         if (g) centerOn(g, reason);
       } else if (reason === 'selection' && phase === 'idle' && !userBusy()) {
@@ -777,81 +550,15 @@
     }
   };
 
-  // ---------- image loads: per-card re-measure, never a whole-rail reset ----------
-  const remeasureCard = (card) => {
-    if (!cozyRail()) return;
-    const g = geom.find((x) => x.el === card);
-    if (!g || !g.flyer) return;
-    if (g.tea) g.tea.style.maxHeight = 'none';
-    g.flyer.style.maxHeight = 'none';
-    g.flyerFull = g.flyer.offsetHeight;
-    if (g.tea) {
-      g.teaFull = g.tea.offsetHeight;
-      g.teaClamp = Math.min(g.teaFull, Math.round(2 * lineHeightOf(g.tea)));
-    }
-    const expandedH = g.el.offsetHeight;
-    if (g.tea) g.tea.style.maxHeight = g.teaClamp + 'px';
-    g.flyer.style.maxHeight = '0px';
-    g.denseH = g.el.offsetHeight;
-    g.growth = Math.max(0, expandedH - g.denseH);
-    g.lastE = -1; g.lastTea = -1; g.lastFly = -1; g.lastOp = -1; g.lastThumbOp = -1;
-    const el = list();
-    if (phase === 'scrub') {
-      railFrame(); // the writer's next pass would fix it anyway; do it now
-    } else if (nearestGeom(el.scrollLeft) === g) {
-      // the centered, settled card just got its art — grow it smoothly
-      el.classList.add('rail-settling');
-      commitFrame();
-      clearTimeout(settleTimer);
-      settleTimer = setTimeout(() => {
-        el.classList.remove('rail-settling');
-        // this timer can replace settle()'s own — carry its phase reset or
-        // an image landing in the settle tail wedges phase at 'settle'
-        if (phase === 'settle') phase = 'idle';
-      }, 200);
-    } else {
-      applyE(g, 0);
-      commitFrame();
-    }
-  };
-  const onImgEvent = (e) => {
-    const img = e.target;
-    if (!img || img.tagName !== 'IMG' || !img.closest) return;
-    const flyer = img.closest('.events-list .event-flyer');
-    if (!flyer) return;
-    const card = flyer.closest('.event-card');
-    if (card) remeasureCard(card);
-  };
-  document.addEventListener('load', onImgEvent, true);
-  document.addEventListener('error', onImgEvent, true);
-
-  const predecodeNear = (centerCard) => {
-    if (!centerCard || !isMobile() || !railActive()) return;
-    const cs = cards();
-    const i = cs.indexOf(centerCard);
-    if (i < 0) return;
-    for (let k = Math.max(0, i - 2); k <= Math.min(cs.length - 1, i + 2); k++) {
-      const img = cs[k].querySelector('.event-flyer img');
-      if (!img) continue;
-      if (img.loading === 'lazy') img.loading = 'eager';
-      if (img.decode) img.decode().catch(() => {});
-    }
-  };
-
   // ---------- the two loader events + environment changes ----------
   document.addEventListener('chunky:selection-changed', () => syncRailState('selection'));
   document.addEventListener('chunky:events-rendered', () => {
     armThumbs();
     markOverflows();
     syncRailState('render');
-    predecodeNear(centeredCard());
   });
   window.addEventListener('resize', () => {
     denseMapH = -1;
-    if (railActive() && isMobile()) {
-      buildGeom();
-      if (!isDense()) commitFrame();
-    }
     markOverflows();
     syncRailState('resize');
   });
@@ -876,13 +583,8 @@
     openSheet,
     state: () => ({
       mode, phase, railOwner, landedSlug, grantSlug, touchActive,
-      programmatic, interacted, committedH, vSmooth: Math.round(vSmooth * 100) / 100,
-      railActive: railActive()
+      programmatic, interacted, railActive: railActive()
     }),
-    geom: () => geom.map((g) => ({
-      slug: g.slug.slice(0, 14), denseH: g.denseH, growth: g.growth,
-      flyerFull: g.flyerFull, lastE: g.lastE
-    })),
-    settle: () => settle(false)
+    geom: () => geom.map((g) => ({ slug: g.slug.slice(0, 14), center: g.center }))
   };
 })();

--- a/js/dusk-rail.js
+++ b/js/dusk-rail.js
@@ -549,7 +549,15 @@
     const t = e.target;
     if (!t || !t.classList || !t.classList.contains('events-list') || !t.classList.contains('rail-active')) return;
     if (phase === 'settle') return; // transition tail; new input restarts scrub
-    if (phase === 'idle' && !programmatic) phase = 'scrub'; // wheel/trackpad gestures have no touchstart
+    if (phase === 'idle' && !programmatic) {
+      // wheel/trackpad gestures have no touchstart — do its cleanup here:
+      // the writer must never run while settle transitions are enabled
+      phase = 'scrub';
+      clearTimeout(settleTimer);
+      t.classList.remove('rail-settling');
+      lastFrameSL = t.scrollLeft;
+      lastFrameT = performance.now();
+    }
     if (phase === 'scrub') {
       gestureScrolled = true;
       if (!frameRaf) frameRaf = requestAnimationFrame(onScrubFrame);
@@ -662,7 +670,33 @@
       const t = Math.round(target.offsetLeft + target.offsetWidth / 2 - el.clientWidth / 2);
       if (Math.abs(el.scrollLeft - t) >= 1) { programmatic = true; el.scrollLeft = t; }
     }
-    commitFrame(); // same task as the class flip — ONE paint: list -> open rail
+    if (!isDense() && geom.length) {
+      // cozy entry is a BLOOM, not a snap: the first paint shows the rail in
+      // its dense frame (buildGeom already locked every card to e=0 — just
+      // add the thumb opacities and the dense band), then the tapped card
+      // eases open under .rail-settling. Double-rAF so the dense keyframe
+      // actually paints before the transition starts.
+      geom.forEach((g) => applyE(g, 0));
+      const b = nearestGeom(el.scrollLeft);
+      const box = bandBox();
+      if (box && b) {
+        committedH = Math.round(b.denseH) + BAND_PAD;
+        lastBandT = committedH;
+        box.style.height = committedH + 'px';
+      }
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        if (!cozyRail() || phase !== 'idle' || touchActive) return;
+        el.classList.add('rail-settling');
+        commitFrame();
+        clearTimeout(settleTimer);
+        settleTimer = setTimeout(() => {
+          el.classList.remove('rail-settling');
+          if (phase === 'settle') phase = 'idle';
+        }, 200);
+      }));
+    } else {
+      commitFrame(); // dense: same task as the class flip — ONE paint
+    }
     resizeMap();
     dbgNote('rail ON');
   };

--- a/js/dusk-rail.js
+++ b/js/dusk-rail.js
@@ -1,0 +1,834 @@
+// dusk-rail.js — the mobile COZY/DENSE view system (dusk pages only).
+//
+// COZY  = the production vertical list until an event is selected, then a
+//         horizontal swipe rail whose card expansion is scroll-linked.
+// DENSE = a fixed-screen trifold: week grid / 246px card rail / map.
+//
+// Contract with the rest of the site (no MutationObservers, no retry timers):
+//   'chunky:events-rendered'   the loader finished swapping grid+list DOM
+//   'chunky:selection-changed' the loader painted a selection change
+//   'dusk:controls-mounted'    dusk-ui (re)assembled the header controls row
+//
+// Owner laws baked in:
+//   - the map CAMERA never moves programmatically (marker highlight only)
+//   - geometry NEVER keys off .selected — a mid-flight re-render's stale
+//     .selected must not be able to move or resize anything
+//   - no programmatic rail scrolling during a user gesture or within 600ms
+//     after it; programmatic centering only on init, a trusted tap's grant,
+//     or restoring the landed card after a re-render
+//   - transitions exist ONLY under .rail-settling; the per-frame writer and
+//     CSS transitions are mutually exclusive by state machine, not by luck
+(function () {
+  'use strict';
+  const html = document.documentElement;
+  if (!html.classList.contains('dusk')) return;
+
+  const params = new URLSearchParams(location.search);
+  const mmMobile = window.matchMedia('(max-width: 768.9px)');
+  const isMobile = () => mmMobile.matches;
+  const loader = () => window.calendarLoader;
+  const list = () => document.querySelector('.events-list');
+  const resizeMap = () => { try { window.eventsMap && window.eventsMap.resize(); } catch (e) {} };
+  const cssEscape = (s) => (window.CSS && CSS.escape) ? CSS.escape(s) : String(s).replace(/["\\]/g, '\\$&');
+
+  // ---------- field debug (?swipelog=1 / ?bandlog=1): on-screen stamps ----------
+  const swipelog = params.get('swipelog') === '1';
+  const bandlog = params.get('bandlog') === '1';
+  const dbg = [];
+  let dbgBox = null;
+  const pushNote = (line) => {
+    dbg.push(new Date().toISOString().slice(11, 23) + ' ' + line);
+    if (dbg.length > 6) dbg.shift();
+    if (!dbgBox) {
+      dbgBox = document.createElement('div');
+      dbgBox.style.cssText = 'position:fixed;left:6px;bottom:6px;z-index:10030;background:rgba(0,0,0,.82);color:#8f8;font:9px/1.4 monospace;padding:6px 8px;border-radius:8px;max-width:88vw;pointer-events:none;white-space:pre;';
+      document.body.appendChild(dbgBox);
+    }
+    dbgBox.textContent = dbg.join('\n');
+  };
+  const dbgNote = (line) => { if (swipelog) pushNote(line); };
+  const bandNote = (line) => { if (bandlog) pushNote(line); };
+
+  // ---------- mode: cozy (default) | dense ----------
+  const MODE_KEY = 'chunky-view-mode';
+  let mode = params.get('mode');
+  if (mode !== 'cozy' && mode !== 'dense') {
+    try { mode = localStorage.getItem(MODE_KEY); } catch (e) { mode = null; }
+  }
+  if (mode !== 'dense') mode = 'cozy';
+  const isDense = () => mode === 'dense';
+  const applyModeClass = () => {
+    html.classList.remove('mode-cozy', 'mode-dense');
+    html.classList.add('mode-' + mode);
+  };
+  applyModeClass();
+  if (params.get('mode') === mode) {
+    try { localStorage.setItem(MODE_KEY, mode); } catch (e) {}
+  }
+
+  const modeBtn = document.createElement('button');
+  modeBtn.type = 'button';
+  modeBtn.className = 'mode-toggle';
+  modeBtn.setAttribute('aria-label', 'Switch view density');
+  const paintModeLabel = () => { modeBtn.textContent = isDense() ? 'DENSE' : 'COZY'; };
+  const mountToggle = () => {
+    const switcher = document.querySelector('header .city-switcher');
+    if (!switcher) return;
+    if (modeBtn.parentElement !== switcher.parentElement || modeBtn.nextElementSibling !== switcher) {
+      switcher.parentElement.insertBefore(modeBtn, switcher);
+    }
+    paintModeLabel();
+  };
+  document.addEventListener('dusk:controls-mounted', mountToggle);
+  const setMode = (m) => {
+    if ((m !== 'cozy' && m !== 'dense') || m === mode) return;
+    mode = m;
+    try { localStorage.setItem(MODE_KEY, m); } catch (e) {}
+    try {
+      const u = new URL(location.href);
+      u.searchParams.set('mode', m);
+      history.replaceState(history.state, '', u);
+    } catch (e) {}
+    applyModeClass();
+    paintModeLabel();
+    denseMapH = -1;
+    if (isDense()) markOverflows();
+    syncRailState('mode-switch');
+    dbgNote('mode -> ' + m);
+  };
+  modeBtn.addEventListener('click', (e) => { e.preventDefault(); setMode(isDense() ? 'cozy' : 'dense'); });
+
+  // ---------- flyer lightbox (corner-thumb tap target) ----------
+  let lightbox = null;
+  const openLightbox = (url) => {
+    if (!url) return;
+    if (!lightbox) {
+      lightbox = document.createElement('div');
+      lightbox.className = 'rail-lightbox';
+      lightbox.addEventListener('click', () => lightbox.classList.remove('open'));
+      document.body.appendChild(lightbox);
+    }
+    lightbox.innerHTML = '<img alt="">';
+    lightbox.querySelector('img').src = url;
+    lightbox.classList.add('open');
+  };
+  // the loader emits .rail-thumb empty; give it its art only on mobile so the
+  // desktop's display:none thumb never triggers an image fetch
+  const armThumbs = () => {
+    if (!isMobile()) return;
+    document.querySelectorAll('.events-list .event-card .rail-thumb').forEach((btn) => {
+      if (btn.style.backgroundImage) return;
+      const card = btn.closest('.event-card');
+      const flyer = card && card.querySelector('.event-flyer[data-flyer-url]');
+      const url = flyer && flyer.getAttribute('data-flyer-url');
+      if (url) btn.style.backgroundImage = 'url("' + url.replace(/"/g, '%22') + '")';
+    });
+  };
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest && e.target.closest('.rail-thumb');
+    if (!btn) return;
+    e.preventDefault();
+    e.stopPropagation(); // a thumb tap must not toggle the card's selection
+    const card = btn.closest('.event-card');
+    const img = card && card.querySelector('.event-flyer img');
+    const flyer = card && card.querySelector('.event-flyer[data-flyer-url]');
+    openLightbox((img && (img.currentSrc || img.src)) || (flyer && flyer.getAttribute('data-flyer-url')));
+  }, true);
+
+  // ---------- dense description sheet (+ '…more' chip) ----------
+  // cozy shows the full description inline (the rail expansion IS the sheet);
+  // only dense clamps text and offers the bottom sheet.
+  let sheet = null;
+  const closeSheet = () => {
+    if (!sheet) return;
+    sheet.classList.remove('up');
+    setTimeout(() => sheet.classList.remove('open'), 320);
+  };
+  const openSheet = (card) => {
+    if (!sheet) {
+      sheet = document.createElement('div');
+      sheet.className = 'rail-sheet';
+      sheet.innerHTML = '<div class="sheet-panel"></div>';
+      sheet.addEventListener('click', (e) => {
+        if (!(e.target.closest && e.target.closest('.sheet-panel'))) closeSheet();
+      });
+      document.body.appendChild(sheet);
+    }
+    const panel = sheet.querySelector('.sheet-panel');
+    panel.innerHTML = '';
+    const h = document.createElement('h3');
+    h.className = 'sheet-title';
+    h.textContent = ((card.querySelector('.ec-title') || {}).textContent || '').trim();
+    panel.appendChild(h);
+    const rows = card.querySelector('.ec-rows');
+    if (rows) {
+      const r = rows.cloneNode(true);
+      r.classList.add('sheet-rows');
+      panel.appendChild(r);
+    }
+    const tea = card.querySelector('.ec-tea');
+    if (tea) {
+      const d = document.createElement('p');
+      d.className = 'sheet-desc';
+      d.textContent = tea.textContent.trim();
+      panel.appendChild(d);
+    }
+    // carry the card's aurora custom props so the sheet paints as the card
+    const inline = card.getAttribute('style');
+    if (inline) panel.setAttribute('style', inline); else panel.removeAttribute('style');
+    sheet.classList.add('open');
+    requestAnimationFrame(() => requestAnimationFrame(() => sheet.classList.add('up')));
+  };
+  const teaOverflows = (el) => !!el && el.scrollHeight > el.clientHeight + 1;
+  const markOverflows = () => {
+    if (!isMobile() || !isDense()) return;
+    document.querySelectorAll('.events-list .event-card').forEach((card) => {
+      const tea = card.querySelector('.ec-tea');
+      if (!tea) return;
+      let chip = card.querySelector('.ec-more');
+      const over = teaOverflows(tea);
+      if (over && !chip) {
+        chip = document.createElement('button');
+        chip.type = 'button';
+        chip.className = 'ec-more';
+        chip.textContent = '\u2026more';
+        chip.setAttribute('aria-label', 'Show full description');
+        tea.insertAdjacentElement('afterend', chip);
+      }
+      if (chip) chip.style.display = over ? '' : 'none';
+    });
+  };
+  document.addEventListener('click', (e) => {
+    if (!isMobile() || !isDense()) return;
+    const chip = e.target.closest && e.target.closest('.ec-more');
+    const teaHit = !chip && e.target.closest && e.target.closest('.ec-tea');
+    if (!chip && !teaHit) return;
+    const card = (chip || teaHit).closest('.event-card');
+    if (!card) return;
+    if (chip || teaOverflows(card.querySelector('.ec-tea'))) {
+      e.preventDefault();
+      e.stopPropagation();
+      openSheet(card);
+    }
+  }, true);
+
+  // ---------- mobile month view: the grid alone; a pill opens its week ----------
+  const updateMonthFull = () => {
+    const isMonth = !!document.querySelector('.calendar-day.month-day');
+    html.classList.toggle('month-full', isMonth && isMobile());
+  };
+  document.addEventListener('click', (e) => {
+    if (!html.classList.contains('month-full') || !e.isTrusted) return;
+    const pill = e.target.closest && e.target.closest('.calendar-grid .event-item');
+    const day = !pill && e.target.closest && e.target.closest('.calendar-day.month-day');
+    if (!pill && !day) return;
+    const dayEl = pill ? pill.closest('[data-date]') : day;
+    const date = dayEl && dayEl.getAttribute('data-date');
+    if (!date) return;
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    const l = loader();
+    if (!l) return;
+    const slug = pill && pill.getAttribute('data-event-slug');
+    if (slug && l.openWeekAt) l.openWeekAt(slug, date);
+    else if (l.switchToWeekView) l.switchToWeekView(date);
+  }, true);
+
+  // ================= the rail =================
+  const USER_QUIET = 600;
+  const DENSE_MIN = 246;
+  const BAND_PAD = 16;
+  const V_LO = 0.3, V_HI = 1.2, TAU = 100; // damping: px/ms band + filter time constant
+
+  let touchActive = false, lastUserTouch = -1e9, interacted = false, gestureScrolled = false;
+  let railOwner = 'init', landedSlug = null, grantSlug = null;
+  let phase = 'idle'; // idle | scrub | settle
+  let programmatic = false;
+  let geom = [], step = 0, railWidth = 0;
+  let committedH = 0, lastBandT = -1;
+  let vSmooth = 0, lastFrameSL = -1, lastFrameT = 0;
+  let urlDirty = false;
+  let frameRaf = 0, holdTimer = 0, holdSlug = null;
+  let settleRaf = 0, settleTimer = 0, stillFrames = 0, lastLeft = -1;
+
+  const userBusy = () => touchActive || (performance.now() - lastUserTouch) < USER_QUIET;
+  const cards = () => { const el = list(); return el ? Array.from(el.querySelectorAll('.event-card')) : []; };
+  const cardBySlug = (slug) => {
+    const el = list();
+    return (slug && el) ? el.querySelector('.event-card[data-event-slug="' + cssEscape(slug) + '"]') : null;
+  };
+  const centeredCard = () => {
+    const el = list();
+    if (!el) return null;
+    const mid = el.scrollLeft + el.clientWidth / 2;
+    let best = null, bestD = Infinity;
+    cards().forEach((c) => {
+      const d = Math.abs(c.offsetLeft + c.offsetWidth / 2 - mid);
+      if (d < bestD) { bestD = d; best = c; }
+    });
+    return best;
+  };
+  const bandBox = () => { const el = list(); return el ? (el.closest('.container') || el.parentElement) : null; };
+  const mapSection = () => document.querySelector('.events-map-section');
+  const railActive = () => { const el = list(); return !!el && el.classList.contains('rail-active'); };
+  const cozyRail = () => isMobile() && !isDense() && railActive();
+
+  const lineHeightOf = (el) => {
+    const cs = getComputedStyle(el);
+    const lh = parseFloat(cs.lineHeight);
+    return Number.isFinite(lh) ? lh : Math.round(parseFloat(cs.fontSize) * 1.4);
+  };
+
+  // ---------- geometry: measured, never left mutated across a paint ----------
+  // buildGeom unlocks every card, reads its expanded metrics, re-locks to the
+  // dense state and reads that — ALL in one synchronous task. Layout is
+  // forced twice but paint cannot happen between synchronous DOM writes, so
+  // nothing ever flashes. Callers MUST follow with commitFrame()/railFrame()
+  // in the same task to write the live values back.
+  const buildGeom = () => {
+    geom = [];
+    const el = list();
+    if (!el || !el.classList.contains('rail-active')) return;
+    railWidth = el.clientWidth;
+    const cs = cards();
+    if (!cs.length) return;
+    const expanding = !isDense();
+    geom = cs.map((card) => ({
+      el: card,
+      slug: card.getAttribute('data-event-slug') || '',
+      tea: expanding ? card.querySelector('.ec-tea') : null,
+      flyer: expanding ? card.querySelector('.event-flyer') : null,
+      thumb: card.querySelector('.rail-thumb'),
+      center: 0, teaClamp: 0, teaFull: 0, flyerFull: 0,
+      denseH: 0, growth: 0, expandedH: 0,
+      lastE: -1, lastTea: -1, lastFly: -1, lastOp: -1, lastThumbOp: -1
+    }));
+    if (expanding) {
+      geom.forEach((g) => {
+        if (g.tea) g.tea.style.maxHeight = 'none';
+        if (g.flyer) g.flyer.style.maxHeight = 'none';
+      });
+      geom.forEach((g) => {
+        if (g.tea) {
+          g.teaFull = g.tea.offsetHeight;
+          g.teaClamp = Math.min(g.teaFull, Math.round(2 * lineHeightOf(g.tea)));
+        }
+        g.flyerFull = g.flyer ? g.flyer.offsetHeight : 0;
+        g.expandedH = g.el.offsetHeight;
+      });
+      geom.forEach((g) => {
+        if (g.tea) g.tea.style.maxHeight = g.teaClamp + 'px';
+        if (g.flyer) g.flyer.style.maxHeight = '0px';
+      });
+    }
+    geom.forEach((g) => {
+      g.denseH = g.el.offsetHeight;
+      g.center = g.el.offsetLeft + g.el.offsetWidth / 2;
+      g.growth = expanding ? Math.max(0, g.expandedH - g.denseH) : 0;
+    });
+    step = geom.length > 1
+      ? Math.max(1, geom[1].center - geom[0].center)
+      : Math.max(1, geom[0].el.offsetWidth || railWidth);
+  };
+  const geomStale = () => geom.length > 0 && !geom[0].el.isConnected;
+  const nearestGeom = (sl) => {
+    const mid = sl + railWidth / 2;
+    let best = null, bestD = Infinity;
+    for (let i = 0; i < geom.length; i++) {
+      const d = Math.abs(geom[i].center - mid);
+      if (d < bestD) { bestD = d; best = geom[i]; }
+    }
+    return best;
+  };
+
+  // one card's interpolated state at expansion e (0 dense .. 1 open),
+  // 1px write granularity, skip-unchanged
+  const applyE = (g, e) => {
+    e = e < 0 ? 0 : e > 1 ? 1 : e;
+    if (g.tea) {
+      const teaPx = Math.round(g.teaClamp + e * (g.teaFull - g.teaClamp));
+      if (teaPx !== g.lastTea) { g.tea.style.maxHeight = teaPx + 'px'; g.lastTea = teaPx; }
+    }
+    if (g.flyer) {
+      const flyPx = Math.round(e * g.flyerFull);
+      if (flyPx !== g.lastFly) { g.flyer.style.maxHeight = flyPx + 'px'; g.lastFly = flyPx; }
+      const op = Math.round(e * 100) / 100;
+      if (op !== g.lastOp) { g.flyer.style.opacity = String(op); g.lastOp = op; }
+    }
+    if (g.thumb) {
+      const to = Math.round((1 - e) * 100) / 100;
+      if (to !== g.lastThumbOp) { g.thumb.style.opacity = String(to); g.lastThumbOp = to; }
+    }
+    g.lastE = e;
+  };
+
+  const clearBand = () => {
+    const box = bandBox();
+    if (box) box.style.height = '';
+    const m = mapSection();
+    if (m) m.style.transform = '';
+    committedH = 0; lastBandT = -1; vSmooth = 0; lastFrameSL = -1;
+  };
+  const clearWrites = () => {
+    document.querySelectorAll('.events-list .ec-tea').forEach((t) => { if (t.style.maxHeight) t.style.maxHeight = ''; });
+    document.querySelectorAll('.events-list .event-flyer').forEach((f) => { f.style.maxHeight = ''; f.style.opacity = ''; });
+    document.querySelectorAll('.events-list .rail-thumb').forEach((t) => { if (t.style.opacity) t.style.opacity = ''; });
+  };
+
+  const smoothstep = (a, b, x) => {
+    const t = Math.max(0, Math.min(1, (x - a) / (b - a)));
+    return t * t * (3 - 2 * t);
+  };
+
+  // ---------- the per-frame writer (cozy rail scrub only) ----------
+  // p is a pure function of scroll position with support = the measured
+  // center-to-center step, so adjacent cards' p sum to exactly 1 and the
+  // band interpolates flat/linear between them instead of pumping.
+  const railFrame = () => {
+    if (!cozyRail() || !geom.length) return;
+    const el = list();
+    const sl = el.scrollLeft;
+    const now = performance.now();
+    if (lastFrameSL >= 0) {
+      const dt = Math.max(4, Math.min(64, now - lastFrameT));
+      const v = Math.min(5, Math.abs(sl - lastFrameSL) / dt);
+      // dt-aware one-pole low-pass; NOTHING ever resets this estimator —
+      // a reset mid-gesture is exactly what made damp whipsaw before
+      vSmooth += (v - vSmooth) * (1 - Math.exp(-dt / TAU));
+    }
+    lastFrameSL = sl; lastFrameT = now;
+    const damp = 1 - smoothstep(V_LO, V_HI, vSmooth);
+    const mid = sl + railWidth / 2;
+    let denseBlend = 0, growthSum = 0, wSum = 0;
+    for (let i = 0; i < geom.length; i++) {
+      const g = geom[i];
+      const d = Math.abs(g.center - mid);
+      if (d >= step) { applyE(g, 0); continue; }
+      const p = 1 - d / step;
+      applyE(g, p * damp);
+      denseBlend += p * g.denseH;
+      growthSum += p * damp * g.growth;
+      wSum += p;
+    }
+    const box = bandBox();
+    if (!box) return;
+    const t = wSum > 0
+      ? Math.round(Math.max(DENSE_MIN, denseBlend / wSum + growthSum)) + BAND_PAD
+      : committedH || (DENSE_MIN + BAND_PAD);
+    // gesture frames: the band's LAYOUT height stays frozen (zero relayout
+    // below the rail); the map rides a compositor transform by the delta
+    if (!committedH) {
+      committedH = Math.round(parseFloat(box.style.height)) || t;
+      if (!box.style.height) box.style.height = committedH + 'px';
+    }
+    if (t !== lastBandT) {
+      lastBandT = t;
+      const m = mapSection();
+      if (m) {
+        const shift = t - committedH;
+        m.style.transform = shift ? ('translateY(' + shift + 'px)') : '';
+      }
+      bandNote('band ' + t + ' damp ' + damp.toFixed(2));
+    }
+  };
+
+  // ---------- commit: the resting frame (centered card open, others dense) ----------
+  const commitFrame = () => {
+    const el = list();
+    if (!el || !geom.length) return null;
+    const best = nearestGeom(el.scrollLeft);
+    if (!isDense()) {
+      // dense never writes card geometry (fixed 246px boxes, thumbs always
+      // on) — the resting frame is a cozy concept
+      geom.forEach((g) => applyE(g, g === best ? 1 : 0));
+      const t = (best ? Math.max(DENSE_MIN, best.denseH + best.growth) : DENSE_MIN) + BAND_PAD;
+      const box = bandBox();
+      if (box) box.style.height = t + 'px';
+      const m = mapSection();
+      if (m) m.style.transform = '';
+      committedH = t; lastBandT = t;
+      bandNote('commit ' + t);
+    }
+    return best;
+  };
+
+  // ---------- settle: writer OFF first, then one transitioned write ----------
+  const settle = (fromUser) => {
+    const el = list();
+    if (!el) return;
+    clearTimeout(holdTimer);
+    let bestEl = null;
+    if (cozyRail() && geom.length) {
+      phase = 'settle';
+      el.classList.add('rail-settling'); // enables the ONLY transitions in the system
+      const best = commitFrame();
+      bestEl = best && best.el;
+      clearTimeout(settleTimer);
+      settleTimer = setTimeout(() => {
+        el.classList.remove('rail-settling');
+        if (phase === 'settle') phase = 'idle';
+      }, 200);
+    } else {
+      phase = 'idle';
+      bestEl = centeredCard();
+    }
+    if (fromUser && bestEl) {
+      railOwner = 'user';
+      landedSlug = bestEl.getAttribute('data-event-slug') || landedSlug;
+      dbgNote('landed ' + (landedSlug || '?').slice(0, 16));
+      realSelect(landedSlug);
+    }
+    flushUrl();
+    predecodeNear(bestEl || centeredCard());
+  };
+
+  const armSettleWatch = () => {
+    if (settleRaf) return;
+    stillFrames = 0; lastLeft = -1;
+    const tick = () => {
+      const el = list();
+      if (!el || !railActive()) { settleRaf = 0; return; }
+      if (touchActive) { stillFrames = 0; lastLeft = el.scrollLeft; settleRaf = setTimeout(tick, 16); return; }
+      if (el.scrollLeft === lastLeft) stillFrames++; else { stillFrames = 0; lastLeft = el.scrollLeft; }
+      if (stillFrames >= 6) { settleRaf = 0; finishGesture(); return; }
+      settleRaf = setTimeout(tick, 16);
+    };
+    settleRaf = setTimeout(tick, 16);
+  };
+  const finishGesture = () => {
+    const wasProg = programmatic;
+    programmatic = false;
+    if (phase === 'scrub') settle(true);
+    else if (wasProg) settle(false);
+  };
+  document.addEventListener('scrollend', (e) => {
+    const t = e.target;
+    if (!t || !t.classList || !t.classList.contains('events-list')) return;
+    if (touchActive) return; // a resting finger is not a settle
+    if (settleRaf) { clearTimeout(settleRaf); settleRaf = 0; }
+    finishGesture();
+  }, true);
+
+  // ---------- live selection during the scrub ----------
+  // drives the SITE'S real selection (pill spotlight, marker highlight) with
+  // the URL write deferred to one flush per gesture
+  const realSelect = (slug) => {
+    const l = loader();
+    if (!l || !slug || l.selectedEventSlug === slug) return;
+    const pill = document.querySelector('.calendar-grid .event-item[data-event-slug="' + cssEscape(slug) + '"]');
+    const dayEl = pill && pill.closest('[data-date]');
+    const dateISO = dayEl ? dayEl.getAttribute('data-date') : null;
+    try { l.toggleEventSelection(slug, dateISO, { deferUrl: true }); } catch (e) {}
+    urlDirty = true;
+    landedSlug = slug;
+  };
+  const flushUrl = () => {
+    const l = loader();
+    if (l && urlDirty) {
+      urlDirty = false;
+      try { l.syncUrl(true); } catch (e) {}
+    }
+  };
+
+  const onScrubFrame = () => {
+    frameRaf = 0;
+    if (phase !== 'scrub' || !railActive()) return;
+    if (geomStale()) buildGeom();
+    railFrame();
+    const el = list();
+    const g = el && nearestGeom(el.scrollLeft);
+    if (g && g.slug && g.slug !== holdSlug) {
+      holdSlug = g.slug;
+      clearTimeout(holdTimer);
+      holdTimer = setTimeout(() => { if (phase === 'scrub') realSelect(g.slug); }, 120);
+    }
+  };
+
+  document.addEventListener('scroll', (e) => {
+    if (!isMobile()) return;
+    const t = e.target;
+    if (!t || !t.classList || !t.classList.contains('events-list') || !t.classList.contains('rail-active')) return;
+    if (phase === 'settle') return; // transition tail; new input restarts scrub
+    if (phase === 'idle' && !programmatic) phase = 'scrub'; // wheel/trackpad gestures have no touchstart
+    if (phase === 'scrub') {
+      gestureScrolled = true;
+      if (!frameRaf) frameRaf = requestAnimationFrame(onScrubFrame);
+    }
+    armSettleWatch();
+  }, { capture: true, passive: true });
+
+  // ---------- gestures + ownership ----------
+  const onTouch = (e) => {
+    if (!isMobile()) return;
+    if (!(e.target.closest && e.target.closest('.events-list'))) return;
+    interacted = true;
+    touchActive = true;
+    gestureScrolled = false;
+    railOwner = 'user';
+    lastUserTouch = performance.now();
+    const el = list();
+    if (el && el.classList.contains('rail-active')) {
+      // a new gesture cancels any settle in flight — transitions off NOW,
+      // synchronously, before the finger moves a single pixel
+      clearTimeout(settleTimer);
+      el.classList.remove('rail-settling');
+      phase = 'scrub';
+      lastFrameSL = el.scrollLeft;
+      lastFrameT = performance.now();
+    }
+  };
+  const offTouch = () => {
+    if (!touchActive) return;
+    touchActive = false;
+    lastUserTouch = performance.now();
+    if (!gestureScrolled && phase === 'scrub') phase = 'idle'; // plain tap, no drag
+  };
+  document.addEventListener('touchstart', onTouch, { passive: true, capture: true });
+  document.addEventListener('pointerdown', onTouch, { passive: true, capture: true });
+  ['touchend', 'touchcancel', 'pointerup', 'pointercancel'].forEach((ev) =>
+    document.addEventListener(ev, offTouch, { passive: true, capture: true }));
+  // a REAL tap (trusted) on a pill or card grants centering for that slug
+  document.addEventListener('click', (e) => {
+    if (!e.isTrusted) return;
+    const pill = e.target.closest && e.target.closest('.calendar-grid .event-item');
+    const card = !pill && e.target.closest && e.target.closest('.events-list .event-card');
+    const src = pill || card;
+    if (!src) return;
+    const slug = src.getAttribute('data-event-slug');
+    if (!slug) return;
+    landedSlug = slug;
+    grantSlug = slug;
+    dbgNote((pill ? 'pill' : 'card') + ' tap -> grant ' + slug.slice(0, 16));
+  }, true);
+
+  const centerOn = (card, reason, instant) => {
+    const el = list();
+    if (!el || !card || !isMobile()) return false;
+    const slug = card.getAttribute('data-event-slug');
+    const granted = !!grantSlug && grantSlug === slug;
+    // a grant IS the user's own tap — it bypasses the post-gesture quiet
+    // period (which exists to block UNREQUESTED programmatic moves); init
+    // centering still defers to an active finger
+    if (!granted && railOwner !== 'init') { dbgNote('DENY center (' + reason + ')'); return false; }
+    if (!granted && userBusy()) { dbgNote('SKIP center (busy)'); return false; }
+    if (granted) grantSlug = null;
+    landedSlug = slug;
+    const target = Math.round(card.offsetLeft + card.offsetWidth / 2 - el.clientWidth / 2);
+    if (Math.abs(el.scrollLeft - target) < 4) return true;
+    programmatic = true;
+    dbgNote('center(' + reason + ') @' + target);
+    el.scrollTo({ left: target, behavior: (instant || !interacted) ? 'auto' : 'smooth' });
+    armSettleWatch();
+    return true;
+  };
+
+  // ---------- rail structure: synchronous, single-frame switches ----------
+  let denseMapH = -1;
+  const sizeDenseMap = () => {
+    const sec = mapSection();
+    if (!sec) return;
+    if (!isMobile() || !isDense() || html.classList.contains('month-full')) {
+      if (sec.style.height) { sec.style.height = ''; sec.style.flex = ''; resizeMap(); }
+      denseMapH = -1;
+      return;
+    }
+    const main = document.querySelector('main.city-page');
+    if (!main) return;
+    const h = Math.max(140, Math.floor(main.getBoundingClientRect().bottom - sec.getBoundingClientRect().top - 6));
+    if (h === denseMapH) return;
+    denseMapH = h;
+    sec.style.height = h + 'px';
+    sec.style.flex = 'none';
+    resizeMap();
+  };
+
+  const selectedSlug = () => { const l = loader(); return (l && l.selectedEventSlug) || null; };
+
+  const enterRail = (targetSlug) => {
+    const el = list();
+    if (!el) return;
+    el.classList.add('rail-active');
+    armThumbs();
+    buildGeom();
+    const target = cardBySlug(targetSlug) || cardBySlug(landedSlug) || cards()[0];
+    if (target) {
+      landedSlug = target.getAttribute('data-event-slug') || landedSlug;
+      if (grantSlug === landedSlug) grantSlug = null;
+      const t = Math.round(target.offsetLeft + target.offsetWidth / 2 - el.clientWidth / 2);
+      if (Math.abs(el.scrollLeft - t) >= 1) { programmatic = true; el.scrollLeft = t; }
+    }
+    commitFrame(); // same task as the class flip — ONE paint: list -> open rail
+    resizeMap();
+    dbgNote('rail ON');
+  };
+  const exitRail = () => {
+    const el = list();
+    if (!el) return;
+    clearTimeout(settleTimer);
+    el.classList.remove('rail-active', 'rail-settling');
+    phase = 'idle';
+    clearBand();
+    clearWrites();
+    const back = cardBySlug(landedSlug);
+    geom = [];
+    if (back) { try { back.scrollIntoView({ block: 'nearest' }); } catch (e) {} }
+    resizeMap();
+    dbgNote('rail OFF');
+  };
+
+  // rebuild + restore after a loader re-render while railed (fresh DOM means
+  // all inline writes and geometry are gone; landedSlug is the anchor)
+  const restoreRail = () => {
+    const el = list();
+    if (!el) return;
+    armThumbs();
+    buildGeom();
+    const back = cardBySlug(landedSlug) || cardBySlug(selectedSlug()) || cards()[0];
+    if (back) {
+      const t = Math.round(back.offsetLeft + back.offsetWidth / 2 - el.clientWidth / 2);
+      if (Math.abs(el.scrollLeft - t) >= 1) { programmatic = true; el.scrollLeft = t; }
+    }
+    commitFrame();
+  };
+
+  const syncRailState = (reason) => {
+    const el = list();
+    if (!el) return;
+    if (!isMobile()) {
+      if (el.classList.contains('rail-active')) {
+        el.classList.remove('rail-active', 'rail-settling');
+        phase = 'idle';
+        clearBand();
+        clearWrites();
+        geom = [];
+      }
+      updateMonthFull();
+      return;
+    }
+    updateMonthFull();
+    sizeDenseMap();
+    const want = !html.classList.contains('month-full') && (isDense() || !!selectedSlug());
+    const has = el.classList.contains('rail-active');
+    if (want && !has) enterRail(selectedSlug());
+    else if (!want && has) exitRail();
+    else if (want && has) {
+      if (reason === 'render' || geomStale()) restoreRail();
+      else if (reason === 'mode-switch') {
+        // the outgoing mode's inline writes (cozy band height, flyer/tea
+        // max-heights) must not leak into the incoming one
+        clearBand();
+        clearWrites();
+        buildGeom();
+        commitFrame();
+      }
+      else if (grantSlug) {
+        const g = cardBySlug(grantSlug);
+        if (g) centerOn(g, reason);
+      }
+    }
+  };
+
+  // ---------- image loads: per-card re-measure, never a whole-rail reset ----------
+  const remeasureCard = (card) => {
+    if (!cozyRail()) return;
+    const g = geom.find((x) => x.el === card);
+    if (!g || !g.flyer) return;
+    if (g.tea) g.tea.style.maxHeight = 'none';
+    g.flyer.style.maxHeight = 'none';
+    g.flyerFull = g.flyer.offsetHeight;
+    if (g.tea) {
+      g.teaFull = g.tea.offsetHeight;
+      g.teaClamp = Math.min(g.teaFull, Math.round(2 * lineHeightOf(g.tea)));
+    }
+    const expandedH = g.el.offsetHeight;
+    if (g.tea) g.tea.style.maxHeight = g.teaClamp + 'px';
+    g.flyer.style.maxHeight = '0px';
+    g.denseH = g.el.offsetHeight;
+    g.growth = Math.max(0, expandedH - g.denseH);
+    g.lastE = -1; g.lastTea = -1; g.lastFly = -1; g.lastOp = -1; g.lastThumbOp = -1;
+    const el = list();
+    if (phase === 'scrub') {
+      railFrame(); // the writer's next pass would fix it anyway; do it now
+    } else if (nearestGeom(el.scrollLeft) === g) {
+      // the centered, settled card just got its art — grow it smoothly
+      el.classList.add('rail-settling');
+      commitFrame();
+      clearTimeout(settleTimer);
+      settleTimer = setTimeout(() => el.classList.remove('rail-settling'), 200);
+    } else {
+      applyE(g, 0);
+      commitFrame();
+    }
+  };
+  const onImgEvent = (e) => {
+    const img = e.target;
+    if (!img || img.tagName !== 'IMG' || !img.closest) return;
+    const flyer = img.closest('.events-list .event-flyer');
+    if (!flyer) return;
+    const card = flyer.closest('.event-card');
+    if (card) remeasureCard(card);
+  };
+  document.addEventListener('load', onImgEvent, true);
+  document.addEventListener('error', onImgEvent, true);
+
+  const predecodeNear = (centerCard) => {
+    if (!centerCard || !isMobile() || !railActive()) return;
+    const cs = cards();
+    const i = cs.indexOf(centerCard);
+    if (i < 0) return;
+    for (let k = Math.max(0, i - 2); k <= Math.min(cs.length - 1, i + 2); k++) {
+      const img = cs[k].querySelector('.event-flyer img');
+      if (!img) continue;
+      if (img.loading === 'lazy') img.loading = 'eager';
+      if (img.decode) img.decode().catch(() => {});
+    }
+  };
+
+  // ---------- the two loader events + environment changes ----------
+  document.addEventListener('chunky:selection-changed', () => syncRailState('selection'));
+  document.addEventListener('chunky:events-rendered', () => {
+    armThumbs();
+    markOverflows();
+    syncRailState('render');
+    predecodeNear(centeredCard());
+  });
+  window.addEventListener('resize', () => {
+    denseMapH = -1;
+    if (railActive() && isMobile()) {
+      buildGeom();
+      if (!isDense()) commitFrame();
+    }
+    markOverflows();
+    syncRailState('resize');
+  });
+  mmMobile.addEventListener('change', () => {
+    denseMapH = -1;
+    armThumbs();
+    markOverflows();
+    syncRailState('breakpoint');
+  });
+  document.addEventListener('DOMContentLoaded', () => {
+    mountToggle();
+    armThumbs();
+    syncRailState('boot');
+  });
+  mountToggle();
+  syncRailState('boot');
+
+  // ---------- debug surface ----------
+  window.duskRail = {
+    setMode,
+    openLightbox,
+    openSheet,
+    state: () => ({
+      mode, phase, railOwner, landedSlug, grantSlug, touchActive,
+      programmatic, interacted, committedH, vSmooth: Math.round(vSmooth * 100) / 100,
+      railActive: railActive()
+    }),
+    geom: () => geom.map((g) => ({
+      slug: g.slug.slice(0, 14), denseH: g.denseH, growth: g.growth,
+      flyerFull: g.flyerFull, lastE: g.lastE
+    })),
+    settle: () => settle(false)
+  };
+})();

--- a/js/dusk-rail.js
+++ b/js/dusk-rail.js
@@ -205,38 +205,29 @@
       l.querySelectorAll('.share-event-btn').forEach((b) => b.remove());
       if (l.children.length) panel.appendChild(l);
     }
-    // the venue map: a small static MapLibre view on the event's own pin
-    // (interactive:false — a pannable map inside a scrolling sheet fights
-    // the finger, and the camera never moves after creation)
-    destroySheetMap();
-    const lat = parseFloat(card.getAttribute('data-lat'));
-    const lng = parseFloat(card.getAttribute('data-lng'));
-    if (window.maplibregl && Number.isFinite(lat) && Number.isFinite(lng) && (lat !== 0 || lng !== 0)) {
-      const mapDiv = document.createElement('div');
-      mapDiv.className = 'sheet-map';
-      panel.appendChild(mapDiv);
-      const pinColor = (card.style.getPropertyValue('--c1') || '').trim() || '#667eea';
-      requestAnimationFrame(() => {
-        if (!sheet.classList.contains('open') || !mapDiv.isConnected) return;
-        try {
-          sheetMap = new maplibregl.Map({
-            container: mapDiv,
-            style: 'https://tiles.openfreemap.org/styles/liberty',
-            center: [lng, lat],
-            zoom: 14,
-            interactive: false
-          });
-          new maplibregl.Marker({ color: pinColor }).setLngLat([lng, lat]).addTo(sheetMap);
-          sheetMap.once('load', () => { if (sheetMap) sheetMap.resize(); });
-        } catch (e) { mapDiv.remove(); }
-      });
-    }
     const tea = card.querySelector('.ec-tea');
     if (tea) {
       const d = document.createElement('p');
       d.className = 'sheet-desc';
       d.textContent = tea.textContent.trim();
       panel.appendChild(d);
+    }
+    // the map, at the BOTTOM of the sheet: the loader builds a read-only
+    // twin of the main page's map (same style/theme/favicon icons/city
+    // framing, this event's icon selected, the rest dimmed, none clickable)
+    destroySheetMap();
+    const l = loader();
+    if (l && l.createSheetMap) {
+      const mapDiv = document.createElement('div');
+      mapDiv.className = 'sheet-map';
+      panel.appendChild(mapDiv);
+      const slug = card.getAttribute('data-event-slug');
+      requestAnimationFrame(() => {
+        if (!sheet.classList.contains('open') || !mapDiv.isConnected) return;
+        sheetMap = l.createSheetMap(mapDiv, slug);
+        if (!sheetMap) mapDiv.remove();
+        else sheetMap.once('load', () => { if (sheetMap) sheetMap.resize(); });
+      });
     }
     // carry the card's aurora custom props so the sheet paints as the card
     const inline = card.getAttribute('style');

--- a/js/dusk-rail.js
+++ b/js/dusk-rail.js
@@ -94,6 +94,10 @@
     denseMapH = -1;
     if (isDense()) markOverflows();
     syncRailState('mode-switch');
+    // the week grid's pill cap is mode-dependent (dense caps singles at 4)
+    // — re-render so the calendar reflects the new mode
+    const l = loader();
+    if (l && l.updateCalendarDisplay) { try { l.updateCalendarDisplay(); } catch (e) {} }
     dbgNote('mode -> ' + m);
   };
   modeBtn.addEventListener('click', (e) => { e.preventDefault(); setMode(isDense() ? 'cozy' : 'dense'); });
@@ -143,10 +147,19 @@
   // dense uses it for clamped descriptions ('…more' chip); month view (both
   // modes) opens it in place of navigating to the event's week.
   let sheet = null;
+  let sheetMap = null;
+  const destroySheetMap = () => {
+    if (!sheetMap) return;
+    try { sheetMap.remove(); } catch (e) {}
+    sheetMap = null;
+  };
   const closeSheet = () => {
     if (!sheet) return;
     sheet.classList.remove('up');
-    setTimeout(() => sheet.classList.remove('open'), 320);
+    setTimeout(() => {
+      sheet.classList.remove('open');
+      destroySheetMap(); // after the slide-down so the map doesn't vanish mid-flight
+    }, 320);
   };
   const openSheet = (card) => {
     if (!card) return;
@@ -191,6 +204,32 @@
       // shipping a dead control; the plain anchors work as-is
       l.querySelectorAll('.share-event-btn').forEach((b) => b.remove());
       if (l.children.length) panel.appendChild(l);
+    }
+    // the venue map: a small static MapLibre view on the event's own pin
+    // (interactive:false — a pannable map inside a scrolling sheet fights
+    // the finger, and the camera never moves after creation)
+    destroySheetMap();
+    const lat = parseFloat(card.getAttribute('data-lat'));
+    const lng = parseFloat(card.getAttribute('data-lng'));
+    if (window.maplibregl && Number.isFinite(lat) && Number.isFinite(lng) && (lat !== 0 || lng !== 0)) {
+      const mapDiv = document.createElement('div');
+      mapDiv.className = 'sheet-map';
+      panel.appendChild(mapDiv);
+      const pinColor = (card.style.getPropertyValue('--c1') || '').trim() || '#667eea';
+      requestAnimationFrame(() => {
+        if (!sheet.classList.contains('open') || !mapDiv.isConnected) return;
+        try {
+          sheetMap = new maplibregl.Map({
+            container: mapDiv,
+            style: 'https://tiles.openfreemap.org/styles/liberty',
+            center: [lng, lat],
+            zoom: 14,
+            interactive: false
+          });
+          new maplibregl.Marker({ color: pinColor }).setLngLat([lng, lat]).addTo(sheetMap);
+          sheetMap.once('load', () => { if (sheetMap) sheetMap.resize(); });
+        } catch (e) { mapDiv.remove(); }
+      });
     }
     const tea = card.querySelector('.ec-tea');
     if (tea) {
@@ -354,6 +393,15 @@
         landedSlug = c.getAttribute('data-event-slug') || landedSlug;
         dbgNote('landed ' + (landedSlug || '?').slice(0, 16));
         realSelect(landedSlug);
+        // dense caps the week grid's pills at 4/day — if the landed event's
+        // pill is one of the hidden ones, re-render (the cap always swaps
+        // the SELECTED event into view). Only ever at settle: a re-render
+        // mid-gesture would fight the finger.
+        if (isDense() && landedSlug
+            && !document.querySelector('.calendar-grid .event-item[data-event-slug="' + cssEscape(landedSlug) + '"]')) {
+          const l = loader();
+          if (l && l.updateCalendarDisplay) { try { l.updateCalendarDisplay(); } catch (e) {} }
+        }
       }
     }
     flushUrl();
@@ -551,7 +599,20 @@
   };
 
   // ---------- the two loader events + environment changes ----------
-  document.addEventListener('chunky:selection-changed', () => syncRailState('selection'));
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  let lastScrollSlug = null;
+  document.addEventListener('chunky:selection-changed', (e) => {
+    // cozy select: bring the week grid + the (now lone) card into view
+    const slug = (e.detail && e.detail.slug) || null;
+    if (isMobile() && !isDense() && slug && slug !== lastScrollSlug
+        && !html.classList.contains('month-full')) {
+      try {
+        window.scrollTo({ top: 0, behavior: prefersReducedMotion.matches ? 'auto' : 'smooth' });
+      } catch (e2) { window.scrollTo(0, 0); }
+    }
+    lastScrollSlug = slug;
+    syncRailState('selection');
+  });
   document.addEventListener('chunky:events-rendered', () => {
     armThumbs();
     markOverflows();

--- a/js/dusk-rail.js
+++ b/js/dusk-rail.js
@@ -167,10 +167,15 @@
     }
     // the map, at the BOTTOM of the sheet: the loader builds a read-only
     // twin of the main page's map (same style/theme/favicon icons/city
-    // framing, this event's icon selected, the rest dimmed, none clickable)
+    // framing, this event's icon selected, the rest dimmed, none clickable).
+    // An event with NO location (Bear Happy Hour) gets no map at all — a
+    // city map with every icon dimmed and none highlighted reads as broken.
     destroySheetMap();
+    const lat = parseFloat(card.getAttribute('data-lat'));
+    const lng = parseFloat(card.getAttribute('data-lng'));
+    const hasLocation = Number.isFinite(lat) && Number.isFinite(lng) && (lat !== 0 || lng !== 0);
     const l = loader();
-    if (l && l.createSheetMap) {
+    if (hasLocation && l && l.createSheetMap) {
       const mapDiv = document.createElement('div');
       mapDiv.className = 'sheet-map';
       panel.appendChild(mapDiv);

--- a/js/dusk-ui.js
+++ b/js/dusk-ui.js
@@ -276,6 +276,9 @@
         const next = document.getElementById('next-period');
         if (prev) prev.textContent = '\u2039';
         if (next) next.textContent = '\u203a';
+        // header row is (re)assembled \u2014 dusk-rail mounts its mode toggle on
+        // this, riding the same observer/refresh cadence with no timers
+        document.dispatchEvent(new CustomEvent('dusk:controls-mounted'));
     }
 
     function trackHeaderHeight() {

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -564,8 +564,11 @@ class DynamicCalendarLoader extends CalendarCore {
         }
     }
     
-    // Toggle/select event for URL/state
-    toggleEventSelection(eventSlug, eventDateISO) {
+    // Toggle/select event for URL/state.
+    // options.deferUrl: skip the URL write — the caller owns it (the mobile
+    // rail selects live while the finger is still down and must not spam
+    // history.replaceState per frame; it flushes one syncUrl on settle).
+    toggleEventSelection(eventSlug, eventDateISO, options = {}) {
         if (!eventSlug) return;
         const normalizedDateISO = eventDateISO && /^\d{4}-\d{2}-\d{2}$/.test(eventDateISO) ? eventDateISO : this.formatDateToISO(this.currentDate);
         
@@ -602,9 +605,11 @@ class DynamicCalendarLoader extends CalendarCore {
         
         // Update visual selection state once (handles both selection and deselection)
         this.updateSelectionVisualState();
-        
+
         // Reflect selection in URL
-        this.syncUrl(true);
+        if (!options.deferUrl) {
+            this.syncUrl(true);
+        }
     }
 
     // Update visual selection state across all views (calendar, list, map)
@@ -688,6 +693,12 @@ class DynamicCalendarLoader extends CalendarCore {
             
             logger.debug('EVENT', 'Cleared all selections and ensured calendar events are unselected');
         }
+
+        // Selection changed and every view is painted — modules that layer on
+        // top (the mobile rail) listen for this instead of observing the DOM
+        document.dispatchEvent(new CustomEvent('chunky:selection-changed', {
+            detail: { slug: this.selectedEventSlug, dateISO: this.selectedEventDateISO }
+        }));
     }
 
     // Lazily create the flyer <img> the first time a card is selected.
@@ -1495,6 +1506,23 @@ class DynamicCalendarLoader extends CalendarCore {
         
         // Clear current selection when jumping views
         this.clearEventSelection();
+        await this.updateCalendarDisplay();
+        this.syncUrl(true);
+    }
+
+    // Jump to week view centered on a date WITH an event selected — the
+    // mobile month-full view navigates month pill → that event's week.
+    // Not switchToWeekView: that path deliberately clears the selection.
+    async openWeekAt(eventSlug, dateISO) {
+        if (!eventSlug || !/^\d{4}-\d{2}-\d{2}$/.test(dateISO || '')) return;
+        const parts = dateISO.split('-');
+        const parsed = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]));
+        if (isNaN(parsed.getTime())) return;
+        this.currentDate = parsed;
+        this.currentView = 'week';
+        this.selectedEventSlug = eventSlug;
+        this.selectedEventDateISO = dateISO;
+        this.updateViewToggleActive();
         await this.updateCalendarDisplay();
         this.syncUrl(true);
     }
@@ -2840,6 +2868,7 @@ class DynamicCalendarLoader extends CalendarCore {
             <div class="event-card detailed aurora" data-event-slug="${slug}" data-lat="${this.escapeCardText(event.coordinates?.lat || '')}" data-lng="${this.escapeCardText(event.coordinates?.lng || '')}"${auroraStyle}>
                 ${flyerHtml}
                 <div class="ec-panel">
+                    ${flyerUrl ? '<button class="rail-thumb" type="button" aria-label="Show flyer"></button>' : ''}
                     <div class="ec-titlerow">
                         ${faviconHtml}
                         <h3 class="ec-title">${this.escapeCardText(event.name)}</h3>
@@ -4205,8 +4234,15 @@ class DynamicCalendarLoader extends CalendarCore {
                     city: this.currentCity
                 });
             }
+
+            // The grid and list DOM are both fresh at this point (the map
+            // init below awaits network/location and can land seconds later)
+            // — layered modules rebuild on this event, not on MutationObserver
+            document.dispatchEvent(new CustomEvent('chunky:events-rendered', {
+                detail: { view: this.currentView }
+            }));
         }
-        
+
         // Update map (show for both week and month views)
         // Initialize map if not in hideEvents mode
         try {

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -3529,34 +3529,10 @@ class DynamicCalendarLoader extends CalendarCore {
                 return dateA.getTime() - dateB.getTime();
             });
 
-            // DENSE mobile week: the trifold squeezes the grid, so cap the
-            // single-day pills at 4 per column (+N beyond — the owner can
-            // "easily see 4 items without the UI looking weird"). Multi-day
-            // bars always render (lane continuity across columns), and the
-            // SELECTED event is always swapped into the visible set.
-            let dayEventsToRender = filteredDayEvents;
-            let hiddenSinglesCount = 0;
-            const DENSE_WEEK_SINGLE_CAP = 4;
-            const denseMobileWeek = document.documentElement.classList.contains('mode-dense')
-                && window.matchMedia && window.matchMedia('(max-width: 768.9px)').matches;
-            if (denseMobileWeek) {
-                const multiDayForDay = filteredDayEvents.filter(ev => this.isMultiDay(ev));
-                const singlesForDay = filteredDayEvents.filter(ev => !this.isMultiDay(ev));
-                if (singlesForDay.length > DENSE_WEEK_SINGLE_CAP) {
-                    let shownSingles = singlesForDay.slice(0, DENSE_WEEK_SINGLE_CAP);
-                    const selectedHidden = this.selectedEventSlug
-                        ? singlesForDay.find(ev => ev.slug === this.selectedEventSlug && shownSingles.indexOf(ev) === -1)
-                        : null;
-                    if (selectedHidden) {
-                        shownSingles = shownSingles.slice(0, DENSE_WEEK_SINGLE_CAP - 1).concat(selectedHidden);
-                    }
-                    hiddenSinglesCount = singlesForDay.length - shownSingles.length;
-                    dayEventsToRender = multiDayForDay.concat(shownSingles);
-                }
-            }
-
-            const eventsHtml = dayEventsToRender.length > 0
-                ? dayEventsToRender.map(event => {
+            // Week view never hides events — the mobile week frame grows
+            // downward when a big week (festival runs) needs the room
+            const eventsHtml = filteredDayEvents.length > 0
+                ? filteredDayEvents.map(event => {
                     const isMultiDay = this.isMultiDay(event);
                     const mobileTime = isMultiDay && window.formatEventDates ? window.formatEventDates(event) : (event.time ? this.formatTimeForMobile(event.time) : null);
 
@@ -3598,7 +3574,7 @@ class DynamicCalendarLoader extends CalendarCore {
                             <div class="event-venue">${this.generateFaviconChipHtml(event)}${event.bar || ''}</div>
                         </div>
                     `;
-                }).join('') + (hiddenSinglesCount > 0 ? `<div class="more-events">+${hiddenSinglesCount}</div>` : '')
+                }).join('')
                 : '';
 
             const isToday = day.getTime() === today.getTime();

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -3890,9 +3890,13 @@ class DynamicCalendarLoader extends CalendarCore {
         }
 
         try {
+            // The bottom sheet's read-only map twin (createSheetMap) renders
+            // exactly this marker set
+            this.lastMapEvents = events;
+
             // Filter events with valid coordinates
-            const eventsWithCoords = events.filter(event => 
-                event.coordinates?.lat && event.coordinates?.lng && 
+            const eventsWithCoords = events.filter(event =>
+                event.coordinates?.lat && event.coordinates?.lng &&
                 !isNaN(event.coordinates.lat) && !isNaN(event.coordinates.lng)
             );
 
@@ -4064,6 +4068,66 @@ class DynamicCalendarLoader extends CalendarCore {
             // Favicons now load directly in marker creation
         } catch (error) {
             logger.componentError('MAP', 'Failed to initialize map', error);
+        }
+    }
+
+    // A read-only twin of the main events map for the bottom sheet: same
+    // style, same purple-water recolor (applyTheme), the same favicon marker
+    // elements from createMarkerIcon over the SAME event set the main map
+    // shows (lastMapEvents), and the city's own framing (city zoom, fitBounds
+    // zooms out only — exactly the main map's fit). The given slug's marker
+    // carries the main map's selected state, the rest its dimmed state; NO
+    // marker is clickable — the sheet map is a viewer, not a selector.
+    // Returns the map instance so the caller can .remove() it on close.
+    createSheetMap(container, selectedSlug) {
+        if (typeof maplibregl === 'undefined' || !container || !this.currentCityConfig?.coordinates) {
+            return null;
+        }
+        try {
+            const cityConfig = this.currentCityConfig;
+            const events = this.lastMapEvents || [];
+            const mapZoom = cityConfig.mapZoom || 10;
+            const map = new maplibregl.Map({
+                container,
+                style: 'https://tiles.openfreemap.org/styles/liberty',
+                center: [cityConfig.coordinates.lng, cityConfig.coordinates.lat],
+                zoom: mapZoom,
+                renderWorldCopies: false
+            });
+            map.on('style.load', () => {
+                this.applyTheme(map);
+            });
+            map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-left');
+            const bounds = new maplibregl.LngLatBounds();
+            let markerCount = 0;
+            events.forEach(event => {
+                if (!(event.coordinates?.lat && event.coordinates?.lng) ||
+                    isNaN(event.coordinates.lat) || isNaN(event.coordinates.lng)) {
+                    return;
+                }
+                const markerIcon = this.createMarkerIcon(event);
+                // mirror highlightMapMarker's classes: the sheet's event is
+                // selected, everything else dimmed (and an unmapped sheet
+                // event leaves all markers dimmed, same as the main map)
+                if (event.slug === selectedSlug) {
+                    markerIcon.classList.add('marker-selected');
+                } else {
+                    markerIcon.classList.add('marker-dimmed');
+                }
+                new maplibregl.Marker({ element: markerIcon, anchor: 'bottom' })
+                    .setLngLat([event.coordinates.lng, event.coordinates.lat])
+                    .addTo(map);
+                bounds.extend([event.coordinates.lng, event.coordinates.lat]);
+                markerCount++;
+            });
+            if (markerCount > 0) {
+                map.fitBounds(bounds, { padding: 20, maxZoom: mapZoom });
+            }
+            logger.debug('MAP', 'Sheet map created', { markerCount, selectedSlug });
+            return map;
+        } catch (error) {
+            logger.warn('MAP', 'Sheet map creation failed', { error: error?.message });
+            return null;
         }
     }
 

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -3529,8 +3529,34 @@ class DynamicCalendarLoader extends CalendarCore {
                 return dateA.getTime() - dateB.getTime();
             });
 
-            const eventsHtml = filteredDayEvents.length > 0 
-                ? filteredDayEvents.map(event => {
+            // DENSE mobile week: the trifold squeezes the grid, so cap the
+            // single-day pills at 4 per column (+N beyond — the owner can
+            // "easily see 4 items without the UI looking weird"). Multi-day
+            // bars always render (lane continuity across columns), and the
+            // SELECTED event is always swapped into the visible set.
+            let dayEventsToRender = filteredDayEvents;
+            let hiddenSinglesCount = 0;
+            const DENSE_WEEK_SINGLE_CAP = 4;
+            const denseMobileWeek = document.documentElement.classList.contains('mode-dense')
+                && window.matchMedia && window.matchMedia('(max-width: 768.9px)').matches;
+            if (denseMobileWeek) {
+                const multiDayForDay = filteredDayEvents.filter(ev => this.isMultiDay(ev));
+                const singlesForDay = filteredDayEvents.filter(ev => !this.isMultiDay(ev));
+                if (singlesForDay.length > DENSE_WEEK_SINGLE_CAP) {
+                    let shownSingles = singlesForDay.slice(0, DENSE_WEEK_SINGLE_CAP);
+                    const selectedHidden = this.selectedEventSlug
+                        ? singlesForDay.find(ev => ev.slug === this.selectedEventSlug && shownSingles.indexOf(ev) === -1)
+                        : null;
+                    if (selectedHidden) {
+                        shownSingles = shownSingles.slice(0, DENSE_WEEK_SINGLE_CAP - 1).concat(selectedHidden);
+                    }
+                    hiddenSinglesCount = singlesForDay.length - shownSingles.length;
+                    dayEventsToRender = multiDayForDay.concat(shownSingles);
+                }
+            }
+
+            const eventsHtml = dayEventsToRender.length > 0
+                ? dayEventsToRender.map(event => {
                     const isMultiDay = this.isMultiDay(event);
                     const mobileTime = isMultiDay && window.formatEventDates ? window.formatEventDates(event) : (event.time ? this.formatTimeForMobile(event.time) : null);
 
@@ -3564,7 +3590,7 @@ class DynamicCalendarLoader extends CalendarCore {
                             seenMultiDayEvents.add(occurrenceId);
                         }
                     }
-                    
+
                     return `
                         <div class="event-item${flowClass}" data-event-slug="${event.slug}" title="${event.name} at ${event.bar || 'Location'}${event.time ? ' - ' + event.time : ''}">
                             ${showTitle ? this.generateEventNameElements(event, hideEvents) : `<div style="visibility: hidden;">${this.generateEventNameElements(event, hideEvents)}</div>`}
@@ -3572,7 +3598,7 @@ class DynamicCalendarLoader extends CalendarCore {
                             <div class="event-venue">${this.generateFaviconChipHtml(event)}${event.bar || ''}</div>
                         </div>
                     `;
-                }).join('')
+                }).join('') + (hiddenSinglesCount > 0 ? `<div class="more-events">+${hiddenSinglesCount}</div>` : '')
                 : '';
 
             const isToday = day.getTime() === today.getTime();
@@ -3732,9 +3758,10 @@ class DynamicCalendarLoader extends CalendarCore {
             // hidden single renders itself instead of a pointless "+1" chip.
             const multiDaySegments = filteredDayEvents.filter(event => this.isMultiDay(event));
             const singleDayEvents = filteredDayEvents.filter(event => !this.isMultiDay(event));
-            const singleCap = singleDayEvents.length === 3 ? 3 : 2;
-            const eventsToShow = multiDaySegments.concat(singleDayEvents.slice(0, singleCap));
-            const additionalEventsCount = Math.max(0, singleDayEvents.length - singleCap);
+            // Month shows EVERY event — the +N collapse hid real events, and
+            // the mobile month view is now a primary browsing surface
+            const eventsToShow = multiDaySegments.concat(singleDayEvents);
+            const additionalEventsCount = 0;
             
             const eventsHtml = eventsToShow.length > 0 
                 ? eventsToShow.map(event => {

--- a/la/index.html
+++ b/la/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/london/index.html
+++ b/london/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/nola/index.html
+++ b/nola/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/nyc/index.html
+++ b/nyc/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/palm-springs/index.html
+++ b/palm-springs/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/philly/index.html
+++ b/philly/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/phoenix/index.html
+++ b/phoenix/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/portland/index.html
+++ b/portland/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/ptown/index.html
+++ b/ptown/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/san-diego/index.html
+++ b/san-diego/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/seattle/index.html
+++ b/seattle/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/sf/index.html
+++ b/sf/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/sitges/index.html
+++ b/sitges/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -7280,7 +7280,9 @@ html.dusk body {
         z-index: 3;
         box-shadow: 0 3px 10px rgba(0, 0, 0, 0.35);
         cursor: pointer;
-        background-color: transparent;
+        /* a quiet ground so a thumb whose art is still downloading reads as
+           a plate, not an invisible button that pops in */
+        background-color: rgba(10, 12, 24, 0.35);
         background-size: cover;
         background-position: center;
         transition: none;
@@ -7358,10 +7360,14 @@ html.dusk body {
         justify-content: center;
     }
     /* every dense card is the SAME 246px box (titlerow + rows + 2-line tea +
-       links measured at 390px); sparse cards simply end early inside it */
+       links measured at 390px); sparse cards simply end early inside it.
+       Dense is a STATIC mode: nothing on a card ever animates or fades —
+       owner report: "middle cards magically slowly fade in. It's weird" */
     html.mode-dense .events-list.rail-active > .event-card {
         height: 246px;
         overflow: hidden;
+        animation: none !important;
+        transition: none !important;
     }
     /* the corner thumb is the ONLY image surface in dense */
     html.mode-dense .events-list .event-card .event-flyer { display: none; }
@@ -7413,6 +7419,9 @@ html.dusk body {
        sections every render (dynamic-calendar-loader.js updateCalendarDisplay) */
     html.month-full .events,
     html.month-full .events-map-section { display: none !important; }
+    /* the COZY/DENSE distinction has no meaning on the grid-only month
+       screen — hide the toggle (mode state is kept; it returns with week) */
+    html.month-full .mode-toggle { display: none; }
     html.month-full body,
     html.month-full main.city-page { overflow: auto; }
     html.month-full main.city-page { display: block; }
@@ -7481,8 +7490,11 @@ html.dusk body {
     overflow-y: auto;
     border-radius: 18px 18px 0 0;
     padding: 18px 18px calc(20px + env(safe-area-inset-bottom));
-    /* the card's aurora custom props ride in on the panel's style attribute */
-    background: var(--c1, var(--background-primary, #14172a));
+    /* the card's aurora custom props ride in on the panel's style attribute;
+       the fallback chain must mirror the aurora card's own (--primary-color,
+       then the site indigo) — an event with no color data otherwise landed
+       on the LIGHT --background-primary and the sheet washed out */
+    background: var(--c1, var(--primary-color, #667eea));
     box-shadow: 0 -14px 40px rgba(0, 0, 0, 0.5);
     transform: translateY(100%);
     transition: transform 300ms cubic-bezier(0.2, 0.7, 0.3, 1);
@@ -7530,6 +7542,15 @@ html.dusk body {
     justify-content: center;
 }
 .rail-sheet .sheet-links .event-link i { font-size: 0.95rem; }
+/* the venue mini-map: static (interactive:false), pin on the event */
+.rail-sheet .sheet-map {
+    height: 180px;
+    margin: 12px 0 0;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 6px 20px rgba(6, 8, 20, 0.35);
+}
+.rail-sheet .sheet-map canvas { border-radius: 12px; }
 /* the cloned when/venue/cover rows lose the card scope that sizes their
    icons/badges — pin the sheet rows to the card's own metrics */
 .rail-sheet .sheet-rows {

--- a/styles.css
+++ b/styles.css
@@ -6877,7 +6877,7 @@ html.dusk body {
 }
 /* iOS paints its default grey rectangle over any click-bound element on
    press — the cards are click-bound <div>s, so every tap flashed grey */
-.dusk .event-card, .dusk .event-item, .dusk .rail-thumb, .dusk .mode-toggle {
+.dusk .event-card, .dusk .event-item, .dusk .rail-thumb {
     -webkit-tap-highlight-color: transparent;
 }
 @media (prefers-reduced-motion: reduce) {
@@ -7153,42 +7153,12 @@ html.dusk body {
 
 /* =====================================================================
    COZY / DENSE — the mobile view system (js/dusk-rail.js).
-   COZY  = the production vertical list (select = the rest hide, like the
-           site always did), with descriptions never clamped.
-   DENSE = a fixed-screen trifold: week grid / 246px card rail with corner
-           flyer thumbs + bottom sheet / map. No rail geometry ever animates.
-   html.mode-cozy | html.mode-dense are set by dusk-rail (dusk pages,
-   mobile <769px only). .rail-active lives on .events-list (dense only).
+   Mobile has ONE mode (dense): week grid / 246px card rail with corner
+   flyer thumbs + bottom sheet / map. No rail geometry ever animates.
+   html.mode-dense is set unconditionally by dusk-rail (dusk pages);
+   .rail-active lives on .events-list. A COZY alternate mode existed,
+   was field-tested, and was removed 2026-08-25 along with its toggle.
    ===================================================================== */
-
-/* the mode toggle: quiet text, immediately left of the city switcher */
-.mode-toggle {
-    background: transparent;
-    border: 0;
-    cursor: pointer;
-    color: rgba(255, 255, 255, 0.6);
-    font-size: 0.78rem;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    padding: 0.1rem 0.05rem;
-    margin-left: auto;
-    margin-right: 0.55rem;
-    line-height: 1.2;
-    align-self: center;
-    display: none;
-    transition: color 0.12s ease;
-}
-.mode-toggle:active { color: #fff; }
-@media (max-width: 768.9px) {
-    .dusk .mode-toggle { display: inline-block; }
-    /* both carried margin-left:auto — neutralize the switcher's when the
-       toggle precedes it so they sit tight together */
-    .dusk .mode-toggle + .city-switcher { margin-left: 0; }
-}
-@media (min-width: 769px) {
-    .mode-toggle { display: none; }
-}
 
 /* the corner flyer thumb: loader-emitted on every flyer card, inert and
    invisible outside the mobile rail (dusk-rail assigns its art on mobile
@@ -7302,55 +7272,51 @@ html.dusk body {
     .dusk .event-card.detailed:hover {
         transform: none;
     }
-}
-
-/* ---------- COZY: today's list, with the full story always shown ------
-   Cozy is the production vertical list; selecting a card hides the rest
-   (the behavior the site always had). The only cozy deltas: descriptions
-   are never clamped, and the dense-mode '…more' chip never appears. */
-@media (max-width: 768.9px) {
-    /* outweigh the production clamp at .event-card.detailed.aurora .ec-tea */
-    html.mode-cozy .event-card.detailed.aurora .ec-tea {
-        display: block;
-        -webkit-line-clamp: unset;
-        max-height: none;
-        overflow: visible;
-    }
-    html.mode-cozy .event-card .ec-more { display: none; }
-    /* selecting hides the rest — the desktop keeps the filter spotlight
-       (the base rule near the old hider), mobile cozy hides like today */
-    html.mode-cozy .events-list.selection-mode .event-card:not(.selected) {
-        display: none;
+    /* the base slideInSmooth section reveal (staggered 0.4-1.0s delays,
+       fill:both) holds each section INVISIBLE through its delay and then
+       slowly fades it in on every load — the dense "middle cards magically
+       slowly fade in" report. Its companion transition:all 0.6s also
+       animates any mode-class layout change. The mobile trifold is a
+       static frame: none of it runs here (desktop keeps its load reveal). */
+    .dusk .weekly-calendar,
+    .dusk .events,
+    .dusk .events-map-section {
+        animation: none !important;
+        transition: none !important;
     }
 }
 
-/* ---------- DENSE: the fixed-screen trifold ---------- */
+/* ---------- DENSE: the mobile trifold ----------
+   Fills exactly one screen when the week fits (the map takes the rest via
+   dusk-rail's sizeDenseMap). A BIG week (festival runs) grows the page
+   DOWNWARD and the map keeps a 200px floor — layers never overlap and the
+   page simply scrolls. */
 @media (max-width: 768.9px) {
-    html.mode-dense, html.mode-dense body { height: 100%; }
     html.mode-dense body {
-        overflow: hidden;
+        overflow-x: hidden;
+        overflow-y: auto;
         display: flex;
         flex-direction: column;
-        height: 100dvh;
+        min-height: 100dvh;
     }
     html.mode-dense body > header { flex: 0 0 auto; }
     html.mode-dense main.city-page {
-        flex: 1 1 0;
+        flex: 1 1 auto;
         min-height: 0;
         display: flex;
         flex-direction: column;
-        overflow: hidden;
+        overflow: visible;
     }
     html.mode-dense .weekly-calendar { flex: 0 0 auto; }
     html.mode-dense body > footer,
     html.mode-dense .site-footer { display: none; }
-    /* the card band centers in the space it shares with the map */
+    /* the card band never shrinks below its content — a tall grid pushes
+       everything down instead of squeezing the cards under the map */
     html.mode-dense .events {
-        flex: 0 1 auto;
+        flex: 0 0 auto;
         display: flex;
         flex-direction: column;
         justify-content: center;
-        min-height: 0;
         padding-top: 0.5rem;
         padding-bottom: 0.5rem;
     }
@@ -7381,12 +7347,11 @@ html.dusk body {
         -webkit-box-orient: vertical;
         overflow: hidden;
     }
-    /* the map takes whatever is left (height/flex also set inline by
-       dusk-rail's sizeDenseMap — the !important pair outranks the week-map
-       pixel height dusk-ui writes inline) */
+    /* the map's height is written inline by dusk-rail's sizeDenseMap
+       (fill-to-viewport, 200px floor); this is just the pre-JS fallback */
     html.mode-dense .events-map-section {
-        flex: 1 1 0px !important;
-        min-height: 120px;
+        flex: 0 0 auto;
+        min-height: 200px;
         padding: 0;
         margin: 0;
     }
@@ -7419,9 +7384,6 @@ html.dusk body {
        sections every render (dynamic-calendar-loader.js updateCalendarDisplay) */
     html.month-full .events,
     html.month-full .events-map-section { display: none !important; }
-    /* the COZY/DENSE distinction has no meaning on the grid-only month
-       screen — hide the toggle (mode state is kept; it returns with week) */
-    html.month-full .mode-toggle { display: none; }
     html.month-full body,
     html.month-full main.city-page { overflow: auto; }
     html.month-full main.city-page { display: block; }

--- a/styles.css
+++ b/styles.css
@@ -7542,15 +7542,18 @@ html.dusk body {
     justify-content: center;
 }
 .rail-sheet .sheet-links .event-link i { font-size: 0.95rem; }
-/* the venue mini-map: static (interactive:false), pin on the event */
+/* the sheet's map: a read-only twin of the main page's map, at the sheet's
+   bottom — pannable/zoomable, markers not clickable (pointer-events off on
+   the marker layer only; map gestures pass through the canvas) */
 .rail-sheet .sheet-map {
-    height: 180px;
-    margin: 12px 0 0;
+    height: 220px;
+    margin: 14px 0 0;
     border-radius: 12px;
     overflow: hidden;
     box-shadow: 0 6px 20px rgba(6, 8, 20, 0.35);
 }
 .rail-sheet .sheet-map canvas { border-radius: 12px; }
+.rail-sheet .sheet-map .maplibregl-marker { pointer-events: none; }
 /* the cloned when/venue/cover rows lose the card scope that sizes their
    icons/badges — pin the sheet rows to the card's own metrics */
 .rail-sheet .sheet-rows {

--- a/styles.css
+++ b/styles.css
@@ -7296,6 +7296,11 @@ html.dusk body {
         transition: none;
         animation: none;
     }
+    /* no hover lift on touch: iOS makes :hover sticky on tap, so the tapped
+       card jumped up 5px and sat there — the "weird lift" on center cards */
+    .dusk .event-card.detailed:hover {
+        transform: none;
+    }
 }
 
 /* ---------- COZY: scroll-linked expansion ---------- */
@@ -7307,32 +7312,34 @@ html.dusk body {
         contain: layout paint;
     }
     /* base = dense (e=0); the writer's inline max-height/opacity carry e.
-       The 12px flyer gap is the IMG's top margin inside this overflow-hidden
-       box — layout height includes it, max-height:0 compresses it away, and
-       nothing ever animates padding (animated padding under border-box was
-       what clipped the image bottom in the prototype) */
+       The image keeps its PRODUCTION framing (centered, 12px side insets,
+       own radius + shadow, orientation height caps) — only the container's
+       max-height/opacity ever animate. Its 12px TOP padding moves onto the
+       img's margin: a border-box container with vertical padding can never
+       reach max-height:0 (the 12px stub was the prototype's reason for
+       animating padding, which is what clipped the image bottom). */
     html.mode-cozy .events-list.rail-active > .event-card .event-flyer {
-        display: block;
         max-height: 0;
         opacity: 0;
         overflow: hidden;
-        margin: 0;
-        padding: 0;
+        padding-top: 0;
+        padding-bottom: 0;
+        /* aurora's flex default (stretch) pins the img height to the
+           flyer's own max-height — circular, so the unlocked measurement
+           reads ~0 and the image never appears. Top-align instead. */
+        align-items: flex-start;
         transition: none;
     }
     html.mode-cozy .events-list.rail-active > .event-card .event-flyer img {
-        display: block;
-        width: 100%;
-        height: auto;
-        max-height: 45vh;
-        object-fit: contain;
         margin: 12px 0 0;
     }
-    /* no ghost flyer gap on the panel — the flyer's own box carries it */
+    /* no ghost flyer gap on the panel at e=0 (the production hairline would
+       sit as a stray line on the card's top edge while the flyer is
+       collapsed); the panel keeps production radius 0 — the card clips its
+       own corners, so no aurora ever pokes around rounded glass */
     html.mode-cozy .events-list.rail-active > .event-card .event-flyer + .ec-panel {
         margin-top: 0;
         border-top: none;
-        border-radius: 16px;
     }
     /* description: measured max-height (writer), line-clamp OFF — a clean
        cut at e≈0 (line-clamp can't interpolate) */
@@ -7439,7 +7446,6 @@ html.dusk body {
     html.mode-dense .events-list .event-card .event-flyer + .ec-panel {
         margin-top: 0;
         border-top: none;
-        border-radius: 16px;
     }
     html.mode-dense .event-card .ec-tea {
         display: -webkit-box;

--- a/styles.css
+++ b/styles.css
@@ -7153,13 +7153,12 @@ html.dusk body {
 
 /* =====================================================================
    COZY / DENSE — the mobile view system (js/dusk-rail.js).
-   COZY  = the production vertical list until an event is selected, then a
-           horizontal swipe rail with scroll-linked card expansion.
-   DENSE = a fixed-screen trifold: week grid / 246px card rail / map.
+   COZY  = the production vertical list (select = the rest hide, like the
+           site always did), with descriptions never clamped.
+   DENSE = a fixed-screen trifold: week grid / 246px card rail with corner
+           flyer thumbs + bottom sheet / map. No rail geometry ever animates.
    html.mode-cozy | html.mode-dense are set by dusk-rail (dusk pages,
-   mobile <769px only). .rail-active/.rail-settling live on .events-list.
-   Motion law: transitions on rail geometry exist ONLY under .rail-settling
-   — during a gesture the JS writer's inline styles ARE the animation.
+   mobile <769px only). .rail-active lives on .events-list (dense only).
    ===================================================================== */
 
 /* the mode toggle: quiet text, immediately left of the city switcher */
@@ -7303,101 +7302,24 @@ html.dusk body {
     }
 }
 
-/* ---------- COZY: scroll-linked expansion ---------- */
+/* ---------- COZY: today's list, with the full story always shown ------
+   Cozy is the production vertical list; selecting a card hides the rest
+   (the behavior the site always had). The only cozy deltas: descriptions
+   are never clamped, and the dense-mode '…more' chip never appears. */
 @media (max-width: 768.9px) {
-    html.mode-cozy .events-list.rail-active > .event-card {
-        min-height: 246px;
-        overflow: hidden;
-        /* a card's internal growth can't reflow the rest of the page */
-        contain: layout paint;
-    }
-    /* base = dense (e=0); the writer's inline max-height/opacity carry e.
-       The image keeps its PRODUCTION framing (centered, 12px side insets,
-       own radius + shadow, orientation height caps) — only the container's
-       max-height/opacity ever animate. Its 12px TOP padding moves onto the
-       img's margin: a border-box container with vertical padding can never
-       reach max-height:0 (the 12px stub was the prototype's reason for
-       animating padding, which is what clipped the image bottom). */
-    html.mode-cozy .events-list.rail-active > .event-card .event-flyer {
-        max-height: 0;
-        opacity: 0;
-        overflow: hidden;
-        padding-top: 0;
-        padding-bottom: 0;
-        /* aurora's flex default (stretch) pins the img height to the
-           flyer's own max-height — circular, so the unlocked measurement
-           reads ~0 and the image never appears. Top-align instead. */
-        align-items: flex-start;
-        transition: none;
-    }
-    html.mode-cozy .events-list.rail-active > .event-card .event-flyer img {
-        margin: 12px 0 0;
-    }
-    /* no ghost flyer gap on the panel at e=0 (the production hairline would
-       sit as a stray line on the card's top edge while the flyer is
-       collapsed); the panel keeps production radius 0 — the card clips its
-       own corners, so no aurora ever pokes around rounded glass */
-    html.mode-cozy .events-list.rail-active > .event-card .event-flyer + .ec-panel {
-        margin-top: 0;
-        border-top: none;
-    }
-    /* description: measured max-height (writer), line-clamp OFF — a clean
-       cut at e≈0 (line-clamp can't interpolate) */
-    html.mode-cozy .events-list.rail-active > .event-card .ec-tea {
-        display: block;
-        -webkit-line-clamp: unset;
-        max-height: 2.8em;
-        overflow: hidden;
-        transition: none;
-    }
-    /* cozy's LIST state is the production list, whole story shown */
-    html.mode-cozy .events-list:not(.rail-active) .event-card .ec-tea {
+    /* outweigh the production clamp at .event-card.detailed.aurora .ec-tea */
+    html.mode-cozy .event-card.detailed.aurora .ec-tea {
         display: block;
         -webkit-line-clamp: unset;
         max-height: none;
         overflow: visible;
     }
     html.mode-cozy .event-card .ec-more { display: none; }
-    /* the band: the animated height lives on the CONTAINER (an x-scroll list
-       can never have overflow-y visible); the list centers inside it and
-       tall neighbours peek equally top/bottom. The section stacks above the
-       map so the overhang paints over it. */
-    html.mode-cozy .events:has(.events-list.rail-active) {
-        position: relative;
-        z-index: 5;
-        overflow: visible;
+    /* selecting hides the rest — the desktop keeps the filter spotlight
+       (the base rule near the old hider), mobile cozy hides like today */
+    html.mode-cozy .events-list.selection-mode .event-card:not(.selected) {
+        display: none;
     }
-    html.mode-cozy .events:has(.events-list.rail-active) .container {
-        display: flex;
-        align-items: center;
-        overflow: visible;
-        transition: none;
-    }
-    html.mode-cozy .events:has(.events-list.rail-active.rail-settling) .container {
-        transition: height 150ms ease-out;
-    }
-    html.mode-cozy .events-list.rail-active {
-        flex: none;
-        width: 100%;
-        height: auto;
-    }
-    /* during a gesture the band's LAYOUT height is frozen and the map rides
-       a compositor transform; at settle the real height commits and the
-       transform goes home, both easing 150ms in sync */
-    html.mode-cozy .events:has(.events-list.rail-active) ~ .events-map-section {
-        will-change: transform;
-    }
-    html.mode-cozy .events:has(.events-list.rail-active.rail-settling) ~ .events-map-section {
-        transition: transform 150ms ease-out;
-    }
-    /* settle: e snaps to exactly 1/0 — the ONLY transitions in the system */
-    html.mode-cozy .events-list.rail-active.rail-settling > .event-card .event-flyer,
-    html.mode-cozy .events-list.rail-active.rail-settling > .event-card .ec-tea,
-    html.mode-cozy .events-list.rail-active.rail-settling > .event-card .rail-thumb {
-        transition: max-height 150ms ease-out, opacity 150ms ease-out;
-    }
-    html.mode-cozy.month-full .events .container { height: auto; }
-    html.mode-cozy.month-full .events-list { height: auto; }
 }
 
 /* ---------- DENSE: the fixed-screen trifold ---------- */
@@ -7569,6 +7491,45 @@ html.dusk body {
 .rail-sheet.up .sheet-panel { transform: none; }
 .rail-sheet .sheet-title { margin: 0 0 8px; font-size: 1.15rem; }
 .rail-sheet .sheet-desc { margin: 12px 0 0; line-height: 1.55; }
+/* the flyer rides the sheet exactly as it rides the card: centered, own
+   radius + shadow; tap opens the lightbox */
+.rail-sheet .sheet-flyer {
+    display: flex;
+    justify-content: center;
+    margin: 0 0 12px;
+}
+.rail-sheet .sheet-flyer img {
+    display: block;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 38dvh;
+    border-radius: 10px;
+    box-shadow: 0 6px 20px rgba(6, 8, 20, 0.45);
+    cursor: pointer;
+}
+/* the cloned links row loses the aurora card scope — mirror the card's own
+   round glass buttons (share button is stripped from the clone) */
+.rail-sheet .sheet-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.42rem;
+    margin: 2px 0 0;
+}
+.rail-sheet .sheet-links .event-link {
+    width: 32px;
+    height: 32px;
+    margin: 0;
+    padding: 0;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.rail-sheet .sheet-links .event-link i { font-size: 0.95rem; }
 /* the cloned when/venue/cover rows lose the card scope that sizes their
    icons/badges — pin the sheet rows to the card's own metrics */
 .rail-sheet .sheet-rows {

--- a/styles.css
+++ b/styles.css
@@ -2096,7 +2096,9 @@ body.index-page main {
     background: var(--background-primary);
     border-radius: 15px;
     padding: 2rem;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    /* only the hover lift animates — `all` caught the selection filter/class
+       swaps mid-frame and flashed the card on every tap */
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     position: relative;
     will-change: transform;
 }
@@ -4299,9 +4301,18 @@ footer {
 }
 
 
-/* Hide non-selected events when in selection mode */
-.events-list.selection-mode .event-card:not(.selected) {
-    display: none;
+/* Selection = spotlight, never hide: display:none here collapsed the page
+   height in one frame on every tap (scroll clamp + map resize = the press
+   "blink"). Dim via filter, not opacity, matching the calendar-grid
+   spotlight — translucent cards double-composite over the map/section
+   backgrounds. The mobile rail (.rail-active) is excluded: there the
+   centered position IS the selection signal, and the live scrub flips the
+   selection every few hundred ms — a filter swap would strobe. */
+.events-list.selection-mode:not(.rail-active) .event-card:not(.selected) {
+    filter: saturate(0.35) brightness(0.5);
+}
+.events-list.selection-mode:not(.rail-active) .event-card.selected {
+    filter: none;
 }
 
 /* Removed highlightPulse animation - using persistent selection only */
@@ -6862,6 +6873,11 @@ html.dusk body {
 .dusk .view-btn, .dusk .nav-btn, .dusk .today-btn {
     transition: color 0.12s ease, background-color 0.12s ease, border-color 0.12s ease;
 }
+/* iOS paints its default grey rectangle over any click-bound element on
+   press — the cards are click-bound <div>s, so every tap flashed grey */
+.dusk .event-card, .dusk .event-item, .dusk .rail-thumb, .dusk .mode-toggle {
+    -webkit-tap-highlight-color: transparent;
+}
 @media (prefers-reduced-motion: reduce) {
     .dusk *, .dusk *::before, .dusk *::after {
         animation: none !important;
@@ -7129,4 +7145,475 @@ html.dusk body {
     background: transparent;
     border: none;
     pointer-events: none;
+}
+
+/* =====================================================================
+   COZY / DENSE — the mobile view system (js/dusk-rail.js).
+   COZY  = the production vertical list until an event is selected, then a
+           horizontal swipe rail with scroll-linked card expansion.
+   DENSE = a fixed-screen trifold: week grid / 246px card rail / map.
+   html.mode-cozy | html.mode-dense are set by dusk-rail (dusk pages,
+   mobile <769px only). .rail-active/.rail-settling live on .events-list.
+   Motion law: transitions on rail geometry exist ONLY under .rail-settling
+   — during a gesture the JS writer's inline styles ARE the animation.
+   ===================================================================== */
+
+/* the mode toggle: quiet text, immediately left of the city switcher */
+.mode-toggle {
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 0.1rem 0.05rem;
+    margin-left: auto;
+    margin-right: 0.55rem;
+    line-height: 1.2;
+    align-self: center;
+    display: none;
+    transition: color 0.12s ease;
+}
+.mode-toggle:active { color: #fff; }
+@media (max-width: 768.9px) {
+    .dusk .mode-toggle { display: inline-block; }
+    /* both carried margin-left:auto — neutralize the switcher's when the
+       toggle precedes it so they sit tight together */
+    .dusk .mode-toggle + .city-switcher { margin-left: 0; }
+}
+@media (min-width: 769px) {
+    .mode-toggle { display: none; }
+}
+
+/* the corner flyer thumb: loader-emitted on every flyer card, inert and
+   invisible outside the mobile rail (dusk-rail assigns its art on mobile
+   only, so the hidden desktop button never fetches an image) */
+.event-card .rail-thumb { display: none; }
+
+/* ---------- the rail (both modes share the horizontal geometry) ---------- */
+@media (max-width: 768.9px) {
+    .dusk .events:has(.events-list.rail-active) .container {
+        padding-left: 0;
+        padding-right: 0;
+    }
+    .dusk .events-list.rail-active {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        gap: 0.6rem;
+        align-items: center;
+        overflow-x: auto;
+        overflow-y: hidden;
+        overscroll-behavior-x: contain;
+        scroll-snap-type: x mandatory;
+        -webkit-overflow-scrolling: touch;
+        /* programmatic scrolls pass behavior explicitly; a smooth container
+           fights iOS momentum + snap */
+        scroll-behavior: auto;
+        /* symmetric phantom gutters = (100vw − cardWidth)/2 so the FIRST and
+           LAST cards snap to center with empty space beside them */
+        padding: 6px 2.8rem;
+        scrollbar-width: none;
+    }
+    .dusk .events-list.rail-active::-webkit-scrollbar { display: none; }
+    .dusk .events-list.rail-active > .event-card {
+        /* width pinned to the viewport so the wide end-gutters don't
+           shrink it (same 300px at 390px wide as the vertical list) */
+        flex: 0 0 calc(100vw - 5.6rem);
+        max-width: none;
+        width: auto;
+        margin: 0;
+        height: auto;
+        align-self: center;
+        position: relative;
+        scroll-snap-align: center;
+        scroll-snap-stop: normal;
+    }
+    /* the panel fills the card box and the links row pins to its BOTTOM —
+       the card's dark aurora ground can never paint below the glass panel
+       (the cozy "darker extra space" bug was exactly this rule missing) */
+    .dusk .events-list.rail-active > .event-card .ec-panel {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+    .dusk .events-list.rail-active > .event-card .ec-panel > .event-links {
+        margin-top: auto;
+    }
+    /* titles stay 2-line clamped at every expansion (interpolating a title
+       reads badly); rail cards never render shorter than the dense box */
+    .dusk .events-list.rail-active > .event-card .ec-title {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+    /* the rail's loading / "No events found" message: a full-width centered
+       band member, not a squeezed flex item off to the left */
+    .dusk .events-list.rail-active .loading-message {
+        flex: 0 0 calc(100% - 3.2rem);
+        margin: 0 auto;
+        align-self: center;
+        background: transparent;
+        font-size: 15px;
+        padding: 24px 12px;
+    }
+    .dusk .events-list.rail-active:has(> .event-card:only-of-type) { justify-content: center; }
+    /* corner thumb, shared: always-on in dense, writer-faded in cozy */
+    .dusk .events-list.rail-active > .event-card .rail-thumb {
+        display: block;
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        width: 56px;
+        height: 56px;
+        padding: 0;
+        border: 0;
+        border-radius: 12px;
+        overflow: hidden;
+        z-index: 3;
+        box-shadow: 0 3px 10px rgba(0, 0, 0, 0.35);
+        cursor: pointer;
+        background-color: transparent;
+        background-size: cover;
+        background-position: center;
+        transition: none;
+    }
+    .dusk .events-list.rail-active > .event-card:has(.rail-thumb) .ec-titlerow {
+        padding-right: 64px;
+    }
+    /* no map motion (owner rule): the map never animates layout; the only
+       sanctioned movement is the cozy band's settle transform below */
+    .dusk .events-map-section,
+    .dusk .map-container {
+        transition: none;
+        animation: none;
+    }
+}
+
+/* ---------- COZY: scroll-linked expansion ---------- */
+@media (max-width: 768.9px) {
+    html.mode-cozy .events-list.rail-active > .event-card {
+        min-height: 246px;
+        overflow: hidden;
+        /* a card's internal growth can't reflow the rest of the page */
+        contain: layout paint;
+    }
+    /* base = dense (e=0); the writer's inline max-height/opacity carry e.
+       The 12px flyer gap is the IMG's top margin inside this overflow-hidden
+       box — layout height includes it, max-height:0 compresses it away, and
+       nothing ever animates padding (animated padding under border-box was
+       what clipped the image bottom in the prototype) */
+    html.mode-cozy .events-list.rail-active > .event-card .event-flyer {
+        display: block;
+        max-height: 0;
+        opacity: 0;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+        transition: none;
+    }
+    html.mode-cozy .events-list.rail-active > .event-card .event-flyer img {
+        display: block;
+        width: 100%;
+        height: auto;
+        max-height: 45vh;
+        object-fit: contain;
+        margin: 12px 0 0;
+    }
+    /* no ghost flyer gap on the panel — the flyer's own box carries it */
+    html.mode-cozy .events-list.rail-active > .event-card .event-flyer + .ec-panel {
+        margin-top: 0;
+        border-top: none;
+        border-radius: 16px;
+    }
+    /* description: measured max-height (writer), line-clamp OFF — a clean
+       cut at e≈0 (line-clamp can't interpolate) */
+    html.mode-cozy .events-list.rail-active > .event-card .ec-tea {
+        display: block;
+        -webkit-line-clamp: unset;
+        max-height: 2.8em;
+        overflow: hidden;
+        transition: none;
+    }
+    /* cozy's LIST state is the production list, whole story shown */
+    html.mode-cozy .events-list:not(.rail-active) .event-card .ec-tea {
+        display: block;
+        -webkit-line-clamp: unset;
+        max-height: none;
+        overflow: visible;
+    }
+    html.mode-cozy .event-card .ec-more { display: none; }
+    /* the band: the animated height lives on the CONTAINER (an x-scroll list
+       can never have overflow-y visible); the list centers inside it and
+       tall neighbours peek equally top/bottom. The section stacks above the
+       map so the overhang paints over it. */
+    html.mode-cozy .events:has(.events-list.rail-active) {
+        position: relative;
+        z-index: 5;
+        overflow: visible;
+    }
+    html.mode-cozy .events:has(.events-list.rail-active) .container {
+        display: flex;
+        align-items: center;
+        overflow: visible;
+        transition: none;
+    }
+    html.mode-cozy .events:has(.events-list.rail-active.rail-settling) .container {
+        transition: height 150ms ease-out;
+    }
+    html.mode-cozy .events-list.rail-active {
+        flex: none;
+        width: 100%;
+        height: auto;
+    }
+    /* during a gesture the band's LAYOUT height is frozen and the map rides
+       a compositor transform; at settle the real height commits and the
+       transform goes home, both easing 150ms in sync */
+    html.mode-cozy .events:has(.events-list.rail-active) ~ .events-map-section {
+        will-change: transform;
+    }
+    html.mode-cozy .events:has(.events-list.rail-active.rail-settling) ~ .events-map-section {
+        transition: transform 150ms ease-out;
+    }
+    /* settle: e snaps to exactly 1/0 — the ONLY transitions in the system */
+    html.mode-cozy .events-list.rail-active.rail-settling > .event-card .event-flyer,
+    html.mode-cozy .events-list.rail-active.rail-settling > .event-card .ec-tea,
+    html.mode-cozy .events-list.rail-active.rail-settling > .event-card .rail-thumb {
+        transition: max-height 150ms ease-out, opacity 150ms ease-out;
+    }
+    html.mode-cozy.month-full .events .container { height: auto; }
+    html.mode-cozy.month-full .events-list { height: auto; }
+}
+
+/* ---------- DENSE: the fixed-screen trifold ---------- */
+@media (max-width: 768.9px) {
+    html.mode-dense, html.mode-dense body { height: 100%; }
+    html.mode-dense body {
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        height: 100dvh;
+    }
+    html.mode-dense body > header { flex: 0 0 auto; }
+    html.mode-dense main.city-page {
+        flex: 1 1 0;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+    html.mode-dense .weekly-calendar { flex: 0 0 auto; }
+    html.mode-dense body > footer,
+    html.mode-dense .site-footer { display: none; }
+    /* the card band centers in the space it shares with the map */
+    html.mode-dense .events {
+        flex: 0 1 auto;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        min-height: 0;
+        padding-top: 0.5rem;
+        padding-bottom: 0.5rem;
+    }
+    html.mode-dense .events .container {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+    }
+    /* every dense card is the SAME 246px box (titlerow + rows + 2-line tea +
+       links measured at 390px); sparse cards simply end early inside it */
+    html.mode-dense .events-list.rail-active > .event-card {
+        height: 246px;
+        overflow: hidden;
+    }
+    /* the corner thumb is the ONLY image surface in dense */
+    html.mode-dense .events-list .event-card .event-flyer { display: none; }
+    html.mode-dense .events-list .event-card .event-flyer + .ec-panel {
+        margin-top: 0;
+        border-top: none;
+        border-radius: 16px;
+    }
+    html.mode-dense .event-card .ec-tea {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+    /* the map takes whatever is left (height/flex also set inline by
+       dusk-rail's sizeDenseMap — the !important pair outranks the week-map
+       pixel height dusk-ui writes inline) */
+    html.mode-dense .events-map-section {
+        flex: 1 1 0px !important;
+        min-height: 120px;
+        padding: 0;
+        margin: 0;
+    }
+    html.mode-dense .events-map-section::before,
+    html.mode-dense .events-map-section h2,
+    html.mode-dense .events-map-section p { display: none; }
+    html.mode-dense .events-map-section .container {
+        height: 100%;
+        padding: 0 0.6rem 0.6rem;
+    }
+    html.mode-dense .map-container,
+    html.mode-dense #events-map {
+        height: 100% !important;
+        min-height: 0;
+        border-radius: 16px;
+    }
+    /* attribution collapses to the (i) so the small map isn't a banner */
+    html.mode-dense .maplibregl-ctrl-attrib:not(.maplibregl-compact) { display: none; }
+    html.mode-dense .maplibregl-ctrl-attrib {
+        font-size: 9px;
+        line-height: 1.2;
+        max-width: 62%;
+        padding: 1px 4px;
+    }
+}
+
+/* ---------- mobile month view: the month grid IS the screen ---------- */
+@media (max-width: 768.9px) {
+    /* !important is required: the loader writes display:block INLINE on both
+       sections every render (dynamic-calendar-loader.js updateCalendarDisplay) */
+    html.month-full .events,
+    html.month-full .events-map-section { display: none !important; }
+    html.month-full body,
+    html.month-full main.city-page { overflow: auto; }
+    html.month-full main.city-page { display: block; }
+}
+
+/* ---------- flyer lightbox (corner-thumb tap) ---------- */
+/* above the fixed header (z 9998); the sheet sits just under the lightbox */
+.rail-lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 10020;
+    display: none;
+    background: rgba(5, 6, 10, 0.88);
+    align-items: center;
+    justify-content: center;
+    padding: calc(14px + env(safe-area-inset-top)) calc(14px + env(safe-area-inset-right))
+             calc(14px + env(safe-area-inset-bottom)) calc(14px + env(safe-area-inset-left));
+    overflow: hidden;
+}
+.rail-lightbox.open { display: flex; }
+.rail-lightbox img {
+    max-width: 100%;
+    max-height: calc(100dvh - 28px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    border-radius: 14px;
+    box-shadow: 0 18px 60px rgba(0, 0, 0, 0.6);
+}
+
+/* ---------- dense description sheet + '…more' chip ---------- */
+.ec-more {
+    background: none;
+    border: 0;
+    padding: 0 2px;
+    margin: 2px 0 0;
+    align-self: flex-start;
+    font-size: 0.8rem;
+    opacity: 0.78;
+    color: inherit;
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+.rail-sheet {
+    position: fixed;
+    inset: 0;
+    z-index: 10010;
+    display: none;
+    background: rgba(5, 6, 10, 0.55);
+}
+.rail-sheet.open { display: block; }
+.rail-sheet .sheet-panel {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    max-height: 78dvh;
+    overflow-y: auto;
+    border-radius: 18px 18px 0 0;
+    padding: 18px 18px calc(20px + env(safe-area-inset-bottom));
+    /* the card's aurora custom props ride in on the panel's style attribute */
+    background: var(--c1, var(--background-primary, #14172a));
+    box-shadow: 0 -14px 40px rgba(0, 0, 0, 0.5);
+    transform: translateY(100%);
+    transition: transform 300ms cubic-bezier(0.2, 0.7, 0.3, 1);
+    color: #fff;
+}
+.rail-sheet.up .sheet-panel { transform: none; }
+.rail-sheet .sheet-title { margin: 0 0 8px; font-size: 1.15rem; }
+.rail-sheet .sheet-desc { margin: 12px 0 0; line-height: 1.55; }
+/* the cloned when/venue/cover rows lose the card scope that sizes their
+   icons/badges — pin the sheet rows to the card's own metrics */
+.rail-sheet .sheet-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin: 0;
+}
+.rail-sheet .sheet-rows .ec-row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+}
+.rail-sheet .sheet-rows .ec-ico {
+    display: block;
+    width: 15px;
+    height: 15px;
+    flex: 0 0 15px;
+    opacity: 0.85;
+}
+.rail-sheet .sheet-rows .event-day {
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    border-radius: 0;
+    font-size: inherit;
+    font-weight: inherit;
+    color: inherit;
+    display: inline;
+    box-shadow: none;
+    min-height: 0;
+    min-width: 0;
+}
+.rail-sheet .sheet-rows .ec-badges {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    margin-left: 0.15rem;
+}
+.rail-sheet .sheet-rows .recurring-badge,
+.rail-sheet .sheet-rows .date-badge,
+.rail-sheet .sheet-rows .distance-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin: 0;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    color: #fff;
+    font-size: 0.66rem;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+}
+.rail-sheet .sheet-rows .ec-badge-ico {
+    display: block;
+    width: 10px;
+    height: 10px;
+    flex: 0 0 10px;
 }

--- a/styles.css
+++ b/styles.css
@@ -6106,9 +6106,11 @@ body.loaded {
     will-change: transform;
 }
 
-/* Smooth event card interactions */
+/* Smooth event card interactions — hover lift only: this later duplicate
+   used to say `all`, silently re-widening the scoped transition at the
+   card's base rule and catching the selection filter swap mid-tap */
 .event-card.detailed {
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     will-change: transform;
 }
 
@@ -7087,8 +7089,10 @@ html.dusk body {
         flex-direction: column;
         gap: 1rem;
     }
-    /* a selected card takes the full width again */
-    .dusk .events-list.selection-mode .ml-col { display: contents; }}
+    /* (the display:contents collapse that lived here served the old
+       hide-on-select behavior — with the selection spotlight the columns
+       simply stay put) */
+}
 
 /* month spreads to three columns only when three columns actually fit */
 @media (min-width: 1200px) {
@@ -7513,6 +7517,10 @@ html.dusk body {
 
 /* ---------- dense description sheet + '…more' chip ---------- */
 .ec-more {
+    /* hidden everywhere by default — chips inserted under mobile dense can
+       survive a breakpoint crossing (iPad rotation) and must not strand as
+       dead controls in desktop or cozy cards */
+    display: none;
     background: none;
     border: 0;
     padding: 0 2px;
@@ -7524,6 +7532,9 @@ html.dusk body {
     cursor: pointer;
     text-decoration: underline dotted;
     text-underline-offset: 2px;
+}
+@media (max-width: 768.9px) {
+    html.mode-dense .event-card .ec-more { display: inline-block; }
 }
 .rail-sheet {
     position: fixed;

--- a/toronto/index.html
+++ b/toronto/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>

--- a/vegas/index.html
+++ b/vegas/index.html
@@ -303,5 +303,6 @@
     <script src="../js/dynamic-calendar-loader.js"></script>
     <script src="../js/app.js"></script>
     <script src="../js/dusk-ui.js"></script>
+    <script src="../js/dusk-rail.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Ships the mobile redesign as first-class site code. The design converged through four rounds of on-phone field review: a COZY/DENSE dual-mode system (and before it a scroll-linked swipe rail) was built, tested, and cut — **mobile has exactly one mode now**.

## What ships (mobile <769px, dusk city pages)

- **The trifold**: week grid / 246px card rail with corner flyer thumbs (tap → lightbox) / map filling the rest. Swiping the rail drives the site's real selection live (pill spotlight + map marker follow), with one URL write per gesture.
- **Nothing is ever hidden**: week and month views show every event pill. A big week (Sitges bear week, 50 pills) grows the page downward — the card band never shrinks below its content and the map keeps a 200px floor, so layers can't overlap; the page just scrolls.
- **Bottom sheet** (dense '…more' chip + month view pill taps, replacing week-navigation): flyer image (tap → lightbox), title, detail rows, link buttons, full description, and a **read-only twin of the main map** at the bottom — same style, same purple-water theme, same favicon icon markers over the same event set, city framing, this event's icon highlighted and the rest dimmed; pan/zoom live, markers not clickable.
- **Month view** is the grid alone (list+map hidden); the city switcher stays top-right.
- **Static frame**: the base slideInSmooth staggered section reveal and its `transition: all 0.6s` are dead on mobile dusk (they held sections invisible then slowly faded them in on every load); hover lift disabled (iOS sticky :hover); `-webkit-tap-highlight-color` cleared; nothing on a dense card animates. Desktop keeps its load reveal.

## Desktop (the one intended change)

Selection no longer hides cards — non-selected cards dim via the calendar-grid filter spotlight. The leftover `.ml-col{display:contents}` collapse (which scrambled the masonry once cards stayed visible) and a duplicate `transition:all` rule are also fixed.

## Integration seams

- Loader dispatches `chunky:events-rendered` / `chunky:selection-changed`; dusk-ui dispatches `dusk:controls-mounted` — zero MutationObservers, zero retry timers in the rail module.
- `toggleEventSelection(slug, dateISO, {deferUrl})`; `generateEventCard` emits the `.rail-thumb` button (inert on desktop, art assigned mobile-only); `openWeekAt()`; `createSheetMap()` (+ `lastMapEvents` stash in `initializeMap`).
- Map camera never moved programmatically; the sheet map is a separate instance created per open and destroyed on close.

**NEW runtime file: `js/dusk-rail.js`** (`city.html` + all city pages regenerated for the script tag). Map PiP parked as a future add-on.

## Verification

- Quiet suite green; WebKit probes at 390/1100/1440 across nyc + sitges: trifold fills exactly one screen when the week fits (map edge at viewport bottom), Sitges bear week grows to 1155px with a 0px seam between band and map at its floor; month shows all pills with the switcher 16px from the right edge; sheet DOM ends with the map twin (1 selected + dimmed favicon markers, nav control, no click handlers); desktop masonry intact with spotlight-only selection changes.
- Adversarial review pre-merge fixed 6 defects; four rounds of on-phone field review at rybook:8745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP