### PR TITLE
Parked multi-day labels honor the selection spotlight

### DIFF
--- a/js/dusk-ui.js
+++ b/js/dusk-ui.js
@@ -360,6 +360,7 @@
                 t.style.whiteSpace = 'nowrap';
             }
             el.style.top = (sr.top - gr.top) + 'px';
+            el.setAttribute('data-event-slug', lead.getAttribute('data-event-slug') || '');
             layer.appendChild(el);
             floatLabels.push({
                 lead, span, el,
@@ -371,6 +372,7 @@
             });
         });
         updateFloatLabels();
+        updateFloatLabelDim();
     }
     function updateFloatLabels() {
         const grid = document.querySelector('.calendar-grid.week-strip');
@@ -412,6 +414,20 @@
         if (!t || !t.classList || !t.classList.contains('week-strip')) return;
         updateFloatLabels();
     }, { capture: true, passive: true });
+
+    // spotlight parity: the overlay lives OUTSIDE the grid, so the
+    // calendar's :has(.selected) filter never reaches a parked label — a
+    // non-selected run's label must mute like its bar whenever some OTHER
+    // event is selected (and stay bright when its own run is selected or
+    // nothing is)
+    function updateFloatLabelDim() {
+        const sel = (window.calendarLoader && window.calendarLoader.selectedEventSlug) || null;
+        floatLabels.forEach(L => {
+            const slug = L.el.getAttribute('data-event-slug');
+            L.el.classList.toggle('md-label-dim', !!(sel && slug !== sel));
+        });
+    }
+    document.addEventListener('chunky:selection-changed', updateFloatLabelDim);
 
     function paintMultiDayRuns() {
         const segs = [...document.querySelectorAll('.event-item.multi-day[data-event-slug]')];

--- a/styles.css
+++ b/styles.css
@@ -7740,3 +7740,8 @@ html.dusk body {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+/* parked-label spotlight parity: same mute as the calendar pills */
+.md-label-layer .md-float-label.md-label-dim {
+    filter: saturate(0.35) brightness(0.4);
+}


### PR DESCRIPTION
Follow-up to #1705. The parked multi-day label lives in an overlay **outside** the grid scroller (that's what makes it compositor-still), so the calendar's `:has(.selected)` spotlight filter never reached it — a muted bar wore a full-white label whenever a different event was selected.

Float labels now carry their event slug and mirror the spotlight by class (`md-label-dim`, the exact `saturate(0.35) brightness(0.4)` the pills use), synced on `chunky:selection-changed` and at label build.

Verified headless across all three states: another event selected → label muted with its bar; its own run selected → bright; nothing selected → bright; deselect → restored. The riding (in-pill) label needed nothing — it inherits its pill's filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP