### PR TITLE
Strip polish: no flashing on rebuilds, deeper buffers, quieter controls

### DIFF
--- a/js/dusk-ui.js
+++ b/js/dusk-ui.js
@@ -451,6 +451,15 @@
     }
 
     // Re-render happens via wholesale innerHTML swaps — observe and repaint.
+    // The loader dispatches this in the SAME task as its grid swap, so
+    // painting here colors the fresh pills before the browser paints them.
+    // The MutationObserver below only ever repaints on the NEXT frame —
+    // i.e. after a frame of default-colored pills, which is the blink when
+    // more months load (mobile month view shows pills, not cards).
+    document.addEventListener('chunky:events-rendered', () => {
+        try { paintPills(); } catch (e) {}
+    });
+
     let scheduled = false;
     const observer = new MutationObserver(() => {
         if (scheduled) return;

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -4332,20 +4332,6 @@ class DynamicCalendarLoader extends CalendarCore {
         grid.scrollTo({ left: Math.round(newStart * dayW), behavior: 'smooth' });
     }
 
-    // Strip rebuild (extending the rendered range around the user): flags
-    // the grid so a quiet progress hairline shows — the only moment the
-    // continuous calendar does real work, and previously it was silent.
-    async rebuildStrip() {
-        const grid = document.querySelector('.calendar-grid');
-        if (grid) grid.classList.add('strip-rebuilding');
-        try {
-            await this.updateCalendarDisplay();
-        } finally {
-            const g = document.querySelector('.calendar-grid');
-            if (g) g.classList.remove('strip-rebuilding');
-        }
-    }
-
     // A selection whose day slid outside the visible window RESETS — leaving
     // it active greyed the whole calendar/map/list with nothing visibly
     // selected (owner report: select fuzzy, swipe it out of view)
@@ -4378,28 +4364,69 @@ class DynamicCalendarLoader extends CalendarCore {
     // recreating its favicon chips made every icon in the week view flash
     // (owner report). Same trick the events list uses for its cards.
     swapHtmlPreservingImages(container, html) {
-        // key on the RESOLVED url (the .src property), not the attribute:
-        // the two sides can spell the same image relatively vs absolutely
+        const shell = document.createElement('div');
+        shell.innerHTML = html;
+
+        // 1. REUSE unchanged day cells outright. A strip rebuild re-renders a
+        // range that mostly overlaps what is already on screen; recreating
+        // those cells threw away their pills' colours and their favicons'
+        // decoded pixels, which is the blink at a month edge. A cell whose
+        // markup is byte-identical is moved across as the SAME node, so
+        // nothing about it repaints.
+        const oldCells = new Map();
+        container.querySelectorAll('[data-date]').forEach(cell => {
+            const key = cell.getAttribute('data-date');
+            if (key && !oldCells.has(key)) oldCells.set(key, cell);
+        });
+        let reusedCells = 0;
+        if (oldCells.size) {
+            shell.querySelectorAll('[data-date]').forEach(fresh => {
+                const key = fresh.getAttribute('data-date');
+                const old = key && oldCells.get(key);
+                if (!old) return;
+                const sig = this.hashString(fresh.outerHTML);
+                if (old.dataset.cellSig === sig) {
+                    oldCells.delete(key);
+                    fresh.replaceWith(old);
+                    reusedCells++;
+                } else {
+                    fresh.dataset.cellSig = sig;
+                }
+            });
+        } else {
+            shell.querySelectorAll('[data-date]').forEach(fresh => {
+                fresh.dataset.cellSig = this.hashString(fresh.outerHTML);
+            });
+        }
+
+        // 2. for whatever is genuinely new, still hand over already-decoded
+        // <img> nodes by RESOLVED url (the two sides can spell the same
+        // image relatively vs absolutely)
         const pool = new Map();
         container.querySelectorAll('img').forEach(img => {
             const src = img.src;
             if (src && img.complete && img.naturalWidth > 0 && !pool.has(src)) pool.set(src, img);
         });
-        if (!pool.size) {
-            container.innerHTML = html;
-            return;
+        if (pool.size) {
+            shell.querySelectorAll('img').forEach(img => {
+                if (!img.isConnected && !shell.contains(img)) return;
+                const src = img.src;
+                const donor = src && pool.get(src);
+                if (donor && donor !== img && !shell.contains(donor)) {
+                    pool.delete(src);
+                    img.replaceWith(donor);
+                }
+            });
         }
-        const shell = document.createElement('div');
-        shell.innerHTML = html;
-        shell.querySelectorAll('img').forEach(img => {
-            const src = img.src;
-            const donor = src && pool.get(src);
-            if (donor) {
-                pool.delete(src);
-                img.replaceWith(donor);
-            }
-        });
         container.replaceChildren(...shell.childNodes);
+        logger.debug('CALENDAR', 'Grid swap reused cells', { reusedCells });
+    }
+
+    // djb2 — cheap, stable content signature for reconciliation
+    hashString(str) {
+        let hash = 5381;
+        for (let i = 0; i < str.length; i++) hash = ((hash << 5) + hash + str.charCodeAt(i)) >>> 0;
+        return String(hash);
     }
 
     // Header label for the visible period (title slot + date range)
@@ -4535,7 +4562,7 @@ class DynamicCalendarLoader extends CalendarCore {
             this.currentDate = newStart;
             this.clearSelectionIfOutOfBounds();
             if (nearEdge) {
-                await this.rebuildStrip();
+                await this.updateCalendarDisplay();
                 return;
             }
             this.sizeWeekStripHeight();
@@ -4580,7 +4607,7 @@ class DynamicCalendarLoader extends CalendarCore {
             this.pendingStripAnchor = anchorCell
                 ? { dateKey: anchorCell.getAttribute('data-date'), offset: anchorOffset }
                 : null;
-            await this.rebuildStrip();
+            await this.updateCalendarDisplay();
             return;
         }
         this.updateHeaderPeriodLabel();

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -3542,7 +3542,16 @@ class DynamicCalendarLoader extends CalendarCore {
         const stripEnd = new Date(lastDay);
         stripEnd.setDate(lastDay.getDate() + (6 - lastDay.getDay()));
         stripEnd.setHours(23, 59, 59, 999);
-        const stripEvents = this.getFilteredEvents({ start: stripStart, end: stripEnd });
+        // Query a WIDER range than the strip's nominal bounds: generateMonthView
+        // rounds its cell range up to whole weeks, so it renders a few days
+        // past stripEnd — those cells came out EMPTY (their events were never
+        // queried) even when the day had events, and they changed content on
+        // the next rebuild once the range moved. Pad both ends by a week.
+        const queryStart = new Date(stripStart);
+        queryStart.setDate(queryStart.getDate() - 7);
+        const queryEnd = new Date(stripEnd);
+        queryEnd.setDate(queryEnd.getDate() + 7);
+        const stripEvents = this.getFilteredEvents({ start: queryStart, end: queryEnd });
         this.lastStripEvents = stripEvents;
         const dayHeadersHtml = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(d => `
             <div class="calendar-day-header"><h4>${d}</h4></div>`).join('');

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -126,7 +126,7 @@ class DynamicCalendarLoader extends CalendarCore {
         // the grid renders wider than the visible period and scrolls
         // natively; cards/map/label/URL follow on scroll settle only.
         this.stripStartDate = null;   // week strip: date of column 0
-        this.stripDayCount = 35;      // week strip: visible week ± 14 days
+        this.stripDayCount = 63;      // week strip: visible week ± 28 days
         this.stripMonths = [];        // month strip: rendered month firsts
         this.lastStripEvents = [];    // events across the rendered strip
         this.suppressGridScrollUntil = 0;
@@ -3517,7 +3517,7 @@ class DynamicCalendarLoader extends CalendarCore {
 
         if (this.currentView === 'week') {
             const stripStart = new Date(start);
-            stripStart.setDate(stripStart.getDate() - 14);
+            stripStart.setDate(stripStart.getDate() - 28);
             this.stripStartDate = new Date(stripStart);
             const stripEnd = new Date(stripStart);
             stripEnd.setDate(stripStart.getDate() + this.stripDayCount - 1);
@@ -3527,7 +3527,7 @@ class DynamicCalendarLoader extends CalendarCore {
             return this.generateWeekView(stripEvents, stripStart, stripEnd, today, hideEvents, this.stripDayCount);
         }
 
-        const months = [-2, -1, 0, 1, 2].map(d => new Date(start.getFullYear(), start.getMonth() + d, 1));
+        const months = [-3, -2, -1, 0, 1, 2, 3].map(d => new Date(start.getFullYear(), start.getMonth() + d, 1));
         this.stripMonths = months;
         // CONTINUOUS weeks, "like a calendar": Sunday on/before the previous
         // month's 1st through Saturday on/after the next month's last day —
@@ -4332,6 +4332,20 @@ class DynamicCalendarLoader extends CalendarCore {
         grid.scrollTo({ left: Math.round(newStart * dayW), behavior: 'smooth' });
     }
 
+    // Strip rebuild (extending the rendered range around the user): flags
+    // the grid so a quiet progress hairline shows — the only moment the
+    // continuous calendar does real work, and previously it was silent.
+    async rebuildStrip() {
+        const grid = document.querySelector('.calendar-grid');
+        if (grid) grid.classList.add('strip-rebuilding');
+        try {
+            await this.updateCalendarDisplay();
+        } finally {
+            const g = document.querySelector('.calendar-grid');
+            if (g) g.classList.remove('strip-rebuilding');
+        }
+    }
+
     // A selection whose day slid outside the visible window RESETS — leaving
     // it active greyed the whole calendar/map/list with nothing visibly
     // selected (owner report: select fuzzy, swipe it out of view)
@@ -4357,6 +4371,35 @@ class DynamicCalendarLoader extends CalendarCore {
             return;
         }
         this.clearEventSelection();
+    }
+
+    // Swap a container's HTML while REUSING already-decoded <img> nodes by
+    // src. The calendar grid is innerHTML-swapped on every strip rebuild;
+    // recreating its favicon chips made every icon in the week view flash
+    // (owner report). Same trick the events list uses for its cards.
+    swapHtmlPreservingImages(container, html) {
+        // key on the RESOLVED url (the .src property), not the attribute:
+        // the two sides can spell the same image relatively vs absolutely
+        const pool = new Map();
+        container.querySelectorAll('img').forEach(img => {
+            const src = img.src;
+            if (src && img.complete && img.naturalWidth > 0 && !pool.has(src)) pool.set(src, img);
+        });
+        if (!pool.size) {
+            container.innerHTML = html;
+            return;
+        }
+        const shell = document.createElement('div');
+        shell.innerHTML = html;
+        shell.querySelectorAll('img').forEach(img => {
+            const src = img.src;
+            const donor = src && pool.get(src);
+            if (donor) {
+                pool.delete(src);
+                img.replaceWith(donor);
+            }
+        });
+        container.replaceChildren(...shell.childNodes);
     }
 
     // Header label for the visible period (title slot + date range)
@@ -4487,12 +4530,12 @@ class DynamicCalendarLoader extends CalendarCore {
             newStart.setDate(newStart.getDate() + idx);
             newStart.setHours(0, 0, 0, 0);
             const changed = newStart.getTime() !== this.getCurrentPeriodBounds().start.getTime();
-            const nearEdge = idx <= 6 || idx >= this.stripDayCount - 13;
+            const nearEdge = idx <= 10 || idx >= this.stripDayCount - 17;
             if (!changed && !nearEdge) return;
             this.currentDate = newStart;
             this.clearSelectionIfOutOfBounds();
             if (nearEdge) {
-                await this.updateCalendarDisplay();
+                await this.rebuildStrip();
                 return;
             }
             this.sizeWeekStripHeight();
@@ -4537,7 +4580,7 @@ class DynamicCalendarLoader extends CalendarCore {
             this.pendingStripAnchor = anchorCell
                 ? { dateKey: anchorCell.getAttribute('data-date'), offset: anchorOffset }
                 : null;
-            await this.updateCalendarDisplay();
+            await this.rebuildStrip();
             return;
         }
         this.updateHeaderPeriodLabel();
@@ -4760,6 +4803,18 @@ class DynamicCalendarLoader extends CalendarCore {
     // Update calendar display with filtered events
     async updateCalendarDisplay(hideEvents = false) {
         logger.time('CALENDAR', 'Calendar display update');
+        // Resolve per-event colours BEFORE the first paint: cards rendered
+        // without them fall back to the site indigo + 3-blob gradient and
+        // then repaint, which read as "purple/gradient before switching to
+        // their main color". Bounded so a stalled fetch can't hold the UI.
+        if (!hideEvents && this.currentCity && !this.eventColorsByCity.has(this.currentCity)) {
+            try {
+                await Promise.race([
+                    this.loadEventColors(this.currentCity),
+                    new Promise(resolve => setTimeout(resolve, 1200))
+                ]);
+            } catch (e) {}
+        }
         const filteredEvents = this.getFilteredEvents();
         
         logger.info('CALENDAR', `🔍 UPDATE_DISPLAY: Updating calendar display (${hideEvents ? 'HIDDEN for measurement' : 'VISIBLE for display'})`, {
@@ -4782,7 +4837,7 @@ class DynamicCalendarLoader extends CalendarCore {
             const calendarGrid = document.querySelector('.calendar-grid');
             if (calendarGrid) {
                 logger.debug('CALENDAR', 'Updating calendar grid HTML');
-                calendarGrid.innerHTML = this.generateCalendarEvents(filteredEvents, hideEvents);
+                this.swapHtmlPreservingImages(calendarGrid, this.generateCalendarEvents(filteredEvents, hideEvents));
                 
                 // For measurement mode, make the grid invisible to users but keep same layout constraints
                 if (hideEvents) {

--- a/js/dynamic-calendar-loader.js
+++ b/js/dynamic-calendar-loader.js
@@ -4379,25 +4379,22 @@ class DynamicCalendarLoader extends CalendarCore {
             if (key && !oldCells.has(key)) oldCells.set(key, cell);
         });
         let reusedCells = 0;
-        if (oldCells.size) {
-            shell.querySelectorAll('[data-date]').forEach(fresh => {
-                const key = fresh.getAttribute('data-date');
-                const old = key && oldCells.get(key);
-                if (!old) return;
-                const sig = this.hashString(fresh.outerHTML);
-                if (old.dataset.cellSig === sig) {
-                    oldCells.delete(key);
-                    fresh.replaceWith(old);
-                    reusedCells++;
-                } else {
-                    fresh.dataset.cellSig = sig;
-                }
-            });
-        } else {
-            shell.querySelectorAll('[data-date]').forEach(fresh => {
-                fresh.dataset.cellSig = this.hashString(fresh.outerHTML);
-            });
-        }
+        shell.querySelectorAll('[data-date]').forEach(fresh => {
+            // EVERY fresh cell gets stamped, including ones with no previous
+            // counterpart: an unstamped cell can never be reused later, and
+            // the cells a rebuild newly renders are exactly the ones the
+            // NEXT rebuild has to keep (the "second drag blinks" bug).
+            const sig = this.hashString(fresh.outerHTML);
+            const key = fresh.getAttribute('data-date');
+            const old = key && oldCells.get(key);
+            if (old && old.dataset.cellSig === sig) {
+                oldCells.delete(key);
+                fresh.replaceWith(old);
+                reusedCells++;
+                return;
+            }
+            fresh.dataset.cellSig = sig;
+        });
 
         // 2. for whatever is genuinely new, still hand over already-decoded
         // <img> nodes by RESOLVED url (the two sides can spell the same

--- a/styles.css
+++ b/styles.css
@@ -7780,27 +7780,3 @@ html.dusk body {
         background-position: 50% 0;
     }
 }
-
-/* "there's more this way": a soft fade at the scrollable edges of each
-   strip so the visible window never reads as a dead end */
-.dusk .weekly-calendar .container:has(> .calendar-grid.week-strip) {
-    position: relative;
-}
-.dusk .weekly-calendar .container:has(> .calendar-grid.week-strip)::before,
-.dusk .weekly-calendar .container:has(> .calendar-grid.week-strip)::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 14px;
-    z-index: 4;
-    pointer-events: none;
-}
-.dusk .weekly-calendar .container:has(> .calendar-grid.week-strip)::before {
-    left: 0;
-    background: linear-gradient(90deg, rgba(7, 9, 15, 0.55), transparent);
-}
-.dusk .weekly-calendar .container:has(> .calendar-grid.week-strip)::after {
-    right: 0;
-    background: linear-gradient(270deg, rgba(7, 9, 15, 0.55), transparent);
-}

--- a/styles.css
+++ b/styles.css
@@ -7745,38 +7745,3 @@ html.dusk body {
 .md-label-layer .md-float-label.md-label-dim {
     filter: saturate(0.35) brightness(0.4);
 }
-
-/* the continuous strip's only real work moment: extending the rendered
-   range. A quiet hairline sweeps the grid's top edge — no spinner, no
-   layout shift, and it cannot be mistaken for content. */
-/* on the SECTION, not the scroller (inside a scroller an absolute pseudo
-   spans the CONTENT width — 63 day columns — so the sweep would run
-   mostly off-screen) and not on .container either, whose pseudos already
-   carry the edge fades below */
-.dusk .weekly-calendar:has(.calendar-grid.strip-rebuilding) { position: relative; }
-.dusk .weekly-calendar:has(.calendar-grid.strip-rebuilding)::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: auto;
-    width: auto;
-    height: 2px;
-    z-index: 12;
-    background: linear-gradient(90deg, transparent, var(--primary-color, #667eea), transparent);
-    background-size: 45% 100%;
-    background-repeat: no-repeat;
-    animation: stripLoadSweep 900ms ease-in-out infinite;
-    pointer-events: none;
-}
-@keyframes stripLoadSweep {
-    from { background-position: -45% 0; }
-    to { background-position: 145% 0; }
-}
-@media (prefers-reduced-motion: reduce) {
-    .dusk .weekly-calendar:has(.calendar-grid.strip-rebuilding)::after {
-        animation: none;
-        background-position: 50% 0;
-    }
-}

--- a/styles.css
+++ b/styles.css
@@ -6778,20 +6778,27 @@ html.dusk body {
     padding-bottom: 4px;
     transform: translateY(-3px);
 }
-/* colour-only feedback: a hover/active BACKGROUND drew a rounded square
-   around the chevrons (and iOS keeps :hover stuck after a tap), and
-   `transform: none` cancelled the optical translateY above, so the glyph
-   visibly dropped 3px when pressed. Quiet text controls stay quiet. */
+/* Quiet text controls stay quiet, and press feedback must not OUTLIVE the
+   press. Three traps here, all previously live:
+   - a hover/active BACKGROUND drew a rounded square behind the glyph;
+   - iOS leaves :hover stuck after a tap and a tapped button keeps :focus,
+     so any colour set on those states never went away (white forever);
+   - `transform: none` on hover cancelled the optical translateY below, so
+     the glyph dropped 3px when pressed.
+   Background stays transparent and the transform is held CONSTANT in every
+   state (the base sheet scales nav-btns on hover-capable devices and would
+   otherwise replace it); colour brightens only while actually held down,
+   or on a real pointer's hover. */
 .dusk .nav-btn:hover,
 .dusk .nav-btn:active,
 .dusk .nav-btn:focus,
 .dusk .nav-btn:focus-visible {
     background: transparent;
-    color: #fff;
-    /* hold the optical offset in EVERY state: the base stylesheet scales
-       nav-btns on real-hover devices, which would replace this translate
-       and drop the glyph on desktop too */
     transform: translateY(-3px);
+}
+.dusk .nav-btn:active { color: #fff; }
+@media (hover: hover) and (pointer: fine) {
+    .dusk .nav-btn:hover { color: #fff; }
 }
 .dusk .date-range {
     color: #fff;
@@ -6867,7 +6874,11 @@ html.dusk body {
 .dusk .today-btn:hover,
 .dusk .today-btn:active,
 .dusk .today-btn:focus,
-.dusk .today-btn:focus-visible { background: transparent; color: #fff; transform: none; }
+.dusk .today-btn:focus-visible { background: transparent; transform: none; }
+.dusk .today-btn:active { color: #fff; }
+@media (hover: hover) and (pointer: fine) {
+    .dusk .today-btn:hover { color: #fff; }
+}
 
 /* phone: same row, one size down */
 @media (max-width: 480px) {
@@ -6896,7 +6907,8 @@ html.dusk body {
 }
 /* iOS paints its default grey rectangle over any click-bound element on
    press — the cards are click-bound <div>s, so every tap flashed grey */
-.dusk .event-card, .dusk .event-item, .dusk .rail-thumb {
+.dusk .event-card, .dusk .event-item, .dusk .rail-thumb,
+.dusk .nav-btn, .dusk .today-btn, .dusk .view-btn {
     -webkit-tap-highlight-color: transparent;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/styles.css
+++ b/styles.css
@@ -6778,7 +6778,21 @@ html.dusk body {
     padding-bottom: 4px;
     transform: translateY(-3px);
 }
-.dusk .nav-btn:hover { background: rgba(255, 255, 255, 0.12); color: #fff; transform: none; }
+/* colour-only feedback: a hover/active BACKGROUND drew a rounded square
+   around the chevrons (and iOS keeps :hover stuck after a tap), and
+   `transform: none` cancelled the optical translateY above, so the glyph
+   visibly dropped 3px when pressed. Quiet text controls stay quiet. */
+.dusk .nav-btn:hover,
+.dusk .nav-btn:active,
+.dusk .nav-btn:focus,
+.dusk .nav-btn:focus-visible {
+    background: transparent;
+    color: #fff;
+    /* hold the optical offset in EVERY state: the base stylesheet scales
+       nav-btns on real-hover devices, which would replace this translate
+       and drop the glyph on desktop too */
+    transform: translateY(-3px);
+}
 .dusk .date-range {
     color: #fff;
     font-size: 0.95rem;
@@ -6850,7 +6864,10 @@ html.dusk body {
     transition: opacity 0.12s ease;
 }
 .dusk .header-controls-row.off-today .today-btn { visibility: visible; opacity: 1; }
-.dusk .today-btn:hover { transform: none; background: rgba(255, 255, 255, 0.08); }
+.dusk .today-btn:hover,
+.dusk .today-btn:active,
+.dusk .today-btn:focus,
+.dusk .today-btn:focus-visible { background: transparent; color: #fff; transform: none; }
 
 /* phone: same row, one size down */
 @media (max-width: 480px) {

--- a/styles.css
+++ b/styles.css
@@ -7745,3 +7745,62 @@ html.dusk body {
 .md-label-layer .md-float-label.md-label-dim {
     filter: saturate(0.35) brightness(0.4);
 }
+
+/* the continuous strip's only real work moment: extending the rendered
+   range. A quiet hairline sweeps the grid's top edge — no spinner, no
+   layout shift, and it cannot be mistaken for content. */
+/* on the SECTION, not the scroller (inside a scroller an absolute pseudo
+   spans the CONTENT width — 63 day columns — so the sweep would run
+   mostly off-screen) and not on .container either, whose pseudos already
+   carry the edge fades below */
+.dusk .weekly-calendar:has(.calendar-grid.strip-rebuilding) { position: relative; }
+.dusk .weekly-calendar:has(.calendar-grid.strip-rebuilding)::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: auto;
+    width: auto;
+    height: 2px;
+    z-index: 12;
+    background: linear-gradient(90deg, transparent, var(--primary-color, #667eea), transparent);
+    background-size: 45% 100%;
+    background-repeat: no-repeat;
+    animation: stripLoadSweep 900ms ease-in-out infinite;
+    pointer-events: none;
+}
+@keyframes stripLoadSweep {
+    from { background-position: -45% 0; }
+    to { background-position: 145% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .dusk .weekly-calendar:has(.calendar-grid.strip-rebuilding)::after {
+        animation: none;
+        background-position: 50% 0;
+    }
+}
+
+/* "there's more this way": a soft fade at the scrollable edges of each
+   strip so the visible window never reads as a dead end */
+.dusk .weekly-calendar .container:has(> .calendar-grid.week-strip) {
+    position: relative;
+}
+.dusk .weekly-calendar .container:has(> .calendar-grid.week-strip)::before,
+.dusk .weekly-calendar .container:has(> .calendar-grid.week-strip)::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 14px;
+    z-index: 4;
+    pointer-events: none;
+}
+.dusk .weekly-calendar .container:has(> .calendar-grid.week-strip)::before {
+    left: 0;
+    background: linear-gradient(90deg, rgba(7, 9, 15, 0.55), transparent);
+}
+.dusk .weekly-calendar .container:has(> .calendar-grid.week-strip)::after {
+    right: 0;
+    background: linear-gradient(270deg, rgba(7, 9, 15, 0.55), transparent);
+}


### PR DESCRIPTION
Follow-ups to the continuous calendar (#1705/#1706), all from on-device review. Three files, +135/−9.

## No more flashing when the calendar loads more days/months
- **Day cells are reused, not rebuilt.** A strip rebuild used to re-render every cell (231 of them), so every pill and favicon in view became a new node and repainted — colors included. The grid swap now reconciles by date: a cell whose markup is byte-identical is moved across as the *same* node. Measured on realistic drags: **42 of 42 visible cells survive**, on every consecutive drag.
- **Icons keep their pixels** where cells genuinely change: already-decoded `<img>` nodes are handed over by resolved URL (attribute-keyed matching silently failed — the two sides can spell the same image relatively vs absolutely).
- **Cards no longer flash indigo/gradient.** Aurora colors (`data/event-colors/<city>.json`) loaded *after* first paint, so cards rendered on the `--primary-color` fallback and repainted. Colors are resolved before painting now, bounded by a 1.2s race so a stalled fetch can't hold the UI.
- **Pills get their colors in the same task as the render.** dusk-ui only repainted from its MutationObserver's rAF — one frame after the default-colored pills had already painted.

## A real bug found along the way
`generateMonthView` rounds its cell range up to whole weeks, so the strip renders a few days **past** the range events were queried for. Those cells rendered **empty even when the day had events** (2026-12-06 was silently missing its Beer Blast), and "gained" events on the next rebuild. The query now pads a week past both strip edges.

## Deeper buffers
Week renders the visible week **±28 days** (63 columns, was ±14); month renders **±3 months** (~231 cells, was ±2). Rebuilds are now rare — which is why the loading affordances I first added (sweep hairline, edge fades) were dropped again as unnecessary noise.

## Quieter header controls
The chevrons and Today button no longer paint a rounded square on press (a `:hover` background — iOS leaves `:hover` stuck after a tap), no longer drop 3px when pressed (`transform: none` was cancelling their optical offset), and no longer stay white afterwards (color feedback is now `:active`-only, or hover on real pointers). They also join the `-webkit-tap-highlight-color: transparent` list.

## Verification
Quiet suite green (1984). Headless at 390px: 42/42 visible cell reuse across three consecutive drags with 100% signature coverage; first-paint card color (`#f2592a`); 139/144 pills colored with rAF frozen (proving same-task painting); boundary-day events present; CSSOM audit showing the only remaining state-color rules are `:active` and pointer-hover, with resting colors unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP