### PR TITLE
Stamp _mergeNoOp both ways so a stale _changes stops mislabeling real merges

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -15831,10 +15831,17 @@ ${results.errors.length > 0 ? `❌ Errors: ${results.errors.length}` : "✅ No e
       // _mergeNoOp is the write path's own no-op stamp (shared-core: final
       // payload field-identical to the calendar record, notes projection
       // included) — the same skip filterEventsForExecution enforces, so the
-      // pile and the gate agree in live AND dryRun runs. The _changes form
-      // below stays for saved runs recorded before the stamp existed.
+      // pile and the gate agree in live AND dryRun runs.
       event._mergeNoOp === true ||
-      (this.normalizeIntentAction(event) === "merge" &&
+      // LEGACY ONLY: _changes is stamped back at merge time, before the
+      // sanity/notes passes that can still change the payload, so an empty
+      // _changes is not proof of a no-op — an overnight-span-corrected
+      // event (endDate rewritten after the stamp) filed a real UPDATE under
+      // "Already Saved (No Action)" while the gate wrote it. shared-core now
+      // stamps _mergeNoOp false in exactly that case, so this fallback may
+      // only speak for runs recorded before the stamp existed (undefined).
+      (event._mergeNoOp === undefined &&
+        this.normalizeIntentAction(event) === "merge" &&
         Array.isArray(event._changes) &&
         event._changes.length === 0)
     ) {

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -10205,6 +10205,33 @@ test('write-policy: a _mergeNoOp merge sits in the already-saved pile and never 
   assert.equal(adapter.getWriteActionFromEvent(unstamped), 'update');
 });
 
+test('write-policy: an empty _changes never outranks a false _mergeNoOp (GOLIDLOXX span-correction shape)', () => {
+  const adapter = buildAdapter();
+  // Run 20260828-105507: the calendar carried the same wrong 9PM→4PM end as
+  // the scrape, so merge arbitration stamped _changes empty; the
+  // overnight-span sanity rule then corrected endDate -12h AFTER that stamp.
+  // shared-core judges the FINAL payload and stamps _mergeNoOp false, so the
+  // card must stay actionable — it sat under "Already Saved (No Action)"
+  // while the write gate correctly executed the UPDATE he then tapped.
+  const corrected = freshRound3Event(BEEFMINCE_NOOP_EVENT);
+  corrected._changes = [];
+  corrected._mergeNoOp = false;
+  corrected._sanityFlags = [{ code: 'overnight-span-corrected', detail: 'end corrected -12h to a 7h overnight span' }];
+  const placement = adapter.classifyEventForResultsSection(corrected);
+  assert.equal(placement.section, 'actionable',
+    'a stamped-false merge is a real write, whatever the stale _changes says');
+  assert.equal(placement.reason, '', 'actionable cards carry no already-saved chip');
+  assert.equal(adapter.getWriteActionFromEvent(corrected), 'update',
+    'and the badge keeps promising the UPDATE the gate performs');
+
+  // The legacy form still speaks for runs recorded before the stamp existed.
+  const legacy = freshRound3Event(BEEFMINCE_NOOP_EVENT);
+  legacy._changes = [];
+  delete legacy._mergeNoOp;
+  assert.equal(adapter.classifyEventForResultsSection(legacy).section, 'saved',
+    'an unstamped saved run keeps reading its empty _changes as a no-op');
+});
+
 test('round3: every existing bridge handler id and page handler survives the cleanup', async () => {
   const adapter = buildAdapter();
   // Bridge action ids round-trip through the URL parser.

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -15710,8 +15710,20 @@ class SharedCore {
                 const changedBeyondNotes = finalWriteChanges.filter(field => field !== 'notes');
                 const notesIdentical = !finalWriteChanges.includes('notes')
                     || this.notesProjectionsMatch(analyzedEvent._existingEvent.notes, analyzedEvent.notes);
-                if (changedBeyondNotes.length === 0 && notesIdentical) {
-                    analyzedEvent._mergeNoOp = true;
+                // Stamped BOTH ways on purpose. A `false` stamp is what tells
+                // the results UI that THIS run judged the final payload, so
+                // its legacy _changes fallback must stand down: _changes is
+                // computed back at merge time (mergeEvents), before the
+                // sanity/notes passes that can still mutate the payload, so
+                // an empty _changes no longer proves "nothing to write".
+                // Live proof (run 20260828-105507, GOLIDLOXX AUGUST): the
+                // overnight-span-corrected sanity rule rewrote endDate -12h
+                // AFTER _changes was stamped empty, and the card landed in
+                // "Already Saved (No Action)" while the write gate below
+                // correctly executed the UPDATE. Only a run recorded before
+                // this stamp existed leaves _mergeNoOp undefined.
+                analyzedEvent._mergeNoOp = changedBeyondNotes.length === 0 && notesIdentical;
+                if (analyzedEvent._mergeNoOp) {
                     console.log(`⏸️ MERGE: "${analyzedEvent.title || 'Unknown'}" produced no field changes — write skipped`);
                 }
             }

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -16044,7 +16044,7 @@ test('merge no-op fail-closed: one real field change writes, and a verdict-line-
     buildPrepCalendarAdapter([{ ...calendarRecord, startDate: new Date(calendarRecord.startDate), endDate: new Date(calendarRecord.endDate) }]),
     {});
   assert.equal(changedRun[0]._action, 'merge');
-  assert.equal(changedRun[0]._mergeNoOp, undefined, 'a real field change is never stamped as a no-op');
+  assert.equal(changedRun[0]._mergeNoOp, false, 'a real field change is stamped false — evaluated, not a no-op');
   assert.equal(SharedCore.filterEventsForExecution(changedRun).length, 1, 'the changed merge still writes');
 
   // Verdict-line-only twin: same fields, but the owner tapped manual-bear in
@@ -16059,8 +16059,72 @@ test('merge no-op fail-closed: one real field change writes, and a verdict-line-
   assert.equal(core.parseNotesIntoFields(verdictRun[0].notes).bearSource,
     'manual-bear (overrode ai: tapped in results)',
     'the manual verdict is in the merged payload');
-  assert.equal(verdictRun[0]._mergeNoOp, undefined, 'a verdict-note-only difference is a change');
+  assert.equal(verdictRun[0]._mergeNoOp, false, 'a verdict-note-only difference is a change');
   assert.equal(SharedCore.filterEventsForExecution(verdictRun).length, 1, 'the verdict write still lands');
+});
+
+// GOLIDLOXX AUGUST, run 20260828-105507 (he tapped the merge and asked why a
+// card in "Already Saved (No Action)" proposed one). Red Eye's API gives the
+// event a 9PM->4PM span; the calendar already held that same wrong end, so
+// merge arbitration found NOTHING to change and stamped _changes empty. The
+// overnight-span sanity correction then rewrote endDate -12h — AFTER that
+// stamp. The write was real; only the results-UI pile disagreed, because it
+// trusted the stale _changes. The fix is the false stamp asserted here: it
+// tells the UI this run judged the FINAL payload.
+test('merge no-op ordering: a post-merge sanity correction is stamped false, never left to stale _changes', async () => {
+  const core = createCore();
+  // Sat 9PM EDT -> Sun 4PM EDT: the 19h span rule 11 corrects to 7h.
+  const badStart = new Date('2026-08-30T01:00:00.000Z');
+  const badEnd = new Date('2026-08-30T20:00:00.000Z');
+  const scraped = () => ({
+    title: 'GOLIDLOXX AUGUST',
+    startDate: new Date(badStart),
+    endDate: new Date(badEnd),
+    bar: 'Red Eye NY',
+    city: 'nyc',
+    timezone: 'America/New_York',
+    location: '40.7577763,-73.9925418',
+    website: 'https://redeyeny.com',
+    bearSource: 'keyword',
+    shortName: 'GOLDI-LOXX'
+  });
+
+  // Settle the record once (same two-pass shape as the BEEFMINCE cases) and
+  // put the UNCORRECTED end back: that is the historical record — written
+  // before the correction rule existed — the re-scrape merges into.
+  const seedRecord = {
+    title: 'GOLIDLOXX AUGUST',
+    startDate: new Date(badStart),
+    endDate: new Date(badEnd),
+    location: '40.7577763,-73.9925418',
+    notes: 'bar: Red Eye NY'
+  };
+  const settled = await core.prepareEventsForCalendar(
+    [scraped()], buildPrepCalendarAdapter([seedRecord]), {});
+  assert.equal(settled[0]._action, 'merge');
+  const calendarRecord = {
+    title: settled[0].title,
+    startDate: new Date(badStart),
+    endDate: new Date(badEnd),
+    location: settled[0].location,
+    notes: settled[0].notes
+  };
+
+  const rerun = await core.prepareEventsForCalendar(
+    [scraped()], buildPrepCalendarAdapter([calendarRecord]), {});
+  assert.equal(rerun.length, 1);
+  const merged = rerun[0];
+  assert.equal(merged._action, 'merge');
+  assert.ok(!merged._changes.includes('endDate'),
+    'merge-time _changes cannot see the end correction — scraper and calendar carried the same wrong end');
+  assert.equal(new Date(merged.endDate).toISOString(), '2026-08-30T08:00:00.000Z',
+    'the sanity pass corrected the end AFTER _changes was stamped');
+  assert.ok((merged._sanityFlags || []).some(flag => flag.code === 'overnight-span-corrected'),
+    'the correction is the one flagged on the card');
+  assert.equal(merged._mergeNoOp, false,
+    'stamped false: this run judged the final payload, so the UI must not read the stale _changes');
+  assert.equal(SharedCore.filterEventsForExecution(rerun).length, 1,
+    'the corrected end reaches the calendar — the merge he ran was real');
 });
 
 test('notesProjectionsMatch: pure line reordering is a no-op, any real line difference is a change', () => {


### PR DESCRIPTION
## The report

GOLIDLOXX AUGUST came back from a rerun filed under **Already Saved (No Action)** — "nothing will be written" — while the same card carried a `MERGE · 1 UPDATE` badge. Tapping the merge did write. Which one was lying?

The **merge was right**. The card's pile was wrong.

## What happened

Red Eye's API gives that event a 9PM → **4PM** span (an AM/PM slip at the source), and the calendar already held the same wrong end. So merge arbitration compared the two, found nothing to change, and stamped `_changes = []`. The `overnight-span-corrected` sanity rule then rewrote `endDate` −12h to a 7h overnight party — **after** that stamp.

Recomputing the write diff against the full calendar record for that event:

```
changes vs calendar record: ["endDate"]
notes projections match:    true
calendar end: 2026-08-30T20:00:00Z  →  written end: 2026-08-30T08:00:00Z
```

The write gate had this right all along: `buildAnalyzedCalendarEvent` re-judges the **final** payload, saw the changed end, and declined to stamp `_mergeNoOp` — so `filterEventsForExecution` kept the UPDATE. It just never recorded a *negative* verdict, and the results UI's legacy fallback (`merge && _changes.length === 0` → already-saved) filled the silence with the stale list.

## The fix

- **`shared-core.js`** — stamp `_mergeNoOp` **true and false**. A `false` stamp is the run saying "I judged the final payload." Every consumer already tests `=== true`, so the skip behaviour is untouched.
- **`scriptable-adapter.js`** — the `_changes.length === 0` fallback now applies only when the stamp is `undefined`, i.e. saved runs recorded before it existed.

## Verification

- Quiet suite: **1986 pass, 0 fail** (2 new tests; two existing assertions moved from `undefined` to `false`).
- New `shared-core` test reproduces the ordering end to end: merge-time `_changes` cannot see the correction, the final payload has the corrected end, `_mergeNoOp === false`, and the event still reaches the write.
- New adapter test pins both directions: stamped-false + empty `_changes` → Actionable/UPDATE; unstamped legacy run → still already-saved.
- Replaying the real run `20260828-105507` through the patched classifier flips **exactly the two misfiled cards** — GOLIDLOXX AUGUST and MEGAWOOF AMERICA LAS VEGAS DADDIES AT WORK, both `overnight-span-corrected`, both `changes: endDate` — into Actionable/UPDATE, leaving the genuine no-ops where they were.

No new runtime files; no changes to what gets written, only to what the card claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP