### PR TITLE
An empty scraped date never clears the calendar's end (Club Chub could not save)

### DIFF
--- a/scripts/adapters/scriptable-adapter.js
+++ b/scripts/adapters/scriptable-adapter.js
@@ -4050,6 +4050,16 @@ class ScriptableAdapter {
 
               actionCounts.merge.push(event.title);
               const targetEvent = event._existingEvent;
+              // The write mutates the LIVE EventKit record in place, and that
+              // same object is what the saved run serializes as "what the
+              // calendar had". A failed save leaves the mutation standing, so
+              // the run JSON then reports the post-write payload as the
+              // pre-write record — run 20260828-163440 recorded the NEW title
+              // and a null end for a write that never landed, which reads as
+              // "it saved and then reverted". Swap in a pre-write snapshot
+              // (identifier included, so every downstream lookup still works)
+              // and mutate only the live object from here on.
+              event._existingEvent = this.snapshotCalendarRecord(targetEvent);
 
               // Apply the final merged values (event object already contains final values)
               // Note: Scriptable cannot read or write the native CalendarEvent.url field,
@@ -4057,7 +4067,20 @@ class ScriptableAdapter {
               targetEvent.title = event.title;
               // Same typed-setter hazard as the create path below.
               targetEvent.startDate = this.toCalendarWriteDate(event.startDate);
-              targetEvent.endDate = this.resolveCalendarWriteEndDate(event);
+              // Never CLEAR a stored end: EventKit rejects an endless event
+              // outright ("No end date has been set."), losing the whole write.
+              // shared-core keeps the calendar end when a scrape has none, so
+              // this is the boundary backstop for any other producer.
+              const resolvedEndDate = this.resolveCalendarWriteEndDate(event);
+              if (resolvedEndDate === null || resolvedEndDate === undefined) {
+                if (targetEvent.endDate) {
+                  console.log(
+                    `📱 Scriptable: ⚠️ "${event.title}" merged payload carries no endDate — keeping the calendar's stored end`,
+                  );
+                }
+              } else {
+                targetEvent.endDate = resolvedEndDate;
+              }
               targetEvent.location = event.location;
               targetEvent.notes = event.notes;
 
@@ -4177,6 +4200,24 @@ class ScriptableAdapter {
   // data and dropping the event would lose a real night; both shapes are
   // instead surfaced report-only by SharedCore.getEventSanityFlags as
   // `end-not-after-start`.
+  // A plain, pre-write copy of a live EventKit record, for the analyzed
+  // event's `_existingEvent` slot. Carries exactly the fields the results UI,
+  // the merge comparison and the saved-run serializer read off it —
+  // `identifier` included, so series lookups and override-key checks keep
+  // working — and nothing that the calendar write is about to mutate.
+  snapshotCalendarRecord(record) {
+    if (!record || typeof record !== "object") return record;
+    return {
+      title: record.title,
+      identifier: record.identifier,
+      startDate: record.startDate,
+      endDate: record.endDate,
+      location: record.location,
+      notes: record.notes,
+      url: record.url,
+    };
+  }
+
   resolveCalendarWriteEndDate(event) {
     // Coerced, never `instanceof` — Scriptable hands every module its own Date
     // constructor, so a Date built in shared-core fails `instanceof Date` here.

--- a/scripts/adapters/scriptable-adapter.test.js
+++ b/scripts/adapters/scriptable-adapter.test.js
@@ -5916,6 +5916,55 @@ test('recordCalendarWriteFailures creates errors[] when absent and is a no-op on
   assert.deepEqual(clean.errors, []);
 });
 
+// Club Chub MEAT MARKET, run 20260828-163440. The event was renamed at the
+// source (Wig Out → MEAT MARKET) and sickening.events' JSON-LD carries no end
+// time, so the merged payload reached this boundary with endDate null. EventKit
+// refused the whole write — "No end date has been set." — 1 of 1 failed, every
+// attempt. The merge no longer produces that payload (shared-core keeps the
+// calendar end when a scrape has none); this is the boundary backstop, plus the
+// pre-write snapshot that keeps the saved run honest about what the calendar
+// held when a write does fail.
+test('merge write: a missing endDate never clears the stored end, and _existingEvent keeps the pre-write record', async () => {
+  const adapter = buildAdapter();
+  adapter.getOrCreateCalendar = async () => ({ title: 'chunky-dad-fortlauderdale' });
+  const stored = {
+    title: 'CLUB CHUB: The Wig Out Party',
+    identifier: 'CAL:BE92AFDE',
+    startDate: new Date('2026-11-01T21:00:00.000Z'),
+    endDate: new Date('2026-11-02T02:00:00.000Z'),
+    location: '',
+    notes: 'bar: Eagle Wilton Manors',
+    saveCount: 0,
+    async save() { this.saveCount += 1; }
+  };
+  const event = {
+    title: 'Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors',
+    city: 'fortlauderdale',
+    _action: 'merge',
+    startDate: new Date('2026-11-01T21:00:00.000Z'),
+    endDate: null,
+    location: '',
+    notes: 'bar: Eagle Wilton Manors\nwebsite: https://clubchubusa.com',
+    _existingEvent: stored
+  };
+
+  const processed = await adapter.executeCalendarActions([event], {});
+  assert.equal(processed, 1, 'the write lands instead of failing on the empty end');
+  assert.equal(stored.saveCount, 1, 'the record was saved once');
+  assert.equal(stored.endDate.toISOString(), '2026-11-02T02:00:00.000Z',
+    'the calendar keeps its stored end — an empty payload never clears it');
+  assert.equal(stored.title, 'Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors',
+    'the rename still applies');
+
+  assert.equal(event._existingEvent.title, 'CLUB CHUB: The Wig Out Party',
+    'the saved run still reports the title the calendar HELD, not the one just written');
+  assert.equal(event._existingEvent.identifier, 'CAL:BE92AFDE',
+    'the snapshot keeps the identifier every downstream lookup reads');
+  assert.equal(event._existingEvent.endDate.toISOString(), '2026-11-02T02:00:00.000Z');
+  assert.equal(typeof event._existingEvent.save, 'undefined',
+    'the snapshot is plain data — the live record is not handed to the serializer');
+});
+
 // ---------------------------------------------------------------------------
 // Size-driven pagination (Scriptable flow) + show-everything (web flow).
 //

--- a/scripts/shared-core.js
+++ b/scripts/shared-core.js
@@ -10690,6 +10690,26 @@ class SharedCore {
                 continue;
             }
 
+            // A MISSING scraped start/end is an extraction gap, exactly like
+            // every other field's — but the generic empty-scrape rule below
+            // excludes the dates on the assumption their own rules own them.
+            // Those rules cover a DEGENERATE end (above) and CONFLICTING dates
+            // (routeDateConflictToAi); neither fires when the scrape simply
+            // has no end, so the default 'ai' strategy let the empty value
+            // through and cleared the calendar's end. EventKit then refuses
+            // the write outright — "No end date has been set." — so the event
+            // can never save again (Club Chub MEAT MARKET, run
+            // 20260828-163440: sickening.events' JSON-LD carries no endDate,
+            // the calendar had 9PM, execution failed 1 of 1 every attempt).
+            // Nothing to arbitrate here: one side is absent.
+            if ((fieldName === 'startDate' || fieldName === 'endDate')
+                && this.isEmptyArbitrationValue(scraperValue)
+                && !this.isEmptyArbitrationValue(calendarValue)) {
+                mergedObject[fieldName] = calendarValue;
+                console.log(`📅 MERGE: "${mergeTitle}" ${fieldName} kept from calendar (scrape found none)`);
+                continue;
+            }
+
             // Orientation image slots are NEVER cleared by a run that found no
             // candidate of that shape. URL-derived orientation is knowable for
             // only a minority of image URLs, so an empty imageVertical/
@@ -11184,24 +11204,32 @@ class SharedCore {
         
         // Create the final event object that represents exactly what will be saved
         const finalEvent = {
-            // Core calendar fields
+            // Copy all merged fields to final event
+            ...mergedObject,
+
+            // Core calendar fields, applied AFTER the spread. Written BEFORE
+            // it, every one of these fallbacks was dead on arrival: a key
+            // present on mergedObject with a falsy value (endDate: null,
+            // location: undefined) overwrote the fallback it was meant to be
+            // guarded by. Only `notes` survived, because it is re-applied
+            // below. Two live failures traced to exactly this: MEAT MARKET's
+            // null endDate reaching EventKit ("No end date has been set."),
+            // and BEEFMINCE New Year's Eve reporting a phantom location
+            // change (undefined vs the calendar's null) on every run.
             title: mergedObject.title || calendarObject.title,
             startDate: mergedObject.startDate || calendarObject.startDate,
             endDate: mergedObject.endDate || calendarObject.endDate,
             location: mergedObject.location || calendarObject.location,
-            notes: newNotes,
-            // url is a VIEW of the canonical merged website (one logical field) —
-            // kept because the web adapter and display read event.url; it is
-            // never independently stored ('url' is skipped by the merge loop, so
-            // the mergedObject spread below cannot override this).
-            url: mergedObject.website || '',
-            
-            // Copy all merged fields to final event
-            ...mergedObject,
-            
+
             // Override notes with the newly built ones
             notes: newNotes,
-            
+
+            // url is a VIEW of the canonical merged website (one logical field) —
+            // kept because the web adapter and display read event.url; it is
+            // never independently stored ('url' is skipped by the merge loop,
+            // so mergedObject carries no url of its own).
+            url: mergedObject.website || '',
+
             // Preserve existing event reference for saving
             _existingEvent: existingEvent,
             _action: 'merge',

--- a/scripts/shared-core.test.js
+++ b/scripts/shared-core.test.js
@@ -16127,6 +16127,58 @@ test('merge no-op ordering: a post-merge sanity correction is stamped false, nev
     'the corrected end reaches the calendar — the merge he ran was real');
 });
 
+// Club Chub MEAT MARKET, run 20260828-163440 (renamed at the source from "The
+// Wig Out Party"). sickening.events' JSON-LD carries no endDate, and the dates
+// are exempt from the generic "an empty scrape never deletes" rule — so the
+// empty value cleared the calendar's 9PM end and EventKit refused the write
+// outright ("No end date has been set."), failing 1 of 1 on every attempt.
+// Second assertion covers the same class one layer down: createFinalEventObject
+// spread mergedObject AFTER its own `|| calendarObject.x` fallbacks, so every
+// one of them was dead — which is also how BEEFMINCE New Year's Eve reported a
+// phantom location change (undefined vs the calendar's empty string) forever.
+test('merge: an empty scraped end never clears the calendar end, and the core-field fallbacks survive the spread', async () => {
+  const core = createCore();
+  const existing = {
+    title: 'CLUB CHUB: The Wig Out Party',
+    identifier: 'CAL:BE92AFDE',
+    startDate: new Date('2026-11-01T21:00:00.000Z'),
+    endDate: new Date('2026-11-02T02:00:00.000Z'),
+    location: '',
+    notes: 'bar: Eagle Wilton Manors\nwebsite: https://clubchubusa.com'
+  };
+  const scraped = {
+    title: 'Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors',
+    startDate: new Date('2026-11-01T21:00:00.000Z'),
+    endDate: null,
+    bar: 'Eagle Wilton Manors',
+    city: 'dallas',
+    timezone: 'America/New_York',
+    website: 'https://clubchubusa.com',
+    // What getResolvedFieldPriorities stamps on every ai-web event: the 'ai'
+    // strategy is what let the empty side through.
+    _fieldPriorities: {
+      startDate: { priority: ['ai-web'], merge: 'ai' },
+      endDate: { priority: ['ai-web'], merge: 'ai' },
+      location: { priority: ['ai-web'], merge: 'ai' }
+    }
+  };
+
+  const final = await core.createFinalEventObject(existing, scraped, {});
+  assert.equal(new Date(final.endDate).toISOString(), '2026-11-02T02:00:00.000Z',
+    'the calendar end survives a scrape that found none');
+  // The title is decided by AI arbitration, which no test wires up (offline it
+  // falls back deterministically) — so pin only that the date guard did not
+  // start freezing OTHER fields to the calendar side.
+  assert.ok(
+    ['CLUB CHUB: The Wig Out Party', 'Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors']
+      .includes(final.title),
+    'title still resolves through arbitration, not through the date guard');
+  assert.equal(final.location, '',
+    'location falls back to the calendar value instead of the spread\'s undefined');
+  assert.ok(!(final._changes || []).includes('location'),
+    'so no phantom location change is reported');
+});
+
 test('notesProjectionsMatch: pure line reordering is a no-op, any real line difference is a change', () => {
   const core = createCore();
   const notes = 'bar: Royal Vauxhall Tavern\nwebsite: https://beefmince.com\nbearSource: keyword';


### PR DESCRIPTION
## The report

Club Chub's Wig Out event, renamed at the source to **MEAT MARKET**, offered 6 changes on every scrape. Executing did nothing — and it wasn't silent:

```
🔄 MERGE: "Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors" clobbered 6 fields
         (endDate, key, title, description, address, gmaps)
Executing actions for 1 events
✓ Processed 0 events: 1 merged
✗ Failed to process 1 events: Club Chub Presents: MEAT MARKET @ Eagle Wilton Manors
First error: No end date has been set.
```

## Why

sickening.events' JSON-LD has no `endDate` (`provided=[title, description, city, bar, address, startDate, url, ticketUrl, image…]`). The calendar held 9PM. The merge took the empty side.

The generic *"an empty scraped value is an extraction gap, never a deletion instruction"* rule explicitly exempts the dates:

```js
// startDate/endDate are excluded: their own rules above/below own them
if (fieldName !== 'startDate' && fieldName !== 'endDate' && fieldName !== 'key' && …)
```

Those rules cover a **degenerate** end (`end <= start`) and **conflicting** dates. Neither fires when the scrape simply has none, so the default `endDate: { merge: 'ai' }` strategy let null through — with nothing to arbitrate, one side being absent.

The safety net one function later could not catch it:

```js
const finalEvent = {
  endDate: mergedObject.endDate || calendarObject.endDate,   // ← intended guard
  location: mergedObject.location || calendarObject.location,
  …
  ...mergedObject,        // ← spread runs AFTER; a falsy present key wins
```

Every one of those fallbacks was dead on arrival (only `notes` survived, being re-applied below). **That is also the BEEFMINCE New Year's Eve bug** from the previous report: `location` resolving to `undefined` against the calendar's empty string, a phantom change re-written on every run.

## The fix

- **`shared-core.js`** — an empty scraped `startDate`/`endDate` keeps the calendar's value, with its own log line. Core-field fallbacks moved **after** the spread so they actually apply.
- **`scriptable-adapter.js`** — boundary backstop: a payload with no end never clears a stored one. And the live EventKit record is snapshotted **before** the write mutates it, so a failed save no longer leaves the saved run reporting the post-write payload as the pre-write record (run `20260828-163440` recorded the new title and a null end for a write that never landed — it reads as "saved, then reverted").

## Verification

- Quiet suite: **1988 pass, 0 fail** (2 new tests).
- Replaying the **real** failed merge (`20260828-163503`'s recorded scraper + calendar objects) through the patched code: end stays `2026-11-02T02:00:00.000Z`, the rename still lands, and `endDate` drops out of the clobber list (6 fields → 5). That write would now save.
- New adapter test drives the live write path with a null-end payload: the stored end survives, the rename applies, `_existingEvent` still reports the pre-write title.

## Not in this PR

The renamed event still wears the **old Wig Out flyer**. That is a separate bug with a confirmed cause: sickening.events hosts event artwork under a path containing `logos`, so the `hasLogoSegment` rung classified the real MEAT MARKET poster as a site logo and kept the calendar's stale Eventbrite image. The image arbitration already has an OCR-title-evidence rung that outranks the path heuristic — it never fired because the JSON-LD route skips OCR entirely. Reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPvhx88qaX3FdiLUqKKqP